### PR TITLE
No longer assert when using noderef on an _Atomic type

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -553,6 +553,8 @@ Bug Fixes in This Version
   the unsupported type instead of the ``register`` keyword (#GH109776).
 - Fixed a crash when emit ctor for global variant with flexible array init (#GH113187).
 - Fixed a crash when GNU statement expression contains invalid statement (#GH113468).
+- Fixed a failed assertion when using ``__attribute__((noderef))`` on an
+  ``_Atomic``-qualified type (#GH116124).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/Frontend/noderef.cpp
+++ b/clang/test/Frontend/noderef.cpp
@@ -186,6 +186,5 @@ const int *const_cast_check(NODEREF int *x) {
 
 namespace GH116124 {
 // This declaration would previously cause a failed assertion.
-int *_Atomic a __attribute__((noderef)); // expected-note {{declared here}}
-int x = *a;                              // expected-warning{{dereferencing a; was declared with a 'noderef' type}}
+int *_Atomic a __attribute__((noderef));
 }

--- a/clang/test/Frontend/noderef.cpp
+++ b/clang/test/Frontend/noderef.cpp
@@ -183,3 +183,9 @@ int *const_cast_check(NODEREF const int *x) {
 const int *const_cast_check(NODEREF int *x) {
   return const_cast<const int *>(x); // expected-warning{{casting to dereferenceable pointer removes 'noderef' attribute}}
 }
+
+namespace GH116124 {
+// This declaration would previously cause a failed assertion.
+int *_Atomic a __attribute__((noderef)); // expected-note {{declared here}}
+int x = *a;                              // expected-warning{{dereferencing a; was declared with a 'noderef' type}}
+}


### PR DESCRIPTION
When filling out the type locations for a declarator, we handled atomic types and we handled noderef types, but we didn't handle atomic noderef types.

Fixes #116124