### PR TITLE
[libc++][test] Fix invalid low-level const conversion in limited_allocator

### DIFF
--- a/libcxx/test/support/test_allocator.h
+++ b/libcxx/test/support/test_allocator.h
@@ -477,9 +477,6 @@ public:
   TEST_CONSTEXPR_CXX20 pointer allocate(size_type n) { return handle_->template allocate<T>(n); }
   TEST_CONSTEXPR_CXX20 void deallocate(pointer p, size_type n) { handle_->template deallocate<T>(p, n); }
   TEST_CONSTEXPR size_type max_size() const { return N; }
-
-  // In C++11, constexpr non-static member functions are implicitly const, but this is no longer the case since C++14.
-  TEST_CONSTEXPR_CXX14 BuffT* getHandle() { return handle_.get(); }
   TEST_CONSTEXPR const BuffT* getHandle() const { return handle_.get(); }
 };
 

--- a/libcxx/test/support/test_allocator.h
+++ b/libcxx/test/support/test_allocator.h
@@ -477,7 +477,10 @@ public:
   TEST_CONSTEXPR_CXX20 pointer allocate(size_type n) { return handle_->template allocate<T>(n); }
   TEST_CONSTEXPR_CXX20 void deallocate(pointer p, size_type n) { handle_->template deallocate<T>(p, n); }
   TEST_CONSTEXPR size_type max_size() const { return N; }
-  TEST_CONSTEXPR BuffT* getHandle() const { return handle_.get(); }
+
+  // In C++11, constexpr non-static member functions are implicitly const, but this is no longer the case since C++14.
+  TEST_CONSTEXPR_CXX14 BuffT* getHandle() { return handle_.get(); }
+  TEST_CONSTEXPR const BuffT* getHandle() const { return handle_.get(); }
 };
 
 template <class T, class U, std::size_t N>


### PR DESCRIPTION
This PR fixes an invalid low-level const conversion bug in `limited_allocator`. As this class is a widely used utility for testing allocator-aware containers, it is important to fix it. It is a very simple fix by just adding a const qualification. 

The bug did not crash our tests likely because our current usage of the template has not invoked the specific member function. However, we can trigger an immediate compilation error through explicit template instantiation or by using the operators == or !=.