### PR TITLE
[RegAlloc] Remove redundant prints of LiveInterval weight.

### DIFF
--- a/llvm/lib/CodeGen/RegAllocBase.cpp
+++ b/llvm/lib/CodeGen/RegAllocBase.cpp
@@ -105,7 +105,7 @@ void RegAllocBase::allocatePhysRegs() {
     // result from splitting.
     LLVM_DEBUG(dbgs() << "\nselectOrSplit "
                       << TRI->getRegClassName(MRI->getRegClass(VirtReg->reg()))
-                      << ':' << *VirtReg << " w=" << VirtReg->weight() << '\n');
+                      << ':' << *VirtReg << '\n');
 
     using VirtRegVec = SmallVector<Register, 4>;
 

--- a/llvm/lib/CodeGen/RegAllocEvictionAdvisor.cpp
+++ b/llvm/lib/CodeGen/RegAllocEvictionAdvisor.cpp
@@ -157,7 +157,7 @@ bool DefaultEvictionAdvisor::shouldEvict(const LiveInterval &A, bool IsHint,
     return true;
 
   if (A.weight() > B.weight()) {
-    LLVM_DEBUG(dbgs() << "should evict: " << B << " w= " << B.weight() << '\n');
+    LLVM_DEBUG(dbgs() << "should evict: " << B << '\n');
     return true;
   }
   return false;


### PR DESCRIPTION
LiveInterval::print has included the weight since early 2018. We don't need to print again after we print the interval.