### PR TITLE
[BOLT][merge-fdata] Fix basic sample profile aggregation without LBR info

### DIFF
--- a/bolt/test/merge-fdata-bat-no-lbr.test
+++ b/bolt/test/merge-fdata-bat-no-lbr.test
@@ -1,0 +1,20 @@
+## Check that merge-fdata correctly handles merging two fdata files with both boltedcollection and no_lbr tags.
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: merge-fdata %t/a.fdata %t/b.fdata -o %t/merged.fdata
+# RUN: FileCheck %s --input-file %t/merged.fdata
+
+# CHECK: boltedcollection
+# CHECK: no_lbr
+# CHECK: main 2
+
+#--- a.fdata
+boltedcollection
+no_lbr
+main 1
+#--- b.fdata
+boltedcollection
+no_lbr
+main 1

--- a/bolt/test/merge-fdata-lbr-mode.test
+++ b/bolt/test/merge-fdata-lbr-mode.test
@@ -1,0 +1,15 @@
+## Check that merge-fdata tool doesn't falsely print no_lbr when not in no-lbr mode
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: merge-fdata %t/a.fdata %t/b.fdata -o %t/merged.fdata
+# RUN: FileCheck %s --input-file %t/merged.fdata
+
+# CHECK-NOT: no_lbr
+# CHECK: main 2
+
+#--- a.fdata
+main 1
+#--- b.fdata
+main 1

--- a/bolt/test/merge-fdata-mixed-bat-no-lbr.test
+++ b/bolt/test/merge-fdata-mixed-bat-no-lbr.test
@@ -1,0 +1,16 @@
+## Check that merge-fdata doesn't incorrectly merge two fdata files with boltedcollection and no_lbr tags.
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: not merge-fdata %t/a.fdata %t/b.fdata 2>&1 | FileCheck %s
+
+# CHECK: cannot mix profile collected in BOLT and non-BOLT deployments
+
+#--- a.fdata
+boltedcollection
+no_lbr
+main 1
+#--- b.fdata
+no_lbr
+main 1

--- a/bolt/test/merge-fdata-mixed-mode.test
+++ b/bolt/test/merge-fdata-mixed-mode.test
@@ -1,0 +1,15 @@
+## Check that merge-fdata tool correctly reports error message
+## when trying to merge 'no-lbr' and 'lbr' profiles
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: not merge-fdata %t/a.fdata %t/b.fdata 2>&1 | FileCheck %s
+
+# CHECK: cannot mix 'no_lbr' and 'lbr' profiles.
+
+#--- a.fdata
+no_lbr
+main 1
+#--- b.fdata
+main 1

--- a/bolt/test/merge-fdata-no-lbr-mode.test
+++ b/bolt/test/merge-fdata-no-lbr-mode.test
@@ -1,0 +1,18 @@
+## Check that merge-fdata tool correctly processes fdata files with header
+## string produced by no-lbr mode (no_lbr)
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: merge-fdata %t/a.fdata %t/b.fdata -o %t/merged.fdata
+# RUN: FileCheck %s --input-file %t/merged.fdata
+
+# CHECK: no_lbr
+# CHECK: main 2
+
+#--- a.fdata
+no_lbr
+main 1
+#--- b.fdata
+no_lbr
+main 1

--- a/bolt/tools/merge-fdata/merge-fdata.cpp
+++ b/bolt/tools/merge-fdata/merge-fdata.cpp
@@ -265,6 +265,7 @@ bool isYAML(const StringRef Filename) {
 void mergeLegacyProfiles(const SmallVectorImpl<std::string> &Filenames) {
   errs() << "Using legacy profile format.\n";
   std::optional<bool> BoltedCollection;
+  std::optional<bool> NoLBRCollection;
   std::mutex BoltedCollectionMutex;
   typedef StringMap<uint64_t> ProfileTy;
 
@@ -297,7 +298,22 @@ void mergeLegacyProfiles(const SmallVectorImpl<std::string> &Filenames) {
               "cannot mix profile collected in BOLT and non-BOLT deployments");
         BoltedCollection = false;
       }
-
+      // Check if the string "no_lbr" is in the first line
+      // (or second line if BoltedCollection is true)
+      size_t CheckNoLBRPos = Buf.find('\n');
+      if (CheckNoLBRPos != StringRef::npos) {
+        StringRef FirstLine = Buf.substr(0, CheckNoLBRPos);
+        if (FirstLine.contains("no_lbr")) {
+          if (!NoLBRCollection.value_or(true))
+            report_error(Filename, "cannot mix 'no_lbr' and 'lbr' profiles");
+          NoLBRCollection = true;
+          Buf = Buf.drop_front(CheckNoLBRPos + 1);
+        } else {
+          if (NoLBRCollection.value_or(false))
+            report_error(Filename, "cannot mix 'no_lbr' and 'lbr' profiles");
+          NoLBRCollection = false;
+        }
+      }
       Profile = &Profiles[tid];
     }
 
@@ -336,6 +352,8 @@ void mergeLegacyProfiles(const SmallVectorImpl<std::string> &Filenames) {
 
   if (BoltedCollection.value_or(false))
     output() << "boltedcollection\n";
+  if (NoLBRCollection.value_or(false))
+    output() << "no_lbr\n";
   for (const auto &[Key, Value] : MergedProfile)
     output() << Key << " " << Value << "\n";
 


### PR DESCRIPTION
When a basic sample profile is gathered without LBR info, the generated profile contains a "no-lbr" tag in the first line of the fdata file. This PR fixes merge-fdata to recognize and save this tag to the output file.