### PR TITLE
[lldb] Fix "exact match" debug_names type queries

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -527,7 +527,7 @@ void DebugNamesDWARFIndex::GetTypesWithQuery(
   ConstString name = query.GetTypeBasename();
   std::vector<lldb_private::CompilerContext> query_context =
       query.GetContextRef();
-  if (query_context.size() <= 1)
+  if (query_context.size() <= 1 && !query.GetExactMatch())
     return GetTypes(name, callback);
 
   llvm::SmallVector<CompilerContext> parent_contexts =

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/find-basic-type.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/find-basic-type.cpp
@@ -4,6 +4,8 @@
 // RUN: ld.lld %t.o -o %t
 // RUN: lldb-test symbols --name=foo --find=type %t | \
 // RUN:   FileCheck --check-prefix=NAME %s
+// RUN: lldb-test symbols --name=::foo --find=type %t | \
+// RUN:   FileCheck --check-prefix=EXACT %s
 // RUN: lldb-test symbols --name=foo --context=context --find=type %t | \
 // RUN:   FileCheck --check-prefix=CONTEXT %s
 // RUN: lldb-test symbols --name=not_there --find=type %t | \
@@ -12,6 +14,8 @@
 // RUN: %clang %s -g -c -o %t --target=x86_64-apple-macosx
 // RUN: lldb-test symbols --name=foo --find=type %t | \
 // RUN:   FileCheck --check-prefix=NAME %s
+// RUN: lldb-test symbols --name=::foo --find=type %t | \
+// RUN:   FileCheck --check-prefix=EXACT %s
 // RUN: lldb-test symbols --name=foo --context=context --find=type %t | \
 // RUN:   FileCheck --check-prefix=CONTEXT %s
 // RUN: lldb-test symbols --name=not_there --find=type %t | \
@@ -22,6 +26,8 @@
 // RUN: llvm-readobj --sections %t | FileCheck %s --check-prefix NAMES
 // RUN: lldb-test symbols --name=foo --find=type %t | \
 // RUN:   FileCheck --check-prefix=NAME %s
+// RUN: lldb-test symbols --name=::foo --find=type %t | \
+// RUN:   FileCheck --check-prefix=EXACT %s
 // RUN: lldb-test symbols --name=foo --context=context --find=type %t | \
 // RUN:   FileCheck --check-prefix=CONTEXT %s
 // RUN: lldb-test symbols --name=not_there --find=type %t | \
@@ -31,9 +37,11 @@
 
 // EMPTY: Found 0 types:
 // NAME: Found 4 types:
+// EXACT: Found 1 types:
 // CONTEXT: Found 1 types:
 struct foo { };
 // NAME-DAG: name = "foo", {{.*}} decl = find-basic-type.cpp:[[@LINE-1]]
+// EXACT-DAG: name = "foo", {{.*}} decl = find-basic-type.cpp:[[@LINE-2]]
 
 namespace bar {
 int context;


### PR DESCRIPTION
.. in the global namespace

The problem was the interaction of #116989 with an optimization in GetTypesWithQuery. The optimization was only correct for non-exact matches, but that didn't matter before this PR due to the "second layer of defense". After that was removed, the query started returning more types than it should.