### PR TITLE
[sanitizer] Use /tmp/ not /tmp/dir/ in tests

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp
@@ -345,8 +345,7 @@ TEST(SanitizerCommon, ReportFile) {
   SpinMutex report_file_mu;
   ReportFile report_file = {&report_file_mu, kStderrFd, "", "", 0};
   char tmpfile[128];
-  temp_file_name(tmpfile, sizeof(tmpfile),
-                 "sanitizer_common.reportfile.tmp.");
+  temp_file_name(tmpfile, sizeof(tmpfile), "sanitizer_common.reportfile.tmp.");
   report_file.SetReportPath(tmpfile);
   const char *path = report_file.GetReportPath();
   EXPECT_EQ(internal_strncmp(tmpfile, path, strlen(tmpfile)), 0);

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp
@@ -346,7 +346,7 @@ TEST(SanitizerCommon, ReportFile) {
   ReportFile report_file = {&report_file_mu, kStderrFd, "", "", 0};
   char tmpfile[128];
   temp_file_name(tmpfile, sizeof(tmpfile),
-                 "dir/sanitizer_common.reportfile.tmp.");
+                 "sanitizer_common.reportfile.tmp.");
   report_file.SetReportPath(tmpfile);
   const char *path = report_file.GetReportPath();
   EXPECT_EQ(internal_strncmp(tmpfile, path, strlen(tmpfile)), 0);


### PR DESCRIPTION
Tests fail if the user doesn't own /tmp/dir/.  On hosts with multiple users running the test suite, who owns /tmp/dir/ can become a race.