### PR TITLE
Fix build issues with libc mem* benchmarks

### DIFF
--- a/libc/benchmarks/CMakeLists.txt
+++ b/libc/benchmarks/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(libc-memory-benchmark
 target_include_directories(libc-memory-benchmark
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${LIBC_SOURCE_DIR}
 )
 target_link_libraries(libc-memory-benchmark
     PUBLIC

--- a/libc/benchmarks/LibcBenchmark.h
+++ b/libc/benchmarks/LibcBenchmark.h
@@ -211,7 +211,7 @@ BenchmarkResult benchmark(const BenchmarkOptions &Options,
     // Measuring this Batch.
     const auto StartTime = Clock.now();
     for (const auto Parameter : Batch) {
-      const auto Production = foo(Parameter);
+      auto Production = foo(Parameter);
       benchmark::DoNotOptimize(Production);
     }
     const auto EndTime = Clock.now();

--- a/libc/benchmarks/MemorySizeDistributions.cpp
+++ b/libc/benchmarks/MemorySizeDistributions.cpp
@@ -185,11 +185,9 @@ ArrayRef<MemorySizeDistribution> getMemcmpSizeDistributions() {
 MemorySizeDistribution
 getDistributionOrDie(ArrayRef<MemorySizeDistribution> Distributions,
                      StringRef Name) {
-  size_t Index = 0;
   for (const auto &MSD : Distributions) {
     if (MSD.Name == Name)
       return MSD;
-    ++Index;
   }
   std::string Message;
   raw_string_ostream Stream(Message);

--- a/libc/benchmarks/MemorySizeDistributions.cpp
+++ b/libc/benchmarks/MemorySizeDistributions.cpp
@@ -185,10 +185,10 @@ ArrayRef<MemorySizeDistribution> getMemcmpSizeDistributions() {
 MemorySizeDistribution
 getDistributionOrDie(ArrayRef<MemorySizeDistribution> Distributions,
                      StringRef Name) {
-  for (const auto &MSD : Distributions) {
+  for (const auto &MSD : Distributions)
     if (MSD.Name == Name)
       return MSD;
-  }
+
   std::string Message;
   raw_string_ostream Stream(Message);
   Stream << "Unknown MemorySizeDistribution '" << Name


### PR DESCRIPTION
Fix a few issues found when trying to build the benchmark:

Errors

1. Unable to find include "src/__support/macros/config.h" in LibcMemoryBenchmarkMain.cpp

Warnings

2. Unused variable warning `Index` in MemorySizeDistributions.cpp
3. Fix deprecation warning for const-ref version of `DoNotOptimize`. warning: 'DoNotOptimize<void *>' is deprecated: The const-ref version of this method can permit undesired compiler optimizations in benchmarks