### PR TITLE
[mlir] Improve doc in `OpFormatGen.cpp` (NFC)

### DIFF
--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -2033,8 +2033,8 @@ static void genPropDictPrinter(OperationFormat &fmt, Operator &op,
   for (const NamedAttribute *namedAttr : fmt.usedAttributes)
     body << "  elidedProps.push_back(\"" << namedAttr->name << "\");\n";
 
-  // Add code to check attributes for equality with the default value
-  // for attributes with the elidePrintingDefaultValue bit set.
+  // Add code to check attributes for equality with their default values.
+  // Default-valued attributes will not be printed when their value matches the default.
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
     const Attribute &attr = namedAttr.attr;
     if (!attr.isDerivedAttr() && attr.hasDefaultValue()) {
@@ -2080,8 +2080,9 @@ static void genAttrDictPrinter(OperationFormat &fmt, Operator &op,
     body << "  elidedAttrs.push_back(\"" << key << "\");\n";
   for (const NamedAttribute *attr : fmt.usedAttributes)
     body << "  elidedAttrs.push_back(\"" << attr->name << "\");\n";
-  // Add code to check attributes for equality with the default value
-  // for attributes with the elidePrintingDefaultValue bit set.
+  
+  // Add code to check attributes for equality with their default values.
+  // Default-valued attributes will not be printed when their value matches the default.
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
     const Attribute &attr = namedAttr.attr;
     if (!attr.isDerivedAttr() && attr.hasDefaultValue()) {

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -2034,7 +2034,8 @@ static void genPropDictPrinter(OperationFormat &fmt, Operator &op,
     body << "  elidedProps.push_back(\"" << namedAttr->name << "\");\n";
 
   // Add code to check attributes for equality with their default values.
-  // Default-valued attributes will not be printed when their value matches the default.
+  // Default-valued attributes will not be printed when their value matches the
+  // default.
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
     const Attribute &attr = namedAttr.attr;
     if (!attr.isDerivedAttr() && attr.hasDefaultValue()) {
@@ -2080,9 +2081,10 @@ static void genAttrDictPrinter(OperationFormat &fmt, Operator &op,
     body << "  elidedAttrs.push_back(\"" << key << "\");\n";
   for (const NamedAttribute *attr : fmt.usedAttributes)
     body << "  elidedAttrs.push_back(\"" << attr->name << "\");\n";
-  
+
   // Add code to check attributes for equality with their default values.
-  // Default-valued attributes will not be printed when their value matches the default.
+  // Default-valued attributes will not be printed when their value matches the
+  // default.
   for (const NamedAttribute &namedAttr : op.getAttributes()) {
     const Attribute &attr = namedAttr.attr;
     if (!attr.isDerivedAttr() && attr.hasDefaultValue()) {


### PR DESCRIPTION
The comment is misleading because attributes do not have `elidePrintingDefaultValue` bit. It appears that `elidePrintingDefaultValue` was never merged upstream (see: https://reviews.llvm.org/D135398 ), but the comment was likely introduced by mistake in a later revision (https://reviews.llvm.org/D135993.).