### PR TITLE
[llvm] `APFloat`: Query `hasNanOrInf` from semantics

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -311,6 +311,7 @@ struct APFloatBase {
   static unsigned int semanticsIntSizeInBits(const fltSemantics&, bool);
   static bool semanticsHasZero(const fltSemantics &);
   static bool semanticsHasSignedRepr(const fltSemantics &);
+  static bool semanticsHasNanOrInf(const fltSemantics &);
 
   // Returns true if any number described by \p Src can be precisely represented
   // by a normal (not subnormal) value in \p Dst.
@@ -1126,21 +1127,6 @@ public:
   ///
   /// \param Semantics - type float semantics
   static APFloat getAllOnesValue(const fltSemantics &Semantics);
-
-  /// Returns true if the given semantics supports either NaN or Infinity.
-  ///
-  /// \param Sem - type float semantics
-  static bool hasNanOrInf(const fltSemantics &Sem) {
-    switch (SemanticsToEnum(Sem)) {
-    default:
-      return true;
-    // Below Semantics do not support {NaN or Inf}
-    case APFloat::S_Float6E3M2FN:
-    case APFloat::S_Float6E2M3FN:
-    case APFloat::S_Float4E2M1FN:
-      return false;
-    }
-  }
 
   /// Returns true if the given semantics has actual significand.
   ///

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -375,6 +375,10 @@ bool APFloatBase::semanticsHasSignedRepr(const fltSemantics &semantics) {
   return semantics.hasSignedRepr;
 }
 
+bool APFloatBase::semanticsHasNanOrInf(const fltSemantics &semantics) {
+  return semantics.nonFiniteBehavior != fltNonfiniteBehavior::FiniteOnly;
+}
+
 bool APFloatBase::isRepresentableAsNormalIn(const fltSemantics &Src,
                                             const fltSemantics &Dst) {
   // Exponent range must be larger.

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -832,7 +832,8 @@ TEST(APFloatTest, IsSmallestNormalized) {
     EXPECT_FALSE(APFloat::getZero(Semantics, false).isSmallestNormalized());
     EXPECT_FALSE(APFloat::getZero(Semantics, true).isSmallestNormalized());
 
-    if (APFloat::hasNanOrInf(Semantics)) {
+    if (APFloat::semanticsHasNanOrInf(Semantics)) {
+      // Types that do not support Inf will return NaN when asked for Inf.
       EXPECT_FALSE(APFloat::getInf(Semantics, false).isSmallestNormalized());
       EXPECT_FALSE(APFloat::getInf(Semantics, true).isSmallestNormalized());
 
@@ -7344,7 +7345,8 @@ TEST(APFloatTest, getExactLog2) {
     EXPECT_EQ(INT_MIN, APFloat::getZero(Semantics, false).getExactLog2Abs());
     EXPECT_EQ(INT_MIN, APFloat::getZero(Semantics, true).getExactLog2Abs());
 
-    if (APFloat::hasNanOrInf(Semantics)) {
+    if (APFloat::semanticsHasNanOrInf(Semantics)) {
+      // Types that do not support Inf will return NaN when asked for Inf.
       EXPECT_EQ(INT_MIN, APFloat::getInf(Semantics).getExactLog2());
       EXPECT_EQ(INT_MIN, APFloat::getInf(Semantics, true).getExactLog2());
       EXPECT_EQ(INT_MIN, APFloat::getNaN(Semantics, false).getExactLog2());


### PR DESCRIPTION
Whether a floating point type supports NaN or infinity can be queried from its semantics. No need to hard-code a list of types.