### PR TITLE
[LTO] Use .at instead of .lookup to avoid copies. (NFC)

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -1540,8 +1540,7 @@ void llvm::gatherImportedSummariesForModule(
     auto &SummariesForIndex =
         LookupOrCreate(ModuleToSummariesForIndex, FromModule);
 
-    const auto &DefinedGVSummaries =
-        ModuleToDefinedGVSummaries.lookup(FromModule);
+    const auto &DefinedGVSummaries = ModuleToDefinedGVSummaries.at(FromModule);
     const auto &DS = DefinedGVSummaries.find(GUID);
     assert(DS != DefinedGVSummaries.end() &&
            "Expected a defined summary for imported global value");


### PR DESCRIPTION
`DenseMap::lookup` returns by value (because it default-creates the returned value if the key isn't present in the map), which means that we do a lot of copying here. Since we assert that something is present in the returned value two lines below this call, it's safe to use `.at` here instead.

Copying and then destroying dense maps here is responsible for 60% of the time spent in LTO indexing in a large internal build.