### PR TITLE
[libc++] Guard `__pad_and_output` with `_LIBCPP_HAS_LOCALIZATION`

### DIFF
--- a/libcxx/include/__iterator/ostreambuf_iterator.h
+++ b/libcxx/include/__iterator/ostreambuf_iterator.h
@@ -65,9 +65,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI ostreambuf_iterator& operator++(int) { return *this; }
   _LIBCPP_HIDE_FROM_ABI bool failed() const _NOEXCEPT { return __sbuf_ == nullptr; }
 
+#if _LIBCPP_HAS_LOCALIZATION
   template <class _Ch, class _Tr>
   friend _LIBCPP_HIDE_FROM_ABI ostreambuf_iterator<_Ch, _Tr> __pad_and_output(
       ostreambuf_iterator<_Ch, _Tr> __s, const _Ch* __ob, const _Ch* __op, const _Ch* __oe, ios_base& __iob, _Ch __fl);
+#endif // _LIBCPP_HAS_LOCALIZATION
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__locale_dir/pad_and_output.h
+++ b/libcxx/include/__locale_dir/pad_and_output.h
@@ -10,11 +10,14 @@
 #define _LIBCPP___LOCALE_DIR_PAD_AND_OUTPUT_H
 
 #include <__config>
-#include <ios>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#if _LIBCPP_HAS_LOCALIZATION
+
+#  include <ios>
+
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -79,5 +82,7 @@ _LIBCPP_HIDE_FROM_ABI ostreambuf_iterator<_CharT, _Traits> __pad_and_output(
 }
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_HAS_LOCALIZATION
 
 #endif // _LIBCPP___LOCALE_DIR_PAD_AND_OUTPUT_H


### PR DESCRIPTION
This fixes errors for no-localization builds (possibly introduced by #116223).