### PR TITLE
[lldb] fix SourceManagerTestCase freeze

### DIFF
--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -37,6 +37,9 @@ class SourceManagerTestCase(TestBase):
         # Find the line number to break inside main().
         self.file = self.getBuildArtifact("main-copy.c")
         self.line = line_number("main.c", "// Set break point at this line.")
+        # disable "There is a running process, kill it and restart?" prompt
+        self.runCmd("settings set auto-confirm true")
+        self.addTearDownHook(lambda: self.runCmd("settings clear auto-confirm"))
 
     def modify_content(self):
         # Read the main.c file content.


### PR DESCRIPTION
Currently lldb testsuite requires some interactive input:

```
test_artificial_source_location (TestSourceManager.SourceManagerTestCase)
There is a running process, kill it and restart?: [Y/n]
```

This patch sets lldb auto-confirm flag to true before SourceManagerTestCase start, so the test doesn't freeze now.