### PR TITLE
[memprof] Use llvm::function_ref instead of std::function

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -895,11 +895,12 @@ struct LinearFrameIdConverter {
 // call stack array in the profile.
 struct LinearCallStackIdConverter {
   const unsigned char *CallStackBase;
-  std::function<Frame(LinearFrameId)> FrameIdToFrame;
+  llvm::function_ref<Frame(LinearFrameId)> FrameIdToFrame;
 
   LinearCallStackIdConverter() = delete;
-  LinearCallStackIdConverter(const unsigned char *CallStackBase,
-                             std::function<Frame(LinearFrameId)> FrameIdToFrame)
+  LinearCallStackIdConverter(
+      const unsigned char *CallStackBase,
+      llvm::function_ref<Frame(LinearFrameId)> FrameIdToFrame)
       : CallStackBase(CallStackBase), FrameIdToFrame(FrameIdToFrame) {}
 
   std::vector<Frame> operator()(LinearCallStackId LinearCSId) {
@@ -966,13 +967,14 @@ struct CallerCalleePairExtractor {
   // The base address of the radix tree array.
   const unsigned char *CallStackBase;
   // A functor to convert a linear FrameId to a Frame.
-  std::function<Frame(LinearFrameId)> FrameIdToFrame;
+  llvm::function_ref<Frame(LinearFrameId)> FrameIdToFrame;
   // A map from caller GUIDs to lists of call sites in respective callers.
   DenseMap<uint64_t, SmallVector<CallEdgeTy, 0>> CallerCalleePairs;
 
   CallerCalleePairExtractor() = delete;
-  CallerCalleePairExtractor(const unsigned char *CallStackBase,
-                            std::function<Frame(LinearFrameId)> FrameIdToFrame)
+  CallerCalleePairExtractor(
+      const unsigned char *CallStackBase,
+      llvm::function_ref<Frame(LinearFrameId)> FrameIdToFrame)
       : CallStackBase(CallStackBase), FrameIdToFrame(FrameIdToFrame) {}
 
   void operator()(LinearCallStackId LinearCSId) {

--- a/llvm/lib/ProfileData/InstrProfReader.cpp
+++ b/llvm/lib/ProfileData/InstrProfReader.cpp
@@ -1688,10 +1688,11 @@ IndexedMemProfReader::getMemProfCallerCalleePairs() const {
   // duplicates, we first collect them in the form of a bit vector before
   // processing them.
   for (const memprof::IndexedMemProfRecord &IndexedRecord :
-       MemProfRecordTable->data())
+       MemProfRecordTable->data()) {
     for (const memprof::IndexedAllocationInfo &IndexedAI :
          IndexedRecord.AllocSites)
       Worklist.set(IndexedAI.CSId);
+  }
 
   // Collect caller-callee pairs for each linear call stack ID in Worklist.
   for (unsigned CS : Worklist.set_bits())


### PR DESCRIPTION
We've seen bugs where we lost track of error states stored in the
functor because we passed the functor by value (that is,
std::function) as opposed to reference (llvm::function_ref).

This patch fixes a couple of places we pass functors by value.

While we are at it, this patch adds curly braces around a "for" loop
spanning multiple lines.
