### PR TITLE
[clang][CIR] Fix missing dependency of MLIRCIR

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -3,6 +3,9 @@ add_clang_library(MLIRCIR
   CIRDialect.cpp
   CIRTypes.cpp
 
+  DEPENDS
+  MLIRCIROpsIncGen
+
   LINK_LIBS PUBLIC
   MLIRIR
   )


### PR DESCRIPTION
Building `MLIRCIR` will report an error `CIROpsDialect.h.inc` not found. This is because `MLIRCIR` hasn't declared its dependence on the tablegen target `MLIRCIROpsIncGen`. This patch fixes the issue.