### PR TITLE
[libc++] Remove <istream> and <ostream> includes from <iomanip>

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -503,6 +503,7 @@ set(files
   __locale_dir/locale_base_api/openbsd.h
   __locale_dir/locale_base_api/win32.h
   __locale_dir/locale_guard.h
+  __locale_dir/pad_and_output.h
   __locale_dir/support/apple.h
   __locale_dir/support/bsd_like.h
   __locale_dir/support/freebsd.h
@@ -596,6 +597,7 @@ set(files
   __numeric/transform_reduce.h
   __ostream/basic_ostream.h
   __ostream/print.h
+  __ostream/put_character_sequence.h
   __pstl/backend.h
   __pstl/backend_fwd.h
   __pstl/backends/default.h

--- a/libcxx/include/__locale_dir/pad_and_output.h
+++ b/libcxx/include/__locale_dir/pad_and_output.h
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___LOCALE_DIR_PAD_AND_OUTPUT_H
+#define _LIBCPP___LOCALE_DIR_PAD_AND_OUTPUT_H
+
+#include <__config>
+#include <ios>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class _CharT, class _OutputIterator>
+_LIBCPP_HIDE_FROM_ABI _OutputIterator __pad_and_output(
+    _OutputIterator __s, const _CharT* __ob, const _CharT* __op, const _CharT* __oe, ios_base& __iob, _CharT __fl) {
+  streamsize __sz = __oe - __ob;
+  streamsize __ns = __iob.width();
+  if (__ns > __sz)
+    __ns -= __sz;
+  else
+    __ns = 0;
+  for (; __ob < __op; ++__ob, ++__s)
+    *__s = *__ob;
+  for (; __ns; --__ns, ++__s)
+    *__s = __fl;
+  for (; __ob < __oe; ++__ob, ++__s)
+    *__s = *__ob;
+  __iob.width(0);
+  return __s;
+}
+
+template <class _CharT, class _Traits>
+_LIBCPP_HIDE_FROM_ABI ostreambuf_iterator<_CharT, _Traits> __pad_and_output(
+    ostreambuf_iterator<_CharT, _Traits> __s,
+    const _CharT* __ob,
+    const _CharT* __op,
+    const _CharT* __oe,
+    ios_base& __iob,
+    _CharT __fl) {
+  if (__s.__sbuf_ == nullptr)
+    return __s;
+  streamsize __sz = __oe - __ob;
+  streamsize __ns = __iob.width();
+  if (__ns > __sz)
+    __ns -= __sz;
+  else
+    __ns = 0;
+  streamsize __np = __op - __ob;
+  if (__np > 0) {
+    if (__s.__sbuf_->sputn(__ob, __np) != __np) {
+      __s.__sbuf_ = nullptr;
+      return __s;
+    }
+  }
+  if (__ns > 0) {
+    basic_string<_CharT, _Traits> __sp(__ns, __fl);
+    if (__s.__sbuf_->sputn(__sp.data(), __ns) != __ns) {
+      __s.__sbuf_ = nullptr;
+      return __s;
+    }
+  }
+  __np = __oe - __op;
+  if (__np > 0) {
+    if (__s.__sbuf_->sputn(__op, __np) != __np) {
+      __s.__sbuf_ = nullptr;
+      return __s;
+    }
+  }
+  __iob.width(0);
+  return __s;
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___LOCALE_DIR_PAD_AND_OUTPUT_H

--- a/libcxx/include/__ostream/basic_ostream.h
+++ b/libcxx/include/__ostream/basic_ostream.h
@@ -16,6 +16,7 @@
 #  include <__exception/operations.h>
 #  include <__memory/shared_ptr.h>
 #  include <__memory/unique_ptr.h>
+#  include <__ostream/put_character_sequence.h>
 #  include <__system_error/error_code.h>
 #  include <__type_traits/conjunction.h>
 #  include <__type_traits/enable_if.h>
@@ -494,33 +495,6 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(const
   }
 #  endif // _LIBCPP_HAS_EXCEPTIONS
   return *this;
-}
-
-template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
-__put_character_sequence(basic_ostream<_CharT, _Traits>& __os, const _CharT* __str, size_t __len) {
-#  if _LIBCPP_HAS_EXCEPTIONS
-  try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
-    typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
-    if (__s) {
-      typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
-      if (std::__pad_and_output(
-              _Ip(__os),
-              __str,
-              (__os.flags() & ios_base::adjustfield) == ios_base::left ? __str + __len : __str,
-              __str + __len,
-              __os,
-              __os.fill())
-              .failed())
-        __os.setstate(ios_base::badbit | ios_base::failbit);
-    }
-#  if _LIBCPP_HAS_EXCEPTIONS
-  } catch (...) {
-    __os.__set_badbit_and_consider_rethrow();
-  }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
-  return __os;
 }
 
 template <class _CharT, class _Traits>

--- a/libcxx/include/__ostream/put_character_sequence.h
+++ b/libcxx/include/__ostream/put_character_sequence.h
@@ -1,0 +1,59 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___OSTREAM_PUT_CHARACTER_SEQUENCE_H
+#define _LIBCPP___OSTREAM_PUT_CHARACTER_SEQUENCE_H
+
+#include <__config>
+
+#if _LIBCPP_HAS_LOCALIZATION
+
+#  include <__cstddef/size_t.h>
+#  include <__fwd/ostream.h>
+#  include <__iterator/ostreambuf_iterator.h>
+#  include <__locale_dir/pad_and_output.h>
+#  include <ios>
+
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class _CharT, class _Traits>
+_LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
+__put_character_sequence(basic_ostream<_CharT, _Traits>& __os, const _CharT* __str, size_t __len) {
+#  if _LIBCPP_HAS_EXCEPTIONS
+  try {
+#  endif // _LIBCPP_HAS_EXCEPTIONS
+    typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
+    if (__s) {
+      typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
+      if (std::__pad_and_output(
+              _Ip(__os),
+              __str,
+              (__os.flags() & ios_base::adjustfield) == ios_base::left ? __str + __len : __str,
+              __str + __len,
+              __os,
+              __os.fill())
+              .failed())
+        __os.setstate(ios_base::badbit | ios_base::failbit);
+    }
+#  if _LIBCPP_HAS_EXCEPTIONS
+  } catch (...) {
+    __os.__set_badbit_and_consider_rethrow();
+  }
+#  endif // _LIBCPP_HAS_EXCEPTIONS
+  return __os;
+}
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_HAS_LOCALIZATION
+
+#endif // _LIBCPP___OSTREAM_PUT_CHARACTER_SEQUENCE_H

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -46,9 +46,9 @@ template <class charT, class traits, class Allocator>
 
 #if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__ostream/basic_ostream.h>
+#  include <__ostream/put_character_sequence.h>
 #  include <ios>
-#  include <istream>
+#  include <iosfwd>
 #  include <locale>
 #  include <version>
 
@@ -546,5 +546,20 @@ quoted(basic_string_view<_CharT, _Traits> __sv, _CharT __delim = _CharT('"'), _C
 _LIBCPP_END_NAMESPACE_STD
 
 #endif // _LIBCPP_HAS_LOCALIZATION
+
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <array>
+#  include <bitset>
+#  include <deque>
+#  include <format>
+#  include <functional>
+#  include <istream>
+#  include <ostream>
+#  include <print>
+#  include <queue>
+#  include <stack>
+#  include <unordered_map>
+#  include <vector>
+#endif
 
 #endif // _LIBCPP_IOMANIP

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -203,6 +203,7 @@ template <class charT> class messages_byname;
 #  include <__iterator/istreambuf_iterator.h>
 #  include <__iterator/ostreambuf_iterator.h>
 #  include <__locale>
+#  include <__locale_dir/pad_and_output.h>
 #  include <__memory/unique_ptr.h>
 #  include <__type_traits/make_unsigned.h>
 #  include <cerrno>
@@ -1238,66 +1239,6 @@ protected:
 
 template <class _CharT, class _OutputIterator>
 locale::id num_put<_CharT, _OutputIterator>::id;
-
-template <class _CharT, class _OutputIterator>
-_LIBCPP_HIDE_FROM_ABI _OutputIterator __pad_and_output(
-    _OutputIterator __s, const _CharT* __ob, const _CharT* __op, const _CharT* __oe, ios_base& __iob, _CharT __fl) {
-  streamsize __sz = __oe - __ob;
-  streamsize __ns = __iob.width();
-  if (__ns > __sz)
-    __ns -= __sz;
-  else
-    __ns = 0;
-  for (; __ob < __op; ++__ob, ++__s)
-    *__s = *__ob;
-  for (; __ns; --__ns, ++__s)
-    *__s = __fl;
-  for (; __ob < __oe; ++__ob, ++__s)
-    *__s = *__ob;
-  __iob.width(0);
-  return __s;
-}
-
-template <class _CharT, class _Traits>
-_LIBCPP_HIDE_FROM_ABI ostreambuf_iterator<_CharT, _Traits> __pad_and_output(
-    ostreambuf_iterator<_CharT, _Traits> __s,
-    const _CharT* __ob,
-    const _CharT* __op,
-    const _CharT* __oe,
-    ios_base& __iob,
-    _CharT __fl) {
-  if (__s.__sbuf_ == nullptr)
-    return __s;
-  streamsize __sz = __oe - __ob;
-  streamsize __ns = __iob.width();
-  if (__ns > __sz)
-    __ns -= __sz;
-  else
-    __ns = 0;
-  streamsize __np = __op - __ob;
-  if (__np > 0) {
-    if (__s.__sbuf_->sputn(__ob, __np) != __np) {
-      __s.__sbuf_ = nullptr;
-      return __s;
-    }
-  }
-  if (__ns > 0) {
-    basic_string<_CharT, _Traits> __sp(__ns, __fl);
-    if (__s.__sbuf_->sputn(__sp.data(), __ns) != __ns) {
-      __s.__sbuf_ = nullptr;
-      return __s;
-    }
-  }
-  __np = __oe - __op;
-  if (__np > 0) {
-    if (__s.__sbuf_->sputn(__op, __np) != __np) {
-      __s.__sbuf_ = nullptr;
-      return __s;
-    }
-  }
-  __iob.width(0);
-  return __s;
-}
 
 template <class _CharT, class _OutputIterator>
 _OutputIterator

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1460,7 +1460,9 @@ module std [system] {
 
   module locale {
     header "locale"
-    header "__locale_dir/locale_guard.h"
+
+    module locale_guard   { header "__locale_dir/locale_guard.h" }
+    module pad_and_output { header "__locale_dir/pad_and_output.h" }
 
     module support {
       header "__locale_dir/locale_base_api.h"
@@ -1641,6 +1643,7 @@ module std [system] {
       header "__ostream/print.h"
       export *
     }
+    module put_character_sequence { header "__ostream/put_character_sequence.h" }
 
     header "ostream"
     export *

--- a/libcxx/test/libcxx/transitive_includes/cxx23.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx23.csv
@@ -331,7 +331,6 @@ experimental/utility initializer_list
 experimental/utility limits
 experimental/utility utility
 experimental/utility version
-filesystem bitset
 filesystem cctype
 filesystem cerrno
 filesystem climits
@@ -349,7 +348,6 @@ filesystem initializer_list
 filesystem iomanip
 filesystem ios
 filesystem iosfwd
-filesystem istream
 filesystem limits
 filesystem locale
 filesystem new
@@ -498,7 +496,6 @@ future tuple
 future typeinfo
 future version
 initializer_list version
-iomanip bitset
 iomanip cctype
 iomanip cerrno
 iomanip climits
@@ -515,7 +512,6 @@ iomanip cwctype
 iomanip initializer_list
 iomanip ios
 iomanip iosfwd
-iomanip istream
 iomanip limits
 iomanip locale
 iomanip new

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -331,7 +331,6 @@ experimental/utility initializer_list
 experimental/utility limits
 experimental/utility utility
 experimental/utility version
-filesystem bitset
 filesystem cctype
 filesystem cerrno
 filesystem climits
@@ -349,7 +348,6 @@ filesystem initializer_list
 filesystem iomanip
 filesystem ios
 filesystem iosfwd
-filesystem istream
 filesystem limits
 filesystem locale
 filesystem new
@@ -497,7 +495,6 @@ future tuple
 future typeinfo
 future version
 initializer_list version
-iomanip bitset
 iomanip cctype
 iomanip cerrno
 iomanip climits
@@ -514,7 +511,6 @@ iomanip cwctype
 iomanip initializer_list
 iomanip ios
 iomanip iosfwd
-iomanip istream
 iomanip limits
 iomanip locale
 iomanip new


### PR DESCRIPTION
This reduces the include time of `<filesystem>` by ~50ms.
