### PR TITLE
[ValueTracking] Infer NonEqual from dominating conditions/assumptions

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3857,6 +3857,50 @@ static bool isKnownNonEqual(const Value *V1, const Value *V2,
       match(V2, m_PtrToIntSameSize(Q.DL, m_Value(B))))
     return isKnownNonEqual(A, B, DemandedElts, Depth + 1, Q);
 
+  if (!Q.CxtI)
+    return false;
+
+  // Try to infer NonEqual based on information from dominating conditions.
+  if (Q.DC && Q.DT) {
+    for (BranchInst *BI : Q.DC->conditionsFor(V1)) {
+      Value *Cond = BI->getCondition();
+      BasicBlockEdge Edge0(BI->getParent(), BI->getSuccessor(0));
+      if (isImpliedCondition(Cond, ICmpInst::ICMP_NE, V1, V2, Q.DL,
+                             /*LHSIsTrue=*/true, Depth)
+              .value_or(false) &&
+          Q.DT->dominates(Edge0, Q.CxtI->getParent()))
+        return true;
+
+      BasicBlockEdge Edge1(BI->getParent(), BI->getSuccessor(1));
+      if (isImpliedCondition(Cond, ICmpInst::ICMP_NE, V1, V2, Q.DL,
+                             /*LHSIsTrue=*/false, Depth)
+              .value_or(false) &&
+          Q.DT->dominates(Edge1, Q.CxtI->getParent()))
+        return true;
+    }
+  }
+
+  if (!Q.AC)
+    return false;
+
+  // Try to infer NonEqual based on information from assumptions.
+  for (auto &AssumeVH : Q.AC->assumptionsFor(V1)) {
+    if (!AssumeVH)
+      continue;
+    CallInst *I = cast<CallInst>(AssumeVH);
+
+    assert(I->getFunction() == Q.CxtI->getFunction() &&
+           "Got assumption for the wrong function!");
+    assert(I->getIntrinsicID() == Intrinsic::assume &&
+           "must be an assume intrinsic");
+
+    if (isImpliedCondition(I->getArgOperand(0), ICmpInst::ICMP_NE, V1, V2, Q.DL,
+                           /*LHSIsTrue=*/true, Depth)
+            .value_or(false) &&
+        isValidAssumeForContext(I, Q.CxtI, Q.DT))
+      return true;
+  }
+
   return false;
 }
 
