### PR TITLE
[TableGen] Remove comments from generated validateOperandClass

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2491,7 +2491,6 @@ static void emitValidateOperandClass(AsmMatcherInfo &Info, raw_ostream &OS) {
     if (!CI.isUserClass())
       continue;
 
-    OS << "  // '" << CI.ClassName << "' class\n";
     OS << "  case " << CI.Name << ": {\n";
     OS << "    DiagnosticPredicate DP(Operand." << CI.PredicateMethod
        << "());\n";


### PR DESCRIPTION
This generated comments like:

  // 'BoolReg' class
  case MCK_BoolReg: {

which seem redundant because the name is always repeated on the next
line as part of the MCK_ enumerator.
