### PR TITLE
[AArch64][CostModel] Consider the cost of const vector

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -1449,6 +1449,14 @@ public:
                                             const APInt &DemandedDstElts,
                                             TTI::TargetCostKind CostKind) const;
 
+  /// \return Cost of materializing a constant.
+  InstructionCost getConstantMaterializationCost(
+      ArrayRef<Constant *> VL, Type *SrcTy,
+      TTI::TargetCostKind CostKind = TTI::TCK_RecipThroughput,
+      ArrayRef<SmallVector<Constant *>> ConstVectsPerTree = {},
+      ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc = {})
+      const;
+
   /// \return The cost of Load and Store instructions.
   InstructionCost
   getMemoryOpCost(unsigned Opcode, Type *Src, Align Alignment,
@@ -2146,6 +2154,12 @@ public:
   getReplicationShuffleCost(Type *EltTy, int ReplicationFactor, int VF,
                             const APInt &DemandedDstElts,
                             TTI::TargetCostKind CostKind) = 0;
+
+  virtual InstructionCost getConstantMaterializationCost(
+      ArrayRef<Constant *> VL, Type *SrcTy,
+      TTI::TargetCostKind CostKind = TTI::TCK_RecipThroughput,
+      ArrayRef<SmallVector<Constant *>> ConstVectsPerTree = {},
+      ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc = {}) = 0;
 
   virtual InstructionCost
   getMemoryOpCost(unsigned Opcode, Type *Src, Align Alignment,
@@ -2849,6 +2863,15 @@ public:
                             TTI::TargetCostKind CostKind) override {
     return Impl.getReplicationShuffleCost(EltTy, ReplicationFactor, VF,
                                           DemandedDstElts, CostKind);
+  }
+  InstructionCost getConstantMaterializationCost(
+      ArrayRef<Constant *> VL, Type *SrcTy,
+      TTI::TargetCostKind CostKind = TTI::TCK_RecipThroughput,
+      ArrayRef<SmallVector<Constant *>> ConstVectsPerTree = {},
+      ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc = {})
+      override {
+    return Impl.getConstantMaterializationCost(
+        VL, SrcTy, CostKind, ConstVectsPerTree, MaterializedConstVectsPerFunc);
   }
   InstructionCost getMemoryOpCost(unsigned Opcode, Type *Src, Align Alignment,
                                   unsigned AddressSpace,

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -730,6 +730,15 @@ public:
     return 1;
   }
 
+  InstructionCost getConstantMaterializationCost(
+      ArrayRef<Constant *> VL, Type *SrcTy,
+      TTI::TargetCostKind CostKind = TTI::TCK_RecipThroughput,
+      ArrayRef<SmallVector<Constant *>> ConstVectsPerTree = {},
+      ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc = {})
+      const {
+    return 0;
+  }
+
   InstructionCost getMemoryOpCost(unsigned Opcode, Type *Src, Align Alignment,
                                   unsigned AddressSpace,
                                   TTI::TargetCostKind CostKind,

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -1368,11 +1368,19 @@ public:
     return Cost;
   }
 
-  InstructionCost
-  getMemoryOpCost(unsigned Opcode, Type *Src, MaybeAlign Alignment,
-                  unsigned AddressSpace, TTI::TargetCostKind CostKind,
-                  TTI::OperandValueInfo OpInfo = {TTI::OK_AnyValue, TTI::OP_None},
-                  const Instruction *I = nullptr) {
+  InstructionCost getConstantMaterializationCost(
+      ArrayRef<Constant *> VL, Type *SrcTy,
+      TTI::TargetCostKind CostKind = TTI::TCK_RecipThroughput,
+      ArrayRef<SmallVector<Constant *>> ConstVectsPerTree = {},
+      ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc = {}) {
+    return 0;
+  }
+
+  InstructionCost getMemoryOpCost(
+      unsigned Opcode, Type *Src, MaybeAlign Alignment, unsigned AddressSpace,
+      TTI::TargetCostKind CostKind,
+      TTI::OperandValueInfo OpInfo = {TTI::OK_AnyValue, TTI::OP_None},
+      const Instruction *I = nullptr) {
     assert(!Src->isVoidTy() && "Invalid type");
     // Assume types, such as structs, are expensive.
     if (getTLI()->getValueType(DL, Src,  true) == MVT::Other)

--- a/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
@@ -22,6 +22,7 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constant.h"
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
@@ -80,6 +81,12 @@ public:
                TargetLibraryInfo *TLI_, AAResults *AA_, LoopInfo *LI_,
                DominatorTree *DT_, AssumptionCache *AC_, DemandedBits *DB_,
                OptimizationRemarkEmitter *ORE_);
+
+  // Store constant vector(s) used in the vectorized tree. This helps in
+  // avoiding counting the constant vector cost twice if it has already been
+  // materialized.
+  static inline SmallVector<SmallVector<Constant *>>
+      MaterializedConstVectsPerFunc = {};
 
 private:
   /// Collect store and getelementptr instructions and organize them

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -1099,6 +1099,14 @@ InstructionCost TargetTransformInfo::getReplicationShuffleCost(
   return Cost;
 }
 
+InstructionCost TargetTransformInfo::getConstantMaterializationCost(
+    ArrayRef<Constant *> VL, Type *SrcTy, TTI::TargetCostKind CostKind,
+    ArrayRef<SmallVector<Constant *>> ConstVectsPerTree,
+    ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc) const {
+  return TTIImpl->getConstantMaterializationCost(
+      VL, SrcTy, CostKind, ConstVectsPerTree, MaterializedConstVectsPerFunc);
+}
+
 InstructionCost TargetTransformInfo::getMemoryOpCost(
     unsigned Opcode, Type *Src, Align Alignment, unsigned AddressSpace,
     TTI::TargetCostKind CostKind, TTI::OperandValueInfo OpInfo,

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -3785,12 +3785,116 @@ bool AArch64TTIImpl::useNeonVector(const Type *Ty) const {
   return isa<FixedVectorType>(Ty) && !ST->useSVEForFixedLengthVectors();
 }
 
-InstructionCost AArch64TTIImpl::getMemoryOpCost(unsigned Opcode, Type *Ty,
-                                                MaybeAlign Alignment,
-                                                unsigned AddressSpace,
-                                                TTI::TargetCostKind CostKind,
-                                                TTI::OperandValueInfo OpInfo,
-                                                const Instruction *I) {
+template <typename T>
+static bool HaveIdenticalVectVals(ArrayRef<Constant *> A,
+                                  ArrayRef<Constant *> B) {
+  auto R = zip(A, B);
+  return all_of(R, [&](std::tuple<Constant *, Constant *> P) {
+    return cast<T>(get<0>(P))->getValue() == cast<T>(get<1>(P))->getValue();
+  });
+}
+
+template <typename T>
+static bool HaveIdenticalVectTy(ArrayRef<Constant *> A,
+                                ArrayRef<Constant *> B) {
+  auto R1 = all_of(A, [&](Constant *C) { return isa<T>(C); });
+  auto R2 = all_of(B, [&](Constant *C) { return isa<T>(C); });
+  return R1 & R2;
+}
+
+template <typename T>
+static bool AreIdenticalVects(ArrayRef<Constant *> A, ArrayRef<Constant *> B) {
+  if (A.empty() || B.empty() || !HaveIdenticalVectTy<T>(A, B))
+    return false;
+  return HaveIdenticalVectVals<T>(A, B);
+}
+
+InstructionCost AArch64TTIImpl::getConstantMaterializationCost(
+    ArrayRef<Constant *> VL, Type *SrcTy, TTI::TargetCostKind CostKind,
+    ArrayRef<SmallVector<Constant *>> ConstVectsPerTree,
+    ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc) {
+  // Compute the scalar cost.
+  InstructionCost Cost;
+  if (!SrcTy->isVectorTy()) {
+    // FIXME: Consider floating point types as well.
+    auto *C = dyn_cast<ConstantInt>(VL[0]);
+    return C ? getIntImmCost(C->getValue(), C->getType(), CostKind)
+             : InstructionCost::getInvalid();
+  } else // Vector cost.
+  {
+    // FIXME: Consider floating point types as well.
+    if (!all_of(VL, IsaPred<ConstantInt>))
+      return InstructionCost::getInvalid();
+
+    auto isSplat = [](ArrayRef<Constant *> VL) {
+      Value *FirstNonUndef = nullptr;
+      for (Value *V : VL) {
+        if (isa<UndefValue>(V))
+          continue;
+        if (!FirstNonUndef) {
+          FirstNonUndef = V;
+          continue;
+        }
+        if (V != FirstNonUndef)
+          return false;
+      }
+      return FirstNonUndef != nullptr;
+    };
+    // FIXME: Calculate cost of scalar realization + broadcast.
+    if (isSplat(VL) || all_of(VL, IsaPred<UndefValue, PoisonValue>))
+      return InstructionCost::getInvalid();
+    // Check if this VL has already been materialized in the function.
+    for (auto &V : MaterializedConstVectsPerFunc) {
+      if (AreIdenticalVects<ConstantInt>(V, VL))
+        return 0;
+    }
+    // Check if this VL has already been seen in the SLP tree.
+    for (auto &V : ConstVectsPerTree) {
+      if (AreIdenticalVects<ConstantInt>(V, VL))
+        return 0;
+    }
+    auto *EltTy = VL[0]->getType();
+    auto *VTy = FixedVectorType::get(EltTy, VL.size());
+    auto LT = getTypeLegalizationCost(VTy);
+    // FIXME: Consider types with more legalization cost.
+    if (LT.first > 1)
+      return InstructionCost::getInvalid();
+    if (useNeonVector(VTy)) {
+      if (ST->hasSVE()) {
+        auto Elts = VTy->getNumElements();
+
+        // `index` instruction can be emitted for Elts > 2. We can't analyze
+        // this.
+        if (Elts > 2)
+          return InstructionCost::getInvalid();
+
+        // Check if all the constants are in the range -16 to 15. If not, this
+        // results in scalar/immediate index instruction.
+        auto FirstVal = cast<ConstantInt>(VL[0])->getSExtValue();
+        auto SecondVal = cast<ConstantInt>(VL[1])->getSExtValue();
+        auto IsInIndexInstrImmRange = [](int64_t Val) {
+          return Val >= -16 && Val <= 15;
+        };
+        if (IsInIndexInstrImmRange(FirstVal) &&
+            IsInIndexInstrImmRange(std::abs(SecondVal - FirstVal)))
+          Cost = 2;
+        else // It's mov + index.
+          Cost = 4;
+      } else {
+        // This results in `adrp + ldr` instruction.
+        Cost = 4;
+      }
+    } else {
+      Cost = InstructionCost::getInvalid();
+    }
+    return Cost;
+  }
+}
+
+InstructionCost AArch64TTIImpl::getMemoryOpCost(
+    unsigned Opcode, Type *Ty, MaybeAlign Alignment, unsigned AddressSpace,
+    TTI::TargetCostKind CostKind, TTI::OperandValueInfo OpInfo,
+    const Instruction *I, InstructionCost ConstVectScalarCost) {
   EVT VT = TLI->getValueType(DL, Ty, true);
   // Type legalization can't handle structs
   if (VT == MVT::Other)
@@ -3845,6 +3949,7 @@ InstructionCost AArch64TTIImpl::getMemoryOpCost(unsigned Opcode, Type *Ty,
       // Otherwise we need to scalarize.
       return cast<FixedVectorType>(Ty)->getNumElements() * 2;
     }
+
     EVT EltVT = VT.getVectorElementType();
     unsigned EltSize = EltVT.getScalarSizeInBits();
     if (!isPowerOf2_32(EltSize) || EltSize < 8 || EltSize > 64 ||

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.h
@@ -234,11 +234,18 @@ public:
                                                     bool IsZeroCmp) const;
   bool useNeonVector(const Type *Ty) const;
 
-  InstructionCost
-  getMemoryOpCost(unsigned Opcode, Type *Src, MaybeAlign Alignment,
-                  unsigned AddressSpace, TTI::TargetCostKind CostKind,
-                  TTI::OperandValueInfo OpInfo = {TTI::OK_AnyValue, TTI::OP_None},
-                  const Instruction *I = nullptr);
+  InstructionCost getConstantMaterializationCost(
+      ArrayRef<Constant *> VL, Type *SrcTy,
+      TTI::TargetCostKind CostKind = TTI::TCK_RecipThroughput,
+      ArrayRef<SmallVector<Constant *>> ConstVectsPerTree = {},
+      ArrayRef<SmallVector<Constant *>> MaterializedConstVectsPerFunc = {});
+
+  InstructionCost getMemoryOpCost(
+      unsigned Opcode, Type *Src, MaybeAlign Alignment, unsigned AddressSpace,
+      TTI::TargetCostKind CostKind,
+      TTI::OperandValueInfo OpInfo = {TTI::OK_AnyValue, TTI::OP_None},
+      const Instruction *I = nullptr,
+      InstructionCost ConstVectScalarCost = InstructionCost::getInvalid());
 
   InstructionCost getCostOfKeepingLiveOverCall(ArrayRef<Type *> Tys);
 

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/memory-runtime-checks.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/memory-runtime-checks.ll
@@ -600,15 +600,27 @@ bb15:                                             ; preds = %bb15, %bb14
 define void @test_bounds_removed_before_runtime_checks(ptr %A, ptr %B, i1 %c) {
 ; CHECK-LABEL: @test_bounds_removed_before_runtime_checks(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store <2 x i32> <i32 10, i32 300>, ptr [[A:%.*]], align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = fmul float 1.000000e+01, 2.000000e+01
+; CHECK-NEXT:    [[TMP2:%.*]] = fptosi float [[TMP1]] to i32
+; CHECK-NEXT:    [[TMP3:%.*]] = fmul float 3.000000e+01, 2.000000e+01
+; CHECK-NEXT:    [[TMP4:%.*]] = fptosi float [[TMP3]] to i32
+; CHECK-NEXT:    [[TMP5:%.*]] = icmp sgt i32 100, [[TMP2]]
+; CHECK-NEXT:    [[TMP6:%.*]] = select i1 [[TMP5]], i32 [[TMP2]], i32 10
+; CHECK-NEXT:    [[TMP7:%.*]] = select i1 false, i32 0, i32 [[TMP6]]
+; CHECK-NEXT:    [[TMP8:%.*]] = icmp sgt i32 200, [[TMP4]]
+; CHECK-NEXT:    [[TMP9:%.*]] = select i1 [[TMP8]], i32 [[TMP4]], i32 300
+; CHECK-NEXT:    [[TMP10:%.*]] = select i1 false, i32 0, i32 [[TMP9]]
+; CHECK-NEXT:    store i32 [[TMP7]], ptr [[A:%.*]], align 8
+; CHECK-NEXT:    [[TMP12:%.*]] = getelementptr inbounds [[STRUCT:%.*]], ptr [[A]], i64 0, i32 1
+; CHECK-NEXT:    store i32 [[TMP10]], ptr [[TMP12]], align 4
 ; CHECK-NEXT:    [[TMP13:%.*]] = load ptr, ptr [[B:%.*]], align 8
 ; CHECK-NEXT:    br i1 [[C:%.*]], label [[BB23:%.*]], label [[BB14:%.*]]
 ; CHECK:       bb14:
-; CHECK-NEXT:    [[TMP15:%.*]] = sext i32 10 to i64
+; CHECK-NEXT:    [[TMP15:%.*]] = sext i32 [[TMP7]] to i64
 ; CHECK-NEXT:    [[TMP16:%.*]] = add nsw i64 2, [[TMP15]]
 ; CHECK-NEXT:    [[TMP17:%.*]] = getelementptr inbounds i32, ptr [[TMP13]], i64 [[TMP16]]
 ; CHECK-NEXT:    [[TMP19:%.*]] = getelementptr inbounds i8, ptr [[TMP17]], i64 3
-; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr inbounds [[STRUCT:%.*]], ptr [[A]], i64 0, i32 2
+; CHECK-NEXT:    [[TMP20:%.*]] = getelementptr inbounds [[STRUCT]], ptr [[A]], i64 0, i32 2
 ; CHECK-NEXT:    store float 0.000000e+00, ptr [[TMP20]], align 8
 ; CHECK-NEXT:    [[TMP21:%.*]] = load i8, ptr [[TMP19]], align 1
 ; CHECK-NEXT:    [[TMP22:%.*]] = getelementptr inbounds [[STRUCT]], ptr [[A]], i64 0, i32 3

--- a/llvm/test/Transforms/SLPVectorizer/AArch64/vec3-base.ll
+++ b/llvm/test/Transforms/SLPVectorizer/AArch64/vec3-base.ll
@@ -279,10 +279,13 @@ define void @phi_store3(ptr %dst) {
 ; POW2-ONLY:       invoke.cont8.loopexit:
 ; POW2-ONLY-NEXT:    br label [[EXIT]]
 ; POW2-ONLY:       exit:
-; POW2-ONLY-NEXT:    [[P_2:%.*]] = phi i32 [ 3, [[ENTRY:%.*]] ], [ 0, [[INVOKE_CONT8_LOOPEXIT:%.*]] ]
-; POW2-ONLY-NEXT:    [[TMP0:%.*]] = phi <2 x i32> [ <i32 1, i32 2>, [[ENTRY]] ], [ poison, [[INVOKE_CONT8_LOOPEXIT]] ]
-; POW2-ONLY-NEXT:    [[DST_2:%.*]] = getelementptr i32, ptr [[DST:%.*]], i32 2
-; POW2-ONLY-NEXT:    store <2 x i32> [[TMP0]], ptr [[DST]], align 4
+; POW2-ONLY-NEXT:    [[P_0:%.*]] = phi i32 [ 1, [[ENTRY:%.*]] ], [ 0, [[INVOKE_CONT8_LOOPEXIT:%.*]] ]
+; POW2-ONLY-NEXT:    [[P_1:%.*]] = phi i32 [ 2, [[ENTRY]] ], [ 0, [[INVOKE_CONT8_LOOPEXIT]] ]
+; POW2-ONLY-NEXT:    [[P_2:%.*]] = phi i32 [ 3, [[ENTRY]] ], [ 0, [[INVOKE_CONT8_LOOPEXIT]] ]
+; POW2-ONLY-NEXT:    [[DST_1:%.*]] = getelementptr i32, ptr [[DST:%.*]], i32 1
+; POW2-ONLY-NEXT:    [[DST_2:%.*]] = getelementptr i32, ptr [[DST]], i32 2
+; POW2-ONLY-NEXT:    store i32 [[P_0]], ptr [[DST]], align 4
+; POW2-ONLY-NEXT:    store i32 [[P_1]], ptr [[DST_1]], align 4
 ; POW2-ONLY-NEXT:    store i32 [[P_2]], ptr [[DST_2]], align 4
 ; POW2-ONLY-NEXT:    ret void
 ;


### PR DESCRIPTION
Currently, we consider cost of const vector as zero. Consider the below e.g
```
%1 = add <2 x float> %1, <float 21.0, float 22.0>
```
Here, the cost of const vector `<float 21.0, float 22.0>` is considered zero.

However, this might not be the case. On AArch64 platform, this results in `adrp + ldr` instruction corresponding to this const vector.

This patch alters the AArch64 cost-model to consider the cost of const vector.

Perf results with SPEC17(tested on `-mcpu = neoverse-v2`)(uplift indicated by + sign): 
| Benchmark  | Perf diff(%) |
| ------------- | ------------- |
541.leela | +(2.2 - 3)%
