### PR TITLE
[llvm-objdump] Default to --mattr=+all for AArch64be and AArch64_32

### DIFF
--- a/llvm/test/tools/llvm-objdump/ELF/AArch64/mattr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AArch64/mattr.s
@@ -1,6 +1,10 @@
 ## When --mattr and --mcpu are both empty, disassemble all known instructions.
 # RUN: llvm-mc -filetype=obj -triple=aarch64 -mattr=+all %s -o %t
 # RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s --check-prefixes=CHECK,ALL
+# RUN: llvm-mc -filetype=obj -triple=aarch64_be -mattr=+all %s -o %t
+# RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s --check-prefixes=CHECK,ALL
+# RUN: llvm-mc -filetype=obj -triple=aarch64_32 -mattr=+all %s -o %t
+# RUN: llvm-objdump -d --no-show-raw-insn %t | FileCheck %s --check-prefixes=CHECK,ALL
 
 ## If --mattr or --mcpu is specified, don't default to --mattr=+all.
 # RUN: llvm-objdump -d --no-show-raw-insn --mattr=+v8a %t | FileCheck %s --check-prefixes=CHECK,UNKNOWN

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -2556,7 +2556,7 @@ static void disassembleObject(ObjectFile *Obj, bool InlineRelocs) {
   if (!MAttrs.empty()) {
     for (unsigned I = 0; I != MAttrs.size(); ++I)
       Features.AddFeature(MAttrs[I]);
-  } else if (MCPU.empty() && Obj->getArch() == llvm::Triple::aarch64) {
+  } else if (MCPU.empty() && Obj->makeTriple().isAArch64()) {
     Features.AddFeature("+all");
   }
 


### PR DESCRIPTION
GNU objdump disassembles all unknown instructions by default. 
Complement for [D128030](https://reviews.llvm.org/D128030)。