### PR TITLE
[Clang][Driver] report unsupported option error when link + compile in same process

### DIFF
--- a/clang/test/Driver/unsupported-option.c
+++ b/clang/test/Driver/unsupported-option.c
@@ -17,3 +17,13 @@
 // RUN: not %clang -fprofile-sample-use=code.prof --target=powerpc-ibm-aix %s 2>&1 | \
 // RUN: FileCheck %s --check-prefix=AIX-PROFILE-SAMPLE
 // AIX-PROFILE-SAMPLE: error: unsupported option '-fprofile-sample-use=' for target
+
+// -mhtm is unsupported on x86_64. Test that using it in different command
+// line permutations generates an `unsupported option` error.
+// RUN: not %clang --target=x86_64 -### %s -mhtm 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=UNSUP_OPT
+// RUN: not %clang --target=x86_64 -### %s -mhtm -lc 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=UNSUP_OPT
+// RUN: not %clang --target=x86_64 -### -mhtm -lc %s 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=UNSUP_OPT
+// UNSUP_OPT: error: unsupported option


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/116278

This change updates clang to report unsupported option errors regardless of the command line argument order.

When clang is invoked with a source file and without `-c` it will both compile and link. When an unsupported option is also part of the command line clang should generated an error. However, if the source file name comes before an object file, eg: `-lc`, the error is ignored.

```
$ clang --target=x86_64 -lc hello.c -mhtm
clang: error: unsupported option '-mhtm' for target 'x86_64'
$ echo $?
1
```

but if `-lc` comes after `hello.c` the error is dropped

```
$ clang --target=x86_64 hello.c -mhtm -lc
$ echo $?
0
```

after this change clang will report the error regardless of the command line argument order.