### PR TITLE
[HLSL][SPIRV][DXIL] Implement `WaveActiveSum` intrinsic

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -4795,6 +4795,12 @@ def HLSLWaveActiveCountBits : LangBuiltin<"HLSL_LANG"> {
   let Prototype = "unsigned int(bool)";
 }
 
+def HLSLWaveActiveSum : LangBuiltin<"HLSL_LANG"> {
+  let Spellings = ["__builtin_hlsl_wave_active_sum"];
+  let Attributes = [NoThrow, Const];
+  let Prototype = "void (...)";
+}
+
 def HLSLWaveGetLaneIndex : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_wave_get_lane_index"];
   let Attributes = [NoThrow, Const];

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9299,6 +9299,9 @@ def err_typecheck_expect_scalar_or_vector : Error<
   "a vector of such type is required">;
 def err_typecheck_expect_any_scalar_or_vector : Error<
   "invalid operand of type %0 where a scalar or vector is required">;
+def err_typecheck_expect_scalar_or_vector_not_type : Error<
+  "invalid operand of type %0 where %1 or "
+  "a vector of such type is not allowed">;
 def err_typecheck_expect_flt_or_vector : Error<
   "invalid operand of type %0 where floating, complex or "
   "a vector of such types is required">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9300,8 +9300,7 @@ def err_typecheck_expect_scalar_or_vector : Error<
 def err_typecheck_expect_any_scalar_or_vector : Error<
   "invalid operand of type %0 where a scalar or vector is required">;
 def err_typecheck_expect_scalar_or_vector_not_type : Error<
-  "invalid operand of type %0 where %1 or "
-  "a vector of such type is not allowed">;
+  "invalid operand of type %0">;
 def err_typecheck_expect_flt_or_vector : Error<
   "invalid operand of type %0 where floating, complex or "
   "a vector of such types is required">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9298,9 +9298,7 @@ def err_typecheck_expect_scalar_or_vector : Error<
   "invalid operand of type %0 where %1 or "
   "a vector of such type is required">;
 def err_typecheck_expect_any_scalar_or_vector : Error<
-  "invalid operand of type %0 where a scalar or vector is required">;
-def err_typecheck_expect_scalar_or_vector_not_type : Error<
-  "invalid operand of type %0">;
+  "invalid operand of type %0%select{| where a scalar or vector is required}1">;
 def err_typecheck_expect_flt_or_vector : Error<
   "invalid operand of type %0 where floating, complex or "
   "a vector of such types is required">;

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -19191,11 +19191,11 @@ static Intrinsic::ID getWaveActiveSumIntrinsic(llvm::Triple::ArchType Arch,
                                                CGHLSLRuntime &RT, QualType QT) {
   switch (Arch) {
   case llvm::Triple::spirv:
-    return llvm::Intrinsic::spv_wave_active_sum;
+    return llvm::Intrinsic::spv_wave_reduce_sum;
   case llvm::Triple::dxil: {
     if (QT->isUnsignedIntegerType())
-      return llvm::Intrinsic::dx_wave_active_usum;
-    return llvm::Intrinsic::dx_wave_active_sum;
+      return llvm::Intrinsic::dx_wave_reduce_usum;
+    return llvm::Intrinsic::dx_wave_reduce_sum;
   }
   default:
     llvm_unreachable("Intrinsic WaveActiveSum"

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -19186,6 +19186,23 @@ static Intrinsic::ID getFirstBitHighIntrinsic(CGHLSLRuntime &RT, QualType QT) {
   return RT.getFirstBitUHighIntrinsic();
 }
 
+// Return wave active sum that corresponds to the QT scalar type
+static Intrinsic::ID getWaveActiveSumIntrinsic(llvm::Triple::ArchType Arch,
+                                               CGHLSLRuntime &RT, QualType QT) {
+  switch (Arch) {
+  case llvm::Triple::spirv:
+    return llvm::Intrinsic::spv_wave_active_sum;
+  case llvm::Triple::dxil: {
+    if (QT->isUnsignedIntegerType())
+      return llvm::Intrinsic::dx_wave_active_usum;
+    return llvm::Intrinsic::dx_wave_active_sum;
+  }
+  default:
+    llvm_unreachable("Intrinsic WaveActiveSum"
+                     " not supported by target architecture");
+  }
+}
+
 Value *CodeGenFunction::EmitHLSLBuiltinExpr(unsigned BuiltinID,
                                             const CallExpr *E,
                                             ReturnValueSlot ReturnValue) {
@@ -19490,6 +19507,23 @@ case Builtin::BI__builtin_hlsl_elementwise_isinf: {
     return EmitRuntimeCall(
         Intrinsic::getOrInsertDeclaration(&CGM.getModule(), ID),
         ArrayRef{OpExpr});
+  }
+  case Builtin::BI__builtin_hlsl_wave_active_sum: {
+    // Due to the use of variadic arguments, explicitly retreive argument
+    Value *OpExpr = EmitScalarExpr(E->getArg(0));
+    llvm::FunctionType *FT = llvm::FunctionType::get(
+        OpExpr->getType(), ArrayRef{OpExpr->getType()}, false);
+    Intrinsic::ID IID = getWaveActiveSumIntrinsic(
+        getTarget().getTriple().getArch(), CGM.getHLSLRuntime(),
+        E->getArg(0)->getType());
+
+    // Get overloaded name
+    std::string Name =
+        Intrinsic::getName(IID, ArrayRef{OpExpr->getType()}, &CGM.getModule());
+    return EmitRuntimeCall(CGM.CreateRuntimeFunction(FT, Name, {},
+                                                     /*Local=*/false,
+                                                     /*AssumeConvergent=*/true),
+                           ArrayRef{OpExpr}, "hlsl.wave.active.sum");
   }
   case Builtin::BI__builtin_hlsl_wave_get_lane_index: {
     // We don't define a SPIR-V intrinsic, instead it is a SPIR-V built-in

--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -2402,98 +2402,98 @@ __attribute__((convergent)) double4 WaveReadLaneAt(double4, int32_t);
 
 _HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) half WaveActiveSum(half);
+__attribute__((convergent)) half WaveActiveSum(half);
 _HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) half2 WaveActiveSum(half2);
+__attribute__((convergent)) half2 WaveActiveSum(half2);
 _HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) half3 WaveActiveSum(half3);
+__attribute__((convergent)) half3 WaveActiveSum(half3);
 _HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) half4 WaveActiveSum(half4);
+__attribute__((convergent)) half4 WaveActiveSum(half4);
 
 #ifdef __HLSL_ENABLE_16_BIT
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int16_t WaveActiveSum(int16_t);
+__attribute__((convergent)) int16_t WaveActiveSum(int16_t);
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int16_t2 WaveActiveSum(int16_t2);
+__attribute__((convergent)) int16_t2 WaveActiveSum(int16_t2);
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int16_t3 WaveActiveSum(int16_t3);
+__attribute__((convergent)) int16_t3 WaveActiveSum(int16_t3);
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int16_t4 WaveActiveSum(int16_t4);
+__attribute__((convergent)) int16_t4 WaveActiveSum(int16_t4);
 
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint16_t WaveActiveSum(uint16_t);
+__attribute__((convergent)) uint16_t WaveActiveSum(uint16_t);
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
+__attribute__((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
+__attribute__((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
 _HLSL_AVAILABILITY(shadermodel, 6.0)
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
+__attribute__((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
 #endif
 
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int WaveActiveSum(int);
+__attribute__((convergent)) int WaveActiveSum(int);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int2 WaveActiveSum(int2);
+__attribute__((convergent)) int2 WaveActiveSum(int2);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int3 WaveActiveSum(int3);
+__attribute__((convergent)) int3 WaveActiveSum(int3);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int4 WaveActiveSum(int4);
+__attribute__((convergent)) int4 WaveActiveSum(int4);
 
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint WaveActiveSum(uint);
+__attribute__((convergent)) uint WaveActiveSum(uint);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint2 WaveActiveSum(uint2);
+__attribute__((convergent)) uint2 WaveActiveSum(uint2);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint3 WaveActiveSum(uint3);
+__attribute__((convergent)) uint3 WaveActiveSum(uint3);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint4 WaveActiveSum(uint4);
+__attribute__((convergent)) uint4 WaveActiveSum(uint4);
 
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int64_t WaveActiveSum(int64_t);
+__attribute__((convergent)) int64_t WaveActiveSum(int64_t);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int64_t2 WaveActiveSum(int64_t2);
+__attribute__((convergent)) int64_t2 WaveActiveSum(int64_t2);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int64_t3 WaveActiveSum(int64_t3);
+__attribute__((convergent)) int64_t3 WaveActiveSum(int64_t3);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) int64_t4 WaveActiveSum(int64_t4);
+__attribute__((convergent)) int64_t4 WaveActiveSum(int64_t4);
 
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint64_t WaveActiveSum(uint64_t);
+__attribute__((convergent)) uint64_t WaveActiveSum(uint64_t);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint64_t2 WaveActiveSum(uint64_t2);
+__attribute__((convergent)) uint64_t2 WaveActiveSum(uint64_t2);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint64_t3 WaveActiveSum(uint64_t3);
+__attribute__((convergent)) uint64_t3 WaveActiveSum(uint64_t3);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) uint64_t4 WaveActiveSum(uint64_t4);
+__attribute__((convergent)) uint64_t4 WaveActiveSum(uint64_t4);
 
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) float WaveActiveSum(float);
+__attribute__((convergent)) float WaveActiveSum(float);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) float2 WaveActiveSum(float2);
+__attribute__((convergent)) float2 WaveActiveSum(float2);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) float3 WaveActiveSum(float3);
+__attribute__((convergent)) float3 WaveActiveSum(float3);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) float4 WaveActiveSum(float4);
+__attribute__((convergent)) float4 WaveActiveSum(float4);
 
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) double WaveActiveSum(double);
+__attribute__((convergent)) double WaveActiveSum(double);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) double2 WaveActiveSum(double2);
+__attribute__((convergent)) double2 WaveActiveSum(double2);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) double3 WaveActiveSum(double3);
+__attribute__((convergent)) double3 WaveActiveSum(double3);
 _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
