### PR TITLE
[NFC][clang] Fix header comment in llvm/test/MC/AArch64/local-bounds-single-trap.ll

### DIFF
--- a/llvm/test/MC/AArch64/local-bounds-single-trap.ll
+++ b/llvm/test/MC/AArch64/local-bounds-single-trap.ll
@@ -1,7 +1,8 @@
 ; RUN: llc -O3 -mtriple arm64-linux -filetype asm -o - %s | FileCheck %s -check-prefix CHECK-ASM
-; What this test does is check that even with nomerge, the functions still get merged in
-; compiled code as the ubsantrap call gets lowered to a single instruction: brk.
-
+; This test checks that nomerge correctly prevents the traps from being merged
+; in the compiled code.
+; Prior to ae6dc64ec670891cb15049277e43133d4df7fb4b, this test showed that
+; nomerge did not work correctly.
 
 @B = dso_local global [10 x i8] zeroinitializer, align 1
 @B2 = dso_local global [10 x i8] zeroinitializer, align 1


### PR DESCRIPTION
llvm/test/MC/AArch64/local-bounds-single-trap.ll was introduced in https://github.com/llvm/llvm-project/pull/65972 to demonstrate that nomerge did not work properly, which is documented in the header comment.

https://github.com/llvm/llvm-project/pull/101549 fixed nomerge for trap builtins and https://github.com/llvm/llvm-project/commit/ae6dc64ec670891cb15049277e43133d4df7fb4b updated the test assertions, but not the header comment. This patch updates the header comment accordingly.