### PR TITLE
Make sure that the `std::optional<>` result is checked before being accessed

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -394,9 +394,13 @@ Expected<DWARFAddressRangesVector> DWARFDie::getAddressRanges() const {
 
   std::optional<DWARFFormValue> Value = find(DW_AT_ranges);
   if (Value) {
+    std::optional<uint64_t> SecOff = Value->getAsSectionOffset();
+    if (!SecOff) {
+      return DWARFAddressRangesVector();
+    }
     if (Value->getForm() == DW_FORM_rnglistx)
-      return U->findRnglistFromIndex(*Value->getAsSectionOffset());
-    return U->findRnglistFromOffset(*Value->getAsSectionOffset());
+      return U->findRnglistFromIndex(*SecOff);
+    return U->findRnglistFromOffset(*SecOff);
   }
   return DWARFAddressRangesVector();
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -393,16 +393,17 @@ Expected<DWARFAddressRangesVector> DWARFDie::getAddressRanges() const {
     return DWARFAddressRangesVector{{LowPC, HighPC, Index}};
 
   std::optional<DWARFFormValue> Value = find(DW_AT_ranges);
-  if (Value) {
-    std::optional<uint64_t> SecOff = Value->getAsSectionOffset();
-    if (!SecOff) {
-      return DWARFAddressRangesVector();
-    }
-    if (Value->getForm() == DW_FORM_rnglistx)
-      return U->findRnglistFromIndex(*SecOff);
-    return U->findRnglistFromOffset(*SecOff);
-  }
-  return DWARFAddressRangesVector();
+  if (!Value)
+    return DWARFAddressRangesVector();
+
+  std::optional<uint64_t> SecOff = Value->getAsSectionOffset();
+  if (!SecOff)
+    return DWARFAddressRangesVector();
+
+  if (Value->getForm() == DW_FORM_rnglistx)
+    return U->findRnglistFromIndex(*SecOff);
+
+  return U->findRnglistFromOffset(*SecOff);
 }
 
 bool DWARFDie::addressRangeContainsAddress(const uint64_t Address) const {


### PR DESCRIPTION
In some cases (c.f. the attached binary), `getAsSectionOffset()` is failing and thus, the inline de-referencing
is wrong.  

[D_test.bin.zip](https://github.com/user-attachments/files/17784093/D_test.bin.zip)
