### PR TITLE
Make SBFrame::GetLanguageSpecificData() const

### DIFF
--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -125,7 +125,7 @@ public:
   /// Language plugins can use this API to report language-specific
   /// runtime information about this compile unit, such as additional
   /// language version details or feature flags.
-  SBStructuredData GetLanguageSpecificData();
+  SBStructuredData GetLanguageSpecificData() const;
 
   /// Gets the lexical block that defines the stack frame. Another way to think
   /// of this is it will return the block that contains all of the variables

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -1155,7 +1155,7 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
   return expr_result;
 }
 
-SBStructuredData SBFrame::GetLanguageSpecificData() {
+SBStructuredData SBFrame::GetLanguageSpecificData() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBStructuredData sb_data;


### PR DESCRIPTION
One last diff I missed between Swift and LLVM.