### PR TITLE
[clang][bytecode][NFC] Reject invalid FromTypes in emitBuiltinBitcast

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6514,6 +6514,8 @@ bool Compiler<Emitter>::emitBuiltinBitCast(const CastExpr *E) {
       return false;
     if (!this->emitGetPtrLocal(TempOffset, E))
       return false;
+  } else {
+    return false;
   }
 
   if (!ToT || ToT == PT_Ptr) {


### PR DESCRIPTION
instead of silently accepting them and failing later.