### PR TITLE
Revert "[libc++] Remove workaround which allows setting _LIBCPP_OVERRIDABLE_FUNC_VIS externally (#113139)"

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -402,7 +402,11 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS _LIBCPP_VISIBILITY("default")
 #    define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
-#    define _LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_VISIBILITY("default")
+
+// TODO: Make this a proper customization point or remove the option to override it.
+#    ifndef _LIBCPP_OVERRIDABLE_FUNC_VIS
+#      define _LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_VISIBILITY("default")
+#    endif
 
 #    if !defined(_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS)
 // The inline should be removed once PR32114 is resolved


### PR DESCRIPTION
This reverts commit 2e686d6d17c4cc7608510a856055e6ca79fcb917.

See https://github.com/llvm/llvm-project/issues/117571