### PR TITLE
[mlir][Parser][NFC] Make `parseFloatFromIntegerLiteral` a standalone function

### DIFF
--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -16,6 +16,12 @@
 
 namespace mlir {
 namespace detail {
+/// Parse a floating point value from an integer literal token.
+FailureOr<APFloat>
+parseFloatFromIntegerLiteral(function_ref<InFlightDiagnostic()> emitError,
+                             const Token &tok, bool isNegative,
+                             const llvm::fltSemantics &semantics);
+
 //===----------------------------------------------------------------------===//
 // Parser
 //===----------------------------------------------------------------------===//
@@ -150,12 +156,6 @@ public:
 
   /// Parse an optional integer value only in decimal format from the stream.
   OptionalParseResult parseOptionalDecimalInteger(APInt &result);
-
-  /// Parse a floating point value from an integer literal token.
-  ParseResult parseFloatFromIntegerLiteral(std::optional<APFloat> &result,
-                                           const Token &tok, bool isNegative,
-                                           const llvm::fltSemantics &semantics,
-                                           size_t typeSizeInBits);
 
   /// Returns true if the current token corresponds to a keyword.
   bool isCurrentTokenAKeyword() const {


### PR DESCRIPTION
Make `parseFloatFromIntegerLiteral` a standalone function, so that it can be reused in a newly added helper function (in a future commit).

Also drop the `typeSizeInBits` argument. It can be taken from the APFloat semantics.
