### PR TITLE
[lldb][test] Disable inline_sites_live.cpp for non-Windows targets

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
@@ -1,5 +1,5 @@
 // clang-format off
-// REQUIRES: system-windows
+// REQUIRES: target-windows
 
 // RUN: %build -o %t.exe -- %s
 // RUN: %lldb -f %t.exe -s \


### PR DESCRIPTION
This is a follow-up for the conversation here
https://github.com/llvm/llvm-project/pull/115722/.

This test is designed for Windows target/PDB format, so it shouldn't be built and run for DWARF/etc.