### PR TITLE
[libc] Implement process_mrelease

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -252,6 +252,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.mman.munlockall
     libc.src.sys.mman.munmap
     libc.src.sys.mman.remap_file_pages
+    libc.src.sys.mman.process_mrelease
     libc.src.sys.mman.posix_madvise
     libc.src.sys.mman.shm_open
     libc.src.sys.mman.shm_unlink

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -251,6 +251,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.mman.munmap
     libc.src.sys.mman.remap_file_pages
     libc.src.sys.mman.posix_madvise
+    libc.src.sys.mman.process_mrelease
     libc.src.sys.mman.shm_open
     libc.src.sys.mman.shm_unlink
 

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -252,6 +252,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.mman.munmap
     libc.src.sys.mman.remap_file_pages
     libc.src.sys.mman.posix_madvise
+    libc.src.sys.mman.process_mrelease
     libc.src.sys.mman.shm_open
     libc.src.sys.mman.shm_unlink
 

--- a/libc/include/sys/syscall.h.def
+++ b/libc/include/sys/syscall.h.def
@@ -2349,5 +2349,12 @@
 #define SYS_writev __NR_writev
 #endif
 
+#ifdef __NR_process_mrelease
+#define SYS_process_mrelease __NR_process_mrelease
+#endif
+
+#ifdef __NR_pidfd_open
+#define SYS_pidfd_open __NR_pidfd_open
+#endif
 
 #endif // LLVM_LIBC_SYS_SYSCALL_H

--- a/libc/newhdrgen/yaml/sys/mman.yaml
+++ b/libc/newhdrgen/yaml/sys/mman.yaml
@@ -132,3 +132,10 @@ functions:
     return_type: int
     arguments:
       - type: const char *
+  - name: process_mrelease
+    standards:
+      - Linux
+    return_type: int
+    arguments:
+      - type: int
+      - type: unsigned int

--- a/libc/spec/linux.td
+++ b/libc/spec/linux.td
@@ -112,6 +112,12 @@ def Linux : StandardSpec<"Linux"> {
             ArgSpec<IntType>,
             ArgSpec<SizeTType>,
             ArgSpec<IntType>,
+        FunctionSpec<
+          "process_mrelease",
+          RetValSpec<IntType>,
+          [
+            ArgSpec<IntType>,
+            ArgSpec<UnsignedIntType>
           ]
         >,
         FunctionSpec<

--- a/libc/src/sys/mman/CMakeLists.txt
+++ b/libc/src/sys/mman/CMakeLists.txt
@@ -113,6 +113,7 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.mremap
 )
