### PR TITLE
[Clang] Deleting an incomplete enum type is not an error

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -766,6 +766,7 @@ Bug Fixes to C++ Support
 - Fixed an assertion failure caused by mangled names with invalid identifiers. (#GH112205)
 - Fixed an incorrect lambda scope of generic lambdas that caused Clang to crash when computing potential lambda
   captures at the end of a full expression. (#GH115931)
+- Clang no longer rejects deleting a pointer of incomplete enumeration type. (#GH99278)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -3747,9 +3747,9 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
     } else if (!Pointee->isDependentType()) {
       // FIXME: This can result in errors if the definition was imported from a
       // module but is hidden.
-      if (!RequireCompleteType(StartLoc, Pointee,
-                               Pointee->isStructureOrClassType() &&
-                                       LangOpts.CPlusPlus26
+      if (!Pointee->isStructureOrClassType() ||
+          !RequireCompleteType(StartLoc, Pointee,
+                               LangOpts.CPlusPlus26
                                    ? diag::err_delete_incomplete
                                    : diag::warn_delete_incomplete,
                                Ex.get())) {

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -3748,7 +3748,8 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
       // FIXME: This can result in errors if the definition was imported from a
       // module but is hidden.
       if (!RequireCompleteType(StartLoc, Pointee,
-                               LangOpts.CPlusPlus26
+                               Pointee->isStructureOrClassType() &&
+                                       LangOpts.CPlusPlus26
                                    ? diag::err_delete_incomplete
                                    : diag::warn_delete_incomplete,
                                Ex.get())) {

--- a/clang/test/SemaCXX/new-delete.cpp
+++ b/clang/test/SemaCXX/new-delete.cpp
@@ -541,10 +541,9 @@ namespace PR10504 {
 }
 
 #if __cplusplus >= 201103L
-enum GH99278_1 { // expected-note {{definition of 'GH99278_1' is not complete until the closing '}'}}
+enum GH99278_1 {
     zero = decltype(delete static_cast<GH99278_1*>(nullptr), 0){}
-    // expected-warning@-1 {{deleting pointer to incomplete type}}
-    // expected-warning@-2 {{expression with side effects has no effect in an unevaluated context}}
+    // expected-warning@-1 {{expression with side effects has no effect in an unevaluated context}}
 };
 #endif
 

--- a/clang/test/SemaCXX/new-delete.cpp
+++ b/clang/test/SemaCXX/new-delete.cpp
@@ -540,6 +540,14 @@ namespace PR10504 {
   void f(A *x) { delete x; } // expected-warning {{delete called on 'PR10504::A' that is abstract but has non-virtual destructor}}
 }
 
+#if __cplusplus >= 201103L
+enum GH99278_1 { // expected-note {{definition of 'GH99278_1' is not complete until the closing '}'}}
+    zero = decltype(delete static_cast<GH99278_1*>(nullptr), 0){}
+    // expected-warning@-1 {{deleting pointer to incomplete type}}
+    // expected-warning@-2 {{expression with side effects has no effect in an unevaluated context}}
+};
+#endif
+
 struct PlacementArg {};
 inline void *operator new[](size_t, const PlacementArg &) throw () {
   return 0;


### PR DESCRIPTION
The changes introduced in #97733 accidentally prevented to delete an incomplete enum (the validity of which has been confirmed by CWG2925

Fixes #99278