### PR TITLE
[MergedLoadStore] Preserve common metadata when sinking stores.

### DIFF
--- a/llvm/lib/Transforms/Scalar/MergedLoadStoreMotion.cpp
+++ b/llvm/lib/Transforms/Scalar/MergedLoadStoreMotion.cpp
@@ -84,6 +84,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Local.h"
 
 using namespace llvm;
 
@@ -256,14 +257,7 @@ void MergedLoadStoreMotion::sinkStoresAndGEPs(BasicBlock *BB, StoreInst *S0,
   // Intersect optional metadata.
   S0->andIRFlags(S1);
 
-  // Keep metadata present on both instructions.
-  SmallVector<std::pair<unsigned, MDNode *>> MDs;
-  S0->getAllMetadataOtherThanDebugLoc(MDs);
-  SmallVector<unsigned> CommonMDs;
-  for (const auto &[Kind, MD] : MDs)
-    if (S1->getMetadata(Kind) == MD)
-      CommonMDs.push_back(Kind);
-  S0->dropUnknownNonDebugMetadata(CommonMDs);
+  combineMetadataForCSE(S0, S1, true);
   S0->applyMergedLocation(S0->getDebugLoc(), S1->getDebugLoc());
   S0->mergeDIAssignID(S1);
 

--- a/llvm/test/Transforms/MergedLoadStoreMotion/preserve-store-metadata.ll
+++ b/llvm/test/Transforms/MergedLoadStoreMotion/preserve-store-metadata.ll
@@ -3,7 +3,6 @@
 
 target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
 
-; FIXME: Can preserve common metadata on the sunk store.
 define void @perserve_common_metadata(i1 %c, ptr %dst, ptr %min) {
 ; CHECK-LABEL: define void @perserve_common_metadata(
 ; CHECK-SAME: i1 [[C:%.*]], ptr [[DST:%.*]], ptr [[MIN:%.*]]) {

--- a/llvm/test/Transforms/MergedLoadStoreMotion/preserve-store-metadata.ll
+++ b/llvm/test/Transforms/MergedLoadStoreMotion/preserve-store-metadata.ll
@@ -19,7 +19,7 @@ define void @perserve_common_metadata(i1 %c, ptr %dst, ptr %min) {
 ; CHECK-NEXT:    br label %[[RETURN]]
 ; CHECK:       [[RETURN]]:
 ; CHECK-NEXT:    [[DOTSINK:%.*]] = phi ptr [ [[DST]], %[[THEN]] ], [ null, %[[ELSE]] ]
-; CHECK-NEXT:    store ptr [[DOTSINK]], ptr [[GEP_DST_16]], align 8
+; CHECK-NEXT:    store ptr [[DOTSINK]], ptr [[GEP_DST_16]], align 8, !tbaa [[TBAA4:![0-9]+]], !alias.scope [[META6:![0-9]+]], !noalias [[META6]], !llvm.access.group [[ACC_GRP9:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -48,7 +48,7 @@ define void @clear_different_metadata(i1 %c, ptr %dst, ptr %min) {
 ; CHECK-NEXT:    [[GEP_DST_16:%.*]] = getelementptr inbounds nuw i8, ptr [[DST]], i64 16
 ; CHECK-NEXT:    br i1 [[C]], label %[[THEN:.*]], label %[[ELSE:.*]]
 ; CHECK:       [[THEN]]:
-; CHECK-NEXT:    store ptr [[DST]], ptr [[MIN]], align 8, !tbaa [[TBAA4:![0-9]+]]
+; CHECK-NEXT:    store ptr [[DST]], ptr [[MIN]], align 8, !tbaa [[TBAA10:![0-9]+]]
 ; CHECK-NEXT:    br label %[[RETURN:.*]]
 ; CHECK:       [[ELSE]]:
 ; CHECK-NEXT:    [[GEP_DST_24:%.*]] = getelementptr inbounds nuw i8, ptr [[DST]], i64 24
@@ -99,6 +99,12 @@ return:
 ; CHECK: [[META2]] = !{!"omnipotent char", [[META3:![0-9]+]], i64 0}
 ; CHECK: [[META3]] = !{!"Simple C++ TBAA"}
 ; CHECK: [[TBAA4]] = !{[[META5:![0-9]+]], [[META5]], i64 0, i64 0}
-; CHECK: [[META5]] = !{!"p2 _Foo", [[META6:![0-9]+]]}
-; CHECK: [[META6]] = !{!"any pointer", [[META2]], i64 0}
+; CHECK: [[META5]] = !{!"long", [[META2]]}
+; CHECK: [[META6]] = !{[[META7:![0-9]+]]}
+; CHECK: [[META7]] = distinct !{[[META7]], [[META8:![0-9]+]]}
+; CHECK: [[META8]] = distinct !{[[META8]]}
+; CHECK: [[ACC_GRP9]] = distinct !{}
+; CHECK: [[TBAA10]] = !{[[META11:![0-9]+]], [[META11]], i64 0, i64 0}
+; CHECK: [[META11]] = !{!"p2 _Foo", [[META12:![0-9]+]]}
+; CHECK: [[META12]] = !{!"any pointer", [[META2]], i64 0}
 ;.


### PR DESCRIPTION
When sinking a store, preserve common metadata present on stores on both sides of the diamond.