### PR TITLE
[libc][search] implement POSIX `lsearch` function

### DIFF
--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -18,7 +18,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.ctype.toupper
 
     # search.h entrypoints
-    libc.src.search.lfind 
+    libc.src.search.lfind
+    libc.src.search.lsearch 
 
     # string.h entrypoints
     libc.src.string.bcmp

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -961,6 +961,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.search.hsearch_r
     libc.src.search.insque
     libc.src.search.lfind
+    libc.src.search.lsearch
     libc.src.search.remque
 
     # threads.h entrypoints

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -185,6 +185,7 @@ if(LLVM_LIBC_FULL_BUILD)
   list(APPEND TARGET_LIBC_ENTRYPOINTS
     # search.h entrypoints
     libc.src.search.lfind
+    libc.src.search.lsearch
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -899,6 +899,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.search.hsearch_r
     libc.src.search.insque
     libc.src.search.lfind
+    libc.src.search.lsearch
     libc.src.search.remque
 
     # threads.h entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1044,6 +1044,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.search.hsearch_r
     libc.src.search.insque
     libc.src.search.lfind
+    libc.src.search.lsearch
     libc.src.search.remque
 
     # threads.h entrypoints

--- a/libc/docs/libc_search.rst
+++ b/libc/docs/libc_search.rst
@@ -43,7 +43,7 @@ hdestroy                     |check|
 hsearch                      |check|
 insque                       |check|
 lfind                        |check|
-lsearch
+lsearch                      |check|
 remque                       |check|
 tdelete
 tfind

--- a/libc/newhdrgen/yaml/search.yaml
+++ b/libc/newhdrgen/yaml/search.yaml
@@ -68,3 +68,13 @@ functions:
       - type: size_t *
       - type: size_t
       - type: __lsearchcompare_t
+  - name: lsearch
+    standards:
+      - POSIX
+    return_type: void *
+    arguments:
+      - type: const void *
+      - type: void *
+      - type: size_t *
+      - type: size_t
+      - type: __lsearchcompare_t

--- a/libc/spec/posix.td
+++ b/libc/spec/posix.td
@@ -1632,6 +1632,17 @@ def POSIX : StandardSpec<"POSIX"> {
                 ArgSpec<SizeTType>,
                 ArgSpec<LSearchCompareT>
             ]
+        >,  
+        FunctionSpec<
+            "lsearch",
+            RetValSpec<VoidPtr>,
+            [
+                ArgSpec<ConstVoidPtr>,
+                ArgSpec<VoidPtr>,
+                ArgSpec<SizeTPtr>,
+                ArgSpec<SizeTType>,
+                ArgSpec<LSearchCompareT>
+            ]
         >
     ]
   >;

--- a/libc/src/search/CMakeLists.txt
+++ b/libc/src/search/CMakeLists.txt
@@ -110,3 +110,16 @@ add_entrypoint_object(
     libc.src.__support.CPP.cstddef
     libc.src.__support.memory_size
 )
+
+add_entrypoint_object(
+  lsearch
+  SRCS
+    lsearch.cpp
+  HDRS
+    lsearch.h
+  DEPENDS
+    libc.include.search
+    libc.src.__support.CPP.cstddef
+    libc.src.__support.memory_size
+    libc.src.string.memory_utils.inline_memcpy
+)

