### PR TITLE
[llvm][TableGen] Add a !initialized predicate to allow testing for ?

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -223,12 +223,13 @@ TableGen provides "bang operators" that have a wide variety of uses:
                : !div         !empty       !eq          !exists      !filter
                : !find        !foldl       !foreach     !ge          !getdagarg
                : !getdagname  !getdagop    !gt          !head        !if
-               : !interleave  !isa         !le          !listconcat  !listflatten
-               : !listremove  !listsplat   !logtwo      !lt          !mul
-               : !ne          !not         !or          !range       !repr
-               : !setdagarg   !setdagname  !setdagop    !shl         !size
-               : !sra         !srl         !strconcat   !sub         !subst
-               : !substr      !tail        !tolower     !toupper     !xor
+               : !initialized !interleave  !isa         !le          !listconcat
+               : !listflatten !listremove  !listsplat   !logtwo      !lt
+               : !mul         !ne          !not         !or          !range
+               : !repr        !setdagarg   !setdagname  !setdagop    !shl
+               : !size        !sra         !srl         !strconcat   !sub
+               : !subst       !substr      !tail        !tolower     !toupper
+               : !xor
 
 The ``!cond`` operator has a slightly different
 syntax compared to other bang operators, so it is defined separately:
@@ -555,7 +556,7 @@ previous case, if the *right-hand-side* operand is an undefined name or a
 global name, it is treated as a verbatim string of characters. The
 left-hand-side operand is treated normally.
 
-Values can have a trailing paste operator, in which case the left-hand-side 
+Values can have a trailing paste operator, in which case the left-hand-side
 operand is concatenated to an empty string.
 
 `Appendix B: Paste Operator Examples`_ presents examples of the behavior of
@@ -1814,6 +1815,10 @@ and non-0 as true.
   This operator evaluates the *test*, which must produce a ``bit`` or
   ``int``. If the result is not 0, the *then* expression is produced; otherwise
   the *else* expression is produced.
+
+``!initialized(``\ *a*\ ``)``
+  This is produces a 1 if *a* is not the unitialized value (``?``) and 0
+  otherwise.
 
 ``!interleave(``\ *list*\ ``,`` *delim*\ ``)``
     This operator concatenates the items in the *list*, interleaving the

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -1817,7 +1817,7 @@ and non-0 as true.
   the *else* expression is produced.
 
 ``!initialized(``\ *a*\ ``)``
-  This is produces a 1 if *a* is not the unitialized value (``?``) and 0
+  This operator produces 1 if *a* is not the uninitialized value (``?``) and 0
   otherwise.
 
 ``!interleave(``\ *list*\ ``,`` *delim*\ ``)``

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -860,6 +860,7 @@ public:
     LOG2,
     REPR,
     LISTFLATTEN,
+    INITIALIZED,
   };
 
 private:

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -918,7 +918,7 @@ const Init *UnOpInit::Fold(const Record *CurRec, bool IsFinal) const {
     break;
 
   case INITIALIZED:
-    if (isa_and_nonnull<UnsetInit>(LHS))
+    if (isa<UnsetInit>(LHS))
       return IntInit::get(RK, 0);
     if (LHS->isConcrete())
       return IntInit::get(RK, 1);

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -917,6 +917,13 @@ const Init *UnOpInit::Fold(const Record *CurRec, bool IsFinal) const {
       return NewInit;
     break;
 
+  case INITIALIZED:
+    if (isa_and_nonnull<UnsetInit>(LHS))
+      return IntInit::get(RK, 0);
+    if (LHS->isConcrete())
+      return IntInit::get(RK, 1);
+    break;
+
   case NOT:
     if (const auto *LHSi = dyn_cast_or_null<IntInit>(
             LHS->convertInitializerTo(IntRecTy::get(RK))))
@@ -1051,6 +1058,9 @@ std::string UnOpInit::getAsString() const {
     break;
   case TOUPPER:
     Result = "!toupper";
+    break;
+  case INITIALIZED:
+    Result = "!initialized";
     break;
   }
   return Result + "(" + LHS->getAsString() + ")";

--- a/llvm/lib/TableGen/TGLexer.cpp
+++ b/llvm/lib/TableGen/TGLexer.cpp
@@ -633,6 +633,7 @@ tgtok::TokKind TGLexer::LexExclaim() {
           .Case("listremove", tgtok::XListRemove)
           .Case("range", tgtok::XRange)
           .Case("strconcat", tgtok::XStrConcat)
+          .Case("initialized", tgtok::XInitialized)
           .Case("interleave", tgtok::XInterleave)
           .Case("substr", tgtok::XSubstr)
           .Case("find", tgtok::XFind)

--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -135,6 +135,7 @@ enum TokKind {
   XTail,
   XSize,
   XEmpty,
+  XInitialized,
   XIf,
   XCond,
   XEq,

--- a/llvm/test/TableGen/initialized.td
+++ b/llvm/test/TableGen/initialized.td
@@ -1,0 +1,59 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+
+// CHECK: class F<Y [[ARG:.+]] = ?> {
+// CHECK: string ret = !if(!initialized([[ARG]].str), [[ARG]].str, "N/A");
+// CHECK: }
+
+// CHECK-LABEL: def C
+// CHECK: bit c0 = 0
+// CHECK: bit c1 = 1
+// CHECK: bit c2 = 1
+def C {
+  bit c0 = !initialized(?);
+  bit c1 = !initialized(0);
+  bit c2 = !initialized(1);
+}
+
+class Y {
+  string str = ?;
+}
+
+class F<Y y> {
+  string ret = !if(!initialized(y.str), y.str, "N/A");
+}
+
+def Y0 : Y;
+def Y1 : Y {
+  let str = "foo";
+}
+
+// CHECK-LABEL: def FY0
+// CHECK: string ret = "N/A";
+// CHECK-LABEL: def FY1
+// CHECK: string ret = "foo";
+def FY0 : F<Y0>;
+def FY1 : F<Y1>;
+
+class G<Y y> {
+  list<string> v = [y.str];
+  bit isInit = !initialized(v);
+}
+
+// CHECK-LABEL: def GY0
+// CHECK: isInit = 1
+// CHECK-LABEL: def GY1
+// CHECK: isInit = 1
+def GY0 : G<Y0>;
+def GY1 : G<Y1>;
+
+class Thing;
+def aThing : Thing;
+class Propagate<Thing t> {
+  Thing ret = !if(!initialized(t), t, ?);
+}
+// CHECK-LABEL: def PropagateNothing
+// CHECK: Thing ret = ?
+// CHECK-LABEL: def PropagateThing
+// CHECK: Thing ret = aThing
+def PropagateNothing : Propagate<?>;
+def PropagateThing : Propagate<aThing>;


### PR DESCRIPTION
There are cases (like in an upcoming patch to MLIR's `Property` class) where the ? value is a useful null value. However, existing predicates make ti difficult to test if the value in a record one is operating is ? or not.

This commit adds the !initialized predicate, which is 1 on concrete, non-? values and 0 on ?.