### PR TITLE
[lldb] Add additional assertions to TestVTableValue.test_overwrite_vtable

### DIFF
--- a/lldb/test/API/functionalities/vtable/TestVTableValue.py
+++ b/lldb/test/API/functionalities/vtable/TestVTableValue.py
@@ -2,7 +2,6 @@
 Make sure the getting a variable path works and doesn't crash.
 """
 
-
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.decorators import *
@@ -142,7 +141,12 @@ class TestVTableValue(TestBase):
             "\x01\x01\x01\x01\x01\x01\x01\x01" if is_64bit else "\x01\x01\x01\x01"
         )
         error = lldb.SBError()
-        process.WriteMemory(vtable_addr, data, error)
+        bytes_written = process.WriteMemory(vtable_addr, data, error)
+
+        self.assertSuccess(error)
+        self.assertGreater(
+            bytes_written, 0, "Failed to overwrite first entry in vtable"
+        )
 
         scribbled_child = vtable.GetChildAtIndex(0)
         self.assertEqual(


### PR DESCRIPTION
If this test fails, you're likely going to see something like "Assertion Error: A != B" which doesn't really give much explanation for why this failed.

Instead of ignoring the error, we should assert that it succeeded. This will lead to a better error message, for example:
`AssertionError: 'memory write failed for 0x102d7c018' is not success`