### PR TITLE
Call setup_host_tools for more tools.

### DIFF
--- a/clang/tools/clang-offload-bundler/CMakeLists.txt
+++ b/clang/tools/clang-offload-bundler/CMakeLists.txt
@@ -12,6 +12,9 @@ add_clang_tool(clang-offload-bundler
   intrinsics_gen
   )
 
+setup_host_tool(clang-offload-bundler CLANG_OFFLOAD_BUNDLER
+  clang-offload-bundler_exe clang-offload-bundler_target)
+
 set(CLANG_OFFLOAD_BUNDLER_LIB_DEPS
   clangBasic
   clangDriver

--- a/clang/tools/clang-offload-packager/CMakeLists.txt
+++ b/clang/tools/clang-offload-packager/CMakeLists.txt
@@ -11,6 +11,9 @@ add_clang_tool(clang-offload-packager
   ${tablegen_deps}
   )
 
+setup_host_tool(clang-offload-packager CLANG_OFFLOAD_PACKAGER_EXE
+  clang-offload-packager_exe clang-offload-packager_target)
+
 clang_target_link_libraries(clang-offload-packager
   PRIVATE
   clangBasic

--- a/llvm/tools/llvm-ar/CMakeLists.txt
+++ b/llvm/tools/llvm-ar/CMakeLists.txt
@@ -19,6 +19,8 @@ add_llvm_tool(llvm-ar
   GENERATE_DRIVER
   )
 
+setup_host_tool(llvm-ar LLVM_AR llvm_ar_exe llvm_ar_target)
+
 add_llvm_tool_symlink(llvm-ranlib llvm-ar)
 add_llvm_tool_symlink(llvm-lib llvm-ar)
 add_llvm_tool_symlink(llvm-dlltool llvm-ar)


### PR DESCRIPTION
This change allows external projects to call for host versions of clang-offload-bundler, clang-offload-packager, and llvm-ar.

This has no effect in LLVM itself, which does not make use of this, but is going to be used in DPC++'s libsycl. That is meant to be upstreamed at some point, so it probably makes sense to get this into LLVM already and avoid future conflicts.