### PR TITLE
Fix capacity increase issue with `shrink_to_fit` for `__split_buffer`

### DIFF
--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -410,12 +410,14 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::shrink_to_fi
     try {
 #endif // _LIBCPP_HAS_EXCEPTIONS
       __split_buffer<value_type, __alloc_rr&> __t(size(), 0, __alloc_);
-      __t.__construct_at_end(move_iterator<pointer>(__begin_), move_iterator<pointer>(__end_));
-      __t.__end_ = __t.__begin_ + (__end_ - __begin_);
-      std::swap(__first_, __t.__first_);
-      std::swap(__begin_, __t.__begin_);
-      std::swap(__end_, __t.__end_);
-      std::swap(__cap_, __t.__cap_);
+      if (__t.capacity() < capacity()) {
+        __t.__construct_at_end(move_iterator<pointer>(__begin_), move_iterator<pointer>(__end_));
+        __t.__end_ = __t.__begin_ + (__end_ - __begin_);
+        std::swap(__first_, __t.__first_);
+        std::swap(__begin_, __t.__begin_);
+        std::swap(__end_, __t.__end_);
+        std::swap(__cap_, __t.__cap_);
+      }
 #if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
     }


### PR DESCRIPTION
This PR fixes the issue where `__split_buffer::shrink_to_fit` may unexpectedly increase the capacity, similar to the issue for `std::vector` in #97895. A [demo](https://godbolt.org/z/reEEGMnz4) to reproduce this problem is available. The fix follows the same approach used in #97895 for `std::vector`.

Note: An alternative approach would be simply remove this function. However, the current fix is as simple as removing it. 