### PR TITLE
[lldb] Fix regex support in SBTarget.modules_access

### DIFF
--- a/lldb/bindings/interface/SBTargetExtensions.i
+++ b/lldb/bindings/interface/SBTargetExtensions.i
@@ -79,11 +79,11 @@ STRING_EXTENSION_LEVEL_OUTSIDE(SBTarget, lldb::eDescriptionLevelBrief)
                         module = self.sbtarget.GetModuleAtIndex(idx)
                         if module.uuid == key:
                             return module
-                elif type(key) is re.SRE_Pattern:
+                elif isinstance(key, type(re.compile(''))):
                     matching_modules = []
                     for idx in range(num_modules):
                         module = self.sbtarget.GetModuleAtIndex(idx)
-                        re_match = key.search(module.path.fullpath)
+                        re_match = key.search(module.file.fullpath)
                         if re_match:
                             matching_modules.append(module)
                     return matching_modules

--- a/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
+++ b/lldb/test/API/lang/cpp/stl/TestStdCXXDisassembly.py
@@ -3,6 +3,7 @@ Test the lldb disassemble command on lib stdc++.
 """
 
 import os
+import re
 import lldb
 from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
@@ -30,15 +31,11 @@ class StdCXXDisassembleTestCase(TestBase):
                 self.runCmd("disassemble -n '%s'" % function.GetName())
 
         lib_stdcxx = "FAILHORRIBLYHERE"
-        # Iterate through the available modules, looking for stdc++ library...
-        for i in range(target.GetNumModules()):
-            module = target.GetModuleAtIndex(i)
-            fs = module.GetFileSpec()
-            if fs.GetFilename().startswith("libstdc++") or fs.GetFilename().startswith(
-                "libc++"
-            ):
-                lib_stdcxx = str(fs)
-                break
+        # Find the stdc++ library...
+        stdlib_regex = re.compile(r"/lib(std)?c\+\+")
+        for module in target.module[stdlib_regex]:
+            lib_stdcxx = module.file.fullpath
+            break
 
         # At this point, lib_stdcxx is the full path to the stdc++ library and
         # module is the corresponding SBModule.


### PR DESCRIPTION
First, `SRE_Pattern` does not exist on newer Python's, use `type(re.compile(''))` like other Python extensions do. The dynamic type is because some earlier versions of Python 3 do not have `re.Pattern`.

Second, `SBModule` has a `file` property, not a `path` property.