### PR TITLE
[clang-tidy] Adjust size-empty doc because C++11 size() is constant-time

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/ContainerSizeEmptyCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/ContainerSizeEmptyCheck.h
@@ -18,12 +18,10 @@ namespace clang::tidy::readability {
 /// a call to `empty()`.
 ///
 /// The emptiness of a container should be checked using the `empty()` method
-/// instead of the `size()` method. It is not guaranteed that `size()` is a
-/// constant-time function, and it is generally more efficient and also shows
-/// clearer intent to use `empty()`. Furthermore some containers may implement
-/// the `empty()` method but not implement the `size()` method. Using `empty()`
-/// whenever possible makes it easier to switch to another container in the
-/// future.
+/// instead of the `size()` method. It shows clearer intent to use `empty()`.
+/// Furthermore some containers may implement the `empty()` method but not
+/// implement the `size()` method. Using `empty()` whenever possible makes it
+/// easier to switch to another container in the future.
 class ContainerSizeEmptyCheck : public ClangTidyCheck {
 public:
   ContainerSizeEmptyCheck(StringRef Name, ClangTidyContext *Context);

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
@@ -8,12 +8,10 @@ Checks whether a call to the ``size()``/``length()`` method can be replaced
 with a call to ``empty()``.
 
 The emptiness of a container should be checked using the ``empty()`` method
-instead of the ``size()``/``length()`` method. It is not guaranteed that
-``size()``/``length()`` is a constant-time function, and it is generally more
-efficient and also shows clearer intent to use ``empty()``. Furthermore some
-containers may implement the ``empty()`` method but not implement the ``size()``
-or ``length()`` method. Using ``empty()`` whenever possible makes it easier to
-switch to another container in the future.
+instead of the ``size()``/``length()`` method. It shows clearer intent to use
+``empty()``. Furthermore some containers may implement the ``empty()`` method
+but not implement the ``size()`` or ``length()`` method. Using ``empty()``
+whenever possible makes it easier to switch to another container in the future.
 
 The check issues warning if a container has ``empty()`` and ``size()`` or
 ``length()`` methods matching following signatures:


### PR DESCRIPTION
From C++11, a conforming `size()` method is guaranteed to be a constant-time function. `empty()` is not _generally_ more efficient than `size()`. It might even be implemented in terms of `size()`.

----

Notes:
- Microsoft's STL had implemented `empty()` as `return size() == 0`, until May 2021: https://github.com/microsoft/STL/pull/1836/files
- The time complexity of `size()` (specifically for `std::set`) was discussed by the library working group in 2007-2009: https://cplusplus.github.io/LWG/issue632