### PR TITLE
[NVPTX] Add unreachable for TMA Inst Printer

### DIFF
--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.cpp
@@ -450,4 +450,6 @@ void NVPTXInstPrinter::printTmaReductionMode(const MCInst *MI, int OpNum,
     O << ".xor";
     return;
   }
+  llvm_unreachable(
+      "Invalid Reduction Op in printCpAsyncBulkTensorReductionMode");
 }


### PR DESCRIPTION
This patch adds the llvm_reachable() for TMA
reduction opcode printer method, outside the
switch.

We had this inside the default-case leading to
the warning below (and hence was removed):
error: default label in switch which covers all enumeration values
       [-Werror,-Wcovered-switch-default]