### PR TITLE
[LLDB][ThreadELFCore] Set all the properties of ELFLinuxSigInfo to a non build dependent size

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.h
@@ -83,10 +83,10 @@ struct ELFLinuxSigInfo {
   int32_t si_errno;
   int32_t si_code;
   // Copied from siginfo_t so we don't have to include signal.h on non 'Nix
-  // builds.
+  // builds. Slight modifications to ensure no 32b vs 64b differences.
   struct {
-    lldb::addr_t si_addr;  /* faulting insn/memory ref. */
-    short int si_addr_lsb; /* Valid LSB of the reported address.  */
+    lldb::addr_t si_addr; /* faulting insn/memory ref. */
+    int16_t si_addr_lsb;  /* Valid LSB of the reported address.  */
     union {
       /* used when si_code=SEGV_BNDERR */
       struct {
@@ -98,7 +98,8 @@ struct ELFLinuxSigInfo {
     } bounds;
   } sigfault;
 
-  enum { eUnspecified, eNT_SIGINFO } note_type;
+  enum SigInfoNoteType : uint8_t { eUnspecified, eNT_SIGINFO };
+  SigInfoNoteType note_type;
 
   ELFLinuxSigInfo();
 

--- a/lldb/source/Plugins/Process/elf-core/ThreadElfCore.h
+++ b/lldb/source/Plugins/Process/elf-core/ThreadElfCore.h
@@ -84,7 +84,7 @@ struct ELFLinuxSigInfo {
   int32_t si_code;
   // Copied from siginfo_t so we don't have to include signal.h on non 'Nix
   // builds. Slight modifications to ensure no 32b vs 64b differences.
-  struct {
+  struct alignas(8) {
     lldb::addr_t si_addr; /* faulting insn/memory ref. */
     int16_t si_addr_lsb;  /* Valid LSB of the reported address.  */
     union {


### PR DESCRIPTION
On #110065 the changes to LinuxSigInfo Struct introduced some variables that will differ in size on 32b or 64b. I've rectified this by setting them all to build independent types.