### PR TITLE
[lldb/Target] Add null-check before dereferencing inlined_info (NFC)

### DIFF
--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1239,7 +1239,8 @@ const char *StackFrame::GetFunctionName() {
     if (inlined_block) {
       const InlineFunctionInfo *inlined_info =
           inlined_block->GetInlinedFunctionInfo();
-      name = inlined_info->GetName().AsCString();
+      if (inlined_info)
+        name = inlined_info->GetName().AsCString();
     }
   }
 
@@ -1265,7 +1266,8 @@ const char *StackFrame::GetDisplayFunctionName() {
     if (inlined_block) {
       const InlineFunctionInfo *inlined_info =
           inlined_block->GetInlinedFunctionInfo();
-      name = inlined_info->GetDisplayName().AsCString();
+      if (inlined_info)
+        name = inlined_info->GetDisplayName().AsCString();
     }
   }
 


### PR DESCRIPTION
This patch is a follow-up to 9c7701fa78037af03be10ed168fd3c75a2ed1aef and adds extra-null checks before dereferencing the inlined_info pointer.