### PR TITLE
Convert the StackFrameList mutex to a shared mutex.

### DIFF
--- a/lldb/include/lldb/Target/StackFrameList.h
+++ b/lldb/include/lldb/Target/StackFrameList.h
@@ -104,15 +104,20 @@ protected:
   /// Realizes frames up to (and including) end_idx (which can be greater than
   /// the actual number of frames.)
   /// Returns true if the function was interrupted, false otherwise.
-  /// Must be called with a shared_locked mutex.  This might unlock the
-  /// shared side if it needs to fetch more frames, but will reacquire the
-  /// shared lock on the way out.
+  /// Must be called with a shared_locked mutex locked.
   bool GetFramesUpTo(uint32_t end_idx, InterruptionControl allow_interrupt,
                      std::shared_lock<std::shared_mutex> &guard);
 
-  /// Does not hold the StackFrameList mutex.  Same comment as GetFramesUpTo.
-  void GetOnlyConcreteFramesUpTo(uint32_t end_idx, Unwind &unwinder,
-                                 std::shared_lock<std::shared_mutex> &guard);
+  /// These two Fetch frames APIs must be called with the stack mutex shared
+  /// lock acquired.  They are the only places where we acquire the writer
+  /// end of the stack list mutex to add frames, but they will always exit with
+  /// the shared side reacquired.
+  /// Returns true if fetching frames was interrupted, false otherwise
+  bool FetchFramesUpTo(uint32_t end_idx, InterruptionControl allow_interrupt,
+                       std::shared_lock<std::shared_mutex> &guard);
+
+  void FetchOnlyConcreteFramesUpTo(uint32_t end_idx,
+                                   std::shared_lock<std::shared_mutex> &guard);
 
   // This gets called without the StackFrameList lock held, callers should
   // hold the lock.

--- a/lldb/include/lldb/Target/StackFrameList.h
+++ b/lldb/include/lldb/Target/StackFrameList.h
@@ -101,21 +101,20 @@ protected:
 
   bool SetFrameAtIndex(uint32_t idx, lldb::StackFrameSP &frame_sp);
 
-  /// Realizes frames up to (and including) end_idx (which can be greater than  
-  /// the actual number of frames.)  
+  /// Realizes frames up to (and including) end_idx (which can be greater than
+  /// the actual number of frames.)
   /// Returns true if the function was interrupted, false otherwise.
   /// Must be called with a shared_locked mutex.  This might unlock the
-  /// shared side if it needs to fetch more frames, but will reacquire the 
+  /// shared side if it needs to fetch more frames, but will reacquire the
   /// shared lock on the way out.
-  bool GetFramesUpTo(uint32_t end_idx, 
-      InterruptionControl allow_interrupt,
-      std::shared_lock<std::shared_mutex> &guard);
+  bool GetFramesUpTo(uint32_t end_idx, InterruptionControl allow_interrupt,
+                     std::shared_lock<std::shared_mutex> &guard);
 
   /// Does not hold the StackFrameList mutex.  Same comment as GetFramesUpTo.
   void GetOnlyConcreteFramesUpTo(uint32_t end_idx, Unwind &unwinder,
-      std::shared_lock<std::shared_mutex> &guard);
+                                 std::shared_lock<std::shared_mutex> &guard);
 
-  // This gets called without the StackFrameList lock held, callers should 
+  // This gets called without the StackFrameList lock held, callers should
   // hold the lock.
   void SynthesizeTailCallFrames(StackFrame &next_frame);
 
@@ -155,7 +154,7 @@ protected:
   /// if we need more frames we may swap shared for unique to fulfill that
   /// requirement.
   mutable std::shared_mutex m_list_mutex;
-  
+
   // Setting the inlined depth should be protected against other attempts to
   // change it, but since it doesn't mutate the list itself, we can limit the
   // critical regions it produces by having a separate mutex.
@@ -189,8 +188,9 @@ protected:
 
 private:
   uint32_t SetSelectedFrameNoLock(lldb_private::StackFrame *frame);
-  lldb::StackFrameSP GetFrameAtIndexNoLock(uint32_t idx,
-      std::shared_lock<std::shared_mutex> &guard);
+  lldb::StackFrameSP
+  GetFrameAtIndexNoLock(uint32_t idx,
+                        std::shared_lock<std::shared_mutex> &guard);
 
   StackFrameList(const StackFrameList &) = delete;
   const StackFrameList &operator=(const StackFrameList &) = delete;

--- a/lldb/include/lldb/Target/StackFrameList.h
+++ b/lldb/include/lldb/Target/StackFrameList.h
@@ -94,7 +94,7 @@ public:
                    bool show_frame_info, uint32_t num_frames_with_source,
                    bool show_unique = false, bool show_hidden = false,
                    const char *frame_marker = nullptr);
-                
+
   /// Returns whether we have currently fetched all the frames of a stack.
   bool WereAllFramesFetched() const;
 
@@ -118,13 +118,13 @@ protected:
   /// fetch frames or not.
   bool GetFramesUpTo(uint32_t end_idx, InterruptionControl allow_interrupt);
 
-  // This should be called with either the reader or writer end of the list 
+  // This should be called with either the reader or writer end of the list
   // mutex held:
-  bool GetAllFramesFetched() const { 
-    return m_concrete_frames_fetched == UINT32_MAX; 
+  bool GetAllFramesFetched() const {
+    return m_concrete_frames_fetched == UINT32_MAX;
   }
 
-  // This should be called with the writer end of the list mutex held. 
+  // This should be called with the writer end of the list mutex held.
   void SetAllFramesFetched() { m_concrete_frames_fetched = UINT32_MAX; }
 
   bool DecrementCurrentInlinedDepth();
@@ -197,7 +197,7 @@ private:
   GetFrameAtIndexNoLock(uint32_t idx,
                         std::shared_lock<std::shared_mutex> &guard);
 
-  /// These two Fetch frames APIs and SynthesizeTailCallFrames are called in 
+  /// These two Fetch frames APIs and SynthesizeTailCallFrames are called in
   /// GetFramesUpTo, they are the ones that actually add frames.  They must be
   /// called with the writer end of the list mutex held.
 

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -415,10 +415,6 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
     guard.lock();
   });
 
-  if (m_frames.size() > end_idx || GetAllFramesFetched()) {
-    return false;
-  }
-
 #if defined(DEBUG_STACK_FRAMES)
   StreamFile s(stdout, false);
 #endif
