### PR TITLE
Improve error output for duplicate symbol for `llvm-link` and `lto`

### DIFF
--- a/llvm/lib/Linker/LinkModules.cpp
+++ b/llvm/lib/Linker/LinkModules.cpp
@@ -321,8 +321,21 @@ bool ModuleLinker::shouldLinkFromSource(bool &LinkFromSrc,
   assert(!Dest.hasExternalWeakLinkage());
   assert(Dest.hasExternalLinkage() && Src.hasExternalLinkage() &&
          "Unexpected linkage type!");
-  return emitError("Linking globals named '" + Src.getName() +
-                   "': symbol multiply defined!");
+
+  std::string message = ("Linking globals named '" + Src.getName() +
+                      "': symbol multiply defined!").str();
+  if (auto SrcParent = Src.getParent(); SrcParent != nullptr) {
+    message += " (source: ";
+    message += SrcParent->getName();
+    message += ")";
+  }
+
+  if (auto DestParent = Dest.getParent(); DestParent != nullptr) {
+    message += " (dest: ";
+    message += DestParent->getName();
+    message += ")";
+  }
+  return emitError(message);
 }
 
 bool ModuleLinker::linkIfNeeded(GlobalValue &GV,

--- a/llvm/test/LTO/X86/Inputs/duplicate1.ll
+++ b/llvm/test/LTO/X86/Inputs/duplicate1.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @this_function_is_duplicated() {
+entry:
+  ret void
+}

--- a/llvm/test/LTO/X86/Inputs/duplicate2.ll
+++ b/llvm/test/LTO/X86/Inputs/duplicate2.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @this_function_is_duplicated() {
+entry:
+  ret void
+}

--- a/llvm/test/LTO/X86/duplicate_symbol.test
+++ b/llvm/test/LTO/X86/duplicate_symbol.test
@@ -1,0 +1,5 @@
+RUN: llvm-as %S/Inputs/duplicate1.ll -o %t.duplicate1.bc
+RUN: llvm-as %S/Inputs/duplicate2.ll -o %t.duplicate2.bc
+RUN: not llvm-lto %t.duplicate1.bc %t.duplicate2.bc -o %t.lto.obj 2>&1 | FileCheck %s
+CHECK: symbol multiply defined!
+CHECK: duplicate2

--- a/llvm/test/tools/llvm-link/Inputs/duplicate1.ll
+++ b/llvm/test/tools/llvm-link/Inputs/duplicate1.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @this_function_is_duplicated() {
+entry:
+  ret void
+}

--- a/llvm/test/tools/llvm-link/Inputs/duplicate2.ll
+++ b/llvm/test/tools/llvm-link/Inputs/duplicate2.ll
@@ -1,0 +1,6 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @this_function_is_duplicated() {
+entry:
+  ret void
+}

--- a/llvm/test/tools/llvm-link/duplicate_symbol.test
+++ b/llvm/test/tools/llvm-link/duplicate_symbol.test
@@ -1,0 +1,5 @@
+RUN: llvm-as %S/Inputs/duplicate1.ll -o %t.duplicate1.bc
+RUN: llvm-as %S/Inputs/duplicate2.ll -o %t.duplicate2.bc
+RUN: not llvm-link %t.duplicate1.bc %t.duplicate2.bc -o %t.duplicate.linked.bc 2>&1 | FileCheck %s
+CHECK: symbol multiply defined!
+CHECK: duplicate2


### PR DESCRIPTION
When linking bitcode files (not native object files), the `llvm-lto` and `llvm-link` tools report an error when a symbol name is defined in more than one input bitcode file.  Debugging this problem is difficult, because `llvm-lto` (and `llvm-link`) only shows the name of the duplicated symbol, but does not show the name of the bitcode files that contained the duplicated symbol name.

This PR adds the name of the modules that contributed the symbol to the error. This makes debugging symbol collisions easier.  The PR also adds regression tests for `llvm-lto` and `llvm-link`.

Unfortunately, I did not see an easy way to get the module name for *both* modules that produced a symbol name collision.  This PR shows the module names for both the "source" and "destination" modules, but only the "source" is an input bitcode file.  The "destination" module is the output module (LTO object or linked object) that is being generated.  If reviewers can suggest a way to get the information for both modules, it would be appreciated and I would update the PR.

