### PR TITLE
[SandboxIR] Don't add dup instantiation for clang

### DIFF
--- a/llvm/lib/SandboxIR/Constant.cpp
+++ b/llvm/lib/SandboxIR/Constant.cpp
@@ -302,7 +302,7 @@ template class GlobalWithNodeAPI<GlobalVariable, llvm::GlobalVariable,
 template class GlobalWithNodeAPI<GlobalAlias, llvm::GlobalAlias, GlobalValue,
                                  llvm::GlobalValue>;
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 // These are needed for SandboxIRTest when building with LLVM_BUILD_LLVM_DYLIB
 template LLVM_EXPORT_TEMPLATE GlobalIFunc &
 GlobalWithNodeAPI<GlobalIFunc, llvm::GlobalIFunc, GlobalObject,


### PR DESCRIPTION
On Windows some clang-based compiler(eg: clang-cl, icx) also define _MSC_VER.

