### PR TITLE
[mlir] Fix wrong names in LinalgOps and ScalableValueBoundsConstraintSet

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -523,7 +523,7 @@ public:
         isInteger(arg0) && arg0.getType().getIntOrFloatBitWidth() == 1;
     bool tailFloatingPoint =
         isFloatingPoint(arg0) && isFloatingPoint(arg1) && isFloatingPoint(arg2);
-    bool tailInteger = isInteger(arg0) && isInteger(arg1) && isInteger(arg1);
+    bool tailInteger = isInteger(arg0) && isInteger(arg1) && isInteger(arg2);
     OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointToEnd(&block);
     switch (ternaryFn) {

--- a/mlir/lib/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.cpp
+++ b/mlir/lib/Dialect/Vector/IR/ScalableValueBoundsConstraintSet.cpp
@@ -107,7 +107,7 @@ ScalableValueBoundsConstraintSet::computeScalableBound(
 
   AffineMap bound = [&] {
     if (boundType == BoundType::EQ && !invalidBound(lowerBound) &&
-        lowerBound[0] == lowerBound[0]) {
+        lowerBound[0] == upperBound[0]) {
       return lowerBound[0];
     } else if (boundType == BoundType::LB && !invalidBound(lowerBound)) {
       return lowerBound[0];


### PR DESCRIPTION
Fix for some mistakes in source code found using PVS Studio.

Inspired by: https://pvs-studio.com/en/blog/posts/cpp/1188/

Fixed:
- [Bug 2](https://pvs-studio.com/en/blog/posts/cpp/1188/#ID725051E718)
- [Bug 3](https://pvs-studio.com/en/blog/posts/cpp/1188/#IDFA2459368E)