### PR TITLE
[libc] Fix the GPU build when building inside the NATIVE project

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -52,22 +52,9 @@ set(LIBC_NAMESPACE ${default_namespace}
 
 # We will build the GPU utilities if we are not doing a runtimes build.
 option(LIBC_BUILD_GPU_LOADER "Always build the GPU loader utilities" OFF)
-if(LIBC_BUILD_GPU_LOADER OR NOT LLVM_RUNTIMES_BUILD)
-  foreach(_name ${LLVM_RUNTIME_TARGETS})
-    if("libc" IN_LIST RUNTIMES_${_name}_LLVM_ENABLE_RUNTIMES)
-      if("${_name}" STREQUAL "amdgcn-amd-amdhsa" OR "${_name}" STREQUAL "nvptx64-nvidia-cuda")
-        set(LIBC_NEED_LOADER_UTILS TRUE)
-      endif()
-    endif()
-  endforeach()
-  if("${LIBC_TARGET_TRIPLE}" STREQUAL "amdgcn-amd-amdhsa" OR
-     "${LIBC_TARGET_TRIPLE}" STREQUAL "nvptx64-nvidia-cuda")
-    set(LIBC_NEED_LOADER_UTILS TRUE)
-  endif()
-  if(LIBC_NEED_LOADER_UTILS)
-    add_subdirectory(utils/gpu)
-    return()
-  endif()
+if(LIBC_BUILD_GPU_LOADER OR ((NOT LLVM_RUNTIMES_BUILD) AND LLVM_LIBC_GPU_BUILD))
+  add_subdirectory(utils/gpu)
+  return()
 endif()
 
 add_subdirectory(newhdrgen)

--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -78,6 +78,9 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
       list(APPEND libc_flags -DLLVM_FORCE_BUILD_RUNTIME=ON)
     endif()
   endif()
+  if(LLVM_LIBC_GPU_BUILD)
+    list(APPEND libc_flags -DLLVM_LIBC_GPU_BUILD=ON)
+  endif()
 
   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt
     COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"


### PR DESCRIPTION
Summary:
We use the NATIVE directory for cross-compiling tools that need to be
run on the host. This was not forwarding the CMake arguments we used to
check if this was a GPU compile that created its own tools. Forward that
and simplify.

Fixes https://github.com/llvm/llvm-project/issues/118558
