### PR TITLE
[Clang] [Parser] Fixing all callers of `ParseExternalDeclaration` that didn't parse gnu attributes

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1687,6 +1687,8 @@ private:
   DeclGroupPtrTy ParseExternalDeclaration(ParsedAttributes &DeclAttrs,
                                           ParsedAttributes &DeclSpecAttrs,
                                           ParsingDeclSpec *DS = nullptr);
+  DeclGroupPtrTy ParseExternalDeclarationWithAttrs(
+                                                 ParsingDeclSpec *DS = nullptr);
   bool isDeclarationAfterDeclarator();
   bool isStartOfFunctionDefinition(const ParsingDeclarator &Declarator);
   DeclGroupPtrTy ParseDeclarationOrFunctionDefinition(

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -267,9 +267,11 @@ void Parser::ParseInnerNamespace(const InnerNamespaceInfoList &InnerNSs,
     while (!tryParseMisplacedModuleImport() && Tok.isNot(tok::r_brace) &&
            Tok.isNot(tok::eof)) {
       ParsedAttributes DeclAttrs(AttrFactory);
-      MaybeParseCXX11Attributes(DeclAttrs);
-      ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
-      ParseExternalDeclaration(DeclAttrs, EmptyDeclSpecAttrs);
+      ParsedAttributes DeclSpecAttrs(AttrFactory);
+      while (MaybeParseCXX11Attributes(DeclAttrs) ||
+              MaybeParseGNUAttributes(DeclSpecAttrs))
+        ;
+      ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
     }
 
     // The caller is what called check -- we are simply calling
@@ -468,9 +470,11 @@ Decl *Parser::ParseExportDeclaration() {
   if (Tok.isNot(tok::l_brace)) {
     // FIXME: Factor out a ParseExternalDeclarationWithAttrs.
     ParsedAttributes DeclAttrs(AttrFactory);
-    MaybeParseCXX11Attributes(DeclAttrs);
-    ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
-    ParseExternalDeclaration(DeclAttrs, EmptyDeclSpecAttrs);
+    ParsedAttributes DeclSpecAttrs(AttrFactory);
+    while (MaybeParseCXX11Attributes(DeclAttrs) ||
+            MaybeParseGNUAttributes(DeclSpecAttrs))
+      ;
+    ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
     return Actions.ActOnFinishExportDecl(getCurScope(), ExportDecl,
                                          SourceLocation());
   }
@@ -481,9 +485,11 @@ Decl *Parser::ParseExportDeclaration() {
   while (!tryParseMisplacedModuleImport() && Tok.isNot(tok::r_brace) &&
          Tok.isNot(tok::eof)) {
     ParsedAttributes DeclAttrs(AttrFactory);
-    MaybeParseCXX11Attributes(DeclAttrs);
-    ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
-    ParseExternalDeclaration(DeclAttrs, EmptyDeclSpecAttrs);
+    ParsedAttributes DeclSpecAttrs(AttrFactory);
+    while (MaybeParseCXX11Attributes(DeclAttrs) ||
+            MaybeParseGNUAttributes(DeclSpecAttrs))
+      ;
+    ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
   }
 
   T.consumeClose();

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -266,12 +266,7 @@ void Parser::ParseInnerNamespace(const InnerNamespaceInfoList &InnerNSs,
   if (index == InnerNSs.size()) {
     while (!tryParseMisplacedModuleImport() && Tok.isNot(tok::r_brace) &&
            Tok.isNot(tok::eof)) {
-      ParsedAttributes DeclAttrs(AttrFactory);
-      ParsedAttributes DeclSpecAttrs(AttrFactory);
-      while (MaybeParseCXX11Attributes(DeclAttrs) ||
-              MaybeParseGNUAttributes(DeclSpecAttrs))
-        ;
-      ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
+      ParseExternalDeclarationWithAttrs();
     }
 
     // The caller is what called check -- we are simply calling
@@ -426,12 +421,7 @@ Decl *Parser::ParseLinkage(ParsingDeclSpec &DS, DeclaratorContext Context) {
         break;
       [[fallthrough]];
     default:
-      ParsedAttributes DeclAttrs(AttrFactory);
-      ParsedAttributes DeclSpecAttrs(AttrFactory);
-      while (MaybeParseCXX11Attributes(DeclAttrs) ||
-             MaybeParseGNUAttributes(DeclSpecAttrs))
-        ;
-      ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
+      ParseExternalDeclarationWithAttrs();
       continue;
     }
 
@@ -468,13 +458,7 @@ Decl *Parser::ParseExportDeclaration() {
       Tok.is(tok::l_brace) ? Tok.getLocation() : SourceLocation());
 
   if (Tok.isNot(tok::l_brace)) {
-    // FIXME: Factor out a ParseExternalDeclarationWithAttrs.
-    ParsedAttributes DeclAttrs(AttrFactory);
-    ParsedAttributes DeclSpecAttrs(AttrFactory);
-    while (MaybeParseCXX11Attributes(DeclAttrs) ||
-            MaybeParseGNUAttributes(DeclSpecAttrs))
-      ;
-    ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
+    ParseExternalDeclarationWithAttrs();
     return Actions.ActOnFinishExportDecl(getCurScope(), ExportDecl,
                                          SourceLocation());
   }
@@ -484,12 +468,7 @@ Decl *Parser::ParseExportDeclaration() {
 
   while (!tryParseMisplacedModuleImport() && Tok.isNot(tok::r_brace) &&
          Tok.isNot(tok::eof)) {
-    ParsedAttributes DeclAttrs(AttrFactory);
-    ParsedAttributes DeclSpecAttrs(AttrFactory);
-    while (MaybeParseCXX11Attributes(DeclAttrs) ||
-            MaybeParseGNUAttributes(DeclSpecAttrs))
-      ;
-    ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
+    ParseExternalDeclarationWithAttrs();
   }
 
   T.consumeClose();

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -2286,13 +2286,7 @@ Parser::ParseObjCAtImplementationDeclaration(SourceLocation AtLoc,
   {
     ObjCImplParsingDataRAII ObjCImplParsing(*this, ObjCImpDecl);
     while (!ObjCImplParsing.isFinished() && !isEofOrEom()) {
-      ParsedAttributes DeclAttrs(AttrFactory);
-      ParsedAttributes DeclSpecAttrs(AttrFactory);
-      while (MaybeParseCXX11Attributes(DeclAttrs) ||
-              MaybeParseGNUAttributes(DeclSpecAttrs))
-        ;
-      if (DeclGroupPtrTy DGP =
-              ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs)) {
+      if (DeclGroupPtrTy DGP = ParseExternalDeclarationWithAttrs()) {
         DeclGroupRef DG = DGP.get();
         DeclsInGroup.append(DG.begin(), DG.end());
       }

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -2287,10 +2287,12 @@ Parser::ParseObjCAtImplementationDeclaration(SourceLocation AtLoc,
     ObjCImplParsingDataRAII ObjCImplParsing(*this, ObjCImpDecl);
     while (!ObjCImplParsing.isFinished() && !isEofOrEom()) {
       ParsedAttributes DeclAttrs(AttrFactory);
-      MaybeParseCXX11Attributes(DeclAttrs);
-      ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
+      ParsedAttributes DeclSpecAttrs(AttrFactory);
+      while (MaybeParseCXX11Attributes(DeclAttrs) ||
+              MaybeParseGNUAttributes(DeclSpecAttrs))
+        ;
       if (DeclGroupPtrTy DGP =
-              ParseExternalDeclaration(DeclAttrs, EmptyDeclSpecAttrs)) {
+              ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs)) {
         DeclGroupRef DG = DGP.get();
         DeclsInGroup.append(DG.begin(), DG.end());
       }

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2314,10 +2314,12 @@ Parser::DeclGroupPtrTy Parser::ParseOpenMPDeclarativeDirectiveWithExtDecl(
       // Here we expect to see some function declaration.
       if (AS == AS_none) {
         assert(TagType == DeclSpec::TST_unspecified);
-        ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
-        MaybeParseCXX11Attributes(Attrs);
+        ParsedAttributes DeclSpecAttrs(AttrFactory);
+        while (MaybeParseCXX11Attributes(Attrs) ||
+                MaybeParseGNUAttributes(DeclSpecAttrs))
+          ;
         ParsingDeclSpec PDS(*this);
-        Ptr = ParseExternalDeclaration(Attrs, EmptyDeclSpecAttrs, &PDS);
+        Ptr = ParseExternalDeclaration(Attrs, DeclSpecAttrs, &PDS);
       } else {
         Ptr =
             ParseCXXClassMemberDeclarationWithPragmas(AS, Attrs, TagType, Tag);

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -745,17 +745,7 @@ bool Parser::ParseTopLevelDecl(DeclGroupPtrTy &Result,
     break;
   }
 
-  ParsedAttributes DeclAttrs(AttrFactory);
-  ParsedAttributes DeclSpecAttrs(AttrFactory);
-  // GNU attributes are applied to the declaration specification while the
-  // standard attributes are applied to the declaration.  We parse the two
-  // attribute sets into different containters so we can apply them during
-  // the regular parsing process.
-  while (MaybeParseCXX11Attributes(DeclAttrs) ||
-         MaybeParseGNUAttributes(DeclSpecAttrs))
-    ;
-
-  Result = ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs);
+  Result = ParseExternalDeclarationWithAttrs();
   // An empty Result might mean a line with ';' or some parsing error, ignore
   // it.
   if (Result) {
@@ -1072,6 +1062,17 @@ Parser::ParseExternalDeclaration(ParsedAttributes &Attrs,
   // This routine returns a DeclGroup, if the thing we parsed only contains a
   // single decl, convert it now.
   return Actions.ConvertDeclToDeclGroup(SingleDecl);
+}
+
+/// Parse CXX11 and GNU attributes and passes them to `ParseExternalDeclaration`
+Parser::DeclGroupPtrTy
+Parser::ParseExternalDeclarationWithAttrs(ParsingDeclSpec *DS) {
+  ParsedAttributes DeclAttrs(AttrFactory);
+  ParsedAttributes DeclSpecAttrs(AttrFactory);
+  while (MaybeParseCXX11Attributes(DeclAttrs) ||
+          MaybeParseGNUAttributes(DeclSpecAttrs))
+    ;
+  return ParseExternalDeclaration(DeclAttrs, DeclSpecAttrs, DS);
 }
 
 /// Determine whether the current token, if it occurs after a
@@ -2431,12 +2432,7 @@ void Parser::ParseMicrosoftIfExistsExternalDeclaration() {
   // Parse the declarations.
   // FIXME: Support module import within __if_exists?
   while (Tok.isNot(tok::r_brace) && !isEofOrEom()) {
-    ParsedAttributes Attrs(AttrFactory);
-    ParsedAttributes DeclSpecAttrs(AttrFactory);
-    while (MaybeParseCXX11Attributes(Attrs) ||
-            MaybeParseGNUAttributes(DeclSpecAttrs))
-      ;
-    DeclGroupPtrTy Result = ParseExternalDeclaration(Attrs, DeclSpecAttrs);
+    DeclGroupPtrTy Result = ParseExternalDeclarationWithAttrs();
     if (Result && !getCurScope()->getParent())
       Actions.getASTConsumer().HandleTopLevelDecl(Result.get());
   }

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2432,9 +2432,11 @@ void Parser::ParseMicrosoftIfExistsExternalDeclaration() {
   // FIXME: Support module import within __if_exists?
   while (Tok.isNot(tok::r_brace) && !isEofOrEom()) {
     ParsedAttributes Attrs(AttrFactory);
-    MaybeParseCXX11Attributes(Attrs);
-    ParsedAttributes EmptyDeclSpecAttrs(AttrFactory);
-    DeclGroupPtrTy Result = ParseExternalDeclaration(Attrs, EmptyDeclSpecAttrs);
+    ParsedAttributes DeclSpecAttrs(AttrFactory);
+    while (MaybeParseCXX11Attributes(Attrs) ||
+            MaybeParseGNUAttributes(DeclSpecAttrs))
+      ;
+    DeclGroupPtrTy Result = ParseExternalDeclaration(Attrs, DeclSpecAttrs);
     if (Result && !getCurScope()->getParent())
       Actions.getASTConsumer().HandleTopLevelDecl(Result.get());
   }

--- a/clang/test/Parser/cxx-attributes.cpp
+++ b/clang/test/Parser/cxx-attributes.cpp
@@ -25,6 +25,9 @@ namespace PR17666 {
 
   typedef int __attribute__((aligned(int(1)))) T1;
   typedef int __attribute__((aligned(int))) T2; // expected-error {{expected '(' for function-style cast}}
+
+  class C;
+  __attribute__((attr)) [[nodiscard]] C f(); // expected-warning{{unknown attribute 'attr' ignored}}
 }
 
 __attribute((typename)) int x; // expected-warning {{unknown attribute 'typename' ignored}}


### PR DESCRIPTION
Not all callers of `ParseExternalDeclaration` were parsing gnu attributes, this caused issues with namespaces declarations attributes needing to be in a specific order (See #73890).
This PR fixes this in namespaces, exports, and three other places. It also adds a test to ensure a non-regression of this behavior.

Fixes: #73890 