### PR TITLE
[MLIR][TOSA] Update PowOp output name from z to output

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -828,7 +828,7 @@ def Tosa_PowOp : Tosa_ElementwiseOp<"pow", [SameOperandsAndResultElementType]> {
   );
 
   let results = (outs
-    Tosa_Tensor:$z
+    Tosa_Tensor:$output
   );
 }
 


### PR DESCRIPTION
To match the latest specification: https://www.mlplatform.org/tosa/tosa_spec.html#_pow