### PR TITLE
[AIX] Fix AIX BuildBot failure as AIX linker doesn't support version script.

### DIFF
--- a/clang/tools/clang-shlib/CMakeLists.txt
+++ b/clang/tools/clang-shlib/CMakeLists.txt
@@ -48,11 +48,13 @@ add_clang_library(clang-cpp
                   ${_OBJECTS}
                   LINK_LIBS
                   ${_DEPS})
+# AIX linker does not support version script
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  configure_file(simple_version_script.map.in simple_version_script.map)
 
-configure_file(simple_version_script.map.in simple_version_script.map)
-
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_options(clang-cpp PRIVATE LINKER:--version-script,${CMAKE_CURRENT_BINARY_DIR}/simple_version_script.map)
+  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_options(clang-cpp PRIVATE LINKER:--version-script,${CMAKE_CURRENT_BINARY_DIR}/simple_version_script.map)
+  endif()
 endif()
 
 # Optimize function calls for default visibility definitions to avoid PLT and


### PR DESCRIPTION
AIX BuildBot failed due to https://github.com/llvm/llvm-project/pull/116556 as AIX linker does not support version script. 
This PR is to fix the failure

This PR is on behalf of gnikolov@ca.ibm.com