### PR TITLE
[MLIR][mlir-opt] Add option to turn off verifier on parsing

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -183,6 +183,13 @@ public:
   }
   bool shouldVerifyPasses() const { return verifyPassesFlag; }
 
+  /// Set whether to run the verifier on parsing.
+  MlirOptMainConfig &verifyOnParsing(bool verify) {
+    disableVerifierOnParsingFlag = !verify;
+    return *this;
+  }
+  bool shouldVerifyOnParsing() const { return !disableVerifierOnParsingFlag; }
+
   /// Set whether to run the verifier after each transformation pass.
   MlirOptMainConfig &verifyRoundtrip(bool verify) {
     verifyRoundtripFlag = verify;
@@ -251,6 +258,9 @@ protected:
 
   /// Run the verifier after each transformation pass.
   bool verifyPassesFlag = true;
+
+  /// Disable the verifier on parsing.
+  bool disableVerifierOnParsingFlag = false;
 
   /// Verify that the input IR round-trips perfectly.
   bool verifyRoundtripFlag = false;

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -159,6 +159,11 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::desc("Run the verifier after each transformation pass"),
         cl::location(verifyPassesFlag), cl::init(true));
 
+    static cl::opt<bool, /*ExternalStorage=*/true> disableVerifyOnParsing(
+        "mlir-very-unsafe-disable-verifier-on-parsing",
+        cl::desc("Disable the verifier on parsing (very unsafe)"),
+        cl::location(disableVerifierOnParsingFlag), cl::init(false));
+
     static cl::opt<bool, /*ExternalStorage=*/true> verifyRoundtrip(
         "verify-roundtrip",
         cl::desc("Round-trip the IR after parsing and ensure it succeeds"),
@@ -310,7 +315,7 @@ static LogicalResult doVerifyRoundTrip(Operation *op,
                 OpPrintingFlags().printGenericOpForm().enableDebugInfo());
     }
     FallbackAsmResourceMap fallbackResourceMap;
-    ParserConfig parseConfig(&roundtripContext, /*verifyAfterParse=*/true,
+    ParserConfig parseConfig(&roundtripContext, config.shouldVerifyOnParsing(),
                              &fallbackResourceMap);
     roundtripModule = parseSourceString<Operation *>(buffer, parseConfig);
     if (!roundtripModule) {
@@ -377,7 +382,7 @@ performActions(raw_ostream &os,
   // untouched.
   PassReproducerOptions reproOptions;
   FallbackAsmResourceMap fallbackResourceMap;
-  ParserConfig parseConfig(context, /*verifyAfterParse=*/true,
+  ParserConfig parseConfig(context, config.shouldVerifyOnParsing(),
                            &fallbackResourceMap);
   if (config.shouldRunReproducer())
     reproOptions.attachResourceParser(parseConfig);


### PR DESCRIPTION
The MLIR developer guide advocates only verifying local aspects of an operation (see
https://mlir.llvm.org/getting_started/DeveloperGuide/#ir-verifier). This likely implies that verifiers should be fast.

Sometimes, however, a developer may not wish to wait for the verifier (imagine they did not follow the verifier guidelines and chased use-def chains), or may wish to disable it. Indeed, mlir-opt already contains the `--verify-each` flag which turns off the verifier in passes, but not in parsing.

Add a command-line option,
`--mlir-very-unsafe-disable-verifier-on-parsing`, which similarly turns off the verifier on parsing.

------

This implements the discussion from https://discourse.llvm.org/t/optionally-turn-off-verifier-during-parsing/82805
CC @joker-eph (thank you)