### PR TITLE
[libc] Fix fpbits test running 80bit ld everywhere

### DIFF
--- a/libc/test/src/__support/FPUtil/fpbits_test.cpp
+++ b/libc/test/src/__support/FPUtil/fpbits_test.cpp
@@ -124,6 +124,7 @@ TEST(LlvmLibcFPBitsTest, FPType_IEEE754_Binary128) {
       UInt128(Rep::quiet_nan()));
 }
 
+#ifdef LIBC_TYPES_LONG_DOUBLE_IS_X86_FLOAT80
 TEST(LlvmLibcFPBitsTest, FPType_X86_Binary80) {
   using Rep = FPRep<FPType::X86_Binary80>;
 
@@ -269,6 +270,7 @@ TEST(LlvmLibcFPBitsTest, FPType_X86_Binary80_IsNan) {
 #error "unhandled long double type"
 #endif
 }
+#endif // LIBC_TYPES_LONG_DOUBLE_IS_X86_FLOAT80
 
 enum class FP {
   ZERO,


### PR DESCRIPTION
After #115084 the 80 bit long double tests error if sizeof(long double)
isn't 96 or 128 bits. This caused failures in long double is double
systems (since long double is 64 bits) so I've disabled the 80 bit long
double tests on systems that don't use them.
