### PR TITLE
[SandboxIR][SandboxVectorizer][NFC] Move Region to SandboxVectorizer.

### DIFF
--- a/llvm/include/llvm/SandboxIR/Pass.h
+++ b/llvm/include/llvm/SandboxIR/Pass.h
@@ -20,7 +20,6 @@ class ScalarEvolution;
 namespace sandboxir {
 
 class Function;
-class Region;
 
 class Analyses {
   AAResults *AA = nullptr;
@@ -74,15 +73,6 @@ public:
   FunctionPass(StringRef Name) : Pass(Name) {}
   /// \Returns true if it modifies \p F.
   virtual bool runOnFunction(Function &F, const Analyses &A) = 0;
-};
-
-/// A pass that runs on a sandbox::Region.
-class RegionPass : public Pass {
-public:
-  /// \p Name can't contain any spaces or start with '-'.
-  RegionPass(StringRef Name) : Pass(Name) {}
-  /// \Returns true if it modifies \p R.
-  virtual bool runOnRegion(Region &R, const Analyses &A) = 0;
 };
 
 } // namespace sandboxir

--- a/llvm/include/llvm/SandboxIR/PassManager.h
+++ b/llvm/include/llvm/SandboxIR/PassManager.h
@@ -211,15 +211,6 @@ public:
   bool runOnFunction(Function &F, const Analyses &A) final;
 };
 
-class RegionPassManager final : public PassManager<RegionPass, RegionPass> {
-public:
-  RegionPassManager(StringRef Name) : PassManager(Name) {}
-  RegionPassManager(StringRef Name, StringRef Pipeline,
-                    CreatePassFunc CreatePass)
-      : PassManager(Name, Pipeline, CreatePass) {}
-  bool runOnRegion(Region &R, const Analyses &A) final;
-};
-
 } // namespace llvm::sandboxir
 
 #endif // LLVM_SANDBOXIR_PASSMANAGER_H

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -19,6 +19,7 @@
 #include "llvm/SandboxIR/PassManager.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Legality.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 
 namespace llvm::sandboxir {
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h
@@ -1,11 +1,9 @@
 #ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_NULLPASS_H
 #define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_NULLPASS_H
 
-#include "llvm/SandboxIR/Pass.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 
 namespace llvm::sandboxir {
-
-class Region;
 
 /// A Region pass that does nothing, for use as a placeholder in tests.
 class NullPass final : public RegionPass {

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h
@@ -1,8 +1,7 @@
 #ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTINSTRUCTIONCOUNT_H
 #define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTINSTRUCTIONCOUNT_H
 
-#include "llvm/SandboxIR/Pass.h"
-#include "llvm/SandboxIR/Region.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 
 namespace llvm::sandboxir {
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/SandboxIR/Pass.h"
 #include "llvm/SandboxIR/PassManager.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 
 namespace llvm::sandboxir {
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Region.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Region.h
@@ -128,7 +128,6 @@ public:
   bool runOnRegion(Region &R, const Analyses &A) final;
 };
 
-
 } // namespace llvm::sandboxir
 
 #endif // LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_REGION_H

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Region.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Region.h
@@ -14,6 +14,8 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/SandboxIR/Instruction.h"
+#include "llvm/SandboxIR/Pass.h"
+#include "llvm/SandboxIR/PassManager.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm::sandboxir {
@@ -106,6 +108,26 @@ public:
   }
 #endif
 };
+
+/// A pass that runs on a Region.
+class RegionPass : public Pass {
+public:
+  /// \p Name can't contain any spaces or start with '-'.
+  RegionPass(StringRef Name) : Pass(Name) {}
+  /// \Returns true if it modifies \p R.
+  virtual bool runOnRegion(Region &R, const Analyses &A) = 0;
+};
+
+/// A PassManager for passes that operate on Regions.
+class RegionPassManager final : public PassManager<RegionPass, RegionPass> {
+public:
+  RegionPassManager(StringRef Name) : PassManager(Name) {}
+  RegionPassManager(StringRef Name, StringRef Pipeline,
+                    CreatePassFunc CreatePass)
+      : PassManager(Name, Pipeline, CreatePass) {}
+  bool runOnRegion(Region &R, const Analyses &A) final;
+};
+
 
 } // namespace llvm::sandboxir
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h
@@ -14,6 +14,7 @@
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/SandboxIR/Pass.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 
 #include <memory>
 

