### PR TITLE
[libc++] Run the test suite with optimizations by default

### DIFF
--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -193,7 +193,7 @@ DEFAULT_PARAMETERS = [
         choices=["none", "speed", "size"],
         type=str,
         help="The optimization level to use when compiling the test suite.",
-        default="none",
+        default="speed",
         actions=lambda opt: filter(None, [
             AddCompileFlag(lambda cfg: getSpeedOptimizationFlag(cfg)) if opt == "speed" else None,
             AddCompileFlag(lambda cfg: getSizeOptimizationFlag(cfg)) if opt == "size" else None,


### PR DESCRIPTION
In production, libc++ is used with optimizations enabled 99.9% of the time. Therefore, I think it makes sense to run our tests with optimizations enabled by default, to be closer to what people actually use in production. It's still possible to disable optimizations for debugging purposes or other reasons.

This also removes the pitfall of trying to run the benchmarks but forgetting to set the optimization level.