### PR TITLE
[RISCV] Fix FP64 DinX R Regclass

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -20531,7 +20531,7 @@ RISCVTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
       break;
     case 'R':
       if (VT == MVT::f64 && !Subtarget.is64Bit() && Subtarget.hasStdExtZdinx())
-        return std::make_pair(0U, &RISCV::GPRF64PairCRegClass);
+        return std::make_pair(0U, &RISCV::GPRF64PairNoX0RegClass);
       return std::make_pair(0U, &RISCV::GPRPairNoX0RegClass);
     default:
       break;

--- a/llvm/test/CodeGen/RISCV/zdinx-asm-constraint.ll
+++ b/llvm/test/CodeGen/RISCV/zdinx-asm-constraint.ll
@@ -29,21 +29,15 @@ entry:
 define dso_local void @zdinx_asm_R(ptr nocapture noundef writeonly %a, double noundef %b, double noundef %c) nounwind {
 ; CHECK-LABEL: zdinx_asm_R:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    addi sp, sp, -16
-; CHECK-NEXT:    sw s0, 12(sp) # 4-byte Folded Spill
-; CHECK-NEXT:    sw s1, 8(sp) # 4-byte Folded Spill
 ; CHECK-NEXT:    mv a5, a4
-; CHECK-NEXT:    mv s1, a2
+; CHECK-NEXT:    mv a7, a2
 ; CHECK-NEXT:    mv a4, a3
-; CHECK-NEXT:    mv s0, a1
+; CHECK-NEXT:    mv a6, a1
 ; CHECK-NEXT:    #APP
-; CHECK-NEXT:    fsgnjx.d a2, s0, a4
+; CHECK-NEXT:    fsgnjx.d a2, a6, a4
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    sw a2, 8(a0)
 ; CHECK-NEXT:    sw a3, 12(a0)
-; CHECK-NEXT:    lw s0, 12(sp) # 4-byte Folded Reload
-; CHECK-NEXT:    lw s1, 8(sp) # 4-byte Folded Reload
-; CHECK-NEXT:    addi sp, sp, 16
 ; CHECK-NEXT:    ret
 entry:
   %arrayidx = getelementptr inbounds double, ptr %a, i32 1


### PR DESCRIPTION
This was a typo in llvm/llvm-project#112983 that didn't cause build failures but is still wrong.

---

I have half a PR to merge the GPR and GPRF64 classes, but this should go in before that (rebasing that PR is how I noticed this problem)