--- a/llvm/lib/SandboxIR/CMakeLists.txt
+++ b/llvm/lib/SandboxIR/CMakeLists.txt
@@ -8,7 +8,6 @@ add_llvm_component_library(LLVMSandboxIR
   Module.cpp
   Pass.cpp
   PassManager.cpp
-  Region.cpp
   Tracker.cpp
   Type.cpp
   User.cpp

--- a/llvm/lib/SandboxIR/PassManager.cpp
+++ b/llvm/lib/SandboxIR/PassManager.cpp
@@ -20,14 +20,4 @@ bool FunctionPassManager::runOnFunction(Function &F, const Analyses &A) {
   return Change;
 }
 
-bool RegionPassManager::runOnRegion(Region &R, const Analyses &A) {
-  bool Change = false;
-  for (auto &Pass : Passes) {
-    Change |= Pass->runOnRegion(R, A);
-    // TODO: run the verifier.
-  }
-  // TODO: Check ChangeAll against hashes before/after.
-  return Change;
-}
-
 } // namespace llvm::sandboxir

--- a/llvm/lib/Transforms/Vectorize/CMakeLists.txt
+++ b/llvm/lib/Transforms/Vectorize/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_component_library(LLVMVectorize
   SandboxVectorizer/Legality.cpp
   SandboxVectorizer/Passes/BottomUpVec.cpp
   SandboxVectorizer/Passes/RegionsFromMetadata.cpp
+  SandboxVectorizer/Region.cpp
   SandboxVectorizer/SandboxVectorizer.cpp
   SandboxVectorizer/SandboxVectorizerPassBuilder.cpp
   SandboxVectorizer/Scheduler.cpp

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.cpp
@@ -8,7 +8,7 @@
 
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h"
 
-#include "llvm/SandboxIR/Region.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h"
 
 namespace llvm::sandboxir {

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Region.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Region.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/SandboxIR/Region.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Region.h"
 #include "llvm/SandboxIR/Function.h"
 
 namespace llvm::sandboxir {
@@ -79,6 +79,16 @@ SmallVector<std::unique_ptr<Region>> Region::createRegionsFromMD(Function &F) {
     }
   }
   return Regions;
+}
+
+bool RegionPassManager::runOnRegion(Region &R, const Analyses &A) {
+  bool Change = false;
+  for (auto &Pass : Passes) {
+    Change |= Pass->runOnRegion(R, A);
+    // TODO: run the verifier.
+  }
+  // TODO: Check ChangeAll against hashes before/after.
+  return Change;
 }
 
 } // namespace llvm::sandboxir

