### PR TITLE
[clang] Fix a use-after-free in expression evaluation

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -4515,6 +4515,8 @@ handleLValueToRValueConversion(EvalInfo &Info, const Expr *Conv, QualType Type,
       }
 
       APValue Lit;
+      // Make sure we clean up the temporary created below.
+      FullExpressionRAII CleanupTemps(Info);
       if (!Evaluate(Lit, Info, CLE->getInitializer()))
         return false;
 


### PR DESCRIPTION
following ASAN failure is fixed with this patch.
We store cleanups in EvalInfo, which are usually run with certain
ScopeRAII objects.
We can have temporaries in the cleanup stack, backed by CallStackFrame.
If such temporaries aren't destroyed before the enclosing
CallStackFrame, we end up accessing the freed temporary to run the
cleanup.

```
=================================================================
==553356==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c63f05a65b0 at pc 0x561e4add6ae7 bp 0x7fff430f7770 sp 0x7fff430f7768
READ of size 4 at 0x7c63f05a65b0 thread T0
    #0 0x561e4add6ae6 in clang::APValue::operator=(clang::APValue&&) third_party/llvm/llvm-project/clang/lib/AST/APValue.cpp:394:9
    #1 0x561e4b41fd0b in (anonymous namespace)::Cleanup::endLifetime((anonymous namespace)::EvalInfo&, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:749:27
    #2 0x561e4b4d42a7 in (anonymous namespace)::ScopeRAII<((anonymous namespace)::ScopeKind)1>::cleanup((anonymous namespace)::EvalInfo&, bool, unsigned int) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:1449:41
    #3 0x561e4b4246ec in destroy third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:1427:17
    #4 0x561e4b4246ec in ~ScopeRAII third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:1433:9
    #5 0x561e4b4246ec in EvaluateCond((anonymous namespace)::EvalInfo&, clang::VarDecl const*, clang::Expr const*, bool&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5185:1
    #6 0x561e4b41ea8c in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5555:17
    #7 0x561e4b423755 in EvaluateLoopBody((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5221:24
    #8 0x561e4b41d597 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5635:28
    #9 0x561e4b41d341 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5521:28
    #10 0x561e4b40113c in HandleFunctionCall(clang::SourceLocation, clang::FunctionDecl const*, (anonymous namespace)::LValue const*, clang::Expr const*, llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, clang::Stmt const*, (anonymous namespace)::EvalInfo&, clang::APValue&, (anonymous namespace)::LValue const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6520:24
    #11 0x561e4b4c9652 in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8332:10
    #12 0x561e4b4c9652 in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #13 0x561e4b4c9652 in visitNonBuiltinCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9749:28
    #14 0x561e4b4c9652 in (anonymous namespace)::PointerExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9763:12
    #15 0x561e4b4c3e5b in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::PointerExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #16 0x561e4b3ff820 in EvaluatePointer third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9458:60
    #17 0x561e4b3ff820 in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16343:10
    #18 0x561e4b41f204 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5511:17
    #19 0x561e4b41d341 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5521:28
    #20 0x561e4b40113c in HandleFunctionCall(clang::SourceLocation, clang::FunctionDecl const*, (anonymous namespace)::LValue const*, clang::Expr const*, llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, clang::Stmt const*, (anonymous namespace)::EvalInfo&, clang::APValue&, (anonymous namespace)::LValue const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6520:24
    #21 0x561e4b4c9652 in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8332:10
    #22 0x561e4b4c9652 in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #23 0x561e4b4c9652 in visitNonBuiltinCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9749:28
    #24 0x561e4b4c9652 in (anonymous namespace)::PointerExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9763:12
    #25 0x561e4b4c3e5b in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::PointerExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #26 0x561e4b3ff820 in EvaluatePointer third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9458:60
    #27 0x561e4b3ff820 in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16343:10
    #28 0x561e4b4ad3c2 in EvaluateAsBooleanCondition third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:2742:8
    #29 0x561e4b4ad3c2 in (anonymous namespace)::IntExprEvaluator::VisitCastExpr(clang::CastExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:14877:10
    #30 0x561e4b49f192 in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::IntExprEvaluator, bool>::Visit(clang::Stmt const*) third_party/llvm/llvm-project/clang/include/clang/AST/StmtVisitor.h
    #31 0x561e4b3ff8af in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16339:41
    #32 0x561e4b4a0dd2 in EvaluateAsBooleanCondition third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:2742:8
    #33 0x561e4b4a0dd2 in (anonymous namespace)::IntExprEvaluator::VisitUnaryOperator(clang::UnaryOperator const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:14795:10
    #34 0x561e4b49f0db in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::IntExprEvaluator, bool>::Visit(clang::Stmt const*) third_party/llvm/llvm-project/clang/include/clang/AST/StmtVisitor.h
    #35 0x561e4b3ff8af in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16339:41
    #36 0x561e4b3fbe35 in EvaluateAsRValue((anonymous namespace)::EvalInfo&, clang::Expr const*, clang::APValue&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16455:8
    #37 0x561e4b3fc278 in clang::Expr::EvaluateForOverflow(clang::ASTContext const&) const third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16903:11
    #38 0x561e4a020e69 in clang::Sema::CheckForIntOverflow(clang::Expr const*) third_party/crosstool/v18/stable/src/libcxx/include/__memory/uninitialized_algorithms.h
    #39 0x561e4a021cd7 in clang::Sema::CheckCompletedExpr(clang::Expr*, clang::SourceLocation, bool) third_party/llvm/llvm-project/clang/lib/Sema/SemaChecking.cpp:12989:5
    #40 0x561e4a4b9d2e in clang::Sema::ActOnFinishFullExpr(clang::Expr*, clang::SourceLocation, bool, bool, bool) third_party/llvm/llvm-project/clang/lib/Sema/SemaExprCXX.cpp:9225:3
    #41 0x561e4a372e20 in MakeFullExpr third_party/llvm/llvm-project/clang/include/clang/Sema/Sema.h:7292:9
    #42 0x561e4a372e20 in clang::Sema::ActOnCondition(clang::Scope*, clang::SourceLocation, clang::Expr*, clang::Sema::ConditionKind, bool) third_party/llvm/llvm-project/clang/lib/Sema/SemaExpr.cpp:20363:26
    #43 0x561e49b5407d in clang::Parser::ParseCXXCondition(clang::ActionResult<clang::Stmt*, true>*, clang::SourceLocation, clang::Sema::ConditionKind, bool, clang::Parser::ForRangeInfo*, bool) third_party/llvm/llvm-project/clang/lib/Parse/ParseExprCXX.cpp:2204:20
    #44 0x561e49c000a8 in clang::Parser::ParseParenExprOrCondition(clang::ActionResult<clang::Stmt*, true>*, clang::Sema::ConditionResult&, clang::SourceLocation, clang::Sema::ConditionKind, clang::SourceLocation&, clang::SourceLocation&) third_party/llvm/llvm-project/clang/lib/Parse/ParseStmt.cpp:1376:12
    #45 0x561e49bf6c2f in clang::Parser::ParseIfStatement(clang::SourceLocation*) third_party/llvm/llvm-project/clang/lib/Parse/ParseStmt.cpp:1587:9
    #46 0x561e49bf2d6d in clang::Parser::ParseStatementOrDeclarationAfterAttributes(llvm::SmallVector<clang::Stmt*, 32u>&, clang::Parser::ParsedStmtContext, clang::SourceLocation*, clang::ParsedAttributes&, clang::ParsedAttributes&) third_party/llvm/llvm-project/clang/lib/Parse/ParseStmt.cpp:325:12
    #47 0x561e49bf0a6e in clang::Parser::ParseStatementOrDeclaration(llvm::SmallVector<clang::Stmt*, 32u>&, clang::Parser::ParsedStmtContext, clang::SourceLocation*) third_party/llvm/llvm-project/clang/lib/Parse/ParseStmt.cpp:125:20
    #48 0x561e49bff57d in clang::Parser::ParseCompoundStatementBody(bool) third_party/llvm/llvm-project/clang/lib/Parse/ParseStmt.cpp:1267:11
    #49 0x561e49c0136e in clang::Parser::ParseFunctionStatementBody(clang::Decl*, clang::Parser::ParseScope&) third_party/llvm/llvm-project/clang/lib/Parse/ParseStmt.cpp:2577:21
    #50 0x561e49afa4fd in clang::Parser::ParseFunctionDefinition(clang::ParsingDeclarator&, clang::Parser::ParsedTemplateInfo const&, clang::Parser::LateParsedAttrList*) third_party/llvm/llvm-project/clang/lib/Parse/Parser.cpp:1520:10
    #51 0x561e49ba6e44 in clang::Parser::ParseDeclGroup(clang::ParsingDeclSpec&, clang::DeclaratorContext, clang::ParsedAttributes&, clang::Parser::ParsedTemplateInfo&, clang::SourceLocation*, clang::Parser::ForRangeInit*) third_party/llvm/llvm-project/clang/lib/Parse/ParseDecl.cpp:2460:17
    #52 0x561e49af8746 in clang::Parser::ParseDeclOrFunctionDefInternal(clang::ParsedAttributes&, clang::ParsedAttributes&, clang::ParsingDeclSpec&, clang::AccessSpecifier) third_party/llvm/llvm-project/clang/lib/Parse/Parser.cpp:1244:10
    #53 0x561e49af79f8 in clang::Parser::ParseDeclarationOrFunctionDefinition(clang::ParsedAttributes&, clang::ParsedAttributes&, clang::ParsingDeclSpec*, clang::AccessSpecifier) third_party/llvm/llvm-project/clang/lib/Parse/Parser.cpp:1266:12
    #54 0x561e49af5d96 in clang::Parser::ParseExternalDeclaration(clang::ParsedAttributes&, clang::ParsedAttributes&, clang::ParsingDeclSpec*) third_party/llvm/llvm-project/clang/lib/Parse/Parser.cpp:1069:14
    #55 0x561e49b6c42c in clang::Parser::ParseInnerNamespace(llvm::SmallVector<clang::Parser::InnerNamespaceInfo, 4u> const&, unsigned int, clang::SourceLocation&, clang::ParsedAttributes&, clang::BalancedDelimiterTracker&) third_party/llvm/llvm-project/clang/lib/Parse/ParseDeclCXX.cpp:276:7
    #56 0x561e49b6c5d7 in clang::Parser::ParseInnerNamespace(llvm::SmallVector<clang::Parser::InnerNamespaceInfo, 4u> const&, unsigned int, clang::SourceLocation&, clang::ParsedAttributes&, clang::BalancedDelimiterTracker&) third_party/llvm/llvm-project/clang/lib/Parse/ParseDeclCXX.cpp:298:3
    #57 0x561e49b6b7c3 in clang::Parser::ParseNamespace(clang::DeclaratorContext, clang::SourceLocation&, clang::SourceLocation) third_party/llvm/llvm-project/clang/lib/Parse/ParseDeclCXX.cpp:253:3
    #58 0x561e49ba337a in clang::Parser::ParseDeclaration(clang::DeclaratorContext, clang::SourceLocation&, clang::ParsedAttributes&, clang::ParsedAttributes&, clang::SourceLocation*) third_party/llvm/llvm-project/clang/lib/Parse/ParseDecl.cpp
    #59 0x561e49af563a in clang::Parser::ParseExternalDeclaration(clang::ParsedAttributes&, clang::ParsedAttributes&, clang::ParsingDeclSpec*) third_party/llvm/llvm-project/clang/lib/Parse/Parser.cpp:985:14
    #60 0x561e49af3779 in clang::Parser::ParseTopLevelDecl(clang::OpaquePtr<clang::DeclGroupRef>&, clang::Sema::ModuleImportState&) third_party/llvm/llvm-project/clang/lib/Parse/Parser.cpp:758:12
    #61 0x561e49aec6ae in clang::ParseAST(clang::Sema&, bool, bool) third_party/llvm/llvm-project/clang/lib/Parse/ParseAST.cpp:171:20
    #62 0x561e496f13ae in clang::ASTFrontendAction::ExecuteAction() third_party/llvm/llvm-project/clang/lib/Frontend/FrontendAction.cpp:1191:3
    #63 0x561e496f0874 in clang::FrontendAction::Execute() third_party/llvm/llvm-project/clang/lib/Frontend/FrontendAction.cpp:1077:8
    #64 0x561e49644511 in clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) third_party/llvm/llvm-project/clang/lib/Frontend/CompilerInstance.cpp:1062:33
    #65 0x561e47ffe1b9 in clang::ExecuteCompilerInvocation(clang::CompilerInstance*) third_party/llvm/llvm-project/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp:296:25
    #66 0x561e47fee631 in cc1_main(llvm::ArrayRef<char const*>, char const*, void*) third_party/llvm/llvm-project/clang/tools/driver/cc1_main.cpp:286:15
    #67 0x561e47fe9912 in ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&, llvm::ToolContext const&) third_party/llvm/llvm-project/clang/tools/driver/driver.cpp:218:12
    #68 0x561e47fec7e6 in operator() third_party/llvm/llvm-project/clang/tools/driver/driver.cpp:360:14
    #69 0x561e47fec7e6 in int llvm::function_ref<int (llvm::SmallVectorImpl<char const*>&)>::callback_fn<clang_main(int, char**, llvm::ToolContext const&)::$_0>(long, llvm::SmallVectorImpl<char const*>&) third_party/llvm/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
    #70 0x561e498bc531 in operator() third_party/llvm/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
    #71 0x561e498bc531 in operator() third_party/llvm/llvm-project/clang/lib/Driver/Job.cpp:437:34
    #72 0x561e498bc531 in void llvm::function_ref<void ()>::callback_fn<clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__u::optional<llvm::StringRef>>, std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>*, bool*) const::$_0>(long) third_party/llvm/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:12
    #73 0x561e4ff969e8 in operator() third_party/llvm/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
    #74 0x561e4ff969e8 in llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) third_party/llvm/llvm-project/llvm/lib/Support/CrashRecoveryContext.cpp:426:3
    #75 0x561e498bb331 in clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__u::optional<llvm::StringRef>>, std::__u::basic_string<char, std::__u::char_traits<char>, std::__u::allocator<char>>*, bool*) const third_party/llvm/llvm-project/clang/lib/Driver/Job.cpp:437:12
    #76 0x561e49860e38 in clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&, bool) const third_party/llvm/llvm-project/clang/lib/Driver/Compilation.cpp:196:15
    #77 0x561e49861154 in clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::__u::pair<int, clang::driver::Command const*>>&, bool) const third_party/llvm/llvm-project/clang/lib/Driver/Compilation.cpp:250:19
    #78 0x561e49886037 in clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__u::pair<int, clang::driver::Command const*>>&) third_party/llvm/llvm-project/clang/lib/Driver/Driver.cpp:1968:5
    #79 0x561e47fe8c7d in clang_main(int, char**, llvm::ToolContext const&) third_party/llvm/llvm-project/clang/tools/driver/driver.cpp:396:21
    #80 0x561e47fe6ae7 in main blaze-out/k8-opt-asan/bin/third_party/llvm/llvm-project/clang/clang-driver.cpp:17:10
    #81 0x7fb3f13c33d3 in __libc_start_main (/usr/grte/v5/lib64/libc.so.6+0x613d3) (BuildId: 9a996398ce14a94560b0c642eb4f6e94)
    #82 0x561e47f0a229 in _start /usr/grte/v5/debug-src/src/csu/../sysdeps/x86_64/start.S:120

0x7c63f05a65b0 is located 48 bytes inside of 104-byte region [0x7c63f05a6580,0x7c63f05a65e8)
freed by thread T0 here:
    #0 0x561e47fe5342 in operator delete(void*, unsigned long) third_party/llvm/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:155:3
    #1 0x561e4b4c2fcc in __libcpp_operator_delete<void *, unsigned long> third_party/crosstool/v18/stable/src/libcxx/include/new:286:3
    #2 0x561e4b4c2fcc in __do_deallocate_handle_size<> third_party/crosstool/v18/stable/src/libcxx/include/new:310:10
    #3 0x561e4b4c2fcc in __libcpp_deallocate third_party/crosstool/v18/stable/src/libcxx/include/new:323:12
    #4 0x561e4b4c2fcc in deallocate third_party/crosstool/v18/stable/src/libcxx/include/__memory/allocator.h:135:7
    #5 0x561e4b4c2fcc in deallocate third_party/crosstool/v18/stable/src/libcxx/include/__memory/allocator_traits.h:313:9
    #6 0x561e4b4c2fcc in std::__u::__tree<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, std::__u::__map_value_compare<std::__u::pair<void const*, unsigned int>, std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, std::__u::less<std::__u::pair<void const*, unsigned int>>, true>, std::__u::allocator<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>>>::destroy(std::__u::__tree_node<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, void*>*) third_party/crosstool/v18/stable/src/libcxx/include/__tree:1549:5
    #7 0x561e4b400340 in ~__tree third_party/crosstool/v18/stable/src/libcxx/include/__tree:1539:3
    #8 0x561e4b400340 in ~map third_party/crosstool/v18/stable/src/libcxx/include/map:1138:112
    #9 0x561e4b400340 in (anonymous namespace)::CallStackFrame::~CallStackFrame() third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:1524:1
    #10 0x561e4b49697b in HandleConstructorCall(clang::Expr const*, (anonymous namespace)::LValue const&, (anonymous namespace)::CallRef, clang::CXXConstructorDecl const*, (anonymous namespace)::EvalInfo&, clang::APValue&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6742:1
    #11 0x561e4b400cca in HandleConstructorCall(clang::Expr const*, (anonymous namespace)::LValue const&, llvm::ArrayRef<clang::Expr const*>, clang::CXXConstructorDecl const*, (anonymous namespace)::EvalInfo&, clang::APValue&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6753:10
    #12 0x561e4b45cfae in (anonymous namespace)::RecordExprEvaluator::VisitCXXConstructExpr(clang::CXXConstructExpr const*, clang::QualType) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:10792:10
    #13 0x561e4b45dae7 in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::RecordExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #14 0x561e4b3f963e in EvaluateRecord third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:10917:50
    #15 0x561e4b3f963e in EvaluateInPlace(clang::APValue&, (anonymous namespace)::EvalInfo&, (anonymous namespace)::LValue const&, clang::Expr const*, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16425:14
    #16 0x561e4b3ff0b3 in EvaluateCallArg(clang::ParmVarDecl const*, clang::Expr const*, (anonymous namespace)::CallRef, (anonymous namespace)::EvalInfo&, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6403:8
    #17 0x561e4b440530 in EvaluateArgs(llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, (anonymous namespace)::EvalInfo&, clang::FunctionDecl const*, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6442:10
    #18 0x561e4b4a503e in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8298:12
    #19 0x561e4b4a503e in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #20 0x561e4b4a503e in (anonymous namespace)::IntExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:12700:33
    #21 0x561e4b49f1a5 in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::IntExprEvaluator, bool>::Visit(clang::Stmt const*) third_party/llvm/llvm-project/clang/include/clang/AST/StmtVisitor.h
    #22 0x561e4b3ff8af in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16339:41
    #23 0x561e4b424658 in EvaluateAsBooleanCondition third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:2742:8
    #24 0x561e4b424658 in EvaluateCond((anonymous namespace)::EvalInfo&, clang::VarDecl const*, clang::Expr const*, bool&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5182:8
    #25 0x561e4b41ea8c in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5555:17
    #26 0x561e4b423755 in EvaluateLoopBody((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5221:24
    #27 0x561e4b41d597 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5635:28
    #28 0x561e4b41d341 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5521:28
    #29 0x561e4b40113c in HandleFunctionCall(clang::SourceLocation, clang::FunctionDecl const*, (anonymous namespace)::LValue const*, clang::Expr const*, llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, clang::Stmt const*, (anonymous namespace)::EvalInfo&, clang::APValue&, (anonymous namespace)::LValue const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6520:24
    #30 0x561e4b4c9652 in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8332:10
    #31 0x561e4b4c9652 in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #32 0x561e4b4c9652 in visitNonBuiltinCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9749:28
    #33 0x561e4b4c9652 in (anonymous namespace)::PointerExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9763:12
    #34 0x561e4b4c3e5b in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::PointerExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #35 0x561e4b3ff820 in EvaluatePointer third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9458:60
    #36 0x561e4b3ff820 in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16343:10
    #37 0x561e4b41f204 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5511:17
    #38 0x561e4b41d341 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5521:28
    #39 0x561e4b40113c in HandleFunctionCall(clang::SourceLocation, clang::FunctionDecl const*, (anonymous namespace)::LValue const*, clang::Expr const*, llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, clang::Stmt const*, (anonymous namespace)::EvalInfo&, clang::APValue&, (anonymous namespace)::LValue const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6520:24
    #40 0x561e4b4c9652 in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8332:10
    #41 0x561e4b4c9652 in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #42 0x561e4b4c9652 in visitNonBuiltinCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9749:28
    #43 0x561e4b4c9652 in (anonymous namespace)::PointerExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9763:12
    #44 0x561e4b4c3e5b in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::PointerExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #45 0x561e4b3ff820 in EvaluatePointer third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9458:60
    #46 0x561e4b3ff820 in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16343:10
    #47 0x561e4b4ad3c2 in EvaluateAsBooleanCondition third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:2742:8
    #48 0x561e4b4ad3c2 in (anonymous namespace)::IntExprEvaluator::VisitCastExpr(clang::CastExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:14877:10
    #49 0x561e4b49f192 in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::IntExprEvaluator, bool>::Visit(clang::Stmt const*) third_party/llvm/llvm-project/clang/include/clang/AST/StmtVisitor.h

previously allocated by thread T0 here:
    #0 0x561e47fe46bd in operator new(unsigned long) third_party/llvm/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:86:3
    #1 0x561e4b424d00 in __libcpp_operator_new<unsigned long> third_party/crosstool/v18/stable/src/libcxx/include/new:277:10
    #2 0x561e4b424d00 in __libcpp_allocate third_party/crosstool/v18/stable/src/libcxx/include/new:301:10
    #3 0x561e4b424d00 in allocate third_party/crosstool/v18/stable/src/libcxx/include/__memory/allocator.h:120:32
    #4 0x561e4b424d00 in allocate third_party/crosstool/v18/stable/src/libcxx/include/__memory/allocator_traits.h:281:16
    #5 0x561e4b424d00 in __construct_node<const std::__u::piecewise_construct_t &, std::__u::tuple<std::__u::pair<const void *, unsigned int> &&>, std::__u::tuple<> > third_party/crosstool/v18/stable/src/libcxx/include/__tree:1820:21
    #6 0x561e4b424d00 in std::__u::pair<std::__u::__tree_iterator<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, std::__u::__tree_node<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, void*>*, long>, bool> std::__u::__tree<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, std::__u::__map_value_compare<std::__u::pair<void const*, unsigned int>, std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>, std::__u::less<std::__u::pair<void const*, unsigned int>>, true>, std::__u::allocator<std::__u::__value_type<std::__u::pair<void const*, unsigned int>, clang::APValue>>>::__emplace_unique_key_args<std::__u::pair<void const*, unsigned int>, std::__u::piecewise_construct_t const&, std::__u::tuple<std::__u::pair<void const*, unsigned int>&&>, std::__u::tuple<>>(std::__u::pair<void const*, unsigned int> const&, std::__u::piecewise_construct_t const&, std::__u::tuple<std::__u::pair<void const*, unsigned int>&&>&&, std::__u::tuple<>&&) third_party/crosstool/v18/stable/src/libcxx/include/__tree:1787:25
    #7 0x561e4b424a03 in operator[] third_party/crosstool/v18/stable/src/libcxx/include/map:1531:8
    #8 0x561e4b424a03 in (anonymous namespace)::CallStackFrame::createLocal(clang::APValue::LValueBase, void const*, clang::QualType, (anonymous namespace)::ScopeKind) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:1963:21
    #9 0x561e4b42bd95 in clang::APValue& (anonymous namespace)::CallStackFrame::createTemporary<clang::Expr>(clang::Expr const*, clang::QualType, (anonymous namespace)::ScopeKind, (anonymous namespace)::LValue&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:1944:10
    #10 0x561e4b3ffd17 in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16367:27
    #11 0x561e4b40429c in handleLValueToRValueConversion((anonymous namespace)::EvalInfo&, clang::Expr const*, clang::QualType, (anonymous namespace)::LValue const&, clang::APValue&, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:4518:12
    #12 0x561e4b496e9c in handleTrivialCopy((anonymous namespace)::EvalInfo&, clang::ParmVarDecl const*, clang::Expr const*, clang::APValue&, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6469:10
    #13 0x561e4b494fdd in HandleConstructorCall(clang::Expr const*, (anonymous namespace)::LValue const&, (anonymous namespace)::CallRef, clang::CXXConstructorDecl const*, (anonymous namespace)::EvalInfo&, clang::APValue&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6582:12
    #14 0x561e4b400cca in HandleConstructorCall(clang::Expr const*, (anonymous namespace)::LValue const&, llvm::ArrayRef<clang::Expr const*>, clang::CXXConstructorDecl const*, (anonymous namespace)::EvalInfo&, clang::APValue&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6753:10
    #15 0x561e4b45cfae in (anonymous namespace)::RecordExprEvaluator::VisitCXXConstructExpr(clang::CXXConstructExpr const*, clang::QualType) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:10792:10
    #16 0x561e4b45dae7 in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::RecordExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #17 0x561e4b3f963e in EvaluateRecord third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:10917:50
    #18 0x561e4b3f963e in EvaluateInPlace(clang::APValue&, (anonymous namespace)::EvalInfo&, (anonymous namespace)::LValue const&, clang::Expr const*, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16425:14
    #19 0x561e4b3ff0b3 in EvaluateCallArg(clang::ParmVarDecl const*, clang::Expr const*, (anonymous namespace)::CallRef, (anonymous namespace)::EvalInfo&, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6403:8
    #20 0x561e4b440530 in EvaluateArgs(llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, (anonymous namespace)::EvalInfo&, clang::FunctionDecl const*, bool) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6442:10
    #21 0x561e4b4a503e in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8298:12
    #22 0x561e4b4a503e in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #23 0x561e4b4a503e in (anonymous namespace)::IntExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:12700:33
    #24 0x561e4b49f1a5 in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::IntExprEvaluator, bool>::Visit(clang::Stmt const*) third_party/llvm/llvm-project/clang/include/clang/AST/StmtVisitor.h
    #25 0x561e4b3ff8af in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16339:41
    #26 0x561e4b424658 in EvaluateAsBooleanCondition third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:2742:8
    #27 0x561e4b424658 in EvaluateCond((anonymous namespace)::EvalInfo&, clang::VarDecl const*, clang::Expr const*, bool&) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5182:8
    #28 0x561e4b41ea8c in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5555:17
    #29 0x561e4b423755 in EvaluateLoopBody((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5221:24
    #30 0x561e4b41d597 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5635:28
    #31 0x561e4b41d341 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5521:28
    #32 0x561e4b40113c in HandleFunctionCall(clang::SourceLocation, clang::FunctionDecl const*, (anonymous namespace)::LValue const*, clang::Expr const*, llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, clang::Stmt const*, (anonymous namespace)::EvalInfo&, clang::APValue&, (anonymous namespace)::LValue const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6520:24
    #33 0x561e4b4c9652 in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8332:10
    #34 0x561e4b4c9652 in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #35 0x561e4b4c9652 in visitNonBuiltinCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9749:28
    #36 0x561e4b4c9652 in (anonymous namespace)::PointerExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9763:12
    #37 0x561e4b4c3e5b in clang::StmtVisitorBase<llvm::make_const_ptr, (anonymous namespace)::PointerExprEvaluator, bool>::Visit(clang::Stmt const*) blaze-out/k8-opt-asan/genfiles/third_party/llvm/llvm-project/clang/include/clang/AST/StmtNodes.inc
    #38 0x561e4b3ff820 in EvaluatePointer third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9458:60
    #39 0x561e4b3ff820 in Evaluate(clang::APValue&, (anonymous namespace)::EvalInfo&, clang::Expr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:16343:10
    #40 0x561e4b41f204 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5511:17
    #41 0x561e4b41d341 in EvaluateStmt((anonymous namespace)::StmtResult&, (anonymous namespace)::EvalInfo&, clang::Stmt const*, clang::SwitchCase const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:5521:28
    #42 0x561e4b40113c in HandleFunctionCall(clang::SourceLocation, clang::FunctionDecl const*, (anonymous namespace)::LValue const*, clang::Expr const*, llvm::ArrayRef<clang::Expr const*>, (anonymous namespace)::CallRef, clang::Stmt const*, (anonymous namespace)::EvalInfo&, clang::APValue&, (anonymous namespace)::LValue const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:6520:24
    #43 0x561e4b4c9652 in handleCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8332:10
    #44 0x561e4b4c9652 in VisitCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:8132:10
    #45 0x561e4b4c9652 in visitNonBuiltinCallExpr third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9749:28
    #46 0x561e4b4c9652 in (anonymous namespace)::PointerExprEvaluator::VisitCallExpr(clang::CallExpr const*) third_party/llvm/llvm-project/clang/lib/AST/ExprConstant.cpp:9763:12
```
