### PR TITLE
[Flang][OpenMP] Error gracefully for dependence-type with depobj

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -139,9 +139,10 @@ genDependKindAttr(lower::AbstractConverter &converter,
     break;
   case omp::clause::DependenceType::Mutexinoutset:
   case omp::clause::DependenceType::Inoutset:
-    TODO(currentLocation, "INOUTSET and MUTEXINOUTSET are not supported yet");
-    break;
   case omp::clause::DependenceType::Depobj:
+    TODO(currentLocation,
+         "INOUTSET, MUTEXINOUTSET and DEPOBJ dependence-types");
+    break;
   case omp::clause::DependenceType::Sink:
   case omp::clause::DependenceType::Source:
     llvm_unreachable("unhandled parser task dependence type");

--- a/flang/test/Lower/OpenMP/Todo/depend-clause-depobj.f90
+++ b/flang/test/Lower/OpenMP/Todo/depend-clause-depobj.f90
@@ -2,10 +2,9 @@
 !RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -o - %s 2>&1 | FileCheck %s
 
 !CHECK: not yet implemented: INOUTSET, MUTEXINOUTSET and DEPOBJ dependence-types
+
 subroutine f00(x)
   integer :: x
-  !$omp task depend(inoutset: x)
-  x = x + 1
+  !$omp task depend(depobj: x)
   !$omp end task
 end
-

--- a/flang/test/Lower/OpenMP/Todo/depend-clause-mutexinoutset.f90
+++ b/flang/test/Lower/OpenMP/Todo/depend-clause-mutexinoutset.f90
@@ -1,7 +1,7 @@
 !RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -fopenmp-version=52 -o - %s 2>&1 | FileCheck %s
 !RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 -o - %s 2>&1 | FileCheck %s
 
-!CHECK: not yet implemented: INOUTSET and MUTEXINOUTSET are not supported yet
+!CHECK: not yet implemented: INOUTSET, MUTEXINOUTSET and DEPOBJ dependence-types
 subroutine f00(x)
   integer :: x
   !$omp task depend(mutexinoutset: x)


### PR DESCRIPTION
It also modifies the error message to specify it is the dependence-type that is not supported.

Resolves the crash in https://github.com/llvm/llvm-project/issues/115647. A fix can come in later as part of future OpenMP version support. 