### PR TITLE
[TSan] Increase the number of simultaneously locked mutexes that a thread can hold

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_deadlock_detector.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_deadlock_detector.h
@@ -120,7 +120,7 @@ class DeadlockDetectorTLS {
     u32 lock;
     u32 stk;
   };
-  LockWithContext all_locks_with_contexts_[64];
+  LockWithContext all_locks_with_contexts_[128];
   uptr n_all_locks_;
 };
 

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,23 +1,22 @@
-// RUN: %clangxx_tsan %s -fsanitize=thread -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_tsan %s -fsanitize=thread -o %t
+// RUN: %run %t 128
+// RUN: not %run %t 129
 
 #include <mutex>
-#include <stdio.h>
+#include <string>
 
-int main() {
-  const unsigned short NUM_OF_MTX = 128;
-  std::mutex mutexes[NUM_OF_MTX];
+int main(int argc, char *argv[]) {
+  int num_of_mtx = std::stoi(argv[1]);
 
-  for (int i = 0; i < NUM_OF_MTX; i++) {
+  std::mutex* mutexes = new std::mutex[num_of_mtx];
+
+  for (int i = 0; i < num_of_mtx; i++) {
     mutexes[i].lock();
   }
-  for (int i = 0; i < NUM_OF_MTX; i++) {
+  for (int i = 0; i < num_of_mtx; i++) {
     mutexes[i].unlock();
   }
 
-  printf("Success\n");
-
+  delete[] mutexes;
   return 0;
 }
-
-// CHECK: Success
-// CHECK-NOT: ThreadSanitizer: CHECK failed

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -2,18 +2,18 @@
 // RUN: %run %t 128
 
 #include <mutex>
-#include <vector>
 #include <string>
+#include <vector>
 
 int main(int argc, char *argv[]) {
   int num_of_mtx = std::atoi(argv[1]);
 
   std::vector<std::mutex> mutexes(num_of_mtx);
 
-  for (auto& mu : mutexes) {
+  for (auto &mu : mutexes) {
     mu.lock();
   }
-  for (auto& mu : mutexes) {
+  for (auto &mu : mutexes) {
     mu.unlock();
   }
 

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,22 +1,22 @@
-// RUN: %clangxx_tsan %s -fsanitize=thread -o %t && %run %t 2>&1 | Filecheck %s
+// RUN: %clangxx_tsan %s -fsanitize=thread -o %t && %run %t 2>&1 | FileCheck %s
 
 #include <mutex>
 #include <stdio.h>
 
-int main(){
-    const unsigned short NUM_OF_MTX = 128;
-    std::mutex mutexes[NUM_OF_MTX];
+int main() {
+  const unsigned short NUM_OF_MTX = 128;
+  std::mutex mutexes[NUM_OF_MTX];
 
-    for(int i = 0; i < NUM_OF_MTX; i++){
-        mutexes[i].lock();
-    }
-    for(int i = 0; i < NUM_OF_MTX; i++){
-        mutexes[i].unlock();
-    }
+  for (int i = 0; i < NUM_OF_MTX; i++) {
+    mutexes[i].lock();
+  }
+  for (int i = 0; i < NUM_OF_MTX; i++) {
+    mutexes[i].unlock();
+  }
 
-    printf("Success\n");
+  printf("Success\n");
 
-    return 0;
+  return 0;
 }
 
 // CHECK: Success

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,22 +1,22 @@
-// RUN: %clangxx_tsan %s -fsanitize=thread -o %t
+// RUN: %clangxx_tsan -O1 %s %link_libcxx_tsan -fsanitize=thread -o %t
 // RUN: %run %t 128
 // RUN: not %run %t 129
 
 #include <mutex>
+#include <vector>
 #include <string>
 
 int main(int argc, char *argv[]) {
-  int num_of_mtx = std::stoi(argv[1]);
+  int num_of_mtx = std::atoi(argv[1]);
 
-  std::mutex *mutexes = new std::mutex[num_of_mtx];
+  std::vector<std::mutex> mutexes(num_of_mtx);
 
-  for (int i = 0; i < num_of_mtx; i++) {
-    mutexes[i].lock();
+  for (auto& mu : mutexes) {
+    mu.lock();
   }
-  for (int i = 0; i < num_of_mtx; i++) {
-    mutexes[i].unlock();
+  for (auto& mu : mutexes) {
+    mu.unlock();
   }
 
-  delete[] mutexes;
   return 0;
 }

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx_tsan -O1 %s %link_libcxx_tsan -fsanitize=thread -o %t
 // RUN: %run %t 128
-// RUN: not %run %t 129
+// RUN: %env_tsan_opts=fast_unwind_on_fatal=1 not %run %t 129
 
 #include <mutex>
 #include <vector>

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -8,7 +8,7 @@
 int main(int argc, char *argv[]) {
   int num_of_mtx = std::stoi(argv[1]);
 
-  std::mutex* mutexes = new std::mutex[num_of_mtx];
+  std::mutex *mutexes = new std::mutex[num_of_mtx];
 
   for (int i = 0; i < num_of_mtx; i++) {
     mutexes[i].lock();

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,0 +1,23 @@
+// RUN: %clangxx_tsan %s -fsanitize=thread -o %t && %run %t 2>&1 | Filecheck %s
+
+#include <mutex>
+#include <stdio.h>
+
+int main(){
+    const unsigned short NUM_OF_MTX = 128;
+    std::mutex mutexes[NUM_OF_MTX];
+
+    for(int i = 0; i < NUM_OF_MTX; i++){
+        mutexes[i].lock();
+    }
+    for(int i = 0; i < NUM_OF_MTX; i++){
+        mutexes[i].unlock();
+    }
+
+    printf("Success\n");
+
+    return 0;
+}
+
+// CHECK: Success
+// CHECK-NOT: ThreadSanitizer: CHECK failed

--- a/compiler-rt/test/tsan/many_held_mutex.cpp
+++ b/compiler-rt/test/tsan/many_held_mutex.cpp
@@ -1,6 +1,5 @@
 // RUN: %clangxx_tsan -O1 %s %link_libcxx_tsan -fsanitize=thread -o %t
 // RUN: %run %t 128
-// RUN: %env_tsan_opts=fast_unwind_on_fatal=1 not %run %t 129
 
 #include <mutex>
 #include <vector>


### PR DESCRIPTION
I've run into an issue where TSan can't be used on some code without turning off deadlock detection because a thread tries to hold too many mutexes. It would be preferable to be able to use deadlock detection as that is a major benefit of TSan.

Its mentioned in https://github.com/google/sanitizers/issues/950 that the 64 mutex limit was an arbitrary number. I've increased it to 128 and all the tests still pass. Considering the increasing number of cores on CPUs and how programs can now use more threads to take advantage of it, I think raising the limit to 128 would be some good future proofing