### PR TITLE
[MachineLateInstrsCleanup] Minor fixing (NFC).

### DIFF
--- a/llvm/lib/CodeGen/MachineLateInstrsCleanup.cpp
+++ b/llvm/lib/CodeGen/MachineLateInstrsCleanup.cpp
@@ -57,7 +57,6 @@ class MachineLateInstrsCleanup : public MachineFunctionPass {
 
   void removeRedundantDef(MachineInstr *MI);
   void clearKillsForDef(Register Reg, MachineBasicBlock *MBB,
-                        MachineBasicBlock::iterator I,
                         BitVector &VisitedPreds);
 
 public:
@@ -110,14 +109,11 @@ bool MachineLateInstrsCleanup::runOnMachineFunction(MachineFunction &MF) {
   return Changed;
 }
 
-// Clear any previous kill flag on Reg found before I in MBB. Walk backwards
-// in MBB and if needed continue in predecessors until a use/def of Reg is
-// encountered. This seems to be faster in practice than tracking kill flags
-// in a map.
-void MachineLateInstrsCleanup::
-clearKillsForDef(Register Reg, MachineBasicBlock *MBB,
-                 MachineBasicBlock::iterator I,
-                 BitVector &VisitedPreds) {
+// Clear any preceding kill flag on Reg after removing a redundant
+// definition.
+void MachineLateInstrsCleanup::clearKillsForDef(Register Reg,
+                                                MachineBasicBlock *MBB,
+                                                BitVector &VisitedPreds) {
   VisitedPreds.set(MBB->getNumber());
 
   // Kill flag in MBB
@@ -137,13 +133,13 @@ clearKillsForDef(Register Reg, MachineBasicBlock *MBB,
   assert(!MBB->pred_empty() && "Predecessor def not found!");
   for (MachineBasicBlock *Pred : MBB->predecessors())
     if (!VisitedPreds.test(Pred->getNumber()))
-      clearKillsForDef(Reg, Pred, Pred->end(), VisitedPreds);
+      clearKillsForDef(Reg, Pred, VisitedPreds);
 }
 
 void MachineLateInstrsCleanup::removeRedundantDef(MachineInstr *MI) {
   Register Reg = MI->getOperand(0).getReg();
   BitVector VisitedPreds(MI->getMF()->getNumBlockIDs());
-  clearKillsForDef(Reg, MI->getParent(), MI->getIterator(), VisitedPreds);
+  clearKillsForDef(Reg, MI->getParent(), VisitedPreds);
   MI->eraseFromParent();
   ++NumRemoved;
 }


### PR DESCRIPTION
With cb57b7a7, MachineLateInstrsCleanup switched to using a map to keep track of kill flags to remedy compile time regressions seen with huge functions.

It seems that the comment above clearKillsForDef() became stale with that commit, and also that one of the arguments to it became unused, both of which  this patch fixes.
