### PR TITLE
[MLIR][mlir-opt] add support for disabling diagnostics

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -183,9 +183,8 @@ public:
   }
   bool shouldUseExplicitModule() const { return useExplicitModuleFlag; }
 
-  /// Set whether to check that emitted diagnostics match `expected-*` lines
-  /// on the corresponding line. This is meant for implementing diagnostic
-  /// tests.
+  /// Set whether to check that emitted diagnostics match `expected-*` lines on
+  /// the corresponding line. This is meant for implementing diagnostic tests.
   MlirOptMainConfig &verifyDiagnostics(bool verify) {
     verifyDiagnosticsFlag = verify;
     return *this;

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -221,7 +221,7 @@ protected:
   /// Verbosity level of diagnostic information. 0: Errors only,
   /// 1: Errors and warnings, 2: Errors, warnings and remarks.
   VerbosityLevel diagnosticVerbosityLevelFlag =
-      VerbosityLevel::ErrorsAndWarnings;
+      VerbosityLevel::ErrorsWarningsAndRemarks;
 
   /// Print the pipeline that will be run.
   bool dumpPassPipelineFlag = false;
@@ -271,9 +271,8 @@ protected:
   /// Use an explicit top-level module op during parsing.
   bool useExplicitModuleFlag = false;
 
-  /// Set whether to check that emitted diagnostics match `expected-*` lines
-  /// on the corresponding line. This is meant for implementing diagnostic
-  /// tests.
+  /// Set whether to check that emitted diagnostics match `expected-*` lines on
+  /// the corresponding line. This is meant for implementing diagnostic tests.
   bool verifyDiagnosticsFlag = false;
 
   /// Run the verifier after each transformation pass.
@@ -287,14 +286,13 @@ protected:
 };
 
 /// This defines the function type used to setup the pass manager. This can be
-/// used to pass in a callback to setup a default pass pipeline to be applied
-/// on the loaded IR.
+/// used to pass in a callback to setup a default pass pipeline to be applied on
+/// the loaded IR.
 using PassPipelineFn = llvm::function_ref<LogicalResult(PassManager &pm)>;
 
 /// Register and parse command line options.
 /// - toolName is used for the header displayed by `--help`.
-/// - registry should contain all the dialects that can be parsed in the
-/// source.
+/// - registry should contain all the dialects that can be parsed in the source.
 /// - return std::pair<std::string, std::string> for
 ///   inputFilename and outputFilename command line option values.
 std::pair<std::string, std::string>
