### PR TITLE
[Driver] Support fprofile-sample-use= for CL

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -2660,7 +2660,7 @@ usual build cycle when using sample profilers for optimization:
 
      > clang-cl /O2 -gdwarf -gline-tables-only ^
        /clang:-fdebug-info-for-profiling /clang:-funique-internal-linkage-names ^
-       /fprofile-sample-use=code.prof code.cc /Fe:code /fuse-ld=lld /link /debug:dwarf
+       /fprofile-sample-use=code.prof code.cc /Fe:code -fuse-ld=lld /link /debug:dwarf
 
    [OPTIONAL] Sampling-based profiles can have inaccuracies or missing block/
    edge counters. The profile inference algorithm (profi) can be used to infer
@@ -2679,7 +2679,7 @@ usual build cycle when using sample profilers for optimization:
 
      > clang-cl /clang:-fsample-profile-use-profi /O2 -gdwarf -gline-tables-only ^
        /clang:-fdebug-info-for-profiling /clang:-funique-internal-linkage-names ^
-       /fprofile-sample-use=code.prof code.cc /Fe:code /fuse-ld=lld /link /debug:dwarf
+       /fprofile-sample-use=code.prof code.cc /Fe:code -fuse-ld=lld /link /debug:dwarf
 
 Sample Profile Formats
 """"""""""""""""""""""

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1736,7 +1736,7 @@ def fno_profile_sample_use : Flag<["-"], "fno-profile-sample-use">, Group<f_Grou
     Visibility<[ClangOption, CLOption]>;
 def fprofile_sample_use_EQ : Joined<["-"], "fprofile-sample-use=">,
     Group<f_Group>,
-    Visibility<[ClangOption, CC1Option]>,
+    Visibility<[ClangOption, CLOption, CC1Option]>,
     HelpText<"Enable sample-based profile guided optimizations">,
     MarshallingInfoString<CodeGenOpts<"SampleProfileFile">>;
 def fprofile_sample_accurate : Flag<["-"], "fprofile-sample-accurate">,
@@ -8484,6 +8484,9 @@ def _SLASH_fp_strict : CLFlag<"fp:strict">, HelpText<"">, Alias<ffp_model_EQ>, A
 def _SLASH_fsanitize_EQ_address : CLFlag<"fsanitize=address">,
   HelpText<"Enable AddressSanitizer">,
   Alias<fsanitize_EQ>, AliasArgs<["address"]>;
+def : CLJoined<"fno-profile-sample-use">, Alias<fno_profile_sample_use>;
+def : CLJoined<"fprofile-sample-use:">, Alias<fprofile_sample_use_EQ>;
+def : CLJoined<"fprofile-sample-use=">, Alias<fprofile_sample_use_EQ>;
 def _SLASH_GA : CLFlag<"GA">, Alias<ftlsmodel_EQ>, AliasArgs<["local-exec"]>,
   HelpText<"Assume thread-local variables are defined in the executable">;
 def _SLASH_GR : CLFlag<"GR">, HelpText<"Emit RTTI data (default)">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8484,7 +8484,6 @@ def _SLASH_fp_strict : CLFlag<"fp:strict">, HelpText<"">, Alias<ffp_model_EQ>, A
 def _SLASH_fsanitize_EQ_address : CLFlag<"fsanitize=address">,
   HelpText<"Enable AddressSanitizer">,
   Alias<fsanitize_EQ>, AliasArgs<["address"]>;
-def : CLJoined<"fno-profile-sample-use">, Alias<fno_profile_sample_use>;
 def : CLJoined<"fprofile-sample-use:">, Alias<fprofile_sample_use_EQ>;
 def : CLJoined<"fprofile-sample-use=">, Alias<fprofile_sample_use_EQ>;
 def _SLASH_GA : CLFlag<"GA">, Alias<ftlsmodel_EQ>, AliasArgs<["local-exec"]>,

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -101,6 +101,14 @@
 // CHECK-PROFILE-USE: "-fprofile-instrument-use-path=default.profdata"
 // CHECK-PROFILE-USE-FILE: "-fprofile-instrument-use-path=/tmp/somefile.prof"
 
+// RUN: %clang_cl -### /FA -fprofile-sample-use=%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
+// RUN: %clang_cl -### /FA /fprofile-sample-use=%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
+// RUN: %clang_cl -### /FA /fprofile-sample-use:%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
+// CHECK-PROFILE-SAMPLE-USE: "-fprofile-sample-use={{.*}}/file.prof"
+
+// RUN: %clang_cl -### /FA /fprofile-sample-use=%S/Inputs/file.prof /fno-profile-sample-use -- %s 2>&1 | FileCheck -check-prefix=CHECK-NO-PROFILE-SAMPLE-USE %s
+// CHECK-NO-PROFILE-SAMPLE-USE-NOT: "-fprofile-sample-use={{.*}}/file.prof"
+
 // RUN: %clang_cl /GA -### -- %s 2>&1 | FileCheck -check-prefix=GA %s
 // GA: -ftls-model=local-exec
 

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -106,9 +106,6 @@
 // RUN: %clang_cl -### /FA /fprofile-sample-use:%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
 // CHECK-PROFILE-SAMPLE-USE: "-fprofile-sample-use={{.*}}/file.prof"
 
-// RUN: %clang_cl -### /FA /fprofile-sample-use=%S/Inputs/file.prof /fno-profile-sample-use -- %s 2>&1 | FileCheck -check-prefix=CHECK-NO-PROFILE-SAMPLE-USE %s
-// CHECK-NO-PROFILE-SAMPLE-USE-NOT: "-fprofile-sample-use={{.*}}/file.prof"
-
 // RUN: %clang_cl /GA -### -- %s 2>&1 | FileCheck -check-prefix=GA %s
 // GA: -ftls-model=local-exec
 


### PR DESCRIPTION
Sampling PGO has already been supported on Windows. This patch adds
/fprofile-sample-use= /fprofile-sample-use: /fno-profile-sample-use and
supports -fprofile-sample-use= for CL.