### PR TITLE
Workflows: Drop Windows release builds and use more powerful runners for others

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -83,7 +83,6 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-22.04
-          - windows-2022
           - macos-13
           - macos-14
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -173,7 +173,7 @@ jobs:
         echo "build-runs-on=$build_runs_on" >> $GITHUB_OUTPUT
         echo "test-runs-on=$test_runs_on" >> $GITHUB_OUTPUT
 
-  build-release-package
+  build-release-package:
     name: "Build Release Package"
     needs: prepare
     if: >-

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -179,7 +179,7 @@ jobs:
     needs: prepare
     if: >-
       github.repository == 'llvm/llvm-project'
-    runs-on: ${{ needs.prepare.outputs.runs-on }}
+    runs-on: ${{ needs.prepare.outputs.build-runs-on }}
     steps:
 
     - name: Checkout Actions
@@ -322,8 +322,8 @@ jobs:
         upload \
         --files ${{ needs.prepare.outputs.release-binary-filename }}*
 
-  test-stage3:
-    name: "Test Stage 3"
+  test-release:
+    name: "Test Release"
     needs:
       - prepare
       - build-release-package

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -160,7 +160,7 @@ jobs:
             ;;
           macos-14)
             if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-              build_runs_on="${{ input.runs-on }}"
+              build_runs_on="${{ inputs.runs-on }}"
             else
               build_runs_on="depot-macos-14"
             fi

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -165,9 +165,10 @@ jobs:
               build_runs_on="depot-macos-14"
             fi
             test_runs_on="${{ inputs.runs-on }}"
+            ;;
           *)
-            runs_on="${{ inputs.runs-on }}"
-            multi_stage="true"
+            test_runs_on="${{ inputs.runs-on }}"
+            build_runs_on=$test_runs_on
             ;;
         esac
         echo "build-runs-on=$build_runs_on" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,7 +18,6 @@ on:
         type: choice
         options:
           - ubuntu-22.04
-          - windows-2022
           - macos-13
           - macos-14
 
@@ -60,8 +59,8 @@ jobs:
       enable-pgo: ${{ steps.vars.outputs.enable-pgo }}
       release-binary-basename: ${{ steps.vars.outputs.release-binary-basename }}
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
-      runs-on: ${{ steps.vars.outputs.runs-on }}
-      multi-stage: ${{ steps.vars.outputs.multi-stage }}
+      build-runs-on: ${{ steps.vars.outputs.build-runs-on }}
+      test-runs-on: ${{ steps.vars.outputs.build-runs-on }}
 
     steps:
     # It's good practice to use setup-python, but this is also required on macos-14
@@ -148,19 +147,34 @@ jobs:
         echo "build-flang=$build_flang" >> $GITHUB_OUTPUT
         case "${{ inputs.runs-on }}" in
           ubuntu-22.04)
-            runs_on="depot-${{ inputs.runs-on }}-16"
-            multi_stage="false"
+            build_runs_on="depot-${{ inputs.runs-on }}-16"
+            test_runs_on=$build_runs_on
             ;;
+          macos-13)
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+              build_runs_on="${{ inputs.runs-on }}"
+            else
+              build_runs_on="macos-13-large"
+            fi
+            test_runs_on="${{ inputs.runs-on }}"
+            ;;
+          macos-14)
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+              build_runs_on="${{ input.runs-on }}"
+            else
+              build_runs_on="depot-macos-14"
+            fi
+            test_runs_on="${{ inputs.runs-on }}"
           *)
             runs_on="${{ inputs.runs-on }}"
             multi_stage="true"
             ;;
         esac
-        echo "runs-on=$runs_on" >> $GITHUB_OUTPUT
-        echo "multi-stage=$multi_stage" >> $GITHUB_OUTPUT
+        echo "build-runs-on=$build_runs_on" >> $GITHUB_OUTPUT
+        echo "test-runs-on=$test_runs_on" >> $GITHUB_OUTPUT
 
-  build-stage1:
-    name: "Build Stage 1"
+  build-release-package
+    name: "Build Release Package"
     needs: prepare
     if: >-
       github.repository == 'llvm/llvm-project'
@@ -210,7 +224,7 @@ jobs:
         key: sccache-${{ runner.os }}-${{ runner.arch }}-release
         variant: sccache
 
