### PR TITLE
ConstraintElim: assert on invalid union field (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -164,6 +164,7 @@ struct FactOrCheck {
   }
 
   Instruction *getContextInst() const {
+    assert(!isConditionFact());
     if (Ty == EntryTy::UseCheck)
       return getContextInstForUse(*U);
     return Inst;


### PR DESCRIPTION
getContextInst currently returns an invalid union field, when it is called with a ConditionFact, although existing callers don't do this. In order to error out early and serve as documentation for future callers, add an assert forbidding the behavior.