### PR TITLE
[OpenMP][Wasm][Emscripten] Fixed 'No gettid found, use getpid instead' warning

### DIFF
--- a/openmp/runtime/src/kmp_wrapper_getpid.h
+++ b/openmp/runtime/src/kmp_wrapper_getpid.h
@@ -36,6 +36,9 @@
 #elif KMP_OS_AIX
 #include <pthread.h>
 #define __kmp_gettid() pthread_self()
+#elif KMP_OS_EMSCRIPTEN
+// Emscripten defines gettid without defining SYS_gettid
+#define __kmp_gettid() gettid()
 #elif defined(SYS_gettid)
 // Hopefully other Unix systems define SYS_gettid syscall for getting os thread
 // id


### PR DESCRIPTION
Fixed 'No gettid found, use getpid instead' compilation warning as Emscripten defines ```gettid``` without defining ```SYS_gettid``` [[1](https://github.com/emscripten-core/emsdk/issues/908#issuecomment-940090540), [2](https://github.com/emscripten-core/emscripten/pull/15189)]

Note that for Emscripten ```gettid``` is just (from [[3](https://github.com/emscripten-core/emscripten/blob/f56ee36bc635341f3d538513c57558e6e302a444/system/lib/libc/musl/src/linux/gettid.c#L7)])
```
pid_t gettid(void)
{
	return __pthread_self()->tid;
}
```



[1] https://github.com/emscripten-core/emsdk/issues/908#issuecomment-940090540
[2] https://github.com/emscripten-core/emscripten/pull/15189
[3] https://github.com/emscripten-core/emscripten/blob/f56ee36bc635341f3d538513c57558e6e302a444/system/lib/libc/musl/src/linux/gettid.c#L7