### PR TITLE
[SmallPtrSet] Optimize contains (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -219,9 +219,9 @@ protected:
   bool contains_imp(const void *Ptr) const {
     if (isSmall()) {
       // Linear search for the item.
-      for (const void *const *APtr = SmallArray, *const *E =
-                                                     SmallArray + NumNonEmpty;
-           APtr != E; ++APtr)
+      const void *const *APtr = SmallArray;
+      const void *const *E = SmallArray + NumNonEmpty;
+      for (; APtr != E; ++APtr)
         if (*APtr == Ptr)
           return true;
       return false;

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -216,6 +216,20 @@ protected:
     return EndPointer();
   }
 
+  bool contains_imp(const void *Ptr) const {
+    if (isSmall()) {
+      // Linear search for the item.
+      for (const void *const *APtr = SmallArray, *const *E =
+                                                     SmallArray + NumNonEmpty;
+           APtr != E; ++APtr)
+        if (*APtr == Ptr)
+          return true;
+      return false;
+    }
+
+    return doFind(Ptr) != nullptr;
+  }
+
   bool isSmall() const { return CurArray == SmallArray; }
 
 private:
@@ -433,13 +447,13 @@ public:
 
   /// count - Return 1 if the specified pointer is in the set, 0 otherwise.
   size_type count(ConstPtrType Ptr) const {
-    return find_imp(ConstPtrTraits::getAsVoidPointer(Ptr)) != EndPointer();
+    return contains_imp(ConstPtrTraits::getAsVoidPointer(Ptr));
   }
   iterator find(ConstPtrType Ptr) const {
     return makeIterator(find_imp(ConstPtrTraits::getAsVoidPointer(Ptr)));
   }
   bool contains(ConstPtrType Ptr) const {
-    return find_imp(ConstPtrTraits::getAsVoidPointer(Ptr)) != EndPointer();
+    return contains_imp(ConstPtrTraits::getAsVoidPointer(Ptr));
   }
 
   template <typename IterT>


### PR DESCRIPTION
Instead of going through find_imp(), implement a specialized contains_imp() that directly returns a boolean instead of a pointer that needs to be compared to EndPointer().

This gives a nice compile-time improvement: https://llvm-compile-time-tracker.com/compare.php?from=352f8688d0ca250c9e8774321f6c3bcd4298cc09&to=80f10c61f8a4042e03b5873c35c46eb905a76d4a&stat=instructions:u