### PR TITLE
[libc++] Bump libc++ CI to a more recent version of the Docker image

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -44,13 +44,12 @@ env:
   GCC_STABLE_VERSION: "13"
   LLVM_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer-19"
   CLANG_CRASH_DIAGNOSTICS_DIR: "crash_diagnostics"
-  LIBCXX_LINUX_IMAGE_TAG: "0fd6f684b9c84c32d6cbfd9742402e788b2879f1"
 
 jobs:
   stage1:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/llvm/libcxx-linux-builder:${{ env.LIBCXX_LINUX_IMAGE_TAG }}
+    container: ghcr.io/llvm/libcxx-linux-builder:0fd6f684b9c84c32d6cbfd9742402e788b2879f1
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -87,7 +86,7 @@ jobs:
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/llvm/libcxx-linux-builder:${{ env.LIBCXX_LINUX_IMAGE_TAG }}
+    container: ghcr.io/llvm/libcxx-linux-builder:0fd6f684b9c84c32d6cbfd9742402e788b2879f1
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
@@ -175,7 +174,7 @@ jobs:
         - config: 'generic-msan'
           machine: libcxx-self-hosted-linux
     runs-on: ${{ matrix.machine }}
-    container: ghcr.io/llvm/libcxx-linux-builder:${{ env.LIBCXX_LINUX_IMAGE_TAG }}
+    container: ghcr.io/llvm/libcxx-linux-builder:0fd6f684b9c84c32d6cbfd9742402e788b2879f1
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.config }}

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -50,7 +50,7 @@ jobs:
   stage1:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/llvm/libcxx-linux-builder:{{LIBCXX_LINUX_IMAGE_TAG}}
+    container: ghcr.io/llvm/libcxx-linux-builder:${{ LIBCXX_LINUX_IMAGE_TAG }}
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -87,7 +87,7 @@ jobs:
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/llvm/libcxx-linux-builder:{{LIBCXX_LINUX_IMAGE_TAG}}
+    container: ghcr.io/llvm/libcxx-linux-builder:${{ LIBCXX_LINUX_IMAGE_TAG }}
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
@@ -175,7 +175,7 @@ jobs:
         - config: 'generic-msan'
           machine: libcxx-self-hosted-linux
     runs-on: ${{ matrix.machine }}
-    container: ghcr.io/llvm/libcxx-linux-builder:{{LIBCXX_LINUX_IMAGE_TAG}}
+    container: ghcr.io/llvm/libcxx-linux-builder:${{ LIBCXX_LINUX_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.config }}

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -50,7 +50,7 @@ jobs:
   stage1:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/llvm/libcxx-linux-builder:${{ LIBCXX_LINUX_IMAGE_TAG }}
+    container: ghcr.io/llvm/libcxx-linux-builder:${{ env.LIBCXX_LINUX_IMAGE_TAG }}
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -87,7 +87,7 @@ jobs:
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/llvm/libcxx-linux-builder:${{ LIBCXX_LINUX_IMAGE_TAG }}
+    container: ghcr.io/llvm/libcxx-linux-builder:${{ env.LIBCXX_LINUX_IMAGE_TAG }}
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
@@ -175,7 +175,7 @@ jobs:
         - config: 'generic-msan'
           machine: libcxx-self-hosted-linux
     runs-on: ${{ matrix.machine }}
-    container: ghcr.io/llvm/libcxx-linux-builder:${{ LIBCXX_LINUX_IMAGE_TAG }}
+    container: ghcr.io/llvm/libcxx-linux-builder:${{ env.LIBCXX_LINUX_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.config }}

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -44,13 +44,13 @@ env:
   GCC_STABLE_VERSION: "13"
   LLVM_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer-19"
   CLANG_CRASH_DIAGNOSTICS_DIR: "crash_diagnostics"
-
+  LIBCXX_LINUX_IMAGE_TAG: "0fd6f684b9c84c32d6cbfd9742402e788b2879f1"
 
 jobs:
   stage1:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/libcxx/actions-builder:testing-2024-09-21
+    container: ghcr.io/llvm/libcxx-linux-builder:{{LIBCXX_LINUX_IMAGE_TAG}}
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -87,7 +87,7 @@ jobs:
   stage2:
     if: github.repository_owner == 'llvm'
     runs-on: libcxx-self-hosted-linux
-    container: ghcr.io/libcxx/actions-builder:testing-2024-09-21
+    container: ghcr.io/llvm/libcxx-linux-builder:{{LIBCXX_LINUX_IMAGE_TAG}}
     needs: [ stage1 ]
     continue-on-error: false
     strategy:
@@ -175,7 +175,7 @@ jobs:
         - config: 'generic-msan'
           machine: libcxx-self-hosted-linux
     runs-on: ${{ matrix.machine }}
-    container: ghcr.io/libcxx/actions-builder:testing-2024-09-21
+    container: ghcr.io/llvm/libcxx-linux-builder:{{LIBCXX_LINUX_IMAGE_TAG}}
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.config }}


### PR DESCRIPTION
The Docker image was built using the recently introduced Action that builds and pushes to the LLVM Docker registry.