### PR TITLE
[PS5][Driver] Allow `-T` to override `--default-script`

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -303,10 +303,12 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // with the SDK. The scripts are inside <sdkroot>/target/lib, which is
     // added as a search path elsewhere.
     // "PRX" has long stood for "PlayStation Relocatable eXecutable".
-    CmdArgs.push_back("--default-script");
-    CmdArgs.push_back(Static   ? "static.script"
-                      : Shared ? "prx.script"
-                               : "main.script");
+    if (!Args.hasArgNoClaim(options::OPT_T)) {
+      CmdArgs.push_back("--default-script");
+      CmdArgs.push_back(Static   ? "static.script"
+                        : Shared ? "prx.script"
+                                 : "main.script");
+    }
   }
 
   if (Static)

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -67,18 +67,23 @@
 // CHECK-NO-EXE-NOT: "--unresolved-symbols
 // CHECK-NO-EXE-NOT: "-z"
 
-// Test that an appropriate linker script is supplied by the driver.
+// Test that an appropriate linker script is supplied by the driver, but can
+// be overridden with -T.
 
 // RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-SCRIPT -DSCRIPT=main %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-SCRIPT -DSCRIPT=prx %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -static -### 2>&1 | FileCheck --check-prefixes=CHECK-SCRIPT -DSCRIPT=static %s
 // RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-SCRIPT %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -T custom.script -### 2>&1 | FileCheck --check-prefixes=CHECK-CUSTOM-SCRIPT --implicit-check-not "\"{{-T|--script|--default-script}}\"" %s
 
 // CHECK-SCRIPT: {{ld(\.exe)?}}"
 // CHECK-SCRIPT-SAME: "--default-script" "[[SCRIPT]].script"
 
 // CHECK-NO-SCRIPT: {{ld(\.exe)?}}"
 // CHECK-NO-SCRIPT-NOT: "--default-script"
+
+// CHECK-CUSTOM-SCRIPT: {{ld(\.exe)?}}"
+// CHECK-CUSTOM-SCRIPT-SAME: "-T" "custom.script"
 
 // Test that -static is forwarded to the linker
 


### PR DESCRIPTION
If a linker script is explicitly supplied, there's no benefit to supplying a default script.

SIE tracker: TOOLCHAIN-17524