### PR TITLE
[memprof] Use ArrayRef instead of std::vector<LinearFrameId> (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -1134,7 +1134,7 @@ public:
              const llvm::DenseMap<FrameId, LinearFrameId> &MemProfFrameIndexes,
              llvm::DenseMap<FrameId, FrameStat> &FrameHistogram);
 
-  const std::vector<LinearFrameId> &getRadixArray() const { return RadixArray; }
+  ArrayRef<LinearFrameId> getRadixArray() const { return RadixArray; }
 
   llvm::DenseMap<CallStackId, LinearCallStackId> takeCallStackPos() {
     return std::move(CallStackPos);


### PR DESCRIPTION
LLVM Programmer's Manual prefers ArrayRef over actual sequential
container types for read accesses.
