### PR TITLE
[MLIR] Removing dead values for branches

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -172,7 +172,8 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 /// iff it has no memory effects and none of its results are live.
 ///
 /// It is assumed that `op` is simple. Here, a simple op is one which isn't a
-/// symbol op, or a symbol-user op.
+/// symbol op, a symbol-user op, a region branch op, a branch op, a region
+/// branch terminator op, or return-like.
 static void cleanSimpleOp(Operation *op, RunLivenessAnalysis &la) {
   if (!isMemoryEffectFree(op) || hasLive(op->getResults(), la))
     return;

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -172,7 +172,7 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 /// iff it has no memory effects and none of its results are live.
 ///
 /// It is assumed that `op` is simple. Here, a simple op is one which isn't a
-/// symbol op, a symbol-user op, a region branch op, a branch op, a region
+/// function-like op, a call-like op, a region branch op, a branch op, a region
 /// branch terminator op, or return-like.
 static void cleanSimpleOp(Operation *op, RunLivenessAnalysis &la) {
   if (!isMemoryEffectFree(op) || hasLive(op->getResults(), la))

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -564,12 +564,11 @@ static void cleanRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 }
 
 // 1. Iterate over each successor block of the given BranchOpInterface
-// operation.
+//    operation.
 // 2. For each successor block:
 //    a. Retrieve the operands passed to the successor.
 //    b. Use the provided liveness analysis (`RunLivenessAnalysis`) to determine
-//    which
-//       operands are live in the successor block.
+//       which operands are live in the successor block.
 //    c. Mark each operand as live or dead based on the analysis.
 // 3. Remove dead operands from the branch operation and arguments accordingly
 

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -172,8 +172,7 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 /// iff it has no memory effects and none of its results are live.
 ///
 /// It is assumed that `op` is simple. Here, a simple op is one which isn't a
-/// symbol op, a symbol-user op, a region branch op, a branch op, a region
-/// branch terminator op, or return-like.
+/// symbol op, or a symbol-user op.
 static void cleanSimpleOp(Operation *op, RunLivenessAnalysis &la) {
   if (!isMemoryEffectFree(op) || hasLive(op->getResults(), la))
     return;

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -35,8 +35,9 @@ func.func @acceptable_ir_has_cleanable_loop_of_conditional_and_branch_op(%arg0: 
   %non_live = arith.constant 0 : i32
   // CHECK-NOT: arith.constant
   cf.br ^bb1(%non_live : i32)
+  // CHECK: cf.br ^[[BB1:bb[0-9]+]]
 ^bb1(%non_live_1 : i32):
-  // CHECK: ^[[BB1:bb[0-9]+]]:
+  // CHECK: ^[[BB1]]:
   %non_live_5 = arith.constant 1 : i32
   cf.br ^bb3(%non_live_1, %non_live_5 : i32, i32)
   // CHECK: cf.br ^[[BB3:bb[0-9]+]]

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -61,6 +61,25 @@ func.func @acceptable_ir_has_cleanable_simple_op_with_unconditional_branch_op(%a
 
 // -----
 
+// Checking that iter_args are properly handled
+//
+func.func @cleanable_loop_iter_args_value(%arg0: index) -> index {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c10 = arith.constant 10 : index
+  %non_live = arith.constant 0 : index
+  // CHECK-NOT: non_live
+  %result, %result_non_live = scf.for %i = %c0 to %c10 step %c1 iter_args(%live_arg = %arg0, %non_live_arg = %non_live) -> (index, index) {
+    %new_live = arith.addi %live_arg, %i : index
+  // CHECK-NOT: non_live_arg
+    scf.yield %new_live, %non_live_arg : index, index
+  }
+  // CHECK-NOT: result_non_live
+  return %result : index
+}
+
+// -----
+
 // Note that this cleanup cannot be done by the `canonicalize` pass.
 //
 // CHECK-LABEL: func.func private @clean_func_op_remove_argument_and_return_value() {

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -28,15 +28,32 @@ module @named_module_acceptable {
 
 // -----
 
-// The IR remains untouched because of the presence of a branch op `cf.cond_br`.
+// The IR is optimized regardless of the presence of a branch op `cf.cond_br`.
 //
-func.func @dont_touch_unacceptable_ir_has_cleanable_simple_op_with_branch_op(%arg0: i1) {
+func.func @acceptable_ir_has_cleanable_simple_op_with_branch_op(%arg0: i1) {
   %non_live = arith.constant 0 : i32
-  // expected-error @+1 {{cannot optimize an IR with branch ops}}
+  // CHECK-NOT: non_live
   cf.cond_br %arg0, ^bb1(%non_live : i32), ^bb2(%non_live : i32)
 ^bb1(%non_live_0 : i32):
+  // CHECK-NOT: non_live_0
   cf.br ^bb3
 ^bb2(%non_live_1 : i32):
+  // CHECK-NOT: non_live_1
+  cf.br ^bb3
+^bb3:
+  return
+}
+
+// -----
+
+// Arguments of unconditional branch op `cf.br` are properly removed.
+//
+func.func @acceptable_ir_has_cleanable_simple_op_with_unconditional_branch_op(%arg0: i1) {
+  %non_live = arith.constant 0 : i32
+  // CHECK-NOT: non_live
+  cf.br ^bb1(%non_live : i32)
+^bb1(%non_live_1 : i32):
+  // CHECK-NOT: non_live_1
   cf.br ^bb3
 ^bb3:
   return

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -31,7 +31,7 @@ module @named_module_acceptable {
 // The IR contains both conditional and unconditional branches with a loop
 // in which the last cf.cond_br is referncing the first cf.br
 //
-func.func @acceptable_ir_has_cleanable_simple_op_with_unconditional_branch_op(%arg0: i1) {
+func.func @acceptable_ir_has_cleanable_loop_of_conditional_and_branch_op(%arg0: i1) {
   %non_live = arith.constant 0 : i32
   // CHECK-NOT: arith.constant
   cf.br ^bb1(%non_live : i32)

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -71,7 +71,7 @@ func.func @cleanable_loop_iter_args_value(%arg0: index) -> index {
   // CHECK-NOT: non_live
   %result, %result_non_live = scf.for %i = %c0 to %c10 step %c1 iter_args(%live_arg = %arg0, %non_live_arg = %non_live) -> (index, index) {
     %new_live = arith.addi %live_arg, %i : index
-  // CHECK-NOT: non_live_arg
+    // CHECK: scf.for %[[ARG_0:.*]] = %c0 to %c10 step %c1 iter_args(%[[ARG_1:.*]] = %arg0)
     scf.yield %new_live, %non_live_arg : index, index
   }
   // CHECK-NOT: result_non_live

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -54,8 +54,9 @@ func.func @acceptable_ir_has_cleanable_simple_op_with_unconditional_branch_op(%a
   cf.br ^bb1(%non_live : i32)
 ^bb1(%non_live_1 : i32):
   // CHECK-NOT: non_live_1
-  cf.br ^bb3
-^bb3:
+  cf.br ^bb3(%non_live_1 : i32)
+  // CHECK-NOT: non_live_2
+^bb3(%non_live_2 : i32):
   return
 }
 

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -28,24 +28,6 @@ module @named_module_acceptable {
 
 // -----
 
-// The IR is optimized regardless of the presence of a branch op `cf.cond_br`.
-//
-func.func @acceptable_ir_has_cleanable_simple_op_with_branch_op(%arg0: i1) {
-  %non_live = arith.constant 0 : i32
-  // CHECK-NOT: non_live
-  cf.cond_br %arg0, ^bb1(%non_live : i32), ^bb2(%non_live : i32)
-^bb1(%non_live_0 : i32):
-  // CHECK-NOT: non_live_0
-  cf.br ^bb3
-^bb2(%non_live_1 : i32):
-  // CHECK-NOT: non_live_1
-  cf.br ^bb3
-^bb3:
-  return
-}
-
-// -----
-
 // The IR contains both conditional and unconditional branches with a loop
 // in which the last cf.cond_br is referncing the first cf.br
 //

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -37,10 +37,11 @@ func.func @acceptable_ir_has_cleanable_loop_of_conditional_and_branch_op(%arg0: 
   cf.br ^bb1(%non_live : i32)
 ^bb1(%non_live_1 : i32):
   // CHECK: ^[[BB1:bb[0-9]+]]:
-  cf.br ^bb3(%non_live_1 : i32)
+  %non_live_5 = arith.constant 1 : i32
+  cf.br ^bb3(%non_live_1, %non_live_5 : i32, i32)
   // CHECK: cf.br ^[[BB3:bb[0-9]+]]
   // CHECK-NOT: i32
-^bb3(%non_live_2 : i32):
+^bb3(%non_live_2 : i32, %non_live_6 : i32):
   // CHECK: ^[[BB3]]:
   cf.cond_br %arg0, ^bb1(%non_live_2 : i32), ^bb4(%non_live_2 : i32)
   // CHECK: cf.cond_br %arg0, ^[[BB1]], ^[[BB4:bb[0-9]+]]


### PR DESCRIPTION
Fixing RemoveDeadValues to properly remove arguments from BranchOpInterface operations.
This is a follow-up for: https://github.com/llvm/llvm-project/pull/117405
cc: @joker-eph @codemzs 