### PR TITLE
[PGO] Fix incorrect count threshold calculation when 0% cutoff

### DIFF
--- a/llvm/lib/ProfileData/ProfileSummaryBuilder.cpp
+++ b/llvm/lib/ProfileData/ProfileSummaryBuilder.cpp
@@ -77,9 +77,18 @@ static const uint32_t DefaultCutoffsData[] = {
 const ArrayRef<uint32_t> ProfileSummaryBuilder::DefaultCutoffs =
     DefaultCutoffsData;
 
+// An entry for the 0th percentile to correctly calculate hot/cold count
+// thresholds when -profile-summary-cutoff-hot/cold is 0.  If the hot cutoff is
+// 0, no sample counts are treated as hot.  If the cold cutoff is 0, all sample
+// counts are treated as cold.  Assumes there is no UINT64_MAX sample counts.
+static const ProfileSummaryEntry ZeroCutoffEntry = {0, UINT64_MAX, 0};
+
 const ProfileSummaryEntry &
 ProfileSummaryBuilder::getEntryForPercentile(const SummaryEntryVector &DS,
                                              uint64_t Percentile) {
+  if (Percentile == 0)
+    return ZeroCutoffEntry;
+
   auto It = partition_point(DS, [=](const ProfileSummaryEntry &Entry) {
     return Entry.Cutoff < Percentile;
   });

--- a/llvm/test/Analysis/ProfileSummary/basic.ll
+++ b/llvm/test/Analysis/ProfileSummary/basic.ll
@@ -2,12 +2,16 @@
 ; RUN: opt < %s -disable-output -profile-summary-hot-count=500 -passes=print-profile-summary -S 2>&1 | FileCheck %s -check-prefixes=OVERRIDE-HOT
 ; RUN: opt < %s -disable-output -profile-summary-cold-count=0 -passes=print-profile-summary -S 2>&1 | FileCheck %s -check-prefixes=OVERRIDE-COLD
 ; RUN: opt < %s -disable-output -profile-summary-cold-count=200 -profile-summary-hot-count=1000 -passes=print-profile-summary -S 2>&1 | FileCheck %s -check-prefixes=OVERRIDE-BOTH
+; RUN: opt < %s -disable-output -profile-summary-cutoff-hot=0 -passes=print-profile-summary -S 2>&1 | FileCheck %s -check-prefixes=HOT-CUTOFF-0
+; RUN: opt < %s -disable-output -profile-summary-cutoff-cold=0 -profile-summary-hot-count=18446744073709551615 -passes=print-profile-summary -S 2>&1 | FileCheck %s -check-prefixes=COLD-CUTOFF-0
 
 define void @f1() !prof !20 {
 ; CHECK-LABEL: f1 :hot
 ; OVERRIDE-HOT-LABEL: f1
 ; OVERRIDE-COLD-LABEL: f1 :hot
 ; OVERRIDE-BOTH-LABEL: f1
+; HOT-CUTOFF-0-LABEL: f1{{$}}
+; COLD-CUTOFF-0-LABEL: f1 :cold
 
   ret void
 }
@@ -17,6 +21,8 @@ define void @f2() !prof !21 {
 ; OVERRIDE-HOT-LABEL: f2 :cold
 ; OVERRIDE-COLD-LABEL: f2
 ; OVERRIDE-BOTH-LABEL: f2
+; HOT-CUTOFF-0-LABEL: f2 :cold
+; COLD-CUTOFF-0-LABEL: f2 :cold
 
   ret void
 }
@@ -26,6 +32,8 @@ define void @f3() !prof !22 {
 ; OVERRIDE-HOT-LABEL: f3
 ; OVERRIDE-COLD-LABEL: f3
 ; OVERRIDE-BOTH-LABEL: f3
+; HOT-CUTOFF-0-LABEL: f3{{$}}
+; COLD-CUTOFF-0-LABEL: f3 :cold
 
   ret void
 }


### PR DESCRIPTION
DefaultCutoffsData does not have an entry for the 0th percentile.  As a result, when the getEntryForPercentile method is called with a percentile argument of 0, it returns a ProfileSummaryEntry for the 1st percentile instead.  This behavior affects the threshold calculations, such as getHotCountThreshold, causing them to incorrectly identify some sample profile counts as hot when they should not be.

This patch addresses the issue by handling the 0th percentile case in the getEntryForPercentile method.  This ensures that when the -profile-summary-cutoff-hot (or -cold) option is set to 0, no sample counts are treated as hot (or all sample counts are treated as cold).