### PR TITLE
[NFC] Fix uninitialized scalar field in constructor.

### DIFF
--- a/clang-tools-extra/clangd/index/MemIndex.h
+++ b/clang-tools-extra/clangd/index/MemIndex.h
@@ -43,6 +43,7 @@ public:
     KeepAlive = std::shared_ptr<void>(
         std::make_shared<Payload>(std::move(BackingData)), nullptr);
     this->BackingDataSize = BackingDataSize;
+    this->IdxContents = IndexContents::All;
   }
 
   template <typename SymbolRange, typename RefRange, typename RelationRange,

--- a/clang-tools-extra/clangd/index/MemIndex.h
+++ b/clang-tools-extra/clangd/index/MemIndex.h
@@ -93,7 +93,7 @@ private:
   // Set of files which were used during this index build.
   llvm::StringSet<> Files;
   // Contents of the index (symbols, references, etc.)
-  IndexContents IdxContents;
+  IndexContents IdxContents = IndexContents::None;
   std::shared_ptr<void> KeepAlive; // poor man's move-only std::any
   // Size of memory retained by KeepAlive.
   size_t BackingDataSize = 0;

--- a/clang-tools-extra/clangd/index/MemIndex.h
+++ b/clang-tools-extra/clangd/index/MemIndex.h
@@ -43,7 +43,6 @@ public:
     KeepAlive = std::shared_ptr<void>(
         std::make_shared<Payload>(std::move(BackingData)), nullptr);
     this->BackingDataSize = BackingDataSize;
-    this->IdxContents = IndexContents::All;
   }
 
   template <typename SymbolRange, typename RefRange, typename RelationRange,

--- a/clang-tools-extra/clangd/index/dex/Dex.h
+++ b/clang-tools-extra/clangd/index/dex/Dex.h
@@ -58,6 +58,7 @@ public:
     KeepAlive = std::shared_ptr<void>(
         std::make_shared<Payload>(std::move(BackingData)), nullptr);
     this->BackingDataSize = BackingDataSize;
+    this->IdxContents = IndexContents::All;
   }
 
   template <typename SymbolRange, typename RefsRange, typename RelationsRange,

--- a/clang-tools-extra/clangd/index/dex/Dex.h
+++ b/clang-tools-extra/clangd/index/dex/Dex.h
@@ -58,7 +58,6 @@ public:
     KeepAlive = std::shared_ptr<void>(
         std::make_shared<Payload>(std::move(BackingData)), nullptr);
     this->BackingDataSize = BackingDataSize;
-    this->IdxContents = IndexContents::All;
   }
 
   template <typename SymbolRange, typename RefsRange, typename RelationsRange,
@@ -124,7 +123,7 @@ private:
   // Set of files which were used during this index build.
   llvm::StringSet<> Files;
   // Contents of the index (symbols, references, etc.)
-  IndexContents IdxContents;
+  IndexContents IdxContents = IndexContents::None;
   // Size of memory retained by KeepAlive.
   size_t BackingDataSize = 0;
 };


### PR DESCRIPTION
Non-static class field is not initialized in constructor.