### PR TITLE
[AArch64] Do not mark homogeneous prolog/epilog functions optnone

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
@@ -169,9 +169,7 @@ static MachineFunction &createFrameHelperMachineFunction(Module *M,
   F->setLinkage(GlobalValue::LinkOnceODRLinkage);
   F->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
 
-  // Set no-opt/minsize, so we don't insert padding between outlined
-  // functions.
-  F->addFnAttr(Attribute::OptimizeNone);
+  // Set minsize, so we don't insert padding between outlined functions.
   F->addFnAttr(Attribute::NoInline);
   F->addFnAttr(Attribute::MinSize);
   F->addFnAttr(Attribute::Naked);

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-frame-tail.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog-frame-tail.ll
@@ -51,8 +51,8 @@ declare i32 @_Z3hoov() nounwind ssp optsize
 ; CHECK-LABEL:  _OUTLINED_FUNCTION_PROLOG_FRAME48_x30x29x19x20d8d9d10d11:
 ; CHECK:      stp     d11, d10, [sp, #-48]!
 ; CHECK-NEXT: stp     d9, d8, [sp, #16]
-; CHECK-NEXT: stp     x20, x19, [sp, #32]
 ; CHECK-NEXT: add     x29, sp, #48
+; CHECK-NEXT: stp     x20, x19, [sp, #32]
 ; CHECK-NEXT: ret
 
 ; CHECK-LABEL: _OUTLINED_FUNCTION_EPILOG_TAIL_x30x29x19x20d8d9d10d11:
@@ -69,8 +69,8 @@ declare i32 @_Z3hoov() nounwind ssp optsize
 ; CHECK-LINUX-LABEL:  OUTLINED_FUNCTION_PROLOG_FRAME32_x19x20x30x29d8d9d10d11:
 ; CHECK-LINUX:      stp     d11, d10, [sp, #-32]!
 ; CHECK-LINUX-NEXT: stp     d9, d8, [sp, #16]
-; CHECK-LINUX-NEXT: stp     x20, x19, [sp, #48]
 ; CHECK-LINUX-NEXT: add     x29, sp, #32
+; CHECK-LINUX-NEXT: stp     x20, x19, [sp, #48]
 ; CHECK-LINUX-NEXT: ret
 
 ; CHECK-LINUX-LABEL: OUTLINED_FUNCTION_EPILOG_TAIL_x19x20x30x29d8d9d10d11:

--- a/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-homogeneous-prolog-epilog.ll
@@ -67,8 +67,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 ; CHECK-LINUX-NEXT: ret
 
 ; CHECK-LINUX-LABEL: OUTLINED_FUNCTION_EPILOG_x19x20x21x22x30x29:
-; CHECK-LINUX:      mov     x16, x30
-; CHECK-LINUX-NEXT: ldp     x20, x19, [sp, #32]
+; CHECK-LINUX:      ldp     x20, x19, [sp, #32]
+; CHECK-LINUX-NEXT: mov     x16, x30
 ; CHECK-LINUX-NEXT: ldp     x22, x21, [sp, #16]
 ; CHECK-LINUX-NEXT: ldp     x29, x30, [sp], #48
 ; CHECK-LINUX-NEXT: ret     x16


### PR DESCRIPTION
The verifier complains that synthesized IR functions have minsize and optnone attributes which are incompatible. This patch removes optnone attribute and updates affected tests as needed.