### PR TITLE
[mlir] Add DLTI transform ops section

### DIFF
--- a/mlir/docs/Dialects/Transform.md
+++ b/mlir/docs/Dialects/Transform.md
@@ -427,6 +427,10 @@ ops rather than having the methods directly act on the payload IR.
 
 [include "Dialects/DebugExtensionOps.md"]
 
+## DLTI Transform Operations
+
+[include "Dialects/DLTITransformOps.md"]
+
 ## IRDL (extension) Transform Operations
 
 [include "Dialects/IRDLExtensionOps.md"]


### PR DESCRIPTION
Adds missing _DLTI Transform Operations_ section to the transform dialect documentation.