### PR TITLE
[flang][Driver] Add correct libraries to driver

### DIFF
--- a/flang/tools/flang-driver/CMakeLists.txt
+++ b/flang/tools/flang-driver/CMakeLists.txt
@@ -6,6 +6,7 @@ link_directories(${LLVM_LIBRARY_DIR})
 
 set( LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
+  MC
   Option
   Support
   TargetParser


### PR DESCRIPTION
A recent commit (23d7a6cedb519853508) introduced a dependency on libLLVMMC.so. This is to handle the `-print-supported-cpus` option which uses `llvm/MC/SubtargetInfo`. It requires libLLVMMC to be linked into the flang-driver which the previous commit did not do. This fixes that issue.