### PR TITLE
[Nomination] Add additional Apple representative to the Security Group

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -36,6 +36,7 @@ meet the criteria for inclusion below. The list is in the format
 `* ${full_name} (${affiliation}) [${github_username}]`. If a github
 username for an individual isn't available, the brackets will be empty.
 
+* Abhay Kanhere (Apple) [@AbhayKanhere]
 * Ahmed Bougacha (Apple) [@ahmedbougacha]
 * Artur Pilipenko (Azul Systems Inc) []
 * Boovaragavan Dasarathan (Nvidia) [@mrragava]


### PR DESCRIPTION
I'd like to nominate myself as an additional Apple representative (vendor contact) on the llvm security group.

I met many of you at the llvm-dev meeting roundtable(s) in Santa Clara. I closely work with @ahmedbougacha @jroelofs at Apple.

- Abhay