### PR TITLE
Reland "[ObjectYAML][ELF] Take alignment into account when generating notes"

### DIFF
--- a/llvm/lib/ObjectYAML/ELFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/ELFEmitter.cpp
@@ -1799,6 +1799,21 @@ void ELFState<ELFT>::writeSectionContent(Elf_Shdr &SHeader,
   if (!Section.Notes)
     return;
 
+  unsigned Align;
+  switch (SHeader.sh_addralign) {
+  case 0:
+  case 4:
+    Align = 4;
+    break;
+  case 8:
+    Align = 8;
+    break;
+  default:
+    reportError(Section.Name + ": invalid alignment for a note section: 0x" +
+                Twine::utohexstr(SHeader.sh_addralign));
+    return;
+  }
+
   uint64_t Offset = CBA.tell();
   for (const ELFYAML::NoteEntry &NE : *Section.Notes) {
     // Write name size.
@@ -1820,14 +1835,15 @@ void ELFState<ELFT>::writeSectionContent(Elf_Shdr &SHeader,
     if (!NE.Name.empty()) {
       CBA.write(NE.Name.data(), NE.Name.size());
       CBA.write('\0');
-      CBA.padToAlignment(4);
     }
 
     // Write description and padding.
     if (NE.Desc.binary_size() != 0) {
+      CBA.padToAlignment(Align);
       CBA.writeAsBinary(NE.Desc);
-      CBA.padToAlignment(4);
     }
+
+    CBA.padToAlignment(Align);
   }
 
   SHeader.sh_size = CBA.tell() - Offset;

--- a/llvm/lib/ObjectYAML/ELFEmitter.cpp
+++ b/llvm/lib/ObjectYAML/ELFEmitter.cpp
@@ -1800,7 +1800,7 @@ void ELFState<ELFT>::writeSectionContent(Elf_Shdr &SHeader,
     return;
 
   unsigned Align;
-  switch (SHeader.sh_addralign) {
+  switch (Section.AddressAlign) {
   case 0:
   case 4:
     Align = 4;
@@ -1810,7 +1810,7 @@ void ELFState<ELFT>::writeSectionContent(Elf_Shdr &SHeader,
     break;
   default:
     reportError(Section.Name + ": invalid alignment for a note section: 0x" +
-                Twine::utohexstr(SHeader.sh_addralign));
+                Twine::utohexstr(Section.AddressAlign));
     return;
   }
 

--- a/llvm/test/tools/yaml2obj/ELF/note-section.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/note-section.yaml
@@ -333,3 +333,132 @@ Sections:
       - Name: ABC
         Desc: '123456'
         Type: NT_VERSION
+
+## Check that an incorrect alignment is reported
+
+# RUN: not yaml2obj --docnum=16 %s 2>&1 | FileCheck %s --check-prefix=ERR_ALIGN1
+# ERR_ALIGN1: error: .note.foo: invalid alignment for a note section: 0x1
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  ELFDATA2LSB
+  Type:  ET_EXEC
+Sections:
+  - Name:         .note.foo
+    Type:         SHT_NOTE
+    AddressAlign: 1
+    Notes:
+      - Type: 0x1
+
+## Check that note entries and their `Desc` fields are aligned according to the
+## specified section alignment
+
+# RUN: yaml2obj --docnum=17 %s -o - | \
+# RUN:   llvm-readobj --sections --section-data --notes - | \
+# RUN:   FileCheck %s --check-prefix=TEST17
+
+# TEST17:      Name: .note.foo4
+# TEST17:      SectionData (
+# TEST17-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST17-NEXT:   0010: 00000000 01020000 00000000 03000000  |................|
+# TEST17-NEXT:   0020: 02000000 03040500 04000000 00000000  |................|
+# TEST17-NEXT:   0030: 03000000 474E5500                    |....GNU.|
+# TEST17-NEXT: )
+# TEST17:      Name: .note.foo8
+# TEST17:      SectionData (
+# TEST17-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST17-NEXT:   0010: 00000000 00000000 01020000 00000000  |................|
+# TEST17-NEXT:   0020: 00000000 03000000 02000000 00000000  |................|
+# TEST17-NEXT:   0030: 03040500 00000000 04000000 00000000  |................|
+# TEST17-NEXT:   0040: 03000000 474E5500                    |....GNU.|
+# TEST17-NEXT: )
+# TEST17:      NoteSections [
+# TEST17-NEXT:   NoteSection {
+# TEST17-NEXT:     Name: .note.foo4
+# TEST17-NEXT:     Offset:
+# TEST17-NEXT:     Size:
+# TEST17-NEXT:     Notes [
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: ABCD
+# TEST17-NEXT:         Data size: 0x2
+# TEST17-NEXT:         Type: NT_VERSION (version)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 0102                                 |..|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: 
+# TEST17-NEXT:         Data size: 0x3
+# TEST17-NEXT:         Type: NT_ARCH (architecture)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 030405                               |...|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: GNU
+# TEST17-NEXT:         Data size: 0x0
+# TEST17-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
+# TEST17-NEXT:         Build ID: 
+# TEST17-NEXT:       }
+# TEST17-NEXT:     ]
+# TEST17-NEXT:   }
+# TEST17-NEXT:   NoteSection {
+# TEST17-NEXT:     Name: .note.foo8
+# TEST17-NEXT:     Offset:
+# TEST17-NEXT:     Size:
+# TEST17-NEXT:     Notes [
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: ABCD
+# TEST17-NEXT:         Data size: 0x2
+# TEST17-NEXT:         Type: NT_VERSION (version)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 0102                                 |..|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: 
+# TEST17-NEXT:         Data size: 0x3
+# TEST17-NEXT:         Type: NT_ARCH (architecture)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 030405                               |...|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: GNU
+# TEST17-NEXT:         Data size: 0x0
+# TEST17-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
+# TEST17-NEXT:         Build ID: 
+# TEST17-NEXT:       }
+# TEST17-NEXT:     ]
+# TEST17-NEXT:   }
+# TEST17-NEXT: ]
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  ELFDATA2LSB
+  Type:  ET_EXEC
+Sections:
+  - Name:         .note.foo4
+    Type:         SHT_NOTE
+    AddressAlign: 4
+    Notes:
+      - Name: ABCD
+        Type: NT_VERSION
+        Desc: 0102
+      - Type: NT_ARCH
+        Desc: 030405
+      - Name: GNU
+        Type: NT_GNU_BUILD_ID
+  - Name:        .note.foo8
+    Type:         SHT_NOTE
+    AddressAlign: 8
+    Notes:
+      - Name: ABCD
+        Type: NT_VERSION
+        Desc: 0102
+      - Type: NT_ARCH
+        Desc: 030405
+      - Name: GNU
+        Type: NT_GNU_BUILD_ID

--- a/llvm/test/tools/yaml2obj/ELF/note-section.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/note-section.yaml
@@ -471,6 +471,10 @@ Sections:
 ## field even if "ShAddrAlign" is also specified; an unexpected value in the
 ## "ShAddrAlign" property does not trigger an incorrect alignment error.
 
+# RUN: yaml2obj --docnum=18 -D ADDRALIGN=0 -D SHADDRALIGN=8 %s -o - | \
+# RUN:   llvm-readobj --sections --section-data --notes - | \
+# RUN:   FileCheck %s --check-prefixes=TEST18,TEST18_4
+
 # RUN: yaml2obj --docnum=18 -D ADDRALIGN=4 -D SHADDRALIGN=3 %s -o - | \
 # RUN:   llvm-readobj --sections --section-data --notes - | \
 # RUN:   FileCheck %s --check-prefixes=TEST18,TEST18_4

--- a/llvm/test/tools/yaml2obj/ELF/note-section.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/note-section.yaml
@@ -351,7 +351,7 @@ Sections:
     Notes:
       - Type: 0x1
 
-## Check that note entries and their `Desc` fields are aligned according to the
+## Check that note entries and their "Desc" fields are aligned according to the
 ## specified section alignment.
 
 # RUN: yaml2obj --docnum=17 -D ELFCLASS=64 %s -o - | \
@@ -458,6 +458,50 @@ Sections:
   - Name:        .note.foo8
     Type:         SHT_NOTE
     AddressAlign: 8
+    Notes:
+      - Name: ABCD
+        Type: NT_VERSION
+        Desc: 0102
+      - Type: NT_ARCH
+        Desc: 030405
+      - Name: GNU
+        Type: NT_GNU_BUILD_ID
+
+## Check that the alignment for note entries is taken from the "AddressAlign"
+## field even if "ShAddrAlign" is also specified; an unexpected value in the
+## "ShAddrAlign" property does not trigger an incorrect alignment error.
+
+# RUN: yaml2obj --docnum=18 -D ADDRALIGN=4 -D SHADDRALIGN=3 %s -o - | \
+# RUN:   llvm-readobj --sections --section-data --notes - | \
+# RUN:   FileCheck %s --check-prefixes=TEST18,TEST18_4
+
+# RUN: yaml2obj --docnum=18 -D ADDRALIGN=8 -D SHADDRALIGN=4 %s -o - | \
+# RUN:   llvm-readobj --sections --section-data --notes - | \
+# RUN:   FileCheck %s --check-prefixes=TEST18,TEST18_8
+
+# TEST18:        Name: .note
+# TEST18:        SectionData (
+# TEST18_4-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST18_4-NEXT:   0010: 00000000 01020000 00000000 03000000  |................|
+# TEST18_4-NEXT:   0020: 02000000 03040500 04000000 00000000  |................|
+# TEST18_4-NEXT:   0030: 03000000 474E5500                    |....GNU.|
+# TEST18_8-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST18_8-NEXT:   0010: 00000000 00000000 01020000 00000000  |................|
+# TEST18_8-NEXT:   0020: 00000000 03000000 02000000 00000000  |................|
+# TEST18_8-NEXT:   0030: 03040500 00000000 04000000 00000000  |................|
+# TEST18_8-NEXT:   0040: 03000000 474E5500                    |....GNU.|
+# TEST18-NEXT:   )
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  ELFDATA2LSB
+  Type:  ET_EXEC
+Sections:
+  - Name:         .note
+    Type:         SHT_NOTE
+    AddressAlign: [[ADDRALIGN]]
+    ShAddrAlign:  [[SHADDRALIGN]]
     Notes:
       - Name: ABCD
         Type: NT_VERSION

--- a/llvm/test/tools/yaml2obj/ELF/note-section.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/note-section.yaml
@@ -354,124 +354,95 @@ Sections:
 ## Check that note entries and their `Desc` fields are aligned according to the
 ## specified section alignment.
 
-# RUN: yaml2obj --docnum=17 %s -o - | \
+# RUN: yaml2obj --docnum=17 -D ELFCLASS=64 %s -o - | \
 # RUN:   llvm-readobj --sections --section-data --notes - | \
-# RUN:   FileCheck %s --check-prefix=TEST1718
+# RUN:   FileCheck %s --check-prefix=TEST17
 
-# RUN: yaml2obj --docnum=18 %s -o - | \
+# RUN: yaml2obj --docnum=17 -D ELFCLASS=32 %s -o - | \
 # RUN:   llvm-readobj --sections --section-data --notes - | \
-# RUN:   FileCheck %s --check-prefix=TEST1718
+# RUN:   FileCheck %s --check-prefix=TEST17
 
-# TEST1718:      Name: .note.foo4
-# TEST1718:      SectionData (
-# TEST1718-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
-# TEST1718-NEXT:   0010: 00000000 01020000 00000000 03000000  |................|
-# TEST1718-NEXT:   0020: 02000000 03040500 04000000 00000000  |................|
-# TEST1718-NEXT:   0030: 03000000 474E5500                    |....GNU.|
-# TEST1718-NEXT: )
-# TEST1718:      Name: .note.foo8
-# TEST1718:      SectionData (
-# TEST1718-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
-# TEST1718-NEXT:   0010: 00000000 00000000 01020000 00000000  |................|
-# TEST1718-NEXT:   0020: 00000000 03000000 02000000 00000000  |................|
-# TEST1718-NEXT:   0030: 03040500 00000000 04000000 00000000  |................|
-# TEST1718-NEXT:   0040: 03000000 474E5500                    |....GNU.|
-# TEST1718-NEXT: )
-# TEST1718:      NoteSections [
-# TEST1718-NEXT:   NoteSection {
-# TEST1718-NEXT:     Name: .note.foo4
-# TEST1718-NEXT:     Offset:
-# TEST1718-NEXT:     Size:
-# TEST1718-NEXT:     Notes [
-# TEST1718-NEXT:       {
-# TEST1718-NEXT:         Owner: ABCD
-# TEST1718-NEXT:         Data size: 0x2
-# TEST1718-NEXT:         Type: NT_VERSION (version)
-# TEST1718-NEXT:         Description data (
-# TEST1718-NEXT:           0000: 0102                                 |..|
-# TEST1718-NEXT:         )
-# TEST1718-NEXT:       }
-# TEST1718-NEXT:       {
-# TEST1718-NEXT:         Owner: 
-# TEST1718-NEXT:         Data size: 0x3
-# TEST1718-NEXT:         Type: NT_ARCH (architecture)
-# TEST1718-NEXT:         Description data (
-# TEST1718-NEXT:           0000: 030405                               |...|
-# TEST1718-NEXT:         )
-# TEST1718-NEXT:       }
-# TEST1718-NEXT:       {
-# TEST1718-NEXT:         Owner: GNU
-# TEST1718-NEXT:         Data size: 0x0
-# TEST1718-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
-# TEST1718-NEXT:         Build ID: 
-# TEST1718-NEXT:       }
-# TEST1718-NEXT:     ]
-# TEST1718-NEXT:   }
-# TEST1718-NEXT:   NoteSection {
-# TEST1718-NEXT:     Name: .note.foo8
-# TEST1718-NEXT:     Offset:
-# TEST1718-NEXT:     Size:
-# TEST1718-NEXT:     Notes [
-# TEST1718-NEXT:       {
-# TEST1718-NEXT:         Owner: ABCD
-# TEST1718-NEXT:         Data size: 0x2
-# TEST1718-NEXT:         Type: NT_VERSION (version)
-# TEST1718-NEXT:         Description data (
-# TEST1718-NEXT:           0000: 0102                                 |..|
-# TEST1718-NEXT:         )
-# TEST1718-NEXT:       }
-# TEST1718-NEXT:       {
-# TEST1718-NEXT:         Owner: 
-# TEST1718-NEXT:         Data size: 0x3
-# TEST1718-NEXT:         Type: NT_ARCH (architecture)
-# TEST1718-NEXT:         Description data (
-# TEST1718-NEXT:           0000: 030405                               |...|
-# TEST1718-NEXT:         )
-# TEST1718-NEXT:       }
-# TEST1718-NEXT:       {
-# TEST1718-NEXT:         Owner: GNU
-# TEST1718-NEXT:         Data size: 0x0
-# TEST1718-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
-# TEST1718-NEXT:         Build ID: 
-# TEST1718-NEXT:       }
-# TEST1718-NEXT:     ]
-# TEST1718-NEXT:   }
-# TEST1718-NEXT: ]
+# TEST17:      Name: .note.foo4
+# TEST17:      SectionData (
+# TEST17-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST17-NEXT:   0010: 00000000 01020000 00000000 03000000  |................|
+# TEST17-NEXT:   0020: 02000000 03040500 04000000 00000000  |................|
+# TEST17-NEXT:   0030: 03000000 474E5500                    |....GNU.|
+# TEST17-NEXT: )
+# TEST17:      Name: .note.foo8
+# TEST17:      SectionData (
+# TEST17-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST17-NEXT:   0010: 00000000 00000000 01020000 00000000  |................|
+# TEST17-NEXT:   0020: 00000000 03000000 02000000 00000000  |................|
+# TEST17-NEXT:   0030: 03040500 00000000 04000000 00000000  |................|
+# TEST17-NEXT:   0040: 03000000 474E5500                    |....GNU.|
+# TEST17-NEXT: )
+# TEST17:      NoteSections [
+# TEST17-NEXT:   NoteSection {
+# TEST17-NEXT:     Name: .note.foo4
+# TEST17-NEXT:     Offset:
+# TEST17-NEXT:     Size:
+# TEST17-NEXT:     Notes [
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: ABCD
+# TEST17-NEXT:         Data size: 0x2
+# TEST17-NEXT:         Type: NT_VERSION (version)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 0102                                 |..|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: 
+# TEST17-NEXT:         Data size: 0x3
+# TEST17-NEXT:         Type: NT_ARCH (architecture)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 030405                               |...|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: GNU
+# TEST17-NEXT:         Data size: 0x0
+# TEST17-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
+# TEST17-NEXT:         Build ID: 
+# TEST17-NEXT:       }
+# TEST17-NEXT:     ]
+# TEST17-NEXT:   }
+# TEST17-NEXT:   NoteSection {
+# TEST17-NEXT:     Name: .note.foo8
+# TEST17-NEXT:     Offset:
+# TEST17-NEXT:     Size:
+# TEST17-NEXT:     Notes [
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: ABCD
+# TEST17-NEXT:         Data size: 0x2
+# TEST17-NEXT:         Type: NT_VERSION (version)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 0102                                 |..|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: 
+# TEST17-NEXT:         Data size: 0x3
+# TEST17-NEXT:         Type: NT_ARCH (architecture)
+# TEST17-NEXT:         Description data (
+# TEST17-NEXT:           0000: 030405                               |...|
+# TEST17-NEXT:         )
+# TEST17-NEXT:       }
+# TEST17-NEXT:       {
+# TEST17-NEXT:         Owner: GNU
+# TEST17-NEXT:         Data size: 0x0
+# TEST17-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
+# TEST17-NEXT:         Build ID: 
+# TEST17-NEXT:       }
+# TEST17-NEXT:     ]
+# TEST17-NEXT:   }
+# TEST17-NEXT: ]
 
 --- !ELF
 FileHeader:
-  Class: ELFCLASS64
+  Class: ELFCLASS[[ELFCLASS]]
   Data:  ELFDATA2LSB
   Type:  ET_EXEC
-Sections:
-  - Name:         .note.foo4
-    Type:         SHT_NOTE
-    AddressAlign: 4
-    Notes:
-      - Name: ABCD
-        Type: NT_VERSION
-        Desc: 0102
-      - Type: NT_ARCH
-        Desc: 030405
-      - Name: GNU
-        Type: NT_GNU_BUILD_ID
-  - Name:        .note.foo8
-    Type:         SHT_NOTE
-    AddressAlign: 8
-    Notes:
-      - Name: ABCD
-        Type: NT_VERSION
-        Desc: 0102
-      - Type: NT_ARCH
-        Desc: 030405
-      - Name: GNU
-        Type: NT_GNU_BUILD_ID
-
---- !ELF
-FileHeader:
-  Class: ELFCLASS32
-  Data:  ELFDATA2LSB
-  Type:  ET_REL
 Sections:
   - Name:         .note.foo4
     Type:         SHT_NOTE

--- a/llvm/test/tools/yaml2obj/ELF/note-section.yaml
+++ b/llvm/test/tools/yaml2obj/ELF/note-section.yaml
@@ -334,7 +334,7 @@ Sections:
         Desc: '123456'
         Type: NT_VERSION
 
-## Check that an incorrect alignment is reported
+## Check that an incorrect alignment is reported.
 
 # RUN: not yaml2obj --docnum=16 %s 2>&1 | FileCheck %s --check-prefix=ERR_ALIGN1
 # ERR_ALIGN1: error: .note.foo: invalid alignment for a note section: 0x1
@@ -352,93 +352,126 @@ Sections:
       - Type: 0x1
 
 ## Check that note entries and their `Desc` fields are aligned according to the
-## specified section alignment
+## specified section alignment.
 
 # RUN: yaml2obj --docnum=17 %s -o - | \
 # RUN:   llvm-readobj --sections --section-data --notes - | \
-# RUN:   FileCheck %s --check-prefix=TEST17
+# RUN:   FileCheck %s --check-prefix=TEST1718
 
-# TEST17:      Name: .note.foo4
-# TEST17:      SectionData (
-# TEST17-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
-# TEST17-NEXT:   0010: 00000000 01020000 00000000 03000000  |................|
-# TEST17-NEXT:   0020: 02000000 03040500 04000000 00000000  |................|
-# TEST17-NEXT:   0030: 03000000 474E5500                    |....GNU.|
-# TEST17-NEXT: )
-# TEST17:      Name: .note.foo8
-# TEST17:      SectionData (
-# TEST17-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
-# TEST17-NEXT:   0010: 00000000 00000000 01020000 00000000  |................|
-# TEST17-NEXT:   0020: 00000000 03000000 02000000 00000000  |................|
-# TEST17-NEXT:   0030: 03040500 00000000 04000000 00000000  |................|
-# TEST17-NEXT:   0040: 03000000 474E5500                    |....GNU.|
-# TEST17-NEXT: )
-# TEST17:      NoteSections [
-# TEST17-NEXT:   NoteSection {
-# TEST17-NEXT:     Name: .note.foo4
-# TEST17-NEXT:     Offset:
-# TEST17-NEXT:     Size:
-# TEST17-NEXT:     Notes [
-# TEST17-NEXT:       {
-# TEST17-NEXT:         Owner: ABCD
-# TEST17-NEXT:         Data size: 0x2
-# TEST17-NEXT:         Type: NT_VERSION (version)
-# TEST17-NEXT:         Description data (
-# TEST17-NEXT:           0000: 0102                                 |..|
-# TEST17-NEXT:         )
-# TEST17-NEXT:       }
-# TEST17-NEXT:       {
-# TEST17-NEXT:         Owner: 
-# TEST17-NEXT:         Data size: 0x3
-# TEST17-NEXT:         Type: NT_ARCH (architecture)
-# TEST17-NEXT:         Description data (
-# TEST17-NEXT:           0000: 030405                               |...|
-# TEST17-NEXT:         )
-# TEST17-NEXT:       }
-# TEST17-NEXT:       {
-# TEST17-NEXT:         Owner: GNU
-# TEST17-NEXT:         Data size: 0x0
-# TEST17-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
-# TEST17-NEXT:         Build ID: 
-# TEST17-NEXT:       }
-# TEST17-NEXT:     ]
-# TEST17-NEXT:   }
-# TEST17-NEXT:   NoteSection {
-# TEST17-NEXT:     Name: .note.foo8
-# TEST17-NEXT:     Offset:
-# TEST17-NEXT:     Size:
-# TEST17-NEXT:     Notes [
-# TEST17-NEXT:       {
-# TEST17-NEXT:         Owner: ABCD
-# TEST17-NEXT:         Data size: 0x2
-# TEST17-NEXT:         Type: NT_VERSION (version)
-# TEST17-NEXT:         Description data (
-# TEST17-NEXT:           0000: 0102                                 |..|
-# TEST17-NEXT:         )
-# TEST17-NEXT:       }
-# TEST17-NEXT:       {
-# TEST17-NEXT:         Owner: 
-# TEST17-NEXT:         Data size: 0x3
-# TEST17-NEXT:         Type: NT_ARCH (architecture)
-# TEST17-NEXT:         Description data (
-# TEST17-NEXT:           0000: 030405                               |...|
-# TEST17-NEXT:         )
-# TEST17-NEXT:       }
-# TEST17-NEXT:       {
-# TEST17-NEXT:         Owner: GNU
-# TEST17-NEXT:         Data size: 0x0
-# TEST17-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
-# TEST17-NEXT:         Build ID: 
-# TEST17-NEXT:       }
-# TEST17-NEXT:     ]
-# TEST17-NEXT:   }
-# TEST17-NEXT: ]
+# RUN: yaml2obj --docnum=18 %s -o - | \
+# RUN:   llvm-readobj --sections --section-data --notes - | \
+# RUN:   FileCheck %s --check-prefix=TEST1718
+
+# TEST1718:      Name: .note.foo4
+# TEST1718:      SectionData (
+# TEST1718-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST1718-NEXT:   0010: 00000000 01020000 00000000 03000000  |................|
+# TEST1718-NEXT:   0020: 02000000 03040500 04000000 00000000  |................|
+# TEST1718-NEXT:   0030: 03000000 474E5500                    |....GNU.|
+# TEST1718-NEXT: )
+# TEST1718:      Name: .note.foo8
+# TEST1718:      SectionData (
+# TEST1718-NEXT:   0000: 05000000 02000000 01000000 41424344  |............ABCD|
+# TEST1718-NEXT:   0010: 00000000 00000000 01020000 00000000  |................|
+# TEST1718-NEXT:   0020: 00000000 03000000 02000000 00000000  |................|
+# TEST1718-NEXT:   0030: 03040500 00000000 04000000 00000000  |................|
+# TEST1718-NEXT:   0040: 03000000 474E5500                    |....GNU.|
+# TEST1718-NEXT: )
+# TEST1718:      NoteSections [
+# TEST1718-NEXT:   NoteSection {
+# TEST1718-NEXT:     Name: .note.foo4
+# TEST1718-NEXT:     Offset:
+# TEST1718-NEXT:     Size:
+# TEST1718-NEXT:     Notes [
+# TEST1718-NEXT:       {
+# TEST1718-NEXT:         Owner: ABCD
+# TEST1718-NEXT:         Data size: 0x2
+# TEST1718-NEXT:         Type: NT_VERSION (version)
+# TEST1718-NEXT:         Description data (
+# TEST1718-NEXT:           0000: 0102                                 |..|
+# TEST1718-NEXT:         )
+# TEST1718-NEXT:       }
+# TEST1718-NEXT:       {
+# TEST1718-NEXT:         Owner: 
+# TEST1718-NEXT:         Data size: 0x3
+# TEST1718-NEXT:         Type: NT_ARCH (architecture)
+# TEST1718-NEXT:         Description data (
+# TEST1718-NEXT:           0000: 030405                               |...|
+# TEST1718-NEXT:         )
+# TEST1718-NEXT:       }
+# TEST1718-NEXT:       {
+# TEST1718-NEXT:         Owner: GNU
+# TEST1718-NEXT:         Data size: 0x0
+# TEST1718-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
+# TEST1718-NEXT:         Build ID: 
+# TEST1718-NEXT:       }
+# TEST1718-NEXT:     ]
+# TEST1718-NEXT:   }
+# TEST1718-NEXT:   NoteSection {
+# TEST1718-NEXT:     Name: .note.foo8
+# TEST1718-NEXT:     Offset:
+# TEST1718-NEXT:     Size:
+# TEST1718-NEXT:     Notes [
+# TEST1718-NEXT:       {
+# TEST1718-NEXT:         Owner: ABCD
+# TEST1718-NEXT:         Data size: 0x2
+# TEST1718-NEXT:         Type: NT_VERSION (version)
+# TEST1718-NEXT:         Description data (
+# TEST1718-NEXT:           0000: 0102                                 |..|
+# TEST1718-NEXT:         )
+# TEST1718-NEXT:       }
+# TEST1718-NEXT:       {
+# TEST1718-NEXT:         Owner: 
+# TEST1718-NEXT:         Data size: 0x3
+# TEST1718-NEXT:         Type: NT_ARCH (architecture)
+# TEST1718-NEXT:         Description data (
+# TEST1718-NEXT:           0000: 030405                               |...|
+# TEST1718-NEXT:         )
+# TEST1718-NEXT:       }
+# TEST1718-NEXT:       {
+# TEST1718-NEXT:         Owner: GNU
+# TEST1718-NEXT:         Data size: 0x0
+# TEST1718-NEXT:         Type: NT_GNU_BUILD_ID (unique build ID bitstring)
+# TEST1718-NEXT:         Build ID: 
+# TEST1718-NEXT:       }
+# TEST1718-NEXT:     ]
+# TEST1718-NEXT:   }
+# TEST1718-NEXT: ]
 
 --- !ELF
 FileHeader:
   Class: ELFCLASS64
   Data:  ELFDATA2LSB
   Type:  ET_EXEC
+Sections:
+  - Name:         .note.foo4
+    Type:         SHT_NOTE
+    AddressAlign: 4
+    Notes:
+      - Name: ABCD
+        Type: NT_VERSION
+        Desc: 0102
+      - Type: NT_ARCH
+        Desc: 030405
+      - Name: GNU
+        Type: NT_GNU_BUILD_ID
+  - Name:        .note.foo8
+    Type:         SHT_NOTE
+    AddressAlign: 8
+    Notes:
+      - Name: ABCD
+        Type: NT_VERSION
+        Desc: 0102
+      - Type: NT_ARCH
+        Desc: 030405
+      - Name: GNU
+        Type: NT_GNU_BUILD_ID
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS32
+  Data:  ELFDATA2LSB
+  Type:  ET_REL
 Sections:
   - Name:         .note.foo4
     Type:         SHT_NOTE


### PR DESCRIPTION
This relands #118157 with a fix for the use of an uninitialized variable.

The [System V ABI](https://www.sco.com/developers/gabi/latest/ch5.pheader.html#note_section) states that the note entries and their descriptor fields must be aligned to 4 or 8 bytes for 32-bit or 64-bit objects respectively. In practice, 64-bit systems can use both alignments, with the actual format being determined by the alignment of the segment. For example, the [Linux gABI extension](https://github.com/hjl-tools/linux-abi/wiki/linux-abi-draft.pdf) contains a special note on this, see 2.1.7 "Alignment of Note Sections".

This patch adjusts the format of the generated notes to the specified section alignment. Since `llvm-readobj` was fixed in a similar way in [D150022](https://reviews.llvm.org/D150022), "[Object] Fix handling of Elf_Nhdr with sh_addralign=8", the generated notes can now be parsed successfully by the tool.