### PR TITLE
[LLDB] Fix error returns in CastToBasicType and CastToEnumType in ValueObject.

### DIFF
--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3348,8 +3348,8 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   }
 
   Status error = Status::FromErrorString("Unable to perform requested cast");
-  return ValueObjectConstResult::Create(
-      exe_ctx.GetBestExecutionContextScope(), error.Clone());
+  return ValueObjectConstResult::Create(exe_ctx.GetBestExecutionContextScope(),
+                                        error.Clone());
 }
 
 lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
@@ -3416,8 +3416,8 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
     }
   }
   Status error = Status::FromErrorString("Cannot perform requested cast");
-  return ValueObjectConstResult::Create(
-      exe_ctx.GetBestExecutionContextScope(), error.Clone());
+  return ValueObjectConstResult::Create(exe_ctx.GetBestExecutionContextScope(),
+                                        error.Clone());
 }
 
 ValueObject::EvaluationPoint::EvaluationPoint() : m_mod_id(), m_exe_ctx_ref() {}

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3196,18 +3196,15 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   bool is_integer = GetCompilerType().IsInteger();
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
-  if (!type.IsScalarType()) {
-    Status error = Status::FromErrorString("target type must be a scalar");
+  if (!type.IsScalarType())
     return ValueObjectConstResult::Create(
-        exe_ctx.GetBestExecutionContextScope(), error.Clone());
-  }
+        exe_ctx.GetBestExecutionContextScope(),
+        Status::FromErrorString("target type must be a scalar"));
 
-  if (!is_scalar && !is_enum && !is_pointer) {
-    Status error =
-        Status::FromErrorString("argument must be a scalar, enum, or pointer");
+  if (!is_scalar && !is_enum && !is_pointer)
     return ValueObjectConstResult::Create(
-        exe_ctx.GetBestExecutionContextScope(), error.Clone());
-  }
+        exe_ctx.GetBestExecutionContextScope(),
+        Status::FromErrorString("argument must be a scalar, enum, or pointer"));
 
   lldb::TargetSP target = GetTargetSP();
   uint64_t type_byte_size = 0;
@@ -3218,18 +3215,15 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
     val_byte_size = temp.value();
 
   if (is_pointer) {
-    if (!type.IsInteger() && !type.IsBoolean()) {
-      Status error =
-          Status::FromErrorString("target type must be an integer or boolean");
+    if (!type.IsInteger() && !type.IsBoolean())
       return ValueObjectConstResult::Create(
-          exe_ctx.GetBestExecutionContextScope(), error.Clone());
-    }
-    if (!type.IsBoolean() && type_byte_size < val_byte_size) {
-      Status error = Status::FromErrorString(
-          "target type cannot be smaller than the pointer type");
+          exe_ctx.GetBestExecutionContextScope(),
+          Status::FromErrorString("target type must be an integer or boolean"));
+    if (!type.IsBoolean() && type_byte_size < val_byte_size)
       return ValueObjectConstResult::Create(
-          exe_ctx.GetBestExecutionContextScope(), error.Clone());
-    }
+          exe_ctx.GetBestExecutionContextScope(),
+          Status::FromErrorString(
+              "target type cannot be smaller than the pointer type"));
   }
 
   if (type.IsBoolean()) {
@@ -3241,13 +3235,12 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
       if (float_value_or_err)
         return ValueObject::CreateValueObjectFromBool(
             target, !float_value_or_err->isZero(), "result");
-      else {
-        Status error = Status::FromErrorStringWithFormat(
-            "cannot get value as APFloat: %s",
-            llvm::toString(float_value_or_err.takeError()).c_str());
+      else
         return ValueObjectConstResult::Create(
-            exe_ctx.GetBestExecutionContextScope(), error.Clone());
-      }
+            exe_ctx.GetBestExecutionContextScope(),
+            Status::FromErrorStringWithFormat(
+                "cannot get value as APFloat: %s",
+                llvm::toString(float_value_or_err.takeError()).c_str()));
     }
   }
 
