### PR TITLE
Fix GCC build problem with 288f05f related to SmallVector.

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -3460,7 +3460,7 @@ namespace linalg {
 /// Returns a list of AffineMap with the typical matmul indexing charactristic.
 SmallVector<AffineMap> MatmulOp::getDefaultIndexingMaps(MLIRContext *context) {
   AffineExpr d0, d1, d2;
-  SmallVector<AffineMap, 3> indexingMaps;
+  SmallVector<AffineMap> indexingMaps;
   bindDims(context, d0, d1, d2);
   indexingMaps.push_back(AffineMap::get(3, 0, {d0, d2}, context));
   indexingMaps.push_back(AffineMap::get(3, 0, {d2, d1}, context));


### PR DESCRIPTION
Below is the error message for reference.

/llvm-project/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp: In static member function 'static llvm::SmallVector<mlir::AffineMap> mlir::linalg::MatmulOp::getDefaultIndexingMaps(mlir::MLIRContext*)':
/llvm-project/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp:3468:10: error: could not convert 'indexingMaps' from 'SmallVector<[...],3>' to 'SmallVector<[...],6>'
 3468 |   return indexingMaps;
      |          ^~~~~~~~~~~~
      |          |
      |          SmallVector<[...],3>

Here is the link to the failure.
https://lab.llvm.org/buildbot/#/builders/117/builds/3919
...
