### PR TITLE
[libc] Resolve multi-line comment error

### DIFF
--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -27,8 +27,7 @@
 //
 // For examples:
 // #define LLVM_LIBC_FUNCTION_ATTR_memcpy LLVM_LIBC_EMPTY, [[gnu::weak]]
-// #define LLVM_LIBC_FUNCTION_ATTR_memchr LLVM_LIBC_EMPTY, [[gnu::weak]]       \
-//                                        [[gnu::visibility("default")]]
+// #define LLVM_LIBC_FUNCTION_ATTR_memchr LLVM_LIBC_EMPTY, [[gnu::weak]] [[gnu::visibility("default")]]
 #define LLVM_LIBC_EMPTY
 
 #define GET_SECOND(first, second, ...) second

--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -21,6 +21,7 @@
 #define LLVM_LIBC_FUNCTION_ATTR
 #endif
 
+// clang-format off
 // Allow each function `func` to have extra attributes specified by defining:
 // `LLVM_LIBC_FUNCTION_ATTR_func` macro, which should always start with
 // "LLVM_LIBC_EMPTY, "
@@ -28,6 +29,7 @@
 // For examples:
 // #define LLVM_LIBC_FUNCTION_ATTR_memcpy LLVM_LIBC_EMPTY, [[gnu::weak]]
 // #define LLVM_LIBC_FUNCTION_ATTR_memchr LLVM_LIBC_EMPTY, [[gnu::weak]] [[gnu::visibility("default")]]
+// clang-format on
 #define LLVM_LIBC_EMPTY
 
 #define GET_SECOND(first, second, ...) second


### PR DESCRIPTION
gcc interprets a backslash '\\' as the last char before a new line as a line continuation character, even in a comment context. This can produce an "error: multi-line comment [-Werror=comment]".

This removes the line continuation so that the comment can compile with gcc.