### PR TITLE
[flang] Refine handling of NULL() actual to non-optional allocatable …

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -74,7 +74,8 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     IndexVarRedefinition, IncompatibleImplicitInterfaces,
     VectorSubscriptFinalization, UndefinedFunctionResult, UselessIomsg,
     MismatchingDummyProcedure, SubscriptedEmptyArray, UnsignedLiteralTruncation,
-    CompatibleDeclarationsFromDistinctModules)
+    CompatibleDeclarationsFromDistinctModules,
+    NullActualForDefaultIntentAllocatable)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -84,8 +84,10 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnUsage_.set(UsageWarning::UndefinedFunctionResult);
   warnUsage_.set(UsageWarning::UselessIomsg);
   warnUsage_.set(UsageWarning::UnsignedLiteralTruncation);
+  warnUsage_.set(UsageWarning::NullActualForDefaultIntentAllocatable);
   // New warnings, on by default
   warnLanguage_.set(LanguageFeature::SavedLocalInSpecExpr);
+  warnLanguage_.set(LanguageFeature::NullActualForAllocatable);
 }
 
 // Ignore case and any inserted punctuation (like '-'/'_')

--- a/flang/test/Semantics/call27.f90
+++ b/flang/test/Semantics/call27.f90
@@ -1,12 +1,26 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1 -pedantic
 ! Catch NULL() actual argument association with allocatable dummy argument
 program test
-  !ERROR: NULL() actual argument 'NULL()' may not be associated with allocatable dummy argument 'a=' without INTENT(IN)
+  real, allocatable :: a
+  !ERROR: NULL() actual argument 'NULL()' may not be associated with allocatable dummy argument dummy argument 'a=' that is INTENT(OUT) or INTENT(IN OUT)
+  call foo0(null())
+  !WARNING: NULL() actual argument 'NULL()' should not be associated with allocatable dummy argument dummy argument 'a=' without INTENT(IN)
   call foo1(null())
   !PORTABILITY: Allocatable dummy argument 'a=' is associated with NULL()
   call foo2(null())
   call foo3(null()) ! ok
+  !ERROR: Actual argument associated with INTENT(IN OUT) dummy argument 'a=' is not definable
+  !BECAUSE: 'null(mold=a)' is a null pointer
+  call foo0(null(mold=a))
+  !WARNING: A null pointer should not be associated with allocatable dummy argument 'a=' without INTENT(IN)
+  call foo1(null(mold=a))
+  !PORTABILITY: Allocatable dummy argument 'a=' is associated with a null pointer
+  call foo2(null(mold=a))
+  call foo3(null(mold=a)) ! ok
  contains
+  subroutine foo0(a)
+    real, allocatable, intent(in out) :: a
+  end subroutine
   subroutine foo1(a)
     real, allocatable :: a
   end subroutine


### PR DESCRIPTION
…dummy

We presently allow a NULL() actual argument to associate with a non-optional dummy allocatable argument only under INTENT(IN).  This is too strict, as it precludes the case of a dummy argument with default intent. Continue to require that the actual argument be definable under INTENT(OUT) and INTENT(IN OUT), and (contra XLF) interpret NULL() as being an expression, not a definable variable, even when it is given an allocatable MOLD.

Fixes https://github.com/llvm/llvm-project/issues/115984.