@@ -3261,14 +3254,12 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
             int_value_or_err->extOrTrunc(type_byte_size * CHAR_BIT);
         return ValueObject::CreateValueObjectFromAPInt(target, ext, type,
                                                        "result");
-      } else {
-        Status error = Status::FromErrorStringWithFormat(
-            "cannot get value as APSInt: %s",
-            llvm::toString(int_value_or_err.takeError()).c_str());
-        ;
+      } else
         return ValueObjectConstResult::Create(
-            exe_ctx.GetBestExecutionContextScope(), error.Clone());
-      }
+            exe_ctx.GetBestExecutionContextScope(),
+            Status::FromErrorStringWithFormat(
+                "cannot get value as APSInt: %s",
+                llvm::toString(int_value_or_err.takeError()).c_str()));
     } else if (is_scalar && is_float) {
       llvm::APSInt integer(type_byte_size * CHAR_BIT, !type.IsSigned());
       bool is_exact;
@@ -3280,13 +3271,12 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
 
         // Casting floating point values that are out of bounds of the target
         // type is undefined behaviour.
-        if (status & llvm::APFloatBase::opInvalidOp) {
-          Status error = Status::FromErrorStringWithFormat(
-              "invalid type cast detected: %s",
-              llvm::toString(float_value_or_err.takeError()).c_str());
+        if (status & llvm::APFloatBase::opInvalidOp)
           return ValueObjectConstResult::Create(
-              exe_ctx.GetBestExecutionContextScope(), error.Clone());
-        }
+              exe_ctx.GetBestExecutionContextScope(),
+              Status::FromErrorStringWithFormat(
+                  "invalid type cast detected: %s",
+                  llvm::toString(float_value_or_err.takeError()).c_str()));
         return ValueObject::CreateValueObjectFromAPInt(target, integer, type,
                                                        "result");
       }
@@ -3305,11 +3295,11 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                          "result");
       } else {
-        Status error = Status::FromErrorStringWithFormat(
-            "cannot get value as APSInt: %s",
-            llvm::toString(int_value_or_err.takeError()).c_str());
         return ValueObjectConstResult::Create(
-            exe_ctx.GetBestExecutionContextScope(), error.Clone());
+            exe_ctx.GetBestExecutionContextScope(),
+            Status::FromErrorStringWithFormat(
+                "cannot get value as APSInt: %s",
+                llvm::toString(int_value_or_err.takeError()).c_str()));
       }
     } else {
       if (is_integer) {
@@ -3321,11 +3311,11 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
           return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                            "result");
         } else {
-          Status error = Status::FromErrorStringWithFormat(
-              "cannot get value as APSInt: %s",
-              llvm::toString(int_value_or_err.takeError()).c_str());
           return ValueObjectConstResult::Create(
-              exe_ctx.GetBestExecutionContextScope(), error.Clone());
+              exe_ctx.GetBestExecutionContextScope(),
+              Status::FromErrorStringWithFormat(
+                  "cannot get value as APSInt: %s",
+                  llvm::toString(int_value_or_err.takeError()).c_str()));
         }
       }
       if (is_float) {
@@ -3337,19 +3327,19 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
           return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                            "result");
         } else {
-          Status error = Status::FromErrorStringWithFormat(
-              "cannot get value as APFloat: %s",
-              llvm::toString(float_value_or_err.takeError()).c_str());
           return ValueObjectConstResult::Create(
-              exe_ctx.GetBestExecutionContextScope(), error.Clone());
+              exe_ctx.GetBestExecutionContextScope(),
+              Status::FromErrorStringWithFormat(
+                  "cannot get value as APFloat: %s",
+                  llvm::toString(float_value_or_err.takeError()).c_str()));
         }
       }
     }
   }
 
-  Status error = Status::FromErrorString("Unable to perform requested cast");
-  return ValueObjectConstResult::Create(exe_ctx.GetBestExecutionContextScope(),
-                                        error.Clone());
+  return ValueObjectConstResult::Create(
+      exe_ctx.GetBestExecutionContextScope(),
+      Status::FromErrorString("Unable to perform requested cast"));
 }
 
 lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
