### PR TITLE
[clang][Driver] Use shared_ptr in the Compilation class

### DIFF
--- a/clang/include/clang/Driver/Compilation.h
+++ b/clang/include/clang/Driver/Compilation.h
@@ -61,11 +61,11 @@ class Compilation {
       OrderedOffloadingToolchains;
 
   /// The original (untranslated) input argument list.
-  llvm::opt::InputArgList *Args;
+  std::shared_ptr<llvm::opt::InputArgList> Args;
 
   /// The driver translated arguments. Note that toolchains may perform their
   /// own argument translation.
-  llvm::opt::DerivedArgList *TranslatedArgs;
+  std::shared_ptr<llvm::opt::DerivedArgList> TranslatedArgs;
 
   /// The list of actions we've created via MakeAction.  This is not accessible
   /// to consumers; it's here just to manage ownership.
@@ -100,7 +100,7 @@ class Compilation {
       return false;
     }
   };
-  std::map<TCArgsKey, llvm::opt::DerivedArgList *> TCArgs;
+  std::map<TCArgsKey, std::shared_ptr<llvm::opt::DerivedArgList>> TCArgs;
 
   /// Temporary files which should be removed on exit.
   llvm::opt::ArgStringList TempFiles;
@@ -134,8 +134,9 @@ class Compilation {
 
 public:
   Compilation(const Driver &D, const ToolChain &DefaultToolChain,
-              llvm::opt::InputArgList *Args,
-              llvm::opt::DerivedArgList *TranslatedArgs, bool ContainsError);
+              std::shared_ptr<llvm::opt::InputArgList> Args,
+              std::shared_ptr<llvm::opt::DerivedArgList> TranslatedArgs,
+              bool ContainsError);
   ~Compilation();
 
   const Driver &getDriver() const { return TheDriver; }

