### PR TITLE
[nfc][mlir][scf]: Define scf.for lower/upper bounds can be also negative or zero

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -153,9 +153,10 @@ def ForOp : SCF_Op<"for",
     operation defines an SSA value for its induction variable. It has one
     region capturing the loop body. The induction variable is represented as an
     argument of this region. This SSA value is a signless integer or index.
-    The step is a value of same type but required to be positive. The lower and
-    upper bounds specify a half-open range: the range includes the lower bound
-    but does not include the upper bound.
+    The step is a value of same type but required to be positive, the lower and
+    upper bounds can be also negative or zero. The lower and upper bounds specify
+    a half-open range: the iteration is executed iff the signed comparison of induction
+    variable value is less than the upper bound and bigger or equal to the lower bound.
 
     The body region must contain exactly one block that terminates with
     `scf.yield`. Calling ForOp::build will create such a region and insert


### PR DESCRIPTION
Per the discussion here: https://github.com/llvm/llvm-project/pull/116748#discussion_r1848680070 , this commit properly declare that lower and upper bounds can be also negative or zero.