### PR TITLE
[rtsan] Remove mkfifoat interceptor

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -746,16 +746,6 @@ INTERCEPTOR(int, mkfifo, const char *pathname, mode_t mode) {
   return REAL(mkfifo)(pathname, mode);
 }
 
-// see comment above about -Wunguarded-availability-new
-// and why we disable it here
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-INTERCEPTOR(int, mkfifoat, int dirfd, const char *pathname, mode_t mode) {
-  __rtsan_notify_intercepted_call("mkfifoat");
-  return REAL(mkfifoat)(dirfd, pathname, mode);
-}
-#pragma clang diagnostic pop
-
 // Preinit
 void __rtsan::InitializeInterceptors() {
   INTERCEPT_FUNCTION(calloc);
@@ -859,7 +849,6 @@ void __rtsan::InitializeInterceptors() {
 
   INTERCEPT_FUNCTION(pipe);
   INTERCEPT_FUNCTION(mkfifo);
-  INTERCEPT_FUNCTION(mkfifoat);
 }
 
 #endif // SANITIZER_POSIX

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -971,21 +971,6 @@ TEST(TestRtsanInterceptors, MkfifoDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
-#if __has_builtin(__builtin_available) && SANITIZER_APPLE
-#define MKFIFOAT_AVAILABLE() (__builtin_available(macOS 10.13, *))
-#else
-// We are going to assume this is true until we hit systems where it isn't
-#define MKFIFOAT_AVAILABLE() (true)
-#endif
-
-TEST(TestRtsanInterceptors, MkfifoatDiesWhenRealtime) {
-  if (MKFIFOAT_AVAILABLE()) {
-    auto Func = []() { mkfifoat(0, "/tmp/rtsan_test_fifo", 0); };
-    ExpectRealtimeDeath(Func, "mkfifoat");
-    ExpectNonRealtimeSurvival(Func);
-  }
-}
-
 TEST(TestRtsanInterceptors, PipeDiesWhenRealtime) {
   int fds[2];
   auto Func = [&fds]() { pipe(fds); };


### PR DESCRIPTION
This partially reverts #116915 [fce917d](https://github.com/llvm/llvm-project/commit/fce917d39d97b8697e04fc52b1727307fc341212)

I mis-read the version that mkfifoat was introduced in darwin. It was introduced in 13.0, while I guarded against 10.13 (as you can see in the code:

```
#define MKFIFOAT_AVAILABLE() (__builtin_available(macOS 10.13, *))
```

The fix is more difficult than just declaring this as 13.0, we have to pre-declare a weak symbol as we do with aligned_alloc etc, which takes a bit of time. 

This is a band-aid while we work on that (or kick it into the future)