### PR TITLE
[DWARF] Fix DWARTTypePrinter unable to print qualified name for DW_TAG_typedef DIE

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
@@ -69,6 +69,7 @@ private:
     case dwarf::DW_TAG_union_type:
     case dwarf::DW_TAG_namespace:
     case dwarf::DW_TAG_enumeration_type:
+    case dwarf::DW_TAG_typedef:
       return true;
     default:
       break;

--- a/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-string.test
+++ b/llvm/test/tools/dsymutil/X86/DWARFLinkerParallel/odr-string.test
@@ -132,11 +132,11 @@ CHECK: 0x[[STRING:[0-9a-f]*]]: DW_TAG_typedef{{.*[[:space:]].*}}DW_AT_type{{.*}}
 
 CHECK:DW_TAG_reference_type
 
-CHECK: 0x[[CONST_STR_REF:[0-9a-f]*]]: DW_TAG_reference_type{{.*[[:space:]].*}}DW_AT_type{{.*}}0x[[CONST_STRING:[0-9a-f]*]] "const string"
+CHECK: 0x[[CONST_STR_REF:[0-9a-f]*]]: DW_TAG_reference_type{{.*[[:space:]].*}}DW_AT_type{{.*}}0x[[CONST_STRING:[0-9a-f]*]] "const std::__1::string"
 
 CHECK:DW_TAG_const_type
 
-CHECK: 0x[[CONST_STRING]]: DW_TAG_const_type{{.*[[:space:]].*}}DW_AT_type{{.*}}0x[[STRING]] "string"
+CHECK: 0x[[CONST_STRING]]: DW_TAG_const_type{{.*[[:space:]].*}}DW_AT_type{{.*}}0x[[STRING]] "std::__1::string"
 
 
 CHECK: Compile Unit:
@@ -148,7 +148,7 @@ CHECK: DW_AT_high_pc
 CHECK: DW_AT_name{{.*}}"PrintSize"
 CHECK: DW_TAG_formal_parameter
 CHECK: DW_AT_name{{.*}}"String"
-CHECK: DW_AT_type{{.*}}0x00000000[[CONST_STR_REF]] "const string &"
+CHECK: DW_AT_type{{.*}}0x00000000[[CONST_STR_REF]] "const std::__1::string &"
 
 CHECK: Compile Unit:
 CHECK: DW_TAG_compile_unit

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDieTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDieTest.cpp
@@ -9,6 +9,7 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/DebugInfo/DWARF/DWARFCompileUnit.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
+#include "llvm/DebugInfo/DWARF/DWARFTypePrinter.h"
 #include "llvm/ObjectYAML/DWARFEmitter.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
@@ -704,4 +705,138 @@ TEST(DWARFDie, getNameFromTypeUnit) {
   ASSERT_STREQ(Die.getName(DINameKind::ShortName), "STRUCT");
 }
 
+void testAppendAndTerminateTemplateParameters(const DWARFDie &DIE,
+                                              const std::string &Expected) {
+  std::string TemplateName;
+  llvm::raw_string_ostream TemplateNameOS(TemplateName);
+  llvm::DWARFTypePrinter<DWARFDie> TemplateNamePrinter(TemplateNameOS);
+  TemplateNamePrinter.appendAndTerminateTemplateParameters(DIE);
+  EXPECT_THAT(TemplateName, Expected);
+}
+
+void testAppendQualifiedName(const DWARFDie &DIE, const std::string &Expected) {
+  std::string QualifiedName;
+  llvm::raw_string_ostream TemplateNameOS(QualifiedName);
+  llvm::DWARFTypePrinter<DWARFDie> TemplateNamePrinter(TemplateNameOS);
+  TemplateNamePrinter.appendQualifiedName(DIE);
+  EXPECT_THAT(QualifiedName, Expected);
+}
+
+TEST(DWARFDie, DWARFTypePrinterTest) {
+  // Make sure we can get template parameters and qualified names correctly with
+  // DWARFTypePrinter when using -gsimple-template-names.
+
+  // 0x0000000b: DW_TAG_compile_unit
+  // 0x0000000c:   DW_TAG_base_type
+  //                 DW_AT_name      ("int")
+  // 0x00000011:   DW_TAG_structure_type
+  //                 DW_AT_name      ("t1")
+  // 0x00000015:     DW_TAG_template_type_parameter
+  //                   DW_AT_type    (0x0000001f "t3<int>")
+  // 0x0000001a:     DW_TAG_structure_type
+  //                   DW_AT_name    ("t2")
+  // 0x0000001e:     NULL
+  // 0x0000001f:   DW_TAG_structure_type
+  //                 DW_AT_name      ("t3")
+  // 0x00000023:     DW_TAG_template_type_parameter
+  //                   DW_AT_type    (0x0000000c "int")
+  // 0x00000028:     NULL
+  // 0x00000029:   NULL
+  const char *yamldata = R"(
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+        - Code:            0x2
+          Tag:             DW_TAG_base_type
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x3
+          Tag:             DW_TAG_structure_type
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x4
+          Tag:             DW_TAG_template_type_parameter
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_type
+              Form:            DW_FORM_ref4
+        - Code:            0x5
+          Tag:             DW_TAG_structure_type
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x6
+          Tag:             DW_TAG_structure_type
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+        - Code:            0x7
+          Tag:             DW_TAG_template_type_parameter
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_type
+              Form:            DW_FORM_ref4
+        - Code:            0x8
+          Tag:             DW_TAG_typedef
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_type
+              Form:            DW_FORM_ref4
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_string
+  debug_info:
+    - Version:         4
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0xDEADBEEFDEADBEEF
+              CStr:            int
+        - AbbrCode:        0x3
+          Values:
+            - Value:           0xDEADBEEFDEADBEEF
+              CStr:            t1
+        - AbbrCode:        0x4
+          Values:
+            - Value:            0x0000001f # update
+        - AbbrCode:        0x5
+          Values:
+            - Value:           0xDEADBEEFDEADBEEF
+              CStr:            t2
+        - AbbrCode:        0x0
+        - AbbrCode:        0x6
+          Values:
+            - Value:           0xDEADBEEFDEADBEEF
+              CStr:            t3
+        - AbbrCode:        0x7
+          Values:
+            - Value:            0x0000000c # update
+        - AbbrCode:        0x8
+          Values:
+            - Value:            0x0000000c
+            - CStr:            my_int
+        - AbbrCode:        0x0
+        - AbbrCode:        0x0)";
+  Expected<StringMap<std::unique_ptr<MemoryBuffer>>> Sections =
+      DWARFYAML::emitDebugSections(StringRef(yamldata),
+                                   /*IsLittleEndian=*/true,
+                                   /*Is64BitAddrSize=*/true);
+  ASSERT_THAT_EXPECTED(Sections, Succeeded());
+  std::unique_ptr<DWARFContext> Ctx =
+      DWARFContext::create(*Sections, 4, /*isLittleEndian=*/true);
+  testAppendAndTerminateTemplateParameters(Ctx->getDIEForOffset(0x11),
+                                           "<t3<int> >");
+  testAppendQualifiedName(Ctx->getDIEForOffset(0x1a), "t1<t3<int> >::t2");
+  testAppendQualifiedName(Ctx->getDIEForOffset(0x28), "t3<int>::my_int");
+}
 } // end anonymous namespace


### PR DESCRIPTION
Fix a bug introduced in https://github.com/llvm/llvm-project/pull/117071.

Ideally the DWARTTypePrinter test should go to `llvm/unittests/DebugInfo/DWARF/DWARTTypePrinterTest.cpp`.