### PR TITLE
[docs][asan][lsan] Drop list of supported architechures

### DIFF
--- a/clang/docs/AddressSanitizer.rst
+++ b/clang/docs/AddressSanitizer.rst
@@ -326,15 +326,13 @@ Supported Platforms
 
 AddressSanitizer is supported on:
 
-* Linux i386/x86\_64 (tested on Ubuntu 12.04)
-* macOS 10.7 - 10.11 (i386/x86\_64)
+* Linux
+* macOS
 * iOS Simulator
-* Android ARM
-* NetBSD i386/x86\_64
-* FreeBSD i386/x86\_64 (tested on FreeBSD 11-current)
-* Windows 8.1+ (i386/x86\_64)
-
-Ports to various other platforms are in progress.
+* Android
+* NetBSD
+* FreeBSD
+* Windows 8.1+
 
 Current Status
 ==============

--- a/clang/docs/LeakSanitizer.rst
+++ b/clang/docs/LeakSanitizer.rst
@@ -54,11 +54,11 @@ constraints in mind and may compromise the security of the resulting executable.
 Supported Platforms
 ===================
 
-* Android aarch64/i386/x86_64
-* Fuchsia aarch64/x86_64
-* Linux arm/aarch64/mips64/ppc64/ppc64le/riscv64/s390x/i386/x86\_64
-* macOS aarch64/i386/x86\_64
-* NetBSD i386/x86_64
+* Android
+* Fuchsia
+* Linux
+* macOS
+* NetBSD
 
 More Information
 ================


### PR DESCRIPTION
Full list is quite long, and quality of implementation can
vary.

Drop the lists to avoid confusion like
https://github.com/rust-lang/rust/pull/123617#issuecomment-2471695102

We don't maintain these for other sanitizers.
