### PR TITLE
[X86][StrictFP] Add missing patterns for AVX512 fmin/fmax

### DIFF
--- a/llvm/lib/Target/X86/X86InstrAVX512.td
+++ b/llvm/lib/Target/X86/X86InstrAVX512.td
@@ -5690,13 +5690,13 @@ defm VDIV : avx512_fp_binop_p<0x5E, "vdiv", any_fdiv, fdiv, HasAVX512,
                               SchedWriteFDivSizes>,
             avx512_fp_binop_ph<0x5E, "vdiv", any_fdiv, fdiv, SchedWriteFDivSizes>,
             avx512_fp_binop_p_round<0x5E, "vdiv", X86fdivRnd, SchedWriteFDivSizes>;
-defm VMIN : avx512_fp_binop_p<0x5D, "vmin", X86fmin, X86fmin, HasAVX512,
+defm VMIN : avx512_fp_binop_p<0x5D, "vmin", X86any_fmin, X86fmin, HasAVX512,
                               SchedWriteFCmpSizes, 0>,
-            avx512_fp_binop_ph<0x5D, "vmin", X86fmin, X86fmin, SchedWriteFCmpSizes, 0>,
+            avx512_fp_binop_ph<0x5D, "vmin", X86any_fmin, X86fmin, SchedWriteFCmpSizes, 0>,
             avx512_fp_binop_p_sae<0x5D, "vmin", X86fminSAE, SchedWriteFCmpSizes>;
-defm VMAX : avx512_fp_binop_p<0x5F, "vmax", X86fmax, X86fmax, HasAVX512,
+defm VMAX : avx512_fp_binop_p<0x5F, "vmax", X86any_fmax, X86fmax, HasAVX512,
                               SchedWriteFCmpSizes, 0>,
-            avx512_fp_binop_ph<0x5F, "vmax", X86fmax, X86fmax, SchedWriteFCmpSizes, 0>,
+            avx512_fp_binop_ph<0x5F, "vmax", X86any_fmax, X86fmax, SchedWriteFCmpSizes, 0>,
             avx512_fp_binop_p_sae<0x5F, "vmax", X86fmaxSAE, SchedWriteFCmpSizes>;
 let isCodeGenOnly = 1 in {
   defm VMINC : avx512_fp_binop_p<0x5D, "vmin", X86fminc, X86fminc, HasAVX512,

--- a/llvm/test/CodeGen/X86/vec-strict-cmp-128.ll
+++ b/llvm/test/CodeGen/X86/vec-strict-cmp-128.ll
@@ -6040,6 +6040,53 @@ define <2 x i64> @test_v2f64_uno_s(<2 x i64> %a, <2 x i64> %b, <2 x double> %f1,
   ret <2 x i64> %res
 }
 
+define <2 x double> @test_v4f64_ogt2_s(<2 x double> %a, <2 x double> %b) #0 {
+; SSE-32-LABEL: test_v4f64_ogt2_s:
+; SSE-32:       # %bb.0:
+; SSE-32-NEXT:    maxpd %xmm1, %xmm0
+; SSE-32-NEXT:    retl
+;
+; SSE-64-LABEL: test_v4f64_ogt2_s:
+; SSE-64:       # %bb.0:
+; SSE-64-NEXT:    maxpd %xmm1, %xmm0
+; SSE-64-NEXT:    retq
+;
+; AVX-32-LABEL: test_v4f64_ogt2_s:
+; AVX-32:       # %bb.0:
+; AVX-32-NEXT:    vmaxpd %xmm1, %xmm0, %xmm0
+; AVX-32-NEXT:    retl
+;
+; AVX-64-LABEL: test_v4f64_ogt2_s:
+; AVX-64:       # %bb.0:
+; AVX-64-NEXT:    vmaxpd %xmm1, %xmm0, %xmm0
+; AVX-64-NEXT:    retq
+;
+; AVX512-32-LABEL: test_v4f64_ogt2_s:
+; AVX512-32:       # %bb.0:
+; AVX512-32-NEXT:    vmaxpd %xmm1, %xmm0, %xmm0
+; AVX512-32-NEXT:    retl
+;
+; AVX512-64-LABEL: test_v4f64_ogt2_s:
+; AVX512-64:       # %bb.0:
+; AVX512-64-NEXT:    vmaxpd %xmm1, %xmm0, %xmm0
+; AVX512-64-NEXT:    retq
+;
+; AVX512F-32-LABEL: test_v4f64_ogt2_s:
+; AVX512F-32:       # %bb.0:
+; AVX512F-32-NEXT:    vmaxpd %xmm1, %xmm0, %xmm0
+; AVX512F-32-NEXT:    retl
+;
+; AVX512F-64-LABEL: test_v4f64_ogt2_s:
+; AVX512F-64:       # %bb.0:
+; AVX512F-64-NEXT:    vmaxpd %xmm1, %xmm0, %xmm0
+; AVX512F-64-NEXT:    retq
+  %cond = call <2 x i1> @llvm.experimental.constrained.fcmps.v2f64(
+                                               <2 x double> %a, <2 x double> %b, metadata !"ogt",
+                                               metadata !"fpexcept.strict") #0
+  %res = select <2 x i1> %cond, <2 x double> %a, <2 x double> %b
+  ret <2 x double> %res
+}
+
 attributes #0 = { strictfp nounwind }
 
 declare <4 x i1> @llvm.experimental.constrained.fcmp.v4f32(<4 x float>, <4 x float>, metadata, metadata)


### PR DESCRIPTION
Fix crash after #109512, see https://godbolt.org/z/M6aP5Ka4j