### PR TITLE
[libc] Make fstatvfs test less flakey

### DIFF
--- a/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/fstatvfs_test.cpp
@@ -33,8 +33,12 @@ TEST(LlvmLibcSysFStatvfsTest, FStatvfsBasic) {
 TEST(LlvmLibcSysFStatvfsTest, FStatvfsInvalidPath) {
   struct statvfs buf;
 
-  constexpr const char *FILENAME = "statvfs.testdir";
+  constexpr const char *FILENAME = "fstatvfs.testdir";
   auto TEST_DIR = libc_make_test_file_path(FILENAME);
+
+  // Always delete the folder so that we start in a consistent state.
+  LIBC_NAMESPACE::rmdir(TEST_DIR);
+  LIBC_NAMESPACE::libc_errno = 0; // Reset errno
 
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
               Succeeds(0));

--- a/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
+++ b/libc/test/src/sys/statvfs/linux/statvfs_test.cpp
@@ -33,6 +33,10 @@ TEST(LlvmLibcSysStatvfsTest, StatvfsInvalidPath) {
   constexpr const char *FILENAME = "statvfs.testdir";
   auto TEST_DIR = libc_make_test_file_path(FILENAME);
 
+  // Always delete the folder so that we start in a consistent state.
+  LIBC_NAMESPACE::rmdir(TEST_DIR);
+  LIBC_NAMESPACE::libc_errno = 0; // Reset errno
+
   ASSERT_THAT(LIBC_NAMESPACE::mkdirat(AT_FDCWD, TEST_DIR, S_IRWXU),
               Succeeds(0));
 


### PR DESCRIPTION
Apparently I forgot to fix the filename for the fstatvfs test so that
it's different from the statvfs test, oops. This patch fixes that and
also deletes the folder if it already exists.