-__attribute((convergent)) double4 WaveActiveSum(double4);
+__attribute__((convergent)) double4 WaveActiveSum(double4);
 
 //===----------------------------------------------------------------------===//
 // sign builtins

--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -2397,6 +2397,105 @@ _HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_read_lane_at)
 __attribute__((convergent)) double4 WaveReadLaneAt(double4, int32_t);
 
 //===----------------------------------------------------------------------===//
+// WaveActiveSum builtins
+//===----------------------------------------------------------------------===//
+
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) half WaveActiveSum(half);
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) half2 WaveActiveSum(half2);
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) half3 WaveActiveSum(half3);
+_HLSL_16BIT_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) half4 WaveActiveSum(half4);
+
+#ifdef __HLSL_ENABLE_16_BIT
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int16_t WaveActiveSum(int16_t);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int16_t2 WaveActiveSum(int16_t2);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int16_t3 WaveActiveSum(int16_t3);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int16_t4 WaveActiveSum(int16_t4);
+
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint16_t WaveActiveSum(uint16_t);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint16_t2 WaveActiveSum(uint16_t2);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint16_t3 WaveActiveSum(uint16_t3);
+_HLSL_AVAILABILITY(shadermodel, 6.0)
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint16_t4 WaveActiveSum(uint16_t4);
+#endif
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int WaveActiveSum(int);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int2 WaveActiveSum(int2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int3 WaveActiveSum(int3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int4 WaveActiveSum(int4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint WaveActiveSum(uint);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint2 WaveActiveSum(uint2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint3 WaveActiveSum(uint3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint4 WaveActiveSum(uint4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int64_t WaveActiveSum(int64_t);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int64_t2 WaveActiveSum(int64_t2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int64_t3 WaveActiveSum(int64_t3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) int64_t4 WaveActiveSum(int64_t4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint64_t WaveActiveSum(uint64_t);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint64_t2 WaveActiveSum(uint64_t2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint64_t3 WaveActiveSum(uint64_t3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) uint64_t4 WaveActiveSum(uint64_t4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) float WaveActiveSum(float);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) float2 WaveActiveSum(float2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) float3 WaveActiveSum(float3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) float4 WaveActiveSum(float4);
+
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) double WaveActiveSum(double);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) double2 WaveActiveSum(double2);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) double3 WaveActiveSum(double3);
+_HLSL_BUILTIN_ALIAS(__builtin_hlsl_wave_active_sum)
+__attribute((convergent)) double4 WaveActiveSum(double4);
+
+//===----------------------------------------------------------------------===//
 // sign builtins
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1865,10 +1865,10 @@ static bool CheckAnyScalarOrVector(Sema *S, CallExpr *TheCall,
   return false;
 }
 
-static bool CheckNotBoolType(Sema *S, CallExpr *TheCall, unsigned ArgIndex) {
+static bool CheckWaveActive(Sema *S, CallExpr *TheCall) {
   QualType BoolType = S->getASTContext().BoolTy;
-  assert(TheCall->getNumArgs() >= ArgIndex);
-  QualType ArgType = TheCall->getArg(ArgIndex)->getType();
+  assert(TheCall->getNumArgs() >= 1);
+  QualType ArgType = TheCall->getArg(0)->getType();
   auto *VTy = ArgType->getAs<VectorType>();
   // is the bool or vector<bool>
   if (S->Context.hasSameUnqualifiedType(ArgType, BoolType) ||
@@ -2179,7 +2179,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     // Ensure input expr type is a scalar/vector and the same as the return type
     if (CheckAnyScalarOrVector(&SemaRef, TheCall, 0))
       return true;
-    if (CheckNotBoolType(&SemaRef, TheCall, 0))
+    if (CheckWaveActive(&SemaRef, TheCall))
       return true;
     ExprResult Expr = TheCall->getArg(0);
     QualType ArgTyExpr = Expr.get()->getType();

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1865,18 +1865,18 @@ static bool CheckAnyScalarOrVector(Sema *S, CallExpr *TheCall,
   return false;
 }
 
-static bool CheckNotScalarType(Sema *S, CallExpr *TheCall, QualType Scalar,
-                               unsigned ArgIndex) {
+static bool CheckNotBoolType(Sema *S, CallExpr *TheCall, unsigned ArgIndex) {
+  QualType BoolType = S->getASTContext().BoolTy;
   assert(TheCall->getNumArgs() >= ArgIndex);
   QualType ArgType = TheCall->getArg(ArgIndex)->getType();
   auto *VTy = ArgType->getAs<VectorType>();
-  // is the scalar or vector<scalar>
-  if (S->Context.hasSameUnqualifiedType(ArgType, Scalar) ||
+  // is the bool or vector<bool>
+  if (S->Context.hasSameUnqualifiedType(ArgType, BoolType) ||
       (VTy &&
-       S->Context.hasSameUnqualifiedType(VTy->getElementType(), Scalar))) {
+       S->Context.hasSameUnqualifiedType(VTy->getElementType(), BoolType))) {
     S->Diag(TheCall->getArg(0)->getBeginLoc(),
             diag::err_typecheck_expect_scalar_or_vector_not_type)
-        << ArgType << Scalar;
+        << ArgType << BoolType;
     return true;
   }
   return false;
@@ -2179,7 +2179,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     // Ensure input expr type is a scalar/vector and the same as the return type
     if (CheckAnyScalarOrVector(&SemaRef, TheCall, 0))
       return true;
-    if (CheckNotScalarType(&SemaRef, TheCall, getASTContext().BoolTy, 0))
+    if (CheckNotBoolType(&SemaRef, TheCall, 0))
       return true;
     ExprResult Expr = TheCall->getArg(0);
     QualType ArgTyExpr = Expr.get()->getType();

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1865,6 +1865,23 @@ static bool CheckAnyScalarOrVector(Sema *S, CallExpr *TheCall,
   return false;
 }
 
+static bool CheckNotScalarType(Sema *S, CallExpr *TheCall, QualType Scalar,
+                               unsigned ArgIndex) {
+  assert(TheCall->getNumArgs() >= ArgIndex);
+  QualType ArgType = TheCall->getArg(ArgIndex)->getType();
+  auto *VTy = ArgType->getAs<VectorType>();
+  // is the scalar or vector<scalar>
+  if (S->Context.hasSameUnqualifiedType(ArgType, Scalar) ||
+      (VTy &&
+       S->Context.hasSameUnqualifiedType(VTy->getElementType(), Scalar))) {
+    S->Diag(TheCall->getArg(0)->getBeginLoc(),
+            diag::err_typecheck_expect_scalar_or_vector_not_type)
+        << ArgType << Scalar;
+    return true;
+  }
+  return false;
+}
+
 static bool CheckBoolSelect(Sema *S, CallExpr *TheCall) {
   assert(TheCall->getNumArgs() == 3);
   Expr *Arg1 = TheCall->getArg(1);
@@ -2153,6 +2170,20 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     QualType ArgTyA = A.get()->getType();
     // return type is the same as the input type
     TheCall->setType(ArgTyA);
+    break;
+  }
+  case Builtin::BI__builtin_hlsl_wave_active_sum: {
+    if (SemaRef.checkArgCount(TheCall, 1))
+      return true;
+
+    // Ensure input expr type is a scalar/vector and the same as the return type
+    if (CheckAnyScalarOrVector(&SemaRef, TheCall, 0))
+      return true;
+    if (CheckNotScalarType(&SemaRef, TheCall, getASTContext().BoolTy, 0))
+      return true;
+    ExprResult Expr = TheCall->getArg(0);
+    QualType ArgTyExpr = Expr.get()->getType();
+    TheCall->setType(ArgTyExpr);
     break;
   }
   // Note these are llvm builtins that we want to catch invalid intrinsic

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1859,7 +1859,7 @@ static bool CheckAnyScalarOrVector(Sema *S, CallExpr *TheCall,
         (VTy && VTy->getElementType()->isScalarType()))) {
     S->Diag(TheCall->getArg(0)->getBeginLoc(),
             diag::err_typecheck_expect_any_scalar_or_vector)
-        << ArgType;
+        << ArgType << 1;
     return true;
   }
   return false;
@@ -1875,8 +1875,8 @@ static bool CheckWaveActive(Sema *S, CallExpr *TheCall) {
       (VTy &&
        S->Context.hasSameUnqualifiedType(VTy->getElementType(), BoolType))) {
     S->Diag(TheCall->getArg(0)->getBeginLoc(),
-            diag::err_typecheck_expect_scalar_or_vector_not_type)
-        << ArgType << BoolType;
+            diag::err_typecheck_expect_any_scalar_or_vector)
+        << ArgType << 0;
     return true;
   }
   return false;

--- a/clang/test/CodeGenHLSL/builtins/WaveActiveSum.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/WaveActiveSum.hlsl
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   dxil-pc-shadermodel6.3-compute %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -triple \
+// RUN:   spirv-pc-vulkan-compute %s -emit-llvm -disable-llvm-passes -o - | \
+// RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-SPIRV
+
+// Test basic lowering to runtime function call.
+
+// CHECK-LABEL: test_int
+int test_int(int expr) {
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.active.sum.i32([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.active.sum.i32([[TY]] %[[#]])
+  // CHECK:  ret [[TY]] %[[RET]]
+  return WaveActiveSum(expr);
+}
+
+// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.active.sum.i32([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare spir_func [[TY]] @llvm.spv.wave.active.sum.i32([[TY]]) #[[#attr:]]
+
+// CHECK-LABEL: test_uint64_t
+uint64_t test_uint64_t(uint64_t expr) {
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.active.sum.i64([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.active.usum.i64([[TY]] %[[#]])
+  // CHECK:  ret [[TY]] %[[RET]]
+  return WaveActiveSum(expr);
+}
+
+// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.active.usum.i64([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare spir_func [[TY]] @llvm.spv.wave.active.sum.i64([[TY]]) #[[#attr:]]
+
+// Test basic lowering to runtime function call with array and float value.
+
+// CHECK-LABEL: test_floatv4
+float4 test_floatv4(float4 expr) {
+  // CHECK-SPIRV:  %[[RET1:.*]] = call spir_func [[TY1:.*]] @llvm.spv.wave.active.sum.v4f32([[TY1]] %[[#]]
+  // CHECK-DXIL:  %[[RET1:.*]] = call [[TY1:.*]] @llvm.dx.wave.active.sum.v4f32([[TY1]] %[[#]])
+  // CHECK:  ret [[TY1]] %[[RET1]]
+  return WaveActiveSum(expr);
+}
+
+// CHECK-DXIL: declare [[TY1]] @llvm.dx.wave.active.sum.v4f32([[TY1]]) #[[#attr]]
+// CHECK-SPIRV: declare spir_func [[TY1]] @llvm.spv.wave.active.sum.v4f32([[TY1]]) #[[#attr]]
+
+// CHECK: attributes #[[#attr]] = {{{.*}} convergent {{.*}}}

--- a/clang/test/CodeGenHLSL/builtins/WaveActiveSum.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/WaveActiveSum.hlsl
@@ -9,37 +9,37 @@
 
 // CHECK-LABEL: test_int
 int test_int(int expr) {
-  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.active.sum.i32([[TY]] %[[#]])
-  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.active.sum.i32([[TY]] %[[#]])
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.reduce.sum.i32([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.reduce.sum.i32([[TY]] %[[#]])
   // CHECK:  ret [[TY]] %[[RET]]
   return WaveActiveSum(expr);
 }
 
-// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.active.sum.i32([[TY]]) #[[#attr:]]
-// CHECK-SPIRV: declare spir_func [[TY]] @llvm.spv.wave.active.sum.i32([[TY]]) #[[#attr:]]
+// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.reduce.sum.i32([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare spir_func [[TY]] @llvm.spv.wave.reduce.sum.i32([[TY]]) #[[#attr:]]
 
 // CHECK-LABEL: test_uint64_t
 uint64_t test_uint64_t(uint64_t expr) {
-  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.active.sum.i64([[TY]] %[[#]])
-  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.active.usum.i64([[TY]] %[[#]])
+  // CHECK-SPIRV:  %[[RET:.*]] = call spir_func [[TY:.*]] @llvm.spv.wave.reduce.sum.i64([[TY]] %[[#]])
+  // CHECK-DXIL:  %[[RET:.*]] = call [[TY:.*]] @llvm.dx.wave.reduce.usum.i64([[TY]] %[[#]])
   // CHECK:  ret [[TY]] %[[RET]]
   return WaveActiveSum(expr);
 }
 
-// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.active.usum.i64([[TY]]) #[[#attr:]]
-// CHECK-SPIRV: declare spir_func [[TY]] @llvm.spv.wave.active.sum.i64([[TY]]) #[[#attr:]]
+// CHECK-DXIL: declare [[TY]] @llvm.dx.wave.reduce.usum.i64([[TY]]) #[[#attr:]]
+// CHECK-SPIRV: declare spir_func [[TY]] @llvm.spv.wave.reduce.sum.i64([[TY]]) #[[#attr:]]
 
 // Test basic lowering to runtime function call with array and float value.
 
 // CHECK-LABEL: test_floatv4
 float4 test_floatv4(float4 expr) {
-  // CHECK-SPIRV:  %[[RET1:.*]] = call spir_func [[TY1:.*]] @llvm.spv.wave.active.sum.v4f32([[TY1]] %[[#]]
-  // CHECK-DXIL:  %[[RET1:.*]] = call [[TY1:.*]] @llvm.dx.wave.active.sum.v4f32([[TY1]] %[[#]])
+  // CHECK-SPIRV:  %[[RET1:.*]] = call spir_func [[TY1:.*]] @llvm.spv.wave.reduce.sum.v4f32([[TY1]] %[[#]]
+  // CHECK-DXIL:  %[[RET1:.*]] = call [[TY1:.*]] @llvm.dx.wave.reduce.sum.v4f32([[TY1]] %[[#]])
   // CHECK:  ret [[TY1]] %[[RET1]]
   return WaveActiveSum(expr);
 }
 
-// CHECK-DXIL: declare [[TY1]] @llvm.dx.wave.active.sum.v4f32([[TY1]]) #[[#attr]]
-// CHECK-SPIRV: declare spir_func [[TY1]] @llvm.spv.wave.active.sum.v4f32([[TY1]]) #[[#attr]]
+// CHECK-DXIL: declare [[TY1]] @llvm.dx.wave.reduce.sum.v4f32([[TY1]]) #[[#attr]]
+// CHECK-SPIRV: declare spir_func [[TY1]] @llvm.spv.wave.reduce.sum.v4f32([[TY1]]) #[[#attr]]
 
 // CHECK: attributes #[[#attr]] = {{{.*}} convergent {{.*}}}

--- a/clang/test/CodeGenHLSL/builtins/WaveActiveSum.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/WaveActiveSum.hlsl
@@ -33,8 +33,8 @@ uint64_t test_uint64_t(uint64_t expr) {
 
 // CHECK-LABEL: test_floatv4
 float4 test_floatv4(float4 expr) {
-  // CHECK-SPIRV:  %[[RET1:.*]] = call spir_func [[TY1:.*]] @llvm.spv.wave.reduce.sum.v4f32([[TY1]] %[[#]]
-  // CHECK-DXIL:  %[[RET1:.*]] = call [[TY1:.*]] @llvm.dx.wave.reduce.sum.v4f32([[TY1]] %[[#]])
+  // CHECK-SPIRV:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn spir_func [[TY1:.*]] @llvm.spv.wave.reduce.sum.v4f32([[TY1]] %[[#]]
+  // CHECK-DXIL:  %[[RET1:.*]] = call reassoc nnan ninf nsz arcp afn [[TY1:.*]] @llvm.dx.wave.reduce.sum.v4f32([[TY1]] %[[#]])
   // CHECK:  ret [[TY1]] %[[RET1]]
   return WaveActiveSum(expr);
 }

--- a/clang/test/SemaHLSL/BuiltIns/WaveActiveSum-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/WaveActiveSum-errors.hlsl
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -emit-llvm-only -disable-llvm-passes -verify
+
+int test_too_few_arg() {
+  return __builtin_hlsl_wave_active_sum();
+  // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
+}
+
+float2 test_too_many_arg(float2 p0) {
+  return __builtin_hlsl_wave_active_sum(p0, p0);
+  // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
+}
+
+bool test_expr_bool_type_check(bool p0) {
+  return __builtin_hlsl_wave_active_sum(p0);
+  // expected-error@-1 {{invalid operand of type 'bool' where 'bool' or a vector of such type is not allowed}}
+}
+
+bool2 test_expr_bool_vec_type_check(bool2 p0) {
+  return __builtin_hlsl_wave_active_sum(p0);
+  // expected-error@-1 {{invalid operand of type 'bool2' (aka 'vector<bool, 2>') where 'bool' or a vector of such type is not allowed}}
+}
+
+struct S { float f; };
+
+S test_expr_struct_type_check(S p0) {
+  return __builtin_hlsl_wave_active_sum(p0);
+  // expected-error@-1 {{invalid operand of type 'S' where a scalar or vector is required}}
+}

--- a/clang/test/SemaHLSL/BuiltIns/WaveActiveSum-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/WaveActiveSum-errors.hlsl
@@ -12,12 +12,12 @@ float2 test_too_many_arg(float2 p0) {
 
 bool test_expr_bool_type_check(bool p0) {
   return __builtin_hlsl_wave_active_sum(p0);
-  // expected-error@-1 {{invalid operand of type 'bool' where 'bool' or a vector of such type is not allowed}}
+  // expected-error@-1 {{invalid operand of type 'bool'}}
 }
 
 bool2 test_expr_bool_vec_type_check(bool2 p0) {
   return __builtin_hlsl_wave_active_sum(p0);
-  // expected-error@-1 {{invalid operand of type 'bool2' (aka 'vector<bool, 2>') where 'bool' or a vector of such type is not allowed}}
+  // expected-error@-1 {{invalid operand of type 'bool2' (aka 'vector<bool, 2>')}}
 }
 
 struct S { float f; };

--- a/llvm/include/llvm/IR/IntrinsicsDirectX.td
+++ b/llvm/include/llvm/IR/IntrinsicsDirectX.td
@@ -105,8 +105,8 @@ def int_dx_wave_active_countbits : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i1
 def int_dx_wave_all : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_any : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_getlaneindex : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrConvergent, IntrNoMem]>;
-def int_dx_wave_active_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
-def int_dx_wave_active_usum : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+def int_dx_wave_reduce_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+def int_dx_wave_reduce_usum : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_is_first_lane : DefaultAttrsIntrinsic<[llvm_i1_ty], [], [IntrConvergent]>;
 def int_dx_wave_readlane : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>, llvm_i32_ty], [IntrConvergent, IntrNoMem]>;
 def int_dx_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;

--- a/llvm/include/llvm/IR/IntrinsicsDirectX.td
+++ b/llvm/include/llvm/IR/IntrinsicsDirectX.td
@@ -105,6 +105,8 @@ def int_dx_wave_active_countbits : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i1
 def int_dx_wave_all : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_any : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_getlaneindex : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrConvergent, IntrNoMem]>;
+def int_dx_wave_active_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+def int_dx_wave_active_usum : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
 def int_dx_wave_is_first_lane : DefaultAttrsIntrinsic<[llvm_i1_ty], [], [IntrConvergent]>;
 def int_dx_wave_readlane : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>, llvm_i32_ty], [IntrConvergent, IntrNoMem]>;
 def int_dx_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -91,7 +91,7 @@ let TargetPrefix = "spv" in {
   def int_spv_wave_active_countbits : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_all : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_any : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
-  def int_spv_wave_active_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
+  def int_spv_wave_reduce_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_is_first_lane : DefaultAttrsIntrinsic<[llvm_i1_ty], [], [IntrConvergent]>;
   def int_spv_wave_readlane : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>, llvm_i32_ty], [IntrConvergent, IntrNoMem]>;
   def int_spv_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;

--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -91,6 +91,7 @@ let TargetPrefix = "spv" in {
   def int_spv_wave_active_countbits : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_all : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_any : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i1_ty], [IntrConvergent, IntrNoMem]>;
+  def int_spv_wave_active_sum : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>], [IntrConvergent, IntrNoMem]>;
   def int_spv_wave_is_first_lane : DefaultAttrsIntrinsic<[llvm_i1_ty], [], [IntrConvergent]>;
   def int_spv_wave_readlane : DefaultAttrsIntrinsic<[llvm_any_ty], [LLVMMatchType<0>, llvm_i32_ty], [IntrConvergent, IntrNoMem]>;
   def int_spv_sign : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i32_ty>], [llvm_any_ty], [IntrNoMem]>;

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -348,7 +348,7 @@ class IntrinArgI32  <int value> : IntrinArgSelect<IntrinArgSelect_I32,   value>;
 //     IntrinSelect<int_dx_wave_active_usum,
 //       [ IntrinArgIndex<0>, IntrinArgI8<0>, IntrinArgI8<1> ]
 //     >,
-//     IntrinSelect<int_dx_wave_active_sum,
+//     IntrinSelect<int_dx_wave_reduce_sum,
 //       [ IntrinArgIndex<0>, IntrinArgI8<0>, IntrinArgI8<0> ]
 //     >,
 //   ]
@@ -991,10 +991,10 @@ def WaveActiveOp : DXILOp<119, waveActiveOp> {
   let Doc = "returns the result of the operation across waves";
   let intrinsics = [
     IntrinSelect<
-        int_dx_wave_active_sum,
+        int_dx_wave_reduce_sum,
         [ IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Sum>, IntrinArgI8<SignedOpKind_Signed> ]>,
     IntrinSelect<
-        int_dx_wave_active_usum,
+        int_dx_wave_reduce_usum,
         [ IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Sum>, IntrinArgI8<SignedOpKind_Unsigned> ]>,
   ];
 

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -303,6 +303,14 @@ defvar BarrierMode_GroupMemoryBarrierWithGroupSync  = 9;
 defvar BarrierMode_AllMemoryBarrier                 = 10;
 defvar BarrierMode_AllMemoryBarrierWithGroupSync    = 11;
 
+defvar WaveOpKind_Sum     = 0;
+defvar WaveOpKind_Product = 1;
+defvar WaveOpKind_Min     = 2;
+defvar WaveOpKind_Max     = 3;
+
+defvar SignedOpKind_Signed   = 0;
+defvar SignedOpKind_Unsigned = 1;
+
 // Intrinsic arg selection
 class IntrinArgSelectType;
 def IntrinArgSelect_Index : IntrinArgSelectType;
@@ -977,6 +985,24 @@ def WaveActiveAnyTrue : DXILOp<113, waveAnyTrue> {
   let arguments = [Int1Ty];
   let result = Int1Ty;
   let stages = [Stages<DXIL1_0, [all_stages]>];
+}
+
+def WaveActiveOp : DXILOp<119, waveActiveOp> {
+  let Doc = "returns the result of the operation across waves";
+  let intrinsics = [
+    IntrinSelect<
+        int_dx_wave_active_sum,
+        [ IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Sum>, IntrinArgI8<SignedOpKind_Signed> ]>,
+    IntrinSelect<
+        int_dx_wave_active_usum,
+        [ IntrinArgIndex<0>, IntrinArgI8<WaveOpKind_Sum>, IntrinArgI8<SignedOpKind_Unsigned> ]>,
+  ];
+
+  let arguments = [OverloadTy, Int8Ty, Int8Ty];
+  let result = OverloadTy;
+  let overloads = [Overloads<DXIL1_0, [HalfTy, FloatTy, DoubleTy, Int16Ty, Int32Ty, Int64Ty]>];
+  let stages = [Stages<DXIL1_0, [all_stages]>];
+  let attributes = [Attributes<DXIL1_0, [ReadNone]>];
 }
 
 def WaveIsFirstLane :  DXILOp<110, waveIsFirstLane> {

--- a/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
@@ -40,6 +40,8 @@ bool DirectXTTIImpl::isTargetIntrinsicTriviallyScalarizable(
   switch (ID) {
   case Intrinsic::dx_frac:
   case Intrinsic::dx_rsqrt:
+  case Intrinsic::dx_wave_active_sum:
+  case Intrinsic::dx_wave_active_usum:
   case Intrinsic::dx_wave_readlane:
   case Intrinsic::dx_asdouble:
   case Intrinsic::dx_splitdouble:

--- a/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
@@ -40,8 +40,8 @@ bool DirectXTTIImpl::isTargetIntrinsicTriviallyScalarizable(
   switch (ID) {
   case Intrinsic::dx_frac:
   case Intrinsic::dx_rsqrt:
-  case Intrinsic::dx_wave_active_sum:
-  case Intrinsic::dx_wave_active_usum:
+  case Intrinsic::dx_wave_reduce_sum:
+  case Intrinsic::dx_wave_reduce_usum:
   case Intrinsic::dx_wave_readlane:
   case Intrinsic::dx_asdouble:
   case Intrinsic::dx_splitdouble:

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -205,6 +205,9 @@ private:
   bool selectDot4AddPackedExpansion(Register ResVReg, const SPIRVType *ResType,
                                     MachineInstr &I) const;
 
+  bool selectWaveActiveSum(Register ResVReg, const SPIRVType *ResType,
+                           MachineInstr &I) const;
+
   void renderImm32(MachineInstrBuilder &MIB, const MachineInstr &I,
                    int OpIdx) const;
   void renderFImm64(MachineInstrBuilder &MIB, const MachineInstr &I,
@@ -2071,6 +2074,31 @@ bool SPIRVInstructionSelector::selectWaveActiveCountBits(
   return Result;
 }
 
+bool SPIRVInstructionSelector::selectWaveActiveSum(Register ResVReg,
+                                                   const SPIRVType *ResType,
+                                                   MachineInstr &I) const {
+  assert(I.getNumOperands() == 3);
+  assert(I.getOperand(2).isReg());
+  MachineBasicBlock &BB = *I.getParent();
+  Register InputRegister = I.getOperand(2).getReg();
+  SPIRVType *InputType = GR.getSPIRVTypeForVReg(InputRegister);
+
+  if (!InputType)
+    report_fatal_error("Input Type could not be determined.");
+
+  SPIRVType *IntTy = GR.getOrCreateSPIRVIntegerType(32, I, TII);
+  // Retreive the operation to use based on input type
+  bool IsFloatTy = GR.isScalarOrVectorOfType(InputRegister, SPIRV::OpTypeFloat);
+  auto Opcode =
+      IsFloatTy ? SPIRV::OpGroupNonUniformFAdd : SPIRV::OpGroupNonUniformIAdd;
+  return BuildMI(BB, I, I.getDebugLoc(), TII.get(Opcode))
+      .addDef(ResVReg)
+      .addUse(GR.getSPIRVTypeID(ResType))
+      .addUse(GR.getOrCreateConstInt(SPIRV::Scope::Subgroup, I, IntTy, TII))
+      .addImm(SPIRV::GroupOperation::Reduce)
+      .addUse(I.getOperand(2).getReg());
+}
+
 bool SPIRVInstructionSelector::selectBitreverse(Register ResVReg,
                                                 const SPIRVType *ResType,
                                                 MachineInstr &I) const {
@@ -2998,6 +3026,8 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
     return selectWaveOpInst(ResVReg, ResType, I, SPIRV::OpGroupNonUniformAny);
   case Intrinsic::spv_wave_is_first_lane:
     return selectWaveOpInst(ResVReg, ResType, I, SPIRV::OpGroupNonUniformElect);
+  case Intrinsic::spv_wave_active_sum:
+    return selectWaveActiveSum(ResVReg, ResType, I);
   case Intrinsic::spv_wave_readlane:
     return selectWaveOpInst(ResVReg, ResType, I,
                             SPIRV::OpGroupNonUniformShuffle);

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -205,7 +205,7 @@ private:
   bool selectDot4AddPackedExpansion(Register ResVReg, const SPIRVType *ResType,
                                     MachineInstr &I) const;
 
-  bool selectWaveActiveSum(Register ResVReg, const SPIRVType *ResType,
+  bool selectWaveReduceSum(Register ResVReg, const SPIRVType *ResType,
                            MachineInstr &I) const;
 
   void renderImm32(MachineInstrBuilder &MIB, const MachineInstr &I,
@@ -2074,7 +2074,7 @@ bool SPIRVInstructionSelector::selectWaveActiveCountBits(
   return Result;
 }
 
-bool SPIRVInstructionSelector::selectWaveActiveSum(Register ResVReg,
+bool SPIRVInstructionSelector::selectWaveReduceSum(Register ResVReg,
                                                    const SPIRVType *ResType,
                                                    MachineInstr &I) const {
   assert(I.getNumOperands() == 3);
@@ -3026,8 +3026,8 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
     return selectWaveOpInst(ResVReg, ResType, I, SPIRV::OpGroupNonUniformAny);
   case Intrinsic::spv_wave_is_first_lane:
     return selectWaveOpInst(ResVReg, ResType, I, SPIRV::OpGroupNonUniformElect);
-  case Intrinsic::spv_wave_active_sum:
-    return selectWaveActiveSum(ResVReg, ResType, I);
+  case Intrinsic::spv_wave_reduce_sum:
+    return selectWaveReduceSum(ResVReg, ResType, I);
   case Intrinsic::spv_wave_readlane:
     return selectWaveOpInst(ResVReg, ResType, I,
                             SPIRV::OpGroupNonUniformShuffle);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1352,9 +1352,7 @@ void addInstrRequirements(const MachineInstr &MI,
     case SPIRV::GroupOperation::Reduce:
     case SPIRV::GroupOperation::InclusiveScan:
     case SPIRV::GroupOperation::ExclusiveScan:
-      Reqs.addCapability(SPIRV::Capability::Kernel);
       Reqs.addCapability(SPIRV::Capability::GroupNonUniformArithmetic);
-      Reqs.addCapability(SPIRV::Capability::GroupNonUniformBallot);
       break;
     case SPIRV::GroupOperation::ClusteredReduce:
       Reqs.addCapability(SPIRV::Capability::GroupNonUniformClustered);

--- a/llvm/test/CodeGen/DirectX/WaveActiveSum.ll
+++ b/llvm/test/CodeGen/DirectX/WaveActiveSum.ll
@@ -1,0 +1,143 @@
+; RUN: opt -S -scalarizer -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library < %s | FileCheck %s
+
+; Test that for scalar values, WaveActiveSum maps down to the DirectX op
+
+define noundef half @wave_active_sum_half(half noundef %expr) {
+entry:
+; CHECK: call half @dx.op.waveActiveOp.f16(i32 119, half %expr, i8 0, i8 0)
+  %ret = call half @llvm.dx.wave.active.sum.f16(half %expr)
+  ret half %ret
+}
+
+define noundef float @wave_active_sum_float(float noundef %expr) {
+entry:
+; CHECK: call float @dx.op.waveActiveOp.f32(i32 119, float %expr, i8 0, i8 0)
+  %ret = call float @llvm.dx.wave.active.sum.f32(float %expr)
+  ret float %ret
+}
+
+define noundef double @wave_active_sum_double(double noundef %expr) {
+entry:
+; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr, i8 0, i8 0)
+  %ret = call double @llvm.dx.wave.active.sum.f64(double %expr)
+  ret double %ret
+}
+
+define noundef i16 @wave_active_sum_i16(i16 noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr, i8 0, i8 0)
+  %ret = call i16 @llvm.dx.wave.active.sum.i16(i16 %expr)
+  ret i16 %ret
+}
+
+define noundef i32 @wave_active_sum_i32(i32 noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr, i8 0, i8 0)
+  %ret = call i32 @llvm.dx.wave.active.sum.i32(i32 %expr)
+  ret i32 %ret
+}
+
+define noundef i64 @wave_active_sum_i64(i64 noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr, i8 0, i8 0)
+  %ret = call i64 @llvm.dx.wave.active.sum.i64(i64 %expr)
+  ret i64 %ret
+}
+
+define noundef i16 @wave_active_usum_i16(i16 noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr, i8 0, i8 1)
+  %ret = call i16 @llvm.dx.wave.active.usum.i16(i16 %expr)
+  ret i16 %ret
+}
+
+define noundef i32 @wave_active_usum_i32(i32 noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr, i8 0, i8 1)
+  %ret = call i32 @llvm.dx.wave.active.usum.i32(i32 %expr)
+  ret i32 %ret
+}
+
+define noundef i64 @wave_active_usum_i64(i64 noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr, i8 0, i8 1)
+  %ret = call i64 @llvm.dx.wave.active.usum.i64(i64 %expr)
+  ret i64 %ret
+}
+
+declare half @llvm.dx.wave.active.sum.f16(half)
+declare float @llvm.dx.wave.active.sum.f32(float)
+declare double @llvm.dx.wave.active.sum.f64(double)
+
+declare i16 @llvm.dx.wave.active.sum.i16(i16)
+declare i32 @llvm.dx.wave.active.sum.i32(i32)
+declare i64 @llvm.dx.wave.active.sum.i64(i64)
+
+declare i16 @llvm.dx.wave.active.usum.i16(i16)
+declare i32 @llvm.dx.wave.active.usum.i32(i32)
+declare i64 @llvm.dx.wave.active.usum.i64(i64)
+
+; Test that for vector values, WaveActiveSum scalarizes and maps down to the
+; DirectX op
+
+define noundef <2 x half> @wave_active_sum_v2half(<2 x half> noundef %expr) {
+entry:
+; CHECK: call half @dx.op.waveActiveOp.f16(i32 119, half %expr.i0, i8 0, i8 0)
+; CHECK: call half @dx.op.waveActiveOp.f16(i32 119, half %expr.i1, i8 0, i8 0)
+  %ret = call <2 x half> @llvm.dx.wave.active.sum.v2f16(<2 x half> %expr)
+  ret <2 x half> %ret
+}
+
+define noundef <3 x i32> @wave_active_sum_v3i32(<3 x i32> noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i0, i8 0, i8 0)
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i1, i8 0, i8 0)
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i2, i8 0, i8 0)
+  %ret = call <3 x i32> @llvm.dx.wave.active.sum.v3i32(<3 x i32> %expr)
+  ret <3 x i32> %ret
+}
+
+define noundef <4 x double> @wave_active_sum_v4f64(<4 x double> noundef %expr) {
+entry:
+; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i0, i8 0, i8 0)
+; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i1, i8 0, i8 0)
+; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i2, i8 0, i8 0)
+; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i3, i8 0, i8 0)
+  %ret = call <4 x double> @llvm.dx.wave.active.sum.v464(<4 x double> %expr)
+  ret <4 x double> %ret
+}
+
+declare <2 x half> @llvm.dx.wave.active.sum.v2f16(<2 x half>)
+declare <3 x i32> @llvm.dx.wave.active.sum.v3i32(<3 x i32>)
+declare <4 x double> @llvm.dx.wave.active.sum.v4f64(<4 x double>)
+
+define noundef <2 x i16> @wave_active_usum_v2i16(<2 x i16> noundef %expr) {
+entry:
+; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr.i0, i8 0, i8 1)
+; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr.i1, i8 0, i8 1)
+  %ret = call <2 x i16> @llvm.dx.wave.active.usum.v2f16(<2 x i16> %expr)
+  ret <2 x i16> %ret
+}
+
+define noundef <3 x i32> @wave_active_usum_v3i32(<3 x i32> noundef %expr) {
+entry:
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i0, i8 0, i8 1)
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i1, i8 0, i8 1)
+; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i2, i8 0, i8 1)
+  %ret = call <3 x i32> @llvm.dx.wave.active.usum.v3i32(<3 x i32> %expr)
+  ret <3 x i32> %ret
+}
+
+define noundef <4 x i64> @wave_active_usum_v4f64(<4 x i64> noundef %expr) {
+entry:
+; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i0, i8 0, i8 1)
+; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i1, i8 0, i8 1)
+; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i2, i8 0, i8 1)
+; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i3, i8 0, i8 1)
+  %ret = call <4 x i64> @llvm.dx.wave.active.usum.v464(<4 x i64> %expr)
+  ret <4 x i64> %ret
+}
+
+declare <2 x i16> @llvm.dx.wave.active.usum.v2f16(<2 x i16>)
+declare <3 x i32> @llvm.dx.wave.active.usum.v3i32(<3 x i32>)
+declare <4 x i64> @llvm.dx.wave.active.usum.v4f64(<4 x i64>)

--- a/llvm/test/CodeGen/DirectX/WaveActiveSum.ll
+++ b/llvm/test/CodeGen/DirectX/WaveActiveSum.ll
@@ -5,77 +5,77 @@
 define noundef half @wave_active_sum_half(half noundef %expr) {
 entry:
 ; CHECK: call half @dx.op.waveActiveOp.f16(i32 119, half %expr, i8 0, i8 0)
-  %ret = call half @llvm.dx.wave.active.sum.f16(half %expr)
+  %ret = call half @llvm.dx.wave.reduce.sum.f16(half %expr)
   ret half %ret
 }
 
 define noundef float @wave_active_sum_float(float noundef %expr) {
 entry:
 ; CHECK: call float @dx.op.waveActiveOp.f32(i32 119, float %expr, i8 0, i8 0)
-  %ret = call float @llvm.dx.wave.active.sum.f32(float %expr)
+  %ret = call float @llvm.dx.wave.reduce.sum.f32(float %expr)
   ret float %ret
 }
 
 define noundef double @wave_active_sum_double(double noundef %expr) {
 entry:
 ; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr, i8 0, i8 0)
-  %ret = call double @llvm.dx.wave.active.sum.f64(double %expr)
+  %ret = call double @llvm.dx.wave.reduce.sum.f64(double %expr)
   ret double %ret
 }
 
 define noundef i16 @wave_active_sum_i16(i16 noundef %expr) {
 entry:
 ; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr, i8 0, i8 0)
-  %ret = call i16 @llvm.dx.wave.active.sum.i16(i16 %expr)
+  %ret = call i16 @llvm.dx.wave.reduce.sum.i16(i16 %expr)
   ret i16 %ret
 }
 
 define noundef i32 @wave_active_sum_i32(i32 noundef %expr) {
 entry:
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr, i8 0, i8 0)
-  %ret = call i32 @llvm.dx.wave.active.sum.i32(i32 %expr)
+  %ret = call i32 @llvm.dx.wave.reduce.sum.i32(i32 %expr)
   ret i32 %ret
 }
 
 define noundef i64 @wave_active_sum_i64(i64 noundef %expr) {
 entry:
 ; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr, i8 0, i8 0)
-  %ret = call i64 @llvm.dx.wave.active.sum.i64(i64 %expr)
+  %ret = call i64 @llvm.dx.wave.reduce.sum.i64(i64 %expr)
   ret i64 %ret
 }
 
 define noundef i16 @wave_active_usum_i16(i16 noundef %expr) {
 entry:
 ; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr, i8 0, i8 1)
-  %ret = call i16 @llvm.dx.wave.active.usum.i16(i16 %expr)
+  %ret = call i16 @llvm.dx.wave.reduce.usum.i16(i16 %expr)
   ret i16 %ret
 }
 
 define noundef i32 @wave_active_usum_i32(i32 noundef %expr) {
 entry:
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr, i8 0, i8 1)
-  %ret = call i32 @llvm.dx.wave.active.usum.i32(i32 %expr)
+  %ret = call i32 @llvm.dx.wave.reduce.usum.i32(i32 %expr)
   ret i32 %ret
 }
 
 define noundef i64 @wave_active_usum_i64(i64 noundef %expr) {
 entry:
 ; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr, i8 0, i8 1)
-  %ret = call i64 @llvm.dx.wave.active.usum.i64(i64 %expr)
+  %ret = call i64 @llvm.dx.wave.reduce.usum.i64(i64 %expr)
   ret i64 %ret
 }
 
-declare half @llvm.dx.wave.active.sum.f16(half)
-declare float @llvm.dx.wave.active.sum.f32(float)
-declare double @llvm.dx.wave.active.sum.f64(double)
+declare half @llvm.dx.wave.reduce.sum.f16(half)
+declare float @llvm.dx.wave.reduce.sum.f32(float)
+declare double @llvm.dx.wave.reduce.sum.f64(double)
 
-declare i16 @llvm.dx.wave.active.sum.i16(i16)
-declare i32 @llvm.dx.wave.active.sum.i32(i32)
-declare i64 @llvm.dx.wave.active.sum.i64(i64)
+declare i16 @llvm.dx.wave.reduce.sum.i16(i16)
+declare i32 @llvm.dx.wave.reduce.sum.i32(i32)
+declare i64 @llvm.dx.wave.reduce.sum.i64(i64)
 
-declare i16 @llvm.dx.wave.active.usum.i16(i16)
-declare i32 @llvm.dx.wave.active.usum.i32(i32)
-declare i64 @llvm.dx.wave.active.usum.i64(i64)
+declare i16 @llvm.dx.wave.reduce.usum.i16(i16)
+declare i32 @llvm.dx.wave.reduce.usum.i32(i32)
+declare i64 @llvm.dx.wave.reduce.usum.i64(i64)
 
 ; Test that for vector values, WaveActiveSum scalarizes and maps down to the
 ; DirectX op
@@ -84,7 +84,7 @@ define noundef <2 x half> @wave_active_sum_v2half(<2 x half> noundef %expr) {
 entry:
 ; CHECK: call half @dx.op.waveActiveOp.f16(i32 119, half %expr.i0, i8 0, i8 0)
 ; CHECK: call half @dx.op.waveActiveOp.f16(i32 119, half %expr.i1, i8 0, i8 0)
-  %ret = call <2 x half> @llvm.dx.wave.active.sum.v2f16(<2 x half> %expr)
+  %ret = call <2 x half> @llvm.dx.wave.reduce.sum.v2f16(<2 x half> %expr)
   ret <2 x half> %ret
 }
 
@@ -93,7 +93,7 @@ entry:
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i0, i8 0, i8 0)
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i1, i8 0, i8 0)
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i2, i8 0, i8 0)
-  %ret = call <3 x i32> @llvm.dx.wave.active.sum.v3i32(<3 x i32> %expr)
+  %ret = call <3 x i32> @llvm.dx.wave.reduce.sum.v3i32(<3 x i32> %expr)
   ret <3 x i32> %ret
 }
 
@@ -103,19 +103,19 @@ entry:
 ; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i1, i8 0, i8 0)
 ; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i2, i8 0, i8 0)
 ; CHECK: call double @dx.op.waveActiveOp.f64(i32 119, double %expr.i3, i8 0, i8 0)
-  %ret = call <4 x double> @llvm.dx.wave.active.sum.v464(<4 x double> %expr)
+  %ret = call <4 x double> @llvm.dx.wave.reduce.sum.v464(<4 x double> %expr)
   ret <4 x double> %ret
 }
 
-declare <2 x half> @llvm.dx.wave.active.sum.v2f16(<2 x half>)
-declare <3 x i32> @llvm.dx.wave.active.sum.v3i32(<3 x i32>)
-declare <4 x double> @llvm.dx.wave.active.sum.v4f64(<4 x double>)
+declare <2 x half> @llvm.dx.wave.reduce.sum.v2f16(<2 x half>)
+declare <3 x i32> @llvm.dx.wave.reduce.sum.v3i32(<3 x i32>)
+declare <4 x double> @llvm.dx.wave.reduce.sum.v4f64(<4 x double>)
 
 define noundef <2 x i16> @wave_active_usum_v2i16(<2 x i16> noundef %expr) {
 entry:
 ; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr.i0, i8 0, i8 1)
 ; CHECK: call i16 @dx.op.waveActiveOp.i16(i32 119, i16 %expr.i1, i8 0, i8 1)
-  %ret = call <2 x i16> @llvm.dx.wave.active.usum.v2f16(<2 x i16> %expr)
+  %ret = call <2 x i16> @llvm.dx.wave.reduce.usum.v2f16(<2 x i16> %expr)
   ret <2 x i16> %ret
 }
 
@@ -124,7 +124,7 @@ entry:
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i0, i8 0, i8 1)
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i1, i8 0, i8 1)
 ; CHECK: call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %expr.i2, i8 0, i8 1)
-  %ret = call <3 x i32> @llvm.dx.wave.active.usum.v3i32(<3 x i32> %expr)
+  %ret = call <3 x i32> @llvm.dx.wave.reduce.usum.v3i32(<3 x i32> %expr)
   ret <3 x i32> %ret
 }
 
@@ -134,10 +134,10 @@ entry:
 ; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i1, i8 0, i8 1)
 ; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i2, i8 0, i8 1)
 ; CHECK: call i64 @dx.op.waveActiveOp.i64(i32 119, i64 %expr.i3, i8 0, i8 1)
