### PR TITLE
[clang-format] Add support for `.cjs` as JavaScript file extension

### DIFF
--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -49,7 +49,7 @@ to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
                                      supported:
                                        CSharp: .cs
                                        Java: .java
-                                       JavaScript: .mjs .js .ts
+                                       JavaScript: .mjs .js .ts .cjs
                                        Json: .json
                                        Objective-C: .m .mm
                                        Proto: .proto .protodevel

--- a/clang/docs/ClangFormat.rst
+++ b/clang/docs/ClangFormat.rst
@@ -49,7 +49,7 @@ to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
                                      supported:
                                        CSharp: .cs
                                        Java: .java
-                                       JavaScript: .mjs .js .ts .cjs
+                                       JavaScript: .js .mjs .cjs .ts
                                        Json: .json
                                        Objective-C: .m .mm
                                        Proto: .proto .protodevel

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3950,6 +3950,7 @@ static FormatStyle::LanguageKind getLanguageByFileName(StringRef FileName) {
     return FormatStyle::LK_Java;
   if (FileName.ends_with_insensitive(".js") ||
       FileName.ends_with_insensitive(".mjs") ||
+      FileName.ends_with_insensitive(".cjs") ||
       FileName.ends_with_insensitive(".ts")) {
     return FormatStyle::LK_JavaScript; // (module) JavaScript or TypeScript.
   }

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -87,7 +87,7 @@ static cl::opt<std::string> AssumeFileName(
              "supported:\n"
              "  CSharp: .cs\n"
              "  Java: .java\n"
-             "  JavaScript: .mjs .js .ts\n"
+             "  JavaScript: .cjs .mjs .js .ts\n"
              "  Json: .json\n"
              "  Objective-C: .m .mm\n"
              "  Proto: .proto .protodevel\n"

--- a/clang/tools/clang-format/ClangFormat.cpp
+++ b/clang/tools/clang-format/ClangFormat.cpp
@@ -87,7 +87,7 @@ static cl::opt<std::string> AssumeFileName(
              "supported:\n"
              "  CSharp: .cs\n"
              "  Java: .java\n"
-             "  JavaScript: .cjs .mjs .js .ts\n"
+             "  JavaScript: .js .mjs .cjs .ts\n"
              "  Json: .json\n"
              "  Objective-C: .m .mm\n"
              "  Proto: .proto .protodevel\n"

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -94,7 +94,7 @@ def main():
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java
-      'mjs', 'js',  # JavaScript
+      'cjs', 'mjs', 'js',  # JavaScript
       'ts',  # TypeScript
       'cs',  # C Sharp
       'json',  # Json

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -94,7 +94,7 @@ def main():
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java
-      'js', 'mjs', 'cjs',   # JavaScript
+      'js', 'mjs', 'cjs',  # JavaScript
       'ts',  # TypeScript
       'cs',  # C Sharp
       'json',  # Json

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -94,7 +94,7 @@ def main():
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java
-      'cjs', 'mjs', 'js',  # JavaScript
+      'js', 'mjs', 'cjs',   # JavaScript
       'ts',  # TypeScript
       'cs',  # C Sharp
       'json',  # Json


### PR DESCRIPTION
Node uses `.cjs` as an extension for 'common javascript' modules.