### PR TITLE
[lldb] Remove broken comments originally written as table headers (NFC)

### DIFF
--- a/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
@@ -36,12 +36,6 @@ using namespace lldb;
 using namespace lldb_private;
 
 static const RegisterInfo g_register_infos[] = {
-    //  NAME       ALT       SZ OFF ENCODING         FORMAT          EH_FRAME
-    //  DWARF               GENERIC                     PROCESS PLUGIN
-    //  LLDB NATIVE
-    //  ========== =======   == === =============    ============
-    //  ======================= =================== ===========================
-    //  ======================= ======================
     {"r0",
      nullptr,
      4,

--- a/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
@@ -38,13 +38,6 @@ using namespace lldb_private;
 LLDB_PLUGIN_DEFINE(ABISysV_arm)
 
 static const RegisterInfo g_register_infos[] = {
-    //  NAME       ALT       SZ OFF ENCODING         FORMAT          EH_FRAME
-    //  DWARF               GENERIC                     PROCESS PLUGIN
-    //  LLDB NATIVE            VALUE REGS    INVALIDATE REGS
-    //  ========== =======   == === =============    ============
-    //  ======================= =================== ===========================
-    //  ======================= ====================== ==========
-    //  ===============
     {"r0",
      nullptr,
      4,

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
@@ -78,12 +78,6 @@ enum dwarf_regnums {
 };
 
 static const RegisterInfo g_register_infos[] = {
-    //  NAME      ALT    SZ OFF ENCODING        FORMAT         EH_FRAME
-    //  DWARF                   GENERIC                     PROCESS PLUGINS
-    //  LLDB NATIVE            VALUE REGS  INVALIDATE REGS
-    //  ========  ======  == === =============  ===========    ============
-    //  ==============          ============                =================
-    //  ===================     ========== =================
     {"r0",
      "zero",
      4,

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
@@ -78,12 +78,6 @@ enum dwarf_regnums {
 };
 
 static const RegisterInfo g_register_infos_mips64[] = {
-    //  NAME      ALT    SZ OFF ENCODING        FORMAT         EH_FRAME
-    //  DWARF                   GENERIC                     PROCESS PLUGIN
-    //  LLDB NATIVE
-    //  ========  ======  == === =============  ==========     =============
-    //  =================       ====================        =================
-    //  ====================
     {"r0",
      "zero",
      8,

--- a/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_arm.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_arm.cpp
@@ -184,13 +184,6 @@ enum {
    sizeof(RegisterContextDarwin_arm::EXC))
 
 static RegisterInfo g_register_infos[] = {
-    // General purpose registers
-    //  NAME        ALT     SZ  OFFSET              ENCODING        FORMAT
-    //  EH_FRAME                DWARF               GENERIC
-    //  PROCESS PLUGIN          LLDB NATIVE
-    //  ======      ======= ==  =============       =============   ============
-    //  ===============         ===============     =========================
-    //  =====================   =============
     {"r0",
      nullptr,
      4,

--- a/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_i386.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_i386.cpp
@@ -165,11 +165,6 @@ enum {
    sizeof(RegisterContextDarwin_i386::EXC))
 
 static RegisterInfo g_register_infos[] = {
-    //  Macro auto defines most stuff   eh_frame                DWARF
-    //  GENERIC                    PROCESS PLUGIN       LLDB
-    //  =============================== =======================
-    //  ===================   =========================  ==================
-    //  =================
     {DEFINE_GPR(eax, nullptr),
      {ehframe_eax, dwarf_eax, LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM,
       gpr_eax},

--- a/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_x86_64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextDarwin_x86_64.cpp
@@ -184,11 +184,6 @@ enum ehframe_dwarf_regnums {
 
 // General purpose registers for 64 bit
 static RegisterInfo g_register_infos[] = {
-    //  Macro auto defines most stuff   EH_FRAME                    DWARF
-    //  GENERIC                    PROCESS PLUGIN       LLDB
-    //  =============================== ======================
-    //  ===================      ========================== ====================
-    //  ===================
     {DEFINE_GPR(rax, nullptr),
      {ehframe_dwarf_gpr_rax, ehframe_dwarf_gpr_rax, LLDB_INVALID_REGNUM,
       LLDB_INVALID_REGNUM, gpr_rax},

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm.h
@@ -363,13 +363,6 @@ static uint32_t g_q15_contained[] = {fpu_q15, LLDB_INVALID_REGNUM};
   }
 
 static RegisterInfo g_register_infos_arm[] = {
-    //  NAME         ALT     SZ   OFFSET          ENCODING          FORMAT
-    //  EH_FRAME             DWARF                GENERIC
-    //  PROCESS PLUGIN       LLDB NATIVE      VALUE REGS      INVALIDATE REGS
-    //  ===========  ======= ==   ==============  ================
-    //  ====================    ===================  ===================
-    //  ==========================  ===================  =============
-    //  ==============  =================
     {
         "r0",
         nullptr,

--- a/lldb/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/x64/RegisterContextWindows_x64.cpp
@@ -163,12 +163,6 @@ enum RegisterIndex {
 
 // Array of all register information supported by Windows x86
 RegisterInfo g_register_infos[] = {
-    //  Macro auto defines most stuff     eh_frame                  DWARF
-    //  GENERIC
-    //  GDB                  LLDB                  VALUE REGS    INVALIDATE REGS
-    //  ================================  =========================
-    //  ======================  =========================
-    //  ===================  =================     ==========    ===============
     DEFINE_GPR(rax, nullptr, LLDB_INVALID_REGNUM),
     DEFINE_GPR(rbx, nullptr, LLDB_INVALID_REGNUM),
     DEFINE_GPR(rcx, nullptr, LLDB_REGNUM_GENERIC_ARG1),

--- a/lldb/source/Plugins/Process/Windows/Common/x86/RegisterContextWindows_x86.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/x86/RegisterContextWindows_x86.cpp
@@ -51,12 +51,6 @@ enum RegisterIndex {
 
 // Array of all register information supported by Windows x86
 RegisterInfo g_register_infos[] = {
-    //  Macro auto defines most stuff   eh_frame                DWARF
-    //  GENERIC                    GDB                   LLDB
-    //  VALUE REGS    INVALIDATE REGS
-    //  ==============================  =======================
-    //  ===================  =========================  ===================
-    //  =================  ==========    ===============
     {DEFINE_GPR(eax, nullptr),
      {ehframe_eax_i386, dwarf_eax_i386, LLDB_INVALID_REGNUM,
       LLDB_INVALID_REGNUM, lldb_eax_i386},


### PR DESCRIPTION
Automatic formatting has removed the utility of these comments.
