### PR TITLE
[Clang] ensure mangled names are valid identifiers before being suggested in ifunc/alias attributes notes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -763,6 +763,7 @@ Bug Fixes to C++ Support
 - Fixed a bug where bounds of partially expanded pack indexing expressions were checked too early. (#GH116105)
 - Fixed an assertion failure caused by using ``consteval`` in condition in consumed analyses. (#GH117385)
 - Fix a crash caused by incorrect argument position in merging deduced template arguments. (#GH113659)
+- Fixed an assertion failure caused by mangled names with invalid identifiers. (#GH112205)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -602,7 +602,8 @@ static bool checkAliasedGlobal(
     // mangled name.
     for (const auto &[Decl, Name] : MangledDeclNames) {
       if (const auto *ND = dyn_cast<NamedDecl>(Decl.getDecl())) {
-        if (ND->getName() == GV->getName()) {
+        IdentifierInfo *II = ND->getIdentifier();
+        if (II && II->getName() == GV->getName()) {
           Diags.Report(Location, diag::note_alias_mangled_name_alternative)
               << Name
               << FixItHint::CreateReplacement(

--- a/clang/test/CodeGen/alias.cpp
+++ b/clang/test/CodeGen/alias.cpp
@@ -26,6 +26,9 @@ __attribute__((unused, alias("resolver"), deprecated("hahahaha, isn't C great?")
 void func();
 // expected-error@-2 {{alias must point to a defined variable or function}}
 // expected-note@-3 {{must refer to its mangled name}}
+
+void *operator new(unsigned long) __attribute__((alias("A"))); // expected-error {{alias must point to a defined variable or function}} \
+                                                               // expected-note {{the function or variable specified in an alias must refer to its mangled name}}
 #endif
 
 // CHECK: @_ZN4libc4log2Ed ={{.*}} alias double (double), ptr @log2


### PR DESCRIPTION
Fixes #112205

--- 

Commit that introduced this feature - https://github.com/llvm/llvm-project/commit/9306ef9750b7a319d59f6d3e4977e01e39b8f161