### PR TITLE
[flang] Update CommandTest for AIX (NFC)

### DIFF
--- a/flang/unittests/Runtime/CommandTest.cpp
+++ b/flang/unittests/Runtime/CommandTest.cpp
@@ -352,9 +352,6 @@ TEST_F(ZeroArguments, ECLGeneralErrorCommandErrorSync) {
 #if defined(_WIN32)
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 6);
   CheckDescriptorEqStr(cmdMsg.get(), "Invalid command lineXXXXXXXXX");
-#elif defined(_AIX)
-  CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 6);
-  CheckDescriptorEqStr(cmdMsg.get(), "Invalid command lineXXXXXXXXX");
 #else
   CheckDescriptorEqInt<std::int64_t>(cmdStat.get(), 3);
   CheckDescriptorEqStr(cmdMsg.get(), "Command line execution failed");


### PR DESCRIPTION
With the change in https://github.com/llvm/llvm-project/commit/e335563806e0466f33ecce80a9fd5a39a3aead47, the behavior for `ECLGeneralErrorCommandErrorSync` on AIX is no longer different from that on Linux.