### PR TITLE
[clang][codegen] Mention the invariant that LLVM demangler should be …

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2048,7 +2048,8 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
                  ND));
 
   // This invariant should hold true in the future.
-  // Prior work: https://discourse.llvm.org/t/rfc-clang-diagnostic-for-demangling-failures/82835/8
+  // Prior work:
+  // https://discourse.llvm.org/t/rfc-clang-diagnostic-for-demangling-failures/82835/8
   // https://github.com/llvm/llvm-project/issues/111345
   // assert(llvm::isMangledName(MangledName) &&
   //        llvm::demangle(MangledName) != MangledName &&

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2047,6 +2047,13 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
                  GD.getWithKernelReferenceKind(KernelReferenceKind::Kernel),
                  ND));
 
+  // This invariant should hold true in the future.
+  // Prior work: https://discourse.llvm.org/t/rfc-clang-diagnostic-for-demangling-failures/82835/8
+  // https://github.com/llvm/llvm-project/issues/111345
+  // assert(llvm::isMangledName(MangledName) &&
+  //        llvm::demangle(MangledName) != MangledName &&
+  //        "LLVM demangler must demangle clang-generated names");
+
   auto Result = Manglings.insert(std::make_pair(MangledName, GD));
   return MangledDeclNames[CanonicalGD] = Result.first->first();
 }

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2051,7 +2051,8 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
   // Prior work:
   // https://discourse.llvm.org/t/rfc-clang-diagnostic-for-demangling-failures/82835/8
   // https://github.com/llvm/llvm-project/issues/111345
-  // assert(llvm::isMangledName(MangledName) &&
+  // assert((MangledName.startswith("_Z") || MangledName.startswith("?")) &&
+  //        !GD->hasAttr<AsmLabelAttr>() &&
   //        llvm::demangle(MangledName) != MangledName &&
   //        "LLVM demangler must demangle clang-generated names");
 


### PR DESCRIPTION
…able to handle mangled names generated by clang.

https://discourse.llvm.org/t/rfc-clang-diagnostic-for-demangling-failures/82835/8

Since we're putting the work on the above RFC on hold, let's leave a comment in the source code pointing to prior efforts and the suggestion of further steps.