### PR TITLE
[analyzer] Modernize, improve and promote chroot checker

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -985,8 +985,15 @@ Moved checkers
   original checkers were implemented only using AST matching and make more
   sense as a single clang-tidy check.
 
-- The checker ``alpha.unix.Chroot`` was modernized, improved and moved from
-  alpha to a main Unix family checker.
+- The checker ``alpha.unix.Chroot`` was modernized, improved and moved to
+  ``unix.Chroot``. Testing was done on open source projects that use chroot(),
+  and false issues addressed in the improvements based on real use cases. Open
+  source projects used for testing include nsjail, lxroot, dive and ruri.
+  This checker conforms to SEI Cert C recommendation `POS05-C. Limit access to
+  files by creating a jail
+  <https://wiki.sei.cmu.edu/confluence/display/c/POS05-C.+Limit+access+to+files+by+creating+a+jail>`_.
+  Fixes (#GH34697).
+  (#GH117791) [Documentation](https://clang.llvm.org/docs/analyzer/checkers.html#unix-chroot-c).
 
 .. _release-notes-sanitizers:
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -985,6 +985,9 @@ Moved checkers
   original checkers were implemented only using AST matching and make more
   sense as a single clang-tidy check.
 
+- The checker ``alpha.unix.Chroot`` was modernized, improved and moved from
+  alpha to a main Unix family checker.
+
 .. _release-notes-sanitizers:
 
 Sanitizers

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1750,6 +1750,21 @@ Critical section handling functions modeled by this checker:
    }
  }
 
+.. _unix-Chroot:
+
+unix.Chroot (C)
+"""""""""""""""""""""
+Check improper use of chroot.
+
+.. code-block:: c
+
+ void f();
+
+ void test() {
+   chroot("/usr/local");
+   f(); // warn: no call of chdir("/") immediately after chroot
+ }
+
 .. _unix-Errno:
 
 unix.Errno (C)
@@ -3274,21 +3289,6 @@ SEI CERT checkers which tries to find errors based on their `C coding rules <htt
 
 alpha.unix
 ^^^^^^^^^^
-
-.. _alpha-unix-Chroot:
-
-alpha.unix.Chroot (C)
-"""""""""""""""""""""
-Check improper use of chroot.
-
-.. code-block:: c
-
- void f();
-
- void test() {
-   chroot("/usr/local");
-   f(); // warn: no call of chdir("/") immediately after chroot
- }
 
 .. _alpha-unix-PthreadLock:
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1757,19 +1757,25 @@ unix.Chroot (C)
 Check improper use of chroot described by SEI Cert C recommendation `POS05-C.
 Limit access to files by creating a jail
 <https://wiki.sei.cmu.edu/confluence/display/c/POS05-C.+Limit+access+to+files+by+creating+a+jail>`_.
-The checker finds usage patterns where chdir() is not called immediately
-after a call to chroot().
+The checker finds usage patterns where ``chdir("/")`` is not called immediately
+after a call to ``chroot(path)``.
 
 .. code-block:: c
 
  void f();
 
