### PR TITLE
[memprof] Use a new constructor of IndexedAllocationInfo (NFC)

### DIFF
--- a/llvm/unittests/Transforms/Instrumentation/MemProfUseTest.cpp
+++ b/llvm/unittests/Transforms/Instrumentation/MemProfUseTest.cpp
@@ -323,7 +323,7 @@ makeRecordV2(std::initializer_list<::llvm::memprof::CallStackId> AllocFrames,
   for (const auto &CSId : AllocFrames) {
     // We don't populate IndexedAllocationInfo::CallStack because we use it only
     // in Version1.
-    MR.AllocSites.push_back({{}, CSId, Block, Schema});
+    MR.AllocSites.emplace_back(CSId, Block, Schema);
   }
   for (const auto &CSId : CallSiteFrames)
     MR.CallSiteIds.push_back(CSId);


### PR DESCRIPTION
IndexedAllocationInfo now has a new constructor that allows us to omit
the inline call stack, which is going away soon.  This patch migrates
away from the old constructor.
