### PR TITLE
[NFC][LLVM] Fix a couple of build warnings

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RTDyldMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RTDyldMemoryManager.cpp
@@ -42,7 +42,7 @@ extern "C" void __deregister_frame(void *);
 // but using the MingW runtime.
 static void __register_frame(void *p) {
   static bool Searched = false;
-  static void((*rf)(void *)) = 0;
+  static void (*rf)(void *) = 0;
 
   if (!Searched) {
     Searched = true;
@@ -55,7 +55,7 @@ static void __register_frame(void *p) {
 
 static void __deregister_frame(void *p) {
   static bool Searched = false;
-  static void((*df)(void *)) = 0;
+  static void (*df)(void *) = 0;
 
   if (!Searched) {
     Searched = true;

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -182,12 +182,14 @@ Error Config::addSaveTemps(std::string OutputFileName, bool UseInputModulePath,
 #define HANDLE_EXTENSION(Ext)                                                  \
   llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
+#undef HANDLE_EXTENSION
 
 static void RegisterPassPlugins(ArrayRef<std::string> PassPlugins,
                                 PassBuilder &PB) {
 #define HANDLE_EXTENSION(Ext)                                                  \
   get##Ext##PluginInfo().RegisterPassBuilderCallbacks(PB);
 #include "llvm/Support/Extension.def"
+#undef HANDLE_EXTENSION
 
   // Load requested pass plugins and let them register pass builder callbacks
   for (auto &PluginFN : PassPlugins) {


### PR DESCRIPTION
- Fix `HANDLE_EXTENSION` macro redefinition warning in LTOBackend.cpp
- Fix "unnecessary brackets" around rf/df variable definitions warning.