### PR TITLE
[Clang][Parser] Add a warning to ambiguous uses of T...[N] types

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -718,6 +718,11 @@ def warn_empty_init_statement : Warning<
   "has no effect">, InGroup<EmptyInitStatement>, DefaultIgnore;
 def err_keyword_as_parameter : Error <
   "invalid parameter name: '%0' is a keyword">;
+def warn_pre_cxx26_ambiguous_pack_indexing_type : Warning<
+  "parameter packs without specifying a name would become a pack indexing "
+  "declaration in C++2c onwards">, InGroup<CXXPre26Compat>;
+def note_add_a_name_to_pre_cxx26_parameter_packs : Note<
+  "add a name to disambiguate">;
 
 // C++ derived classes
 def err_dup_virtual : Error<"duplicate 'virtual' in base specifier">;

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -719,10 +719,8 @@ def warn_empty_init_statement : Warning<
 def err_keyword_as_parameter : Error <
   "invalid parameter name: '%0' is a keyword">;
 def warn_pre_cxx26_ambiguous_pack_indexing_type : Warning<
-  "parameter packs without specifying a name would become a pack indexing "
-  "declaration in C++2c onwards">, InGroup<CXXPre26Compat>;
-def note_add_a_name_to_pre_cxx26_parameter_packs : Note<
-  "add a name to disambiguate">;
+  "%0 is no longer a pack expansion but a pack "
+  "indexing type; add a name to specify a pack expansion">, InGroup<CXXPre26Compat>;
 
 // C++ derived classes
 def err_dup_virtual : Error<"duplicate 'virtual' in base specifier">;

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -260,9 +260,9 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
     //   declares a pack of parameters without specifying a declarator-id
     //   becomes ill-formed.
     //
