### PR TITLE
[libc++] Update the status for lwg-3143

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -1,7 +1,7 @@
 "Issue #","Issue Name","Meeting","Status","First released version","GitHub issue","Notes"
 "`LWG2839 <https://wg21.link/LWG2839>`__","Self-move-assignment of library types, again","2020-11 (Virtual)","|Nothing To Do|","","`#104255 <https://github.com/llvm/llvm-project/issues/104255>`__",""
 "`LWG3117 <https://wg21.link/LWG3117>`__","Missing ``packaged_task`` deduction guides","2020-11 (Virtual)","|Complete|","16","`#104256 <https://github.com/llvm/llvm-project/issues/104256>`__",""
-"`LWG3143 <https://wg21.link/LWG3143>`__","``monotonic_buffer_resource`` growth policy is unclear","2020-11 (Virtual)","","","`#104258 <https://github.com/llvm/llvm-project/issues/104258>`__",""
+"`LWG3143 <https://wg21.link/LWG3143>`__","``monotonic_buffer_resource`` growth policy is unclear","2020-11 (Virtual)","|Complete|","16","`#104258 <https://github.com/llvm/llvm-project/issues/104258>`__",""
 "`LWG3195 <https://wg21.link/LWG3195>`__","What is the stored pointer value of an empty ``weak_ptr``?","2020-11 (Virtual)","|Nothing To Do|","","`#104259 <https://github.com/llvm/llvm-project/issues/104259>`__",""
 "`LWG3211 <https://wg21.link/LWG3211>`__","``std::tuple<>`` should be trivially constructible","2020-11 (Virtual)","|Complete|","9","`#104260 <https://github.com/llvm/llvm-project/issues/104260>`__",""
 "`LWG3236 <https://wg21.link/LWG3236>`__","Random access iterator requirements lack limiting relational operators domain to comparing those from the same range","2020-11 (Virtual)","|Nothing To Do|","","`#104261 <https://github.com/llvm/llvm-project/issues/104261>`__",""

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_mem.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_mem.pass.cpp
@@ -20,30 +20,35 @@
 #include "count_new.h"
 #include "test_macros.h"
 
-void test_geometric_progression() {
-  // mem.res.monotonic.buffer 1.3
-  // Each additional buffer is larger than the previous one, following a
-  // geometric progression.
-
+void test_allocate_mem() {
   globalMemCounter.reset();
   std::pmr::monotonic_buffer_resource mono1(100, std::pmr::new_delete_resource());
   std::pmr::memory_resource& r1 = mono1;
 
   assert(globalMemCounter.checkNewCalledEq(0));
   std::size_t next_buffer_size = 100;
-  void* ret               = r1.allocate(10, 1);
+  void* ret                    = r1.allocate(10, 1);
   assert(ret != nullptr);
   assert(globalMemCounter.checkNewCalledEq(1));
   assert(globalMemCounter.last_new_size >= next_buffer_size);
-  next_buffer_size = globalMemCounter.last_new_size + 1;
+  next_buffer_size = globalMemCounter.last_new_size;
 
-  int new_called = 1;
+  int new_called = globalMemCounter.new_called;
   while (new_called < 5) {
     ret = r1.allocate(10, 1);
+    assert(ret != nullptr);
     if (globalMemCounter.new_called > new_called) {
       assert(globalMemCounter.new_called == new_called + 1);
-      assert(globalMemCounter.last_new_size >= next_buffer_size);
-      next_buffer_size = globalMemCounter.last_new_size + 1;
+
+#ifndef _LIBCPP_VERSION
+      assert(globalMemCounter.last_new_size >= 100);
+#else
+      // a libc++ specific test.
+      constexpr auto foot_size{4 * sizeof(void*)};
+      next_buffer_size = next_buffer_size * 2 - foot_size;
+      assert(globalMemCounter.last_new_size == next_buffer_size);
+#endif // _LIBCPP_VERSION
+
       new_called += 1;
     }
   }
@@ -51,7 +56,7 @@ void test_geometric_progression() {
 
 int main(int, char**) {
 #if TEST_SUPPORTS_LIBRARY_INTERNAL_ALLOCATIONS && !defined(DISABLE_NEW_COUNT)
-  test_geometric_progression();
+  test_allocate_mem();
 #endif
 
   return 0;


### PR DESCRIPTION
Current implementation uses the larger one either requested bytes or growth factor multiply previous buffer size.

This patch updates the status of LWG 3143 and adds a libc++-specific test case to test geometric progression.

Close #104258 