### PR TITLE
[lldb] Fix ELF core debugging

### DIFF
--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -157,6 +157,12 @@ DynamicLoader::GetSectionListFromModule(const ModuleSP module) const {
 ModuleSP DynamicLoader::FindModuleViaTarget(const FileSpec &file) {
   Target &target = m_process->GetTarget();
   ModuleSpec module_spec(file, target.GetArchitecture());
+  ModuleSpec module_spec_from_process;
+  // Process may be able to augment the module_spec with UUID, e.g. ELF core.
+  if (m_process->GetModuleSpec(file, target.GetArchitecture(),
+                               module_spec_from_process)) {
+    module_spec = module_spec_from_process;
+  }
 
   if (ModuleSP module_sp = target.GetImages().FindFirstModule(module_spec))
     return module_sp;

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -286,6 +286,22 @@ void ProcessElfCore::UpdateBuildIdForNTFileEntries() {
   }
 }
 
+bool ProcessElfCore::GetModuleSpec(const FileSpec &module_file_spec,
+                                   const ArchSpec &arch,
+                                   ModuleSpec &module_spec) {
+  module_spec.Clear();
+  for (NT_FILE_Entry &entry : m_nt_file_entries) {
+    if (module_file_spec.GetPath() == entry.path) {
+      module_spec.GetFileSpec() = module_file_spec;
+      module_spec.GetArchitecture() = arch;
+      module_spec.GetUUID() = entry.uuid;
+      return true;
+    }
+  }
+
+  return false;
+}
+
 lldb_private::DynamicLoader *ProcessElfCore::GetDynamicLoader() {
   if (m_dyld_up.get() == nullptr)
     m_dyld_up.reset(DynamicLoader::FindPlugin(

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
@@ -163,6 +163,10 @@ private:
   // Populate gnu uuid for each NT_FILE entry
   void UpdateBuildIdForNTFileEntries();
 
+  bool GetModuleSpec(const lldb_private::FileSpec &module_file_spec,
+                     const lldb_private::ArchSpec &arch,
+                     lldb_private::ModuleSpec &module_spec) override;
+
   // Returns the value of certain type of note of a given start address
   lldb_private::UUID FindBuidIdInCoreMemory(lldb::addr_t address);
 


### PR DESCRIPTION
DynamicLoader does not use ProcessElfCore NT_FILE entries to get
UUID. Use GetModuleSpec to get UUID from Process.