### PR TITLE
[SPIR-V] Disable Machine Sink pass in SPIR-V Backend

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -102,6 +102,7 @@ public:
   SPIRVTargetMachine &getSPIRVTargetMachine() const {
     return getTM<SPIRVTargetMachine>();
   }
+  void addMachineSSAOptimization() override;
   void addIRPasses() override;
   void addISelPrepare() override;
 
@@ -127,6 +128,16 @@ private:
 // the entire pipeline, so return nullptr to disable register allocation.
 FunctionPass *SPIRVPassConfig::createTargetRegisterAllocator(bool) {
   return nullptr;
+}
+
+// Disable passes that may break CFG.
+void SPIRVPassConfig::addMachineSSAOptimization() {
+  // Some standard passes that optimize machine instructions in SSA form uses
+  // MI.isPHI() that doesn't account for OpPhi in SPIR-V and so are able to
+  // break the CFG (e.g., MachineSink).
+  disablePass(&MachineSinkingID);
+
+  TargetPassConfig::addMachineSSAOptimization();
 }
 
 // Disable passes that break from assuming no virtual registers exist.


### PR DESCRIPTION
Some standard passes that optimize machine instructions in SSA form uses MI.isPHI() that doesn't account for OpPhi in SPIR-V and so are able to break the CFG. MachineSink is among such passes (see for example https://github.com/llvm/llvm-project/blob/1884ffc41c20b1e08b30eef4e8ebbcc54543a139/llvm/lib/CodeGen/MachineSink.cpp#L630), so this PR disables the pass to ensure correctness of the generated code.

There is a reproducer of the issue that demonstrates how MachineSink is able to generate an invalid code for the SPIR-V Backend

```
error: line 6837: OpPhi must appear within a non-entry block before all non-OpPhi instructions (except for OpLine, which can be mixed with OpPhi).
  %z_fra_3_1 = OpPhi %uint %and187 %4250 %inc194 %4257 %uint_0 %4264
```

The reproducer is a part of SYCL end-to-end test suite (https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/DeviceLib/imf_fp32_rounding_test.cpp). At the moment it doesn't seem feasible to make it a part of the SPIR-V Backend test suite due to a far too big size of the intermediate LLVM IR that causes the problem.