### PR TITLE
[NFC][RISCV] Remove CFIIndex argument from allocateStack

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.h
@@ -79,7 +79,8 @@ public:
   }
 
   void allocateStack(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
-                     StackOffset Offset, bool EmitCFI, unsigned CFIIndex) const;
+                     MachineFunction &MF, StackOffset Offset,
+                     uint64_t RealStackSize, bool EmitCFI) const;
 
 protected:
   const RISCVSubtarget &STI;


### PR DESCRIPTION
Calculates CFIIndex inside RISCVFrameLowering::allocateStack instead of sending it by argument.