### PR TITLE
[clang-format] fix: add missing `default_extensions` values to `git-clang-format`

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -94,11 +94,13 @@ def main():
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java
-      'js',  # JavaScript
+      'mjs', 'js',  # JavaScript
       'ts',  # TypeScript
       'cs',  # C Sharp
       'json',  # Json
-      'sv', 'svh', 'v', 'vh', # Verilog
+      'sv', 'svh', 'v', 'vh',  # Verilog
+      'td',  # TableGen
+      'txtpb', 'textpb', 'pb.txt', 'textproto', 'asciipb',  # TextProto
       ])
 
   p = argparse.ArgumentParser(


### PR DESCRIPTION
Hello,

Although the properties listed in the code below are used as supported file extensions, some of these extensions do not exist in `git-clang-format` as `default_extensions`. This causes inconsistency when using `git-clang-format` with `clang-format`.

Therefore, I added the missing supported default extensions to `git-clang-format`.

https://github.com/llvm/llvm-project/blob/b214ca82daeece1568268ebc0fbcc2eaa649425b/clang/tools/clang-format/ClangFormat.cpp#L87-L96