### PR TITLE
[lldb] Fix a positioning bug in diagnostics output

### DIFF
--- a/lldb/source/Utility/DiagnosticsRendering.cpp
+++ b/lldb/source/Utility/DiagnosticsRendering.cpp
@@ -121,10 +121,10 @@ void RenderDiagnosticDetails(Stream &stream,
         continue;
 
       stream << std::string(loc.column - x_pos, ' ') << cursor;
-      ++x_pos;
+      x_pos = loc.column + 1;
       for (unsigned i = 0; i + 1 < loc.length; ++i) {
         stream << underline;
-        ++x_pos;
+        x_pos += 1;
       }
     }
   }

--- a/lldb/unittests/Utility/DiagnosticsRenderingTest.cpp
+++ b/lldb/unittests/Utility/DiagnosticsRenderingTest.cpp
@@ -74,9 +74,27 @@ TEST_F(ErrorDisplayTest, RenderStatus) {
     auto line2 = lines.first;
     lines = lines.second.split('\n');
     auto line3 = lines.first;
-    //               1234567
+    //                1234567
     ASSERT_EQ(line1, "^~~ ^~~");
     ASSERT_EQ(line2, "|   error: Y");
     ASSERT_EQ(line3, "error: X");
+  }
+  {
+    // Test diagnostics on the same line are emitted correctly.
+    SourceLocation loc1 = {FileSpec{"a.c"}, 1, 2, 0, false, true};
+    SourceLocation loc2 = {FileSpec{"a.c"}, 1, 6, 0, false, true};
+    std::string result =
+        Render({DiagnosticDetail{loc1, eSeverityError, "X", "X"},
+                DiagnosticDetail{loc2, eSeverityError, "Y", "Y"}});
+    auto lines = StringRef(result).split('\n');
+    auto line1 = lines.first;
+    lines = lines.second.split('\n');
+    auto line2 = lines.first;
+    lines = lines.second.split('\n');
+    auto line3 = lines.first;
+    //                1234567
+    ASSERT_EQ(line1, " ^   ^");
+    ASSERT_EQ(line2, " |   error: Y");
+    ASSERT_EQ(line3, " error: X");
   }
 }


### PR DESCRIPTION
The old code did not take the indentation into account.