### PR TITLE
[TableGen] Simplify generated code for isSubclass

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2551,7 +2551,8 @@ static void emitIsSubclass(CodeGenTarget &Target,
     }
 
     if (SuperClasses.empty()) {
-      OS << "  static constexpr ArrayRef<uint16_t> " << A.Name << "_SuperClasses;\n";
+      OS << "  static constexpr ArrayRef<uint16_t> " << A.Name
+         << "_SuperClasses;\n";
       continue;
     }
 

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2571,8 +2571,8 @@ static void emitIsSubclass(CodeGenTarget &Target,
     OS << "    " << A.Name << "_SuperClasses,\n";
   OS << "  };\n\n";
 
-  OS << "  ArrayRef<uint16_t> SuperClasses = SuperClassTable[(unsigned)A];\n";
-  OS << "  return binary_search(SuperClasses, (unsigned)B);\n";
+  OS << "  ArrayRef<uint16_t> SuperClasses = SuperClassTable[A];\n";
+  OS << "  return binary_search(SuperClasses, B);\n";
 
   OS << "}\n\n";
 }

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2572,8 +2572,7 @@ static void emitIsSubclass(CodeGenTarget &Target,
   OS << "  };\n\n";
 
   OS << "  ArrayRef<uint16_t> SuperClasses = SuperClassTable[(unsigned)A];\n";
-  OS << "  const uint16_t *It = lower_bound(SuperClasses, (unsigned)B);\n";
-  OS << "  return It != SuperClasses.end() && *It == (unsigned)B;\n";
+  OS << "  return binary_search(SuperClasses, (unsigned)B);\n";
 
   OS << "}\n\n";
 }

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2554,20 +2554,21 @@ static void emitIsSubclass(CodeGenTarget &Target,
   OS << "    {0, 0, 0},\n"; // OptionalMatchClass
   for (const auto &A : Infos) {
     SmallVector<bool> SuperClasses;
-    SuperClasses.push_back(false); // InvalidMatchClass
+    SuperClasses.push_back(false);        // InvalidMatchClass
     SuperClasses.push_back(A.IsOptional); // OptionalMatchClass
     for (const auto &B : Infos)
       SuperClasses.push_back(&A != &B && A.isSubsetOf(B));
 
     // Trim leading and trailing zeros.
-    auto End = find_if(reverse(SuperClasses), [](bool B){ return B; }).base();
-    auto Start = std::find_if(SuperClasses.begin(), End, [](bool B){ return B; });
+    auto End = find_if(reverse(SuperClasses), [](bool B) { return B; }).base();
+    auto Start =
+        std::find_if(SuperClasses.begin(), End, [](bool B) { return B; });
 
     unsigned Offset = SuperClassData.size();
     SuperClassData.append(Start, End);
 
-    OS << "    {" << Offset << ", " << (Start - SuperClasses.begin()) << ", " <<
-        (End - Start) << "},\n";
+    OS << "    {" << Offset << ", " << (Start - SuperClasses.begin()) << ", "
+       << (End - Start) << "},\n";
   }
   OS << "  };\n\n";
 


### PR DESCRIPTION
Implement isSubclass with direct lookup into some tables instead of
nested switches.

Part of the motivation for this is improving compile time when clang-18
is used as a host compiler, since it seems to have trouble with very
large switch statements.
