### PR TITLE
Fix to account for multiple ISA enumeration

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -207,7 +207,7 @@ Expected<std::string> getTargetTripleAndFeatures(hsa_agent_t Agent) {
     llvm::StringRef TripleTarget(ISAName.begin(), Length);
     if (TripleTarget.consume_front("amdgcn-amd-amdhsa"))
       Target = TripleTarget.ltrim('-').rtrim('\0').str();
-    return HSA_STATUS_SUCCESS;
+    return HSA_STATUS_INFO_BREAK;
   });
   if (Err)
     return Err;


### PR DESCRIPTION
When multiple ISAs are enumerated per agent, existing code picked up the last one. Incumbent is the first one and thus the fixed code picks up the first one. This fix is expected to be short-lived --- to be followed by code object version 6 generic ISA support.