### PR TITLE
[clang-tidy][NFC]remove deps of clang in clang tidy test

### DIFF
--- a/clang-tools-extra/test/CMakeLists.txt
+++ b/clang-tools-extra/test/CMakeLists.txt
@@ -50,8 +50,6 @@ set(CLANG_TOOLS_TEST_DEPS
   clang-resource-headers
 
   clang-tidy
-  # Clang-tidy tests need clang for building modules.
-  clang
 )
 
 # Add lit test dependencies.


### PR DESCRIPTION
It is introduced in https://reviews.llvm.org/D59528, but I don't find any usage of clang in clang tidy test.
