### PR TITLE
[JITLink][AArch32] Add explicit visibility macros to functions needed by unittests

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ExecutionEngine/JITLink/aarch32.h"
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/TargetParser/ARMTargetParser.h"
 
@@ -31,7 +32,7 @@ namespace llvm {
 namespace jitlink {
 
 /// Translate from ELF relocation type to JITLink-internal edge kind.
-Expected<aarch32::EdgeKind_aarch32>
+LLVM_ABI Expected<aarch32::EdgeKind_aarch32>
 getJITLinkEdgeKind(uint32_t ELFType, const aarch32::ArmConfig &ArmCfg) {
   switch (ELFType) {
   case ELF::R_ARM_ABS32:
@@ -75,7 +76,7 @@ getJITLinkEdgeKind(uint32_t ELFType, const aarch32::ArmConfig &ArmCfg) {
 }
 
 /// Translate from JITLink-internal edge kind back to ELF relocation type.
-Expected<uint32_t> getELFRelocationType(Edge::Kind Kind) {
+LLVM_ABI Expected<uint32_t> getELFRelocationType(Edge::Kind Kind) {
   switch (static_cast<aarch32::EdgeKind_aarch32>(Kind)) {
   case aarch32::Data_Delta32:
     return ELF::R_ARM_REL32;

--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/MathExtras.h"
@@ -60,7 +61,7 @@ int64_t decodeImmBT4BlT1BlxT2(uint32_t Hi, uint32_t Lo) {
 ///
 ///   S:I1:I2:Imm10:Imm11:0 -> [ 00000:S:Imm10, 00:J1:0:J2:Imm11 ]
 ///
-HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value) {
+LLVM_ABI HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value) {
   uint32_t S = (Value >> 14) & 0x0400;
   uint32_t J1 = (((~(Value >> 10)) ^ (Value >> 11)) & 0x2000);
   uint32_t J2 = (((~(Value >> 11)) ^ (Value >> 13)) & 0x0800);
@@ -74,7 +75,7 @@ HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value) {
 ///
 ///   [ 00000:S:Imm10, 00:J1:0:J2:Imm11] -> S:I1:I2:Imm10:Imm11:0
 ///
-int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo) {
+LLVM_ABI int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo) {
   uint32_t S = Hi & 0x0400;
   uint32_t I1 = ~((Lo ^ (Hi << 3)) << 10) & 0x00800000;
   uint32_t I2 = ~((Lo ^ (Hi << 1)) << 11) & 0x00400000;
@@ -88,7 +89,7 @@ int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo) {
 ///
 ///   Imm24:00 ->  00000000:Imm24
 ///
-uint32_t encodeImmBA1BlA1BlxA2(int64_t Value) {
+LLVM_ABI uint32_t encodeImmBA1BlA1BlxA2(int64_t Value) {
   return (Value >> 2) & 0x00ffffff;
 }
 
@@ -97,7 +98,7 @@ uint32_t encodeImmBA1BlA1BlxA2(int64_t Value) {
 ///
 ///   00000000:Imm24 ->  Imm24:00
 ///
-int64_t decodeImmBA1BlA1BlxA2(int64_t Value) {
+LLVM_ABI int64_t decodeImmBA1BlA1BlxA2(int64_t Value) {
   return SignExtend64<26>((Value & 0x00ffffff) << 2);
 }
 
@@ -106,7 +107,7 @@ int64_t decodeImmBA1BlA1BlxA2(int64_t Value) {
 ///
 ///   Imm4:Imm1:Imm3:Imm8 -> [ 00000:i:000000:Imm4, 0:Imm3:0000:Imm8 ]
 ///
-HalfWords encodeImmMovtT1MovwT3(uint16_t Value) {
+LLVM_ABI HalfWords encodeImmMovtT1MovwT3(uint16_t Value) {
   uint32_t Imm4 = (Value >> 12) & 0x0f;
   uint32_t Imm1 = (Value >> 11) & 0x01;
   uint32_t Imm3 = (Value >> 8) & 0x07;
@@ -119,7 +120,7 @@ HalfWords encodeImmMovtT1MovwT3(uint16_t Value) {
 ///
 ///   [ 00000:i:000000:Imm4, 0:Imm3:0000:Imm8 ] -> Imm4:Imm1:Imm3:Imm8
 ///
-uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
+LLVM_ABI uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
   uint32_t Imm4 = Hi & 0x0f;
   uint32_t Imm1 = (Hi >> 10) & 0x01;
   uint32_t Imm3 = (Lo >> 12) & 0x07;
@@ -133,7 +134,7 @@ uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
 ///
 ///   Rd4 -> [0000000000000000, 0000:Rd4:00000000]
 ///
-HalfWords encodeRegMovtT1MovwT3(int64_t Value) {
+LLVM_ABI HalfWords encodeRegMovtT1MovwT3(int64_t Value) {
   uint32_t Rd4 = (Value & 0x0f) << 8;
   return HalfWords{0, Rd4};
 }
@@ -142,7 +143,7 @@ HalfWords encodeRegMovtT1MovwT3(int64_t Value) {
 ///
 ///   [0000000000000000, 0000:Rd4:00000000] -> Rd4
 ///
-int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
+LLVM_ABI int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
   uint32_t Rd4 = (Lo >> 8) & 0x0f;
   return Rd4;
 }
@@ -152,7 +153,7 @@ int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo) {
 ///
 ///   Imm4:Imm12 -> 000000000000:Imm4:0000:Imm12
 ///
-uint32_t encodeImmMovtA1MovwA2(uint16_t Value) {
+LLVM_ABI uint32_t encodeImmMovtA1MovwA2(uint16_t Value) {
   uint32_t Imm4 = (Value >> 12) & 0x0f;
   uint32_t Imm12 = Value & 0x0fff;
   return (Imm4 << 16) | Imm12;
@@ -163,7 +164,7 @@ uint32_t encodeImmMovtA1MovwA2(uint16_t Value) {
 ///
 ///   000000000000:Imm4:0000:Imm12 -> Imm4:Imm12
 ///
-uint16_t decodeImmMovtA1MovwA2(uint64_t Value) {
+LLVM_ABI uint16_t decodeImmMovtA1MovwA2(uint64_t Value) {
   uint32_t Imm4 = (Value >> 16) & 0x0f;
   uint32_t Imm12 = Value & 0x0fff;
   return (Imm4 << 12) | Imm12;
@@ -174,7 +175,7 @@ uint16_t decodeImmMovtA1MovwA2(uint64_t Value) {
 ///
 ///   Rd4 -> 0000000000000000:Rd4:000000000000
 ///
-uint32_t encodeRegMovtA1MovwA2(int64_t Value) {
+LLVM_ABI uint32_t encodeRegMovtA1MovwA2(int64_t Value) {
   uint32_t Rd4 = (Value & 0x00000f) << 12;
   return Rd4;
 }
@@ -184,7 +185,7 @@ uint32_t encodeRegMovtA1MovwA2(int64_t Value) {
 ///
 ///   0000000000000000:Rd4:000000000000 -> Rd4
 ///
-int64_t decodeRegMovtA1MovwA2(uint64_t Value) {
+LLVM_ABI int64_t decodeRegMovtA1MovwA2(uint64_t Value) {
   uint32_t Rd4 = (Value >> 12) & 0x00000f;
   return Rd4;
 }

--- a/llvm/unittests/ExecutionEngine/JITLink/AArch32Tests.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/AArch32Tests.cpp
@@ -8,6 +8,7 @@
 
 #include <llvm/BinaryFormat/ELF.h>
 #include <llvm/ExecutionEngine/JITLink/aarch32.h>
+#include <llvm/Support/Compiler.h>
 
 #include "gtest/gtest.h"
 
@@ -96,21 +97,21 @@ namespace llvm {
 namespace jitlink {
 namespace aarch32 {
 
-HalfWords encodeImmBT4BlT1BlxT2(int64_t Value);
-HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value);
-uint32_t encodeImmBA1BlA1BlxA2(int64_t Value);
-HalfWords encodeImmMovtT1MovwT3(uint16_t Value);
-HalfWords encodeRegMovtT1MovwT3(int64_t Value);
-uint32_t encodeImmMovtA1MovwA2(uint16_t Value);
-uint32_t encodeRegMovtA1MovwA2(int64_t Value);
+LLVM_ABI HalfWords encodeImmBT4BlT1BlxT2(int64_t Value);
+LLVM_ABI HalfWords encodeImmBT4BlT1BlxT2_J1J2(int64_t Value);
+LLVM_ABI uint32_t encodeImmBA1BlA1BlxA2(int64_t Value);
+LLVM_ABI HalfWords encodeImmMovtT1MovwT3(uint16_t Value);
+LLVM_ABI HalfWords encodeRegMovtT1MovwT3(int64_t Value);
+LLVM_ABI uint32_t encodeImmMovtA1MovwA2(uint16_t Value);
+LLVM_ABI uint32_t encodeRegMovtA1MovwA2(int64_t Value);
 
-int64_t decodeImmBT4BlT1BlxT2(uint32_t Hi, uint32_t Lo);
-int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo);
-int64_t decodeImmBA1BlA1BlxA2(int64_t Value);
-uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo);
-int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo);
-uint16_t decodeImmMovtA1MovwA2(uint64_t Value);
-int64_t decodeRegMovtA1MovwA2(uint64_t Value);
+LLVM_ABI int64_t decodeImmBT4BlT1BlxT2(uint32_t Hi, uint32_t Lo);
+LLVM_ABI int64_t decodeImmBT4BlT1BlxT2_J1J2(uint32_t Hi, uint32_t Lo);
+LLVM_ABI int64_t decodeImmBA1BlA1BlxA2(int64_t Value);
+LLVM_ABI uint16_t decodeImmMovtT1MovwT3(uint32_t Hi, uint32_t Lo);
+LLVM_ABI int64_t decodeRegMovtT1MovwT3(uint32_t Hi, uint32_t Lo);
+LLVM_ABI uint16_t decodeImmMovtA1MovwA2(uint64_t Value);
+LLVM_ABI int64_t decodeRegMovtA1MovwA2(uint64_t Value);
 
 } // namespace aarch32
 } // namespace jitlink


### PR DESCRIPTION
Without these there will be missing symbol errors when building JITLinkTests for windows shared library builds with explicit symbol visibility macros are enabled.

This is part of the work to enable LLVM_BUILD_LLVM_DYLIB and LLVM plugins on window.