### PR TITLE
[lldb] For a host socket, add a method to print the listening address.

### DIFF
--- a/lldb/include/lldb/Host/Socket.h
+++ b/lldb/include/lldb/Host/Socket.h
@@ -151,6 +151,9 @@ public:
   // If this Socket is connected then return the URI used to connect.
   virtual std::string GetRemoteConnectionURI() const { return ""; };
 
+  // If the Socket is listening then return the URI for clients to connect.
+  virtual std::string GetListeningConnectionURI() const { return ""; }
+
 protected:
   Socket(SocketProtocol protocol, bool should_close);
 

--- a/lldb/include/lldb/Host/Socket.h
+++ b/lldb/include/lldb/Host/Socket.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "lldb/Host/MainLoopBase.h"
 #include "lldb/Utility/Timeout.h"
@@ -152,7 +153,7 @@ public:
   virtual std::string GetRemoteConnectionURI() const { return ""; };
 
   // If the Socket is listening then return the URI for clients to connect.
-  virtual std::string GetListeningConnectionURI() const { return ""; }
+  virtual std::vector<std::string> GetListeningConnectionURI() const { return {}; }
 
 protected:
   Socket(SocketProtocol protocol, bool should_close);

--- a/lldb/include/lldb/Host/Socket.h
+++ b/lldb/include/lldb/Host/Socket.h
@@ -153,7 +153,9 @@ public:
   virtual std::string GetRemoteConnectionURI() const { return ""; };
 
   // If the Socket is listening then return the URI for clients to connect.
-  virtual std::vector<std::string> GetListeningConnectionURI() const { return {}; }
+  virtual std::vector<std::string> GetListeningConnectionURI() const {
+    return {};
+  }
 
 protected:
   Socket(SocketProtocol protocol, bool should_close);

--- a/lldb/include/lldb/Host/common/TCPSocket.h
+++ b/lldb/include/lldb/Host/common/TCPSocket.h
@@ -52,6 +52,8 @@ public:
 
   std::string GetRemoteConnectionURI() const override;
 
+  std::string GetListeningConnectionURI() const override;
+
 private:
   TCPSocket(NativeSocket socket, const TCPSocket &listen_socket);
 

--- a/lldb/include/lldb/Host/common/TCPSocket.h
+++ b/lldb/include/lldb/Host/common/TCPSocket.h
@@ -13,6 +13,8 @@
 #include "lldb/Host/Socket.h"
 #include "lldb/Host/SocketAddress.h"
 #include <map>