@@ -721,6 +717,7 @@ StackFrameSP StackFrameList::GetFrameWithStackID(const StackID &stack_id) {
 }
 
 bool StackFrameList::SetFrameAtIndex(uint32_t idx, StackFrameSP &frame_sp) {
+  std::unique_lock<std::shared_mutex> guard(m_list_mutex);
   if (idx >= m_frames.size())
     m_frames.resize(idx + 1);
   // Make sure allocation succeeded by checking bounds again

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -650,35 +650,7 @@ StackFrameSP StackFrameList::GetFrameAtIndexNoLock(
   }
 
   if (idx < m_frames.size()) {
-    if (m_show_inlined_frames) {
-      // When inline frames are enabled we actually create all the frames in
-      // GetFramesUpTo.
       frame_sp = m_frames[idx];
-    } else {
-      addr_t pc, cfa;
-      bool behaves_like_zeroth_frame = (idx == 0);
-      if (m_thread.GetUnwinder().GetFrameInfoAtIndex(
-              idx, cfa, pc, behaves_like_zeroth_frame)) {
-        const bool cfa_is_valid = true;
-        frame_sp = std::make_shared<StackFrame>(
-            m_thread.shared_from_this(), idx, idx, cfa, cfa_is_valid, pc,
-            StackFrame::Kind::Regular, behaves_like_zeroth_frame, nullptr);
-
-        Function *function =
-            frame_sp->GetSymbolContext(eSymbolContextFunction).function;
-        if (function) {
-          // When we aren't showing inline functions we always use the top
-          // most function block as the scope.
-          frame_sp->SetSymbolContextScope(&function->GetBlock(false));
-        } else {
-          // Set the symbol scope from the symbol regardless if it is nullptr
-          // or valid.
-          frame_sp->SetSymbolContextScope(
-              frame_sp->GetSymbolContext(eSymbolContextSymbol).symbol);
-        }
-        SetFrameAtIndex(idx, frame_sp);
-      }
-    }
   } else if (original_idx == 0) {
     // There should ALWAYS be a frame at index 0.  If something went wrong with
     // the CurrentInlinedDepth such that there weren't as many frames as we

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -576,7 +576,7 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
 }
 
 uint32_t StackFrameList::GetNumFrames(bool can_create) {
-  if (!GetAllFramesFetched() && can_create) {
+  if (!WereAllFramesFetched() && can_create) {
     // Don't allow interrupt or we might not return the correct count
     GetFramesUpTo(UINT32_MAX, DoNotAllowInterruption);
   }

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -138,35 +138,6 @@ void StackFrameList::SetCurrentInlinedDepth(uint32_t new_depth) {
     m_current_inlined_pc = m_thread.GetRegisterContext()->GetPC();
 }
 
-void StackFrameList::GetOnlyConcreteFramesUpTo(
-    uint32_t end_idx, Unwind &unwinder,
-    std::shared_lock<std::shared_mutex> &guard) {
-  assert(m_thread.IsValid() && "Expected valid thread");
-  assert(m_frames.size() <= end_idx && "Expected there to be frames to fill");
-
-  if (end_idx < m_concrete_frames_fetched)
-    return;
-  { // Scope for swapping reader and writer locks
-    m_list_mutex.lock();
-    auto on_exit = llvm::make_scope_exit([&]() {
-      m_list_mutex.unlock();
-      guard.lock();
-    });
-    if (end_idx < m_concrete_frames_fetched)
-      return;
-
-    uint32_t num_frames = unwinder.GetFramesUpTo(end_idx);
-    if (num_frames <= end_idx + 1) {
-      // Done unwinding.
-      m_concrete_frames_fetched = UINT32_MAX;
-    }
-
-    // Don't create the frames eagerly. Defer this work to GetFrameAtIndex,
-    // which can lazily query the unwinder to create frames.
-    m_frames.resize(num_frames);
-  }
-}
-
 /// A sequence of calls that comprise some portion of a backtrace. Each frame
 /// is represented as a pair of a callee (Function *) and an address within the
 /// callee.
@@ -376,196 +347,17 @@ bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
   if (m_frames.size() > end_idx || GetAllFramesFetched())
     return false;
 
-  Unwind &unwinder = m_thread.GetUnwinder();
-
   if (!m_show_inlined_frames) {
-    GetOnlyConcreteFramesUpTo(end_idx, unwinder, guard);
+    if (end_idx < m_concrete_frames_fetched)
+      return false;
+    // We're adding concrete frames now:
+    // FIXME: This should also be interruptible:
+    FetchOnlyConcreteFramesUpTo(end_idx, guard);
     return false;
   }
 
-  // We're going to have to add frames, so get the writer side of the lock,
-  // and then when we're done, relock the reader side.
-  guard.unlock();
-  { // Scope for switching the writer -> reader and back
-    m_list_mutex.lock();
-    auto on_exit = llvm::make_scope_exit([&]() {
-      m_list_mutex.unlock();
-      guard.lock();
-    });
-
-    if (m_frames.size() > end_idx || GetAllFramesFetched()) {
-      return false;
-    }
-
-#if defined(DEBUG_STACK_FRAMES)
-    StreamFile s(stdout, false);
-#endif
-    // If we are hiding some frames from the outside world, we need to add
-    // those onto the total count of frames to fetch.  However, we don't need
-    // to do that if end_idx is 0 since in that case we always get the first
-    // concrete frame and all the inlined frames below it...  And of course, if
-    // end_idx is UINT32_MAX that means get all, so just do that...
-
-    uint32_t inlined_depth = 0;
-    if (end_idx > 0 && end_idx != UINT32_MAX) {
-      inlined_depth = GetCurrentInlinedDepth();
-      if (inlined_depth != UINT32_MAX) {
-        if (end_idx > 0)
-          end_idx += inlined_depth;
-      }
-    }
-
-    StackFrameSP unwind_frame_sp;
-    Debugger &dbg = m_thread.GetProcess()->GetTarget().GetDebugger();
-    do {
-      uint32_t idx = m_concrete_frames_fetched++;
-      lldb::addr_t pc = LLDB_INVALID_ADDRESS;
-      lldb::addr_t cfa = LLDB_INVALID_ADDRESS;
-      bool behaves_like_zeroth_frame = (idx == 0);
-      if (idx == 0) {
-        // We might have already created frame zero, only create it if we need
-        // to.
-        if (m_frames.empty()) {
-          RegisterContextSP reg_ctx_sp(m_thread.GetRegisterContext());
-
-          if (reg_ctx_sp) {
-            const bool success = unwinder.GetFrameInfoAtIndex(
-                idx, cfa, pc, behaves_like_zeroth_frame);
-            // There shouldn't be any way not to get the frame info for frame
-            // 0. But if the unwinder can't make one, lets make one by hand
-            // with the SP as the CFA and see if that gets any further.
-            if (!success) {
-              cfa = reg_ctx_sp->GetSP();
-              pc = reg_ctx_sp->GetPC();
-            }
-
-            unwind_frame_sp = std::make_shared<StackFrame>(
-                m_thread.shared_from_this(), m_frames.size(), idx, reg_ctx_sp,
-                cfa, pc, behaves_like_zeroth_frame, nullptr);
-            m_frames.push_back(unwind_frame_sp);
-          }
-        } else {
-          unwind_frame_sp = m_frames.front();
-          cfa = unwind_frame_sp->m_id.GetCallFrameAddress();
-        }
-      } else {
-        // Check for interruption when building the frames.
-        // Do the check in idx > 0 so that we'll always create a 0th frame.
-        if (allow_interrupt &&
-            INTERRUPT_REQUESTED(dbg, "Interrupted having fetched {0} frames",
-                                m_frames.size())) {
-          was_interrupted = true;
-          break;
-        }
-
-        const bool success = unwinder.GetFrameInfoAtIndex(
-            idx, cfa, pc, behaves_like_zeroth_frame);
-        if (!success) {
-          // We've gotten to the end of the stack.
-          SetAllFramesFetched();
-          break;
-        }
-        const bool cfa_is_valid = true;
-        unwind_frame_sp = std::make_shared<StackFrame>(
-            m_thread.shared_from_this(), m_frames.size(), idx, cfa,
-            cfa_is_valid, pc, StackFrame::Kind::Regular,
-            behaves_like_zeroth_frame, nullptr);
-
-        // Create synthetic tail call frames between the previous frame and the
-        // newly-found frame. The new frame's index may change after this call,
-        // although its concrete index will stay the same.
-        SynthesizeTailCallFrames(*unwind_frame_sp.get());
-
-        m_frames.push_back(unwind_frame_sp);
-      }
-
-      assert(unwind_frame_sp);
-      SymbolContext unwind_sc = unwind_frame_sp->GetSymbolContext(
-          eSymbolContextBlock | eSymbolContextFunction);
-      Block *unwind_block = unwind_sc.block;
-      TargetSP target_sp = m_thread.CalculateTarget();
-      if (unwind_block) {
-        Address curr_frame_address(
-            unwind_frame_sp->GetFrameCodeAddressForSymbolication());
-
-        SymbolContext next_frame_sc;
-        Address next_frame_address;
-
-        while (unwind_sc.GetParentOfInlinedScope(
-            curr_frame_address, next_frame_sc, next_frame_address)) {
-          next_frame_sc.line_entry.ApplyFileMappings(target_sp);
-          behaves_like_zeroth_frame = false;
-          StackFrameSP frame_sp(new StackFrame(
-              m_thread.shared_from_this(), m_frames.size(), idx,
-              unwind_frame_sp->GetRegisterContextSP(), cfa, next_frame_address,
-              behaves_like_zeroth_frame, &next_frame_sc));
-
-          m_frames.push_back(frame_sp);
-          unwind_sc = next_frame_sc;
-          curr_frame_address = next_frame_address;
-        }
-      }
-    } while (m_frames.size() - 1 < end_idx);
-
-    // Don't try to merge till you've calculated all the frames in this stack.
-    if (GetAllFramesFetched() && m_prev_frames_sp) {
-      StackFrameList *prev_frames = m_prev_frames_sp.get();
-      StackFrameList *curr_frames = this;
-
-#if defined(DEBUG_STACK_FRAMES)
-      s.PutCString("\nprev_frames:\n");
-      prev_frames->Dump(&s);
-      s.PutCString("\ncurr_frames:\n");
-      curr_frames->Dump(&s);
-      s.EOL();
-#endif
-      size_t curr_frame_num, prev_frame_num;
-
-      for (curr_frame_num = curr_frames->m_frames.size(),
-          prev_frame_num = prev_frames->m_frames.size();
-           curr_frame_num > 0 && prev_frame_num > 0;
-           --curr_frame_num, --prev_frame_num) {
-        const size_t curr_frame_idx = curr_frame_num - 1;
-        const size_t prev_frame_idx = prev_frame_num - 1;
-        StackFrameSP curr_frame_sp(curr_frames->m_frames[curr_frame_idx]);
-        StackFrameSP prev_frame_sp(prev_frames->m_frames[prev_frame_idx]);
-
-#if defined(DEBUG_STACK_FRAMES)
-        s.Printf("\n\nCurr frame #%u ", curr_frame_idx);
-        if (curr_frame_sp)
-          curr_frame_sp->Dump(&s, true, false);
-        else
-          s.PutCString("NULL");
-        s.Printf("\nPrev frame #%u ", prev_frame_idx);
-        if (prev_frame_sp)
-          prev_frame_sp->Dump(&s, true, false);
-        else
-          s.PutCString("NULL");
-#endif
-
-        StackFrame *curr_frame = curr_frame_sp.get();
-        StackFrame *prev_frame = prev_frame_sp.get();
-
-        if (curr_frame == nullptr || prev_frame == nullptr)
-          break;
-
-        // Check the stack ID to make sure they are equal.
-        if (curr_frame->GetStackID() != prev_frame->GetStackID())
-          break;
-
-        prev_frame->UpdatePreviousFrameFromCurrentFrame(*curr_frame);
-        // Now copy the fixed up previous frame into the current frames so the
-        // pointer doesn't change.
-        m_frames[curr_frame_idx] = prev_frame_sp;
-
-#if defined(DEBUG_STACK_FRAMES)
-        s.Printf("\n    Copying previous frame to current frame");
-#endif
-      }
-      // We are done with the old stack frame list, we can release it now.
-      m_prev_frames_sp.reset();
-    }
-  } // End scope for writer lock
+  // We're adding concrete and inlined frames now:
+  was_interrupted = FetchFramesUpTo(end_idx, allow_interrupt, guard);
 
 #if defined(DEBUG_STACK_FRAMES)
   s.PutCString("\n\nNew frames:\n");
@@ -576,6 +368,226 @@ bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
   if (!GetAllFramesFetched())
     return was_interrupted;
   return false;
+  
+}
+
+void StackFrameList::FetchOnlyConcreteFramesUpTo(
+    uint32_t end_idx, std::shared_lock<std::shared_mutex> &guard) {
+  assert(m_thread.IsValid() && "Expected valid thread");
+  assert(m_frames.size() <= end_idx && "Expected there to be frames to fill");
+  assert(guard.owns_lock() && "Must be called with the shared lock acquired"); 
+
+  Unwind &unwinder = m_thread.GetUnwinder();
+
+  guard.unlock();
+  m_list_mutex.lock();
+  auto on_exit = llvm::make_scope_exit([&]() {
+    m_list_mutex.unlock();
+    guard.lock();
+  });
+  if (end_idx < m_concrete_frames_fetched)
+    return;
+
+  uint32_t num_frames = unwinder.GetFramesUpTo(end_idx);
+  if (num_frames <= end_idx + 1) {
+    // Done unwinding.
+    m_concrete_frames_fetched = UINT32_MAX;
+  }
+
+  // Don't create the frames eagerly. Defer this work to GetFrameAtIndex,
+  // which can lazily query the unwinder to create frames.
+  m_frames.resize(num_frames);
+}
+
+
+bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
+                                   InterruptionControl allow_interrupt,
+                                   std::shared_lock<std::shared_mutex> &guard) {
+  assert(guard.owns_lock() && "Must be called with the shared lock acquired");
+
+  Unwind &unwinder = m_thread.GetUnwinder();
+  bool was_interrupted = false;
+
+  guard.unlock();
+  m_list_mutex.lock();
+  auto on_exit = llvm::make_scope_exit([&]() {
+    m_list_mutex.unlock();
+    guard.lock();
+  });
+
+  if (m_frames.size() > end_idx || GetAllFramesFetched()) {
+    return false;
+  }
+
+#if defined(DEBUG_STACK_FRAMES)
+  StreamFile s(stdout, false);
+#endif
+  // If we are hiding some frames from the outside world, we need to add
+  // those onto the total count of frames to fetch.  However, we don't need
+  // to do that if end_idx is 0 since in that case we always get the first
+  // concrete frame and all the inlined frames below it...  And of course, if
+  // end_idx is UINT32_MAX that means get all, so just do that...
+
+  uint32_t inlined_depth = 0;
+  if (end_idx > 0 && end_idx != UINT32_MAX) {
+    inlined_depth = GetCurrentInlinedDepth();
+    if (inlined_depth != UINT32_MAX) {
+      if (end_idx > 0)
+        end_idx += inlined_depth;
+    }
+  }
+
+  StackFrameSP unwind_frame_sp;
+  Debugger &dbg = m_thread.GetProcess()->GetTarget().GetDebugger();
+  do {
+    uint32_t idx = m_concrete_frames_fetched++;
+    lldb::addr_t pc = LLDB_INVALID_ADDRESS;
+    lldb::addr_t cfa = LLDB_INVALID_ADDRESS;
+    bool behaves_like_zeroth_frame = (idx == 0);
+    if (idx == 0) {
+      // We might have already created frame zero, only create it if we need
+      // to.
+      if (m_frames.empty()) {
+        RegisterContextSP reg_ctx_sp(m_thread.GetRegisterContext());
+
+        if (reg_ctx_sp) {
+          const bool success = unwinder.GetFrameInfoAtIndex(
+              idx, cfa, pc, behaves_like_zeroth_frame);
+          // There shouldn't be any way not to get the frame info for frame
+          // 0. But if the unwinder can't make one, lets make one by hand
+          // with the SP as the CFA and see if that gets any further.
+          if (!success) {
+            cfa = reg_ctx_sp->GetSP();
+            pc = reg_ctx_sp->GetPC();
+          }
+
+          unwind_frame_sp = std::make_shared<StackFrame>(
+              m_thread.shared_from_this(), m_frames.size(), idx, reg_ctx_sp,
+              cfa, pc, behaves_like_zeroth_frame, nullptr);
+          m_frames.push_back(unwind_frame_sp);
+        }
+      } else {
+        unwind_frame_sp = m_frames.front();
+        cfa = unwind_frame_sp->m_id.GetCallFrameAddress();
+      }
+    } else {
+      // Check for interruption when building the frames.
+      // Do the check in idx > 0 so that we'll always create a 0th frame.
+      if (allow_interrupt &&
+          INTERRUPT_REQUESTED(dbg, "Interrupted having fetched {0} frames",
+                              m_frames.size())) {
+        was_interrupted = true;
+        break;
+      }
+
+      const bool success = unwinder.GetFrameInfoAtIndex(
+          idx, cfa, pc, behaves_like_zeroth_frame);
+      if (!success) {
+        // We've gotten to the end of the stack.
+        SetAllFramesFetched();
+        break;
+      }
+      const bool cfa_is_valid = true;
+      unwind_frame_sp = std::make_shared<StackFrame>(
+          m_thread.shared_from_this(), m_frames.size(), idx, cfa,
+          cfa_is_valid, pc, StackFrame::Kind::Regular,
+          behaves_like_zeroth_frame, nullptr);
+
+      // Create synthetic tail call frames between the previous frame and the
+      // newly-found frame. The new frame's index may change after this call,
+      // although its concrete index will stay the same.
+      SynthesizeTailCallFrames(*unwind_frame_sp.get());
+
+      m_frames.push_back(unwind_frame_sp);
+    }
+
+    assert(unwind_frame_sp);
+    SymbolContext unwind_sc = unwind_frame_sp->GetSymbolContext(
+        eSymbolContextBlock | eSymbolContextFunction);
+    Block *unwind_block = unwind_sc.block;
+    TargetSP target_sp = m_thread.CalculateTarget();
+    if (unwind_block) {
+      Address curr_frame_address(
+          unwind_frame_sp->GetFrameCodeAddressForSymbolication());
+
+      SymbolContext next_frame_sc;
+      Address next_frame_address;
+
+      while (unwind_sc.GetParentOfInlinedScope(
+          curr_frame_address, next_frame_sc, next_frame_address)) {
+        next_frame_sc.line_entry.ApplyFileMappings(target_sp);
+        behaves_like_zeroth_frame = false;
+        StackFrameSP frame_sp(new StackFrame(
+            m_thread.shared_from_this(), m_frames.size(), idx,
+            unwind_frame_sp->GetRegisterContextSP(), cfa, next_frame_address,
+            behaves_like_zeroth_frame, &next_frame_sc));
+
+        m_frames.push_back(frame_sp);
+        unwind_sc = next_frame_sc;
+        curr_frame_address = next_frame_address;
+      }
+    }
+  } while (m_frames.size() - 1 < end_idx);
+
+  // Don't try to merge till you've calculated all the frames in this stack.
+  if (GetAllFramesFetched() && m_prev_frames_sp) {
+    StackFrameList *prev_frames = m_prev_frames_sp.get();
+    StackFrameList *curr_frames = this;
+
+#if defined(DEBUG_STACK_FRAMES)
+    s.PutCString("\nprev_frames:\n");
+    prev_frames->Dump(&s);
+    s.PutCString("\ncurr_frames:\n");
+    curr_frames->Dump(&s);
+    s.EOL();
+#endif
+    size_t curr_frame_num, prev_frame_num;
+
+    for (curr_frame_num = curr_frames->m_frames.size(),
+        prev_frame_num = prev_frames->m_frames.size();
+         curr_frame_num > 0 && prev_frame_num > 0;
+         --curr_frame_num, --prev_frame_num) {
+      const size_t curr_frame_idx = curr_frame_num - 1;
+      const size_t prev_frame_idx = prev_frame_num - 1;
+      StackFrameSP curr_frame_sp(curr_frames->m_frames[curr_frame_idx]);
+      StackFrameSP prev_frame_sp(prev_frames->m_frames[prev_frame_idx]);
+
+#if defined(DEBUG_STACK_FRAMES)
+      s.Printf("\n\nCurr frame #%u ", curr_frame_idx);
+      if (curr_frame_sp)
+        curr_frame_sp->Dump(&s, true, false);
+      else
+        s.PutCString("NULL");
+      s.Printf("\nPrev frame #%u ", prev_frame_idx);
+      if (prev_frame_sp)
+        prev_frame_sp->Dump(&s, true, false);
+      else
+        s.PutCString("NULL");
+#endif
+
+      StackFrame *curr_frame = curr_frame_sp.get();
+      StackFrame *prev_frame = prev_frame_sp.get();
+
+      if (curr_frame == nullptr || prev_frame == nullptr)
+        break;
+
+      // Check the stack ID to make sure they are equal.
+      if (curr_frame->GetStackID() != prev_frame->GetStackID())
+        break;
+
+      prev_frame->UpdatePreviousFrameFromCurrentFrame(*curr_frame);
+      // Now copy the fixed up previous frame into the current frames so the
+      // pointer doesn't change.
+      m_frames[curr_frame_idx] = prev_frame_sp;
+
+#if defined(DEBUG_STACK_FRAMES)
+      s.Printf("\n    Copying previous frame to current frame");
+#endif
+    }
+    // We are done with the old stack frame list, we can release it now.
+    m_prev_frames_sp.reset();
+  }
+  return was_interrupted;
 }
 
 uint32_t StackFrameList::GetNumFrames(bool can_create) {

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -25,6 +25,7 @@
 #include "lldb/Target/Unwind.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 #include <memory>
@@ -138,22 +139,33 @@ void StackFrameList::SetCurrentInlinedDepth(uint32_t new_depth) {
 }
 
 void StackFrameList::GetOnlyConcreteFramesUpTo(uint32_t end_idx,
-                                               Unwind &unwinder) {
+                                               Unwind &unwinder,
+      std::shared_lock<std::shared_mutex> &guard) {
   assert(m_thread.IsValid() && "Expected valid thread");
   assert(m_frames.size() <= end_idx && "Expected there to be frames to fill");
 
   if (end_idx < m_concrete_frames_fetched)
     return;
+  { // Scope for swapping reader and writer locks
+    m_list_mutex.lock();
+    auto on_exit = llvm::make_scope_exit(
+      [&]() { 
+        m_list_mutex.unlock();
+        guard.lock();
+      });
+    if (end_idx < m_concrete_frames_fetched)
+      return;
 
-  uint32_t num_frames = unwinder.GetFramesUpTo(end_idx);
-  if (num_frames <= end_idx + 1) {
-    // Done unwinding.
-    m_concrete_frames_fetched = UINT32_MAX;
+    uint32_t num_frames = unwinder.GetFramesUpTo(end_idx);
+    if (num_frames <= end_idx + 1) {
+      // Done unwinding.
+      m_concrete_frames_fetched = UINT32_MAX;
+    }
+
+    // Don't create the frames eagerly. Defer this work to GetFrameAtIndex,
+    // which can lazily query the unwinder to create frames.
+    m_frames.resize(num_frames);
   }
-
-  // Don't create the frames eagerly. Defer this work to GetFrameAtIndex,
-  // which can lazily query the unwinder to create frames.
-  m_frames.resize(num_frames);
 }
 
 /// A sequence of calls that comprise some portion of a backtrace. Each frame
@@ -353,7 +365,8 @@ void StackFrameList::SynthesizeTailCallFrames(StackFrame &next_frame) {
 }
 
 bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
-                                   InterruptionControl allow_interrupt) {
+                                   InterruptionControl allow_interrupt,
+      std::shared_lock<std::shared_mutex> &guard) {
   // Do not fetch frames for an invalid thread.
   bool was_interrupted = false;
   if (!m_thread.IsValid())
@@ -367,177 +380,193 @@ bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
   Unwind &unwinder = m_thread.GetUnwinder();
 
   if (!m_show_inlined_frames) {
-    GetOnlyConcreteFramesUpTo(end_idx, unwinder);
+    GetOnlyConcreteFramesUpTo(end_idx, unwinder, guard);
     return false;
   }
+  
+  // We're going to have to add frames, so get the writer side of the lock,
+  // and then when we're done, relock the reader side.
+  guard.unlock();
+  { // Scope for switching the writer -> reader and back
+    m_list_mutex.lock();
+    auto on_exit = llvm::make_scope_exit(
+      [&]() { 
+        m_list_mutex.unlock();
+        guard.lock();
+      });
 
-#if defined(DEBUG_STACK_FRAMES)
-  StreamFile s(stdout, false);
-#endif
-  // If we are hiding some frames from the outside world, we need to add
-  // those onto the total count of frames to fetch.  However, we don't need
-  // to do that if end_idx is 0 since in that case we always get the first
-  // concrete frame and all the inlined frames below it...  And of course, if
-  // end_idx is UINT32_MAX that means get all, so just do that...
-
-  uint32_t inlined_depth = 0;
-  if (end_idx > 0 && end_idx != UINT32_MAX) {
-    inlined_depth = GetCurrentInlinedDepth();
-    if (inlined_depth != UINT32_MAX) {
-      if (end_idx > 0)
-        end_idx += inlined_depth;
+    if (m_frames.size() > end_idx || GetAllFramesFetched()) {
+      return false;
     }
-  }
+    
+  #if defined(DEBUG_STACK_FRAMES)
+    StreamFile s(stdout, false);
+  #endif
+    // If we are hiding some frames from the outside world, we need to add
+    // those onto the total count of frames to fetch.  However, we don't need
+    // to do that if end_idx is 0 since in that case we always get the first
+    // concrete frame and all the inlined frames below it...  And of course, if
+    // end_idx is UINT32_MAX that means get all, so just do that...
 
-  StackFrameSP unwind_frame_sp;
-  Debugger &dbg = m_thread.GetProcess()->GetTarget().GetDebugger();
-  do {
-    uint32_t idx = m_concrete_frames_fetched++;
-    lldb::addr_t pc = LLDB_INVALID_ADDRESS;
-    lldb::addr_t cfa = LLDB_INVALID_ADDRESS;
-    bool behaves_like_zeroth_frame = (idx == 0);
-    if (idx == 0) {
-      // We might have already created frame zero, only create it if we need
-      // to.
-      if (m_frames.empty()) {
-        RegisterContextSP reg_ctx_sp(m_thread.GetRegisterContext());
+    uint32_t inlined_depth = 0;
+    if (end_idx > 0 && end_idx != UINT32_MAX) {
+      inlined_depth = GetCurrentInlinedDepth();
+      if (inlined_depth != UINT32_MAX) {
+        if (end_idx > 0)
+          end_idx += inlined_depth;
+      }
+    }
 
-        if (reg_ctx_sp) {
-          const bool success = unwinder.GetFrameInfoAtIndex(
-              idx, cfa, pc, behaves_like_zeroth_frame);
-          // There shouldn't be any way not to get the frame info for frame
-          // 0. But if the unwinder can't make one, lets make one by hand
-          // with the SP as the CFA and see if that gets any further.
-          if (!success) {
-            cfa = reg_ctx_sp->GetSP();
-            pc = reg_ctx_sp->GetPC();
+    StackFrameSP unwind_frame_sp;
+    Debugger &dbg = m_thread.GetProcess()->GetTarget().GetDebugger();
+    do {
+      uint32_t idx = m_concrete_frames_fetched++;
+      lldb::addr_t pc = LLDB_INVALID_ADDRESS;
+      lldb::addr_t cfa = LLDB_INVALID_ADDRESS;
+      bool behaves_like_zeroth_frame = (idx == 0);
+      if (idx == 0) {
+        // We might have already created frame zero, only create it if we need
+        // to.
+        if (m_frames.empty()) {
+          RegisterContextSP reg_ctx_sp(m_thread.GetRegisterContext());
+
+          if (reg_ctx_sp) {
+            const bool success = unwinder.GetFrameInfoAtIndex(
+                idx, cfa, pc, behaves_like_zeroth_frame);
+            // There shouldn't be any way not to get the frame info for frame
+            // 0. But if the unwinder can't make one, lets make one by hand
+            // with the SP as the CFA and see if that gets any further.
+            if (!success) {
+              cfa = reg_ctx_sp->GetSP();
+              pc = reg_ctx_sp->GetPC();
+            }
+
+            unwind_frame_sp = std::make_shared<StackFrame>(
+                m_thread.shared_from_this(), m_frames.size(), idx, reg_ctx_sp,
+                cfa, pc, behaves_like_zeroth_frame, nullptr);
+            m_frames.push_back(unwind_frame_sp);
           }
-
-          unwind_frame_sp = std::make_shared<StackFrame>(
-              m_thread.shared_from_this(), m_frames.size(), idx, reg_ctx_sp,
-              cfa, pc, behaves_like_zeroth_frame, nullptr);
-          m_frames.push_back(unwind_frame_sp);
+        } else {
+          unwind_frame_sp = m_frames.front();
+          cfa = unwind_frame_sp->m_id.GetCallFrameAddress();
         }
       } else {
-        unwind_frame_sp = m_frames.front();
-        cfa = unwind_frame_sp->m_id.GetCallFrameAddress();
-      }
-    } else {
-      // Check for interruption when building the frames.
-      // Do the check in idx > 0 so that we'll always create a 0th frame.
-      if (allow_interrupt 
-          && INTERRUPT_REQUESTED(dbg, "Interrupted having fetched {0} frames",
-                                 m_frames.size())) {
-          was_interrupted = true;
+        // Check for interruption when building the frames.
+        // Do the check in idx > 0 so that we'll always create a 0th frame.
+        if (allow_interrupt 
+            && INTERRUPT_REQUESTED(dbg, "Interrupted having fetched {0} frames",
+                                   m_frames.size())) {
+            was_interrupted = true;
+            break;
+        }
+
+        const bool success =
+            unwinder.GetFrameInfoAtIndex(idx, cfa, pc, behaves_like_zeroth_frame);
+        if (!success) {
+          // We've gotten to the end of the stack.
+          SetAllFramesFetched();
           break;
+        }
+        const bool cfa_is_valid = true;
+        unwind_frame_sp = std::make_shared<StackFrame>(
+            m_thread.shared_from_this(), m_frames.size(), idx, cfa, cfa_is_valid,
+            pc, StackFrame::Kind::Regular, behaves_like_zeroth_frame, nullptr);
+
+        // Create synthetic tail call frames between the previous frame and the
+        // newly-found frame. The new frame's index may change after this call,
+        // although its concrete index will stay the same.
+        SynthesizeTailCallFrames(*unwind_frame_sp.get());
+
+        m_frames.push_back(unwind_frame_sp);
       }
 
-      const bool success =
-          unwinder.GetFrameInfoAtIndex(idx, cfa, pc, behaves_like_zeroth_frame);
-      if (!success) {
-        // We've gotten to the end of the stack.
-        SetAllFramesFetched();
-        break;
+      assert(unwind_frame_sp);
+      SymbolContext unwind_sc = unwind_frame_sp->GetSymbolContext(
+          eSymbolContextBlock | eSymbolContextFunction);
+      Block *unwind_block = unwind_sc.block;
+      TargetSP target_sp = m_thread.CalculateTarget();
+      if (unwind_block) {
+        Address curr_frame_address(
+            unwind_frame_sp->GetFrameCodeAddressForSymbolication());
+
+        SymbolContext next_frame_sc;
+        Address next_frame_address;
+
+        while (unwind_sc.GetParentOfInlinedScope(
+            curr_frame_address, next_frame_sc, next_frame_address)) {
+          next_frame_sc.line_entry.ApplyFileMappings(target_sp);
+          behaves_like_zeroth_frame = false;
+          StackFrameSP frame_sp(new StackFrame(
+              m_thread.shared_from_this(), m_frames.size(), idx,
+              unwind_frame_sp->GetRegisterContextSP(), cfa, next_frame_address,
+              behaves_like_zeroth_frame, &next_frame_sc));
+
+          m_frames.push_back(frame_sp);
+          unwind_sc = next_frame_sc;
+          curr_frame_address = next_frame_address;
+        }
       }
-      const bool cfa_is_valid = true;
-      unwind_frame_sp = std::make_shared<StackFrame>(
-          m_thread.shared_from_this(), m_frames.size(), idx, cfa, cfa_is_valid,
-          pc, StackFrame::Kind::Regular, behaves_like_zeroth_frame, nullptr);
+    } while (m_frames.size() - 1 < end_idx);
 
-      // Create synthetic tail call frames between the previous frame and the
-      // newly-found frame. The new frame's index may change after this call,
-      // although its concrete index will stay the same.
-      SynthesizeTailCallFrames(*unwind_frame_sp.get());
+    // Don't try to merge till you've calculated all the frames in this stack.
+    if (GetAllFramesFetched() && m_prev_frames_sp) {
+      StackFrameList *prev_frames = m_prev_frames_sp.get();
+      StackFrameList *curr_frames = this;
 
-      m_frames.push_back(unwind_frame_sp);
-    }
+  #if defined(DEBUG_STACK_FRAMES)
+      s.PutCString("\nprev_frames:\n");
+      prev_frames->Dump(&s);
+      s.PutCString("\ncurr_frames:\n");
+      curr_frames->Dump(&s);
+      s.EOL();
+  #endif
+      size_t curr_frame_num, prev_frame_num;
 
-    assert(unwind_frame_sp);
-    SymbolContext unwind_sc = unwind_frame_sp->GetSymbolContext(
-        eSymbolContextBlock | eSymbolContextFunction);
-    Block *unwind_block = unwind_sc.block;
-    TargetSP target_sp = m_thread.CalculateTarget();
-    if (unwind_block) {
-      Address curr_frame_address(
-          unwind_frame_sp->GetFrameCodeAddressForSymbolication());
+      for (curr_frame_num = curr_frames->m_frames.size(),
+          prev_frame_num = prev_frames->m_frames.size();
+           curr_frame_num > 0 && prev_frame_num > 0;
+           --curr_frame_num, --prev_frame_num) {
+        const size_t curr_frame_idx = curr_frame_num - 1;
+        const size_t prev_frame_idx = prev_frame_num - 1;
+        StackFrameSP curr_frame_sp(curr_frames->m_frames[curr_frame_idx]);
+        StackFrameSP prev_frame_sp(prev_frames->m_frames[prev_frame_idx]);
 
-      SymbolContext next_frame_sc;
-      Address next_frame_address;
+  #if defined(DEBUG_STACK_FRAMES)
+        s.Printf("\n\nCurr frame #%u ", curr_frame_idx);
+        if (curr_frame_sp)
+          curr_frame_sp->Dump(&s, true, false);
+        else
+          s.PutCString("NULL");
+        s.Printf("\nPrev frame #%u ", prev_frame_idx);
+        if (prev_frame_sp)
+          prev_frame_sp->Dump(&s, true, false);
+        else
+          s.PutCString("NULL");
+  #endif
 
-      while (unwind_sc.GetParentOfInlinedScope(
-          curr_frame_address, next_frame_sc, next_frame_address)) {
-        next_frame_sc.line_entry.ApplyFileMappings(target_sp);
-        behaves_like_zeroth_frame = false;
-        StackFrameSP frame_sp(new StackFrame(
-            m_thread.shared_from_this(), m_frames.size(), idx,
-            unwind_frame_sp->GetRegisterContextSP(), cfa, next_frame_address,
-            behaves_like_zeroth_frame, &next_frame_sc));
+        StackFrame *curr_frame = curr_frame_sp.get();
+        StackFrame *prev_frame = prev_frame_sp.get();
 
-        m_frames.push_back(frame_sp);
-        unwind_sc = next_frame_sc;
-        curr_frame_address = next_frame_address;
+        if (curr_frame == nullptr || prev_frame == nullptr)
+          break;
+
+        // Check the stack ID to make sure they are equal.
+        if (curr_frame->GetStackID() != prev_frame->GetStackID())
+          break;
+
+        prev_frame->UpdatePreviousFrameFromCurrentFrame(*curr_frame);
+        // Now copy the fixed up previous frame into the current frames so the
+        // pointer doesn't change.
+        m_frames[curr_frame_idx] = prev_frame_sp;
+
+  #if defined(DEBUG_STACK_FRAMES)
+        s.Printf("\n    Copying previous frame to current frame");
+  #endif
       }
+      // We are done with the old stack frame list, we can release it now.
+      m_prev_frames_sp.reset();
     }
-  } while (m_frames.size() - 1 < end_idx);
-
-  // Don't try to merge till you've calculated all the frames in this stack.
-  if (GetAllFramesFetched() && m_prev_frames_sp) {
-    StackFrameList *prev_frames = m_prev_frames_sp.get();
-    StackFrameList *curr_frames = this;
-
-#if defined(DEBUG_STACK_FRAMES)
-    s.PutCString("\nprev_frames:\n");
-    prev_frames->Dump(&s);
-    s.PutCString("\ncurr_frames:\n");
-    curr_frames->Dump(&s);
-    s.EOL();
-#endif
-    size_t curr_frame_num, prev_frame_num;
-
-    for (curr_frame_num = curr_frames->m_frames.size(),
-        prev_frame_num = prev_frames->m_frames.size();
-         curr_frame_num > 0 && prev_frame_num > 0;
-         --curr_frame_num, --prev_frame_num) {
-      const size_t curr_frame_idx = curr_frame_num - 1;
-      const size_t prev_frame_idx = prev_frame_num - 1;
-      StackFrameSP curr_frame_sp(curr_frames->m_frames[curr_frame_idx]);
-      StackFrameSP prev_frame_sp(prev_frames->m_frames[prev_frame_idx]);
-
-#if defined(DEBUG_STACK_FRAMES)
-      s.Printf("\n\nCurr frame #%u ", curr_frame_idx);
-      if (curr_frame_sp)
-        curr_frame_sp->Dump(&s, true, false);
-      else
-        s.PutCString("NULL");
-      s.Printf("\nPrev frame #%u ", prev_frame_idx);
-      if (prev_frame_sp)
-        prev_frame_sp->Dump(&s, true, false);
-      else
-        s.PutCString("NULL");
-#endif
-
-      StackFrame *curr_frame = curr_frame_sp.get();
-      StackFrame *prev_frame = prev_frame_sp.get();
-
-      if (curr_frame == nullptr || prev_frame == nullptr)
-        break;
-
-      // Check the stack ID to make sure they are equal.
-      if (curr_frame->GetStackID() != prev_frame->GetStackID())
-        break;
-
-      prev_frame->UpdatePreviousFrameFromCurrentFrame(*curr_frame);
-      // Now copy the fixed up previous frame into the current frames so the
-      // pointer doesn't change.
-      m_frames[curr_frame_idx] = prev_frame_sp;
-
-#if defined(DEBUG_STACK_FRAMES)
-      s.Printf("\n    Copying previous frame to current frame");
-#endif
-    }
-    // We are done with the old stack frame list, we can release it now.
-    m_prev_frames_sp.reset();
-  }
+  } // End scope for writer lock
 
 #if defined(DEBUG_STACK_FRAMES)
   s.PutCString("\n\nNew frames:\n");
@@ -551,11 +580,11 @@ bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
 }
 
 uint32_t StackFrameList::GetNumFrames(bool can_create) {
-  std::lock_guard<std::mutex> guard(m_mutex);
+  std::shared_lock<std::shared_mutex> guard(m_list_mutex);
 
   if (can_create) {
     // Don't allow interrupt or we might not return the correct count
-    GetFramesUpTo(UINT32_MAX, DoNotAllowInterruption); 
+    GetFramesUpTo(UINT32_MAX, DoNotAllowInterruption, guard); 
   }
   return GetVisibleStackFrameIndex(m_frames.size());
 }
@@ -564,7 +593,7 @@ void StackFrameList::Dump(Stream *s) {
   if (s == nullptr)
     return;
 
-  std::lock_guard<std::mutex> guard(m_mutex);
+  std::shared_lock<std::shared_mutex> guard(m_list_mutex);
 
   const_iterator pos, begin = m_frames.begin(), end = m_frames.end();
   for (pos = begin; pos != end; ++pos) {
@@ -581,11 +610,12 @@ void StackFrameList::Dump(Stream *s) {
 }
 
 StackFrameSP StackFrameList::GetFrameAtIndex(uint32_t idx) {
-  std::lock_guard<std::mutex> guard(m_mutex);
-  return GetFrameAtIndexNoLock(idx);
+  std::shared_lock<std::shared_mutex> guard(m_list_mutex);
+  return GetFrameAtIndexNoLock(idx, guard);
 }
 
-StackFrameSP StackFrameList::GetFrameAtIndexNoLock(uint32_t idx) {
+StackFrameSP StackFrameList::GetFrameAtIndexNoLock(uint32_t idx,
+      std::shared_lock<std::shared_mutex> &guard) {
   StackFrameSP frame_sp;
   uint32_t original_idx = idx;
 
@@ -602,7 +632,7 @@ StackFrameSP StackFrameList::GetFrameAtIndexNoLock(uint32_t idx) {
   // GetFramesUpTo will fill m_frames with as many frames as you asked for, if
   // there are that many.  If there weren't then you asked for too many frames.
   // GetFramesUpTo returns true if interrupted:
-  if (GetFramesUpTo(idx)) {
+  if (GetFramesUpTo(idx, AllowInterruption, guard)) {
     Log *log = GetLog(LLDBLog::Thread);
     LLDB_LOG(log, "GetFrameAtIndex was interrupted");
     return {};
@@ -665,12 +695,12 @@ StackFrameList::GetFrameWithConcreteFrameIndex(uint32_t unwind_idx) {
   // after we make all the inlined frames. Most of the time the unwind frame
   // index (or the concrete frame index) is the same as the frame index.
   uint32_t frame_idx = unwind_idx;
-  std::lock_guard<std::mutex> guard(m_mutex);
-  StackFrameSP frame_sp(GetFrameAtIndexNoLock(frame_idx));
+  std::shared_lock<std::shared_mutex> guard(m_list_mutex);
+  StackFrameSP frame_sp(GetFrameAtIndexNoLock(frame_idx, guard));
   while (frame_sp) {
     if (frame_sp->GetFrameIndex() == unwind_idx)
       break;
-    frame_sp = GetFrameAtIndexNoLock(++frame_idx);
+    frame_sp = GetFrameAtIndexNoLock(++frame_idx, guard);
   }
   return frame_sp;
 }
@@ -684,7 +714,7 @@ StackFrameSP StackFrameList::GetFrameWithStackID(const StackID &stack_id) {
   StackFrameSP frame_sp;
 
   if (stack_id.IsValid()) {
-    std::lock_guard<std::mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_list_mutex);
     uint32_t frame_idx = 0;
     // Do a binary search in case the stack frame is already in our cache
     collection::const_iterator begin = m_frames.begin();
@@ -698,7 +728,7 @@ StackFrameSP StackFrameList::GetFrameWithStackID(const StackID &stack_id) {
       }
     }
     do {
-      frame_sp = GetFrameAtIndexNoLock(frame_idx);
+      frame_sp = GetFrameAtIndexNoLock(frame_idx, guard);
       if (frame_sp && frame_sp->GetStackID() == stack_id)
         break;
       frame_idx++;
@@ -785,7 +815,7 @@ uint32_t StackFrameList::GetSelectedFrameIndex(
   if (!m_selected_frame_idx && select_most_relevant)
     SelectMostRelevantFrame();
   { // Scope for lock guard
-    std::lock_guard<std::mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_list_mutex);
     if (!m_selected_frame_idx) {
       // If we aren't selecting the most relevant frame, and the selected frame
       // isn't set, then don't force a selection here, just return 0.
@@ -801,7 +831,7 @@ uint32_t StackFrameList::GetSelectedFrameIndex(
 uint32_t StackFrameList::SetSelectedFrame(lldb_private::StackFrame *frame) {
   uint32_t result = 0;
   {
-    std::lock_guard<std::mutex> guard(m_mutex);
+    std::shared_lock<std::shared_mutex> guard(m_list_mutex);
     result = SetSelectedFrameNoLock(frame);
   }
   SetDefaultFileAndLineToSelectedFrame();
@@ -861,7 +891,7 @@ void StackFrameList::SetDefaultFileAndLineToSelectedFrame() {
 // does not describe how StackFrameLists are currently used.
 // Clear is currently only used to clear the list in the destructor.
 void StackFrameList::Clear() {
-  std::lock_guard<std::mutex> guard(m_mutex);
+  std::unique_lock<std::shared_mutex> guard(m_list_mutex);
   m_frames.clear();
   m_concrete_frames_fetched = 0;
   m_selected_frame_idx.reset();
@@ -869,7 +899,7 @@ void StackFrameList::Clear() {
 
 lldb::StackFrameSP
 StackFrameList::GetStackFrameSPForStackFramePtr(StackFrame *stack_frame_ptr) {
-  std::lock_guard<std::mutex> guard(m_mutex);
+  std::shared_lock<std::shared_mutex> guard(m_list_mutex);
   const_iterator pos;
   const_iterator begin = m_frames.begin();
   const_iterator end = m_frames.end();

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -341,14 +341,14 @@ void StackFrameList::SynthesizeTailCallFrames(StackFrame &next_frame) {
 bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
                                    InterruptionControl allow_interrupt) {
   // GetFramesUpTo is always called with the intent to add frames, so get the
-  // writer lock: 
+  // writer lock:
   std::unique_lock<std::shared_mutex> guard(m_list_mutex);
-  // Now that we have the lock, check to make sure someone didn't get there 
+  // Now that we have the lock, check to make sure someone didn't get there
   // ahead of us:
-  if (m_frames.size() > end_idx || GetAllFramesFetched()) 
+  if (m_frames.size() > end_idx || GetAllFramesFetched())
     return false;
 
-  // Do not fetch frames for an invalid thread.  
+  // Do not fetch frames for an invalid thread.
   bool was_interrupted = false;
   if (!m_thread.IsValid())
     return false;
@@ -371,7 +371,7 @@ bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
   Dump(&s);
   s.EOL();
 #endif
-  return was_interrupted;  
+  return was_interrupted;
 }
 
 void StackFrameList::FetchOnlyConcreteFramesUpTo(uint32_t end_idx) {
@@ -394,9 +394,8 @@ void StackFrameList::FetchOnlyConcreteFramesUpTo(uint32_t end_idx) {
   m_frames.resize(num_frames);
 }
 
-
 bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
-                                   InterruptionControl allow_interrupt) {
+                                     InterruptionControl allow_interrupt) {
   Unwind &unwinder = m_thread.GetUnwinder();
   bool was_interrupted = false;
 
@@ -461,8 +460,8 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
         break;
       }
 
-      const bool success = unwinder.GetFrameInfoAtIndex(
-          idx, cfa, pc, behaves_like_zeroth_frame);
+      const bool success =
+          unwinder.GetFrameInfoAtIndex(idx, cfa, pc, behaves_like_zeroth_frame);
       if (!success) {
         // We've gotten to the end of the stack.
         SetAllFramesFetched();
@@ -470,9 +469,8 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
       }
       const bool cfa_is_valid = true;
       unwind_frame_sp = std::make_shared<StackFrame>(
-          m_thread.shared_from_this(), m_frames.size(), idx, cfa,
-          cfa_is_valid, pc, StackFrame::Kind::Regular,
-          behaves_like_zeroth_frame, nullptr);
+          m_thread.shared_from_this(), m_frames.size(), idx, cfa, cfa_is_valid,
+          pc, StackFrame::Kind::Regular, behaves_like_zeroth_frame, nullptr);
 
       // Create synthetic tail call frames between the previous frame and the
       // newly-found frame. The new frame's index may change after this call,
@@ -637,10 +635,10 @@ StackFrameSP StackFrameList::GetFrameAtIndex(uint32_t idx) {
     return {};
   }
 
-  {  // Now we're accessing m_frames as a reader, so acquire the reader lock.
+  { // Now we're accessing m_frames as a reader, so acquire the reader lock.
     std::shared_lock<std::shared_mutex> guard(m_list_mutex);
     if (idx < m_frames.size()) {
-        frame_sp = m_frames[idx];
+      frame_sp = m_frames[idx];
     } else if (original_idx == 0) {
       // There should ALWAYS be a frame at index 0.  If something went wrong
       // with the CurrentInlinedDepth such that there weren't as many frames as
@@ -798,8 +796,7 @@ StackFrameList::GetSelectedFrameIndex(SelectMostRelevant select_most_relevant) {
   return *m_selected_frame_idx;
 }
 
-uint32_t
-StackFrameList::SetSelectedFrame(lldb_private::StackFrame *frame) {
+uint32_t StackFrameList::SetSelectedFrame(lldb_private::StackFrame *frame) {
   std::shared_lock<std::shared_mutex> guard(m_list_mutex);
 
   const_iterator pos;

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1449,7 +1449,7 @@ void Thread::ClearStackFrames() {
   // frames:
   // FIXME: At some point we can try to splice in the frames we have fetched
   // into the new frame as we make it, but let's not try that now.
-  if (m_curr_frames_sp && m_curr_frames_sp->GetAllFramesFetched())
+  if (m_curr_frames_sp && m_curr_frames_sp->WereAllFramesFetched())
     m_prev_frames_sp.swap(m_curr_frames_sp);
   m_curr_frames_sp.reset();
 

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -23,7 +23,7 @@ class SBBreakpointCallbackCase(TestBase):
         self.generateSource("test_listener_resume.cpp")
         self.generateSource("test_stop-hook.cpp")
         self.generateSource("test_concurrent_unwind.cpp")
-        
+
     @skipIfRemote
     # clang-cl does not support throw or catch (llvm.org/pr24538)
     @skipIfWindows
@@ -98,7 +98,11 @@ class SBBreakpointCallbackCase(TestBase):
     @skipIfHostIncompatibleWithTarget
     def test_concurrent_unwind(self):
         """Test that you can run a python command in a stop-hook when stdin is File based."""
-        self.build_and_test("driver.cpp test_concurrent_unwind.cpp", "test_concurrent_unwind", inferior_source="deep_stack.cpp")
+        self.build_and_test(
+            "driver.cpp test_concurrent_unwind.cpp",
+            "test_concurrent_unwind",
+            inferior_source="deep_stack.cpp",
+        )
 
     def build_and_test(self, sources, test_name, inferior_source="inferior.cpp"):
         """Build LLDB test from sources, and run expecting 0 exit code"""

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -22,7 +22,8 @@ class SBBreakpointCallbackCase(TestBase):
         self.generateSource("test_listener_event_process_state.cpp")
         self.generateSource("test_listener_resume.cpp")
         self.generateSource("test_stop-hook.cpp")
-
+        self.generateSource("test_concurrent_unwind.cpp")
+        
     @skipIfRemote
     # clang-cl does not support throw or catch (llvm.org/pr24538)
     @skipIfWindows
@@ -91,7 +92,15 @@ class SBBreakpointCallbackCase(TestBase):
             "test_listener_resume",
         )
 
-    def build_and_test(self, sources, test_name, args=None):
+    @skipIfRemote
+    # clang-cl does not support throw or catch (llvm.org/pr24538)
+    @skipIfWindows
+    @skipIfHostIncompatibleWithTarget
+    def test_concurrent_unwind(self):
+        """Test that you can run a python command in a stop-hook when stdin is File based."""
+        self.build_and_test("driver.cpp test_concurrent_unwind.cpp", "test_concurrent_unwind", inferior_source="deep_stack.cpp")
+
+    def build_and_test(self, sources, test_name, inferior_source="inferior.cpp"):
         """Build LLDB test from sources, and run expecting 0 exit code"""
 
         # These tests link against host lldb API.
@@ -104,7 +113,7 @@ class SBBreakpointCallbackCase(TestBase):
             )
 
         self.inferior = "inferior_program"
-        self.buildProgram("inferior.cpp", self.inferior)
+        self.buildProgram(inferior_source, self.inferior)
         self.addTearDownHook(lambda: os.remove(self.getBuildArtifact(self.inferior)))
 
         self.buildDriver(sources, test_name)

--- a/lldb/test/API/api/multithreaded/deep_stack.cpp
+++ b/lldb/test/API/api/multithreaded/deep_stack.cpp
@@ -1,0 +1,17 @@
+// This is a test program that makes a deep stack
+// so we can test unwinding from multiple threads.
+
+void call_me(int input) {
+  if (input > 1000) {
+    input += 1; // Set a breakpoint here
+    if (input > 1001)
+      input += 1;
+    return;
+  } else
+    call_me(++input);
+}
+
+int main() {
+  call_me(0);
+  return 0;
+}

--- a/lldb/test/API/api/multithreaded/test_concurrent_unwind.cpp.template
+++ b/lldb/test/API/api/multithreaded/test_concurrent_unwind.cpp.template
@@ -1,0 +1,91 @@
+#include "pseudo_barrier.h"
+
+#include <atomic>
+#include <thread>
+
+%include_SB_APIs%
+
+#include "common.h"
+
+using namespace lldb;
+
+void test (SBDebugger &dbg, std::vector<std::string> args) {
+
+SBError error;
+  dbg.SetAsync(false);
+  SBTarget target = dbg.CreateTarget(args.at(0).c_str());
+  if (!target.IsValid())
+    throw Exception("Invalid target");
+
+  // Now set our breakpoint and launch:
+  SBFileSpec main_sourcefile("deep_stack.cpp");
+  SBBreakpoint bkpt = target.BreakpointCreateBySourceRegex("Set a breakpoint here",
+                                                           main_sourcefile);
+  if (bkpt.GetNumLocations() == 0)
+    throw Exception("Main breakpoint got no locations");
+
+  SBLaunchInfo launch_info = target.GetLaunchInfo();
+  SBProcess process = target.Launch(launch_info, error);
+  if (error.Fail())
+    throw Exception("Failed to launch process");
+  if (!process.IsValid())
+    throw Exception("Process is not valid");
+  if (process.GetState() != lldb::eStateStopped)
+    throw Exception("Process was not stopped");
+
+  size_t num_threads = process.GetNumThreads();
+  if (num_threads != 1)
+    throw Exception("Unexpected number of threads.");
+  SBThread cur_thread = process.GetThreadAtIndex(0);
+  if (!cur_thread.IsValid())
+    throw Exception("Didn't get a valid thread");
+
+  // Record the number of frames at the point where we stopped:
+  const size_t num_frames = cur_thread.GetNumFrames();
+  // Now step once to clear the frame cache:
+  cur_thread.StepOver();
+  
+  // Create three threads and set them to getting frames simultaneously,
+  // and make sure we don't deadlock.
+  pseudo_barrier_t rendevous;
+  pseudo_barrier_init(rendevous, 5);
+  std::atomic_size_t success(true);
+  std::atomic_size_t largest(0);
+
+  auto lambda = [&](size_t stride){
+    pseudo_barrier_wait(rendevous);
+    bool younger = true;
+    while (1) {
+      size_t cursor = largest;
+      if (cursor > stride && !younger) {
+        cursor -= stride;
+        younger = true;
+      } else {
+        cursor += stride;
+        largest += stride;
+        younger = false;
+      }
+      SBFrame frame = cur_thread.GetFrameAtIndex(cursor);
+      if (!frame.IsValid()) {
+        if (cursor < num_frames)
+          success = false;
+        break;
+      }
+    }
+    
+  };
+
+  std::thread thread1(lambda, 1);
+  std::thread thread2(lambda, 3);
+  std::thread thread3(lambda, 5);
+  std::thread thread4(lambda, 7);
+  std::thread thread5(lambda, 11);
+  thread1.join();
+  thread2.join();
+  thread3.join();
+  thread4.join();
+  thread5.join();
+  
+  if (!success)
+    throw Exception("One thread stopped before 1000");
+}


### PR DESCRIPTION
 In fact, there's only one public API in StackFrameList that changes
 the list explicitly.  The rest only change the list if you happen to
ask for more frames than lldb has currently fetched and that 
always adds frames "behind the user's back".  So we were
much more prone to deadlocking than we needed to be.

This patch uses a shared_mutex instead, and when we have to add more
frames (in GetFramesUpTo) we switches to exclusive long enough to add
the frames, then goes back to shared.
    
Most of the work here was actually getting the stack frame list locking to not
require a recursive mutex (shared mutexes aren't recursive). 
    
I also added a test that has 5 threads progressively asking for more
frames simultaneously to make sure we get back valid frames and don't
deadlock.
