### PR TITLE
[Orc] Fix build error in JITLoaderVTune

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
@@ -15,6 +15,7 @@
 #if LLVM_USE_INTEL_JITEVENTS
 #include "IntelJITEventsWrapper.h"
 #include "ittnotify.h"
+#include <map>
 
 using namespace llvm;
 using namespace llvm::orc;


### PR DESCRIPTION
Revert removal of `#include <map>` in https://github.com/llvm/llvm-project/commit/1f4d91ecb8529678a3d3919d7523743bd21942ca#diff-c76b4e403936f869d0254d51dbbe95b21bb136d21d07cd94fc840817f8185833R14.

I've been getting the following error since that commit
```
 [18:34:04] /workspace/srcdir/llvm-project/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp:115:28: error: ‘map’ in namespace ‘std’ does not name a template type
[18:34:04]   115 | using NativeCodeMap = std::map<uint64_t, SourceLocations>;
[18:34:04]       |                            ^~~
[18:34:04] /workspace/srcdir/llvm-project/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp:18:1: note: ‘std::map’ is defined in header ‘<map>’; did you forget to ‘#include <map>’?
[18:34:04]    17 | #include "ittnotify.h"
[18:34:04]   +++ |+#include <map>
[18:34:04]    18 |
```