### PR TITLE
[InlineAdvisor] Update documentation for `PluginInlineAdvisorAnalysis` (NFC).

### DIFF
--- a/llvm/include/llvm/Analysis/InlineAdvisor.h
+++ b/llvm/include/llvm/Analysis/InlineAdvisor.h
@@ -247,37 +247,30 @@ private:
 ///
 /// namespace {
 ///
-/// InlineAdvisor *defaultAdvisorFactory(Module &M, FunctionAnalysisManager
-/// &FAM,
-///                                      InlineParams Params, InlineContext IC)
-///                                      {
+/// InlineAdvisor *defaultAdvisorFactory(Module &M,
+///                                      FunctionAnalysisManager &FAM,
+///                                      InlineParams Params,
+///                                      InlineContext IC) {
 ///   return new DefaultInlineAdvisor(M, FAM, Params, IC);
 /// }
-///
-/// struct DefaultDynamicAdvisor : PassInfoMixin<DefaultDynamicAdvisor> {
-///   PreservedAnalyses run(Module &, ModuleAnalysisManager &MAM) {
-///     PluginInlineAdvisorAnalysis PA(defaultAdvisorFactory);
-///     MAM.registerPass([&] { return PA; });
-///     return PreservedAnalyses::all();
-///   }
-/// };
 ///
 /// } // namespace
 ///
 /// extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
 /// llvmGetPassPluginInfo() {
 ///   return {LLVM_PLUGIN_API_VERSION, "DynamicDefaultAdvisor",
-///   LLVM_VERSION_STRING,
+///           LLVM_VERSION_STRING,
 ///           [](PassBuilder &PB) {
-///             PB.registerPipelineStartEPCallback(
-///                 [](ModulePassManager &MPM, OptimizationLevel Level) {
-///                   MPM.addPass(DefaultDynamicAdvisor());
+///             PB.registerAnalysisRegistrationCallback(
+///                 [](ModuleAnalysisManager &MAM) {
+///                   PluginInlineAdvisorAnalysis PA(defaultAdvisorFactory);
+///                   MAM.registerPass([&] { return PA; });
 ///                 });
 ///           }};
 /// }
 ///
 /// A plugin must implement an AdvisorFactory and register it with a
-/// PluginInlineAdvisorAnlysis to the provided ModuleanAlysisManager.
+/// PluginInlineAdvisorAnlysis to the provided ModuleAnalysisManager.
 ///
 /// If such a plugin has been registered
 /// InlineAdvisorAnalysis::Result::tryCreate will return the dynamically loaded

--- a/llvm/unittests/Analysis/InlineAdvisorPlugin/InlineAdvisorPlugin.cpp
+++ b/llvm/unittests/Analysis/InlineAdvisorPlugin/InlineAdvisorPlugin.cpp
@@ -17,32 +17,16 @@ InlineAdvisor *DefaultAdvisorFactory(Module &M, FunctionAnalysisManager &FAM,
   return new DefaultInlineAdvisor(M, FAM, Params, IC);
 }
 
-struct DefaultDynamicAdvisor : PassInfoMixin<DefaultDynamicAdvisor> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM) {
-    PluginInlineAdvisorAnalysis DA(DefaultAdvisorFactory);
-    MAM.registerPass([&] { return DA; });
-    return PreservedAnalyses::all();
-  }
-};
-
 } // namespace
 
 /* New PM Registration */
 llvm::PassPluginLibraryInfo getDefaultDynamicAdvisorPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "DynamicDefaultAdvisor", LLVM_VERSION_STRING,
           [](PassBuilder &PB) {
-            PB.registerPipelineStartEPCallback(
-                [](ModulePassManager &MPM, OptimizationLevel Level) {
-                  MPM.addPass(DefaultDynamicAdvisor());
-                });
-            PB.registerPipelineParsingCallback(
-                [](StringRef Name, ModulePassManager &PM,
-                   ArrayRef<PassBuilder::PipelineElement> InnerPipeline) {
-                  if (Name == "dynamic-inline-advisor") {
-                    PM.addPass(DefaultDynamicAdvisor());
-                    return true;
-                  }
-                  return false;
+            PB.registerAnalysisRegistrationCallback(
+                [](ModuleAnalysisManager &MAM) {
+                  PluginInlineAdvisorAnalysis PA(DefaultAdvisorFactory);
+                  MAM.registerPass([&] { return PA; });
                 });
           }};
 }

--- a/llvm/unittests/Analysis/PluginInlineAdvisorAnalysisTest.cpp
+++ b/llvm/unittests/Analysis/PluginInlineAdvisorAnalysisTest.cpp
@@ -66,8 +66,6 @@ struct CompilerInstance {
     Expected<PassPlugin> Plugin = PassPlugin::Load(PluginPath);
     ASSERT_TRUE(!!Plugin) << "Plugin path: " << PluginPath;
     Plugin->registerPassBuilderCallbacks(PB);
-    ASSERT_THAT_ERROR(PB.parsePassPipeline(MPM, "dynamic-inline-advisor"),
-                      Succeeded());
   }
 
   // connect the FooOnlyInlineAdvisor to our compiler instance


### PR DESCRIPTION
This commit updates the documentation for `PluginInlineAdvisorAnalysis` based on the feedback in PR#114615 suggesting that `registerAnalysisRegistrationCallback` should be the preferred method to register the plugin inline advisor analysis.