### PR TITLE
Rename GetLanguageInfo to GetLanguageSpecificData

### DIFF
--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -125,7 +125,7 @@ public:
   /// Language plugins can use this API to report language-specific
   /// runtime information about this compile unit, such as additional
   /// language version details or feature flags.
-  SBStructuredData GetLanguageInfo();
+  SBStructuredData GetLanguageSpecificData();
 
   /// Gets the lexical block that defines the stack frame. Another way to think
   /// of this is it will return the block that contains all of the variables

--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -244,7 +244,7 @@ public:
   /// Language runtime plugins can use this API to report
   /// language-specific runtime information about this compile unit,
   /// such as additional language version details or feature flags.
-  virtual StructuredData::ObjectSP GetLanguageInfo(SymbolContext sc);
+  virtual StructuredData::ObjectSP GetLanguageSpecificData(SymbolContext sc);
 
 protected:
   // The static GetRuntimeUnwindPlan method above is only implemented in the

--- a/lldb/include/lldb/Target/StackFrame.h
+++ b/lldb/include/lldb/Target/StackFrame.h
@@ -412,7 +412,7 @@ public:
   /// Language plugins can use this API to report language-specific
   /// runtime information about this compile unit, such as additional
   /// language version details or feature flags.
-  StructuredData::ObjectSP GetLanguageInfo();
+  StructuredData::ObjectSP GetLanguageSpecificData();
 
   /// Get the frame's demangled name.
   ///

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -1155,7 +1155,7 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
   return expr_result;
 }
 
-SBStructuredData SBFrame::GetLanguageInfo() {
+SBStructuredData SBFrame::GetLanguageSpecificData() {
   LLDB_INSTRUMENT_VA(this);
 
   SBStructuredData sb_data;
@@ -1165,7 +1165,7 @@ SBStructuredData SBFrame::GetLanguageInfo() {
   if (!frame)
     return sb_data;
 
-  StructuredData::ObjectSP data(frame->GetLanguageInfo());
+  StructuredData::ObjectSP data(frame->GetLanguageSpecificData());
   sb_data.m_impl_up->SetObjectSP(data);
   return sb_data;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3398,7 +3398,8 @@ std::optional<uint64_t> AppleObjCRuntimeV2::GetSharedCacheImageHeaderVersion() {
   return std::nullopt;
 }
 
-StructuredData::ObjectSP AppleObjCRuntimeV2::GetLanguageInfo(SymbolContext sc) {
+StructuredData::ObjectSP
+AppleObjCRuntimeV2::GetLanguageSpecificData(SymbolContext sc) {
   auto dict_up = std::make_unique<StructuredData::Dictionary>();
   dict_up->AddItem("Objective-C runtime version",
                    std::make_unique<StructuredData::UnsignedInteger>(2));

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -106,7 +106,7 @@ public:
 
   std::optional<uint64_t> GetSharedCacheImageHeaderVersion();
 
-  StructuredData::ObjectSP GetLanguageInfo(SymbolContext sc) override;
+  StructuredData::ObjectSP GetLanguageSpecificData(SymbolContext sc) override;
 
 protected:
   lldb::BreakpointResolverSP

--- a/lldb/source/Target/LanguageRuntime.cpp
+++ b/lldb/source/Target/LanguageRuntime.cpp
@@ -277,7 +277,8 @@ LanguageRuntime::GetRuntimeUnwindPlan(Thread &thread, RegisterContext *regctx,
   return UnwindPlanSP();
 }
 
-StructuredData::ObjectSP LanguageRuntime::GetLanguageInfo(SymbolContext sc) {
+StructuredData::ObjectSP
+LanguageRuntime::GetLanguageSpecificData(SymbolContext sc) {
   return {};
 }
 

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1231,14 +1231,14 @@ bool StackFrame::IsHidden() {
   return false;
 }
 
-StructuredData::ObjectSP StackFrame::GetLanguageInfo() {
+StructuredData::ObjectSP StackFrame::GetLanguageSpecificData() {
   auto process_sp = CalculateProcess();
   SourceLanguage language = GetLanguage();
   if (!language)
     return {};
   if (auto runtime_sp =
           process_sp->GetLanguageRuntime(language.AsLanguageType()))
-    return runtime_sp->GetLanguageInfo(
+    return runtime_sp->GetLanguageSpecificData(
         GetSymbolContext(eSymbolContextFunction));
   return {};
 }

--- a/lldb/test/API/lang/objc/languageinfo/TestObjCLanguageSpecificData.py
+++ b/lldb/test/API/lang/objc/languageinfo/TestObjCLanguageSpecificData.py
@@ -11,6 +11,6 @@ class ObjCiVarIMPTestCase(TestBase):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(self, "main")
         frame = thread.GetFrameAtIndex(0)
-        lang_info = frame.GetLanguageInfo()
+        lang_info = frame.GetLanguageSpecificData()
         version = lang_info.GetValueForKey("Objective-C runtime version")
         self.assertEqual(version.GetIntegerValue(), 2)


### PR DESCRIPTION
Unbeknownst to me the Swift LLDB branch already had an almost identical API with this name, so it makes sense to merge the two.