### PR TITLE
[NFC] Fix potential underflow constant.

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/CrtpConstructorAccessibilityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/CrtpConstructorAccessibilityCheck.cpp
@@ -58,10 +58,10 @@ getDerivedParameter(const ClassTemplateSpecializationDecl *CRTP,
                Arg.getAsType()->getAsCXXRecordDecl() == Derived;
       });
 
-  return AnyOf ? CRTP->getSpecializedTemplate()
-                     ->getTemplateParameters()
-                     ->getParam(Idx - 1)
-               : nullptr;
+  return AnyOf && Idx > 0 ? CRTP->getSpecializedTemplate()
+                                ->getTemplateParameters()
+                                ->getParam(Idx - 1)
+                          : nullptr;
 }
 
 static std::vector<FixItHint>


### PR DESCRIPTION
If the range for `llvm::any_of` is empty, `Idx` will be `0` and an underflow might occur when computing `Idx-1`.