### PR TITLE
[llvm][ARM] Missing switch statement handles

### DIFF
--- a/llvm/lib/Target/ARM/ARMSubtarget.cpp
+++ b/llvm/lib/Target/ARM/ARMSubtarget.cpp
@@ -292,7 +292,9 @@ void ARMSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
   case CortexR5:
   case CortexR7:
   case CortexM3:
+  case CortexM55:
   case CortexM7:
+  case CortexM85:
   case CortexR52:
   case CortexR52plus:
   case CortexX1:


### PR DESCRIPTION
PR #115153 added enums which needed to be handled in a switch statement. This trips up buildbot.
