### PR TITLE
[libc] remove references to LIBC_HDRGEN_EXE

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -69,8 +69,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
          "-DLLVM_EXTERNAL_${name}_SOURCE_DIR=${LLVM_EXTERNAL_${name}_SOURCE_DIR}")
   endforeach()
 
-  if("libc" IN_LIST LLVM_ENABLE_PROJECTS AND NOT LIBC_HDRGEN_EXE)
-    set(libc_flags -DLLVM_LIBC_FULL_BUILD=ON -DLIBC_HDRGEN_ONLY=ON)
+  if("libc" IN_LIST LLVM_ENABLE_PROJECTS)
+    set(libc_flags -DLLVM_LIBC_FULL_BUILD=ON)
     if(MSVC)
       # Due to some issues mentioned in llvm/projects/CMakeLists.txt, libc build is disabled by
       # default in the cross target when building with MSVC compatible compilers on Windows. Add

--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -69,17 +69,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
          "-DLLVM_EXTERNAL_${name}_SOURCE_DIR=${LLVM_EXTERNAL_${name}_SOURCE_DIR}")
   endforeach()
 
-  if("libc" IN_LIST LLVM_ENABLE_PROJECTS)
-    set(libc_flags -DLLVM_LIBC_FULL_BUILD=ON)
-    if(MSVC)
-      # Due to some issues mentioned in llvm/projects/CMakeLists.txt, libc build is disabled by
-      # default in the cross target when building with MSVC compatible compilers on Windows. Add
-      # LLVM_FORCE_BUILD_RUNTIME to bypass this issue and force its building on Windows.
-      list(APPEND libc_flags -DLLVM_FORCE_BUILD_RUNTIME=ON)
-    endif()
-  endif()
   if(LLVM_LIBC_GPU_BUILD)
-    list(APPEND libc_flags -DLLVM_LIBC_GPU_BUILD=ON)
+    set(libc_flags -DLLVM_LIBC_GPU_BUILD=ON)
   endif()
 
   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt


### PR DESCRIPTION
Further cleanups from old hdrgen removal. I didn't realize there were cmake
variables related to old hdrgen spread out throughout more of the source tree.

Link: #117220
Link: #117208
