### PR TITLE
[lldb] Fix index boundaries check, Change wrong int literal

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3278,7 +3278,7 @@ bool AppleObjCRuntimeV2::NonPointerISACache::EvaluateNonPointerISA(
       }
 
       // If the index is still out of range then this isn't a pointer.
-      if (index > m_indexed_isa_cache.size())
+      if (index >= m_indexed_isa_cache.size())
         return false;
 
       LLDB_LOGF(log, "AOCRT::NPI Evaluate(ret_isa = 0x%" PRIx64 ")",

--- a/lldb/source/Plugins/Process/Linux/IntelPTSingleBufferTrace.cpp
+++ b/lldb/source/Plugins/Process/Linux/IntelPTSingleBufferTrace.cpp
@@ -150,7 +150,7 @@ GeneratePerfEventConfigValue(bool enable_tsc,
   if (enable_tsc) {
     if (Expected<uint32_t> offset = ReadIntelPTConfigFile(
             kTSCBitOffsetFile, IntelPTConfigFileType::BitOffset))
-      config |= 1 << *offset;
+      config |= 1ULL << *offset;
     else
       return offset.takeError();
   }


### PR DESCRIPTION
Fix for some mistakes in source code found using PVS Studio.

Inspired by: https://pvs-studio.com/en/blog/posts/cpp/1188/

Fixed:
- [Bug 8](https://pvs-studio.com/en/blog/posts/cpp/1188/#ID0EFA5EA398)
- [Bug 10](https://pvs-studio.com/en/blog/posts/cpp/1188/#ID0BFC185CF3)