### PR TITLE
[hexagon] Require "asserts" build for widen-not-load test

### DIFF
--- a/llvm/test/CodeGen/Hexagon/widen-not-load.ll
+++ b/llvm/test/CodeGen/Hexagon/widen-not-load.ll
@@ -1,6 +1,8 @@
 ; Test that double word post increment load is not generated.
 
-; RUN: llc -march=hexagon -O2 -debug-only=hexagon-load-store-widening %s -o 2>&1 - | FileCheck %s
+; REQUIRES: asserts
+; RUN: llc -march=hexagon -O2 -debug-only=hexagon-load-store-widening \
+; RUN:      %s -o 2>&1 - | FileCheck %s
 
 ; Loads with positive invalid postinc is not widened
 define ptr @test1() {


### PR DESCRIPTION
This test fails on the `clang-x64-windows-msvc` builder:

      .---command stderr------------
      | C:\b\slave\clang-x64-windows-msvc\llvm-project\llvm\test\CodeGen\Hexagon\widen-not-load.ll:7:16: error: CHECK-LABEL: expected string not found in input
      | ; CHECK-LABEL: test1
      |                ^
      | <stdin>:1:1: note: scanning from here
      | llc.exe: Unknown command line argument '-debug-only=hexagon-load-store-widening'. Try: 'c:\b\slave\clang-x64-windows-msvc\build\stage1\bin\llc.exe --help'
      | ^
      | <stdin>:1:35: note: possible intended match here
      | llc.exe: Unknown command line argument '-debug-only=hexagon-load-store-widening'. Try: 'c:\b\slave\clang-x64-windows-msvc\build\stage1\bin\llc.exe --help'
      |                                   ^