### PR TITLE
[GPU] ASAN failure due to use of erased operation

### DIFF
--- a/mlir/lib/Dialect/GPU/TransformOps/GPUTransformOps.cpp
+++ b/mlir/lib/Dialect/GPU/TransformOps/GPUTransformOps.cpp
@@ -853,6 +853,8 @@ DiagnosedSilenceableFailure mlir::transform::gpu::mapNestedForallToThreadsImpl(
                                  "requires size-3 thread mapping");
   }
 
+  Block *parentBlock = target->getBlock();
+
   // Create an early zero index value for replacements.
   Location loc = target->getLoc();
   Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
@@ -872,7 +874,7 @@ DiagnosedSilenceableFailure mlir::transform::gpu::mapNestedForallToThreadsImpl(
 
   // Replace ids of dimensions known to be 1 by 0 to simplify the IR.
   // Here, the result of mapping determines the available mapping sizes.
-  replaceUnitMappingIdsHelper<ThreadIdOp>(rewriter, loc, target, zero,
+  replaceUnitMappingIdsHelper<ThreadIdOp>(rewriter, loc, parentBlock, zero,
                                           blockDims);
 
   return DiagnosedSilenceableFailure::success();


### PR DESCRIPTION
If the target op is an scf.forall op which is erased by `rewriteOneForallCommonImpl` method, it leads to an ASAN failure since it's used later by `replaceUnitMappingIdsHelper` fn.

Follows the same philosophy as done here:
https://github.com/llvm/llvm-project/blob/aff98e4be05a1060e489ce62a88ee0ff365e571a/mlir/lib/Dialect/GPU/TransformOps/GPUTransformOps.cpp#L599 and later passed to the same method here:
https://github.com/llvm/llvm-project/blob/aff98e4be05a1060e489ce62a88ee0ff365e571a/mlir/lib/Dialect/GPU/TransformOps/GPUTransformOps.cpp#L629