### PR TITLE
Revert "[Clang] Fix name lookup for dependent bases (#114978)"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -279,9 +279,6 @@ Resolutions to C++ Defect Reports
   by default.
   (`CWG2521: User-defined literals and reserved identifiers <https://cplusplus.github.io/CWG/issues/2521.html>`_).
 
-- Fix name lookup for a dependent base class that is the current instantiation.  
-  (`CWG591: When a dependent base class is the current instantiation <https://cplusplus.github.io/CWG/issues/591.html>`_).
-
 C Language Changes
 ------------------
 

--- a/clang/test/CXX/drs/cwg5xx.cpp
+++ b/clang/test/CXX/drs/cwg5xx.cpp
@@ -1178,61 +1178,17 @@ namespace cwg590 { // cwg590: yes
   template<typename T> typename A<T>::B::C A<T>::B::C::f(A<T>::B::C) {}
 }
 
-namespace cwg591 { // cwg591: yes
+namespace cwg591 { // cwg591: no
   template<typename T> struct A {
     typedef int M;
     struct B {
       typedef void M;
       struct C;
-      struct D;
-    };
-  };
-
-  template<typename T> struct G {
-    struct B {
-      typedef int M;
-      struct C {
-        typedef void M;
-        struct D;
-      };
-    };
-  };
-
-  template<typename T> struct H {
-    template<typename U> struct B {
-      typedef int M;
-      template<typename F> struct C {
-        typedef void M;
-        struct D;
-        struct P;
-      };
     };
   };
 
   template<typename T> struct A<T>::B::C : A<T> {
-    M m;
-  };
-
-  template<typename T> struct G<T>::B::C::D : B {
-    M m;
-  };
-
-  template<typename T>
-  template<typename U>
-  template<typename F>
-  struct H<T>::B<U>::C<F>::D : B<U> {
-    M m;
-  };
-
-  template<typename T> struct A<T>::B::D : A<T*> {
-    M m;
-    // expected-error@-1 {{field has incomplete type 'M' (aka 'void'}}
-  };
-
-  template<typename T>
-  template<typename U>
-  template<typename F>
-  struct H<T>::B<U>::C<F>::P : B<F> {
+    // FIXME: Should find member of non-dependent base class A<T>.
     M m;
     // expected-error@-1 {{field has incomplete type 'M' (aka 'void'}}
   };

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -3599,7 +3599,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/591.html">591</a></td>
     <td>CD4</td>
     <td>When a dependent base class is the current instantiation</td>
-    <td class="none" align="center">Yes</td>
+    <td class="none" align="center">No</td>
   </tr>
   <tr id="592">
     <td><a href="https://cplusplus.github.io/CWG/issues/592.html">592</a></td>


### PR DESCRIPTION
This reverts commit 486644723038555a224fd09d462bb5099e64809e as requested by the commit author.

Buildbots fail:
* https://lab.llvm.org/buildbot/#/builders/164/builds/4945
* https://lab.llvm.org/buildbot/#/builders/52/builds/4021