### PR TITLE
[analyzer] [MallocChecker] Less aggressive analysis of functions

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3156,7 +3156,7 @@ void MallocChecker::checkPreCall(const CallEvent &Call,
     return;
   }
 
-  bool hasDef = false;
+  bool HasDef = false;
 
   // We will check for double free in the post visit.
   if (const AnyFunctionCall *FC = dyn_cast<AnyFunctionCall>(&Call)) {
@@ -3164,7 +3164,7 @@ void MallocChecker::checkPreCall(const CallEvent &Call,
     if (!FD)
       return;
 
-    hasDef = FD->getDefinition() != nullptr;
+    HasDef = FD->getDefinition() != nullptr;
 
     if (ChecksEnabled[CK_MallocChecker] && isFreeingCall(Call))
       return;
@@ -3177,8 +3177,8 @@ void MallocChecker::checkPreCall(const CallEvent &Call,
       return;
   }
 
-  if (ChecksEnabled[CK_MallocChecker] && !Call.isInSystemHeader() && hasDef)
-      return;
+  if (ChecksEnabled[CK_MallocChecker] && !Call.isInSystemHeader() && HasDef)
+    return;
 
   // Check arguments for being used after free.
   for (unsigned I = 0, E = Call.getNumArgs(); I != E; ++I) {


### PR DESCRIPTION
It seems to me that the `unix.Malloc` checker is too aggressive when it comes to analyzing function arguments.

For example it warns on such code (there is no directly usage of freed memory - but just pointer copying):

```cpp
#include "stdlib.h"

static void test_empty(int* p) {
  return;
}

void test() {
  int *p = (int*)malloc(sizeof(int));
  free(p);

  test_empty(p);  //  use after free warning causing
}
```

it leads to fp like that:

```cpp
#include "stdlib.h"

static void test_realloc(int* p) { 
  p = (int*)malloc(sizeof(int));
  free(p);
  return;
}

void test() {
  int *p = (int*)malloc(sizeof(int));
  free(p);

  test_realloc(p);  //  use after free warning causing
}
```

I believe that when a function is not from standard library and not external (it has a definition in the compilation unit) then checker can continue to analyze the function body further until an actual freed memory use is encountered but not warn on the call arguments in the case where there is simply copying of a pointer, and not its dereferencing.