### PR TITLE
[llvm-debuginfo-analyzer] Remove superfluous link components.

### DIFF
--- a/llvm/unittests/DebugInfo/LogicalView/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/LogicalView/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
-  AllTargetsDescs
-  AllTargetsDisassemblers
-  AllTargetsInfos
   AsmPrinter
   DebugInfoDWARF
   DebugInfoLogicalView


### PR DESCRIPTION
As 'LLVM_TARGETS_TO_BUILD' control which targets are enabled, the lines:

  AllTargetsDescs
  AllTargetsDisassemblers
  AllTargetsInfos

are redundant.