### PR TITLE
[clang-cl][flang][dxc] Fix opts exposed to clang-cl/dxc by mistake

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1055,7 +1055,7 @@ def z : Separate<["-"], "z">, Flags<[LinkerInput]>,
 def offload_link : Flag<["--"], "offload-link">, Group<Link_Group>,
   HelpText<"Use the new offloading linker to perform the link job.">;
 def Xlinker : Separate<["-"], "Xlinker">, Flags<[LinkerInput, RenderAsInput]>,
-  Visibility<[ClangOption, FlangOption]>,
+  Visibility<[ClangOption, CLOption, FlangOption]>,
   HelpText<"Pass <arg> to the linker">, MetaVarName<"<arg>">,
   Group<Link_Group>;
 def Xoffload_linker : JoinedAndSeparate<["-"], "Xoffload-linker">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1055,11 +1055,11 @@ def z : Separate<["-"], "z">, Flags<[LinkerInput]>,
 def offload_link : Flag<["--"], "offload-link">, Group<Link_Group>,
   HelpText<"Use the new offloading linker to perform the link job.">;
 def Xlinker : Separate<["-"], "Xlinker">, Flags<[LinkerInput, RenderAsInput]>,
-  Visibility<[ClangOption, CLOption, FlangOption, DXCOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   HelpText<"Pass <arg> to the linker">, MetaVarName<"<arg>">,
   Group<Link_Group>;
 def Xoffload_linker : JoinedAndSeparate<["-"], "Xoffload-linker">,
-  Visibility<[ClangOption, CLOption, FlangOption, DXCOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   HelpText<"Pass <arg> to the offload linkers or the ones identified by -<triple>">,
   MetaVarName<"<triple> <arg>">, Group<Link_Group>;
 def Xpreprocessor : Separate<["-"], "Xpreprocessor">, Group<Preprocessor_Group>,
@@ -1175,7 +1175,7 @@ def compatibility__version : JoinedOrSeparate<["-"], "compatibility_version">;
 def config : Joined<["--"], "config=">, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>, MetaVarName<"<file>">,
   HelpText<"Specify configuration file">;
-def : Separate<["--"], "config">, Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>, Alias<config>;
+def : Separate<["--"], "config">, Visibility<[ClangOption, FlangOption]>, Alias<config>;
 def no_default_config : Flag<["--"], "no-default-config">,
   Flags<[NoXarchOption]>, Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   HelpText<"Disable loading default configuration files">;
@@ -1989,7 +1989,7 @@ def : Flag<["-"], "fno-diagnostics-color">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   Alias<fno_color_diagnostics>;
 def fdiagnostics_color_EQ : Joined<["-"], "fdiagnostics-color=">, Group<f_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   Values<"auto,always,never">,
   HelpText<"When to use colors in diagnostics">;
 def fansi_escape_codes : Flag<["-"], "fansi-escape-codes">, Group<f_Group>,
@@ -2015,10 +2015,10 @@ argument are escaped with backslashes. This format differs from the format of
 the equivalent section produced by GCC with the -frecord-gcc-switches flag.
 This option is currently only supported on ELF targets.}]>,
   Group<f_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
+  Visibility<[ClangOption, FlangOption]>;
 def fno_record_command_line : Flag<["-"], "fno-record-command-line">,
   Group<f_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
+  Visibility<[ClangOption, FlangOption]>;
 def : Flag<["-"], "frecord-gcc-switches">, Alias<frecord_command_line>;
 def : Flag<["-"], "fno-record-gcc-switches">, Alias<fno_record_command_line>;
 def fcommon : Flag<["-"], "fcommon">, Group<f_Group>,
