### PR TITLE
[rtsan] Add option to allow printing of duplicate stacks

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -55,11 +55,7 @@ static void OnViolation(const BufferedStackTrace &stack,
   StackDepotHandle handle = StackDepotPut_WithHandle(stack);
 
   const bool is_stack_novel = handle.use_count() == 0;
-
-  // Marked UNLIKELY as if user is runing with halt_on_error=false
-  // we expect a high number of duplicate stacks. We are willing
-  // To pay for the first insertion.
-  if (UNLIKELY(is_stack_novel)) {
+  if (is_stack_novel || !flags().suppress_equal_stacks) {
     IncrementUniqueErrorCount();
 
     {

--- a/compiler-rt/lib/rtsan/rtsan_flags.inc
+++ b/compiler-rt/lib/rtsan/rtsan_flags.inc
@@ -19,3 +19,6 @@
 RTSAN_FLAG(bool, halt_on_error, true, "Exit after first reported error.")
 RTSAN_FLAG(bool, print_stats_on_exit, false, "Print stats on exit.")
 RTSAN_FLAG(const char *, suppressions, "", "Suppressions file name.")
+RTSAN_FLAG(bool, suppress_equal_stacks, true,
+           "Suppress a report if we've already output another report "
+           "with the same stack.")

--- a/compiler-rt/test/rtsan/deduplicate_errors.cpp
+++ b/compiler-rt/test/rtsan/deduplicate_errors.cpp
@@ -1,5 +1,6 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
 // RUN: env RTSAN_OPTIONS="halt_on_error=false,print_stats_on_exit=true" %run %t 2>&1 | FileCheck %s
+// RUN: env RTSAN_OPTIONS="halt_on_error=false,suppress_equal_stacks=false" %run %t 2>&1 | FileCheck %s --check-prefix=CHECK-DUPLICATES
 
 // UNSUPPORTED: ios
 
@@ -37,3 +38,6 @@ int main() {
 // CHECK: RealtimeSanitizer exit stats:
 // CHECK-NEXT: Total error count: 220
 // CHECK-NEXT: Unique error count: 4
+
+// CHECK-DUPLICATES-COUNT-220: ==ERROR:
+// CHECK-DUPLICATES-NOT: ==ERROR:


### PR DESCRIPTION
Following the example of tsan, as well as the naming of this flag:

https://github.com/llvm/llvm-project/blob/1c8ac4c620fa1532cd597aa5c478c8faf7ea14e4/compiler-rt/lib/tsan/rtl/tsan_flags.inc#L23-L25

This would allow users to determine if they want to see ALL output from rtsan.


I also chose to remove UNLIKELY, as it is now up to the flag whether or not it is likely that we go through this conditional. I think it may just be better to leave it to the branch predictor anyway.