### PR TITLE
[memprof] Remove an unused using directive

### DIFF
--- a/llvm/unittests/Transforms/Instrumentation/MemProfUseTest.cpp
+++ b/llvm/unittests/Transforms/Instrumentation/MemProfUseTest.cpp
@@ -26,7 +26,6 @@ using namespace llvm;
 using namespace llvm::memprof;
 using testing::Contains;
 using testing::ElementsAre;
-using testing::FieldsAre;
 using testing::Pair;
 using testing::SizeIs;
 using testing::UnorderedElementsAre;


### PR DESCRIPTION
We've switched to LineLocation from FieldsAre, so we don't need this
"using" directive anymore.
