### PR TITLE
[clang-repl]: Print stack-trace on crash

### DIFF
--- a/clang/tools/clang-repl/ClangRepl.cpp
+++ b/clang/tools/clang-repl/ClangRepl.cpp
@@ -139,6 +139,8 @@ ReplListCompleter::operator()(llvm::StringRef Buffer, size_t Pos,
 
 llvm::ExitOnError ExitOnErr;
 int main(int argc, const char **argv) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+
   ExitOnErr.setBanner("clang-repl: ");
   llvm::cl::ParseCommandLineOptions(argc, argv);
 


### PR DESCRIPTION
Call `llvm::sys::PrintStackTraceOnErrorSignal` at the start of main to
1. Print a strack trace on crash
2. Disable the assertion failed popup in Windows Debug Builds

Other tools (for example clang-check or clang-query) already do this.

This fixes debug build bots on windows hanging (waiting for the popup to be dismissed) and ultimately getting terminated due to timeout. See https://lab.llvm.org/buildbot/#/builders/81/builds/2646/steps/6/logs/stdio for an example of the hang