### PR TITLE
[libc++] Fix CI issues recently introduced by localization changes

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -202,13 +202,13 @@ jobs:
       matrix:
         include:
         - config: generic-cxx03
-          os: macos-latest
+          os: macos-15
         - config: generic-cxx23
-          os: macos-latest
+          os: macos-15
         - config: generic-modules
-          os: macos-latest
+          os: macos-15
         - config: apple-configuration
-          os: macos-latest
+          os: macos-15
         - config: apple-system
           os: macos-13
         - config: apple-system-hardened

--- a/libcxx/test/std/experimental/simd/simd.class/simd_unary.pass.cpp
+++ b/libcxx/test/std/experimental/simd/simd.class/simd_unary.pass.cpp
@@ -12,9 +12,8 @@
 //   Pass-by-value arguments with alignment greater than register width are not supported.
 // XFAIL: target=powerpc{{.*}}-ibm-{{.*}} && (clang-17 || clang-18)
 
-// FIXME: The following issue occurs on macOS 13.7 with Apple clang 15.0.0:
-//   clang: error: unable to execute command: Illegal instruction: 4
-// XFAIL: target=x86_64-apple-macosx13.7
+// This test crashes AppleClang 15 but not later versions.
+// UNSUPPORTED: apple-clang-15
 
 // FIXME: The following issue occurs on Windows to Armv7 Ubuntu Linux:
 //   Assertion failed: N->getValueType(0) == MVT::v1i1 && "Expected v1i1 type"


### PR DESCRIPTION
After a recent Github Actions runner policy change [1], the version of Xcode included in
the macos-14 image went from Xcode 16 to Xcode 15, breaking our build bots.

This moves the bots to the macos 15 (public preview) image, which contains Xcode 16.

Also, adjust an UNSUPPORTED annotation that was incorrectly targeting macos 13.7
when it should have been targeting a version of AppleClang.

[1]: https://github.com/actions/runner-images/issues/10703