### PR TITLE
[CMake] Enable CMP0179 alongside CMP0156 for deduplication on LLD

### DIFF
--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -37,4 +37,13 @@ endif()
 # building with the Apple linker.
 if(POLICY CMP0156)
   cmake_policy(SET CMP0156 NEW)
+
+  # CMP0179: De-duplication of static libraries on link lines keeps first occurrence.
+  # Dependent on CMP0156=NEW. Unifies the behaviour across platforms.
+  # Works around a LLD bug ELF backend bug (#116669) and required for CMP0156
+  # to have an effect for affected versions. Also fixes building with CMake 3.31.0,
+  # which lacked the workaround of ignoring CMP0156 unless this is enabled.
+  if(POLICY CMP0179)
+    cmake_policy(SET CMP0179 NEW)
+  endif()
 endif()


### PR DESCRIPTION
LLD has a bug regarding ordering of static link libraries in the ELF backend, which has been reported as #116669.
CMake 3.31.0 started properly deduplicating static libraries for LLD causing the following linking failure for `libclang-cpp.so` with `-DLLVM_LINK_LLVM_DYLIB=ON`:
```
ld.lld: error: undefined symbol: llvm::omp::getOpenMPClauseName(llvm::omp::Clause)
>>> referenced by OpenMPKinds.cpp
>>>               tools/clang/lib/Basic/CMakeFiles/obj.clangBasic.dir/OpenMPKinds.cpp.o:(clang::getOpenMPSimpleClauseTypeName(llvm::omp::Clause, unsigned int))
>>> referenced by SemaOpenMP.cpp
>>>               tools/clang/lib/Sema/CMakeFiles/obj.clangSema.dir/SemaOpenMP.cpp.o:(clang::SemaOpenMP::CheckOMPRequiresDecl(clang::SourceLocation, llvm::ArrayRef<clang::OMPClause*>))
>>> referenced by SemaOpenMP.cpp
>>>               tools/clang/lib/Sema/CMakeFiles/obj.clangSema.dir/SemaOpenMP.cpp.o:(clang::SemaOpenMP::CheckOMPRequiresDecl(clang::SourceLocation, llvm::ArrayRef<clang::OMPClause*>))
>>> referenced 166 more times

[tons more]
```

CMake 3.31 also introduced CMP0179, which builds on CMP0156 and makes the deduplication consistent across platforms.
By coincidence this works around the above LLD deficiency and is the fix that CMake 3.31.1 will implement.
However, the fix is to ignore CMP0156 unless CMP0179 is also enabled, i.e. no more deduplication.
So enable CMP0179 to keep the benefits of deduplication from CMP0156 on LLD and fix the build for CMake 3.31.0.

See: #116669
See: https://gitlab.kitware.com/cmake/cmake/-/issues/26447
Fixes: cb90d5b3ef463f0a471f9c6d39978c3764021dea
