### PR TITLE
Port Preserved[Module|Function]HashAnalysis to Analysis

### DIFF
--- a/llvm/include/llvm/Analysis/StructuralHash.h
+++ b/llvm/include/llvm/Analysis/StructuralHash.h
@@ -1,4 +1,4 @@
-//=- StructuralHash.h - Structural Hash Printing --*- C++ -*-----------------=//
+//=- StructuralHash.h - Structural Hash Printing and Analysis --*- C++ -*----=//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,39 @@
 #define LLVM_ANALYSIS_STRUCTURALHASH_H
 
 #include "llvm/IR/PassManager.h"
+#include "llvm/IR/StructuralHash.h"
 
 namespace llvm {
+
+struct PreservedFunctionHashAnalysis
+    : public AnalysisInfoMixin<PreservedFunctionHashAnalysis> {
+  static AnalysisKey Key;
+
+  struct FunctionHash {
+    uint64_t Hash;
+  };
+
+  using Result = FunctionHash;
+
+  Result run(Function &F, FunctionAnalysisManager &FAM) {
+    return Result{StructuralHash(F)};
+  }
+};
+
+struct PreservedModuleHashAnalysis
+    : public AnalysisInfoMixin<PreservedModuleHashAnalysis> {
+  static AnalysisKey Key;
+
+  struct ModuleHash {
+    uint64_t Hash;
+  };
+
+  using Result = ModuleHash;
+
+  Result run(Module &F, ModuleAnalysisManager &FAM) {
+    return Result{StructuralHash(F)};
+  }
+};
 
 enum class StructuralHashOptions {
   None,              /// Hash with opcode only.

--- a/llvm/lib/Analysis/StructuralHash.cpp
+++ b/llvm/lib/Analysis/StructuralHash.cpp
@@ -8,6 +8,11 @@
 //
 // This file defines the StructuralHashPrinterPass which is used to show
 // the structural hash of all functions in a module and the module itself.
+// This file defines the StructuralHashPrinterPass and the
+// PreservedFunctionHashAnalysis and PreservedModuleHashAnalysis keys.
+//
+// The StructuralHashPrinterPass is used to show the structural hash of all
+// functions in a module and the module itself.
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,6 +22,10 @@
 #include "llvm/Support/Format.h"
 
 using namespace llvm;
+
+AnalysisKey PreservedFunctionHashAnalysis::Key;
+
+AnalysisKey PreservedModuleHashAnalysis::Key;
 
 PreservedAnalyses StructuralHashPrinterPass::run(Module &M,
                                                  ModuleAnalysisManager &MAM) {

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Analysis/CallGraphSCCPass.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/StructuralHash.h"
 #include "llvm/CodeGen/MIRPrinter.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
@@ -30,7 +31,6 @@
 #include "llvm/IR/PassInstrumentation.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/PrintPasses.h"
-#include "llvm/IR/StructuralHash.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/CrashRecoveryContext.h"
@@ -1302,40 +1302,6 @@ public:
 };
 
 AnalysisKey PreservedCFGCheckerAnalysis::Key;
-
-struct PreservedFunctionHashAnalysis
-    : public AnalysisInfoMixin<PreservedFunctionHashAnalysis> {
-  static AnalysisKey Key;
-
-  struct FunctionHash {
-    uint64_t Hash;
-  };
-
-  using Result = FunctionHash;
-
-  Result run(Function &F, FunctionAnalysisManager &FAM) {
-    return Result{StructuralHash(F)};
-  }
-};
-
-AnalysisKey PreservedFunctionHashAnalysis::Key;
-
-struct PreservedModuleHashAnalysis
-    : public AnalysisInfoMixin<PreservedModuleHashAnalysis> {
-  static AnalysisKey Key;
-
-  struct ModuleHash {
-    uint64_t Hash;
-  };
-
-  using Result = ModuleHash;
-
-  Result run(Module &F, ModuleAnalysisManager &FAM) {
-    return Result{StructuralHash(F)};
-  }
-};
-
-AnalysisKey PreservedModuleHashAnalysis::Key;
 
 bool PreservedCFGCheckerInstrumentation::CFG::invalidate(
     Function &F, const PreservedAnalyses &PA,


### PR DESCRIPTION
The new IRNormalizer Pass (#113780) must invalidate `Preserved[Module|Function]HashAnalysis`. To invalidate the analyses, they must be made available to [TransformUtils](https://github.com/llvm/llvm-project/blob/0dcb0acf8265e1486f4f3715cef01987af1391cd/llvm/lib/Transforms/Utils/CMakeLists.txt#L1). TransformUtils depends on [Analysis](https://github.com/llvm/llvm-project/blob/0dcb0acf8265e1486f4f3715cef01987af1391cd/llvm/lib/Transforms/Utils/CMakeLists.txt#L99). Thus, port `Preserved[Module|Function]HashAnalysis` to Analysis. 