### PR TITLE
[flang][OpenMP] Update frontend support for DEFAULTMAP clause

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3544,7 +3544,7 @@ struct OmpDefaultmapClause {
   TUPLE_CLASS_BOILERPLATE(OmpDefaultmapClause);
   ENUM_CLASS(
       ImplicitBehavior, Alloc, To, From, Tofrom, Firstprivate, None, Default)
-  ENUM_CLASS(VariableCategory, Scalar, Aggregate, Allocatable, Pointer)
+  ENUM_CLASS(VariableCategory, All, Scalar, Aggregate, Allocatable, Pointer)
   std::tuple<ImplicitBehavior, std::optional<VariableCategory>> t;
 };
 

--- a/flang/lib/Lower/OpenMP/Clauses.cpp
+++ b/flang/lib/Lower/OpenMP/Clauses.cpp
@@ -561,17 +561,20 @@ Defaultmap make(const parser::OmpClause::Defaultmap &inp,
   CLAUSET_ENUM_CONVERT( //
       convert2, wrapped::VariableCategory, Defaultmap::VariableCategory,
       // clang-format off
-      MS(Scalar,       Scalar)
       MS(Aggregate,    Aggregate)
-      MS(Pointer,      Pointer)
+      MS(All,          All)
       MS(Allocatable,  Allocatable)
+      MS(Pointer,      Pointer)
+      MS(Scalar,       Scalar)
       // clang-format on
   );
 
   auto &t0 = std::get<wrapped::ImplicitBehavior>(inp.v.t);
   auto &t1 = std::get<std::optional<wrapped::VariableCategory>>(inp.v.t);
+
+  auto category = t1 ? convert2(*t1) : Defaultmap::VariableCategory::All;
   return Defaultmap{{/*ImplicitBehavior=*/convert1(t0),
-                     /*VariableCategory=*/maybeApply(convert2, t1)}};
+                     /*VariableCategory=*/category}};
 }
 
 Doacross makeDoacross(const parser::OmpDoacross &doa,

--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -30,6 +30,7 @@
 #include "flang/Optimizer/Builder/Todo.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
+#include "flang/Parser/characters.h"
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/openmp-directive-sets.h"
 #include "flang/Semantics/tools.h"
@@ -2881,7 +2882,9 @@ static void genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
         !std::holds_alternative<clause::InReduction>(clause.u) &&
         !std::holds_alternative<clause::Mergeable>(clause.u) &&
         !std::holds_alternative<clause::TaskReduction>(clause.u)) {
-      TODO(clauseLocation, "OpenMP Block construct clause");
+      std::string name =
+          parser::ToUpperCaseLetters(llvm::omp::getOpenMPClauseName(clause.id));
+      TODO(clauseLocation, name + " clause is not implemented yet");
     }
   }
 

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -270,7 +270,7 @@ TYPE_PARSER(construct<OmpMapClause>(
 // 2.19.7.2 defaultmap(implicit-behavior[:variable-category])
 //  implicit-behavior -> ALLOC | TO | FROM | TOFROM | FIRSRTPRIVATE | NONE |
 //  DEFAULT
-//  variable-category -> SCALAR | AGGREGATE | ALLOCATABLE | POINTER
+//  variable-category -> ALL | SCALAR | AGGREGATE | ALLOCATABLE | POINTER
 TYPE_PARSER(construct<OmpDefaultmapClause>(
     construct<OmpDefaultmapClause::ImplicitBehavior>(
         "ALLOC" >> pure(OmpDefaultmapClause::ImplicitBehavior::Alloc) ||
@@ -283,6 +283,7 @@ TYPE_PARSER(construct<OmpDefaultmapClause>(
         "DEFAULT" >> pure(OmpDefaultmapClause::ImplicitBehavior::Default)),
     maybe(":" >>
         construct<OmpDefaultmapClause::VariableCategory>(
+            "ALL"_id >> pure(OmpDefaultmapClause::VariableCategory::All) ||
             "SCALAR" >> pure(OmpDefaultmapClause::VariableCategory::Scalar) ||
             "AGGREGATE" >>
                 pure(OmpDefaultmapClause::VariableCategory::Aggregate) ||

--- a/flang/test/Lower/OpenMP/Todo/defaultmap-clause.f90
+++ b/flang/test/Lower/OpenMP/Todo/defaultmap-clause.f90
@@ -1,0 +1,8 @@
+!RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -fopenmp-version=45 -o - %s 2>&1 | FileCheck %s
+!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=45 -o - %s 2>&1 | FileCheck %s
+
+!CHECK: not yet implemented: DEFAULTMAP clause is not implemented yet
+subroutine f00
+  !$omp target defaultmap(tofrom:scalar)
+  !$omp end target
+end

--- a/flang/test/Lower/OpenMP/Todo/task_detach.f90
+++ b/flang/test/Lower/OpenMP/Todo/task_detach.f90
@@ -6,7 +6,7 @@
 ! `detach` clause
 !===============================================================================
 
-! CHECK: not yet implemented: OpenMP Block construct clause
+! CHECK: not yet implemented: DETACH clause is not implemented yet
 subroutine omp_task_detach()
   use omp_lib
   integer (kind=omp_event_handle_kind) :: event

--- a/flang/test/Lower/OpenMP/Todo/task_untied.f90
+++ b/flang/test/Lower/OpenMP/Todo/task_untied.f90
@@ -5,7 +5,7 @@
 ! `untied` clause
 !===============================================================================
 
-! CHECK: not yet implemented: OpenMP Block construct clause
+! CHECK: not yet implemented: UNTIED clause is not implemented yet
 subroutine omp_task_untied()
   !$omp task untied
   call foo()

--- a/flang/test/Parser/OpenMP/defaultmap-clause.f90
+++ b/flang/test/Parser/OpenMP/defaultmap-clause.f90
@@ -1,0 +1,84 @@
+!RUN: %flang_fc1 -fdebug-unparse -fopenmp -fopenmp-version=52 %s | FileCheck --ignore-case --check-prefix="UNPARSE" %s
+!RUN: %flang_fc1 -fdebug-dump-parse-tree -fopenmp -fopenmp-version=52 %s | FileCheck --check-prefix="PARSE-TREE" %s
+
+subroutine f00
+  !$omp target defaultmap(from)
+  !$omp end target
+end
+
+!UNPARSE: SUBROUTINE f00
+!UNPARSE: !$OMP TARGET  DEFAULTMAP(FROM)
+!UNPARSE: !$OMP END TARGET
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: OmpBeginBlockDirective
+!PARSE-TREE: | OmpBlockDirective -> llvm::omp::Directive = target
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
+!PARSE-TREE: | | ImplicitBehavior = From
+!PARSE-TREE: Block
+
+subroutine f01
+  !$omp target defaultmap(firstprivate: aggregate)
+  !$omp end target
+end
+
+!UNPARSE: SUBROUTINE f01
+!UNPARSE: !$OMP TARGET  DEFAULTMAP(FIRSTPRIVATE:AGGREGATE)
+!UNPARSE: !$OMP END TARGET
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: OmpBeginBlockDirective
+!PARSE-TREE: | OmpBlockDirective -> llvm::omp::Directive = target
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
+!PARSE-TREE: | | ImplicitBehavior = Firstprivate
+!PARSE-TREE: | | VariableCategory = Aggregate
+
+subroutine f02
+  !$omp target defaultmap(alloc: all)
+  !$omp end target
+end
+
+!UNPARSE: SUBROUTINE f02
+!UNPARSE: !$OMP TARGET  DEFAULTMAP(ALLOC:ALL)
+!UNPARSE: !$OMP END TARGET
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: OmpBeginBlockDirective
+!PARSE-TREE: | OmpBlockDirective -> llvm::omp::Directive = target
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
+!PARSE-TREE: | | ImplicitBehavior = Alloc
+!PARSE-TREE: | | VariableCategory = All
+
+! Both "all" and "allocatable" are valid, and "all" is a prefix of
+! "allocatable". Make sure we parse this correctly.
+subroutine f03
+  !$omp target defaultmap(alloc: allocatable)
+  !$omp end target
+end
+
+!UNPARSE: SUBROUTINE f03
+!UNPARSE: !$OMP TARGET  DEFAULTMAP(ALLOC:ALLOCATABLE)
+!UNPARSE: !$OMP END TARGET
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: OmpBeginBlockDirective
+!PARSE-TREE: | OmpBlockDirective -> llvm::omp::Directive = target
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
+!PARSE-TREE: | | ImplicitBehavior = Alloc
+!PARSE-TREE: | | VariableCategory = Allocatable
+
+subroutine f04
+  !$omp target defaultmap(tofrom: scalar)
+  !$omp end target
+end
+
+!UNPARSE: SUBROUTINE f04
+!UNPARSE: !$OMP TARGET  DEFAULTMAP(TOFROM:SCALAR)
+!UNPARSE: !$OMP END TARGET
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: OmpBeginBlockDirective
+!PARSE-TREE: | OmpBlockDirective -> llvm::omp::Directive = target
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
+!PARSE-TREE: | | ImplicitBehavior = Tofrom
+!PARSE-TREE: | | VariableCategory = Scalar

--- a/flang/test/Semantics/OpenMP/combined-constructs.f90
+++ b/flang/test/Semantics/OpenMP/combined-constructs.f90
@@ -33,7 +33,7 @@ program main
   enddo
   !$omp end target parallel
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
+  !ERROR: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v1.1, try -fopenmp-version=50
   !$omp target parallel defaultmap(tofrom)
   do i = 1, N
      a(i) = 3.14
@@ -80,7 +80,7 @@ program main
   enddo
   !$omp end target parallel do
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
+  !ERROR: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v1.1, try -fopenmp-version=50
   !$omp target parallel do defaultmap(tofrom)
   do i = 1, N
      a(i) = 3.14
@@ -140,7 +140,7 @@ program main
   enddo
   !$omp end target teams
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
+  !ERROR: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v1.1, try -fopenmp-version=50
   !$omp target teams defaultmap(tofrom)
   do i = 1, N
      a(i) = 3.14
@@ -240,7 +240,7 @@ program main
   enddo
   !$omp end target teams distribute
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
+  !ERROR: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v1.1, try -fopenmp-version=50
   !$omp target teams distribute defaultmap(tofrom)
   do i = 1, N
      a(i) = 3.14
@@ -333,7 +333,7 @@ program main
   enddo
   !$omp end target teams distribute parallel do
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
+  !ERROR: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v1.1, try -fopenmp-version=50
   !$omp target teams distribute parallel do defaultmap(tofrom)
   do i = 1, N
      a(i) = 3.14
@@ -433,7 +433,7 @@ program main
   enddo
   !$omp end target teams distribute parallel do simd
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
+  !ERROR: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v1.1, try -fopenmp-version=50
   !$omp target teams distribute parallel do simd defaultmap(tofrom)
   do i = 1, N
      a(i) = 3.14

--- a/flang/test/Semantics/OpenMP/defaultmap-clause-v45.f90
+++ b/flang/test/Semantics/OpenMP/defaultmap-clause-v45.f90
@@ -1,0 +1,34 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=45 -Werror
+
+subroutine f00
+!WARNING: The DEFAULTMAP clause requires a variable-category SCALAR in OpenMP v4.5, try -fopenmp-version=50
+  !$omp target defaultmap(tofrom)
+  !$omp end target
+end
+
+subroutine f01
+!WARNING: AGGREGATE is not allowed in OpenMP v4.5, try -fopenmp-version=50
+  !$omp target defaultmap(tofrom:aggregate)
+  !$omp end target
+end
+
+subroutine f02
+!WARNING: FROM is not allowed in OpenMP v4.5, try -fopenmp-version=50
+  !$omp target defaultmap(from:scalar)
+  !$omp end target
+end
+
+subroutine f03
+!WARNING: ALL is not allowed in OpenMP v4.5, try -fopenmp-version=52
+  !$omp target defaultmap(tofrom:all)
+  !$omp end target
+end
+
+subroutine f04
+!WARNING: FROM is not allowed in OpenMP v4.5, try -fopenmp-version=50
+!WARNING: POINTER is not allowed in OpenMP v4.5, try -fopenmp-version=50
+  !$omp target defaultmap(from:pointer)
+  !$omp end target
+end
+
+

--- a/flang/test/Semantics/OpenMP/defaultmap-clause-v50.f90
+++ b/flang/test/Semantics/OpenMP/defaultmap-clause-v50.f90
@@ -1,0 +1,23 @@
+!RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=50 -Werror
+
+subroutine f00
+  !$omp target defaultmap(tofrom)
+  !$omp end target
+end
+
+subroutine f01
+  !$omp target defaultmap(tofrom:aggregate)
+  !$omp end target
+end
+
+subroutine f02
+  !$omp target defaultmap(from:scalar)
+  !$omp end target
+end
+
+subroutine f03
+!WARNING: ALL is not allowed in OpenMP v5.0, try -fopenmp-version=52
+  !$omp target defaultmap(tofrom:all)
+  !$omp end target
+end
+

--- a/flang/test/Semantics/OpenMP/device-constructs.f90
+++ b/flang/test/Semantics/OpenMP/device-constructs.f90
@@ -44,7 +44,6 @@ program main
   enddo
   !$omp end target
 
-  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
   !$omp target defaultmap(tofrom)
   do i = 1, N
      a = 3.14

--- a/llvm/include/llvm/Frontend/OpenMP/ClauseT.h
+++ b/llvm/include/llvm/Frontend/OpenMP/ClauseT.h
@@ -490,7 +490,7 @@ template <typename T, typename I, typename E> //
 struct DefaultmapT {
   ENUM(ImplicitBehavior, Alloc, To, From, Tofrom, Firstprivate, None, Default,
        Present);
-  ENUM(VariableCategory, Scalar, Aggregate, Pointer, Allocatable);
+  ENUM(VariableCategory, All, Scalar, Aggregate, Pointer, Allocatable);
   using TupleTrait = std::true_type;
   std::tuple<ImplicitBehavior, OPT(VariableCategory)> t;
 };


### PR DESCRIPTION
Add ALL variable category, implement semantic checks to verify the validity of the clause, improve error messages, add testcases.

The variable category modifier is optional since 5.0, make sure we allow it to be missing. If it is missing, assume "all" in clause conversion.