### PR TITLE
[llvm] Replace `UndefValue::get` with `PoisonValue::get` in unit test

### DIFF
--- a/llvm/unittests/Analysis/PhiValuesTest.cpp
+++ b/llvm/unittests/Analysis/PhiValuesTest.cpp
@@ -34,14 +34,14 @@ TEST(PhiValuesTest, SimplePhi) {
   BasicBlock *If = BasicBlock::Create(C, "if", F);
   BasicBlock *Else = BasicBlock::Create(C, "else", F);
   BasicBlock *Then = BasicBlock::Create(C, "then", F);
-  BranchInst::Create(If, Else, UndefValue::get(I1Ty), Entry);
+  BranchInst::Create(If, Else, PoisonValue::get(I1Ty), Entry);
   BranchInst::Create(Then, If);
   BranchInst::Create(Then, Else);
 
-  Value *Val1 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val1", Entry);
-  Value *Val2 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val2", Entry);
-  Value *Val3 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val3", Entry);
-  Value *Val4 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val4", Entry);
+  Value *Val1 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val1", Entry);
+  Value *Val2 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val2", Entry);
+  Value *Val3 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val3", Entry);
+  Value *Val4 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val4", Entry);
 
   PHINode *Phi1 = PHINode::Create(I32Ty, 2, "phi1", Then);
   Phi1->addIncoming(Val1, If);
@@ -104,17 +104,17 @@ TEST(PhiValuesTest, DependentPhi) {
   BasicBlock *If2 = BasicBlock::Create(C, "if2", F);
   BasicBlock *Else2 = BasicBlock::Create(C, "else2", F);
   BasicBlock *End = BasicBlock::Create(C, "then", F);
-  BranchInst::Create(If1, Else1, UndefValue::get(I1Ty), Entry);
+  BranchInst::Create(If1, Else1, PoisonValue::get(I1Ty), Entry);
   BranchInst::Create(Then, If1);
   BranchInst::Create(Then, Else1);
-  BranchInst::Create(If2, Else2, UndefValue::get(I1Ty), Then);
+  BranchInst::Create(If2, Else2, PoisonValue::get(I1Ty), Then);
   BranchInst::Create(End, If2);
   BranchInst::Create(End, Else2);
 
-  Value *Val1 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val1", Entry);
-  Value *Val2 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val2", Entry);
-  Value *Val3 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val3", Entry);
-  Value *Val4 = new LoadInst(I32Ty, UndefValue::get(PtrTy), "val4", Entry);
+  Value *Val1 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val1", Entry);
+  Value *Val2 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val2", Entry);
+  Value *Val3 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val3", Entry);
+  Value *Val4 = new LoadInst(I32Ty, PoisonValue::get(PtrTy), "val4", Entry);
 
   PHINode *Phi1 = PHINode::Create(I32Ty, 2, "phi1", Then);
   Phi1->addIncoming(Val1, If1);


### PR DESCRIPTION
Since these `UndefValue::get` are acted as placeholders, I think it's safe to replace them with poison values.
There are a lot of `UndefValue::get` in LLVM, I'll start fixing the ones in `unittests` while fixing the regression tests.

@nunoplopes @regehr 