### PR TITLE
[Workflows] Improve GitHub Actions Security hardening

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: .github/workflows/containers/github-action-ci/
       - name: Change podman Root Direcotry
         run: |
@@ -67,6 +68,7 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: .github/workflows/containers/github-action-ci/
 
       - name: Change podman Root Direcotry

--- a/.github/workflows/ci-post-commit-analyzer.yml
+++ b/.github/workflows/ci-post-commit-analyzer.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1

--- a/.github/workflows/commit-access-review.yml
+++ b/.github/workflows/commit-access-review.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,6 +62,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
       - name: Get subprojects that have doc changes
         id: docs-changed-subprojects
@@ -98,6 +99,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
       - name: Setup Python env
         uses: actions/setup-python@v5

--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Extract author email

--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout Automation Script
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: llvm/utils/git/
           ref: main
 

--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: |
             .github/workflows/unprivileged-download-artifact/action.yml
           sparse-checkout-cone-mode: false

--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 250
 
       - name: Get LLVM version

--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -55,6 +55,8 @@ jobs:
             cxx: 'g++-14'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: ${{ matrix.config }}.${{ matrix.cxx }}
         run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
         env:
@@ -101,6 +103,8 @@ jobs:
             cxx: 'clang++-18'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: ${{ matrix.config }}
         run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
         env:
@@ -165,6 +169,8 @@ jobs:
     container: ghcr.io/llvm/libcxx-linux-builder:0fd6f684b9c84c32d6cbfd9742402e788b2879f1
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: ${{ matrix.config }}
         run: libcxx/utils/ci/run-buildbot ${{ matrix.config }}
         env:
@@ -203,6 +209,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 'latest'
@@ -243,6 +251,8 @@ jobs:
         - { config: mingw-incomplete-sysroot, mingw: true }
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           choco install -y ninja

--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Build the Linux builder image
       working-directory: libcxx/utils/ci

--- a/.github/workflows/libcxx-check-generated-files.yml
+++ b/.github/workflows/libcxx-check-generated-files.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: aminya/setup-cpp@v1

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -88,6 +88,7 @@ jobs:
       # clean: false.
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 250
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 250
 
       - name: Get LLVM version

--- a/.github/workflows/merged-prs.yml
+++ b/.github/workflows/merged-prs.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout Automation Script
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: llvm/utils/git/
           ref: main
 

--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout Automation Script
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: llvm/utils/git/
           ref: main
 

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout through merge base
@@ -42,6 +43,7 @@ jobs:
       - name: Fetch code formatting utils
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: ${{ github.repository }}
           ref: ${{ github.base_ref }}
           sparse-checkout: |

--- a/.github/workflows/pr-request-release-note.yml
+++ b/.github/workflows/pr-request-release-note.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout Scripts
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          persist-credentials: false
           sparse-checkout: |
             llvm/utils/git/requirements.txt
             llvm/utils/git/github-automation.py

--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout Automation Script
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: llvm/utils/git/
           ref: main
 

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -23,6 +23,8 @@ jobs:
     if: github.repository == 'llvm/llvm-project'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 #v4.1.6
+        with:
+          persist-credentials: false
       - name: "Run Audit Script"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -70,6 +70,8 @@ jobs:
 
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
 
     - name: Install Dependencies
       shell: bash
@@ -155,6 +157,7 @@ jobs:
     - name: Checkout Actions
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
+        persist-credentials: false
         ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
         sparse-checkout: |
           .github/workflows/
@@ -176,6 +179,7 @@ jobs:
     - name: Checkout LLVM
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
+        persist-credentials: false
         ref: ${{ needs.prepare.outputs.ref }}
 
     - name: Copy main workflows
@@ -229,6 +233,7 @@ jobs:
     - name: Checkout Actions
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
         sparse-checkout: |
           .github/workflows/
@@ -263,6 +268,7 @@ jobs:
     - name: Checkout Actions
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
         sparse-checkout: |
           .github/workflows/
@@ -312,6 +318,7 @@ jobs:
     - name: Checkout Actions
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
         sparse-checkout: |
           .github/workflows/
@@ -362,6 +369,7 @@ jobs:
     - name: Checkout Actions
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
         sparse-checkout: |
           .github/workflows/
@@ -423,6 +431,7 @@ jobs:
     - name: Checkout Release Scripts
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
+        persist-credentials: false
         sparse-checkout: |
           llvm/utils/release/github-upload-release.py
           llvm/utils/git/requirements.txt
@@ -475,6 +484,7 @@ jobs:
     - name: Checkout Actions
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: ${{ (github.event_name == 'pull_request' && github.sha) || 'main' }}
         sparse-checkout: |
           .github/workflows/

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
 
       - name: Setup Python env
         uses: actions/setup-python@v5

--- a/.github/workflows/release-doxygen.yml
+++ b/.github/workflows/release-doxygen.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
 
       - name: Setup Python env
         uses: actions/setup-python@v5

--- a/.github/workflows/release-lit.yml
+++ b/.github/workflows/release-lit.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          persist-credentials: false
           ref: "llvmorg-${{ inputs.release-version }}"
 
       - name: Install dependencies

--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          persist-credentials: false
           ref: ${{ needs.inputs.outputs.ref }}
           fetch-tags: true
       - name: Install Dependencies

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout LLVM
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
 
       - name: Create Release
         env:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install dependencies

--- a/.github/workflows/workflow-checks.yml
+++ b/.github/workflows/workflow-checks.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Workflow Checks
+
+on:
+  push:
+    paths: [".github/workflows/*.ya?ml"]
+  pull_request:
+    paths: [".github/workflows/*.ya?ml"]
+
+jobs:
+  zizmor:
+    name: Workflow Security Checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Add Homebrew to PATH
+        run: echo "/home/linuxbrew/.linuxbrew/bin" >>"${GITHUB_PATH}"
+
+      - name: Get zizmor
+        run: brew install zizmor
+
+      - name: Run zizmor
+        run: zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
`zizmor`[^1] is a static analysis tool that identifies many common
security problems in GitHub Actions workflows.

Running it on this repository produces 138 findings:

```
❯ zizmor .
[result details omitted]

138 findings: 0 unknown, 56 informational, 0 low, 41 medium, 41 high
```

This workflow runs `zizmor` whenever any workflow is changed. The
results will be available under the "Code Scanning" page in the
"Security" tab of this repository. (Viewing this page may require
sufficient access rights to this repo.)

I've also fixed a few of the issues identified like the one below:
```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/carlocab/github/llvm-project/.github/workflows/pr-subscriber.yml:16:9
   |
16 |         - name: Checkout Automation Script
   |  _________-
17 | |         uses: actions/checkout@v4
18 | |         with:
19 | |           sparse-checkout: llvm/utils/git/
20 | |           ref: main
   | |___________________- does not set persist-credentials: false
```

[^1]: https://github.com/woodruffw/zizmor
