### PR TITLE
Re-land "[SandboxIR] Add debug checker to compare IR before/after a revert (#115968)"

### DIFF
--- a/llvm/include/llvm/SandboxIR/Context.h
+++ b/llvm/include/llvm/SandboxIR/Context.h
@@ -44,11 +44,12 @@ public:
 
 protected:
   LLVMContext &LLVMCtx;
-  friend class Type;        // For LLVMCtx.
-  friend class PointerType; // For LLVMCtx.
-  friend class IntegerType; // For LLVMCtx.
-  friend class StructType;  // For LLVMCtx.
-  friend class Region;      // For LLVMCtx.
+  friend class Type;              // For LLVMCtx.
+  friend class PointerType;       // For LLVMCtx.
+  friend class IntegerType;       // For LLVMCtx.
+  friend class StructType;        // For LLVMCtx.
+  friend class Region;            // For LLVMCtx.
+  friend class IRSnapshotChecker; // To snapshot LLVMModuleToModuleMap.
 
   Tracker IRTracker;
 

--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -11,6 +11,7 @@
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/SandboxIR/BasicBlock.h"
 #include "llvm/SandboxIR/Constant.h"

--- a/llvm/lib/SandboxIR/Tracker.cpp
+++ b/llvm/lib/SandboxIR/Tracker.cpp
@@ -69,9 +69,7 @@ bool IRSnapshotChecker::diff(const ContextSnapshot &Orig,
   return DifferenceFound;
 }
 
-void IRSnapshotChecker::save() {
-  OrigContextSnapshot = takeSnapshot();
-}
+void IRSnapshotChecker::save() { OrigContextSnapshot = takeSnapshot(); }
 
 void IRSnapshotChecker::expectNoDiff() {
   ContextSnapshot CurrContextSnapshot = takeSnapshot();

--- a/llvm/lib/SandboxIR/Tracker.cpp
+++ b/llvm/lib/SandboxIR/Tracker.cpp
@@ -57,7 +57,7 @@ bool IRSnapshotChecker::diff(const ContextSnapshot &Orig,
       dbgs() << "Current:\n" << CurrFS.TextualIR << "\n";
     }
   }
-  // Check that Curr doesn't somehow contain any new modules.
+  // Check that Curr doesn't contain any new functions.
   for (const auto &[F, CurrFS] : Curr) {
     if (!Orig.contains(F)) {
       DifferenceFound = true;

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -1844,3 +1844,41 @@ define void @foo(i32 %arg, float %farg) {
   Ctx.revert();
   EXPECT_FALSE(FAdd->getFastMathFlags() != OrigFMF);
 }
+
+TEST_F(TrackerTest, IRSnapshotCheckerNoChanges) {
+  parseIR(C, R"IR(
+define i32 @foo(i32 %arg) {
+  %add0 = add i32 %arg, %arg
+  ret i32 %add0
+}
+)IR");
+  Function &LLVMF = *M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+
+  [[maybe_unused]] auto *F = Ctx.createFunction(&LLVMF);
+  sandboxir::IRSnapshotChecker Checker(Ctx);
+  Checker.save();
+  Checker.expectNoDiff();
+}
+
+TEST_F(TrackerTest, IRSnapshotCheckerDiesWithUnexpectedChanges) {
+  parseIR(C, R"IR(
+define i32 @foo(i32 %arg) {
+  %add0 = add i32 %arg, %arg
+  %add1 = add i32 %add0, %arg
+  ret i32 %add1
+}
+)IR");
+  Function &LLVMF = *M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+
+  auto *F = Ctx.createFunction(&LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  sandboxir::Instruction *Add0 = &*It++;
+  sandboxir::Instruction *Add1 = &*It++;
+  sandboxir::IRSnapshotChecker Checker(Ctx);
+  Checker.save();
+  Add1->setOperand(1, Add0);
+  EXPECT_DEATH(Checker.expectNoDiff(), "Found IR difference");
+}

--- a/llvm/unittests/SandboxIR/TrackerTest.cpp
+++ b/llvm/unittests/SandboxIR/TrackerTest.cpp
@@ -1845,6 +1845,9 @@ define void @foo(i32 %arg, float %farg) {
   EXPECT_FALSE(FAdd->getFastMathFlags() != OrigFMF);
 }
 
+// IRSnapshotChecker is only defined in debug mode.
+#ifndef NDEBUG
+
 TEST_F(TrackerTest, IRSnapshotCheckerNoChanges) {
   parseIR(C, R"IR(
 define i32 @foo(i32 %arg) {
@@ -1907,3 +1910,5 @@ define i32 @foo(i32 %arg) {
   // The new snapshot should have replaced the old one, so this should succeed.
   Checker.expectNoDiff();
 }
+
+#endif // NDEBUG


### PR DESCRIPTION
This PR re-lands https://github.com/llvm/llvm-project/pull/115968 with a fix for a buildbot failure.

The `IRSnapshotChecker` class is only defined in debug mode, so its unit tests must also be inside `#ifndef NDEBUG`.