### PR TITLE
[lldb] Remove child_process_inherit from the socket classes

### DIFF
--- a/lldb/include/lldb/Host/Socket.h
+++ b/lldb/include/lldb/Host/Socket.h
@@ -94,7 +94,6 @@ public:
   static void Terminate();
 
   static std::unique_ptr<Socket> Create(const SocketProtocol protocol,
-                                        bool child_processes_inherit,
                                         Status &error);
 
   virtual Status Connect(llvm::StringRef name) = 0;
@@ -115,14 +114,13 @@ public:
   // implemented separately because the caller may wish to manipulate or query
   // the socket after it is initialized, but before entering a blocking accept.
   static llvm::Expected<std::unique_ptr<TCPSocket>>
-  TcpListen(llvm::StringRef host_and_port, bool child_processes_inherit,
-            int backlog = 5);
+  TcpListen(llvm::StringRef host_and_port, int backlog = 5);
 
   static llvm::Expected<std::unique_ptr<Socket>>
-  TcpConnect(llvm::StringRef host_and_port, bool child_processes_inherit);
+  TcpConnect(llvm::StringRef host_and_port);
 
   static llvm::Expected<std::unique_ptr<UDPSocket>>
-  UdpConnect(llvm::StringRef host_and_port, bool child_processes_inherit);
+  UdpConnect(llvm::StringRef host_and_port);
 
   static int GetOption(NativeSocket sockfd, int level, int option_name,
                        int &option_value);
@@ -154,8 +152,7 @@ public:
   virtual std::string GetRemoteConnectionURI() const { return ""; };
 
 protected:
-  Socket(SocketProtocol protocol, bool should_close,
-         bool m_child_process_inherit);
+  Socket(SocketProtocol protocol, bool should_close);
 
   virtual size_t Send(const void *buf, const size_t num_bytes);
 
@@ -163,15 +160,12 @@ protected:
   static Status GetLastError();
   static void SetLastError(Status &error);
   static NativeSocket CreateSocket(const int domain, const int type,
-                                   const int protocol,
-                                   bool child_processes_inherit, Status &error);
+                                   const int protocol, Status &error);
   static NativeSocket AcceptSocket(NativeSocket sockfd, struct sockaddr *addr,
-                                   socklen_t *addrlen,
-                                   bool child_processes_inherit, Status &error);
+                                   socklen_t *addrlen, Status &error);
 
   SocketProtocol m_protocol;
   NativeSocket m_socket;
-  bool m_child_processes_inherit;
   bool m_should_close_fd;
 };
 

