### PR TITLE
[SelectionDAG][PPC][SystemZ] Fix GET_DYNAMIC_AREA_OFFSET chain result

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3499,7 +3499,7 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
     break;
   case ISD::GET_DYNAMIC_AREA_OFFSET:
     Results.push_back(DAG.getConstant(0, dl, Node->getValueType(0)));
-    Results.push_back(Results[0].getValue(0));
+    Results.push_back(Node->getOperand(0));
     break;
   case ISD::FCOPYSIGN:
     Results.push_back(ExpandFCOPYSIGN(Node));

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -7401,9 +7401,9 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
     if (PtrTy.getFixedSizeInBits() < ResTy.getFixedSizeInBits())
       report_fatal_error("Wrong result type for @llvm.get.dynamic.area.offset"
                          " intrinsic!");
-    Res = DAG.getNode(ISD::GET_DYNAMIC_AREA_OFFSET, sdl, DAG.getVTList(ResTy),
-                      Op);
-    DAG.setRoot(Op);
+    Res =
+        DAG.getNode(ISD::GET_DYNAMIC_AREA_OFFSET, sdl, {ResTy, MVT::Other}, Op);
+    DAG.setRoot(Res.getValue(1));
     setValue(&I, Res);
     return;
   }

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -7916,16 +7916,12 @@ PPCTargetLowering::LowerGET_DYNAMIC_AREA_OFFSET(SDValue Op,
                                                 SelectionDAG &DAG) const {
   SDLoc dl(Op);
 
-  // Get the correct type for integers.
-  EVT IntVT = Op.getValueType();
-
   // Get the inputs.
   SDValue Chain = Op.getOperand(0);
   SDValue FPSIdx = getFramePointerFrameIndex(DAG);
   // Build a DYNAREAOFFSET node.
   SDValue Ops[2] = {Chain, FPSIdx};
-  SDVTList VTs = DAG.getVTList(IntVT);
-  return DAG.getNode(PPCISD::DYNAREAOFFSET, dl, VTs, Ops);
+  return DAG.getNode(PPCISD::DYNAREAOFFSET, dl, Op->getVTList(), Ops);
 }
 
 SDValue PPCTargetLowering::LowerSTACKRESTORE(SDValue Op,

--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -4127,7 +4127,10 @@ SDValue SystemZTargetLowering::lowerGET_DYNAMIC_AREA_OFFSET(
     SDValue Op, SelectionDAG &DAG) const {
   SDLoc DL(Op);
 
-  return DAG.getNode(SystemZISD::ADJDYNALLOC, DL, MVT::i64);
+  // FIXME: SystemZISD::ADJDYNALLOC should be chained.
+  SDValue Result = DAG.getNode(SystemZISD::ADJDYNALLOC, DL, MVT::i64);
+  SDValue Chain = Op->getOperand(0);
+  return DAG.getMergeValues({Result, Chain}, DL);
 }
 
 SDValue SystemZTargetLowering::lowerSMUL_LOHI(SDValue Op,


### PR DESCRIPTION
The node has a chain, but it wasn't handled correctly:

- DAG builder didn't update the root
- DAG legalizer replaced the chain result with integer 0
- PPC and SystemZ lowerings didn't return the chain result at all

SystemZ lowering is still incorrect because it now returns the source chain. Fixing it turned out to be a non-trivial task, so I left a FIXME.