### PR TITLE
[mlir][arith] Fix build after #114152 (part 3)

### DIFF
--- a/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_dialect_library(MLIRArithTransforms
   MLIRAnalysis
   MLIRArithDialect
   MLIRBufferizationDialect
+  MLIRBufferizationTransforms
   MLIRFuncDialect
   MLIRFuncTransforms
   MLIRInferIntRangeInterface


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/114152, `MLIRFuncTransforms` no longer depends on `MLIRBufferizationTransforms`. This commit adds a missing dependency that is no longer transitively included.