### PR TITLE
[flang][test] Recognize !$acc and !$omp spelled with capital letters

### DIFF
--- a/flang/test/Semantics/test_symbols.py
+++ b/flang/test/Semantics/test_symbols.py
@@ -29,7 +29,7 @@ flang_fc1_options = "-fdebug-unparse-with-symbols"
 # Strips out blank lines and all comments except for "!DEF:", "!REF:", "!$acc" and "!$omp"
 with open(src, "r") as text_in:
     for line in text_in:
-        text = re.sub(r"!(?![DR]EF:|\$omp|\$acc).*", "", line)
+        text = re.sub(r"!(?![DR]EF:|\$[Oo][Mm][Pp]|\$[Aa][Cc][Cc]).*", "", line)
         text = re.sub(r"^\s*$", "", text)
         diff1 += text
 

--- a/flang/test/Semantics/test_symbols.py
+++ b/flang/test/Semantics/test_symbols.py
@@ -29,7 +29,7 @@ flang_fc1_options = "-fdebug-unparse-with-symbols"
 # Strips out blank lines and all comments except for "!DEF:", "!REF:", "!$acc" and "!$omp"
 with open(src, "r") as text_in:
     for line in text_in:
-        text = re.sub(r"!(?![DR]EF:|\$[Oo][Mm][Pp]|\$[Aa][Cc][Cc]).*", "", line)
+        text = re.sub(r"!(?![DR]EF:|\$omp|\$acc).*", "", line, re.I)
         text = re.sub(r"^\s*$", "", text)
         diff1 += text
 


### PR DESCRIPTION
If there are any continuation lines in the source, they will be printed by the unparser with capital letters (at least in case of OpenMP). To avoid having them stripped out, recognize their spellings using capital letters as well.