### PR TITLE
[win/asan] Avoid warnings in interception_win.cpp.

### DIFF
--- a/compiler-rt/lib/interception/interception_win.cpp
+++ b/compiler-rt/lib/interception/interception_win.cpp
@@ -418,7 +418,7 @@ static void *AllocateTrampolineRegion(uptr min_addr, uptr max_addr,
   ReportError(
       "interception_win: AllocateTrampolineRegion failed to find free memory; "
       "min_addr: %p, max_addr: %p, func_addr: %p, granularity: %zu\n",
-      (void *)min_addr, (void *)max_addr, granularity);
+      (void *)min_addr, (void *)max_addr, (void *)func_addr, granularity);
   return nullptr;
 #else
   return ::VirtualAlloc(nullptr,
@@ -1247,7 +1247,7 @@ uptr InternalGetProcAddress(void *module, const char *func_name) {
         char function_name[256];
         size_t funtion_name_length = _strlen(func);
         if (funtion_name_length >= sizeof(function_name) - 1) {
-          ReportError("interception_win: func too long: '%s'\n", func);
+          ReportError("interception_win: func too long: '%s'\n", (char *)func);
           InterceptionFailed();
         }
 


### PR DESCRIPTION
warning: format specifies type 'void *' but the argument has type 'uptr' (aka 'unsigned long long') [-Wformat] (observed at x86_64, in AllocateTrampolineRegion)

warning: format specifies type 'char *' but the argument has type 'RVAPtr<char>' [-Wformat] (observed at x86_64, in InternalGetProcAddress)