### PR TITLE
[TableGen] Use heterogenous lookups with std::map (NFC)

### DIFF
--- a/clang/utils/TableGen/MveEmitter.cpp
+++ b/clang/utils/TableGen/MveEmitter.cpp
@@ -471,7 +471,7 @@ private:
 
 public:
   virtual ~Result() = default;
-  using Scope = std::map<std::string, Ptr>;
+  using Scope = std::map<std::string, Ptr, std::less<>>;
   virtual void genCode(raw_ostream &OS, CodeGenParamAllocator &) const = 0;
   virtual bool hasIntegerConstantValue() const { return false; }
   virtual uint32_t integerConstantValue() const { return 0; }
@@ -1278,7 +1278,7 @@ Result::Ptr EmitterBase::getCodeForDagArg(const DagInit *D, unsigned ArgNum,
     if (!isa<UnsetInit>(Arg))
       PrintFatalError(
           "dag operator argument should not have both a value and a name");
-    auto it = Scope.find(std::string(Name));
+    auto it = Scope.find(Name);
     if (it == Scope.end())
       PrintFatalError("unrecognized variable name '" + Name + "'");
     return it->second;


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
