### PR TITLE
[GISel] Add generic implementation for @llvm.expect.with.probability when optimizations are disabled

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2431,6 +2431,7 @@ bool IRTranslator::translateKnownIntrinsic(const CallInst &CI, Intrinsic::ID ID,
   case Intrinsic::invariant_end:
     return true;
   case Intrinsic::expect:
+  case Intrinsic::expect_with_probability:
   case Intrinsic::annotation:
   case Intrinsic::ptr_annotation:
   case Intrinsic::launder_invariant_group:

--- a/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-no-op-intrinsics.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/irtranslator-no-op-intrinsics.ll
@@ -20,9 +20,8 @@ define i64 @expect_with_probability_i64(i64 %arg0) {
   ; CHECK-NEXT:   liveins: $x0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 1
-  ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(s64) = G_INTRINSIC intrinsic(@llvm.expect.with.probability), [[COPY]](s64), [[C]](s64), double 5.000000e-01
-  ; CHECK-NEXT:   $x0 = COPY [[INT]](s64)
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s64) = COPY [[COPY]](s64)
+  ; CHECK-NEXT:   $x0 = COPY [[COPY1]](s64)
   ; CHECK-NEXT:   RET_ReallyLR implicit $x0
   %expval = call i64 @llvm.expect.with.probability.i64(i64 %arg0, i64 1, double 0.5)
   ret i64 %expval

--- a/llvm/test/CodeGen/Generic/builtin-expect-with-probability.ll
+++ b/llvm/test/CodeGen/Generic/builtin-expect-with-probability.ll
@@ -1,4 +1,5 @@
 ; RUN: llc < %s
+; RUN: llc -global-isel < %s
 
 declare i32 @llvm.expect.with.probability(i32, i32, double)
 

--- a/llvm/test/CodeGen/Generic/builtin-expect-with-probability.ll
+++ b/llvm/test/CodeGen/Generic/builtin-expect-with-probability.ll
@@ -1,5 +1,4 @@
 ; RUN: llc < %s
-; RUN: llc -global-isel < %s
 
 declare i32 @llvm.expect.with.probability(i32, i32, double)
 


### PR DESCRIPTION
Handle @llvm.expect.with.probability in GlobalISel in the same way @llvm.expect is handled, passing the value through as-is. This can be encountered if the intrinsic is used without optimizations, which would otherwise transform it out.

Fixes #115411 for GlobalISel