### PR TITLE
[MLIR] Add SystemZ arg extensions for some tests

### DIFF
--- a/mlir/test/CAPI/execution_engine.c
+++ b/mlir/test/CAPI/execution_engine.c
@@ -55,7 +55,11 @@ void testSimpleExecution(void) {
       ctx, mlirStringRefCreateFromCString(
                // clang-format off
 "module {                                                                    \n"
+#ifdef __s390__
+"  func.func @add(%arg0 : i32) -> (i32 {llvm.signext}) attributes { llvm.emit_c_interface } {     \n"
+#else
 "  func.func @add(%arg0 : i32) -> i32 attributes { llvm.emit_c_interface } {     \n"
+#endif
 "    %res = arith.addi %arg0, %arg0 : i32                                        \n"
 "    return %res : i32                                                           \n"
 "  }                                                                             \n"

--- a/mlir/test/mlir-cpu-runner/simple.mlir
+++ b/mlir/test/mlir-cpu-runner/simple.mlir
@@ -1,15 +1,47 @@
-// RUN: mlir-cpu-runner %s -argext-abi-check=false | FileCheck %s
-// RUN: mlir-cpu-runner %s -e foo  -argext-abi-check=false | FileCheck -check-prefix=NOMAIN %s
-// RUN: mlir-cpu-runner %s --entry-point-result=i32 -e int32_main -argext-abi-check=false | FileCheck -check-prefix=INT32MAIN %s
-// RUN: mlir-cpu-runner %s --entry-point-result=i64 -e int64_main -argext-abi-check=false | FileCheck -check-prefix=INT64MAIN %s
-// RUN: mlir-cpu-runner %s -O3  -argext-abi-check=false | FileCheck %s
+// RUN: %if target={{s390x-.*}} %{                                  \
+// RUN:   mlir-cpu-runner %s -argext-abi-check=false | FileCheck %s \
+// RUN: %} %else %{                                                 \
+// RUN:   mlir-cpu-runner %s  | FileCheck %s                        \
+// RUN: %}
+
+// RUN: %if target={{s390x-.*}} %{                                                              \
+// RUN:   mlir-cpu-runner %s -e foo -argext-abi-check=false | FileCheck -check-prefix=NOMAIN %s \
+// RUN: %} %else %{                                                                             \
+// RUN:   mlir-cpu-runner %s -e foo | FileCheck -check-prefix=NOMAIN %s                         \
+// RUN: %}
+
+// RUN: %if target={{s390x-.*}} %{                                                                                                  \
+// RUN:   mlir-cpu-runner %s --entry-point-result=i32 -e int32_main  -argext-abi-check=false | FileCheck -check-prefix=INT32MAIN %s \
+// RUN: %} %else %{                                                                                                                 \
+// RUN:   mlir-cpu-runner %s --entry-point-result=i32 -e int32_main | FileCheck -check-prefix=INT32MAIN %s                          \
+// RUN: %}
+
+// RUN: %if target={{s390x-.*}} %{                                                                                                 \
+// RUN:   mlir-cpu-runner %s --entry-point-result=i64 -e int64_main -argext-abi-check=false | FileCheck -check-prefix=INT64MAIN %s \
+// RUN: %} %else %{                                                                                                                \
+// RUN:   mlir-cpu-runner %s --entry-point-result=i64 -e int64_main | FileCheck -check-prefix=INT64MAIN %s                         \
+// RUN: %}
+
+// RUN: %if target={{s390x-.*}} %{                                      \
+// RUN:   mlir-cpu-runner %s -O3 -argext-abi-check=false | FileCheck %s \
+// RUN: %} %else %{                                                     \
+// RUN:   mlir-cpu-runner %s -O3 | FileCheck %s                         \
+// RUN: %}
 
 // RUN: cp %s %t
-// RUN: mlir-cpu-runner %t -dump-object-file -argext-abi-check=false | FileCheck %t
+// RUN: %if target={{s390x-.*}} %{                                                    \
+// RUN:   mlir-cpu-runner %t -dump-object-file -argext-abi-check=false | FileCheck %t \
+// RUN: %} %else %{                                                                   \
+// RUN:   mlir-cpu-runner %t -dump-object-file | FileCheck %t                         \
+// RUN: %}
+
 // RUN: ls %t.o
 // RUN: rm %t.o
-
-// RUN: mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o -argext-abi-check=false | FileCheck %s
+// RUN: %if target={{s390x-.*}} %{                                                                               \
+// RUN:   mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o -argext-abi-check=false | FileCheck %s \
+// RUN: %} %else %{                                                                                              \
+// RUN:   mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o | FileCheck %s                         \
+// RUN: %}
 // RUN: ls %T/test.o
 // RUN: rm %T/test.o
 

--- a/mlir/test/mlir-cpu-runner/simple.mlir
+++ b/mlir/test/mlir-cpu-runner/simple.mlir
@@ -1,15 +1,15 @@
-// RUN: mlir-cpu-runner %s | FileCheck %s
-// RUN: mlir-cpu-runner %s -e foo | FileCheck -check-prefix=NOMAIN %s
-// RUN: mlir-cpu-runner %s --entry-point-result=i32 -e int32_main | FileCheck -check-prefix=INT32MAIN %s
-// RUN: mlir-cpu-runner %s --entry-point-result=i64 -e int64_main | FileCheck -check-prefix=INT64MAIN %s
-// RUN: mlir-cpu-runner %s -O3 | FileCheck %s
+// RUN: mlir-cpu-runner %s -argext-abi-check=false | FileCheck %s
+// RUN: mlir-cpu-runner %s -e foo  -argext-abi-check=false | FileCheck -check-prefix=NOMAIN %s
+// RUN: mlir-cpu-runner %s --entry-point-result=i32 -e int32_main -argext-abi-check=false | FileCheck -check-prefix=INT32MAIN %s
+// RUN: mlir-cpu-runner %s --entry-point-result=i64 -e int64_main -argext-abi-check=false | FileCheck -check-prefix=INT64MAIN %s
+// RUN: mlir-cpu-runner %s -O3  -argext-abi-check=false | FileCheck %s
 
 // RUN: cp %s %t
-// RUN: mlir-cpu-runner %t -dump-object-file | FileCheck %t
+// RUN: mlir-cpu-runner %t -dump-object-file -argext-abi-check=false | FileCheck %t
 // RUN: ls %t.o
 // RUN: rm %t.o
 
-// RUN: mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o | FileCheck %s
+// RUN: mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o -argext-abi-check=false | FileCheck %s
 // RUN: ls %T/test.o
 // RUN: rm %T/test.o
 

--- a/mlir/test/mlir-cpu-runner/simple.mlir
+++ b/mlir/test/mlir-cpu-runner/simple.mlir
@@ -1,47 +1,22 @@
-// RUN: %if target={{s390x-.*}} %{                                  \
-// RUN:   mlir-cpu-runner %s -argext-abi-check=false | FileCheck %s \
-// RUN: %} %else %{                                                 \
-// RUN:   mlir-cpu-runner %s  | FileCheck %s                        \
-// RUN: %}
-
-// RUN: %if target={{s390x-.*}} %{                                                              \
-// RUN:   mlir-cpu-runner %s -e foo -argext-abi-check=false | FileCheck -check-prefix=NOMAIN %s \
-// RUN: %} %else %{                                                                             \
-// RUN:   mlir-cpu-runner %s -e foo | FileCheck -check-prefix=NOMAIN %s                         \
-// RUN: %}
-
-// RUN: %if target={{s390x-.*}} %{                                                                                                  \
-// RUN:   mlir-cpu-runner %s --entry-point-result=i32 -e int32_main  -argext-abi-check=false | FileCheck -check-prefix=INT32MAIN %s \
-// RUN: %} %else %{                                                                                                                 \
-// RUN:   mlir-cpu-runner %s --entry-point-result=i32 -e int32_main | FileCheck -check-prefix=INT32MAIN %s                          \
-// RUN: %}
-
-// RUN: %if target={{s390x-.*}} %{                                                                                                 \
-// RUN:   mlir-cpu-runner %s --entry-point-result=i64 -e int64_main -argext-abi-check=false | FileCheck -check-prefix=INT64MAIN %s \
-// RUN: %} %else %{                                                                                                                \
-// RUN:   mlir-cpu-runner %s --entry-point-result=i64 -e int64_main | FileCheck -check-prefix=INT64MAIN %s                         \
-// RUN: %}
-
-// RUN: %if target={{s390x-.*}} %{                                      \
-// RUN:   mlir-cpu-runner %s -O3 -argext-abi-check=false | FileCheck %s \
-// RUN: %} %else %{                                                     \
-// RUN:   mlir-cpu-runner %s -O3 | FileCheck %s                         \
-// RUN: %}
+// RUN: mlir-cpu-runner %s %if target={{s390x-.*}} %{ -argext-abi-check=false %} \
+// RUN:   | FileCheck %s
+// RUN: mlir-cpu-runner %s -e foo %if target={{s390x-.*}} %{ -argext-abi-check=false %} \
+// RUN:   | FileCheck -check-prefix=NOMAIN %s
+// RUN: mlir-cpu-runner %s --entry-point-result=i32 -e int32_main %if target={{s390x-.*}} \
+// RUN:   %{ -argext-abi-check=false %} | FileCheck -check-prefix=INT32MAIN %s
+// RUN: mlir-cpu-runner %s --entry-point-result=i64 -e int64_main %if target={{s390x-.*}} \
+// RUN:   %{ -argext-abi-check=false %} | FileCheck -check-prefix=INT64MAIN %s
+// RUN: mlir-cpu-runner %s -O3 %if target={{s390x-.*}} %{ -argext-abi-check=false %} \
+// RUN:   | FileCheck %s
 
 // RUN: cp %s %t
-// RUN: %if target={{s390x-.*}} %{                                                    \
-// RUN:   mlir-cpu-runner %t -dump-object-file -argext-abi-check=false | FileCheck %t \
-// RUN: %} %else %{                                                                   \
-// RUN:   mlir-cpu-runner %t -dump-object-file | FileCheck %t                         \
-// RUN: %}
-
+// RUN: mlir-cpu-runner %t -dump-object-file %if target={{s390x-.*}} \
+// RUN:   %{ -argext-abi-check=false %} | FileCheck %t
 // RUN: ls %t.o
 // RUN: rm %t.o
-// RUN: %if target={{s390x-.*}} %{                                                                               \
-// RUN:   mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o -argext-abi-check=false | FileCheck %s \
-// RUN: %} %else %{                                                                                              \
-// RUN:   mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o | FileCheck %s                         \
-// RUN: %}
+
+// RUN: mlir-cpu-runner %s -dump-object-file -object-filename=%T/test.o \
+// RUN:   %if target={{s390x-.*}} %{ -argext-abi-check=false %} | FileCheck %s
 // RUN: ls %T/test.o
 // RUN: rm %T/test.o
 


### PR DESCRIPTION
The SystemZ ABI requires that i32 values should be extended when passed between functions. 

This patch fixes some tests that were lacking this, either by adding some SystemZ specific inlinings of test functions or by disabling the verification of this with the CL option controlling this.

Fixes #115564
