### PR TITLE
[lldb] Remove ConnectionFileDescriptor::child_process_inherit

### DIFF
--- a/lldb/include/lldb/Host/posix/ConnectionFileDescriptorPosix.h
+++ b/lldb/include/lldb/Host/posix/ConnectionFileDescriptorPosix.h
@@ -31,7 +31,7 @@ public:
   typedef llvm::function_ref<void(llvm::StringRef local_socket_id)>
       socket_id_callback_type;
 
-  ConnectionFileDescriptor(bool child_processes_inherit = false);
+  ConnectionFileDescriptor();
 
   ConnectionFileDescriptor(int fd, bool owns_fd);
 
@@ -64,9 +64,6 @@ public:
   bool InterruptRead() override;
 
   lldb::IOObjectSP GetReadObject() override { return m_io_sp; }
-
-  bool GetChildProcessesInherit() const;
-  void SetChildProcessesInherit(bool child_processes_inherit);
 
 protected:
   void OpenCommandPipe();
@@ -135,7 +132,6 @@ protected:
   std::atomic<bool> m_shutting_down; // This marks that we are shutting down so
                                      // if we get woken up from
   // BytesAvailable to disconnect, we won't try to read again.
-  bool m_child_processes_inherit;
 
   std::string m_uri;
 


### PR DESCRIPTION
It's never set to true. Inheritable FDs are also dangerous as they can end up processes which know nothing about them. It's better to explicitly pass a specific FD to a specific subprocess, which we already mostly can do using the ProcessLaunchInfo FileActions.