### PR TITLE
[Clang] [NFC] Migrate visitors in ARCMigrate

### DIFF
--- a/clang/lib/ARCMigrate/ObjCMT.cpp
+++ b/clang/lib/ARCMigrate/ObjCMT.cpp
@@ -7,16 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "Transforms.h"
-#include "clang/Analysis/RetainSummaryManager.h"
 #include "clang/ARCMigrate/ARCMT.h"
 #include "clang/ARCMigrate/ARCMTActions.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/NSAPI.h"
 #include "clang/AST/ParentMap.h"
-#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Analysis/DomainSpecific/CocoaConventions.h"
+#include "clang/Analysis/RetainSummaryManager.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Edit/Commit.h"
 #include "clang/Edit/EditedSource.h"
@@ -309,67 +309,68 @@ namespace {
     return true;
   }
 
-class ObjCMigrator : public RecursiveASTVisitor<ObjCMigrator> {
-  ObjCMigrateASTConsumer &Consumer;
-  ParentMap &PMap;
+  class ObjCMigrator : public DynamicRecursiveASTVisitor {
+    ObjCMigrateASTConsumer &Consumer;
+    ParentMap &PMap;
 
-public:
-  ObjCMigrator(ObjCMigrateASTConsumer &consumer, ParentMap &PMap)
-    : Consumer(consumer), PMap(PMap) { }
-
-  bool shouldVisitTemplateInstantiations() const { return false; }
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
-
-  bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
-    if (Consumer.ASTMigrateActions & FrontendOptions::ObjCMT_Literals) {
-      edit::Commit commit(*Consumer.Editor);
-      edit::rewriteToObjCLiteralSyntax(E, *Consumer.NSAPIObj, commit, &PMap);
-      Consumer.Editor->commit(commit);
+  public:
+    ObjCMigrator(ObjCMigrateASTConsumer &consumer, ParentMap &PMap)
+        : Consumer(consumer), PMap(PMap) {
+      ShouldVisitTemplateInstantiations = false;
+      ShouldWalkTypesOfTypeLocs = false;
     }
 
-    if (Consumer.ASTMigrateActions & FrontendOptions::ObjCMT_Subscripting) {
-      edit::Commit commit(*Consumer.Editor);
-      edit::rewriteToObjCSubscriptSyntax(E, *Consumer.NSAPIObj, commit);
-      Consumer.Editor->commit(commit);
+    bool VisitObjCMessageExpr(ObjCMessageExpr *E) override {
+      if (Consumer.ASTMigrateActions & FrontendOptions::ObjCMT_Literals) {
+        edit::Commit commit(*Consumer.Editor);
+        edit::rewriteToObjCLiteralSyntax(E, *Consumer.NSAPIObj, commit, &PMap);
+        Consumer.Editor->commit(commit);
+      }
+
+      if (Consumer.ASTMigrateActions & FrontendOptions::ObjCMT_Subscripting) {
+        edit::Commit commit(*Consumer.Editor);
+        edit::rewriteToObjCSubscriptSyntax(E, *Consumer.NSAPIObj, commit);
+        Consumer.Editor->commit(commit);
+      }
+
+      if (Consumer.ASTMigrateActions &
+          FrontendOptions::ObjCMT_PropertyDotSyntax) {
+        edit::Commit commit(*Consumer.Editor);
+        rewriteToPropertyDotSyntax(E, Consumer.PP, *Consumer.NSAPIObj, commit,
+                                   &PMap);
+        Consumer.Editor->commit(commit);
+      }
+
+      return true;
     }
 
-    if (Consumer.ASTMigrateActions & FrontendOptions::ObjCMT_PropertyDotSyntax) {
-      edit::Commit commit(*Consumer.Editor);
-      rewriteToPropertyDotSyntax(E, Consumer.PP, *Consumer.NSAPIObj,
-                                 commit, &PMap);
-      Consumer.Editor->commit(commit);
+    bool TraverseObjCMessageExpr(ObjCMessageExpr *E) override {
+      // Do depth first; we want to rewrite the subexpressions first so that if
+      // we have to move expressions we will move them already rewritten.
+      for (Stmt *SubStmt : E->children())
+        if (!TraverseStmt(SubStmt))
+          return false;
+
+      return WalkUpFromObjCMessageExpr(E);
+    }
+  };
+
+  class BodyMigrator : public DynamicRecursiveASTVisitor {
+    ObjCMigrateASTConsumer &Consumer;
+    std::unique_ptr<ParentMap> PMap;
+
+  public:
+    BodyMigrator(ObjCMigrateASTConsumer &consumer) : Consumer(consumer) {
+      ShouldVisitTemplateInstantiations = false;
+      ShouldWalkTypesOfTypeLocs = false;
     }
 
-    return true;
-  }
-
-  bool TraverseObjCMessageExpr(ObjCMessageExpr *E) {
-    // Do depth first; we want to rewrite the subexpressions first so that if
-    // we have to move expressions we will move them already rewritten.
-    for (Stmt *SubStmt : E->children())
-      if (!TraverseStmt(SubStmt))
-        return false;
-
-    return WalkUpFromObjCMessageExpr(E);
-  }
-};
-
-class BodyMigrator : public RecursiveASTVisitor<BodyMigrator> {
-  ObjCMigrateASTConsumer &Consumer;
-  std::unique_ptr<ParentMap> PMap;
-
-public:
-  BodyMigrator(ObjCMigrateASTConsumer &consumer) : Consumer(consumer) { }
-
-  bool shouldVisitTemplateInstantiations() const { return false; }
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
-
-  bool TraverseStmt(Stmt *S) {
-    PMap.reset(new ParentMap(S));
-    ObjCMigrator(Consumer, *PMap).TraverseStmt(S);
-    return true;
-  }
-};
+    bool TraverseStmt(Stmt *S) override {
+      PMap.reset(new ParentMap(S));
+      ObjCMigrator(Consumer, *PMap).TraverseStmt(S);
+      return true;
+    }
+  };
 } // end anonymous namespace
 
 void ObjCMigrateASTConsumer::migrateDecl(Decl *D) {
@@ -1672,12 +1673,14 @@ void ObjCMigrateASTConsumer::migrateAddMethodAnnotation(
 }
 
 namespace {
-class SuperInitChecker : public RecursiveASTVisitor<SuperInitChecker> {
+class SuperInitChecker : public DynamicRecursiveASTVisitor {
 public:
-  bool shouldVisitTemplateInstantiations() const { return false; }
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
+  SuperInitChecker() {
+    ShouldVisitTemplateInstantiations = false;
+    ShouldWalkTypesOfTypeLocs = false;
+  }
 
-  bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
+  bool VisitObjCMessageExpr(ObjCMessageExpr *E) override {
     if (E->getReceiverKind() == ObjCMessageExpr::SuperInstance) {
       if (E->getMethodFamily() == OMF_init)
         return false;

--- a/clang/lib/ARCMigrate/TransAPIUses.cpp
+++ b/clang/lib/ARCMigrate/TransAPIUses.cpp
@@ -16,9 +16,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Sema/SemaDiagnostic.h"
 
 using namespace clang;
@@ -27,7 +28,7 @@ using namespace trans;
 
 namespace {
 
-class APIChecker : public RecursiveASTVisitor<APIChecker> {
+class APIChecker : public DynamicRecursiveASTVisitor {
   MigrationPass &Pass;
 
   Selector getReturnValueSel, setReturnValueSel;
@@ -51,7 +52,7 @@ public:
     zoneSel = sels.getNullarySelector(&ids.get("zone"));
   }
 
-  bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
+  bool VisitObjCMessageExpr(ObjCMessageExpr *E) override {
     // NSInvocation.
     if (E->isInstanceMessage() &&
         E->getReceiverInterface() &&

--- a/clang/lib/ARCMigrate/TransARCAssign.cpp
+++ b/clang/lib/ARCMigrate/TransARCAssign.cpp
@@ -20,9 +20,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Sema/SemaDiagnostic.h"
 
 using namespace clang;
@@ -31,14 +32,14 @@ using namespace trans;
 
 namespace {
 
-class ARCAssignChecker : public RecursiveASTVisitor<ARCAssignChecker> {
+class ARCAssignChecker : public DynamicRecursiveASTVisitor {
   MigrationPass &Pass;
   llvm::DenseSet<VarDecl *> ModifiedVars;
 
 public:
   ARCAssignChecker(MigrationPass &pass) : Pass(pass) { }
 
-  bool VisitBinaryOperator(BinaryOperator *Exp) {
+  bool VisitBinaryOperator(BinaryOperator *Exp) override {
     if (Exp->getType()->isDependentType())
       return true;
 

--- a/clang/lib/ARCMigrate/TransBlockObjCVariable.cpp
+++ b/clang/lib/ARCMigrate/TransBlockObjCVariable.cpp
@@ -24,10 +24,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Basic/SourceManager.h"
 
 using namespace clang;
@@ -36,18 +37,16 @@ using namespace trans;
 
 namespace {
 
-class RootBlockObjCVarRewriter :
-                          public RecursiveASTVisitor<RootBlockObjCVarRewriter> {
+class RootBlockObjCVarRewriter : public DynamicRecursiveASTVisitor {
   llvm::DenseSet<VarDecl *> &VarsToChange;
 
-  class BlockVarChecker : public RecursiveASTVisitor<BlockVarChecker> {
+  class BlockVarChecker : public DynamicRecursiveASTVisitor {
     VarDecl *Var;
 
-    typedef RecursiveASTVisitor<BlockVarChecker> base;
   public:
     BlockVarChecker(VarDecl *var) : Var(var) { }
 
-    bool TraverseImplicitCastExpr(ImplicitCastExpr *castE) {
+    bool TraverseImplicitCastExpr(ImplicitCastExpr *castE) override {
       if (DeclRefExpr *
             ref = dyn_cast<DeclRefExpr>(castE->getSubExpr())) {
         if (ref->getDecl() == Var) {
@@ -59,10 +58,10 @@ class RootBlockObjCVarRewriter :
         }
       }
 
-      return base::TraverseImplicitCastExpr(castE);
+      return DynamicRecursiveASTVisitor::TraverseImplicitCastExpr(castE);
     }
 
-    bool VisitDeclRefExpr(DeclRefExpr *E) {
+    bool VisitDeclRefExpr(DeclRefExpr *E) override {
       if (E->getDecl() == Var)
         return false; // The reference of the variable, and not just its value,
                       //  is needed.
@@ -74,7 +73,7 @@ public:
   RootBlockObjCVarRewriter(llvm::DenseSet<VarDecl *> &VarsToChange)
     : VarsToChange(VarsToChange) { }
 
-  bool VisitBlockDecl(BlockDecl *block) {
+  bool VisitBlockDecl(BlockDecl *block) override {
     SmallVector<VarDecl *, 4> BlockVars;
 
     for (const auto &I : block->captures()) {
@@ -108,14 +107,14 @@ private:
   }
 };
 
-class BlockObjCVarRewriter : public RecursiveASTVisitor<BlockObjCVarRewriter> {
+class BlockObjCVarRewriter : public DynamicRecursiveASTVisitor {
   llvm::DenseSet<VarDecl *> &VarsToChange;
 
 public:
   BlockObjCVarRewriter(llvm::DenseSet<VarDecl *> &VarsToChange)
     : VarsToChange(VarsToChange) { }
 
-  bool TraverseBlockDecl(BlockDecl *block) {
+  bool TraverseBlockDecl(BlockDecl *block) override {
     RootBlockObjCVarRewriter(VarsToChange).TraverseDecl(block);
     return true;
   }

--- a/clang/lib/ARCMigrate/TransEmptyStatementsAndDealloc.cpp
+++ b/clang/lib/ARCMigrate/TransEmptyStatementsAndDealloc.cpp
@@ -18,9 +18,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/SourceManager.h"
 
@@ -143,14 +144,13 @@ public:
   }
 };
 
-class EmptyStatementsRemover :
-                            public RecursiveASTVisitor<EmptyStatementsRemover> {
+class EmptyStatementsRemover : public DynamicRecursiveASTVisitor {
   MigrationPass &Pass;
 
 public:
   EmptyStatementsRemover(MigrationPass &pass) : Pass(pass) { }
 
-  bool TraverseStmtExpr(StmtExpr *E) {
+  bool TraverseStmtExpr(StmtExpr *E) override {
     CompoundStmt *S = E->getSubStmt();
     for (CompoundStmt::body_iterator
            I = S->body_begin(), E = S->body_end(); I != E; ++I) {
@@ -161,7 +161,7 @@ public:
     return true;
   }
 
-  bool VisitCompoundStmt(CompoundStmt *S) {
+  bool VisitCompoundStmt(CompoundStmt *S) override {
     for (auto *I : S->body())
       check(I);
     return true;

--- a/clang/lib/ARCMigrate/TransGCAttrs.cpp
+++ b/clang/lib/ARCMigrate/TransGCAttrs.cpp
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/SemaDiagnostic.h"
@@ -23,26 +24,24 @@ using namespace trans;
 namespace {
 
 /// Collects all the places where GC attributes __strong/__weak occur.
-class GCAttrsCollector : public RecursiveASTVisitor<GCAttrsCollector> {
+class GCAttrsCollector : public DynamicRecursiveASTVisitor {
   MigrationContext &MigrateCtx;
   bool FullyMigratable;
   std::vector<ObjCPropertyDecl *> &AllProps;
 
-  typedef RecursiveASTVisitor<GCAttrsCollector> base;
 public:
   GCAttrsCollector(MigrationContext &ctx,
                    std::vector<ObjCPropertyDecl *> &AllProps)
-    : MigrateCtx(ctx), FullyMigratable(false),
-      AllProps(AllProps) { }
+      : MigrateCtx(ctx), FullyMigratable(false), AllProps(AllProps) {
+    ShouldWalkTypesOfTypeLocs = false;
+  }
 
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
-
-  bool VisitAttributedTypeLoc(AttributedTypeLoc TL) {
+  bool VisitAttributedTypeLoc(AttributedTypeLoc TL) override {
     handleAttr(TL);
     return true;
   }
 
-  bool TraverseDecl(Decl *D) {
+  bool TraverseDecl(Decl *D) override {
     if (!D || D->isImplicit())
       return true;
 
@@ -54,7 +53,7 @@ public:
     } else if (DeclaratorDecl *DD = dyn_cast<DeclaratorDecl>(D)) {
       lookForAttribute(DD, DD->getTypeSourceInfo());
     }
-    return base::TraverseDecl(D);
+    return DynamicRecursiveASTVisitor::TraverseDecl(D);
   }
 
   void lookForAttribute(Decl *D, TypeSourceInfo *TInfo) {

--- a/clang/lib/ARCMigrate/TransProperties.cpp
+++ b/clang/lib/ARCMigrate/TransProperties.cpp
@@ -29,8 +29,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/SemaDiagnostic.h"
@@ -281,12 +282,12 @@ private:
     return MigrateCtx.addPropertyAttribute(attr, atLoc);
   }
 
-  class PlusOneAssign : public RecursiveASTVisitor<PlusOneAssign> {
+  class PlusOneAssign : public DynamicRecursiveASTVisitor {
     ObjCIvarDecl *Ivar;
   public:
     PlusOneAssign(ObjCIvarDecl *D) : Ivar(D) {}
 
-    bool VisitBinaryOperator(BinaryOperator *E) {
+    bool VisitBinaryOperator(BinaryOperator *E) override {
       if (E->getOpcode() != BO_Assign)
         return true;
 

--- a/clang/lib/ARCMigrate/TransProtectedScope.cpp
+++ b/clang/lib/ARCMigrate/TransProtectedScope.cpp
@@ -14,6 +14,7 @@
 #include "Internals.h"
 #include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Sema/SemaDiagnostic.h"
 
@@ -23,14 +24,14 @@ using namespace trans;
 
 namespace {
 
-class LocalRefsCollector : public RecursiveASTVisitor<LocalRefsCollector> {
+class LocalRefsCollector : public DynamicRecursiveASTVisitor {
   SmallVectorImpl<DeclRefExpr *> &Refs;
 
 public:
   LocalRefsCollector(SmallVectorImpl<DeclRefExpr *> &refs)
     : Refs(refs) { }
 
-  bool VisitDeclRefExpr(DeclRefExpr *E) {
+  bool VisitDeclRefExpr(DeclRefExpr *E) override {
     if (ValueDecl *D = E->getDecl())
       if (D->getDeclContext()->getRedeclContext()->isFunctionOrMethod())
         Refs.push_back(E);
@@ -52,7 +53,7 @@ struct CaseInfo {
     : SC(S), Range(Range), State(St_Unchecked) {}
 };
 
-class CaseCollector : public RecursiveASTVisitor<CaseCollector> {
+class CaseCollector : public DynamicRecursiveASTVisitor {
   ParentMap &PMap;
   SmallVectorImpl<CaseInfo> &Cases;
 
@@ -60,7 +61,7 @@ public:
   CaseCollector(ParentMap &PMap, SmallVectorImpl<CaseInfo> &Cases)
     : PMap(PMap), Cases(Cases) { }
 
-  bool VisitSwitchStmt(SwitchStmt *S) {
+  bool VisitSwitchStmt(SwitchStmt *S) override {
     SwitchCase *Curr = S->getSwitchCaseList();
     if (!Curr)
       return true;

--- a/clang/lib/ARCMigrate/TransRetainReleaseDealloc.cpp
+++ b/clang/lib/ARCMigrate/TransRetainReleaseDealloc.cpp
@@ -16,9 +16,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ParentMap.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
@@ -31,8 +32,7 @@ using namespace trans;
 
 namespace {
 
-class RetainReleaseDeallocRemover :
-                       public RecursiveASTVisitor<RetainReleaseDeallocRemover> {
+class RetainReleaseDeallocRemover : public DynamicRecursiveASTVisitor {
   Stmt *Body;
   MigrationPass &Pass;
 
@@ -57,7 +57,7 @@ public:
     TraverseStmt(body);
   }
 
-  bool VisitObjCMessageExpr(ObjCMessageExpr *E) {
+  bool VisitObjCMessageExpr(ObjCMessageExpr *E) override {
     switch (E->getMethodFamily()) {
     default:
       if (E->isInstanceMessage() && E->getSelector() == FinalizeSel)
@@ -448,7 +448,6 @@ private:
 
     return false;
   }
-
 };
 
 } // anonymous namespace

--- a/clang/lib/ARCMigrate/TransUnbridgedCasts.cpp
+++ b/clang/lib/ARCMigrate/TransUnbridgedCasts.cpp
@@ -462,6 +462,6 @@ private:
 } // end anonymous namespace
 
 void trans::rewriteUnbridgedCasts(MigrationPass &pass) {
-  BodyTransform<UnbridgedCastRewriter> trans(pass);
+  BodyTransform_OLD<UnbridgedCastRewriter> trans(pass);
   trans.TraverseDecl(pass.Ctx.getTranslationUnitDecl());
 }

--- a/clang/lib/ARCMigrate/TransUnusedInitDelegate.cpp
+++ b/clang/lib/ARCMigrate/TransUnusedInitDelegate.cpp
@@ -19,9 +19,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Transforms.h"
 #include "Internals.h"
+#include "Transforms.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/Sema/SemaDiagnostic.h"
 
 using namespace clang;
@@ -30,7 +31,7 @@ using namespace trans;
 
 namespace {
 
-class UnusedInitRewriter : public RecursiveASTVisitor<UnusedInitRewriter> {
+class UnusedInitRewriter : public DynamicRecursiveASTVisitor {
   Stmt *Body;
   MigrationPass &Pass;
 
@@ -46,7 +47,7 @@ public:
     TraverseStmt(body);
   }
 
-  bool VisitObjCMessageExpr(ObjCMessageExpr *ME) {
+  bool VisitObjCMessageExpr(ObjCMessageExpr *ME) override {
     if (ME->isDelegateInitCall() &&
         isRemovable(ME) &&
         Pass.TA.hasDiagnostic(diag::err_arc_unused_init_message,

--- a/clang/lib/ARCMigrate/Transforms.cpp
+++ b/clang/lib/ARCMigrate/Transforms.cpp
@@ -10,6 +10,7 @@
 #include "Internals.h"
 #include "clang/ARCMigrate/ARCMT.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Analysis/DomainSpecific/CocoaConventions.h"
 #include "clang/Basic/SourceManager.h"
@@ -211,14 +212,17 @@ StringRef trans::getNilString(MigrationPass &Pass) {
 
 namespace {
 
-class ReferenceClear : public RecursiveASTVisitor<ReferenceClear> {
+class ReferenceClear : public DynamicRecursiveASTVisitor {
   ExprSet &Refs;
 public:
   ReferenceClear(ExprSet &refs) : Refs(refs) { }
-  bool VisitDeclRefExpr(DeclRefExpr *E) { Refs.erase(E); return true; }
+  bool VisitDeclRefExpr(DeclRefExpr *E) override {
+    Refs.erase(E);
+    return true;
+  }
 };
 
-class ReferenceCollector : public RecursiveASTVisitor<ReferenceCollector> {
+class ReferenceCollector : public DynamicRecursiveASTVisitor {
   ValueDecl *Dcl;
   ExprSet &Refs;
 
@@ -226,23 +230,22 @@ public:
   ReferenceCollector(ValueDecl *D, ExprSet &refs)
     : Dcl(D), Refs(refs) { }
 
-  bool VisitDeclRefExpr(DeclRefExpr *E) {
+  bool VisitDeclRefExpr(DeclRefExpr *E) override {
     if (E->getDecl() == Dcl)
       Refs.insert(E);
     return true;
   }
 };
 
-class RemovablesCollector : public RecursiveASTVisitor<RemovablesCollector> {
+class RemovablesCollector : public DynamicRecursiveASTVisitor {
   ExprSet &Removables;
 
 public:
-  RemovablesCollector(ExprSet &removables)
-  : Removables(removables) { }
+  RemovablesCollector(ExprSet &removables) : Removables(removables) {
+    ShouldWalkTypesOfTypeLocs = false;
+  }
 
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
-
-  bool TraverseStmtExpr(StmtExpr *E) {
+  bool TraverseStmtExpr(StmtExpr *E) override {
     CompoundStmt *S = E->getSubStmt();
     for (CompoundStmt::body_iterator
         I = S->body_begin(), E = S->body_end(); I != E; ++I) {
@@ -253,29 +256,29 @@ public:
     return true;
   }
 
-  bool VisitCompoundStmt(CompoundStmt *S) {
+  bool VisitCompoundStmt(CompoundStmt *S) override {
     for (auto *I : S->body())
       mark(I);
     return true;
   }
 
-  bool VisitIfStmt(IfStmt *S) {
+  bool VisitIfStmt(IfStmt *S) override {
     mark(S->getThen());
     mark(S->getElse());
     return true;
   }
 
-  bool VisitWhileStmt(WhileStmt *S) {
+  bool VisitWhileStmt(WhileStmt *S) override {
     mark(S->getBody());
     return true;
   }
 
-  bool VisitDoStmt(DoStmt *S) {
+  bool VisitDoStmt(DoStmt *S) override {
     mark(S->getBody());
     return true;
   }
 
-  bool VisitForStmt(ForStmt *S) {
+  bool VisitForStmt(ForStmt *S) override {
     mark(S->getInit());
     mark(S->getInc());
     mark(S->getBody());
@@ -315,26 +318,25 @@ void trans::collectRemovables(Stmt *S, ExprSet &exprs) {
 
 namespace {
 
-class ASTTransform : public RecursiveASTVisitor<ASTTransform> {
+class ASTTransform : public DynamicRecursiveASTVisitor {
   MigrationContext &MigrateCtx;
-  typedef RecursiveASTVisitor<ASTTransform> base;
 
 public:
-  ASTTransform(MigrationContext &MigrateCtx) : MigrateCtx(MigrateCtx) { }
+  ASTTransform(MigrationContext &MigrateCtx) : MigrateCtx(MigrateCtx) {
+    ShouldWalkTypesOfTypeLocs = false;
+  }
 
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
-
-  bool TraverseObjCImplementationDecl(ObjCImplementationDecl *D) {
+  bool TraverseObjCImplementationDecl(ObjCImplementationDecl *D) override {
     ObjCImplementationContext ImplCtx(MigrateCtx, D);
     for (MigrationContext::traverser_iterator
            I = MigrateCtx.traversers_begin(),
            E = MigrateCtx.traversers_end(); I != E; ++I)
       (*I)->traverseObjCImplementation(ImplCtx);
 
-    return base::TraverseObjCImplementationDecl(D);
+    return DynamicRecursiveASTVisitor::TraverseObjCImplementationDecl(D);
   }
 
-  bool TraverseStmt(Stmt *rootS) {
+  bool TraverseStmt(Stmt *rootS) override {
     if (!rootS)
       return true;
 
@@ -347,7 +349,6 @@ public:
     return true;
   }
 };
-
 }
 
 MigrationContext::~MigrationContext() {

--- a/clang/lib/ARCMigrate/Transforms.h
+++ b/clang/lib/ARCMigrate/Transforms.h
@@ -9,9 +9,11 @@
 #ifndef LLVM_CLANG_LIB_ARCMIGRATE_TRANSFORMS_H
 #define LLVM_CLANG_LIB_ARCMIGRATE_TRANSFORMS_H
 
+#include "clang/AST/DeclObjC.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
+#include "clang/AST/ExprObjC.h"
 #include "clang/AST/ParentMap.h"
-#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/StmtObjC.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/SaveAndRestore.h"
 
@@ -181,29 +183,6 @@ bool hasSideEffects(Expr *E, ASTContext &Ctx);
 bool isGlobalVar(Expr *E);
 /// Returns "nil" or "0" if 'nil' macro is not actually defined.
 StringRef getNilString(MigrationPass &Pass);
-
-template <typename BODY_TRANS>
-class BodyTransform_OLD
-    : public RecursiveASTVisitor<BodyTransform_OLD<BODY_TRANS>> {
-  MigrationPass &Pass;
-  Decl *ParentD;
-
-  typedef RecursiveASTVisitor<BodyTransform_OLD<BODY_TRANS>> base;
-
-public:
-  BodyTransform_OLD(MigrationPass &pass) : Pass(pass), ParentD(nullptr) {}
-
-  bool TraverseStmt(Stmt *rootS) {
-    if (rootS)
-      BODY_TRANS(Pass).transformBody(rootS, ParentD);
-    return true;
-  }
-
-  bool TraverseObjCMethodDecl(ObjCMethodDecl *D) {
-    SaveAndRestore<Decl *> SetParent(ParentD, D);
-    return base::TraverseObjCMethodDecl(D);
-  }
-};
 
 class BodyTransform : public DynamicRecursiveASTVisitor {
 protected:


### PR DESCRIPTION
This pr migrates AST visitors in `ARCMigrate` to use `DynamicRecursiveASTVisitor`.

This is part of an ongoing refactor. For more context, see #110040, #93462.

Most of the visitors were fairly simple to migrate, but one that I wasn’t fully able to untangle was `BodyTransform`: For three of its uses, I’ve had to introduce a fairly ugly `bool`, and the last one (`UnbridgedCastRewriter`) simply breaks if I try to refactor it in the same way as the other three (as in, one of the tests keeps failing, and I have no idea what to do about it...). I candidly am not really sure what the problem is w/ that one—it also doesn’t help that I have no understanding whatsoever of ARCMigrate nor of Objective-C.

If you think the way I went about dealing w/ `BodyTransform` is too janky, I can revert those 4 visitors again—most of the other visitors can still be migrated just fine and aren’t affected by that.