### PR TITLE
[Clang] Add Doug Wyatt and myself as maintainers for function effect analysis

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -184,6 +184,7 @@ Function Effect Analysis
 | Sirraide
 | aeternalmail\@gmail.com (email), Sirraide (GitHub), Ætérnal (Discord), Sirraide (Discourse)
 
+
 Tools
 -----
 These maintainers are responsible for user-facing tools under the Clang

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -176,6 +176,14 @@ Thread Safety Analysis
 | aaron.puchert\@sap.com (email), aaronpuchert (GitHub), aaronpuchert (Discourse)
 
 
+Function Effect Analysis
+~~~~~~~~~~~~~~~~~~~~~~~~
+| Doug Wyatt
+| dwyatt\@apple.com (email), dougsonos (GitHub)
+
+| Sirraide
+| aeternalmail\@gmail.com (email), Sirraide (GitHub), Ætérnal (Discord), Sirraide (Discourse)
+
 Tools
 -----
 These maintainers are responsible for user-facing tools under the Clang

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -179,7 +179,7 @@ Thread Safety Analysis
 Function Effect Analysis
 ~~~~~~~~~~~~~~~~~~~~~~~~
 | Doug Wyatt
-| dwyatt\@apple.com (email), dougsonos (GitHub)
+| dwyatt\@apple.com (email), dougsonos (GitHub), dougsonos (Discourse)
 
 | Sirraide
 | aeternalmail\@gmail.com (email), Sirraide (GitHub), Ætérnal (Discord), Sirraide (Discourse)


### PR DESCRIPTION
Doug implemented quite literally all of it and has been continuously improving the implementation by handling more language constructs we had initially missed. I spent a lot of time reviewing the implementation of the attributes as well as the analysis pass, so in other words, the two of us are probably best equipped to answer any questions that might arise wrt this part of Clang.

@dougsonos I hope you’re fine w/ me nominating you, because I’m familiar w/ the implementation, but not so much realtime processing and its requirements... Also, can you check if I found the right email?