### PR TITLE
[OpenMP][Build][Wasm][116552] Fixed build problem when compiling with Emscripten on Windows

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -26,16 +26,22 @@ if(${LIBOMP_OMPT_SUPPORT})
 endif()
 
 # Generate message catalog files: kmp_i18n_id.inc and kmp_i18n_default.inc
+set(LIBOMP_MESSAGE_CONVERTER_EXTRA_ARGS "")
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+  # Required as Python doesn't inherit CMake's environment setup and uses the host system as the target system by default
+  set(LIBOMP_MESSAGE_CONVERTER_EXTRA_ARGS ${LIBOMP_MESSAGE_CONVERTER_EXTRA_ARGS} --target-system-override=${CMAKE_SYSTEM_NAME})
+endif()
+
 add_custom_command(
   OUTPUT  kmp_i18n_id.inc
   COMMAND ${Python3_EXECUTABLE} ${LIBOMP_TOOLS_DIR}/message-converter.py
-          --enum=kmp_i18n_id.inc ${LIBOMP_SRC_DIR}/i18n/en_US.txt
+          --enum=kmp_i18n_id.inc ${LIBOMP_MESSAGE_CONVERTER_EXTRA_ARGS} ${LIBOMP_SRC_DIR}/i18n/en_US.txt
   DEPENDS ${LIBOMP_SRC_DIR}/i18n/en_US.txt ${LIBOMP_TOOLS_DIR}/message-converter.py
 )
 add_custom_command(
   OUTPUT  kmp_i18n_default.inc
   COMMAND ${Python3_EXECUTABLE} ${LIBOMP_TOOLS_DIR}/message-converter.py
-          --default=kmp_i18n_default.inc ${LIBOMP_SRC_DIR}/i18n/en_US.txt
+          --default=kmp_i18n_default.inc ${LIBOMP_MESSAGE_CONVERTER_EXTRA_ARGS} ${LIBOMP_SRC_DIR}/i18n/en_US.txt
   DEPENDS ${LIBOMP_SRC_DIR}/i18n/en_US.txt ${LIBOMP_TOOLS_DIR}/message-converter.py
 )
 

--- a/openmp/runtime/tools/message-converter.py
+++ b/openmp/runtime/tools/message-converter.py
@@ -21,7 +21,7 @@ from libomputils import ScriptError, error
 
 class TargetPlatform:
     """Convenience class for handling the target platform for configuration/compilation"""
-    
+
     system_override = None
     """
     Target system name override by the user.
@@ -30,14 +30,14 @@ class TargetPlatform:
 
     def set_system_override(override_system):
         """
-        Set a system override for the target. 
+        Set a system override for the target.
         Please follow the style from https://docs.python.org/3/library/platform.html#platform.system
         """
         TargetPlatform.system_override = override_system
 
     def system():
         """
-        Target System name. 
+        Target System name.
         It follows the conventions from https://docs.python.org/3/library/platform.html#platform.system
         """
         if TargetPlatform.system_override is None:
@@ -390,11 +390,11 @@ def main():
         "--message", metavar="FILE", help="Generate message file named FILE"
     )
     parser.add_argument(
-        "--target-system-override", 
-        metavar="TARGET_SYSTEM_NAME", 
+        "--target-system-override",
+        metavar="TARGET_SYSTEM_NAME",
         help="Target System override.\n"
         "By default the target system is the host system\n"
-        "See possible values at https://docs.python.org/3/library/platform.html#platform.system"
+        "See possible values at https://docs.python.org/3/library/platform.html#platform.system",
     )
     parser.add_argument("inputfile")
     commandArgs = parser.parse_args()

--- a/openmp/runtime/tools/message-converter.py
+++ b/openmp/runtime/tools/message-converter.py
@@ -19,6 +19,32 @@ import sys
 from libomputils import ScriptError, error
 
 
+class TargetPlatform:
+    """Convenience class for handling the target platform for configuration/compilation"""
+    
+    system_override = None
+    """
+    Target system name override by the user.
+    It follows the conventions from https://docs.python.org/3/library/platform.html#platform.system
+    """
+
+    def set_system_override(override_system):
+        """
+        Set a system override for the target. 
+        Please follow the style from https://docs.python.org/3/library/platform.html#platform.system
+        """
+        TargetPlatform.system_override = override_system
+
+    def system():
+        """
+        Target System name. 
+        It follows the conventions from https://docs.python.org/3/library/platform.html#platform.system
+        """
+        if TargetPlatform.system_override is None:
+            return platform.system()
+        return TargetPlatform.system_override
+
+
 class ParseMessageDataError(ScriptError):
     """Convenience class for parsing message data file errors"""
 
@@ -55,7 +81,7 @@ class Message(object):
         self.text = text
 
     def toSrc(self):
-        if platform.system() == "Windows":
+        if TargetPlatform.system().casefold() == "Windows".casefold():
             return re.sub(r"%([0-9])\$(s|l?[du])", r"%\1!\2!", self.text)
         return str(self.text)
 
@@ -363,6 +389,13 @@ def main():
     parser.add_argument(
         "--message", metavar="FILE", help="Generate message file named FILE"
     )
+    parser.add_argument(
+        "--target-system-override", 
+        metavar="TARGET_SYSTEM_NAME", 
+        help="Target System override.\n"
+        "By default the target system is the host system\n"
+        "See possible values at https://docs.python.org/3/library/platform.html#platform.system"
+    )
     parser.add_argument("inputfile")
     commandArgs = parser.parse_args()
 
@@ -371,6 +404,8 @@ def main():
         return
     data = MessageData.create(commandArgs.inputfile)
     prefix = commandArgs.prefix
+    if commandArgs.target_system_override:
+        TargetPlatform.set_system_override(commandArgs.target_system_override)
     if commandArgs.enum:
         generate_enum_file(commandArgs.enum, prefix, data)
     if commandArgs.default:
@@ -378,7 +413,7 @@ def main():
     if commandArgs.signature:
         generate_signature_file(commandArgs.signature, data)
     if commandArgs.message:
-        if platform.system() == "Windows":
+        if TargetPlatform.system().casefold() == "Windows".casefold():
             generate_message_file_windows(commandArgs.message, data)
         else:
             generate_message_file_unix(commandArgs.message, data)


### PR DESCRIPTION
Fixed OpenMP build issue when building Wasm using Emscripten in Windows, as raised in https://github.com/llvm/llvm-project/issues/116552, with the proposed solution at https://github.com/llvm/llvm-project/issues/116552#issuecomment-2483029900

Adds the ```--target-system-override``` flag to ```message-converter.py``` to handle the case where the target system is not the host system. Useful when compiling with Emscripten in Windows, as Python detects the host system as the target system by default when it should be Emscripten. 

Sets the use of the previous functionality in ```\openmp\runtime\src\CMakeLists.txt``` when compiling with Emscripten to solve the issue raised at https://github.com/llvm/llvm-project/issues/116552