### PR TITLE
[lldb] Simplify DumpValueObjectOptions::PointerDepth (NFC)

### DIFF
--- a/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
+++ b/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
@@ -22,13 +22,12 @@ namespace lldb_private {
 class DumpValueObjectOptions {
 public:
   struct PointerDepth {
-    enum class Mode { Always, Default, Never } m_mode;
-    uint32_t m_count;
+    uint32_t m_count = 0;
 
     PointerDepth Decremented() const {
       if (m_count > 0)
-        return PointerDepth{m_mode, m_count - 1};
-      return PointerDepth{m_mode, m_count};
+        return {m_count - 1};
+      return *this;
     }
 
     bool CanAllowExpansion() const;
@@ -65,8 +64,7 @@ public:
 
   DumpValueObjectOptions(ValueObject &valobj);
 
-  DumpValueObjectOptions &
-  SetMaximumPointerDepth(PointerDepth depth = {PointerDepth::Mode::Never, 0});
+  DumpValueObjectOptions &SetMaximumPointerDepth(uint32_t depth);
 
   DumpValueObjectOptions &SetMaximumDepth(uint32_t depth, bool is_default);
 

--- a/lldb/source/DataFormatters/DumpValueObjectOptions.cpp
+++ b/lldb/source/DataFormatters/DumpValueObjectOptions.cpp
@@ -14,10 +14,8 @@ using namespace lldb;
 using namespace lldb_private;
 
 DumpValueObjectOptions::DumpValueObjectOptions()
-    : m_summary_sp(), m_root_valobj_name(),
-      m_max_ptr_depth(PointerDepth{PointerDepth::Mode::Default, 0}),
-      m_decl_printing_helper(), m_child_printing_decider(),
-      m_pointer_as_array(), m_use_synthetic(true),
+    : m_summary_sp(), m_root_valobj_name(), m_decl_printing_helper(),
+      m_child_printing_decider(), m_pointer_as_array(), m_use_synthetic(true),
       m_scope_already_checked(false), m_flat_output(false), m_ignore_cap(false),
       m_show_types(false), m_show_location(false), m_use_objc(false),
       m_hide_root_type(false), m_hide_root_name(false), m_hide_name(false),
@@ -33,8 +31,8 @@ DumpValueObjectOptions::DumpValueObjectOptions(ValueObject &valobj)
 }
 
 DumpValueObjectOptions &
-DumpValueObjectOptions::SetMaximumPointerDepth(PointerDepth depth) {
-  m_max_ptr_depth = depth;
+DumpValueObjectOptions::SetMaximumPointerDepth(uint32_t depth) {
+  m_max_ptr_depth = {depth};
   return *this;
 }
 

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -503,14 +503,7 @@ ValueObjectPrinter::PrintObjectDescriptionIfNeeded(bool value_printed,
 }
 
 bool DumpValueObjectOptions::PointerDepth::CanAllowExpansion() const {
-  switch (m_mode) {
-  case Mode::Always:
-  case Mode::Default:
-    return m_count > 0;
-  case Mode::Never:
-    return false;
-  }
-  return false;
+  return m_count > 0;
 }
 
 bool ValueObjectPrinter::ShouldPrintChildren(

--- a/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
+++ b/lldb/source/Interpreter/OptionGroupValueObjectDisplay.cpp
@@ -190,8 +190,7 @@ DumpValueObjectOptions OptionGroupValueObjectDisplay::GetAsDumpOptions(
     LanguageRuntimeDescriptionDisplayVerbosity lang_descr_verbosity,
     lldb::Format format, lldb::TypeSummaryImplSP summary_sp) {
   DumpValueObjectOptions options;
-  options.SetMaximumPointerDepth(
-      {DumpValueObjectOptions::PointerDepth::Mode::Always, ptr_depth});
+  options.SetMaximumPointerDepth(ptr_depth);
   if (use_objc)
     options.SetShowSummary(false);
   else


### PR DESCRIPTION
`Mode::Always` and `Mode::Default` are handled identically. `Mode::Never` is the same as having a count of 0.
