### PR TITLE
[clang-tidy] fix false positive in bugprone-return-const-ref-from-parameter

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ReturnConstRefFromParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ReturnConstRefFromParameterCheck.cpp
@@ -21,11 +21,13 @@ void ReturnConstRefFromParameterCheck::registerMatchers(MatchFinder *Finder) {
           to(parmVarDecl(hasType(hasCanonicalType(
                              qualType(lValueReferenceType(pointee(
                                           qualType(isConstQualified()))))
-                                 .bind("type"))))
+                                 .bind("type"))),
+                         hasDeclContext(functionDecl().bind("owner")))
                  .bind("param")))
           .bind("dref"));
   const auto Func =
-      functionDecl(hasReturnTypeLoc(loc(
+      functionDecl(equalsBoundNode("owner"),
+                   hasReturnTypeLoc(loc(
                        qualType(hasCanonicalType(equalsBoundNode("type"))))))
           .bind("func");
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -179,7 +179,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-return-const-ref-from-parameter
   <clang-tidy/checks/bugprone/return-const-ref-from-parameter>` check to
   diagnose potential dangling references when returning a ``const &`` parameter
-  by using the conditional operator ``cond ? var1 : var2``.
+  by using the conditional operator ``cond ? var1 : var2`` and no longer giving
+  false positives for functions which contain lambda.
   
 - Improved :doc:`bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/sizeof-expression>` check to find suspicious

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/return-const-ref-from-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/return-const-ref-from-parameter.cpp
@@ -76,6 +76,9 @@ struct C {
 // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: returning a constant reference parameter
 };
 
+const auto Lf1 = [](const T& t) -> const T& { return t; };
+// CHECK-MESSAGES: :[[@LINE-1]]:54: warning: returning a constant reference parameter
+
 } // namespace invalid
 
 namespace false_negative_because_dependent_and_not_instantiated {
@@ -150,6 +153,14 @@ void instantiate(const int &param, const float &paramf, int &mut_param, float &m
         itf6(mut_param);
         itf6(mut_paramf);
 }
+
+template<class T>
+void f(const T& t) {
+    const auto get = [&t] -> const T& { return t; };
+    return T{};
+}
+
+const auto Lf1 = [](T& t) -> const T& { return t; };
 
 } // namespace valid
 


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/issues/115743