### PR TITLE
[mlir][LLVM][NFC] Implement `print/parse` for `LLVMStructType`

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -233,7 +233,7 @@ def LLVMStructType : LLVMType<"LLVMStruct", "struct", [
     bool isIdentified() const;
 
     /// Checks if a struct is opaque.
-    bool isOpaque();
+    bool isOpaque() const;
 
     /// Checks if a struct is initialized.
     bool isInitialized();

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -480,7 +480,7 @@ LogicalResult LLVMStructType::setBody(ArrayRef<Type> types, bool isPacked) {
 
 bool LLVMStructType::isPacked() const { return getImpl()->isPacked(); }
 bool LLVMStructType::isIdentified() const { return getImpl()->isIdentified(); }
-bool LLVMStructType::isOpaque() {
+bool LLVMStructType::isOpaque() const {
   return getImpl()->isIdentified() &&
          (getImpl()->isOpaque() || !getImpl()->isInitialized());
 }


### PR DESCRIPTION
The printing and parsing logic for struct types was still using ad-hoc functions instead of the more conventional `print` and `parse` methods whose declarations are automatically generated by TableGen.

This PR effectively renames these functions and uses them directly as implementations for `print` and `parse` of `LLVMStructType`.

This additionally fixes linking errors when users or auto generated code may call `print` and `parse` directly.

Fixes https://github.com/llvm/llvm-project/issues/117927