### PR TITLE
[libc][z/OS] Remove ASCII trick to fix EBDIC std::from_char

### DIFF
--- a/libc/src/__support/high_precision_decimal.h
+++ b/libc/src/__support/high_precision_decimal.h
@@ -350,7 +350,8 @@ public:
     if (!saw_dot)
       this->decimal_point = total_digits;
 
-    if (num_cur < num_len && ((num_string[num_cur] | 32) == 'e')) {
+    if (num_cur < num_len &&
+        (num_string[num_cur] == 'e' || num_string[num_cur] == 'E')) {
       ++num_cur;
       if (isdigit(num_string[num_cur]) || num_string[num_cur] == '+' ||
           num_string[num_cur] == '-') {


### PR DESCRIPTION
This PR will fix the following lit in all EBCDIC variations on z/OS:
`std/utilities/charconv/charconv.from.chars/floating_point.pass.cpp`

The trick to test for `e` and `E` is working only in ASCII.
The fix is to simply test for both lower and upper case exponent letter `e` and `E` respectfully.