### PR TITLE
[FormattedStream] Add ASCII fast path

### DIFF
--- a/llvm/lib/Support/FormattedStream.cpp
+++ b/llvm/lib/Support/FormattedStream.cpp
@@ -75,6 +75,13 @@ void formatted_raw_ostream::UpdatePosition(const char *Ptr, size_t Size) {
   // Now scan the rest of the buffer.
   unsigned NumBytes;
   for (const char *End = Ptr + Size; Ptr < End; Ptr += NumBytes) {
+    // Fast path for printable ASCII characters without special handling.
+    if (*Ptr >= 0x20 && *Ptr <= 0x7e) {
+      NumBytes = 1;
+      ++Column;
+      continue;
+    }
+
     NumBytes = getNumBytesForUTF8(*Ptr);
 
     // The buffer might end part way through a UTF-8 code unit sequence for a


### PR DESCRIPTION
Printing IR spends a large amount of time updating the column count via generic UTF-8 APIs. Speed it up by adding a fast path for the common printable ASCII case.

This makes `-print-on-crash -print-module-scope` about two times faster.