### PR TITLE
[PowerPC][Backend] using signed extend value instead of zero extend value for isIntS34Immediate()

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -2703,7 +2703,7 @@ bool llvm::isIntS34Immediate(SDNode *N, int64_t &Imm) {
   if (!isa<ConstantSDNode>(N))
     return false;
 
-  Imm = (int64_t)N->getAsZExtVal();
+  Imm = (int64_t)cast<ConstantSDNode>(N)->getSExtValue();
   return isInt<34>(Imm);
 }
 bool llvm::isIntS34Immediate(SDValue Op, int64_t &Imm) {
@@ -2925,7 +2925,7 @@ bool PPCTargetLowering::SelectAddressRegImm34(SDValue N, SDValue &Disp,
   if (N.getOpcode() == ISD::ADD) {
     if (!isIntS34Immediate(N.getOperand(1), Imm))
       return false;
-    Disp = DAG.getTargetConstant(Imm, dl, N.getValueType());
+    Disp = DAG.getSignedTargetConstant(Imm, dl, N.getValueType());
     if (FrameIndexSDNode *FI = dyn_cast<FrameIndexSDNode>(N.getOperand(0)))
       Base = DAG.getTargetFrameIndex(FI->getIndex(), N.getValueType());
     else
@@ -2946,12 +2946,12 @@ bool PPCTargetLowering::SelectAddressRegImm34(SDValue N, SDValue &Disp,
       Base = DAG.getTargetFrameIndex(FI->getIndex(), N.getValueType());
     else
       Base = N.getOperand(0);
-    Disp = DAG.getTargetConstant(Imm, dl, N.getValueType());
+    Disp = DAG.getSignedTargetConstant(Imm, dl, N.getValueType());
     return true;
   }
 
   if (isIntS34Immediate(N, Imm)) { // If the address is a 34-bit const.
-    Disp = DAG.getTargetConstant(Imm, dl, N.getValueType());
+    Disp = DAG.getSignedTargetConstant(Imm, dl, N.getValueType());
     Base = DAG.getRegister(PPC::ZERO8, N.getValueType());
     return true;
   }

--- a/llvm/test/CodeGen/PowerPC/pr118695.ll
+++ b/llvm/test/CodeGen/PowerPC/pr118695.ll
@@ -3,7 +3,7 @@
 ; CHECK:      # %bb.0:                                # %bb
 ; CHECK-NEXT:   lwz 3, L..C0(2)                         # @dvar
 ; CHECK-NEXT:   plxv 0, -152758(3), 0
-; CHECK-NEXT:   stxv 0, 0(0)
+; CHECK-NEXT:   stxv 0, 0(3)
 ; CHECK-NEXT:   blr
 
 %0 = type <{ double }>
@@ -12,6 +12,6 @@
 define void @Test() {
 bb:
 	%i9 = load <2 x double>, ptr getelementptr inbounds (i8, ptr @dvar, i64 -152758), align 8
-	store <2 x double> %i9, ptr null, align 8
+	store <2 x double> %i9, ptr @dvar, align 8
 	ret void
 }

--- a/llvm/test/CodeGen/PowerPC/pr118695.ll
+++ b/llvm/test/CodeGen/PowerPC/pr118695.ll
@@ -1,0 +1,17 @@
+; RUN: llc < %s -verify-machineinstrs -mtriple=powerpc-aix- -mcpu=pwr10 | FileCheck %s
+
+; CHECK:      # %bb.0:                                # %bb
+; CHECK-NEXT:   lwz 3, L..C0(2)                         # @dvar
+; CHECK-NEXT:   plxv 0, -152758(3), 0
+; CHECK-NEXT:   stxv 0, 0(0)
+; CHECK-NEXT:   blr
+
+%0 = type <{ double }>
+@dvar = external global [2352637 x %0]
+
+define void @Test() {
+bb:
+	%i9 = load <2 x double>, ptr getelementptr inbounds (i8, ptr @dvar, i64 -152758), align 8
+	store <2 x double> %i9, ptr null, align 8
+	ret void
+}


### PR DESCRIPTION
The patch fix the issue https://github.com/llvm/llvm-project/issues/118695

