### PR TITLE
[InstCombine] Simplify `add nsw/nuw i1` to `or disjoint i1`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1549,8 +1549,11 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
                                               I.hasNoUnsignedWrap()))
     return R;
   Type *Ty = I.getType();
-  if (Ty->isIntOrIntVectorTy(1))
+  if (Ty->isIntOrIntVectorTy(1)) {
+    if (I.hasNoUnsignedWrap() || I.hasNoSignedWrap())
+      return BinaryOperator::CreateDisjoint(Instruction::Or, LHS, RHS);
     return BinaryOperator::CreateXor(LHS, RHS);
+  }
 
   // X + X --> X << 1
   if (LHS == RHS) {

--- a/llvm/test/Transforms/InstCombine/add2.ll
+++ b/llvm/test/Transforms/InstCombine/add2.ll
@@ -498,3 +498,21 @@ define i32 @sub_undemanded_low_bits(i32 %x) {
   %shr = lshr i32 %sub, 4
   ret i32 %shr
 }
+
+define i1 @add_nuw_i1(i1 %x, i1 %y) {
+; CHECK-LABEL: @add_nuw_i1(
+; CHECK-NEXT:    [[Z:%.*]] = or disjoint i1 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[Z]]
+;
+  %z = add nuw i1 %x, %y
+  ret i1 %z
+}
+
+define i1 @add_nsw_i1(i1 %x, i1 %y) {
+; CHECK-LABEL: @add_nsw_i1(
+; CHECK-NEXT:    [[Z:%.*]] = or disjoint i1 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    ret i1 [[Z]]
+;
+  %z = add nsw i1 %x, %y
+  ret i1 %z
+}


### PR DESCRIPTION
Optimize `add nsw i1`/`add nuw i1` to `or disjoint i1`.

Alive2: [nsw](https://alive2.llvm.org/ce/z/e8SDhV), [nuw](https://alive2.llvm.org/ce/z/dtE6ZL)

Closes #118164.