@@ -3358,18 +3348,16 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
   bool is_float = GetCompilerType().IsFloat();
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
-  if (!is_enum && !is_integer && !is_float) {
-    Status error = Status::FromErrorString(
-        "argument must be an integer, a float, or an enum");
+  if (!is_enum && !is_integer && !is_float)
     return ValueObjectConstResult::Create(
-        exe_ctx.GetBestExecutionContextScope(), error.Clone());
-  }
+        exe_ctx.GetBestExecutionContextScope(),
+        Status::FromErrorString(
+            "argument must be an integer, a float, or an enum"));
 
-  if (!type.IsEnumerationType()) {
-    Status error = Status::FromErrorString("target type must be an enum");
+  if (!type.IsEnumerationType())
     return ValueObjectConstResult::Create(
-        exe_ctx.GetBestExecutionContextScope(), error.Clone());
-  }
+        exe_ctx.GetBestExecutionContextScope(),
+        Status::FromErrorString("target type must be an enum"));
 
   lldb::TargetSP target = GetTargetSP();
   uint64_t byte_size = 0;
@@ -3386,20 +3374,18 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
 
       // Casting floating point values that are out of bounds of the target
       // type is undefined behaviour.
-      if (status & llvm::APFloatBase::opInvalidOp) {
-        Status error = Status::FromErrorStringWithFormat(
-            "invalid type cast detected: %s",
-            llvm::toString(value_or_err.takeError()).c_str());
+      if (status & llvm::APFloatBase::opInvalidOp)
         return ValueObjectConstResult::Create(
-            exe_ctx.GetBestExecutionContextScope(), error.Clone());
-      }
+            exe_ctx.GetBestExecutionContextScope(),
+            Status::FromErrorStringWithFormat(
+                "invalid type cast detected: %s",
+                llvm::toString(value_or_err.takeError()).c_str()));
       return ValueObject::CreateValueObjectFromAPInt(target, integer, type,
                                                      "result");
-    } else {
-      Status error = Status::FromErrorString("cannot get value as APFloat");
+    } else
       return ValueObjectConstResult::Create(
-          exe_ctx.GetBestExecutionContextScope(), error.Clone());
-    }
+          exe_ctx.GetBestExecutionContextScope(),
+          Status::FromErrorString("cannot get value as APFloat"));
   } else {
     // Get the value as APSInt and extend or truncate it to the requested size.
     auto value_or_err = GetValueAsAPSInt();
@@ -3407,17 +3393,16 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
       llvm::APSInt ext = value_or_err->extOrTrunc(byte_size * CHAR_BIT);
       return ValueObject::CreateValueObjectFromAPInt(target, ext, type,
                                                      "result");
-    } else {
-      Status error = Status::FromErrorStringWithFormat(
-          "cannot get value as APSInt: %s",
-          llvm::toString(value_or_err.takeError()).c_str());
+    } else
       return ValueObjectConstResult::Create(
-          exe_ctx.GetBestExecutionContextScope(), error.Clone());
-    }
+          exe_ctx.GetBestExecutionContextScope(),
+          Status::FromErrorStringWithFormat(
+              "cannot get value as APSInt: %s",
+              llvm::toString(value_or_err.takeError()).c_str()));
   }
-  Status error = Status::FromErrorString("Cannot perform requested cast");
-  return ValueObjectConstResult::Create(exe_ctx.GetBestExecutionContextScope(),
-                                        error.Clone());
+  return ValueObjectConstResult::Create(
+      exe_ctx.GetBestExecutionContextScope(),
+      Status::FromErrorString("Cannot perform requested cast"));
 }
 
 ValueObject::EvaluationPoint::EvaluationPoint() : m_mod_id(), m_exe_ctx_ref() {}


### PR DESCRIPTION


Update the error returns in ValueObject::CastToBasicType and ValueObject::CastToEnumType to create new errors and return a ValueObjectConstResult with the error, rather tnan updating the error in (and returning) the input ValueObject.