### PR TITLE
[RISCV] Mark vmvNr.v as implicitly using vtype

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoV.td
@@ -1726,7 +1726,7 @@ foreach n = [1, 2, 4, 8] in {
   def VMV#n#R_V  : RVInstV<0b100111, !add(n, -1), OPIVI, (outs vrc:$vd),
                            (ins vrc:$vs2), "vmv" # n # "r.v", "$vd, $vs2">,
                    VMVRSched<n> {
-    let Uses = [];
+    let Uses = [VTYPE];
     let vm = 1;
   }
 }

--- a/llvm/test/MachineVerifier/RISCV/subreg-liveness.mir
+++ b/llvm/test/MachineVerifier/RISCV/subreg-liveness.mir
@@ -19,8 +19,8 @@ body:             |
     ; CHECK: liveins: $v0, $v8, $v9, $v10, $v11
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $v16m2 = PseudoVMV_V_I_M2 undef renamable $v16m2, 0, -1, 3 /* e8 */, 0 /* tu, mu */, implicit $vl, implicit $vtype
-    ; CHECK-NEXT: $v20m2 = VMV2R_V $v14m2, implicit $v12_v13_v14_v15_v16
+    ; CHECK-NEXT: $v20m2 = VMV2R_V $v14m2, implicit $v12_v13_v14_v15_v16, implicit $vtype
     renamable $v16m2 = PseudoVMV_V_I_M2 undef renamable $v16m2, 0, -1, 3 /* e8 */, 0 /* tu, mu */, implicit $vl, implicit $vtype
-    $v20m2 = VMV2R_V $v14m2, implicit $v12_v13_v14_v15_v16
+    $v20m2 = VMV2R_V $v14m2, implicit $v12_v13_v14_v15_v16, implicit $vtype
 
 ...

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/vmv.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/vmv.s
@@ -293,12 +293,12 @@ vfmv.f.s f7, v16
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      280
-# CHECK-NEXT: Total Cycles:      523
+# CHECK-NEXT: Total Cycles:      524
 # CHECK-NEXT: Total uOps:        280
 
 # CHECK:      Dispatch Width:    3
-# CHECK-NEXT: uOps Per Cycle:    0.54
-# CHECK-NEXT: IPC:               0.54
+# CHECK-NEXT: uOps Per Cycle:    0.53
+# CHECK-NEXT: IPC:               0.53
 # CHECK-NEXT: Block RThroughput: 512.0
 
 # CHECK:      Instruction Info:

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP600/vmv.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP600/vmv.s
@@ -260,12 +260,12 @@ vmv8r.v	v8, v16
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      256
-# CHECK-NEXT: Total Cycles:      237
+# CHECK-NEXT: Total Cycles:      255
 # CHECK-NEXT: Total uOps:        256
 
 # CHECK:      Dispatch Width:    4
-# CHECK-NEXT: uOps Per Cycle:    1.08
-# CHECK-NEXT: IPC:               1.08
+# CHECK-NEXT: uOps Per Cycle:    1.00
+# CHECK-NEXT: IPC:               1.00
 # CHECK-NEXT: Block RThroughput: 240.0
 
 # CHECK:      Instruction Info:


### PR DESCRIPTION
This was pointed out in https://github.com/llvm/llvm-project/pull/118283#issuecomment-2512895919. We cannot move these between vtype definitions as they depend on SEW and require vill to be clear.