@@ -5643,7 +5643,7 @@ def gpulibc : Flag<["-"], "gpulibc">, Visibility<[ClangOption, CC1Option, FlangO
   HelpText<"Link the LLVM C Library for GPUs">;
 def nogpulibc : Flag<["-"], "nogpulibc">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 def nodefaultlibs : Flag<["-"], "nodefaultlibs">,
-  Visibility<[ClangOption, FlangOption, CLOption, DXCOption]>;
+  Visibility<[ClangOption, FlangOption]>;
 def nodriverkitlib : Flag<["-"], "nodriverkitlib">;
 def nofixprebinding : Flag<["-"], "nofixprebinding">;
 def nolibc : Flag<["-"], "nolibc">;
@@ -5665,10 +5665,10 @@ def nostdincxx : Flag<["-"], "nostdinc++">, Visibility<[ClangOption, CC1Option]>
   HelpText<"Disable standard #include directories for the C++ standard library">,
   MarshallingInfoNegativeFlag<HeaderSearchOpts<"UseStandardCXXIncludes">>;
 def nostdlib : Flag<["-"], "nostdlib">,
-  Visibility<[ClangOption, CLOption, FlangOption, DXCOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   Group<Link_Group>;
 def stdlib : Flag<["-"], "stdlib">,
-  Visibility<[ClangOption, CLOption, FlangOption, DXCOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   Group<Link_Group>;
 def nostdlibxx : Flag<["-"], "nostdlib++">;
 def object : Flag<["-"], "object">;
@@ -5782,7 +5782,7 @@ def resource_dir_EQ : Joined<["-"], "resource-dir=">, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   Alias<resource_dir>;
 def rpath : Separate<["-"], "rpath">, Flags<[LinkerInput]>, Group<Link_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
+  Visibility<[ClangOption, FlangOption]>;
 def rtlib_EQ : Joined<["-", "--"], "rtlib=">, Visibility<[ClangOption, CLOption, FlangOption]>,
   HelpText<"Compiler runtime library to use">;
 def frtlib_add_rpath: Flag<["-"], "frtlib-add-rpath">, Flags<[NoArgumentUnused]>,
@@ -5846,7 +5846,7 @@ def segs__read__write__addr : Separate<["-"], "segs_read_write_addr">;
 def segs__read__ : Joined<["-"], "segs_read_">;
 def shared_libgcc : Flag<["-"], "shared-libgcc">;
 def shared : Flag<["-", "--"], "shared">, Group<Link_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
+  Visibility<[ClangOption, FlangOption]>;
 def single__module : Flag<["-"], "single_module">;
 def specs_EQ : Joined<["-", "--"], "specs=">, Group<Link_Group>;
 def specs : Separate<["-", "--"], "specs">, Flags<[Unsupported]>;
@@ -5856,7 +5856,7 @@ def start_no_unused_arguments : Flag<["--"], "start-no-unused-arguments">,
 def static_libgcc : Flag<["-"], "static-libgcc">;
 def static_libstdcxx : Flag<["-"], "static-libstdc++">;
 def static : Flag<["-", "--"], "static">, Group<Link_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+  Visibility<[ClangOption, FlangOption]>,
   Flags<[NoArgumentUnused]>;
 def std_default_EQ : Joined<["-"], "std-default=">;
 def std_EQ : Joined<["-", "--"], "std=">,

--- a/clang/test/Driver/unknown-arg-drivermodes.test
+++ b/clang/test/Driver/unknown-arg-drivermodes.test
@@ -10,7 +10,8 @@
 // RUN: -static                    \
 // RUN: -stdlib                    \
 // RUN: -Xoffload-linker           \
-// RUN: -### -x c++ -c - < /dev/null 2>&1 | FileCheck %s --check-prefix=CL
+// RUN: -### -x c++ -c - < /dev/null 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CL --implicit-check-not="warning:"
 
 // RUN: not %clang_dxc             \
 // RUN: --config                   \
@@ -25,7 +26,8 @@
 // RUN: -stdlib                    \
 // RUN: -Xlinker                   \
 // RUN: -Xoffload-linker           \
-// RUN: -### -T lib_6_3 -Vd - < /dev/null 2>&1 | FileCheck %s --check-prefix=DXC
+// RUN: -### -T lib_6_3 -Vd - < /dev/null 2>&1 \
+// RUN: | FileCheck %s --check-prefix=DXC --implicit-check-not="error:"
 
 // CL: warning: unknown argument ignored in clang-cl: '--config'
 // CL: warning: unknown argument ignored in clang-cl: '-fdiagnostics-color=auto'

--- a/clang/test/Driver/unknown-arg-drivermodes.test
+++ b/clang/test/Driver/unknown-arg-drivermodes.test
@@ -9,7 +9,6 @@
 // RUN: -shared                    \
 // RUN: -static                    \
 // RUN: -stdlib                    \
-// RUN: -Xlinker                   \
 // RUN: -Xoffload-linker           \
 // RUN: -### -x c++ -c - < /dev/null 2>&1 | FileCheck %s --check-prefix=CL
 
@@ -38,7 +37,6 @@
 // CL: warning: unknown argument ignored in clang-cl: '-shared'
 // CL: warning: unknown argument ignored in clang-cl: '-static'
 // CL: warning: unknown argument ignored in clang-cl: '-stdlib'
-// CL: warning: unknown argument ignored in clang-cl: '-Xlinker'
 // CL: warning: unknown argument ignored in clang-cl: '-Xoffload-linker'
 
 // DXC: error: unknown argument: '--config'

--- a/clang/test/Driver/unknown-arg-drivermodes.test
+++ b/clang/test/Driver/unknown-arg-drivermodes.test
@@ -1,0 +1,55 @@
+// RUN: %clang_cl                  \
+// RUN: --config                   \
+// RUN: -fdiagnostics-color=auto   \
+// RUN: -fno-record-command-line   \
+// RUN: -frecord-command-line      \
+// RUN: -nodefaultlibs             \
+// RUN: -nostdlib                  \
+// RUN: -rpath                     \
+// RUN: -shared                    \
+// RUN: -static                    \
+// RUN: -stdlib                    \
+// RUN: -Xlinker                   \
+// RUN: -Xoffload-linker           \
+// RUN: -### -x c++ -c - < /dev/null 2>&1 | FileCheck %s --check-prefix=CL
+
+// RUN: not %clang_dxc             \
+// RUN: --config                   \
+// RUN: -fdiagnostics-color=auto   \
+// RUN: -fno-record-command-line   \
+// RUN: -frecord-command-line      \
+// RUN: -nodefaultlibs             \
+// RUN: -nostdlib                  \
+// RUN: -rpath                     \
+// RUN: -shared                    \
+// RUN: -static                    \
+// RUN: -stdlib                    \
+// RUN: -Xlinker                   \
+// RUN: -Xoffload-linker           \
+// RUN: -### -T lib_6_3 -Vd - < /dev/null 2>&1 | FileCheck %s --check-prefix=DXC
+
+// CL: warning: unknown argument ignored in clang-cl: '--config'
+// CL: warning: unknown argument ignored in clang-cl: '-fdiagnostics-color=auto'
+// CL: warning: unknown argument ignored in clang-cl: '-fno-record-command-line'
+// CL: warning: unknown argument ignored in clang-cl: '-frecord-command-line'
+// CL: warning: unknown argument ignored in clang-cl: '-nodefaultlibs'
+// CL: warning: unknown argument ignored in clang-cl: '-nostdlib'
+// CL: warning: unknown argument ignored in clang-cl: '-rpath'
+// CL: warning: unknown argument ignored in clang-cl: '-shared'
+// CL: warning: unknown argument ignored in clang-cl: '-static'
+// CL: warning: unknown argument ignored in clang-cl: '-stdlib'
+// CL: warning: unknown argument ignored in clang-cl: '-Xlinker'
+// CL: warning: unknown argument ignored in clang-cl: '-Xoffload-linker'
+
+// DXC: error: unknown argument: '--config'
+// DXC: error: unknown argument: '-fdiagnostics-color=auto'
+// DXC: error: unknown argument: '-fno-record-command-line'
+// DXC: error: unknown argument: '-frecord-command-line'
+// DXC: error: unknown argument: '-nodefaultlibs'
+// DXC: error: unknown argument: '-nostdlib'
+// DXC: error: unknown argument: '-rpath'
+// DXC: error: unknown argument: '-shared'
+// DXC: error: unknown argument: '-static'
+// DXC: error: unknown argument: '-stdlib'
+// DXC: error: unknown argument: '-Xlinker'
+// DXC: error: unknown argument: '-Xoffload-linker'


### PR DESCRIPTION
When these options were enabled for flang the visibility was also extended to clang-cl and dxc. I believe this was due to a misunderstanding of the default value for `Visibility`.

This is marked as draft because I would like to discuss if any of these options should remain, and once that is done add tests to ensure they or are not supported for the relevant driver modes.