### PR TITLE
[llvm-objcopy] Always update indirectsymoff in MachO

### DIFF
--- a/llvm/lib/ObjCopy/MachO/MachOLayoutBuilder.cpp
+++ b/llvm/lib/ObjCopy/MachO/MachOLayoutBuilder.cpp
@@ -360,13 +360,10 @@ Error MachOLayoutBuilder::layoutTail(uint64_t Offset) {
           MLC.dysymtab_command_data.nextrel != 0)
         return createStringError(llvm::errc::not_supported,
                                  "shared library is not yet supported");
-
-      if (!O.IndirectSymTable.Symbols.empty()) {
-        MLC.dysymtab_command_data.indirectsymoff = StartOfIndirectSymbols;
-        MLC.dysymtab_command_data.nindirectsyms =
-            O.IndirectSymTable.Symbols.size();
-      }
-
+      MLC.dysymtab_command_data.indirectsymoff =
+          O.IndirectSymTable.Symbols.size() ? StartOfIndirectSymbols : 0;
+      MLC.dysymtab_command_data.nindirectsyms =
+          O.IndirectSymTable.Symbols.size();
       updateDySymTab(MLC);
       break;
     }

--- a/llvm/test/tools/llvm-objcopy/MachO/dysymtab-zero-indirectsym.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/dysymtab-zero-indirectsym.test
@@ -1,0 +1,48 @@
+## Show that llvm-strip correctly zeroes out indirectsymoff and indirectsyms
+## in LC_DYSYMTAB if there are no symbols
+#
+# RUN: yaml2obj %s -o %t
+# RUN: llvm-strip --strip-all %t -o %t.stripped
+# RUN: obj2yaml %t.stripped | FileCheck %s
+
+# CHECK: indirectsymoff: 0
+# CHECK-NEXT: nindirectsyms: 0
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x01000007
+  cpusubtype:      0x80000003
+  filetype:        0x00000002
+  ncmds:           2
+  sizeofcmds:      104
+  flags:           0x00200085
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          0
+    nsyms:           0
+    stroff:          0
+    strsize:         0
+  - cmd:             LC_DYSYMTAB
+    cmdsize:         80
+    ilocalsym:       0
+    nlocalsym:       0
+    iextdefsym:      0
+    nextdefsym:      0
+    iundefsym:       0
+    nundefsym:       0
+    tocoff:          0
+    ntoc:            0
+    modtaboff:       0
+    nmodtab:         0
+    extrefsymoff:    0
+    nextrefsyms:     0
+    indirectsymoff:  42
+    nindirectsyms:   0
+    extreloff:       0
+    nextrel:         0
+    locreloff:       0
+    nlocrel:         0
+...


### PR DESCRIPTION
Let's say we've run llvm-strip over some MachO. The resulting MachO became smaller and there are no indirect symbols anymore.

Then according to previous code we would not update indirectsymoff field. This would lead to `MachOWriter::totalSize()` report size that is larger than the new MachO. As a result we would get MachO that has zero bytes past contents of the very last load command.

Codesign has a strict check that size of MachO file must be equal to

    lastLoadCommand.offset + lastLoadCommand.size

If this is not satisfied codesign reports the following error

    main executable failed strict validation

Fixes #117723