### PR TITLE
[mlir][IntRangeInference] Handle ceildivsi(INT_MIN, x > 1) as expected

### DIFF
--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -249,6 +249,19 @@ func.func @ceil_divsi(%arg0 : index) -> i1 {
     func.return %10 : i1
 }
 
+// CHECK-LABEL: func @ceil_divsi_intmin_bug_115293
+// CHECK: %[[ret:.*]] = arith.constant true
+// CHECK: return %[[ret]]
+func.func @ceil_divsi_intmin_bug_115293() -> i1 {
+    %cIntMin_i64 = arith.constant -9223372036854775808 : i64
+    %cDenom_i64 = arith.constant 1189465982 : i64
+    %cRes_i64 = arith.constant 7754212542 : i64
+
+    %0 = arith.ceildivsi %cIntMin_i64, %cDenom_i64 : i64
+    %1 = arith.cmpi eq, %0, %cRes_i64 : i64
+    func.return %1 : i1
+}
+
 // CHECK-LABEL: func @floor_divsi
 // CHECK: %[[true:.*]] = arith.constant true
 // CHECK: return %[[true]]

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -254,13 +254,11 @@ func.func @ceil_divsi(%arg0 : index) -> i1 {
 // CHECK: return %[[ret]]
 func.func @ceil_divsi_intmin_bug_115293() -> i1 {
     %intMin_i64 = test.with_bounds { smin = -9223372036854775808 : si64, smax = -9223372036854775808 : si64, umin = 9223372036854775808 : ui64, umax = 9223372036854775808 : ui64 } : i64
+    %denom_i64 = test.with_bounds { smin = 1189465982 : si64, smax = 1189465982 : si64, umin = 1189465982 : ui64, umax = 1189465982 : ui64 } : i64
+    %res_i64 = test.with_bounds { smin = 7754212542 : si64, smax = 7754212542 : si64, umin = 7754212542 : ui64, umax = 7754212542 : ui64 }  : i64
 
-    %cIntMin_i64 = arith.constant -9223372036854775808 : i64
-    %cDenom_i64 = arith.constant 1189465982 : i64
-    %cRes_i64 = arith.constant 7754212542 : i64
-
-    %0 = arith.ceildivsi %cIntMin_i64, %cDenom_i64 : i64
-    %1 = arith.cmpi eq, %0, %cRes_i64 : i64
+    %0 = arith.ceildivsi %intMin_i64, %denom_i64 : i64
+    %1 = arith.cmpi eq, %0, %res_i64 : i64
     func.return %1 : i1
 }
 

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -253,6 +253,8 @@ func.func @ceil_divsi(%arg0 : index) -> i1 {
 // CHECK: %[[ret:.*]] = arith.constant true
 // CHECK: return %[[ret]]
 func.func @ceil_divsi_intmin_bug_115293() -> i1 {
+    %intMin_i64 = test.with_bounds { smin = -9223372036854775808 : si64, smax = -9223372036854775808 : si64, umin = 9223372036854775808 : ui64, umax = 9223372036854775808 : ui64 } : i64
+
     %cIntMin_i64 = arith.constant -9223372036854775808 : i64
     %cDenom_i64 = arith.constant 1189465982 : i64
     %cRes_i64 = arith.constant 7754212542 : i64


### PR DESCRIPTION
Fixes #115293

While the definition of ceildivsi is integer division, rounding up, most implementations will use `-(-a / b)` for dividing `a ceildiv b` with `a` negative and `b` positive.

Mathematically, and for most integers, these two definitions are equivalent. However, with `a == INT_MIN`, the initial negation is a noop, which means that, while divinding and rounding up would give a negative result, `-((- INT_MIN) / b)` is `-(INT_MIN / b)`, which is positive.

This commit adds a special case to ceilDivSI inference to handle this case and bring it in line with the operational instead of the mathematical semantics of ceiling division.