### PR TITLE
[mlir][CallGraph] Add edges for callable symbol references in CallGraph

### DIFF
--- a/mlir/include/mlir/Analysis/CallGraph.h
+++ b/mlir/include/mlir/Analysis/CallGraph.h
@@ -16,6 +16,7 @@
 #ifndef MLIR_ANALYSIS_CALLGRAPH_H
 #define MLIR_ANALYSIS_CALLGRAPH_H
 
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/MapVector.h"
@@ -42,11 +43,12 @@ public:
   /// This class represents a directed edge between two nodes in the callgraph.
   class Edge {
     enum class Kind {
-      // An 'Abstract' edge represents an opaque, non-operation, reference
-      // between this node and the target. Edges of this type are only valid
-      // from the external node, as there is no valid connection to an operation
-      // in the module.
-      Abstract,
+      // A 'Ref' edge represents a reference between this node and the target.
+      // Edges of this type exist whenever any operation references a callable
+      // node. A callable node which may be referenced externally is connected
+      // with a reference edge from the entry node. All 'Call' edges and 'Child'
+      // edges are inherently reference edges in the callgraph.
+      Ref,
 
       // A 'Call' edge represents a direct reference to the target node via a
       // call-like operation within the callable region of this node.
@@ -60,8 +62,8 @@ public:
     };
 
   public:
-    /// Returns true if this edge represents an `Abstract` edge.
-    bool isAbstract() const { return targetAndKind.getInt() == Kind::Abstract; }
+    /// Returns true if this edge is only a `Ref` edge but not a call or child.
+    bool isRef() const { return targetAndKind.getInt() == Kind::Ref; }
 
     /// Returns true if this edge represents a `Call` edge.
     bool isCall() const { return targetAndKind.getInt() == Kind::Call; }
@@ -95,16 +97,21 @@ public:
   /// on non-external nodes.
   Region *getCallableRegion() const;
 
-  /// Adds an abstract reference edge to the given node. An abstract edge does
-  /// not come from any observable operations, so this is only valid on the
-  /// external node.
-  void addAbstractEdge(CallGraphNode *node);
+  /// Adds a reference edge to the given node. A reference comes from
+  /// external node or any observable operations.
+  void addRefEdge(CallGraphNode *node);
 
   /// Add an outgoing call edge from this node.
   void addCallEdge(CallGraphNode *node);
 
   /// Adds a reference edge to the given child node.
   void addChildEdge(CallGraphNode *child);
+
+  /// Remove edges to the target node.
+  void removeEdgesTo(CallGraphNode *target);
+
+  /// Remove all edges for this callgraph node.
+  void removeAllEdges();
 
   /// Iterator over the outgoing edges of this node.
   using iterator = SmallVectorImpl<Edge>::const_iterator;
@@ -113,6 +120,13 @@ public:
 
   /// Returns true if this node has any child edges.
   bool hasChildren() const;
+
+  /// Return true if this node is dead.
+  bool isDead() const { return !isExternal() && getNumReferences() == 0; }
+
+  /// Returns the number of edges in this callgraph that refer
+  /// to this node.
+  unsigned getNumReferences() const { return NumReferences; }
 
 private:
   /// DenseMap info for callgraph edges.
@@ -142,6 +156,17 @@ private:
   SetVector<Edge, SmallVector<Edge, 4>,
             llvm::SmallDenseSet<Edge, 4, EdgeKeyInfo>>
       edges;
+
+  /// The number of edges in this callgraph that refer to this
+  /// callgraph node.
+  unsigned NumReferences = 0;
+
+  /// Decrease reference counter when an edge refers to this callgraph node
+  /// is removed.
+  void dropRef() { --NumReferences; }
+
+  /// Add reference counter when a new edge refers to this callgraph node.
+  void addRef() { ++NumReferences; }
 
   // Provide access to private methods.
   friend class CallGraph;
@@ -199,6 +224,11 @@ public:
   /// is used when resolving calls that reference callables via a symbol
   /// reference.
   CallGraphNode *resolveCallable(CallOpInterface call,
+                                 SymbolTableCollection &symbolTable) const;
+
+  /// Resolve the callable for given symbol to a node in the callgraph, or the
+  /// external node if a valid node was not resolved.
+  CallGraphNode *resolveCallable(Operation *op, SymbolRefAttr symbolRef,
                                  SymbolTableCollection &symbolTable) const;
 
   /// Erase the given node from the callgraph.

--- a/mlir/test/Analysis/test-callgraph.mlir
+++ b/mlir/test/Analysis/test-callgraph.mlir
@@ -8,30 +8,32 @@ module attributes {test.name = "simple"} {
     return
   }
 
+  // CHECK-NOT: Node{{.*}}func_b
   func.func private @func_b()
 
-  // CHECK: Node{{.*}}func_c
+  // CHECK: Node{{.*}}func_c{{.*}}private
   // CHECK-NEXT: Call-Edge{{.*}}Unknown-Callee-Node
-  func.func @func_c() {
+  func.func private @func_c() {
     call @func_b() : () -> ()
     return
   }
 
   // CHECK: Node{{.*}}func_d
-  // CHECK-NEXT: Call-Edge{{.*}}func_c
+  // CHECK-NEXT: Call-Edge{{.*}}func_c{{.*}}private
   func.func @func_d() {
     call @func_c() : () -> ()
     return
   }
 
   // CHECK: Node{{.*}}func_e
-  // CHECK-DAG: Call-Edge{{.*}}func_c
+  // CHECK-DAG: Call-Edge{{.*}}func_c{{.*}}private
   // CHECK-DAG: Call-Edge{{.*}}func_d
   // CHECK-DAG: Call-Edge{{.*}}func_e
+  // CHECK-DAG: Ref-Edge{{.*}}func_a
   func.func @func_e() {
     call @func_c() : () -> ()
     call @func_d() : () -> ()
-    call @func_e() : () -> ()
+    call @func_e() { use = @func_a } : () -> ()
     return
   }
 
@@ -49,6 +51,48 @@ module attributes {test.name = "simple"} {
     call_indirect %fn() : () -> ()
     return
   }
+
+  // CHECK: Node{{.*}}func_g
+  // CHECK: Ref-Edge{{.*}}func_c
+  // CHECK: Call-Edge{{.*}}Unknown-Callee-Node
+  func.func @func_g() -> (() -> ()) {
+    // A private symbol maybe escaped.
+    %0 = func.constant @func_c : () -> ()
+    call_indirect %0() : () -> ()
+    return %0 : () -> ()
+  }
+
+  // CHECK: Node{{.*}}func_h{{.*}}private
+  func.func private @func_h() {
+    return
+  }
+
+  // non-callable top level operation reference a non-symbolic callable node.
+  %0 = "test.functional_region_op"() ({
+    func.call @func_f() : () -> ()
+    "test.return"() : () -> ()
+  }) : () -> (() -> ())
+
+  // If a referenced symbol only has declaration, there would not be
+  // a reference edge from external node to it.
+  "live.user"() { use = @func_b } : () -> ()
+
+  // non-callable top level operation reference callable symbol.
+  "live.user"() { use = @func_c } : () -> ()
+  func.call @func_h() : () -> ()
+
+  // CHECK: Node{{.*}}External-Caller-Node
+  // CHECK-NEXT: Ref-Edge{{.*}}func_a
+  // CHECK-NEXT: Ref-Edge{{.*}}func_d
+  // CHECK-NEXT: Ref-Edge{{.*}}func_e
+  // CHECK-NEXT: Ref-Edge{{.*}}func_f
+  // CHECK-NEXT: Ref-Edge{{.*}}func_g
+  // CHECK-NEXT: Ref-Edge{{.*}}test.functional_region_op
+  // CHECK-NOT: Ref-Edge{{.*}}func_b
+  // CHECK-NEXT: Ref-Edge{{.*}}func_c{{.*}}private
+  // CHECK-NEXT: Ref-Edge{{.*}}func_h{{.*}}private
+
+  // CHECK: Node{{.*}}Unknown-Callee-Node
 }
 
 // -----
@@ -56,18 +100,30 @@ module attributes {test.name = "simple"} {
 // CHECK-LABEL: Testing : "nested"
 module attributes {test.name = "nested"} {
   module @nested_module {
-    // CHECK: Node{{.*}}func_a
-    func.func @func_a() {
+    // CHECK: Node{{.*}}func_a{{.*}}nested
+    func.func nested @func_a() {
+      return
+    }
+    // CHECK: Node{{.*}}func_b{{.*}}nested
+    func.func nested @func_b() {
       return
     }
   }
 
-  // CHECK: Node{{.*}}func_b
-  // CHECK: Call-Edge{{.*}}func_a
-  func.func @func_b() {
-    "test.conversion_call_op"() { callee = @nested_module::@func_a } : () -> ()
+  // CHECK: Node{{.*}}func_c
+  // CHECK: Call-Edge{{.*}}func_a{{.*}}nested
+  // CHECK: Ref-Edge{{.*}}func_b{{.*}}nested
+  func.func @func_c() {
+    "test.conversion_call_op"() { use = @nested_module::@func_b, callee = @nested_module::@func_a } : () -> ()
     return
   }
+
+  // CHECK: Node{{.*}}External-Caller-Node
+  // CHECK-NEXT: Ref-Edge{{.*}}func_c
+  // CHECK-NOT: Ref-Edge{{.*}}func_a
+  // CHECK-NOT: Ref-Edge{{.*}}func_b
+
+  // CHECK: Node{{.*}}Unknown-Callee-Node
 }
 
 // -----
@@ -95,4 +151,3 @@ module attributes {test.name = "SCC"} {
   // CHECK: SCC :
   // CHECK-NEXT: Node{{.*}}External-Caller-Node
 }
-

--- a/mlir/test/Transforms/inlining-dce.mlir
+++ b/mlir/test/Transforms/inlining-dce.mlir
@@ -10,7 +10,7 @@ func.func private @dead_function() {
 
 // Function becomes dead after inlining.
 // CHECK-NOT: func private @dead_function_b
-func.func @dead_function_b() {
+func.func private @dead_function_b() {
   return
 }
 
@@ -41,6 +41,35 @@ func.func private @dead_function_d() {
 func.func @live_function_c() {
   call @dead_function_c() : () -> ()
   call @dead_function_d() : () -> ()
+  return
+}
+
+// A transitive example, but no one be called by live-function.
+
+// CHECK-NOT: func private @dead_function_e
+func.func private @dead_function_e() {
+  call @live_function_b() : () -> ()
+  return
+}
+
+// CHECK-NOT: func private @dead_function_f
+func.func private @dead_function_f() {
+  call @dead_function_e() : () -> ()
+  return
+}
+
+// A function constant is inlined after optimization
+
+// CHECK-NOT: func private @dead_function_h
+func.func private @dead_function_h() {
+  call @live_function_b() : () -> ()
+  return
+}
+
+// CHECK: func @live_function_f
+func.func @live_function_f() {
+  %0 = func.constant @dead_function_h : () -> ()
+  call_indirect %0() : () -> ()
   return
 }
 


### PR DESCRIPTION
This patch introduces a reference edge to represent callable symbol
references in `CallGraph Analysis`. References edges exist whenever
any operation references a callable node. Any callable symbol might
be referenced by external node is also connected with a reference
edge from entry node. The callgraph will represent both direct call
and any potential call might be formed through static optimization.

This implementation refers to many design concepts of `LazyCallGraph`
in LLVM : bf71a34eb9e25c6080d5058a553dbcb75676ff95. The difference is
that mlir retaines the entry and exit nodes, and add references counter
for each callgraph node, which is easy to find a dead node.

This patch also improves readable callgraph, which is supported to dump
all nodes in callgraph and dump references number of each nodes.