### PR TITLE
[MSP430] Default to unsigned char

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1341,6 +1341,7 @@ static bool isSignedCharDefault(const llvm::Triple &Triple) {
     return false;
 
   case llvm::Triple::hexagon:
+  case llvm::Triple::msp430:
   case llvm::Triple::ppcle:
   case llvm::Triple::ppc64le:
   case llvm::Triple::riscv32:

--- a/clang/test/Driver/msp430-char.c
+++ b/clang/test/Driver/msp430-char.c
@@ -1,0 +1,5 @@
+/// Check that char is unsigned by default.
+// RUN: %clang -### %s --target=msp430 -c 2>&1
+// RUN: %clang -### %s --target=msp430 -c 2>&1 | FileCheck%s
+// CHECK: "-cc1" "-triple" "msp430"
+// CHECK-SAME: "-fno-signed-char"

--- a/clang/test/Driver/msp430-char.c
+++ b/clang/test/Driver/msp430-char.c
@@ -1,5 +1,4 @@
 /// Check that char is unsigned by default.
-// RUN: %clang -### %s --target=msp430 -c 2>&1
 // RUN: %clang -### %s --target=msp430 -c 2>&1 | FileCheck%s
 // CHECK: "-cc1" "-triple" "msp430"
 // CHECK-SAME: "-fno-signed-char"

--- a/clang/test/Driver/msp430-char.c
+++ b/clang/test/Driver/msp430-char.c
@@ -1,4 +1,4 @@
 /// Check that char is unsigned by default.
-// RUN: %clang -### %s --target=msp430 -c 2>&1 | FileCheck%s
+// RUN: %clang -### %s --target=msp430 -c 2>&1 | FileCheck %s
 // CHECK: "-cc1" "-triple" "msp430"
 // CHECK-SAME: "-fno-signed-char"


### PR DESCRIPTION
This matches the ABI document at https://www.ti.com/lit/pdf/slaa534 as
well as the GCC implementation.

Partially fixes https://github.com/llvm/llvm-project/issues/115957.
