### PR TITLE
[lldb] rename fooSynthProvider module

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/synthcapping/SynthcappingSynthProvider.py
+++ b/lldb/test/API/functionalities/data-formatter/synthcapping/SynthcappingSynthProvider.py
@@ -1,15 +1,15 @@
 import lldb
 
 
-class fooSynthProvider:
+class SynthcappingSynthProvider:
     # For testing purposes, we'll keep track of the maximum value of
     # max_num_children we've been called with.
     MAX_NUM_CHILDREN_MAX = 0
 
     @classmethod
     def reset_max_num_children_max(cls):
-        old_value = fooSynthProvider.MAX_NUM_CHILDREN_MAX
-        fooSynthProvider.MAX_NUM_CHILDREN_MAX = 0
+        old_value = SynthcappingSynthProvider.MAX_NUM_CHILDREN_MAX
+        SynthcappingSynthProvider.MAX_NUM_CHILDREN_MAX = 0
         return old_value
 
     def __init__(self, valobj, dict):
@@ -17,8 +17,8 @@ class fooSynthProvider:
         self.int_type = valobj.GetType().GetBasicType(lldb.eBasicTypeInt)
 
     def num_children(self, max_num_children):
-        fooSynthProvider.MAX_NUM_CHILDREN_MAX = max(
-            fooSynthProvider.MAX_NUM_CHILDREN_MAX, max_num_children
+        SynthcappingSynthProvider.MAX_NUM_CHILDREN_MAX = max(
+            SynthcappingSynthProvider.MAX_NUM_CHILDREN_MAX, max_num_children
         )
         return 3
 

--- a/lldb/test/API/functionalities/data-formatter/synthcapping/TestSyntheticCapping.py
+++ b/lldb/test/API/functionalities/data-formatter/synthcapping/TestSyntheticCapping.py
@@ -49,8 +49,8 @@ class SyntheticCappingTestCase(TestBase):
         self.addTearDownHook(cleanup)
 
         # set up the synthetic children provider
-        self.runCmd("script from fooSynthProvider import *")
-        self.runCmd("type synth add -l fooSynthProvider foo")
+        self.runCmd("script from SynthcappingSynthProvider import *")
+        self.runCmd("type synth add -l SynthcappingSynthProvider foo")
 
         # note that the value of fake_a depends on target byte order
         if process.GetByteOrder() == lldb.eByteOrderLittle:
@@ -71,7 +71,7 @@ class SyntheticCappingTestCase(TestBase):
         # num_children() should be called with at most max_num_children=257
         # (target.max-children-count + 1)
         self.expect(
-            "script fooSynthProvider.reset_max_num_children_max()", substrs=["257"]
+            "script SynthcappingSynthProvider.reset_max_num_children_max()", substrs=["257"]
         )
 
         # check that capping works
@@ -86,7 +86,7 @@ class SyntheticCappingTestCase(TestBase):
             ],
         )
         self.expect(
-            "script fooSynthProvider.reset_max_num_children_max()", substrs=["3"]
+            "script SynthcappingSynthProvider.reset_max_num_children_max()", substrs=["3"]
         )
 
         self.expect("frame variable f00_1", matching=False, substrs=["r = 34"])
@@ -95,5 +95,5 @@ class SyntheticCappingTestCase(TestBase):
 
         self.expect("frame variable f00_1", matching=True, substrs=["r = 34"])
         self.expect(
-            "script fooSynthProvider.reset_max_num_children_max()", substrs=["257"]
+            "script SynthcappingSynthProvider.reset_max_num_children_max()", substrs=["257"]
         )


### PR DESCRIPTION
Currently SyntheticCappingTestCase fails with
```
AttributeError: type object 'fooSynthProvider' has no attribute
'reset_max_num_children_max'
```

The source of the issue is that lldb during PythonSynthDataFormatterTestCase imports fooSynthProvider.py module and after that during SyntheticCappingTestCase tries to import another module with the same name, finds out that it already has the module and as a result, SyntheticCappingTestCase uses the old module instead the right one.

I've just renamed the module that SyntheticCappingTestCase is supposed to use to avoid such collision.