### PR TITLE
[ExprConst] Handle floating- and char literals in FastEvaluateAsRValue

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -16473,7 +16473,7 @@ static bool FastEvaluateAsRValue(const Expr *Exp, Expr::EvalResult &Result,
                                  const ASTContext &Ctx, bool &IsConst) {
   // Fast-path evaluations of integer literals, since we sometimes see files
   // containing vast quantities of these.
-  if (const IntegerLiteral *L = dyn_cast<IntegerLiteral>(Exp)) {
+  if (const auto *L = dyn_cast<IntegerLiteral>(Exp)) {
     Result.Val = APValue(APSInt(L->getValue(),
                                 L->getType()->isUnsignedIntegerType()));
     IsConst = true;
@@ -16482,6 +16482,18 @@ static bool FastEvaluateAsRValue(const Expr *Exp, Expr::EvalResult &Result,
 
   if (const auto *L = dyn_cast<CXXBoolLiteralExpr>(Exp)) {
     Result.Val = APValue(APSInt(APInt(1, L->getValue())));
+    IsConst = true;
+    return true;
+  }
+
+  if (const auto *FL = dyn_cast<FloatingLiteral>(Exp)) {
+    Result.Val = APValue(FL->getValue());
+    IsConst = true;
+    return true;
+  }
+
+  if (const auto *L = dyn_cast<CharacterLiteral>(Exp)) {
+    Result.Val = APValue(Ctx.MakeIntValue(L->getValue(), L->getType()));
     IsConst = true;
     return true;
   }


### PR DESCRIPTION
This is part of a three-patch series that results in some nice (but not substantial) compile-time improvements: http://llvm-compile-time-tracker.com/compare.php?from=fe1c4f0106fe4fd6d61c38ba46e71fda8f4d1573&to=0824d621b2c035a3befb564153b31309a9a79d97&stat=instructions%3Au

The results for just this patch are here: http://llvm-compile-time-tracker.com/compare.php?from=fe1c4f0106fe4fd6d61c38ba46e71fda8f4d1573&to=6f7f51b476a37dc7c80427fede077e6798a83be8&stat=instructions:u