### PR TITLE
[clang][bytecode] Reject memcpy dummy pointers after null check

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1813,9 +1813,6 @@ static bool interp__builtin_memcpy(InterpState &S, CodePtr OpPC,
 
   bool Move = (ID == Builtin::BI__builtin_memmove || ID == Builtin::BImemmove);
 
-  if (DestPtr.isDummy() || SrcPtr.isDummy())
-    return false;
-
   // If the size is zero, we treat this as always being a valid no-op.
   if (Size.isZero()) {
     S.Stk.push<Pointer>(DestPtr);
@@ -1829,6 +1826,10 @@ static bool interp__builtin_memcpy(InterpState &S, CodePtr OpPC,
         << DiagPtr.toDiagnosticString(S.getASTContext());
     return false;
   }
+
+  // As a last resort, reject dummy pointers.
+  if (DestPtr.isDummy() || SrcPtr.isDummy())
+    return false;
 
   if (!DoBitCastPtr(S, OpPC, SrcPtr, DestPtr))
     return false;

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1169,6 +1169,10 @@ namespace BuiltinMemcpy {
   static_assert(__builtin_memcpy(null_incomplete, null_incomplete, sizeof(wchar_t))); // both-error {{not an integral constant expression}} \
                                                                                       // both-note {{source of 'memcpy' is nullptr}}
 
+  wchar_t global;
+  constexpr wchar_t *null = 0;
+  static_assert(__builtin_memcpy(&global, null, sizeof(wchar_t))); // both-error {{not an integral constant expression}} \
+                                                                   // both-note {{source of 'memcpy' is nullptr}}
 
   constexpr int simpleMove() {
     int a = 12;


### PR DESCRIPTION
To match the diagnostic output of the current interpreter.