### PR TITLE
[libunwind] Make sure `__STDC_FORMAT_MACROS` is defined to ensure `PRId64` is available

### DIFF
--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -12,6 +12,10 @@
 #ifndef __DWARF_PARSER_HPP__
 #define __DWARF_PARSER_HPP__
 
+#ifndef __STDC_FORMAT_MACROS
+// Ensure PRId64 macro is available
+#define __STDC_FORMAT_MACROS 1
+#endif
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/102980 for further details.