### PR TITLE
[Support] Use macro var args to allow templates within DEBUG_WITH_TYPE

### DIFF
--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -61,15 +61,15 @@ void setCurrentDebugTypes(const char **Types, unsigned Count);
 ///
 /// This will emit the debug information if -debug is present, and -debug-only
 /// is not specified, or is specified as "bitset".
-#define DEBUG_WITH_TYPE(TYPE, X)                                        \
-  do { if (::llvm::DebugFlag && ::llvm::isCurrentDebugType(TYPE)) { X; } \
+#define DEBUG_WITH_TYPE(TYPE, ...)                                        \
+  do { if (::llvm::DebugFlag && ::llvm::isCurrentDebugType(TYPE)) { __VA_ARGS__; } \
   } while (false)
 
 #else
 #define isCurrentDebugType(X) (false)
 #define setCurrentDebugType(X) do { (void)(X); } while (false)
 #define setCurrentDebugTypes(X, N) do { (void)(X); (void)(N); } while (false)
-#define DEBUG_WITH_TYPE(TYPE, X) do { } while (false)
+#define DEBUG_WITH_TYPE(TYPE, ...) do { } while (false)
 #endif
 
 /// This boolean is set to true if the '-debug' command line option
@@ -98,7 +98,7 @@ raw_ostream &dbgs();
 //
 // LLVM_DEBUG(dbgs() << "Bitset contains: " << Bitset << "\n");
 //
-#define LLVM_DEBUG(X) DEBUG_WITH_TYPE(DEBUG_TYPE, X)
+#define LLVM_DEBUG(...) DEBUG_WITH_TYPE(DEBUG_TYPE, __VA_ARGS__)
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -61,15 +61,20 @@ void setCurrentDebugTypes(const char **Types, unsigned Count);
 ///
 /// This will emit the debug information if -debug is present, and -debug-only
 /// is not specified, or is specified as "bitset".
-#define DEBUG_WITH_TYPE(TYPE, ...)                                        \
-  do { if (::llvm::DebugFlag && ::llvm::isCurrentDebugType(TYPE)) { __VA_ARGS__; } \
+#define DEBUG_WITH_TYPE(TYPE, ...)                                             \
+  do {                                                                         \
+    if (::llvm::DebugFlag && ::llvm::isCurrentDebugType(TYPE)) {               \
+      __VA_ARGS__;                                                             \
+    }                                                                          \
   } while (false)
 
 #else
 #define isCurrentDebugType(X) (false)
 #define setCurrentDebugType(X) do { (void)(X); } while (false)
 #define setCurrentDebugTypes(X, N) do { (void)(X); (void)(N); } while (false)
-#define DEBUG_WITH_TYPE(TYPE, ...) do { } while (false)
+#define DEBUG_WITH_TYPE(TYPE, ...)                                             \
+  do {                                                                         \
+  } while (false)
 #endif
 
 /// This boolean is set to true if the '-debug' command line option

--- a/llvm/unittests/Support/DebugTest.cpp
+++ b/llvm/unittests/Support/DebugTest.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 
@@ -29,5 +31,23 @@ TEST(DebugTest, Basic) {
   DEBUG_WITH_TYPE("A", os2 << "A");
   DEBUG_WITH_TYPE("B", os2 << "B");
   EXPECT_EQ("A", os2.str());
+}
+
+TEST(DebugTest, CommaInDebugBlock) {
+  std::string s1, s2;
+  raw_string_ostream os1(s1), os2(s2);
+  static const char *DT[] = {"A", "B"};  
+  static const char Letters[] = {'X', 'Y', 'Z'};  
+  
+  llvm::DebugFlag = true;
+  setCurrentDebugTypes(DT, 2);
+  DEBUG_WITH_TYPE("A", {
+    SmallMapVector <int, char, 4> map;
+    for (int i = 0; i < 3; i++) 
+      map[i] = Letters[i];
+    for (int i = 2; i >= 0; i--)
+      os1 << map[i];
+  });
+  EXPECT_EQ("ZYX", os1.str());
 }
 #endif

--- a/llvm/unittests/Support/DebugTest.cpp
+++ b/llvm/unittests/Support/DebugTest.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ADT/MapVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
@@ -36,14 +36,14 @@ TEST(DebugTest, Basic) {
 TEST(DebugTest, CommaInDebugBlock) {
   std::string s1, s2;
   raw_string_ostream os1(s1), os2(s2);
-  static const char *DT[] = {"A", "B"};  
-  static const char Letters[] = {'X', 'Y', 'Z'};  
-  
+  static const char *DT[] = {"A", "B"};
+  static const char Letters[] = {'X', 'Y', 'Z'};
+
   llvm::DebugFlag = true;
   setCurrentDebugTypes(DT, 2);
   DEBUG_WITH_TYPE("A", {
-    SmallMapVector <int, char, 4> map;
-    for (int i = 0; i < 3; i++) 
+    SmallMapVector<int, char, 4> map;
+    for (int i = 0; i < 3; i++)
       map[i] = Letters[i];
     for (int i = 2; i >= 0; i--)
       os1 << map[i];


### PR DESCRIPTION
Use variadic args with DEBUG_WITH_TYPE("name", ...) macros to resolve a compilation failure that occurs when using a comma within the last macro argument. Commas come up when instantiating templates such as SmallMapVector that require multiple template args.