### PR TITLE
[RISCV][Xqcicsr] Instructions have Side Effects

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -50,7 +50,7 @@ class QCIStore_ScaleIdx<bits<4> func4, string opcodestr>
 //===----------------------------------------------------------------------===//
 
 let Predicates = [HasVendorXqcicsr, IsRV32], DecoderNamespace = "Xqcicsr" in {
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
+let hasSideEffects = 1, mayLoad = 0, mayStore = 0 in {
   def QC_CSRRWR : RVInstR<0b1000110, 0b000, OPC_SYSTEM, (outs GPR:$rd),
                           (ins GPR:$rs1, GPRNoX0:$rs2), "qc.csrrwr",
                           "$rd, $rs1, $rs2">;


### PR DESCRIPTION
Xqcicsr was added in #117169. I missed that `hasSideEffects` was set to 0, rather than 1 (which all other CSR-modifying instructions have).

This has no effect on the current assembly-only support, but I think is worth fixing before I forget. I accidentally fixed the closing comment in 9300274a12d758368c036812d903b73d70d64ea4.