--- a/lldb/include/lldb/Host/common/TCPSocket.h
+++ b/lldb/include/lldb/Host/common/TCPSocket.h
@@ -17,9 +17,8 @@
 namespace lldb_private {
 class TCPSocket : public Socket {
 public:
-  TCPSocket(bool should_close, bool child_processes_inherit);
-  TCPSocket(NativeSocket socket, bool should_close,
-            bool child_processes_inherit);
+  explicit TCPSocket(bool should_close);
+  TCPSocket(NativeSocket socket, bool should_close);
   ~TCPSocket() override;
 
   // returns port number or 0 if error

--- a/lldb/include/lldb/Host/common/UDPSocket.h
+++ b/lldb/include/lldb/Host/common/UDPSocket.h
@@ -14,10 +14,10 @@
 namespace lldb_private {
 class UDPSocket : public Socket {
 public:
-  UDPSocket(bool should_close, bool child_processes_inherit);
+  explicit UDPSocket(bool should_close);
 
   static llvm::Expected<std::unique_ptr<UDPSocket>>
-  Connect(llvm::StringRef name, bool child_processes_inherit);
+  CreateConnected(llvm::StringRef name);
 
   std::string GetRemoteConnectionURI() const override;
 

--- a/lldb/include/lldb/Host/linux/AbstractSocket.h
+++ b/lldb/include/lldb/Host/linux/AbstractSocket.h
@@ -14,7 +14,7 @@
 namespace lldb_private {
 class AbstractSocket : public DomainSocket {
 public:
-  AbstractSocket(bool child_processes_inherit);
+  AbstractSocket();
 
 protected:
   size_t GetNameOffset() const override;

--- a/lldb/include/lldb/Host/posix/DomainSocket.h
+++ b/lldb/include/lldb/Host/posix/DomainSocket.h
@@ -14,9 +14,8 @@
 namespace lldb_private {
 class DomainSocket : public Socket {
 public:
-  DomainSocket(NativeSocket socket, bool should_close,
-               bool child_processes_inherit);
-  DomainSocket(bool should_close, bool child_processes_inherit);
+  DomainSocket(NativeSocket socket, bool should_close);
+  explicit DomainSocket(bool should_close);
 
   Status Connect(llvm::StringRef name) override;
   Status Listen(llvm::StringRef name, int backlog) override;
@@ -29,7 +28,7 @@ public:
   std::string GetRemoteConnectionURI() const override;
 
 protected:
-  DomainSocket(SocketProtocol protocol, bool child_processes_inherit);
+  DomainSocket(SocketProtocol protocol);
 
   virtual size_t GetNameOffset() const;
   virtual void DeleteSocketFile(llvm::StringRef name);

--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -180,12 +180,9 @@ bool Socket::FindProtocolByScheme(const char *scheme,
   return false;
 }
 
-Socket::Socket(SocketProtocol protocol, bool should_close,
-               bool child_processes_inherit)
+Socket::Socket(SocketProtocol protocol, bool should_close)
     : IOObject(eFDTypeSocket), m_protocol(protocol),
-      m_socket(kInvalidSocketValue),
-      m_child_processes_inherit(child_processes_inherit),
-      m_should_close_fd(should_close) {}
+      m_socket(kInvalidSocketValue), m_should_close_fd(should_close) {}
 
 Socket::~Socket() { Close(); }
 
@@ -214,24 +211,21 @@ void Socket::Terminate() {
 }
 
 std::unique_ptr<Socket> Socket::Create(const SocketProtocol protocol,
-                                       bool child_processes_inherit,
                                        Status &error) {
   error.Clear();
 
+  const bool should_close = true;
   std::unique_ptr<Socket> socket_up;
   switch (protocol) {
   case ProtocolTcp:
-    socket_up =
-        std::make_unique<TCPSocket>(true, child_processes_inherit);
+    socket_up = std::make_unique<TCPSocket>(should_close);
     break;
   case ProtocolUdp:
-    socket_up =
-        std::make_unique<UDPSocket>(true, child_processes_inherit);
+    socket_up = std::make_unique<UDPSocket>(should_close);
     break;
   case ProtocolUnixDomain:
 #if LLDB_ENABLE_POSIX
-    socket_up =
-        std::make_unique<DomainSocket>(true, child_processes_inherit);
+    socket_up = std::make_unique<DomainSocket>(should_close);
 #else
     error = Status::FromErrorString(
         "Unix domain sockets are not supported on this platform.");
@@ -239,8 +233,7 @@ std::unique_ptr<Socket> Socket::Create(const SocketProtocol protocol,
     break;
   case ProtocolUnixAbstract:
 #ifdef __linux__
-    socket_up =
-        std::make_unique<AbstractSocket>(child_processes_inherit);
+    socket_up = std::make_unique<AbstractSocket>();
 #else
     error = Status::FromErrorString(
         "Abstract domain sockets are not supported on this platform.");
@@ -255,14 +248,12 @@ std::unique_ptr<Socket> Socket::Create(const SocketProtocol protocol,
 }
 
 llvm::Expected<std::unique_ptr<Socket>>
-Socket::TcpConnect(llvm::StringRef host_and_port,
-                   bool child_processes_inherit) {
+Socket::TcpConnect(llvm::StringRef host_and_port) {
   Log *log = GetLog(LLDBLog::Connection);
   LLDB_LOG(log, "host_and_port = {0}", host_and_port);
 
   Status error;
-  std::unique_ptr<Socket> connect_socket(
-      Create(ProtocolTcp, child_processes_inherit, error));
+  std::unique_ptr<Socket> connect_socket = Create(ProtocolTcp, error);
   if (error.Fail())
     return error.ToError();
 
@@ -274,13 +265,12 @@ Socket::TcpConnect(llvm::StringRef host_and_port,
 }
 
 llvm::Expected<std::unique_ptr<TCPSocket>>
-Socket::TcpListen(llvm::StringRef host_and_port, bool child_processes_inherit,
-                  int backlog) {
+Socket::TcpListen(llvm::StringRef host_and_port, int backlog) {
   Log *log = GetLog(LLDBLog::Connection);
   LLDB_LOG(log, "host_and_port = {0}", host_and_port);
 
   std::unique_ptr<TCPSocket> listen_socket(
-      new TCPSocket(true, child_processes_inherit));
+      new TCPSocket(/*should_close=*/true));
 
   Status error = listen_socket->Listen(host_and_port, backlog);
   if (error.Fail())
@@ -290,9 +280,8 @@ Socket::TcpListen(llvm::StringRef host_and_port, bool child_processes_inherit,
 }
 
 llvm::Expected<std::unique_ptr<UDPSocket>>
-Socket::UdpConnect(llvm::StringRef host_and_port,
-                   bool child_processes_inherit) {
-  return UDPSocket::Connect(host_and_port, child_processes_inherit);
+Socket::UdpConnect(llvm::StringRef host_and_port) {
+  return UDPSocket::CreateConnected(host_and_port);
 }
 
 llvm::Expected<Socket::HostAndPort> Socket::DecodeHostAndPort(llvm::StringRef host_and_port) {
@@ -445,13 +434,11 @@ int Socket::CloseSocket(NativeSocket sockfd) {
 }
 
 NativeSocket Socket::CreateSocket(const int domain, const int type,
-                                  const int protocol,
-                                  bool child_processes_inherit, Status &error) {
+                                  const int protocol, Status &error) {
   error.Clear();
   auto socket_type = type;
 #ifdef SOCK_CLOEXEC
-  if (!child_processes_inherit)
-    socket_type |= SOCK_CLOEXEC;
+  socket_type |= SOCK_CLOEXEC;
 #endif
   auto sock = ::socket(domain, socket_type, protocol);
   if (sock == kInvalidSocketValue)
@@ -483,8 +470,7 @@ Status Socket::Accept(const Timeout<std::micro> &timeout, Socket *&socket) {
 }
 
 NativeSocket Socket::AcceptSocket(NativeSocket sockfd, struct sockaddr *addr,
-                                  socklen_t *addrlen,
-                                  bool child_processes_inherit, Status &error) {
+                                  socklen_t *addrlen, Status &error) {
   error.Clear();
 #if defined(ANDROID_USE_ACCEPT_WORKAROUND)
   // Hack:
@@ -494,7 +480,7 @@ NativeSocket Socket::AcceptSocket(NativeSocket sockfd, struct sockaddr *addr,
   // available in older kernels. Using an older libc would fix this issue, but
   // introduce other ones, as the old libraries were quite buggy.
   int fd = syscall(__NR_accept, sockfd, addr, addrlen);
-  if (fd >= 0 && !child_processes_inherit) {
+  if (fd >= 0) {
     int flags = ::fcntl(fd, F_GETFD);
     if (flags != -1 && ::fcntl(fd, F_SETFD, flags | FD_CLOEXEC) != -1)
       return fd;
@@ -503,10 +489,7 @@ NativeSocket Socket::AcceptSocket(NativeSocket sockfd, struct sockaddr *addr,
   }
   return fd;
 #elif defined(SOCK_CLOEXEC) && defined(HAVE_ACCEPT4)
-  int flags = 0;
-  if (!child_processes_inherit) {
-    flags |= SOCK_CLOEXEC;
-  }
+  int flags = SOCK_CLOEXEC;
   NativeSocket fd = llvm::sys::RetryAfterSignal(
       static_cast<NativeSocket>(-1), ::accept4, sockfd, addr, addrlen, flags);
 #else

--- a/lldb/source/Host/linux/AbstractSocket.cpp
+++ b/lldb/source/Host/linux/AbstractSocket.cpp
@@ -13,8 +13,7 @@
 using namespace lldb;
 using namespace lldb_private;
 
-AbstractSocket::AbstractSocket(bool child_processes_inherit)
-    : DomainSocket(ProtocolUnixAbstract, child_processes_inherit) {}
+AbstractSocket::AbstractSocket() : DomainSocket(ProtocolUnixAbstract) {}
 
 size_t AbstractSocket::GetNameOffset() const { return 1; }
 

--- a/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
+++ b/lldb/source/Host/posix/ConnectionFileDescriptorPosix.cpp
@@ -535,7 +535,7 @@ lldb::ConnectionStatus ConnectionFileDescriptor::AcceptSocket(
     Status *error_ptr) {
   Status error;
   std::unique_ptr<Socket> listening_socket =
-      Socket::Create(socket_protocol, /*child_processes_inherit=*/false, error);
+      Socket::Create(socket_protocol, error);
   Socket *accepted_socket;
 
   if (!error.Fail())
@@ -562,8 +562,7 @@ ConnectionFileDescriptor::ConnectSocket(Socket::SocketProtocol socket_protocol,
                                         llvm::StringRef socket_name,
                                         Status *error_ptr) {
   Status error;
-  std::unique_ptr<Socket> socket =
-      Socket::Create(socket_protocol, /*child_processes_inherit=*/false, error);
+  std::unique_ptr<Socket> socket = Socket::Create(socket_protocol, error);
 
   if (!error.Fail())
     error = socket->Connect(socket_name);
@@ -644,8 +643,7 @@ ConnectionFileDescriptor::ConnectUDP(llvm::StringRef s,
                                      Status *error_ptr) {
   if (error_ptr)
     *error_ptr = Status();
-  llvm::Expected<std::unique_ptr<UDPSocket>> socket =
-      Socket::UdpConnect(s, /*child_processes_inherit=*/false);
+  llvm::Expected<std::unique_ptr<UDPSocket>> socket = Socket::UdpConnect(s);
   if (!socket) {
     if (error_ptr)
       *error_ptr = Status::FromError(socket.takeError());
@@ -690,7 +688,7 @@ ConnectionFileDescriptor::ConnectFD(llvm::StringRef s,
       // this. For now, we assume we must assume we don't own it.
 
       std::unique_ptr<TCPSocket> tcp_socket;
-      tcp_socket = std::make_unique<TCPSocket>(fd, false, false);
+      tcp_socket = std::make_unique<TCPSocket>(fd, /*should_close=*/false);
       // Try and get a socket option from this file descriptor to see if
       // this is a socket and set m_is_socket accordingly.
       int resuse;

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1216,9 +1216,8 @@ void GDBRemoteCommunication::DumpHistory(Stream &strm) { m_history.Dump(strm); }
 llvm::Error
 GDBRemoteCommunication::ConnectLocally(GDBRemoteCommunication &client,
                                        GDBRemoteCommunication &server) {
-  const bool child_processes_inherit = false;
   const int backlog = 5;
-  TCPSocket listen_socket(true, child_processes_inherit);
+  TCPSocket listen_socket(true);
   if (llvm::Error error =
           listen_socket.Listen("localhost:0", backlog).ToError())
     return error;

--- a/lldb/tools/lldb-server/lldb-platform.cpp
+++ b/lldb/tools/lldb-server/lldb-platform.cpp
@@ -181,8 +181,7 @@ static Status ListenGdbConnectionsIfNeeded(
   if (protocol != Socket::ProtocolTcp)
     return Status();
 
-  gdb_sock = std::make_unique<TCPSocket>(
-      /*should_close=*/true, /*child_processes_inherit=*/false);
+  gdb_sock = std::make_unique<TCPSocket>(/*should_close=*/true);
   Status error = gdb_sock->Listen(gdb_address, backlog);
   if (error.Fail())
     return error;
@@ -474,12 +473,10 @@ int main_platform(int argc, char *argv[]) {
     GDBRemoteCommunicationServerPlatform platform(protocol, gdbserver_port);
     Socket *socket;
     if (protocol == Socket::ProtocolTcp)
-      socket = new TCPSocket(sockfd, /*should_close=*/true,
-                             /*child_processes_inherit=*/false);
+      socket = new TCPSocket(sockfd, /*should_close=*/true);
     else {
 #if LLDB_ENABLE_POSIX
-      socket = new DomainSocket(sockfd, /*should_close=*/true,
-                                /*child_processes_inherit=*/false);
+      socket = new DomainSocket(sockfd, /*should_close=*/true);
 #else
       WithColor::error() << "lldb-platform child: Unix domain sockets are not "
                             "supported on this platform.";
@@ -510,8 +507,7 @@ int main_platform(int argc, char *argv[]) {
     return socket_error;
   }
 
-  std::unique_ptr<Socket> platform_sock =
-      Socket::Create(protocol, /*child_processes_inherit=*/false, error);
+  std::unique_ptr<Socket> platform_sock = Socket::Create(protocol, error);
   if (error.Fail()) {
     printf("Failed to create platform socket: %s\n", error.AsCString());
     return socket_error;

--- a/lldb/unittests/Host/MainLoopTest.cpp
+++ b/lldb/unittests/Host/MainLoopTest.cpp
@@ -27,17 +27,14 @@ public:
   SubsystemRAII<FileSystem, Socket> subsystems;
 
   void SetUp() override {
-    bool child_processes_inherit = false;
     Status error;
-    std::unique_ptr<TCPSocket> listen_socket_up(
-        new TCPSocket(true, child_processes_inherit));
+    auto listen_socket_up = std::make_unique<TCPSocket>(true);
     ASSERT_TRUE(error.Success());
     error = listen_socket_up->Listen("localhost:0", 5);
     ASSERT_TRUE(error.Success());
 
     Socket *accept_socket;
-    std::unique_ptr<TCPSocket> connect_socket_up(
-        new TCPSocket(true, child_processes_inherit));
+    auto connect_socket_up = std::make_unique<TCPSocket>(true);
     error = connect_socket_up->Connect(
         llvm::formatv("localhost:{0}", listen_socket_up->GetLocalPortNumber())
             .str());

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -100,7 +100,7 @@ TEST_P(SocketTest, DomainMainLoopAccept) {
     return;
 
   auto listen_socket_up = std::make_unique<DomainSocket>(
-      /*should_close=*/true, /*child_process_inherit=*/false);
+      /*should_close=*/true);
   Status error = listen_socket_up->Listen(Path, 5);
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
   ASSERT_TRUE(listen_socket_up->IsValid());
@@ -115,7 +115,7 @@ TEST_P(SocketTest, DomainMainLoopAccept) {
   ASSERT_THAT_EXPECTED(expected_handles, llvm::Succeeded());
 
   auto connect_socket_up = std::make_unique<DomainSocket>(
-      /*should_close=*/true, /*child_process_inherit=*/false);
+      /*should_close=*/true);
   ASSERT_THAT_ERROR(connect_socket_up->Connect(Path).ToError(),
                     llvm::Succeeded());
   ASSERT_TRUE(connect_socket_up->IsValid());
@@ -160,9 +160,7 @@ TEST_P(SocketTest, TCPMainLoopAccept) {
   if (!HostSupportsProtocol())
     return;
 
-  const bool child_processes_inherit = false;
-  auto listen_socket_up =
-      std::make_unique<TCPSocket>(true, child_processes_inherit);
+  auto listen_socket_up = std::make_unique<TCPSocket>(true);
   Status error = listen_socket_up->Listen(
       llvm::formatv("[{0}]:0", GetParam().localhost_ip).str(), 5);
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
@@ -177,8 +175,7 @@ TEST_P(SocketTest, TCPMainLoopAccept) {
       });
   ASSERT_THAT_EXPECTED(expected_handles, llvm::Succeeded());
 
-  std::unique_ptr<TCPSocket> connect_socket_up(
-      new TCPSocket(true, child_processes_inherit));
+  auto connect_socket_up = std::make_unique<TCPSocket>(true);
   ASSERT_THAT_ERROR(
       connect_socket_up
           ->Connect(llvm::formatv("[{0}]:{1}", GetParam().localhost_ip,
@@ -218,7 +215,7 @@ TEST_P(SocketTest, UDPConnect) {
   if (!HostSupportsIPv4())
     return;
   llvm::Expected<std::unique_ptr<UDPSocket>> socket =
-      UDPSocket::Connect("127.0.0.1:0", /*child_processes_inherit=*/false);
+      UDPSocket::CreateConnected("127.0.0.1:0");
 
   ASSERT_THAT_EXPECTED(socket, llvm::Succeeded());
   EXPECT_TRUE(socket.get()->IsValid());
@@ -253,7 +250,7 @@ TEST_P(SocketTest, UDPGetConnectURI) {
   if (!HostSupportsIPv4())
     return;
   llvm::Expected<std::unique_ptr<UDPSocket>> socket =
-      UDPSocket::Connect("127.0.0.1:0", /*child_processes_inherit=*/false);
+      UDPSocket::CreateConnected("127.0.0.1:0");
   ASSERT_THAT_EXPECTED(socket, llvm::Succeeded());
 
   std::string uri = socket.get()->GetRemoteConnectionURI();

--- a/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
+++ b/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
@@ -24,18 +24,15 @@ void lldb_private::CreateConnectedSockets(
     llvm::StringRef listen_remote_address,
     const std::function<std::string(const SocketType &)> &get_connect_addr,
     std::unique_ptr<SocketType> *a_up, std::unique_ptr<SocketType> *b_up) {
-  bool child_processes_inherit = false;
   Status error;
-  std::unique_ptr<SocketType> listen_socket_up(
-      new SocketType(true, child_processes_inherit));
+  auto listen_socket_up = std::make_unique<SocketType>(true);
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
   error = listen_socket_up->Listen(listen_remote_address, 5);
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
   ASSERT_TRUE(listen_socket_up->IsValid());
 
   std::string connect_remote_address = get_connect_addr(*listen_socket_up);
-  std::unique_ptr<SocketType> connect_socket_up(
-      new SocketType(true, child_processes_inherit));
+  auto connect_socket_up = std::make_unique<SocketType>(true);
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
   error = connect_socket_up->Connect(connect_remote_address);
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
@@ -85,8 +82,7 @@ void lldb_private::CreateDomainConnectedSockets(
 #endif
 
 static bool CheckIPSupport(llvm::StringRef Proto, llvm::StringRef Addr) {
-  llvm::Expected<std::unique_ptr<TCPSocket>> Sock = Socket::TcpListen(
-      Addr, /*child_processes_inherit=*/false);
+  llvm::Expected<std::unique_ptr<TCPSocket>> Sock = Socket::TcpListen(Addr);
   if (Sock)
     return true;
   llvm::Error Err = Sock.takeError();

--- a/lldb/unittests/debugserver/RNBSocketTest.cpp
+++ b/lldb/unittests/debugserver/RNBSocketTest.cpp
@@ -29,7 +29,7 @@ static void ServerCallbackv4(const void *baton, in_port_t port) {
     char addr_buffer[256];
     sprintf(addr_buffer, "%s:%d", (const char *)baton, port);
     llvm::Expected<std::unique_ptr<Socket>> socket_or_err =
-        Socket::TcpConnect(addr_buffer, false);
+        Socket::TcpConnect(addr_buffer);
     ASSERT_THAT_EXPECTED(socket_or_err, llvm::Succeeded());
     Socket *client_socket = socket_or_err->get();
 

--- a/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/TestClient.cpp
@@ -87,7 +87,7 @@ TestClient::launchCustom(StringRef Log, bool disable_stdio,
   const std::string &LocalhostIP = *LocalhostIPOrErr;
 
   Status status;
-  TCPSocket listen_socket(true, false);
+  TCPSocket listen_socket(true);
   status = listen_socket.Listen(LocalhostIP + ":0", 5);
   if (status.Fail())
     return status.ToError();


### PR DESCRIPTION
It's never set to true. Also, using inheritable FDs in a multithreaded process pretty much guarantees descriptor leaks. It's better to explicitly pass a specific FD to a specific subprocess, which we already mostly can do using the ProcessLaunchInfo FileActions.