### PR TITLE
[libc] provide binary compatibility with syscall symbol

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -1002,6 +1002,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # unistd.h entrypoints
     libc.src.unistd.__llvm_libc_syscall
+    libc.src.unistd.syscall_compat
     libc.src.unistd._exit
     libc.src.unistd.environ
     libc.src.unistd.execv

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -940,6 +940,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # unistd.h entrypoints
     libc.src.unistd.__llvm_libc_syscall
+    libc.src.unistd.syscall_compat
     libc.src.unistd._exit
     libc.src.unistd.environ
     libc.src.unistd.execv

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1094,6 +1094,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # unistd.h entrypoints
     libc.src.unistd.__llvm_libc_syscall
+    libc.src.unistd.syscall_compat
     libc.src.unistd._exit
     libc.src.unistd.environ
     libc.src.unistd.execv

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -253,6 +253,13 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  syscall_compat
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.syscall_compat
+)
+
+add_entrypoint_object(
   sysconf
   ALIAS
   DEPENDS

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -466,6 +466,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  syscall_compat
+  SRCS
+  syscall_compat.cpp
+  HDRS
+    ../syscall_compat.h
+  DEPENDS
+    .__llvm_libc_syscall
+)
+
+add_entrypoint_object(
   sysconf
   SRCS
     sysconf.cpp

--- a/libc/src/unistd/linux/syscall_compat.cpp
+++ b/libc/src/unistd/linux/syscall_compat.cpp
@@ -1,0 +1,32 @@
+//===-- Linux implementation of syscall (va compat) -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/syscall_compat.h"
+#include "src/__support/common.h"
+#include "src/unistd/syscall.h"
+
+#include "src/__support/macros/config.h"
+#include <stdarg.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+#undef syscall
+LLVM_LIBC_FUNCTION(long, syscall, (long n, ...)) {
+  va_list args;
+  va_start(args, n);
+  long arg1 = va_arg(args, long);
+  long arg2 = va_arg(args, long);
+  long arg3 = va_arg(args, long);
+  long arg4 = va_arg(args, long);
+  long arg5 = va_arg(args, long);
+  long arg6 = va_arg(args, long);
+  va_end(args);
+  return __llvm_libc_syscall(n, arg1, arg2, arg3, arg4, arg5, arg6);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/syscall_compat.h
+++ b/libc/src/unistd/syscall_compat.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for syscall (va compat) -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_SYSCALL_COMPAT_H
+#define LLVM_LIBC_SRC_UNISTD_SYSCALL_COMPAT_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+#pragma push_macro("syscall")
+#undef syscall
+long syscall(long number, ...);
+#pragma pop_macro("syscall")
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_SYSCALL_COMPAT_H

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -429,6 +429,7 @@ add_libc_unittest(
     libc.include.sys_syscall
     libc.src.errno.errno 
     libc.src.unistd.__llvm_libc_syscall
+    libc.src.unistd.syscall_compat
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 

--- a/libc/test/src/unistd/syscall_test.cpp
+++ b/libc/test/src/unistd/syscall_test.cpp
@@ -8,6 +8,7 @@
 
 #include "src/errno/libc_errno.h"
 #include "src/unistd/syscall.h"
+#include "src/unistd/syscall_compat.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -175,5 +176,14 @@ TEST(LlvmLibcSyscallTest, FileLinkCreateDestroy) {
   ASSERT_ERRNO_SUCCESS();
 
   ASSERT_GE(LIBC_NAMESPACE::syscall(SYS_close, dir_fd), 0l);
+  ASSERT_ERRNO_SUCCESS();
+}
+
+TEST(LlvmLibcSyscallTest, TrivialCallCompat) {
+  LIBC_NAMESPACE::libc_errno = 0;
+#pragma push_macro("syscall")
+#undef syscall
+  ASSERT_GE(LIBC_NAMESPACE::syscall(SYS_gettid), 0l);
+#pragma pop_macro("syscall")
   ASSERT_ERRNO_SUCCESS();
 }


### PR DESCRIPTION
Glibc and MUSL both provides `syscall` as a binary. Inside LLVM-libc, we provides it as a macro backed by `__llvm_libc_syscall` which is not binary compatible with other implementations. This PR provides the symbol for better compatibility for those applications assuming the existence of the symbol.