### PR TITLE
[GlobalISel] Document minimum legality requirements for G_IMPLICIT_DEF.

### DIFF
--- a/llvm/docs/GlobalISel/Legalizer.rst
+++ b/llvm/docs/GlobalISel/Legalizer.rst
@@ -338,8 +338,8 @@ G_BUILD_VECTOR_TRUNC, G_CONCAT_VECTORS, G_UNMERGE_VALUES, G_PTRTOINT, and
 G_INTTOPTR have already been noted above. In addition to those, the following
 operations have requirements:
 
-* At least one G_IMPLICIT_DEF must be legal. This is usually trivial as it
-  requires no code to be selected.
+* For every type that can be produced by any instruction, G_IMPLICIT_DEF must be
+  legal. This is usually trivial as it requires no code to be selected.
 * G_PHI must be legal for all types in the producer and consumer typesets. This
   is usually trivial as it requires no code to be selected.
 * At least one G_FRAME_INDEX must be legal

--- a/llvm/docs/GlobalISel/Legalizer.rst
+++ b/llvm/docs/GlobalISel/Legalizer.rst
@@ -339,7 +339,7 @@ G_INTTOPTR have already been noted above. In addition to those, the following
 operations have requirements:
 
 * For every type that can be produced by any instruction, G_IMPLICIT_DEF must be
-  legal. This is usually trivial as it requires no code to be selected.
+  legal.
 * G_PHI must be legal for all types in the producer and consumer typesets. This
   is usually trivial as it requires no code to be selected.
 * At least one G_FRAME_INDEX must be legal


### PR DESCRIPTION
So that @tschuett can fix up #117439

The reason for this change is to clarify an existing technical restriction of LLVM: there needs to be a way to implicitly define a type if there is any way to legally define that type by another means.