### PR TITLE
[memprof] Use IndexedMemProfRecord in MemProfReader (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProfReader.h
+++ b/llvm/include/llvm/ProfileData/MemProfReader.h
@@ -46,7 +46,8 @@ public:
     return Iterator(this);
   }
 
-  // Take the complete profile data.
+  // Take the complete profile data.  Once this function is invoked,
+  // MemProfReader no longer owns the MemProf profile.
   IndexedMemProfData takeMemProfData() { return std::move(MemProfData); }
 
   virtual Error
@@ -82,7 +83,7 @@ public:
   virtual ~MemProfReader() = default;
 
   // Initialize the MemProfReader with the given MemProf profile.
-  MemProfReader(IndexedMemProfData MemProfData)
+  MemProfReader(IndexedMemProfData &&MemProfData)
       : MemProfData(std::move(MemProfData)) {}
 
 protected:

--- a/llvm/include/llvm/ProfileData/MemProfReader.h
+++ b/llvm/include/llvm/ProfileData/MemProfReader.h
@@ -42,43 +42,28 @@ public:
   using Iterator = InstrProfIterator<GuidMemProfRecordPair, MemProfReader>;
   Iterator end() { return Iterator(); }
   Iterator begin() {
-    Iter = FunctionProfileData.begin();
+    Iter = MemProfData.Records.begin();
     return Iterator(this);
   }
 
   // Take the complete profile data.
-  IndexedMemProfData takeMemProfData() {
-    // TODO: Once we replace the three member variables, namely IdToFrame,
-    // CSIdToCallStack, and FunctionProfileData, with MemProfData, replace the
-    // following code with just "return std::move(MemProfData);".
-    IndexedMemProfData MemProfData;
-    // Copy key-value pairs because IdToFrame uses DenseMap, whereas
-    // IndexedMemProfData::Frames uses MapVector.
-    for (const auto &[FrameId, F] : IdToFrame)
-      MemProfData.Frames.try_emplace(FrameId, F);
-    // Copy key-value pairs because CSIdToCallStack uses DenseMap, whereas
-    // IndexedMemProfData::CallStacks uses MapVector.
-    for (const auto &[CSId, CS] : CSIdToCallStack)
-      MemProfData.CallStacks.try_emplace(CSId, CS);
-    MemProfData.Records = FunctionProfileData;
-    return MemProfData;
-  }
+  IndexedMemProfData takeMemProfData() { return std::move(MemProfData); }
 
   virtual Error
   readNextRecord(GuidMemProfRecordPair &GuidRecord,
                  std::function<const Frame(const FrameId)> Callback = nullptr) {
-    if (FunctionProfileData.empty())
+    if (MemProfData.Records.empty())
       return make_error<InstrProfError>(instrprof_error::empty_raw_profile);
 
-    if (Iter == FunctionProfileData.end())
+    if (Iter == MemProfData.Records.end())
       return make_error<InstrProfError>(instrprof_error::eof);
 
     if (Callback == nullptr)
       Callback =
           std::bind(&MemProfReader::idToFrame, this, std::placeholders::_1);
 
-    CallStackIdConverter<decltype(CSIdToCallStack)> CSIdConv(CSIdToCallStack,
-                                                             Callback);
+    CallStackIdConverter<decltype(MemProfData.CallStacks)> CSIdConv(
+        MemProfData.CallStacks, Callback);
 
     const IndexedMemProfRecord &IndexedRecord = Iter->second;
     GuidRecord = {
@@ -97,28 +82,18 @@ public:
   virtual ~MemProfReader() = default;
 
   // Initialize the MemProfReader with the given MemProf profile.
-  MemProfReader(IndexedMemProfData MemProfData) {
-    for (const auto &[FrameId, F] : MemProfData.Frames)
-      IdToFrame.try_emplace(FrameId, F);
-    for (const auto &[CSId, CS] : MemProfData.CallStacks)
-      CSIdToCallStack.try_emplace(CSId, CS);
-    FunctionProfileData = std::move(MemProfData.Records);
-  }
+  MemProfReader(IndexedMemProfData MemProfData)
+      : MemProfData(std::move(MemProfData)) {}
 
 protected:
   // A helper method to extract the frame from the IdToFrame map.
   const Frame &idToFrame(const FrameId Id) const {
-    auto It = IdToFrame.find(Id);
-    assert(It != IdToFrame.end() && "Id not found in map.");
-    return It->getSecond();
+    auto It = MemProfData.Frames.find(Id);
+    assert(It != MemProfData.Frames.end() && "Id not found in map.");
+    return It->second;
   }
-  // A mapping from FrameId (a hash of the contents) to the frame.
-  llvm::DenseMap<FrameId, Frame> IdToFrame;
-  // A mapping from CallStackId to the call stack.
-  llvm::DenseMap<CallStackId, llvm::SmallVector<FrameId>> CSIdToCallStack;
-  // A mapping from function GUID, hash of the canonical function symbol to the
-  // memprof profile data for that function, i.e allocation and callsite info.
-  llvm::MapVector<GlobalValue::GUID, IndexedMemProfRecord> FunctionProfileData;
+  // A complete pacakge of the MemProf profile.
+  IndexedMemProfData MemProfData;
   // An iterator to the internal function profile data structure.
   llvm::MapVector<GlobalValue::GUID, IndexedMemProfRecord>::iterator Iter;
 };

--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -440,7 +440,7 @@ TEST(MemProf, BaseMemProfReader) {
   FakeRecord.AllocSites.emplace_back(/*CSId=*/CSId, /*MB=*/Block);
   MemProfData.Records.insert({F1.hash(), FakeRecord});
 
-  MemProfReader Reader(MemProfData);
+  MemProfReader Reader(std::move(MemProfData));
 
   llvm::SmallVector<MemProfRecord, 1> Records;
   for (const auto &KeyRecordPair : Reader) {
@@ -478,7 +478,7 @@ TEST(MemProf, BaseMemProfReaderWithCSIdMap) {
       /*MB=*/Block);
   MemProfData.Records.insert({F1.hash(), FakeRecord});
 
-  MemProfReader Reader(MemProfData);
+  MemProfReader Reader(std::move(MemProfData));
 
   llvm::SmallVector<MemProfRecord, 1> Records;
   for (const auto &KeyRecordPair : Reader) {


### PR DESCRIPTION
IndexedMemProfRecord contains a complete package of the MemProf
profile, including frames, call stacks, and records.  This patch
replaces the three member variables of MemProfReader with
IndexedMemProfRecord.

This transition significantly simplies both the constructor and the
final "take" method:

  MemProfReader(IndexedMemProfData MemProfData)
      : MemProfData(std::move(MemProfData)) {}

  IndexedMemProfData takeMemProfData() { return std::move(MemProfData); }
