### PR TITLE
[MLIR][Arith] Add ExpandOps to convertArithToLLVM

### DIFF
--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/VectorPattern.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -477,6 +478,7 @@ struct ArithToLLVMConversionPass
       options.overrideIndexBitwidth(indexBitwidth);
 
     LLVMTypeConverter converter(&getContext(), options);
+    mlir::arith::populateArithExpandOpsPatterns(patterns);
     mlir::arith::populateArithToLLVMConversionPatterns(converter, patterns);
 
     if (failed(applyPartialConversion(getOperation(), target,
@@ -503,6 +505,7 @@ struct ArithToLLVMDialectInterface : public ConvertToLLVMPatternInterface {
   void populateConvertToLLVMConversionPatterns(
       ConversionTarget &target, LLVMTypeConverter &typeConverter,
       RewritePatternSet &patterns) const final {
+    mlir::arith::populateArithExpandOpsPatterns(patterns);
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   }
 };

--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -478,8 +478,8 @@ struct ArithToLLVMConversionPass
       options.overrideIndexBitwidth(indexBitwidth);
 
     LLVMTypeConverter converter(&getContext(), options);
-    mlir::arith::populateArithExpandOpsPatterns(patterns);
-    mlir::arith::populateArithToLLVMConversionPatterns(converter, patterns);
+    arith::populateArithExpandOpsPatterns(patterns);
+    arith::populateArithToLLVMConversionPatterns(converter, patterns);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
@@ -505,7 +505,7 @@ struct ArithToLLVMDialectInterface : public ConvertToLLVMPatternInterface {
   void populateConvertToLLVMConversionPatterns(
       ConversionTarget &target, LLVMTypeConverter &typeConverter,
       RewritePatternSet &patterns) const final {
-    mlir::arith::populateArithExpandOpsPatterns(patterns);
+    arith::populateArithExpandOpsPatterns(patterns);
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   }
 };

--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -478,7 +478,7 @@ struct ArithToLLVMConversionPass
       options.overrideIndexBitwidth(indexBitwidth);
 
     LLVMTypeConverter converter(&getContext(), options);
-    arith::populateArithExpandOpsPatterns(patterns);
+    arith::populateCeilFloorDivExpandOpsPatterns(patterns);
     arith::populateArithToLLVMConversionPatterns(converter, patterns);
 
     if (failed(applyPartialConversion(getOperation(), target,
@@ -505,7 +505,7 @@ struct ArithToLLVMDialectInterface : public ConvertToLLVMPatternInterface {
   void populateConvertToLLVMConversionPatterns(
       ConversionTarget &target, LLVMTypeConverter &typeConverter,
       RewritePatternSet &patterns) const final {
-    arith::populateArithExpandOpsPatterns(patterns);
+    arith::populateCeilFloorDivExpandOpsPatterns (patterns);
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   }
 };

--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -505,7 +505,7 @@ struct ArithToLLVMDialectInterface : public ConvertToLLVMPatternInterface {
   void populateConvertToLLVMConversionPatterns(
       ConversionTarget &target, LLVMTypeConverter &typeConverter,
       RewritePatternSet &patterns) const final {
-    arith::populateCeilFloorDivExpandOpsPatterns (patterns);
+    arith::populateCeilFloorDivExpandOpsPatterns(patterns);
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   }
 };

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -540,6 +540,45 @@ func.func @select(%arg0 : i1, %arg1 : i32, %arg2 : i32) -> i32 {
 
 // -----
 
+// CHECK-LABEL: @ceildivsi
+func.func @ceildivsi(%arg0 : i64) -> i64 {
+  // CHECK: llvm.icmp "sgt" %arg0, %1 : i64
+  // CHECK: llvm.select %3, %2, %0 : i1, i64
+  // CHECK: llvm.add %4, %arg0 : i64
+  // CHECK: llvm.sdiv %5, %arg0 : i64
+  // CHECK: llvm.add %6, %0 : i64
+  // CHECK: llvm.sub %1, %arg0 : i64
+  // CHECK: llvm.sdiv %8, %arg0 : i64
+  %0 = arith.ceildivsi %arg0, %arg0 : i64
+  return %0: i64
+}
+
+// CHECK-LABEL: @ceildivui
+func.func @ceildivui(%arg0 : i32) -> i32 {
+  // CHECK: llvm.icmp "eq" %arg0, %0 : i32
+  // CHECK: llvm.sub %arg0, %2 : i32
+  // CHECK: llvm.udiv %3, %arg0 : i32
+  // CHECK: llvm.add %4, %2 : i32
+  // CHECK: llvm.select %1, %0, %5 : i1, i32
+  %0 = arith.ceildivui %arg0, %arg0 : i32
+  return %0: i32
+}
+
+// -----
+
+// CHECK-LABEL: @floordivsi
+func.func @floordivsi(%arg0 : i32, %arg1 : i32) -> i32 {
+  // CHECK: %0 = llvm.sdiv %arg0, %arg1 : i32
+  // CHECK: %1 = llvm.mul %0, %arg1 : i32
+  // CHECK: %2 = llvm.icmp "ne" %arg0, %1 : i32
+  // CHECK: %3 = llvm.mlir.constant(0 : i32) : i32
+  // CHECK: %4 = llvm.icmp "slt" %arg0, %3 : i32
+  %0 = arith.floordivsi %arg0, %arg1 : i32
+  return %0 : i32
+}
+
+// -----
+
 // CHECK-LABEL: @minmaxi
 func.func @minmaxi(%arg0 : i32, %arg1 : i32) -> i32 {
   // CHECK: = llvm.intr.smin(%arg0, %arg1) : (i32, i32) -> i32
@@ -564,25 +603,6 @@ func.func @minmaxf(%arg0 : f32, %arg1 : f32) -> f32 {
   // CHECK: = llvm.intr.maxnum(%arg0, %arg1) : (f32, f32) -> f32
   %3 = arith.maxnumf %arg0, %arg1 : f32
   return %0 : f32
-}
-
-// -----
-
-// CHECK-LABEL: @ceilops
-func.func @ceilops(%arg0 : index, %arg1 : i32) -> index {
-  // CHECK-NOT: = arith.
-  %0 = arith.ceildivsi %arg0, %arg0 : index
-  %1 = arith.ceildivui %arg1, %arg1 : i32
-  return %0 : index
-}
-
-// -----
-
-// CHECK-LABEL: @floordivsi
-func.func @floordivsi(%arg0 : i32, %arg1 : i32) -> i32 {
-  // CHECK-NOT: = arith.
-  %0 = arith.floordivsi %arg0, %arg1 : i32
-  return %0 : i32
 }
 
 // -----

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -568,6 +568,25 @@ func.func @minmaxf(%arg0 : f32, %arg1 : f32) -> f32 {
 
 // -----
 
+// CHECK-LABEL: @ceilops
+func.func @ceilops(%arg0 : index, %arg1 : i32) -> index {
+  // CHECK-NOT: = arith.
+  %0 = arith.ceildivsi %arg0, %arg0 : index
+  %1 = arith.ceildivui %arg1, %arg1 : i32
+  return %0 : index
+}
+
+// -----
+
+// CHECK-LABEL: @floordivsi
+func.func @floordivsi(%arg0 : i32, %arg1 : i32) -> i32 {
+  // CHECK-NOT: = arith.
+  %0 = arith.floordivsi %arg0, %arg1 : i32
+  return %0 : i32
+}
+
+// -----
+
 // CHECK-LABEL: @fastmath
 func.func @fastmath(%arg0: f32, %arg1: f32, %arg2: i32) {
 // CHECK: llvm.fadd %arg0, %arg1  {fastmathFlags = #llvm.fastmath<fast>} : f32


### PR DESCRIPTION
Arith Floor and Ceil ops would not get lowered when running --convert-arith-to-llvm.