### PR TITLE
[ADT] Add convenience function `filter_to_vector`

### DIFF
--- a/llvm/include/llvm/ADT/SmallVectorExtras.h
+++ b/llvm/include/llvm/ADT/SmallVectorExtras.h
@@ -19,12 +19,28 @@
 
 namespace llvm {
 
+/// Filter a range to a SmallVector with the element types deduced.
+template <unsigned Size, class ContainerTy, class PredicateFn>
+auto filter_to_vector(ContainerTy &&C, PredicateFn &&Pred) {
+  return to_vector<Size>(make_filter_range(std::forward<ContainerTy>(C),
+                                           std::forward<PredicateFn>(Pred)));
+}
+
+/// Filter a range to a SmallVector with the element types deduced.
+template <class ContainerTy, class PredicateFn>
+auto filter_to_vector(ContainerTy &&C, PredicateFn &&Pred) {
+  return to_vector(make_filter_range(std::forward<ContainerTy>(C),
+                                     std::forward<PredicateFn>(Pred)));
+}
+
 /// Map a range to a SmallVector with element types deduced from the mapping.
 template <unsigned Size, class ContainerTy, class FuncTy>
 auto map_to_vector(ContainerTy &&C, FuncTy &&F) {
   return to_vector<Size>(
       map_range(std::forward<ContainerTy>(C), std::forward<FuncTy>(F)));
 }
+
+/// Map a range to a SmallVector with element types deduced from the mapping.
 template <class ContainerTy, class FuncTy>
 auto map_to_vector(ContainerTy &&C, FuncTy &&F) {
   return to_vector(

--- a/llvm/unittests/ADT/CMakeLists.txt
+++ b/llvm/unittests/ADT/CMakeLists.txt
@@ -75,8 +75,8 @@ add_llvm_unittest(ADTTests
   SmallPtrSetTest.cpp
   SmallSetTest.cpp
   SmallStringTest.cpp
-  SmallVectorTest.cpp
   SmallVectorExtrasTest.cpp
+  SmallVectorTest.cpp
   SparseBitVectorTest.cpp
   SparseMultiSetTest.cpp
   SparseSetTest.cpp

--- a/llvm/unittests/ADT/CMakeLists.txt
+++ b/llvm/unittests/ADT/CMakeLists.txt
@@ -76,6 +76,7 @@ add_llvm_unittest(ADTTests
   SmallSetTest.cpp
   SmallStringTest.cpp
   SmallVectorTest.cpp
+  SmallVectorExtrasTest.cpp
   SparseBitVectorTest.cpp
   SparseMultiSetTest.cpp
   SparseSetTest.cpp

--- a/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/ADT/SmallVectorExtrasTest.cpp ------------------------------===//
+//===- llvm/unittest/ADT/SmallVectorExtrasTest.cpp ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorExtrasTest.cpp
@@ -1,0 +1,37 @@
+//===- llvm/unittest/ADT/SmallVectorExtrasTest.cpp ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// SmallVectorExtras unit tests.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <type_traits>
+#include <vector>
+
+using testing::ElementsAre;
+
+namespace llvm {
+namespace {
+
+TEST(SmallVectorExtrasTest, FilterToVector) {
+  std::vector<int> Numbers = {0, 1, 2, 3, 4};
+  auto Odd = filter_to_vector<2>(Numbers, [](int X) { return (X % 2) != 0; });
+  static_assert(std::is_same_v<decltype(Odd), SmallVector<int, 2>>);
+  EXPECT_THAT(Odd, ElementsAre(1, 3));
+
+  auto Even = filter_to_vector(Numbers, [](int X) { return (X % 2) == 0; });
+  static_assert(std::is_same_v<decltype(Even), SmallVector<int>>);
+  EXPECT_THAT(Even, ElementsAre(0, 2, 4));
+}
+
+} // end namespace
+} // namespace llvm


### PR DESCRIPTION
This materializes a filter range as a small vector.

Similar to `map_to_vector`, this new utility function lives in the `SmallVectorExtras.h` header.