### PR TITLE
[flang] Fix continuation when line begins with empty macro expansion

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -234,7 +234,7 @@ void Prescanner::Statement() {
             directiveSentinel_ = newLineClass.sentinel;
             disableSourceContinuation_ = false;
           } else {
-            disableSourceContinuation_ =
+            disableSourceContinuation_ = !replaced->empty() &&
                 newLineClass.kind != LineClassification::Kind::Source;
           }
         }

--- a/flang/test/Preprocessing/bug117297.F90
+++ b/flang/test/Preprocessing/bug117297.F90
@@ -1,0 +1,7 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+!CHECK: CALL myfunc( 'hello ' // 'world' // 'again')
+#define NOCOMMENT
+NOCOMMENT CALL myfunc( 'hello ' // &
+NOCOMMENT 'world' // &
+NOCOMMENT 'again' )
+end


### PR DESCRIPTION
A free form source line that begins with a macro should still be classified as a source line, and have its continuation lines work, even if the macro expands to an empty replacement.

Fixes https://github.com/llvm/llvm-project/issues/117297.