-    - name: Configure Stage 1 Clang
+    - name: Configure
       id: build
       shell: bash
       run: |
@@ -223,21 +237,13 @@ jobs:
             -DBOOTSTRAP_CPACK_PACKAGE_FILE_NAME="${{ needs.prepare.outputs.release-binary-basename }}" \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-    - name: Build Stage 1 Clang
+    - name: Build
       shell: bash
       run: |
-        if [ "${{ needs.prepare.outputs.multi-stage}}" = "false" ]; then
-          ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
-          mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
-        else
-          ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build
-          # There is a race condition on the MacOS builders and this command is here
-          # to help debug that when it happens.
-          ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
-        fi
+        ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
+        mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
     
     - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
-      if: needs.prepare.outputs.multi-stage == 'false'
       with:
         name: ${{ runner.os }}-${{ runner.arch }}-release-binary
         # Due to path differences on Windows when running in bash vs running on node,
@@ -247,7 +253,6 @@ jobs:
 
     # Clean up some build files to reduce size of artifact.
     - name: Clean Up Build Directory
-      if: needs.prepare.outputs.multi-stage == 'false'
       shell: bash
       run: |
         find ${{ steps.setup-stage.outputs.build-prefix }}/build -iname ${{ needs.prepare.outputs.release-binary-filename }} -delete
@@ -258,208 +263,12 @@ jobs:
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
 
