### PR TITLE
[clang-reorder-fields] Handle macros fields declarations.

### DIFF
--- a/clang-tools-extra/test/clang-reorder-fields/FieldAnnotationsInMacros.cpp
+++ b/clang-tools-extra/test/clang-reorder-fields/FieldAnnotationsInMacros.cpp
@@ -1,0 +1,9 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order y,x %s -- | FileCheck %s
+
+#define GUARDED_BY(x) __attribute__((guarded_by(x)))
+
+class Foo {
+  int x GUARDED_BY(x); // CHECK: {{^  int y;}}
+  int y;               // CHECK-NEXT: {{^  int x GUARDED_BY\(x\);}}
+};
+


### PR DESCRIPTION
Right now fields with macro declarations break the tool:

```

struct Foo {
  Mutex mu;
  int x GUARDED_BY(mu);
  int y;
};
```

reordered by mu,y,x yields:

```
struct Foo {
  Mutex mu;
  int y GUARDED_BY(mu);
  int x;
};
```