### PR TITLE
[BOLT] Fix for bughunter.sh in offline mode

### DIFF
--- a/bolt/utils/bughunter.sh
+++ b/bolt/utils/bughunter.sh
@@ -131,7 +131,7 @@ if [[ $FAIL -eq "0" ]]; then
         fi
     else
         echo "Did it pass? Type the return code [0 = pass, 1 = fail]"
-        read -n1 PASS
+        read -n1 FAIL
     fi
     if [[ $FAIL -eq "0" ]] ; then
         echo "  Warning: optimized binary passes."
@@ -205,7 +205,7 @@ while [[ "$CONTINUE" -ne "0" ]] ; do
             echo "  OPTIMIZED_BINARY failure=$FAIL"
         else
             echo "Did it pass? Type the return code [0 = pass, 1 = fail]"
-            read -n1 PASS
+            read -n1 FAIL
         fi
     else
         FAIL=1


### PR DESCRIPTION
In offline mode, the script sets 'PASS' variable and does not use it.
Surrounding code suggests using 'FAIL' variable instead.