### PR TITLE
[clang] Fix -Wdangling false negative regressions caused by 117315

### DIFF
--- a/clang/lib/Sema/CheckExprLifetime.cpp
+++ b/clang/lib/Sema/CheckExprLifetime.cpp
@@ -269,10 +269,14 @@ template <typename T> static bool isRecordWithAttr(QualType Type) {
   //
   // Note: it is possible for a specialization declaration to have an attribute
   // even if the primary template does not.
+  //
+  // FIXME: What if the primary template and explicit specialization
+  // declarations have conflicting attributes? We should consider diagnosing
+  // this scenario.
   bool Result = RD->hasAttr<T>();
 
   if (auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(RD))
-    Result |= (bool)CTSD->getSpecializedTemplate()->getTemplatedDecl();
+    Result |= CTSD->getSpecializedTemplate()->getTemplatedDecl()->hasAttr<T>();
 
   return Result;
 }

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -670,3 +670,26 @@ void test13() {
 }
 
 } // namespace GH100526
+
+namespace std {
+template <typename T>
+class __set_iterator {};
+
+template<typename T>
+struct BB {
+  typedef  __set_iterator<T> iterator;
+};
+
+template <typename T>
+class set {
+public:
+  typedef typename BB<T>::iterator iterator;
+  iterator begin() const;
+};
+} // namespace std
+namespace GH118064{
+
+void test() {
+  auto y = std::set<int>{}.begin(); // expected-warning {{object backing the pointer}}
+}
+} // namespace GH118064


### PR DESCRIPTION
A specialization declaration can have an attribute even if the primary template does not, particularly when the specialization is instantiated from an annotated using-alias declaration.

Fix #118064