### PR TITLE
libc: fixup include path and bazel stale comments

### DIFF
--- a/libc/src/__support/OSUtil/linux/exit.cpp
+++ b/libc/src/__support/OSUtil/linux/exit.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/OSUtil/linux/syscall.h" // syscall_impl
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
-#include "syscall.h"     // For internal syscall function.
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -74,7 +74,6 @@ def libc_function(
             for.
       srcs: The .cpp files which contain the function implementation.
       weak: Make the symbol corresponding to the libc function "weak".
-      deps: The list of target dependencies if any.
       copts: The list of options to add to the C++ compilation command.
       local_defines: The preprocessor defines which will be prepended with -D
                      and passed to the compile command of this target but not
@@ -138,9 +137,6 @@ def libc_math_function(
 
     Args:
       name: The name of the function.
-      specializations: List of machine specializations available for this
-                       function. Possible specializations are "generic",
-                       "aarch64" and "x86_64".
       additional_deps: Other deps like helper cc_library targes used by the
                        math function.
     """


### PR DESCRIPTION
Downstream builders are having issues with this local include. Use a fuller
path that's more standard throughout the codebase.

Also some of the comments in the bazel overlay are stale. Remove them.

Reported-by: Brooks Moses <bmoses@google.com>
