### PR TITLE
[LoopVectorize] Ensure fairness when selecting epilogue VFs

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4731,7 +4731,7 @@ VectorizationFactor LoopVectorizationPlanner::selectEpilogueVectorizationFactor(
 
   unsigned Multiplier = IC;
   if (MainLoopVF.isScalable())
-    Multiplier = getVScaleForTuning(OrigLoop, TTI).value_or(1);
+    Multiplier *= getVScaleForTuning(OrigLoop, TTI).value_or(1);
 
   if (!CM.isEpilogueVectorizationProfitable(MainLoopVF, Multiplier)) {
     LLVM_DEBUG(dbgs() << "LEV: Epilogue vectorization is not profitable for "


### PR DESCRIPTION
Whilst rebasing PR #116247 I discovered an issue where PR #108190 seems to have unintentionally introduced an unfairness in selecting epilogue VFs by making potentially better choices for fixed-width VFs compared to scalable VFs. When considering whether epilogue vectorisation is profitable or not the latest algorithm appears to be:

```
bool IsProfitable = false;
if (VF.isFixed())
  IsProfitable = (IC * VF.getFixedValue())
     >= EpilogueVectorizationMinVF;
else
  IsProfitable = (getVScaleForTuning() * VF.getKnownMinValue())
     >= EpilogueVectorizationMinVF;
```

Instead, the estimate for the number of scalar iterations processed in the main vector loop should be

  (IC * estimatedRuntimeVF)