### PR TITLE
[libc] Set default visibility for LLVM functions

### DIFF
--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -18,7 +18,7 @@
 #include "src/__support/macros/properties/architectures.h"
 
 #ifndef LLVM_LIBC_FUNCTION_ATTR
-#define LLVM_LIBC_FUNCTION_ATTR
+#define LLVM_LIBC_FUNCTION_ATTR [[gnu::visibility("default")]]
 #endif
 
 // MacOS needs to be excluded because it does not support aliasing.


### PR DESCRIPTION
This is a follow up to 5ff3ff3 addressing the issue reported in #74881.