### PR TITLE
[Driver] Remove non MSVC CL flags /fprofile-sample-use

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8506,8 +8506,6 @@ def _SLASH_fp_strict : CLFlag<"fp:strict">, HelpText<"">, Alias<ffp_model_EQ>, A
 def _SLASH_fsanitize_EQ_address : CLFlag<"fsanitize=address">,
   HelpText<"Enable AddressSanitizer">,
   Alias<fsanitize_EQ>, AliasArgs<["address"]>;
-def : CLJoined<"fprofile-sample-use:">, Alias<fprofile_sample_use_EQ>;
-def : CLJoined<"fprofile-sample-use=">, Alias<fprofile_sample_use_EQ>;
 def _SLASH_GA : CLFlag<"GA">, Alias<ftlsmodel_EQ>, AliasArgs<["local-exec"]>,
   HelpText<"Assume thread-local variables are defined in the executable">;
 def _SLASH_GR : CLFlag<"GR">, HelpText<"Emit RTTI data (default)">;

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -101,11 +101,6 @@
 // CHECK-PROFILE-USE: "-fprofile-instrument-use-path=default.profdata"
 // CHECK-PROFILE-USE-FILE: "-fprofile-instrument-use-path=/tmp/somefile.prof"
 
-// RUN: %clang_cl -### /FA -fprofile-sample-use=%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
-// RUN: %clang_cl -### /FA /fprofile-sample-use=%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
-// RUN: %clang_cl -### /FA /fprofile-sample-use:%S/Inputs/file.prof -- %s 2>&1 | FileCheck --check-prefix=CHECK-PROFILE-SAMPLE-USE %s
-// CHECK-PROFILE-SAMPLE-USE: "-fprofile-sample-use={{.*}}/file.prof"
-
 // RUN: %clang_cl /GA -### -- %s 2>&1 | FileCheck -check-prefix=GA %s
 // GA: -ftls-model=local-exec
 
@@ -718,6 +713,7 @@
 // RUN:     -fbracket-depth=123 \
 // RUN:     -fprofile-generate \
 // RUN:     -fprofile-generate=dir \
+// RUN:     -fprofile-sample-use=%S/Inputs/file.prof \
 // RUN:     -fno-profile-generate \
 // RUN:     -fno-profile-instr-generate \
 // RUN:     -fno-profile-instr-use \


### PR DESCRIPTION
Those flags are introduced in #117282. They are not supported by MSVC.