### PR TITLE
[lit] Fix missing command for external Windows shell

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1216,6 +1216,8 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
                 commands[i] = match.expand(
                     "echo '\\1' > nul && " if command else "echo '\\1' > nul"
                 )
+                if command:
+                    commands[i] += command
         f.write("@echo on\n")
         f.write("\n@if %ERRORLEVEL% NEQ 0 EXIT\n".join(commands))
     else:


### PR DESCRIPTION
On Windows, when using the external shell (.bat) the command to be executed is not generated. This is a regression introduced by https://reviews.llvm.org/D122569.

A command of the form `RUN: mycmd` is internally transformed into `dbg(line XX) mycmd`. Previously `dbg()` was substituted by `echo \\1 && `, with `\\1` matching the content of `dbg()`, in the string containing the command to be executed. The new code relies on `str.expand()` which correctly expands `\\1`, but as the template does not reference the command at all, it is lost. The generated .bat file is invalid as there is nothing after the last `&&`.

Fix by appending the command as is done for the common case further down (line 1257).