### PR TITLE
[memprof] Remove inline call stacks

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -344,21 +344,11 @@ using LinearCallStackId = uint32_t;
 struct IndexedAllocationInfo {
   // The dynamic calling context for the allocation in bottom-up (leaf-to-root)
   // order. Frame contents are stored out-of-line.
-  // TODO: Remove once we fully transition to CSId.
-  llvm::SmallVector<FrameId> CallStack;
-  // Conceptually the same as above.  We are going to keep both CallStack and
-  // CallStackId while we are transitioning from CallStack to CallStackId.
   CallStackId CSId = 0;
   // The statistics obtained from the runtime for the allocation.
   PortableMemInfoBlock Info;
 
   IndexedAllocationInfo() = default;
-  // This constructor is soft deprecated.  It will be removed once we remove all
-  // users of the CallStack field.
-  IndexedAllocationInfo(ArrayRef<FrameId> CS, CallStackId CSId,
-                        const MemInfoBlock &MB,
-                        const MemProfSchema &Schema = getFullSchema())
-      : CallStack(CS), CSId(CSId), Info(MB, Schema) {}
   IndexedAllocationInfo(CallStackId CSId, const MemInfoBlock &MB,
                         const MemProfSchema &Schema = getFullSchema())
       : CSId(CSId), Info(MB, Schema) {}
@@ -415,21 +405,14 @@ struct IndexedMemProfRecord {
   // list of inline locations in bottom-up order i.e. from leaf to root. The
   // inline location list may include additional entries, users should pick
   // the last entry in the list with the same function GUID.
-  llvm::SmallVector<llvm::SmallVector<FrameId>> CallSites;
-  // Conceptually the same as above.  We are going to keep both CallSites and
-  // CallSiteIds while we are transitioning from CallSites to CallSiteIds.
   llvm::SmallVector<CallStackId> CallSiteIds;
 
-  void clear() {
-    AllocSites.clear();
-    CallSites.clear();
-  }
+  void clear() { AllocSites.clear(); }
 
   void merge(const IndexedMemProfRecord &Other) {
     // TODO: Filter out duplicates which may occur if multiple memprof
     // profiles are merged together using llvm-profdata.
     AllocSites.append(Other.AllocSites);
-    CallSites.append(Other.CallSites);
   }
 
   size_t serializedSize(const MemProfSchema &Schema,

--- a/llvm/lib/ProfileData/MemProfReader.cpp
+++ b/llvm/lib/ProfileData/MemProfReader.cpp
@@ -507,7 +507,7 @@ Error RawMemProfReader::mapRawProfileToRecords() {
     for (size_t I = 0; /*Break out using the condition below*/; I++) {
       const Frame &F = idToFrame(Callstack[I]);
       IndexedMemProfRecord &Record = MemProfData.Records[F.Function];
-      Record.AllocSites.emplace_back(Callstack, CSId, MIB);
+      Record.AllocSites.emplace_back(CSId, MIB);
 
       if (!F.IsInlineFrame)
         break;
@@ -522,7 +522,6 @@ Error RawMemProfReader::mapRawProfileToRecords() {
     for (LocationPtr Loc : Locs) {
       CallStackId CSId = hashCallStack(*Loc);
       MemProfData.CallStacks.insert({CSId, *Loc});
-      Record.CallSites.push_back(*Loc);
       Record.CallSiteIds.push_back(CSId);
     }
   }


### PR DESCRIPTION
Now that MemProf format version 1 has been removed, nobody uses:

- IndexedAllocationInfo::CallStack
- IndexedMemProfRecord::CallSites

This patch removed the dead struct fields.

You might notice that IndexedMemProfRecord::{clear,merge} do not
mention CallSiteIds at all.  I think it's an oversight.  clear doesn't
matter at the moment because we call it during serialization to reduce
memory footprint.  merge is simply not as well tested as it should be.
I'll follow up with a separate patch to address these issues.
