### PR TITLE
[Clang][Darwin] Centralize framework search paths for headers & libraries.

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -1,4 +1,4 @@
-//===--- DarwinSDKInfo.h - SDK Information parser for darwin ----*- C++ -*-===//
+//===--- DarwinSDKInfo.h - SDK Information for darwin -----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -191,6 +191,17 @@ private:
 /// the SDK has no SDKSettings.json, or a valid \c DarwinSDKInfo otherwise.
 Expected<std::optional<DarwinSDKInfo>>
 parseDarwinSDKInfo(llvm::vfs::FileSystem &VFS, StringRef SDKRootPath);
+
+/// Get the system platform prefix for the active target triple.
+StringRef getSystemPrefix(const llvm::Triple &T);
+
+using KnownSystemPaths = std::array<std::string, 2>;
+
+/// Compute and get the common system search paths for header frontend and
+/// library linker searching.
+///
+/// \param T The active target triple to determine platform specific paths.
+KnownSystemPaths getCommonSystemPaths(llvm::Triple T);
 
 } // end namespace clang
 

--- a/clang/lib/Lex/InitHeaderSearch.cpp
+++ b/clang/lib/Lex/InitHeaderSearch.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Config/config.h" // C_INCLUDE_DIRS
@@ -339,13 +340,11 @@ void InitHeaderSearch::AddDefaultIncludePaths(
   if (triple.isOSDarwin()) {
     if (HSOpts.UseStandardSystemIncludes) {
       // Add the default framework include paths on Darwin.
-      if (triple.isDriverKit()) {
-        AddPath("/System/DriverKit/System/Library/Frameworks", System, true);
-      } else {
-        AddPath("/System/Library/Frameworks", System, true);
-        AddPath("/System/Library/SubFrameworks", System, true);
+      for (const StringRef Path : getCommonSystemPaths(triple))
+        AddPath(Path, System, true);
+
+      if (!triple.isDriverKit())
         AddPath("/Library/Frameworks", System, true);
-      }
     }
     return;
   }

--- a/clang/test/Driver/driverkit-path.c
+++ b/clang/test/Driver/driverkit-path.c
@@ -18,9 +18,11 @@ int main() { return 0; }
 // LD64-OLD: "-isysroot" "[[PATH:[^"]*]]Inputs/DriverKit19.0.sdk"
 // LD64-OLD: "-L[[PATH]]Inputs/DriverKit19.0.sdk/System/DriverKit/usr/lib"
 // LD64-OLD: "-F[[PATH]]Inputs/DriverKit19.0.sdk/System/DriverKit/System/Library/Frameworks"
+// LD64-OLD: "-F[[PATH]]Inputs/DriverKit19.0.sdk/System/DriverKit/System/Library/SubFrameworks"
 // LD64-NEW: "-isysroot" "[[PATH:[^"]*]]Inputs/DriverKit19.0.sdk"
 // LD64-NEW-NOT: "-L[[PATH]]Inputs/DriverKit19.0.sdk/System/DriverKit/usr/lib"
 // LD64-NEW-NOT: "-F[[PATH]]Inputs/DriverKit19.0.sdk/System/DriverKit/System/Library/Frameworks"
+// LD64-NEW-NOT: "-F[[PATH]]Inputs/DriverKit19.0.sdk/System/DriverKit/System/Library/SubFrameworks"
 
 
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -isysroot %S/Inputs/DriverKit19.0.sdk -E -v -x c++ 2>&1 | FileCheck %s --check-prefix=INC
@@ -31,3 +33,4 @@ int main() { return 0; }
 // INC:       /lib{{(64)?}}/clang/{{[^/ ]+}}/include
 // INC:       [[PATH]]/System/DriverKit/usr/include
 // INC:       [[PATH]]/System/DriverKit/System/Library/Frameworks (framework directory)
+// INC:       [[PATH]]/System/DriverKit/System/Library/SubFrameworks (framework directory)


### PR DESCRIPTION
* Use the centralized API to add `SubFrameworks` for driverkit targets.