### PR TITLE
[mlir-python] Emit only dialect `EnumAttr` registrations.

### DIFF
--- a/mlir/test/python/dialects/affine.py
+++ b/mlir/test/python/dialects/affine.py
@@ -333,3 +333,8 @@ def testAffineIfWithElse():
             affine.AffineYieldOp([x_false, y_false])
         add = arith.AddIOp(if_op.results[0], if_op.results[1])
         return
+
+
+@constructAndPrintInModule
+def test_double_AtomicRMWKindAttr_registration():
+    from mlir.dialects import _affine_enum_gen


### PR DESCRIPTION
## Problem

Currently we emit `EnumAttr` bindings indiscriminately (i.e., without considering `-bind-dialect`). This leads to two things

1. duplicated `class <OTHERDIALECT>Enum`s for every `<DIALECT>_enums_gen.py` that uses `<OTHERDIALECT>Enum`;
2. similarly, duplicated `@register_attribute_builder("<OTHERDIALECT>EnumAttr")` 

Note, the duplication is due to the fact that tablegen has no "memory" across emitted files so it has no knowledge that it has already emitted `XYZEnumAttr` in both `_<DIALECT>_enums_gen.py` and `_<OTHERDIALECT>_enums_gen.py`.

The first isn't an issue because even if they're duplicated, they're mechanically kept in sync. 

**The second is an issue** because [`attributeBuilderMap`](https://github.com/llvm/llvm-project/blob/7c850867b9ef4427375da6d83c34d0b9c944fcb8/mlir/lib/Bindings/Python/Globals.h#L120) doesn't automatically replace/override registrations (nor should it). For example, we have [`linalg.iterator_type`](https://github.com/llvm/llvm-project/blob/e7d09cecc9123f89ace1712a617e252d78b179e9/mlir/include/mlir/Dialect/Linalg/IR/LinalgBase.td#L78) and IREE has [`iree_gpu.iterator_type`](https://github.com/iree-org/iree/blob/fdc2d6a5987343b688226af11ad8f398f4acdcdb/compiler/src/iree/compiler/Codegen/Dialect/GPU/IR/IREEGPUAttrs.td#L22) and thus if you try to use both `_linalg_enums_gen.py` and `_iree_gpu_enums_gen.py` you will get 

```
RuntimeError: Attribute builder for 'IteratorType' is already registered with func: <function _iteratortype at 0x7f4f678cc5e0>
```

## Solution

The only solution is to cease indiscriminate emission of registration calls. In this PR I do that, i.e., I add `-bind-dialect` to `-gen-python-enum-bindings` and filter which `register_attribute_builder` calls are emitted. The effect is that `builtin` dialect attribute builder registration calls are no longer emitted anywhere. So those have to be written by hand somewhere. Here I put them adjacent to where they were being emitted prior (i.e., in the `<DIALECT>.py`) . I also actually use the dialect to prefix the builder lookup key. So 

```
@register_attribute_builder("MatchInterfaceEnum")
```

becomes

```
@register_attribute_builder("builtin.MatchInterfaceEnum")
```