### PR TITLE
[Support] Add IWYU pragma for ManagedStatic.h

### DIFF
--- a/llvm/lib/Support/Parallel.cpp
+++ b/llvm/lib/Support/Parallel.cpp
@@ -8,7 +8,7 @@
 
 #include "llvm/Support/Parallel.h"
 #include "llvm/Config/llvm-config.h"
-#include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/ManagedStatic.h" // IWYU pragma: keep
 #include "llvm/Support/Threading.h"
 
 #include <atomic>


### PR DESCRIPTION
We need ManagedStatic on Windows, which we cannot detect if we are
running clang-tidy's misc-include-cleaner on non-Windows machines.
