### PR TITLE
[clang-format] Add test to ensure formatting options docs are updated

### DIFF
--- a/clang/docs/tools/dump_format_style.py
+++ b/clang/docs/tools/dump_format_style.py
@@ -487,5 +487,6 @@ with open(DOC_FILE, encoding="utf-8") as f:
 
 contents = substitute(contents, "FORMAT_STYLE_OPTIONS", options_text)
 
-with open(DOC_FILE, "wb") as output:
+output_file_path = sys.argv[1] if len(sys.argv) == 2 else DOC_FILE
+with open(output_file_path, "wb") as output:
     output.write(contents.encode())

--- a/clang/test/Format/docs_updated.test
+++ b/clang/test/Format/docs_updated.test
@@ -1,0 +1,2 @@
+// RUN: %python %S/../../docs/tools/dump_format_style.py %t
+// RUN: diff %t %S/../../docs/ClangFormatStyleOptions.rst

--- a/clang/test/Format/lit.local.cfg
+++ b/clang/test/Format/lit.local.cfg
@@ -17,4 +17,5 @@ config.suffixes = [
     ".textpb",
     ".asciipb",
     ".td",
+    ".test"
 ]


### PR DESCRIPTION
This patch adds a lit test to clang format to ensure that the ClangFormatStyleOptions doc page has been updated appropriately. The test just runs the automatic update script and diffs the outputs to ensure they are the same.