### PR TITLE
[mlir,python] Expose replaceAllUsesExcept to Python bindings

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -961,16 +961,9 @@ MLIR_CAPI_EXPORTED void mlirValueReplaceAllUsesOfWith(MlirValue of,
 /// 'exceptions'. The 'exceptions' parameter is an array of MlirOperation
 /// pointers with a length of 'numExceptions'.
 MLIR_CAPI_EXPORTED void
-mlirValueReplaceAllUsesExceptWithSet(MlirValue of, MlirValue with,
-                                     MlirOperation *exceptions,
-                                     intptr_t numExceptions);
-
-/// Replace all uses of 'of' value with 'with' value, updating anything in the
-/// IR that uses 'of' to use 'with' instead, except if the user is
-/// 'exceptedUser'.
-MLIR_CAPI_EXPORTED void
-mlirValueReplaceAllUsesExceptWithSingle(MlirValue of, MlirValue with,
-                                        MlirOperation exceptedUser);
+mlirValueReplaceAllUsesExcept(MlirValue of, MlirValue with,
+                              intptr_t numExceptions,
+                              MlirOperation *exceptions);
 
 //===----------------------------------------------------------------------===//
 // OpOperand API.

--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -956,6 +956,22 @@ MLIR_CAPI_EXPORTED MlirOpOperand mlirValueGetFirstUse(MlirValue value);
 MLIR_CAPI_EXPORTED void mlirValueReplaceAllUsesOfWith(MlirValue of,
                                                       MlirValue with);
 
+/// Replace all uses of 'of' value with 'with' value, updating anything in the
+/// IR that uses 'of' to use 'with' instead, except if the user is listed in
+/// 'exceptions'. The 'exceptions' parameter is an array of MlirOperation
+/// pointers with a length of 'numExceptions'.
+MLIR_CAPI_EXPORTED void
+mlirValueReplaceAllUsesExceptWithSet(MlirValue of, MlirValue with,
+                                     MlirOperation *exceptions,
+                                     intptr_t numExceptions);
+
+/// Replace all uses of 'of' value with 'with' value, updating anything in the
+/// IR that uses 'of' to use 'with' instead, except if the user is
+/// 'exceptedUser'.
+MLIR_CAPI_EXPORTED void
+mlirValueReplaceAllUsesExceptWithSingle(MlirValue of, MlirValue with,
+                                        MlirOperation exceptedUser);
+
 //===----------------------------------------------------------------------===//
 // OpOperand API.
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3726,22 +3726,14 @@ void mlir::python::populateIRCore(py::module &m) {
           kValueReplaceAllUsesWithDocstring)
       .def(
           "replace_all_uses_except",
-          [](PyValue &self, PyValue &with, PyOperation &exception) {
-            MlirValue selfValue = self.get();
-            MlirValue withValue = with.get();
-            MlirOperation exceptedUser = exception.get();
-
-            mlirValueReplaceAllUsesExceptWithSingle(selfValue, withValue,
-                                                    exceptedUser);
+          [](MlirValue self, MlirValue with, MlirOperation exception) {
+            mlirValueReplaceAllUsesExceptWithSingle(self, with, exception);
           },
           py::arg("with"), py::arg("exceptions"),
           kValueReplaceAllUsesExceptDocstring)
       .def(
           "replace_all_uses_except",
-          [](PyValue &self, PyValue &with, py::list exceptions) {
-            MlirValue selfValue = self.get();
-            MlirValue withValue = with.get();
-
+          [](MlirValue self, MlirValue with, py::list exceptions) {
             // Convert Python list to a SmallVector of MlirOperations
             llvm::SmallVector<MlirOperation, 4> exceptionOps;
             for (py::handle exception : exceptions) {
@@ -3749,7 +3741,7 @@ void mlir::python::populateIRCore(py::module &m) {
             }
 
             mlirValueReplaceAllUsesExceptWithSet(
-                selfValue, withValue, exceptionOps.data(),
+                self, with, exceptionOps.data(),
                 static_cast<intptr_t>(exceptionOps.size()));
           },
           py::arg("with"), py::arg("exceptions"),

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3728,7 +3728,7 @@ void mlir::python::populateIRCore(py::module &m) {
           "replace_all_uses_except",
           [](MlirValue self, MlirValue with, PyOperation &exception) {
             MlirOperation exceptedUser = exception.get();
-            mlirValueReplaceAllUsesExceptWithSingle(self, with, exceptedUser);
+            mlirValueReplaceAllUsesExcept(self, with, 1, &exceptedUser);
           },
           py::arg("with"), py::arg("exceptions"),
           kValueReplaceAllUsesExceptDocstring)
@@ -3736,14 +3736,14 @@ void mlir::python::populateIRCore(py::module &m) {
           "replace_all_uses_except",
           [](MlirValue self, MlirValue with, py::list exceptions) {
             // Convert Python list to a SmallVector of MlirOperations
-            llvm::SmallVector<MlirOperation, 4> exceptionOps;
+            llvm::SmallVector<MlirOperation> exceptionOps;
             for (py::handle exception : exceptions) {
               exceptionOps.push_back(exception.cast<PyOperation &>().get());
             }
 
-            mlirValueReplaceAllUsesExceptWithSet(
-                self, with, exceptionOps.data(),
-                static_cast<intptr_t>(exceptionOps.size()));
+            mlirValueReplaceAllUsesExcept(
+                self, with, static_cast<intptr_t>(exceptionOps.size()),
+                exceptionOps.data());
           },
           py::arg("with"), py::arg("exceptions"),
           kValueReplaceAllUsesExceptDocstring)

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -3726,8 +3726,9 @@ void mlir::python::populateIRCore(py::module &m) {
           kValueReplaceAllUsesWithDocstring)
       .def(
           "replace_all_uses_except",
-          [](MlirValue self, MlirValue with, MlirOperation exception) {
-            mlirValueReplaceAllUsesExceptWithSingle(self, with, exception);
+          [](MlirValue self, MlirValue with, PyOperation &exception) {
+            MlirOperation exceptedUser = exception.get();
+            mlirValueReplaceAllUsesExceptWithSingle(self, with, exceptedUser);
           },
           py::arg("with"), py::arg("exceptions"),
           kValueReplaceAllUsesExceptDocstring)

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -1014,8 +1014,8 @@ void mlirValueReplaceAllUsesExceptWithSet(MlirValue oldValue,
                                           MlirValue newValue,
                                           MlirOperation *exceptions,
                                           intptr_t numExceptions) {
-  auto oldValueCpp = unwrap(oldValue);
-  auto newValueCpp = unwrap(newValue);
+  Value oldValueCpp = unwrap(oldValue);
+  Value newValueCpp = unwrap(newValue);
 
   llvm::SmallPtrSet<mlir::Operation *, 4> exceptionSet;
   for (intptr_t i = 0; i < numExceptions; ++i) {
@@ -1028,9 +1028,9 @@ void mlirValueReplaceAllUsesExceptWithSet(MlirValue oldValue,
 void mlirValueReplaceAllUsesExceptWithSingle(MlirValue oldValue,
                                              MlirValue newValue,
                                              MlirOperation exceptedUser) {
-  auto oldValueCpp = unwrap(oldValue);
-  auto newValueCpp = unwrap(newValue);
-  auto exceptedUserCpp = unwrap(exceptedUser);
+  Value oldValueCpp = unwrap(oldValue);
+  Value newValueCpp = unwrap(newValue);
+  Operation *exceptedUserCpp = unwrap(exceptedUser);
 
   oldValueCpp.replaceAllUsesExcept(newValueCpp, exceptedUserCpp);
 }

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -1010,10 +1010,9 @@ void mlirValueReplaceAllUsesOfWith(MlirValue oldValue, MlirValue newValue) {
   unwrap(oldValue).replaceAllUsesWith(unwrap(newValue));
 }
 
-void mlirValueReplaceAllUsesExceptWithSet(MlirValue oldValue,
-                                          MlirValue newValue,
-                                          MlirOperation *exceptions,
-                                          intptr_t numExceptions) {
+void mlirValueReplaceAllUsesExcept(MlirValue oldValue, MlirValue newValue,
+                                   intptr_t numExceptions,
+                                   MlirOperation *exceptions) {
   Value oldValueCpp = unwrap(oldValue);
   Value newValueCpp = unwrap(newValue);
 
@@ -1023,16 +1022,6 @@ void mlirValueReplaceAllUsesExceptWithSet(MlirValue oldValue,
   }
 
   oldValueCpp.replaceAllUsesExcept(newValueCpp, exceptionSet);
-}
-
-void mlirValueReplaceAllUsesExceptWithSingle(MlirValue oldValue,
-                                             MlirValue newValue,
-                                             MlirOperation exceptedUser) {
-  Value oldValueCpp = unwrap(oldValue);
-  Value newValueCpp = unwrap(newValue);
-  Operation *exceptedUserCpp = unwrap(exceptedUser);
-
-  oldValueCpp.replaceAllUsesExcept(newValueCpp, exceptedUserCpp);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/Visitors.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Parser/Parser.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/ThreadPool.h"
 
 #include <cstddef>
@@ -1007,6 +1008,31 @@ MlirOpOperand mlirValueGetFirstUse(MlirValue value) {
 
 void mlirValueReplaceAllUsesOfWith(MlirValue oldValue, MlirValue newValue) {
   unwrap(oldValue).replaceAllUsesWith(unwrap(newValue));
+}
+
+void mlirValueReplaceAllUsesExceptWithSet(MlirValue oldValue,
+                                          MlirValue newValue,
+                                          MlirOperation *exceptions,
+                                          intptr_t numExceptions) {
+  auto oldValueCpp = unwrap(oldValue);
+  auto newValueCpp = unwrap(newValue);
+
+  llvm::SmallPtrSet<mlir::Operation *, 4> exceptionSet;
+  for (intptr_t i = 0; i < numExceptions; ++i) {
+    exceptionSet.insert(unwrap(exceptions[i]));
+  }
+
+  oldValueCpp.replaceAllUsesExcept(newValueCpp, exceptionSet);
+}
+
+void mlirValueReplaceAllUsesExceptWithSingle(MlirValue oldValue,
+                                             MlirValue newValue,
+                                             MlirOperation exceptedUser) {
+  auto oldValueCpp = unwrap(oldValue);
+  auto newValueCpp = unwrap(newValue);
+  auto exceptedUserCpp = unwrap(exceptedUser);
+
+  oldValueCpp.replaceAllUsesExcept(newValueCpp, exceptedUserCpp);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/python/ir/value.py
+++ b/mlir/test/python/ir/value.py
@@ -161,7 +161,7 @@ def testValueReplaceAllUsesWithExcept():
             op1 = Operation.create("custom.op1", operands=[value])
             op2 = Operation.create("custom.op2", operands=[value])
             value2 = Operation.create("custom.op3", results=[i32]).results[0]
-            value.replace_all_uses_except(value2, [op1])
+            value.replace_all_uses_except(value2, op1)
 
     assert len(list(value.uses)) == 1
 

--- a/mlir/test/python/ir/value.py
+++ b/mlir/test/python/ir/value.py
@@ -148,6 +148,77 @@ def testValueReplaceAllUsesWith():
         print(f"Use operand_number: {use.operand_number}")
 
 
+# CHECK-LABEL: TEST: testValueReplaceAllUsesWithExcept
+@run
+def testValueReplaceAllUsesWithExcept():
+    ctx = Context()
+    ctx.allow_unregistered_dialects = True
+    with Location.unknown(ctx):
+        i32 = IntegerType.get_signless(32)
+        module = Module.create()
+        with InsertionPoint(module.body):
+            value = Operation.create("custom.op1", results=[i32]).results[0]
+            op1 = Operation.create("custom.op1", operands=[value])
+            op2 = Operation.create("custom.op2", operands=[value])
+            value2 = Operation.create("custom.op3", results=[i32]).results[0]
+            value.replace_all_uses_except(value2, [op1])
+
+    assert len(list(value.uses)) == 1
+
+    # CHECK: Use owner: "custom.op2"
+    # CHECK: Use operand_number: 0
+    for use in value2.uses:
+        assert use.owner in [op2]
+        print(f"Use owner: {use.owner}")
+        print(f"Use operand_number: {use.operand_number}")
+
+    # CHECK: Use owner: "custom.op1"
+    # CHECK: Use operand_number: 0
+    for use in value.uses:
+        assert use.owner in [op1]
+        print(f"Use owner: {use.owner}")
+        print(f"Use operand_number: {use.operand_number}")
+
+
+# CHECK-LABEL: TEST: testValueReplaceAllUsesWithMultipleExceptions
+@run
+def testValueReplaceAllUsesWithMultipleExceptions():
+    ctx = Context()
+    ctx.allow_unregistered_dialects = True
+    with Location.unknown(ctx):
+        i32 = IntegerType.get_signless(32)
+        module = Module.create()
+        with InsertionPoint(module.body):
+            value = Operation.create("custom.op1", results=[i32]).results[0]
+            op1 = Operation.create("custom.op1", operands=[value])
+            op2 = Operation.create("custom.op2", operands=[value])
+            op3 = Operation.create("custom.op3", operands=[value])
+            value2 = Operation.create("custom.op4", results=[i32]).results[0]
+
+            # Replace all uses of `value` with `value2`, except for `op1` and `op2`.
+            value.replace_all_uses_except(value2, [op1, op2])
+
+    # After replacement, only `op3` should use `value2`, while `op1` and `op2` should still use `value`.
+    assert len(list(value.uses)) == 2
+    assert len(list(value2.uses)) == 1
+
+    # CHECK: Use owner: "custom.op3"
+    # CHECK: Use operand_number: 0
+    for use in value2.uses:
+        assert use.owner in [op3]
+        print(f"Use owner: {use.owner}")
+        print(f"Use operand_number: {use.operand_number}")
+
+    # CHECK: Use owner: "custom.op2"
+    # CHECK: Use operand_number: 0
+    # CHECK: Use owner: "custom.op1"
+    # CHECK: Use operand_number: 0
+    for use in value.uses:
+        assert use.owner in [op1, op2]
+        print(f"Use owner: {use.owner}")
+        print(f"Use operand_number: {use.operand_number}")
+
+
 # CHECK-LABEL: TEST: testValuePrintAsOperand
 @run
 def testValuePrintAsOperand():


### PR DESCRIPTION
Problem originally described in [the forums here](https://discourse.llvm.org/t/mlir-python-expose-replaceallusesexcept/83068/1).

Using the MLIR Python bindings, the method [`replaceAllUsesWith`](https://mlir.llvm.org/doxygen/classmlir_1_1Value.html#ac56b0fdb6246bcf7fa1805ba0eb71aa2) for `Value` is exposed, e.g.,

```python
orig_value.replace_all_uses_with(
    new_value               
)
```

However, in my use-case I am separating a block into multiple blocks, so thus want to exclude certain Operations from having their Values replaced (since I want them to diverge).

Within Value, we have [`replaceAllUsesExcept`](https://mlir.llvm.org/doxygen/classmlir_1_1Value.html#a9ec8d5c61f8a6aada4062f609372cce4), where we can pass the Operations which should be skipped.

This is not currently exposed in the Python bindings: this PR fixes this.  Adds `replace_all_uses_except`, which works with individual Operations, and lists of Operations.