### PR TITLE
[lldb] Add logging for missing `.dwo` files

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1963,6 +1963,14 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
         "{1:x16}",
         error_dwo_path.GetPath().c_str(), cu_die.GetOffset()));
 
+    if (Log *log = GetLog(LLDBLog::Symbols)) {
+      GetObjectFile()->GetModule()->LogMessage(
+          log,
+          "unable to locate .dwo debug file \"{0}\" for skeleton DIE "
+          "{1:x16}",
+          error_dwo_path.GetPath().c_str(), unit.GetOffset());
+    }
+
     if (m_dwo_warning_issued.test_and_set(std::memory_order_relaxed) == false) {
       GetObjectFile()->GetModule()->ReportWarning(
           "unable to locate separate debug file (dwo, dwp). Debugging will be "


### PR DESCRIPTION
I had a hard time to debug a `dwo` file whose file was not found. This log message would have saved me a lot of time.