### PR TITLE
[Github] fix libc documentation path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -162,7 +162,7 @@ jobs:
           cmake -B libc-build -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_RUNTIMES="libc" -DLLVM_ENABLE_SPHINX=ON ./runtimes
           TZ=UTC ninja -C libc-build docs-libc-html
           mkdir built-docs/libc
-          cp -r libc-build/docs/* built-docs/libc/
+          cp -r libc-build/libc/docs/* built-docs/libc/
       - name: Build LLD docs
         if: steps.docs-changed-subprojects.outputs.lld_any_changed == 'true'
         run: |


### PR DESCRIPTION
Running `ninja docs-libc-html` produces content in {build_dir}/libc/docs, not
{build_dir}/docs. Presubmit jobs for "Test documentation build" were failing as
a result of commit 97f94af3560d ("[Github] Upload built docs as artifact from
test build docs job (#118159)")

Link: #118159
Link: #117220