### PR TITLE
[LoopInterchange] Redundant isLexicographicallyPositive check

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -204,11 +204,12 @@ static bool isLegalToInterChangeLoops(CharMatrix &DepMatrix,
   std::vector<char> Cur;
   // For each row check if it is valid to interchange.
   for (unsigned Row = 0; Row < NumRows; ++Row) {
-    // Create temporary DepVector check its lexicographical order
-    // before and after swapping OuterLoop vs InnerLoop
+    // A dependence vector has to be lexigraphically positive. We could assert
+    // that here, as a sanity check for the dependency analysis, but it can
+    // contain "don't know" elements ('*'), which will be rightfully
+    // interpreted as not lexicographical positive. So, skip that sanity check,
+    // it suffices just to check the interchanged direction vector.
     Cur = DepMatrix[Row];
-    if (!isLexicographicallyPositive(Cur))
-      return false;
     std::swap(Cur[InnerLoopId], Cur[OuterLoopId]);
     if (!isLexicographicallyPositive(Cur))
       return false;


### PR DESCRIPTION
Two checks are performed to see if a direction vector is lexigraphically positive: before and after the interchange transformation. A direction vector has to be positive, so the check before transformation is more of a sanity check to see if the dependence analysis is correct, but it is redundant with the sanity check that is performed after the interchange permute.

We can't assert that the direction vector before is lexicographically positive, because the "don't know" elements are rightfully interpreted as not lexicographically positive. But if there's a "don't know" element, then the permuted direction vector will be rejected too, so the outcome is the same, so let's just skip the first check all together. 