### PR TITLE
[Tablegen] Add more comments for result numbers to DAGISelEmitter.cpp

### DIFF
--- a/llvm/utils/TableGen/Common/DAGISelMatcher.h
+++ b/llvm/utils/TableGen/Common/DAGISelMatcher.h
@@ -834,13 +834,16 @@ class EmitIntegerMatcher : public Matcher {
   int64_t Val;
   MVT::SimpleValueType VT;
 
+  unsigned ResultNo;
+
 public:
-  EmitIntegerMatcher(int64_t val, MVT::SimpleValueType vt)
+  EmitIntegerMatcher(int64_t val, MVT::SimpleValueType vt, unsigned resultNo)
       : Matcher(EmitInteger), Val(SignExtend64(val, MVT(vt).getSizeInBits())),
-        VT(vt) {}
+        VT(vt), ResultNo(resultNo) {}
 
   int64_t getValue() const { return Val; }
   MVT::SimpleValueType getVT() const { return VT; }
+  unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) { return N->getKind() == EmitInteger; }
 
@@ -858,12 +861,16 @@ class EmitStringIntegerMatcher : public Matcher {
   std::string Val;
   MVT::SimpleValueType VT;
 
+  unsigned ResultNo;
+
 public:
-  EmitStringIntegerMatcher(const std::string &val, MVT::SimpleValueType vt)
-      : Matcher(EmitStringInteger), Val(val), VT(vt) {}
+  EmitStringIntegerMatcher(const std::string &val, MVT::SimpleValueType vt,
+                           unsigned resultNo)
+      : Matcher(EmitStringInteger), Val(val), VT(vt), ResultNo(resultNo) {}
 
   const std::string &getValue() const { return Val; }
   MVT::SimpleValueType getVT() const { return VT; }
+  unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) {
     return N->getKind() == EmitStringInteger;
@@ -884,12 +891,16 @@ class EmitRegisterMatcher : public Matcher {
   const CodeGenRegister *Reg;
   MVT::SimpleValueType VT;
 
+  unsigned ResultNo;
+
 public:
-  EmitRegisterMatcher(const CodeGenRegister *reg, MVT::SimpleValueType vt)
-      : Matcher(EmitRegister), Reg(reg), VT(vt) {}
+  EmitRegisterMatcher(const CodeGenRegister *reg, MVT::SimpleValueType vt,
+                      unsigned resultNo)
+      : Matcher(EmitRegister), Reg(reg), VT(vt), ResultNo(resultNo) {}
 
   const CodeGenRegister *getReg() const { return Reg; }
   MVT::SimpleValueType getVT() const { return VT; }
+  unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) { return N->getKind() == EmitRegister; }
 
@@ -907,11 +918,14 @@ private:
 class EmitConvertToTargetMatcher : public Matcher {
   unsigned Slot;
 
+  unsigned ResultNo;
+
 public:
-  EmitConvertToTargetMatcher(unsigned slot)
-      : Matcher(EmitConvertToTarget), Slot(slot) {}
+  EmitConvertToTargetMatcher(unsigned slot, unsigned resultNo)
+      : Matcher(EmitConvertToTarget), Slot(slot), ResultNo(resultNo) {}
 
   unsigned getSlot() const { return Slot; }
+  unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) {
     return N->getKind() == EmitConvertToTarget;
@@ -985,12 +999,17 @@ class EmitNodeXFormMatcher : public Matcher {
   unsigned Slot;
   const Record *NodeXForm;
 
+  unsigned ResultNo;
+
 public:
-  EmitNodeXFormMatcher(unsigned slot, const Record *nodeXForm)
-      : Matcher(EmitNodeXForm), Slot(slot), NodeXForm(nodeXForm) {}
+  EmitNodeXFormMatcher(unsigned slot, const Record *nodeXForm,
+                       unsigned resultNo)
+      : Matcher(EmitNodeXForm), Slot(slot), NodeXForm(nodeXForm),
+        ResultNo(resultNo) {}
 
   unsigned getSlot() const { return Slot; }
   const Record *getNodeXForm() const { return NodeXForm; }
+  unsigned getResultNo() const { return ResultNo; }
 
   static bool classof(const Matcher *N) {
     return N->getKind() == EmitNodeXForm;

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -798,6 +798,8 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
       break;
     }
     unsigned Bytes = OpBytes + EmitSignedVBRValue(Val, OS);
+    if (!OmitComments)
+      OS << " // " << Val << " #" << cast<EmitIntegerMatcher>(N)->getResultNo();
     OS << '\n';
     return Bytes;
   }
@@ -818,7 +820,10 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
       OpBytes = EmitVBRValue(VT, OS) + 1;
       break;
     }
-    OS << Val << ",\n";
+    OS << Val << ',';
+    if (!OmitComments)
+      OS << " // #" << cast<EmitStringIntegerMatcher>(N)->getResultNo();
+    OS << '\n';
     return OpBytes + 1;
   }
 
