### PR TITLE
[lldb] Include `<chrono>` for `system_clock` and `now`

### DIFF
--- a/lldb/tools/lldb-dap/ProgressEvent.h
+++ b/lldb/tools/lldb-dap/ProgressEvent.h
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <optional>
 #include <queue>


### PR DESCRIPTION
I am a member of Microsoft vcpkg, due to there are new changes merged by microsoft/STL#5105, which revealed a conformance issue in `llvm`. It must add include `<chrono>` to fix this error.

Compiler error with this STL change:
```
D:\b\llvm\src\org-18.1.6-e754cb1d0b.clean\lldb\tools\lldb-dap\ProgressEvent.h(79): error C2039: 'system_clock': is not a member of 'std::chrono'
D:\b\llvm\src\org-18.1.6-e754cb1d0b.clean\lldb\tools\lldb-dap\ProgressEvent.cpp(134): error C3083: 'system_clock': the symbol to the left of a '::' must be a type
D:\b\llvm\src\org-18.1.6-e754cb1d0b.clean\lldb\tools\lldb-dap\ProgressEvent.cpp(134): error C2039: 'now': is not a member of 'std::chrono'
```
