### PR TITLE
[AMDGPU] Do not allow the region address space to be converted to generic

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -120,7 +120,8 @@ public:
               toTargetAddressSpace(A) == llvm::AMDGPUAS::FLAT_ADDRESS)) &&
             isTargetAddressSpace(B) &&
             toTargetAddressSpace(B) >= llvm::AMDGPUAS::FLAT_ADDRESS &&
-            toTargetAddressSpace(B) <= llvm::AMDGPUAS::PRIVATE_ADDRESS);
+            toTargetAddressSpace(B) <= llvm::AMDGPUAS::PRIVATE_ADDRESS &&
+            toTargetAddressSpace(B) != llvm::AMDGPUAS::REGION_ADDRESS);
   }
 
   uint64_t getMaxPointerWidth() const override {

--- a/clang/test/Sema/amdgcn-address-spaces.c
+++ b/clang/test/Sema/amdgcn-address-spaces.c
@@ -9,7 +9,7 @@
 #define _AS999 __attribute__((address_space(999)))
 
 void *p1(void _AS1 *p) { return p; }
-void *p2(void _AS2 *p) { return p; }
+void *p2(void _AS2 *p) { return p; } // expected-error {{returning '_AS2 void *' from a function with result type 'void *' changes address space of pointer}}
 void *p3(void _AS3 *p) { return p; }
 void *p4(void _AS4 *p) { return p; }
 void *p5(void _AS5 *p) { return p; }


### PR DESCRIPTION
Summary:
Previous changes relaxed the address space rules based on what the
target says about them. This accidentally included the AS(2) region as
convertible to generic. Simply check for AS(2) and reject it.
