### PR TITLE
[clang] Fix division by zero in ACLEIntrinsic constructor

### DIFF
--- a/clang/utils/TableGen/MveEmitter.cpp
+++ b/clang/utils/TableGen/MveEmitter.cpp
@@ -1415,7 +1415,10 @@ ACLEIntrinsic::ACLEIntrinsic(EmitterBase &ME, const Record *R,
         } else if (Bounds->getName() == "IB_LaneIndex") {
           IA.boundsType = ImmediateArg::BoundsType::ExplicitRange;
           IA.i1 = 0;
-          IA.i2 = 128 / Param->sizeInBits() - 1;
+          unsigned sizeInBits = Param->sizeInBits();
+          if (sizeInBits == 0)
+            PrintFatalError("Division by zero: Param->sizeInBits() is zero.");
+          IA.i2 = 128 / sizeInBits() - 1;
         } else if (Bounds->isSubClassOf("IB_EltBit")) {
           IA.boundsType = ImmediateArg::BoundsType::ExplicitRange;
           IA.i1 = Bounds->getValueAsInt("base");


### PR DESCRIPTION
Ensure that Param->sizeInBits() is not zero before performing division to prevent undefined behavior. Add a check and print a fatal error if sizeInBits is zero.