### PR TITLE
[DirectX] Fix crash in DXILFlattenArrays for function declarations

### DIFF
--- a/llvm/lib/Target/DirectX/DXILFlattenArrays.cpp
+++ b/llvm/lib/Target/DirectX/DXILFlattenArrays.cpp
@@ -402,7 +402,7 @@ static bool flattenArrays(Module &M) {
   DenseMap<GlobalVariable *, GlobalVariable *> GlobalMap;
   flattenGlobalArrays(M, GlobalMap);
   for (auto &F : make_early_inc_range(M.functions())) {
-    if (F.isIntrinsic())
+    if (F.isDeclaration())
       continue;
     MadeChange |= Impl.visit(F);
   }

--- a/llvm/test/CodeGen/DirectX/flatten-array.ll
+++ b/llvm/test/CodeGen/DirectX/flatten-array.ll
@@ -186,3 +186,6 @@ define void @global_gep_store() {
   store i32 1, i32* %3, align 4
   ret void
 }
+
+; Make sure we don't try to walk the body of a function declaration.
+declare void @opaque_function()


### PR DESCRIPTION
We were skipping intrinsics here, but really we need to skip all function declarations - if the function doesn't have a body there's nothing to walk.