--- a/clang/include/clang/Driver/Compilation.h
+++ b/clang/include/clang/Driver/Compilation.h
@@ -61,7 +61,7 @@ class Compilation {
       OrderedOffloadingToolchains;
 
   /// The original (untranslated) input argument list.
-  std::shared_ptr<llvm::opt::InputArgList> Args;
+  std::unique_ptr<llvm::opt::InputArgList> Args;
 
   /// The driver translated arguments. Note that toolchains may perform their
   /// own argument translation.
@@ -134,7 +134,7 @@ class Compilation {
 
 public:
   Compilation(const Driver &D, const ToolChain &DefaultToolChain,
-              std::shared_ptr<llvm::opt::InputArgList> Args,
+              std::unique_ptr<llvm::opt::InputArgList> Args,
               std::shared_ptr<llvm::opt::DerivedArgList> TranslatedArgs,
               bool ContainsError);
   ~Compilation();

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -77,7 +77,7 @@ Compilation::getArgsForToolChain(const ToolChain *TC, StringRef BoundArch,
       NewDAL.reset(TC->TranslateXarchArgs(*OpenMPArgs, BoundArch,
                                           DeviceOffloadKind, &AllocatedArgs));
       if (!NewDAL)
-        NewDAL = OpenMPArgs;
+        NewDAL = std::move(OpenMPArgs);
     }
 
     if (!NewDAL) {
@@ -88,7 +88,7 @@ Compilation::getArgsForToolChain(const ToolChain *TC, StringRef BoundArch,
     } else {
       Entry.reset(TC->TranslateArgs(*NewDAL, BoundArch, DeviceOffloadKind));
       if (!Entry)
-        Entry = std::shared_ptr<DerivedArgList>(NewDAL);
+        Entry = std::move(NewDAL);
     }
 
     // Add allocated arguments to the final DAL.

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -33,7 +33,8 @@ using namespace driver;
 using namespace llvm::opt;
 
 Compilation::Compilation(const Driver &D, const ToolChain &_DefaultToolChain,
-                         InputArgList *_Args, DerivedArgList *_TranslatedArgs,
+                         std::shared_ptr<InputArgList> _Args,
+                         std::shared_ptr<DerivedArgList> _TranslatedArgs,
                          bool ContainsError)
     : TheDriver(D), DefaultToolChain(_DefaultToolChain), Args(_Args),
       TranslatedArgs(_TranslatedArgs), ContainsError(ContainsError) {
@@ -47,14 +48,6 @@ Compilation::~Compilation() {
   // the file names might be derived from the input arguments.
   if (!TheDriver.isSaveTempsEnabled() && !ForceKeepTempFiles)
     CleanupFileList(TempFiles);
-
-  delete TranslatedArgs;
-  delete Args;
-
-  // Free any derived arg lists.
-  for (auto Arg : TCArgs)
-    if (Arg.second != TranslatedArgs)
-      delete Arg.second;
 }
 
 const DerivedArgList &
@@ -63,41 +56,39 @@ Compilation::getArgsForToolChain(const ToolChain *TC, StringRef BoundArch,
   if (!TC)
     TC = &DefaultToolChain;
 
-  DerivedArgList *&Entry = TCArgs[{TC, BoundArch, DeviceOffloadKind}];
+  std::shared_ptr<DerivedArgList> &Entry =
+      TCArgs[{TC, BoundArch, DeviceOffloadKind}];
   if (!Entry) {
     SmallVector<Arg *, 4> AllocatedArgs;
-    DerivedArgList *OpenMPArgs = nullptr;
+    std::shared_ptr<DerivedArgList> OpenMPArgs;
     // Translate OpenMP toolchain arguments provided via the -Xopenmp-target flags.
     if (DeviceOffloadKind == Action::OFK_OpenMP) {
       const ToolChain *HostTC = getSingleOffloadToolChain<Action::OFK_Host>();
       bool SameTripleAsHost = (TC->getTriple() == HostTC->getTriple());
-      OpenMPArgs = TC->TranslateOpenMPTargetArgs(
-          *TranslatedArgs, SameTripleAsHost, AllocatedArgs);
+      OpenMPArgs.reset(TC->TranslateOpenMPTargetArgs(
+          *TranslatedArgs, SameTripleAsHost, AllocatedArgs));
     }
 
-    DerivedArgList *NewDAL = nullptr;
+    std::shared_ptr<DerivedArgList> NewDAL;
     if (!OpenMPArgs) {
-      NewDAL = TC->TranslateXarchArgs(*TranslatedArgs, BoundArch,
-                                      DeviceOffloadKind, &AllocatedArgs);
+      NewDAL.reset(TC->TranslateXarchArgs(*TranslatedArgs, BoundArch,
+                                          DeviceOffloadKind, &AllocatedArgs));
     } else {
-      NewDAL = TC->TranslateXarchArgs(*OpenMPArgs, BoundArch, DeviceOffloadKind,
-                                      &AllocatedArgs);
+      NewDAL.reset(TC->TranslateXarchArgs(*OpenMPArgs, BoundArch,
+                                          DeviceOffloadKind, &AllocatedArgs));
       if (!NewDAL)
         NewDAL = OpenMPArgs;
-      else
-        delete OpenMPArgs;
     }
 
     if (!NewDAL) {
-      Entry = TC->TranslateArgs(*TranslatedArgs, BoundArch, DeviceOffloadKind);
+      Entry.reset(
+          TC->TranslateArgs(*TranslatedArgs, BoundArch, DeviceOffloadKind));
       if (!Entry)
         Entry = TranslatedArgs;
     } else {
-      Entry = TC->TranslateArgs(*NewDAL, BoundArch, DeviceOffloadKind);
+      Entry.reset(TC->TranslateArgs(*NewDAL, BoundArch, DeviceOffloadKind));
       if (!Entry)
-        Entry = NewDAL;
-      else
-        delete NewDAL;
+        Entry = std::shared_ptr<DerivedArgList>(NewDAL);
     }
 
     // Add allocated arguments to the final DAL.
@@ -290,9 +281,6 @@ void Compilation::initCompilationForDiagnostics() {
 
   // Force re-creation of the toolchain Args, otherwise our modifications just
   // above will have no effect.
-  for (auto Arg : TCArgs)
-    if (Arg.second != TranslatedArgs)
-      delete Arg.second;
   TCArgs.clear();
 
   // Redirect stdout/stderr to /dev/null.

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -33,11 +33,11 @@ using namespace driver;
 using namespace llvm::opt;
 
 Compilation::Compilation(const Driver &D, const ToolChain &_DefaultToolChain,
-                         std::shared_ptr<InputArgList> _Args,
+                         std::unique_ptr<InputArgList> _Args,
                          std::shared_ptr<DerivedArgList> _TranslatedArgs,
                          bool ContainsError)
-    : TheDriver(D), DefaultToolChain(_DefaultToolChain), Args(_Args),
-      TranslatedArgs(_TranslatedArgs), ContainsError(ContainsError) {
+    : TheDriver(D), DefaultToolChain(_DefaultToolChain), Args(std::move(_Args)),
+      TranslatedArgs(std::move(_TranslatedArgs)), ContainsError(ContainsError) {
   // The offloading host toolchain is the default toolchain.
   OrderedOffloadingToolchains.insert(
       std::make_pair(Action::OFK_Host, &DefaultToolChain));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1485,7 +1485,7 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
       std::make_unique<InputArgList>(std::move(Args));
 
   // Perform the default argument translations.
-  DerivedArgList *TranslatedArgs = TranslateInputArgs(*UArgs);
+  std::unique_ptr<DerivedArgList> TranslatedArgs(TranslateInputArgs(*UArgs));
 
   // Owned by the host.
   const ToolChain &TC = getToolChain(
@@ -1544,8 +1544,8 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   }
 
   // The compilation takes ownership of Args.
-  Compilation *C = new Compilation(*this, TC, UArgs.release(), TranslatedArgs,
-                                   ContainsError);
+  Compilation *C = new Compilation(*this, TC, std::move(UArgs),
+                                   std::move(TranslatedArgs), ContainsError);
 
   if (!HandleImmediateArgs(*C))
     return C;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1552,7 +1552,7 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
 
   // Construct the list of inputs.
   InputList Inputs;
-  BuildInputs(C->getDefaultToolChain(), *TranslatedArgs, Inputs);
+  BuildInputs(C->getDefaultToolChain(), C->getArgs(), Inputs);
 
   // Populate the tool chains for the offloading devices, if any.
   CreateOffloadingDeviceToolChains(*C, Inputs);


### PR DESCRIPTION
This patch replaces uses of raw pointers by shared_ptrs in the Driver's Compilation class.

The manual memory management which was done before this patch could be error prone. Plus, code is now simpler.