@@ -851,24 +856,32 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
       break;
     }
     if (Reg) {
-      OS << getQualifiedName(Reg->TheDef) << ",\n";
+      OS << getQualifiedName(Reg->TheDef);
     } else {
       OS << "0 ";
       if (!OmitComments)
         OS << "/*zero_reg*/";
-      OS << ",\n";
     }
+
+    OS << ',';
+    if (!OmitComments)
+      OS << " // #" << Matcher->getResultNo();
+    OS << '\n';
     return OpBytes + 1;
   }
 
   case Matcher::EmitConvertToTarget: {
-    unsigned Slot = cast<EmitConvertToTargetMatcher>(N)->getSlot();
-    if (Slot < 8) {
-      OS << "OPC_EmitConvertToTarget" << Slot << ",\n";
-      return 1;
-    }
-    OS << "OPC_EmitConvertToTarget, " << Slot << ",\n";
-    return 2;
+    const EmitConvertToTargetMatcher *CTTM =
+        cast<EmitConvertToTargetMatcher>(N);
+    unsigned Slot = CTTM->getSlot();
+    OS << "OPC_EmitConvertToTarget";
+    if (Slot >= 8)
+      OS << ", ";
+    OS << Slot << ',';
+    if (!OmitComments)
+      OS << " // #" << CTTM->getResultNo();
+    OS << '\n';
+    return 1 + (Slot >= 8);
   }
 
   case Matcher::EmitMergeInputChains: {
@@ -914,7 +927,8 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
     OS << "OPC_EmitNodeXForm, " << getNodeXFormID(XF->getNodeXForm()) << ", "
        << XF->getSlot() << ',';
     if (!OmitComments)
-      OS << " // " << XF->getNodeXForm()->getName();
+      OS << " // " << XF->getNodeXForm()->getName() << " #"
+         << XF->getResultNo();
     OS << '\n';
     return 3;
   }

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -871,8 +871,7 @@ unsigned MatcherTableEmitter::EmitMatcher(const Matcher *N,
   }
 
   case Matcher::EmitConvertToTarget: {
-    const EmitConvertToTargetMatcher *CTTM =
-        cast<EmitConvertToTargetMatcher>(N);
+    const auto *CTTM = cast<EmitConvertToTargetMatcher>(N);
     unsigned Slot = CTTM->getSlot();
     OS << "OPC_EmitConvertToTarget";
     if (Slot >= 8)

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -651,7 +651,7 @@ void MatcherGen::EmitResultOfNamedOperand(
   if (!N.isLeaf()) {
     StringRef OperatorName = N.getOperator()->getName();
     if (OperatorName == "imm" || OperatorName == "fpimm") {
-      AddMatcher(new EmitConvertToTargetMatcher(SlotNo));
+      AddMatcher(new EmitConvertToTargetMatcher(SlotNo, NextRecordedOperandNo));
       ResultOps.push_back(NextRecordedOperandNo++);
       return;
     }
@@ -666,7 +666,8 @@ void MatcherGen::EmitResultLeafAsOperand(const TreePatternNode &N,
   assert(N.isLeaf() && "Must be a leaf");
 
   if (const IntInit *II = dyn_cast<IntInit>(N.getLeafValue())) {
-    AddMatcher(new EmitIntegerMatcher(II->getValue(), N.getSimpleType(0)));
+    AddMatcher(new EmitIntegerMatcher(II->getValue(), N.getSimpleType(0),
+                                      NextRecordedOperandNo));
     ResultOps.push_back(NextRecordedOperandNo++);
     return;
   }
@@ -676,13 +677,15 @@ void MatcherGen::EmitResultLeafAsOperand(const TreePatternNode &N,
     const Record *Def = DI->getDef();
     if (Def->isSubClassOf("Register")) {
       const CodeGenRegister *Reg = CGP.getTargetInfo().getRegBank().getReg(Def);
-      AddMatcher(new EmitRegisterMatcher(Reg, N.getSimpleType(0)));
+      AddMatcher(new EmitRegisterMatcher(Reg, N.getSimpleType(0),
+                                         NextRecordedOperandNo));
       ResultOps.push_back(NextRecordedOperandNo++);
       return;
     }
 
     if (Def->getName() == "zero_reg") {
-      AddMatcher(new EmitRegisterMatcher(nullptr, N.getSimpleType(0)));
+      AddMatcher(new EmitRegisterMatcher(nullptr, N.getSimpleType(0),
+                                         NextRecordedOperandNo));
       ResultOps.push_back(NextRecordedOperandNo++);
       return;
     }
@@ -710,12 +713,13 @@ void MatcherGen::EmitResultLeafAsOperand(const TreePatternNode &N,
           CGP.getTargetInfo().getRegisterClass(Def);
       if (RC.EnumValue <= 127) {
         std::string Value = RC.getQualifiedIdName();
-        AddMatcher(new EmitStringIntegerMatcher(Value, MVT::i32));
-        ResultOps.push_back(NextRecordedOperandNo++);
+        AddMatcher(new EmitStringIntegerMatcher(Value, MVT::i32,
+                                                NextRecordedOperandNo));
       } else {
-        AddMatcher(new EmitIntegerMatcher(RC.EnumValue, MVT::i32));
-        ResultOps.push_back(NextRecordedOperandNo++);
+        AddMatcher(new EmitIntegerMatcher(RC.EnumValue, MVT::i32,
+                                          NextRecordedOperandNo));
       }
+      ResultOps.push_back(NextRecordedOperandNo++);
       return;
     }
 
@@ -728,13 +732,15 @@ void MatcherGen::EmitResultLeafAsOperand(const TreePatternNode &N,
         const CodeGenSubRegIndex *I = RB.findSubRegIdx(Def);
         assert(I && "Cannot find subreg index by name!");
         if (I->EnumValue > 127) {
-          AddMatcher(new EmitIntegerMatcher(I->EnumValue, MVT::i32));
+          AddMatcher(new EmitIntegerMatcher(I->EnumValue, MVT::i32,
+                                            NextRecordedOperandNo));
           ResultOps.push_back(NextRecordedOperandNo++);
           return;
         }
       }
       std::string Value = getQualifiedName(Def);
-      AddMatcher(new EmitStringIntegerMatcher(Value, MVT::i32));
+      AddMatcher(
+          new EmitStringIntegerMatcher(Value, MVT::i32, NextRecordedOperandNo));
       ResultOps.push_back(NextRecordedOperandNo++);
       return;
     }
@@ -995,7 +1001,8 @@ void MatcherGen::EmitResultSDNodeXFormAsOperand(
   // The input currently must have produced exactly one result.
   assert(InputOps.size() == 1 && "Unexpected input to SDNodeXForm");
 
-  AddMatcher(new EmitNodeXFormMatcher(InputOps[0], N.getOperator()));
+  AddMatcher(new EmitNodeXFormMatcher(InputOps[0], N.getOperator(),
+                                      NextRecordedOperandNo));
   ResultOps.push_back(NextRecordedOperandNo++);
 }
 


### PR DESCRIPTION
Print what result number the Emit* nodes are storing their results in. This makes it easy to track the inputs of later opcodes that consume these results.