### PR TITLE
[Flang][OpenMP] Do not default privatize symbols that are not variables

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2112,7 +2112,7 @@ void OmpAttributeVisitor::Post(const parser::OpenMPAllocatorsConstruct &x) {
 
 static bool IsPrivatizable(const Symbol *sym) {
   auto *misc{sym->detailsIf<MiscDetails>()};
-  return !IsProcedure(*sym) && !IsNamedConstant(*sym) &&
+  return IsVariableName(*sym) && !IsProcedure(*sym) && !IsNamedConstant(*sym) &&
       !semantics::IsAssumedSizeArray(
           *sym) && /* OpenMP 5.2, 5.1.1: Assumed-size arrays are shared*/
       !sym->owner().IsDerivedType() &&

--- a/flang/test/Semantics/OpenMP/critical_within_default.f90
+++ b/flang/test/Semantics/OpenMP/critical_within_default.f90
@@ -1,0 +1,17 @@
+! RUN: %flang_fc1 -fopenmp -fdebug-dump-symbols %s | FileCheck %s
+! Test that we do not make a private copy of the critical name
+
+!CHECK:  MainProgram scope: mn
+!CHECK-NEXT:    j size=4 offset=0: ObjectEntity type: INTEGER(4)
+!CHECK-NEXT:    OtherConstruct scope:
+!CHECK-NEXT:      j (OmpPrivate): HostAssoc
+!CHECK-NEXT:      k2 (OmpCriticalLock): Unknown
+program mn
+  integer :: j
+  j=2
+  !$omp parallel default(private)
+    !$omp critical(k2)
+    j=200
+    !$omp end critical(k2)
+  !$omp end parallel
+end 


### PR DESCRIPTION
Fixes an issue where the compiler is trying to default privatize construct names.

Fixes #112572