### PR TITLE
[ValueTracking] Handle and/or of conditions in `computeKnownFPClassFromContext`

### DIFF
--- a/llvm/test/Transforms/InstCombine/fpclass-from-dom-cond.ll
+++ b/llvm/test/Transforms/InstCombine/fpclass-from-dom-cond.ll
@@ -56,8 +56,7 @@ define i1 @test2_or(double %x, i1 %cond) {
 ; CHECK:       if.then:
 ; CHECK-NEXT:    ret i1 false
 ; CHECK:       if.end:
-; CHECK-NEXT:    [[CMP_I:%.*]] = fcmp oeq double [[X]], 0.000000e+00
-; CHECK-NEXT:    ret i1 [[CMP_I]]
+; CHECK-NEXT:    ret i1 false
 ;
 entry:
   %cmp = fcmp olt double %x, 0x3EB0C6F7A0000000
@@ -266,7 +265,6 @@ if.else:
   ret i1 false
 }
 
-; TODO: handle and/or conditions
 define i1 @test11_and(float %x, i1 %cond2) {
 ; CHECK-LABEL: define i1 @test11_and(
 ; CHECK-SAME: float [[X:%.*]], i1 [[COND2:%.*]]) {
@@ -274,8 +272,7 @@ define i1 @test11_and(float %x, i1 %cond2) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i1 [[COND]], [[COND2]]
 ; CHECK-NEXT:    br i1 [[AND]], label [[IF_THEN:%.*]], label [[IF_ELSE:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[RET1:%.*]] = fcmp oeq float [[X]], 0x7FF0000000000000
-; CHECK-NEXT:    ret i1 [[RET1]]
+; CHECK-NEXT:    ret i1 false
 ; CHECK:       if.else:
 ; CHECK-NEXT:    ret i1 false
 ;
@@ -290,7 +287,6 @@ if.else:
   ret i1 false
 }
 
-; TODO: handle and/or conditions
 define i1 @test12_or(float %x, i1 %cond2) {
 ; CHECK-LABEL: define i1 @test12_or(
 ; CHECK-SAME: float [[X:%.*]], i1 [[COND2:%.*]]) {
@@ -301,7 +297,7 @@ define i1 @test12_or(float %x, i1 %cond2) {
 ; CHECK:       if.then:
 ; CHECK-NEXT:    ret i1 false
 ; CHECK:       if.else:
-; CHECK-NEXT:    [[RET:%.*]] = call i1 @llvm.is.fpclass.f32(float [[X]], i32 783)
+; CHECK-NEXT:    [[RET:%.*]] = call i1 @llvm.is.fpclass.f32(float [[X]], i32 780)
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/fpclass-from-dom-cond.ll
+++ b/llvm/test/Transforms/InstCombine/fpclass-from-dom-cond.ll
@@ -46,6 +46,32 @@ if.end:
   ret i1 %cmp.i
 }
 
+define i1 @test2_or(double %x, i1 %cond) {
+; CHECK-LABEL: define i1 @test2_or(
+; CHECK-SAME: double [[X:%.*]], i1 [[COND:%.*]]) {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[CMP:%.*]] = fcmp olt double [[X]], 0x3EB0C6F7A0000000
+; CHECK-NEXT:    [[OR:%.*]] = or i1 [[CMP]], [[COND]]
+; CHECK-NEXT:    br i1 [[OR]], label [[IF_THEN:%.*]], label [[IF_END:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    ret i1 false
+; CHECK:       if.end:
+; CHECK-NEXT:    [[CMP_I:%.*]] = fcmp oeq double [[X]], 0.000000e+00
+; CHECK-NEXT:    ret i1 [[CMP_I]]
+;
+entry:
+  %cmp = fcmp olt double %x, 0x3EB0C6F7A0000000
+  %or = or i1 %cmp, %cond
+  br i1 %or, label %if.then, label %if.end
+
+if.then:
+  ret i1 false
+
+if.end:
+  %cmp.i = fcmp oeq double %x, 0.000000e+00
+  ret i1 %cmp.i
+}
+
 define i1 @test3(float %x) {
 ; CHECK-LABEL: define i1 @test3(
 ; CHECK-SAME: float [[X:%.*]]) {


### PR DESCRIPTION
Fix a typo introduced by  https://github.com/llvm/llvm-project/pull/83161.
This patch also supports decomposition of and/or expressions in `computeKnownFPClassFromContext`.
Compile-time improvement: http://llvm-compile-time-tracker.com/compare.php?from=688bb432c4b618de69a1d0e7807077a22f15762a&to=07493fc354b686f0aca79d6f817091a757bd7cd5&stat=instructions:u
