### PR TITLE
[llvm][llvm-readobj] Add NT_ARM_GCS Linux core note type

### DIFF
--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1724,6 +1724,7 @@ enum : unsigned {
   NT_ARM_ZA = 0x40c,
   NT_ARM_ZT = 0x40d,
   NT_ARM_FPMR = 0x40e,
+  NT_ARM_GCS = 0x410,
 
   NT_FILE = 0x46494c45,
   NT_PRXFPREG = 0x46e62b7f,

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -136,6 +136,7 @@ void ScalarEnumerationTraits<ELFYAML::ELF_NT>::enumeration(
   ECase(NT_ARM_ZA);
   ECase(NT_ARM_ZT);
   ECase(NT_ARM_FPMR);
+  ECase(NT_ARM_GCS);
   ECase(NT_FILE);
   ECase(NT_PRXFPREG);
   ECase(NT_SIGINFO);

--- a/llvm/test/tools/llvm-readobj/ELF/note-core.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-core.test
@@ -265,6 +265,11 @@
 # RUN: llvm-readelf --notes %t_nt_arm_fpmr.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_FPMR (AArch64 Floating Point Mode Register)"
 # RUN: llvm-readobj --notes %t_nt_arm_fpmr.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_FPMR (AArch64 Floating Point Mode Register)"
 
+## Check ELF::NT_ARM_GCS
+# RUN: yaml2obj %s -DTYPE=0x410 -o %t_nt_arm_gcs.o
+# RUN: llvm-readelf --notes %t_nt_arm_gcs.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_ARM_GCS (AArch64 Guarded Control Stack state)"
+# RUN: llvm-readobj --notes %t_nt_arm_gcs.o | FileCheck %s --check-prefix=CHECK-LLVM -DDESC="NT_ARM_GCS (AArch64 Guarded Control Stack state)"
+
 ## Check ELF::NT_FILE.
 # RUN: yaml2obj %s -DTYPE=0x46494c45 -o %t_nt_file.o
 # RUN: llvm-readelf --notes %t_nt_file.o | FileCheck %s --check-prefix=CHECK-GNU  -DDESC="NT_FILE (mapped files)"

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -6057,6 +6057,7 @@ const NoteType CoreNoteTypes[] = {
     {ELF::NT_ARM_ZA, "NT_ARM_ZA (AArch64 SME ZA registers)"},
     {ELF::NT_ARM_ZT, "NT_ARM_ZT (AArch64 SME ZT registers)"},
     {ELF::NT_ARM_FPMR, "NT_ARM_FPMR (AArch64 Floating Point Mode Register)"},
+    {ELF::NT_ARM_GCS, "NT_ARM_GCS (AArch64 Guarded Control Stack state)"},
 
     {ELF::NT_FILE, "NT_FILE (mapped files)"},
     {ELF::NT_PRXFPREG, "NT_PRXFPREG (user_xfpregs structure)"},


### PR DESCRIPTION
The ARM Guarded Control Stack extension (GCS) is similar to existing shadow stack extensions for other architectures.

The core note will include which features of GCS are enabled, which have been locked in their current state, and the stack pointer of the shadow stack.

Note that 0x40f is NT_ARM_POE, FPMR is supported by LLDB and GCS will be soon, POE is not at this time. So NT_ARM_POE will be added when that work starts.

See https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf.h.