### PR TITLE
[clang][RISCV] Support `norelax` attribute for RISCV

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3220,6 +3220,14 @@ def RISCVVectorCC: DeclOrTypeAttr, TargetSpecificAttr<TargetRISCV> {
  let Documentation = [RISCVVectorCCDocs];
 }
 
+def RISCVNoRelax: DeclOrTypeAttr, TargetSpecificAttr<TargetRISCV> {
+ let Spellings = [CXX11<"riscv", "norelax">,
+                  C23<"riscv", "norelax">,
+                  Clang<"norelax">];
+ let Documentation = [RISCVNoRelaxDocs];
+}
+
+
 def Target : InheritableAttr {
   let Spellings = [GCC<"target">];
   let Args = [StringArgument<"featuresStr">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5818,6 +5818,15 @@ them if they use them.
  }];
 }
 
+def RISCVNoRelaxDocs : Documentation {
+ let Category = DocCatFunction;
+ let Content = [{
+The ``riscv_norelax`` attribute can be applied to a function to disable the 
+relax optimization for that specific function.
+ }];
+}
+
+
 def PreferredNameDocs : Documentation {
   let Category = DocCatDecl;
   let Content = [{

--- a/clang/include/clang/Sema/SemaRISCV.h
+++ b/clang/include/clang/Sema/SemaRISCV.h
@@ -44,6 +44,7 @@ public:
   void handleInterruptAttr(Decl *D, const ParsedAttr &AL);
   bool isAliasValid(unsigned BuiltinID, llvm::StringRef AliasName);
   bool isValidFMVExtension(StringRef Ext);
+  void handleRISCVNoRelaxAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 
   /// Indicate RISC-V vector builtin functions enabled or not.
   bool DeclareRVVBuiltins = false;

--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -599,6 +599,11 @@ public:
     if (CGM.getCodeGenOpts().CFProtectionReturn)
       Fn->addFnAttr("hw-shadow-stack");
 
+    const auto *NoRelaxAttr = FD->getAttr<RISCVNoRelaxAttr>();
+
+    if (NoRelaxAttr)
+      Fn->addFnAttr("norelax");
+
     const auto *Attr = FD->getAttr<RISCVInterruptAttr>();
     if (!Attr)
       return;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6911,6 +6911,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   case ParsedAttr::AT_RISCVVectorCC:
     handleCallConvAttr(S, D, AL);
     break;
+  case ParsedAttr::AT_RISCVNoRelax:
+    S.RISCV().handleRISCVNoRelaxAttr(S, D, AL);
+    break;
   case ParsedAttr::AT_Suppress:
     handleSuppressAttr(S, D, AL);
     break;

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -1494,6 +1494,17 @@ bool SemaRISCV::isValidFMVExtension(StringRef Ext) {
   return -1 != RISCVISAInfo::getRISCVFeaturesBitsInfo(Ext).second;
 }
 
+void SemaRISCV::handleRISCVNoRelaxAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+
+  if (!isa<FunctionDecl>(D)) {
+    S.Diag(AL.getLoc(), diag::warn_attribute_wrong_decl_type)
+        << AL << AL.isRegularKeywordAttribute() << ExpectedFunctionOrMethod;
+    return;
+  }
+
+  D->addAttr(::new (S.Context) RISCVNoRelaxAttr(S.Context, AL));
+}
+
 SemaRISCV::SemaRISCV(Sema &S) : SemaBase(S) {}
 
 } // namespace clang

--- a/clang/test/CodeGen/RISCV/riscv-norelax.c
+++ b/clang/test/CodeGen/RISCV/riscv-norelax.c
@@ -1,0 +1,19 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -triple riscv64 \
+// RUN: -emit-llvm -o - %s | FileCheck %s
+
+// CHECK-LABEL: define dso_local void @func1(
+// CHECK-SAME: ) #0 {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    ret void
+//
+__attribute__((norelax)) void func1() {}
+
+// CHECK-LABEL: define dso_local void @func2(
+// CHECK-SAME: ) #0 {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    ret void
+//
+[[riscv::norelax]] void func2() {}
+
+// CHECK: attributes #0 = { {{.*}} "norelax" {{.*}} }

--- a/clang/test/CodeGen/RISCV/riscv-norelax.cpp
+++ b/clang/test/CodeGen/RISCV/riscv-norelax.cpp
@@ -1,0 +1,19 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 -std=c++11 -triple riscv64 \
+// RUN: -emit-llvm -o - %s | FileCheck %s
+
+// CHECK-LABEL: define dso_local void @_Z5func1v(
+// CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    ret void
+//
+__attribute__((norelax)) void func1() {}
+
+// CHECK-LABEL: define dso_local void @_Z5func2v(
+// CHECK-SAME: ) #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    ret void
+//
+[[riscv::norelax]] void func2() {}
+
+// CHECK: attributes #0 = { {{.*}} "norelax" {{.*}} }

--- a/clang/test/Sema/riscv-norelax.c
+++ b/clang/test/Sema/riscv-norelax.c
@@ -1,0 +1,12 @@
+// REQUIRES: riscv-registered-target
+// RUN: %clang_cc1 %s -triple riscv64 -verify
+
+__attribute__((norelax)) int var; // expected-warning {{'norelax' attribute only applies to functions and methods}}
+
+__attribute__((norelax)) void func() {}
+__attribute__((norelax(1))) void func_invalid(); // expected-error {{'norelax' attribute takes no arguments}}
+
+[[riscv::norelax]] int var2; // expected-warning {{'norelax' attribute only applies to functions and methods}}
+
+[[riscv::norelax]] void func2() {}
+[[riscv::norelax(1)]] void func_invalid2(); // expected-error {{'norelax' attribute takes no arguments}}


### PR DESCRIPTION
Base on https://github.com/riscv-non-isa/riscv-c-api-doc/pull/94.

This patch support the `norelax` attribute for RISC-V target in clang.