### PR TITLE
[DebugInfo] Add DW_AT_artificial for compiler generated static member.

### DIFF
--- a/llvm/test/DebugInfo/Generic/artificial-static-member.ll
+++ b/llvm/test/DebugInfo/Generic/artificial-static-member.ll
@@ -1,3 +1,4 @@
+; REQUIRES: x86_64-linux
 ; RUN: llc -O0 -filetype=obj < %s |   \
 ; RUN: llvm-dwarfdump --debug-info - | FileCheck %s
 


### PR DESCRIPTION
Consider the case when the compiler generates a static member. Any consumer of the debug info generated for that case, would benefit if that member has the DW_AT_artificial flag.

Fix buildbot failure on: llvm-clang-aarch64-darwin
- Add specific configuration: x86_64-linux