### PR TITLE
Register callbacks in Region for instruction creation/deletion.

### DIFF
--- a/llvm/include/llvm/SandboxIR/Region.h
+++ b/llvm/include/llvm/SandboxIR/Region.h
@@ -63,6 +63,11 @@ class Region {
 
   Context &Ctx;
 
+  /// ID (for later deregistration) of the "create instruction" callback.
+  Context::CallbackID CreateInstCB;
+  /// ID (for later deregistration) of the "erase instruction" callback.
+  Context::CallbackID EraseInstCB;
+
   // TODO: Add cost modeling.
   // TODO: Add a way to encode/decode region info to/from metadata.
 

--- a/llvm/lib/SandboxIR/Region.cpp
+++ b/llvm/lib/SandboxIR/Region.cpp
@@ -15,9 +15,17 @@ Region::Region(Context &Ctx) : Ctx(Ctx) {
   LLVMContext &LLVMCtx = Ctx.LLVMCtx;
   auto *RegionStrMD = MDString::get(LLVMCtx, RegionStr);
   RegionMDN = MDNode::getDistinct(LLVMCtx, {RegionStrMD});
+
+  CreateInstCB = Ctx.registerCreateInstrCallback(
+      [this](Instruction *NewInst) { add(NewInst); });
+  EraseInstCB = Ctx.registerEraseInstrCallback(
+      [this](Instruction *ErasedInst) { remove(ErasedInst); });
 }
 
-Region::~Region() {}
+Region::~Region() {
+  Ctx.unregisterCreateInstrCallback(CreateInstCB);
+  Ctx.unregisterEraseInstrCallback(EraseInstCB);
+}
 
 void Region::add(Instruction *I) {
   Insts.insert(I);


### PR DESCRIPTION
This will keep the current Region updated when region passes add/delete instructions.