+
 add_entrypoint_object(
   process_mrelease 
   ALIAS 

--- a/libc/src/sys/mman/CMakeLists.txt
+++ b/libc/src/sys/mman/CMakeLists.txt
@@ -2,39 +2,119 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
 
-add_entrypoint_object(madvise ALIAS DEPENDS .${LIBC_TARGET_OS}.madvise)
+add_entrypoint_object(
+  madvise
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.madvise
+)
 
-add_entrypoint_object(mmap ALIAS DEPENDS .${LIBC_TARGET_OS}.mmap)
+add_entrypoint_object(
+  mmap
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mmap
+)
 
-add_entrypoint_object(munmap ALIAS DEPENDS .${LIBC_TARGET_OS}.munmap)
+add_entrypoint_object(
+  munmap
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.munmap
+)
 
-add_entrypoint_object(mprotect ALIAS DEPENDS .${LIBC_TARGET_OS}.mprotect)
+add_entrypoint_object(
+  mprotect
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mprotect
+)
 
-add_entrypoint_object(posix_madvise ALIAS DEPENDS
-                      .${LIBC_TARGET_OS}.posix_madvise)
+add_entrypoint_object(
+  posix_madvise
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.posix_madvise
+)
 
-add_entrypoint_object(mincore ALIAS DEPENDS .${LIBC_TARGET_OS}.mincore)
+add_entrypoint_object(
+  mincore
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mincore
+)
 
-add_entrypoint_object(mlock ALIAS DEPENDS .${LIBC_TARGET_OS}.mlock)
+add_entrypoint_object(
+  mlock
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mlock
+)
 
-add_entrypoint_object(mlock2 ALIAS DEPENDS .${LIBC_TARGET_OS}.mlock2)
+add_entrypoint_object(
+  mlock2
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mlock2
+)
 
-add_entrypoint_object(munlock ALIAS DEPENDS .${LIBC_TARGET_OS}.munlock)
+add_entrypoint_object(
+  munlock
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.munlock
+)
 
-add_entrypoint_object(mlockall ALIAS DEPENDS .${LIBC_TARGET_OS}.mlockall)
+add_entrypoint_object(
+  mlockall
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mlockall
+)
 
-add_entrypoint_object(munlockall ALIAS DEPENDS .${LIBC_TARGET_OS}.munlockall)
+add_entrypoint_object(
+  munlockall
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.munlockall
+)
 
-add_entrypoint_object(msync ALIAS DEPENDS .${LIBC_TARGET_OS}.msync)
+add_entrypoint_object(
+  msync
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.msync
+)
 
-add_entrypoint_object(remap_file_pages ALIAS DEPENDS
-                      .${LIBC_TARGET_OS}.remap_file_pages)
+add_entrypoint_object(
+  remap_file_pages
+  ALIAS
+  DEPENDS
+  .${LIBC_TARGET_OS}.remap_file_pages
+)
 
-add_entrypoint_object(shm_open ALIAS DEPENDS .${LIBC_TARGET_OS}.shm_open)
+add_entrypoint_object(
+  shm_open
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.shm_open
+)
 
-add_entrypoint_object(shm_unlink ALIAS DEPENDS .${LIBC_TARGET_OS}.shm_unlink)
+add_entrypoint_object(
+  shm_unlink
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.shm_unlink
+)
 
-add_entrypoint_object(mremap ALIAS DEPENDS .${LIBC_TARGET_OS}.mremap)
-
-add_entrypoint_object(process_mrelease ALIAS DEPENDS
-                      .${LIBC_TARGET_OS}.process_mrelease)
+add_entrypoint_object(
+  mremap
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.mremap
+)
+add_entrypoint_object(
+  process_mrelease 
+  ALIAS 
+  DEPENDS
+    .${LIBC_TARGET_OS}.process_mrelease)

--- a/libc/src/sys/mman/CMakeLists.txt
+++ b/libc/src/sys/mman/CMakeLists.txt
@@ -2,114 +2,39 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
 
-add_entrypoint_object(
-  madvise
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.madvise
-)
+add_entrypoint_object(madvise ALIAS DEPENDS .${LIBC_TARGET_OS}.madvise)
 
-add_entrypoint_object(
-  mmap
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mmap
-)
+add_entrypoint_object(mmap ALIAS DEPENDS .${LIBC_TARGET_OS}.mmap)
 
-add_entrypoint_object(
-  munmap
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.munmap
-)
+add_entrypoint_object(munmap ALIAS DEPENDS .${LIBC_TARGET_OS}.munmap)
 
-add_entrypoint_object(
-  mprotect
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mprotect
-)
+add_entrypoint_object(mprotect ALIAS DEPENDS .${LIBC_TARGET_OS}.mprotect)
 
-add_entrypoint_object(
-  posix_madvise
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.posix_madvise
-)
+add_entrypoint_object(posix_madvise ALIAS DEPENDS
+                      .${LIBC_TARGET_OS}.posix_madvise)
 
-add_entrypoint_object(
-  mincore
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mincore
-)
+add_entrypoint_object(mincore ALIAS DEPENDS .${LIBC_TARGET_OS}.mincore)
 
-add_entrypoint_object(
-  mlock
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mlock
-)
+add_entrypoint_object(mlock ALIAS DEPENDS .${LIBC_TARGET_OS}.mlock)
 
-add_entrypoint_object(
-  mlock2
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mlock2
-)
+add_entrypoint_object(mlock2 ALIAS DEPENDS .${LIBC_TARGET_OS}.mlock2)
 
-add_entrypoint_object(
-  munlock
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.munlock
-)
+add_entrypoint_object(munlock ALIAS DEPENDS .${LIBC_TARGET_OS}.munlock)
 
-add_entrypoint_object(
-  mlockall
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mlockall
-)
+add_entrypoint_object(mlockall ALIAS DEPENDS .${LIBC_TARGET_OS}.mlockall)
 
-add_entrypoint_object(
-  munlockall
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.munlockall
-)
+add_entrypoint_object(munlockall ALIAS DEPENDS .${LIBC_TARGET_OS}.munlockall)
 
-add_entrypoint_object(
-  msync
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.msync
-)
+add_entrypoint_object(msync ALIAS DEPENDS .${LIBC_TARGET_OS}.msync)
 
-add_entrypoint_object(
-  remap_file_pages
-  ALIAS
-  DEPENDS
-  .${LIBC_TARGET_OS}.remap_file_pages
-)
+add_entrypoint_object(remap_file_pages ALIAS DEPENDS
+                      .${LIBC_TARGET_OS}.remap_file_pages)
 
-add_entrypoint_object(
-  shm_open
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.shm_open
-)
+add_entrypoint_object(shm_open ALIAS DEPENDS .${LIBC_TARGET_OS}.shm_open)
 
-add_entrypoint_object(
-  shm_unlink
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.shm_unlink
-)
+add_entrypoint_object(shm_unlink ALIAS DEPENDS .${LIBC_TARGET_OS}.shm_unlink)
 
-add_entrypoint_object(
-  mremap
-  ALIAS
-  DEPENDS
-    .${LIBC_TARGET_OS}.mremap
-)
+add_entrypoint_object(mremap ALIAS DEPENDS .${LIBC_TARGET_OS}.mremap)
+
+add_entrypoint_object(process_mrelease ALIAS DEPENDS
+                      .${LIBC_TARGET_OS}.process_mrelease)

--- a/libc/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/src/sys/mman/linux/CMakeLists.txt
@@ -1,26 +1,28 @@
 add_entrypoint_object(
   madvise
   SRCS
-  madvise.cpp
+    madvise.cpp
   HDRS
-  ../madvise.h
+    ../madvise.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   mmap
   SRCS
-  mmap.cpp
+    mmap.cpp
   HDRS
-  ../mmap.h
+    ../mmap.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   mremap
@@ -34,180 +36,193 @@ add_entrypoint_object(
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
-
 add_entrypoint_object(
   munmap
   SRCS
-  munmap.cpp
+    munmap.cpp
   HDRS
-  ../munmap.h
+    ../munmap.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   mprotect
   SRCS
-  mprotect.cpp
+    mprotect.cpp
   HDRS
-  ../mprotect.h
+    ../mprotect.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   posix_madvise
   SRCS
-  posix_madvise.cpp
+    posix_madvise.cpp
   HDRS
-  ../posix_madvise.h
+    ../posix_madvise.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+)
 
 add_entrypoint_object(
   mincore
   SRCS
-  mincore.cpp
+    mincore.cpp
   HDRS
-  ../mincore.h
+    ../mincore.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   mlock
   SRCS
-  mlock.cpp
+    mlock.cpp
   HDRS
-  ../mlock.h
+    ../mlock.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   mlock2
   SRCS
-  mlock2.cpp
+    mlock2.cpp
   HDRS
-  ../mlock2.h
+    ../mlock2.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   munlock
   SRCS
-  munlock.cpp
+    munlock.cpp
   HDRS
-  ../munlock.h
+    ../munlock.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   mlockall
   SRCS
-  mlockall.cpp
+    mlockall.cpp
   HDRS
-  ../mlockall.h
+    ../mlockall.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   munlockall
   SRCS
-  munlockall.cpp
+    munlockall.cpp
   HDRS
-  ../munlockall.h
+    ../munlockall.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   msync
   SRCS
-  msync.cpp
+    msync.cpp
   HDRS
-  ../msync.h
+    ../msync.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_entrypoint_object(
   remap_file_pages
   SRCS
-  remap_file_pages.cpp
+    remap_file_pages.cpp
   HDRS
-  ../remap_file_pages.h
+    ../remap_file_pages.h
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
 
 add_header_library(
   shm_common
   HDRS
-  shm_common.h
+    shm_common.h
   DEPENDS
-  libc.src.__support.CPP.array
-  libc.src.__support.CPP.string_view
-  libc.src.__support.CPP.optional
-  libc.src.__support.common
-  libc.src.errno.errno
-  libc.src.string.memory_utils.inline_memcpy)
+    libc.src.__support.CPP.array
+    libc.src.__support.CPP.string_view
+    libc.src.__support.CPP.optional
+    libc.src.__support.common
+    libc.src.errno.errno
+    libc.src.string.memory_utils.inline_memcpy
+)
 
 add_entrypoint_object(
   shm_open
   SRCS
-  shm_open.cpp
+    shm_open.cpp
   HDRS
-  ../shm_open.h
+    ../shm_open.h
   DEPENDS
-  libc.src.fcntl.open
-  libc.hdr.types.mode_t
-  .shm_common)
+    libc.src.fcntl.open
+    libc.hdr.types.mode_t
+    .shm_common
+)
 
 add_entrypoint_object(
   shm_unlink
   SRCS
-  shm_unlink.cpp
+    shm_unlink.cpp
   HDRS
-  ../shm_unlink.h
+    ../shm_unlink.h
   DEPENDS
-  libc.src.unistd.unlink
-  .shm_common)
+    libc.src.unistd.unlink
+    .shm_common
+)
 
 add_entrypoint_object(
   process_mrelease
   SRCS
-  process_mrelease.cpp
+    process_mrelease.cpp
   HDRS
-  ../process_mrelease.h
+    ../process_mrelease.h
   DEPENDS
-  libc.include.signal
-  libc.src.signal.kill
-  libc.include.sys_syscall
-  libc.src.__support.OSUtil.osutil
-  libc.src.errno.errno)
+    libc.include.signal
+    libc.src.signal.kill
+    libc.include.sys_syscall
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno)

--- a/libc/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/src/sys/mman/linux/CMakeLists.txt
@@ -221,8 +221,6 @@ add_entrypoint_object(
   HDRS
     ../process_mrelease.h
   DEPENDS
-    libc.include.signal
-    libc.src.signal.kill
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno)

--- a/libc/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/src/sys/mman/linux/CMakeLists.txt
@@ -1,28 +1,26 @@
 add_entrypoint_object(
   madvise
   SRCS
-    madvise.cpp
+  madvise.cpp
   HDRS
-    ../madvise.h
+  ../madvise.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   mmap
   SRCS
-    mmap.cpp
+  mmap.cpp
   HDRS
-    ../mmap.h
+  ../mmap.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   mremap
@@ -40,177 +38,176 @@ add_entrypoint_object(
 add_entrypoint_object(
   munmap
   SRCS
-    munmap.cpp
+  munmap.cpp
   HDRS
-    ../munmap.h
+  ../munmap.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   mprotect
   SRCS
-    mprotect.cpp
+  mprotect.cpp
   HDRS
-    ../mprotect.h
+  ../mprotect.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   posix_madvise
   SRCS
-    posix_madvise.cpp
+  posix_madvise.cpp
   HDRS
-    ../posix_madvise.h
+  ../posix_madvise.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil)
 
 add_entrypoint_object(
   mincore
   SRCS
-    mincore.cpp
+  mincore.cpp
   HDRS
-    ../mincore.h
+  ../mincore.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   mlock
   SRCS
-    mlock.cpp
+  mlock.cpp
   HDRS
-    ../mlock.h
+  ../mlock.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   mlock2
   SRCS
-    mlock2.cpp
+  mlock2.cpp
   HDRS
-    ../mlock2.h
+  ../mlock2.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   munlock
   SRCS
-    munlock.cpp
+  munlock.cpp
   HDRS
-    ../munlock.h
+  ../munlock.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   mlockall
   SRCS
-    mlockall.cpp
+  mlockall.cpp
   HDRS
-    ../mlockall.h
+  ../mlockall.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   munlockall
   SRCS
-    munlockall.cpp
+  munlockall.cpp
   HDRS
-    ../munlockall.h
+  ../munlockall.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   msync
   SRCS
-    msync.cpp
+  msync.cpp
   HDRS
-    ../msync.h
+  ../msync.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_entrypoint_object(
   remap_file_pages
   SRCS
-    remap_file_pages.cpp
+  remap_file_pages.cpp
   HDRS
-    ../remap_file_pages.h
+  ../remap_file_pages.h
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.__support.OSUtil.osutil
-    libc.src.errno.errno
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)
 
 add_header_library(
   shm_common
   HDRS
-    shm_common.h
+  shm_common.h
   DEPENDS
-    libc.src.__support.CPP.array
-    libc.src.__support.CPP.string_view
-    libc.src.__support.CPP.optional
-    libc.src.__support.common
-    libc.src.errno.errno
-    libc.src.string.memory_utils.inline_memcpy
-)
+  libc.src.__support.CPP.array
+  libc.src.__support.CPP.string_view
+  libc.src.__support.CPP.optional
+  libc.src.__support.common
+  libc.src.errno.errno
+  libc.src.string.memory_utils.inline_memcpy)
 
 add_entrypoint_object(
   shm_open
   SRCS
-    shm_open.cpp
+  shm_open.cpp
   HDRS
-    ../shm_open.h
+  ../shm_open.h
   DEPENDS
-    libc.src.fcntl.open
-    libc.hdr.types.mode_t
-    .shm_common
-)
+  libc.src.fcntl.open
+  libc.hdr.types.mode_t
+  .shm_common)
 
 add_entrypoint_object(
   shm_unlink
   SRCS
-    shm_unlink.cpp
+  shm_unlink.cpp
   HDRS
-    ../shm_unlink.h
+  ../shm_unlink.h
   DEPENDS
-    libc.src.unistd.unlink
-    .shm_common
-)
+  libc.src.unistd.unlink
+  .shm_common)
+
+add_entrypoint_object(
+  process_mrelease
+  SRCS
+  process_mrelease.cpp
+  HDRS
+  ../process_mrelease.h
+  DEPENDS
+  libc.include.signal
+  libc.src.signal.kill
+  libc.include.sys_syscall
+  libc.src.__support.OSUtil.osutil
+  libc.src.errno.errno)

--- a/libc/src/sys/mman/linux/process_mrelease.cpp
+++ b/libc/src/sys/mman/linux/process_mrelease.cpp
@@ -1,0 +1,33 @@
+//===---------- Linux implementation of the mrelease function -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sys/mman/process_mrelease.h"
+
+#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/common.h"
+
+#include "src/__support/macros/config.h"
+#include "src/errno/libc_errno.h"
+#include <linux/param.h> // For EXEC_PAGESIZE.
+#include <sys/syscall.h> // For syscall numbers.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, process_mrelease, (int pidfd, unsigned int flags)) {
+  long ret =
+      LIBC_NAMESPACE::syscall_impl<int>(SYS_process_mrelease, pidfd, flags);
+
+  if (ret < 0) {
+    libc_errno = static_cast<int>(-ret);
+    return libc_errno;
+  }
+
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sys/mman/linux/process_mrelease.cpp
+++ b/libc/src/sys/mman/linux/process_mrelease.cpp
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(int, process_mrelease, (int pidfd, unsigned int flags)) {
 
   if (ret < 0) {
     libc_errno = static_cast<int>(-ret);
-    return libc_errno;
+    return -1;
   }
 
   return 0;

--- a/libc/src/sys/mman/process_mrelease.h
+++ b/libc/src/sys/mman/process_mrelease.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for process_mrelease  function -----------------*-
+// C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H
+#define LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H
+
+#include "src/__support/macros/config.h"
+#include <sys/mman.h> // For size_t and off_t
+
+namespace LIBC_NAMESPACE_DECL {
+
+int process_mrelease(int pidfd, unsigned int flags);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H

--- a/libc/src/sys/mman/process_mrelease.h
+++ b/libc/src/sys/mman/process_mrelease.h
@@ -1,11 +1,10 @@
-//===-- Implementation header for process_mrelease  function -----------------*-
-// C++ -*-===//
+//===-- Implementation header for process_mrelease function --------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===----------------------------------------------------------------------===//
+//===-------------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H
 #define LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H

--- a/libc/src/sys/mman/process_mrelease.h
+++ b/libc/src/sys/mman/process_mrelease.h
@@ -1,10 +1,10 @@
-//===-- Implementation header for process_mrelease function --------*- C++ -*-===//
+//===-- Implementation header for process_mrelease function -*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-------------------------------------------------------------------------===//
+//===------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H
 #define LLVM_LIBC_SRC_SYS_MMAN_PROCESS_MRELEASE_H

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -1,17 +1,16 @@
-add_custom_target(libc_sys_mman_unittests)
-
 add_libc_unittest(
   mmap_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  mmap_test.cpp
+    mmap_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
 
 add_libc_unittest(
   mremap_test
@@ -29,172 +28,170 @@ add_libc_unittest(
 )
 
 if (NOT LLVM_USE_SANITIZER)
-if(NOT LLVM_USE_SANITIZER)
   add_libc_unittest(
     mprotect_test
     SUITE
-    libc_sys_mman_unittests
+      libc_sys_mman_unittests
     SRCS
-    mprotect_test.cpp
+      mprotect_test.cpp
     DEPENDS
-    libc.include.sys_mman
-    libc.include.signal
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.sys.mman.mprotect
-    libc.test.UnitTest.ErrnoSetterMatcher)
+      libc.include.sys_mman
+      libc.include.signal
+      libc.src.errno.errno
+      libc.src.sys.mman.mmap
+      libc.src.sys.mman.munmap
+      libc.src.sys.mman.mprotect
+      libc.test.UnitTest.ErrnoSetterMatcher
+  )
 endif()
 
 add_libc_unittest(
   madvise_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
   madvise_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.sys.mman.madvise
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.sys.mman.madvise
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
+
 
 add_libc_unittest(
   posix_madvise_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
   posix_madvise_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.sys.mman.posix_madvise
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.sys.mman.posix_madvise
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
 
 add_libc_unittest(
   mincore_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  mincore_test.cpp
+    mincore_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.include.unistd
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.sys.mman.madvise
-  libc.src.sys.mman.mincore
-  libc.src.sys.mman.mlock
-  libc.src.sys.mman.munlock
-  libc.src.unistd.sysconf
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.include.unistd
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.sys.mman.madvise
+    libc.src.sys.mman.mincore
+    libc.src.sys.mman.mlock
+    libc.src.sys.mman.munlock
+    libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
 
 add_libc_unittest(
   mlock_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  mlock_test.cpp
+    mlock_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.include.unistd
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.sys.mman.madvise
-  libc.src.sys.mman.mincore
-  libc.src.sys.mman.mlock
-  libc.src.sys.mman.mlock2
-  libc.src.sys.mman.munlock
-  libc.src.sys.mman.mlockall
-  libc.src.sys.mman.munlockall
-  libc.src.sys.resource.getrlimit
-  libc.src.__support.OSUtil.osutil
-  libc.src.unistd.sysconf
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.include.unistd
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.sys.mman.madvise
+    libc.src.sys.mman.mincore
+    libc.src.sys.mman.mlock
+    libc.src.sys.mman.mlock2
+    libc.src.sys.mman.munlock
+    libc.src.sys.mman.mlockall
+    libc.src.sys.mman.munlockall
+    libc.src.sys.resource.getrlimit
+    libc.src.__support.OSUtil.osutil
+    libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
 
 add_libc_unittest(
   msync_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  msync_test.cpp
+    msync_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.include.unistd
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.sys.mman.msync
-  libc.src.sys.mman.mincore
-  libc.src.sys.mman.mlock
-  libc.src.sys.mman.munlock
-  libc.src.unistd.sysconf
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.include.unistd
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.sys.mman.msync
+    libc.src.sys.mman.mincore
+    libc.src.sys.mman.mlock
+    libc.src.sys.mman.munlock
+    libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
 
 add_libc_unittest(
   remap_file_pages_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  remap_file_pages_test.cpp
+    remap_file_pages_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_stat
-  libc.src.unistd.sysconf
-  libc.test.UnitTest.ErrnoSetterMatcher
-  libc.src.sys.mman.remap_file_pages
-  libc.src.errno.errno
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap)
+    libc.include.sys_mman
+    libc.include.sys_stat
+    libc.src.unistd.sysconf
+    libc.test.UnitTest.ErrnoSetterMatcher
+    libc.src.sys.mman.remap_file_pages
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+)
 
 add_libc_unittest(
   shm_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  shm_test.cpp
+    shm_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.errno.errno
-  libc.src.fcntl.fcntl
-  libc.src.sys.mman.shm_open
-  libc.src.sys.mman.shm_unlink
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.unistd.ftruncate
-  libc.src.unistd.close
-  libc.src.__support.OSUtil.osutil
-  libc.hdr.fcntl_macros
-  libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.errno.errno
+    libc.src.fcntl.fcntl
+    libc.src.sys.mman.shm_open
+    libc.src.sys.mman.shm_unlink
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.unistd.ftruncate
+    libc.src.unistd.close
+    libc.src.__support.OSUtil.osutil
+    libc.hdr.fcntl_macros
+    libc.test.UnitTest.ErrnoSetterMatcher
+)
 
 add_libc_unittest(
   process_mrelease_test
   SUITE
-  libc_sys_mman_unittests
+    libc_sys_mman_unittests
   SRCS
-  process_mrelease_test.cpp
+    process_mrelease_test.cpp
   DEPENDS
-  libc.include.sys_mman
-  libc.include.sys_syscall
-  libc.src.errno.errno
-  libc.src.fcntl.fcntl
-  libc.include.sys_wait
-  libc.src.sys.wait.waitpid
-  libc.src.sys.mman.process_mrelease
-  libc.src.sys.mman.mmap
-  libc.src.sys.mman.munmap
-  libc.src.unistd.ftruncate
-  libc.src.unistd.close
-  libc.src.__support.OSUtil.osutil
-  libc.test.UnitTest.ErrnoSetterMatcher)
-
-# add_libc_unittest( process_mrelease_test SUITE libc_sys_mman_unittests SRCS
-# process_mrelease_test.cpp DEPENDS libc.include.sys_mman
-# libc.include.sys_syscall libc.src.errno.errno
-# libc.src.sys.mman.process_mrelease libc.test.UnitTest.ErrnoSetterMatcher)
+    libc.include.sys_mman
+    libc.include.sys_syscall
+    libc.src.errno.errno
+    libc.src.sys.mman.process_mrelease
+    libc.src.unistd.close
+    libc.src.stdlib.exit
+    libc.src.__support.OSUtil.osutil
+    libc.src.__support.threads.sleep)

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -194,6 +194,8 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.mman.process_mrelease
     libc.src.unistd.close
+    libc.src.signal.kill
+    libc.include.signal
     libc.src.stdlib.exit
     libc.src.__support.OSUtil.osutil
     libc.src.__support.threads.sleep)

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -3,16 +3,15 @@ add_custom_target(libc_sys_mman_unittests)
 add_libc_unittest(
   mmap_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
-    mmap_test.cpp
+  mmap_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
+  libc.include.sys_mman
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.test.UnitTest.ErrnoSetterMatcher)
 
 add_libc_unittest(
   mremap_test
@@ -30,154 +29,172 @@ add_libc_unittest(
 )
 
 if (NOT LLVM_USE_SANITIZER)
+if(NOT LLVM_USE_SANITIZER)
   add_libc_unittest(
     mprotect_test
     SUITE
-      libc_sys_mman_unittests
+    libc_sys_mman_unittests
     SRCS
-      mprotect_test.cpp
+    mprotect_test.cpp
     DEPENDS
-      libc.include.sys_mman
-      libc.include.signal
-      libc.src.errno.errno
-      libc.src.sys.mman.mmap
-      libc.src.sys.mman.munmap
-      libc.src.sys.mman.mprotect
-      libc.test.UnitTest.ErrnoSetterMatcher
-  )
+    libc.include.sys_mman
+    libc.include.signal
+    libc.src.errno.errno
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.munmap
+    libc.src.sys.mman.mprotect
+    libc.test.UnitTest.ErrnoSetterMatcher)
 endif()
 
 add_libc_unittest(
   madvise_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
   madvise_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.sys.mman.madvise
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
-
+  libc.include.sys_mman
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.sys.mman.madvise
+  libc.test.UnitTest.ErrnoSetterMatcher)
 
 add_libc_unittest(
   posix_madvise_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
   posix_madvise_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.sys.mman.posix_madvise
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
+  libc.include.sys_mman
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.sys.mman.posix_madvise
+  libc.test.UnitTest.ErrnoSetterMatcher)
 
 add_libc_unittest(
   mincore_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
-    mincore_test.cpp
+  mincore_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.include.unistd
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.sys.mman.madvise
-    libc.src.sys.mman.mincore
-    libc.src.sys.mman.mlock
-    libc.src.sys.mman.munlock
-    libc.src.unistd.sysconf
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
+  libc.include.sys_mman
+  libc.include.unistd
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.sys.mman.madvise
+  libc.src.sys.mman.mincore
+  libc.src.sys.mman.mlock
+  libc.src.sys.mman.munlock
+  libc.src.unistd.sysconf
+  libc.test.UnitTest.ErrnoSetterMatcher)
 
 add_libc_unittest(
   mlock_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
-    mlock_test.cpp
+  mlock_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.include.unistd
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.sys.mman.madvise
-    libc.src.sys.mman.mincore
-    libc.src.sys.mman.mlock
-    libc.src.sys.mman.mlock2
-    libc.src.sys.mman.munlock
-    libc.src.sys.mman.mlockall
-    libc.src.sys.mman.munlockall
-    libc.src.sys.resource.getrlimit
-    libc.src.__support.OSUtil.osutil
-    libc.src.unistd.sysconf
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
+  libc.include.sys_mman
+  libc.include.unistd
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.sys.mman.madvise
+  libc.src.sys.mman.mincore
+  libc.src.sys.mman.mlock
+  libc.src.sys.mman.mlock2
+  libc.src.sys.mman.munlock
+  libc.src.sys.mman.mlockall
+  libc.src.sys.mman.munlockall
+  libc.src.sys.resource.getrlimit
+  libc.src.__support.OSUtil.osutil
+  libc.src.unistd.sysconf
+  libc.test.UnitTest.ErrnoSetterMatcher)
 
 add_libc_unittest(
   msync_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
-    msync_test.cpp
+  msync_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.include.unistd
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.sys.mman.msync
-    libc.src.sys.mman.mincore
-    libc.src.sys.mman.mlock
-    libc.src.sys.mman.munlock
-    libc.src.unistd.sysconf
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
+  libc.include.sys_mman
+  libc.include.unistd
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.sys.mman.msync
+  libc.src.sys.mman.mincore
+  libc.src.sys.mman.mlock
+  libc.src.sys.mman.munlock
+  libc.src.unistd.sysconf
+  libc.test.UnitTest.ErrnoSetterMatcher)
 
 add_libc_unittest(
   remap_file_pages_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
-    remap_file_pages_test.cpp
+  remap_file_pages_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_stat
-    libc.src.unistd.sysconf
-    libc.test.UnitTest.ErrnoSetterMatcher
-    libc.src.sys.mman.remap_file_pages
-    libc.src.errno.errno
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-)
+  libc.include.sys_mman
+  libc.include.sys_stat
+  libc.src.unistd.sysconf
+  libc.test.UnitTest.ErrnoSetterMatcher
+  libc.src.sys.mman.remap_file_pages
+  libc.src.errno.errno
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap)
 
 add_libc_unittest(
   shm_test
   SUITE
-    libc_sys_mman_unittests
+  libc_sys_mman_unittests
   SRCS
-    shm_test.cpp
+  shm_test.cpp
   DEPENDS
-    libc.include.sys_mman
-    libc.include.sys_syscall
-    libc.src.errno.errno
-    libc.src.fcntl.fcntl
-    libc.src.sys.mman.shm_open
-    libc.src.sys.mman.shm_unlink
-    libc.src.sys.mman.mmap
-    libc.src.sys.mman.munmap
-    libc.src.unistd.ftruncate
-    libc.src.unistd.close
-    libc.src.__support.OSUtil.osutil
-    libc.hdr.fcntl_macros
-    libc.test.UnitTest.ErrnoSetterMatcher
-)
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.errno.errno
+  libc.src.fcntl.fcntl
+  libc.src.sys.mman.shm_open
+  libc.src.sys.mman.shm_unlink
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.unistd.ftruncate
+  libc.src.unistd.close
+  libc.src.__support.OSUtil.osutil
+  libc.hdr.fcntl_macros
+  libc.test.UnitTest.ErrnoSetterMatcher)
+
+add_libc_unittest(
+  process_mrelease_test
+  SUITE
+  libc_sys_mman_unittests
+  SRCS
+  process_mrelease_test.cpp
+  DEPENDS
+  libc.include.sys_mman
+  libc.include.sys_syscall
+  libc.src.errno.errno
+  libc.src.fcntl.fcntl
+  libc.include.sys_wait
+  libc.src.sys.wait.waitpid
+  libc.src.sys.mman.process_mrelease
+  libc.src.sys.mman.mmap
+  libc.src.sys.mman.munmap
+  libc.src.unistd.ftruncate
+  libc.src.unistd.close
+  libc.src.__support.OSUtil.osutil
+  libc.test.UnitTest.ErrnoSetterMatcher)
+
+# add_libc_unittest( process_mrelease_test SUITE libc_sys_mman_unittests SRCS
+# process_mrelease_test.cpp DEPENDS libc.include.sys_mman
+# libc.include.sys_syscall libc.src.errno.errno
+# libc.src.sys.mman.process_mrelease libc.test.UnitTest.ErrnoSetterMatcher)

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_custom_target(libc_sys_mman_unittests)
+
 add_libc_unittest(
   mmap_test
   SUITE

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -200,4 +200,4 @@ add_libc_unittest(
     libc.src.__support.OSUtil.osutil
     libc.src.__support.threads.sleep
     libc.test.UnitTest.ErrnoSetterMatcher
-    )
+)

--- a/libc/test/src/sys/mman/linux/CMakeLists.txt
+++ b/libc/test/src/sys/mman/linux/CMakeLists.txt
@@ -198,4 +198,6 @@ add_libc_unittest(
     libc.include.signal
     libc.src.stdlib.exit
     libc.src.__support.OSUtil.osutil
-    libc.src.__support.threads.sleep)
+    libc.src.__support.threads.sleep
+    libc.test.UnitTest.ErrnoSetterMatcher
+    )

--- a/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
+++ b/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
@@ -23,8 +23,7 @@ int pidfd_open(pid_t pid, unsigned int flags) {
 }
 
 TEST(LlvmLibcMProcessMReleaseTest, NoError) {
-  pid_t child_pid = LIBC_NAMESPACE::fork();
-
+  pid_t child_pid = fork();
   EXPECT_GE(child_pid, 0);
 
   if (child_pid == 0) {
@@ -49,7 +48,6 @@ TEST(LlvmLibcMProcessMReleaseTest, NoError) {
 
 TEST(LlvmLibcMProcessMReleaseTest, ErrorNotKilled) {
   pid_t child_pid = fork();
-
   EXPECT_GE(child_pid, 0);
 
   if (child_pid == 0) {

--- a/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
+++ b/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
@@ -1,0 +1,74 @@
+//===-- Unittests for process_mrelease
+//-------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/threads/sleep.h"
+#include "src/errno/libc_errno.h"
+#include "src/signal/kill.h"
+#include "src/stdlib/exit.h"
+#include "src/sys/mman/process_mrelease.h"
+#include "src/unistd/close.h"
+#include "src/unistd/fork.h"
+#include "test/UnitTest/LibcTest.h"
+
+#include <sys/syscall.h>
+
+int pidfd_open(pid_t pid, unsigned int flags) {
+  return LIBC_NAMESPACE::syscall_impl(SYS_pidfd_open, pid, flags);
+}
+
+TEST(LlvmLibcMProcessMReleaseTest, NoError) {
+  pid_t child_pid = LIBC_NAMESPACE::fork();
+
+  EXPECT_GE(child_pid, 0);
+
+  if (child_pid == 0) {
+    // Child process: wait a bit then exit gracefully.
+    LIBC_NAMESPACE::sleep_briefly();
+    LIBC_NAMESPACE::exit(0);
+  } else {
+    // Parent process: wait a bit and then kill the child.
+    // Give child process some time to start.
+    LIBC_NAMESPACE::sleep_briefly();
+    int pidfd = pidfd_open(child_pid, 0);
+    EXPECT_GE(pidfd, 0);
+
+    // Send SIGKILL to child process
+    LIBC_NAMESPACE::kill(child_pid, SIGKILL);
+
+    EXPECT_EQ(LIBC_NAMESPACE::process_mrelease(pidfd, 0), 0);
+
+    LIBC_NAMESPACE::close(pidfd);
+  }
+}
+
+TEST(LlvmLibcMProcessMReleaseTest, ErrorNotKilled) {
+  pid_t child_pid = fork();
+
+  EXPECT_GE(child_pid, 0);
+
+  if (child_pid == 0) {
+    // Child process: wait a bit then exit gracefully.
+    LIBC_NAMESPACE::sleep_briefly();
+    LIBC_NAMESPACE::exit(0);
+  } else {
+    // Give child process some time to start.
+    LIBC_NAMESPACE::sleep_briefly();
+    int pidfd = pidfd_open(child_pid, 0);
+    EXPECT_GE(pidfd, 0);
+
+    ASSERT_EQ(LIBC_NAMESPACE::process_mrelease(pidfd, 0), EINVAL);
+
+    LIBC_NAMESPACE::close(pidfd);
+  }
+}
+
+TEST(LlvmLibcMProcessMReleaseTest, ErrorNonExistingPidfd) {
+
+  ASSERT_EQ(LIBC_NAMESPACE::process_mrelease(12345, 0), EBADF);
+}

--- a/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
+++ b/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
@@ -1,3 +1,10 @@
+//===-- Unittests for process_mrelease ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 //===-- Unittests for process_mrelease
 //-------------------------------------===//
 //
@@ -68,5 +75,5 @@ TEST(LlvmLibcMProcessMReleaseTest, ErrorNotKilled) {
 
 TEST(LlvmLibcMProcessMReleaseTest, ErrorNonExistingPidfd) {
 
-  ASSERT_EQ(LIBC_NAMESPACE::process_mrelease(12345, 0), EBADF);
+  ASSERT_EQ(LIBC_NAMESPACE::process_mrelease(-1, 0), EBADF);
 }

--- a/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
+++ b/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
@@ -5,14 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//===-- Unittests for process_mrelease
-//-------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
+
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/threads/sleep.h"
 #include "src/errno/libc_errno.h"

--- a/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
+++ b/libc/test/src/sys/mman/linux/process_mrelease_test.cpp
@@ -25,7 +25,7 @@ int pidfd_open(pid_t pid, unsigned int flags) {
   return LIBC_NAMESPACE::syscall_impl(SYS_pidfd_open, pid, flags);
 }
 
-TEST(LlvmLibcMProcessMReleaseTest, NoError) {
+TEST(LlvmLibcProcessMReleaseTest, NoError) {
   pid_t child_pid = fork();
   EXPECT_GE(child_pid, 0);
 
@@ -49,7 +49,7 @@ TEST(LlvmLibcMProcessMReleaseTest, NoError) {
   }
 }
 
-TEST(LlvmLibcMProcessMReleaseTest, ErrorNotKilled) {
+TEST(LlvmLibcProcessMReleaseTest, ErrorNotKilled) {
   pid_t child_pid = fork();
   EXPECT_GE(child_pid, 0);
 
@@ -69,6 +69,6 @@ TEST(LlvmLibcMProcessMReleaseTest, ErrorNotKilled) {
   }
 }
 
-TEST(LlvmLibcMProcessMReleaseTest, ErrorNonExistingPidfd) {
+TEST(LlvmLibcProcessMReleaseTest, ErrorNonExistingPidfd) {
   EXPECT_THAT(LIBC_NAMESPACE::process_mrelease(-1, 0), Fails(EBADF));
 }


### PR DESCRIPTION
This PR implements process_mrelease.
A previous PR was merged #117503, but failed on merge due to an issue in the tests. Namely the failing tests were comparing against return type as opposed to errno. This is fixed in this PR.