### PR TITLE
[CIR] Fix warning in CIRGenAction.cpp

### DIFF
--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -66,9 +66,6 @@ public:
         MlirModule->print(*OutputStream, Flags);
       }
       break;
-    default:
-      llvm_unreachable("NYI: CIRGenAction other than EmitCIR");
-      break;
     }
   }
 };


### PR DESCRIPTION
Fix a compiler warning in `CIRGenConsumer::HandleTranslationUnit` in `clang/lib/CIR/FrontendAction/CIRGenAction.cpp`.  The warning was about a `default:` section in a switch statement that already covered all the values of an enum.  Delete the `default:` section.