### PR TITLE
[llvm][Support][Windows] Avoid crash calling remove_directories()

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -25,6 +25,7 @@
 // These two headers must be included last, and make sure shlobj is required
 // after Windows.h to make sure it picks up our definition of _WIN32_WINNT
 #include "llvm/Support/Windows/WindowsSupport.h"
+#include <atlbase.h>
 #include <shellapi.h>
 #include <shlobj.h>
 
@@ -1387,35 +1388,33 @@ std::error_code remove_directories(const Twine &path, bool IgnoreErrors) {
   Path16.push_back(0);
   Path16.push_back(0);
 
-  HRESULT HR =
-      CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-  if (SUCCEEDED(HR)) {
-    IFileOperation *FileOp = NULL;
-    HR = CoCreateInstance(CLSID_FileOperation, NULL, CLSCTX_ALL,
-                          IID_PPV_ARGS(&FileOp));
-    if (SUCCEEDED(HR)) {
-      HR = FileOp->SetOperationFlags(FOF_NO_UI | FOFX_NOCOPYHOOKS);
-      if (SUCCEEDED(HR)) {
-        PIDLIST_ABSOLUTE PIDL = ILCreateFromPathW(Path16.data());
-        IShellItem *ShItem = NULL;
-        HR = SHCreateItemFromIDList(PIDL, IID_PPV_ARGS(&ShItem));
-        if (SUCCEEDED(HR)) {
-          HR = FileOp->DeleteItem(ShItem, NULL);
-          if (SUCCEEDED(HR)) {
-            HR = FileOp->PerformOperations();
-          }
-          ShItem->Release();
-        }
-        ILFree(PIDL);
-      }
-      FileOp->Release();
-    }
-    CoUninitialize();
-  }
-
-  int result = FAILED(HR) ? HRESULT_CODE(HR) : 0;
-  if (result != 0 && !IgnoreErrors)
-    return mapWindowsError(result);
+  HRESULT HR;
+  do {
+    HR =
+        CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    if (FAILED(HR))
+      break;
+    auto Uninitialize = make_scope_exit([] { CoUninitialize(); });
+    CComPtr<IFileOperation> FileOp;
+    HR = FileOp.CoCreateInstance(CLSID_FileOperation);
+    if (FAILED(HR))
+      break;
+    HR = FileOp->SetOperationFlags(FOF_NO_UI | FOFX_NOCOPYHOOKS);
+    if (FAILED(HR))
+      break;
+    PIDLIST_ABSOLUTE PIDL = ILCreateFromPathW(Path16.data());
+    auto FreePIDL = make_scope_exit([&PIDL] { ILFree(PIDL); });
+    CComPtr<IShellItem> ShItem;
+    HR = SHCreateItemFromIDList(PIDL, IID_PPV_ARGS(&ShItem));
+    if (FAILED(HR))
+      break;
+    HR = FileOp->DeleteItem(ShItem, NULL);
+    if (FAILED(HR))
+      break;
+    HR = FileOp->PerformOperations();
+  } while (false);
+  if (FAILED(HR) && !IgnoreErrors)
+    return mapWindowsError(HRESULT_CODE(HR));
   return std::error_code();
 }
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1387,12 +1387,31 @@ std::error_code remove_directories(const Twine &path, bool IgnoreErrors) {
   Path16.push_back(0);
   Path16.push_back(0);
 
-  SHFILEOPSTRUCTW shfos = {};
-  shfos.wFunc = FO_DELETE;
-  shfos.pFrom = Path16.data();
-  shfos.fFlags = FOF_NO_UI;
+  HRESULT HR = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+  if (SUCCEEDED(HR)) {
+    IFileOperation *FileOp;
+    HR = CoCreateInstance(CLSID_FileOperation, NULL, CLSCTX_ALL,
+                          IID_PPV_ARGS(&FileOp));
+    if (SUCCEEDED(HR)) {
+      HR = FileOp->SetOperationFlags(FOF_NO_UI | FOFX_NOCOPYHOOKS);
+      if (SUCCEEDED(HR)) {
+        IShellItem *ShItem = NULL;
+        HR = SHCreateItemFromParsingName(Path16.data(), NULL,
+                                         IID_PPV_ARGS(&ShItem));
+        if (SUCCEEDED(HR)) {
+          HR = FileOp->DeleteItem(ShItem, NULL);
+          ShItem->Release();
+        }
+        if (SUCCEEDED(HR)) {
+          HR = FileOp->PerformOperations();
+        }
+      }
+      FileOp->Release();
+    }
+  }
+  CoUninitialize();
 
-  int result = ::SHFileOperationW(&shfos);
+  int result = FAILED(HR) ? HRESULT_CODE(HR) : 0;
   if (result != 0 && !IgnoreErrors)
     return mapWindowsError(result);
   return std::error_code();

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1387,29 +1387,31 @@ std::error_code remove_directories(const Twine &path, bool IgnoreErrors) {
   Path16.push_back(0);
   Path16.push_back(0);
 
-  HRESULT HR = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+  HRESULT HR =
+      CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
   if (SUCCEEDED(HR)) {
-    IFileOperation *FileOp;
+    IFileOperation *FileOp = NULL;
     HR = CoCreateInstance(CLSID_FileOperation, NULL, CLSCTX_ALL,
                           IID_PPV_ARGS(&FileOp));
     if (SUCCEEDED(HR)) {
       HR = FileOp->SetOperationFlags(FOF_NO_UI | FOFX_NOCOPYHOOKS);
       if (SUCCEEDED(HR)) {
+        PIDLIST_ABSOLUTE PIDL = ILCreateFromPathW(Path16.data());
         IShellItem *ShItem = NULL;
-        HR = SHCreateItemFromParsingName(Path16.data(), NULL,
-                                         IID_PPV_ARGS(&ShItem));
+        HR = SHCreateItemFromIDList(PIDL, IID_PPV_ARGS(&ShItem));
         if (SUCCEEDED(HR)) {
           HR = FileOp->DeleteItem(ShItem, NULL);
+          if (SUCCEEDED(HR)) {
+            HR = FileOp->PerformOperations();
+          }
           ShItem->Release();
         }
-        if (SUCCEEDED(HR)) {
-          HR = FileOp->PerformOperations();
-        }
+        ILFree(PIDL);
       }
       FileOp->Release();
     }
+    CoUninitialize();
   }
-  CoUninitialize();
 
   int result = FAILED(HR) ? HRESULT_CODE(HR) : 0;
   if (result != 0 && !IgnoreErrors)


### PR DESCRIPTION
We faced an unexpected crash in SHELL32_CallFileCopyHooks() on the buildbot [lldb-remote-linux-win](https://lab.llvm.org/staging/#/builders/197/builds/1066). The host is Windows Server 2022 w/o any 3rd party shell extensions. See #118032 for more details.
Based on [this article](https://devblogs.microsoft.com/oldnewthing/20120330-00/?p=7963).