### PR TITLE
[flang][debug] Improve check for global variable detection.

### DIFF
--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -102,14 +102,14 @@ void AddDebugInfoPass::handleDeclareOp(fir::cg::XDeclareOp declOp,
   if (result.first != fir::NameUniquer::NameKind::VARIABLE)
     return;
   // If this DeclareOp actually represents a global then treat it as such.
-  if (auto global = symbolTable->lookup<fir::GlobalOp>(declOp.getUniqName())) {
-    handleGlobalOp(global, fileAttr, scopeAttr, typeGen, symbolTable, declOp);
-    return;
+  mlir::Operation *defOp = declOp.getMemref().getDefiningOp();
+  if (defOp && llvm::isa<fir::AddrOfOp>(defOp)) {
+    if (auto global =
+            symbolTable->lookup<fir::GlobalOp>(declOp.getUniqName())) {
+      handleGlobalOp(global, fileAttr, scopeAttr, typeGen, symbolTable, declOp);
+      return;
+    }
   }
-
-  // Only accept local variables.
-  if (result.second.procs.empty())
-    return;
 
   // FIXME: There may be cases where an argument is processed a bit before
   // DeclareOp is generated. In that case, DeclareOp may point to an


### PR DESCRIPTION
When a global variable is used in the OpenMP target region, it is passed as an argument to the function that implements target region. But the `DeclareOp` for this incarnation still have the original name of the variable. As some of our checks to decide if a variable is global or nor are based on the name, this can result in a local variable being treated as global. This PR hardens the check a bit. We now also check that memory ref is actually an `AddrOfOp` before looking at the name.