### PR TITLE
[InstCombine] Remove redundant fptrunc of select fold (NFCI)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -1866,24 +1866,6 @@ Instruction *InstCombinerImpl::visitFPTrunc(FPTruncInst &FPT) {
 
       return UnaryOperator::CreateFNegFMF(InnerTrunc, Op);
     }
-
-    // If we are truncating a select that has an extended operand, we can
-    // narrow the other operand and do the select as a narrow op.
-    Value *Cond, *X, *Y;
-    if (match(Op, m_Select(m_Value(Cond), m_FPExt(m_Value(X)), m_Value(Y))) &&
-        X->getType() == Ty) {
-      // fptrunc (select Cond, (fpext X), Y --> select Cond, X, (fptrunc Y)
-      Value *NarrowY = Builder.CreateFPTrunc(Y, Ty);
-      Value *Sel = Builder.CreateSelect(Cond, X, NarrowY, "narrow.sel", Op);
-      return replaceInstUsesWith(FPT, Sel);
-    }
-    if (match(Op, m_Select(m_Value(Cond), m_Value(Y), m_FPExt(m_Value(X)))) &&
-        X->getType() == Ty) {
-      // fptrunc (select Cond, Y, (fpext X) --> select Cond, (fptrunc Y), X
-      Value *NarrowY = Builder.CreateFPTrunc(Y, Ty);
-      Value *Sel = Builder.CreateSelect(Cond, NarrowY, X, "narrow.sel", Op);
-      return replaceInstUsesWith(FPT, Sel);
-    }
   }
 
   if (auto *II = dyn_cast<IntrinsicInst>(FPT.getOperand(0))) {


### PR DESCRIPTION
This was subsumed by FoldOpIntoSelect() in #116073, and has incorrect FMF propagation on top.