### PR TITLE
[lldb] Fix DW_OP_piece-O3 test on AArch64 Windows

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/DW_OP_piece-O3.c
+++ b/lldb/test/Shell/SymbolFile/DWARF/DW_OP_piece-O3.c
@@ -7,7 +7,7 @@
 
 // RUN: %clang_host -O3 -gdwarf %s -o %t
 // RUN: %lldb %t \
-// RUN:   -o "b 25" \
+// RUN:   -o "b done" \
 // RUN:   -o "r" \
 // RUN:   -o "p/x array[2]" \
 // RUN:   -b | FileCheck %s
@@ -17,10 +17,10 @@
 
 static char array[5] = {0, 1, 2, 3, 4};
 
-void func() __attribute__((noinline));
-void func() { ++array[2]; };
+int done() __attribute__((noinline));
+int done() { return array[2]; };
 
 int main(void) {
-  func();
-  return 0;
+  ++array[2];
+  return done();
 }


### PR DESCRIPTION
Making a breakpoint on a line causes an error on aarch64-pc-windows. This patch changes the test so that a breakpoint can be made on a function name.
#117168