### PR TITLE
LangRef: Avoid to use llvm.{vp.,}vector.reduce.f{min,max} if possible

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -19870,7 +19870,7 @@ This instruction has the same comparison semantics as the '``llvm.maxnum.*``'
 intrinsic.  If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
 
-It is deprecated, since the different order of inputs may produce different
+Don't use it if possible, since the different order of inputs may produce different
 outputs, and it is hard to optimize with Vector or SIMD extensions.
 Use '``llvm.vector.reduce.fmaximum``' or '``llvm.vector.reduce.fmaximumnum``' instead.
 
@@ -19903,7 +19903,7 @@ This instruction has the same comparison semantics as the '``llvm.minnum.*``'
 intrinsic. If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
 
-It is deprecated, since the different order of inputs may produce different
+Don't use it if possible, since the different order of inputs may produce different
 outputs, and it is hard to optimize with Vector or SIMD extensions.
 Use '``llvm.vector.reduce.fminimum``' or '``llvm.vector.reduce.fminimumnum``' instead.
 
@@ -23536,7 +23536,7 @@ This instruction has the same comparison semantics as the
 
 To ignore the start value, the neutral value can be used.
 
-It is deprecated, since the different order of inputs may produce different
+Don't use it if possible, since the different order of inputs may produce different
 outputs, and it is hard to optimize with Vector or SIMD extensions.
 Use '``llvm.vp.vector.reduce.fmaximum``' or '``llvm.vp.vector.reduce.fmaximumnum``' instead.
 
@@ -23607,7 +23607,7 @@ This instruction has the same comparison semantics as the
 
 To ignore the start value, the neutral value can be used.
 
-It is deprecated, since the different order of inputs may produce different
+Don't use it if possible, since the different order of inputs may produce different
 outputs, and it is hard to optimize with Vector or SIMD extensions.
 Use '``llvm.vp.vector.reduce.fminimum``' or '``llvm.vp.vector.reduce.fminimumnum``' instead.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -19870,6 +19870,10 @@ This instruction has the same comparison semantics as the '``llvm.maxnum.*``'
 intrinsic.  If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
 
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vector.reduce.fmaximum``' or '``llvm.vector.reduce.fmaximumnum``' instead.
+
 Arguments:
 """"""""""
 The argument to this intrinsic must be a vector of floating-point values.
@@ -19898,6 +19902,10 @@ matches the element-type of the vector input.
 This instruction has the same comparison semantics as the '``llvm.minnum.*``'
 intrinsic. If the intrinsic call has the ``nnan`` fast-math flag, then the
 operation can assume that NaNs are not present in the input vector.
+
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vector.reduce.fminimum``' or '``llvm.vector.reduce.fminimumnum``' instead.
 
 Arguments:
 """"""""""
@@ -23528,6 +23536,10 @@ This instruction has the same comparison semantics as the
 
 To ignore the start value, the neutral value can be used.
 
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vp.vector.reduce.fmaximum``' or '``llvm.vp.vector.reduce.fmaximumnum``' instead.
+
 Examples:
 """""""""
 
@@ -23594,6 +23606,10 @@ This instruction has the same comparison semantics as the
 '``llvm.minnum.*``' intrinsic).
 
 To ignore the start value, the neutral value can be used.
+
+It is deprecated, since the different order of inputs may produce different
+outputs, and it is hard to optimize with Vector or SIMD extensions.
+Use '``llvm.vp.vector.reduce.fminimum``' or '``llvm.vp.vector.reduce.fminimumnum``' instead.
 
 Examples:
 """""""""


### PR DESCRIPTION
The semantics about sNaN of these instructions are not clear enough. If there is a sNaN in the vector, the result may differs due to the position of the sNaN value.

Since then, it is difficult to optimize with Vector or SIMD extensions.

Users may use the `fminimum/fmaximum ` or `fminimumnum/fmaximumnum` if possible.