### PR TITLE
[InstSimplify] Refine `abs(min/undef, true)` to `poison`

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -3018,9 +3018,9 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
       assert(C1 && "Must be constant int");
       assert((C1->isOne() || C1->isZero()) && "Must be 0 or 1");
 
-      // Undef or minimum val operand with poison min --> undef
+      // Undef or minimum val operand with poison min --> poison
       if (C1->isOne() && (!C0 || C0->isMinSignedValue()))
-        return UndefValue::get(Ty);
+        return PoisonValue::get(Ty);
 
       // Undef operand with no poison min --> 0 (sign bit must be clear)
       if (!C0)

--- a/llvm/test/Transforms/InstSimplify/ConstProp/abs.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/abs.ll
@@ -6,7 +6,7 @@ declare <8 x i8> @llvm.abs.v8i8(<8 x i8>, i1)
 
 define i8 @undef_val_min_poison() {
 ; CHECK-LABEL: @undef_val_min_poison(
-; CHECK-NEXT:    ret i8 undef
+; CHECK-NEXT:    ret i8 poison
 ;
   %r = call i8 @llvm.abs.i8(i8 undef, i1 true)
   ret i8 %r
@@ -22,7 +22,7 @@ define i8 @undef_val_min_not_poison() {
 
 define i8 @min_val_min_poison() {
 ; CHECK-LABEL: @min_val_min_poison(
-; CHECK-NEXT:    ret i8 undef
+; CHECK-NEXT:    ret i8 poison
 ;
   %r = call i8 @llvm.abs.i8(i8 -128, i1 true)
   ret i8 %r


### PR DESCRIPTION
Calls to `@llvm.abs(undef, i1 true)` and `@llvm.abs(INT_MIN, i1 true)` can be optimized to `poison` instead of `undef`.

[Alive2](https://alive2.llvm.org/ce/z/Hg-2ug)