### PR TITLE
[Driver] Pass `--cuda-path` to test

### DIFF
--- a/clang/test/Driver/cuda-no-threadsafe-statics.cu
+++ b/clang/test/Driver/cuda-no-threadsafe-statics.cu
@@ -2,7 +2,8 @@
 // compilation only.
 //
 // RUN: %clang -### -x cuda --target=x86_64-linux-gnu -c --cuda-gpu-arch=sm_20 %s \
-// RUN:            -nocudainc -nocudalib --no-cuda-version-check 2>&1 | FileCheck %s
+// RUN:            -nocudainc -nocudalib --cuda-path=%S/Inputs/CUDA_80/usr/local/cuda \
+// RUN:            2>&1 | FileCheck %s
 
 // RUN: %clang -### -x hip --target=x86_64-linux-gnu -c --cuda-gpu-arch=gfx1010 %s \
 // RUN:            -nocudainc -nocudalib 2>&1 | FileCheck %s

--- a/clang/test/Driver/cuda-no-threadsafe-statics.cu
+++ b/clang/test/Driver/cuda-no-threadsafe-statics.cu
@@ -2,7 +2,7 @@
 // compilation only.
 //
 // RUN: %clang -### -x cuda --target=x86_64-linux-gnu -c --cuda-gpu-arch=sm_20 %s \
-// RUN:            -nocudainc -nocudalib 2>&1 | FileCheck %s
+// RUN:            -nocudainc -nocudalib --no-cuda-version-check 2>&1 | FileCheck %s
 
 // RUN: %clang -### -x hip --target=x86_64-linux-gnu -c --cuda-gpu-arch=gfx1010 %s \
 // RUN:            -nocudainc -nocudalib 2>&1 | FileCheck %s


### PR DESCRIPTION
My local build, on Debian GNU/Linux 12 (bookworm), complains
```
clang: error: GPU arch sm_20 is supported by CUDA versions between 7.0 and 8.0 (inclusive), but installation at /usr/lib/cuda is 11.8; use '--cuda-path' to specify a different CUDA install, pass a different GPU arch with '--cuda-gpu-arch', or pass '--no-cuda-version-check'
```

Fix it by passing `--cuda-path`. Hope this doesn't affect the original intention of the test. 