@@ -10231,10 +10275,10 @@ void llvm::findValuesAffectedByCondition(
         Worklist.push_back(B);
       }
     } else if (match(V, m_ICmp(Pred, m_Value(A), m_Value(B)))) {
-      AddCmpOperands(A, B);
-
       bool HasRHSC = match(B, m_ConstantInt());
       if (ICmpInst::isEquality(Pred)) {
+        AddAffected(A);
+        AddAffected(B);
         if (HasRHSC) {
           Value *Y;
           // (X & C) or (X | C).
@@ -10248,6 +10292,7 @@ void llvm::findValuesAffectedByCondition(
           }
         }
       } else {
+        AddCmpOperands(A, B);
         if (HasRHSC) {
           // Handle (A + C1) u< C2, which is the canonical form of
           // A > C3 && A < C4.

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3865,17 +3865,17 @@ static bool isKnownNonEqual(const Value *V1, const Value *V2,
     for (BranchInst *BI : Q.DC->conditionsFor(V1)) {
       Value *Cond = BI->getCondition();
       BasicBlockEdge Edge0(BI->getParent(), BI->getSuccessor(0));
-      if (isImpliedCondition(Cond, ICmpInst::ICMP_NE, V1, V2, Q.DL,
+      if (Q.DT->dominates(Edge0, Q.CxtI->getParent()) &&
+          isImpliedCondition(Cond, ICmpInst::ICMP_NE, V1, V2, Q.DL,
                              /*LHSIsTrue=*/true, Depth)
-              .value_or(false) &&
-          Q.DT->dominates(Edge0, Q.CxtI->getParent()))
+              .value_or(false))
         return true;
 
       BasicBlockEdge Edge1(BI->getParent(), BI->getSuccessor(1));
-      if (isImpliedCondition(Cond, ICmpInst::ICMP_NE, V1, V2, Q.DL,
+      if (Q.DT->dominates(Edge1, Q.CxtI->getParent()) &&
+          isImpliedCondition(Cond, ICmpInst::ICMP_NE, V1, V2, Q.DL,
                              /*LHSIsTrue=*/false, Depth)
-              .value_or(false) &&
-          Q.DT->dominates(Edge1, Q.CxtI->getParent()))
+              .value_or(false))
         return true;
     }
   }

--- a/llvm/test/Analysis/BasicAA/fallback-mayalias.ll
+++ b/llvm/test/Analysis/BasicAA/fallback-mayalias.ll
@@ -3,7 +3,7 @@
 ; Check that BasicAA falls back to MayAlias (instead of PartialAlias) when none
 ; of its little tricks are applicable.
 
-; CHECK: MayAlias: float* %arrayidxA, float* %arrayidxB
+; CHECK: NoAlias: float* %arrayidxA, float* %arrayidxB
 
 define void @fallback_mayalias(ptr noalias nocapture %C, i64 %i, i64 %j) local_unnamed_addr {
 entry:

--- a/llvm/test/Transforms/InstCombine/icmp-dom.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-dom.ll
@@ -569,11 +569,7 @@ define i1 @test_nonequal_domcond1(i64 %x, i64 %y, i64 %z, i64 %w) {
 ; CHECK-NEXT:    [[OR_COND:%.*]] = select i1 [[COND1]], i1 true, i1 [[COND2]]
 ; CHECK-NEXT:    br i1 [[OR_COND]], label [[IF_END:%.*]], label [[IF_THEN:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[SUB1:%.*]] = sub i64 [[W]], [[Z]]
-; CHECK-NEXT:    [[SUB2:%.*]] = sub i64 [[Y]], [[X]]
-; CHECK-NEXT:    [[UMIN:%.*]] = call i64 @llvm.umin.i64(i64 [[SUB1]], i64 [[SUB2]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[UMIN]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ; CHECK:       if.end:
 ; CHECK-NEXT:    ret i1 false
 ;
@@ -602,11 +598,7 @@ define i1 @test_nonequal_domcond2(i64 %x, i64 %y, i64 %z, i64 %w) {
 ; CHECK-NEXT:    [[OR_COND:%.*]] = select i1 [[COND1]], i1 [[COND2]], i1 false
 ; CHECK-NEXT:    br i1 [[OR_COND]], label [[IF_THEN:%.*]], label [[IF_END:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[SUB1:%.*]] = sub i64 [[W]], [[Z]]
-; CHECK-NEXT:    [[SUB2:%.*]] = sub i64 [[Y]], [[X]]
-; CHECK-NEXT:    [[UMIN:%.*]] = call i64 @llvm.umin.i64(i64 [[SUB1]], i64 [[SUB2]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[UMIN]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ; CHECK:       if.end:
 ; CHECK-NEXT:    ret i1 false
 ;
@@ -634,11 +626,7 @@ define i1 @test_nonequal_assume(i64 %x, i64 %y, i64 %z, i64 %w) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND1]])
 ; CHECK-NEXT:    [[COND2:%.*]] = icmp ne i64 [[W:%.*]], [[Z:%.*]]
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND2]])
-; CHECK-NEXT:    [[SUB1:%.*]] = sub i64 [[W]], [[Z]]
-; CHECK-NEXT:    [[SUB2:%.*]] = sub i64 [[Y]], [[X]]
-; CHECK-NEXT:    [[UMIN:%.*]] = call i64 @llvm.umin.i64(i64 [[SUB1]], i64 [[SUB2]])
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i64 [[UMIN]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ;
 entry:
   %cond1 = icmp ne i64 %y, %x


### PR DESCRIPTION
This patch adds context-sensitive analysis support for `isKnownNonEqual`. It is required for https://github.com/llvm/llvm-project/issues/117436.
