### PR TITLE
[CMake] Simplify building of bolt-optimized clang for distribution builds

### DIFF
--- a/llvm/cmake/modules/LLVMDistributionSupport.cmake
+++ b/llvm/cmake/modules/LLVMDistributionSupport.cmake
@@ -280,6 +280,8 @@ function(llvm_distribution_add_targets)
 	# bolt optimized clang is built with the rest of the distribution.
 	if (target STREQUAL "clang" AND TARGET clang-bolt)
 	  add_dependencies(${distribution_target} clang-bolt)
+	  add_dependencies(install-${distribution_target} clang-bolt)
+	  add_dependencies(install-${distribution_target}-stripped clang-bolt)
 	endif()
       endif()
 

--- a/llvm/cmake/modules/LLVMDistributionSupport.cmake
+++ b/llvm/cmake/modules/LLVMDistributionSupport.cmake
@@ -276,6 +276,11 @@ function(llvm_distribution_add_targets)
       # This happens for example if a target is an INTERFACE target.
       if(TARGET ${target})
         add_dependencies(${distribution_target} ${target})
+	# Add a special case for bolt-optimized clang.  This will ensure that the
+	# bolt optimized clang is built with the rest of the distribution.
+	if (target STREQUAL "clang" AND TARGET clang-bolt)
+	  add_dependencies(${distribution_target} clang-bolt)
+	endif()
       endif()
 
       if(TARGET install-${target})


### PR DESCRIPTION
Currently if you want to do a distribution build (i.e. using LLVM_DISTIRIBUTION_COMPONENTS) with a bolt-optimized clang, then you need to pass two separate targets to ninja like this:

ninja -C build clang-bolt distribiution

This patch simplifies this workflow so that you can do a distribution build with a bolt-optimized build with just a single target:

ninja -C build distribution