-    // However, we still avoid parsing them as pack expansions because this is a
-    // rare use case of packs, despite being partway non-conforming, to ensure
-    // semantic consistency given that we have backported this feature.
+    // However, we still treat it as a pack indexing type because the use case
+    // is fairly rare, to ensure semantic consistency given that we have
+    // backported this feature to pre-C++26 modes.
     if (!Tok.is(tok::coloncolon) && !getLangOpts().CPlusPlus26 &&
         getCurScope()->isFunctionDeclarationScope())
       Diag(Start, diag::warn_pre_cxx26_ambiguous_pack_indexing_type) << Type;

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -238,7 +238,8 @@ bool Parser::ParseOptionalCXXScopeSpecifier(
 
   else if (!HasScopeSpecifier && Tok.is(tok::identifier) &&
            GetLookAheadToken(1).is(tok::ellipsis) &&
-           GetLookAheadToken(2).is(tok::l_square)) {
+           GetLookAheadToken(2).is(tok::l_square) &&
+           !GetLookAheadToken(3).is(tok::r_square)) {
     SourceLocation Start = Tok.getLocation();
     DeclSpec DS(AttrFactory);
     SourceLocation CCLoc;

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p13.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p13.cpp
@@ -57,10 +57,11 @@ template<typename T>
 void b(T[] ...);
 
 template<typename T>
-void c(T ... []); // expected-error {{expected expression}} \
-                  // expected-error {{type 'T[]' of function parameter pack does not contain any unexpanded parameter packs}} \
-                  // expected-warning {{would become a pack indexing declaration in C++2c onwards}} \
-                  // expected-note {{add a name to disambiguate}}
+void c(T ... []); // expected-error {{type 'T[]' of function parameter pack does not contain any unexpanded parameter packs}}
+
+// A function that takes pointers to each type T as arguments, after any decay.
+template <typename ...T>
+void g(T...[]);
 
 template<typename T>
 void d(T ... x[]); // expected-error{{type 'T[]' of function parameter pack does not contain any unexpanded parameter packs}}

--- a/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p13.cpp
+++ b/clang/test/CXX/dcl.decl/dcl.meaning/dcl.fct/p13.cpp
@@ -58,8 +58,9 @@ void b(T[] ...);
 
 template<typename T>
 void c(T ... []); // expected-error {{expected expression}} \
-                  // expected-error {{'T' does not refer to the name of a parameter pack}} \
-                  // expected-warning {{pack indexing is a C++2c extension}}
+                  // expected-error {{type 'T[]' of function parameter pack does not contain any unexpanded parameter packs}} \
+                  // expected-warning {{would become a pack indexing declaration in C++2c onwards}} \
+                  // expected-note {{add a name to disambiguate}}
 
 template<typename T>
 void d(T ... x[]); // expected-error{{type 'T[]' of function parameter pack does not contain any unexpanded parameter packs}}

--- a/clang/test/Parser/cxx0x-decl.cpp
+++ b/clang/test/Parser/cxx0x-decl.cpp
@@ -214,12 +214,8 @@ struct MemberComponentOrder : Base {
 void NoMissingSemicolonHere(struct S
                             [3]);
 template<int ...N> void NoMissingSemicolonHereEither(struct S... [N]);
-// expected-error@-1 {{'S' does not refer to the name of a parameter pack}} \
-// expected-error@-1 {{declaration of anonymous struct must be a definition}} \
-// expected-error@-1 {{expected parameter declarator}} \
-// expected-error@-1 {{pack indexing is a C++2c extension}} \
-
-
+// expected-warning@-1 {{parameter packs without specifying a name would become a pack indexing declaration in C++2c onwards}} \
+// expected-note@-1 {{add a name to disambiguate}}
 
 // This must be at the end of the file; we used to look ahead past the EOF token here.
 // expected-error@+1 {{expected unqualified-id}} expected-error@+1{{expected ';'}}

--- a/clang/test/Parser/cxx0x-decl.cpp
+++ b/clang/test/Parser/cxx0x-decl.cpp
@@ -214,8 +214,12 @@ struct MemberComponentOrder : Base {
 void NoMissingSemicolonHere(struct S
                             [3]);
 template<int ...N> void NoMissingSemicolonHereEither(struct S... [N]);
-// expected-warning@-1 {{parameter packs without specifying a name would become a pack indexing declaration in C++2c onwards}} \
-// expected-note@-1 {{add a name to disambiguate}}
+// expected-warning@-1 {{'S...[N]' is no longer a pack expansion but a pack indexing type; add a name to specify a pack expansion}} \
+// expected-error@-1 {{'S' does not refer to the name of a parameter pack}} \
+// expected-error@-1 {{declaration of anonymous struct must be a definition}} \
+// expected-error@-1 {{expected parameter declarator}} \
+// expected-error@-1 {{pack indexing is a C++2c extension}} \
+
 
 // This must be at the end of the file; we used to look ahead past the EOF token here.
 // expected-error@+1 {{expected unqualified-id}} expected-error@+1{{expected ';'}}

--- a/clang/test/Parser/cxx0x-decl.cpp
+++ b/clang/test/Parser/cxx0x-decl.cpp
@@ -221,6 +221,7 @@ template<int ...N> void NoMissingSemicolonHereEither(struct S... [N]);
 // expected-error@-1 {{pack indexing is a C++2c extension}} \
 
 
+
 // This must be at the end of the file; we used to look ahead past the EOF token here.
 // expected-error@+1 {{expected unqualified-id}} expected-error@+1{{expected ';'}}
 using

--- a/clang/test/Parser/cxx2c-pack-indexing.cpp
+++ b/clang/test/Parser/cxx2c-pack-indexing.cpp
@@ -12,8 +12,7 @@ struct S {
             // expected-note {{to match this '['}} \
            // expected-warning{{declaration does not declare anything}}
 
-    T...[]; // expected-error{{expected expression}} \
-           // expected-warning{{declaration does not declare anything}}
+    T...[]; // expected-error{{expected member name or ';' after declaration specifiers}}
 
     void f(auto... v) {
         decltype(v...[1]) a = v...[1];
@@ -65,7 +64,7 @@ int main() {
 }
 
 
-namespace GH11460 {
+namespace GH111460 {
 template <typename... T>
 requires( ); // expected-error {{expected expression}}
 struct SS {

--- a/clang/test/SemaCXX/cxx2c-pack-indexing-ext-diags.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing-ext-diags.cpp
@@ -19,3 +19,27 @@ void f(T... t) {
     // cxx11-warning@+1 {{pack indexing is a C++2c extension}}
     T...[0] c;
 }
+
+template <typename... T>
+void g(T... [1]); // cxx11-warning {{parameter packs without specifying a name would become a pack indexing declaration in C++2c onwards}} \
+                  // cxx11-note {{add a name to disambiguate}} \
+                  // cxx26-warning {{pack indexing is incompatible with C++ standards before C++2c}} \
+                  // cxx26-note {{candidate function template not viable}}
+
+template <typename... T>
+void h(T... param[1]);
+
+template <class T>
+struct S {
+  using type = T;
+};
+
+template <typename... T>
+void h(typename T... [1]::type); // cxx11-warning {{pack indexing is a C++2c extension}} \
+                                 // cxx26-warning {{pack indexing is incompatible with C++ standards before C++2c}}
+
+void call() {
+  g<int, double>(nullptr, nullptr); // cxx26-error {{no matching function for call to 'g'}}
+  h<int, double>(nullptr, nullptr);
+  h<S<int>, S<const char *>>("hello");
+}

--- a/clang/test/SemaCXX/cxx2c-pack-indexing-ext-diags.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing-ext-diags.cpp
@@ -41,6 +41,7 @@ void h(typename T... [1]::type); // cxx11-warning {{pack indexing is a C++2c ext
 
 template <typename... T>
 void x(T... [0]); // cxx11-warning {{'T...[0]' is no longer a pack expansion but a pack indexing type; add a name to specify a pack expansion}} \
+                  // cxx11-warning {{pack indexing is a C++2c extension}} \
                   // cxx26-warning {{pack indexing is incompatible with C++ standards before C++2c}}
 
 void call() {

--- a/clang/test/SemaCXX/cxx2c-pack-indexing-ext-diags.cpp
+++ b/clang/test/SemaCXX/cxx2c-pack-indexing-ext-diags.cpp
@@ -21,8 +21,9 @@ void f(T... t) {
 }
 
 template <typename... T>
-void g(T... [1]); // cxx11-warning {{parameter packs without specifying a name would become a pack indexing declaration in C++2c onwards}} \
-                  // cxx11-note {{add a name to disambiguate}} \
+void g(T... [1]); // cxx11-warning {{'T...[1]' is no longer a pack expansion but a pack indexing type; add a name to specify a pack expansion}} \
+                  // cxx11-warning {{pack indexing is a C++2c extension}} \
+                  // cxx11-note {{candidate function template not viable}} \
                   // cxx26-warning {{pack indexing is incompatible with C++ standards before C++2c}} \
                   // cxx26-note {{candidate function template not viable}}
 
@@ -38,8 +39,14 @@ template <typename... T>
 void h(typename T... [1]::type); // cxx11-warning {{pack indexing is a C++2c extension}} \
                                  // cxx26-warning {{pack indexing is incompatible with C++ standards before C++2c}}
 
+template <typename... T>
+void x(T... [0]); // cxx11-warning {{'T...[0]' is no longer a pack expansion but a pack indexing type; add a name to specify a pack expansion}} \
+                  // cxx26-warning {{pack indexing is incompatible with C++ standards before C++2c}}
+
 void call() {
-  g<int, double>(nullptr, nullptr); // cxx26-error {{no matching function for call to 'g'}}
+  g<int, double>(nullptr, nullptr); // cxx26-error {{no matching function for call to 'g'}} \
+                                    // cxx11-error {{no matching function for call to 'g'}}
   h<int, double>(nullptr, nullptr);
   h<S<int>, S<const char *>>("hello");
+  x<int*>(nullptr);
 }


### PR DESCRIPTION
`void f(T... [N])` is no longer treated as a function with a parameter of pack expansion type after the implementation of the pack indexing feature. This patch introduces a warning to clarify such cases while maintaining it as a pack indexing type in all language modes.

Fixes https://github.com/llvm/llvm-project/issues/115222
