### PR TITLE
[NFC][Utils] Extract BuildDebugInfoMDMap from CloneFunctionInto

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Cloning.h
+++ b/llvm/include/llvm/Transforms/Utils/Cloning.h
@@ -220,6 +220,14 @@ DISubprogram *CollectDebugInfoForCloning(const Function &F,
                                          CloneFunctionChangeType Changes,
                                          DebugInfoFinder &DIFinder);
 
+/// Build a map of debug info to use during Metadata cloning.
+/// Returns true if cloning would need module level changes and false if there
+/// would only be local changes.
+bool BuildDebugInfoMDMap(DenseMap<const Metadata *, TrackingMDRef> &MD,
+                         CloneFunctionChangeType Changes,
+                         DebugInfoFinder &DIFinder,
+                         DISubprogram *SPClonedWithinModule);
+
 /// This class captures the data input to the InlineFunction call, and records
 /// the auxiliary results produced by it.
 class InlineFunctionInfo {


### PR DESCRIPTION
Stacked PRs:
 * #118630
 * #118629
 * #118628
 * #118627
 * #118625
 * #118624
 * #118623
 * __->__#118622


--- --- ---

### [NFC][Utils] Extract BuildDebugInfoMDMap from CloneFunctionInto


Summary:
Extract the logic to build up a metadata map to use in metadata cloning
into a separate function.

Test Plan:
ninja check-llvm-unit check-llvm
