### PR TITLE
[MLIR] RemoveDeadValues: Allowing IRs with global constants to get dead values removed

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -579,7 +579,6 @@ void RemoveDeadValues::runOnOperation() {
     if (op == module)
       return WalkResult::advance();
     if (isa<BranchOpInterface>(op) ||
-        (isa<SymbolOpInterface>(op) && !isa<FunctionOpInterface>(op)) ||
         (isa<SymbolUserOpInterface>(op) && !isa<CallOpInterface>(op))) {
       op->emitError() << "cannot optimize an IR with non-function symbol ops, "
                          "non-call symbol user ops or branch ops\n";

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -573,14 +573,13 @@ void RemoveDeadValues::runOnOperation() {
   Operation *module = getOperation();
 
   // The removal of non-live values is performed iff there are no branch ops,
-  // all symbol ops present in the IR are function-like, and all symbol user ops
-  // present in the IR are call-like.
+  // and all symbol user ops present in the IR are call-like.
   WalkResult acceptableIR = module->walk([&](Operation *op) {
     if (op == module)
       return WalkResult::advance();
     if (isa<BranchOpInterface>(op) ||
         (isa<SymbolUserOpInterface>(op) && !isa<CallOpInterface>(op))) {
-      op->emitError() << "cannot optimize an IR with non-function symbol ops, "
+      op->emitError() << "cannot optimize an IR with "
                          "non-call symbol user ops or branch ops\n";
       return WalkResult::interrupt();
     }

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -3,7 +3,7 @@
 // The IR is updated regardless of memref.global private constant
 //
 module {
-  memref.global "private" constant @__dont_touch_unacceptable_ir : memref<i32> = dense<0>
+  memref.global "private" constant @__something_global : memref<i32> = dense<0>
   func.func @main(%arg0: i32) -> i32 {
     %0 = tensor.empty() : tensor<10xbf16>
     // CHECK-NOT: tensor.empty
@@ -29,7 +29,7 @@ module @named_module_acceptable {
 //
 func.func @dont_touch_unacceptable_ir_has_cleanable_simple_op_with_branch_op(%arg0: i1) {
   %non_live = arith.constant 0 : i32
-  // expected-error @+1 {{cannot optimize an IR with non-function symbol ops, non-call symbol user ops or branch ops}}
+  // expected-error @+1 {{cannot optimize an IR with non-call symbol user ops or branch ops}}
   cf.cond_br %arg0, ^bb1(%non_live : i32), ^bb2(%non_live : i32)
 ^bb1(%non_live_0 : i32):
   cf.br ^bb3

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -1,12 +1,12 @@
 // RUN: mlir-opt %s -remove-dead-values -split-input-file -verify-diagnostics | FileCheck %s
 
-// The IR remains untouched because of the presence of a non-function-like
-// symbol op inside the module (const @__dont_touch_unacceptable_ir).
+// The IR is updated regardless of memref.global private constant
 //
 module {
-// expected-error @+1 {{cannot optimize an IR with non-function symbol ops, non-call symbol user ops or branch ops}}
   memref.global "private" constant @__dont_touch_unacceptable_ir : memref<i32> = dense<0>
   func.func @main(%arg0: i32) -> i32 {
+    %0 = tensor.empty() : tensor<10xbf16>
+    // CHECK-NOT: tensor.empty
     return %arg0 : i32
   }
 }


### PR DESCRIPTION
This change is related to discussion:
https://discourse.llvm.org/t/question-on-criteria-for-acceptable-ir-in-removedeadvaluespass/83131

I do not know the original reason to disallow the optimization on modules with global private constant. Please let me know what am I missing, I will be happy to make it better. Thank you!

CC: @Wheest 