### PR TITLE
[DOCS] Remove bullet point on improving security over time.

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -9,7 +9,6 @@ The LLVM Security Group has the following goals:
 3. Allow distributors time to investigate and deploy fixes before wide dissemination of vulnerabilities or mitigation shortcomings.
 4. Ensure timely notification and release to vendors who package and distribute LLVM-based toolchains and projects.
 5. Ensure timely notification to users of LLVM-based toolchains whose compiled code is security-sensitive, through the `CVE process`_.
-6. Strive to improve security over time, for example by adding additional testing, fuzzing, and hardening after fixing issues.
 
 *Note*: these goals ensure timely action, provide disclosure timing when issues are reported, and respect vendors' / packagers' / users' constraints.
 


### PR DESCRIPTION
Remove the 6th bullet point "Strive to improve security over time, for example by adding additional testing, fuzzing and hardening after fixing issues."

At the security group meeting on 2024-11-19 we discussed the role the security group was performing in practice. We are in effect acting as a security response group, dealing with issues raised via the process given in the LLVM Security group page. We are not proactively adding additional testing fuzzing and hardening. While this could be considered an aspirational goal, it may give the implication that the LLVM Security Group is handling or at worst guaranteeing security for the LLVM project when in practice it is not.

Meeting notes:
https://discourse.llvm.org/t/llvm-security-group-public-sync-ups/62735/32