### PR TITLE
[RISCV] Correct the precedence in isVRegClass

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.h
@@ -39,7 +39,7 @@ enum {
 
 /// \returns the IsVRegClass for the register class.
 static inline bool isVRegClass(uint64_t TSFlags) {
-  return TSFlags & IsVRegClassShiftMask >> IsVRegClassShift;
+  return (TSFlags & IsVRegClassShiftMask) >> IsVRegClassShift;
 }
 
 /// \returns the LMUL for the register class.


### PR DESCRIPTION
Right shift has higher precedence than bitwise and, so it should be
parentheses around & operator. This case works as expected because
IsVRegClassShift is 0, other cases will fail.
