### PR TITLE
[mlir,python] Fix case when `FuncOp.arg_attrs` is not set

### DIFF
--- a/mlir/python/mlir/dialects/func.py
+++ b/mlir/python/mlir/dialects/func.py
@@ -105,6 +105,10 @@ class FuncOp(FuncOp):
 
     @property
     def arg_attrs(self):
+        if ARGUMENT_ATTRIBUTE_NAME not in self.attributes:
+            self.attributes[ARGUMENT_ATTRIBUTE_NAME] = ArrayAttr.get(
+                [DictAttr.get({}) for _ in self.type.inputs]
+            )
         return ArrayAttr(self.attributes[ARGUMENT_ATTRIBUTE_NAME])
 
     @arg_attrs.setter

--- a/mlir/python/mlir/dialects/func.py
+++ b/mlir/python/mlir/dialects/func.py
@@ -106,9 +106,7 @@ class FuncOp(FuncOp):
     @property
     def arg_attrs(self):
         if ARGUMENT_ATTRIBUTE_NAME not in self.attributes:
-            self.attributes[ARGUMENT_ATTRIBUTE_NAME] = ArrayAttr.get(
-                [DictAttr.get({}) for _ in self.type.inputs]
-            )
+            return ArrayAttr.get([DictAttr.get({}) for _ in self.type.inputs])
         return ArrayAttr(self.attributes[ARGUMENT_ATTRIBUTE_NAME])
 
     @arg_attrs.setter

--- a/mlir/test/python/dialects/func.py
+++ b/mlir/test/python/dialects/func.py
@@ -104,3 +104,16 @@ def testFunctionCalls():
 # CHECK:   %1 = call @qux() : () -> f32
 # CHECK:   return
 # CHECK: }
+
+
+# CHECK-LABEL: TEST: testFunctionArgAttrs
+@constructAndPrintInModule
+def testFunctionArgAttrs():
+    foo = func.FuncOp("foo", ([("arg0", F32Type.get())], []))
+
+    assert len(foo.arg_attrs) == 1
+    assert foo.arg_attrs[0] = ir.DictAttr.get({})
+
+    foo.arg_attrs = [DictAttr.get({"test.foo": StringAttr.get("bar")})]
+
+    assert foo.arg_attrs[0]["test.foo"] == StringAttr.get("bar")

--- a/mlir/test/python/dialects/func.py
+++ b/mlir/test/python/dialects/func.py
@@ -109,11 +109,27 @@ def testFunctionCalls():
 # CHECK-LABEL: TEST: testFunctionArgAttrs
 @constructAndPrintInModule
 def testFunctionArgAttrs():
-    foo = func.FuncOp("foo", ([("arg0", F32Type.get())], []))
+    foo = func.FuncOp("foo", ([F32Type.get()], []))
+    foo.sym_visibility = StringAttr.get("private")
+    foo2 = func.FuncOp("foo2", ([F32Type.get(), F32Type.get()], []))
+    foo2.sym_visibility = StringAttr.get("private")
+
+    empty_attr = DictAttr.get({})
+    test_attr = DictAttr.get({"test.foo": StringAttr.get("bar")})
+    test_attr2 = DictAttr.get({"test.baz": StringAttr.get("qux")})
 
     assert len(foo.arg_attrs) == 1
-    assert foo.arg_attrs[0] == DictAttr.get({})
+    assert foo.arg_attrs[0] == empty_attr
 
-    foo.arg_attrs = [DictAttr.get({"test.foo": StringAttr.get("bar")})]
-
+    foo.arg_attrs = [test_attr]
     assert foo.arg_attrs[0]["test.foo"] == StringAttr.get("bar")
+
+    assert len(foo2.arg_attrs) == 2
+    assert foo2.arg_attrs == ArrayAttr.get([empty_attr, empty_attr])
+
+    foo2.arg_attrs = [empty_attr, test_attr2]
+    assert foo2.arg_attrs == ArrayAttr.get([empty_attr, test_attr2])
+
+
+# CHECK: func private @foo(f32 {test.foo = "bar"})
+# CHECK: func private @foo2(f32, f32  {test.baz = "qux"})

--- a/mlir/test/python/dialects/func.py
+++ b/mlir/test/python/dialects/func.py
@@ -112,7 +112,7 @@ def testFunctionArgAttrs():
     foo = func.FuncOp("foo", ([("arg0", F32Type.get())], []))
 
     assert len(foo.arg_attrs) == 1
-    assert foo.arg_attrs[0] = ir.DictAttr.get({})
+    assert foo.arg_attrs[0] == DictAttr.get({})
 
     foo.arg_attrs = [DictAttr.get({"test.foo": StringAttr.get("bar")})]
 


### PR DESCRIPTION
FuncOps can have `arg_attrs`, an array of dictionary attributes associated with their arguments.

E.g., 

```mlir
func.func @main(%arg0: tensor<8xf32> {test.attr_name = "value"}, %arg1: tensor<8x16xf32>)
```

These are exposed via the MLIR Python bindings with `my_funcop.arg_attrs`.

In this case, it would return `[{test.attr_name = "value"}, {}]`, i.e., `%arg1` has an empty `DictAttr`.

However, if I try and access this property from a FuncOp with an empty `arg_attrs`, e.g.,

```mlir
func.func @main(%arg0: tensor<8xf32>, %arg1: tensor<8x16xf32>)
```

This raises the error:

```python
    return ArrayAttr(self.attributes[ARGUMENT_ATTRIBUTE_NAME])
                     ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'attempt to access a non-existent attribute'
```

This PR fixes this by returning the expected `[{}, {}]`.