### PR TITLE
[lldb] Fixed find-module.test in case of a remote target

### DIFF
--- a/lldb/test/Shell/Minidump/Windows/find-module.test
+++ b/lldb/test/Shell/Minidump/Windows/find-module.test
@@ -1,7 +1,7 @@
 Test that we correctly find a PE/COFF file in our executable search path, and
 use it when opening minidumps.
 
-XFAIL: remote{{.*}}
+XFAIL: system-windows && remote-linux
 
 RUN: yaml2obj %S/Inputs/find-module.exe.yaml -o %T/find-module.exe
 RUN: yaml2obj %S/Inputs/find-module.dmp.yaml -o %T/find-module.dmp


### PR DESCRIPTION
Changing from UNSUPPOERTED to XFAIL in #94165 break x86 linux host / Aarch64 linux target build https://lab.llvm.org/buildbot/#/builders/195/builds/1047