### PR TITLE
[clang-tidy] ignore `[[clang::lifetimebound]]` param in return-const-ref-from-parameter

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -184,7 +184,8 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/return-const-ref-from-parameter>` check to
   diagnose potential dangling references when returning a ``const &`` parameter
   by using the conditional operator ``cond ? var1 : var2`` and no longer giving
-  false positives for functions which contain lambda.
+  false positives for functions which contain lambda and ignore parameters
+  with ``[[clang::lifetimebound]]`` attribute.
   
 - Improved :doc:`bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/sizeof-expression>` check to find suspicious

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/return-const-ref-from-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/return-const-ref-from-parameter.rst
@@ -42,9 +42,10 @@ on the control flow of the function, an overload where all problematic
 
 This issue can also be resolved by adding ``[[clang::lifetimebound]]``. Clang
 enable ``-Wdangling`` warning by default which can detect mis-uses of the
-annotated function. See `lifetimebound attribute<https://clang.llvm.org/docs/AttributeReference.html#id11>`_
+annotated function. See `lifetimebound attribute <https://clang.llvm.org/docs/AttributeReference.html#id11>`_
 for details.
 
 .. code-block:: c++
+
   const int &f(const int &a [[clang::lifetimebound]]) { return a; } // no warning
   const int &v = f(1); // warning: temporary bound to local reference 'v' will be destroyed at the end of the full-expression [-Wdangling]

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/return-const-ref-from-parameter.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/return-const-ref-from-parameter.rst
@@ -12,15 +12,6 @@ after the call. When the function returns such a parameter also as constant refe
 then the returned reference can be used after the object it refers to has been
 destroyed.
 
-This issue can be resolved by declaring an overload of the problematic function
-where the ``const &`` parameter is instead declared as ``&&``. The developer has
-to ensure that the implementation of that function does not produce a
-use-after-free, the exact error that this check is warning against.
-Marking such an ``&&`` overload as ``deleted``, will silence the warning as 
-well. In the case of different ``const &`` parameters being returned depending
-on the control flow of the function, an overload where all problematic
-``const &`` parameters have been declared as ``&&`` will resolve the issue.
-
 Example
 -------
 
@@ -38,3 +29,22 @@ Example
 
   const S& s = fn(S{1});
   s.v; // use after free
+
+
+This issue can be resolved by declaring an overload of the problematic function
+where the ``const &`` parameter is instead declared as ``&&``. The developer has
+to ensure that the implementation of that function does not produce a
+use-after-free, the exact error that this check is warning against.
+Marking such an ``&&`` overload as ``deleted``, will silence the warning as 
+well. In the case of different ``const &`` parameters being returned depending
+on the control flow of the function, an overload where all problematic
+``const &`` parameters have been declared as ``&&`` will resolve the issue.
+
+This issue can also be resolved by adding ``[[clang::lifetimebound]]``. Clang
+enable ``-Wdangling`` warning by default which can detect mis-uses of the
+annotated function. See `lifetimebound attribute<https://clang.llvm.org/docs/AttributeReference.html#id11>`_
+for details.
+
+.. code-block:: c++
+  const int &f(const int &a [[clang::lifetimebound]]) { return a; } // no warning
+  const int &v = f(1); // warning: temporary bound to local reference 'v' will be destroyed at the end of the full-expression [-Wdangling]

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/return-const-ref-from-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/return-const-ref-from-parameter.cpp
@@ -197,3 +197,9 @@ int const &overload_params_difference3(int p1, int const &a, int p2) { return a;
 int const &overload_params_difference3(int p1, long &&a, int p2);
 
 } // namespace overload
+
+namespace gh117696 {
+namespace use_lifetime_bound_attr {
+int const &f(int const &a [[clang::lifetimebound]]) { return a; }
+} // namespace use_lifetime_bound_attr
+} // namespace gh117696


### PR DESCRIPTION
Fixed #117696