### PR TITLE
[LLD][AArch64] Detach Landing Pad creation from Thunk creation

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -2366,9 +2366,8 @@ bool ThunkCreator::createThunks(uint32_t pass,
             uint64_t src = isec->getVA(rel.offset);
 
             // If we are a relocation to an existing Thunk, check if it is
-            // still in range, or if it needs a landing pad created. If not
-            // range then Rel will be altered to point to its original target
-            // so another Thunk can be generated.
+            // still in range. If not then Rel will be altered to point to its
+            // original target so another Thunk can be generated.
             if (pass > 0 && normalizeExistingThunk(rel, src))
               continue;
 

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -2293,6 +2293,31 @@ bool ThunkCreator::normalizeExistingThunk(Relocation &rel, uint64_t src) {
   return false;
 }
 
+// When indirect branches are restricted, such as AArch64 BTI Thunks may need
+// to target a linker generated landing pad instead of the target. This needs
+// to be done once per pass as the need for a BTI thunk is dependent whether
+// a thunk is short or long. We iterate over all the thunks to make sure we
+// catch thunks that have been created but are no longer live. Non-live thunks
+// are not reachable via normalizeExistingThunk() but are still written.
+bool ThunkCreator::addSyntheticLandingPads() {
+  bool addressesChanged = false;
+  for (Thunk *t : allThunks) {
+    if (t->needsSyntheticLandingPad()) {
+      Thunk *lpt;
+      bool isNew;
+      auto &dr = cast<Defined>(t->destination);
+      std::tie(lpt, isNew) = getSyntheticLandingPad(dr, t->addend);
+      if (isNew) {
+        addressesChanged = true;
+        ThunkSection *ts = getISThunkSec(cast<InputSection>(dr.section));
+        ts->addThunk(lpt);
+      }
+      t->landingPad = lpt->getThunkTargetSym();
+    }
+  }
+  return addressesChanged;
+}
+
 // Process all relocations from the InputSections that have been assigned
 // to InputSectionDescriptions and redirect through Thunks if needed. The
 // function should be called iteratively until it returns false.
@@ -2326,6 +2351,9 @@ bool ThunkCreator::createThunks(uint32_t pass,
   if (pass == 0 && ctx.target->getThunkSectionSpacing())
     createInitialThunkSections(outputSections);
 
+  if (ctx.arg.emachine == EM_AARCH64)
+    addressesChanged = addSyntheticLandingPads();
+
   // Create all the Thunks and insert them into synthetic ThunkSections. The
   // ThunkSections are later inserted back into InputSectionDescriptions.
   // We separate the creation of ThunkSections from the insertion of the
@@ -2338,8 +2366,9 @@ bool ThunkCreator::createThunks(uint32_t pass,
             uint64_t src = isec->getVA(rel.offset);
 
             // If we are a relocation to an existing Thunk, check if it is
-            // still in range. If not then Rel will be altered to point to its
-            // original target so another Thunk can be generated.
+            // still in range, or if it needs a landing pad created. If not
+            // range then Rel will be altered to point to its original target
+            // so another Thunk can be generated.
             if (pass > 0 && normalizeExistingThunk(rel, src))
               continue;
 
@@ -2360,20 +2389,7 @@ bool ThunkCreator::createThunks(uint32_t pass,
                 ts = getISDThunkSec(os, isec, isd, rel, src);
               ts->addThunk(t);
               thunks[t->getThunkTargetSym()] = t;
-
-              // When indirect branches are restricted, such as AArch64 BTI
-              // Thunks may need to target a linker generated landing pad
-              // instead of the target.
-              if (t->needsSyntheticLandingPad()) {
-                Thunk *lpt;
-                auto &dr = cast<Defined>(t->destination);
-                std::tie(lpt, isNew) = getSyntheticLandingPad(dr, t->addend);
-                if (isNew) {
-                  ts = getISThunkSec(cast<InputSection>(dr.section));
-                  ts->addThunk(lpt);
-                }
-                t->landingPad = lpt->getThunkTargetSym();
-              }
+              allThunks.push_back(t);
             }
 
             // Redirect relocation to Thunk, we never go via the PLT to a Thunk

--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -2302,18 +2302,17 @@ bool ThunkCreator::normalizeExistingThunk(Relocation &rel, uint64_t src) {
 bool ThunkCreator::addSyntheticLandingPads() {
   bool addressesChanged = false;
   for (Thunk *t : allThunks) {
-    if (t->needsSyntheticLandingPad()) {
-      Thunk *lpt;
-      bool isNew;
-      auto &dr = cast<Defined>(t->destination);
-      std::tie(lpt, isNew) = getSyntheticLandingPad(dr, t->addend);
-      if (isNew) {
-        addressesChanged = true;
-        ThunkSection *ts = getISThunkSec(cast<InputSection>(dr.section));
-        ts->addThunk(lpt);
-      }
-      t->landingPad = lpt->getThunkTargetSym();
+    if (!t->needsSyntheticLandingPad())
+      continue;
+    Thunk *lpt;
+    bool isNew;
+    auto &dr = cast<Defined>(t->destination);
+    std::tie(lpt, isNew) = getSyntheticLandingPad(dr, t->addend);
+    if (isNew) {
+      addressesChanged = true;
+      getISThunkSec(cast<InputSection>(dr.section))->addThunk(lpt);
     }
+    t->landingPad = lpt->getThunkTargetSym();
   }
   return addressesChanged;
 }

--- a/lld/ELF/Relocations.h
+++ b/lld/ELF/Relocations.h
@@ -183,6 +183,8 @@ private:
 
   bool normalizeExistingThunk(Relocation &rel, uint64_t src);
 
+  bool addSyntheticLandingPads();
+
   Ctx &ctx;
 
   // Record all the available Thunks for a (Symbol, addend) pair, where Symbol
@@ -215,6 +217,9 @@ private:
   llvm::DenseMap<std::pair<std::pair<SectionBase *, uint64_t>, int64_t>,
                  Thunk *>
       landingPadsBySectionAndAddend;
+
+  // All the nonLandingPad thunks that have been created, in order of creation.
+  std::vector<Thunk *> allThunks;
 
   // The number of completed passes of createThunks this permits us
   // to do one time initialization on Pass 0 and put a limit on the


### PR DESCRIPTION
Move Landing Pad Creation to a new function that checks each thunk every pass to see if it needs a landing pad. This permits a thunk to be created without needing a landing pad, but later needing one due to drifting out of direct branch range and requiring an indirect branch.

We record all the Thunks created so far in a new vector rather than trying to iterate over the DenseMap as we need a deterministic order of adding LandingPadThunks due to the short branch fall through. We cannot use normalizeExistingThunk() either as that only iterates through live thunks.

Fixes: https://crbug.com/377438309
Original PR: https://github.com/llvm/llvm-project/pull/108989

Sending without a new test case to fix existing test. A new regression test will come in a separate PR as coming up with a small enough reproducer for this case is non-trivial.