### PR TITLE
[TableGen] Fix validateOperandClass for non Phyical Reg

### DIFF
--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2522,8 +2522,9 @@ static void emitValidateOperandClass(const CodeGenTarget &Target,
   for (auto &MatchClassName : Table)
     OS << "      " << MatchClassName << ",\n";
   OS << "    };\n\n";
-  OS << "    MatchClassKind OpKind = "
-        "(MatchClassKind)Table[Operand.getReg().id()];\n";
+  OS << "    auto RegID=Operand.getReg().id();\n";
+  OS << "    MatchClassKind OpKind =  Register::isPhysicalRegister(RegID)?"
+        "(MatchClassKind)Table[RegID]: InvalidMatchClass;\n";
   OS << "    return isSubclass(OpKind, Kind) ? "
      << "(unsigned)MCTargetAsmParser::Match_Success :\n                     "
      << "                 getDiagKindFromRegisterClass(Kind);\n  }\n\n";

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2523,7 +2523,7 @@ static void emitValidateOperandClass(const CodeGenTarget &Target,
     OS << "      " << MatchClassName << ",\n";
   OS << "    };\n\n";
   OS << "    auto RegID=Operand.getReg().id();\n";
-  OS << "    MatchClassKind OpKind =  Register::isPhysicalRegister(RegID)?"
+  OS << "    MatchClassKind OpKind =  MCRegister::isPhysicalRegister(RegID)?"
         "(MatchClassKind)Table[RegID]: InvalidMatchClass;\n";
   OS << "    return isSubclass(OpKind, Kind) ? "
      << "(unsigned)MCTargetAsmParser::Match_Success :\n                     "

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2522,9 +2522,9 @@ static void emitValidateOperandClass(const CodeGenTarget &Target,
   for (auto &MatchClassName : Table)
     OS << "      " << MatchClassName << ",\n";
   OS << "    };\n\n";
-  OS << "    auto RegID=Operand.getReg().id();\n";
-  OS << "    MatchClassKind OpKind =  MCRegister::isPhysicalRegister(RegID)?"
-        "(MatchClassKind)Table[RegID]: InvalidMatchClass;\n";
+  OS << "    unsigned RegID=Operand.getReg().id();\n";
+  OS << "    MatchClassKind OpKind =  MCRegister::isPhysicalRegister(RegID) ? "
+        "(MatchClassKind)Table[RegID] : InvalidMatchClass;\n";
   OS << "    return isSubclass(OpKind, Kind) ? "
      << "(unsigned)MCTargetAsmParser::Match_Success :\n                     "
      << "                 getDiagKindFromRegisterClass(Kind);\n  }\n\n";

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2522,8 +2522,8 @@ static void emitValidateOperandClass(const CodeGenTarget &Target,
   for (auto &MatchClassName : Table)
     OS << "      " << MatchClassName << ",\n";
   OS << "    };\n\n";
-  OS << "    unsigned RegID=Operand.getReg().id();\n";
-  OS << "    MatchClassKind OpKind =  MCRegister::isPhysicalRegister(RegID) ? "
+  OS << "    unsigned RegID = Operand.getReg().id();\n";
+  OS << "    MatchClassKind OpKind = MCRegister::isPhysicalRegister(RegID) ? "
         "(MatchClassKind)Table[RegID] : InvalidMatchClass;\n";
   OS << "    return isSubclass(OpKind, Kind) ? "
      << "(unsigned)MCTargetAsmParser::Match_Success :\n                     "


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/b71704436e61
Rewrote the register operands handling,
but the Table only contains physical regs, we will SEGV when there are
non physical regs.