+#include <string>
+#include <vector>
 
 namespace lldb_private {
 class TCPSocket : public Socket {
@@ -52,7 +54,7 @@ public:
 
   std::string GetRemoteConnectionURI() const override;
 
-  std::string GetListeningConnectionURI() const override;
+  std::vector<std::string> GetListeningConnectionURI() const override;
 
 private:
   TCPSocket(NativeSocket socket, const TCPSocket &listen_socket);

--- a/lldb/include/lldb/Host/posix/DomainSocket.h
+++ b/lldb/include/lldb/Host/posix/DomainSocket.h
@@ -27,6 +27,8 @@ public:
 
   std::string GetRemoteConnectionURI() const override;
 
+  std::string GetListeningConnectionURI() const override;
+
 protected:
   DomainSocket(SocketProtocol protocol);
 

--- a/lldb/include/lldb/Host/posix/DomainSocket.h
+++ b/lldb/include/lldb/Host/posix/DomainSocket.h
@@ -10,6 +10,8 @@
 #define LLDB_HOST_POSIX_DOMAINSOCKET_H
 
 #include "lldb/Host/Socket.h"
+#include <string>
+#include <vector>
 
 namespace lldb_private {
 class DomainSocket : public Socket {
@@ -27,7 +29,7 @@ public:
 
   std::string GetRemoteConnectionURI() const override;
 
-  std::string GetListeningConnectionURI() const override;
+  std::vector<std::string> GetListeningConnectionURI() const override;
 
 protected:
   DomainSocket(SocketProtocol protocol);

--- a/lldb/source/Host/common/TCPSocket.cpp
+++ b/lldb/source/Host/common/TCPSocket.cpp
@@ -81,6 +81,12 @@ std::string TCPSocket::GetLocalIPAddress() const {
     socklen_t sock_addr_len = sock_addr.GetMaxLength();
     if (::getsockname(m_socket, sock_addr, &sock_addr_len) == 0)
       return sock_addr.GetIPAddress();
+  } else if (!m_listen_sockets.empty()) {
+    SocketAddress sock_addr;
+    socklen_t sock_addr_len = sock_addr.GetMaxLength();
+    if (::getsockname(m_listen_sockets.begin()->first, sock_addr,
+                      &sock_addr_len) == 0)
+      return sock_addr.GetIPAddress();
   }
   return "";
 }
@@ -112,6 +118,15 @@ std::string TCPSocket::GetRemoteConnectionURI() const {
     return std::string(llvm::formatv(
         "connect://[{0}]:{1}", GetRemoteIPAddress(), GetRemotePortNumber()));
   }
+  return "";
+}
+
+std::string TCPSocket::GetListeningConnectionURI() const {
+  if (!m_listen_sockets.empty()) {
+    return std::string(llvm::formatv(
+        "connection://[{0}]:{1}", GetLocalIPAddress(), GetLocalPortNumber()));
+  }
+
   return "";
 }
 
@@ -176,8 +191,9 @@ Status TCPSocket::Listen(llvm::StringRef name, int backlog) {
 
   if (host_port->hostname == "*")
     host_port->hostname = "0.0.0.0";
-  std::vector<SocketAddress> addresses = SocketAddress::GetAddressInfo(
-      host_port->hostname.c_str(), nullptr, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP);
+  std::vector<SocketAddress> addresses =
+      SocketAddress::GetAddressInfo(host_port->hostname.c_str(), nullptr,
+                                    AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP);
   for (SocketAddress &address : addresses) {
     int fd =
         Socket::CreateSocket(address.GetFamily(), kType, IPPROTO_TCP, error);
@@ -191,7 +207,7 @@ Status TCPSocket::Listen(llvm::StringRef name, int backlog) {
     }
 
     SocketAddress listen_address = address;
-    if(!listen_address.IsLocalhost())
+    if (!listen_address.IsLocalhost())
       listen_address.SetToAnyAddress(address.GetFamily(), host_port->port);
     else
       listen_address.SetPort(host_port->port);

--- a/lldb/source/Host/common/TCPSocket.cpp
+++ b/lldb/source/Host/common/TCPSocket.cpp
@@ -116,14 +116,10 @@ std::string TCPSocket::GetRemoteConnectionURI() const {
 }
 
 std::vector<std::string> TCPSocket::GetListeningConnectionURI() const {
-  if (m_listen_sockets.empty())
-    return {};
-
   std::vector<std::string> URIs;
-  for (auto &s : m_listen_sockets)
-    URIs.emplace_back(llvm::formatv(
-        "connection://[{0}]:{1}", s.second.GetIPAddress(), s.second.GetPort()));
-
+  for (const auto &[fd, addr] : m_listen_sockets)
+    URIs.emplace_back(llvm::formatv("connection://[{0}]:{1}",
+                                    addr.GetIPAddress(), addr.GetPort()));
   return URIs;
 }
 

--- a/lldb/source/Host/posix/DomainSocket.cpp
+++ b/lldb/source/Host/posix/DomainSocket.cpp
@@ -86,7 +86,8 @@ Status DomainSocket::Connect(llvm::StringRef name) {
   if (error.Fail())
     return error;
   if (llvm::sys::RetryAfterSignal(-1, ::connect, GetNativeSocket(),
-        (struct sockaddr *)&saddr_un, saddr_un_len) < 0)
+                                  (struct sockaddr *)&saddr_un,
+                                  saddr_un_len) < 0)
     SetLastError(error);
 
   return error;
@@ -174,4 +175,18 @@ std::string DomainSocket::GetRemoteConnectionURI() const {
   return llvm::formatv(
       "{0}://{1}",
       GetNameOffset() == 0 ? "unix-connect" : "unix-abstract-connect", name);
+}
+
+std::string DomainSocket::GetListeningConnectionURI() const {
+  if (m_socket == kInvalidSocketValue)
+    return "";
+
+  struct sockaddr_un addr;
+  bzero(&addr, sizeof(struct sockaddr_un));
+  addr.sun_family = AF_UNIX;
+  socklen_t addr_len = sizeof(struct sockaddr_un);
+  if (::getsockname(m_socket, (struct sockaddr *)&addr, &addr_len) != 0)
+    return "";
+
+  return llvm::formatv("unix-connect://{0}", addr.sun_path);
 }

--- a/lldb/source/Host/posix/DomainSocket.cpp
+++ b/lldb/source/Host/posix/DomainSocket.cpp
@@ -86,8 +86,7 @@ Status DomainSocket::Connect(llvm::StringRef name) {
   if (error.Fail())
     return error;
   if (llvm::sys::RetryAfterSignal(-1, ::connect, GetNativeSocket(),
-                                  (struct sockaddr *)&saddr_un,
-                                  saddr_un_len) < 0)
+        (struct sockaddr *)&saddr_un, saddr_un_len) < 0)
     SetLastError(error);
 
   return error;
@@ -177,16 +176,16 @@ std::string DomainSocket::GetRemoteConnectionURI() const {
       GetNameOffset() == 0 ? "unix-connect" : "unix-abstract-connect", name);
 }
 
-std::string DomainSocket::GetListeningConnectionURI() const {
+std::vector<std::string> DomainSocket::GetListeningConnectionURI() const {
   if (m_socket == kInvalidSocketValue)
-    return "";
+    return {};
 
   struct sockaddr_un addr;
   bzero(&addr, sizeof(struct sockaddr_un));
   addr.sun_family = AF_UNIX;
   socklen_t addr_len = sizeof(struct sockaddr_un);
   if (::getsockname(m_socket, (struct sockaddr *)&addr, &addr_len) != 0)
-    return "";
+    return {};
 
-  return llvm::formatv("unix-connect://{0}", addr.sun_path);
+  return {llvm::formatv("unix-connect://{0}", addr.sun_path)};
 }

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -299,7 +299,8 @@ TEST_P(SocketTest, UDPGetConnectURI) {
 #if LLDB_ENABLE_POSIX
 TEST_P(SocketTest, DomainGetConnectURI) {
   llvm::SmallString<64> domain_path;
-  std::error_code EC = llvm::sys::fs::createUniqueDirectory("DomainListenConnectAccept", domain_path);
+  std::error_code EC =
+      llvm::sys::fs::createUniqueDirectory("DomainListenConnectAccept", domain_path);
   ASSERT_FALSE(EC);
   llvm::sys::path::append(domain_path, "test");
 

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -105,9 +105,9 @@ TEST_P(SocketTest, DomainListenGetListeningConnectionURI) {
   ASSERT_THAT_ERROR(error.ToError(), llvm::Succeeded());
   ASSERT_TRUE(listen_socket_up->IsValid());
 
-  const auto &URIs = listen_socket_up->GetListeningConnectionURI();
-  ASSERT_EQ(URIs.size(), 1u);
-  ASSERT_EQ(URIs[0], llvm::formatv("unix-connect://{0}", Path).str());
+  ASSERT_THAT(
+      listen_socket_up->GetListeningConnectionURI(),
+      testing::ElementsAre(llvm::formatv("unix-connect://{0}", Path).str()));
 }
 
 TEST_P(SocketTest, DomainMainLoopAccept) {
@@ -262,12 +262,12 @@ TEST_P(SocketTest, TCPListen0GetListeningConnectionURI) {
   ASSERT_THAT_EXPECTED(sock, llvm::Succeeded());
   ASSERT_TRUE(sock.get()->IsValid());
 
-  for (const auto &URI : sock.get()->GetListeningConnectionURI()) {
-    EXPECT_EQ(URI,
-              llvm::formatv("connection://[{0}]:{1}", GetParam().localhost_ip,
-                            sock->get()->GetLocalPortNumber())
-                  .str());
-  }
+  EXPECT_THAT(
+      sock.get()->GetListeningConnectionURI(),
+      testing::ElementsAre(llvm::formatv("connection://[{0}]:{1}",
+                                         GetParam().localhost_ip,
+                                         sock->get()->GetLocalPortNumber())
+                               .str()));
 }
 
 TEST_P(SocketTest, TCPGetConnectURI) {

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -253,6 +253,9 @@ TEST_P(SocketTest, TCPListen0GetPort) {
 }
 
 TEST_P(SocketTest, TCPListen0GetListeningConnectionURI) {
+  if (!HostSupportsProtocol())
+    return;
+
   std::string addr = llvm::formatv("[{0}]:0", GetParam().localhost_ip).str();
   llvm::Expected<std::unique_ptr<TCPSocket>> sock = Socket::TcpListen(addr);
   ASSERT_THAT_EXPECTED(sock, llvm::Succeeded());


### PR DESCRIPTION
This is most useful if you are listening on an address like 'localhost:0' and want to know the resolved ip + port of the socket listener.