### PR TITLE
[Clang] Fix typo 'dereferencable' to 'dereferenceable'

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -2665,7 +2665,7 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
         llvm::AttributeSet::get(getLLVMContext(), Attrs);
   }
 
-  // Apply `nonnull`, `dereferencable(N)` and `align N` to the `this` argument,
+  // Apply `nonnull`, `dereferenceable(N)` and `align N` to the `this` argument,
   // unless this is a thunk function.
   // FIXME: fix this properly, https://reviews.llvm.org/D100388
   if (FI.isInstanceMethod() && !IRFunctionArgs.hasInallocaArg() &&


### PR DESCRIPTION
This patch corrects the typo 'dereferencable' to 'dereferenceable' in CGCall.cpp.
The typo is located within a comment inside the `void CodeGenModule::ConstructAttributeList` function.