### PR TITLE
[Mips] Reduce number of selectVSplatUimm/Simm functions by using templates.

### DIFF
--- a/llvm/lib/Target/Mips/MipsISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsISelDAGToDAG.cpp
@@ -160,42 +160,8 @@ bool MipsDAGToDAGISel::selectVSplat(SDNode *N, APInt &Imm,
   return false;
 }
 
-bool MipsDAGToDAGISel::selectVSplatUimm1(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatUimm2(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatUimm3(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatUimm4(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatUimm5(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatUimm6(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatUimm8(SDValue N, SDValue &Imm) const {
-  llvm_unreachable("Unimplemented function.");
-  return false;
-}
-
-bool MipsDAGToDAGISel::selectVSplatSimm5(SDValue N, SDValue &Imm) const {
+bool MipsDAGToDAGISel::selectVSplatCommon(SDValue N, SDValue &Imm, bool Signed,
+                                          unsigned ImmBitSize) const {
   llvm_unreachable("Unimplemented function.");
   return false;
 }

--- a/llvm/lib/Target/Mips/MipsISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsISelDAGToDAG.cpp
@@ -163,7 +163,6 @@ bool MipsDAGToDAGISel::selectVSplat(SDNode *N, APInt &Imm,
 bool MipsDAGToDAGISel::selectVSplatCommon(SDValue N, SDValue &Imm, bool Signed,
                                           unsigned ImmBitSize) const {
   llvm_unreachable("Unimplemented function.");
-  return false;
 }
 
 bool MipsDAGToDAGISel::selectVSplatUimmPow2(SDValue N, SDValue &Imm) const {

--- a/llvm/lib/Target/Mips/MipsISelDAGToDAG.h
+++ b/llvm/lib/Target/Mips/MipsISelDAGToDAG.h
@@ -92,22 +92,18 @@ private:
   /// Select constant vector splats.
   virtual bool selectVSplat(SDNode *N, APInt &Imm,
                             unsigned MinSizeInBits) const;
-  /// Select constant vector splats whose value fits in a uimm1.
-  virtual bool selectVSplatUimm1(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a uimm2.
-  virtual bool selectVSplatUimm2(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a uimm3.
-  virtual bool selectVSplatUimm3(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a uimm4.
-  virtual bool selectVSplatUimm4(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a uimm5.
-  virtual bool selectVSplatUimm5(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a uimm6.
-  virtual bool selectVSplatUimm6(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a uimm8.
-  virtual bool selectVSplatUimm8(SDValue N, SDValue &Imm) const;
-  /// Select constant vector splats whose value fits in a simm5.
-  virtual bool selectVSplatSimm5(SDValue N, SDValue &Imm) const;
+  virtual bool selectVSplatCommon(SDValue N, SDValue &Imm, bool Signed,
+                                  unsigned ImmBitSize) const;
+  /// Select constant vector splats whose value fits in a uimm<Bits>.
+  template <unsigned Bits>
+  bool selectVSplatUimm(SDValue N, SDValue &Imm) const {
+    return selectVSplatCommon(N, Imm, false, Bits);
+  }
+  /// Select constant vector splats whose value fits in a simm<Bits>.
+  template <unsigned Bits>
+  bool selectVSplatSimm(SDValue N, SDValue &Imm) const {
+    return selectVSplatCommon(N, Imm, true, Bits);
+  }
   /// Select constant vector splats whose value is a power of 2.
   virtual bool selectVSplatUimmPow2(SDValue N, SDValue &Imm) const;
   /// Select constant vector splats whose value is the inverse of a

--- a/llvm/lib/Target/Mips/MipsMSAInstrInfo.td
+++ b/llvm/lib/Target/Mips/MipsMSAInstrInfo.td
@@ -249,67 +249,67 @@ class SplatComplexPattern<Operand opclass, ValueType ty, int numops, string fn,
 }
 
 def vsplati8_uimm3 : SplatComplexPattern<vsplat_uimm3, v16i8, 1,
-                                         "selectVSplatUimm3",
+                                         "selectVSplatUimm<3>",
                                          [build_vector, bitconvert]>;
 
 def vsplati8_uimm4 : SplatComplexPattern<vsplat_uimm4, v16i8, 1,
-                                         "selectVSplatUimm4",
+                                         "selectVSplatUimm<4>",
                                          [build_vector, bitconvert]>;
 
 def vsplati8_uimm5 : SplatComplexPattern<vsplat_uimm5, v16i8, 1,
-                                         "selectVSplatUimm5",
+                                         "selectVSplatUimm<5>",
                                          [build_vector, bitconvert]>;
 
 def vsplati8_uimm8 : SplatComplexPattern<vsplat_uimm8, v16i8, 1,
-                                         "selectVSplatUimm8",
+                                         "selectVSplatUimm<8>",
                                          [build_vector, bitconvert]>;
 
 def vsplati8_simm5 : SplatComplexPattern<vsplat_simm5, v16i8, 1,
-                                         "selectVSplatSimm5",
+                                         "selectVSplatSimm<5>",
                                          [build_vector, bitconvert]>;
 
 def vsplati16_uimm3 : SplatComplexPattern<vsplat_uimm3, v8i16, 1,
-                                          "selectVSplatUimm3",
+                                          "selectVSplatUimm<3>",
                                           [build_vector, bitconvert]>;
 
 def vsplati16_uimm4 : SplatComplexPattern<vsplat_uimm4, v8i16, 1,
-                                          "selectVSplatUimm4",
+                                          "selectVSplatUimm<4>",
                                           [build_vector, bitconvert]>;
 
 def vsplati16_uimm5 : SplatComplexPattern<vsplat_uimm5, v8i16, 1,
-                                          "selectVSplatUimm5",
+                                          "selectVSplatUimm<5>",
                                           [build_vector, bitconvert]>;
 
 def vsplati16_simm5 : SplatComplexPattern<vsplat_simm5, v8i16, 1,
-                                          "selectVSplatSimm5",
+                                          "selectVSplatSimm<5>",
                                           [build_vector, bitconvert]>;
 
 def vsplati32_uimm2 : SplatComplexPattern<vsplat_uimm2, v4i32, 1,
-                                          "selectVSplatUimm2",
+                                          "selectVSplatUimm<2>",
                                           [build_vector, bitconvert]>;
 
 def vsplati32_uimm5 : SplatComplexPattern<vsplat_uimm5, v4i32, 1,
-                                          "selectVSplatUimm5",
+                                          "selectVSplatUimm<5>",
                                           [build_vector, bitconvert]>;
 
 def vsplati32_simm5 : SplatComplexPattern<vsplat_simm5, v4i32, 1,
-                                          "selectVSplatSimm5",
+                                          "selectVSplatSimm<5>",
                                           [build_vector, bitconvert]>;
 
 def vsplati64_uimm1 : SplatComplexPattern<vsplat_uimm1, v2i64, 1,
-                                          "selectVSplatUimm1",
+                                          "selectVSplatUimm<1>",
                                           [build_vector, bitconvert]>;
 
 def vsplati64_uimm5 : SplatComplexPattern<vsplat_uimm5, v2i64, 1,
-                                          "selectVSplatUimm5",
+                                          "selectVSplatUimm<5>",
                                           [build_vector, bitconvert]>;
 
 def vsplati64_uimm6 : SplatComplexPattern<vsplat_uimm6, v2i64, 1,
-                                          "selectVSplatUimm6",
+                                          "selectVSplatUimm<6>",
                                           [build_vector, bitconvert]>;
 
 def vsplati64_simm5 : SplatComplexPattern<vsplat_simm5, v2i64, 1,
-                                          "selectVSplatSimm5",
+                                          "selectVSplatSimm<5>",
                                           [build_vector, bitconvert]>;
 
 // Any build_vector that is a constant splat with a value that is an exact

--- a/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
+++ b/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.cpp
@@ -569,52 +569,6 @@ selectVSplatCommon(SDValue N, SDValue &Imm, bool Signed,
   return false;
 }
 
-// Select constant vector splats.
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm1(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 1);
-}
-
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm2(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 2);
-}
-
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm3(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 3);
-}
-
-// Select constant vector splats.
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm4(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 4);
-}
-
-// Select constant vector splats.
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm5(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 5);
-}
-
-// Select constant vector splats.
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm6(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 6);
-}
-
-// Select constant vector splats.
-bool MipsSEDAGToDAGISel::
-selectVSplatUimm8(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, false, 8);
-}
-
-// Select constant vector splats.
-bool MipsSEDAGToDAGISel::
-selectVSplatSimm5(SDValue N, SDValue &Imm) const {
-  return selectVSplatCommon(N, Imm, true, 5);
-}
-
 // Select constant vector splats whose value is a power of 2.
 //
 // In addition to the requirements of selectVSplat(), this function returns

--- a/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.h
+++ b/llvm/lib/Target/Mips/MipsSEISelDAGToDAG.h
@@ -95,23 +95,7 @@ private:
                     unsigned MinSizeInBits) const override;
   /// Select constant vector splats whose value fits in a given integer.
   bool selectVSplatCommon(SDValue N, SDValue &Imm, bool Signed,
-                                  unsigned ImmBitSize) const;
-  /// Select constant vector splats whose value fits in a uimm1.
-  bool selectVSplatUimm1(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a uimm2.
-  bool selectVSplatUimm2(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a uimm3.
-  bool selectVSplatUimm3(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a uimm4.
-  bool selectVSplatUimm4(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a uimm5.
-  bool selectVSplatUimm5(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a uimm6.
-  bool selectVSplatUimm6(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a uimm8.
-  bool selectVSplatUimm8(SDValue N, SDValue &Imm) const override;
-  /// Select constant vector splats whose value fits in a simm5.
-  bool selectVSplatSimm5(SDValue N, SDValue &Imm) const override;
+                          unsigned ImmBitSize) const override;
   /// Select constant vector splats whose value is a power of 2.
   bool selectVSplatUimmPow2(SDValue N, SDValue &Imm) const override;
   /// Select constant vector splats whose value is the inverse of a


### PR DESCRIPTION
The implementaton of methods only vary by what arguments they pass to selectVSplatCommon.

Turn selectVSplatCommon into a virtual function and use template methods in the base class to pass the immediate size.