### PR TITLE
[lldb] Convert file address to load address when reading memory for DW_OP_piece

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/DW_OP_piece-O3.c
+++ b/lldb/test/Shell/SymbolFile/DWARF/DW_OP_piece-O3.c
@@ -1,0 +1,23 @@
+// Check that optimized with -O3 values that have a file address can be read
+// DWARF info:
+// 0x00000023:   DW_TAG_variable
+//                 DW_AT_name      ("array")
+//                 DW_AT_type      (0x00000032 "char[5]")
+//                 DW_AT_location  (DW_OP_piece 0x2, DW_OP_addrx 0x0, DW_OP_piece 0x1)
+
+// RUN: %clang_host -O3 -gdwarf %s -o %t
+// RUN: %lldb %t \
+// RUN:   -o "b 22" \
+// RUN:   -o "r" \
+// RUN:   -o "p/x array[2]" \
+// RUN:   -b | FileCheck %s
+//
+// CHECK: (lldb) p/x array[2]
+// CHECK: (char) 0x03
+
+static char array[5] = {0, 1, 2, 3, 4};
+
+int main(void) {
+  array[2]++;
+  return 0;
+}


### PR DESCRIPTION
When parsing an optimized value and reading a piece from a file address, LLDB tries to read the data from memory using that address.
This patch converts file address to load address before reading the memory.

Fixes #111313
Fixes #97484