### PR TITLE
[GlobalISel][ARM] Legalize reset_fpmode

### DIFF
--- a/llvm/lib/Target/ARM/ARMLegalizerInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMLegalizerInfo.cpp
@@ -472,8 +472,7 @@ bool ARMLegalizerInfo::legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI,
     // To get the default FP mode all control bits are cleared:
     // FPSCR = FPSCR & (FPStatusBits | FPReservedBits)
     LLT FPEnvTy = LLT::scalar(32);
-    auto FPEnv = MRI.createGenericVirtualRegister(FPEnvTy);
-    MIRBuilder.buildGetFPEnv(FPEnv);
+    auto FPEnv = MIRBuilder.buildGetFPEnv(FPEnvTy);
     auto NotModeBitMask = MIRBuilder.buildConstant(
         FPEnvTy, ARM::FPStatusBits | ARM::FPReservedBits);
     auto NewFPSCR = MIRBuilder.buildAnd(FPEnvTy, FPEnv, NotModeBitMask);

--- a/llvm/lib/Target/ARM/ARMLegalizerInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMLegalizerInfo.cpp
@@ -473,11 +473,11 @@ bool ARMLegalizerInfo::legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI,
     // FPSCR = FPSCR & (FPStatusBits | FPReservedBits)
     LLT FPEnvTy = LLT::scalar(32);
     auto FPEnv = MRI.createGenericVirtualRegister(FPEnvTy);
-    MIRBuilder.buildInstr(G_GET_FPENV).addDef({FPEnv});
+    MIRBuilder.buildGetFPEnv(FPEnv);
     auto NotModeBitMask = MIRBuilder.buildConstant(
         FPEnvTy, ARM::FPStatusBits | ARM::FPReservedBits);
     auto NewFPSCR = MIRBuilder.buildAnd(FPEnvTy, FPEnv, NotModeBitMask);
-    MIRBuilder.buildInstr(G_SET_FPENV).addUse(NewFPSCR.getReg(0));
+    MIRBuilder.buildSetFPEnv(NewFPSCR);
     break;
   }
   }

--- a/llvm/test/CodeGen/ARM/GlobalISel/fpenv.ll
+++ b/llvm/test/CodeGen/ARM/GlobalISel/fpenv.ll
@@ -165,5 +165,22 @@ entry:
   ret void
 }
 
+define void @reset_fpmode() nounwind {
+; CHECK-LABEL: reset_fpmode:
+; CHECK:       @ %bb.0: @ %entry
+; CHECK-NEXT:    vmrs r0, fpscr
+; CHECK-NEXT:    ldr r1, .LCPI11_0
+; CHECK-NEXT:    and r0, r0, r1
+; CHECK-NEXT:    vmsr fpscr, r0
+; CHECK-NEXT:    mov pc, lr
+; CHECK-NEXT:    .p2align 2
+; CHECK-NEXT:  @ %bb.1:
+; CHECK-NEXT:  .LCPI11_0:
+; CHECK-NEXT:    .long 4160774399 @ 0xf80060ff
+entry:
+  call void @llvm.reset.fpmode()
+  ret void
+}
+
 attributes #0 = { nounwind "use-soft-float"="true" }
 


### PR DESCRIPTION
Implement lowering intrinsic `reset_fpmode` in Global Selector for ARM target.