### PR TITLE
[NFC][Utils] Remove DebugInfoFinder parameter from CloneBasicBlock

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Cloning.h
+++ b/llvm/include/llvm/Transforms/Utils/Cloning.h
@@ -119,8 +119,7 @@ struct ClonedCodeInfo {
 /// parameter.
 BasicBlock *CloneBasicBlock(const BasicBlock *BB, ValueToValueMapTy &VMap,
                             const Twine &NameSuffix = "", Function *F = nullptr,
-                            ClonedCodeInfo *CodeInfo = nullptr,
-                            DebugInfoFinder *DIFinder = nullptr);
+                            ClonedCodeInfo *CodeInfo = nullptr);
 
 /// Return a copy of the specified function and add it to that
 /// function's module.  Also, any references specified in the VMap are changed


### PR DESCRIPTION
Stacked PRs:
 * #118630
 * #118629
 * #118628
 * #118627
 * #118626
 * #118625
 * #118624
 * #118623
 * #118622
 * #118621
 * __->__#118620


--- --- ---

### [NFC][Utils] Remove DebugInfoFinder parameter from CloneBasicBlock


Summary:
There was a single usage of CloneBasicBlock with non-default
DebugInfoFinder inside CloneFunctionInto which has been refactored in
more focused.

Test Plan:
ninja check-llvm-unit check-llvm