### PR TITLE
Add a more complete example to mlir-reduce docs

### DIFF
--- a/mlir/docs/Tools/mlir-reduce.md
+++ b/mlir/docs/Tools/mlir-reduce.md
@@ -26,27 +26,82 @@ to the tree traversal strategy. The different strategies may lead to different
 results and different time complexity. You can run as
 `-reduction-tree='traversal-mode=0'` to select the mode for example.
 
+### Example MLIR input
+
+```mlir
+// query-test.mlir
+func.func @func1() {
+  // A func can be pruned if it's not relevant to the error.
+  return
+}
+
+func.func @func2(%arg0: i1) -> f32 {
+  %0 = arith.constant 1 : i32
+  %1 = arith.constant 2 : i32
+  %2 = arith.constant 2.2 : f32
+  %3 = arith.constant 5.3 : f32
+  %4 = arith.addi %0, %1 : i32
+  %5 = arith.addf %2, %3 : f32
+  %6 = arith.muli %4, %4 : i32
+  %7 = arith.subi %6, %4 : i32
+  %8 = arith.select %arg0, %5, %2 : f32
+  %9 = arith.addf %2, %8 : f32
+  return %9 : f32
+}
+```
+
 ### Write the script for testing interestingness
 
-As mentioned, you need to provide a command to `mlir-reduce` which identifies
-cases you're interested in. For each intermediate output generated during
-reduction, `mlir-reduce` will run the command over the it, the script should
-returns 1 for interesting case, 0 otherwise. The sample script,
+You need to provide a command to `mlir-reduce` which identifies cases you're
+interested in. For each intermediate output generated during reduction,
+`mlir-reduce` will run the command over the it, the script should returns 1 for
+interesting case, 0 otherwise. For the IR above, a sample script might simply
+look for the presence of the `arith.fptosi` operation. A more realistic script
+would check for the presence of a particular kind of error message in stderr.
 
 ```shell
-mlir-opt -convert-vector-to-spirv $1 | grep "failed to materialize"
-if [[ $? -eq 1 ]]; then
+#!/bin/bash
+#
+# query-test.sh
+# `2>&1` redirects stderr (where errors and diagnostics are printed) to stdout
+# so it can be piped to grep.
+#
+# Note mlir-opt needs to be on your path, or else replace mlir-opt with the
+# absolute path to the binary. If mlir-opt cannot be found, this interestingness
+# test will report "uninteresting on the first run, and mlir-reduce will
+# report that the input is not marked as interesting.
+#
+mlir-opt $1 2>&1 | grep "arith.select"
+
+# grep's exit code is 0 if the queried string is found
+if [[ $? -eq 0 ]]; then
   exit 1
 else
   exit 0
 fi
 ```
 
-The sample usage will be like, note that the `test` argument is part of the mode
-argument.
+### Running the example
+
+The sample usage will be as follows, noting that the `test` argument is part of
+the mode argument.
 
 ```shell
-mlir-reduce $INPUT -reduction-tree='traversal-mode=0 test=$TEST_SCRIPT'
+mlir-reduce query-test.mlir -reduction-tree='traversal-mode=0 test=query-test.sh'
+```
+
+The output:
+
+```
+module {
+  func.func @func2(%arg0: i1) -> f32 {
+    %cst = arith.constant 2.200000e+00 : f32
+    %cst_0 = arith.constant 7.500000e+00 : f32
+    %0 = arith.select %arg0, %cst_0, %cst : f32
+    %1 = arith.addf %0, %cst : f32
+    return %1 : f32
+  }
+}
 ```
 
 ## Available reduction strategies

--- a/mlir/test/mlir-reduce/reduction-tree/doc-example.mlir
+++ b/mlir/test/mlir-reduce/reduction-tree/doc-example.mlir
@@ -1,0 +1,32 @@
+// UNSUPPORTED: system-windows
+// RUN: mlir-reduce %s -reduction-tree='traversal-mode=0 test=%S/../script/grep-select.sh' | FileCheck %s
+
+// This test case is referenced on the website (mlir/docs/Tools/mlir-reduce.md).
+
+func.func @func1() {
+  // A func can be pruned if it's not relevant to the error.
+  return
+}
+
+func.func @func2(%arg0: i1) -> f32 {
+  %0 = arith.constant 1 : i32
+  %1 = arith.constant 2 : i32
+  %2 = arith.constant 2.2 : f32
+  %3 = arith.constant 5.3 : f32
+  %4 = arith.addi %0, %1 : i32
+  %5 = arith.addf %2, %3 : f32
+  %6 = arith.muli %4, %4 : i32
+  %7 = arith.subi %6, %4 : i32
+  %8 = arith.select %arg0, %5, %2 : f32
+  %9 = arith.addf %2, %8 : f32
+  return %9 : f32
+}
+
+// CHECK-NOT: func @func1
+// CHECK-LABEL: func @func2
+// CHECK-SAME: (%arg0: i1) -> f32
+// CHECK-DAG: %[[C22:.*]] = arith.constant 2.200000e+00 : f32
+// CHECK-DAG: %[[C75:.*]] = arith.constant 7.500000e+00 : f32
+// CHECK: %[[SEL:.*]] = arith.select %arg0, %[[C75]], %[[C22]] : f32
+// CHECK: %[[ADD:.*]] = arith.addf %[[SEL]], %[[C22]] : f32
+// CHECK: return %[[ADD]] : f32

--- a/mlir/test/mlir-reduce/script/grep-select.sh
+++ b/mlir/test/mlir-reduce/script/grep-select.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# This script is used by the mlir-reduce documentation example test.
+mlir-opt $1 2>&1 | grep "arith.select" > /dev/null
+if [ $? -eq 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
This PR was started because I noticed bugs in the docs:

- The interestingness test checked for an error, but did not redirect stderr to stdout to include it in the pipe.
- The interestingness test pipe ended with grep, but then checked for an exit code of 1 to mark the input as interesting. However, a pipe's overall exit code is the exit code of the rightmost command, and grep's exit code is zero when it detects the query string, and 1 when it does not detect the query string. So the test was backwards.

Then I wanted to test my fixes to be sure I got it right, and I realized that the doc has no properly runnable example. This PR adds a working example. h/t @aidint for fixing up the input.