### PR TITLE
[flang][Driver] Fix incorrect condition in test

### DIFF
--- a/flang/test/Driver/print-supported-cpus.f90
+++ b/flang/test/Driver/print-supported-cpus.f90
@@ -18,11 +18,11 @@
 ! RUN:   %flang --target=aarch64-unknown-linux-gnu --print-supported-cpus 2>&1 \
 ! RUN:     | FileCheck %s --check-prefixes=AARCH64,CHECK \
 ! RUN: %}
-! RUN: %if x86-registered-target %{ \
+! RUN: %if aarch64-registered-target %{ \
 ! RUN:   %flang --target=aarch64-unknown-linux-gnu -mcpu=help 2>&1 \
 ! RUN:     | FileCheck %s --check-prefixes=AARCH64,CHECK \
 ! RUN: %}
-! RUN: %if x86-registered-target %{ \
+! RUN: %if aarch64-registered-target %{ \
 ! RUN:   %flang --target=aarch64-unknown-linux-gnu -mtune=help 2>&1 \
 ! RUN:     | FileCheck %s --check-prefixes=AARCH64,CHECK \
 ! RUN: %}


### PR DESCRIPTION
The conditions in a test did not match the target that was being requested. This resulted in a test failure when building with -DTARGETS_TO_BUILD=X86. This is now fixed.