### PR TITLE
[llvm][TableGen] Fix misleading error for invalid use of let

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3504,7 +3504,7 @@ bool TGParser::ParseBodyItem(Record *CurRec) {
 
   RecordVal *Field = CurRec->getValue(FieldName);
   if (!Field)
-    return TokError("Value '" + FieldName->getValue() + "' unknown!");
+    return Error(IdLoc, "Value '" + FieldName->getValue() + "' unknown!");
 
   const RecTy *Type = Field->getType();
   if (!BitList.empty() && isa<BitsRecTy>(Type)) {

--- a/llvm/test/TableGen/letUnknownValue.td
+++ b/llvm/test/TableGen/letUnknownValue.td
@@ -1,0 +1,9 @@
+// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s --strict-whitespace
+
+def {
+  /// Let can only override something that already exists.
+  let abc = [];
+// CHECK: error: Value 'abc' unknown!
+// CHECK-NEXT:{{^}}  let abc = [];
+// CHECK-NEXT:{{^}}      ^
+}


### PR DESCRIPTION
Fixes #118490

Point to the value name, otherwise it implies that the part after the '=' is the problem.

Before:
```
/tmp/test.td:2:27: error: Value 'FlattenedFeatures' unknown!
  let FlattenedFeatures = [];
                          ^
```
After:
```
/tmp/test.td:2:7: error: Value 'FlattenedFeatures' unknown!
  let FlattenedFeatures = [];
      ^
```