### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Ignore lambda invocation with arguments

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -114,7 +114,7 @@ public:
         if (!DRE)
           return;
         auto *MD = dyn_cast_or_null<CXXMethodDecl>(DRE->getDecl());
-        if (!MD || CE->getNumArgs() != 1)
+        if (!MD || CE->getNumArgs() < 1)
           return;
         auto *Arg = CE->getArg(0)->IgnoreParenCasts();
         auto *ArgRef = dyn_cast<DeclRefExpr>(Arg);

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -125,7 +125,7 @@ void noescape_lambda() {
 }
 
 void lambda_capture_param(RefCountable* obj) {
-  auto someLambda = [&] {
+  auto someLambda = [&]() {
     obj->method();
   };
   someLambda();
@@ -177,4 +177,11 @@ void trivial_lambda() {
     return ref_countable->trivial();
   };
   trivial_lambda();
+}
+
+void lambda_with_args(RefCountable* obj) {
+  auto trivial_lambda = [&](int v) {
+    obj->method();
+  };
+  trivial_lambda(1);
 }


### PR DESCRIPTION
Fixed a bug that UncountedLambdaCapturesChecker would emit a warning on a lambda capture when the lambda is invoked with arguments. LocalVisitor::VisitCallExpr was not tolerating a lambda invocation with more than 1 arguments.