### PR TITLE
[clang][bytecode] Fix ToType/FromType diagnostic ordering

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -254,7 +254,7 @@ static bool CheckBitcastType(InterpState &S, CodePtr OpPC, QualType T,
   };
   auto note = [&](int Construct, QualType NoteType, SourceRange NoteRange) {
     S.Note(NoteRange.getBegin(), diag::note_constexpr_bit_cast_invalid_subtype)
-        << NoteType << Construct << T << NoteRange;
+        << NoteType << Construct << T.getUnqualifiedType() << NoteRange;
     return false;
   };
 
@@ -388,10 +388,9 @@ bool clang::interp::DoBitCastPtr(InterpState &S, CodePtr OpPC,
   QualType FromType = FromPtr.getType();
   QualType ToType = ToPtr.getType();
 
-  if (!CheckBitcastType(S, OpPC, FromType, /*IsToType=*/false))
-    return false;
-
   if (!CheckBitcastType(S, OpPC, ToType, /*IsToType=*/true))
+    return false;
+  if (!CheckBitcastType(S, OpPC, FromType, /*IsToType=*/false))
     return false;
 
   BitcastBuffer Buffer;

--- a/clang/test/AST/ByteCode/builtin-bit-cast.cpp
+++ b/clang/test/AST/ByteCode/builtin-bit-cast.cpp
@@ -145,6 +145,17 @@ namespace Fail {
                                                 // both-note {{initializer of 'a' is not a constant expression}}
 }
 
+namespace ToPtr {
+  struct S {
+    const int *p = nullptr;
+  };
+  struct P {
+    const int *p; // both-note {{invalid type 'const int *' is a member of 'ToPtr::P'}}
+  };
+  constexpr P p = __builtin_bit_cast(P, S{}); // both-error {{must be initialized by a constant expression}} \
+                                              // both-note {{bit_cast to a pointer type is not allowed in a constant expression}}
+}
+
 namespace NullPtr {
   constexpr nullptr_t N = __builtin_bit_cast(nullptr_t, (intptr_t)1u);
   static_assert(N == nullptr);


### PR DESCRIPTION
We need to check the ToType first, then the FromType. Additionally, remove qualifiers from the parent type of the field we're emitting a note for.