--- a/libc/src/search/lsearch.cpp
+++ b/libc/src/search/lsearch.cpp
@@ -1,0 +1,43 @@
+//===-- Implementation of lsearch -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/search/lsearch.h"
+#include "src/__support/CPP/cstddef.h" // cpp::byte
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/memory_size.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+
+namespace LIBC_NAMESPACE_DECL {
+LLVM_LIBC_FUNCTION(void *, lsearch,
+                   (const void *key, void *base, size_t *nmemb, size_t size,
+                    int (*compar)(const void *, const void *))) {
+  if (key == nullptr || base == nullptr || nmemb == nullptr ||
+      compar == nullptr)
+    return nullptr;
+
+  size_t byte_len = 0;
+  if (internal::mul_overflow(*nmemb, size, &byte_len))
+    return nullptr;
+
+  cpp::byte *next = reinterpret_cast<cpp::byte *>(const_cast<void *>(base));
+  const cpp::byte *end = next + byte_len;
+
+  for (; next < end; next += size)
+    if (compar(key, next) == 0)
+      break;
+
+  if (next == end) {
+    LIBC_NAMESPACE::inline_memcpy(next, key, size);
+    *nmemb += 1;
+  }
+
+  return next;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/search/lsearch.h
+++ b/libc/src/search/lsearch.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for lsearch -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SEARCH_LSEARCH_H
+#define LLVM_LIBC_SRC_SEARCH_LSEARCH_H
+
+#include "src/__support/macros/config.h"
+#include <stddef.h> // size_t
+
+namespace LIBC_NAMESPACE_DECL {
+void *lsearch(const void *key, void *base, size_t *nmemb, size_t size,
+              int (*compar)(const void *, const void *));
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SEARCH_LSEARCH_H

--- a/libc/test/src/search/CMakeLists.txt
+++ b/libc/test/src/search/CMakeLists.txt
@@ -35,3 +35,13 @@ add_libc_unittest(
   DEPENDS
     libc.src.search.lfind
 )
+
+add_libc_unittest(
+  lsearch_test
+  SUITE
+    libc_search_unittests
+  SRCS
+    lsearch_test.cpp
+  DEPENDS
+    libc.src.search.lsearch
+)

--- a/libc/test/src/search/lsearch_test.cpp
+++ b/libc/test/src/search/lsearch_test.cpp
@@ -1,0 +1,79 @@
+//===-- Unittests for lsearch ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/search/lsearch.h"
+#include "test/UnitTest/Test.h"
+
+int compar(const void *a, const void *b) {
+  return *reinterpret_cast<const int *>(a) != *reinterpret_cast<const int *>(b);
+}
+
+TEST(LlvmLibcLsearchTest, SearchHead) {
+  int list[4] = {1, 2, 3, 4};
+  size_t len = 3;
+  int key = 1;
+  void *ret = LIBC_NAMESPACE::lsearch(&key, list, &len, sizeof(int), compar);
+
+  ASSERT_EQ(static_cast<int *>(ret), &list[0]);
+  ASSERT_EQ(len, static_cast<size_t>(3));
+  ASSERT_EQ(list[1], 2);
+  ASSERT_EQ(list[2], 3);
+  ASSERT_EQ(list[3], 4);
+  ASSERT_EQ(list[3], 4);
+}
+
+TEST(LlvmLibcLsearchTest, SearchMiddle) {
+  int list[4] = {1, 2, 3, 4};
+  size_t len = 3;
+  int key = 2;
+  void *ret = LIBC_NAMESPACE::lsearch(&key, list, &len, sizeof(int), compar);
+  ASSERT_EQ(static_cast<int *>(ret), &list[1]);
+  ASSERT_EQ(len, static_cast<size_t>(3));
+  ASSERT_EQ(list[0], 1);
+  ASSERT_EQ(list[1], 2);
+  ASSERT_EQ(list[2], 3);
+  ASSERT_EQ(list[3], 4);
+}
+
+TEST(LlvmLibcLsearchTest, SearchTail) {
+  int list[4] = {1, 2, 3, 4};
+  size_t len = 3;
+  int key = 3;
+  void *ret = LIBC_NAMESPACE::lsearch(&key, list, &len, sizeof(int), compar);
+  ASSERT_EQ(static_cast<int *>(ret), &list[2]);
+  ASSERT_EQ(len, static_cast<size_t>(3));
+  ASSERT_EQ(list[0], 1);
+  ASSERT_EQ(list[1], 2);
+  ASSERT_EQ(list[2], 3);
+  ASSERT_EQ(list[3], 4);
+}
+
+TEST(LlvmLibcLsearchTest, SearchNonExistent) {
+  int list[4] = {1, 2, 3, 4};
+  size_t len = 3;
+  int key = 5;
+  void *ret = LIBC_NAMESPACE::lsearch(&key, list, &len, sizeof(int), compar);
+
+  ASSERT_EQ(static_cast<int *>(ret), &list[3]);
+  ASSERT_EQ(len, static_cast<size_t>(4));
+  ASSERT_EQ(list[0], 1);
+  ASSERT_EQ(list[1], 2);
+  ASSERT_EQ(list[2], 3);
+  ASSERT_EQ(list[3], 5);
+}
+
+TEST(LlvmLibcLsearchTest, SearchNonExistentEmpty) {
+  int list[1] = {1};
+  size_t len = 0;
+  int key = 0;
+  void *ret = LIBC_NAMESPACE::lsearch(&key, list, &len, sizeof(int), compar);
+
+  ASSERT_EQ(static_cast<int *>(ret), &list[0]);
+  ASSERT_EQ(len, static_cast<size_t>(1));
+  ASSERT_EQ(list[0], 0);
+}

--- a/libc/test/src/search/lsearch_test.cpp
+++ b/libc/test/src/search/lsearch_test.cpp
@@ -21,9 +21,9 @@ TEST(LlvmLibcLsearchTest, SearchHead) {
 
   ASSERT_EQ(static_cast<int *>(ret), &list[0]);
   ASSERT_EQ(len, static_cast<size_t>(3));
+  ASSERT_EQ(list[0], 1);
   ASSERT_EQ(list[1], 2);
   ASSERT_EQ(list[2], 3);
-  ASSERT_EQ(list[3], 4);
   ASSERT_EQ(list[3], 4);
 }
 


### PR DESCRIPTION
- Implement `lsearch` (as described by [POSIX standard](https://pubs.opengroup.org/onlinepubs/009696699/functions/lsearch.html))
- Put a checkmark next to `lsearch` in the [Libc support table docs](https://libc.llvm.org/libc_search.html).

