### PR TITLE
[RISCV] Add an implementation of findRepresentativeClass to assign i32 to GPRRegClass for RV64.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -22007,7 +22007,9 @@ RISCVTargetLowering::findRepresentativeClass(const TargetRegisterInfo *TRI,
   switch (VT.SimpleTy) {
   default:
     return TargetLowering::findRepresentativeClass(TRI, VT);
-  case MVT::i8: case MVT::i16: case MVT::i32:
+  case MVT::i8:
+  case MVT::i16:
+  case MVT::i32:
     RRC = &RISCV::GPRRegClass;
     break;
   }

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21996,24 +21996,32 @@ SDValue RISCVTargetLowering::expandIndirectJTBranch(const SDLoc &dl,
   return TargetLowering::expandIndirectJTBranch(dl, Value, Addr, JTI, DAG);
 }
 
-// Some types are listed in the GPR register class to support isel patterns for
-// GISel, but are not legal in SelectionDAG. This prevents the default
-// implementation from finding a register clss for them.
+// If an output pattern produces multiple instructions tablegen may pick an
+// arbitrary type from an instructions destination register class to use for the
+// VT of that MachineSDNode. This VT may be used to look up the representative
+// register class. If the type isn't legal, the default implementation will
+// not find a register class.
+//
+// Some integer types smaller than XLen are listed in the GPR register class to
+// support isel patterns for GISel, but are not legal in SelectionDAG. The
+// arbitrary type tablegen picks may be one of these smaller types.
+//
+// f16 and bf16 are both valid for the FPR16 or GPRF16 register class. It's
+// possible for tablegen to pick bf16 as the arbitrary type for an f16 pattern.
 std::pair<const TargetRegisterClass *, uint8_t>
 RISCVTargetLowering::findRepresentativeClass(const TargetRegisterInfo *TRI,
                                              MVT VT) const {
-  const TargetRegisterClass *RRC = nullptr;
-  uint8_t Cost = 1;
   switch (VT.SimpleTy) {
-  default:
-    return TargetLowering::findRepresentativeClass(TRI, VT);
   case MVT::i8:
   case MVT::i16:
   case MVT::i32:
-    RRC = &RISCV::GPRRegClass;
-    break;
+    return TargetLowering::findRepresentativeClass(TRI, Subtarget.getXLenVT());
+  case MVT::bf16:
+  case MVT::f16:
+    return TargetLowering::findRepresentativeClass(TRI, MVT::f32);
   }
-  return std::make_pair(RRC, Cost);
+
+  return TargetLowering::findRepresentativeClass(TRI, VT);
 }
 
 namespace llvm::RISCVVIntrinsicsTable {

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -22012,6 +22012,8 @@ std::pair<const TargetRegisterClass *, uint8_t>
 RISCVTargetLowering::findRepresentativeClass(const TargetRegisterInfo *TRI,
                                              MVT VT) const {
   switch (VT.SimpleTy) {
+  default:
+    break;
   case MVT::i8:
   case MVT::i16:
   case MVT::i32:

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -21996,6 +21996,24 @@ SDValue RISCVTargetLowering::expandIndirectJTBranch(const SDLoc &dl,
   return TargetLowering::expandIndirectJTBranch(dl, Value, Addr, JTI, DAG);
 }
 
+// Some types are listed in the GPR register class to support isel patterns for
+// GISel, but are not legal in SelectionDAG. This prevents the default
+// implementation from finding a register clss for them.
+std::pair<const TargetRegisterClass *, uint8_t>
+RISCVTargetLowering::findRepresentativeClass(const TargetRegisterInfo *TRI,
+                                             MVT VT) const {
+  const TargetRegisterClass *RRC = nullptr;
+  uint8_t Cost = 1;
+  switch (VT.SimpleTy) {
+  default:
+    return TargetLowering::findRepresentativeClass(TRI, VT);
+  case MVT::i8: case MVT::i16: case MVT::i32:
+    RRC = &RISCV::GPRRegClass;
+    break;
+  }
+  return std::make_pair(RRC, Cost);
+}
+
 namespace llvm::RISCVVIntrinsicsTable {
 
 #define GET_RISCVVIntrinsicsTable_IMPL

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -1051,6 +1051,9 @@ private:
 
   SDValue emitFlushICache(SelectionDAG &DAG, SDValue InChain, SDValue Start,
                           SDValue End, SDValue Flags, SDLoc DL) const;
+
+  std::pair<const TargetRegisterClass *, uint8_t>
+  findRepresentativeClass(const TargetRegisterInfo *TRI, MVT VT) const override;
 };
 
 namespace RISCVVIntrinsicsTable {


### PR DESCRIPTION
This is an alternative fix for #81192. This allows the SelectionDAG scheduler to be able to find a representative register class for i32 on RV64. The representative register class is the super register class with the largest spill size that is also legal. The default implementation of findRepresentativeClass only works for legal types which i32 is not for RV64.

I wanted to remove i32 from the GPR register class to fix the issue, but we need to be able to write some i32 patterns for GISel. And now I need to add i16 to GPR for GISel.

I did some investigation of why tablegen uses i32 in output patterns on RV64. It appears it comes down to a function call ForceArbitraryInstResultType that just picks a type for the output pattern when the isel pattern isn't specific enough. I believe it picks the smallest type(lowested numbered) to resolve the conflict.

A similar issue occurs for f16 and bf16 which both use the FPR16 register class. If the isel pattern doesn't specify, tablegen may find both f16 bf16 and may pick bf16 from Zfh pattern when Zfbfmin isn't present. Since bf16 isn't legal in that case, findRepresentativeClass will fail.

This patch calls the base class with XLenVT to get the representative class since XLenVT is always legal.

For bf16/f16 we call the base class with f32 since all of the f16/bf16 extensions depend on either F or Zfinx which will make f32 a legal type. The final representative register class further depends on whether D or Zdinx is also enabled, but that should be handled by the default implementation.