### PR TITLE
[Clang][AST] Fix PackIndexingExpr AST printout

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -766,6 +766,7 @@ Bug Fixes to AST Handling
   and ``relatedalso`` comment commands.
 - Clang now uses the location of the begin of the member expression for ``CallExpr``
   involving deduced ``this``. (#GH116928)
+- Fixed printout of AST that uses pack indexing expression. (#GH116486)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -2514,7 +2514,10 @@ void StmtPrinter::VisitSizeOfPackExpr(SizeOfPackExpr *E) {
 }
 
 void StmtPrinter::VisitPackIndexingExpr(PackIndexingExpr *E) {
-  OS << E->getPackIdExpression() << "...[" << E->getIndexExpr() << "]";
+  PrintExpr(E->getPackIdExpression());
+  OS << "...[";
+  PrintExpr(E->getIndexExpr());
+  OS << "]";
 }
 
 void StmtPrinter::VisitSubstNonTypeTemplateParmPackExpr(

--- a/clang/test/AST/ast-print-packindexingexpr.cpp
+++ b/clang/test/AST/ast-print-packindexingexpr.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -ast-print -std=c++2c %s | FileCheck %s
+
+template <class... T, unsigned N>
+auto foo(T ...params) {
+  return params...[N];
+}
+
+// CHECK: template <class ...T, unsigned int N> auto foo(T ...params) {
+// CHECK-NEXT: return params...[N];


### PR DESCRIPTION
Fixes #116486 
Also added regression unit test