### PR TITLE
[libc][stdfix] Implement fixed point bitsfx functions in llvm-libc

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -467,6 +467,18 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     libc.src.stdfix.ukbits
     libc.src.stdfix.lkbits
     libc.src.stdfix.ulkbits
+    libc.src.stdfix.bitshr
+    libc.src.stdfix.bitsuhr
+    libc.src.stdfix.bitsr
+    libc.src.stdfix.bitsur
+    libc.src.stdfix.bitslr
+    libc.src.stdfix.bitsulr
+    libc.src.stdfix.bitshk
+    libc.src.stdfix.bitsuhk
+    libc.src.stdfix.bitsk
+    libc.src.stdfix.bitsuk
+    libc.src.stdfix.bitslk
+    libc.src.stdfix.bitsulk
   )
 endif()
 

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -462,6 +462,18 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     libc.src.stdfix.ukbits
     libc.src.stdfix.lkbits
     libc.src.stdfix.ulkbits   
+    libc.src.stdfix.bitshr
+    libc.src.stdfix.bitsuhr
+    libc.src.stdfix.bitsr
+    libc.src.stdfix.bitsur
+    libc.src.stdfix.bitslr
+    libc.src.stdfix.bitsulr
+    libc.src.stdfix.bitshk
+    libc.src.stdfix.bitsuhk
+    libc.src.stdfix.bitsk
+    libc.src.stdfix.bitsuk
+    libc.src.stdfix.bitslk
+    libc.src.stdfix.bitsulk
   )
 endif()
 

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -730,6 +730,19 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     # TODO: https://github.com/llvm/llvm-project/issues/115778
     libc.src.stdfix.lkbits
     libc.src.stdfix.ulkbits
+    libc.src.stdfix.bitshr
+    libc.src.stdfix.bitsuhr
+    libc.src.stdfix.bitsr
+    libc.src.stdfix.bitsur
+    libc.src.stdfix.bitslr
+    libc.src.stdfix.bitsulr
+    libc.src.stdfix.bitshk
+    libc.src.stdfix.bitsuhk
+    libc.src.stdfix.bitsk
+    libc.src.stdfix.bitsuk
+    libc.src.stdfix.bitslk
+    libc.src.stdfix.bitsulk
+
   )
 endif()
 

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -841,6 +841,18 @@ if(LIBC_COMPILER_HAS_FIXED_POINT)
     libc.src.stdfix.ukbits
     libc.src.stdfix.lkbits
     libc.src.stdfix.ulkbits
+    libc.src.stdfix.bitshr
+    libc.src.stdfix.bitsuhr
+    libc.src.stdfix.bitsr
+    libc.src.stdfix.bitsur
+    libc.src.stdfix.bitslr
+    libc.src.stdfix.bitsulr
+    libc.src.stdfix.bitshk
+    libc.src.stdfix.bitsuhk
+    libc.src.stdfix.bitsk
+    libc.src.stdfix.bitsuk
+    libc.src.stdfix.bitslk
+    libc.src.stdfix.bitsulk
   )
 endif()
 

--- a/libc/newhdrgen/yaml/stdfix.yaml
+++ b/libc/newhdrgen/yaml/stdfix.yaml
@@ -147,6 +147,90 @@ functions:
     arguments:
       - type: uint_ulk_t
     guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitshr
+    standards:
+      - stdc_ext
+    return_type: int_hr_t
+    arguments:
+      - type: short fract
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsuhr
+    standards:
+      - stdc_ext
+    return_type: uint_uhr_t
+    arguments:
+      - type: unsigned short fract
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsr
+    standards:
+      - stdc_ext
+    return_type: int_r_t
+    arguments:
+      - type: fract
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsur
+    standards:
+      - stdc_ext
+    return_type: uint_ur_t
+    arguments:
+      - type: unsigned fract
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitslr
+    standards:
+      - stdc_ext
+    return_type: int_lr_t
+    arguments:
+      - type: long fract
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsulr
+    standards:
+      - stdc_ext
+    return_type: uint_ulr_t
+    arguments:
+      - type: unsigned long fract
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitshk
+    standards:
+      - stdc_ext
+    return_type: int_hk_t
+    arguments:
+      - type:  short accum
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsuhk
+    standards:
+      - stdc_ext
+    return_type: uint_uhk_t
+    arguments:
+      - type: unsigned short accum
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsk
+    standards:
+      - stdc_ext
+    return_type: int_k_t
+    arguments:
+      - type: accum
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsuk
+    standards:
+      - stdc_ext
+    return_type: uint_uk_t
+    arguments:
+      - type: unsigned accum
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitslk
+    standards:
+      - stdc_ext
+    return_type: uint_ulr_t
+    arguments:
+      - type: long accum
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
+  - name: bitsulk
+    standards:
+      - stdc_ext
+    return_type: uint_ulk_t
+    arguments:
+      - type: unsigned long accum
+    guard: LIBC_COMPILER_HAS_FIXED_POINT
   - name: roundhk
     standards:
       - stdc_ext

