### PR TITLE
[lldb] Fix the SocketTest failure on unsupported hosts

### DIFF
--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -271,7 +271,7 @@ TEST_P(SocketTest, TCPListen0GetListeningConnectionURI) {
 }
 
 TEST_F(SocketTest, TCPListen0MultiListenerGetListeningConnectionURI) {
-  if (!HostSupportsIPv6() || !HostSupportsIPv4())
+  if (!HostSupportsLocalhostToIPv4() || !HostSupportsLocalhostToIPv6())
     return;
 
   llvm::Expected<std::unique_ptr<TCPSocket>> sock =

--- a/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
+++ b/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
@@ -120,18 +120,24 @@ bool lldb_private::HostSupportsLocalhostToIPv4() {
   if (!HostSupportsIPv4())
     return false;
 
-  auto addresses = SocketAddress::GetAddressInfo("localhost", nullptr, AF_INET,
-                                                 SOCK_STREAM, IPPROTO_TCP);
-  return !addresses.empty();
+  auto addresses = SocketAddress::GetAddressInfo(
+      "localhost", nullptr, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP);
+  return std::find_if(addresses.begin(), addresses.end(),
+                      [](SocketAddress &addr) {
+                        return addr.GetFamily() == AF_INET;
+                      }) != addresses.end();
 }
 
 bool lldb_private::HostSupportsLocalhostToIPv6() {
   if (!HostSupportsIPv6())
     return false;
 
-  auto addresses = SocketAddress::GetAddressInfo("localhost", nullptr, AF_INET6,
-                                                 SOCK_STREAM, IPPROTO_TCP);
-  return !addresses.empty();
+  auto addresses = SocketAddress::GetAddressInfo(
+      "localhost", nullptr, AF_UNSPEC, SOCK_STREAM, IPPROTO_TCP);
+  return std::find_if(addresses.begin(), addresses.end(),
+                      [](SocketAddress &addr) {
+                        return addr.GetFamily() == AF_INET6;
+                      }) != addresses.end();
 }
 
 llvm::Expected<std::string> lldb_private::GetLocalhostIP() {

--- a/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
+++ b/lldb/unittests/TestingSupport/Host/SocketTestUtilities.cpp
@@ -116,6 +116,24 @@ bool lldb_private::HostSupportsIPv6() {
   return CheckIPSupport("IPv6", "[::1]:0");
 }
 
+bool lldb_private::HostSupportsLocalhostToIPv4() {
+  if (!HostSupportsIPv4())
+    return false;
+
+  auto addresses = SocketAddress::GetAddressInfo("localhost", nullptr, AF_INET,
+                                                 SOCK_STREAM, IPPROTO_TCP);
+  return !addresses.empty();
+}
+
+bool lldb_private::HostSupportsLocalhostToIPv6() {
+  if (!HostSupportsIPv6())
+    return false;
+
+  auto addresses = SocketAddress::GetAddressInfo("localhost", nullptr, AF_INET6,
+                                                 SOCK_STREAM, IPPROTO_TCP);
+  return !addresses.empty();
+}
+
 llvm::Expected<std::string> lldb_private::GetLocalhostIP() {
   if (HostSupportsIPv4())
     return "127.0.0.1";

--- a/lldb/unittests/TestingSupport/Host/SocketTestUtilities.h
+++ b/lldb/unittests/TestingSupport/Host/SocketTestUtilities.h
@@ -43,6 +43,11 @@ void CreateDomainConnectedSockets(llvm::StringRef path,
 bool HostSupportsIPv6();
 bool HostSupportsIPv4();
 
+/// Returns true if the name `localhost` maps to a loopback IPv4 address.
+bool HostSupportsLocalhostToIPv4();
+/// Returns true if the name `localhost` maps to a loopback IPv6 address.
+bool HostSupportsLocalhostToIPv6();
+
 /// Return an IP for localhost based on host support.
 ///
 /// This will return either "127.0.0.1" if IPv4 is detected, or "[::1]" if IPv6


### PR DESCRIPTION
The test `SocketTest::TCPListen0MultiListenerGetListeningConnectionURI` is failing on hosts that do not map `localhost` to both an ipv4 and ipv6 address. For example this build https://lab.llvm.org/buildbot/#/builders/195/builds/1909.

To fix this, I added a helper to validate if the host has an /etc/hosts entry for both ipv4 and ipv6, otherwise we skip the test.