### PR TITLE
Guard against self-assignment in the DominatorTreeBase move assignment operator.

### DIFF
--- a/llvm/include/llvm/Support/GenericDomTree.h
+++ b/llvm/include/llvm/Support/GenericDomTree.h
@@ -287,6 +287,8 @@ protected:
   }
 
   DominatorTreeBase &operator=(DominatorTreeBase &&RHS) {
+    if (this == &RHS)
+      return *this;
     Roots = std::move(RHS.Roots);
     DomTreeNodes = std::move(RHS.DomTreeNodes);
     NodeNumberMap = std::move(RHS.NodeNumberMap);


### PR DESCRIPTION
The `DominatorTreeBase` move assignment operator was not self-assignment safe because the last thing it does before returning is to release all resources held by the source object. This issue was reported by a static analysis tool; no self-assignment is known to occur in practice.