-  %ret = call <4 x i64> @llvm.dx.wave.active.usum.v464(<4 x i64> %expr)
+  %ret = call <4 x i64> @llvm.dx.wave.reduce.usum.v464(<4 x i64> %expr)
   ret <4 x i64> %ret
 }
 
-declare <2 x i16> @llvm.dx.wave.active.usum.v2f16(<2 x i16>)
-declare <3 x i32> @llvm.dx.wave.active.usum.v3i32(<3 x i32>)
-declare <4 x i64> @llvm.dx.wave.active.usum.v4f64(<4 x i64>)
+declare <2 x i16> @llvm.dx.wave.reduce.usum.v2f16(<2 x i16>)
+declare <3 x i32> @llvm.dx.wave.reduce.usum.v3i32(<3 x i32>)
+declare <4 x i64> @llvm.dx.wave.reduce.usum.v4f64(<4 x i64>)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WaveActiveSum.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WaveActiveSum.ll
@@ -1,0 +1,41 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32v1.3-vulkan-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32v1.3-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Test lowering to spir-v backend for various types and scalar/vector
+
+; CHECK-DAG:   %[[#f16:]] = OpTypeFloat 16
+; CHECK-DAG:   %[[#f32:]] = OpTypeFloat 32
+; CHECK-DAG:   %[[#uint:]] = OpTypeInt 32 0
+; CHECK-DAG:   %[[#v4_half:]] = OpTypeVector %[[#f16]] 4
+; CHECK-DAG:   %[[#scope:]] = OpConstant %[[#uint]] 3
+
+; CHECK-LABEL: Begin function test_float
+; CHECK:   %[[#fexpr:]] = OpFunctionParameter %[[#f32]]
+define float @test_float(float %fexpr) {
+entry:
+; CHECK:   %[[#fret:]] = OpGroupNonUniformFAdd %[[#f32]] %[[#scope]] Reduce %[[#fexpr]]
+  %0 = call float @llvm.spv.wave.active.sum.f32(float %fexpr)
+  ret float %0
+}
+
+; CHECK-LABEL: Begin function test_int
+; CHECK:   %[[#iexpr:]] = OpFunctionParameter %[[#uint]]
+define i32 @test_int(i32 %iexpr) {
+entry:
+; CHECK:   %[[#iret:]] = OpGroupNonUniformIAdd %[[#uint]] %[[#scope]] Reduce %[[#iexpr]]
+  %0 = call i32 @llvm.spv.wave.active.sum.i32(i32 %iexpr)
+  ret i32 %0
+}
+
+; CHECK-LABEL: Begin function test_vhalf
+; CHECK:   %[[#vbexpr:]] = OpFunctionParameter %[[#v4_half]]
+define <4 x half> @test_vhalf(<4 x half> %vbexpr) {
+entry:
+; CHECK:   %[[#vhalfret:]] = OpGroupNonUniformFAdd %[[#v4_half]] %[[#scope]] Reduce %[[#vbexpr]]
+  %0 = call <4 x half> @llvm.spv.wave.active.sum.v4half(<4 x half> %vbexpr)
+  ret <4 x half> %0
+}
+
+declare float @llvm.spv.wave.active.sum.f32(float)
+declare i32 @llvm.spv.wave.active.sum.i32(i32)
+declare <4 x half> @llvm.spv.wave.active.sum.v4half(<4 x half>)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WaveActiveSum.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WaveActiveSum.ll
@@ -14,7 +14,7 @@
 define float @test_float(float %fexpr) {
 entry:
 ; CHECK:   %[[#fret:]] = OpGroupNonUniformFAdd %[[#f32]] %[[#scope]] Reduce %[[#fexpr]]
-  %0 = call float @llvm.spv.wave.active.sum.f32(float %fexpr)
+  %0 = call float @llvm.spv.wave.reduce.sum.f32(float %fexpr)
   ret float %0
 }
 
@@ -23,7 +23,7 @@ entry:
 define i32 @test_int(i32 %iexpr) {
 entry:
 ; CHECK:   %[[#iret:]] = OpGroupNonUniformIAdd %[[#uint]] %[[#scope]] Reduce %[[#iexpr]]
-  %0 = call i32 @llvm.spv.wave.active.sum.i32(i32 %iexpr)
+  %0 = call i32 @llvm.spv.wave.reduce.sum.i32(i32 %iexpr)
   ret i32 %0
 }
 
@@ -32,10 +32,10 @@ entry:
 define <4 x half> @test_vhalf(<4 x half> %vbexpr) {
 entry:
 ; CHECK:   %[[#vhalfret:]] = OpGroupNonUniformFAdd %[[#v4_half]] %[[#scope]] Reduce %[[#vbexpr]]
-  %0 = call <4 x half> @llvm.spv.wave.active.sum.v4half(<4 x half> %vbexpr)
+  %0 = call <4 x half> @llvm.spv.wave.reduce.sum.v4half(<4 x half> %vbexpr)
   ret <4 x half> %0
 }
 
-declare float @llvm.spv.wave.active.sum.f32(float)
-declare i32 @llvm.spv.wave.active.sum.i32(i32)
-declare <4 x half> @llvm.spv.wave.active.sum.v4half(<4 x half>)
+declare float @llvm.spv.wave.reduce.sum.f32(float)
+declare i32 @llvm.spv.wave.reduce.sum.i32(i32)
+declare <4 x half> @llvm.spv.wave.reduce.sum.v4half(<4 x half>)

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WaveActiveSum.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/WaveActiveSum.ll
@@ -1,5 +1,5 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32v1.3-vulkan-unknown %s -o - | FileCheck %s
-; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32v1.3-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-vulkan-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-vulkan-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; Test lowering to spir-v backend for various types and scalar/vector
 


### PR DESCRIPTION
```    - add clang builtin to Builtins.td
      - link builtin in hlsl_intrinsics
      - add codegen for spirv intrinsic and two directx intrinsics to retain
        signedness information of the operands in CGBuiltin.cpp
      - add semantic analysis in SemaHLSL.cpp
      - add lowering of spirv intrinsic to spirv backend in
        SPIRVInstructionSelector.cpp
      - add lowering of directx intrinsics to WaveActiveOp dxil op in
    DXIL.td

      - add test cases to illustrate passespendent pr merges.
```
Resolves #70106 