### PR TITLE
Add Aaron Puchert as the maintainer for thread safety analysis

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -168,6 +168,12 @@ Constant Expressions
 | mariya.podchishchaeva\@intel.com (email), Fznamznon (GitHub), fznamznon (Discord), Fznamznon (Discourse)
 
 
+Thread Safety Analysis
+~~~~~~~~~~~~~~~~~~~~~~
+| Aaron Puchert
+| aaron.puchert\@sap.com (email), aaronpuchert (GitHub), aaronpuchert (Discourse)
+
+
 Tools
 -----
 These maintainers are responsible for user-facing tools under the Clang


### PR DESCRIPTION
Aaron has been helping out with TSA for several years and is highly knowledgeable about the implementation.