### PR TITLE
[clang][NFC] Generalize getSpecificAttr for const attributes

### DIFF
--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -811,7 +811,7 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
   // Identify loop attribute 'code_align' from Attrs.
   // For attribute code_align:
   // n - 'llvm.loop.align i32 n' metadata will be emitted.
-  if (const auto *CodeAlign = getSpecificAttr<const CodeAlignAttr>(Attrs)) {
+  if (const auto *CodeAlign = getSpecificAttr<CodeAlignAttr>(Attrs)) {
     const auto *CE = cast<ConstantExpr>(CodeAlign->getAlignment());
     llvm::APSInt ArgVal = CE->getResultAsAPSInt();
     setCodeAlign(ArgVal.getSExtValue());


### PR DESCRIPTION
This patch allows using `getSpecificAttr` for getting `const` attributes. Previously, if users of this API would want to get a const Attribute pointer, they had to pass `getSpecificAttr<const XYZ>()`, to get it compile. It feels like an arbitrary limitation as the constness was already encoded in the Attribute container's value type.