### PR TITLE
[CFI] update ignorelist to work with libstdc++ make_shared

### DIFF
--- a/compiler-rt/lib/cfi/cfi_ignorelist.txt
+++ b/compiler-rt/lib/cfi/cfi_ignorelist.txt
@@ -15,3 +15,7 @@ src:*xstddef
 # This ctor is used by std::make_shared and needs to cast to uninitialized T*
 # in order to call std::allocator_traits<T>::construct.
 fun:_ZNSt23_Sp_counted_ptr_inplace*
+
+# std::make_shared use __aligned_buffer as storage, and cast to 
+# uninitialized T* (libstdc++)
+fun:*__aligned_buffer*

--- a/compiler-rt/test/cfi/make_shared.cpp
+++ b/compiler-rt/test/cfi/make_shared.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx_cfi %s -o %t
-// RUN: %t
+// RUN: %run %t
 
 #include <memory>
 

--- a/compiler-rt/test/cfi/make_shared.cpp
+++ b/compiler-rt/test/cfi/make_shared.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx_cfi %s -o %t
+// RUN: %t
+
+#include <memory>
+
+struct Foo {
+  Foo() {}
+  virtual ~Foo() {}
+};
+
+int main(int argc, char **argv) { std::make_shared<Foo>(); }


### PR DESCRIPTION
Fixes https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96946.

We had an old issue with libc++ in https://bugs.llvm.org/show_bug.cgi?id=48993, and it is fixed for libc++, but the same reproducer can still be reproduced with libstdc++(https://godbolt.org/z/n3EWvMKEP).

This patch adds an entry to deal with such cases. 