### PR TITLE
[clangd] Drop requirement for named template parameters

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/DefineOutline.cpp
@@ -467,18 +467,9 @@ public:
       }
     }
 
-    // For function templates, the same limitations as for class templates
-    // apply.
-    if (const TemplateParameterList *Params =
-            MD->getDescribedTemplateParams()) {
-      // FIXME: Is this really needed? It inhibits application on
-      //        e.g. std::enable_if.
-      for (NamedDecl *P : *Params) {
-        if (!P->getIdentifier())
-          return false;
-      }
+    // Function templates must be defined in the same file.
+    if (MD->getDescribedTemplate())
       SameFile = true;
-    }
 
     // The refactoring is meaningless for unnamed classes and namespaces,
     // unless we're outlining in the same file

--- a/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
+++ b/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
@@ -118,12 +118,6 @@ TEST_F(DefineOutlineTest, TriggersOnFunctionDecl) {
     template <> void fo^o<int>() {}
   )cpp");
 
-  // Not available on member function templates with unnamed template
-  // parameters.
-  EXPECT_UNAVAILABLE(R"cpp(
-    struct Foo { template <typename> void ba^r() {} };
-  )cpp");
-
   // Not available on methods of unnamed classes.
   EXPECT_UNAVAILABLE(R"cpp(
     struct Foo {
@@ -410,14 +404,14 @@ inline typename O1<T, U...>::template O2<V, A>::E O1<T, U...>::template O2<V, A>
       {
           R"cpp(
             struct Foo {
-              template <typename T, bool B = true>
+              template <typename T, typename, bool B = true>
               T ^bar() { return {}; }
             };)cpp",
           R"cpp(
             struct Foo {
-              template <typename T, bool B = true>
+              template <typename T, typename, bool B = true>
               T bar() ;
-            };template <typename T, bool B>
+            };template <typename T, typename, bool B>
 inline T Foo::bar() { return {}; }
 )cpp",
           ""},
@@ -426,13 +420,13 @@ inline T Foo::bar() { return {}; }
       {
           R"cpp(
             template <typename T> struct Foo {
-              template <typename U> T ^bar(const T& t, const U& u) { return {}; }
+              template <typename U, bool> T ^bar(const T& t, const U& u) { return {}; }
             };)cpp",
           R"cpp(
             template <typename T> struct Foo {
-              template <typename U> T bar(const T& t, const U& u) ;
+              template <typename U, bool> T bar(const T& t, const U& u) ;
             };template <typename T>
-template <typename U>
+template <typename U, bool>
 inline T Foo<T>::bar(const T& t, const U& u) { return {}; }
 )cpp",
           ""},


### PR DESCRIPTION
... in DefineOutline tweak for function templates. As opposed to class templates, the name is not required for writing an out-of-line definition.