### PR TITLE
Revert "[AIX] Fix AIX BuildBot failure as AIX linker doesn't support version script."

### DIFF
--- a/clang/tools/clang-shlib/CMakeLists.txt
+++ b/clang/tools/clang-shlib/CMakeLists.txt
@@ -48,13 +48,11 @@ add_clang_library(clang-cpp
                   ${_OBJECTS}
                   LINK_LIBS
                   ${_DEPS})
-# AIX linker does not support version script
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
-  configure_file(simple_version_script.map.in simple_version_script.map)
 
-  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_link_options(clang-cpp PRIVATE LINKER:--version-script,${CMAKE_CURRENT_BINARY_DIR}/simple_version_script.map)
-  endif()
+configure_file(simple_version_script.map.in simple_version_script.map)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_options(clang-cpp PRIVATE LINKER:--version-script,${CMAKE_CURRENT_BINARY_DIR}/simple_version_script.map)
 endif()
 
 # Optimize function calls for default visibility definitions to avoid PLT and


### PR DESCRIPTION
Commit https://github.com/llvm/llvm-project/commit/eaa0a21d21962280dc2c03a09152510f6162a576 has fixed the build problem already so the change in llvm/llvm-project#117342 does not make sense any more. I am reverting it. 