### PR TITLE
[lldb] Fix premature MainLoop wakeup on windows

### DIFF
--- a/lldb/source/Host/windows/MainLoopWindows.cpp
+++ b/lldb/source/Host/windows/MainLoopWindows.cpp
@@ -28,7 +28,7 @@ static DWORD ToTimeout(std::optional<MainLoopWindows::TimePoint> point) {
     return WSA_INFINITE;
 
   nanoseconds dur = (std::max)(*point - steady_clock::now(), nanoseconds(0));
-  return duration_cast<milliseconds>(dur).count();
+  return ceil<milliseconds>(dur).count();
 }
 
 MainLoopWindows::MainLoopWindows() {


### PR DESCRIPTION
The windows system APIs only take milliseconds. Make sure we round the sleep interval (in nanoseconds) upwards.