-  build-stage2:
-    name: "Build Stage 2"
-    needs:
-      - prepare
-      - build-stage1
-    if: >- 
-      github.repository == 'llvm/llvm-project' &&
-      needs.prepare.outputs.multi-stage == 'true'
-    runs-on: ${{ needs.prepare.outputs.runs-on }}
-    steps:
-    - name: Checkout Actions
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
-        sparse-checkout: |
-          .github/workflows/
-        sparse-checkout-cone-mode: false
-        path: workflows
-    - name: Setup Stage
-      id: setup-stage
-      uses: ./workflows/.github/workflows/release-binaries-setup-stage
-      with:
-        previous-artifact: build-stage1
-
-    - name: Build Stage 2
-      # Re-enable once PGO builds are supported.
-      if: >-
-        needs.prepare.outputs.enable-pgo == 'true' &&
-        needs.prepare.outputs.multi-stage == 'true'
-      shell: bash
-      run: |
-        ninja -C ${{ steps.setup-stage.outputs.build-prefix}}/build stage2-instrumented
-
-    - name: Save Stage
-      uses: ./workflows/.github/workflows/release-binaries-save-stage
-      with:
-        build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
-
-  build-stage3-clang:
-    name: "Build Stage 3 LLVM/Clang"
-    needs:
-      - prepare
-      - build-stage2
-    if: >- 
-      github.repository == 'llvm/llvm-project' &&
-      needs.prepare.outputs.multi-stage == 'true'
-    runs-on: ${{ needs.prepare.outputs.runs-on }}
-    steps:
-    - name: Checkout Actions
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
-        sparse-checkout: |
-          .github/workflows/
-        sparse-checkout-cone-mode: false
-        path: workflows
-    - name: Setup Stage
-      id: setup-stage
-      uses: ./workflows/.github/workflows/release-binaries-setup-stage
-      with:
-        previous-artifact: build-stage2
-
-    - name: Build LLVM/Clang
-      shell: bash
-      run: |
-        # There is a race condition on the MacOS builders and this command is here
-        # to help debug that when it happens.
-        ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
-        ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-clang
-        # Build some of the larger binaries here too.
-        ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/ \
-            clang-scan-deps \
-            modularize clangd \
-            clangd-indexer \
-            clang-check \
-            ${{ (runner.os == 'Linux' && 'clangd-fuzzer') || '' }} \
-            clang-tidy \
-            llc \
-            lli \
-            llvm-exegesis \
-            llvm-opt-fuzzer \
-            llvm-reduce \
-            llvm-lto \
-            dsymutil
-
-    - name: Save Stage
-      uses: ./workflows/.github/workflows/release-binaries-save-stage
-      with:
-        build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
-
-  build-stage3-flang:
-    name: "Build Stage 3 Flang/MLIR/Bolt"
-    needs:
-      - prepare
-      - build-stage3-clang
-    if: >- 
-      needs.prepare.outputs.multi-stage == 'true'
-    runs-on: ${{ needs.prepare.outputs.runs-on }}
-    steps:
-    - name: Checkout Actions
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
-        sparse-checkout: |
-          .github/workflows/
-        sparse-checkout-cone-mode: false
-        path: workflows
-    - name: Setup Stage
-      id: setup-stage
-      uses: ./workflows/.github/workflows/release-binaries-setup-stage
-      with:
-        previous-artifact: build-stage3-clang
-
-    - name: Build Flang / MLIR / Bolt
-      shell: bash
-      run: |
-        # Build some of the mlir tools that take a long time to link
-        if [ "${{ needs.prepare.outputs.build-flang }}" = "true" ]; then
-          ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/ -j2 flang bbc
-        fi
-        ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/ \
-            mlir-bytecode-parser-fuzzer \
-            mlir-cpu-runner \
-            mlir-lsp-server \
-            mlir-opt \
-            mlir-query \
-            mlir-reduce \
-            mlir-text-parser-fuzzer \
-            mlir-translate \
-            mlir-transform-opt \
-            mlir-cat \
-            mlir-minimal-opt \
-            mlir-minimal-opt-canonicalize \
-            mlir-pdll-lsp-server \
-            llvm-bolt \
-            llvm-bolt-heatmap
-    
-    - name: Save Stage
-      uses: ./workflows/.github/workflows/release-binaries-save-stage
-      with:
-        build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
-
-  build-stage3-all:
-    name: "Build Stage 3"
-    needs:
-      - prepare
-      - build-stage3-flang
-    runs-on: ${{ needs.prepare.outputs.runs-on }}
-    steps:
-    - name: Checkout Actions
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
-        sparse-checkout: |
-          .github/workflows/
-        sparse-checkout-cone-mode: false
-        path: workflows
-    - name: Setup Stage
-      id: setup-stage
-      uses: ./workflows/.github/workflows/release-binaries-setup-stage
-      with:
-        previous-artifact: build-stage3-flang
-
-    - name: Build Release Package
-      shell: bash
-      run: |
-        which cmake
-        ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
-        # Copy Release artifact to the workspace so it is easier to upload.
-        # This is necessary, because on Windows, the build-prefix path can
-        # only be used on bash steps, because it uses the form of /d/files/
-        # and other steps expect D:\files.
-        mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
-
-    - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
-      with:
-        name: ${{ runner.os }}-${{ runner.arch }}-release-binary
-        # Due to path differences on Windows when running in bash vs running on node,
-        # we need to search for files in the current workspace.
-        path: |
-          ${{ needs.prepare.outputs.release-binary-filename }}
-
-    # Clean up some build files to reduce size of artifact.
-    - name: Clean Up Build Directory
-      shell: bash
-      run: |
-        find ${{ steps.setup-stage.outputs.build-prefix }}/build -iname ${{ needs.prepare.outputs.release-binary-filename }} -delete
-        rm -Rf ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/_CPack_Packages
-
-    - name: Save Stage
-      uses: ./workflows/.github/workflows/release-binaries-save-stage
-      with:
-        build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
-
   upload-release-binaries:
     name: "Upload Release Binaries"
     needs:
       - prepare
-      - build-stage3-all
-      - build-stage1
+      - build-release-package
     if: >-
-      always() &&
       github.event_name != 'pull_request' &&
       needs.prepare.outputs.upload == 'true'
     runs-on: ubuntu-22.04
@@ -516,11 +325,10 @@ jobs:
     name: "Test Stage 3"
     needs:
       - prepare
-      - build-stage3-all
+      - build-release-package
     if: >-
-      always() &&
       github.repository == 'llvm/llvm-project'
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ needs.prepare.outputs.test-runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4
@@ -534,7 +342,7 @@ jobs:
       id: setup-stage
       uses: ./workflows/.github/workflows/release-binaries-setup-stage
       with:
-        previous-artifact: ${{ (needs.prepare.outputs.multi-stage == 'false' && 'build-stage1') || 'build-stage3-all' }}
+        previous-artifact: build-release-package
 
     # Need sccache installed, because some stage1 objects are being built for the tests.
     # FIXME: This probably shouldn't be happening.

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -177,8 +177,7 @@ jobs:
   build-release-package:
     name: "Build Release Package"
     needs: prepare
