### PR TITLE
[C++20] Destroying delete can cause a type to be noexcept when deleting

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -656,7 +656,7 @@ Bug Fixes in This Version
   ``_Atomic``-qualified type (#GH116124).
 - No longer return ``false`` for ``noexcept`` expressions involving a
   ``delete`` which resolves to a destroying delete but the type of the object
-  being deleted as a potentially throwing destructor (#GH118660).
+  being deleted has a potentially throwing destructor (#GH118660).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -654,6 +654,9 @@ Bug Fixes in This Version
 - Fixed a crash when GNU statement expression contains invalid statement (#GH113468).
 - Fixed a failed assertion when using ``__attribute__((noderef))`` on an
   ``_Atomic``-qualified type (#GH116124).
+- No longer return ``false`` for ``noexcept`` expressions involving a
+  ``delete`` which resolves to a destroying delete but the type of the object
+  being deleted as a potentially throwing destructor (#GH118660).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1208,10 +1208,8 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
       const FunctionDecl *OperatorDelete = DE->getOperatorDelete();
       CT = canCalleeThrow(*this, DE, OperatorDelete);
       if (!OperatorDelete->isDestroyingOperatorDelete()) {
-        if (const RecordType *RT = DTy->getAs<RecordType>()) {
-          const CXXRecordDecl *RD = cast<CXXRecordDecl>(RT->getDecl());
-          const CXXDestructorDecl *DD = RD->getDestructor();
-          if (DD)
+        if (const auto *RD = DTy->getAsCXXRecordDecl()) {
+          if (const CXXDestructorDecl *DD = RD->getDestructor())
             CT = mergeCanThrow(CT, canCalleeThrow(*this, DE, DD));
         }
         if (CT == CT_Can)

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1206,15 +1206,16 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
       CT = CT_Dependent;
     } else {
       const FunctionDecl *OperatorDelete = DE->getOperatorDelete();
-      CT = canCalleeThrow(*this, DE, OperatorDelete);
-      if (const RecordType *RT = DTy->getAs<RecordType>()) {
-        const CXXRecordDecl *RD = cast<CXXRecordDecl>(RT->getDecl());
-        const CXXDestructorDecl *DD = RD->getDestructor();
-        if (DD && !OperatorDelete->isDestroyingOperatorDelete())
+      if (!OperatorDelete->isDestroyingOperatorDelete()) {
+        CT = canCalleeThrow(*this, DE, OperatorDelete);
+        if (const RecordType *RT = DTy->getAs<RecordType>()) {
+          const CXXRecordDecl *RD = cast<CXXRecordDecl>(RT->getDecl());
+          const CXXDestructorDecl *DD = RD->getDestructor();
           CT = mergeCanThrow(CT, canCalleeThrow(*this, DE, DD));
+        }
+        if (CT == CT_Can)
+          return CT;
       }
-      if (CT == CT_Can)
-        return CT;
     }
     return mergeCanThrow(CT, canSubStmtsThrow(*this, DE));
   }

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1211,7 +1211,8 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
         if (const RecordType *RT = DTy->getAs<RecordType>()) {
           const CXXRecordDecl *RD = cast<CXXRecordDecl>(RT->getDecl());
           const CXXDestructorDecl *DD = RD->getDestructor();
-          CT = mergeCanThrow(CT, canCalleeThrow(*this, DE, DD));
+          if (DD)
+            CT = mergeCanThrow(CT, canCalleeThrow(*this, DE, DD));
         }
         if (CT == CT_Can)
           return CT;

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1206,8 +1206,8 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
       CT = CT_Dependent;
     } else {
       const FunctionDecl *OperatorDelete = DE->getOperatorDelete();
+      CT = canCalleeThrow(*this, DE, OperatorDelete);
       if (!OperatorDelete->isDestroyingOperatorDelete()) {
-        CT = canCalleeThrow(*this, DE, OperatorDelete);
         if (const RecordType *RT = DTy->getAs<RecordType>()) {
           const CXXRecordDecl *RD = cast<CXXRecordDecl>(RT->getDecl());
           const CXXDestructorDecl *DD = RD->getDestructor();

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1205,11 +1205,12 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
     if (DTy.isNull() || DTy->isDependentType()) {
       CT = CT_Dependent;
     } else {
-      CT = canCalleeThrow(*this, DE, DE->getOperatorDelete());
+      const FunctionDecl *OperatorDelete = DE->getOperatorDelete();
+      CT = canCalleeThrow(*this, DE, OperatorDelete);
       if (const RecordType *RT = DTy->getAs<RecordType>()) {
         const CXXRecordDecl *RD = cast<CXXRecordDecl>(RT->getDecl());
         const CXXDestructorDecl *DD = RD->getDestructor();
-        if (DD)
+        if (DD && !OperatorDelete->isDestroyingOperatorDelete())
           CT = mergeCanThrow(CT, canCalleeThrow(*this, DE, DD));
       }
       if (CT == CT_Can)

--- a/clang/test/SemaCXX/noexcept-destroying-delete.cpp
+++ b/clang/test/SemaCXX/noexcept-destroying-delete.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -fcxx-exceptions -Wno-unevaluated-expression -std=c++20 %s
+// expected-no-diagnostics
+
+namespace std {
+  struct destroying_delete_t {
+    explicit destroying_delete_t() = default;
+  };
+
+  inline constexpr destroying_delete_t destroying_delete{};
+}
+
+struct Explicit {
+    ~Explicit() noexcept(false) {}
+
+    void operator delete(Explicit*, std::destroying_delete_t) noexcept {
+    }
+};
+
+Explicit *qn = nullptr;
+// This assertion used to fail, see GH118660
+static_assert(noexcept(delete(qn)));

--- a/clang/test/SemaCXX/noexcept-destroying-delete.cpp
+++ b/clang/test/SemaCXX/noexcept-destroying-delete.cpp
@@ -19,3 +19,15 @@ struct Explicit {
 Explicit *qn = nullptr;
 // This assertion used to fail, see GH118660
 static_assert(noexcept(delete(qn)));
+
+struct ThrowingDestroyingDelete {
+    ~ThrowingDestroyingDelete() noexcept(false) {}
+
+    void operator delete(ThrowingDestroyingDelete*, std::destroying_delete_t) noexcept(false) {
+    }
+};
+
+ThrowingDestroyingDelete *pn = nullptr;
+// noexcept should return false here because the destroying delete itself is a
+// potentially throwing function.
+static_assert(!noexcept(delete(pn)));


### PR DESCRIPTION
Given a `noexcept` operator with an operand that calls `delete`, Clang was not considering whether the selected `operator delete` function was a destroying delete or not when inspecting whether the deleted object type has a throwing destructor. Thus, the operator would return `false` for a type with a potentially throwing destructor even though that destructor would not be called due to the destroying delete. Clang now takes the kind of delete operator into consideration.

Fixes #118660