### PR TITLE
[ExecutionEngine] reinstate necessary include for building with `-DLLVM_USE_INTEL_JITEVENTS`

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
@@ -11,6 +11,7 @@
 
 #include "llvm/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.h"
 #include "llvm/ExecutionEngine/Orc/Shared/VTuneSharedStructs.h"
+#include <map>
 
 #if LLVM_USE_INTEL_JITEVENTS
 #include "IntelJITEventsWrapper.h"


### PR DESCRIPTION
This is a build regression from https://github.com/llvm/llvm-project/commit/1f4d91ecb8529678a3d3919d7523743bd21942ca when using `-DLLVM_USE_INTEL_JITEVENTS=ON` (already commented by @Zentrik on the commit), as `std::map` is evidently used further down in that TU
https://github.com/llvm/llvm-project/blob/c8cd497c9889b051671c7fe2eb6e4b3bbe6606f9/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp#L115

CC @kazutakahirata