--- a/libc/spec/stdc_ext.td
+++ b/libc/spec/stdc_ext.td
@@ -73,6 +73,19 @@ def StdcExt : StandardSpec<"stdc_ext"> {
           GuardedFunctionSpec<"ulrbits", RetValSpec<UnsignedLongFractType>, [ArgSpec<UIntUlrT>], "LIBC_COMPILER_HAS_FIXED_POINT">,
           GuardedFunctionSpec<"uhkbits", RetValSpec<UnsignedShortAccumType>, [ArgSpec<UIntUhkT>], "LIBC_COMPILER_HAS_FIXED_POINT">,
           GuardedFunctionSpec<"ulkbits", RetValSpec<UnsignedLongAccumType>, [ArgSpec<UIntUlkT>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+
+          GuardedFunctionSpec<"bitshr", RetValSpec<IntHrT>, [ArgSpec<ShortFractType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsr", RetValSpec<IntRT>, [ArgSpec<FractType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitslr", RetValSpec<IntLrT>, [ArgSpec<LongFractType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitshk", RetValSpec<IntHkT>, [ArgSpec<ShortAccumType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsk", RetValSpec<IntKT>, [ArgSpec<AccumType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitslk", RetValSpec<IntLkT>, [ArgSpec<LongAccumType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsuhr", RetValSpec<UIntUhrT>, [ArgSpec<UnsignedShortFractType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsur", RetValSpec<UIntUrI>, [ArgSpec<UnsignedFractType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsuk", RetValSpec<UIntUkT>, [ArgSpec<UnsignedAccumType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsulr", RetValSpec<UIntUlrT>, [ArgSpec<UnsignedLongFractType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsuhk", RetValSpec<UIntUhkT>, [ArgSpec<UnsignedShortAccumType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
+          GuardedFunctionSpec<"bitsulk", RetValSpec<UIntUlkT>, [ArgSpec<UnsignedLongAccumType>], "LIBC_COMPILER_HAS_FIXED_POINT">,
       ]
   >;
 

--- a/libc/src/stdfix/CMakeLists.txt
+++ b/libc/src/stdfix/CMakeLists.txt
@@ -53,6 +53,18 @@ foreach(suffix IN ITEMS hr r lr hk k lk uhr ur ulr uhk uk ulk)
       libc.src.__support.CPP.bit
       libc.src.__support.fixed_point.fx_bits
   )
+
+  add_entrypoint_object(
+    bits${suffix}
+    HDRS
+      bits${suffix}.h
+    SRCS
+      bits${suffix}.cpp
+    DEPENDS
+      libc.src.__support.CPP.bit
+      libc.src.__support.fixed_point.fx_bits
+  )
+
 endforeach()
 
 add_entrypoint_object(

--- a/libc/src/stdfix/bitshk.cpp
+++ b/libc/src/stdfix/bitshk.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitshk function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitshk.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int_hk_t, bitshk, (short accum x)) {
+  return cpp::bit_cast<int_hk_t, short accum>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitshk.h
+++ b/libc/src/stdfix/bitshk.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitshk ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSHK_H
+#define LLVM_LIBC_SRC_STDFIX_BITSHK_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int_hk_t bitshk(short accum x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSHK_H

--- a/libc/src/stdfix/bitshr.cpp
+++ b/libc/src/stdfix/bitshr.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitshr function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitshr.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int_hr_t, bitshr, (short fract x)) {
+  return cpp::bit_cast<int_hr_t, short fract>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitshr.h
+++ b/libc/src/stdfix/bitshr.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitshr ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSHR_H
+#define LLVM_LIBC_SRC_STDFIX_BITSHR_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int_hr_t bitshr(short fract x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSHR_H

--- a/libc/src/stdfix/bitsk.cpp
+++ b/libc/src/stdfix/bitsk.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsk function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsk.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int_k_t, bitsk, (accum x)) {
+  return cpp::bit_cast<int_k_t, accum>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsk.h
+++ b/libc/src/stdfix/bitsk.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsk -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSK_H
+#define LLVM_LIBC_SRC_STDFIX_BITSK_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int_k_t bitsk(accum x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSK_H

--- a/libc/src/stdfix/bitslk.cpp
+++ b/libc/src/stdfix/bitslk.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitslk function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitslk.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int_lk_t, bitslk, (long accum x)) {
+  return cpp::bit_cast<int_lk_t, long accum>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitslk.h
+++ b/libc/src/stdfix/bitslk.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitslk ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSLK_H
+#define LLVM_LIBC_SRC_STDFIX_BITSLK_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int_lk_t bitslk(long accum x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSLK_H

--- a/libc/src/stdfix/bitslr.cpp
+++ b/libc/src/stdfix/bitslr.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitslr function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitslr.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int_lr_t, bitslr, (long fract x)) {
+  return cpp::bit_cast<int_lr_t, long fract>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitslr.h
+++ b/libc/src/stdfix/bitslr.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitslr ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSLR_H
+#define LLVM_LIBC_SRC_STDFIX_BITSLR_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int_lr_t bitslr(long fract x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSLR_H

--- a/libc/src/stdfix/bitsr.cpp
+++ b/libc/src/stdfix/bitsr.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsr function ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsr.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(int_r_t, bitsr, (fract x)) {
+  return cpp::bit_cast<int_r_t, fract>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsr.h
+++ b/libc/src/stdfix/bitsr.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsr -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSR_H
+#define LLVM_LIBC_SRC_STDFIX_BITSR_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int_r_t bitsr(fract x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSR_H

--- a/libc/src/stdfix/bitsuhk.cpp
+++ b/libc/src/stdfix/bitsuhk.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsuhk function -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsuhk.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(uint_uhk_t, bitsuhk, (unsigned short accum x)) {
+  return cpp::bit_cast<uint_uhk_t, unsigned short accum>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsuhk.h
+++ b/libc/src/stdfix/bitsuhk.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsuhk -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSUHK_H
+#define LLVM_LIBC_SRC_STDFIX_BITSUHK_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uint_uhk_t bitsuhk(unsigned short accum x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSUHK_H

--- a/libc/src/stdfix/bitsuhr.cpp
+++ b/libc/src/stdfix/bitsuhr.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsuhr function --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsuhr.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(uint_uhr_t, bitsuhr, (unsigned short fract x)) {
+  return cpp::bit_cast<uint_uhr_t, unsigned short fract>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsuhr.h
+++ b/libc/src/stdfix/bitsuhr.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsuhr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSUHR_H
+#define LLVM_LIBC_SRC_STDFIX_BITSUHR_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uint_uhr_t bitsuhr(unsigned short fract x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSUHR_H

--- a/libc/src/stdfix/bitsuk.cpp
+++ b/libc/src/stdfix/bitsuk.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsuk function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsuk.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(uint_uk_t, bitsuk, (unsigned accum x)) {
+  return cpp::bit_cast<uint_uk_t, unsigned accum>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsuk.h
+++ b/libc/src/stdfix/bitsuk.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsuk ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSUK_H
+#define LLVM_LIBC_SRC_STDFIX_BITSUK_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uint_uk_t bitsuk(unsigned accum x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSUK_H

--- a/libc/src/stdfix/bitsulk.cpp
+++ b/libc/src/stdfix/bitsulk.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsulk function --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsulk.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(uint_ulk_t, bitsulk, (unsigned long accum x)) {
+  return cpp::bit_cast<uint_ulk_t, unsigned long accum>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsulk.h
+++ b/libc/src/stdfix/bitsulk.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsulk -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSULK_H
+#define LLVM_LIBC_SRC_STDFIX_BITSULK_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uint_ulk_t bitsulk(unsigned long accum x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSULK_H

--- a/libc/src/stdfix/bitsulr.cpp
+++ b/libc/src/stdfix/bitsulr.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsulr function --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsulr.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(uint_ulr_t, bitsulr, (unsigned long fract x)) {
+  return cpp::bit_cast<uint_ulr_t, unsigned long fract>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsulr.h
+++ b/libc/src/stdfix/bitsulr.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsulr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSULR_H
+#define LLVM_LIBC_SRC_STDFIX_BITSULR_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uint_ulr_t bitsulr(unsigned long fract x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSULR_H

--- a/libc/src/stdfix/bitsur.cpp
+++ b/libc/src/stdfix/bitsur.cpp
@@ -1,0 +1,19 @@
+//===-- Implementation of bitsur function ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "bitsur.h"
+#include "src/__support/common.h"
+#include "src/__support/fixed_point/fx_bits.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(uint_ur_t, bitsur, (unsigned fract x)) {
+  return cpp::bit_cast<uint_ur_t, unsigned fract>(x);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdfix/bitsur.h
+++ b/libc/src/stdfix/bitsur.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for bitsur ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STDFIX_BITSUR_H
+#define LLVM_LIBC_SRC_STDFIX_BITSUR_H
+
+#include "include/llvm-libc-macros/stdfix-macros.h"
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+uint_ur_t bitsur(unsigned fract x);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STDFIX_BITSUR_H

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -229,6 +229,9 @@ TEST_SPECIALIZATION(unsigned int);
 TEST_SPECIALIZATION(unsigned long);
 TEST_SPECIALIZATION(unsigned long long);
 
+// `char`, `signed char` and `unsigned char` are all distinct types
+TEST_SPECIALIZATION(signed char);
+
 TEST_SPECIALIZATION(bool);
 
 // We cannot just use a single UInt128 specialization as that resolves to only

--- a/libc/test/src/stdfix/BitsFxTest.h
+++ b/libc/test/src/stdfix/BitsFxTest.h
@@ -1,0 +1,56 @@
+//===-- Utility class to test fixed point to int conversions ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "test/UnitTest/Test.h"
+
+#include "include/llvm-libc-types/stdfix-types.h"
+#include "src/__support/CPP/bit.h"
+#include "src/__support/fixed_point/fx_bits.h"
+
+template <typename T, typename XType>
+class BitsFxTest : public LIBC_NAMESPACE::testing::Test {
+  using FXRep = LIBC_NAMESPACE::fixed_point::FXRep<T>;
+  static constexpr T zero = FXRep::ZERO();
+  static constexpr T min = FXRep::MIN();
+  static constexpr T max = FXRep::MAX();
+  static constexpr T half = static_cast<T>(0.5);
+  static constexpr T quarter = static_cast<T>(0.25);
+  static constexpr T one =
+      (FXRep::INTEGRAL_LEN > 0) ? static_cast<T>(1) : FXRep::MAX();
+  static constexpr T eps = FXRep::EPS();
+  constexpr XType get_one_or_saturated_fraction() {
+    if (FXRep::INTEGRAL_LEN > 0) {
+      return static_cast<XType>(static_cast<XType>(0x1) << FXRep::FRACTION_LEN);
+    } else {
+      return static_cast<XType>(
+          LIBC_NAMESPACE::mask_trailing_ones<typename FXRep::StorageType,
+                                             FXRep::FRACTION_LEN>());
+    }
+  }
+
+public:
+  typedef XType (*BitsFxFunc)(T);
+
+  void test_special_numbers(BitsFxFunc func) {
+    EXPECT_EQ(static_cast<XType>(0), func(zero));
+    EXPECT_EQ(static_cast<XType>(0x1), func(eps));
+    EXPECT_EQ(static_cast<XType>(static_cast<XType>(0x1)
+                                 << (FXRep::FRACTION_LEN - 1)),
+              func(half));
+    // Occupy the bit to the left of the fixed point for Accum types
+    // Saturate fraction portion for Fract types
+    EXPECT_EQ(get_one_or_saturated_fraction(), func(one));
+  }
+};
+
+#define LIST_BITSFX_TEST(Name, T, XType, func)                                 \
+  using LlvmLibcBits##Name##Test = BitsFxTest<T, XType>;                       \
+  TEST_F(LlvmLibcBits##Name##Test, SpecialNumbers) {                           \
+    test_special_numbers(&func);                                               \
+  }                                                                            \
+  static_assert(true, "Require semicolon.")

--- a/libc/test/src/stdfix/CMakeLists.txt
+++ b/libc/test/src/stdfix/CMakeLists.txt
@@ -73,6 +73,22 @@ foreach(suffix IN ITEMS hr r lr hk k lk uhr ur ulr uhk uk ulk)
       libc.src.__support.CPP.bit
       libc.src.__support.fixed_point.fx_bits
   )
+
+  add_libc_test(
+    bits${suffix}_test
+    SUITE
+      libc-stdfix-tests
+    HDRS
+      BitsFxTest.h
+    SRCS
+      bits${suffix}_test.cpp
+    COMPILE_OPTIONS
+      -O3
+    DEPENDS
+      libc.src.stdfix.bits${suffix}
+      libc.src.__support.CPP.bit
+      libc.src.__support.fixed_point.fx_bits
+  )
 endforeach()
 
 add_libc_test(

--- a/libc/test/src/stdfix/bitshk_test.cpp
+++ b/libc/test/src/stdfix/bitshk_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitshk ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitshk.h"
+
+LIST_BITSFX_TEST(hk, short accum, int_hk_t, LIBC_NAMESPACE::bitshk);

--- a/libc/test/src/stdfix/bitshr_test.cpp
+++ b/libc/test/src/stdfix/bitshr_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitshr ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitshr.h"
+
+LIST_BITSFX_TEST(hr, short fract, int_hr_t, LIBC_NAMESPACE::bitshr);

--- a/libc/test/src/stdfix/bitsk_test.cpp
+++ b/libc/test/src/stdfix/bitsk_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitsk -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsk.h"
+
+LIST_BITSFX_TEST(k, accum, int_k_t, LIBC_NAMESPACE::bitsk);

--- a/libc/test/src/stdfix/bitslk_test.cpp
+++ b/libc/test/src/stdfix/bitslk_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitslk ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitslk.h"
+
+LIST_BITSFX_TEST(lk, long accum, int_lk_t, LIBC_NAMESPACE::bitslk);

--- a/libc/test/src/stdfix/bitslr_test.cpp
+++ b/libc/test/src/stdfix/bitslr_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitslr ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitslr.h"
+
+LIST_BITSFX_TEST(lr, long fract, int_lr_t, LIBC_NAMESPACE::bitslr);

--- a/libc/test/src/stdfix/bitsr_test.cpp
+++ b/libc/test/src/stdfix/bitsr_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitsr -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsr.h"
+
+LIST_BITSFX_TEST(r, fract, int_r_t, LIBC_NAMESPACE::bitsr);

--- a/libc/test/src/stdfix/bitsuhk_test.cpp
+++ b/libc/test/src/stdfix/bitsuhk_test.cpp
@@ -1,0 +1,13 @@
+//===-- Unittests for bitsuhk ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsuhk.h"
+
+LIST_BITSFX_TEST(uhk, unsigned short accum, uint_uhk_t,
+                 LIBC_NAMESPACE::bitsuhk);

--- a/libc/test/src/stdfix/bitsuhr_test.cpp
+++ b/libc/test/src/stdfix/bitsuhr_test.cpp
@@ -1,0 +1,13 @@
+//===-- Unittests for bitsuhr ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsuhr.h"
+
+LIST_BITSFX_TEST(uhr, unsigned short fract, uint_uhr_t,
+                 LIBC_NAMESPACE::bitsuhr);

--- a/libc/test/src/stdfix/bitsuk_test.cpp
+++ b/libc/test/src/stdfix/bitsuk_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitsuk ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsuk.h"
+
+LIST_BITSFX_TEST(uk, unsigned accum, uint_uk_t, LIBC_NAMESPACE::bitsuk);

--- a/libc/test/src/stdfix/bitsulk_test.cpp
+++ b/libc/test/src/stdfix/bitsulk_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitsulk ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsulk.h"
+
+LIST_BITSFX_TEST(ulk, unsigned long accum, uint_ulk_t, LIBC_NAMESPACE::bitsulk);

--- a/libc/test/src/stdfix/bitsulr_test.cpp
+++ b/libc/test/src/stdfix/bitsulr_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitsulr ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsulr.h"
+
+LIST_BITSFX_TEST(ulr, unsigned long fract, uint_ulr_t, LIBC_NAMESPACE::bitsulr);

--- a/libc/test/src/stdfix/bitsur_test.cpp
+++ b/libc/test/src/stdfix/bitsur_test.cpp
@@ -1,0 +1,12 @@
+//===-- Unittests for bitsur ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BitsFxTest.h"
+#include "src/stdfix/bitsur.h"
+
+LIST_BITSFX_TEST(ur, unsigned fract, uint_ur_t, LIBC_NAMESPACE::bitsur);


### PR DESCRIPTION
Fixes #113359 