@@ -304,8 +302,7 @@ registerAndParseCLIOptions(int argc, char **argv, llvm::StringRef toolName,
 /// Perform the core processing behind `mlir-opt`.
 /// - outputStream is the stream where the resulting IR is printed.
 /// - buffer is the in-memory file to parser and process.
-/// - registry should contain all the dialects that can be parsed in the
-/// source.
+/// - registry should contain all the dialects that can be parsed in the source.
 /// - config contains the configuration options for the tool.
 LogicalResult MlirOptMain(llvm::raw_ostream &outputStream,
                           std::unique_ptr<llvm::MemoryBuffer> buffer,
@@ -314,8 +311,7 @@ LogicalResult MlirOptMain(llvm::raw_ostream &outputStream,
 
 /// Implementation for tools like `mlir-opt`.
 /// - toolName is used for the header displayed by `--help`.
-/// - registry should contain all the dialects that can be parsed in the
-/// source.
+/// - registry should contain all the dialects that can be parsed in the source.
 LogicalResult MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
                           DialectRegistry &registry);
 
@@ -324,8 +320,7 @@ LogicalResult MlirOptMain(int argc, char **argv, llvm::StringRef toolName,
 /// CLI options can be accessed before running MlirOptMain.
 /// - inputFilename is the name of the input mlir file.
 /// - outputFilename is the name of the output file.
-/// - registry should contain all the dialects that can be parsed in the
-/// source.
+/// - registry should contain all the dialects that can be parsed in the source.
 LogicalResult MlirOptMain(int argc, char **argv, llvm::StringRef inputFilename,
                           llvm::StringRef outputFilename,
                           DialectRegistry &registry);

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -82,6 +82,9 @@ public:
     return *this;
   }
   bool shouldEmitBytecode() const { return emitBytecodeFlag; }
+
+  bool shouldDisableDiagnostic() const { return disableDiagnosticFlag; }
+
   bool shouldElideResourceDataFromBytecode() const {
     return elideResourceDataFromBytecodeFlag;
   }
@@ -207,6 +210,10 @@ protected:
 
   /// Emit bytecode instead of textual assembly when generating output.
   bool emitBytecodeFlag = false;
+
+  /// Disable the diagnostic handlers. Warnings, errors, remarks, etc. will not
+  /// be printed.
+  bool disableDiagnosticFlag = false;
 
   /// Elide resources when generating bytecode.
   bool elideResourceDataFromBytecodeFlag = false;

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Regex.h"
@@ -108,14 +109,27 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::desc("IRDL file to register before processing the input"),
         cl::location(irdlFileFlag), cl::init(""), cl::value_desc("filename"));
 
+    static cl::opt<VerbosityLevel, /*ExternalStorage=*/true>
+        diagnosticVerbosityLevel(
+            "mlir-diagnostic-verbosity-level",
+            cl::desc("Choose level of diagnostic information"),
+            cl::location(diagnosticVerbosityLevelFlag),
+            cl::init(VerbosityLevel::ErrorsAndWarnings),
+            cl::values(
+                clEnumValN(VerbosityLevel::ErrorsOnly, "errors", "Errors only"),
+                clEnumValN(VerbosityLevel::ErrorsAndWarnings, "warnings",
+                           "Errors and warnings"),
+                clEnumValN(VerbosityLevel::ErrorsWarningsAndRemarks, "remarks",
+                           "Errors, warnings and remarks")));
+
+    static cl::opt<bool, /*ExternalStorage=*/true> disableDiagnosticNotes(
+        "mlir-disable-diagnostic-notes", cl::desc("Disable diagnostic notes."),
+        cl::location(disableDiagnosticNotesFlag), cl::init(false));
+
     static cl::opt<bool, /*ExternalStorage=*/true> enableDebuggerHook(
         "mlir-enable-debugger-hook",
         cl::desc("Enable Debugger hook for debugging MLIR Actions"),
         cl::location(enableDebuggerActionHookFlag), cl::init(false));
-
-    static cl::opt<bool, /*ExternalStorage=*/true> disableRemarkDiagnostic(
-        "mlir-disable-diagnostic", cl::desc("Disable diagnostic information"),
-        cl::location(disableDiagnosticFlag), cl::init(false));
 
     static cl::opt<bool, /*ExternalStorage=*/true> explicitModule(
         "no-implicit-module",
@@ -137,7 +151,8 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::location(showDialectsFlag), cl::init(false));
 
     static cl::opt<std::string, /*ExternalStorage=*/true> splitInputFile{
-        "split-input-file", llvm::cl::ValueOptional,
+        "split-input-file",
+        llvm::cl::ValueOptional,
         cl::callback([&](const std::string &str) {
           // Implicit value: use default marker if flag was used without value.
           if (str.empty())
@@ -145,7 +160,8 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         }),
         cl::desc("Split the input file into chunks using the given or "
                  "default marker and process each chunk independently"),
-        cl::location(splitInputFileFlag), cl::init("")};
+        cl::location(splitInputFileFlag),
+        cl::init("")};
 
     static cl::opt<std::string, /*ExternalStorage=*/true> outputSplitMarker(
         "output-split-marker",
@@ -205,6 +221,44 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
   /// Pointer to static dialectPlugins variable in constructor, needed by
   /// setDialectPluginsCallback(DialectRegistry&).
   cl::list<std::string> *dialectPlugins = nullptr;
+};
+
+/// A scoped diagnostic handler that suppresses certain diagnostics based on
+/// the verbosity level and whether the diagnostic is a note.
+class DiagnosticFilter : public ScopedDiagnosticHandler {
+public:
+  DiagnosticFilter(MLIRContext *ctx, VerbosityLevel verbosityLevel,
+                   bool showNotes = true)
+      : ScopedDiagnosticHandler(ctx) {
+    setHandler([verbosityLevel, showNotes](Diagnostic &diag) {
+      auto severity = diag.getSeverity();
+      switch (severity) {
+      case DiagnosticSeverity::Error:
+        // failure indicates that the error is not handled by the filter and
+        // goes through to the default handler. Therefore, the error can be
+        // successfully printed.
+        return failure();
+      case DiagnosticSeverity::Warning:
+        if (verbosityLevel == VerbosityLevel::ErrorsOnly)
+          return success();
+        else
+          return failure();
+      case DiagnosticSeverity::Remark:
+        if (verbosityLevel == VerbosityLevel::ErrorsOnly ||
+            verbosityLevel == VerbosityLevel::ErrorsAndWarnings)
+          return success();
+        else
+          return failure();
+      case DiagnosticSeverity::Note:
+        if (showNotes)
+          return failure();
+        else
+          return success();
+      default:
+        llvm_unreachable("Unknown diagnostic severity");
+      }
+    });
+  }
 };
 } // namespace
 
