### PR TITLE
[Support] Add IWYU pragma

### DIFF
--- a/llvm/lib/Support/RWMutex.cpp
+++ b/llvm/lib/Support/RWMutex.cpp
@@ -13,7 +13,7 @@
 #include "llvm/Support/RWMutex.h"
 #include "llvm/Config/config.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_THREADS
-#include "llvm/Support/Allocator.h"
+#include "llvm/Support/Allocator.h"  // IWYU pragma: keep
 
 #if defined(LLVM_USE_RW_MUTEX_IMPL)
 using namespace llvm;


### PR DESCRIPTION
The pragma prevents clang-tidy's misc-include-cleaner from reporting
that Allocator.h is not used.  Note that we need the header for
safe_malloc on macos.
