### PR TITLE
[lldb] Reword the "line 0" warning

### DIFF
--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -2007,19 +2007,9 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
           if (num_lines != 0)
             have_source = true;
           // TODO: Give here a one time warning if source file is missing.
-          if (!m_sc.line_entry.line) {
-            ConstString fn_name = m_sc.GetFunctionName();
-
-            if (!fn_name.IsEmpty())
-              strm.Printf(
-                  "Note: this address is compiler-generated code in function "
-                  "%s that has no source code associated with it.",
-                  fn_name.AsCString());
-            else
-              strm.Printf("Note: this address is compiler-generated code that "
-                          "has no source code associated with it.");
-            strm.EOL();
-          }
+          if (!m_sc.line_entry.line)
+            strm << "Note: This address is not associated with a specific line "
+                    "of code. This may be due to compiler optimizations.\n";
         }
       }
       switch (disasm_display) {

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -2008,7 +2008,7 @@ bool StackFrame::GetStatus(Stream &strm, bool show_frame_info, bool show_source,
             have_source = true;
           // TODO: Give here a one time warning if source file is missing.
           if (!m_sc.line_entry.line)
-            strm << "Note: This address is not associated with a specific line "
+            strm << "note: This address is not associated with a specific line "
                     "of code. This may be due to compiler optimizations.\n";
         }
       }

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -336,8 +336,8 @@ class SourceManagerTestCase(TestBase):
                 "stop reason = breakpoint",
                 f"{src_file}:0",
                 "static int foo();",
-                "Note: this address is compiler-generated code in function",
-                "that has no source code associated with it.",
+                "Note: This address is not associated with a specific line "
+                "of code. This may be due to compiler optimizations.",
             ],
         )
 

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -336,7 +336,7 @@ class SourceManagerTestCase(TestBase):
                 "stop reason = breakpoint",
                 f"{src_file}:0",
                 "static int foo();",
-                "Note: This address is not associated with a specific line "
+                "note: This address is not associated with a specific line "
                 "of code. This may be due to compiler optimizations.",
             ],
         )


### PR DESCRIPTION
We got a bug report that this message is confusing.  In this particular case, the line zero was due to compiler tail merging (in optimized code). The main issue was the "no source code" part: in this case it's kind of incorrect because -- even though we can't really know that -- the address is arguably associated with *multiple* lines of source code.

I've tried to make the new wording more neutral, and added a wink towards compiler optimizations. I left out the "compiler generated" part of the message because I couldn't find a way to squeeze that in nicely. I'm also not entirely sure what it was referring to -- if this was (just) function prologue/epilogue, then maybe leaving it out is fine, as we're not likely to stop there anyway (?)

I also left out the function name, because:
- for template functions it gets rather long
- it's already present in the message, potentially twice (once in the "frame summary" line and once in the snippet of code we show for the function declaration)