### PR TITLE
[NFC][RISCV] Refactor allocation of the stack space

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.h
@@ -78,6 +78,9 @@ public:
     return StackId != TargetStackID::ScalableVector;
   }
 
+  void allocateStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
+                     StackOffset Offset, bool EmitCFI, unsigned CFIIndex) const;
+
 protected:
   const RISCVSubtarget &STI;
 


### PR DESCRIPTION
Separates the stack allocations from prologue in preparation for the stack clash protection support.