### PR TITLE
[LLD][AArch64][ARM] Delay adding long thunk mapping symbols

### DIFF
--- a/lld/ELF/Thunks.cpp
+++ b/lld/ELF/Thunks.cpp
@@ -69,6 +69,10 @@ protected:
 private:
   bool mayUseShortThunk = true;
   virtual void writeLong(uint8_t *buf) = 0;
+  // A thunk may be written out as a short or long, and we may not know which
+  // type at thunk creation time. In some thunk implementations the long thunk
+  // has additional mapping symbols. Thus function can be overridden to add
+  // these additional mapping symbols.
   virtual void addLongMapSyms() {}
 };
 
@@ -151,6 +155,7 @@ private:
   // can create layout oscillations in certain corner cases which would prevent
   // the layout from converging.
   bool mayUseShortThunk = true;
+  // See comment in AArch64Thunk.
   virtual void addLongMapSyms() {}
 };
 
@@ -180,6 +185,7 @@ public:
 private:
   // See comment in ARMThunk above.
   bool mayUseShortThunk = true;
+  // See comment in AArch64Thunk.
   virtual void addLongMapSyms() {}
 };
 

--- a/lld/test/ELF/aarch64-thunk-bti-multipass.s
+++ b/lld/test/ELF/aarch64-thunk-bti-multipass.s
@@ -40,15 +40,11 @@ _start:
 // CHECK-LABEL: <_start>:
 // CHECK-NEXT: 10001000: bl  0x10002004 <__AArch64AbsLongThunk_fn1>
 
-/// FIXME, the 2nd ldr and udf are a result of mapping symbols being generated
-/// on Thunk insertion. When that is fixed in lld they will be data statements
-/// like in __AArch64AbsLongThunk_far below.
 // CHECK-LABEL: <__AArch64AbsLongThunk_fn1>:
 // CHECK-NEXT: 10002004: ldr     x16, 0x1000200c <__AArch64AbsLongThunk_fn1+0x8>
 // CHECK-NEXT:           br      x16
-// CHECK-NEXT:           ldr     w0, 0x1000260c <__AArch64AbsLongThunk_fn1+0x608>
-// CHECK-NEXT:           udf     #0x0
-
+// CHECK-NEXT:           00 30 00 18    .word   0x18003000
+// CHECK-NEXT:           00 00 00 00    .word   0x00000000
 
 .section .text.1, "ax", %progbits
 .balign 0x1000


### PR DESCRIPTION
When we create a thunk we don't know whether it will be short or long. Move the emission of the long thunk mapping symbol to when we transition to a long thunk. This improves disassembly and binary analysis as tools like BOLT identify thunks by disassembly.