--- a/llvm/unittests/SandboxIR/CMakeLists.txt
+++ b/llvm/unittests/SandboxIR/CMakeLists.txt
@@ -8,7 +8,6 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(SandboxIRTests
   IntrinsicInstTest.cpp
   PassTest.cpp
-  RegionTest.cpp
   OperatorTest.cpp
   SandboxIRTest.cpp
   TrackerTest.cpp

--- a/llvm/unittests/SandboxIR/PassTest.cpp
+++ b/llvm/unittests/SandboxIR/PassTest.cpp
@@ -13,7 +13,6 @@
 #include "llvm/SandboxIR/Context.h"
 #include "llvm/SandboxIR/Function.h"
 #include "llvm/SandboxIR/PassManager.h"
-#include "llvm/SandboxIR/Region.h"
 #include "llvm/Support/SourceMgr.h"
 #include "gtest/gtest.h"
 
@@ -87,68 +86,6 @@ define void @foo() {
 #endif
 }
 
-TEST_F(PassTest, RegionPass) {
-  auto *F = parseFunction(R"IR(
-define i8 @foo(i8 %v0, i8 %v1) {
-  %t0 = add i8 %v0, 1
-  %t1 = add i8 %t0, %v1, !sandboxvec !0
-  %t2 = add i8 %t1, %v1, !sandboxvec !0
-  ret i8 %t1
-}
-
-!0 = distinct !{!"sandboxregion"}
-)IR",
-                          "foo");
-
-  class TestPass final : public RegionPass {
-    unsigned &InstCount;
-
-  public:
-    TestPass(unsigned &InstCount)
-        : RegionPass("test-pass"), InstCount(InstCount) {}
-    bool runOnRegion(Region &R, const Analyses &A) final {
-      for ([[maybe_unused]] auto &Inst : R) {
-        ++InstCount;
-      }
-      return false;
-    }
-  };
-  unsigned InstCount = 0;
-  TestPass TPass(InstCount);
-  // Check getName(),
-  EXPECT_EQ(TPass.getName(), "test-pass");
-  // Check runOnRegion();
-  llvm::SmallVector<std::unique_ptr<Region>> Regions =
-      Region::createRegionsFromMD(*F);
-  ASSERT_EQ(Regions.size(), 1u);
-  TPass.runOnRegion(*Regions[0], Analyses::emptyForTesting());
-  EXPECT_EQ(InstCount, 2u);
-#ifndef NDEBUG
-  {
-    // Check print().
-    std::string Buff;
-    llvm::raw_string_ostream SS(Buff);
-    TPass.print(SS);
-    EXPECT_EQ(Buff, "test-pass");
-  }
-  {
-    // Check operator<<().
-    std::string Buff;
-    llvm::raw_string_ostream SS(Buff);
-    SS << TPass;
-    EXPECT_EQ(Buff, "test-pass");
-  }
-  // Check pass name assertions.
-  class TestNamePass final : public RegionPass {
-  public:
-    TestNamePass(llvm::StringRef Name) : RegionPass(Name) {}
-    bool runOnRegion(Region &F, const Analyses &A) { return false; }
-  };
-  EXPECT_DEATH(TestNamePass("white space"), ".*whitespace.*");
-  EXPECT_DEATH(TestNamePass("-dash"), ".*start with.*");
-#endif
-}
-
 TEST_F(PassTest, FunctionPassManager) {
   auto *F = parseFunction(R"IR(
 define void @foo() {
@@ -194,65 +131,6 @@ define void @foo() {
   llvm::raw_string_ostream SS(Buff);
   FPM.print(SS);
   EXPECT_EQ(Buff, "test-fpm(test-pass1,test-pass2)");
-#endif // NDEBUG
-}
-
-TEST_F(PassTest, RegionPassManager) {
-  auto *F = parseFunction(R"IR(
-define i8 @foo(i8 %v0, i8 %v1) {
-  %t0 = add i8 %v0, 1
-  %t1 = add i8 %t0, %v1, !sandboxvec !0
-  %t2 = add i8 %t1, %v1, !sandboxvec !0
-  ret i8 %t1
-}
-
-!0 = distinct !{!"sandboxregion"}
-)IR",
-                          "foo");
-
-  class TestPass1 final : public RegionPass {
-    unsigned &InstCount;
-
-  public:
-    TestPass1(unsigned &InstCount)
-        : RegionPass("test-pass1"), InstCount(InstCount) {}
-    bool runOnRegion(Region &R, const Analyses &A) final {
-      for ([[maybe_unused]] auto &Inst : R)
-        ++InstCount;
-      return false;
-    }
-  };
-  class TestPass2 final : public RegionPass {
-    unsigned &InstCount;
-
-  public:
-    TestPass2(unsigned &InstCount)
-        : RegionPass("test-pass2"), InstCount(InstCount) {}
-    bool runOnRegion(Region &R, const Analyses &A) final {
-      for ([[maybe_unused]] auto &Inst : R)
-        ++InstCount;
-      return false;
-    }
-  };
-  unsigned InstCount1 = 0;
-  unsigned InstCount2 = 0;
-
-  RegionPassManager RPM("test-rpm");
-  RPM.addPass(std::make_unique<TestPass1>(InstCount1));
-  RPM.addPass(std::make_unique<TestPass2>(InstCount2));
-  // Check runOnRegion().
-  llvm::SmallVector<std::unique_ptr<Region>> Regions =
-      Region::createRegionsFromMD(*F);
-  ASSERT_EQ(Regions.size(), 1u);
-  RPM.runOnRegion(*Regions[0], Analyses::emptyForTesting());
-  EXPECT_EQ(InstCount1, 2u);
-  EXPECT_EQ(InstCount2, 2u);
-#ifndef NDEBUG
-  // Check dump().
-  std::string Buff;
-  llvm::raw_string_ostream SS(Buff);
-  RPM.print(SS);
-  EXPECT_EQ(Buff, "test-rpm(test-pass1,test-pass2)");
 #endif // NDEBUG
 }
 

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/CMakeLists.txt
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/CMakeLists.txt
@@ -11,7 +11,8 @@ add_llvm_unittest(SandboxVectorizerTests
   DependencyGraphTest.cpp
   IntervalTest.cpp
   LegalityTest.cpp
+  RegionTest.cpp
   SchedulerTest.cpp
-  SeedCollectorTest.cpp	
+  SeedCollectorTest.cpp
   VecUtilsTest.cpp
 )


### PR DESCRIPTION
When I first added the `Region` class I was unclear whether it was SandboxVectorizer-specific or something more general that could go in SandboxIR (as evidenced by the fact that I got the Region.h include guard wrong and didn't have to update it for this commit :)

Now I'm convinced that it belongs in SandboxVectorizer, so I'd like to move it back. This change does just that:

- Region.h, Region.cpp and RegionTest.cpp are moved into the right directories for SandboxVectorizer.

- The `RegionPass` and `RegionPassManager` classes are moved into Region.h. Their tests are moved into RegionTest.cpp as well.

- All the other touched files are just mechanical changes to make everything work. Mainly updating include paths and qualifying some names in tests.