### PR TITLE
[BOLT] Skip out-of-range pending relocations

### DIFF
--- a/bolt/include/bolt/Core/BinarySection.h
+++ b/bolt/include/bolt/Core/BinarySection.h
@@ -66,8 +66,10 @@ class BinarySection {
   // from the original section address.
   RelocationSetType DynamicRelocations;
 
-  // Pending relocations for this section.
-  std::vector<Relocation> PendingRelocations;
+  /// Pending relocations for this section and whether they are optional, i.e.,
+  /// added as part of an optimization. In that case they can be safely omitted
+  /// if flushPendingRelocations discovers they cannot be encoded.
+  std::vector<std::pair<Relocation, bool>> PendingRelocations;
 
   struct BinaryPatch {
     uint64_t Offset;
@@ -375,9 +377,10 @@ public:
     DynamicRelocations.emplace(Reloc);
   }
 
-  /// Add relocation against the original contents of this section.
-  void addPendingRelocation(const Relocation &Rel) {
-    PendingRelocations.push_back(Rel);
+  /// Add relocation against the original contents of this section. When added
+  /// as part of an optimization it is marked as \p Optional.
+  void addPendingRelocation(const Relocation &Rel, bool Optional = false) {
+    PendingRelocations.push_back({Rel, Optional});
   }
 
   /// Add patch to the input contents of this section.

--- a/bolt/include/bolt/Core/BinarySection.h
+++ b/bolt/include/bolt/Core/BinarySection.h
@@ -66,10 +66,8 @@ class BinarySection {
   // from the original section address.
   RelocationSetType DynamicRelocations;
 
-  /// Pending relocations for this section and whether they are optional, i.e.,
-  /// added as part of an optimization. In that case they can be safely omitted
-  /// if flushPendingRelocations discovers they cannot be encoded.
-  std::vector<std::pair<Relocation, bool>> PendingRelocations;
+  // Pending relocations for this section.
+  std::vector<Relocation> PendingRelocations;
 
   struct BinaryPatch {
     uint64_t Offset;
@@ -377,10 +375,9 @@ public:
     DynamicRelocations.emplace(Reloc);
   }
 
-  /// Add relocation against the original contents of this section. When added
-  /// as part of an optimization it is marked as \p Optional.
-  void addPendingRelocation(const Relocation &Rel, bool Optional = false) {
-    PendingRelocations.push_back({Rel, Optional});
+  /// Add relocation against the original contents of this section.
+  void addPendingRelocation(const Relocation &Rel) {
+    PendingRelocations.push_back(Rel);
   }
 
   /// Add patch to the input contents of this section.

--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -86,6 +86,9 @@ public:
   /// Adjust value depending on relocation type (make it PC relative or not).
   static uint64_t encodeValue(uint32_t Type, uint64_t Value, uint64_t PC);
 
+  /// Return true if there are enough bits to encode the relocation value.
+  static bool canEncodeValue(uint32_t Type, uint64_t Value, uint64_t PC);
+
   /// Extract current relocated value from binary contents. This is used for
   /// RISC architectures where values are encoded in specific bits depending
   /// on the relocation value. For X86, we limit to sign extending the value

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1824,7 +1824,7 @@ bool BinaryFunction::scanExternalRefs() {
   // Add relocations unless disassembly failed for this function.
   if (!DisassemblyFailed)
     for (Relocation &Rel : FunctionRelocations)
-      getOriginSection()->addPendingRelocation(Rel);
+      getOriginSection()->addPendingRelocation(Rel, /*Optional*/ true);
 
   // Add patches grouping them together.
   if (!InstructionPatches.empty()) {

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1795,7 +1795,7 @@ bool BinaryFunction::scanExternalRefs() {
     // Create relocation for every fixup.
     for (const MCFixup &Fixup : Fixups) {
       std::optional<Relocation> Rel = BC.MIB->createRelocation(Fixup, *BC.MAB);
-      // Can be skipped under the right circumstances.
+      // Can be skipped in case of overlow during relocation value encoding.
       Rel->setOptional();
       if (!Rel) {
         Success = false;

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1795,6 +1795,8 @@ bool BinaryFunction::scanExternalRefs() {
     // Create relocation for every fixup.
     for (const MCFixup &Fixup : Fixups) {
       std::optional<Relocation> Rel = BC.MIB->createRelocation(Fixup, *BC.MAB);
+      // Can be skipped under the right circumstances.
+      Rel->setOptional();
       if (!Rel) {
         Success = false;
         continue;
@@ -1824,7 +1826,7 @@ bool BinaryFunction::scanExternalRefs() {
   // Add relocations unless disassembly failed for this function.
   if (!DisassemblyFailed)
     for (Relocation &Rel : FunctionRelocations)
-      getOriginSection()->addPendingRelocation(Rel, /*Optional*/ true);
+      getOriginSection()->addPendingRelocation(Rel);
 
   // Add patches grouping them together.
   if (!InstructionPatches.empty()) {

--- a/bolt/lib/Core/BinarySection.cpp
+++ b/bolt/lib/Core/BinarySection.cpp
@@ -190,7 +190,7 @@ void BinarySection::flushPendingRelocations(raw_pwrite_stream &OS,
       // relocations are flushed. Otherwise, PatchEntries should run.
       if (!opts::ForcePatch) {
         BC.errs()
-            << "BOLT-ERROR: Cannot encode relocation for symbol "
+            << "BOLT-ERROR: cannot encode relocation for symbol "
             << Reloc.Symbol->getName()
             << " as it is out-of-range. To proceed must use -force-patch\n";
         exit(1);

--- a/bolt/lib/Core/BinarySection.cpp
+++ b/bolt/lib/Core/BinarySection.cpp
@@ -190,10 +190,9 @@ void BinarySection::flushPendingRelocations(raw_pwrite_stream &OS,
       // relocations are flushed. Otherwise, PatchEntries should run.
       if (!opts::ForcePatch) {
         BC.errs()
-            << "BOLT-ERROR: Cannot fully run scanExternalRefs as pending "
-               "relocation for symbol "
+            << "BOLT-ERROR: Cannot encode relocation for symbol "
             << Reloc.Symbol->getName()
-            << " is out-of-range. Cannot proceed without using -force-patch\n";
+            << " as it is out-of-range. To proceed must use -force-patch\n";
         exit(1);
       }
 

--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -271,6 +271,16 @@ static uint64_t encodeValueX86(uint32_t Type, uint64_t Value, uint64_t PC) {
   return Value;
 }
 
+static bool canEncodeValueAArch64(uint32_t Type, uint64_t Value, uint64_t PC) {
+  switch (Type) {
+  default:
+    llvm_unreachable("unsupported relocation");
+  case ELF::R_AARCH64_CALL26:
+  case ELF::R_AARCH64_JUMP26:
+    return isInt<28>(Value - PC);
+  }
+}
+
 static uint64_t encodeValueAArch64(uint32_t Type, uint64_t Value, uint64_t PC) {
   switch (Type) {
   default:
@@ -301,6 +311,16 @@ static uint64_t encodeValueAArch64(uint32_t Type, uint64_t Value, uint64_t PC) {
     break;
   }
   return Value;
+}
+
+static uint64_t canEncodeValueRISCV(uint32_t Type, uint64_t Value,
+                                    uint64_t PC) {
+  switch (Type) {
+  default:
+    llvm_unreachable("unsupported relocation");
+  case ELF::R_RISCV_64:
+    return true;
+  }
 }
 
 static uint64_t encodeValueRISCV(uint32_t Type, uint64_t Value, uint64_t PC) {
@@ -736,6 +756,19 @@ uint64_t Relocation::encodeValue(uint32_t Type, uint64_t Value, uint64_t PC) {
     return encodeValueRISCV(Type, Value, PC);
   case Triple::x86_64:
     return encodeValueX86(Type, Value, PC);
+  }
+}
+
+bool Relocation::canEncodeValue(uint32_t Type, uint64_t Value, uint64_t PC) {
+  switch (Arch) {
+  default:
+    llvm_unreachable("Unsupported architecture");
+  case Triple::aarch64:
+    return canEncodeValueAArch64(Type, Value, PC);
+  case Triple::riscv64:
+    return canEncodeValueRISCV(Type, Value, PC);
+  case Triple::x86_64:
+    return true;
   }
 }
 

--- a/bolt/unittests/Core/BinaryContext.cpp
+++ b/bolt/unittests/Core/BinaryContext.cpp
@@ -161,6 +161,33 @@ TEST_P(BinaryContextTester, FlushPendingRelocJUMP26) {
       << "Wrong forward branch value\n";
 }
 
+// TODO: BOLT currently asserts when a relocation is out of range.
+TEST_P(BinaryContextTester, FlushOptionalOutOfRangePendingRelocCALL26) {
+  if (GetParam() != Triple::aarch64)
+    GTEST_SKIP();
+
+  // This test checks that flushPendingRelocations skips flushing any optional
+  // pending relocations that cannot be encoded.
+
+  BinarySection &BS = BC->registerOrUpdateSection(
+      ".text", ELF::SHT_PROGBITS, ELF::SHF_EXECINSTR | ELF::SHF_ALLOC);
+  MCSymbol *RelSymbol = BC->getOrCreateGlobalSymbol(4, "Func");
+  ASSERT_TRUE(RelSymbol);
+  BS.addPendingRelocation(
+      Relocation{8, RelSymbol, ELF::R_AARCH64_CALL26, 0, 0});
+
+  SmallVector<char> Vect;
+  raw_svector_ostream OS(Vect);
+
+  // FIXME: bolt must be able to skip pending relocs that are out of range.
+  EXPECT_DEBUG_DEATH(
+      // Resolve relocation symbol to a high value so encoding will be out of
+      // range.
+      BS.flushPendingRelocations(OS,
+                                 [&](const MCSymbol *S) { return 0x800000F; }),
+      ".*only PC \\+/- 128MB is allowed for direct call");
+}
+
 #endif
 
 TEST_P(BinaryContextTester, BaseAddress) {

--- a/bolt/unittests/Core/BinaryContext.cpp
+++ b/bolt/unittests/Core/BinaryContext.cpp
@@ -188,9 +188,8 @@ TEST_P(BinaryContextTester,
   EXPECT_EXIT(BS.flushPendingRelocations(
                   OS, [&](const MCSymbol *S) { return 0x800000F; }),
               ::testing::ExitedWithCode(1),
-              "BOLT-ERROR: Cannot fully run scanExternalRefs as pending "
-              "relocation for symbol Func0x4 is out-of-range. Cannot proceed "
-              "without using -force-patch");
+              "BOLT-ERROR: Cannot encode relocation for symbol Func0x4 as it is"
+              " out-of-range. To proceed must use -force-patch");
 }
 
 TEST_P(BinaryContextTester,

--- a/bolt/unittests/Core/BinaryContext.cpp
+++ b/bolt/unittests/Core/BinaryContext.cpp
@@ -188,7 +188,7 @@ TEST_P(BinaryContextTester,
   EXPECT_EXIT(BS.flushPendingRelocations(
                   OS, [&](const MCSymbol *S) { return 0x800000F; }),
               ::testing::ExitedWithCode(1),
-              "BOLT-ERROR: Cannot encode relocation for symbol Func0x4 as it is"
+              "BOLT-ERROR: cannot encode relocation for symbol Func0x4 as it is"
               " out-of-range. To proceed must use -force-patch");
 }
 

--- a/bolt/unittests/Core/CMakeLists.txt
+++ b/bolt/unittests/Core/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(CoreTests
   LLVMBOLTCore
   LLVMBOLTRewrite
   LLVMBOLTProfile
+  LLVMBOLTUtils
   LLVMTestingSupport
   )
 


### PR DESCRIPTION
When a pending relocation is created it is also marked whether it is
optional or not. It can be optional when such relocation is added as
part of an optimization (i.e., `scanExternalRefs`).

When bolt tries to `flushPendingRelocations`, it safely skips any
optional relocations that cannot be encoded.

Background:
BOLT, as part of scanExternalRefs, identifies external references from
calls and creates some pending relocations for them. Those when flushed
will update references to point to the optimized functions. This
optimization can be disabled using `--no-scan`.

BOLT can assert if any of these pending relocations cannot be encoded.

This patch does not disable this optimization but instead selectively
applies it given that a pending relocation is optional.