### PR TITLE
[clang][bytecode] SourceInfo::Source might be null

### DIFF
--- a/clang/lib/AST/ByteCode/Source.cpp
+++ b/clang/lib/AST/ByteCode/Source.cpp
@@ -33,7 +33,7 @@ SourceRange SourceInfo::getRange() const {
 }
 
 const Expr *SourceInfo::asExpr() const {
-  if (const auto *S = dyn_cast<const Stmt *>(Source))
+  if (const auto *S = dyn_cast_if_present<const Stmt *>(Source))
     return dyn_cast<Expr>(S);
   return nullptr;
 }

--- a/clang/lib/AST/ByteCode/Source.h
+++ b/clang/lib/AST/ByteCode/Source.h
@@ -83,8 +83,12 @@ public:
   SourceLocation getLoc() const;
   SourceRange getRange() const;
 
-  const Stmt *asStmt() const { return dyn_cast<const Stmt *>(Source); }
-  const Decl *asDecl() const { return dyn_cast<const Decl *>(Source); }
+  const Stmt *asStmt() const {
+    return dyn_cast_if_present<const Stmt *>(Source);
+  }
+  const Decl *asDecl() const {
+    return dyn_cast_if_present<const Decl *>(Source);
+  }
   const Expr *asExpr() const;
 
   operator bool() const { return !Source.isNull(); }

--- a/clang/test/SemaCXX/lambda-expressions.cpp
+++ b/clang/test/SemaCXX/lambda-expressions.cpp
@@ -3,6 +3,11 @@
 // RUN: %clang_cc1 -std=c++14 -Wno-unused-value -fsyntax-only -verify=expected,not-cxx03,expected-cxx14 -fblocks %s
 // RUN: %clang_cc1 -std=c++17 -Wno-unused-value -verify=expected,not-cxx03 -ast-dump -fblocks %s | FileCheck %s
 
+// RUN: %clang_cc1 -std=c++11 -Wno-unused-value -fsyntax-only -verify=expected,not-cxx03,cxx03-cxx11,cxx11,expected-cxx14 -fblocks %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++03 -Wno-unused-value -fsyntax-only -verify=expected,cxx03,cxx03-cxx11,expected-cxx14 -fblocks %s -Ddecltype=__decltype -Dstatic_assert=_Static_assert -Wno-c++11-extensions -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++14 -Wno-unused-value -fsyntax-only -verify=expected,not-cxx03,expected-cxx14 -fblocks %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++17 -Wno-unused-value -verify=expected,not-cxx03 -ast-dump -fblocks %s -fexperimental-new-constant-interpreter| FileCheck %s
+
 namespace std { class type_info; };
 
 namespace ExplicitCapture {


### PR DESCRIPTION
This broke in 23fbaff9a3fd2b26418e0c2f10b701049399251f, but the old .dyn_cast<> handled null.