### PR TITLE
[lldb] Improve editline completion formatting

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -238,6 +238,8 @@ public:
   /// Convert the current input lines into a UTF8 StringList
   StringList GetInputAsStringList(int line_count = UINT32_MAX);
 
+  size_t GetTerminalWidth() { return m_terminal_width; }
+
 private:
   /// Sets the lowest line number for multi-line editing sessions.  A value of
   /// zero suppresses line number printing in the prompt.

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -954,10 +954,9 @@ PrintCompletion(FILE *output_file,
     } else {
       // If the completion doesn't fit on the screen, print ellipsis and don't
       // bother with the description.
-      fprintf(output_file, "%s...\n",
-              c.GetCompletion()
-                  .substr(0, max_length - padding_length - ellipsis_length)
-                  .c_str());
+      fprintf(output_file, "%.*s...\n\n",
+              static_cast<int>(max_length - padding_length - ellipsis_length),
+              c.GetCompletion().c_str());
       continue;
     }
 
@@ -1000,12 +999,12 @@ PrintCompletion(FILE *output_file,
       const size_t position = description_col + separator_length;
       const size_t description_lenth = line.size();
       if (position + description_lenth < max_length) {
-        fprintf(output_file, "%s\n", line.str().c_str());
+        fprintf(output_file, "%.*s\n", static_cast<int>(description_lenth),
+                line.data());
       } else {
-        fprintf(output_file, "%s...\n",
-                line.substr(0, max_length - position - ellipsis_length)
-                    .str()
-                    .c_str());
+        fprintf(output_file, "%.*s...\n",
+                static_cast<int>(max_length - position - ellipsis_length),
+                line.data());
         continue;
       }
     }

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -938,7 +938,6 @@ PrintCompletion(FILE *output_file,
   for (const CompletionResult::Completion &c : results) {
     if (c.GetCompletion().empty())
       continue;
-    ;
 
     // Print the leading padding.
     fprintf(output_file, "        ");
@@ -997,9 +996,9 @@ PrintCompletion(FILE *output_file,
 
       first = false;
       const size_t position = description_col + separator_length;
-      const size_t description_lenth = line.size();
-      if (position + description_lenth < max_length) {
-        fprintf(output_file, "%.*s\n", static_cast<int>(description_lenth),
+      const size_t description_length = line.size();
+      if (position + description_length < max_length) {
+        fprintf(output_file, "%.*s\n", static_cast<int>(description_length),
                 line.data());
       } else {
         fprintf(output_file, "%.*s...\n",

--- a/lldb/test/API/terminal/TestEditlineCompletions.py
+++ b/lldb/test/API/terminal/TestEditlineCompletions.py
@@ -6,7 +6,6 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 
 
 class EditlineCompletionsTest(PExpectTest):
-
     @skipIfAsan
     @skipIfEditlineSupportMissing
     @skipIfEditlineWideCharSupportMissing

--- a/lldb/test/API/terminal/TestEditlineCompletions.py
+++ b/lldb/test/API/terminal/TestEditlineCompletions.py
@@ -1,0 +1,70 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+
+class EditlineCompletionsTest(PExpectTest):
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    @skipIfEditlineWideCharSupportMissing
+    def test_completion_truncated(self):
+        """Test that the completion is correctly truncated."""
+        self.launch(dimensions=(10, 20))
+        self.child.send("_regexp-\t")
+        self.child.expect("        _regexp-a...")
+        self.child.expect("        _regexp-b...")
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    @skipIfEditlineWideCharSupportMissing
+    def test_description_truncated(self):
+        """Test that the description is correctly truncated."""
+        self.launch(dimensions=(10, 70))
+        self.child.send("_regexp-\t")
+        self.child.expect(
+            "        _regexp-attach    -- Attach to process by ID or name."
+        )
+        self.child.expect(
+            "        _regexp-break     -- Set a breakpoint using one of several..."
+        )
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    @skipIfEditlineWideCharSupportMissing
+    def test_separator_omitted(self):
+        """Test that the separated is correctly omitted."""
+        self.launch(dimensions=(10, 32), timeout=1)
+        self.child.send("_regexp-\t")
+        self.child.expect("        _regexp-attach   \r\n")
+        self.child.expect("        _regexp-break    \r\n")
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    @skipIfEditlineWideCharSupportMissing
+    def test_separator(self):
+        """Test that the separated is correctly printed."""
+        self.launch(dimensions=(10, 33), timeout=1)
+        self.child.send("_regexp-\t")
+        self.child.expect("        _regexp-attach    -- A...")
+        self.child.expect("        _regexp-break     -- S...")
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    @skipIfEditlineWideCharSupportMissing
+    def test_multiline_description(self):
+        """Test that multi-line descriptions are correctly padded and truncated."""
+        self.launch(dimensions=(10, 72), timeout=1)
+        self.child.send("k\t")
+        self.child.expect(
+            "        kdp-remote -- Connect to a process via remote KDP server."
+        )
+        self.child.expect(
+            "                      If no UDP port is specified, port 41139 is assu..."
+        )
+        self.child.expect(
+            "                      kdp-remote is an abbreviation for 'process conn..."
+        )
+        self.child.expect("        kill       -- Terminate the current target process.")

--- a/lldb/test/API/terminal/TestEditlineCompletions.py
+++ b/lldb/test/API/terminal/TestEditlineCompletions.py
@@ -8,7 +8,6 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 class EditlineCompletionsTest(PExpectTest):
     @skipIfAsan
     @skipIfEditlineSupportMissing
-    @skipIfEditlineWideCharSupportMissing
     def test_completion_truncated(self):
         """Test that the completion is correctly truncated."""
         self.launch(dimensions=(10, 20))
@@ -18,7 +17,6 @@ class EditlineCompletionsTest(PExpectTest):
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
-    @skipIfEditlineWideCharSupportMissing
     def test_description_truncated(self):
         """Test that the description is correctly truncated."""
         self.launch(dimensions=(10, 70))
@@ -32,30 +30,27 @@ class EditlineCompletionsTest(PExpectTest):
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
-    @skipIfEditlineWideCharSupportMissing
     def test_separator_omitted(self):
         """Test that the separated is correctly omitted."""
-        self.launch(dimensions=(10, 32), timeout=1)
+        self.launch(dimensions=(10, 32))
         self.child.send("_regexp-\t")
         self.child.expect("        _regexp-attach   \r\n")
         self.child.expect("        _regexp-break    \r\n")
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
-    @skipIfEditlineWideCharSupportMissing
     def test_separator(self):
         """Test that the separated is correctly printed."""
-        self.launch(dimensions=(10, 33), timeout=1)
+        self.launch(dimensions=(10, 33))
         self.child.send("_regexp-\t")
         self.child.expect("        _regexp-attach    -- A...")
         self.child.expect("        _regexp-break     -- S...")
 
     @skipIfAsan
     @skipIfEditlineSupportMissing
-    @skipIfEditlineWideCharSupportMissing
     def test_multiline_description(self):
         """Test that multi-line descriptions are correctly padded and truncated."""
-        self.launch(dimensions=(10, 72), timeout=1)
+        self.launch(dimensions=(10, 72))
         self.child.send("k\t")
         self.child.expect(
             "        kdp-remote -- Connect to a process via remote KDP server."


### PR DESCRIPTION
This patch improves the formatting of editline completions. The current implementation is naive and doesn't account for the terminal width.

Concretely, the old implementation suffered from the following issues:

 - We would unconditionally pad to the longest completion. If that completion exceeds the width of the terminal, that would result in a lot of superfluous white space and line wrapping.
 - When printing the description, we wouldn't account for the presence of newlines, and they would continue without leading padding.

The new code accounts for both. If the completion exceeds the available terminal width, we show what fits on the current lined followed by ellipsis. We also no longer pad beyond the length of the current line. Finally, we print the description line by line, with the proper leading padding. If a line of the description exceeds the available terminal width, we print ellipsis and won't print the next line.

Before:

```
Available completions:
        _regexp-attach    -- Attach to process by ID or name.
        _regexp-break     -- Set a breakpoint using one of several shorthand
 formats.
        _regexp-bt        -- Show backtrace of the current thread's call sta
ck. Any numeric argument displays at most that many frames. The argument 'al
l' displays all threads. Use 'settings set frame-format' to customize the pr
inting of individual frames and 'settings set thread-format' to customize th
e thread header. Frame recognizers may filter thelist. Use 'thread backtrace
 -u (--unfiltered)' to see them all.
        _regexp-display   -- Evaluate an expression at every stop (see 'help
 target stop-hook'.)

```

After:
```
 Available completions:
        _regexp-attach    -- Attach to process by ID or name.
        _regexp-break     -- Set a breakpoint using one of several shorth...
        _regexp-bt        -- Show backtrace of the current thread's call ...
        _regexp-display   -- Evaluate an expression at every stop (see 'h...
```

rdar://135818198