### PR TITLE
Recommit "[TargetVersion] Only enable on RISC-V and AArch64" (#117110)"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -459,6 +459,8 @@ Attribute Changes in Clang
 - Clang now supports ``[[clang::lifetime_capture_by(X)]]``. Similar to lifetimebound, this can be
   used to specify when a reference to a function parameter is captured by another capturing entity ``X``.
 
+- The ``target_version`` attribute is now only supported for AArch64 and RISC-V architectures.
+
 Improvements to Clang's diagnostics
 -----------------------------------
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3297,7 +3297,7 @@ def Target : InheritableAttr {
   }];
 }
 
-def TargetVersion : InheritableAttr {
+def TargetVersion : InheritableAttr, TargetSpecificAttr<TargetArch<!listconcat(TargetAArch64.Arches, TargetRISCV.Arches)>> {
   let Spellings = [GCC<"target_version">];
   let Args = [StringArgument<"NamesStr">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/test/Sema/attr-target-version-unsupported.c
+++ b/clang/test/Sema/attr-target-version-unsupported.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -fsyntax-only -verify %s
+
+//expected-warning@+1 {{unknown attribute 'target_version' ignored}}
+int __attribute__((target_version("aes"))) foo(void) { return 3; }


### PR DESCRIPTION
Remain InheritableAttr to avoid the warning `TypePrinter.cpp:1953:10: warning: enumeration value ‘TargetVersion’ not handled in switch`

origin messenge

[TargetVersion] Only enable on RISC-V and AArch64 (#115991) Address #115000.

This patch constrains the target_version feature to work only on RISC-V and AArch64 to prevent crashes in Clang.

