### PR TITLE
[mlir][Transforms] Dialect conversion: Fix `replaceUsesOfBlockArgument`

### DIFF
--- a/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
+++ b/mlir/lib/Conversion/FuncToLLVM/FuncToLLVM.cpp
@@ -295,7 +295,7 @@ static void restoreByValRefArgumentType(
         cast<TypeAttr>(byValRefAttr->getValue()).getValue());
 
     auto valueArg = rewriter.create<LLVM::LoadOp>(arg.getLoc(), resTy, arg);
-    rewriter.replaceUsesOfBlockArgument(oldArg, valueArg);
+    rewriter.replaceUsesOfBlockArgument(arg, valueArg);
   }
 }
 

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -1641,7 +1641,7 @@ void ConversionPatternRewriter::replaceUsesOfBlockArgument(BlockArgument from,
   });
   impl->appendRewrite<ReplaceBlockArgRewrite>(from.getOwner(), from,
                                               impl->currentTypeConverter);
-  impl->mapping.map(impl->mapping.lookupOrDefault(from), to);
+  impl->mapping.map(from, to);
 }
 
 Value ConversionPatternRewriter::getRemappedValue(Value key) {

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -124,10 +124,10 @@ func.func @no_remap_nested() {
   // CHECK-NEXT: "foo.region"
   // expected-remark@+1 {{op 'foo.region' is not legalizable}}
   "foo.region"() ({
-    // CHECK-NEXT: ^bb0(%{{.*}}: i64, %{{.*}}: i16, %{{.*}}: i64):
-    ^bb0(%i0: i64, %unused: i16, %i1: i64):
-      // CHECK-NEXT: "test.valid"{{.*}} : (i64, i64)
-      "test.invalid"(%i0, %i1) : (i64, i64) -> ()
+    // CHECK-NEXT: ^bb0(%{{.*}}: f64, %{{.*}}: i16, %{{.*}}: f64):
+    ^bb0(%i0: f64, %unused: i16, %i1: f64):
+      // CHECK-NEXT: "test.valid"{{.*}} : (f64, f64)
+      "test.invalid"(%i0, %i1) : (f64, f64) -> ()
   }) : () -> ()
   // expected-remark@+1 {{op 'func.return' is not legalizable}}
   return

--- a/mlir/test/Transforms/test-legalizer.mlir
+++ b/mlir/test/Transforms/test-legalizer.mlir
@@ -472,3 +472,23 @@ func.func @circular_mapping() {
   %0 = "test.erase_op"() : () -> (i64)
   "test.drop_operands_and_replace_with_valid"(%0) : (i64) -> ()
 }
+
+// -----
+
+// CHECK-LABEL: func @test_replace_uses_of_block_arg() {
+//       CHECK:   "test.convert_block_and_replace_arg"() ({
+//       CHECK:   ^bb0(%[[arg0:.*]]: f64, %[[arg1:.*]]: f64):
+//       CHECK:     %[[producer:.*]] = "test.type_producer"() : () -> f64
+//       CHECK:     %[[cast:.*]] = "test.cast"(%[[producer]], %[[arg1]]) : (f64, f64) -> f32
+//       CHECK:     "test.some_user"(%[[cast]]) : (f32) -> ()
+//       CHECK:   }) {legal} : () -> ()
+//       CHECK:   "test.return"() : () -> ()
+//       CHECK: }
+func.func @test_replace_uses_of_block_arg() {
+  "test.convert_block_and_replace_arg"() ({
+  ^bb0(%arg0: f32):
+    // expected-remark @below{{'test.some_user' is not legalizable}}
+    "test.some_user"(%arg0) : (f32) -> ()
+  }) : () -> ()
+  "test.return"() : () -> ()
+}


### PR DESCRIPTION
This commit fixes the implementation of `ConversionPatternRewriter::replaceUsesOfBlockArgument`. The old implementation was different from what the documentation says.

```
/// Replace all the uses of the block argument `from` with value `to`.
void ConversionPatternRewriter::replaceUsesOfBlockArgument(
    BlockArgument from, Value to) {
  // ...
  impl->mapping.map(impl->mapping.lookupOrDefault(from), to);
}
```

The extra `mapping.lookupOrDefault` was incorrect: we may not replace `from`, but the value that `from` is mapped to (if it is mapped).

This function is typically used after a block signature conversion to "fix up" some block arguments. During a 1:N conversion, an argument materialization is inserted. The old implementation could be used to replace the argument materialization by passing the old block argument as the `from` parameter. This was unintuitive, because it's not the block argument that is being replaced. Furthermore, replacing a block arguments of an erased block (scheduled for erasure to be precise) is incorrect from an API perspective because a block argument of an erased block should not have any uses anymore.

The new implementation of `replaceUsesOfBlockArgument` now does what the documentation says: it replaces the `from` argument. No extra lookup magic anymore. When an argument materialization should be replaced, users can call `replaceOp` on the argument materialization.
