### PR TITLE
[llvm] Remove `br i1 undef` from regression tests

### DIFF
--- a/llvm/test/Transforms/LoopInterchange/lcssa.ll
+++ b/llvm/test/Transforms/LoopInterchange/lcssa.ll
@@ -180,7 +180,7 @@ for.end16:                                        ; preds = %for.exit
 ; REMARK: Interchanged
 ; REMARK-NEXT: lcssa_05
 
-define void @lcssa_05(ptr %ptr) {
+define void @lcssa_05(ptr %ptr, i1 %arg) {
 entry:
   br label %outer.header
 
@@ -190,7 +190,7 @@ outer.header:                                     ; preds = %outer.inc, %entry
 
 for.body3:                                        ; preds = %bb3, %outer.header
   %iv.inner = phi i64 [ %iv.inner.next, %bb3 ], [ 1, %outer.header ]
-  br i1 undef, label %bb2, label %bb3
+  br i1 %arg, label %bb2, label %bb3
 
 bb2:                                              ; preds = %for.body3
   %arrayidx5 = getelementptr inbounds [100 x [100 x i32]], ptr @A, i64 0, i64 %iv.inner, i64 %iv.outer
@@ -225,13 +225,13 @@ for.end16:                                        ; preds = %for.exit
 ; REMARK: UnsupportedExitPHI
 ; REMARK-NEXT: lcssa_06
 
-define void @lcssa_06(ptr %ptr, ptr %ptr1) {
+define void @lcssa_06(ptr %ptr, ptr %ptr1, i1 %arg) {
 entry:
   br label %outer.header
 
 outer.header:                                     ; preds = %outer.inc, %entry
   %iv.outer = phi i64 [ 1, %entry ], [ %iv.outer.next, %outer.inc ]
-  br i1 undef, label %for.body3, label %outer.inc
+  br i1 %arg, label %for.body3, label %outer.inc
 
 for.body3:                                        ; preds = %for.body3, %outer.header
   %iv.inner = phi i64 [ %iv.inner.next, %for.body3 ], [ 1, %outer.header ]
@@ -305,13 +305,13 @@ for.end16:                                        ; preds = %for.exit
 ; is an lcssa phi node outside the loopnest.
 ; REMARK: Interchanged
 ; REMARK-NEXT: lcssa_08
-define i64 @lcssa_08(ptr %Arr) {
+define i64 @lcssa_08(ptr %Arr, i1 %arg) {
 entry:
   br label %for1.header
 
 for1.header:                                         ; preds = %for1.inc, %entry
   %indvars.iv23 = phi i64 [ 0, %entry ], [ %indvars.iv.next24, %for1.inc ]
-  br i1 undef, label %for2, label %for1.inc
+  br i1 %arg, label %for2, label %for1.inc
 
 for2:                                        ; preds = %for2, %for1.header
   %indvars.iv = phi i64 [ 0, %for1.header ], [ %indvars.iv.next.3, %for2 ]

--- a/llvm/test/Transforms/LoopInterchange/pr43176-move-to-new-latch.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43176-move-to-new-latch.ll
@@ -45,7 +45,7 @@ for.cond1.for.end_crit_edge:                      ; preds = %for.inc
 
 for.inc3:                                         ; preds = %for.cond1.for.end_crit_edge
   %inc4 = add nsw i32 %inc41, 1
-  br i1 undef, label %for.body, label %for.cond.for.end5_crit_edge
+  br i1 false, label %for.body, label %for.cond.for.end5_crit_edge
 
 for.cond.for.end5_crit_edge:                      ; preds = %for.inc3
   ret void
@@ -86,7 +86,7 @@ for.cond1.for.end_crit_edge:                      ; preds = %for.inc
 
 for.inc3:                                         ; preds = %for.cond1.for.end_crit_edge
   %inc4 = add nsw i32 %inc41, 1
-  br i1 undef, label %for.body, label %for.cond.for.end5_crit_edge
+  br i1 false, label %for.body, label %for.cond.for.end5_crit_edge
 
 for.cond.for.end5_crit_edge:                      ; preds = %for.inc3
   ret void

--- a/llvm/test/Transforms/LoopInterchange/pr43473-invalid-lcssa-phis-in-inner-exit.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43473-invalid-lcssa-phis-in-inner-exit.ll
@@ -6,7 +6,7 @@
 ; In the 2 test cases below, we have a LCSSA PHI in the inner loop exit, which
 ; is used in the outer loop latch. This is not supported.
 
-define void @test1() {
+define void @test1(i1 %arg) {
 ; CHECK-LABEL: @test1(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[OUTER_HEADER:%.*]]
@@ -19,12 +19,12 @@ define void @test1() {
 ; CHECK-NEXT:    [[TMP0:%.*]] = load double, ptr [[IDX]], align 8
 ; CHECK-NEXT:    store double undef, ptr [[IDX]], align 8
 ; CHECK-NEXT:    [[INNER_IV_NEXT]] = add nuw nsw i64 [[INNER_IV]], 1
-; CHECK-NEXT:    br i1 false, label [[INNER]], label [[OUTER_LATCH]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[INNER]], label [[OUTER_LATCH]]
 ; CHECK:       outer.latch:
 ; CHECK-NEXT:    [[INC43_LCSSA_WIDE_US:%.*]] = phi i64 [ [[INNER_IV_NEXT]], [[INNER]] ]
 ; CHECK-NEXT:    [[TMP1:%.*]] = trunc i64 [[INC43_LCSSA_WIDE_US]] to i32
 ; CHECK-NEXT:    [[OUTER_IV_NEXT]] = add nsw i64 [[OUTER_IV]], 1
-; CHECK-NEXT:    br i1 false, label [[OUTER_HEADER]], label [[OUTER_EXIT:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[OUTER_HEADER]], label [[OUTER_EXIT:%.*]]
 ; CHECK:       outer.exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -41,20 +41,20 @@ inner:                                    ; preds = %for.body28.us, %for.body25.
   %0 = load double, ptr %idx, align 8
   store double undef, ptr %idx, align 8
   %inner.iv.next = add nuw nsw i64 %inner.iv, 1
-  br i1 undef, label %inner, label %outer.latch
+  br i1 %arg, label %inner, label %outer.latch
 
 outer.latch:                ; preds = %inner
   %inc43.lcssa.wide.us = phi i64 [ %inner.iv.next, %inner ]
   %1 = trunc i64 %inc43.lcssa.wide.us to i32
   %outer.iv.next = add nsw i64 %outer.iv, 1
-  br i1 undef, label %outer.header, label %outer.exit
+  br i1 %arg, label %outer.header, label %outer.exit
 
 outer.exit:       ; preds = %for.cond26.for.end44_crit_edge.us
   ret void
 }
 
 ; Same as @test1, but with a dedicated inner loop exit block.
-define void @test2() {
+define void @test2(i1 %arg) {
 ; CHECK-LABEL: @test2(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[OUTER_HEADER:%.*]]
@@ -67,14 +67,14 @@ define void @test2() {
 ; CHECK-NEXT:    [[TMP0:%.*]] = load double, ptr [[IDX]], align 8
 ; CHECK-NEXT:    store double undef, ptr [[IDX]], align 8
 ; CHECK-NEXT:    [[INNER_IV_NEXT]] = add nuw nsw i64 [[INNER_IV]], 1
-; CHECK-NEXT:    br i1 false, label [[INNER]], label [[INNER_EXIT:%.*]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[INNER]], label [[INNER_EXIT:%.*]]
 ; CHECK:       inner.exit:
 ; CHECK-NEXT:    [[INC43_LCSSA_WIDE_US:%.*]] = phi i64 [ [[INNER_IV_NEXT]], [[INNER]] ]
 ; CHECK-NEXT:    br label [[OUTER_LATCH]]
 ; CHECK:       outer.latch:
 ; CHECK-NEXT:    [[TMP1:%.*]] = trunc i64 [[INC43_LCSSA_WIDE_US]] to i32
 ; CHECK-NEXT:    [[OUTER_IV_NEXT]] = add nsw i64 [[OUTER_IV]], 1
-; CHECK-NEXT:    br i1 false, label [[OUTER_HEADER]], label [[OUTER_EXIT:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[OUTER_HEADER]], label [[OUTER_EXIT:%.*]]
 ; CHECK:       outer.exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -91,7 +91,7 @@ inner:                                    ; preds = %for.body28.us, %for.body25.
   %0 = load double, ptr %idx, align 8
   store double undef, ptr %idx, align 8
   %inner.iv.next = add nuw nsw i64 %inner.iv, 1
-  br i1 undef, label %inner, label %inner.exit
+  br i1 %arg, label %inner, label %inner.exit
 
 inner.exit:
   %inc43.lcssa.wide.us = phi i64 [ %inner.iv.next, %inner ]
@@ -100,7 +100,7 @@ inner.exit:
 outer.latch:                ; preds = %inner
   %1 = trunc i64 %inc43.lcssa.wide.us to i32
   %outer.iv.next = add nsw i64 %outer.iv, 1
-  br i1 undef, label %outer.header, label %outer.exit
+  br i1 %arg, label %outer.header, label %outer.exit
 
 outer.exit:       ; preds = %for.cond26.for.end44_crit_edge.us
   ret void

--- a/llvm/test/Transforms/LoopInterchange/pr43797-lcssa-for-multiple-outer-loop-blocks.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43797-lcssa-for-multiple-outer-loop-blocks.ll
@@ -59,7 +59,7 @@ inner.header:                                        ; preds = %for.inc, %for.bo
 
 inner.latch:                                          ; preds = %for.body6
   %inner.idx.inc = add nsw i64 %inner.idx, 1
-  br i1 undef, label %inner.header, label %inner.exit
+  br i1 false, label %inner.header, label %inner.exit
 
 inner.exit:                                          ; preds = %for.inc
   %outer.v = add nsw i64 %outer.idx, 1
@@ -67,7 +67,7 @@ inner.exit:                                          ; preds = %for.inc
 
 outer.latch:                                        ; preds = %for.end
   %outer.idx.inc = add nsw i64 %outer.idx, 1
-  br i1 undef, label %outer.header, label %outer.exit
+  br i1 false, label %outer.header, label %outer.exit
 
 outer.exit:                                        ; preds = %for.inc27
   %exit1.lcssa = phi i64 [ %outer.v, %outer.latch ]
@@ -133,7 +133,7 @@ inner.header:                                        ; preds = %for.inc, %for.bo
 
 inner.latch:                                          ; preds = %for.body6
   %inner.idx.inc = add nsw i64 %inner.idx , 1
-  br i1 undef, label %inner.header, label %inner.exit
+  br i1 false, label %inner.header, label %inner.exit
 
 inner.exit:                                          ; preds = %for.inc
   %outer.v = add nsw i64 %outer.idx, 1
@@ -141,7 +141,7 @@ inner.exit:                                          ; preds = %for.inc
 
 outer.latch:                                        ; preds = %for.end
   %outer.idx.inc = add nsw i64 %outer.idx, 1
-  br i1 undef, label %outer.header, label %outer.exit
+  br i1 false, label %outer.header, label %outer.exit
 
 outer.exit:                                        ; preds = %for.inc27
   %exit1.lcssa = phi i64 [ 0, %entry ], [ %outer.v, %outer.latch ]

--- a/llvm/test/Transforms/LoopInterchange/pr57148.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr57148.ll
@@ -152,11 +152,11 @@ vector.body85:                                    ; preds = %vector.body85, %for
   %1 = getelementptr inbounds [512 x [4 x i32]], ptr @b, i16 0, i16 %0, i16 %j.165
   %2 = load i32, ptr %1, align 1
   %index.next87 = add nuw i16 %index86, 4
-  br i1 undef, label %middle.block80, label %vector.body85
+  br i1 true, label %middle.block80, label %vector.body85
 
 middle.block80:                                   ; preds = %vector.body85
   %inc66 = add nuw nsw i16 %j.165, 1
-  br i1 undef, label %for.inc68, label %for.cond37.preheader
+  br i1 true, label %for.inc68, label %for.cond37.preheader
 
 for.inc68:                                        ; preds = %middle.block80
   %inc69 = add nuw nsw i16 %i.166, 1

--- a/llvm/test/Transforms/LoopLoadElim/pr-48150.ll
+++ b/llvm/test/Transforms/LoopLoadElim/pr-48150.ll
@@ -3,10 +3,10 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:1-p2:32:8:8:32-ni:2"
 target triple = "x86_64-unknown-linux-gnu"
 
-define void @test() {
+define void @test(i1 %arg) {
 ; CHECK-LABEL: test
 bb:
-  br i1 undef, label %bb1, label %bb2
+  br i1 %arg, label %bb1, label %bb2
 
 bb1:                                              ; preds = %bb
   ret void

--- a/llvm/test/Transforms/LoopLoadElim/pr47457.ll
+++ b/llvm/test/Transforms/LoopLoadElim/pr47457.ll
@@ -5,7 +5,7 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Make sure it does not crash with assert.
-define void @test() {
+define void @test(i1 %arg) {
 ; CHECK-LABEL: test
 
 bb:
@@ -13,7 +13,7 @@ bb:
 
 bb1:                                              ; preds = %bb6, %bb1, %bb
   %tmp = phi i32 [ undef, %bb ], [ 0, %bb1 ], [ %tmp3, %bb6 ]
-  br i1 undef, label %bb1, label %bb2
+  br i1 %arg, label %bb1, label %bb2
 
 bb2:                                              ; preds = %bb1
   %tmp3 = add i32 %tmp, 1
@@ -24,7 +24,7 @@ bb5:                                              ; preds = %bb2
   ret void
 
 bb6:                                              ; preds = %bb2
-  br i1 undef, label %bb7, label %bb1
+  br i1 %arg, label %bb7, label %bb1
 
 bb7:                                              ; preds = %bb7, %bb6
   %tmp8 = phi i32 [ %tmp15, %bb7 ], [ %tmp3, %bb6 ]

--- a/llvm/test/Transforms/LoopPredication/predicate-exits.ll
+++ b/llvm/test/Transforms/LoopPredication/predicate-exits.ll
@@ -1117,7 +1117,7 @@ bb3:                                              ; preds = %bb
 
 bb4:                                              ; preds = %bb6, %bb3
   %tmp5 = phi i32 [ %tmp7, %bb6 ], [ 0, %bb3 ]
-  br i1 undef, label %bb10, label %bb6
+  br i1 true, label %bb10, label %bb6
 
 bb6:                                              ; preds = %bb4
   %tmp7 = add nuw nsw i32 %tmp5, 1

--- a/llvm/test/Transforms/LoopRotate/crash.ll
+++ b/llvm/test/Transforms/LoopRotate/crash.ll
@@ -4,27 +4,27 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 target triple = "x86_64-apple-darwin10.0.0"
 
 ; PR8955 - Rotating an outer loop that has a condbr for a latch block.
-define void @test1() nounwind ssp {
+define void @test1(i1 %arg) nounwind ssp {
 entry:
   br label %lbl_283
 
 lbl_283:                                          ; preds = %if.end, %entry
-  br i1 undef, label %if.else, label %if.then
+  br i1 %arg, label %if.else, label %if.then
 
 if.then:                                          ; preds = %lbl_283
-  br i1 undef, label %if.end, label %for.condthread-pre-split
+  br i1 %arg, label %if.end, label %for.condthread-pre-split
 
 for.condthread-pre-split:                         ; preds = %if.then
   br label %for.cond
 
 for.cond:                                         ; preds = %for.cond, %for.condthread-pre-split
-  br i1 undef, label %lbl_281, label %for.cond
+  br i1 %arg, label %lbl_281, label %for.cond
 
 lbl_281:                                          ; preds = %if.end, %for.cond
   br label %if.end
 
 if.end:                                           ; preds = %lbl_281, %if.then
-  br i1 undef, label %lbl_283, label %lbl_281
+  br i1 %arg, label %lbl_283, label %lbl_281
 
 if.else:                                          ; preds = %lbl_283
   ret void
@@ -140,12 +140,12 @@ bb17:		; preds = %bb15
 
 
 ; PR9523 - Non-canonical loop.
-define void @test7(ptr %P) nounwind {
+define void @test7(ptr %P, i1 %arg) nounwind {
 entry:
   indirectbr ptr %P, [label %"3", label %"5"]
 
 "3":                                              ; preds = %"4", %entry
-  br i1 undef, label %"5", label %"4"
+  br i1 %arg, label %"5", label %"4"
 
 "4":                                              ; preds = %"3"
   br label %"3"

--- a/llvm/test/Transforms/LoopRotate/multiple-exits.ll
+++ b/llvm/test/Transforms/LoopRotate/multiple-exits.ll
@@ -199,12 +199,12 @@ declare ptr @__cxa_begin_catch(ptr)
 
 declare void @__cxa_end_catch()
 
-define void @test4() nounwind uwtable {
+define void @test4(i1 %arg) nounwind uwtable {
 entry:
   br label %"7"
 
 "3":                                              ; preds = %"7"
-  br i1 undef, label %"31", label %"4"
+  br i1 %arg, label %"31", label %"4"
 
 "4":                                              ; preds = %"3"
   %. = select i1 undef, float 0x3F50624DE0000000, float undef
@@ -217,7 +217,7 @@ entry:
   br i1 %2, label %"3", label %"8"
 
 "8":                                              ; preds = %"7"
-  br i1 undef, label %"9", label %"31"
+  br i1 %arg, label %"9", label %"31"
 
 "9":                                              ; preds = %"8"
   br label %"33"
@@ -226,7 +226,7 @@ entry:
   unreachable
 
 "31":                                             ; preds = %"8", %"3"
-  br i1 undef, label %"27", label %"32"
+  br i1 %arg, label %"27", label %"32"
 
 "32":                                             ; preds = %"31"
   br label %"33"

--- a/llvm/test/Transforms/LoopRotate/pr22337.ll
+++ b/llvm/test/Transforms/LoopRotate/pr22337.ll
@@ -3,17 +3,17 @@
 @a = external global i8, align 4
 @tmp = global ptr @a
 
-define void @f() {
+define void @f(i1 %arg) {
 ; CHECK-LABEL: define void @f(
 ; CHECK: getelementptr i8, ptr @a, i32 1
 entry:
   br label %for.preheader
 
 for.preheader:
-  br i1 undef, label %if.then8, label %for.body
+  br i1 %arg, label %if.then8, label %for.body
 
 for.body:
-  br i1 undef, label %if.end, label %if.then8
+  br i1 %arg, label %if.end, label %if.then8
 
 if.end:
   %arrayidx = getelementptr i8, ptr @a, i32 1

--- a/llvm/test/Transforms/LoopRotate/pr33701.ll
+++ b/llvm/test/Transforms/LoopRotate/pr33701.ll
@@ -1,6 +1,6 @@
 ; RUN: opt < %s -passes=loop-rotate -verify-dom-info -verify-loop-info -verify-memoryssa -disable-output
 
-define void @func() {
+define void @func(i1 %arg) {
 bb0:
   br label %bb1
 
@@ -10,7 +10,7 @@ bb1:                                              ; preds = %bb4, %bb0
   br i1 %1, label %bb2, label %bb5
 
 bb2:                                              ; preds = %bb1
-  br i1 undef, label %bb6, label %bb4
+  br i1 %arg, label %bb6, label %bb4
 
 bb3:                                              ; No predecessors!
   br label %bb6

--- a/llvm/test/Transforms/LoopRotate/pr37205.ll
+++ b/llvm/test/Transforms/LoopRotate/pr37205.ll
@@ -95,7 +95,7 @@ if.then:                                          ; preds = %for.cond
   br label %for.cond1
 
 for.cond1:                                        ; preds = %for.cond4, %if.then
-  br i1 undef, label %for.body, label %for.end6
+  br i1 false, label %for.body, label %for.end6
 
 for.body:                                         ; preds = %for.cond1
   br i1 false, label %if.then3, label %if.end

--- a/llvm/test/Transforms/LoopRotate/preserve-loop-simplify.ll
+++ b/llvm/test/Transforms/LoopRotate/preserve-loop-simplify.ll
@@ -4,7 +4,7 @@
 ; structures. We manually validate the CFG with FileCheck because currently we
 ; can't cause a failure when LoopSimplify fails to be preserved.
 
-define void @PR18643() {
+define void @PR18643(i1 %arg) {
 ; CHECK-LABEL: @PR18643(
 entry:
   br label %outer.header
@@ -12,7 +12,7 @@ entry:
 
 outer.header:
 ; CHECK: outer.header:
-  br i1 undef, label %inner.header, label %outer.body
+  br i1 %arg, label %inner.header, label %outer.body
 ; CHECK-NEXT: br i1 {{[^,]*}}, label %[[INNER_PREROTATE_PREHEADER:[^,]*]], label %outer.body
 
 ; CHECK: [[INNER_PREROTATE_PREHEADER]]:
@@ -24,13 +24,13 @@ outer.header:
 inner.header:
 ; Now the latch!
 ; CHECK: inner.header:
-  br i1 undef, label %return, label %inner.body
+  br i1 %arg, label %return, label %inner.body
 ; CHECK-NEXT: br i1 {{[^,]*}}, label %[[INNER_SPLIT_RETURN:[^,]*]], label %inner.body
 
 inner.body:
 ; Now the header!
 ; CHECK: inner.body:
-  br i1 undef, label %outer.latch, label %inner.latch
+  br i1 %arg, label %outer.latch, label %inner.latch
 ; CHECK-NEXT: br i1 {{[^,]*}}, label %[[INNER_SPLIT_OUTER_LATCH:[^,]*]], label %inner.header
 
 inner.latch:

--- a/llvm/test/Transforms/LoopRotate/preserve-mssa.ll
+++ b/llvm/test/Transforms/LoopRotate/preserve-mssa.ll
@@ -1,15 +1,15 @@
 ; RUN: opt -S -passes=loop-rotate -verify-memoryssa < %s | FileCheck %s
 
 ; CHECK-LABEL: @multiedge(
-define void @multiedge() {
+define void @multiedge(i1 %arg, i32 %arg2) {
 entry:
   br label %retry
 
 retry:                                            ; preds = %sw.epilog, %entry
-  br i1 undef, label %cleanup, label %if.end
+  br i1 %arg, label %cleanup, label %if.end
 
 if.end:                                           ; preds = %retry
-  switch i32 undef, label %sw.epilog [
+  switch i32 %arg2, label %sw.epilog [
     i32 -3, label %cleanup
     i32 -5, label %cleanup
     i32 -16, label %cleanup
@@ -24,14 +24,14 @@ cleanup:                                          ; preds = %if.end, %if.end, %i
 }
 
 ; CHECK-LABEL: @read_line(
-define internal fastcc i32 @read_line(ptr nocapture %f) unnamed_addr {
+define internal fastcc i32 @read_line(ptr nocapture %f, i1 %arg) unnamed_addr {
 entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %if.end, %entry
   %call = call ptr @prepbuffer(ptr nonnull undef)
   %call1 = call ptr @fgets(ptr %call, i32 8192, ptr %f)
-  br i1 undef, label %if.then, label %if.end
+  br i1 %arg, label %if.then, label %if.end
 
 if.then:                                          ; preds = %for.cond
   ret i32 undef
@@ -47,12 +47,12 @@ declare dso_local i64 @strlen(ptr nocapture) local_unnamed_addr
 
 
 ; CHECK-LABEL: @loop3
-define dso_local fastcc void @loop3() unnamed_addr {
+define dso_local fastcc void @loop3(i1 %arg) unnamed_addr {
 entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %for.body, %entry
-  br i1 undef, label %for.body, label %for.end81
+  br i1 %arg, label %for.body, label %for.end81
 
 for.body:                                         ; preds = %for.cond
   %.idx122.val = load i32, ptr undef, align 8
@@ -64,12 +64,12 @@ for.end81:                                        ; preds = %for.cond
 }
 
 ; CHECK-LABEL: @loop4
-define dso_local fastcc void @loop4() unnamed_addr {
+define dso_local fastcc void @loop4(i1 %arg) unnamed_addr {
 entry:
   br label %while.cond
 
 while.cond:                                       ; preds = %while.body, %entry
-  br i1 undef, label %while.end, label %while.body
+  br i1 %arg, label %while.end, label %while.body
 
 while.body:                                       ; preds = %while.cond
   call fastcc void @cont()
@@ -87,7 +87,7 @@ declare dso_local fastcc void @cont() unnamed_addr
 @glob_array = internal unnamed_addr constant [3 x i32] [i32 1, i32 0, i32 2], align 4
 ; Test against failure in MemorySSAUpdater, when rotate clones instructions as Value.
 ; CHECK-LABEL: @loop5
-define dso_local fastcc void @loop5() unnamed_addr {
+define dso_local fastcc void @loop5(i1 %arg) unnamed_addr {
 entry:
   br label %for.body
 
@@ -98,7 +98,7 @@ for.body:                               ; preds = %if.end, %entry
   %indvar = phi i64 [ %indvar.next, %if.end ], [ 0, %entry ]
   %array = getelementptr inbounds [3 x i32], ptr @glob_array, i64 0, i64 %indvar
   %0 = load i32, ptr %array, align 4
-  br i1 undef, label %do.cond, label %if.end
+  br i1 %arg, label %do.cond, label %if.end
 
 if.end:                                 ; preds = %for.body
   store i32 undef, ptr undef, align 4

--- a/llvm/test/Transforms/LoopSimplify/2010-07-15-IncorrectDomFrontierUpdate.ll
+++ b/llvm/test/Transforms/LoopSimplify/2010-07-15-IncorrectDomFrontierUpdate.ll
@@ -1,9 +1,9 @@
 ; RUN: opt < %s -passes='require<domfrontier>,loop-simplify,require<domfrontier>' -verify-dom-info
 
 
-define void @a() nounwind {
+define void @a(i1 %arg) nounwind {
 entry:
-  br i1 undef, label %bb37, label %bb1.i
+  br i1 %arg, label %bb37, label %bb1.i
 
 bb1.i:                                            ; preds = %bb1.i, %bb
   %indvar = phi i64 [ %indvar.next, %bb1.i ], [ 0, %entry ] ; <i64> [#uses=1]

--- a/llvm/test/Transforms/LoopSimplify/2010-12-26-PHIInfiniteLoop.ll
+++ b/llvm/test/Transforms/LoopSimplify/2010-12-26-PHIInfiniteLoop.ll
@@ -5,19 +5,19 @@ target triple = "x86_64-unknown-freebsd9.0"
 
 declare void @foo(i32 %x)
 
-define fastcc void @inm_merge() nounwind {
+define fastcc void @inm_merge(i1 %arg) nounwind {
 entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %while.cond36.i, %entry
-  br i1 undef, label %do.body, label %for.body
+  br i1 %arg, label %do.body, label %for.body
 
 for.body:                                         ; preds = %for.cond
-  br i1 undef, label %while.cond36.i, label %if.end44
+  br i1 %arg, label %while.cond36.i, label %if.end44
 
 if.end44:                                         ; preds = %for.body
   %call49 = call fastcc i32 @inm_get_source()
-  br i1 undef, label %if.end54, label %for.cond64
+  br i1 %arg, label %if.end54, label %for.cond64
 
 if.end54:                                         ; preds = %if.end44
   br label %while.cond36.i
@@ -28,10 +28,10 @@ while.cond36.i:                                   ; preds = %if.end54, %for.body
 for.cond64:                                       ; preds = %if.end88, %for.cond64, %if.end44
   %error.161 = phi i32 [ %error.161, %for.cond64 ], [ %error.161, %if.end88 ], [ %call49, %if.end44 ]
   call void @foo(i32 %error.161)
-  br i1 undef, label %for.cond64, label %if.end88
+  br i1 %arg, label %for.cond64, label %if.end88
 
 if.end88:                                         ; preds = %for.cond64
-  br i1 undef, label %for.cond64, label %if.end98
+  br i1 %arg, label %for.cond64, label %if.end98
 
 if.end98:                                         ; preds = %if.end88
   unreachable

--- a/llvm/test/Transforms/LoopSimplify/dup-preds.ll
+++ b/llvm/test/Transforms/LoopSimplify/dup-preds.ll
@@ -2,21 +2,21 @@
 target datalayout = "E-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-f128:128:128-v128:128:128-n32:64"
 target triple = "powerpc64le-unknown-linux"
 
-define fastcc void @do_update_md(ptr nocapture readonly %x) #0 {
+define fastcc void @do_update_md(ptr nocapture readonly %x, i1 %arg, i16 %arg2) #0 {
 entry:
-  br i1 undef, label %if.end365, label %lor.lhs.false134
+  br i1 %arg, label %if.end365, label %lor.lhs.false134
 
 lor.lhs.false134:                                 ; preds = %entry
-  br i1 undef, label %lor.lhs.false138, label %if.end365
+  br i1 %arg, label %lor.lhs.false138, label %if.end365
 
 lor.lhs.false138:                                 ; preds = %lor.lhs.false134
-  br i1 undef, label %lor.lhs.false142, label %if.end365
+  br i1 %arg, label %lor.lhs.false142, label %if.end365
 
 lor.lhs.false142:                                 ; preds = %lor.lhs.false138
-  br i1 undef, label %for.body276.lr.ph, label %if.end365
+  br i1 %arg, label %for.body276.lr.ph, label %if.end365
 
 for.body276.lr.ph:                                ; preds = %lor.lhs.false142
-  switch i16 undef, label %if.then288 [
+  switch i16 %arg2, label %if.then288 [
     i16 4, label %for.body344
     i16 2, label %for.body344
   ]

--- a/llvm/test/Transforms/LoopSimplify/indirectbr.ll
+++ b/llvm/test/Transforms/LoopSimplify/indirectbr.ll
@@ -82,15 +82,15 @@ L1:
   ret i64 %y
 }
 
-define void @pr5502() nounwind {
+define void @pr5502(ptr %arg, i1 %arg2) nounwind {
 entry:
   br label %while.cond
 
 while.cond:
-  br i1 undef, label %while.body, label %while.end
+  br i1 %arg2, label %while.body, label %while.end
 
 while.body:
-  indirectbr ptr undef, [label %end_opcode, label %end_opcode]
+  indirectbr ptr %arg, [label %end_opcode, label %end_opcode]
 
 end_opcode:
   br i1 false, label %end_opcode, label %while.cond

--- a/llvm/test/Transforms/LoopSimplify/notify-scev.ll
+++ b/llvm/test/Transforms/LoopSimplify/notify-scev.ll
@@ -17,12 +17,12 @@ target triple = "x86_64-apple-darwin"
 ; CHECK-LABEL: for.cond127.preheader:
 ; CHECK-NOT: for.cond127:
 ; CHECK-LABEL: for.body129:
-define void @t() {
+define void @t(i1 %arg) {
 entry:
   br label %for.body102
 
 for.body102:
-  br i1 undef, label %for.cond127.preheader, label %for.inc203
+  br i1 %arg, label %for.cond127.preheader, label %for.inc203
 
 for.cond127.preheader:
   br label %for.body129
@@ -34,10 +34,10 @@ for.cond127:
 for.body129:
   %uv.013 = phi i32 [ 0, %for.cond127.preheader ], [ %inc191, %for.cond127 ]
   %idxprom130 = sext i32 %uv.013 to i64
-  br i1 undef, label %for.cond135.preheader.lr.ph, label %for.end185
+  br i1 %arg, label %for.cond135.preheader.lr.ph, label %for.end185
 
 for.cond135.preheader.lr.ph:
-  br i1 undef, label %for.cond135.preheader.lr.ph.split.us, label %for.cond135.preheader.lr.ph.split_crit_edge
+  br i1 %arg, label %for.cond135.preheader.lr.ph.split.us, label %for.cond135.preheader.lr.ph.split_crit_edge
 
 for.cond135.preheader.lr.ph.split_crit_edge:
   br label %for.cond135.preheader.lr.ph.split
@@ -51,17 +51,17 @@ for.cond135.preheader.us:
 
 for.end178.us:
   %add184.us = add nsw i32 %block_y.09.us, 4
-  br i1 undef, label %for.end185split.us-lcssa.us, label %for.cond132.us
+  br i1 %arg, label %for.end185split.us-lcssa.us, label %for.cond132.us
 
 for.end174.us:
-  br i1 undef, label %for.cond138.preheader.us, label %for.cond135.for.end178_crit_edge.us
+  br i1 %arg, label %for.cond138.preheader.us, label %for.cond135.for.end178_crit_edge.us
 
 for.inc172.us:
-  br i1 undef, label %for.cond142.preheader.us, label %for.end174.us
+  br i1 %arg, label %for.cond142.preheader.us, label %for.end174.us
 
 for.body145.us:
   %arrayidx163.us = getelementptr inbounds %struct.Params, ptr undef, i64 0, i32 0, i64 %idxprom130, i64 %idxprom146.us
-  br i1 undef, label %for.body145.us, label %for.inc172.us
+  br i1 %arg, label %for.body145.us, label %for.inc172.us
 
 for.cond142.preheader.us:
   %j.04.us = phi i32 [ %block_y.09.us, %for.cond138.preheader.us ], [ undef, %for.inc172.us ]
@@ -72,7 +72,7 @@ for.cond138.preheader.us:
   br label %for.cond142.preheader.us
 
 for.cond132.us:
-  br i1 undef, label %for.cond135.preheader.us, label %for.cond132.for.end185_crit_edge.us-lcssa.us
+  br i1 %arg, label %for.cond135.preheader.us, label %for.cond132.for.end185_crit_edge.us-lcssa.us
 
 for.cond138.preheader.lr.ph.us:
   br label %for.cond138.preheader.us

--- a/llvm/test/Transforms/LoopSimplify/pr28272.ll
+++ b/llvm/test/Transforms/LoopSimplify/pr28272.ll
@@ -8,7 +8,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; after loop-simplify, we crash on assertion.
 
 ; CHECK-LABEL: @foo
-define void @foo() {
+define void @foo(i1 %arg) {
 entry:
   br label %header
 
@@ -37,7 +37,7 @@ bb54:
 }
 
 ; CHECK-LABEL: @foo2
-define void @foo2() {
+define void @foo2(i1 %arg) {
 entry:
   br label %outer
 
@@ -66,7 +66,7 @@ loop2.if:
                                        i32 1, label %bb]
 
 loop2.if.true:
-  br i1 undef, label %loop2, label %bb
+  br i1 %arg, label %loop2, label %bb
 
 loop2.if.false:
   br label %loop2
@@ -78,29 +78,29 @@ bb:
 ; When LoopSimplify separates nested loops, it might break LCSSA form: values
 ; from the original loop might be used in exit blocks of the outer loop.
 ; CHECK-LABEL: @foo3
-define void @foo3() {
+define void @foo3(i1 %arg) {
 entry:
   br label %bb1
 
 bb1:
-  br i1 undef, label %bb2, label %bb1
+  br i1 %arg, label %bb2, label %bb1
 
 bb2:
   %a = phi i32 [ undef, %bb1 ], [ %a, %bb3 ], [ undef, %bb5 ]
-  br i1 undef, label %bb3, label %bb1
+  br i1 %arg, label %bb3, label %bb1
 
 bb3:
   %b = load ptr, ptr undef
-  br i1 undef, label %bb2, label %bb4
+  br i1 %arg, label %bb2, label %bb4
 
 bb4:
-  br i1 undef, label %bb5, label %bb6
+  br i1 %arg, label %bb5, label %bb6
 
 bb5:
-  br i1 undef, label %bb2, label %bb4
+  br i1 %arg, label %bb2, label %bb4
 
 bb6:
-  br i1 undef, label %bb_end, label %bb1
+  br i1 %arg, label %bb_end, label %bb1
 
 bb_end:
   %x = getelementptr i32, ptr %b
@@ -112,7 +112,7 @@ bb_end:
 ; original loop (before separating it was a subloop of the original loop, and
 ; thus didn't require an lcssa phi nodes).
 ; CHECK-LABEL: @foo4
-define void @foo4() {
+define void @foo4(i1 %arg) {
 bb1:
   br label %bb2
 
@@ -126,7 +126,7 @@ bb2.loopexit:                                     ; preds = %bb3
 bb2:                                              ; preds = %bb2.loopexit, %bb2, %bb1
   %i = phi i32 [ 0, %bb1 ], [ %i, %bb2 ], [ %i.ph, %bb2.loopexit ]
   %x = load i32, ptr undef, align 8
-  br i1 undef, label %bb2, label %bb3.preheader
+  br i1 %arg, label %bb2, label %bb3.preheader
 
 ; CHECK: bb3.preheader:
 bb3.preheader:                                    ; preds = %bb2

--- a/llvm/test/Transforms/LoopSimplify/pr30454.ll
+++ b/llvm/test/Transforms/LoopSimplify/pr30454.ll
@@ -7,18 +7,18 @@ declare i8 @bar()
 
 ; Test that we preserve LCSSA form when removing edges from unreachable blocks.
 ; CHECK-LABEL: @foo
-define void @foo() {
+define void @foo(i1 %arg) {
 entry:
   br label %for.cond
 
 for.cond:
   %x = phi i8 [ undef, %entry ], [ %y, %for.latch ]
-  br i1 undef, label %for.latch, label %exit
+  br i1 %arg, label %for.latch, label %exit
 
 ; CHECK:      unreachable.bb:
 ; CHECK-NEXT:   unreachable
 unreachable.bb:
-  br i1 undef, label %exit, label %for.latch
+  br i1 %arg, label %exit, label %for.latch
 
 for.latch:
   %y = call i8 @bar()

--- a/llvm/test/Transforms/LoopSimplify/unreachable-loop-pred.ll
+++ b/llvm/test/Transforms/LoopSimplify/unreachable-loop-pred.ll
@@ -5,7 +5,7 @@
 ; block to the enclosing loop and not get confused by the unreachable
 ; bogus loop entry.
 
-define void @is_extract_cab() nounwind {
+define void @is_extract_cab(i1 %arg) nounwind {
 entry:
   br label %header
 
@@ -13,7 +13,7 @@ header:                                       ; preds = %if.end206, %cond.end66,
   br label %while.body115
 
 while.body115:                                    ; preds = %9, %if.end192, %if.end101
-  br i1 undef, label %header, label %while.body115
+  br i1 %arg, label %header, label %while.body115
 
 foo:
   br label %while.body115

--- a/llvm/test/Transforms/LoopSimplifyCFG/constant-fold-branch.ll
+++ b/llvm/test/Transforms/LoopSimplifyCFG/constant-fold-branch.ll
@@ -2580,12 +2580,12 @@ exit:
   ret i32 %result
 }
 
-define void @test_crash_01() {
+define void @test_crash_01(i1 %arg, i32 %arg2) {
 ; CHECK-LABEL: @test_crash_01(
 ; CHECK-NEXT:  bb:
 ; CHECK-NEXT:    br label [[BB1:%.*]]
 ; CHECK:       bb1:
-; CHECK-NEXT:    br i1 undef, label [[BB17:%.*]], label [[BB2:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[BB17:%.*]], label [[BB2:%.*]]
 ; CHECK:       bb2:
 ; CHECK-NEXT:    switch i32 0, label [[BB2_SPLIT:%.*]] [
 ; CHECK-NEXT:    i32 1, label [[BB19:%.*]]
@@ -2593,7 +2593,7 @@ define void @test_crash_01() {
 ; CHECK:       bb2.split:
 ; CHECK-NEXT:    br label [[BB3:%.*]]
 ; CHECK:       bb3:
-; CHECK-NEXT:    switch i32 undef, label [[BB16:%.*]] [
+; CHECK-NEXT:    switch i32 %arg2, label [[BB16:%.*]] [
 ; CHECK-NEXT:    i32 0, label [[BB15:%.*]]
 ; CHECK-NEXT:    i32 1, label [[BB14:%.*]]
 ; CHECK-NEXT:    i32 2, label [[BB13:%.*]]
@@ -2607,7 +2607,7 @@ define void @test_crash_01() {
 ; CHECK:       bb7:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       bb8:
-; CHECK-NEXT:    switch i32 undef, label [[BB28:%.*]] [
+; CHECK-NEXT:    switch i32 %arg2, label [[BB28:%.*]] [
 ; CHECK-NEXT:    i32 0, label [[BB27:%.*]]
 ; CHECK-NEXT:    i32 1, label [[BB26:%.*]]
 ; CHECK-NEXT:    i32 2, label [[BB23:%.*]]
@@ -2663,7 +2663,7 @@ bb:
   br label %bb1
 
 bb1:                                              ; preds = %bb
-  br i1 undef, label %bb17, label %bb2
+  br i1 %arg, label %bb17, label %bb2
 
 bb2:                                              ; preds = %bb1
   br label %bb3
@@ -2678,7 +2678,7 @@ bb4:                                              ; preds = %bb3
   ]
 
 bb5:                                              ; preds = %bb4
-  switch i32 undef, label %bb16 [
+  switch i32 %arg2, label %bb16 [
   i32 0, label %bb15
   i32 1, label %bb14
   i32 2, label %bb13
@@ -2697,7 +2697,7 @@ bb7:                                              ; preds = %bb5
   unreachable
 
 bb8:                                              ; preds = %bb11, %bb5
-  switch i32 undef, label %bb28 [
+  switch i32 %arg2, label %bb28 [
   i32 0, label %bb27
   i32 1, label %bb26
   i32 2, label %bb23

--- a/llvm/test/Transforms/LoopSimplifyCFG/update_parents.ll
+++ b/llvm/test/Transforms/LoopSimplifyCFG/update_parents.ll
@@ -37,10 +37,10 @@ bb3:                                              ; preds = %bb8, %bb3, %bb2
   br i1 false, label %bb4, label %bb3
 
 bb4:                                              ; preds = %bb8, %bb3
-  br i1 undef, label %bb1, label %bb6
+  br i1 true, label %bb1, label %bb6
 
 bb6:                                              ; preds = %bb4
-  br i1 undef, label %bb2, label %bb8
+  br i1 false, label %bb2, label %bb8
 
 bb8:                                              ; preds = %bb6
   br i1 true, label %bb4, label %bb3
@@ -78,7 +78,7 @@ bb3:
   br i1 false, label %bb4, label %bb3
 
 bb4:
-  br i1 undef, label %bb1, label %subloop1
+  br i1 %c, label %bb1, label %subloop1
 
 subloop1:
   br i1 %c, label %subloop2, label %subloop11
@@ -111,7 +111,7 @@ subloop2_latch:
   br label %subloop2
 
 bb6:
-  br i1 undef, label %bb2, label %bb8
+  br i1 %c, label %bb2, label %bb8
 
 bb8:
   br i1 true, label %bb4, label %bb3

--- a/llvm/test/Transforms/LoopStrengthReduce/2011-10-14-IntPtr.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/2011-10-14-IntPtr.ll
@@ -8,16 +8,16 @@ target triple = "x86_64-apple-darwin"
 ; CHECK-LABEL: @test(
 ; CHECK: phi
 ; CHECK-NOT: phi
-define void @test(i32 %rowStride) ssp align 2 {
+define void @test(i32 %rowStride, i1 %arg) ssp align 2 {
 entry:
-  %cond = select i1 undef, i32 %rowStride, i32 4
+  %cond = select i1 %arg, i32 %rowStride, i32 4
   br label %for.end
 
 for.end.critedge:                                 ; preds = %for.end
   br label %for.end
 
 for.end:                                          ; preds = %for.end.critedge, %entry
-  br i1 undef, label %for.body83, label %for.end.critedge
+  br i1 %arg, label %for.body83, label %for.end.critedge
 
 for.body83:                                       ; preds = %for.body83, %for.end
   %ptr.0157 = phi ptr [ %add.ptr96, %for.body83 ], [ null, %for.end ]

--- a/llvm/test/Transforms/LoopStrengthReduce/2011-12-19-PostincQuadratic.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/2011-12-19-PostincQuadratic.ll
@@ -39,7 +39,7 @@ for.body7:
   %bf.072 = phi i32 [ %t1, %for.body7 ], [ 0, %for.cond.preheader ]
   %t1 = add i32 %bf.072, %indvars.iv77
   %indvars.iv.next78 = add i32 %indvars.iv77, 1
-  br i1 undef, label %for.body43, label %for.body7
+  br i1 true, label %for.body43, label %for.body7
 
 for.body43:
   %bf.459 = phi i32 [ %inc44, %for.body43 ], [ %t1, %for.body7 ]

--- a/llvm/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/2013-01-14-ReuseCast.ll
@@ -15,23 +15,23 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 ; CHECK-NOT: = ptrtoint ptr undef to i64
 ; CHECK: .lr.ph
 ; CHECK: ret void
-define void @VerifyDiagnosticConsumerTest() unnamed_addr nounwind uwtable align 2 {
+define void @VerifyDiagnosticConsumerTest(i1 %arg) unnamed_addr nounwind uwtable align 2 {
 bb:
   %tmp3 = call ptr @getCharData() nounwind
   %tmp4 = call ptr @getCharData() nounwind
   %tmp5 = ptrtoint ptr %tmp4 to i64
   %tmp6 = ptrtoint ptr %tmp3 to i64
   %tmp7 = sub i64 %tmp5, %tmp6
-  br i1 undef, label %bb87, label %.preheader
+  br i1 false, label %bb87, label %.preheader
 
 .preheader:                                       ; preds = %bb10, %bb
-  br i1 undef, label %_ZNK4llvm9StringRef4findEcm.exit42.thread, label %bb10
+  br i1 false, label %_ZNK4llvm9StringRef4findEcm.exit42.thread, label %bb10
 
 bb10:                                             ; preds = %.preheader
-  br i1 undef, label %_ZNK4llvm9StringRef4findEcm.exit42, label %.preheader
+  br i1 true, label %_ZNK4llvm9StringRef4findEcm.exit42, label %.preheader
 
 _ZNK4llvm9StringRef4findEcm.exit42:               ; preds = %bb10
-  br i1 undef, label %_ZNK4llvm9StringRef4findEcm.exit42.thread, label %.lr.ph
+  br i1 false, label %_ZNK4llvm9StringRef4findEcm.exit42.thread, label %.lr.ph
 
 _ZNK4llvm9StringRef4findEcm.exit42.thread:        ; preds = %_ZNK4llvm9StringRef4findEcm.exit42, %.preheader
   unreachable
@@ -48,7 +48,7 @@ _ZNK4llvm9StringRef4findEcm.exit._crit_edge:      ; preds = %bb61, %_ZNK4llvm9St
 
 bb36:                                             ; preds = %_ZNK4llvm9StringRef4findEcm.exit.loopexit, %.lr.ph
   %loc.063 = phi i64 [ undef, %.lr.ph ], [ %i.0.i, %_ZNK4llvm9StringRef4findEcm.exit.loopexit ]
-  switch i8 undef, label %bb57 [
+  switch i8 10, label %bb57 [
     i8 10, label %bb48
     i8 13, label %bb48
   ]
@@ -73,7 +73,7 @@ bb63:                                             ; preds = %bb61
   %tmp64 = getelementptr inbounds i8, ptr %tmp3, i64 %i.0.i
   %tmp65 = load i8, ptr %tmp64, align 1
   %tmp67 = add i64 %i.0.i, 1
-  br i1 undef, label %_ZNK4llvm9StringRef4findEcm.exit.loopexit, label %bb61
+  br i1 %arg, label %_ZNK4llvm9StringRef4findEcm.exit.loopexit, label %bb61
 
 bb87:                                             ; preds = %bb
   ret void

--- a/llvm/test/Transforms/LoopStrengthReduce/AArch64/pr47329.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/AArch64/pr47329.ll
@@ -4,7 +4,7 @@ target triple = "aarch64-unknown-linux-gnu"
 
 @d = internal unnamed_addr global ptr null, align 8
 
-define dso_local i32 @main() local_unnamed_addr {
+define dso_local i32 @main(i1 %arg) local_unnamed_addr {
 entry:
   %.pre.pre = load ptr, ptr @d, align 8
   br label %for.body9
@@ -12,7 +12,7 @@ entry:
 for.body9:                                        ; preds = %for.body9, %entry
   %i = phi ptr [ %.pre.pre, %entry ], [ %incdec.ptr, %for.body9 ]
   %incdec.ptr = getelementptr inbounds ptr, ptr %i, i64 -1
-  br i1 undef, label %for.body9, label %for.inc
+  br i1 %arg, label %for.body9, label %for.inc
 
 for.inc:                                          ; preds = %for.body9
   br label %for.body9.118
@@ -20,7 +20,7 @@ for.inc:                                          ; preds = %for.body9
 for.body9.1:                                      ; preds = %for.inc.547, %for.body9.1
   %i1 = phi ptr [ %incdec.ptr.1, %for.body9.1 ], [ %incdec.ptr.542, %for.inc.547 ]
   %incdec.ptr.1 = getelementptr inbounds ptr, ptr %i1, i64 -1
-  br i1 undef, label %for.body9.1, label %for.inc.1
+  br i1 %arg, label %for.body9.1, label %for.inc.1
 
 for.inc.1:                                        ; preds = %for.body9.1
   br label %for.body9.1.1
@@ -28,7 +28,7 @@ for.inc.1:                                        ; preds = %for.body9.1
 for.body9.2:                                      ; preds = %for.inc.1.5, %for.body9.2
   %i2 = phi ptr [ %incdec.ptr.2, %for.body9.2 ], [ %incdec.ptr.1.5, %for.inc.1.5 ]
   %incdec.ptr.2 = getelementptr inbounds ptr, ptr %i2, i64 -1
-  br i1 undef, label %for.body9.2, label %for.inc.2
+  br i1 %arg, label %for.body9.2, label %for.inc.2
 
 for.inc.2:                                        ; preds = %for.body9.2
   br label %for.body9.2.1
@@ -36,7 +36,7 @@ for.inc.2:                                        ; preds = %for.body9.2
 for.body9.3:                                      ; preds = %for.inc.2.5, %for.body9.3
   %i3 = phi ptr [ %incdec.ptr.3, %for.body9.3 ], [ %incdec.ptr.2.5, %for.inc.2.5 ]
   %incdec.ptr.3 = getelementptr inbounds ptr, ptr %i3, i64 -1
-  br i1 undef, label %for.body9.3, label %for.inc.3
+  br i1 %arg, label %for.body9.3, label %for.inc.3
 
 for.inc.3:                                        ; preds = %for.body9.3
   br label %for.body9.3.1
@@ -44,7 +44,7 @@ for.inc.3:                                        ; preds = %for.body9.3
 for.body9.4:                                      ; preds = %for.inc.3.5, %for.body9.4
   %i4 = phi ptr [ %incdec.ptr.4, %for.body9.4 ], [ %incdec.ptr.3.5, %for.inc.3.5 ]
   %incdec.ptr.4 = getelementptr inbounds ptr, ptr %i4, i64 -1
-  br i1 undef, label %for.body9.4, label %for.inc.4
+  br i1 %arg, label %for.body9.4, label %for.inc.4
 
 for.inc.4:                                        ; preds = %for.body9.4
   br label %for.body9.4.1
@@ -52,7 +52,7 @@ for.inc.4:                                        ; preds = %for.body9.4
 for.body9.5:                                      ; preds = %for.inc.4.5, %for.body9.5
   %i5 = phi ptr [ %incdec.ptr.5, %for.body9.5 ], [ %incdec.ptr.4.5, %for.inc.4.5 ]
   %incdec.ptr.5 = getelementptr inbounds ptr, ptr %i5, i64 -1
-  br i1 undef, label %for.body9.5, label %for.inc.5
+  br i1 %arg, label %for.body9.5, label %for.inc.5
 
 for.inc.5:                                        ; preds = %for.body9.5
   br label %for.body9.5.1
@@ -60,7 +60,7 @@ for.inc.5:                                        ; preds = %for.body9.5
 for.body9.5.1:                                    ; preds = %for.body9.5.1, %for.inc.5
   %i6 = phi ptr [ %incdec.ptr.5.1, %for.body9.5.1 ], [ %incdec.ptr.5, %for.inc.5 ]
   %incdec.ptr.5.1 = getelementptr inbounds ptr, ptr %i6, i64 -1
-  br i1 undef, label %for.body9.5.1, label %for.inc.5.1
+  br i1 %arg, label %for.body9.5.1, label %for.inc.5.1
 
 for.inc.5.1:                                      ; preds = %for.body9.5.1
   br label %for.body9.5.2
@@ -68,7 +68,7 @@ for.inc.5.1:                                      ; preds = %for.body9.5.1
 for.body9.5.2:                                    ; preds = %for.body9.5.2, %for.inc.5.1
   %i7 = phi ptr [ %incdec.ptr.5.2, %for.body9.5.2 ], [ %incdec.ptr.5.1, %for.inc.5.1 ]
   %incdec.ptr.5.2 = getelementptr inbounds ptr, ptr %i7, i64 -1
-  br i1 undef, label %for.body9.5.2, label %for.inc.5.2
+  br i1 %arg, label %for.body9.5.2, label %for.inc.5.2
 
 for.inc.5.2:                                      ; preds = %for.body9.5.2
   br label %for.body9.5.3
@@ -76,7 +76,7 @@ for.inc.5.2:                                      ; preds = %for.body9.5.2
 for.body9.5.3:                                    ; preds = %for.body9.5.3, %for.inc.5.2
   %i8 = phi ptr [ %incdec.ptr.5.3, %for.body9.5.3 ], [ %incdec.ptr.5.2, %for.inc.5.2 ]
   %incdec.ptr.5.3 = getelementptr inbounds ptr, ptr %i8, i64 -1
-  br i1 undef, label %for.body9.5.3, label %for.inc.5.3
+  br i1 %arg, label %for.body9.5.3, label %for.inc.5.3
 
 for.inc.5.3:                                      ; preds = %for.body9.5.3
   br label %for.body9.5.4
@@ -84,7 +84,7 @@ for.inc.5.3:                                      ; preds = %for.body9.5.3
 for.body9.5.4:                                    ; preds = %for.body9.5.4, %for.inc.5.3
   %i9 = phi ptr [ %incdec.ptr.5.4, %for.body9.5.4 ], [ %incdec.ptr.5.3, %for.inc.5.3 ]
   %incdec.ptr.5.4 = getelementptr inbounds ptr, ptr %i9, i64 -1
-  br i1 undef, label %for.body9.5.4, label %for.inc.5.4
+  br i1 %arg, label %for.body9.5.4, label %for.inc.5.4
 
 for.inc.5.4:                                      ; preds = %for.body9.5.4
   br label %for.body9.5.5
@@ -97,7 +97,7 @@ for.body9.5.5:                                    ; preds = %for.body9.5.5, %for
 for.body9.4.1:                                    ; preds = %for.body9.4.1, %for.inc.4
   %i13 = phi ptr [ %incdec.ptr.4.1, %for.body9.4.1 ], [ %incdec.ptr.4, %for.inc.4 ]
   %incdec.ptr.4.1 = getelementptr inbounds ptr, ptr %i13, i64 -1
-  br i1 undef, label %for.body9.4.1, label %for.inc.4.1
+  br i1 %arg, label %for.body9.4.1, label %for.inc.4.1
 
 for.inc.4.1:                                      ; preds = %for.body9.4.1
   br label %for.body9.4.2
@@ -105,7 +105,7 @@ for.inc.4.1:                                      ; preds = %for.body9.4.1
 for.body9.4.2:                                    ; preds = %for.body9.4.2, %for.inc.4.1
   %i14 = phi ptr [ %incdec.ptr.4.2, %for.body9.4.2 ], [ %incdec.ptr.4.1, %for.inc.4.1 ]
   %incdec.ptr.4.2 = getelementptr inbounds ptr, ptr %i14, i64 -1
-  br i1 undef, label %for.body9.4.2, label %for.inc.4.2
+  br i1 %arg, label %for.body9.4.2, label %for.inc.4.2
 
 for.inc.4.2:                                      ; preds = %for.body9.4.2
   br label %for.body9.4.3
@@ -113,7 +113,7 @@ for.inc.4.2:                                      ; preds = %for.body9.4.2
 for.body9.4.3:                                    ; preds = %for.body9.4.3, %for.inc.4.2
   %i15 = phi ptr [ %incdec.ptr.4.3, %for.body9.4.3 ], [ %incdec.ptr.4.2, %for.inc.4.2 ]
   %incdec.ptr.4.3 = getelementptr inbounds ptr, ptr %i15, i64 -1
-  br i1 undef, label %for.body9.4.3, label %for.inc.4.3
+  br i1 %arg, label %for.body9.4.3, label %for.inc.4.3
 
 for.inc.4.3:                                      ; preds = %for.body9.4.3
   br label %for.body9.4.4
@@ -121,7 +121,7 @@ for.inc.4.3:                                      ; preds = %for.body9.4.3
 for.body9.4.4:                                    ; preds = %for.body9.4.4, %for.inc.4.3
   %i16 = phi ptr [ %incdec.ptr.4.4, %for.body9.4.4 ], [ %incdec.ptr.4.3, %for.inc.4.3 ]
   %incdec.ptr.4.4 = getelementptr inbounds ptr, ptr %i16, i64 -1
-  br i1 undef, label %for.body9.4.4, label %for.inc.4.4
+  br i1 %arg, label %for.body9.4.4, label %for.inc.4.4
 
 for.inc.4.4:                                      ; preds = %for.body9.4.4
   br label %for.body9.4.5
@@ -129,7 +129,7 @@ for.inc.4.4:                                      ; preds = %for.body9.4.4
 for.body9.4.5:                                    ; preds = %for.body9.4.5, %for.inc.4.4
   %i17 = phi ptr [ %incdec.ptr.4.5, %for.body9.4.5 ], [ %incdec.ptr.4.4, %for.inc.4.4 ]
   %incdec.ptr.4.5 = getelementptr inbounds ptr, ptr %i17, i64 -1
-  br i1 undef, label %for.body9.4.5, label %for.inc.4.5
+  br i1 %arg, label %for.body9.4.5, label %for.inc.4.5
 
 for.inc.4.5:                                      ; preds = %for.body9.4.5
   br label %for.body9.5
@@ -137,7 +137,7 @@ for.inc.4.5:                                      ; preds = %for.body9.4.5
 for.body9.3.1:                                    ; preds = %for.body9.3.1, %for.inc.3
   %i18 = phi ptr [ %incdec.ptr.3.1, %for.body9.3.1 ], [ %incdec.ptr.3, %for.inc.3 ]
   %incdec.ptr.3.1 = getelementptr inbounds ptr, ptr %i18, i64 -1
-  br i1 undef, label %for.body9.3.1, label %for.inc.3.1
+  br i1 %arg, label %for.body9.3.1, label %for.inc.3.1
 
 for.inc.3.1:                                      ; preds = %for.body9.3.1
   br label %for.body9.3.2
@@ -145,7 +145,7 @@ for.inc.3.1:                                      ; preds = %for.body9.3.1
 for.body9.3.2:                                    ; preds = %for.body9.3.2, %for.inc.3.1
   %i19 = phi ptr [ %incdec.ptr.3.2, %for.body9.3.2 ], [ %incdec.ptr.3.1, %for.inc.3.1 ]
   %incdec.ptr.3.2 = getelementptr inbounds ptr, ptr %i19, i64 -1
-  br i1 undef, label %for.body9.3.2, label %for.inc.3.2
+  br i1 %arg, label %for.body9.3.2, label %for.inc.3.2
 
 for.inc.3.2:                                      ; preds = %for.body9.3.2
   br label %for.body9.3.3
@@ -153,7 +153,7 @@ for.inc.3.2:                                      ; preds = %for.body9.3.2
 for.body9.3.3:                                    ; preds = %for.body9.3.3, %for.inc.3.2
   %i20 = phi ptr [ %incdec.ptr.3.3, %for.body9.3.3 ], [ %incdec.ptr.3.2, %for.inc.3.2 ]
   %incdec.ptr.3.3 = getelementptr inbounds ptr, ptr %i20, i64 -1
-  br i1 undef, label %for.body9.3.3, label %for.inc.3.3
+  br i1 %arg, label %for.body9.3.3, label %for.inc.3.3
 
 for.inc.3.3:                                      ; preds = %for.body9.3.3
   br label %for.body9.3.4
@@ -161,7 +161,7 @@ for.inc.3.3:                                      ; preds = %for.body9.3.3
 for.body9.3.4:                                    ; preds = %for.body9.3.4, %for.inc.3.3
   %i21 = phi ptr [ %incdec.ptr.3.4, %for.body9.3.4 ], [ %incdec.ptr.3.3, %for.inc.3.3 ]
   %incdec.ptr.3.4 = getelementptr inbounds ptr, ptr %i21, i64 -1
-  br i1 undef, label %for.body9.3.4, label %for.inc.3.4
+  br i1 %arg, label %for.body9.3.4, label %for.inc.3.4
 
 for.inc.3.4:                                      ; preds = %for.body9.3.4
   br label %for.body9.3.5
@@ -169,7 +169,7 @@ for.inc.3.4:                                      ; preds = %for.body9.3.4
 for.body9.3.5:                                    ; preds = %for.body9.3.5, %for.inc.3.4
   %i22 = phi ptr [ %incdec.ptr.3.5, %for.body9.3.5 ], [ %incdec.ptr.3.4, %for.inc.3.4 ]
   %incdec.ptr.3.5 = getelementptr inbounds ptr, ptr %i22, i64 -1
-  br i1 undef, label %for.body9.3.5, label %for.inc.3.5
+  br i1 %arg, label %for.body9.3.5, label %for.inc.3.5
 
 for.inc.3.5:                                      ; preds = %for.body9.3.5
   br label %for.body9.4
@@ -177,7 +177,7 @@ for.inc.3.5:                                      ; preds = %for.body9.3.5
 for.body9.2.1:                                    ; preds = %for.body9.2.1, %for.inc.2
   %i23 = phi ptr [ %incdec.ptr.2.1, %for.body9.2.1 ], [ %incdec.ptr.2, %for.inc.2 ]
   %incdec.ptr.2.1 = getelementptr inbounds ptr, ptr %i23, i64 -1
-  br i1 undef, label %for.body9.2.1, label %for.inc.2.1
+  br i1 %arg, label %for.body9.2.1, label %for.inc.2.1
 
 for.inc.2.1:                                      ; preds = %for.body9.2.1
   br label %for.body9.2.2
@@ -185,7 +185,7 @@ for.inc.2.1:                                      ; preds = %for.body9.2.1
 for.body9.2.2:                                    ; preds = %for.body9.2.2, %for.inc.2.1
   %i24 = phi ptr [ %incdec.ptr.2.2, %for.body9.2.2 ], [ %incdec.ptr.2.1, %for.inc.2.1 ]
   %incdec.ptr.2.2 = getelementptr inbounds ptr, ptr %i24, i64 -1
-  br i1 undef, label %for.body9.2.2, label %for.inc.2.2
+  br i1 %arg, label %for.body9.2.2, label %for.inc.2.2
 
 for.inc.2.2:                                      ; preds = %for.body9.2.2
   br label %for.body9.2.3
@@ -193,7 +193,7 @@ for.inc.2.2:                                      ; preds = %for.body9.2.2
 for.body9.2.3:                                    ; preds = %for.body9.2.3, %for.inc.2.2
   %i25 = phi ptr [ %incdec.ptr.2.3, %for.body9.2.3 ], [ %incdec.ptr.2.2, %for.inc.2.2 ]
   %incdec.ptr.2.3 = getelementptr inbounds ptr, ptr %i25, i64 -1
-  br i1 undef, label %for.body9.2.3, label %for.inc.2.3
+  br i1 %arg, label %for.body9.2.3, label %for.inc.2.3
 
 for.inc.2.3:                                      ; preds = %for.body9.2.3
   br label %for.body9.2.4
@@ -201,7 +201,7 @@ for.inc.2.3:                                      ; preds = %for.body9.2.3
 for.body9.2.4:                                    ; preds = %for.body9.2.4, %for.inc.2.3
   %i26 = phi ptr [ %incdec.ptr.2.4, %for.body9.2.4 ], [ %incdec.ptr.2.3, %for.inc.2.3 ]
   %incdec.ptr.2.4 = getelementptr inbounds ptr, ptr %i26, i64 -1
-  br i1 undef, label %for.body9.2.4, label %for.inc.2.4
+  br i1 %arg, label %for.body9.2.4, label %for.inc.2.4
 
 for.inc.2.4:                                      ; preds = %for.body9.2.4
   br label %for.body9.2.5
@@ -209,7 +209,7 @@ for.inc.2.4:                                      ; preds = %for.body9.2.4
 for.body9.2.5:                                    ; preds = %for.body9.2.5, %for.inc.2.4
   %i27 = phi ptr [ %incdec.ptr.2.5, %for.body9.2.5 ], [ %incdec.ptr.2.4, %for.inc.2.4 ]
   %incdec.ptr.2.5 = getelementptr inbounds ptr, ptr %i27, i64 -1
-  br i1 undef, label %for.body9.2.5, label %for.inc.2.5
+  br i1 %arg, label %for.body9.2.5, label %for.inc.2.5
 
 for.inc.2.5:                                      ; preds = %for.body9.2.5
   br label %for.body9.3
@@ -217,7 +217,7 @@ for.inc.2.5:                                      ; preds = %for.body9.2.5
 for.body9.1.1:                                    ; preds = %for.body9.1.1, %for.inc.1
   %i28 = phi ptr [ %incdec.ptr.1.1, %for.body9.1.1 ], [ %incdec.ptr.1, %for.inc.1 ]
   %incdec.ptr.1.1 = getelementptr inbounds ptr, ptr %i28, i64 -1
-  br i1 undef, label %for.body9.1.1, label %for.inc.1.1
+  br i1 %arg, label %for.body9.1.1, label %for.inc.1.1
 
 for.inc.1.1:                                      ; preds = %for.body9.1.1
   br label %for.body9.1.2
@@ -225,7 +225,7 @@ for.inc.1.1:                                      ; preds = %for.body9.1.1
 for.body9.1.2:                                    ; preds = %for.body9.1.2, %for.inc.1.1
   %i29 = phi ptr [ %incdec.ptr.1.2, %for.body9.1.2 ], [ %incdec.ptr.1.1, %for.inc.1.1 ]
   %incdec.ptr.1.2 = getelementptr inbounds ptr, ptr %i29, i64 -1
-  br i1 undef, label %for.body9.1.2, label %for.inc.1.2
+  br i1 %arg, label %for.body9.1.2, label %for.inc.1.2
 
 for.inc.1.2:                                      ; preds = %for.body9.1.2
   br label %for.body9.1.3
@@ -233,7 +233,7 @@ for.inc.1.2:                                      ; preds = %for.body9.1.2
 for.body9.1.3:                                    ; preds = %for.body9.1.3, %for.inc.1.2
   %i30 = phi ptr [ %incdec.ptr.1.3, %for.body9.1.3 ], [ %incdec.ptr.1.2, %for.inc.1.2 ]
   %incdec.ptr.1.3 = getelementptr inbounds ptr, ptr %i30, i64 -1
-  br i1 undef, label %for.body9.1.3, label %for.inc.1.3
+  br i1 %arg, label %for.body9.1.3, label %for.inc.1.3
 
 for.inc.1.3:                                      ; preds = %for.body9.1.3
   br label %for.body9.1.4
@@ -241,7 +241,7 @@ for.inc.1.3:                                      ; preds = %for.body9.1.3
 for.body9.1.4:                                    ; preds = %for.body9.1.4, %for.inc.1.3
   %i31 = phi ptr [ %incdec.ptr.1.4, %for.body9.1.4 ], [ %incdec.ptr.1.3, %for.inc.1.3 ]
   %incdec.ptr.1.4 = getelementptr inbounds ptr, ptr %i31, i64 -1
-  br i1 undef, label %for.body9.1.4, label %for.inc.1.4
+  br i1 %arg, label %for.body9.1.4, label %for.inc.1.4
 
 for.inc.1.4:                                      ; preds = %for.body9.1.4
   br label %for.body9.1.5
@@ -249,7 +249,7 @@ for.inc.1.4:                                      ; preds = %for.body9.1.4
 for.body9.1.5:                                    ; preds = %for.body9.1.5, %for.inc.1.4
   %i32 = phi ptr [ %incdec.ptr.1.5, %for.body9.1.5 ], [ %incdec.ptr.1.4, %for.inc.1.4 ]
   %incdec.ptr.1.5 = getelementptr inbounds ptr, ptr %i32, i64 -1
-  br i1 undef, label %for.body9.1.5, label %for.inc.1.5
+  br i1 %arg, label %for.body9.1.5, label %for.inc.1.5
 
 for.inc.1.5:                                      ; preds = %for.body9.1.5
   br label %for.body9.2
@@ -257,7 +257,7 @@ for.inc.1.5:                                      ; preds = %for.body9.1.5
 for.body9.118:                                    ; preds = %for.body9.118, %for.inc
   %i33 = phi ptr [ %incdec.ptr, %for.inc ], [ %incdec.ptr.114, %for.body9.118 ]
   %incdec.ptr.114 = getelementptr inbounds ptr, ptr %i33, i64 -1
-  br i1 undef, label %for.body9.118, label %for.inc.119
+  br i1 %arg, label %for.body9.118, label %for.inc.119
 
 for.inc.119:                                      ; preds = %for.body9.118
   br label %for.body9.225
@@ -266,7 +266,7 @@ for.body9.225:                                    ; preds = %for.body9.225, %for
   %i34 = phi ptr [ %incdec.ptr.114, %for.inc.119 ], [ %incdec.ptr.221, %for.body9.225 ]
   %incdec.ptr.221 = getelementptr inbounds ptr, ptr %i34, i64 -1
   %i36 = load i64, ptr %i34, align 8
-  br i1 undef, label %for.body9.225, label %for.inc.226
+  br i1 %arg, label %for.body9.225, label %for.inc.226
 
 for.inc.226:                                      ; preds = %for.body9.225
   br label %for.body9.332
@@ -274,7 +274,7 @@ for.inc.226:                                      ; preds = %for.body9.225
 for.body9.332:                                    ; preds = %for.body9.332, %for.inc.226
   %i37 = phi ptr [ %incdec.ptr.221, %for.inc.226 ], [ %incdec.ptr.328, %for.body9.332 ]
   %incdec.ptr.328 = getelementptr inbounds ptr, ptr %i37, i64 -1
-  br i1 undef, label %for.body9.332, label %for.inc.333
+  br i1 %arg, label %for.body9.332, label %for.inc.333
 
 for.inc.333:                                      ; preds = %for.body9.332
   br label %for.body9.439
@@ -282,7 +282,7 @@ for.inc.333:                                      ; preds = %for.body9.332
 for.body9.439:                                    ; preds = %for.body9.439, %for.inc.333
   %i38 = phi ptr [ %incdec.ptr.328, %for.inc.333 ], [ %incdec.ptr.435, %for.body9.439 ]
   %incdec.ptr.435 = getelementptr inbounds ptr, ptr %i38, i64 -1
-  br i1 undef, label %for.body9.439, label %for.inc.440
+  br i1 %arg, label %for.body9.439, label %for.inc.440
 
 for.inc.440:                                      ; preds = %for.body9.439
   br label %for.body9.546
@@ -290,7 +290,7 @@ for.inc.440:                                      ; preds = %for.body9.439
 for.body9.546:                                    ; preds = %for.body9.546, %for.inc.440
   %i39 = phi ptr [ %incdec.ptr.435, %for.inc.440 ], [ %incdec.ptr.542, %for.body9.546 ]
   %incdec.ptr.542 = getelementptr inbounds ptr, ptr %i39, i64 -1
-  br i1 undef, label %for.body9.546, label %for.inc.547
+  br i1 %arg, label %for.body9.546, label %for.inc.547
 
 for.inc.547:                                      ; preds = %for.body9.546
   br label %for.body9.1

--- a/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/lsr-invalid-ptr-extend.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/lsr-invalid-ptr-extend.ll
@@ -59,10 +59,10 @@ for.body:
   br i1 false, label %loopexit, label %for.body
 }
 
-define protected amdgpu_kernel void @baseregtest(i32 %n, i32 %lda) local_unnamed_addr {
+define protected amdgpu_kernel void @baseregtest(i32 %n, i32 %lda, i1 %arg) local_unnamed_addr {
 ; CHECK-LABEL: @baseregtest(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br i1 undef, label [[EXIT:%.*]], label [[IF_END:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[EXIT:%.*]], label [[IF_END:%.*]]
 ; CHECK:       if.end:
 ; CHECK-NEXT:    [[TMP0:%.*]] = tail call i32 @foo()
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl i32 [[TMP0]], 3
@@ -86,7 +86,7 @@ define protected amdgpu_kernel void @baseregtest(i32 %n, i32 %lda) local_unnamed
 ; CHECK-NEXT:    ret void
 ;
 entry:
-  br i1 undef, label %exit, label %if.end
+  br i1 %arg, label %exit, label %if.end
 
 if.end:
   %0 = tail call i32 @foo()

--- a/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/lsr-void-inseltpoison.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/lsr-void-inseltpoison.ll
@@ -3,7 +3,7 @@
 @array = external addrspace(4) constant [32 x [800 x i32]], align 4
 
 ; GCN-LABEL: {{^}}test_lsr_voidty:
-define amdgpu_kernel void @test_lsr_voidty() {
+define amdgpu_kernel void @test_lsr_voidty(i1 %arg) {
 entry:
   br label %for.body
 
@@ -32,5 +32,5 @@ for.body.i:                               ; preds = %for.body.i, %for.body
   %reorder_shuffle2 = shufflevector <4 x i32> %tmp5, <4 x i32> poison, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
   %tmp6 = select <4 x i1> undef, <4 x i32> zeroinitializer, <4 x i32> %reorder_shuffle2
   %inc14 = add nuw nsw i32 %ij, 4
-  br i1 undef, label %for.body, label %for.body.i
+  br i1 %arg, label %for.body, label %for.body.i
 }

--- a/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/lsr-void.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/lsr-void.ll
@@ -3,7 +3,7 @@
 @array = external addrspace(4) constant [32 x [800 x i32]], align 4
 
 ; GCN-LABEL: {{^}}test_lsr_voidty:
-define amdgpu_kernel void @test_lsr_voidty() {
+define amdgpu_kernel void @test_lsr_voidty(i1 %arg) {
 entry:
   br label %for.body
 
@@ -32,5 +32,5 @@ for.body.i:                               ; preds = %for.body.i, %for.body
   %reorder_shuffle2 = shufflevector <4 x i32> %tmp5, <4 x i32> undef, <4 x i32> <i32 3, i32 2, i32 1, i32 0>
   %tmp6 = select <4 x i1> undef, <4 x i32> zeroinitializer, <4 x i32> %reorder_shuffle2
   %inc14 = add nuw nsw i32 %ij, 4
-  br i1 undef, label %for.body, label %for.body.i
+  br i1 %arg, label %for.body, label %for.body.i
 }

--- a/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/preserve-addrspace-assert.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/AMDGPU/preserve-addrspace-assert.ll
@@ -48,7 +48,7 @@ bb1:                                              ; preds = %bb17, %bb
   br label %bb4
 
 bb4:                                              ; preds = %bb1
-  br i1 undef, label %bb8, label %bb5
+  br i1 false, label %bb8, label %bb5
 
 bb5:                                              ; preds = %bb4
   unreachable

--- a/llvm/test/Transforms/LoopStrengthReduce/ARM/addrec-is-loop-invariant.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/ARM/addrec-is-loop-invariant.ll
@@ -4,14 +4,14 @@
 ; not create an Add Reccurence Expression if not all
 ; its operands are loop invariants.
 
-define void @add_rec_expr() {
+define void @add_rec_expr(i1 %arg) {
 entry:
   br label %loop0
 
 loop0:
   %c.0 = phi i32 [ 0, %entry ], [ %inc.0, %loop0 ]
   %inc.0 = add nuw i32 %c.0, 1
-  br i1 undef, label %loop0, label %bb1
+  br i1 %arg, label %loop0, label %bb1
 
 bb1:
   %mul.0 = mul i32 %c.0, %c.0

--- a/llvm/test/Transforms/LoopStrengthReduce/Power/incomplete-phi.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/Power/incomplete-phi.ll
@@ -58,7 +58,7 @@ bb:
 bb3:                                              ; preds = %bb18, %bb
   %i4 = phi i64 [ %i20, %bb18 ], [ 0, %bb ]
   %i5 = phi i64 [ %i21, %bb18 ], [ 1, %bb ]
-  br i1 undef, label %bb22, label %bb9
+  br i1 true, label %bb22, label %bb9
 
 bb9:                                              ; preds = %bb9, %bb3
   %i10 = phi i64 [ 0, %bb3 ], [ %i16, %bb9 ]
@@ -70,7 +70,7 @@ bb9:                                              ; preds = %bb9, %bb3
   br i1 true, label %bb17, label %bb9
 
 bb17:                                             ; preds = %bb9
-  br i1 undef, label %bb18, label %bb22
+  br i1 false, label %bb18, label %bb22
 
 bb18:                                             ; preds = %bb17
   %i19 = add i64 undef, %i4

--- a/llvm/test/Transforms/LoopStrengthReduce/X86/2009-11-10-LSRCrash.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/X86/2009-11-10-LSRCrash.ll
@@ -1,35 +1,35 @@
 ; RUN: llc < %s -mtriple=i386-apple-darwin11
 
-define void @_ZN4llvm20SelectionDAGLowering14visitInlineAsmENS_8CallSiteE() nounwind ssp align 2 {
+define void @_ZN4llvm20SelectionDAGLowering14visitInlineAsmENS_8CallSiteE(i1 %arg) nounwind ssp align 2 {
 entry:
-  br i1 undef, label %bb3.i, label %bb4.i
+  br i1 %arg, label %bb3.i, label %bb4.i
 
 bb3.i:                                            ; preds = %entry
   unreachable
 
 bb4.i:                                            ; preds = %entry
-  br i1 undef, label %bb.i.i, label %_ZNK4llvm8CallSite14getCalledValueEv.exit
+  br i1 %arg, label %bb.i.i, label %_ZNK4llvm8CallSite14getCalledValueEv.exit
 
 bb.i.i:                                           ; preds = %bb4.i
   unreachable
 
 _ZNK4llvm8CallSite14getCalledValueEv.exit:        ; preds = %bb4.i
-  br i1 undef, label %_ZN4llvm4castINS_9InlineAsmEPNS_5ValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS6_.exit, label %bb6.i
+  br i1 %arg, label %_ZN4llvm4castINS_9InlineAsmEPNS_5ValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS6_.exit, label %bb6.i
 
 bb6.i:                                            ; preds = %_ZNK4llvm8CallSite14getCalledValueEv.exit
   unreachable
 
 _ZN4llvm4castINS_9InlineAsmEPNS_5ValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS6_.exit: ; preds = %_ZNK4llvm8CallSite14getCalledValueEv.exit
-  br i1 undef, label %_ZL25hasInlineAsmMemConstraintRSt6vectorIN4llvm9InlineAsm14ConstraintInfoESaIS2_EERKNS0_14TargetLoweringE.exit, label %bb.i
+  br i1 %arg, label %_ZL25hasInlineAsmMemConstraintRSt6vectorIN4llvm9InlineAsm14ConstraintInfoESaIS2_EERKNS0_14TargetLoweringE.exit, label %bb.i
 
 bb.i:                                             ; preds = %_ZN4llvm4castINS_9InlineAsmEPNS_5ValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS6_.exit
   br label %_ZL25hasInlineAsmMemConstraintRSt6vectorIN4llvm9InlineAsm14ConstraintInfoESaIS2_EERKNS0_14TargetLoweringE.exit
 
 _ZL25hasInlineAsmMemConstraintRSt6vectorIN4llvm9InlineAsm14ConstraintInfoESaIS2_EERKNS0_14TargetLoweringE.exit: ; preds = %bb.i, %_ZN4llvm4castINS_9InlineAsmEPNS_5ValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS6_.exit
-  br i1 undef, label %bb50, label %bb27
+  br i1 %arg, label %bb50, label %bb27
 
 bb27:                                             ; preds = %_ZL25hasInlineAsmMemConstraintRSt6vectorIN4llvm9InlineAsm14ConstraintInfoESaIS2_EERKNS0_14TargetLoweringE.exit
-  br i1 undef, label %bb1.i727, label %bb.i.i726
+  br i1 %arg, label %bb1.i727, label %bb.i.i726
 
 bb.i.i726:                                        ; preds = %bb27
   unreachable
@@ -41,7 +41,7 @@ bb50:                                             ; preds = %_ZL25hasInlineAsmMe
   br label %bb107
 
 bb51:                                             ; preds = %bb107
-  br i1 undef, label %bb105, label %bb106
+  br i1 %arg, label %bb105, label %bb106
 
 bb105:                                            ; preds = %bb51
   unreachable
@@ -50,16 +50,16 @@ bb106:                                            ; preds = %bb51
   br label %bb107
 
 bb107:                                            ; preds = %bb106, %bb50
-  br i1 undef, label %bb108, label %bb51
+  br i1 %arg, label %bb108, label %bb51
 
 bb108:                                            ; preds = %bb107
-  br i1 undef, label %bb242, label %bb114
+  br i1 %arg, label %bb242, label %bb114
 
 bb114:                                            ; preds = %bb108
-  br i1 undef, label %bb141, label %bb116
+  br i1 %arg, label %bb141, label %bb116
 
 bb116:                                            ; preds = %bb114
-  br i1 undef, label %bb120, label %bb121
+  br i1 %arg, label %bb120, label %bb121
 
 bb120:                                            ; preds = %bb116
   unreachable
@@ -68,7 +68,7 @@ bb121:                                            ; preds = %bb116
   unreachable
 
 bb141:                                            ; preds = %bb114
-  br i1 undef, label %bb182, label %bb143
+  br i1 %arg, label %bb182, label %bb143
 
 bb143:                                            ; preds = %bb141
   br label %bb157
@@ -99,7 +99,7 @@ bb6.i841:                                         ; preds = %bb157
   unreachable
 
 _ZN4llvm4castINS_14ConstantSDNodeENS_7SDValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS5_.exit: ; preds = %bb157, %bb157
-  br i1 undef, label %bb.i.i.i843, label %bb1.i.i.i844
+  br i1 %arg, label %bb.i.i.i843, label %bb1.i.i.i844
 
 bb.i.i.i843:                                      ; preds = %_ZN4llvm4castINS_14ConstantSDNodeENS_7SDValueEEENS_10cast_rettyIT_T0_E8ret_typeERKS5_.exit
   br i1 %0, label %bb158, label %bb144
@@ -108,13 +108,13 @@ bb1.i.i.i844:                                     ; preds = %_ZN4llvm4castINS_14
   unreachable
 
 bb158:                                            ; preds = %bb.i.i.i843
-  br i1 undef, label %bb177, label %bb176
+  br i1 %arg, label %bb177, label %bb176
 
 bb176:                                            ; preds = %bb158
   unreachable
 
 bb177:                                            ; preds = %bb158
-  br i1 undef, label %bb179, label %bb178
+  br i1 %arg, label %bb179, label %bb178
 
 bb178:                                            ; preds = %bb177
   unreachable

--- a/llvm/test/Transforms/LoopStrengthReduce/X86/2011-07-20-DoubleIV.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/X86/2011-07-20-DoubleIV.ll
@@ -21,7 +21,7 @@ loop:
   %i.01 = phi i32 [ -39, %entry ], [ %inc, %loop ]
   %conv = sitofp i32 %i.01 to double
   %inc = add nsw i32 %i.01, 1
-  br i1 undef, label %loop, label %for.end
+  br i1 true, label %loop, label %for.end
 
 for.end:
   unreachable
@@ -40,7 +40,7 @@ loop:
   %conv = sitofp i32 %i.01 to double
   %div = fdiv double %conv, 4.000000e+01
   %inc = add nsw i32 %i.01, 1
-  br i1 undef, label %loop, label %for.end
+  br i1 false, label %loop, label %for.end
 
 for.end:
   unreachable

--- a/llvm/test/Transforms/LoopStrengthReduce/X86/2012-01-13-phielim.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/X86/2012-01-13-phielim.ll
@@ -88,10 +88,10 @@ exit:                                 ; preds = %cond.true29.i, %cond.true.i
 ; Test phi reuse after LSR that requires SCEVExpander to hoist an
 ; interesting GEP.
 ;
-define void @test2(i32 %n) nounwind uwtable {
+define void @test2(i32 %n, i1 %arg) nounwind uwtable {
 ; CHECK-LABEL: @test2(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br i1 undef, label [[WHILE_END:%.*]], label [[FOR_COND468_PREHEADER:%.*]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[WHILE_END:%.*]], label [[FOR_COND468_PREHEADER:%.*]]
 ; CHECK:       for.cond468.preheader:
 ; CHECK-NEXT:    br label [[FOR_COND468:%.*]]
 ; CHECK:       for.cond468:
@@ -103,12 +103,12 @@ define void @test2(i32 %n) nounwind uwtable {
 ; CHECK:       for.body471:
 ; CHECK-NEXT:    [[SCEVGEP2:%.*]] = getelementptr i8, ptr [[LSR_IV]], i64 8
 ; CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[SCEVGEP2]], align 4
-; CHECK-NEXT:    br i1 false, label [[IF_THEN477]], label [[FOR_INC498_PREHEADER]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[IF_THEN477]], label [[FOR_INC498_PREHEADER]]
 ; CHECK:       for.inc498.preheader:
 ; CHECK-NEXT:    br label [[FOR_INC498:%.*]]
 ; CHECK:       if.then477:
 ; CHECK-NEXT:    [[SCEVGEP]] = getelementptr i8, ptr [[LSR_IV]], i64 12
-; CHECK-NEXT:    [[LSR_IV_NEXT]] = add nuw nsw i32 [[LSR_IV1]], 1
+; CHECK-NEXT:    [[LSR_IV_NEXT]] = add nuw i32 [[LSR_IV1]], 1
 ; CHECK-NEXT:    br label [[FOR_COND468]]
 ; CHECK:       for.inc498:
 ; CHECK-NEXT:    br label [[FOR_INC498]]
@@ -116,7 +116,7 @@ define void @test2(i32 %n) nounwind uwtable {
 ; CHECK-NEXT:    ret void
 ;
 entry:
-  br i1 undef, label %while.end, label %for.cond468
+  br i1 %arg, label %while.end, label %for.cond468
 
 for.cond468:                                      ; preds = %if.then477, %entry
   %indvars.iv1163 = phi i64 [ %indvars.iv.next1164, %if.then477 ], [ 1, %entry ]
@@ -129,7 +129,7 @@ for.cond468:                                      ; preds = %if.then477, %entry
 for.body471:                                      ; preds = %for.cond468
   %first = getelementptr inbounds [5000 x %struct.anon.7.91.199.307.415.475.559.643.751.835.943.1003.1111.1219.1351.1375.1399.1435.1471.1483.1519.1531.1651.1771], ptr @tags, i64 0, i64 %indvars.iv1163, i32 1
   %1 = load i32, ptr %first, align 4
-  br i1 undef, label %if.then477, label %for.inc498
+  br i1 %arg, label %if.then477, label %for.inc498
 
 if.then477:                                       ; preds = %for.body471
   %last = getelementptr inbounds [5000 x %struct.anon.7.91.199.307.415.475.559.643.751.835.943.1003.1111.1219.1351.1375.1399.1435.1471.1483.1519.1531.1651.1771], ptr @tags, i64 0, i64 %indvars.iv1163, i32 2
@@ -147,21 +147,21 @@ while.end:                                        ; preds = %entry
 ; Test redundant phi elimination when the deleted phi's increment is
 ; itself a phi.
 ;
-define fastcc void @test3(ptr nocapture %u) nounwind uwtable ssp {
+define fastcc void @test3(ptr nocapture %u, i1 %arg) nounwind uwtable ssp {
 ; CHECK-LABEL: @test3(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br i1 undef, label [[MESHBB1_PREHEADER:%.*]], label [[MESHBB5:%.*]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[MESHBB1_PREHEADER:%.*]], label [[MESHBB5:%.*]]
 ; CHECK:       meshBB1.preheader:
 ; CHECK-NEXT:    br label [[MESHBB1:%.*]]
 ; CHECK:       for.inc8.us.i:
-; CHECK-NEXT:    br i1 true, label [[MESHBB1_LOOPEXIT:%.*]], label [[MESHBB:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[MESHBB1_LOOPEXIT:%.*]], label [[MESHBB:%.*]]
 ; CHECK:       for.body3.us.i:
 ; CHECK-NEXT:    [[TMP:%.*]] = phi i32 [ [[LSR_IV_NEXT:%.*]], [[MESHBB]] ], [ [[TMP3:%.*]], [[FOR_BODY3_LR_PH_US_I:%.*]] ]
 ; CHECK-NEXT:    [[SCEVGEP:%.*]] = phi ptr [ [[SCEVGEP1:%.*]], [[MESHBB]] ], [ [[U:%.*]], [[FOR_BODY3_LR_PH_US_I]] ]
 ; CHECK-NEXT:    [[OPQ_SA_CALC12:%.*]] = sub i32 undef, 227
 ; CHECK-NEXT:    [[MUL_I_US_I:%.*]] = mul nsw i32 0, [[TMP]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = load double, ptr [[SCEVGEP]], align 8
-; CHECK-NEXT:    br i1 undef, label [[FOR_INC8_US_I:%.*]], label [[MESHBB]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[FOR_INC8_US_I:%.*]], label [[MESHBB]]
 ; CHECK:       for.body3.lr.ph.us.i.loopexit:
 ; CHECK-NEXT:    br label [[FOR_BODY3_LR_PH_US_I]]
 ; CHECK:       for.body3.lr.ph.us.i:
@@ -179,19 +179,19 @@ define fastcc void @test3(ptr nocapture %u) nounwind uwtable ssp {
 ; CHECK-NEXT:    [[MESHSTACKVARIABLE_PHI:%.*]] = phi i32 [ [[OPQ_SA_CALC12]], [[FOR_BODY3_US_I]] ], [ undef, [[FOR_INC8_US_I]] ]
 ; CHECK-NEXT:    [[SCEVGEP1]] = getelementptr i8, ptr [[SCEVGEP]], i64 8
 ; CHECK-NEXT:    [[LSR_IV_NEXT]] = add i32 [[TMP]], 1
-; CHECK-NEXT:    br i1 true, label [[FOR_BODY3_LR_PH_US_I_LOOPEXIT]], label [[FOR_BODY3_US_I]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[FOR_BODY3_LR_PH_US_I_LOOPEXIT]], label [[FOR_BODY3_US_I]]
 ; CHECK:       meshBB1.loopexit:
 ; CHECK-NEXT:    br label [[MESHBB1]]
 ; CHECK:       meshBB1:
 ; CHECK-NEXT:    br label [[FOR_BODY3_LR_PH_US_I]]
 ; CHECK:       meshBB5:
-; CHECK-NEXT:    br i1 undef, label [[EVAL_AT_TIMES_U_EXIT:%.*]], label [[FOR_INC8_US_I2:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[EVAL_AT_TIMES_U_EXIT:%.*]], label [[FOR_INC8_US_I2:%.*]]
 ;
 entry:
-  br i1 undef, label %meshBB1, label %meshBB5
+  br i1 %arg, label %meshBB1, label %meshBB5
 
 for.inc8.us.i:                                    ; preds = %for.body3.us.i
-  br i1 undef, label %meshBB1, label %meshBB
+  br i1 %arg, label %meshBB1, label %meshBB
 
 for.body3.us.i:                                   ; preds = %meshBB, %for.body3.lr.ph.us.i
   %indvars.iv.i.SV.phi = phi i64 [ %indvars.iv.next.i, %meshBB ], [ 0, %for.body3.lr.ph.us.i ]
@@ -203,7 +203,7 @@ for.body3.us.i:                                   ; preds = %meshBB, %for.body3.
   %arrayidx5.us.i = getelementptr inbounds double, ptr %u, i64 %indvars.iv.i.SV.phi
   %2 = load double, ptr %arrayidx5.us.i, align 8
   %indvars.iv.next.i = add i64 %indvars.iv.i.SV.phi, 1
-  br i1 undef, label %for.inc8.us.i, label %meshBB
+  br i1 %arg, label %for.inc8.us.i, label %meshBB
 
 for.body3.lr.ph.us.i:                             ; preds = %meshBB1, %meshBB
   %indvars.iv8.i.SV.phi26 = phi i64 [ undef, %meshBB1 ], [ %indvars.iv8.i.SV.phi24, %meshBB ]
@@ -220,11 +220,11 @@ eval_At_times_u.exit:                             ; preds = %meshBB5
 meshBB:                                           ; preds = %for.body3.us.i, %for.inc8.us.i
   %indvars.iv8.i.SV.phi24 = phi i64 [ undef, %for.body3.us.i ], [ %3, %for.inc8.us.i ]
   %meshStackVariable.phi = phi i32 [ %Opq.sa.calc12, %for.body3.us.i ], [ undef, %for.inc8.us.i ]
-  br i1 undef, label %for.body3.lr.ph.us.i, label %for.body3.us.i
+  br i1 %arg, label %for.body3.lr.ph.us.i, label %for.body3.us.i
 
 meshBB1:                                          ; preds = %for.inc8.us.i, %entry
   br label %for.body3.lr.ph.us.i
 
 meshBB5:                                          ; preds = %entry
-  br i1 undef, label %eval_At_times_u.exit, label %for.inc8.us.i2
+  br i1 %arg, label %eval_At_times_u.exit, label %for.inc8.us.i2
 }

--- a/llvm/test/Transforms/LoopStrengthReduce/X86/no_superflous_induction_vars.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/X86/no_superflous_induction_vars.ll
@@ -2,7 +2,7 @@
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
-define void @indvar_expansion(ptr nocapture readonly %rowsptr) {
+define void @indvar_expansion(ptr nocapture readonly %rowsptr, i1 %arg) {
 entry:
   br label %for.cond
 
@@ -22,7 +22,7 @@ for.cond:
   br i1 %cmp, label %for.cond, label %for.cond2
 
 for.cond2:
-  br i1 undef, label %for.cond2, label %for.body14.lr.ph
+  br i1 %arg, label %for.cond2, label %for.body14.lr.ph
 
 for.body14.lr.ph:
   %sext = shl i64 %indvars.iv44, 32

--- a/llvm/test/Transforms/LoopStrengthReduce/X86/pr40514.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/X86/pr40514.ll
@@ -50,7 +50,7 @@ bb10:                                             ; preds = %bb10, %bb
   %tmp22 = shl i64 %tmp21, 1
   %tmp23 = mul i64 %tmp22, %tmp22
   %tmp24 = add nuw nsw i64 %tmp11, 1
-  br i1 undef, label %bb1, label %bb10
+  br i1 true, label %bb1, label %bb10
 }
 
 

--- a/llvm/test/Transforms/LoopStrengthReduce/callbr-critical-edge-splitting.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/callbr-critical-edge-splitting.ll
@@ -69,11 +69,11 @@ cond.true.i:                                      ; preds = %for.cond
 do.body.i.i.do.body.i.i_crit_edge:                ; preds = %do.body.i.i.do.body.i.i_crit_edge, %cond.true.i
   %pgocount711 = phi i64 [ %0, %do.body.i.i.do.body.i.i_crit_edge ], [ 0, %cond.true.i ]
   %0 = add nuw nsw i64 %pgocount711, 1
-  br i1 undef, label %do.body.i.i.rdrand_int.exit.i_crit_edge, label %do.body.i.i.do.body.i.i_crit_edge
+  br i1 true, label %do.body.i.i.rdrand_int.exit.i_crit_edge, label %do.body.i.i.do.body.i.i_crit_edge
 
 do.body.i.i.rdrand_int.exit.i_crit_edge:          ; preds = %do.body.i.i.do.body.i.i_crit_edge
   %1 = add i64 %0, undef
-  br i1 undef, label %for.end, label %for.inc
+  br i1 true, label %for.end, label %for.inc
 
 for.inc:                                          ; preds = %do.body.i.i.rdrand_int.exit.i_crit_edge
   br label %for.cond

--- a/llvm/test/Transforms/LoopStrengthReduce/dominate-assert.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/dominate-assert.ll
@@ -4,13 +4,13 @@
 declare ptr @_Znwm()
 declare i32 @__gxx_personality_v0(...)
 declare void @g()
-define void @f() personality ptr @__gxx_personality_v0 {
+define void @f(i1 %arg) personality ptr @__gxx_personality_v0 {
 bb0:
   br label %bb1
 bb1:
   %v0 = phi i64 [ 0, %bb0 ], [ %v1, %bb1 ]
   %v1 = add nsw i64 %v0, 1
-  br i1 undef, label %bb2, label %bb1
+  br i1 %arg, label %bb2, label %bb1
 bb2:
   %v2 = icmp eq i64 %v0, 0
   br i1 %v2, label %bb6, label %bb3
@@ -69,34 +69,34 @@ bb7:
 }
 
 ; PR17425
-define void @i() {
+define void @i(i1 %arg) {
 entry:
   br label %while.cond
 
 while.cond:                                       ; preds = %while.cond, %entry
   %c.0 = phi ptr [ undef, %entry ], [ %incdec.ptr, %while.cond ]
   %incdec.ptr = getelementptr inbounds i16, ptr %c.0, i64 1
-  br i1 undef, label %while.cond1, label %while.cond
+  br i1 %arg, label %while.cond1, label %while.cond
 
 while.cond1:                                      ; preds = %while.cond1, %while.cond
   %c.1 = phi ptr [ %incdec.ptr5, %while.cond1 ], [ %c.0, %while.cond ]
   %incdec.ptr5 = getelementptr inbounds i16, ptr %c.1, i64 1
-  br i1 undef, label %while.cond7, label %while.cond1
+  br i1 %arg, label %while.cond7, label %while.cond1
 
 while.cond7:                                      ; preds = %while.cond7, %while.cond1
   %0 = phi ptr [ %incdec.ptr10, %while.cond7 ], [ %c.1, %while.cond1 ]
   %incdec.ptr10 = getelementptr inbounds i16, ptr %0, i64 1
-  br i1 undef, label %while.cond12.preheader, label %while.cond7
+  br i1 %arg, label %while.cond12.preheader, label %while.cond7
 
 while.cond12.preheader:                           ; preds = %while.cond7
-  br i1 undef, label %while.end16, label %while.body13.lr.ph
+  br i1 %arg, label %while.end16, label %while.body13.lr.ph
 
 while.body13:                                     ; preds = %if.else, %while.body13.lr.ph
   %1 = phi ptr [ %2, %while.body13.lr.ph ], [ %incdec.ptr15, %if.else ]
-  br i1 undef, label %while.cond12.outer.loopexit, label %if.else
+  br i1 %arg, label %while.cond12.outer.loopexit, label %if.else
 
 while.cond12.outer.loopexit:                      ; preds = %while.body13
-  br i1 undef, label %while.end16, label %while.body13.lr.ph
+  br i1 %arg, label %while.end16, label %while.body13.lr.ph
 
 while.body13.lr.ph:                               ; preds = %while.cond12.outer.loopexit, %while.cond12.preheader
   %2 = phi ptr [ %1, %while.cond12.outer.loopexit ], [ undef, %while.cond12.preheader ]

--- a/llvm/test/Transforms/LoopStrengthReduce/funclet.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/funclet.ll
@@ -63,7 +63,7 @@ loop_body:                                        ; preds = %iter, %pad
 
 iter:                                             ; preds = %loop_body
   %tmp101 = getelementptr inbounds i8, ptr %tmp99, i32 1
-  br i1 undef, label %unwind_out, label %loop_body
+  br i1 true, label %unwind_out, label %loop_body
 
 unwind_out:                                       ; preds = %iter, %loop_body
   cleanupret from %cleanuppadi4.i.i.i unwind to caller
@@ -130,7 +130,7 @@ loop_body:                                        ; preds = %iter, %pad
 
 iter:                                             ; preds = %loop_body
   %tmp101 = getelementptr inbounds i8, ptr %tmp99, i32 1
-  br i1 undef, label %unwind_out, label %loop_body
+  br i1 true, label %unwind_out, label %loop_body
 }
 
 define void @h() personality ptr @_except_handler3 {
@@ -194,7 +194,7 @@ loop_body:                                        ; preds = %iter, %pad
 
 iter:                                             ; preds = %loop_body
   %tmp101 = getelementptr inbounds i8, ptr %tmp99, i32 1
-  br i1 undef, label %unwind_out, label %loop_body
+  br i1 true, label %unwind_out, label %loop_body
 }
 
 define void @i() personality ptr @_except_handler3 {
@@ -255,7 +255,7 @@ loop_body:                                        ; preds = %iter, %catchpad
 
 iter:                                             ; preds = %loop_body
   %tmp101 = getelementptr inbounds i8, ptr %tmp99, i32 1
-  br i1 undef, label %unwind_out, label %loop_body
+  br i1 true, label %unwind_out, label %loop_body
 
 unwind_out:                                       ; preds = %iter, %loop_body
   unreachable

--- a/llvm/test/Transforms/LoopStrengthReduce/hoist-parent-preheader.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/hoist-parent-preheader.ll
@@ -1,9 +1,9 @@
 ; RUN: opt < %s -loop-reduce -verify
 target triple = "x86_64-apple-darwin10"
 
-define void @myquicksort(ptr %a) nounwind ssp {
+define void @myquicksort(ptr %a, i1 %arg) nounwind ssp {
 entry:
-  br i1 undef, label %loop1, label %return
+  br i1 %arg, label %loop1, label %return
 
 loop1:                                            ; preds = %bb13.loopexit, %entry
   %indvar419 = phi i64 [ %indvar.next420, %loop2.exit ], [ 0, %entry ]
@@ -25,7 +25,7 @@ loop2.backedge:                                   ; preds = %loop2
 
 loop2.exit:                                       ; preds = %loop2
   %indvar.next420 = add i64 %indvar419, 1
-  br i1 undef, label %loop1, label %return
+  br i1 %arg, label %loop1, label %return
 
 return:                                           ; preds = %loop2.exit, %entry
   ret void

--- a/llvm/test/Transforms/LoopStrengthReduce/ivchain.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/ivchain.ll
@@ -12,11 +12,11 @@ target datalayout = "n8:16:32:64"
 
 %struct = type { ptr, ptr, i16, i64, i16, i16, i16, i64, i64, i16, ptr, i64, i64, i64 }
 
-define i32 @test(ptr %h, i32 %more) nounwind uwtable {
+define i32 @test(ptr %h, i32 %more, i1 %arg) nounwind uwtable {
 ; CHECK-LABEL: define i32 @test
-; CHECK-SAME: (ptr [[H:%.*]], i32 [[MORE:%.*]]) #[[ATTR0:[0-9]+]] {
+; CHECK-SAME: (ptr [[H:%.*]], i32 [[MORE:%.*]], i1 [[ARG:%.*]]) #[[ATTR0:[0-9]+]] {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    br i1 undef, label [[LAND_END238:%.*]], label [[RETURN:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[LAND_END238:%.*]], label [[RETURN:%.*]]
 ; CHECK:       land.end238:
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
 ; CHECK:       for.body:
@@ -38,7 +38,7 @@ define i32 @test(ptr %h, i32 %more) nounwind uwtable {
 ; CHECK-NEXT:    ret i32 1
 ;
 entry:
-  br i1 undef, label %land.end238, label %return
+  br i1 %arg, label %land.end238, label %return
 
 land.end238:                                      ; preds = %if.end229
   br label %for.body

--- a/llvm/test/Transforms/LoopStrengthReduce/nonintegral.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/nonintegral.ll
@@ -46,7 +46,7 @@ top:
 L86:                                              ; preds = %L86, %top
   %i.0 = phi i64 [ 0, %top ], [ %tmp, %L86 ]
   %tmp = add i64 %i.0, 1
-  br i1 undef, label %L86, label %if29
+  br i1 false, label %L86, label %if29
 
 if29:                                             ; preds = %L86
   %tmp1 = shl i64 %tmp, 1
@@ -60,13 +60,13 @@ if31:                                             ; preds = %if38, %if29
 L119:                                             ; preds = %L119, %if31
   %i5.0 = phi i64 [ %"#temp#1.sroa.0.022", %if31 ], [ %tmp3, %L119 ]
   %tmp3 = add i64 %i5.0, 1
-  br i1 undef, label %L119, label %if38
+  br i1 false, label %L119, label %if38
 
 if38:                                             ; preds = %L119
   %tmp4 = add i64 %tmp2, %i5.0
   %tmp5 = getelementptr i64, ptr addrspace(10) %arg, i64 %tmp4
   %tmp6 = load i64, ptr addrspace(10) %tmp5
-  br i1 undef, label %done, label %if31
+  br i1 true, label %done, label %if31
 
 done:                                             ; preds = %if38
   ret void

--- a/llvm/test/Transforms/LoopStrengthReduce/pr12048.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/pr12048.ll
@@ -1,6 +1,6 @@
 ; RUN: opt < %s -loop-reduce
 
-define void @resolve_name() nounwind uwtable ssp {
+define void @resolve_name(i1 %arg, i8 %arg2) nounwind uwtable ssp {
   br label %while.cond40.preheader
 while.cond132.while.cond.loopexit_crit_edge:
   br label %while.cond40.preheader
@@ -9,7 +9,7 @@ while.cond40.preheader:
 while.cond40:
   %indvars.iv194 = phi ptr [ null, %while.cond40.preheader ], [ %scevgep, %while.body51 ]
   %tmp.1 = phi ptr [ undef, %while.cond40.preheader ], [ %incdec.ptr, %while.body51 ]
-  switch i8 undef, label %while.body51 [
+  switch i8 %arg2, label %while.body51 [
     i8 0, label %if.then59
   ]
 while.body51:                                     ; preds = %land.end50
@@ -17,7 +17,7 @@ while.body51:                                     ; preds = %land.end50
   %scevgep = getelementptr i8, ptr %indvars.iv194, i64 1
   br label %while.cond40
 if.then59:                                        ; preds = %while.end
-  br i1 undef, label %if.then64, label %if.end113
+  br i1 %arg, label %if.then64, label %if.end113
 if.then64:                                        ; preds = %if.then59
   %incdec.ptr88.tmp.2 = select i1 undef, ptr undef, ptr undef
   br label %if.end113
@@ -33,5 +33,5 @@ while.body139.lr.ph:                              ; preds = %while.cond132.prehe
   br label %while.body139
 while.body139:                                    ; preds = %while.body139, %while.body139.lr.ph
   %start_of_var.0177 = phi ptr [ %tmp.1, %while.body139.lr.ph ], [ null, %while.body139 ]
-  br i1 undef, label %while.cond132.while.cond.loopexit_crit_edge, label %while.body139
+  br i1 %arg, label %while.cond132.while.cond.loopexit_crit_edge, label %while.body139
 }

--- a/llvm/test/Transforms/LoopStrengthReduce/pr50765.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/pr50765.ll
@@ -5,7 +5,7 @@
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:1-p2:32:8:8:32-ni:2"
 target triple = "x86_64-unknown-linux-gnu"
 
-define void @test() {
+define void @test(i1 %arg) {
 ; CHECK-LABEL: test
 bb:
   %tmp = load i32, ptr addrspace(3) undef, align 4
@@ -17,7 +17,7 @@ bb1:                                              ; preds = %bb38, %bb
   %tmp4 = add i32 %tmp3, 1
   %tmp5 = call i32 @llvm.smax.i32(i32 %tmp4, i32 74)
   %tmp6 = add nuw nsw i64 %tmp2, 1
-  br i1 undef, label %bb7, label %bb38
+  br i1 %arg, label %bb7, label %bb38
 
 bb7:                                              ; preds = %bb1
   %tmp8 = trunc i64 %tmp6 to i32

--- a/llvm/test/Transforms/LoopStrengthReduce/scaling-factor-incompat-type.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/scaling-factor-incompat-type.ll
@@ -54,5 +54,5 @@ bb11:                                             ; preds = %bb4
 
 bb13:                                             ; preds = %bb4
   %t14 = add nuw nsw i64 %t5, 6
-  br i1 undef, label %bb1, label %bb4
+  br i1 true, label %bb1, label %bb4
 }

--- a/llvm/test/Transforms/LoopStrengthReduce/scaling_factor_cost_crash.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/scaling_factor_cost_crash.ll
@@ -4,41 +4,41 @@ target triple = "i686-pc-win32"
 
 ; <rdar://problem/14199725> Assertion failed: (CurScaleCost >= 0 && "Legal addressing mode has an illegal cost!")
 ; CHECK-LABEL: @scalingFactorCrash(
-define void @scalingFactorCrash() {
-  br i1 undef, label %1, label %24
+define void @scalingFactorCrash(i1 %arg) {
+  br i1 %arg, label %1, label %24
 
 ; <label>:1                                       ; preds = %0
-  br i1 undef, label %2, label %24
+  br i1 %arg, label %2, label %24
 
 ; <label>:2                                       ; preds = %1
-  br i1 undef, label %3, label %24
+  br i1 %arg, label %3, label %24
 
 ; <label>:3                                       ; preds = %2
-  br i1 undef, label %4, label %24
+  br i1 %arg, label %4, label %24
 
 ; <label>:4                                       ; preds = %3
-  br i1 undef, label %24, label %6
+  br i1 %arg, label %24, label %6
 
 ; <label>:5                                       ; preds = %6
-  br i1 undef, label %24, label %7
+  br i1 %arg, label %24, label %7
 
 ; <label>:6                                       ; preds = %6, %4
-  br i1 undef, label %6, label %5
+  br i1 %arg, label %6, label %5
 
 ; <label>:7                                       ; preds = %9, %5
   br label %8
 
 ; <label>:8                                       ; preds = %8, %7
-  br i1 undef, label %9, label %8
+  br i1 %arg, label %9, label %8
 
 ; <label>:9                                       ; preds = %8
-  br i1 undef, label %7, label %10
+  br i1 %arg, label %7, label %10
 
 ; <label>:10                                      ; preds = %9
-  br i1 undef, label %24, label %11
+  br i1 %arg, label %24, label %11
 
 ; <label>:11                                      ; preds = %10
-  br i1 undef, label %15, label %13
+  br i1 %arg, label %15, label %13
 
 ; <label>:12                                      ; preds = %14
   br label %15
@@ -47,10 +47,10 @@ define void @scalingFactorCrash() {
   br label %14
 
 ; <label>:14                                      ; preds = %14, %13
-  br i1 undef, label %14, label %12
+  br i1 %arg, label %14, label %12
 
 ; <label>:15                                      ; preds = %12, %11
-  br i1 undef, label %16, label %24
+  br i1 %arg, label %16, label %24
 
 ; <label>:16                                      ; preds = %16, %15
   %17 = phi i32 [ %21, %16 ], [ undef, %15 ]
@@ -61,7 +61,7 @@ define void @scalingFactorCrash() {
   %21 = add i32 %20, -1623127498
   %22 = add i32 %21, -542963121
   %23 = icmp ult i32 %22, undef
-  br i1 undef, label %16, label %24
+  br i1 %arg, label %16, label %24
 
 ; <label>:24                                      ; preds = %16, %15, %10, %5, %4, %3, %2, %1, %0
   ret void

--- a/llvm/test/Transforms/LoopStrengthReduce/scev-after-loopinstsimplify.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/scev-after-loopinstsimplify.ll
@@ -18,13 +18,13 @@ target datalayout = "n16"
 
 @a = external global i16, align 1
 
-define void @f1() {
+define void @f1(i1 %arg) {
 entry:
   br label %for.cond
 
 for.cond:                                         ; preds = %land.end, %entry
   %c.0 = phi i16 [ 0, %entry ], [ %dec, %land.end ]
-  br i1 undef, label %for.body, label %for.cond.cleanup
+  br i1 %arg, label %for.body, label %for.cond.cleanup
 
 for.cond.cleanup:                                 ; preds = %for.cond
   ret void

--- a/llvm/test/Transforms/LoopStrengthReduce/scev-expander-lcssa.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/scev-expander-lcssa.ll
@@ -3,10 +3,10 @@
 
 ; Make sure SCEVExpander does not crash and introduce unnecessary LCSSA PHI nodes.
 
-define void @schedule_block() {
+define void @schedule_block(i1 %arg) {
 ; CHECK-LABEL: @schedule_block(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    switch i16 undef, label [[IF_END156_I:%.*]] [
+; CHECK-NEXT:    switch i16 0, label [[IF_END156_I:%.*]] [
 ; CHECK-NEXT:    i16 27, label [[IF_THEN_I:%.*]]
 ; CHECK-NEXT:    i16 28, label [[IF_THEN_I]]
 ; CHECK-NEXT:    i16 29, label [[IF_THEN13_I:%.*]]
@@ -19,7 +19,7 @@ define void @schedule_block() {
 ; CHECK:       land.lhs.true136.i:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       if.end156.i:
-; CHECK-NEXT:    switch i16 undef, label [[WHILE_END256:%.*]] [
+; CHECK-NEXT:    switch i16 32, label [[WHILE_END256:%.*]] [
 ; CHECK-NEXT:    i16 29, label [[IF_THEN210:%.*]]
 ; CHECK-NEXT:    i16 28, label [[IF_THEN210]]
 ; CHECK-NEXT:    i16 27, label [[LAND_LHS_TRUE191:%.*]]
@@ -56,7 +56,7 @@ define void @schedule_block() {
 ; CHECK:       for.end34.i:
 ; CHECK-NEXT:    br i1 false, label [[FOR_COND_I2472]], label [[IF_ELSE_I2488:%.*]]
 ; CHECK:       if.else.i2488:
-; CHECK-NEXT:    br i1 undef, label [[IF_END107_I:%.*]], label [[FOR_BODY45_PREHEADER_I:%.*]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[IF_END107_I:%.*]], label [[FOR_BODY45_PREHEADER_I:%.*]]
 ; CHECK:       for.body45.preheader.i:
 ; CHECK-NEXT:    [[TMP3:%.*]] = sext i32 [[I_0_I]] to i64
 ; CHECK-NEXT:    unreachable
@@ -66,7 +66,7 @@ define void @schedule_block() {
 ; CHECK-NEXT:    unreachable
 ;
 entry:
-  switch i16 undef, label %if.end156.i [
+  switch i16 0, label %if.end156.i [
   i16 27, label %if.then.i
   i16 28, label %if.then.i
   i16 29, label %if.then13.i
@@ -83,7 +83,7 @@ land.lhs.true136.i:                               ; preds = %entry
   unreachable
 
 if.end156.i:                                      ; preds = %entry
-  switch i16 undef, label %while.end256 [
+  switch i16 32, label %while.end256 [
   i16 29, label %if.then210
   i16 28, label %if.then210
   i16 27, label %land.lhs.true191
@@ -110,7 +110,7 @@ while.body1013:                                   ; preds = %for.end
 
 for.cond.i2472:                                   ; preds = %for.end34.i, %while.body1013
   %i.0.i = phi i32 [ 0, %while.body1013 ], [ %2, %for.end34.i ]
-  br i1 undef, label %for.cond3.preheader.i, label %if.end107.i
+  br i1 false, label %for.cond3.preheader.i, label %if.end107.i
 
 for.cond3.preheader.i:                            ; preds = %for.cond.i2472
   %0 = sext i32 %i.0.i to i64
@@ -123,17 +123,17 @@ for.cond3.i:                                      ; preds = %for.body5.i, %for.c
   br label %for.body5.i
 
 for.body5.i:                                      ; preds = %for.cond3.i
-  br i1 undef, label %for.cond3.i, label %for.body5.i.for.end.i2475.loopexit_crit_edge
+  br i1 false, label %for.cond3.i, label %for.body5.i.for.end.i2475.loopexit_crit_edge
 
 for.body5.i.for.end.i2475.loopexit_crit_edge:     ; preds = %for.body5.i
   %2 = trunc i64 %indvars.iv.next302.i to i32
   br label %for.end34.i
 
 for.end34.i:                                      ; preds = %for.body5.i.for.end.i2475.loopexit_crit_edge
-  br i1 undef, label %for.cond.i2472, label %if.else.i2488
+  br i1 false, label %for.cond.i2472, label %if.else.i2488
 
 if.else.i2488:                                    ; preds = %for.end34.i
-  br i1 undef, label %if.end107.i, label %for.body45.preheader.i
+  br i1 %arg, label %if.end107.i, label %for.body45.preheader.i
 
 for.body45.preheader.i:                           ; preds = %if.else.i2488
   %3 = sext i32 %i.0.i to i64

--- a/llvm/test/Transforms/LoopStrengthReduce/uglygep-address-space.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/uglygep-address-space.ll
@@ -38,7 +38,7 @@ bb:
   br label %bb3
 
 bb1:                                              ; preds = %bb3
-  br i1 undef, label %bb10, label %bb2
+  br i1 true, label %bb10, label %bb2
 
 bb2:                                              ; preds = %bb1
   %t = add i16 %t4, 1                         ; <i16> [#uses=1]

--- a/llvm/test/Transforms/LoopStrengthReduce/uglygep.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/uglygep.ll
@@ -38,7 +38,7 @@ bb:
   br label %bb3
 
 bb1:                                              ; preds = %bb3
-  br i1 undef, label %bb10, label %bb2
+  br i1 true, label %bb10, label %bb2
 
 bb2:                                              ; preds = %bb1
   %t = add i64 %t4, 1                         ; <i64> [#uses=1]

--- a/llvm/test/Transforms/LoopUnroll/2011-08-08-PhiUpdate.ll
+++ b/llvm/test/Transforms/LoopUnroll/2011-08-08-PhiUpdate.ll
@@ -143,7 +143,7 @@ bb2:                                              ; preds = %bb1.bb2_crit_edge, 
 
 ; Check phi update for loop with an early-exit.
 ;
-define i32 @test3() nounwind uwtable ssp align 2 {
+define i32 @test3(i1 %arg) nounwind uwtable ssp align 2 {
 ;
 ; CHECK-LABEL: @test3(
 ; CHECK-NEXT:  entry:
@@ -156,9 +156,9 @@ define i32 @test3() nounwind uwtable ssp align 2 {
 ; CHECK-NEXT:    br i1 [[COND2]], label [[EXIT:%.*]], label [[DO_COND:%.*]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    [[TMP7_I:%.*]] = load i32, ptr undef, align 8
-; CHECK-NEXT:    br i1 undef, label [[DO_COND]], label [[LAND_LHS_TRUE:%.*]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[DO_COND]], label [[LAND_LHS_TRUE:%.*]]
 ; CHECK:       land.lhs.true:
-; CHECK-NEXT:    br i1 true, label [[RETURN_LOOPEXIT:%.*]], label [[DO_COND]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[RETURN_LOOPEXIT:%.*]], label [[DO_COND]]
 ; CHECK:       do.cond:
 ; CHECK-NEXT:    [[COND3:%.*]] = call zeroext i1 @check()
 ; CHECK-NEXT:    br i1 [[COND3]], label [[DO_END:%.*]], label [[DO_BODY_1:%.*]]
@@ -167,9 +167,9 @@ define i32 @test3() nounwind uwtable ssp align 2 {
 ; CHECK-NEXT:    br i1 [[COND2_1]], label [[EXIT_1:%.*]], label [[DO_COND_1:%.*]]
 ; CHECK:       exit.1:
 ; CHECK-NEXT:    [[TMP7_I_1:%.*]] = load i32, ptr undef, align 8
-; CHECK-NEXT:    br i1 undef, label [[DO_COND_1]], label [[LAND_LHS_TRUE_1:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[DO_COND_1]], label [[LAND_LHS_TRUE_1:%.*]]
 ; CHECK:       land.lhs.true.1:
-; CHECK-NEXT:    br i1 true, label [[RETURN_LOOPEXIT]], label [[DO_COND_1]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[RETURN_LOOPEXIT]], label [[DO_COND_1]]
 ; CHECK:       do.cond.1:
 ; CHECK-NEXT:    [[COND3_1:%.*]] = call zeroext i1 @check()
 ; CHECK-NEXT:    br i1 [[COND3_1]], label [[DO_END]], label [[DO_BODY_2:%.*]]
@@ -178,9 +178,9 @@ define i32 @test3() nounwind uwtable ssp align 2 {
 ; CHECK-NEXT:    br i1 [[COND2_2]], label [[EXIT_2:%.*]], label [[DO_COND_2:%.*]]
 ; CHECK:       exit.2:
 ; CHECK-NEXT:    [[TMP7_I_2:%.*]] = load i32, ptr undef, align 8
-; CHECK-NEXT:    br i1 undef, label [[DO_COND_2]], label [[LAND_LHS_TRUE_2:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[DO_COND_2]], label [[LAND_LHS_TRUE_2:%.*]]
 ; CHECK:       land.lhs.true.2:
-; CHECK-NEXT:    br i1 true, label [[RETURN_LOOPEXIT]], label [[DO_COND_2]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[RETURN_LOOPEXIT]], label [[DO_COND_2]]
 ; CHECK:       do.cond.2:
 ; CHECK-NEXT:    [[COND3_2:%.*]] = call zeroext i1 @check()
 ; CHECK-NEXT:    br i1 [[COND3_2]], label [[DO_END]], label [[DO_BODY_3:%.*]]
@@ -189,9 +189,9 @@ define i32 @test3() nounwind uwtable ssp align 2 {
 ; CHECK-NEXT:    br i1 [[COND2_3]], label [[EXIT_3:%.*]], label [[DO_COND_3:%.*]]
 ; CHECK:       exit.3:
 ; CHECK-NEXT:    [[TMP7_I_3:%.*]] = load i32, ptr undef, align 8
-; CHECK-NEXT:    br i1 undef, label [[DO_COND_3]], label [[LAND_LHS_TRUE_3:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[DO_COND_3]], label [[LAND_LHS_TRUE_3:%.*]]
 ; CHECK:       land.lhs.true.3:
-; CHECK-NEXT:    br i1 true, label [[RETURN_LOOPEXIT]], label [[DO_COND_3]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[RETURN_LOOPEXIT]], label [[DO_COND_3]]
 ; CHECK:       do.cond.3:
 ; CHECK-NEXT:    [[COND3_3:%.*]] = call zeroext i1 @check()
 ; CHECK-NEXT:    br i1 [[COND3_3]], label [[DO_END]], label [[DO_BODY]], !llvm.loop [[LOOP3:![0-9]+]]
@@ -217,10 +217,10 @@ do.body:                                          ; preds = %do.cond, %if.end
 
 exit:                  ; preds = %do.body
   %tmp7.i = load i32, ptr undef, align 8
-  br i1 undef, label %do.cond, label %land.lhs.true
+  br i1 %arg, label %do.cond, label %land.lhs.true
 
 land.lhs.true:                                    ; preds = %exit
-  br i1 undef, label %return, label %do.cond
+  br i1 %arg, label %return, label %do.cond
 
 do.cond:                                          ; preds = %land.lhs.true, %exit, %do.body
   %cond3 = call zeroext i1 @check()

--- a/llvm/test/Transforms/LoopUnroll/full-unroll-crashers.ll
+++ b/llvm/test/Transforms/LoopUnroll/full-unroll-crashers.ll
@@ -5,7 +5,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 @known_constant = internal unnamed_addr constant [10 x i32] [i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1], align 16
 
-define void @foo1() {
+define void @foo1(i1 %arg) {
 entry:
   br label %for.body
 
@@ -21,7 +21,7 @@ for.exit:
   ret void
 }
 
-define void @foo2() {
+define void @foo2(i1 %arg) {
 entry:
   br label %for.body
 
@@ -36,7 +36,7 @@ for.exit:
   ret void
 }
 
-define void @cmp_undef() {
+define void @cmp_undef(i1 %arg) {
 entry:
   br label %for.body
 
@@ -59,7 +59,7 @@ for.end:                                          ; preds = %for.inc
   ret void
 }
 
-define void @switch() {
+define void @switch(i1 %arg) {
 entry:
   br label %for.body
 
@@ -83,7 +83,7 @@ for.end:
   ret void
 }
 
-define <4 x i32> @vec_load() {
+define <4 x i32> @vec_load(i1 %arg) {
 entry:
   br label %for.body
 
@@ -101,7 +101,7 @@ for.exit:
   ret <4 x i32> %r
 }
 
-define void @ptrtoint_cast() optsize {
+define void @ptrtoint_cast(i1 %arg) optsize {
 entry:
   br label %for.body
 
@@ -119,7 +119,7 @@ for.cond.cleanup:
   ret void
 }
 
-define void @ptrtoint_cast2() {
+define void @ptrtoint_cast2(i1 %arg) {
 entry:
   br i1 false, label %for.body.lr.ph, label %exit
 
@@ -138,14 +138,14 @@ exit:
 
 @i = external global i32, align 4
 
-define void @folded_not_to_constantint() {
+define void @folded_not_to_constantint(i1 %arg) {
 entry:
   br label %for.body
 
 for.body:
   %iv = phi i32 [ 0, %entry ], [ %inc, %for.inc ]
   %m = phi ptr [ @i, %entry ], [ %m, %for.inc ]
-  br i1 undef, label %if.else, label %if.then
+  br i1 %arg, label %if.else, label %if.then
 
 if.then:
   unreachable
@@ -166,13 +166,13 @@ for.end:
   ret void
 }
 
-define void @index_too_large() {
+define void @index_too_large(i1 %arg) {
 entry:
   br label %for.body
 
 for.body:
   %iv = phi i64 [ -73631599, %entry ], [ %iv.next, %for.inc ]
-  br i1 undef, label %for.body2, label %for.inc
+  br i1 %arg, label %for.body2, label %for.inc
 
 for.body2:
   %idx = getelementptr inbounds [10 x i32], ptr @known_constant, i64 0, i64 %iv
@@ -181,13 +181,13 @@ for.body2:
 
 for.inc:
   %iv.next = add nsw i64 %iv, -1
-  br i1 undef, label %for.body, label %for.end
+  br i1 %arg, label %for.body, label %for.end
 
 for.end:
   ret void
 }
 
-define void @cmp_type_mismatch() {
+define void @cmp_type_mismatch(i1 %arg) {
 entry:
   br label %for.header
 
@@ -197,7 +197,7 @@ for.header:
 for.body:
   %d = phi ptr [ null, %for.header ]
   %cmp = icmp eq ptr %d, null
-  br i1 undef, label %for.end, label %for.header
+  br i1 %arg, label %for.end, label %for.header
 
 for.end:
   ret void

--- a/llvm/test/Transforms/LoopUnroll/pr10813.ll
+++ b/llvm/test/Transforms/LoopUnroll/pr10813.ll
@@ -1,8 +1,8 @@
 ; RUN: opt < %s -passes=loop-unroll -disable-output
 
-define void @"f_fu___REFUf[]REFUf[]Uf"() nounwind {
+define void @"f_fu___REFUf[]REFUf[]Uf"(i1 %arg) nounwind {
 allocas:
-  br i1 undef, label %cif_mask_all, label %cif_mixed_test_all
+  br i1 %arg, label %cif_mask_all, label %cif_mixed_test_all
 
 cif_mask_all:                                     ; preds = %allocas
   unreachable
@@ -12,7 +12,7 @@ cif_mixed_test_all:                               ; preds = %allocas
 
 pl_loop.i964:                                     ; preds = %pl_loopend.i973, %cif_mixed_test_all
   %0 = phi i32 [ %pl_nextlane.i971, %pl_loopend.i973 ], [ 0, %cif_mixed_test_all ]
-  br i1 undef, label %pl_dolane.i970, label %pl_loopend.i973
+  br i1 %arg, label %pl_dolane.i970, label %pl_loopend.i973
 
 pl_dolane.i970:                                   ; preds = %pl_loop.i964
   %storeval.i.i969 = extractelement <4 x i8> <i8 0, i8 1, i8 2, i8 3>, i32 %0

--- a/llvm/test/Transforms/LoopUnroll/pr14167.ll
+++ b/llvm/test/Transforms/LoopUnroll/pr14167.ll
@@ -2,7 +2,7 @@
 target datalayout = "E-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v128:128:128-n32:64"
 target triple = "powerpc64le-unknown-linux"
 
-define void @test1() nounwind {
+define void @test1(i1 %arg) nounwind {
 ; Ensure that we don't crash when the trip count == -1.
 ; CHECK-LABEL: @test1(
 entry:
@@ -15,7 +15,7 @@ vector.ph:                                        ; preds = %for.cond2.preheader
   br label %vector.body
 
 vector.body:                                      ; preds = %vector.body, %vector.ph
-  br i1 undef, label %middle.block.loopexit, label %vector.body
+  br i1 %arg, label %middle.block.loopexit, label %vector.body
 
 middle.block.loopexit:                            ; preds = %vector.body
   br label %middle.block
@@ -37,7 +37,7 @@ for.end.loopexit:                                 ; preds = %for.body4
   br label %for.end
 
 for.end:                                          ; preds = %for.end.loopexit, %middle.block
-  br i1 undef, label %for.cond2.preheader, label %for.end15
+  br i1 %arg, label %for.cond2.preheader, label %for.end15
 
 for.end15:                                        ; preds = %for.end
   ret void

--- a/llvm/test/Transforms/LoopUnroll/pr27157.ll
+++ b/llvm/test/Transforms/LoopUnroll/pr27157.ll
@@ -4,12 +4,12 @@
 target datalayout = "E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64"
 
 ; PR27157
-define void @foo() {
+define void @foo(i1 %arg) {
 entry:
   br label %loop_header
 loop_header:
   %iv = phi i64 [ 0, %entry ], [ %iv_next, %loop_latch ]
-  br i1 undef, label %loop_latch, label %loop_exiting_bb1
+  br i1 %arg, label %loop_latch, label %loop_exiting_bb1
 loop_exiting_bb1:
   br i1 false, label %loop_exiting_bb2, label %exit1.loopexit
 loop_exiting_bb2:
@@ -28,19 +28,19 @@ exit2:
   ret void
 }
 
-define void @foo2() {
+define void @foo2(i1 %arg) {
 entry:
   br label %loop.header
 loop.header:
   %iv = phi i32 [ 0, %entry ], [ %iv.inc, %latch ]
   %iv.inc = add i32 %iv, 1
-  br i1 undef, label %diamond, label %latch
+  br i1 %arg, label %diamond, label %latch
 diamond:
-  br i1 undef, label %left, label %right
+  br i1 %arg, label %left, label %right
 left:
-  br i1 undef, label %exit, label %merge
+  br i1 %arg, label %exit, label %merge
 right:
-  br i1 undef, label %exit, label %merge
+  br i1 %arg, label %exit, label %merge
 merge:
   br label %latch
 latch:

--- a/llvm/test/Transforms/LoopUnroll/pr28132.ll
+++ b/llvm/test/Transforms/LoopUnroll/pr28132.ll
@@ -6,7 +6,7 @@ declare void @fn1(ptr)
 
 declare i1 @fn2(ptr, ptr)
 
-define void @fn4() personality ptr @__CxxFrameHandler3 {
+define void @fn4(i1 %arg) personality ptr @__CxxFrameHandler3 {
 entry:
   br label %for.body
 
@@ -21,12 +21,12 @@ call.i.noexc:                                     ; preds = %for.body
           to label %call1.i.noexc unwind label %ehcleanup
 
 call1.i.noexc:                                    ; preds = %call.i.noexc
-  br i1 undef, label %if.then.i, label %if.end4.i
+  br i1 %arg, label %if.then.i, label %if.end4.i
 
 if.then.i:                                        ; preds = %call1.i.noexc
   %tmp1 = load i8, ptr undef, align 4
   %tobool.i = icmp eq i8 undef, undef
-  br i1 undef, label %if.end4.i, label %if.then2.i
+  br i1 %arg, label %if.end4.i, label %if.then2.i
 
 if.then2.i:                                       ; preds = %if.then.i
   %call3.i3 = invoke i1 @fn2(ptr undef, ptr null)

--- a/llvm/test/Transforms/LoopUnroll/rebuild_lcssa.ll
+++ b/llvm/test/Transforms/LoopUnroll/rebuild_lcssa.ll
@@ -127,17 +127,17 @@ Exit:
   ret void
 }
 
-define void @foo3() {
+define void @foo3(i1 %arg) {
 ; CHECK-LABEL: @foo3(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[L1_HEADER:%.*]]
 ; CHECK:       L1_header:
 ; CHECK-NEXT:    [[A:%.*]] = phi ptr [ [[B:%.*]], [[L1_LATCH:%.*]] ], [ null, [[ENTRY:%.*]] ]
-; CHECK-NEXT:    br i1 undef, label [[L2_HEADER_PREHEADER:%.*]], label [[L1_LATCH]]
+; CHECK-NEXT:    br i1 [[ARG:%.*]], label [[L2_HEADER_PREHEADER:%.*]], label [[L1_LATCH]]
 ; CHECK:       L2_header.preheader:
 ; CHECK-NEXT:    br label [[L2_HEADER:%.*]]
 ; CHECK:       L2_header:
-; CHECK-NEXT:    br i1 false, label [[L2_LATCH:%.*]], label [[L1_LATCH_LOOPEXIT:%.*]]
+; CHECK-NEXT:    br i1 [[ARG]], label [[L2_LATCH:%.*]], label [[L1_LATCH_LOOPEXIT:%.*]]
 ; CHECK:       L2_latch:
 ; CHECK-NEXT:    [[A_LCSSA:%.*]] = phi ptr [ [[A]], [[L2_HEADER]] ]
 ; CHECK-NEXT:    br label [[EXIT:%.*]]
@@ -155,10 +155,10 @@ entry:
 
 L1_header:
   %a = phi ptr [ %b, %L1_latch ], [ null, %entry ]
-  br i1 undef, label %L2_header, label %L1_latch
+  br i1 %arg, label %L2_header, label %L1_latch
 
 L2_header:
-  br i1 undef, label %L2_latch, label %L1_latch
+  br i1 %arg, label %L2_latch, label %L1_latch
 
 L2_latch:
   br i1 true, label %L2_exit, label %L2_header

--- a/llvm/test/Transforms/LoopUnroll/runtime-loop-multiple-exits.ll
+++ b/llvm/test/Transforms/LoopUnroll/runtime-loop-multiple-exits.ll
@@ -789,7 +789,7 @@ for.exit2:
 
 ; test with two exiting and three exit blocks.
 ; the non-latch exiting block has a switch.
-define void @test3(i64 %trip, i64 %add) {
+define void @test3(i64 %trip, i64 %add, i1 %arg) {
 ; EPILOG-LABEL: @test3(
 ; EPILOG-NEXT:  entry:
 ; EPILOG-NEXT:    %0 = freeze i64 %trip
@@ -804,7 +804,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    %iv = phi i64 [ 0, %entry.new ], [ %iv_next.7, %loop_latch.7 ]
 ; EPILOG-NEXT:    %sum = phi i64 [ 0, %entry.new ], [ %sum.next.7, %loop_latch.7 ]
 ; EPILOG-NEXT:    %niter = phi i64 [ 0, %entry.new ], [ %niter.next.7, %loop_latch.7 ]
-; EPILOG-NEXT:    br i1 undef, label %loop_latch, label %loop_exiting_bb1
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch, label %loop_exiting_bb1
 ; EPILOG:       loop_exiting_bb1:
 ; EPILOG-NEXT:    switch i64 %sum, label %loop_latch [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -818,7 +818,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ret void
 ; EPILOG:       loop_latch:
 ; EPILOG-NEXT:    %sum.next = add i64 %sum, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.1, label %loop_exiting_bb1.1
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.1, label %loop_exiting_bb1.1
 ; EPILOG:       loop_exiting_bb1.1:
 ; EPILOG-NEXT:    switch i64 %sum.next, label %loop_latch.1 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -826,7 +826,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ]
 ; EPILOG:       loop_latch.1:
 ; EPILOG-NEXT:    %sum.next.1 = add i64 %sum.next, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.2, label %loop_exiting_bb1.2
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.2, label %loop_exiting_bb1.2
 ; EPILOG:       loop_exiting_bb1.2:
 ; EPILOG-NEXT:    switch i64 %sum.next.1, label %loop_latch.2 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -834,7 +834,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ]
 ; EPILOG:       loop_latch.2:
 ; EPILOG-NEXT:    %sum.next.2 = add i64 %sum.next.1, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.3, label %loop_exiting_bb1.3
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.3, label %loop_exiting_bb1.3
 ; EPILOG:       loop_exiting_bb1.3:
 ; EPILOG-NEXT:    switch i64 %sum.next.2, label %loop_latch.3 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -842,7 +842,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ]
 ; EPILOG:       loop_latch.3:
 ; EPILOG-NEXT:    %sum.next.3 = add i64 %sum.next.2, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.4, label %loop_exiting_bb1.4
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.4, label %loop_exiting_bb1.4
 ; EPILOG:       loop_exiting_bb1.4:
 ; EPILOG-NEXT:    switch i64 %sum.next.3, label %loop_latch.4 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -850,7 +850,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ]
 ; EPILOG:       loop_latch.4:
 ; EPILOG-NEXT:    %sum.next.4 = add i64 %sum.next.3, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.5, label %loop_exiting_bb1.5
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.5, label %loop_exiting_bb1.5
 ; EPILOG:       loop_exiting_bb1.5:
 ; EPILOG-NEXT:    switch i64 %sum.next.4, label %loop_latch.5 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -858,7 +858,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ]
 ; EPILOG:       loop_latch.5:
 ; EPILOG-NEXT:    %sum.next.5 = add i64 %sum.next.4, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.6, label %loop_exiting_bb1.6
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.6, label %loop_exiting_bb1.6
 ; EPILOG:       loop_exiting_bb1.6:
 ; EPILOG-NEXT:    switch i64 %sum.next.5, label %loop_latch.6 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -866,7 +866,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    ]
 ; EPILOG:       loop_latch.6:
 ; EPILOG-NEXT:    %sum.next.6 = add i64 %sum.next.5, %add
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.7, label %loop_exiting_bb1.7
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.7, label %loop_exiting_bb1.7
 ; EPILOG:       loop_exiting_bb1.7:
 ; EPILOG-NEXT:    switch i64 %sum.next.6, label %loop_latch.7 [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit
@@ -899,7 +899,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-NEXT:    %iv.epil = phi i64 [ %iv.unr, %loop_header.epil.preheader ], [ %iv_next.epil, %loop_latch.epil ]
 ; EPILOG-NEXT:    %sum.epil = phi i64 [ %sum.unr, %loop_header.epil.preheader ], [ %sum.next.epil, %loop_latch.epil ]
 ; EPILOG-NEXT:    %epil.iter = phi i64 [ 0, %loop_header.epil.preheader ], [ %epil.iter.next, %loop_latch.epil ]
-; EPILOG-NEXT:    br i1 undef, label %loop_latch.epil, label %loop_exiting_bb1.epil
+; EPILOG-NEXT:    br i1 %arg, label %loop_latch.epil, label %loop_exiting_bb1.epil
 ; EPILOG:       loop_exiting_bb1.epil:
 ; EPILOG-NEXT:    switch i64 %sum.epil, label %loop_latch.epil [
 ; EPILOG-NEXT:      i64 24, label %exit1.loopexit1
@@ -931,7 +931,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-BLOCK-NEXT:    %iv = phi i64 [ 0, %entry.new ], [ %iv_next.1, %loop_latch.1 ]
 ; EPILOG-BLOCK-NEXT:    %sum = phi i64 [ 0, %entry.new ], [ %sum.next.1, %loop_latch.1 ]
 ; EPILOG-BLOCK-NEXT:    %niter = phi i64 [ 0, %entry.new ], [ %niter.next.1, %loop_latch.1 ]
-; EPILOG-BLOCK-NEXT:    br i1 undef, label %loop_latch, label %loop_exiting_bb1
+; EPILOG-BLOCK-NEXT:    br i1 %arg, label %loop_latch, label %loop_exiting_bb1
 ; EPILOG-BLOCK:       loop_exiting_bb1:
 ; EPILOG-BLOCK-NEXT:    switch i64 %sum, label %loop_latch [
 ; EPILOG-BLOCK-NEXT:      i64 24, label %exit1.loopexit
@@ -943,7 +943,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-BLOCK-NEXT:    ret void
 ; EPILOG-BLOCK:       loop_latch:
 ; EPILOG-BLOCK-NEXT:    %sum.next = add i64 %sum, %add
-; EPILOG-BLOCK-NEXT:    br i1 undef, label %loop_latch.1, label %loop_exiting_bb1.1
+; EPILOG-BLOCK-NEXT:    br i1 %arg, label %loop_latch.1, label %loop_exiting_bb1.1
 ; EPILOG-BLOCK:       loop_exiting_bb1.1:
 ; EPILOG-BLOCK-NEXT:    switch i64 %sum.next, label %loop_latch.1 [
 ; EPILOG-BLOCK-NEXT:      i64 24, label %exit1.loopexit
@@ -969,7 +969,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; EPILOG-BLOCK:       loop_header.epil.preheader:
 ; EPILOG-BLOCK-NEXT:    br label %loop_header.epil
 ; EPILOG-BLOCK:       loop_header.epil:
-; EPILOG-BLOCK-NEXT:    br i1 undef, label %loop_latch.epil, label %loop_exiting_bb1.epil
+; EPILOG-BLOCK-NEXT:    br i1 %arg, label %loop_latch.epil, label %loop_exiting_bb1.epil
 ; EPILOG-BLOCK:       loop_exiting_bb1.epil:
 ; EPILOG-BLOCK-NEXT:    switch i64 %sum.unr, label %loop_latch.epil [
 ; EPILOG-BLOCK-NEXT:      i64 24, label %exit1
@@ -993,7 +993,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    %iv.prol = phi i64 [ 0, %loop_header.prol.preheader ], [ %iv_next.prol, %loop_latch.prol ]
 ; PROLOG-NEXT:    %sum.prol = phi i64 [ 0, %loop_header.prol.preheader ], [ %sum.next.prol, %loop_latch.prol ]
 ; PROLOG-NEXT:    %prol.iter = phi i64 [ 0, %loop_header.prol.preheader ], [ %prol.iter.next, %loop_latch.prol ]
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.prol, label %loop_exiting_bb1.prol
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.prol, label %loop_exiting_bb1.prol
 ; PROLOG:       loop_exiting_bb1.prol:
 ; PROLOG-NEXT:    switch i64 %sum.prol, label %loop_latch.prol [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit1
@@ -1020,7 +1020,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG:       loop_header:
 ; PROLOG-NEXT:    %iv = phi i64 [ %iv.unr, %entry.new ], [ %iv_next.7, %loop_latch.7 ]
 ; PROLOG-NEXT:    %sum = phi i64 [ %sum.unr, %entry.new ], [ %sum.next.7, %loop_latch.7 ]
-; PROLOG-NEXT:    br i1 undef, label %loop_latch, label %loop_exiting_bb1
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch, label %loop_exiting_bb1
 ; PROLOG:       loop_exiting_bb1:
 ; PROLOG-NEXT:    switch i64 %sum, label %loop_latch [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1034,7 +1034,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ret void
 ; PROLOG:       loop_latch:
 ; PROLOG-NEXT:    %sum.next = add i64 %sum, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.1, label %loop_exiting_bb1.1
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.1, label %loop_exiting_bb1.1
 ; PROLOG:       loop_exiting_bb1.1:
 ; PROLOG-NEXT:    switch i64 %sum.next, label %loop_latch.1 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1042,7 +1042,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ]
 ; PROLOG:       loop_latch.1:
 ; PROLOG-NEXT:    %sum.next.1 = add i64 %sum.next, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.2, label %loop_exiting_bb1.2
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.2, label %loop_exiting_bb1.2
 ; PROLOG:       loop_exiting_bb1.2:
 ; PROLOG-NEXT:    switch i64 %sum.next.1, label %loop_latch.2 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1050,7 +1050,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ]
 ; PROLOG:       loop_latch.2:
 ; PROLOG-NEXT:    %sum.next.2 = add i64 %sum.next.1, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.3, label %loop_exiting_bb1.3
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.3, label %loop_exiting_bb1.3
 ; PROLOG:       loop_exiting_bb1.3:
 ; PROLOG-NEXT:    switch i64 %sum.next.2, label %loop_latch.3 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1058,7 +1058,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ]
 ; PROLOG:       loop_latch.3:
 ; PROLOG-NEXT:    %sum.next.3 = add i64 %sum.next.2, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.4, label %loop_exiting_bb1.4
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.4, label %loop_exiting_bb1.4
 ; PROLOG:       loop_exiting_bb1.4:
 ; PROLOG-NEXT:    switch i64 %sum.next.3, label %loop_latch.4 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1066,7 +1066,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ]
 ; PROLOG:       loop_latch.4:
 ; PROLOG-NEXT:    %sum.next.4 = add i64 %sum.next.3, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.5, label %loop_exiting_bb1.5
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.5, label %loop_exiting_bb1.5
 ; PROLOG:       loop_exiting_bb1.5:
 ; PROLOG-NEXT:    switch i64 %sum.next.4, label %loop_latch.5 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1074,7 +1074,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ]
 ; PROLOG:       loop_latch.5:
 ; PROLOG-NEXT:    %sum.next.5 = add i64 %sum.next.4, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.6, label %loop_exiting_bb1.6
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.6, label %loop_exiting_bb1.6
 ; PROLOG:       loop_exiting_bb1.6:
 ; PROLOG-NEXT:    switch i64 %sum.next.5, label %loop_latch.6 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1082,7 +1082,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-NEXT:    ]
 ; PROLOG:       loop_latch.6:
 ; PROLOG-NEXT:    %sum.next.6 = add i64 %sum.next.5, %add
-; PROLOG-NEXT:    br i1 undef, label %loop_latch.7, label %loop_exiting_bb1.7
+; PROLOG-NEXT:    br i1 %arg, label %loop_latch.7, label %loop_exiting_bb1.7
 ; PROLOG:       loop_exiting_bb1.7:
 ; PROLOG-NEXT:    switch i64 %sum.next.6, label %loop_latch.7 [
 ; PROLOG-NEXT:      i64 24, label %exit1.loopexit
@@ -1114,7 +1114,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-BLOCK:       loop_header.prol.preheader:
 ; PROLOG-BLOCK-NEXT:    br label %loop_header.prol
 ; PROLOG-BLOCK:       loop_header.prol:
-; PROLOG-BLOCK-NEXT:    br i1 undef, label %loop_latch.prol, label %loop_exiting_bb1.prol
+; PROLOG-BLOCK-NEXT:    br i1 %arg, label %loop_latch.prol, label %loop_exiting_bb1.prol
 ; PROLOG-BLOCK:       loop_exiting_bb1.prol:
 ; PROLOG-BLOCK-NEXT:    switch i64 0, label %loop_latch.prol [
 ; PROLOG-BLOCK-NEXT:      i64 24, label %exit1
@@ -1132,7 +1132,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-BLOCK:       loop_header:
 ; PROLOG-BLOCK-NEXT:    %iv = phi i64 [ %iv.unr, %entry.new ], [ %iv_next.1, %loop_latch.1 ]
 ; PROLOG-BLOCK-NEXT:    %sum = phi i64 [ %sum.unr, %entry.new ], [ %sum.next.1, %loop_latch.1 ]
-; PROLOG-BLOCK-NEXT:    br i1 undef, label %loop_latch, label %loop_exiting_bb1
+; PROLOG-BLOCK-NEXT:    br i1 %arg, label %loop_latch, label %loop_exiting_bb1
 ; PROLOG-BLOCK:       loop_exiting_bb1:
 ; PROLOG-BLOCK-NEXT:    switch i64 %sum, label %loop_latch [
 ; PROLOG-BLOCK-NEXT:      i64 24, label %exit1.loopexit
@@ -1144,7 +1144,7 @@ define void @test3(i64 %trip, i64 %add) {
 ; PROLOG-BLOCK-NEXT:    ret void
 ; PROLOG-BLOCK:       loop_latch:
 ; PROLOG-BLOCK-NEXT:    %sum.next = add i64 %sum, %add
-; PROLOG-BLOCK-NEXT:    br i1 undef, label %loop_latch.1, label %loop_exiting_bb1.1
+; PROLOG-BLOCK-NEXT:    br i1 %arg, label %loop_latch.1, label %loop_exiting_bb1.1
 ; PROLOG-BLOCK:       loop_exiting_bb1.1:
 ; PROLOG-BLOCK-NEXT:    switch i64 %sum.next, label %loop_latch.1 [
 ; PROLOG-BLOCK-NEXT:      i64 24, label %exit1.loopexit
@@ -1171,7 +1171,7 @@ entry:
 loop_header:
   %iv = phi i64 [ 0, %entry ], [ %iv_next, %loop_latch ]
   %sum = phi i64 [ 0, %entry ], [ %sum.next, %loop_latch ]
-  br i1 undef, label %loop_latch, label %loop_exiting_bb1
+  br i1 %arg, label %loop_latch, label %loop_exiting_bb1
 
 loop_exiting_bb1:
   switch i64 %sum, label %loop_latch [

--- a/llvm/test/Transforms/LoopUnroll/unloop.ll
+++ b/llvm/test/Transforms/LoopUnroll/unloop.ll
@@ -456,7 +456,7 @@ for.end166:
 ; Remove a loop whose exit branches into a sibling loop.
 ; Ensure that only the loop is removed and rely on verify-loopinfo to
 ; check soundness.
-define void @unloopCriticalEdge() nounwind {
+define void @unloopCriticalEdge(i1 %arg) nounwind {
 ; CHECK-LABEL: @unloopCriticalEdge(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[FOR_COND31:%.*]]
@@ -465,7 +465,7 @@ define void @unloopCriticalEdge() nounwind {
 ; CHECK:       for.body35:
 ; CHECK-NEXT:    br label [[WHILE_COND_I_PREHEADER:%.*]]
 ; CHECK:       while.cond.i.preheader:
-; CHECK-NEXT:    br i1 undef, label [[WHILE_COND_I_PREHEADER_SPLIT:%.*]], label [[WHILE_COND_OUTER_I_LOOPEXIT_SPLIT:%.*]]
+; CHECK-NEXT:    br i1 %arg, label [[WHILE_COND_I_PREHEADER_SPLIT:%.*]], label [[WHILE_COND_OUTER_I_LOOPEXIT_SPLIT:%.*]]
 ; CHECK:       while.cond.i.preheader.split:
 ; CHECK-NEXT:    br label [[WHILE_COND_I:%.*]]
 ; CHECK:       while.cond.i:
@@ -491,13 +491,13 @@ entry:
   br label %for.cond31
 
 for.cond31:
-  br i1 undef, label %for.body35, label %for.end94
+  br i1 false, label %for.body35, label %for.end94
 
 for.body35:
   br label %while.cond.i.preheader
 
 while.cond.i.preheader:
-  br i1 undef, label %while.cond.i.preheader.split, label %while.cond.outer.i.loopexit.split
+  br i1 %arg, label %while.cond.i.preheader.split, label %while.cond.outer.i.loopexit.split
 
 while.cond.i.preheader.split:
   br label %while.cond.i
@@ -521,7 +521,7 @@ while.end:
   br label %for.end78
 
 for.end78:
-  br i1 undef, label %Proc2.exit, label %for.cond.i.preheader
+  br i1 false, label %Proc2.exit, label %for.cond.i.preheader
 
 for.cond.i.preheader:
   br label %for.cond.i
@@ -563,7 +563,7 @@ define void @removeSubloopBlocks() nounwind {
 ; CHECK:       sw.default1711:
 ; CHECK-NEXT:    br label [[DEFCHAR:%.*]]
 ; CHECK:       defchar:
-; CHECK-NEXT:    br i1 undef, label [[IF_END2413:%.*]], label [[IF_THEN2368:%.*]]
+; CHECK-NEXT:    br i1 true, label [[IF_END2413:%.*]], label [[IF_THEN2368:%.*]]
 ; CHECK:       if.then2368:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       if.end2413:
@@ -576,16 +576,16 @@ tryagain.outer:                                   ; preds = %sw.bb304, %entry
   br label %tryagain
 
 tryagain:                                         ; preds = %while.end1699, %tryagain.outer
-  br i1 undef, label %sw.bb1669, label %sw.bb304
+  br i1 false, label %sw.bb1669, label %sw.bb304
 
 sw.bb304:                                         ; preds = %tryagain
-  br i1 undef, label %return, label %tryagain.outer
+  br i1 true, label %return, label %tryagain.outer
 
 sw.bb1669:                                        ; preds = %tryagain
-  br i1 undef, label %sw.default1711, label %while.cond1676
+  br i1 true, label %sw.default1711, label %while.cond1676
 
 while.cond1676:                                   ; preds = %while.body1694, %sw.bb1669
-  br i1 undef, label %while.end1699, label %while.body1694
+  br i1 true, label %while.end1699, label %while.body1694
 
 while.body1694:                                   ; preds = %while.cond1676
   br label %while.cond1676
@@ -597,7 +597,7 @@ sw.default1711:                                   ; preds = %while.end1699, %sw.
   br label %defchar
 
 defchar:                                          ; preds = %sw.default1711, %sw.bb376
-  br i1 undef, label %if.end2413, label %if.then2368
+  br i1 true, label %if.end2413, label %if.then2368
 
 if.then2368:                                      ; preds = %defchar
   unreachable

--- a/llvm/test/Transforms/LoopVectorize/2012-10-20-infloop.ll
+++ b/llvm/test/Transforms/LoopVectorize/2012-10-20-infloop.ll
@@ -20,25 +20,25 @@ for.body:                                         ; preds = %for.body, %entry
  %indvars.iv47 = phi i64 [ 0, %entry ], [ %indvars.iv.next48, %for.body ]
  %0 = phi i32 [ 1, %entry ], [ 0, %for.body ]
  %indvars.iv.next48 = add i64 %indvars.iv47, 1
- br i1 undef, label %for.end, label %for.body
+ br i1 false, label %for.end, label %for.body
 
 for.end:                                          ; preds = %for.body
  unreachable
 }
 
 ;PR14701
-define void @start_model_rare() nounwind uwtable ssp {
+define void @start_model_rare(i1 %arg) nounwind uwtable ssp {
 entry:
-  br i1 undef, label %return, label %if.end
+  br i1 false, label %return, label %if.end
 
 if.end:                                           ; preds = %entry
-  br i1 undef, label %cond.false, label %cond.true
+  br i1 true, label %cond.false, label %cond.true
 
 cond.true:                                        ; preds = %if.end
   unreachable
 
 cond.false:                                       ; preds = %if.end
-  br i1 undef, label %cond.false28, label %cond.true20
+  br i1 true, label %cond.false28, label %cond.true20
 
 cond.true20:                                      ; preds = %cond.false
   unreachable
@@ -49,7 +49,7 @@ cond.false28:                                     ; preds = %cond.false
 for.body40:                                       ; preds = %for.inc50, %cond.false28
   %indvars.iv123 = phi i64 [ 3, %cond.false28 ], [ %indvars.iv.next124, %for.inc50 ]
   %step.0121 = phi i32 [ 1, %cond.false28 ], [ %step.1, %for.inc50 ]
-  br i1 undef, label %if.then46, label %for.inc50
+  br i1 %arg, label %if.then46, label %for.inc50
 
 if.then46:                                        ; preds = %for.body40
   %inc47 = add nsw i32 %step.0121, 1

--- a/llvm/test/Transforms/LoopVectorize/X86/consecutive-ptr-cg-bug.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/consecutive-ptr-cg-bug.ll
@@ -35,7 +35,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; This test was originally vectorized, but now SCEV is smart enough to prove
 ; that its trip count is 1, so it gets ignored by vectorizer.
 ; Function Attrs: uwtable
-define void @test_01() {
+define void @test_01(i1 %arg) {
   br label %.outer
 
 ; <label>:1:                                      ; preds = %2
@@ -43,7 +43,7 @@ define void @test_01() {
 
 ; <label>:2:                                      ; preds = %._crit_edge.loopexit
   %3 = add nsw i32 %.ph, -2
-  br i1 undef, label %1, label %.outer
+  br i1 %arg, label %1, label %.outer
 
 .outer:                                           ; preds = %2, %0
   %.ph = phi i32 [ %3, %2 ], [ 336, %0 ]
@@ -65,7 +65,7 @@ define void @test_01() {
   br i1 %14, label %._crit_edge.loopexit, label %6
 
 ._crit_edge.loopexit:                             ; preds = %._crit_edge.loopexit, %6
-  br i1 undef, label %2, label %._crit_edge.loopexit
+  br i1 %arg, label %2, label %._crit_edge.loopexit
 }
 
 ; After trip count is increased, the test gets vectorized.
@@ -74,7 +74,7 @@ define void @test_01() {
 ; CHECK: store <4 x i32>
 
 ; Function Attrs: uwtable
-define void @test_02() {
+define void @test_02(i1 %arg) {
   br label %.outer
 
 ; <label>:1:                                      ; preds = %2
@@ -82,7 +82,7 @@ define void @test_02() {
 
 ; <label>:2:                                      ; preds = %._crit_edge.loopexit
   %3 = add nsw i32 %.ph, -2
-  br i1 undef, label %1, label %.outer
+  br i1 %arg, label %1, label %.outer
 
 .outer:                                           ; preds = %2, %0
   %.ph = phi i32 [ %3, %2 ], [ 336, %0 ]
@@ -104,5 +104,5 @@ define void @test_02() {
   br i1 %14, label %._crit_edge.loopexit, label %6
 
 ._crit_edge.loopexit:                             ; preds = %._crit_edge.loopexit, %6
-  br i1 undef, label %2, label %._crit_edge.loopexit
+  br i1 %arg, label %2, label %._crit_edge.loopexit
 }

--- a/llvm/test/Transforms/LoopVectorize/X86/pr39160.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/pr39160.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128-ni:1"
 target triple = "x86_64-unknown-linux-gnu"
 
 ; Make sure that we can compile the test without crash.
-define void @barney(ptr %dst) {
+define void @barney(ptr %dst, i1 %arg) {
 
 ; CHECK-LABEL: @barney(
 ; CHECK:       middle.block:
@@ -28,13 +28,13 @@ bb19:                                             ; preds = %bb36, %bb5
   br label %bb50
 
 bb33:                                             ; preds = %bb62
-  br i1 undef, label %bb18, label %bb36
+  br i1 %arg, label %bb18, label %bb36
 
 bb36:                                             ; preds = %bb33
   br label %bb19
 
 bb46:                                             ; preds = %bb50
-  br i1 undef, label %bb48, label %bb59
+  br i1 %arg, label %bb48, label %bb59
 
 bb48:                                             ; preds = %bb46
   %tmp49 = add i32 %tmp52, 14

--- a/llvm/test/Transforms/LoopVectorize/X86/rauw-bug.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/rauw-bug.ll
@@ -13,9 +13,9 @@ target triple = "x86_64-apple-macosx"
 ; radar://15498655
 
 ; CHECK: reduced
-define void @reduced()  {
+define void @reduced(i1 %arg)  {
 entry:
-  br i1 undef, label %while.body, label %while.cond63.preheader.while.end76_crit_edge
+  br i1 %arg, label %while.body, label %while.cond63.preheader.while.end76_crit_edge
 
 while.cond63.preheader.while.end76_crit_edge:
   ret void

--- a/llvm/test/Transforms/LoopVectorize/X86/reduction-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/X86/reduction-crash.ll
@@ -4,7 +4,7 @@ target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f3
 target triple = "i386-apple-darwin"
 
 ; PR15344
-define void @test1(ptr nocapture %arg, i32 %arg1) nounwind {
+define void @test1(ptr nocapture %arg, i32 %arg1, i1 %arg2) nounwind {
 ; CHECK-LABEL: @test1(
 ; CHECK: preheader
 ; CHECK: insertelement <2 x double> zeroinitializer, double %tmp, i32 0
@@ -15,7 +15,7 @@ bb:
 
 bb2:                                              ; preds = %bb
   %tmp = load double, ptr null, align 8
-  br i1 undef, label %bb3, label %bb12
+  br i1 %arg2, label %bb3, label %bb12
 
 bb3:                                              ; preds = %bb3, %bb2
   %tmp4 = phi double [ %tmp9, %bb3 ], [ %tmp, %bb2 ]

--- a/llvm/test/Transforms/LoopVectorize/if-conv-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/if-conv-crash.ll
@@ -4,19 +4,19 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 
 define fastcc void @DD_dump() nounwind uwtable ssp {
 entry:
-  br i1 undef, label %lor.lhs.false, label %if.end25
+  br i1 true, label %lor.lhs.false, label %if.end25
 
 lor.lhs.false:                                    ; preds = %entry
-  br i1 undef, label %if.end21, label %if.else
+  br i1 false, label %if.end21, label %if.else
 
 if.else:                                          ; preds = %lor.lhs.false
-  br i1 undef, label %num_q.exit, label %while.body.i.preheader
+  br i1 false, label %num_q.exit, label %while.body.i.preheader
 
 while.body.i.preheader:                           ; preds = %if.else
   br label %while.body.i
 
 while.body.i:                                     ; preds = %if.end.i, %while.body.i.preheader
-  switch i8 undef, label %if.end.i [
+  switch i8 0, label %if.end.i [
     i8 39, label %if.then.i
     i8 92, label %if.then.i
   ]
@@ -25,7 +25,7 @@ if.then.i:                                        ; preds = %while.body.i, %whil
   br label %if.end.i
 
 if.end.i:                                         ; preds = %if.then.i, %while.body.i
-  br i1 undef, label %num_q.exit, label %while.body.i
+  br i1 false, label %num_q.exit, label %while.body.i
 
 num_q.exit:                                       ; preds = %if.end.i, %if.else
   unreachable

--- a/llvm/test/Transforms/LoopVectorize/incorrect-dom-info.ll
+++ b/llvm/test/Transforms/LoopVectorize/incorrect-dom-info.ll
@@ -6,9 +6,9 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 @PL_utf8skip = external constant [0 x i8]
 
 ; Function Attrs: nounwind ssp uwtable
-define void @Perl_pp_quotemeta() #0 {
+define void @Perl_pp_quotemeta(i1 %arg) #0 {
   %len = alloca i64, align 8
-  br i1 undef, label %2, label %1
+  br i1 %arg, label %2, label %1
 
 ; <label>:1                                       ; preds = %0
   br label %3
@@ -17,31 +17,31 @@ define void @Perl_pp_quotemeta() #0 {
   br label %3
 
 ; <label>:3                                       ; preds = %2, %1
-  br i1 undef, label %34, label %4
+  br i1 %arg, label %34, label %4
 
 ; <label>:4                                       ; preds = %3
-  br i1 undef, label %5, label %6
+  br i1 %arg, label %5, label %6
 
 ; <label>:5                                       ; preds = %4
   br label %6
 
 ; <label>:6                                       ; preds = %5, %4
-  br i1 undef, label %7, label %8
+  br i1 %arg, label %7, label %8
 
 ; <label>:7                                       ; preds = %6
   br label %8
 
 ; <label>:8                                       ; preds = %7, %6
-  br i1 undef, label %.preheader, label %9
+  br i1 %arg, label %.preheader, label %9
 
 .preheader:                                       ; preds = %9, %8
-  br i1 undef, label %.loopexit, label %.lr.ph
+  br i1 %arg, label %.loopexit, label %.lr.ph
 
 ; <label>:9                                       ; preds = %8
-  br i1 undef, label %thread-pre-split.preheader, label %.preheader
+  br i1 %arg, label %thread-pre-split.preheader, label %.preheader
 
 thread-pre-split.preheader:                       ; preds = %9
-  br i1 undef, label %thread-pre-split._crit_edge, label %.lr.ph21
+  br i1 %arg, label %thread-pre-split._crit_edge, label %.lr.ph21
 
 .thread-pre-split.loopexit_crit_edge:             ; preds = %19
   %scevgep.sum = xor i64 %umax, -1
@@ -55,7 +55,7 @@ thread-pre-split.loopexit:                        ; preds = %11, %.thread-pre-sp
 .lr.ph21:                                         ; preds = %26, %thread-pre-split.loopexit, %thread-pre-split.preheader
   %d.020 = phi ptr [ undef, %26 ], [ %d.1.lcssa, %thread-pre-split.loopexit ], [ undef, %thread-pre-split.preheader ]
   %10 = phi i64 [ %28, %26 ], [ undef, %thread-pre-split.loopexit ], [ undef, %thread-pre-split.preheader ]
-  br i1 undef, label %11, label %22
+  br i1 %arg, label %11, label %22
 
 ; <label>:11                                      ; preds = %.lr.ph21
   %12 = getelementptr inbounds [0 x i8], ptr @PL_utf8skip, i64 0, i64 undef
@@ -63,7 +63,7 @@ thread-pre-split.loopexit:                        ; preds = %11, %.thread-pre-sp
   %14 = zext i8 %13 to i64
   %15 = icmp ugt i64 %14, %10
   %. = select i1 %15, i64 %10, i64 %14
-  br i1 undef, label %thread-pre-split.loopexit, label %.lr.ph28
+  br i1 %arg, label %thread-pre-split.loopexit, label %.lr.ph28
 
 .lr.ph28:                                         ; preds = %11
   %16 = xor i64 %10, -1
@@ -79,13 +79,13 @@ thread-pre-split.loopexit:                        ; preds = %11, %.thread-pre-sp
   br i1 %21, label %.thread-pre-split.loopexit_crit_edge, label %19
 
 ; <label>:22                                      ; preds = %.lr.ph21
-  br i1 undef, label %26, label %23
+  br i1 %arg, label %26, label %23
 
 ; <label>:23                                      ; preds = %22
-  br i1 undef, label %26, label %24
+  br i1 %arg, label %26, label %24
 
 ; <label>:24                                      ; preds = %23
-  br i1 undef, label %26, label %25
+  br i1 %arg, label %26, label %25
 
 ; <label>:25                                      ; preds = %24
   br label %26
@@ -93,31 +93,31 @@ thread-pre-split.loopexit:                        ; preds = %11, %.thread-pre-sp
 ; <label>:26                                      ; preds = %25, %24, %23, %22
   %27 = load i64, ptr %len, align 8
   %28 = add i64 %27, -1
-  br i1 undef, label %thread-pre-split._crit_edge, label %.lr.ph21
+  br i1 %arg, label %thread-pre-split._crit_edge, label %.lr.ph21
 
 thread-pre-split._crit_edge:                      ; preds = %26, %thread-pre-split.loopexit, %thread-pre-split.preheader
   br label %.loopexit
 
 .lr.ph:                                           ; preds = %33, %.preheader
-  br i1 undef, label %29, label %thread-pre-split5
+  br i1 %arg, label %29, label %thread-pre-split5
 
 ; <label>:29                                      ; preds = %.lr.ph
-  br i1 undef, label %33, label %30
+  br i1 %arg, label %33, label %30
 
 ; <label>:30                                      ; preds = %29
-  br i1 undef, label %33, label %31
+  br i1 %arg, label %33, label %31
 
 thread-pre-split5:                                ; preds = %.lr.ph
-  br i1 undef, label %33, label %31
+  br i1 %arg, label %33, label %31
 
 ; <label>:31                                      ; preds = %thread-pre-split5, %30
-  br i1 undef, label %33, label %32
+  br i1 %arg, label %33, label %32
 
 ; <label>:32                                      ; preds = %31
   br label %33
 
 ; <label>:33                                      ; preds = %32, %31, %thread-pre-split5, %30, %29
-  br i1 undef, label %.loopexit, label %.lr.ph
+  br i1 %arg, label %.loopexit, label %.lr.ph
 
 .loopexit:                                        ; preds = %33, %thread-pre-split._crit_edge, %.preheader
   br label %35
@@ -126,7 +126,7 @@ thread-pre-split5:                                ; preds = %.lr.ph
   br label %35
 
 ; <label>:35                                      ; preds = %34, %.loopexit
-  br i1 undef, label %37, label %36
+  br i1 %arg, label %37, label %36
 
 ; <label>:36                                      ; preds = %35
   br label %37

--- a/llvm/test/Transforms/LoopVectorize/nsw-crash.ll
+++ b/llvm/test/Transforms/LoopVectorize/nsw-crash.ll
@@ -3,9 +3,9 @@
 target datalayout =
 "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128"
 
-define void @test() {
+define void @test(i1 %arg) {
 entry:
-  br i1 undef, label %while.end, label %while.body.lr.ph
+  br i1 %arg, label %while.end, label %while.body.lr.ph
 
 while.body.lr.ph:
   br label %while.body

--- a/llvm/test/Transforms/LoopVectorize/pr36311.ll
+++ b/llvm/test/Transforms/LoopVectorize/pr36311.ll
@@ -13,16 +13,16 @@ $test = comdat any
 declare i32 @__gxx_personality_v0(...)
 
 ; Function Attrs: uwtable
-define dso_local void @test() local_unnamed_addr #0 comdat align 2 personality ptr @__gxx_personality_v0 {
+define dso_local void @test(i1 %arg) local_unnamed_addr #0 comdat align 2 personality ptr @__gxx_personality_v0 {
 entry:
   br label %for.body51
 
 for.body51:                                       ; preds = %for.body51, %entry
-  br i1 undef, label %for.body51, label %for.body89.lr.ph
+  br i1 %arg, label %for.body51, label %for.body89.lr.ph
 
 for.cond80.loopexit:                              ; preds = %for.body89
   %inc94.lcssa = phi i32 [ %inc94, %for.body89 ]
-  br i1 undef, label %for.body89.lr.ph, label %nrvo.skipdtor.loopexit
+  br i1 %arg, label %for.body89.lr.ph, label %nrvo.skipdtor.loopexit
 
 for.body89.lr.ph:                                 ; preds = %for.cond80.loopexit, %for.body51
   %i79.0179 = phi i32 [ %add90, %for.cond80.loopexit ], [ 0, %for.body51 ]

--- a/llvm/test/Transforms/LoopVectorize/reduction-order.ll
+++ b/llvm/test/Transforms/LoopVectorize/reduction-order.ll
@@ -42,13 +42,13 @@ t31:
 ; exercises the path and bails out without performing vectorization.
 ; CHECK-LABEL: quux
 ; CHECK-NOT: fadd <4 x 
-define void @quux() {
+define void @quux(i1 %arg) {
 bb:
   br label %header
 
 latch:                                              ; preds = %header
   %tmp = phi double [ %tmp6, %header ]
-  br i1 undef, label %header, label %bb2
+  br i1 %arg, label %header, label %bb2
 
 bb2:                                              ; preds = %latch
   %tmp3 = phi double [ %tmp, %latch ]

--- a/llvm/test/Transforms/LowerConstantIntrinsics/stale-worklist-phi.ll
+++ b/llvm/test/Transforms/LowerConstantIntrinsics/stale-worklist-phi.ll
@@ -13,7 +13,7 @@
 
 %s = type { [2 x i16] }
 
-define fastcc void @foo(ptr %p) unnamed_addr {
+define fastcc void @foo(ptr %p, i1 %arg) unnamed_addr {
 entry:
   %0 = tail call i32 @llvm.objectsize.i32.p0(ptr %p, i1 false, i1 false, i1 false) #2
   %1 = icmp ne i32 %0, 0
@@ -24,7 +24,7 @@ for.cond:                                         ; preds = %entry
   br label %cont.i
 
 cont.i:                                           ; preds = %for.cond
-  br i1 undef, label %cont2.i, label %cont2.thread.i
+  br i1 %arg, label %cont2.i, label %cont2.thread.i
 
 cont2.thread.i:                                   ; preds = %cont.i
   br label %handler.type_mismatch3.i

--- a/llvm/test/Transforms/LowerSwitch/condition-phi-unreachable-default.ll
+++ b/llvm/test/Transforms/LowerSwitch/condition-phi-unreachable-default.ll
@@ -10,7 +10,7 @@ entry:
 
 sw.epilog:                                        ; preds = %sw.epilog.outer, %for.body
   %i = phi i32 [ undef, %for.body ], [ 0, %entry ]
-  br i1 undef, label %for.body, label %for.end
+  br i1 true, label %for.body, label %for.end
 
 for.body:                                         ; preds = %sw.epilog
   switch i32 %i, label %sw.epilog [

--- a/llvm/test/Transforms/LowerSwitch/do-not-handle-impossible-values.ll
+++ b/llvm/test/Transforms/LowerSwitch/do-not-handle-impossible-values.ll
@@ -584,7 +584,7 @@ exit:
 
 ; Check that we do not generate redundant comparisons that would have results
 ; known at compile time due to limited range of the value being switch'ed over.
-define void @test12() {
+define void @test12(i1 %arg) {
 ; CHECK-LABEL: @test12(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[FOR_BODY:%.*]]
@@ -603,7 +603,7 @@ define void @test12() {
 ; CHECK-NEXT:    br label [[LATCH]]
 ; CHECK:       latch:
 ; CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[INDVAR]], 1
-; CHECK-NEXT:    br i1 undef, label [[EXIT:%.*]], label [[FOR_BODY]]
+; CHECK-NEXT:    br i1 %arg, label [[EXIT:%.*]], label [[FOR_BODY]]
 ; CHECK:       exit:
 ; CHECK-NEXT:    ret void
 ;
@@ -626,7 +626,7 @@ case.2:
 
 latch:
   %inc = add nuw nsw i32 %indvar, 1
-  br i1 undef, label %exit, label %for.body
+  br i1 %arg, label %exit, label %for.body
 
 exit:
   ret void

--- a/llvm/test/Transforms/LowerSwitch/phi-in-dead-block.ll
+++ b/llvm/test/Transforms/LowerSwitch/phi-in-dead-block.ll
@@ -2,9 +2,9 @@
 
 ; CHECK-LABEL: @phi_in_dead_block(
 ; CHECK-NOT: switch
-define void @phi_in_dead_block() {
+define void @phi_in_dead_block(i1 %arg) {
 bb:
-  br i1 undef, label %bb2, label %bb3
+  br i1 %arg, label %bb2, label %bb3
 
 bb1:                                              ; No predecessors!
   switch i32 undef, label %bb2 [
@@ -21,9 +21,9 @@ bb3:                                              ; preds = %bb1, %bb
 
 ; CHECK-LABEL: @phi_in_dead_block_br_to_self(
 ; CHECK-NOT: switch
-define void @phi_in_dead_block_br_to_self() {
+define void @phi_in_dead_block_br_to_self(i1 %arg) {
 bb:
-  br i1 undef, label %bb2, label %bb3
+  br i1 %arg, label %bb2, label %bb3
 
 bb1:                                              ; No predecessors!
   switch i32 undef, label %bb2 [


### PR DESCRIPTION
This PR removes tests with `br i1 undef` under `llvm/tests/Transforms/Loop*, Lower*`.

@nunoplopes @regehr 