### PR TITLE
Revert "[TargetVersion] Only enable on RISC-V and AArch64"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -459,8 +459,6 @@ Attribute Changes in Clang
 - Clang now supports ``[[clang::lifetime_capture_by(X)]]``. Similar to lifetimebound, this can be
   used to specify when a reference to a function parameter is captured by another capturing entity ``X``.
 
-- The ``target_version`` attribute is now only supported for AArch64 and RISC-V architectures.
-
 Improvements to Clang's diagnostics
 -----------------------------------
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3297,7 +3297,7 @@ def Target : InheritableAttr {
   }];
 }
 
-def TargetVersion : DeclOrTypeAttr, TargetSpecificAttr<TargetArch<!listconcat(TargetAArch64.Arches, TargetRISCV.Arches)>> {
+def TargetVersion : InheritableAttr {
   let Spellings = [GCC<"target_version">];
   let Args = [StringArgument<"NamesStr">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/test/Sema/attr-target-version-unsupported.c
+++ b/clang/test/Sema/attr-target-version-unsupported.c
@@ -1,4 +1,0 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-unknown -fsyntax-only -verify %s
-
-//expected-warning@+1 {{unknown attribute 'target_version' ignored}}
-int __attribute__((target_version("aes"))) foo(void) { return 3; }


### PR DESCRIPTION
Reverts llvm/llvm-project#115991

Due to build fail https://lab.llvm.org/buildbot/#/builders/66/builds/6511