### PR TITLE
[clang] Implement -fstrict-bool

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -2179,6 +2179,11 @@ are listed below.
 
    This option is currently experimental.
 
+.. option:: -f[no-]strict-bool
+
+    Enable optimizations based on the assumption that all ``bool`` values have
+    a bit pattern of either 0 or 1. Enabled by default.
+
 .. option:: -fstrict-vtable-pointers
 
    Enable optimizations based on the strict rules for overwriting polymorphic

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -311,6 +311,7 @@ CODEGENOPT(SimplifyLibCalls  , 1, 1) ///< Set when -fbuiltin is enabled.
 CODEGENOPT(SoftFloat         , 1, 0) ///< -soft-float.
 CODEGENOPT(SpeculativeLoadHardening, 1, 0) ///< Enable speculative load hardening.
 CODEGENOPT(FineGrainedBitfieldAccesses, 1, 0) ///< Enable fine-grained bitfield accesses.
+CODEGENOPT(StrictBool        , 1, 1) ///< Optimize based on bool bit patterns being either 0 or 1.
 CODEGENOPT(StrictEnums       , 1, 0) ///< Optimize based on strict enum definition.
 CODEGENOPT(StrictVTablePointers, 1, 0) ///< Optimize based on the strict vtable pointers
 CODEGENOPT(TimePasses        , 1, 0) ///< Set when -ftime-report or -ftime-report= is enabled.

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3970,6 +3970,12 @@ def fno_debug_macro : Flag<["-"], "fno-debug-macro">, Group<f_Group>,
 def fstrict_aliasing : Flag<["-"], "fstrict-aliasing">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, DXCOption]>,
   HelpText<"Enable optimizations based on strict aliasing rules">;
+defm strict_bool : BoolFOption<"strict-bool",
+  CodeGenOpts<"StrictBool">, DefaultTrue,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable ">,
+  NegFlag<SetFalse, [], [ClangOption, CC1Option], "Disable ">,
+  BothFlags<[], [ClangOption], "optimizations based on bool bit patterns never "
+    "being anything other than 0 or 1">>;
 def fstrict_enums : Flag<["-"], "fstrict-enums">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Enable optimizations based on the strict definition of an enum's "

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5938,6 +5938,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (!Args.hasFlag(options::OPT_fstruct_path_tbaa,
                     options::OPT_fno_struct_path_tbaa, true))
     CmdArgs.push_back("-no-struct-path-tbaa");
+  Args.addOptOutFlag(CmdArgs, options::OPT_fstrict_bool,
+                     options::OPT_fno_strict_bool);
   Args.addOptInFlag(CmdArgs, options::OPT_fstrict_enums,
                     options::OPT_fno_strict_enums);
   Args.addOptOutFlag(CmdArgs, options::OPT_fstrict_return,
@@ -6051,6 +6053,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   // code, where aliases aren't supported.
   if (!RawTriple.isOSDarwin() && !RawTriple.isNVPTX())
     CmdArgs.push_back("-mconstructor-aliases");
+
+  // Assume -fno-strict-bool in the Darwin kernel.
+  if (KernelOrKext)
+    CmdArgs.push_back("-fno-strict-bool");
 
   // Darwin's kernel doesn't support guard variables; just die if we
   // try to use them.

--- a/clang/test/CodeGen/strict-bool.c
+++ b/clang/test/CodeGen/strict-bool.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple armv7-apple-darwin -O1 -fstrict-bool -emit-llvm -o - %s | FileCheck %s -check-prefix=CHECK-STRICT
+// RUN: %clang_cc1 -triple armv7-apple-darwin -O1 -fno-strict-bool -emit-llvm -o - %s | FileCheck %s -check-prefix=CHECK-NO-STRICT
+// RUN: %clang -target armv7-apple-darwin -O1 -mkernel -S -emit-llvm -o - %s | FileCheck %s -check-prefix=CHECK-NO-STRICT
+
+struct has_bool {
+    _Bool b;
+};
+
+int foo(struct has_bool *b) {
+    // CHECK-STRICT: load i8, {{.*}}, !range ![[RANGE_BOOL:[0-9]+]]
+    // CHECK-STRICT-NOT: and i8
+
+    // CHECK-NO-STRICT: [[BOOL:%.+]] = load i8
+    // CHECK-NO-STRICT: and i8 [[BOOL]], 1
+    return b->b;
+}
+
+// CHECK_STRICT: ![[RANGE_BOOL]] = !{i8 0, i8 2}


### PR DESCRIPTION
``bool`` values are stored as i8 in memory, and it is undefined behavior for a ``bool`` value to be any value other than 0 or 1. Clang exploits this with range metadata: ``bool`` load instructions at any optimization level above -O0 are assumed to only have their lowest bit set. This can create memory safety problems when other bits are set, for instance through ``memcpy``.

This change adds a ``-f[no-]strict-bool`` option that controls this behavior. It is enabled by default in order to not upset the status quo, except in the Darwin driver when passing -mkernel.

Radar-ID: 139397212