### PR TITLE
[BOLT] Fix wrong logical-or operator, wrong parenthesis

### DIFF
--- a/bolt/lib/Passes/ShrinkWrapping.cpp
+++ b/bolt/lib/Passes/ShrinkWrapping.cpp
@@ -78,8 +78,8 @@ void CalleeSavedAnalysis::analyzeSaves() {
         // probably dealing with a parameter passed in a stack -- do not mess
         // with it
         if (SRU.isStoreUsed(*FIE,
-                            Prev ? SRU.expr_begin(*Prev) : SRU.expr_begin(BB)),
-            /*IncludeLocalAccesses=*/false) {
+                            Prev ? SRU.expr_begin(*Prev) : SRU.expr_begin(BB),
+            /*IncludeLocalAccesses=*/false)) {
           BlacklistedRegs.set(FIE->RegOrImm);
           CalleeSaved.reset(FIE->RegOrImm);
           Prev = &Inst;

--- a/bolt/lib/Passes/ShrinkWrapping.cpp
+++ b/bolt/lib/Passes/ShrinkWrapping.cpp
@@ -79,7 +79,7 @@ void CalleeSavedAnalysis::analyzeSaves() {
         // with it
         if (SRU.isStoreUsed(*FIE,
                             Prev ? SRU.expr_begin(*Prev) : SRU.expr_begin(BB),
-            /*IncludeLocalAccesses=*/false)) {
+                            /*IncludeLocalAccesses=*/false)) {
           BlacklistedRegs.set(FIE->RegOrImm);
           CalleeSaved.reset(FIE->RegOrImm);
           Prev = &Inst;

--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -580,7 +580,7 @@ Error LinuxKernelRewriter::readORCTables() {
       // As such, we can ignore alternative ORC entries. They will be preserved
       // in the binary, but will not get printed in the instruction stream.
       Inst = BF->getInstructionContainingOffset(Offset);
-      if (Inst || BC.MIB->hasAnnotation(*Inst, "AltInst"))
+      if (Inst && BC.MIB->hasAnnotation(*Inst, "AltInst"))
         continue;
 
       return createStringError(


### PR DESCRIPTION
Fix for some mistakes in source code found using PVS Studio.

Inspired by: https://pvs-studio.com/en/blog/posts/cpp/1188/

Fixed:
- [Bug 1](https://pvs-studio.com/en/blog/posts/cpp/1188/#ID091CDC8D98)
- [Bug 14](https://pvs-studio.com/en/blog/posts/cpp/1188/#IDED4453A677)