### PR TITLE
[LLD][ARM] Allow R_ARM_SBREL32 relocations in debug info

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -1092,7 +1092,7 @@ void InputSection::relocateNonAlloc(Ctx &ctx, uint8_t *buf,
     // R_ABS/R_DTPREL and some other relocations can be used from non-SHF_ALLOC
     // sections.
     if (LLVM_LIKELY(expr == R_ABS) || expr == R_DTPREL || expr == R_GOTPLTREL ||
-        expr == R_RISCV_ADD) {
+        expr == R_RISCV_ADD || expr == R_ARM_SBREL) {
       target.relocateNoSym(bufLoc, type,
                            SignExtend64<bits>(sym.getVA(ctx, addend)));
       continue;

--- a/lld/test/ELF/arm-rwpi-debug-relocs.s
+++ b/lld/test/ELF/arm-rwpi-debug-relocs.s
@@ -1,3 +1,7 @@
+/// Test that R_ARM_SBREL32 relocations in debug info are relocated as if the
+/// static base register (r9) is zero. Real DWARF info will use an expression to
+/// add this to the real value of the static base at runtime.
+
 // REQUIRES: arm
 // RUN: rm -rf %t && split-file %s %t && cd %t
 
@@ -16,10 +20,6 @@
 // DISASM-NEXT:        ...
 // DISASM-NEXT:       104: 00002000
 
-/// Test that R_ARM_SBREL32 relocations in debug info are relocated as if the
-/// static base register (r9) is zero. Real DWARF info will use an expression to
-/// add this to the real value of the static base at runtime.
-
 //--- lds.ld
 SECTIONS {
   data1 0x1000 : { *(data1) }
@@ -28,27 +28,27 @@ SECTIONS {
 
 //--- asm.s
   .text
-	.type	_start,%function
-	.globl	_start
+  .type _start,%function
+  .globl  _start
 _start:
   bx lr
   .size _start, .-_start
 
-	.section data1, "aw", %progbits
-	.type	rw,%object
-	.globl	rw
+  .section data1, "aw", %progbits
+  .type rw,%object
+  .globl  rw
 rw:
-	.long	42
-	.size	rw, 4
+  .long 42
+  .size rw, 4
 
-	.section data2, "aw", %progbits
-	.type	rw2,%object
-	.globl	rw2
+  .section data2, "aw", %progbits
+  .type rw2,%object
+  .globl  rw2
 rw2:
-	.long	1234
-	.size	rw2, 4
+  .long 1234
+  .size rw2, 4
 
-	.section	.debug_something, "", %progbits
-	.long	rw(sbrel)
+  .section  .debug_something, "", %progbits
+  .long rw(sbrel)
   .space 0x100
-	.long	rw2(sbrel)
+  .long rw2(sbrel)

--- a/lld/test/ELF/arm-rwpi-debug-relocs.s
+++ b/lld/test/ELF/arm-rwpi-debug-relocs.s
@@ -2,26 +2,23 @@
 // RUN: rm -rf %t && split-file %s %t && cd %t
 
 // RUN: llvm-mc -filetype=obj -triple=armv7a asm.s -o obj.o
-// RUN: ld.lld -T lds.ld obj.o -o exe.elf -e main 2>&1 | FileCheck %s --implicit-check-not=warning: --allow-empty
+// RUN: ld.lld -T lds.ld obj.o -o exe.elf 2>&1 | FileCheck %s --implicit-check-not=warning: --allow-empty
 // RUN: llvm-objdump -D exe.elf | FileCheck --check-prefix=DISASM %s
 
-// DISASM:      Disassembly of section data1:
-// DISASM:      00001000 <rw>:
-// DISASM-NEXT:     1000: 0000002a
+// DISASM-LABEL: <rw>:
+// DISASM-NEXT:      1000: 0000002a
 
-// DISASM:      Disassembly of section data2:
-// DISASM:      00002000 <rw2>:
-// DISASM-NEXT:     2000: 000004d2
+// DISASM-LABEL: <rw2>:
+// DISASM-NEXT:      2000: 000004d2
 
-// DISASM:      Disassembly of section .debug_something:
-// DISASM:      00000000 <.debug_something>:
-// DISASM-NEXT:        0: 00001000
-// DISASM-NEXT:      ...
-// DISASM-NEXT:      104: 00002000
+// DISASM-LABEL: <.debug_something>:
+// DISASM-NEXT:         0: 00001000
+// DISASM-NEXT:        ...
+// DISASM-NEXT:       104: 00002000
 
-// Test that R_ARM_SBREL32 relocations in debug info are relocated as if the
-// static base register (r9) is zero. Real DWARF info will use an expression to
-// add this to the real value of the static base at runtime.
+/// Test that R_ARM_SBREL32 relocations in debug info are relocated as if the
+/// static base register (r9) is zero. Real DWARF info will use an expression to
+/// add this to the real value of the static base at runtime.
 
 //--- lds.ld
 SECTIONS {
@@ -31,11 +28,11 @@ SECTIONS {
 
 //--- asm.s
   .text
-	.type	main,%function
-	.globl	main
-main:
+	.type	_start,%function
+	.globl	_start
+_start:
   bx lr
-  .size main, .-main
+  .size _start, .-_start
 
 	.section data1, "aw", %progbits
 	.type	rw,%object

--- a/lld/test/ELF/arm-rwpi-debug-relocs.s
+++ b/lld/test/ELF/arm-rwpi-debug-relocs.s
@@ -1,0 +1,57 @@
+// REQUIRES: arm
+// RUN: rm -rf %t && split-file %s %t && cd %t
+
+// RUN: llvm-mc -filetype=obj -triple=armv7a asm.s -o obj.o
+// RUN: ld.lld -T lds.ld obj.o -o exe.elf -e main 2>&1 | FileCheck %s --implicit-check-not=warning: --allow-empty
+// RUN: llvm-objdump -D exe.elf | FileCheck --check-prefix=DISASM %s
+
+// DISASM:      Disassembly of section data1:
+// DISASM:      00001000 <rw>:
+// DISASM-NEXT:     1000: 0000002a
+
+// DISASM:      Disassembly of section data2:
+// DISASM:      00002000 <rw2>:
+// DISASM-NEXT:     2000: 000004d2
+
+// DISASM:      Disassembly of section .debug_something:
+// DISASM:      00000000 <.debug_something>:
+// DISASM-NEXT:        0: 00001000
+// DISASM-NEXT:      ...
+// DISASM-NEXT:      104: 00002000
+
+// Test that R_ARM_SBREL32 relocations in debug info are relocated as if the
+// static base register (r9) is zero. Real DWARF info will use an expression to
+// add this to the real value of the static base at runtime.
+
+//--- lds.ld
+SECTIONS {
+  data1 0x1000 : { *(data1) }
+  data2 0x2000 : { *(data2) }
+}
+
+//--- asm.s
+  .text
+	.type	main,%function
+	.globl	main
+main:
+  bx lr
+  .size main, .-main
+
+	.section data1, "aw", %progbits
+	.type	rw,%object
+	.globl	rw
+rw:
+	.long	42
+	.size	rw, 4
+
+	.section data2, "aw", %progbits
+	.type	rw2,%object
+	.globl	rw2
+rw2:
+	.long	1234
+	.size	rw2, 4
+
+	.section	.debug_something, "", %progbits
+	.long	rw(sbrel)
+  .space 0x100
+	.long	rw2(sbrel)


### PR DESCRIPTION
The R_ARM_SBREL32 relocation is used in debug info for ARM RWPI (read-write position independent) code. Compiler-generated DWARF info will use an expression to add the relocated value to the actual value of the static base (held in r9) at run-time, so it should be relocated as if the static base is at address 0.