### PR TITLE
[CMake] update Apple undefined symbol link flag from suppress

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -251,7 +251,7 @@ endif()
 
 if(APPLE)
   # Darwin-specific linker flags for loadable modules.
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-flat_namespace -Wl,-undefined -Wl,suppress")
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-flat_namespace -Wl,-undefined -Wl,dynamic_lookup")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
the -undefined suppress option for Apple's linker is deprecated and was producing multiple warnings. This updates it to dynamic_lookup, which has much the same effect, but avoids these deprecation warnings.