### PR TITLE
[lld][wasm] Clear lazyBitcodeFiles while resetting context

### DIFF
--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -59,6 +59,7 @@ void Ctx::reset() {
   stubFiles.clear();
   sharedFiles.clear();
   bitcodeFiles.clear();
+  lazyBitcodeFiles.clear();
   syntheticFunctions.clear();
   syntheticGlobals.clear();
   syntheticTables.clear();


### PR DESCRIPTION
Hi @sbc100 

I was looking into a use case involving the link function (which got my attention to reset).

I see that `lazyBitcodeFiles` variable was introduced here https://github.com/llvm/llvm-project/pull/114327 but I don't see it being reset while destroying the context eventually. Hopefully this should be the correct way to address it.