### PR TITLE
[LLD][COFF] Fix handling of invalid ARM64EC function names

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -714,9 +714,8 @@ Symbol *LinkerDriver::addUndefined(StringRef name, bool aliasEC) {
         Symbol *t = ctx.symtab.addUndefined(saver().save(*mangledName));
         u->setWeakAlias(t, true);
       }
-    } else {
-      std::optional<std::string> demangledName =
-          getArm64ECDemangledFunctionName(name);
+    } else if (std::optional<std::string> demangledName =
+                   getArm64ECDemangledFunctionName(name)) {
       Symbol *us = ctx.symtab.addUndefined(saver().save(*demangledName));
       auto u = dyn_cast<Undefined>(us);
       if (u && !u->weakAlias)

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -669,8 +669,11 @@ bool checkLazyECPair(SymbolTable *symtab, StringRef name, InputFile *f) {
   if (std::optional<std::string> mangledName =
           getArm64ECMangledFunctionName(name))
     pairName = std::move(*mangledName);
+  else if (std::optional<std::string> demangledName =
+               getArm64ECDemangledFunctionName(name))
+    pairName = std::move(*demangledName);
   else
-    pairName = *getArm64ECDemangledFunctionName(name);
+    return true;
 
   Symbol *sym = symtab->find(pairName);
   if (!sym)

--- a/lld/test/COFF/arm64ec-invalid-name.s
+++ b/lld/test/COFF/arm64ec-invalid-name.s
@@ -1,0 +1,15 @@
+// REQUIRES: aarch64
+
+// Verify that an error is emitted when attempting to export an invalid function name.
+// RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %s -o %t.obj
+// RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %S/Inputs/loadconfig-arm64ec.s -o %t-loadconfig.obj
+// RUN: not lld-link -machine:arm64ec -dll -noentry "-export:?func" %t-loadconfig.obj %t.obj 2>&1 | FileCheck %s
+// CHECK: error: Invalid ARM64EC function name '?func'
+
+// Verify that we can handle an invalid function name in the archive map.
+// RUN: llvm-lib -machine:arm64ec -out:%t.lib %t.obj
+// RUN: lld-link -machine:arm64ec -dll -noentry %t-loadconfig.obj %t.lib
+
+        .globl "?func"
+"?func":
+        ret


### PR DESCRIPTION
Since these symbols cannot be mangled or demangled, there is no symbol to check for conflicts in `checkLazyECPair`, nor is there an alias to create in `addUndefined`. Attempting to create an import library with such symbols results in an error; the patch includes a test to ensure the error is handled correctly.

This is a follow-up to #115567.