### PR TITLE
[CodeGen] @llvm.experimental.stackmap make operands immediate

### DIFF
--- a/llvm/docs/StackMaps.rst
+++ b/llvm/docs/StackMaps.rst
@@ -112,8 +112,9 @@ Operands:
 
 The first operand is an ID to be encoded within the stack map. The
 second operand is the number of shadow bytes following the
-intrinsic. The variable number of operands that follow are the ``live
-values`` for which locations will be recorded in the stack map.
+intrinsic. These first two operands should be immediate, e.g. cannot
+be passed as variables. The variable number of operands that follow are
+the ``live values`` for which locations will be recorded in the stack map.
 
 To use this intrinsic as a bare-bones stack map, with no code patching
 support, the number of shadow bytes can be set to zero.

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1655,7 +1655,7 @@ def int_strip_invariant_group : DefaultAttrsIntrinsic<[llvm_anyptr_ty],
 //
 def int_experimental_stackmap : DefaultAttrsIntrinsic<[],
                                   [llvm_i64_ty, llvm_i32_ty, llvm_vararg_ty],
-                                  [Throws]>;
+                                  [Throws, ImmArg<ArgIndex<0>>, ImmArg<ArgIndex<1>>]>;
 def int_experimental_patchpoint_void : Intrinsic<[],
                                                  [llvm_i64_ty, llvm_i32_ty,
                                                   llvm_ptr_ty, llvm_i32_ty,

--- a/llvm/test/CodeGen/AArch64/stackmap-args.ll
+++ b/llvm/test/CodeGen/AArch64/stackmap-args.ll
@@ -1,0 +1,22 @@
+; RUN: not llc -mtriple=arm64-linux-gnu < %s 2>&1  | FileCheck %s
+; Tests error when we pass non-immediate parameters to @llvm.experiment.stackmap
+
+define void @first_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; First operand should be immediate
+  %id = add i64 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 %id, i32 0)
+  ret void
+}
+
+define void @second_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; Second operand should be immediate
+  %numShadowByte = add i32 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 %numShadowByte)
+  ret void
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/llvm/test/CodeGen/PowerPC/ppc64-stackmap-args.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-stackmap-args.ll
@@ -1,0 +1,22 @@
+; RUN: not llc -verify-machineinstrs -mcpu=ppc -mtriple=powerpc64-unknown-gnu-linux < %s 2>&1 | FileCheck %s
+; Tests error when we pass non-immediate parameters to @llvm.experiment.stackmap
+
+define void @first_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; First operand should be immediate
+  %id = add i64 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 %id, i32 0)
+  ret void
+}
+
+define void @second_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; Second operand should be immediate
+  %numShadowByte = add i32 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 %numShadowByte)
+  ret void
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/llvm/test/CodeGen/RISCV/rv64-stackmap-args.ll
+++ b/llvm/test/CodeGen/RISCV/rv64-stackmap-args.ll
@@ -1,0 +1,22 @@
+; RUN: not llc -mtriple=riscv64 < %s 2>&1 | FileCheck %s
+; Tests error when we pass non-immediate parameters to @llvm.experiment.stackmap
+
+define void @first_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; First operand should be immediate
+  %id = add i64 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 %id, i32 0)
+  ret void
+}
+
+define void @second_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; Second operand should be immediate
+  %numShadowByte = add i32 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 %numShadowByte)
+  ret void
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/llvm/test/CodeGen/SystemZ/stackmap-args.ll
+++ b/llvm/test/CodeGen/SystemZ/stackmap-args.ll
@@ -1,0 +1,22 @@
+; RUN: not llc -mtriple=s390x-linux-gnu < %s 2>&1 | FileCheck %s
+; Tests error when we pass non-immediate parameters to @llvm.experiment.stackmap
+
+define void @first_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; First operand should be immediate
+  %id = add i64 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 %id, i32 0)
+  ret void
+}
+
+define void @second_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; Second operand should be immediate
+  %numShadowByte = add i32 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 %numShadowByte)
+  ret void
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)

--- a/llvm/test/CodeGen/X86/stackmap-args.ll
+++ b/llvm/test/CodeGen/X86/stackmap-args.ll
@@ -1,0 +1,22 @@
+; RUN: not llc -mtriple=x86_64-apple-darwin -mcpu=corei7 < %s 2>&1 | FileCheck %s
+; Tests error when we pass non-immediate parameters to @llvm.experiment.stackmap
+
+define void @first_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; First operand should be immediate
+  %id = add i64 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 %id, i32 0)
+  ret void
+}
+
+define void @second_arg() {
+; CHECK: immarg operand has non-immediate parameter
+entry:
+  ; Second operand should be immediate
+  %numShadowByte = add i32 0, 0
+  call void (i64, i32, ...) @llvm.experimental.stackmap(i64 1, i32 %numShadowByte)
+  ret void
+}
+
+declare void @llvm.experimental.stackmap(i64, i32, ...)


### PR DESCRIPTION
This pull request modifies the behavior of the `@llvm.experimental.stackmap` intrinsic to require that its two first operands (`id` and `numShadowBytes`) be **immediate values**. This change ensures that variables cannot be passed as two first arguments to this intrinsic.


Related Issue: https://github.com/llvm/llvm-project/issues/115733

### Testing
- Added new test cases to ensure errors are emitted for non-immediate operands.
- Ran the full LLVM test suite to verify no regressions were introduced.