### PR TITLE
[Bolt][PVS] Fix passing incorrect argument as default to isStoreUsed

### DIFF
--- a/bolt/lib/Passes/ShrinkWrapping.cpp
+++ b/bolt/lib/Passes/ShrinkWrapping.cpp
@@ -78,8 +78,8 @@ void CalleeSavedAnalysis::analyzeSaves() {
         // probably dealing with a parameter passed in a stack -- do not mess
         // with it
         if (SRU.isStoreUsed(*FIE,
-                            Prev ? SRU.expr_begin(*Prev) : SRU.expr_begin(BB)),
-            /*IncludeLocalAccesses=*/false) {
+                            Prev ? SRU.expr_begin(*Prev) : SRU.expr_begin(BB),
+            /*IncludeLocalAccesses=*/false)) {
           BlacklistedRegs.set(FIE->RegOrImm);
           CalleeSaved.reset(FIE->RegOrImm);
           Prev = &Inst;


### PR DESCRIPTION
Fixes first issue out of listed in #116944 
Given number of times this method is called, maybe it would make sense to force specifying this parameters explicitly?