### PR TITLE
[clang][transformer] Allow usage of applyFirst with rewriteDescendants

### DIFF
--- a/clang/lib/Tooling/Transformer/RewriteRule.cpp
+++ b/clang/lib/Tooling/Transformer/RewriteRule.cpp
@@ -382,9 +382,10 @@ static std::vector<DynTypedMatcher> taggedMatchers(
   std::vector<DynTypedMatcher> Matchers;
   Matchers.reserve(Cases.size());
   for (const auto &Case : Cases) {
-    std::string Tag = (TagBase + Twine(Case.first)).str();
     // HACK: Many matchers are not bindable, so ensure that tryBind will work.
     DynTypedMatcher BoundMatcher(Case.second.Matcher);
+    const auto [_, ID] = BoundMatcher.getID();
+    std::string Tag = (TagBase + Twine(ID)).str();
     BoundMatcher.setAllowBind(true);
     auto M = *BoundMatcher.tryBind(Tag);
     Matchers.push_back(!M.getTraversalKind()
@@ -469,7 +470,8 @@ size_t transformer::detail::findSelectedCase(const MatchResult &Result,
 
   auto &NodesMap = Result.Nodes.getMap();
   for (size_t i = 0, N = Rule.Cases.size(); i < N; ++i) {
-    std::string Tag = ("Tag" + Twine(i)).str();
+    const auto [_, ID] = Rule.Cases[i].Matcher.getID();
+    std::string Tag = ("Tag" + Twine(ID)).str();
     if (NodesMap.find(Tag) != NodesMap.end())
       return i;
   }


### PR DESCRIPTION
Without these changes a clash appears between a Tag, which is bound to enclosing match, and a Tag, which is associated with first Case of applyFirst in rewriteDescendands.

We fix this by making sure that associated Tags are unique and deterministic as they are intend to be.