### PR TITLE
[PDB] Fix missing `consumeError` which raise error with asserts enabled

### DIFF
--- a/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/SymbolCache.cpp
@@ -388,12 +388,16 @@ SymbolCache::findPublicSymbolBySectOffset(uint32_t Sect, uint32_t Offset) {
     return getSymbolById(Iter->second);
 
   auto Publics = Session.getPDBFile().getPDBPublicsStream();
-  if (!Publics)
+  if (!Publics) {
+    consumeError(Publics.takeError());
     return nullptr;
+  }
 
   auto ExpectedSyms = Session.getPDBFile().getPDBSymbolStream();
-  if (!ExpectedSyms)
+  if (!ExpectedSyms) {
+    consumeError(ExpectedSyms.takeError());
     return nullptr;
+  }
   BinaryStreamRef SymStream =
       ExpectedSyms->getSymbolArray().getUnderlyingStream();
 


### PR DESCRIPTION
As mentioned in the title, the missing `consumeError` trigger assertions 