### PR TITLE
Revert [Clang] prevent errors for deduction guides using deduced type aliases

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -624,9 +624,6 @@ Improvements to Clang's diagnostics
 
 - Fixed a false negative ``-Wunused-private-field`` diagnostic when a defaulted comparison operator is defined out of class (#GH116961).
 
-- Clang now supports using alias templates in deduction guides, aligning with the C++ standard,
-  which treats alias templates as synonyms for their underlying types (#GH54909).
-
 - Clang now diagnoses dangling references for C++20's parenthesized aggregate initialization (#101957).
 
 Improvements to Clang's time-trace

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -11451,29 +11451,23 @@ bool Sema::CheckDeductionGuideDeclarator(Declarator &D, QualType &R,
     bool MightInstantiateToSpecialization = false;
     if (auto RetTST =
             TSI->getTypeLoc().getAsAdjusted<TemplateSpecializationTypeLoc>()) {
-      const TemplateSpecializationType *TST = RetTST.getTypePtr();
-      while (TST && TST->isTypeAlias())
-        TST = TST->getAliasedType()->getAs<TemplateSpecializationType>();
+      TemplateName SpecifiedName = RetTST.getTypePtr()->getTemplateName();
+      bool TemplateMatches = Context.hasSameTemplateName(
+          SpecifiedName, GuidedTemplate, /*IgnoreDeduced=*/true);
 
-      if (TST) {
-        TemplateName SpecifiedName = TST->getTemplateName();
-        bool TemplateMatches = Context.hasSameTemplateName(
-            SpecifiedName, GuidedTemplate, /*IgnoreDeduced=*/true);
-
-        const QualifiedTemplateName *Qualifiers =
-            SpecifiedName.getAsQualifiedTemplateName();
-        assert(Qualifiers && "expected QualifiedTemplate");
-        bool SimplyWritten = !Qualifiers->hasTemplateKeyword() &&
-                             Qualifiers->getQualifier() == nullptr;
-        if (SimplyWritten && TemplateMatches)
-          AcceptableReturnType = true;
-        else {
-          // This could still instantiate to the right type, unless we know it
-          // names the wrong class template.
-          auto *TD = SpecifiedName.getAsTemplateDecl();
-          MightInstantiateToSpecialization =
-              !(TD && isa<ClassTemplateDecl>(TD) && !TemplateMatches);
-        }
+      const QualifiedTemplateName *Qualifiers =
+          SpecifiedName.getAsQualifiedTemplateName();
+      assert(Qualifiers && "expected QualifiedTemplate");
+      bool SimplyWritten = !Qualifiers->hasTemplateKeyword() &&
+                           Qualifiers->getQualifier() == nullptr;
+      if (SimplyWritten && TemplateMatches)
+        AcceptableReturnType = true;
+      else {
+        // This could still instantiate to the right type, unless we know it
+        // names the wrong class template.
+        auto *TD = SpecifiedName.getAsTemplateDecl();
+        MightInstantiateToSpecialization =
+            !(TD && isa<ClassTemplateDecl>(TD) && !TemplateMatches);
       }
     } else if (!RetTy.hasQualifiers() && RetTy->isDependentType()) {
       MightInstantiateToSpecialization = true;

--- a/clang/test/CXX/temp/temp.deduct.guide/p3.cpp
+++ b/clang/test/CXX/temp/temp.deduct.guide/p3.cpp
@@ -33,7 +33,7 @@ template<template<typename> typename TT> struct E { // expected-note 2{{template
 };
 
 A(int) -> int; // expected-error {{deduced type 'int' of deduction guide is not a specialization of template 'A'}}
-template <typename T> A(T)->B<T>;
+template <typename T> A(T)->B<T>;         // expected-error {{deduced type 'B<T>' (aka 'A<T>') of deduction guide is not written as a specialization of template 'A'}}
 template<typename T> A(T*) -> const A<T>; // expected-error {{deduced type 'const A<T>' of deduction guide is not a specialization of template 'A'}}
 
 // A deduction-guide shall be declared in the same scope as the corresponding
@@ -70,12 +70,4 @@ namespace WrongScope {
     using WrongScope::Local;
     Local(int) -> Local<int>; // expected-error {{expected}}
   }
-}
-
-namespace GH54909 {
-template <class T> struct A {};
-struct B {};
-
-template <typename T> using C = B;
-template <typename T> A() -> C<T>; // expected-error {{deduced type 'C<T>' (aka 'GH54909::B') of deduction guide is not a specialization of template 'A'}}
 }


### PR DESCRIPTION
Reverts https://github.com/llvm/llvm-project/pull/117450

---

Revert https://github.com/llvm/llvm-project/pull/117450 because the prior behavior aligns with the standard - _`template-name`_ in the _`simple-template-id`_ in the return type shall be the actual name of a class template rather than some equivalent alias template. Details https://github.com/llvm/llvm-project/issues/54909#issuecomment-2508418355.

