### PR TITLE
[libc] disable process_mrelease for riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -251,7 +251,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.sys.mman.munmap
     libc.src.sys.mman.remap_file_pages
     libc.src.sys.mman.posix_madvise
-    libc.src.sys.mman.process_mrelease
+    # TODO: disabled due to buildbot failure. further investigation needed.
+    # libc.src.sys.mman.process_mrelease
     libc.src.sys.mman.shm_open
     libc.src.sys.mman.shm_unlink
 


### PR DESCRIPTION
`process_mrelease` upsets the RV32 build bot. Disable it for now.