### PR TITLE
[NFC][flang] Fix execute_command_line test for odd environments

### DIFF
--- a/flang/unittests/Runtime/CMakeLists.txt
+++ b/flang/unittests/Runtime/CMakeLists.txt
@@ -36,6 +36,6 @@ target_link_libraries(FlangRuntimeTests
   FortranRuntime
 )
 
-target_compile_definitions(FlangRuntimeTests PRIVATE LLVM_TOOLS_BINARY_DIR="${LLVM_TOOLS_BINARY_DIR}")
+target_compile_definitions(FlangRuntimeTests PRIVATE NOT_EXE="$<TARGET_FILE:not>")
 
 add_subdirectory(CUDA)

--- a/flang/unittests/Runtime/CMakeLists.txt
+++ b/flang/unittests/Runtime/CMakeLists.txt
@@ -36,4 +36,6 @@ target_link_libraries(FlangRuntimeTests
   FortranRuntime
 )
 
+target_compile_definitions(FlangRuntimeTests PRIVATE LLVM_TOOLS_BINARY_DIR="${LLVM_TOOLS_BINARY_DIR}")
+
 add_subdirectory(CUDA)

--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -13,7 +13,6 @@
 #include "flang/Runtime/execute.h"
 #include "flang/Runtime/extensions.h"
 #include "flang/Runtime/main.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include <cstddef>
 #include <cstdlib>

--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -343,9 +343,8 @@ TEST_F(ZeroArguments, ECLValidCommandStatusSetSync) {
 
 TEST_F(ZeroArguments, ECLGeneralErrorCommandErrorSync) {
   llvm::SmallString<64> cmd;
-  if (std::error_code ec = llvm::sys::fs::current_path(cmd))
-    FAIL() << "Failed to obtain the current working directory";
-  llvm::sys::path::append(cmd, "bin", "not");
+  llvm::sys::path::native(LLVM_TOOLS_BINARY_DIR, cmd);
+  llvm::sys::path::append(cmd, "not");
   OwningPtr<Descriptor> command{CharDescriptor(cmd.data())};
   bool wait{true};
   OwningPtr<Descriptor> exitStat{IntDescriptor(404)};

--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -13,7 +13,6 @@
 #include "flang/Runtime/execute.h"
 #include "flang/Runtime/extensions.h"
 #include "flang/Runtime/main.h"
-#include "llvm/Support/Path.h"
 #include <cstddef>
 #include <cstdlib>
 
@@ -341,10 +340,7 @@ TEST_F(ZeroArguments, ECLValidCommandStatusSetSync) {
 }
 
 TEST_F(ZeroArguments, ECLGeneralErrorCommandErrorSync) {
-  llvm::SmallString<64> cmd;
-  llvm::sys::path::native(LLVM_TOOLS_BINARY_DIR, cmd);
-  llvm::sys::path::append(cmd, "not");
-  OwningPtr<Descriptor> command{CharDescriptor(cmd.data())};
+  OwningPtr<Descriptor> command{CharDescriptor(NOT_EXE)};
   bool wait{true};
   OwningPtr<Descriptor> exitStat{IntDescriptor(404)};
   OwningPtr<Descriptor> cmdStat{IntDescriptor(202)};


### PR DESCRIPTION
One of the execute_command_line tests currently runs `cat` on an invalid file and checks its return value, but since we don't control `cat` or the user's path, the return value might not be reliably stable on a per-platform basis. For example, if `git` is installed on Windows in certain configurations it adds a directory to the path containing a `cat` with a different set of error codes to the default Windows one.

This patch changes the test to use the `not` binary built by LLVM for testing purposes, which should always return 1 on any platform regardless of the user's environment.