### PR TITLE
[NFC]Update a ThinLTO test case

### DIFF
--- a/llvm/test/ThinLTO/X86/distributed_indexes.ll
+++ b/llvm/test/ThinLTO/X86/distributed_indexes.ll
@@ -48,6 +48,10 @@
 ; RUN: llvm-dis %t1.bc.thinlto.bc -o - | FileCheck %s --check-prefix=DIS
 ; DIS: aliasee: null
 
+; function-import pass crashed when alias is imported but aliasee doesn't.
+; TODO: Import both alias and aliasee, or neither of them.
+; RUN: not --crash opt -passes=function-import -summary-file=%t1.bc.thinlto.bc %t1.bc -o /dev/null 2>&1
+
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 
 declare void @g(...)

--- a/llvm/test/ThinLTO/X86/distributed_indexes.ll
+++ b/llvm/test/ThinLTO/X86/distributed_indexes.ll
@@ -48,10 +48,7 @@
 ; RUN: llvm-dis %t1.bc.thinlto.bc -o - | FileCheck %s --check-prefix=DIS
 ; DIS: aliasee: null
 
-; function-import pass crashed when alias is imported but aliasee doesn't.
-; TODO: Import both alias and aliasee, or neither of them.
 ; RUN: opt -passes=function-import -import-all-index -summary-file=%t1.bc.thinlto.bc %t1.bc -S -o - 2>&1 | FileCheck %s --check-prefix=IR
-
 ; Tests that analias definition is imported.
 ; IR: define available_externally void @analias
 

--- a/llvm/test/ThinLTO/X86/distributed_indexes.ll
+++ b/llvm/test/ThinLTO/X86/distributed_indexes.ll
@@ -50,7 +50,10 @@
 
 ; function-import pass crashed when alias is imported but aliasee doesn't.
 ; TODO: Import both alias and aliasee, or neither of them.
-; RUN: not --crash opt -passes=function-import -summary-file=%t1.bc.thinlto.bc %t1.bc -o /dev/null 2>&1
+; RUN: opt -passes=function-import -import-all-index -summary-file=%t1.bc.thinlto.bc %t1.bc -S -o - 2>&1 | FileCheck %s --check-prefix=IR
+
+; Tests that analias definition is imported.
+; IR: define available_externally void @analias
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/llvm/test/ThinLTO/X86/import_callee_declaration.ll
+++ b/llvm/test/ThinLTO/X86/import_callee_declaration.ll
@@ -62,6 +62,10 @@
 ; these two GUIDs are declaration.
 ;
 ; RUN: llvm-dis main.bc.thinlto.bc -o - | FileCheck %s --check-prefix=MAIN-DIS
+
+; function-import pass crashed when alias is imported but aliasee doesn't.
+; TODO: Import both alias and aliasee, or neither of them.
+; RUN: not --crash opt -passes=function-import -summary-file=main.bc.thinlto.bc main.bc -o /dev/null 2>&1
 ;
 ; MAIN-DIS: [[LIBMOD:\^[0-9]+]] = module: (path: "lib.bc", hash: (0, 0, 0, 0, 0))
 ; MAIN-DIS: gv: (guid: 2418497564662708935, summaries: (function: (module: [[LIBMOD]], flags: ({{.*}} importType: declaration), insts: 8, {{.*}})))

--- a/llvm/test/ThinLTO/X86/import_callee_declaration.ll
+++ b/llvm/test/ThinLTO/X86/import_callee_declaration.ll
@@ -62,10 +62,6 @@
 ; these two GUIDs are declaration.
 ;
 ; RUN: llvm-dis main.bc.thinlto.bc -o - | FileCheck %s --check-prefix=MAIN-DIS
-
-; function-import pass crashed when alias is imported but aliasee doesn't.
-; TODO: Import both alias and aliasee, or neither of them.
-; RUN: not --crash opt -passes=function-import -summary-file=main.bc.thinlto.bc main.bc -o /dev/null 2>&1
 ;
 ; MAIN-DIS: [[LIBMOD:\^[0-9]+]] = module: (path: "lib.bc", hash: (0, 0, 0, 0, 0))
 ; MAIN-DIS: gv: (guid: 2418497564662708935, summaries: (function: (module: [[LIBMOD]], flags: ({{.*}} importType: declaration), insts: 8, {{.*}})))


### PR DESCRIPTION
Run `function-import` pass in a similar way that it runs in a ThinLTO distributed backend compile and checks that function alias is imported as a definition. More accurately, the function alias [is](https://github.com/llvm/llvm-project/blob/0c98776159cea0d1f391a8e1ac290483d4490240/llvm/lib/Transforms/IPO/FunctionImport.cpp#L1912) a [clone](https://github.com/llvm/llvm-project/blob/0c98776159cea0d1f391a8e1ac290483d4490240/llvm/lib/Transforms/IPO/FunctionImport.cpp#L1782) of the aliasee function.