### PR TITLE
[Clang] Fix handling of non-member functions in isNormalAssignmentOperator()

### DIFF
--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -482,8 +482,8 @@ static bool isNormalAssignmentOperator(const FunctionDecl *FD) {
     if (RetT->isLValueReferenceType()) {
       ASTContext &Ctx = FD->getASTContext();
       QualType LHST;
-      auto *MD = dyn_cast<CXXMethodDecl>(FD);
-      if (MD && MD->isCXXInstanceMember())
+      auto *MD = cast<CXXMethodDecl>(FD);
+      if (MD->isCXXInstanceMember())
         LHST = Ctx.getLValueReferenceType(MD->getFunctionObjectParameterType());
       else
         LHST = MD->getParamDecl(0)->getType();

--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -482,11 +482,11 @@ static bool isNormalAssignmentOperator(const FunctionDecl *FD) {
     if (RetT->isLValueReferenceType()) {
       ASTContext &Ctx = FD->getASTContext();
       QualType LHST;
-      auto *MD = cast<CXXMethodDecl>(FD);
-      if (MD->isCXXInstanceMember())
+      auto *MD = dyn_cast<CXXMethodDecl>(FD);
+      if (MD && MD->isCXXInstanceMember())
         LHST = Ctx.getLValueReferenceType(MD->getFunctionObjectParameterType());
       else
-        LHST = MD->getParamDecl(0)->getType();
+        LHST = FD->getParamDecl(0)->getType();
       if (Ctx.hasSameType(RetT, LHST))
         return true;
     }


### PR DESCRIPTION
This patch correctes the handling of non-member functions in the `isNormalAssignmentOperator` function within `CheckExprLifetime.cpp`. 

The previous implementation incorrectly assumed that `FunctionDecl` is always a `CXXMethodDecl`, leading to potential null pointer dereferencing. 

Change: - Correctly handle the case where `FD` is not a `CXXMethodDecl` by using `FD->getParamDecl(0)->getType()`. 

This fix ensures that the function correctly handles non-member assignment operators, such as: 

`struct S {}; void operator|=(S, S) {}`

This change improves the robustness of the `isNormalAssignmentOperator` function by correctly identifying and handling different types of function declarations.