### PR TITLE
[clang][bytecode] Handle memmove like memcpy

### DIFF
--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1146,4 +1146,11 @@ namespace BuiltinMemcpy {
                                                                                       // both-note {{source of 'memcpy' is nullptr}}
 
 
+  constexpr int simpleMove() {
+    int a = 12;
+    int b = 0;
+    __builtin_memmove(&b, &a, sizeof(a));
+    return b;
+  }
+  static_assert(simpleMove() == 12);
 }


### PR DESCRIPTION
This is the same thing for us, except for diagnostic differences.