### PR TITLE
[memprof] Add IndexedMemProfData::addFrame

### DIFF
--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -1023,6 +1023,12 @@ struct IndexedMemProfData {
 
   // A map to hold call stack id to call stacks.
   llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>> CallStacks;
+
+  FrameId addFrame(const Frame &F) {
+    const FrameId Id = F.hash();
+    Frames.try_emplace(Id, F);
+    return Id;
+  }
 };
 
 struct FrameStat {

--- a/llvm/lib/ProfileData/MemProfReader.cpp
+++ b/llvm/lib/ProfileData/MemProfReader.cpp
@@ -584,9 +584,7 @@ Error RawMemProfReader::symbolizeAndFilterStackFrames(
           GuidToSymbolName.insert({Guid, CanonicalName.str()});
         }
 
-        const FrameId Hash = F.hash();
-        MemProfData.Frames.insert({Hash, F});
-        SymbolizedFrame[VAddr].push_back(Hash);
+        SymbolizedFrame[VAddr].push_back(MemProfData.addFrame(F));
       }
     }
 
@@ -769,11 +767,8 @@ void YAMLMemProfReader::parse(StringRef YAMLData) {
   auto AddCallStack = [&](ArrayRef<Frame> CallStack) -> CallStackId {
     SmallVector<FrameId> IndexedCallStack;
     IndexedCallStack.reserve(CallStack.size());
-    for (const Frame &F : CallStack) {
-      FrameId Id = F.hash();
-      MemProfData.Frames.try_emplace(Id, F);
-      IndexedCallStack.push_back(Id);
-    }
+    for (const Frame &F : CallStack)
+      IndexedCallStack.push_back(MemProfData.addFrame(F));
     CallStackId CSId = hashCallStack(IndexedCallStack);
     MemProfData.CallStacks.try_emplace(CSId, std::move(IndexedCallStack));
     return CSId;

--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -430,8 +430,8 @@ TEST(MemProf, BaseMemProfReader) {
            /*Column=*/5, /*IsInlineFrame=*/true);
   Frame F2(/*Hash=*/IndexedMemProfRecord::getGUID("bar"), /*LineOffset=*/10,
            /*Column=*/2, /*IsInlineFrame=*/false);
-  MemProfData.Frames.insert({F1.hash(), F1});
-  MemProfData.Frames.insert({F2.hash(), F2});
+  MemProfData.addFrame(F1);
+  MemProfData.addFrame(F2);
 
   llvm::SmallVector<FrameId> CallStack{F1.hash(), F2.hash()};
   CallStackId CSId = hashCallStack(CallStack);
@@ -466,8 +466,8 @@ TEST(MemProf, BaseMemProfReaderWithCSIdMap) {
            /*Column=*/5, /*IsInlineFrame=*/true);
   Frame F2(/*Hash=*/IndexedMemProfRecord::getGUID("bar"), /*LineOffset=*/10,
            /*Column=*/2, /*IsInlineFrame=*/false);
-  MemProfData.Frames.insert({F1.hash(), F1});
-  MemProfData.Frames.insert({F2.hash(), F2});
+  MemProfData.addFrame(F1);
+  MemProfData.addFrame(F2);
 
   llvm::SmallVector<FrameId> CallStack = {F1.hash(), F2.hash()};
   CallStackId CSId = hashCallStack(CallStack);


### PR DESCRIPTION
This patch adds a helper function to replace an idiom like:

  FrameId Id = F.hash();
  MemProfData.Frames.try_emplace(Id, F);
  // Do something with Id.
