### PR TITLE
[llvm] Update pgo collection script to reflect Mainainers file

### DIFF
--- a/llvm/utils/collect_and_build_with_pgo.py
+++ b/llvm/utils/collect_and_build_with_pgo.py
@@ -425,7 +425,7 @@ def _looks_like_llvm_dir(directory):
 
     contents = set(os.listdir(directory))
     expected_contents = [
-        "CODE_OWNERS.TXT",
+        "Maintainers.md",
         "cmake",
         "docs",
         "include",


### PR DESCRIPTION
The collect_and_build_with_pgo.py script used CODE_OWNERS.TXT as part of
its heuristic, but now that its gone, the script will fail to recognize
an LLVM checkout.
