### PR TITLE
[vim] Improve iskeyword for LLVM IR

### DIFF
--- a/llvm/utils/vim/ftplugin/llvm.vim
+++ b/llvm/utils/vim/ftplugin/llvm.vim
@@ -11,3 +11,4 @@ setlocal softtabstop=2 shiftwidth=2
 setlocal expandtab
 setlocal comments+=:;
 setlocal commentstring=;\ %s
+setlocal iskeyword=%,@-@,$,a-z,A-Z,48-57,_,.,-

--- a/llvm/utils/vim/ftplugin/llvm.vim
+++ b/llvm/utils/vim/ftplugin/llvm.vim
@@ -11,4 +11,11 @@ setlocal softtabstop=2 shiftwidth=2
 setlocal expandtab
 setlocal comments+=:;
 setlocal commentstring=;\ %s
-setlocal iskeyword=%,@-@,$,a-z,A-Z,48-57,_,.,-
+" We treat sequences of the following characters as forming 'keywords', with
+" the aim of easing movement around LLVM identifiers:
+" * identifier prefixes: '%' and '@' (@-@)
+" * all characters where isalpha() returns TRUE (@)
+" * the digits 0-9 (48-57)
+" * other characters that may form identifiers: '_', '.', '-', '$'
+" Comment this out to restore the default behaviour
+setlocal iskeyword=%,@-@,@,48-57,_,.,-,$


### PR DESCRIPTION
This patch sets the 'iskeyword' variable to characters found in LLVM IR identifiers. Keywords are used in many places in vim, most notably being treated as word boundaries for commands like 'w' and '*'. The aim with this is to improve the navigability and editability of LLVM IR files as now one is able to: skip over entire identifiers with motions (e.g., `w/e/b`); yank/delete whole identifiers (e.g., `diw`); highlight/search for the identifier under the cursor (`*`), etc.

More complicated LLVM identifiers including quotation marks are not supported. The 'iskeyword' variable is just a list of characters, not a regex, and including quotation marks and all the characters permitted in quoted identifiers would expand the scope to almost everything and become less usable. These types of identifiers are rare by comparison.

Note that this does change how words are considered across the entire LLVM IR file, so including strings, comments, names, etc. Given that the majority of editing/navigating LLVM IR is working with and across values, this is arguably a worthwhile trade-off.