### PR TITLE
[DebugInfo] Correct an overly-restrictive REQUIRES clause.

### DIFF
--- a/llvm/test/DebugInfo/Generic/artificial-static-member.ll
+++ b/llvm/test/DebugInfo/Generic/artificial-static-member.ll
@@ -1,4 +1,4 @@
-; REQUIRES: x86_64-linux
+; REQUIRES: target={{x86_64-.*-linux}}
 ; RUN: llc -O0 -filetype=obj < %s |   \
 ; RUN: llvm-dwarfdump --debug-info - | FileCheck %s
 

--- a/llvm/test/DebugInfo/Generic/artificial-static-member.ll
+++ b/llvm/test/DebugInfo/Generic/artificial-static-member.ll
@@ -1,4 +1,4 @@
-; REQUIRES: target={{x86_64-.*-linux}}
+; REQUIRES: target={{x86_64-.*-linux.*}}
 ; RUN: llc -O0 -filetype=obj < %s |   \
 ; RUN: llvm-dwarfdump --debug-info - | FileCheck %s
 


### PR DESCRIPTION
Include a regular expression in the 'REQUIRES' clause, to run
the test on all matching targets (x86_64 *linux*).

The original patch restricted to test just to 'x86_64-linux'
https://github.com/llvm/llvm-project/pull/116327
