### PR TITLE
[rtsan] Add sched_yield interceptor

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -439,6 +439,11 @@ INTERCEPTOR(int, nanosleep, const struct timespec *rqtp,
   return REAL(nanosleep)(rqtp, rmtp);
 }
 
+INTERCEPTOR(int, sched_yield, void) {
+  __rtsan_notify_intercepted_call("sched_yield");
+  return REAL(sched_yield)();
+}
+
 // Memory
 
 INTERCEPTOR(void *, calloc, SIZE_T num, SIZE_T size) {
@@ -819,6 +824,7 @@ void __rtsan::InitializeInterceptors() {
   INTERCEPT_FUNCTION(sleep);
   INTERCEPT_FUNCTION(usleep);
   INTERCEPT_FUNCTION(nanosleep);
+  INTERCEPT_FUNCTION(sched_yield);
 
   INTERCEPT_FUNCTION(accept);
   INTERCEPT_FUNCTION(bind);

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
@@ -65,6 +65,12 @@ TEST(TestRtsan, SleepingAThreadDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
+TEST(TestRtsan, YieldingDiesWhenRealtime) {
+  auto Func = []() { std::this_thread::yield(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
+}
+
 TEST(TestRtsan, IfstreamCreationDiesWhenRealtime) {
   auto Func = []() { std::ifstream ifs{"./file.txt"}; };
   ExpectRealtimeDeath(Func);

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -236,6 +236,12 @@ TEST(TestRtsanInterceptors, NanosleepDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
+TEST(TestRtsanInterceptors, SchedYieldDiesWhenRealtime) {
+  auto Func = []() { sched_yield(); };
+  ExpectRealtimeDeath(Func, "sched_yield");
+  ExpectNonRealtimeSurvival(Func);
+}
+
 /*
     Filesystem
 */


### PR DESCRIPTION
This calls the system calls switch_pri and sys_ulock_wait. It also is one of the more straightforwardly rt-unsafe, in that it gives up this thread's timeslice.