### PR TITLE
[llvm-tblgen] Increase Coverage Index Size

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGISel.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGISel.h
@@ -315,7 +315,7 @@ public:
     OPC_MorphNodeTo1GlueOutput,
     OPC_MorphNodeTo2GlueOutput,
     OPC_CompleteMatch,
-    // Contains offset in table for pattern being selected
+    // Contains 32-bit offset in table for pattern being selected
     OPC_Coverage
   };
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -4045,6 +4045,8 @@ void SelectionDAGISel::SelectCodeCommon(SDNode *NodeToMatch,
       // So it should be safe to assume that this node has been selected
       unsigned index = MatcherTable[MatcherIndex++];
       index |= (MatcherTable[MatcherIndex++] << 8);
+      index |= (MatcherTable[MatcherIndex++] << 16);
+      index |= (MatcherTable[MatcherIndex++] << 24);
       dbgs() << "COVERED: " << getPatternForIndex(index) << "\n";
       dbgs() << "INCLUDED: " << getIncludePathForIndex(index) << "\n";
       continue;

--- a/llvm/test/TableGen/dag-isel-instrument.td
+++ b/llvm/test/TableGen/dag-isel-instrument.td
@@ -1,0 +1,32 @@
+// RUN: llvm-tblgen -gen-dag-isel -instrument-coverage -I %p/../../include %s | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def TestTargetInstrInfo : InstrInfo;
+
+def TestTarget : Target {
+  let InstructionSet = TestTargetInstrInfo;
+}
+
+def REG : Register<"REG">;
+def GPR : RegisterClass<"TestTarget", [i32], 32, (add REG)>;
+
+// CHECK-LABEL: OPC_CheckOpcode, TARGET_VAL(ISD::UDIVREM)
+// CHECK: OPC_EmitNode2None, TARGET_VAL(::INSTR)
+// CHECK-NEXT: Results = #2 #3
+// CHECK-NEXT: OPC_Coverage, COVERAGE_IDX_VAL(0),
+// CHECK-NEXT: OPC_CompleteMatch, 2, 3, 2
+def INSTR : Instruction {
+  let OutOperandList = (outs GPR:$r1, GPR:$r0);
+  let InOperandList = (ins GPR:$t0, GPR:$t1);
+  let Pattern = [(set i32:$r0, i32:$r1, (udivrem i32:$t0, i32:$t1))];
+}
+
+
+// CHECK: getPatternForIndex(unsigned Index)
+// CHECK: static const char *PATTERN_MATCH_TABLE[]
+// CHECK: return StringRef(PATTERN_MATCH_TABLE[Index]);
+
+// CHECK: getIncludePathForIndex(unsigned Index)
+// CHECK: static const char *INCLUDE_PATH_TABLE[]
+// CHECK: return StringRef(INCLUDE_PATH_TABLE[Index]);

--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -381,8 +381,10 @@ static void EndEmitFunction(raw_ostream &OS) {
 
 void MatcherTableEmitter::EmitPatternMatchTable(raw_ostream &OS) {
 
-  assert(isUInt<32>(VecPatterns.size()) &&
-         "Using only 32 bits to encode offset into Pattern Table");
+  if (!isUInt<32>(VecPatterns.size()))
+    report_fatal_error("More patterns defined that can fit into 32-bit Pattern "
+                       "Table index encoding");
+
   assert(VecPatterns.size() == VecIncludeStrings.size() &&
          "The sizes of Pattern and include vectors should be the same");
 


### PR DESCRIPTION
The tablegen backend for DAGISel can, using the `-instrument-coverage` option, save information about which patterns are used. This saves an index into two tables, one that contains a string dump of the pattern, and another that contains the path the pattern came from.

Before this change, these indexes were an unsigned 16-bit value.

The RISC-V backend, however, goes beyond this limit. This change increases the indexes to be represented by a 32-bit unsigned value.

`-instrument-coverage` is not enabled by default, so this should have minimal effect on the default configuration's code size. This is partly why I also just chose to double the size (from 16-bit to 32-bit) rather than going to 24-bit. Hopefully this size will never need to be changed again.

Fixes #118259