### PR TITLE
[LLVM][TableGen] Refine overloaded intrinsic suffix check

### DIFF
--- a/llvm/test/TableGen/intrinsic-overload-conflict.td
+++ b/llvm/test/TableGen/intrinsic-overload-conflict.td
@@ -6,12 +6,16 @@ include "llvm/IR/Intrinsics.td"
 // CHECK: foo = 1,
 def int_foo : Intrinsic<[llvm_any_ty]>;
 
-// No conflicts, since .bar is not a vaid mangled type.
+// No conflicts, since .bar is not a valid mangled type.
 // CHECK: foo_bar,
 def int_foo_bar : Intrinsic<[llvm_i32_ty]>;
 
 // CHECK: foo_bar_f32,
 def int_foo_bar_f32 : Intrinsic<[llvm_i32_ty]>;
+
+// No conflicts, since i is not a valid mangled type without a bitwidth.
+// CHECK: foo_i
+def int_foo_i : Intrinsic<[llvm_i32_ty]>;
 
 #ifdef CONFLICT
 // CHECK-CONFLICT: error: intrinsic `llvm.foo.a3` cannot share prefix `llvm.foo.a3` with another overloaded intrinsic `llvm.foo`

--- a/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
+++ b/llvm/utils/TableGen/Basic/CodeGenIntrinsics.cpp
@@ -157,7 +157,8 @@ static bool doesSuffixLookLikeMangledType(StringRef Suffix) {
     return false;
 
   // [pi][0-9]+
-  if (is_contained("pi", Suffix[0]) && all_of(Suffix.drop_front(), isDigit))
+  if (Suffix.size() > 1 && is_contained("pi", Suffix[0]) &&
+      all_of(Suffix.drop_front(), isDigit))
     return true;
 
   // Match one of the named types.


### PR DESCRIPTION
Previously the check comments indicated that [pi][0-9]+ would match as a type suffix, however the check itself was looking for [pi][0-9]* and hence an 'i' suffix in isolation was being considered as a type suffix despite it not having a bitwidth.

This change makes the check consistent with the comment and looks for [pi][0-9]+