### PR TITLE
[DirectX] Run DXILFinalizeLinkage earlier in the pipeline

### DIFF
--- a/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
+++ b/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
@@ -23,6 +23,8 @@ static bool finalizeLinkage(Module &M) {
 
   // Collect non-entry and non-exported functions to set to internal linkage.
   for (Function &EF : M.functions()) {
+    if (EF.isIntrinsic())
+      continue;
     if (EF.hasFnAttribute("hlsl.shader") || EF.hasFnAttribute("hlsl.export"))
       continue;
     Funcs.insert(&EF);

--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -89,6 +89,7 @@ public:
 
   FunctionPass *createTargetRegisterAllocator(bool) override { return nullptr; }
   void addCodeGenPrepare() override {
+    addPass(createDXILFinalizeLinkageLegacyPass());
     addPass(createDXILIntrinsicExpansionLegacyPass());
     addPass(createDXILDataScalarizationLegacyPass());
     ScalarizerPassOptions DxilScalarOptions;
@@ -96,7 +97,6 @@ public:
     addPass(createDXILFlattenArraysLegacyPass());
     addPass(createScalarizerPass(DxilScalarOptions));
     addPass(createDXILOpLoweringLegacyPass());
-    addPass(createDXILFinalizeLinkageLegacyPass());
     addPass(createDXILTranslateMetadataLegacyPass());
     addPass(createDXILPrepareModulePass());
   }

--- a/llvm/test/CodeGen/DirectX/BufferStore-errors.ll
+++ b/llvm/test/CodeGen/DirectX/BufferStore-errors.ll
@@ -6,7 +6,7 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 ; CHECK: error:
 ; CHECK-SAME: in function storetoomany
 ; CHECK-SAME: typedBufferStore data must be a vector of 4 elements
-define void @storetoomany(<5 x float> %data, i32 %index) {
+define void @storetoomany(<5 x float> %data, i32 %index) "hlsl.export" {
   %buffer = call target("dx.TypedBuffer", <4 x float>, 1, 0, 0)
       @llvm.dx.handle.fromBinding.tdx.TypedBuffer_v4f32_1_0_0(
           i32 0, i32 0, i32 1, i32 0, i1 false)
@@ -21,7 +21,7 @@ define void @storetoomany(<5 x float> %data, i32 %index) {
 ; CHECK: error:
 ; CHECK-SAME: in function storetoofew
 ; CHECK-SAME: typedBufferStore data must be a vector of 4 elements
-define void @storetoofew(<3 x i32> %data, i32 %index) {
+define void @storetoofew(<3 x i32> %data, i32 %index) "hlsl.export" {
   %buffer = call target("dx.TypedBuffer", <4 x i32>, 1, 0, 0)
       @llvm.dx.handle.fromBinding.tdx.TypedBuffer_v4i32_1_0_0(
           i32 0, i32 0, i32 1, i32 0, i1 false)

--- a/llvm/test/CodeGen/DirectX/finalize-linkage-intrinsics.ll
+++ b/llvm/test/CodeGen/DirectX/finalize-linkage-intrinsics.ll
@@ -1,0 +1,8 @@
+; RUN: opt -S -dxil-finalize-linkage -verify -mtriple=dxil-unknown-shadermodel6.5-library %s
+
+define float @f(float %f) "hlsl.export" {
+  %x = call float @llvm.atan.f32(float %f)
+  ret float %x
+}
+
+declare float @llvm.atan.f32(float)

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -7,6 +7,7 @@
 ; CHECK-NEXT: Target Library Information
 ; CHECK-NEXT: Target Transform Information
 ; CHECK-NEXT: ModulePass Manager
+; CHECK-NEXT:   DXIL Finalize Linkage
 ; CHECK-NEXT:   DXIL Intrinsic Expansion
 ; CHECK-NEXT:   DXIL Data Scalarization
 ; CHECK-NEXT:   DXIL Array Flattener
@@ -15,7 +16,6 @@
 ; CHECK-NEXT:     Scalarize vector operations
 ; CHECK-NEXT:   DXIL Resource analysis
 ; CHECK-NEXT:   DXIL Op Lowering
-; CHECK-NEXT:   DXIL Finalize Linkage
 ; CHECK-NEXT:   DXIL resource Information
 ; CHECK-NEXT:   DXIL Shader Flag Analysis
 ; CHECK-NEXT:   DXIL Module Metadata analysis


### PR DESCRIPTION
This moves DXILFinalizeLinkage before the DXIL op lowering passes so that it doesn't end up internalizing any of the `dx.op.*` functions. This also exposed a bug when the pass is run on a module with intrinsics in them - marking the intrinsics as internal will fail the validator.

Fixes #117761