### PR TITLE
[PGO][test] Specify exact match for check labels

### DIFF
--- a/llvm/test/Analysis/ProfileSummary/basic.ll
+++ b/llvm/test/Analysis/ProfileSummary/basic.ll
@@ -7,9 +7,9 @@
 
 define void @f1() !prof !20 {
 ; CHECK-LABEL: f1 :hot
-; OVERRIDE-HOT-LABEL: f1
+; OVERRIDE-HOT-LABEL: f1{{$}}
 ; OVERRIDE-COLD-LABEL: f1 :hot
-; OVERRIDE-BOTH-LABEL: f1
+; OVERRIDE-BOTH-LABEL: f1{{$}}
 ; HOT-CUTOFF-0-LABEL: f1{{$}}
 ; COLD-CUTOFF-0-LABEL: f1 :cold
 
@@ -19,8 +19,8 @@ define void @f1() !prof !20 {
 define void @f2() !prof !21 {
 ; CHECK-LABEL: f2 :cold
 ; OVERRIDE-HOT-LABEL: f2 :cold
-; OVERRIDE-COLD-LABEL: f2
-; OVERRIDE-BOTH-LABEL: f2
+; OVERRIDE-COLD-LABEL: f2{{$}}
+; OVERRIDE-BOTH-LABEL: f2 :cold
 ; HOT-CUTOFF-0-LABEL: f2 :cold
 ; COLD-CUTOFF-0-LABEL: f2 :cold
 
@@ -28,10 +28,10 @@ define void @f2() !prof !21 {
 }
 
 define void @f3() !prof !22 {
-; CHECK-LABEL: f3
-; OVERRIDE-HOT-LABEL: f3
-; OVERRIDE-COLD-LABEL: f3
-; OVERRIDE-BOTH-LABEL: f3
+; CHECK-LABEL: f3 :hot
+; OVERRIDE-HOT-LABEL: f3{{$}}
+; OVERRIDE-COLD-LABEL: f3 :hot
+; OVERRIDE-BOTH-LABEL: f3 :cold
 ; HOT-CUTOFF-0-LABEL: f3{{$}}
 ; COLD-CUTOFF-0-LABEL: f3 :cold
 


### PR DESCRIPTION
Some check labels in the basic.ll test are simply f[1-3], which matches all cases where the function entry is hot, cold, or uncategorized. Since the actual test results for each label have mixed cases, the current labels can be considered ambiguous.

This patch specifies exact matches for each label to ensure more precise validation and to prevent potential regressions in the future.