-    if: >-
-      github.repository == 'llvm/llvm-project'
+    if: github.repository == 'llvm/llvm-project'
     runs-on: ${{ needs.prepare.outputs.build-runs-on }}
     steps:
 
@@ -344,16 +343,6 @@ jobs:
       uses: ./workflows/.github/workflows/release-binaries-setup-stage
       with:
         previous-artifact: build-release-package
-
-    # Need sccache installed, because some stage1 objects are being built for the tests.
-    # FIXME: This probably shouldn't be happening.
-    - name: Setup sccache
-      uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
-      with:
-        # Default to 2G to workaround: https://github.com/hendrikmuhs/ccache-action/issues/174
-        max-size: 2G
-        key: sccache-${{ runner.os }}-${{ runner.arch }}-release
-        variant: sccache
 
     - name: Run Tests
       shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -60,6 +60,8 @@ jobs:
       enable-pgo: ${{ steps.vars.outputs.enable-pgo }}
       release-binary-basename: ${{ steps.vars.outputs.release-binary-basename }}
       release-binary-filename: ${{ steps.vars.outputs.release-binary-filename }}
+      runs-on: ${{ steps.vars.outputs.runs-on }}
+      multi-stage: ${{ steps.vars.outputs.multi-stage }}
 
     steps:
     # It's good practice to use setup-python, but this is also required on macos-14
@@ -144,12 +146,26 @@ jobs:
 
         echo "target-cmake-flags=$target_cmake_flags" >> $GITHUB_OUTPUT
         echo "build-flang=$build_flang" >> $GITHUB_OUTPUT
+        case "${{ inputs.runs-on }}" in
+          ubuntu-22.04)
+            runs_on="depot-${{ inputs.runs-on }}-16"
+            multi_stage="false"
+            ;;
+          *)
+            runs_on="${{ inputs.runs-on }}"
+            multi_stage="true"
+            ;;
+        esac
+        echo "runs-on=$runs_on" >> $GITHUB_OUTPUT
+        echo "multi-stage=$multi_stage" >> $GITHUB_OUTPUT
 
   build-stage1:
     name: "Build Stage 1"
     needs: prepare
-    if: github.repository == 'llvm/llvm-project'
-    runs-on: ${{ inputs.runs-on }}
+    if: >-
+      github.repository == 'llvm/llvm-project' &&
+      needs.prepare.outputs.multi-stage == 'true'
+    runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
 
     - name: Checkout Actions
@@ -195,7 +211,7 @@ jobs:
         key: sccache-${{ runner.os }}-${{ runner.arch }}-release
         variant: sccache
 
-    - name: Build Stage 1 Clang
+    - name: Configure Stage 1 Clang
       id: build
       shell: bash
       run: |
@@ -208,12 +224,44 @@ jobs:
             -DBOOTSTRAP_CPACK_PACKAGE_FILE_NAME="${{ needs.prepare.outputs.release-binary-basename }}" \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-        ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build
-        # There is a race condition on the MacOS builders and this command is here
-        # to help debug that when it happens.
-        ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
+    - name: Build Stage 1 Clang
+      shell: bash
+      run: |
+        if "${{ steps.needs.prepare.outputs.multi-stage}}" = "true"; then
+          ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
+          mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
+        else
+          ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build
+          # There is a race condition on the MacOS builders and this command is here
+          # to help debug that when it happens.
+          ls -ltr ${{ steps.setup-stage.outputs.build-prefix }}/build
+        fi
     
+    - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      if: needs.prepare.outputs.multi-stage == "false"
+      with:
+        name: ${{ runner.os }}-${{ runner.arch }}-release-binary
+        # Due to path differences on Windows when running in bash vs running on node,
+        # we need to search for files in the current workspace.
+        path: |
+          ${{ needs.prepare.outputs.release-binary-filename }}
+
+    # Clean up some build files to reduce size of artifact.
+    - name: Clean Up Build Directory
+      if: needs.prepare.outputs.multi-stage == "false"
+      shell: bash
+      run: |
+        find ${{ steps.setup-stage.outputs.build-prefix }}/build -iname ${{ needs.prepare.outputs.release-binary-filename }} -delete
+        rm -Rf ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/_CPack_Packages
+    
+    - name: Run Tests
+      shell: bash
+      if: needs.prepare.outputs.multi-stage == "false"
+      run: |
+        ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-check-all
+
     - name: Save Stage
