### PR TITLE
[rtsan] Add support for ReportErrorSummary

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -62,8 +62,12 @@ static void OnViolation(const BufferedStackTrace &stack,
   if (UNLIKELY(is_stack_novel)) {
     IncrementUniqueErrorCount();
 
-    PrintDiagnostics(info);
-    stack.Print();
+    {
+      ScopedErrorReportLock l;
+      PrintDiagnostics(info);
+      stack.Print();
+      PrintErrorSummary(info, stack);
+    }
 
     handle.inc_use_count_unsafe();
   }

--- a/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
@@ -39,20 +39,22 @@ public:
 };
 } // namespace
 
+const char *GetErrorTypeStr(const DiagnosticsInfo &info) {
+  switch (info.type) {
+  case DiagnosticsInfoType::InterceptedCall:
+    return "unsafe-library-call";
+  case DiagnosticsInfoType::BlockingCall:
+    return "blocking-call";
+  }
+  CHECK(false);
+  return "(unknown error)";
+}
+
 static void PrintError(const Decorator &decorator,
                        const DiagnosticsInfo &info) {
-  const auto ErrorTypeStr = [&info]() -> const char * {
-    switch (info.type) {
-    case DiagnosticsInfoType::InterceptedCall:
-      return "unsafe-library-call";
-    case DiagnosticsInfoType::BlockingCall:
-      return "blocking-call";
-    }
-    return "(unknown error)";
-  };
 
   Printf("%s", decorator.Error());
-  Report("ERROR: RealtimeSanitizer: %s\n", ErrorTypeStr());
+  Report("ERROR: RealtimeSanitizer: %s\n", GetErrorTypeStr(info));
 }
 
 static void PrintReason(const Decorator &decorator,
@@ -78,10 +80,16 @@ static void PrintReason(const Decorator &decorator,
 }
 
 void __rtsan::PrintDiagnostics(const DiagnosticsInfo &info) {
-  ScopedErrorReportLock l;
+  ScopedErrorReportLock::CheckLocked();
 
   Decorator d;
   PrintError(d, info);
   PrintReason(d, info);
   Printf("%s", d.Default());
+}
+
+void __rtsan::PrintErrorSummary(const DiagnosticsInfo &info,
+                                const BufferedStackTrace &stack) {
+  ScopedErrorReportLock::CheckLocked();
+  ReportErrorSummary(GetErrorTypeStr(info), &stack);
 }

--- a/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
@@ -39,7 +39,7 @@ public:
 };
 } // namespace
 
-const char *GetErrorTypeStr(const DiagnosticsInfo &info) {
+static const char *GetErrorTypeStr(const DiagnosticsInfo &info) {
   switch (info.type) {
   case DiagnosticsInfoType::InterceptedCall:
     return "unsafe-library-call";

--- a/compiler-rt/lib/rtsan/rtsan_diagnostics.h
+++ b/compiler-rt/lib/rtsan/rtsan_diagnostics.h
@@ -30,4 +30,6 @@ struct DiagnosticsInfo {
 };
 
 void PrintDiagnostics(const DiagnosticsInfo &info);
+void PrintErrorSummary(const DiagnosticsInfo &info,
+                       const __sanitizer::BufferedStackTrace &stack);
 } // namespace __rtsan

--- a/compiler-rt/test/rtsan/report_error_summary.cpp
+++ b/compiler-rt/test/rtsan/report_error_summary.cpp
@@ -1,0 +1,32 @@
+// RUN: %clangxx -fsanitize=realtime %s -o %t
+// RUN: %env_rtsan_opts="halt_on_error=false" %run %t 2>&1 | FileCheck %s
+
+// RUN: %clangxx -DTEST_CUSTOM_HANDLER=1 -fsanitize=realtime %s -o %t
+// RUN: not %run %t 2>&1 | FileCheck %s --check-prefixes=CHECK-CUSTOM-HANDLER
+
+// UNSUPPORTED: ios
+
+// Intent: Make sure we support ReporErrorSummary, including custom handlers
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef TEST_CUSTOM_HANDLER
+extern "C" void __sanitizer_report_error_summary(const char *error_summary) {
+  fprintf(stderr, "%s %s\n", "In custom handler! ", error_summary);
+}
+#endif
+
+int blocking_call() [[clang::blocking]] { return 0; }
+
+int main() [[clang::nonblocking]] {
+  void *ptr = malloc(2);
+  blocking_call();
+
+  printf("ptr: %p\n", ptr); // ensure we don't optimize out the malloc
+}
+
+// CHECK: SUMMARY: RealtimeSanitizer: unsafe-library-call
+// CHECK: SUMMARY: RealtimeSanitizer: blocking-call
+
+// CHECK-CUSTOM-HANDLER: In custom handler! SUMMARY: RealtimeSanitizer: unsafe-library-call


### PR DESCRIPTION
Adding support for the extra SUMMARY line that is output by most compilers. This also adds the ability for end-users to specify their own handlers for reporting these errors (see the test).

The output for a basic error will look something like this, where the SUMMARY line is a new addition

```
> ./build/helloWorld
==82636==ERROR: RealtimeSanitizer: unsafe-library-call
Intercepted call to real-time unsafe function `malloc` in real-time context!
    #0 0x000102716620 in malloc rtsan_interceptors_posix.cpp:445
    #1 0x0001021822a8 in process(std::__1::vector<int, std::__1::allocator<int>>&) main.cpp:8
    #2 0x0001021822e8 in main main.cpp:15
    #3 0x00018d8860dc  (<unknown module>)
    #4 0x8d617ffffffffffc  (<unknown module>)

SUMMARY: RealtimeSanitizer: unsafe-library-call main.cpp:8 in process(std::__1::vector<int, std::__1::allocator<int>>&)
```

This compares to something like asan, for instance:
```
> ./build/helloWorld
helloWorld(91968,0x1f5a48c00) malloc: nano zone abandoned due to inability to reserve vm space.
=================================================================
==91968==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6140000001d0 at pc 0x000100d9be58 bp 0x00016f066950 sp 0x00016f066948
WRITE of size 4 at 0x6140000001d0 thread T0
    #0 0x000100d9be54 in violation() main.cpp:17
    #1 0x000100d9be90 in main main.cpp:23
    #2 0x00018d8860dc  (<unknown module>)
    #3 0xe4197ffffffffffc  (<unknown module>)

0x6140000001d0 is located 0 bytes after 400-byte region [0x614000000040,0x6140000001d0)
allocated by thread T0 here:
    #0 0x0001015fc7dc in _Znam asan_new_delete.cpp:114
    #1 0x000100d9be00 in violation() main.cpp:16
    #2 0x000100d9be90 in main main.cpp:23
    #3 0x00018d8860dc  (<unknown module>)
    #4 0xe4197ffffffffffc  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow main.cpp:17 in violation()
...
```