### PR TITLE
[RISCV] f32 roundeven pattern missed for Zfa

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZfa.td
@@ -215,6 +215,7 @@ def: Pat<(any_frint FPR32:$rs1), (FROUNDNX_S FPR32:$rs1, FRM_DYN)>;
 def: Pat<(any_fnearbyint FPR32:$rs1), (FROUND_S FPR32:$rs1, FRM_DYN)>;
 
 def: Pat<(any_fround FPR32:$rs1), (FROUND_S FPR32:$rs1, FRM_RMM)>;
+def: Pat<(any_froundeven FPR32:$rs1), (FROUND_S FPR32:$rs1, FRM_RNE)>;
 def: Pat<(any_ffloor FPR32:$rs1), (FROUND_S FPR32:$rs1, FRM_RDN)>;
 def: Pat<(any_fceil FPR32:$rs1), (FROUND_S FPR32:$rs1, FRM_RUP)>;
 def: Pat<(any_ftrunc FPR32:$rs1), (FROUND_S FPR32:$rs1, FRM_RTZ)>;

--- a/llvm/test/CodeGen/RISCV/double-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/double-zfa.ll
@@ -243,6 +243,17 @@ define double @fround_d_5(double %a) nounwind {
 
 declare double @nearbyint(double) nounwind readnone
 
+define double @fround_d_6(double %a) nounwind {
+; CHECK-LABEL: fround_d_6:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fround.d fa0, fa0, rne
+; CHECK-NEXT:    ret
+  %call = tail call double @llvm.roundeven.f64(double %a) nounwind readnone
+  ret double %call
+}
+
+declare double @llvm.roundeven.f64(double) nounwind readnone
+
 
 define double @froundnx_d(double %a) nounwind {
 ; CHECK-LABEL: froundnx_d:
@@ -378,10 +389,10 @@ define double @select_loadfpimm(double %x) nounwind {
 ; RV32IDZFA-NEXT:    fcvt.d.w fa5, zero
 ; RV32IDZFA-NEXT:    fle.d a0, fa5, fa0
 ; RV32IDZFA-NEXT:    fli.d fa0, 0.5
-; RV32IDZFA-NEXT:    bnez a0, .LBB35_2
+; RV32IDZFA-NEXT:    bnez a0, .LBB36_2
 ; RV32IDZFA-NEXT:  # %bb.1:
 ; RV32IDZFA-NEXT:    fneg.d fa0, fa0
-; RV32IDZFA-NEXT:  .LBB35_2: # %entry
+; RV32IDZFA-NEXT:  .LBB36_2: # %entry
 ; RV32IDZFA-NEXT:    ret
 ;
 ; RV64DZFA-LABEL: select_loadfpimm:
@@ -389,10 +400,10 @@ define double @select_loadfpimm(double %x) nounwind {
 ; RV64DZFA-NEXT:    fmv.d.x fa5, zero
 ; RV64DZFA-NEXT:    fle.d a0, fa5, fa0
 ; RV64DZFA-NEXT:    fli.d fa0, 0.5
-; RV64DZFA-NEXT:    bnez a0, .LBB35_2
+; RV64DZFA-NEXT:    bnez a0, .LBB36_2
 ; RV64DZFA-NEXT:  # %bb.1:
 ; RV64DZFA-NEXT:    fneg.d fa0, fa0
-; RV64DZFA-NEXT:  .LBB35_2: # %entry
+; RV64DZFA-NEXT:  .LBB36_2: # %entry
 ; RV64DZFA-NEXT:    ret
 entry:
   %cmp = fcmp ult double %x, 0.000000e+00

--- a/llvm/test/CodeGen/RISCV/float-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/float-zfa.ll
@@ -198,6 +198,17 @@ define float @fround_s_5(float %a) nounwind {
 
 declare float @nearbyintf(float) nounwind readnone
 
+define float @fround_s_6(float %a) nounwind {
+; CHECK-LABEL: fround_s_6:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fround.s fa0, fa0, rne
+; CHECK-NEXT:    ret
+  %call = tail call float @llvm.roundeven.f32(float %a) nounwind readnone
+  ret float %call
+}
+
+declare float @llvm.roundeven.f32(float) nounwind readnone
+
 
 define float @froundnx_s(float %a) nounwind {
 ; CHECK-LABEL: froundnx_s:
@@ -317,10 +328,10 @@ define float @select_loadfpimm(float %x) nounwind {
 ; CHECK-NEXT:    fmv.w.x fa5, zero
 ; CHECK-NEXT:    fle.s a0, fa5, fa0
 ; CHECK-NEXT:    fli.s fa0, 0.5
-; CHECK-NEXT:    bnez a0, .LBB30_2
+; CHECK-NEXT:    bnez a0, .LBB31_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    fneg.s fa0, fa0
-; CHECK-NEXT:  .LBB30_2: # %entry
+; CHECK-NEXT:  .LBB31_2: # %entry
 ; CHECK-NEXT:    ret
 entry:
   %cmp = fcmp ult float %x, 0.000000e+00

--- a/llvm/test/CodeGen/RISCV/half-zfa.ll
+++ b/llvm/test/CodeGen/RISCV/half-zfa.ll
@@ -140,6 +140,24 @@ define half @fround_h_5(half %a) nounwind {
 
 declare half @llvm.nearbyint.f16(half) nounwind readnone
 
+define half @fround_h_6(half %a) nounwind {
+; CHECK-LABEL: fround_h_6:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    fround.h fa0, fa0, rne
+; CHECK-NEXT:    ret
+;
+; ZFHMIN-LABEL: fround_h_6:
+; ZFHMIN:       # %bb.0:
+; ZFHMIN-NEXT:    fcvt.s.h fa5, fa0
+; ZFHMIN-NEXT:    fround.s fa5, fa5, rne
+; ZFHMIN-NEXT:    fcvt.h.s fa0, fa5
+; ZFHMIN-NEXT:    ret
+  %call = tail call half @llvm.roundeven.f16(half %a) nounwind readnone
+  ret half %call
+}
+
+declare half @llvm.roundeven.f16(half) nounwind readnone
+
 
 define half @froundnx_h(half %a) nounwind {
 ; CHECK-LABEL: froundnx_h:
@@ -321,10 +339,10 @@ define half @select_loadfpimm(half %x) nounwind {
 ; CHECK-NEXT:    fmv.h.x fa5, zero
 ; CHECK-NEXT:    fle.h a0, fa5, fa0
 ; CHECK-NEXT:    fli.h fa0, 0.5
-; CHECK-NEXT:    bnez a0, .LBB16_2
+; CHECK-NEXT:    bnez a0, .LBB17_2
 ; CHECK-NEXT:  # %bb.1:
 ; CHECK-NEXT:    fneg.h fa0, fa0
-; CHECK-NEXT:  .LBB16_2: # %entry
+; CHECK-NEXT:  .LBB17_2: # %entry
 ; CHECK-NEXT:    ret
 ;
 ; ZFHMIN-LABEL: select_loadfpimm:
@@ -334,8 +352,8 @@ define half @select_loadfpimm(half %x) nounwind {
 ; ZFHMIN-NEXT:    fle.s a0, fa4, fa5
 ; ZFHMIN-NEXT:    xori a0, a0, 1
 ; ZFHMIN-NEXT:    slli a0, a0, 1
-; ZFHMIN-NEXT:    lui a1, %hi(.LCPI16_0)
-; ZFHMIN-NEXT:    addi a1, a1, %lo(.LCPI16_0)
+; ZFHMIN-NEXT:    lui a1, %hi(.LCPI17_0)
+; ZFHMIN-NEXT:    addi a1, a1, %lo(.LCPI17_0)
 ; ZFHMIN-NEXT:    add a0, a1, a0
 ; ZFHMIN-NEXT:    flh fa0, 0(a0)
 ; ZFHMIN-NEXT:    ret


### PR DESCRIPTION
Roundeven Pattern missed in TD files for RISCV. I was talking with @topperc  and it seems maybe because it was a c23 thing it got missed in test/td files. Only the   f32 version was missed in TD file. Tests for roundeven.f32/f16/f64 seem to be missing