+      if: needs.prepare.outputs.multi-stage == "true"
       uses: ./workflows-main/.github/workflows/release-binaries-save-stage
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
@@ -223,8 +271,10 @@ jobs:
     needs:
       - prepare
       - build-stage1
-    if: github.repository == 'llvm/llvm-project'
-    runs-on: ${{ inputs.runs-on }}
+    if: >- 
+      github.repository == 'llvm/llvm-project' &&
+      needs.prepare.outputs.multi-stage == 'true'
+    runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4
@@ -242,7 +292,9 @@ jobs:
 
     - name: Build Stage 2
       # Re-enable once PGO builds are supported.
-      if: needs.prepare.outputs.enable-pgo == 'true'
+      if: >-
+        needs.prepare.outputs.enable-pgo == 'true' &&
+        needs.prepare.outputs.multi-stage == 'true'
       shell: bash
       run: |
         ninja -C ${{ steps.setup-stage.outputs.build-prefix}}/build stage2-instrumented
@@ -257,8 +309,10 @@ jobs:
     needs:
       - prepare
       - build-stage2
-    if: github.repository == 'llvm/llvm-project'
-    runs-on: ${{ inputs.runs-on }}
+    if: >- 
+      github.repository == 'llvm/llvm-project' &&
+      needs.prepare.outputs.multi-stage == 'true'
+    runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4
@@ -307,7 +361,9 @@ jobs:
     needs:
       - prepare
       - build-stage3-clang
-    runs-on: ${{ inputs.runs-on }}
+    if: >- 
+      needs.prepare.outputs.multi-stage == 'true'
+    runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4
@@ -357,7 +413,7 @@ jobs:
     needs:
       - prepare
       - build-stage3-flang
-    runs-on: ${{ inputs.runs-on }}
+    runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4
@@ -409,6 +465,7 @@ jobs:
     needs:
       - prepare
       - build-stage3-all
+      - build-stage1
     if: >-
       always() &&
       github.event_name != 'pull_request' &&
@@ -469,8 +526,8 @@ jobs:
       - prepare
       - build-stage3-all
     if: >-
-      github.repository == 'llvm/llvm-project'
-    runs-on: ${{ inputs.runs-on }}
+      github.repository == 'llvm/llvm-project' &&
+    runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -227,7 +227,7 @@ jobs:
     - name: Build Stage 1 Clang
       shell: bash
       run: |
-        if "${{ steps.needs.prepare.outputs.multi-stage}}" = "true"; then
+        if [ "${{ steps.needs.prepare.outputs.multi-stage}}" = "true" ]; then
           ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
           mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
         else
@@ -238,7 +238,7 @@ jobs:
         fi
     
     - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
-      if: needs.prepare.outputs.multi-stage == "false"
+      if: needs.prepare.outputs.multi-stage == 'false'
       with:
         name: ${{ runner.os }}-${{ runner.arch }}-release-binary
         # Due to path differences on Windows when running in bash vs running on node,
@@ -248,7 +248,7 @@ jobs:
 
     # Clean up some build files to reduce size of artifact.
     - name: Clean Up Build Directory
-      if: needs.prepare.outputs.multi-stage == "false"
+      if: needs.prepare.outputs.multi-stage == 'false'
       shell: bash
       run: |
         find ${{ steps.setup-stage.outputs.build-prefix }}/build -iname ${{ needs.prepare.outputs.release-binary-filename }} -delete
@@ -256,12 +256,12 @@ jobs:
     
     - name: Run Tests
       shell: bash
-      if: needs.prepare.outputs.multi-stage == "false"
+      if: needs.prepare.outputs.multi-stage == 'false'
       run: |
         ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-check-all
 
     - name: Save Stage
