### PR TITLE
[mlir][arith] Fix build after #114152 (part 2)

### DIFF
--- a/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(MLIRArithTransforms
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRArithDialect
+  MLIRBufferizationDialect
   MLIRFuncDialect
   MLIRFuncTransforms
   MLIRInferIntRangeInterface


### PR DESCRIPTION
Since #114152, `MLIRFuncTransforms` no longer depends on `MLIRBufferizationDialect`. This commit adds a missing dependency that is no longer transitively included.
