### PR TITLE
[LiveRangeCalc] Fix isJointlyDominated

### DIFF
--- a/llvm/lib/CodeGen/LiveRangeCalc.cpp
+++ b/llvm/lib/CodeGen/LiveRangeCalc.cpp
@@ -441,15 +441,21 @@ bool LiveRangeCalc::isJointlyDominated(const MachineBasicBlock *MBB,
   for (SlotIndex I : Defs)
     DefBlocks.set(Indexes.getMBBFromIndex(I)->getNumber());
 
+  unsigned EntryNum = MF.front().getNumber();
   SetVector<unsigned> PredQueue;
   PredQueue.insert(MBB->getNumber());
   for (unsigned i = 0; i != PredQueue.size(); ++i) {
     unsigned BN = PredQueue[i];
     if (DefBlocks[BN])
-      return true;
+      continue;
+    if (BN == EntryNum) {
+      // We found a path from MBB back to the entry block without hitting any of
+      // the def blocks.
+      return false;
+    }
     const MachineBasicBlock *B = MF.getBlockNumbered(BN);
     for (const MachineBasicBlock *P : B->predecessors())
       PredQueue.insert(P->getNumber());
   }
-  return false;
+  return true;
 }


### PR DESCRIPTION
Check that every path from the entry block to the use block passes
through at least one def block. Previously we only checked that at least
one path passed through a def block.
