### PR TITLE
[libc++] Avoid including <ostream> in <fstream> and <strstream>

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -193,6 +193,8 @@ typedef basic_fstream<wchar_t> wfstream;
 #include <__fwd/fstream.h>
 #include <__locale>
 #include <__memory/addressof.h>
+#include <__memory/unique_ptr.h>
+#include <__ostream/basic_ostream.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_same.h>
 #include <__utility/move.h>
@@ -200,7 +202,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #include <__utility/unreachable.h>
 #include <cstdio>
 #include <istream>
-#include <ostream>
+#include <streambuf>
 #include <typeinfo>
 #include <version>
 

--- a/libcxx/include/strstream
+++ b/libcxx/include/strstream
@@ -130,8 +130,9 @@ private:
 */
 
 #include <__config>
+#include <__ostream/basic_ostream.h>
 #include <istream>
-#include <ostream>
+#include <streambuf>
 #include <version>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -410,13 +410,11 @@ forward_list limits
 forward_list new
 forward_list tuple
 forward_list version
-fstream array
 fstream bitset
 fstream cctype
 fstream cerrno
 fstream climits
 fstream clocale
-fstream cmath
 fstream compare
 fstream cstddef
 fstream cstdint
@@ -427,7 +425,6 @@ fstream ctime
 fstream cwchar
 fstream cwctype
 fstream filesystem
-fstream format
 fstream initializer_list
 fstream iomanip
 fstream ios
@@ -436,9 +433,6 @@ fstream istream
 fstream limits
 fstream locale
 fstream new
-fstream optional
-fstream ostream
-fstream print
 fstream ratio
 fstream stdexcept
 fstream streambuf
@@ -1081,13 +1075,11 @@ string_view limits
 string_view new
 string_view stdexcept
 string_view version
-strstream array
 strstream bitset
 strstream cctype
 strstream cerrno
 strstream climits
 strstream clocale
-strstream cmath
 strstream compare
 strstream cstddef
 strstream cstdint
@@ -1097,7 +1089,6 @@ strstream cstring
 strstream ctime
 strstream cwchar
 strstream cwctype
-strstream format
 strstream initializer_list
 strstream ios
 strstream iosfwd
@@ -1105,9 +1096,6 @@ strstream istream
 strstream limits
 strstream locale
 strstream new
-strstream optional
-strstream ostream
-strstream print
 strstream ratio
 strstream stdexcept
 strstream streambuf

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -410,13 +410,11 @@ forward_list limits
 forward_list new
 forward_list tuple
 forward_list version
-fstream array
 fstream bitset
 fstream cctype
 fstream cerrno
 fstream climits
 fstream clocale
-fstream cmath
 fstream compare
 fstream cstddef
 fstream cstdint
@@ -426,7 +424,6 @@ fstream cstring
 fstream ctime
 fstream cwchar
 fstream cwctype
-fstream format
 fstream initializer_list
 fstream iomanip
 fstream ios
@@ -435,9 +432,6 @@ fstream istream
 fstream limits
 fstream locale
 fstream new
-fstream optional
-fstream ostream
-fstream print
 fstream ratio
 fstream stdexcept
 fstream streambuf
@@ -1080,13 +1074,11 @@ string_view limits
 string_view new
 string_view stdexcept
 string_view version
-strstream array
 strstream bitset
 strstream cctype
 strstream cerrno
 strstream climits
 strstream clocale
-strstream cmath
 strstream compare
 strstream cstddef
 strstream cstdint
@@ -1096,7 +1088,6 @@ strstream cstring
 strstream ctime
 strstream cwchar
 strstream cwctype
-strstream format
 strstream initializer_list
 strstream ios
 strstream iosfwd
@@ -1104,9 +1095,6 @@ strstream istream
 strstream limits
 strstream locale
 strstream new
-strstream optional
-strstream ostream
-strstream print
 strstream ratio
 strstream stdexcept
 strstream streambuf

--- a/libcxx/test/std/input.output/file.streams/fstreams/native_handle_test_helpers.h
+++ b/libcxx/test/std/input.output/file.streams/fstreams/native_handle_test_helpers.h
@@ -10,6 +10,7 @@
 #define TEST_STD_INPUT_OUTPUT_FILE_STREAMS_FSTREAMS_TEST_HELPERS_H
 
 #include <cassert>
+#include <cerrno>
 #include <concepts>
 #include <cstdio>
 #include <fstream>


### PR DESCRIPTION
This reduces the include time of `<fstream>` from ~800ms to ~500ms.
