### PR TITLE
[clang-repl][CMake][MSVC] Use LINKER: instead of `-Wl`

### DIFF
--- a/clang/tools/clang-repl/CMakeLists.txt
+++ b/clang/tools/clang-repl/CMakeLists.txt
@@ -66,7 +66,7 @@ clang_target_link_libraries(clang-repl PRIVATE
 # start to exceed this limit, e.g. when linking for arm-linux-gnueabihf with
 # gold. This flag tells the linker to build a PLT for the full address range.
 # Linkers without this flag are assumed to support proper PLTs by default.
-set(flag_long_plt "-Wl,--long-plt")
+set(flag_long_plt "LINKER:--long-plt")
 check_linker_flag(CXX ${flag_long_plt} HAVE_LINKER_FLAG_LONG_PLT)
 if(HAVE_LINKER_FLAG_LONG_PLT)
   target_link_options(clang-repl PRIVATE ${flag_long_plt})


### PR DESCRIPTION
This should be more portable, and avoids passing the option to `clang-cl` when linking, because `clang-cl` accepts any `-W` flags (normally warning flags) during linking (#118516).