### PR TITLE
[flang] Implement non-standard LNBLNK intrinsic

### DIFF
--- a/flang/docs/Intrinsics.md
+++ b/flang/docs/Intrinsics.md
@@ -1052,6 +1052,9 @@ end program rename_proc
 This intrinsic is an alias for `CPU_TIME`: supporting both a subroutine and a
 function form.
 
+### Non-standard Intrinsics: LNBLNK
+This intrinsic is an alias for `LEN_TRIM`, without the optional KIND argument.
+
 #### Usage and Info
 
 - **Standard:** GNU extension

--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -616,6 +616,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         DefaultLogical},
     {"llt", {{"string_a", SameCharNoLen}, {"string_b", SameCharNoLen}},
         DefaultLogical},
+    {"lnblnk", {{"string", AnyChar}}, DefaultInt},
     {"loc", {{"x", Addressable, Rank::anyOrAssumedRank}}, SubscriptInt,
         Rank::scalar},
     {"log", {{"x", SameFloating}}, SameFloating},

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -434,6 +434,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"lgt", &I::genCharacterCompare<mlir::arith::CmpIPredicate::sgt>},
     {"lle", &I::genCharacterCompare<mlir::arith::CmpIPredicate::sle>},
     {"llt", &I::genCharacterCompare<mlir::arith::CmpIPredicate::slt>},
+    {"lnblnk", &I::genLenTrim},
     {"loc", &I::genLoc, {{{"x", asBox}}}, /*isElemental=*/false},
     {"malloc", &I::genMalloc},
     {"maskl", &I::genMask<mlir::arith::ShLIOp>},

--- a/flang/test/Lower/Intrinsics/len_trim.f90
+++ b/flang/test/Lower/Intrinsics/len_trim.f90
@@ -18,3 +18,22 @@ ltrim = len_trim(c)
 ! CHECK: %[[len:.*]] = arith.addi %[[iterateResult]]#1, %[[c1]]
 ! CHECK: select %[[iterateResult]]#0, %[[c0]], %[[len]]
 end function
+
+! CHECK-LABEL: lnblnk_test
+integer function lnblnk_test(c)
+character(*) :: c
+ltrim = lnblnk(c)
+! CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+! CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
+! CHECK-DAG: %[[cm1:.*]] = arith.constant -1 : index
+! CHECK-DAG: %[[lastChar:.*]] = arith.subi {{.*}}, %[[c1]]
+! CHECK: %[[iterateResult:.*]]:2 = fir.iterate_while (%[[index:.*]] = %[[lastChar]] to %[[c0]] step %[[cm1]]) and ({{.*}}) iter_args({{.*}}) {
+  ! CHECK: %[[addr:.*]] = fir.coordinate_of {{.*}}, %[[index]]
+  ! CHECK: %[[codeAddr:.*]] = fir.convert %[[addr]]
+  ! CHECK: %[[code:.*]] = fir.load %[[codeAddr]]
+  ! CHECK: %[[bool:.*]] = arith.cmpi eq
+  ! CHECK: fir.result %[[bool]], %[[index]]
+! CHECK: }
+! CHECK: %[[len:.*]] = arith.addi %[[iterateResult]]#1, %[[c1]]
+! CHECK: select %[[iterateResult]]#0, %[[c0]], %[[len]]
+end function


### PR DESCRIPTION
This is defined here
https://gcc.gnu.org/onlinedocs/gfortran/LNBLNK.html. It is just an alias to LEN_TRIM.

This was requested by a user:
https://discourse.llvm.org/t/unresolved-externals-with-appendend-underscore/83305