### PR TITLE
[X86] Remove restriction to pre-type legalization for combine in `scalarizeExtEltFP`

### DIFF
--- a/llvm/test/CodeGen/X86/extractelement-fp.ll
+++ b/llvm/test/CodeGen/X86/extractelement-fp.ll
@@ -320,10 +320,18 @@ define <3 x double> @extvselectsetcc_crash(<2 x double> %x) {
 ; X64-LABEL: extvselectsetcc_crash:
 ; X64:       # %bb.0:
 ; X64-NEXT:    vcmpeqpd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0, %xmm1
-; X64-NEXT:    vmovsd {{.*#+}} xmm2 = [1.0E+0,0.0E+0]
-; X64-NEXT:    vandpd %xmm2, %xmm1, %xmm1
-; X64-NEXT:    vinsertf128 $1, %xmm0, %ymm1, %ymm0
-; X64-NEXT:    vpermpd {{.*#+}} ymm0 = ymm0[0,2,3,3]
+; X64-NEXT:    vmovq   %xmm1, %rax
+; X64-NEXT:    testq   %rax, %rax
+; X64-NEXT:    jne     .{{\.?LBB[0-9]+_[0-9]+}}
+; X64-NEXT:  # %bb.2:
+; X64-NEXT:    vxorpd  %xmm1, %xmm1, %xmm1
+; X64-NEXT:    jmp     .{{\.?LBB[0-9]+_[0-9]+}}
+; X64-NEXT:  .{{\.?LBB[0-9]+_[0-9]+}}:
+; X64-NEXT:    vmovsd  {{.*#+}} xmm1 = [1.0E+0,0.0E+0]
+; X64-NEXT:  .{{\.?LBB[0-9]+_[0-9]+}}:
+; X64-NEXT:    vshufpd $1, %xmm0, %xmm0, %xmm2 # xmm2 = xmm0[1,0]
+; X64-NEXT:    vunpcklpd       %xmm0, %xmm1, %xmm0 # xmm0 = xmm1[0],xmm0[0]
+; X64-NEXT:    vinsertf128 $1, %xmm2, %ymm0, %ymm0
 ; X64-NEXT:    retq
 ;
 ; X86-LABEL: extvselectsetcc_crash:


### PR DESCRIPTION
Remove the restriction to pre-type legalization from combine since it was already not being enforced for AVX512 where `v8i1` is a legal type but `i1` itself is not.

Closes #117684
