### PR TITLE
[libc] Rename libc/src/__support/endian.h to endian_internal.h

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -55,7 +55,7 @@ add_header_library(
   common
   HDRS
     common.h
-    endian.h
+    endian_internal.h
     macros/properties/architectures.h
     macros/attributes.h
     macros/properties/cpu_features.h

--- a/libc/src/__support/HashTable/generic/bitmask_impl.inc
+++ b/libc/src/__support/HashTable/generic/bitmask_impl.inc
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/common.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/__support/endian_internal.h
+++ b/libc/src/__support/endian_internal.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC___SUPPORT_ENDIAN_H
-#define LLVM_LIBC_SRC___SUPPORT_ENDIAN_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_ENDIAN_INTERNAL_H
+#define LLVM_LIBC_SRC___SUPPORT_ENDIAN_INTERNAL_H
 
 #include "common.h"
 #include "src/__support/macros/config.h"
@@ -143,4 +143,4 @@ using Endian = internal::Endian<__BYTE_ORDER__>;
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC___SUPPORT_ENDIAN_H
+#endif // LLVM_LIBC_SRC___SUPPORT_ENDIAN_INTERNAL_H

--- a/libc/src/network/htonl.cpp
+++ b/libc/src/network/htonl.cpp
@@ -8,7 +8,7 @@
 
 #include "src/network/htonl.h"
 #include "src/__support/common.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/network/htons.cpp
+++ b/libc/src/network/htons.cpp
@@ -8,7 +8,7 @@
 
 #include "src/network/htons.h"
 #include "src/__support/common.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/network/ntohl.cpp
+++ b/libc/src/network/ntohl.cpp
@@ -8,7 +8,7 @@
 
 #include "src/network/ntohl.h"
 #include "src/__support/common.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/network/ntohs.cpp
+++ b/libc/src/network/ntohs.cpp
@@ -8,7 +8,7 @@
 
 #include "src/network/ntohs.h"
 #include "src/__support/common.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/string/memory_utils/op_generic.h
+++ b/libc/src/string/memory_utils/op_generic.h
@@ -26,7 +26,7 @@
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/common.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
 #include "src/__support/macros/properties/types.h" // LIBC_TYPES_HAS_INT64

--- a/libc/src/string/memory_utils/utils.h
+++ b/libc/src/string/memory_utils/utils.h
@@ -12,7 +12,7 @@
 #include "src/__support/CPP/bit.h"
 #include "src/__support/CPP/cstddef.h"
 #include "src/__support/CPP/type_traits.h"
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/attributes.h" // LIBC_INLINE
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -57,11 +57,11 @@ add_libc_test(
 )
 
 add_libc_test(
-  endian_test
+  endian_internal_test
   SUITE
     libc-support-tests
   SRCS
-    endian_test.cpp
+    endian_internal_test.cpp
   DEPENDS
     libc.src.__support.common
 )

--- a/libc/test/src/__support/endian_internal_test.cpp
+++ b/libc/test/src/__support/endian_internal_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/__support/macros/config.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/network/htonl_test.cpp
+++ b/libc/test/src/network/htonl_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/network/htonl.h"
 #include "src/network/ntohl.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/network/htons_test.cpp
+++ b/libc/test/src/network/htons_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/network/htons.h"
 #include "src/network/ntohs.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/network/ntohl_test.cpp
+++ b/libc/test/src/network/ntohl_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/network/htonl.h"
 #include "src/network/ntohl.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/network/ntohs_test.cpp
+++ b/libc/test/src/network/ntohs_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/endian.h"
+#include "src/__support/endian_internal.h"
 #include "src/network/htons.h"
 #include "src/network/ntohs.h"
 #include "test/UnitTest/Test.h"

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -425,7 +425,7 @@ libc_support_library(
     name = "__support_common",
     hdrs = [
         "src/__support/common.h",
-        "src/__support/endian.h",
+        "src/__support/endian_internal.h",
     ],
     deps = [
         ":__support_macros_attributes",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/__support/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/__support/BUILD.bazel
@@ -30,8 +30,8 @@ libc_test(
 # )
 
 libc_test(
-    name = "endian_test",
-    srcs = ["endian_test.cpp"],
+    name = "endian_internal_test",
+    srcs = ["endian_internal_test.cpp"],
     deps = ["//libc:__support_common"],
 )
 


### PR DESCRIPTION
This prevents a conflict with the Linux system endian.h when built in overlay mode for CPP files in __support.

This issue appeared in PR #106259.