@@ -477,10 +531,10 @@ static LogicalResult processBuffer(raw_ostream &os,
   // If we are in verify diagnostics mode then we have a lot of work to do,
   // otherwise just perform the actions without worrying about it.
   if (!config.shouldVerifyDiagnostics()) {
-    if (config.shouldDisableDiagnostic())
-      return performActions(os, sourceMgr, &context, config);
-
     SourceMgrDiagnosticHandler sourceMgrHandler(*sourceMgr, &context);
+    DiagnosticFilter diagnosticFilter(&context,
+                                      config.getDiagnosticVerbosityLevel(),
+                                      config.shouldShowNotes());
     return performActions(os, sourceMgr, &context, config);
   }
 

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -114,7 +114,7 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
             "mlir-diagnostic-verbosity-level",
             cl::desc("Choose level of diagnostic information"),
             cl::location(diagnosticVerbosityLevelFlag),
-            cl::init(VerbosityLevel::ErrorsAndWarnings),
+            cl::init(VerbosityLevel::ErrorsWarningsAndRemarks),
             cl::values(
                 clEnumValN(VerbosityLevel::ErrorsOnly, "errors", "Errors only"),
                 clEnumValN(VerbosityLevel::ErrorsAndWarnings, "warnings",

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -113,6 +113,10 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::desc("Enable Debugger hook for debugging MLIR Actions"),
         cl::location(enableDebuggerActionHookFlag), cl::init(false));
 
+    static cl::opt<bool, /*ExternalStorage=*/true> disableRemarkDiagnostic(
+        "mlir-disable-diagnostic", cl::desc("Disable diagnostic information"),
+        cl::location(disableDiagnosticFlag), cl::init(false));
+
     static cl::opt<bool, /*ExternalStorage=*/true> explicitModule(
         "no-implicit-module",
         cl::desc("Disable implicit addition of a top-level module op during "
@@ -473,6 +477,9 @@ static LogicalResult processBuffer(raw_ostream &os,
   // If we are in verify diagnostics mode then we have a lot of work to do,
   // otherwise just perform the actions without worrying about it.
   if (!config.shouldVerifyDiagnostics()) {
+    if (config.shouldDisableDiagnostic())
+      return performActions(os, sourceMgr, &context, config);
+
     SourceMgrDiagnosticHandler sourceMgrHandler(*sourceMgr, &context);
     return performActions(os, sourceMgr, &context, config);
   }


### PR DESCRIPTION
This PR adds a command line argument `--mlir-disable-diagnostic` for disabling diagnostic information for mlir-opt. 
When debugging with mlir-opt, some developers would like to disable the diagnostic information and focus specifically on the dumped IR. For example, https://github.com/triton-lang/triton/pull/5250