-      if: needs.prepare.outputs.multi-stage == "true"
+      if: needs.prepare.outputs.multi-stage == 'true'
       uses: ./workflows-main/.github/workflows/release-binaries-save-stage
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -253,14 +253,7 @@ jobs:
         find ${{ steps.setup-stage.outputs.build-prefix }}/build -iname ${{ needs.prepare.outputs.release-binary-filename }} -delete
         rm -Rf ${{ steps.setup-stage.outputs.build-prefix }}/build/tools/clang/stage2-bins/_CPack_Packages
     
-    - name: Run Tests
-      shell: bash
-      if: needs.prepare.outputs.multi-stage == 'false'
-      run: |
-        ninja -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-check-all
-
     - name: Save Stage
-      if: needs.prepare.outputs.multi-stage == 'true'
       uses: ./workflows-main/.github/workflows/release-binaries-save-stage
       with:
         build-prefix: ${{ steps.setup-stage.outputs.build-prefix }}
@@ -525,8 +518,9 @@ jobs:
       - prepare
       - build-stage3-all
     if: >-
+      always() &&
       github.repository == 'llvm/llvm-project'
-    runs-on: ${{ needs.prepare.outputs.runs-on }}
+    runs-on: ${{ input.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4
@@ -540,7 +534,7 @@ jobs:
       id: setup-stage
       uses: ./workflows/.github/workflows/release-binaries-setup-stage
       with:
-        previous-artifact: build-stage3-all
+        previous-artifact: ${{ (needs.prepare.outputs.multi-stage == 'false' && 'build-stage1') || 'build-stage3-all' }}
 
     - name: Run Tests
       shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -520,7 +520,7 @@ jobs:
     if: >-
       always() &&
       github.repository == 'llvm/llvm-project'
-    runs-on: ${{ input.runs-on }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
     - name: Checkout Actions
       uses: actions/checkout@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -163,8 +163,7 @@ jobs:
     name: "Build Stage 1"
     needs: prepare
     if: >-
-      github.repository == 'llvm/llvm-project' &&
-      needs.prepare.outputs.multi-stage == 'true'
+      github.repository == 'llvm/llvm-project'
     runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -226,7 +226,7 @@ jobs:
     - name: Build Stage 1 Clang
       shell: bash
       run: |
-        if [ "${{ steps.needs.prepare.outputs.multi-stage}}" = "true" ]; then
+        if [ "${{ steps.needs.prepare.outputs.multi-stage}}" = "false" ]; then
           ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
           mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
         else

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -526,7 +526,7 @@ jobs:
       - prepare
       - build-stage3-all
     if: >-
-      github.repository == 'llvm/llvm-project' &&
+      github.repository == 'llvm/llvm-project'
     runs-on: ${{ needs.prepare.outputs.runs-on }}
     steps:
     - name: Checkout Actions

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -536,6 +536,16 @@ jobs:
       with:
         previous-artifact: ${{ (needs.prepare.outputs.multi-stage == 'false' && 'build-stage1') || 'build-stage3-all' }}
 
+    # Need sccache installed, because some stage1 objects are being built for the tests.
+    # FIXME: This probably shouldn't be happening.
+    - name: Setup sccache
+      uses: hendrikmuhs/ccache-action@ca3acd2731eef11f1572ccb126356c2f9298d35e # v1.2.9
+      with:
+        # Default to 2G to workaround: https://github.com/hendrikmuhs/ccache-action/issues/174
+        max-size: 2G
+        key: sccache-${{ runner.os }}-${{ runner.arch }}-release
+        variant: sccache
+
     - name: Run Tests
       shell: bash
       run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -226,7 +226,7 @@ jobs:
     - name: Build Stage 1 Clang
       shell: bash
       run: |
-        if [ "${{ steps.needs.prepare.outputs.multi-stage}}" = "false" ]; then
+        if [ "${{ needs.prepare.outputs.multi-stage}}" = "false" ]; then
           ninja -v -C ${{ steps.setup-stage.outputs.build-prefix }}/build stage2-package
           mv ${{ steps.setup-stage.outputs.build-prefix  }}/build/tools/clang/stage2-bins/${{ needs.prepare.outputs.release-binary-filename }} .
         else


### PR DESCRIPTION
We have community provided Windows builds that are better than what we can build on GitHub.  For the Linux/X86 builds and Mac/Aarch64 builds we will use depot runners, for Mac/X86 we will use the larger GitHub runners.