### PR TITLE
[clang][NFC] simplify the unset check in `ParseLabeledStatement`

### DIFF
--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -799,7 +799,7 @@ StmtResult Parser::ParseLabeledStatement(ParsedAttributes &Attrs,
   }
 
   // If we've not parsed a statement yet, parse one now.
-  if (!SubStmt.isInvalid() && !SubStmt.isUsable())
+  if (SubStmt.isUnset())
     SubStmt = ParseStatement(nullptr, StmtCtx);
 
   // Broken substmt shouldn't prevent the label from being added to the AST.


### PR DESCRIPTION
`!isInvalid && !isUsable -> !isInvalid && !(!isInvalid && !isUnset) -> isUnset`
It is more simple to understand.
