### PR TITLE
[SPIRV] Mark maybe unused extractSubvector variable

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2941,7 +2941,7 @@ void SPIRVInstructionSelector::extractSubvector(
     Register &ResVReg, const SPIRVType *ResType, Register &ReadReg,
     MachineInstr &InsertionPoint) const {
   SPIRVType *InputType = GR.getResultType(ReadReg);
-  uint64_t InputSize = GR.getScalarOrVectorComponentCount(InputType);
+  [[maybe_unused]] uint64_t InputSize = GR.getScalarOrVectorComponentCount(InputType);
   uint64_t ResultSize = GR.getScalarOrVectorComponentCount(ResType);
   assert(InputSize > 1 && "The input must be a vector.");
   assert(ResultSize > 1 && "The result must be a vector.");

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -2941,7 +2941,8 @@ void SPIRVInstructionSelector::extractSubvector(
     Register &ResVReg, const SPIRVType *ResType, Register &ReadReg,
     MachineInstr &InsertionPoint) const {
   SPIRVType *InputType = GR.getResultType(ReadReg);
-  [[maybe_unused]] uint64_t InputSize = GR.getScalarOrVectorComponentCount(InputType);
+  [[maybe_unused]] uint64_t InputSize =
+      GR.getScalarOrVectorComponentCount(InputType);
   uint64_t ResultSize = GR.getScalarOrVectorComponentCount(ResType);
   assert(InputSize > 1 && "The input must be a vector.");
   assert(ResultSize > 1 && "The result must be a vector.");


### PR DESCRIPTION
Change #115178 introduced a variable that is only used in an assert, which could result in an unused variable warning in builds without asserts enabled. This just addes the maybe_unused attribute to silence the warning.