### PR TITLE
[libc] Move RPC interface to `libc/shared` to export it

### DIFF
--- a/libc/shared/rpc_util.h
+++ b/libc/shared/rpc_util.h
@@ -6,11 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC___SUPPORT_RPC_RPC_UTIL_H
-#define LLVM_LIBC_SRC___SUPPORT_RPC_RPC_UTIL_H
-
-#include "src/__support/macros/attributes.h"
-#include "src/__support/macros/config.h"
+#ifndef LLVM_LIBC_SHARED_RPC_UTIL_H
+#define LLVM_LIBC_SHARED_RPC_UTIL_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -20,7 +17,10 @@
 #define RPC_TARGET_IS_GPU
 #endif
 
-namespace LIBC_NAMESPACE_DECL {
+#ifndef RPC_INLINE
+#define RPC_INLINE inline
+#endif
+
 namespace rpc {
 
 template <typename T> struct type_identity {
@@ -40,26 +40,26 @@ template <class T> struct is_const<const T> : type_constant<bool, true> {};
 
 /// Freestanding implementation of std::move.
 template <class T>
-LIBC_INLINE constexpr typename remove_reference<T>::type &&move(T &&t) {
+RPC_INLINE constexpr typename remove_reference<T>::type &&move(T &&t) {
   return static_cast<typename remove_reference<T>::type &&>(t);
 }
 
 /// Freestanding implementation of std::forward.
 template <typename T>
-LIBC_INLINE constexpr T &&forward(typename remove_reference<T>::type &value) {
+RPC_INLINE constexpr T &&forward(typename remove_reference<T>::type &value) {
   return static_cast<T &&>(value);
 }
 template <typename T>
-LIBC_INLINE constexpr T &&forward(typename remove_reference<T>::type &&value) {
+RPC_INLINE constexpr T &&forward(typename remove_reference<T>::type &&value) {
   return static_cast<T &&>(value);
 }
 
 struct in_place_t {
-  LIBC_INLINE explicit in_place_t() = default;
+  RPC_INLINE explicit in_place_t() = default;
 };
 
 struct nullopt_t {
-  LIBC_INLINE constexpr explicit nullopt_t() = default;
+  RPC_INLINE constexpr explicit nullopt_t() = default;
 };
 
 constexpr inline in_place_t in_place{};
@@ -75,15 +75,15 @@ template <typename T> class optional {
 
     bool in_use = false;
 
-    LIBC_INLINE ~OptionalStorage() { reset(); }
+    RPC_INLINE ~OptionalStorage() { reset(); }
 
-    LIBC_INLINE constexpr OptionalStorage() : empty() {}
+    RPC_INLINE constexpr OptionalStorage() : empty() {}
 
     template <typename... Args>
-    LIBC_INLINE constexpr explicit OptionalStorage(in_place_t, Args &&...args)
+    RPC_INLINE constexpr explicit OptionalStorage(in_place_t, Args &&...args)
         : stored_value(forward<Args>(args)...) {}
 
-    LIBC_INLINE constexpr void reset() {
+    RPC_INLINE constexpr void reset() {
       if (in_use)
         stored_value.~U();
       in_use = false;
@@ -93,60 +93,54 @@ template <typename T> class optional {
   OptionalStorage<T> storage;
 
 public:
-  LIBC_INLINE constexpr optional() = default;
-  LIBC_INLINE constexpr optional(nullopt_t) {}
+  RPC_INLINE constexpr optional() = default;
+  RPC_INLINE constexpr optional(nullopt_t) {}
 
-  LIBC_INLINE constexpr optional(const T &t) : storage(in_place, t) {
+  RPC_INLINE constexpr optional(const T &t) : storage(in_place, t) {
     storage.in_use = true;
   }
-  LIBC_INLINE constexpr optional(const optional &) = default;
+  RPC_INLINE constexpr optional(const optional &) = default;
 
-  LIBC_INLINE constexpr optional(T &&t) : storage(in_place, move(t)) {
+  RPC_INLINE constexpr optional(T &&t) : storage(in_place, move(t)) {
     storage.in_use = true;
   }
-  LIBC_INLINE constexpr optional(optional &&O) = default;
+  RPC_INLINE constexpr optional(optional &&O) = default;
 
-  LIBC_INLINE constexpr optional &operator=(T &&t) {
+  RPC_INLINE constexpr optional &operator=(T &&t) {
     storage = move(t);
     return *this;
   }
-  LIBC_INLINE constexpr optional &operator=(optional &&) = default;
+  RPC_INLINE constexpr optional &operator=(optional &&) = default;
 
-  LIBC_INLINE constexpr optional &operator=(const T &t) {
+  RPC_INLINE constexpr optional &operator=(const T &t) {
     storage = t;
     return *this;
   }
-  LIBC_INLINE constexpr optional &operator=(const optional &) = default;
+  RPC_INLINE constexpr optional &operator=(const optional &) = default;
 
-  LIBC_INLINE constexpr void reset() { storage.reset(); }
+  RPC_INLINE constexpr void reset() { storage.reset(); }
 
-  LIBC_INLINE constexpr const T &value() const & {
-    return storage.stored_value;
-  }
+  RPC_INLINE constexpr const T &value() const & { return storage.stored_value; }
 
-  LIBC_INLINE constexpr T &value() & { return storage.stored_value; }
+  RPC_INLINE constexpr T &value() & { return storage.stored_value; }
 
-  LIBC_INLINE constexpr explicit operator bool() const {
-    return storage.in_use;
-  }
-  LIBC_INLINE constexpr bool has_value() const { return storage.in_use; }
-  LIBC_INLINE constexpr const T *operator->() const {
+  RPC_INLINE constexpr explicit operator bool() const { return storage.in_use; }
+  RPC_INLINE constexpr bool has_value() const { return storage.in_use; }
+  RPC_INLINE constexpr const T *operator->() const {
     return &storage.stored_value;
   }
-  LIBC_INLINE constexpr T *operator->() { return &storage.stored_value; }
-  LIBC_INLINE constexpr const T &operator*() const & {
+  RPC_INLINE constexpr T *operator->() { return &storage.stored_value; }
+  RPC_INLINE constexpr const T &operator*() const & {
     return storage.stored_value;
   }
-  LIBC_INLINE constexpr T &operator*() & { return storage.stored_value; }
+  RPC_INLINE constexpr T &operator*() & { return storage.stored_value; }
 
-  LIBC_INLINE constexpr T &&value() && { return move(storage.stored_value); }
-  LIBC_INLINE constexpr T &&operator*() && {
-    return move(storage.stored_value);
-  }
+  RPC_INLINE constexpr T &&value() && { return move(storage.stored_value); }
+  RPC_INLINE constexpr T &&operator*() && { return move(storage.stored_value); }
 };
 
 /// Suspend the thread briefly to assist the thread scheduler during busy loops.
-LIBC_INLINE void sleep_briefly() {
+RPC_INLINE void sleep_briefly() {
 #if defined(LIBC_TARGET_ARCH_IS_NVPTX)
   if (__nvvm_reflect("__CUDA_ARCH") >= 700)
     asm("nanosleep.u32 64;" ::: "memory");
@@ -164,7 +158,7 @@ LIBC_INLINE void sleep_briefly() {
 }
 
 /// Conditional to indicate if this process is running on the GPU.
-LIBC_INLINE constexpr bool is_process_gpu() {
+RPC_INLINE constexpr bool is_process_gpu() {
 #ifdef RPC_TARGET_IS_GPU
   return true;
 #else
@@ -173,14 +167,14 @@ LIBC_INLINE constexpr bool is_process_gpu() {
 }
 
 /// Wait for all lanes in the group to complete.
-LIBC_INLINE void sync_lane(uint64_t lane_mask) {
+RPC_INLINE void sync_lane(uint64_t lane_mask) {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_sync_lane(lane_mask);
 #endif
 }
 
 /// Copies the value from the first active thread to the rest.
-LIBC_INLINE uint32_t broadcast_value(uint64_t lane_mask, uint32_t x) {
+RPC_INLINE uint32_t broadcast_value(uint64_t lane_mask, uint32_t x) {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_read_first_lane_u32(lane_mask, x);
 #else
@@ -189,7 +183,7 @@ LIBC_INLINE uint32_t broadcast_value(uint64_t lane_mask, uint32_t x) {
 }
 
 /// Returns the number lanes that participate in the RPC interface.
-LIBC_INLINE uint32_t get_num_lanes() {
+RPC_INLINE uint32_t get_num_lanes() {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_num_lanes();
 #else
@@ -198,7 +192,7 @@ LIBC_INLINE uint32_t get_num_lanes() {
 }
 
 /// Returns the id of the thread inside of an AMD wavefront executing together.
-LIBC_INLINE uint64_t get_lane_mask() {
+RPC_INLINE uint64_t get_lane_mask() {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_lane_mask();
 #else
@@ -207,7 +201,7 @@ LIBC_INLINE uint64_t get_lane_mask() {
 }
 
 /// Returns the id of the thread inside of an AMD wavefront executing together.
-LIBC_INLINE uint32_t get_lane_id() {
+RPC_INLINE uint32_t get_lane_id() {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_lane_id();
 #else
@@ -216,7 +210,7 @@ LIBC_INLINE uint32_t get_lane_id() {
 }
 
 /// Conditional that is only true for a single thread in a lane.
-LIBC_INLINE bool is_first_lane(uint64_t lane_mask) {
+RPC_INLINE bool is_first_lane(uint64_t lane_mask) {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_is_first_in_lane(lane_mask);
 #else
@@ -225,7 +219,7 @@ LIBC_INLINE bool is_first_lane(uint64_t lane_mask) {
 }
 
 /// Returns a bitmask of threads in the current lane for which \p x is true.
-LIBC_INLINE uint64_t ballot(uint64_t lane_mask, bool x) {
+RPC_INLINE uint64_t ballot(uint64_t lane_mask, bool x) {
 #ifdef RPC_TARGET_IS_GPU
   return __gpu_ballot(lane_mask, x);
 #else
@@ -235,7 +229,7 @@ LIBC_INLINE uint64_t ballot(uint64_t lane_mask, bool x) {
 
 /// Return \p val aligned "upwards" according to \p align.
 template <typename V, typename A>
-LIBC_INLINE constexpr V align_up(V val, A align) {
+RPC_INLINE constexpr V align_up(V val, A align) {
   return ((val + V(align) - 1) / V(align)) * V(align);
 }
 
@@ -243,14 +237,14 @@ LIBC_INLINE constexpr V align_up(V val, A align) {
 /// model. On the GPU stack variables are always private to a lane so we can
 /// simply use the variable passed in. On the CPU we need to allocate enough
 /// space for the whole lane and index into it.
-template <typename V> LIBC_INLINE V &lane_value(V *val, uint32_t id) {
+template <typename V> RPC_INLINE V &lane_value(V *val, uint32_t id) {
   if constexpr (is_process_gpu())
     return *val;
   return val[id];
 }
 
 /// Advance the \p p by \p bytes.
-template <typename T, typename U> LIBC_INLINE T *advance(T *ptr, U bytes) {
+template <typename T, typename U> RPC_INLINE T *advance(T *ptr, U bytes) {
   if constexpr (is_const<T>::value)
     return reinterpret_cast<T *>(reinterpret_cast<const uint8_t *>(ptr) +
                                  bytes);
@@ -259,15 +253,14 @@ template <typename T, typename U> LIBC_INLINE T *advance(T *ptr, U bytes) {
 }
 
 /// Wrapper around the optimal memory copy implementation for the target.
-LIBC_INLINE void rpc_memcpy(void *dst, const void *src, size_t count) {
+RPC_INLINE void rpc_memcpy(void *dst, const void *src, size_t count) {
   __builtin_memcpy(dst, src, count);
 }
 
-template <class T> LIBC_INLINE constexpr const T &max(const T &a, const T &b) {
+template <class T> RPC_INLINE constexpr const T &max(const T &a, const T &b) {
   return (a < b) ? b : a;
 }
 
 } // namespace rpc
-} // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC___SUPPORT_RPC_RPC_UTIL_H
+#endif // LLVM_LIBC_SHARED_RPC_UTIL_H

--- a/libc/src/__support/RPC/CMakeLists.txt
+++ b/libc/src/__support/RPC/CMakeLists.txt
@@ -2,20 +2,6 @@ if(NOT LIBC_TARGET_OS_IS_GPU)
   return()
 endif()
 
-add_header_library(
-  rpc
-  HDRS
-    rpc.h
-    rpc_util.h
-  DEPENDS
-    libc.src.__support.common
-    libc.src.__support.CPP.algorithm
-    libc.src.__support.CPP.atomic
-    libc.src.__support.CPP.functional
-    libc.src.__support.CPP.optional
-    libc.src.__support.GPU.utils
-)
-
 add_object_library(
   rpc_client
   SRCS
@@ -25,5 +11,4 @@ add_object_library(
   DEPENDS
     libc.include.gpu_rpc
     libc.src.__support.GPU.utils
-    .rpc
 )

--- a/libc/src/__support/RPC/rpc_client.cpp
+++ b/libc/src/__support/RPC/rpc_client.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "rpc_client.h"
-#include "rpc.h"
+
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/__support/RPC/rpc_client.h
+++ b/libc/src/__support/RPC/rpc_client.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_RPC_RPC_CLIENT_H
 #define LLVM_LIBC_SRC___SUPPORT_RPC_RPC_CLIENT_H
 
-#include "rpc.h"
+#include "shared/rpc.h"
 
 #include "include/llvm-libc-types/rpc_opcodes_t.h"
 #include "src/__support/CPP/type_traits.h"
@@ -17,6 +17,12 @@
 
 namespace LIBC_NAMESPACE_DECL {
 namespace rpc {
+
+using ::rpc::Buffer;
+using ::rpc::Client;
+using ::rpc::Port;
+using ::rpc::Process;
+using ::rpc::Server;
 
 static_assert(cpp::is_trivially_copyable<Client>::value &&
                   sizeof(Process<true>) == sizeof(Process<false>),

--- a/libc/test/integration/startup/gpu/rpc_interface_test.cpp
+++ b/libc/test/integration/startup/gpu/rpc_interface_test.cpp
@@ -17,27 +17,43 @@ using namespace LIBC_NAMESPACE;
 // as long as they are mirrored.
 static void test_interface(bool end_with_send) {
   uint64_t cnt = 0;
-  rpc::Client::Port port = rpc::client.open<RPC_TEST_INTERFACE>();
-  port.send(
-      [&](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = end_with_send; });
-  port.send(
-      [&](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = cnt = cnt + 1; });
-  port.recv([&](rpc::Buffer *buffer, uint32_t) { cnt = buffer->data[0]; });
-  port.send(
-      [&](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = cnt = cnt + 1; });
-  port.recv([&](rpc::Buffer *buffer, uint32_t) { cnt = buffer->data[0]; });
-  port.send(
-      [&](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = cnt = cnt + 1; });
-  port.send(
-      [&](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = cnt = cnt + 1; });
-  port.recv([&](rpc::Buffer *buffer, uint32_t) { cnt = buffer->data[0]; });
-  port.recv([&](rpc::Buffer *buffer, uint32_t) { cnt = buffer->data[0]; });
+  LIBC_NAMESPACE::rpc::Client::Port port =
+      LIBC_NAMESPACE::rpc::client.open<RPC_TEST_INTERFACE>();
+  port.send([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    buffer->data[0] = end_with_send;
+  });
+  port.send([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    buffer->data[0] = cnt = cnt + 1;
+  });
+  port.recv([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    cnt = buffer->data[0];
+  });
+  port.send([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    buffer->data[0] = cnt = cnt + 1;
+  });
+  port.recv([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    cnt = buffer->data[0];
+  });
+  port.send([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    buffer->data[0] = cnt = cnt + 1;
+  });
+  port.send([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    buffer->data[0] = cnt = cnt + 1;
+  });
+  port.recv([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    cnt = buffer->data[0];
+  });
+  port.recv([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    cnt = buffer->data[0];
+  });
   if (end_with_send)
-    port.send([&](rpc::Buffer *buffer, uint32_t) {
+    port.send([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
       buffer->data[0] = cnt = cnt + 1;
     });
   else
-    port.recv([&](rpc::Buffer *buffer, uint32_t) { cnt = buffer->data[0]; });
+    port.recv([&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+      cnt = buffer->data[0];
+    });
   port.close();
 
   ASSERT_TRUE(cnt == 9 && "Invalid number of increments");

--- a/libc/test/integration/startup/gpu/rpc_stream_test.cpp
+++ b/libc/test/integration/startup/gpu/rpc_stream_test.cpp
@@ -34,7 +34,8 @@ static void test_stream() {
 
   inline_memcpy(send_ptr, str, send_size);
   ASSERT_TRUE(inline_memcmp(send_ptr, str, send_size) == 0 && "Data mismatch");
-  rpc::Client::Port port = rpc::client.open<RPC_TEST_STREAM>();
+  LIBC_NAMESPACE::rpc::Client::Port port =
+      LIBC_NAMESPACE::rpc::client.open<RPC_TEST_STREAM>();
   port.send_n(send_ptr, send_size);
   port.recv_n(&recv_ptr, &recv_size,
               [](uint64_t size) { return malloc(size); });
@@ -77,7 +78,8 @@ static void test_divergent() {
   inline_memcpy(buffer, &data[offset], offset);
   ASSERT_TRUE(inline_memcmp(buffer, &data[offset], offset) == 0 &&
               "Data mismatch");
-  rpc::Client::Port port = rpc::client.open<RPC_TEST_STREAM>();
+  LIBC_NAMESPACE::rpc::Client::Port port =
+      LIBC_NAMESPACE::rpc::client.open<RPC_TEST_STREAM>();
   port.send_n(buffer, offset);
   inline_memset(buffer, offset, 0);
   port.recv_n(&recv_ptr, &recv_size, [&](uint64_t) { return buffer; });

--- a/libc/test/integration/startup/gpu/rpc_test.cpp
+++ b/libc/test/integration/startup/gpu/rpc_test.cpp
@@ -18,12 +18,13 @@ static void test_add_simple() {
       10 + 10 * gpu::get_thread_id() + 10 * gpu::get_block_id();
   uint64_t cnt = 0;
   for (uint32_t i = 0; i < num_additions; ++i) {
-    rpc::Client::Port port = rpc::client.open<RPC_TEST_INCREMENT>();
+    LIBC_NAMESPACE::rpc::Client::Port port =
+        LIBC_NAMESPACE::rpc::client.open<RPC_TEST_INCREMENT>();
     port.send_and_recv(
-        [=](rpc::Buffer *buffer, uint32_t) {
+        [=](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
           reinterpret_cast<uint64_t *>(buffer->data)[0] = cnt;
         },
-        [&](rpc::Buffer *buffer, uint32_t) {
+        [&](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
           cnt = reinterpret_cast<uint64_t *>(buffer->data)[0];
         });
     port.close();
@@ -33,8 +34,11 @@ static void test_add_simple() {
 
 // Test to ensure that the RPC mechanism doesn't hang on divergence.
 static void test_noop(uint8_t data) {
-  rpc::Client::Port port = rpc::client.open<RPC_NOOP>();
-  port.send([=](rpc::Buffer *buffer, uint32_t) { buffer->data[0] = data; });
+  LIBC_NAMESPACE::rpc::Client::Port port =
+      LIBC_NAMESPACE::rpc::client.open<RPC_NOOP>();
+  port.send([=](LIBC_NAMESPACE::rpc::Buffer *buffer, uint32_t) {
+    buffer->data[0] = data;
+  });
   port.close();
 }
 

--- a/libc/utils/gpu/server/rpc_server.cpp
+++ b/libc/utils/gpu/server/rpc_server.cpp
@@ -14,15 +14,16 @@
 // Make sure these are included first so they don't conflict with the system.
 #include <limits.h>
 
+#include "shared/rpc.h"
+
 #include "llvmlibc_rpc_server.h"
 
-#include "src/__support/RPC/rpc.h"
+#include "include/llvm-libc-types/rpc_opcodes_t.h"
 #include "src/__support/arg_list.h"
 #include "src/stdio/printf_core/converter.h"
 #include "src/stdio/printf_core/parser.h"
 #include "src/stdio/printf_core/writer.h"
 
-#include "src/stdio/gpu/file.h"
 #include <algorithm>
 #include <atomic>
 #include <cstdio>
@@ -52,6 +53,26 @@ struct TempStorage {
   std::vector<std::unique_ptr<char[]>> storage;
 };
 } // namespace
+
+enum Stream {
+  File = 0,
+  Stdin = 1,
+  Stdout = 2,
+  Stderr = 3,
+};
+
+// Get the associated stream out of an encoded number.
+LIBC_INLINE ::FILE *to_stream(uintptr_t f) {
+  ::FILE *stream = reinterpret_cast<FILE *>(f & ~0x3ull);
+  Stream type = static_cast<Stream>(f & 0x3ull);
+  if (type == Stdin)
+    return stdin;
+  if (type == Stdout)
+    return stdout;
+  if (type == Stderr)
+    return stderr;
+  return stream;
+}
 
 template <bool packed, uint32_t lane_size>
 static void handle_printf(rpc::Server::Port &port, TempStorage &temp_storage) {
@@ -260,7 +281,7 @@ rpc_status_t handle_server_impl(
     port->recv([&](rpc::Buffer *buffer, uint32_t id) {
       data[id] = temp_storage.alloc(buffer->data[0]);
       sizes[id] =
-          fread(data[id], 1, buffer->data[0], file::to_stream(buffer->data[1]));
+          fread(data[id], 1, buffer->data[0], to_stream(buffer->data[1]));
     });
     port->send_n(data, sizes);
     port->send([&](rpc::Buffer *buffer, uint32_t id) {
@@ -273,9 +294,8 @@ rpc_status_t handle_server_impl(
     void *data[lane_size] = {nullptr};
     port->recv([&](rpc::Buffer *buffer, uint32_t id) {
       data[id] = temp_storage.alloc(buffer->data[0]);
-      const char *str =
-          fgets(reinterpret_cast<char *>(data[id]), buffer->data[0],
-                file::to_stream(buffer->data[1]));
+      const char *str = fgets(reinterpret_cast<char *>(data[id]),
+                              buffer->data[0], to_stream(buffer->data[1]));
       sizes[id] = !str ? 0 : std::strlen(str) + 1;
     });
     port->send_n(data, sizes);
@@ -335,46 +355,46 @@ rpc_status_t handle_server_impl(
   }
   case RPC_FEOF: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      buffer->data[0] = feof(file::to_stream(buffer->data[0]));
+      buffer->data[0] = feof(to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_FERROR: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      buffer->data[0] = ferror(file::to_stream(buffer->data[0]));
+      buffer->data[0] = ferror(to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_CLEARERR: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      clearerr(file::to_stream(buffer->data[0]));
+      clearerr(to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_FSEEK: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      buffer->data[0] = fseek(file::to_stream(buffer->data[0]),
-                              static_cast<long>(buffer->data[1]),
-                              static_cast<int>(buffer->data[2]));
+      buffer->data[0] =
+          fseek(to_stream(buffer->data[0]), static_cast<long>(buffer->data[1]),
+                static_cast<int>(buffer->data[2]));
     });
     break;
   }
   case RPC_FTELL: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      buffer->data[0] = ftell(file::to_stream(buffer->data[0]));
+      buffer->data[0] = ftell(to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_FFLUSH: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      buffer->data[0] = fflush(file::to_stream(buffer->data[0]));
+      buffer->data[0] = fflush(to_stream(buffer->data[0]));
     });
     break;
   }
   case RPC_UNGETC: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
-      buffer->data[0] = ungetc(static_cast<int>(buffer->data[0]),
-                               file::to_stream(buffer->data[1]));
+      buffer->data[0] =
+          ungetc(static_cast<int>(buffer->data[0]), to_stream(buffer->data[1]));
     });
     break;
   }


### PR DESCRIPTION
Summary:
Previous patches have made the `rpc.h` header independent of the `libc`
internals. This allows us to include it directly rather than providing
an indirect C API. This patch only does the work to move the header. A
future patch will pull out the `rpc_server` interface and simply replace
it with a single function that handles the opcodes.
