### PR TITLE
[libc++] Update the status for lwg-3120

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -14,7 +14,7 @@
 "`LWG2731 <https://wg21.link/LWG2731>`__","Existence of ``lock_guard<MutexTypes...>::mutex_type`` typedef unclear","2020-11 (Virtual)","|Complete|","5",""
 "`LWG2743 <https://wg21.link/LWG2743>`__","P0083R3 ``node_handle`` private members missing ""exposition only"" comment","2020-11 (Virtual)","|Nothing To Do|","",""
 "`LWG2820 <https://wg21.link/LWG2820>`__","Clarify ``<cstdint>`` macros","2020-11 (Virtual)","|Nothing To Do|","",""
-"`LWG3120 <https://wg21.link/LWG3120>`__","Unclear behavior of ``monotonic_buffer_resource::release()``","2020-11 (Virtual)","","",""
+"`LWG3120 <https://wg21.link/LWG3120>`__","Unclear behavior of ``monotonic_buffer_resource::release()``","2020-11 (Virtual)","|Complete|","16",""
 "`LWG3170 <https://wg21.link/LWG3170>`__","``is_always_equal`` added to ``std::allocator`` makes the standard library treat derived types as always equal","2020-11 (Virtual)","|Complete|","18",""
 "`LWG3036 <https://wg21.link/LWG3036>`__","``polymorphic_allocator::destroy`` is extraneous","2020-11 (Virtual)","|Nothing To Do|","","Reverted by P2875R4"
 "`LWG3171 <https://wg21.link/LWG3171>`__","LWG2989 breaks ``directory_entry`` stream insertion","2020-11 (Virtual)","|Complete|","14",""

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/release_reset_initial_status.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/release_reset_initial_status.pass.cpp
@@ -13,6 +13,8 @@
 
 // class monotonic_buffer_resource
 
+// This test checks the behavior required by LWG3120.
+
 #include <memory_resource>
 #include <cassert>
 

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/release_reset_initial_status.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/release_reset_initial_status.pass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++17
+// UNSUPPORTED: availability-pmr-missing
+
+// <memory_resource>
+
+// class monotonic_buffer_resource
+
+#include <memory_resource>
+#include <cassert>
+
+#include "count_new.h"
+#include "test_macros.h"
+
+int main(int, char**) {
+  {
+    {
+      // When ctor with a next buffer size. After release(), check whether the next buffer size has been reset after release()
+      constexpr size_t expect_next_buffer_size = 512;
+      std::pmr::monotonic_buffer_resource mr{nullptr, expect_next_buffer_size, std::pmr::new_delete_resource()};
+
+      for (int i = 0; i < 100; ++i) {
+        (void)mr.allocate(1);
+        mr.release();
+        ASSERT_WITH_LIBRARY_INTERNAL_ALLOCATIONS(globalMemCounter.checkLastNewSizeGe(expect_next_buffer_size));
+      }
+    }
+    {
+      // Check whether the offset of the initial buffer has been reset after release()
+      constexpr size_t buffer_size = 100;
+      char buffer[buffer_size];
+      std::pmr::monotonic_buffer_resource mr{buffer, buffer_size, std::pmr::null_memory_resource()};
+
+      mr.release();
+      auto expect_mem_start = mr.allocate(60);
+      mr.release();
+      auto ths_mem_start = mr.allocate(60);
+      assert(expect_mem_start == ths_mem_start);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Current implementation already have struct __initial_descriptor which saves the initial state.
When release() called, we will reset ptr __initial_descriptor.__cur_.

This patch update the lwg 3120 issue latest status.

Close #104274 