### PR TITLE
[mlir][docs] Update MLIR's PatternRewriter documentation 

### DIFF
--- a/mlir/docs/PatternRewriter.md
+++ b/mlir/docs/PatternRewriter.md
@@ -73,7 +73,7 @@ public:
     // otherwise.
     // ...
   }
-  void rewrite(Operation *op, PatternRewriter &rewriter) {
+  void rewrite(Operation *op, PatternRewriter &rewriter) const override {
     // The `rewrite` method performs mutations on the IR rooted at `op` using
     // the provided rewriter. All mutations must go through the provided
     // rewriter.
@@ -81,7 +81,7 @@ public:
 
   /// In this section, the `match` and `rewrite` implementation is specified
   /// using a single hook.
-  LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) {
+  LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
     // The `matchAndRewrite` method performs both the matching and the mutation.
     // Note that the match must reach a successful point before IR mutation may
     // take place.


### PR DESCRIPTION
## Description

This PR adds the missing `const override` to the `rewrite` and `matchAndRewrite` declaration in the Pattern Rewriter documentation as described here:

https://github.com/llvm/llvm-project/blob/5cfa8baef33636827e5aa8dd76888c724433b53e/mlir/include/mlir/IR/PatternMatch.h#L237-L265

