### PR TITLE
Move isLocal AST matcher to ASTMatchers

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -17,9 +17,6 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::misc {
 
 namespace {
-// FIXME: This matcher exists in some other code-review as well.
-// It should probably move to ASTMatchers.
-AST_MATCHER(VarDecl, isLocal) { return Node.isLocalVarDecl(); }
 AST_MATCHER_P(DeclStmt, containsAnyDeclaration,
               ast_matchers::internal::Matcher<Decl>, InnerMatcher) {
   return ast_matchers::internal::matchesFirstInPointerRange(

--- a/clang/include/clang/ASTMatchers/ASTMatchers.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchers.h
@@ -739,6 +739,11 @@ AST_MATCHER(FunctionDecl, isMain) {
   return Node.isMain();
 }
 
+// Matches variable declarations that represent local variables.
+AST_MATCHER(VarDecl, isLocal) { 
+    return Node.isLocalVarDecl(); 
+}
+
 /// Matches the specialized template of a specialization declaration.
 ///
 /// Given


### PR DESCRIPTION
The `isLocal` matcher is used in some of clang-tidy's checks; this PR moves it to a common location (e.g., ASTMatchers) to improve reusability.

Fixes #117431 