### PR TITLE
Fix a bug with the hasAncestor AST matcher when a node has several parents without pointer identity

### DIFF
--- a/clang/lib/ASTMatchers/ASTMatchFinder.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchFinder.cpp
@@ -1237,7 +1237,8 @@ private:
           // Make sure we do not visit the same node twice.
           // Otherwise, we'll visit the common ancestors as often as there
           // are splits on the way down.
-          if (Visited.insert(Parent.getMemoizationData()).second)
+          if (Parent.getMemoizationData() == nullptr ||
+              Visited.insert(Parent.getMemoizationData()).second)
             Queue.push_back(Parent);
         }
         Queue.pop_front();

--- a/clang/lib/ASTMatchers/ASTMatchFinder.cpp
+++ b/clang/lib/ASTMatchers/ASTMatchFinder.cpp
@@ -1237,8 +1237,8 @@ private:
           // Make sure we do not visit the same node twice.
           // Otherwise, we'll visit the common ancestors as often as there
           // are splits on the way down.
-          if (Parent.getMemoizationData() == nullptr ||
-              Visited.insert(Parent.getMemoizationData()).second)
+          auto Key = Parent.getMemoizationData();
+          if (Key == nullptr || Visited.insert(Key).second)
             Queue.push_back(Parent);
         }
         Queue.pop_front();

--- a/clang/unittests/ASTMatchers/ASTMatchersTraversalTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersTraversalTest.cpp
@@ -5536,6 +5536,24 @@ TEST(HasAncestor, MatchesInImplicitCode) {
         hasAncestor(recordDecl(hasName("A")))))))));
 }
 
+TEST(HasAncestor, MatchesWithMultipleParentsWithoutPointerIdentity) {
+  EXPECT_TRUE(matches(
+      R"cpp(
+template <int i> class Fact {};
+template <class T> class W {};
+template <class T> struct A
+{
+    static void f() {
+        W<Fact<12>> fact12;
+    }
+};
+void f() {
+    A<int>::f();
+    A<double>::f();
+})cpp",
+      integerLiteral(hasAncestor(functionDecl()))));
+}
+
 TEST(HasParent, MatchesOnlyParent) {
   EXPECT_TRUE(matches(
     "void f() { if (true) { int x = 42; } }",


### PR DESCRIPTION
Before the change, getMemoizationData is used as a key to stop visiting the parents, but if a node has no identity, this is nullptr, which means that the visit will stop as soon as a second node with no identity is visited.