### PR TITLE
[sanitizer_common] mark __elf_aux_vector as weak on FreeBSD

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -57,7 +57,7 @@
 // that, it was never implemented. So just define it to zero.
 #    undef MAP_NORESERVE
 #    define MAP_NORESERVE 0
-extern const Elf_Auxinfo *__elf_aux_vector;
+extern const Elf_Auxinfo *__elf_aux_vector __attribute__((weak));
 extern "C" int __sys_sigaction(int signum, const struct sigaction *act,
                                struct sigaction *oldact);
 #  endif


### PR DESCRIPTION
At some point FreeBSD introduced libsys as a wrapper between syscalls and libc, and then linking sanitized programs started failing with:

```text
  # c++ -fsanitize=address main.cc
  ld: error: undefined symbol: __elf_aux_vector
  >>> referenced by sanitizer_linux_libcdep.cpp:950 (/usr/src/contrib/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp:950)
  >>>               sanitizer_linux_libcdep.o:(__sanitizer::ReExec()) in archive /usr/lib/clang/17/lib/freebsd/libclang_rt.asan-x86_64.a
  c++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Mark `__elf_aux_vector` as weak in the internal sanitizer declaration, so the linker will accept it at link time. The dynamic linker will then take care of the symbol at run time.
