### PR TITLE
[lldb] Fix incorrect nullptr check in DumpAddressAndContent

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -410,31 +410,31 @@ static bool DumpAddressAndContent(Stream &s, const SymbolContext *sc,
                                   const Address &addr,
                                   bool print_file_addr_or_load_addr) {
   Target *target = Target::GetTargetFromContexts(exe_ctx, sc);
+
   addr_t vaddr = LLDB_INVALID_ADDRESS;
-  if (exe_ctx && !target->GetSectionLoadList().IsEmpty())
+  if (target && !target->GetSectionLoadList().IsEmpty())
     vaddr = addr.GetLoadAddress(target);
   if (vaddr == LLDB_INVALID_ADDRESS)
     vaddr = addr.GetFileAddress();
+  if (vaddr == LLDB_INVALID_ADDRESS)
+    return false;
 
-  if (vaddr != LLDB_INVALID_ADDRESS) {
-    int addr_width = 0;
-    if (exe_ctx && target) {
-      addr_width = target->GetArchitecture().GetAddressByteSize() * 2;
-    }
-    if (addr_width == 0)
-      addr_width = 16;
-    if (print_file_addr_or_load_addr) {
-      ExecutionContextScope *exe_scope = nullptr;
-      if (exe_ctx)
-        exe_scope = exe_ctx->GetBestExecutionContextScope();
-      addr.Dump(&s, exe_scope, Address::DumpStyleLoadAddress,
-                Address::DumpStyleModuleWithFileAddress, 0);
-    } else {
-      s.Printf("0x%*.*" PRIx64, addr_width, addr_width, vaddr);
-    }
-    return true;
+  int addr_width = 0;
+  if (target)
+    addr_width = target->GetArchitecture().GetAddressByteSize() * 2;
+  if (addr_width == 0)
+    addr_width = 16;
+
+  if (print_file_addr_or_load_addr) {
+    ExecutionContextScope *exe_scope =
+        exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
+    addr.Dump(&s, exe_scope, Address::DumpStyleLoadAddress,
+              Address::DumpStyleModuleWithFileAddress, 0);
+  } else {
+    s.Printf("0x%*.*" PRIx64, addr_width, addr_width, vaddr);
   }
-  return false;
+
+  return true;
 }
 
 static bool DumpAddressOffsetFromFunction(Stream &s, const SymbolContext *sc,


### PR DESCRIPTION
When checking the section load list, the existing code assumed that a valid execution context guaranteed a valid target. This is a speculative fix for a crash report (without a reproducer).

rdar://133969831