### PR TITLE
[lldb] When using Socket to listen on `localhost:0` on systems supporting ting ipv4 and ipv6 the second socket to initialize will not update the listening address correctly after the call to `bind`.

### DIFF
--- a/lldb/source/Host/common/TCPSocket.cpp
+++ b/lldb/source/Host/common/TCPSocket.cpp
@@ -216,11 +216,11 @@ Status TCPSocket::Listen(llvm::StringRef name, int backlog) {
     }
 
     if (host_port->port == 0) {
-      socklen_t sa_len = address.GetLength();
-      if (getsockname(fd, &address.sockaddr(), &sa_len) == 0)
-        host_port->port = address.GetPort();
+      socklen_t sa_len = listen_address.GetLength();
+      if (getsockname(fd, &listen_address.sockaddr(), &sa_len) == 0)
+        host_port->port = listen_address.GetPort();
     }
-    m_listen_sockets[fd] = address;
+    m_listen_sockets[fd] = listen_address;
   }
 
   if (m_listen_sockets.empty()) {


### PR DESCRIPTION
This results in the second address listed in `Socket::GetListeningConnectionURI` to have port `:0`, which is incorrect.

To fix this, correct which address is used to detect the port and update the unit tests to cover this use case.

Additionally, I updated the SocketTest's to only parameterize tests that can work on ipv4 or ipv6. This means tests like `SocketTest::DecodeHostAndPort` are only run once, instead of twice since they do not change behavior based on parameters.

I also included a new unit test to cover listening on `localhost:0`, validating both sockets correctly list the updated port.