### PR TITLE
[Clang-REPL] Fix crash during `__run_exit_handlers` with dynamic libraries.

### DIFF
--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -719,7 +719,9 @@ llvm::Error Interpreter::LoadDynamicLibrary(const char *name) {
 
   if (auto DLSG = llvm::orc::DynamicLibrarySearchGenerator::Load(
           name, DL.getGlobalPrefix()))
-    EE->getMainJITDylib().addGenerator(std::move(*DLSG));
+    // FIXME: Eventually we should put each library in its own JITDylib and
+    //        turn off process symbols by default.
+    EE->getProcessSymbolsJITDylib()->addGenerator(std::move(*DLSG));
   else
     return DLSG.takeError();
 

--- a/clang/test/Interpreter/crash.cpp
+++ b/clang/test/Interpreter/crash.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 //--- Test.cpp
-%lib vec.dylib
+%lib vec.so
 #include <vector>
 std::vector<int> v;
 %quit

--- a/clang/test/Interpreter/crash.cpp
+++ b/clang/test/Interpreter/crash.cpp
@@ -1,0 +1,20 @@
+// REQUIRES: host-supports-jit, x86_64-linux
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+//
+// RUN: split-file %s %t
+//
+// RUN: %clang++ -std=c++20 -fPIC -c %t/vec.cpp -o %t/vec.o
+// RUN: %clang++ -shared %t/vec.o -o %t/vec.so
+//
+// RUN: cat %t/Test.cpp | LD_LIBRARY_PATH=%t:$LD_LIBRARY_PATH clang-repl
+
+//--- vec.cpp
+#include <vector>
+
+//--- Test.cpp
+%lib vec.dylib
+#include <vector>
+std::vector<int> v;
+%quit


### PR DESCRIPTION
Apply the fix suggested by Lang Hames to address a crash in Clang-REPL that occurs during the execution of `__run_exit_handlers` when using dynamic libraries.