### PR TITLE
Make the `CHECK` lines here resistent to `chandlerc`

### DIFF
--- a/clang/test/CodeGen/ignore-overflow-pattern.c
+++ b/clang/test/CodeGen/ignore-overflow-pattern.c
@@ -21,7 +21,10 @@
 // unsigned negation, for example:
 // unsigned long A = -1UL;
 
+// Skip over parts of the IR containing this file's name.
+// CHECK: source_filename = {{.*}}
 
+// Ensure we don't see anything about handling overflow before the tests below.
 // CHECK-NOT: handle{{.*}}overflow
 
 extern unsigned a, b, c;


### PR DESCRIPTION
Specifically, usernames containing `handle`, such as `chandlerc`, often end up in paths, including the path of this test file which contains the word `overflow`. Combined, they create a match for `handle.*overflow` in the filename on my system (but likely not many others), leading this test to mysteriously fail for unfortunate usernames like mine. =D

No discussion of the amount of time I spent debugging this please. =[