### PR TITLE
[AArch64] Remove unused SDNodes (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2943,10 +2943,6 @@ const char *AArch64TargetLowering::getTargetNodeName(unsigned Opcode) const {
     MAKE_CASE(AArch64ISD::UADDLP)
     MAKE_CASE(AArch64ISD::CALL_RVMARKER)
     MAKE_CASE(AArch64ISD::ASSERT_ZEXT_BOOL)
-    MAKE_CASE(AArch64ISD::MOPS_MEMSET)
-    MAKE_CASE(AArch64ISD::MOPS_MEMSET_TAGGING)
-    MAKE_CASE(AArch64ISD::MOPS_MEMCOPY)
-    MAKE_CASE(AArch64ISD::MOPS_MEMMOVE)
     MAKE_CASE(AArch64ISD::CALL_BTI)
     MAKE_CASE(AArch64ISD::MRRS)
     MAKE_CASE(AArch64ISD::MSRR)
@@ -5921,9 +5917,9 @@ SDValue AArch64TargetLowering::LowerINTRINSIC_W_CHAIN(SDValue Op,
 
     const auto &SDI =
         static_cast<const AArch64SelectionDAGInfo &>(DAG.getSelectionDAGInfo());
-    SDValue MS =
-        SDI.EmitMOPS(AArch64ISD::MOPS_MEMSET_TAGGING, DAG, DL, Chain, Dst, Val,
-                     Size, Alignment, IsVol, DstPtrInfo, MachinePointerInfo{});
+    SDValue MS = SDI.EmitMOPS(AArch64::MOPSMemorySetTaggingPseudo, DAG, DL,
+                              Chain, Dst, Val, Size, Alignment, IsVol,
+                              DstPtrInfo, MachinePointerInfo{});
 
     // MOPS_MEMSET_TAGGING has 3 results (DstWb, SizeWb, Chain) whereas the
     // intrinsic has 2. So hide SizeWb using MERGE_VALUES. Otherwise

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -514,12 +514,6 @@ enum NodeType : unsigned {
   STP,
   STILP,
   STNP,
-
-  // Memory Operations
-  MOPS_MEMSET,
-  MOPS_MEMSET_TAGGING,
-  MOPS_MEMCOPY,
-  MOPS_MEMMOVE,
 };
 
 } // end namespace AArch64ISD

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -10077,14 +10077,6 @@ let Predicates = [HasMOPS, HasMTE] in {
   }
 }
 
-// MOPS Node operands: 0: Dst, 1: Src or Value, 2: Size, 3: Chain
-// MOPS Node results: 0: Dst writeback, 1: Size writeback, 2: Chain
-def SDT_AArch64mops : SDTypeProfile<2, 3, [ SDTCisInt<0>, SDTCisInt<1>, SDTCisInt<2> ]>;
-def AArch64mops_memset : SDNode<"AArch64ISD::MOPS_MEMSET", SDT_AArch64mops>;
-def AArch64mops_memset_tagging : SDNode<"AArch64ISD::MOPS_MEMSET_TAGGING", SDT_AArch64mops>;
-def AArch64mops_memcopy : SDNode<"AArch64ISD::MOPS_MEMCOPY", SDT_AArch64mops>;
-def AArch64mops_memmove : SDNode<"AArch64ISD::MOPS_MEMMOVE", SDT_AArch64mops>;
-
 // MOPS operations always contain three 4-byte instructions
 let Predicates = [HasMOPS], Defs = [NZCV], Size = 12, mayStore = 1 in {
   let mayLoad = 1 in {

--- a/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.cpp
@@ -23,11 +23,11 @@ static cl::opt<bool>
                                 "to lower to librt functions"),
                        cl::init(true));
 
-SDValue AArch64SelectionDAGInfo::EmitMOPS(AArch64ISD::NodeType SDOpcode,
-                                          SelectionDAG &DAG, const SDLoc &DL,
-                                          SDValue Chain, SDValue Dst,
-                                          SDValue SrcOrValue, SDValue Size,
-                                          Align Alignment, bool isVolatile,
+SDValue AArch64SelectionDAGInfo::EmitMOPS(unsigned Opcode, SelectionDAG &DAG,
+                                          const SDLoc &DL, SDValue Chain,
+                                          SDValue Dst, SDValue SrcOrValue,
+                                          SDValue Size, Align Alignment,
+                                          bool isVolatile,
                                           MachinePointerInfo DstPtrInfo,
                                           MachinePointerInfo SrcPtrInfo) const {
 
@@ -36,23 +36,8 @@ SDValue AArch64SelectionDAGInfo::EmitMOPS(AArch64ISD::NodeType SDOpcode,
   if (auto *C = dyn_cast<ConstantSDNode>(Size))
     ConstSize = C->getZExtValue();
 
-  const bool IsSet = SDOpcode == AArch64ISD::MOPS_MEMSET ||
-                     SDOpcode == AArch64ISD::MOPS_MEMSET_TAGGING;
-
-  const auto MachineOpcode = [&]() {
-    switch (SDOpcode) {
-    case AArch64ISD::MOPS_MEMSET:
-      return AArch64::MOPSMemorySetPseudo;
-    case AArch64ISD::MOPS_MEMSET_TAGGING:
-      return AArch64::MOPSMemorySetTaggingPseudo;
-    case AArch64ISD::MOPS_MEMCOPY:
-      return AArch64::MOPSMemoryCopyPseudo;
-    case AArch64ISD::MOPS_MEMMOVE:
-      return AArch64::MOPSMemoryMovePseudo;
-    default:
-      llvm_unreachable("Unhandled MOPS ISD Opcode");
-    }
-  }();
+  const bool IsSet = Opcode == AArch64::MOPSMemorySetPseudo ||
+                     Opcode == AArch64::MOPSMemorySetTaggingPseudo;
 
   MachineFunction &MF = DAG.getMachineFunction();
 
@@ -68,13 +53,13 @@ SDValue AArch64SelectionDAGInfo::EmitMOPS(AArch64ISD::NodeType SDOpcode,
       SrcOrValue = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i64, SrcOrValue);
     SDValue Ops[] = {Dst, Size, SrcOrValue, Chain};
     const EVT ResultTys[] = {MVT::i64, MVT::i64, MVT::Other};
-    MachineSDNode *Node = DAG.getMachineNode(MachineOpcode, DL, ResultTys, Ops);
+    MachineSDNode *Node = DAG.getMachineNode(Opcode, DL, ResultTys, Ops);
     DAG.setNodeMemRefs(Node, {DstOp});
     return SDValue(Node, 2);
   } else {
     SDValue Ops[] = {Dst, SrcOrValue, Size, Chain};
     const EVT ResultTys[] = {MVT::i64, MVT::i64, MVT::i64, MVT::Other};
-    MachineSDNode *Node = DAG.getMachineNode(MachineOpcode, DL, ResultTys, Ops);
+    MachineSDNode *Node = DAG.getMachineNode(Opcode, DL, ResultTys, Ops);
 
     auto SrcFlags = MachineMemOperand::MOLoad | Vol;
     auto *SrcOp =
@@ -150,8 +135,8 @@ SDValue AArch64SelectionDAGInfo::EmitTargetCodeForMemcpy(
       DAG.getMachineFunction().getSubtarget<AArch64Subtarget>();
 
   if (STI.hasMOPS())
-    return EmitMOPS(AArch64ISD::MOPS_MEMCOPY, DAG, DL, Chain, Dst, Src, Size,
-                    Alignment, isVolatile, DstPtrInfo, SrcPtrInfo);
+    return EmitMOPS(AArch64::MOPSMemoryCopyPseudo, DAG, DL, Chain, Dst, Src,
+                    Size, Alignment, isVolatile, DstPtrInfo, SrcPtrInfo);
 
   SMEAttrs Attrs(DAG.getMachineFunction().getFunction());
   if (LowerToSMERoutines && !Attrs.hasNonStreamingInterfaceAndBody())
@@ -168,8 +153,9 @@ SDValue AArch64SelectionDAGInfo::EmitTargetCodeForMemset(
       DAG.getMachineFunction().getSubtarget<AArch64Subtarget>();
 
   if (STI.hasMOPS())
-    return EmitMOPS(AArch64ISD::MOPS_MEMSET, DAG, dl, Chain, Dst, Src, Size,
-                    Alignment, isVolatile, DstPtrInfo, MachinePointerInfo{});
+    return EmitMOPS(AArch64::MOPSMemorySetPseudo, DAG, dl, Chain, Dst, Src,
+                    Size, Alignment, isVolatile, DstPtrInfo,
+                    MachinePointerInfo{});
 
   SMEAttrs Attrs(DAG.getMachineFunction().getFunction());
   if (LowerToSMERoutines && !Attrs.hasNonStreamingInterfaceAndBody())
@@ -186,8 +172,8 @@ SDValue AArch64SelectionDAGInfo::EmitTargetCodeForMemmove(
       DAG.getMachineFunction().getSubtarget<AArch64Subtarget>();
 
   if (STI.hasMOPS())
-    return EmitMOPS(AArch64ISD::MOPS_MEMMOVE, DAG, dl, Chain, Dst, Src, Size,
-                    Alignment, isVolatile, DstPtrInfo, SrcPtrInfo);
+    return EmitMOPS(AArch64::MOPSMemoryMovePseudo, DAG, dl, Chain, Dst, Src,
+                    Size, Alignment, isVolatile, DstPtrInfo, SrcPtrInfo);
 
   SMEAttrs Attrs(DAG.getMachineFunction().getFunction());
   if (LowerToSMERoutines && !Attrs.hasNonStreamingInterfaceAndBody())

--- a/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.h
@@ -19,10 +19,10 @@ namespace llvm {
 
 class AArch64SelectionDAGInfo : public SelectionDAGTargetInfo {
 public:
-  SDValue EmitMOPS(AArch64ISD::NodeType SDOpcode, SelectionDAG &DAG,
-                   const SDLoc &DL, SDValue Chain, SDValue Dst,
-                   SDValue SrcOrValue, SDValue Size, Align Alignment,
-                   bool isVolatile, MachinePointerInfo DstPtrInfo,
+  SDValue EmitMOPS(unsigned Opcode, SelectionDAG &DAG, const SDLoc &DL,
+                   SDValue Chain, SDValue Dst, SDValue SrcOrValue, SDValue Size,
+                   Align Alignment, bool isVolatile,
+                   MachinePointerInfo DstPtrInfo,
                    MachinePointerInfo SrcPtrInfo) const;
 
   SDValue EmitTargetCodeForMemcpy(SelectionDAG &DAG, const SDLoc &dl,


### PR DESCRIPTION
The corresponding enum members were only used by `EmitMOPS`, which
immediately translated them to machine opcodes. Just pass the machine
opcodes instead.
