### PR TITLE
[lldb] Fix TestLoadUnload.py

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1380,6 +1380,8 @@ public:
 
   virtual bool GetProcessInfo(ProcessInstanceInfo &info);
 
+  virtual lldb_private::UUID FindModuleUUID(const llvm::StringRef path);
+
   /// Get the exit status for a process.
   ///
   /// \return

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -157,11 +157,9 @@ DynamicLoader::GetSectionListFromModule(const ModuleSP module) const {
 ModuleSP DynamicLoader::FindModuleViaTarget(const FileSpec &file) {
   Target &target = m_process->GetTarget();
   ModuleSpec module_spec(file, target.GetArchitecture());
-  ModuleSpec module_spec_from_process;
-  // Process may be able to augment the module_spec with UUID, e.g. ELF core.
-  if (m_process->GetModuleSpec(file, target.GetArchitecture(),
-                               module_spec_from_process)) {
-    module_spec = module_spec_from_process;
+  if (UUID uuid = m_process->FindModuleUUID(file.GetPath())) {
+    // Process may be able to augment the module_spec with UUID, e.g. ELF core.
+    module_spec.GetUUID() = uuid;
   }
 
   if (ModuleSP module_sp = target.GetImages().FindFirstModule(module_spec))

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -286,20 +286,12 @@ void ProcessElfCore::UpdateBuildIdForNTFileEntries() {
   }
 }
 
-bool ProcessElfCore::GetModuleSpec(const FileSpec &module_file_spec,
-                                   const ArchSpec &arch,
-                                   ModuleSpec &module_spec) {
-  module_spec.Clear();
-  for (NT_FILE_Entry &entry : m_nt_file_entries) {
-    if (module_file_spec.GetPath() == entry.path) {
-      module_spec.GetFileSpec() = module_file_spec;
-      module_spec.GetArchitecture() = arch;
-      module_spec.GetUUID() = entry.uuid;
-      return true;
-    }
-  }
-
-  return false;
+UUID ProcessElfCore::FindModuleUUID(const llvm::StringRef path) {
+  // Returns the gnu uuid from matched NT_FILE entry
+  for (NT_FILE_Entry &entry : m_nt_file_entries)
+    if (path == entry.path)
+      return entry.uuid;
+  return UUID();
 }
 
 lldb_private::DynamicLoader *ProcessElfCore::GetDynamicLoader() {

--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.h
@@ -163,9 +163,7 @@ private:
   // Populate gnu uuid for each NT_FILE entry
   void UpdateBuildIdForNTFileEntries();
 
-  bool GetModuleSpec(const lldb_private::FileSpec &module_file_spec,
-                     const lldb_private::ArchSpec &arch,
-                     lldb_private::ModuleSpec &module_spec) override;
+  lldb_private::UUID FindModuleUUID(const llvm::StringRef path) override;
 
   // Returns the value of certain type of note of a given start address
   lldb_private::UUID FindBuidIdInCoreMemory(lldb::addr_t address);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -6080,6 +6080,10 @@ bool Process::GetProcessInfo(ProcessInstanceInfo &info) {
   return platform_sp->GetProcessInfo(GetID(), info);
 }
 
+lldb_private::UUID Process::FindModuleUUID(const llvm::StringRef path) {
+  return lldb_private::UUID();
+}
+
 ThreadCollectionSP Process::GetHistoryThreads(lldb::addr_t addr) {
   ThreadCollectionSP threads;
 


### PR DESCRIPTION
ELF core debugging fix #117070 broke TestLoadUnload.py tests due to GetModuleSpec call, ProcessGDBRemote fetches modules from remote. Revise the original PR, renamed FindBuildId to FindModuleUUID.