- void test() {
+ void test_bad() {
    chroot("/usr/local");
    f(); // warn: no call of chdir("/") immediately after chroot
  }
 
- void test() {
+  void test_bad_path() {
+    chroot("/usr/local");
+    chdir("/usr"); // warn: no call of chdir("/") immediately after chroot
+    f();
+  }
+
+ void test_good() {
    chroot("/usr/local");
    chdir("/"); // no warning
    f();

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1753,8 +1753,12 @@ Critical section handling functions modeled by this checker:
 .. _unix-Chroot:
 
 unix.Chroot (C)
-"""""""""""""""""""""
-Check improper use of chroot.
+"""""""""""""""
+Check improper use of chroot described by SEI Cert C recommendation `POS05-C.
+Limit access to files by creating a jail
+<https://wiki.sei.cmu.edu/confluence/display/c/POS05-C.+Limit+access+to+files+by+creating+a+jail>`_.
+The checker finds usage patterns where chdir() is not called immediately
+after a call to chroot().
 
 .. code-block:: c
 
@@ -1763,6 +1767,12 @@ Check improper use of chroot.
  void test() {
    chroot("/usr/local");
    f(); // warn: no call of chdir("/") immediately after chroot
+ }
+
+ void test() {
+   chroot("/usr/local");
+   chdir("/"); // no warning
+   f();
  }
 
 .. _unix-Errno:

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -598,13 +598,13 @@ def VforkChecker : Checker<"Vfork">,
   HelpText<"Check for proper usage of vfork">,
   Documentation<HasDocumentation>;
 
-} // end "unix"
-
-let ParentPackage = UnixAlpha in {
-
 def ChrootChecker : Checker<"Chroot">,
   HelpText<"Check improper use of chroot">,
   Documentation<HasDocumentation>;
+
+} // end "unix"
+
+let ParentPackage = UnixAlpha in {
 
 def PthreadLockChecker : Checker<"PthreadLock">,
   HelpText<"Simple lock -> unlock checker">,

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -134,7 +134,7 @@ public:
     if (!Call)
       return nullptr;
 
-    if (!matchesAnyAsWritten(*Call, Chroot))
+    if (!Chroot.matchesAsWritten(*Call))
       return nullptr;
 
     Satisfied = true;

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -28,8 +28,9 @@
 using namespace clang;
 using namespace ento;
 
-// enum value that represent the jail state
+namespace {
 enum ChrootKind { NO_CHROOT, ROOT_CHANGED, ROOT_CHANGE_FAILED, JAIL_ENTERED };
+} // namespace
 
 // Track chroot state changes for success, failure, state change
 // and "jail"

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -48,7 +48,7 @@ namespace {
 //                                  |                               |
 //                      bug<--foo()--          JAIL_ENTERED<--foo()--
 //
-class ChrootChecker : public Checker<eval::Call, check::PreCall> {
+class ChrootChecker final : public Checker<eval::Call, check::PreCall> {
 public:
   bool evalCall(const CallEvent &Call, CheckerContext &C) const;
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -75,6 +75,7 @@ bool ChrootChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
 bool ChrootChecker::evalChroot(const CallEvent &Call, CheckerContext &C) const {
   BasicValueFactory &BVF = C.getSValBuilder().getBasicValueFactory();
   const LocationContext *LCtx = C.getLocationContext();
+  ProgramStateRef State = C.getState();
 
   // Using CallDescriptions to match on CallExpr, so no need
   // to do null checks.
@@ -84,10 +85,10 @@ bool ChrootChecker::evalChroot(const CallEvent &Call, CheckerContext &C) const {
   SVal Zero = nonloc::ConcreteInt{BVF.getValue(0, IntTy)};
   SVal Minus1 = nonloc::ConcreteInt{BVF.getValue(-1, IntTy)};
 
-  ProgramStateRef State = C.getState();
   ProgramStateRef ChrootFailed = State->BindExpr(CE, LCtx, Minus1);
-  ProgramStateRef ChrootSucceeded = State->BindExpr(CE, LCtx, Zero);
   C.addTransition(ChrootFailed->set<ChrootState>(ROOT_CHANGE_FAILED));
+
+  ProgramStateRef ChrootSucceeded = State->BindExpr(CE, LCtx, Zero);
   C.addTransition(ChrootSucceeded->set<ChrootState>(ROOT_CHANGED));
   return true;
 }

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  This file defines chroot checker, which checks improper use of chroot. This
-//  is described by the SEI Cert C rule POS05-C. The checker is a warning not
-//  a hard failure since it only checks for a recommended rule.
+//  This file defines chroot checker, which checks improper use of chroot.
+//  This is described by the SEI Cert C rule POS05-C.
+//  The checker is a warning not a hard failure since it only checks for a
+//  recommended rule.
 //
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -47,21 +47,17 @@ namespace {
 //                      bug<--foo()--          JAIL_ENTERED<--foo()--
 //
 class ChrootChecker : public Checker<eval::Call, check::PreCall> {
-  // This bug refers to possibly break out of a chroot() jail.
-  const BugType BreakJailBug{this, "Break out of jail"};
-
-  const CallDescription Chroot{CDM::CLibrary, {"chroot"}, 1},
-      Chdir{CDM::CLibrary, {"chdir"}, 1};
-
 public:
-  ChrootChecker() {}
-
   bool evalCall(const CallEvent &Call, CheckerContext &C) const;
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
 
 private:
   void evalChroot(const CallEvent &Call, CheckerContext &C) const;
   void evalChdir(const CallEvent &Call, CheckerContext &C) const;
+
+  const BugType BreakJailBug{this, "Break out of jail"};
+  const CallDescription Chroot{CDM::CLibrary, {"chroot"}, 1};
+  const CallDescription Chdir{CDM::CLibrary, {"chdir"}, 1};
 };
 
 bool ChrootChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -98,9 +98,9 @@ void ChrootChecker::evalChroot(const CallEvent &Call, CheckerContext &C) const {
   const auto *CE = cast<CallExpr>(Call.getOriginExpr());
 
   const LocationContext *LCtx = C.getLocationContext();
-  NonLoc RetVal =
-          SVB.conjureSymbolVal(/*SymbolTag=*/nullptr, ChrootCE, LCtx, IntTy, C.blockCount())
-          .castAs<NonLoc>();
+  NonLoc RetVal = SVB.conjureSymbolVal(/*SymbolTag=*/nullptr, ChrootCE, LCtx,
+                                       IntTy, C.blockCount())
+                      .castAs<NonLoc>();
 
   auto [StateChrootFailed, StateChrootSuccess] = state->assume(RetVal);
 
@@ -110,13 +110,15 @@ void ChrootChecker::evalChroot(const CallEvent &Call, CheckerContext &C) const {
   if (StateChrootFailed) {
     StateChrootFailed = StateChrootFailed->set<ChrootState>(ROOT_CHANGE_FAILED);
     StateChrootFailed = StateChrootFailed->set<ChrootCall>(ChrootCE);
-    C.addTransition(StateChrootFailed->BindExpr(CE, LCtx, nonloc::ConcreteInt{Minus1}));
+    C.addTransition(
+        StateChrootFailed->BindExpr(CE, LCtx, nonloc::ConcreteInt{Minus1}));
   }
 
   if (StateChrootSuccess) {
     StateChrootSuccess = StateChrootSuccess->set<ChrootState>(ROOT_CHANGED);
     StateChrootSuccess = StateChrootSuccess->set<ChrootCall>(ChrootCE);
-    C.addTransition(StateChrootSuccess->BindExpr(CE, LCtx, nonloc::ConcreteInt{Zero}));
+    C.addTransition(
+        StateChrootSuccess->BindExpr(CE, LCtx, nonloc::ConcreteInt{Zero}));
   }
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -171,10 +171,8 @@ void ChrootChecker::checkPreCall(const CallEvent &Call,
   if (!Err)
     return;
 
-  std::unique_ptr<PathSensitiveBugReport> R =
-      std::make_unique<PathSensitiveBugReport>(
-          BreakJailBug, R"(No call of chdir("/") immediately after chroot)",
-          Err);
+  auto R = std::make_unique<PathSensitiveBugReport>(
+      BreakJailBug, R"(No call of chdir("/") immediately after chroot)", Err);
   R->addVisitor<ChrootInvocationVisitor>(Chroot);
   C.emitReport(std::move(R));
 }

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -48,7 +48,7 @@ namespace {
 //
 class ChrootChecker : public Checker<eval::Call, check::PreCall> {
   // This bug refers to possibly break out of a chroot() jail.
-  const BugType BT_BreakJail{this, "Break out of jail"};
+  const BugType BreakJailBug{this, "Break out of jail"};
 
   const CallDescription Chroot{CDM::CLibrary, {"chroot"}, 1},
       Chdir{CDM::CLibrary, {"chdir"}, 1};
@@ -174,7 +174,7 @@ void ChrootChecker::checkPreCall(const CallEvent &Call,
 
   std::unique_ptr<PathSensitiveBugReport> R =
       std::make_unique<PathSensitiveBugReport>(
-          BT_BreakJail, R"(No call of chdir("/") immediately after chroot)",
+          BreakJailBug, R"(No call of chdir("/") immediately after chroot)",
           Err);
   R->addVisitor<ChrootInvocationVisitor>(Chroot);
   C.emitReport(std::move(R));

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
 #include "clang/StaticAnalyzer/Core/Checker.h"
@@ -24,21 +26,30 @@
 using namespace clang;
 using namespace ento;
 
+// enum value that represent the jail state
+enum ChrootKind { NO_CHROOT, ROOT_CHANGED, ROOT_CHANGE_FAILED, JAIL_ENTERED };
+
+// Track chroot state changes for success, failure, state change
+// and "jail"
+REGISTER_TRAIT_WITH_PROGRAMSTATE(ChrootState, ChrootKind)
+
+// Track the call expression to chroot for accurate
+// warning messages
+REGISTER_TRAIT_WITH_PROGRAMSTATE(ChrootCall, const Expr *)
+
 namespace {
 
-// enum value that represent the jail state
-enum Kind { NO_CHROOT, ROOT_CHANGED, JAIL_ENTERED };
-
-bool isRootChanged(intptr_t k) { return k == ROOT_CHANGED; }
-//bool isJailEntered(intptr_t k) { return k == JAIL_ENTERED; }
-
 // This checker checks improper use of chroot.
-// The state transition:
+// The state transitions
+//
+//                          -> ROOT_CHANGE_FAILED
+//                          |
 // NO_CHROOT ---chroot(path)--> ROOT_CHANGED ---chdir(/) --> JAIL_ENTERED
 //                                  |                               |
 //         ROOT_CHANGED<--chdir(..)--      JAIL_ENTERED<--chdir(..)--
 //                                  |                               |
 //                      bug<--foo()--          JAIL_ENTERED<--foo()--
+//
 class ChrootChecker : public Checker<eval::Call, check::PreCall> {
   // This bug refers to possibly break out of a chroot() jail.
   const BugType BT_BreakJail{this, "Break out of jail"};
@@ -49,20 +60,17 @@ class ChrootChecker : public Checker<eval::Call, check::PreCall> {
 public:
   ChrootChecker() {}
 
-  static void *getTag() {
-    static int x;
-    return &x;
-  }
-
   bool evalCall(const CallEvent &Call, CheckerContext &C) const;
   void checkPreCall(const CallEvent &Call, CheckerContext &C) const;
 
 private:
   void evalChroot(const CallEvent &Call, CheckerContext &C) const;
   void evalChdir(const CallEvent &Call, CheckerContext &C) const;
-};
 
-} // end anonymous namespace
+  /// Searches for the ExplodedNode where chroot was called.
+  static const ExplodedNode *getAcquisitionSite(const ExplodedNode *N,
+                                                CheckerContext &C);
+};
 
 bool ChrootChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
   if (Chroot.matches(Call)) {
@@ -80,19 +88,53 @@ bool ChrootChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
 void ChrootChecker::evalChroot(const CallEvent &Call, CheckerContext &C) const {
   ProgramStateRef state = C.getState();
   ProgramStateManager &Mgr = state->getStateManager();
+  const TargetInfo &TI = C.getASTContext().getTargetInfo();
+  SValBuilder &SVB = C.getSValBuilder();
+  BasicValueFactory &BVF = SVB.getBasicValueFactory();
+  ConstraintManager &CM = Mgr.getConstraintManager();
 
-  // Once encouter a chroot(), set the enum value ROOT_CHANGED directly in
-  // the GDM.
-  state = Mgr.addGDM(state, ChrootChecker::getTag(), (void*) ROOT_CHANGED);
-  C.addTransition(state);
+  const QualType sIntTy = C.getASTContext().getIntTypeForBitwidth(
+      /*DestWidth=*/TI.getIntWidth(), /*Signed=*/true);
+
+  const Expr *ChrootCE = Call.getOriginExpr();
+  if (!ChrootCE)
+    return;
+  const auto *CE = cast<CallExpr>(Call.getOriginExpr());
+
+  const LocationContext *LCtx = C.getLocationContext();
+  NonLoc RetVal =
+      C.getSValBuilder()
+          .conjureSymbolVal(nullptr, ChrootCE, LCtx, sIntTy, C.blockCount())
+          .castAs<NonLoc>();
+
+  ProgramStateRef StateChrootFailed, StateChrootSuccess;
+  std::tie(StateChrootFailed, StateChrootSuccess) = state->assume(RetVal);
+
+  const llvm::APSInt &Zero = BVF.getValue(0, sIntTy);
+  const llvm::APSInt &Minus1 = BVF.getValue(-1, sIntTy);
+
+  if (StateChrootFailed) {
+    StateChrootFailed = CM.assumeInclusiveRange(StateChrootFailed, RetVal,
+                                                Minus1, Minus1, true);
+    StateChrootFailed = StateChrootFailed->set<ChrootState>(ROOT_CHANGE_FAILED);
+    StateChrootFailed = StateChrootFailed->set<ChrootCall>(ChrootCE);
+    C.addTransition(StateChrootFailed->BindExpr(CE, LCtx, RetVal));
+  }
+
+  if (StateChrootSuccess) {
+    StateChrootSuccess =
+        CM.assumeInclusiveRange(StateChrootSuccess, RetVal, Zero, Zero, true);
+    StateChrootSuccess = StateChrootSuccess->set<ChrootState>(ROOT_CHANGED);
+    StateChrootSuccess = StateChrootSuccess->set<ChrootCall>(ChrootCE);
+    C.addTransition(StateChrootSuccess->BindExpr(CE, LCtx, RetVal));
+  }
 }
 
 void ChrootChecker::evalChdir(const CallEvent &Call, CheckerContext &C) const {
   ProgramStateRef state = C.getState();
-  ProgramStateManager &Mgr = state->getStateManager();
 
-  // If there are no jail state in the GDM, just return.
-  const void *k = state->FindGDM(ChrootChecker::getTag());
+  // If there are no jail state, just return.
+  const ChrootKind k = C.getState()->get<ChrootState>();
   if (!k)
     return;
 
@@ -104,13 +146,33 @@ void ChrootChecker::evalChdir(const CallEvent &Call, CheckerContext &C) const {
     R = R->StripCasts();
     if (const StringRegion* StrRegion= dyn_cast<StringRegion>(R)) {
       const StringLiteral* Str = StrRegion->getStringLiteral();
-      if (Str->getString() == "/")
-        state = Mgr.addGDM(state, ChrootChecker::getTag(),
-                           (void*) JAIL_ENTERED);
+      if (Str->getString() == "/") {
+        state = state->set<ChrootState>(JAIL_ENTERED);
+      }
     }
   }
 
   C.addTransition(state);
+}
+
+const ExplodedNode *ChrootChecker::getAcquisitionSite(const ExplodedNode *N,
+                                                      CheckerContext &C) {
+  ProgramStateRef State = N->getState();
+  // When bug type is resource leak, exploded node N may not have state info
+  // for leaked file descriptor, but predecessor should have it.
+  if (!State->get<ChrootCall>())
+    N = N->getFirstPred();
+
+  const ExplodedNode *Pred = N;
+  while (N) {
+    State = N->getState();
+    if (!State->get<ChrootCall>())
+      return Pred;
+    Pred = N;
+    N = N->getFirstPred();
+  }
+
+  return nullptr;
 }
 
 // Check the jail state before any function call except chroot and chdir().
@@ -121,16 +183,39 @@ void ChrootChecker::checkPreCall(const CallEvent &Call,
     return;
 
   // If jail state is ROOT_CHANGED, generate BugReport.
-  void *const* k = C.getState()->FindGDM(ChrootChecker::getTag());
-  if (k)
-    if (isRootChanged((intptr_t) *k))
-      if (ExplodedNode *N = C.generateNonFatalErrorNode()) {
-        constexpr llvm::StringLiteral Msg =
-            "No call of chdir(\"/\") immediately after chroot";
-        C.emitReport(
-            std::make_unique<PathSensitiveBugReport>(BT_BreakJail, Msg, N));
-      }
+  const ChrootKind k = C.getState()->get<ChrootState>();
+  if (k == ROOT_CHANGED) {
+    ExplodedNode *Err =
+        C.generateNonFatalErrorNode(C.getState(), C.getPredecessor());
+    if (!Err)
+      return;
+    const Expr *ChrootExpr = C.getState()->get<ChrootCall>();
+
+    const ExplodedNode *ChrootCallNode = getAcquisitionSite(Err, C);
+    assert(ChrootCallNode && "Could not find place of stream opening.");
+
+    PathDiagnosticLocation LocUsedForUniqueing;
+    if (const Stmt *ChrootStmt = ChrootCallNode->getStmtForDiagnostics())
+      LocUsedForUniqueing = PathDiagnosticLocation::createBegin(
+          ChrootStmt, C.getSourceManager(),
+          ChrootCallNode->getLocationContext());
+
+    std::unique_ptr<PathSensitiveBugReport> R =
+        std::make_unique<PathSensitiveBugReport>(
+            BT_BreakJail, "No call of chdir(\"/\") immediately after chroot",
+            Err, LocUsedForUniqueing,
+            ChrootCallNode->getLocationContext()->getDecl());
+
+    R->addNote("chroot called here",
+               PathDiagnosticLocation::create(ChrootCallNode->getLocation(),
+                                              C.getSourceManager()),
+               {ChrootExpr->getSourceRange()});
+
+    C.emitReport(std::move(R));
+  }
 }
+
+} // namespace
 
 void ento::registerChrootChecker(CheckerManager &mgr) {
   mgr.registerChecker<ChrootChecker>();

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -76,9 +76,6 @@ bool ChrootChecker::evalChroot(const CallEvent &Call, CheckerContext &C) const {
   BasicValueFactory &BVF = C.getSValBuilder().getBasicValueFactory();
   const LocationContext *LCtx = C.getLocationContext();
   ProgramStateRef State = C.getState();
-
-  // Using CallDescriptions to match on CallExpr, so no need
-  // to do null checks.
   const auto *CE = cast<CallExpr>(Call.getOriginExpr());
 
   const QualType IntTy = C.getASTContext().IntTy;

--- a/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ChrootChecker.cpp
@@ -181,10 +181,8 @@ void ChrootChecker::checkPreCall(const CallEvent &Call,
 
 } // namespace
 
-void ento::registerChrootChecker(CheckerManager &mgr) {
-  mgr.registerChecker<ChrootChecker>();
+void ento::registerChrootChecker(CheckerManager &Mgr) {
+  Mgr.registerChecker<ChrootChecker>();
 }
 
-bool ento::shouldRegisterChrootChecker(const CheckerManager &mgr) {
-  return true;
-}
+bool ento::shouldRegisterChrootChecker(const CheckerManager &) { return true; }

--- a/clang/test/Analysis/analyzer-enabled-checkers.c
+++ b/clang/test/Analysis/analyzer-enabled-checkers.c
@@ -43,6 +43,7 @@
 // CHECK-NEXT: security.insecureAPI.vfork
 // CHECK-NEXT: unix.API
 // CHECK-NEXT: unix.BlockInCriticalSection
+// CHECK-NEXT: unix.Chroot
 // CHECK-NEXT: unix.cstring.CStringModeling
 // CHECK-NEXT: unix.DynamicMemoryModeling
 // CHECK-NEXT: unix.Errno

--- a/clang/test/Analysis/chroot.c
+++ b/clang/test/Analysis/chroot.c
@@ -58,3 +58,11 @@ void f7(void) {
       // expected-note@-2    {{No call of chdir("/") immediately after chroot}}
   }
 }
+
+void f8() {
+  chroot("/usr/local"); // expected-note {{chroot called here}}
+  chdir("/usr"); // This chdir was ineffective because it's not exactly `chdir("/")`.
+  foo();
+  // expected-warning@-1 {{No call of chdir("/") immediately after chroot}}
+  // expected-note@-2    {{No call of chdir("/") immediately after chroot}}
+}

--- a/clang/test/Analysis/chroot.c
+++ b/clang/test/Analysis/chroot.c
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.unix.Chroot -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=unix.Chroot -verify %s
 
 extern int chroot(const char* path);
 extern int chdir(const char* path);
@@ -7,7 +7,7 @@ void foo(void) {
 }
 
 void f1(void) {
-  chroot("/usr/local"); // root changed.
+  chroot("/usr/local"); // expected-note {{chroot called here}}
   foo(); // expected-warning {{No call of chdir("/") immediately after chroot}}
 }
 
@@ -18,7 +18,37 @@ void f2(void) {
 }
 
 void f3(void) {
-  chroot("/usr/local"); // root changed.
+  chroot("/usr/local"); // expected-note {{chroot called here}}
   chdir("../"); // change working directory, still out of jail.
   foo(); // expected-warning {{No call of chdir("/") immediately after chroot}}
+}
+
+void f4(void) {
+  if (chroot("/usr/local") == 0) {
+      chdir("../"); // change working directory, still out of jail.
+  }
+}
+
+void f5(void) {
+  int v = chroot("/usr/local");
+  if (v == -1) {
+      foo();        // no warning, chroot failed
+      chdir("../"); // change working directory, still out of jail.
+  }
+}
+
+void f6(void) {
+  if (chroot("/usr/local") == -1) {
+      chdir("../"); // change working directory, still out of jail.
+  }
+}
+
+void f7(void) {
+  int v = chroot("/usr/local"); // expected-note {{chroot called here}}
+  if (v == -1) {
+      foo();        // no warning, chroot failed
+      chdir("../"); // change working directory, still out of jail.
+  } else {
+      foo();        // expected-warning {{No call of chdir("/") immediately after chroot}}
+  }
 }

--- a/clang/test/Analysis/show-checker-list.c
+++ b/clang/test/Analysis/show-checker-list.c
@@ -24,10 +24,6 @@
 // RUN:   -analyzer-checker-help-developer \
 // RUN:   2>&1 | FileCheck %s -check-prefix=CHECK-STABLE-ALPHA-DEVELOPER
 
-// CHECK-STABLE-NOT:    alpha.unix.Chroot
-// CHECK-DEVELOPER-NOT: alpha.unix.Chroot
-// CHECK-ALPHA:         alpha.unix.Chroot
-
 // Note that alpha.cplusplus.IteratorModeling is not only an alpha, but also a
 // hidden checker. In this case, we'd only like to see it in the developer list.
 // CHECK-ALPHA-NOT: alpha.cplusplus.IteratorModeling
@@ -42,10 +38,6 @@
 // CHECK-ALPHA-NOT:  debug.ConfigDumper
 
 
-// CHECK-STABLE-ALPHA:         alpha.unix.Chroot
-// CHECK-DEVELOPER-ALPHA:      alpha.unix.Chroot
-// CHECK-STABLE-DEVELOPER-NOT: alpha.unix.Chroot
-
 // CHECK-STABLE-ALPHA:        core.DivideZero
 // CHECK-DEVELOPER-ALPHA-NOT: core.DivideZero
 // CHECK-STABLE-DEVELOPER:    core.DivideZero
@@ -55,6 +47,5 @@
 // CHECK-STABLE-DEVELOPER: debug.ConfigDumper
 
 
-// CHECK-STABLE-ALPHA-DEVELOPER: alpha.unix.Chroot
 // CHECK-STABLE-ALPHA-DEVELOPER: core.DivideZero
 // CHECK-STABLE-ALPHA-DEVELOPER: debug.ConfigDumper

--- a/clang/test/Analysis/std-c-library-functions-arg-enabled-checkers.c
+++ b/clang/test/Analysis/std-c-library-functions-arg-enabled-checkers.c
@@ -51,6 +51,7 @@
 // CHECK-NEXT: security.insecureAPI.vfork
 // CHECK-NEXT: unix.API
 // CHECK-NEXT: unix.BlockInCriticalSection
+// CHECK-NEXT: unix.Chroot
 // CHECK-NEXT: unix.cstring.CStringModeling
 // CHECK-NEXT: unix.DynamicMemoryModeling
 // CHECK-NEXT: unix.Errno


### PR DESCRIPTION
This change modernizes, improves and promotes the chroot checker from alpha to the Unix family of checkers. This checker covers the POS05 recommendations for use of chroot.

The improvements included modeling of a success or failure from chroot and not falsely reporting a warning along an error path. This was made possible through modernizing the checker to be flow sensitive.