### PR TITLE
[memprof] Fix IndexedMemProfRecord::clear

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -416,10 +416,7 @@ struct IndexedMemProfRecord {
   // the last entry in the list with the same function GUID.
   llvm::SmallVector<CallStackId> CallSiteIds;
 
-  void clear() {
-    AllocSites.clear();
-    CallSiteIds.clear();
-  }
+  void clear() { *this = IndexedMemProfRecord(); }
 
   void merge(const IndexedMemProfRecord &Other) {
     // TODO: Filter out duplicates which may occur if multiple memprof

--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -416,7 +416,10 @@ struct IndexedMemProfRecord {
   // the last entry in the list with the same function GUID.
   llvm::SmallVector<CallStackId> CallSiteIds;
 
-  void clear() { AllocSites.clear(); }
+  void clear() {
+    AllocSites.clear();
+    CallSiteIds.clear();
+  }
 
   void merge(const IndexedMemProfRecord &Other) {
     // TODO: Filter out duplicates which may occur if multiple memprof


### PR DESCRIPTION
This patch ensures that IndexedMemProfRecord::clear clears every field
of IndexedMemProfRecord.

This fix is not critical at the moment.  The only use of this function
is in RecordWriterTrait::EmitData to release the memory we are done
with.  That is, we never clear the data structure for the purpose of
reusing it.
