### PR TITLE
[ValueTracking] Handle assume(trunc x to i1) in ComputeKnownBits

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -910,6 +910,16 @@ void llvm::computeKnownBitsFromContext(const Value *V, KnownBits &Known,
       Known.setAllZero();
       return;
     }
+    auto *Trunc = dyn_cast<TruncInst>(Arg);
+    if (Trunc && Trunc->getOperand(0) == V &&
+        isValidAssumeForContext(I, Q.CxtI, Q.DT)) {
+      if (Trunc->hasNoUnsignedWrap()) {
+        Known = KnownBits::makeConstant(APInt(BitWidth, 1));
+        return;
+      }
+      Known.One.setBit(0);
+      return;
+    }
 
     // The remaining tests are all recursive, so bail out if we hit the limit.
     if (Depth == MaxAnalysisRecursionDepth)

--- a/llvm/test/Transforms/InstCombine/assume.ll
+++ b/llvm/test/Transforms/InstCombine/assume.ll
@@ -1013,8 +1013,7 @@ define i1 @assume_trunc_nuw_eq_one(i8 %x) {
 ; CHECK-LABEL: @assume_trunc_nuw_eq_one(
 ; CHECK-NEXT:    [[A:%.*]] = trunc nuw i8 [[X:%.*]] to i1
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[A]])
-; CHECK-NEXT:    [[Q:%.*]] = icmp eq i8 [[X]], 1
-; CHECK-NEXT:    ret i1 [[Q]]
+; CHECK-NEXT:    ret i1 true
 ;
   %a = trunc nuw i8 %x to i1
   call void @llvm.assume(i1 %a)

--- a/llvm/test/Transforms/InstSimplify/shr-nop.ll
+++ b/llvm/test/Transforms/InstSimplify/shr-nop.ll
@@ -385,8 +385,7 @@ define i8 @exact_lshr_lowbit_set_assume_trunc(i8 %x) {
 ; CHECK-LABEL: @exact_lshr_lowbit_set_assume_trunc(
 ; CHECK-NEXT:    [[COND:%.*]] = trunc i8 [[X:%.*]] to i1
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
-; CHECK-NEXT:    [[SHR:%.*]] = lshr exact i8 [[X]], 1
-; CHECK-NEXT:    ret i8 [[SHR]]
+; CHECK-NEXT:    ret i8 [[X]]
 ;
   %cond = trunc i8 %x to i1
   call void @llvm.assume(i1 %cond)


### PR DESCRIPTION
Handle assume( trunc x to i1) in ComputeKnownBits to avoid regressions when converting more icmp to trunc as the https://github.com/llvm/llvm-project/pull/84628 remove the canonicalization `trunc x to i1 -> icmp ne (and x, 1), 0`

proof: https://alive2.llvm.org/ce/z/zAspzb