### PR TITLE
[clang-tidy] ignore consteval function in `ExceptionAnalyzer`

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
@@ -320,6 +320,11 @@ bool isQualificationConvertiblePointer(QualType From, QualType To,
 } // namespace
 
 static bool canThrow(const FunctionDecl *Func) {
+  // consteval specifies every call to the function must produce a compile-time
+  // constant. compile-time constant cannot be evaluate a throw expression.
+  if (Func->isConsteval())
+    return false;
+
   const auto *FunProto = Func->getType()->getAs<FunctionProtoType>();
   if (!FunProto)
     return true;

--- a/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
@@ -320,8 +320,9 @@ bool isQualificationConvertiblePointer(QualType From, QualType To,
 } // namespace
 
 static bool canThrow(const FunctionDecl *Func) {
-  // consteval specifies every call to the function must produce a compile-time
-  // constant. compile-time constant cannot be evaluate a throw expression.
+  // consteval specifies that every call to the function must produce a
+  // compile-time constant, which cannot evaluate a throw expression without
+  // producing a compilation error.
   if (Func->isConsteval())
     return false;
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -162,6 +162,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/dangling-handle>` check to treat `std::span` as a
   handle class.
 
+- Improved :doc:`bugprone-exception-escape
+  <clang-tidy/checks/bugprone/exception-escape>` by fixing false positives
+  when consteval function with throw statements.
+
 - Improved :doc:`bugprone-forwarding-reference-overload
   <clang-tidy/checks/bugprone/forwarding-reference-overload>` check by fixing
   a crash when determining if an ``enable_if[_t]`` was found.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -164,7 +164,7 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-exception-escape
   <clang-tidy/checks/bugprone/exception-escape>` by fixing false positives
-  when consteval function with throw statements.
+  when a consteval function with throw statements.
 
 - Improved :doc:`bugprone-forwarding-reference-overload
   <clang-tidy/checks/bugprone/forwarding-reference-overload>` check by fixing

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/exception-escape-consteval.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/exception-escape-consteval.cpp
@@ -1,0 +1,14 @@
+// RUN: %check_clang_tidy -std=c++20 %s bugprone-exception-escape %t -- \
+// RUN:     -- -fexceptions -Wno-everything
+
+namespace GH104457 {
+
+consteval int consteval_fn(int a) {
+  if (a == 0)
+    throw 1;
+  return a;
+}
+
+int test() noexcept { return consteval_fn(1); }
+
+} // namespace GH104457


### PR DESCRIPTION
`ExceptionAnalyzer` can ignore `consteval` function even if it will throw exception. `consteval` function must produce compile-time constant. But throw statement cannot appear in constant evaluation.
Fixed: #104457.
