### PR TITLE
[libclc] Add missing includes to CLC headers

### DIFF
--- a/libclc/clc/include/clc/geometric/floatn.inc
+++ b/libclc/clc/include/clc/geometric/floatn.inc
@@ -1,3 +1,6 @@
+#include <clc/clcfunc.h>
+#include <clc/clctypes.h>
+
 #define __CLC_FLOAT float
 #define __CLC_FPSIZE 32
 

--- a/libclc/clc/include/clc/integer/gentype.inc
+++ b/libclc/clc/include/clc/integer/gentype.inc
@@ -1,3 +1,6 @@
+#include <clc/clcfunc.h>
+#include <clc/clctypes.h>
+
 // These 2 defines only change when switching between data sizes or base types
 // to keep this file manageable.
 #define __CLC_GENSIZE 8

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -1,3 +1,6 @@
+#include <clc/clcfunc.h>
+#include <clc/clctypes.h>
+
 #define __CLC_SCALAR_GENTYPE float
 #define __CLC_FPSIZE 32
 

--- a/libclc/clc/include/clc/math/unary_intrin.inc
+++ b/libclc/clc/include/clc/math/unary_intrin.inc
@@ -1,3 +1,6 @@
+#include <clc/clcfunc.h>
+#include <clc/clctypes.h>
+
 _CLC_OVERLOAD float __CLC_FUNCTION(float f) __asm(__CLC_INTRINSIC ".f32");
 _CLC_OVERLOAD float2 __CLC_FUNCTION(float2 f) __asm(__CLC_INTRINSIC ".v2f32");
 _CLC_OVERLOAD float3 __CLC_FUNCTION(float3 f) __asm(__CLC_INTRINSIC ".v3f32");

--- a/libclc/clc/include/clc/relational/clc_all.h
+++ b/libclc/clc/include/clc/relational/clc_all.h
@@ -7,6 +7,7 @@
 #else
 
 #include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #define _CLC_ALL_DECL(TYPE) _CLC_OVERLOAD _CLC_DECL int __clc_all(TYPE v);
 

--- a/libclc/clc/include/clc/relational/clc_any.h
+++ b/libclc/clc/include/clc/relational/clc_any.h
@@ -7,6 +7,7 @@
 #else
 
 #include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #define _CLC_ANY_DECL(TYPE) _CLC_OVERLOAD _CLC_DECL int __clc_any(TYPE v);
 

--- a/libclc/clc/include/clc/relational/clc_isequal.h
+++ b/libclc/clc/include/clc/relational/clc_isequal.h
@@ -7,6 +7,7 @@
 #else
 
 #include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #define _CLC_ISEQUAL_DECL(TYPE, RETTYPE)                                       \
   _CLC_OVERLOAD _CLC_DECL RETTYPE __clc_isequal(TYPE x, TYPE y);

--- a/libclc/clc/include/clc/relational/clc_isinf.h
+++ b/libclc/clc/include/clc/relational/clc_isinf.h
@@ -7,6 +7,7 @@
 #else
 
 #include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #define _CLC_ISINF_DECL(RET_TYPE, ARG_TYPE)                                    \
   _CLC_OVERLOAD _CLC_DECL RET_TYPE __clc_isinf(ARG_TYPE);

--- a/libclc/clc/include/clc/relational/clc_isnan.h
+++ b/libclc/clc/include/clc/relational/clc_isnan.h
@@ -7,6 +7,7 @@
 #else
 
 #include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #define _CLC_ISNAN_DECL(RET_TYPE, ARG_TYPE)                                    \
   _CLC_OVERLOAD _CLC_DECL RET_TYPE __clc_isnan(ARG_TYPE);

--- a/libclc/clc/include/clc/relational/floatn.inc
+++ b/libclc/clc/include/clc/relational/floatn.inc
@@ -1,3 +1,5 @@
+#include <clc/clcfunc.h>
+#include <clc/clctypes.h>
 
 #define __CLC_FLOATN float
 #define __CLC_INTN int

--- a/libclc/clc/include/clc/shared/clc_clamp.h
+++ b/libclc/clc/include/clc/shared/clc_clamp.h
@@ -6,9 +6,6 @@
 #define __clc_clamp clamp
 #else
 
-#include <clc/clcfunc.h>
-#include <clc/clctypes.h>
-
 #define __CLC_BODY <clc/shared/clc_clamp.inc>
 #include <clc/integer/gentype.inc>
 


### PR DESCRIPTION
There's no automatic way of checking these headers are self-contained.

Instead of including these common files many times across the whole codebase, we can include them in the generic `gentype.inc` and `floatn.inc` files which are included by most CLC headers.