### PR TITLE
[MC][NFC] Update tests for GOTTPOFF relocation.

### DIFF
--- a/llvm/test/MC/ELF/relocation.s
+++ b/llvm/test/MC/ELF/relocation.s
@@ -18,7 +18,7 @@ bar:
         movl	bar, %edx         # R_X86_64_32S
         movq	bar, %rdx         # R_X86_64_32S
 .long bar                         # R_X86_64_32
-        leaq	foo@GOTTPOFF(%rip), %rax # R_X86_64_GOTTPOFF
+        movq    foo@GOTTPOFF(%rip), %rax # R_X86_64_GOTTPOFF
         movq    foo@GOTTPOFF(%rip), %r31 # R_X86_64_CODE_4_GOTTPOFF
         addq    foo@GOTTPOFF(%rip), %r31 # R_X86_64_CODE_4_GOTTPOFF
         # NDD

--- a/llvm/test/MC/ELF/tls.s
+++ b/llvm/test/MC/ELF/tls.s
@@ -2,15 +2,16 @@
 
 // Test that all symbols are of type STT_TLS.
 
-	leaq	foo1@TLSGD(%rip), %rdi
-        leaq    foo2@GOTTPOFF(%rip), %rdi
-        leaq    foo3@TLSLD(%rip), %rdi
-	.long foo4@GOTTPOFF
-	.long foo5@TLSLD
-	.long foo6@TLSGD
-	.section	.zed,"awT",@progbits
+    leaq    foo1@TLSGD(%rip), %rdi
+    movq    foo2@GOTTPOFF(%rip), %rdi
+    leaq    foo3@TLSLD(%rip), %rdi
+
+    .long foo4@GOTTPOFF
+    .long foo5@TLSLD
+    .long foo6@TLSGD
+    .section    .zed,"awT",@progbits
 foobar:
-	.long	43
+    .long    43
 
 // CHECK:        Symbol {
 // CHECK:          Name: foobar


### PR DESCRIPTION
Update tests for GOTTPOFF relocation as LEA instruction is not supported by linkers for GOTTPOFF relocation. Only MOV and ADD instructions are supported.