### PR TITLE
[hexagon] Add support for llvm.debugtrap

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonDepInstrInfo.td
+++ b/llvm/lib/Target/Hexagon/HexagonDepInstrInfo.td
@@ -40411,6 +40411,7 @@ def Y2_break : HInst<
 tc_55255f2b, TypeCR>, Enc_e3b0c4 {
 let Inst{13-0} = 0b00000000000000;
 let Inst{31-16} = 0b0110110000100000;
+let hasSideEffects = 1;
 let isSolo = 1;
 }
 def Y2_ciad : HInst<

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -1498,7 +1498,7 @@ HexagonTargetLowering::HexagonTargetLowering(const TargetMachine &TM,
   // All operations default to "legal", except:
   // - indexed loads and stores (pre-/post-incremented),
   // - ANY_EXTEND_VECTOR_INREG, ATOMIC_CMP_SWAP_WITH_SUCCESS, CONCAT_VECTORS,
-  //   ConstantFP, DEBUGTRAP, FCEIL, FCOPYSIGN, FEXP, FEXP2, FFLOOR, FGETSIGN,
+  //   ConstantFP, FCEIL, FCOPYSIGN, FEXP, FEXP2, FFLOOR, FGETSIGN,
   //   FLOG, FLOG2, FLOG10, FMAXNUM, FMINNUM, FNEARBYINT, FRINT, FROUND, TRAP,
   //   FTRUNC, PREFETCH, SIGN_EXTEND_VECTOR_INREG, ZERO_EXTEND_VECTOR_INREG,
   // which default to "expand" for at least one type.
@@ -1507,6 +1507,7 @@ HexagonTargetLowering::HexagonTargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ConstantFP,           MVT::f32,   Legal);
   setOperationAction(ISD::ConstantFP,           MVT::f64,   Legal);
   setOperationAction(ISD::TRAP,                 MVT::Other, Legal);
+  setOperationAction(ISD::DEBUGTRAP,            MVT::Other, Legal);
   setOperationAction(ISD::ConstantPool,         MVT::i32,   Custom);
   setOperationAction(ISD::JumpTable,            MVT::i32,   Custom);
   setOperationAction(ISD::BUILD_PAIR,           MVT::i64,   Expand);

--- a/llvm/lib/Target/Hexagon/HexagonPatterns.td
+++ b/llvm/lib/Target/Hexagon/HexagonPatterns.td
@@ -3384,6 +3384,7 @@ def HexagonBARRIER: SDNode<"HexagonISD::BARRIER", SDTNone, [SDNPHasChain]>;
 def: Pat<(HexagonBARRIER), (Y2_barrier)>;
 
 def: Pat<(trap), (PS_crash)>;
+def: Pat<(debugtrap), (Y2_break)>;
 
 // Read cycle counter.
 def SDTInt64Leaf: SDTypeProfile<1, 0, [SDTCisVT<0, i64>]>;

--- a/llvm/test/CodeGen/Hexagon/trap-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/trap-crash.ll
@@ -1,20 +1,25 @@
-; RUN: llc -march=hexagon < %s | FileCheck %s
+; RUN: llc -march=hexagon --verify-machineinstrs < %s | FileCheck %s
 
 ; Generate code that is guaranteed to crash. At the moment, it's a
 ; misaligned load.
+; CHECK-LABEL: f0
 ; CHECK: memd(##3134984174)
 
 target triple = "hexagon"
 
-; Function Attrs: noreturn nounwind
-define i32 @f0() #0 {
+define i32 @f0() noreturn nounwind  {
 entry:
   tail call void @llvm.trap()
   unreachable
 }
 
-; Function Attrs: cold noreturn nounwind
-declare void @llvm.trap() #1
+; CHECK-LABEL: f1
+; CHECK: brkpt
+define i32 @f1() noreturn nounwind {
+entry:
+  tail call void @llvm.debugtrap()
+  unreachable
+}
 
-attributes #0 = { noreturn nounwind "target-cpu"="hexagonv60" }
-attributes #1 = { cold noreturn nounwind }
+declare void @llvm.trap() nounwind
+declare void @llvm.debugtrap() nounwind


### PR DESCRIPTION
Also: set `hasSideEffects` on `Y2_break` instruction.