### PR TITLE
[mlir][Parser] Deduplicate floating-point parsing functionality

### DIFF
--- a/mlir/lib/AsmParser/AsmParserImpl.h
+++ b/mlir/lib/AsmParser/AsmParserImpl.h
@@ -287,9 +287,8 @@ public:
                          APFloat &result) override {
     bool isNegative = parser.consumeIf(Token::minus);
     Token curTok = parser.getToken();
-    auto emitErrorAtTok = [&]() { return emitError(curTok.getLoc(), ""); };
     FailureOr<APFloat> apResult =
-        parseFloatFromLiteral(emitErrorAtTok, curTok, isNegative, semantics);
+        parser.parseFloatFromLiteral(curTok, isNegative, semantics);
     if (failed(apResult))
       return failure();
     parser.consumeToken();

--- a/mlir/lib/AsmParser/AsmParserImpl.h
+++ b/mlir/lib/AsmParser/AsmParserImpl.h
@@ -287,9 +287,9 @@ public:
                          APFloat &result) override {
     bool isNegative = parser.consumeIf(Token::minus);
     Token curTok = parser.getToken();
-    FailureOr<APFloat> apResult =
-        parser.parseFloatFromLiteral(curTok, isNegative, semantics);
-    if (failed(apResult))
+    std::optional<APFloat> apResult;
+    if (failed(parser.parseFloatFromLiteral(apResult, curTok, isNegative,
+                                            semantics)))
       return failure();
     parser.consumeToken();
     result = *apResult;

--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -422,9 +422,8 @@ Attribute Parser::parseDecOrHexAttr(Type type, bool isNegative) {
   }
 
   if (auto floatType = dyn_cast<FloatType>(type)) {
-    auto emitErrorAtTok = [&]() { return emitError(tok.getLoc()); };
     FailureOr<APFloat> result = parseFloatFromIntegerLiteral(
-        emitErrorAtTok, tok, isNegative, floatType.getFloatSemantics());
+        tok, isNegative, floatType.getFloatSemantics());
     if (failed(result))
       return Attribute();
     return FloatAttr::get(floatType, *result);
@@ -658,9 +657,8 @@ TensorLiteralParser::getFloatAttrElements(SMLoc loc, FloatType eltTy,
   for (const auto &signAndToken : storage) {
     bool isNegative = signAndToken.first;
     const Token &token = signAndToken.second;
-    auto emitErrorAtTok = [&]() { return p.emitError(token.getLoc()); };
-    FailureOr<APFloat> result = parseFloatFromLiteral(
-        emitErrorAtTok, token, isNegative, eltTy.getFloatSemantics());
+    FailureOr<APFloat> result =
+        p.parseFloatFromLiteral(token, isNegative, eltTy.getFloatSemantics());
     if (failed(result))
       return failure();
     floatValues.push_back(*result);
@@ -882,10 +880,8 @@ ParseResult DenseArrayElementParser::parseIntegerElement(Parser &p) {
 ParseResult DenseArrayElementParser::parseFloatElement(Parser &p) {
   bool isNegative = p.consumeIf(Token::minus);
   Token token = p.getToken();
-  auto emitErrorAtTok = [&]() { return p.emitError(token.getLoc()); };
-  FailureOr<APFloat> fromIntLit =
-      parseFloatFromLiteral(emitErrorAtTok, token, isNegative,
-                            cast<FloatType>(type).getFloatSemantics());
+  FailureOr<APFloat> fromIntLit = p.parseFloatFromLiteral(
+      token, isNegative, cast<FloatType>(type).getFloatSemantics());
   if (failed(fromIntLit))
     return failure();
   p.consumeToken();

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -16,6 +16,12 @@
 
 namespace mlir {
 namespace detail {
+/// Parse a floating point value from an integer literal token.
+FailureOr<APFloat>
+parseFloatFromIntegerLiteral(function_ref<InFlightDiagnostic()> emitError,
+                             const Token &tok, bool isNegative,
+                             const llvm::fltSemantics &semantics);
+
 //===----------------------------------------------------------------------===//
 // Parser
 //===----------------------------------------------------------------------===//
@@ -150,12 +156,6 @@ public:
 
   /// Parse an optional integer value only in decimal format from the stream.
   OptionalParseResult parseOptionalDecimalInteger(APInt &result);
-
-  /// Parse a floating point value from an integer literal token.
-  ParseResult parseFloatFromIntegerLiteral(std::optional<APFloat> &result,
-                                           const Token &tok, bool isNegative,
-                                           const llvm::fltSemantics &semantics,
-                                           size_t typeSizeInBits);
 
   /// Returns true if the current token corresponds to a keyword.
   bool isCurrentTokenAKeyword() const {

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -22,6 +22,12 @@ parseFloatFromIntegerLiteral(function_ref<InFlightDiagnostic()> emitError,
                              const Token &tok, bool isNegative,
                              const llvm::fltSemantics &semantics);
 
+/// Parse a floating point value from a literal.
+FailureOr<APFloat>
+parseFloatFromLiteral(function_ref<InFlightDiagnostic()> emitError,
+                      const Token &tok, bool isNegative,
+                      const llvm::fltSemantics &semantics);
+
 //===----------------------------------------------------------------------===//
 // Parser
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -153,13 +153,14 @@ public:
   OptionalParseResult parseOptionalDecimalInteger(APInt &result);
 
   /// Parse a floating point value from a literal.
-  FailureOr<APFloat> parseFloatFromLiteral(const Token &tok, bool isNegative,
-                                           const llvm::fltSemantics &semantics);
+  ParseResult parseFloatFromLiteral(std::optional<APFloat> &result,
+                                    const Token &tok, bool isNegative,
+                                    const llvm::fltSemantics &semantics);
 
   /// Parse a floating point value from an integer literal token.
-  FailureOr<APFloat>
-  parseFloatFromIntegerLiteral(const Token &tok, bool isNegative,
-                               const llvm::fltSemantics &semantics);
+  ParseResult parseFloatFromIntegerLiteral(std::optional<APFloat> &result,
+                                           const Token &tok, bool isNegative,
+                                           const llvm::fltSemantics &semantics);
 
   /// Returns true if the current token corresponds to a keyword.
   bool isCurrentTokenAKeyword() const {

--- a/mlir/lib/AsmParser/Parser.h
+++ b/mlir/lib/AsmParser/Parser.h
@@ -16,17 +16,6 @@
 
 namespace mlir {
 namespace detail {
-/// Parse a floating point value from an integer literal token.
-FailureOr<APFloat>
-parseFloatFromIntegerLiteral(function_ref<InFlightDiagnostic()> emitError,
-                             const Token &tok, bool isNegative,
-                             const llvm::fltSemantics &semantics);
-
-/// Parse a floating point value from a literal.
-FailureOr<APFloat>
-parseFloatFromLiteral(function_ref<InFlightDiagnostic()> emitError,
-                      const Token &tok, bool isNegative,
-                      const llvm::fltSemantics &semantics);
 
 //===----------------------------------------------------------------------===//
 // Parser
@@ -162,6 +151,15 @@ public:
 
   /// Parse an optional integer value only in decimal format from the stream.
   OptionalParseResult parseOptionalDecimalInteger(APInt &result);
+
+  /// Parse a floating point value from a literal.
+  FailureOr<APFloat> parseFloatFromLiteral(const Token &tok, bool isNegative,
+                                           const llvm::fltSemantics &semantics);
+
+  /// Parse a floating point value from an integer literal token.
+  FailureOr<APFloat>
+  parseFloatFromIntegerLiteral(const Token &tok, bool isNegative,
+                               const llvm::fltSemantics &semantics);
 
   /// Returns true if the current token corresponds to a keyword.
   bool isCurrentTokenAKeyword() const {

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -45,7 +45,8 @@ func.func @elementsattr_floattype1() -> () {
 // -----
 
 func.func @elementsattr_floattype2() -> () {
-  // expected-error@+1 {{expected floating-point elements, but parsed integer}}
+  // expected-error@below {{unexpected decimal integer literal for a floating point value}}
+  // expected-note@below {{add a trailing dot to make the literal a float}}
   "foo"(){bar = dense<[4]> : tensor<1xf32>} : () -> ()
 }
 
@@ -138,21 +139,22 @@ func.func @float_in_int_tensor() {
 // -----
 
 func.func @float_in_bool_tensor() {
-  // expected-error @+1 {{expected integer elements, but parsed floating-point}}
+  // expected-error@below {{expected integer elements, but parsed floating-point}}
   "foo"() {bar = dense<[true, 42.0]> : tensor<2xi1>} : () -> ()
 }
 
 // -----
 
 func.func @decimal_int_in_float_tensor() {
-  // expected-error @+1 {{expected floating-point elements, but parsed integer}}
+  // expected-error@below {{unexpected decimal integer literal for a floating point value}}
+  // expected-note@below {{add a trailing dot to make the literal a float}}
   "foo"() {bar = dense<[42, 42.0]> : tensor<2xf32>} : () -> ()
 }
 
 // -----
 
 func.func @bool_in_float_tensor() {
-  // expected-error @+1 {{expected floating-point elements, but parsed integer}}
+  // expected-error @+1 {{expected floating point literal}}
   "foo"() {bar = dense<[42.0, true]> : tensor<2xf32>} : () -> ()
 }
 


### PR DESCRIPTION
The following functionality is duplicated in multiple places: trying to parse an APFloat from a floating point literal or an integer in hexadecimal representation (bit pattern). Move it to a common helper function.

NFC apart from the slightly changed error messages. (We now print the exact same error messages regardless of whether the float is parsed standalone or inside of a tensor literal, etc.)
