### PR TITLE
[Clang] [Sema] Support matrix types in pseudo-destructor expressions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -371,6 +371,9 @@ Non-comprehensive list of changes in this release
 - ``__builtin_reduce_and`` function can now be used in constant expressions.
 - ``__builtin_reduce_or`` and ``__builtin_reduce_xor`` functions can now be used in constant expressions.
 
+- Matrix types (a Clang extension) can now be used in pseudo-destructor expressions,
+  which allows them to be stored in STL containers.
+
 New Compiler Flags
 ------------------
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -8189,7 +8189,7 @@ ExprResult Sema::BuildPseudoDestructorExpr(Expr *Base,
     return ExprError();
 
   if (!ObjectType->isDependentType() && !ObjectType->isScalarType() &&
-      !ObjectType->isVectorType()) {
+      !ObjectType->isVectorType() && !ObjectType->isMatrixType()) {
     if (getLangOpts().MSVCCompat && ObjectType->isVoidType())
       Diag(OpLoc, diag::ext_pseudo_dtor_on_void) << Base->getSourceRange();
     else {

--- a/clang/test/CodeGenCXX/matrix-type.cpp
+++ b/clang/test/CodeGenCXX/matrix-type.cpp
@@ -368,3 +368,36 @@ void test_use_matrix_2() {
 
   selector<2> r5 = use_matrix_3(m1);
 }
+
+// CHECK-LABEL: define void @_Z22test_pseudo_destructorv()
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %a = alloca [25 x double], align 8
+// CHECK-NEXT:   %b = alloca [12 x float], align 4
+// CHECK-NEXT:   %0 = load <25 x double>, ptr %a, align 8
+// CHECK-NEXT:   call void @_Z17pseudo_destructorIu11matrix_typeILm5ELm5EdEEvT_(<25 x double> %0)
+// CHECK-NEXT:   %1 = load <12 x float>, ptr %b, align 4
+// CHECK-NEXT:   call void @_Z17pseudo_destructorIu11matrix_typeILm3ELm4EfEEvT_(<12 x float> %1)
+// CHECK-NEXT:   ret void
+
+// CHECK-LABEL: define linkonce_odr void @_Z17pseudo_destructorIu11matrix_typeILm5ELm5EdEEvT_(<25 x double> %t)
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %t.addr = alloca [25 x double], align 8
+// CHECK-NEXT:   store <25 x double> %t, ptr %t.addr, align 8
+// CHECK-NEXT:   ret void
+
+// CHECK-LABEL: define linkonce_odr void @_Z17pseudo_destructorIu11matrix_typeILm3ELm4EfEEvT_(<12 x float> %t)
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %t.addr = alloca [12 x float], align 4
+// CHECK-NEXT:   store <12 x float> %t, ptr %t.addr, align 4
+// CHECK-NEXT:   ret void
+template <typename T>
+void pseudo_destructor(T t) {
+  t.~T();
+}
+
+void test_pseudo_destructor() {
+  dx5x5_t a;
+  fx3x4_t b;
+  pseudo_destructor(a);
+  pseudo_destructor(b);
+}

--- a/clang/test/SemaCXX/matrix-types-pseudo-destructor.cpp
+++ b/clang/test/SemaCXX/matrix-types-pseudo-destructor.cpp
@@ -6,6 +6,12 @@ void f() {
   T().~T();
 }
 
+template <typename T>
+void f1(T *f) {
+  f->~T();
+  (*f).~T();
+}
+
 using mat4 = float __attribute__((matrix_type(4, 4)));
 using mat4i = int __attribute__((matrix_type(4, 4)));
 
@@ -16,4 +22,10 @@ void g() {
   f<mat4>();
   f<mat4i>();
   f<mat4_t<double>>();
+}
+
+void g2(mat4* m1, mat4i* m2, mat4_t<double>* m3) {
+  f1(m1);
+  f1(m2);
+  f1(m3);
 }

--- a/clang/test/SemaCXX/matrix-types-pseudo-destructor.cpp
+++ b/clang/test/SemaCXX/matrix-types-pseudo-destructor.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -fsyntax-only -fenable-matrix -std=c++11 -verify %s
+// expected-no-diagnostics
+
+template <typename T>
+void f() {
+  T().~T();
+}
+
+using mat4 = float __attribute__((matrix_type(4, 4)));
+using mat4i = int __attribute__((matrix_type(4, 4)));
+
+template <typename T>
+using mat4_t = T __attribute__((matrix_type(4, 4)));
+
+void g() {
+  f<mat4>();
+  f<mat4i>();
+  f<mat4_t<double>>();
+}

--- a/clang/test/SemaCXX/matrix-types-pseudo-destructor.cpp
+++ b/clang/test/SemaCXX/matrix-types-pseudo-destructor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fenable-matrix -std=c++11 -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fenable-matrix -verify %s
 // expected-no-diagnostics
 
 template <typename T>


### PR DESCRIPTION
We already support vector types, and since matrix element types have to be scalar types, there should be no problem w/ just enabling this. 

This now also allows matrix types to be stored in STL containers.