### PR TITLE
[flang][OpenMP] Add unparsing of BIND clause argument

### DIFF
--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -2834,6 +2834,7 @@ public:
   WALK_NESTED_ENUM(InquireSpec::LogVar, Kind)
   WALK_NESTED_ENUM(ProcedureStmt, Kind) // R1506
   WALK_NESTED_ENUM(UseStmt, ModuleNature) // R1410
+  WALK_NESTED_ENUM(OmpBindClause, Type) // OMP bind
   WALK_NESTED_ENUM(OmpProcBindClause, Type) // OMP PROC_BIND
   WALK_NESTED_ENUM(OmpDefaultClause, Type) // OMP DEFAULT
   WALK_NESTED_ENUM(OmpDefaultmapClause, ImplicitBehavior) // OMP DEFAULTMAP

--- a/flang/test/Parser/OpenMP/bind-clause.f90
+++ b/flang/test/Parser/OpenMP/bind-clause.f90
@@ -1,0 +1,25 @@
+!RUN: %flang_fc1 -fdebug-unparse -fopenmp -fopenmp-version=50 %s | FileCheck --ignore-case --check-prefix="UNPARSE" %s
+!RUN: %flang_fc1 -fdebug-dump-parse-tree -fopenmp -fopenmp-version=50 %s | FileCheck --check-prefix="PARSE-TREE" %s
+
+subroutine f00
+  !$omp loop bind(parallel)
+  do i = 1, 10
+    continue
+  enddo
+  !$omp end loop
+end
+
+!UNPARSE: SUBROUTINE f00
+!UNPARSE: !$OMP LOOP  BIND(PARALLEL)
+!UNPARSE:  DO i=1_4,10_4
+!UNPARSE:   CONTINUE
+!UNPARSE:  END DO
+!UNPARSE: !$OMP END LOOP
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: ExecutionPartConstruct -> ExecutableConstruct -> OpenMPConstruct -> OpenMPLoopConstruct
+!PARSE-TREE: | OmpBeginLoopDirective
+!PARSE-TREE: | | OmpLoopDirective -> llvm::omp::Directive = loop
+!PARSE-TREE: | | OmpClauseList -> OmpClause -> Bind -> OmpBindClause -> Type = Parallel
+!PARSE-TREE: | DoConstruct
+


### PR DESCRIPTION
Currently the argument of the BIND clause is not printed. This is likely an omission in the original implementation.