### PR TITLE
[clangd] Fix erroneous qualification of template type parameters

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
@@ -239,6 +239,8 @@ getFunctionSourceCode(const FunctionDecl *FD, const DeclContext *TargetContext,
           return;
 
         for (const NamedDecl *ND : Ref.Targets) {
+          if (ND->getKind() == Decl::TemplateTypeParm)
+            return;
           if (ND->getDeclContext() != Ref.Targets.front()->getDeclContext()) {
             elog("Targets from multiple contexts: {0}, {1}",
                  printQualifiedName(*Ref.Targets.front()),

--- a/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
+++ b/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
@@ -411,14 +411,14 @@ inline typename O1<T, U...>::template O2<V, A>::E O1<T, U...>::template O2<V, A>
           R"cpp(
             struct Foo {
               template <typename T, bool B = true>
-              void ^bar() {}
+              T ^bar() { return {}; }
             };)cpp",
           R"cpp(
             struct Foo {
               template <typename T, bool B = true>
-              void bar() ;
+              T bar() ;
             };template <typename T, bool B>
-inline void Foo::bar() {}
+inline T Foo::bar() { return {}; }
 )cpp",
           ""},
 
@@ -426,14 +426,14 @@ inline void Foo::bar() {}
       {
           R"cpp(
             template <typename T> struct Foo {
-              template <typename U> void ^bar(const T& t, const U& u) {}
+              template <typename U> T ^bar(const T& t, const U& u) { return {}; }
             };)cpp",
           R"cpp(
             template <typename T> struct Foo {
-              template <typename U> void bar(const T& t, const U& u) ;
+              template <typename U> T bar(const T& t, const U& u) ;
             };template <typename T>
 template <typename U>
-inline void Foo<T>::bar(const T& t, const U& u) {}
+inline T Foo<T>::bar(const T& t, const U& u) { return {}; }
 )cpp",
           ""},
   };


### PR DESCRIPTION
...in DefineOutline tweak.
E.g. moving the following definition:
  `template<typename T> struct S { T f^oo() const { return T(); } };`
would result in:
 `template<typename T> S<T>::T S::foo() const { return T(); }`
instead of:
  `template<typename T> T S::foo() const { return T(); }`