### PR TITLE
[clang] Document the return value of __builtin_COLUMN

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -4519,7 +4519,7 @@ empty string is returned.
 
 The builtin ``__builtin_COLUMN`` returns the offset from the start of the line,
 beginning from column 1. `This may differ from other implementations.
-<https://en.cppreference.com/w/cpp/utility/source_location/column>`_
+<https://eel.is/c++draft/support.srcloc#tab:support.srcloc.current-row-3-column-2-sentence-2>`_
 
 The builtin ``__builtin_source_location`` returns a pointer to constant static
 data of type ``std::source_location::__impl``. This type must have already been

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -4514,8 +4514,12 @@ default member initializer, the invocation point is the location of the
 constructor or aggregate initialization used to create the object. Otherwise
 the invocation point is the same as the location of the builtin.
 
-When the invocation point of ``__builtin_FUNCTION`` is not a function scope the
+When the invocation point of ``__builtin_FUNCTION`` is not a function scope, the
 empty string is returned.
+
+The builtin ``__builtin_COLUMN`` returns the offset from the start of the line,
+beginning from column 1. `This may differ from other implementations.
+<https://en.cppreference.com/w/cpp/utility/source_location/column>`_
 
 The builtin ``__builtin_source_location`` returns a pointer to constant static
 data of type ``std::source_location::__impl``. This type must have already been


### PR DESCRIPTION
PR for issue #78657

Updated clang/docs/LanguageExtensions.rst to detail the return value of __builtin_COLUMN for this implementation.

--

Fyi, this is my first contribution, so please bear with me.

There already appears to be a unit test for __builtin_COLUMN in clang/test/SemaCXX/source_location.cpp.