### PR TITLE
Add PR check to suggest alternatives to using undef

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -16,7 +16,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.repository == 'llvm/llvm-project'
+    if: github.repository == 'nunoplopes/llvm-project'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -16,7 +16,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.repository == 'nunoplopes/llvm-project'
+    if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -345,7 +345,8 @@ class UndefGetFormatHelper(FormatHelper):
         cmd += files
 
         if args.verbose:
-            print(f"Running: {' '.join(f"'{c}'" for c in cmd)}")
+            cmd_str = ' '.join(f"'{c}'" for c in cmd)
+            print(f"Running: {cmd_str}")
         self.cmd = cmd
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         sys.stdout.write(proc.stderr.decode("utf-8"))

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -391,7 +391,7 @@ You can test this locally with the following command:
 The following files introduce new uses of undef:
 {files}
 
-Undef is now deprecated and should only be used in the rare cases where no replacement is possible. For example, a load of uninitialized memory yields `undef`. You should use `poison` values for placeholders instead.
+[Undef](https://llvm.org/docs/LangRef.html#undefined-values) is now deprecated and should only be used in the rare cases where no replacement is possible. For example, a load of uninitialized memory yields `undef`. You should use `poison` values for placeholders instead.
 
 In tests, avoid using `undef` and having tests that trigger undefined behavior. If you need an operand with some unimportant value, you can add a new argument to the function and use that instead.
 

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -410,6 +410,8 @@ define void @fn(i1 %cond) {{
   br i1 %cond, ...
 }}
 ```
+
+Please refer to the [Undefined Behavior Manual](https://llvm.org/docs/UndefinedBehavior.html) for more information.
 """
         if args.verbose:
             print(f"error: {self.name} failed")

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -382,6 +382,9 @@ define void @fn(i1 %cond) {{
   br i1 %cond, ...
 }}
 '''
+            if args.verbose:
+                print(f"error: {self.name} failed")
+                print(report)
             return report
         else:
             return None

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -345,7 +345,7 @@ class UndefGetFormatHelper(FormatHelper):
         cmd += files
 
         if args.verbose:
-            cmd_str = ' '.join(f"'{c}'" for c in cmd)
+            cmd_str = " ".join(f"'{c}'" for c in cmd)
             print(f"Running: {cmd_str}")
         self.cmd = cmd
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -319,7 +319,7 @@ class UndefGetFormatHelper(FormatHelper):
 
     @property
     def instructions(self) -> str:
-        return " ".join(self.cmd)
+        return " ".join(f"'{c}'" for c in self.cmd)
 
     def filter_changed_files(self, changed_files: List[str]) -> List[str]:
         filtered_files = []
@@ -343,11 +343,10 @@ class UndefGetFormatHelper(FormatHelper):
             cmd.append(args.end_rev)
 
         cmd += files
+        self.cmd = cmd
 
         if args.verbose:
-            cmd_str = " ".join(f"'{c}'" for c in cmd)
-            print(f"Running: {cmd_str}")
-        self.cmd = cmd
+            print(f"Running: {self.instructions}")
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         sys.stdout.write(proc.stderr.decode("utf-8"))
         stdout = proc.stdout.decode("utf-8")


### PR DESCRIPTION
As discussed in [discourse](https://discourse.llvm.org/t/please-dont-use-undef-in-tests-part-2/83388), here's a patch that adds a comment to PRs that introduce new uses of undef.

It uses the the `git diff -S' command to find new uses, to avoid warning about old uses. It further trims down with a regex to get only added (+) lines.

See here for the script in action: https://github.com/nunoplopes/llvm2/pull/12#issuecomment-2514942240

Free feel to suggest better wording for the text, ofc!