### PR TITLE
[ProfileData] Add InstrProfWriter::writeBinaryIds (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProfWriter.h
+++ b/llvm/include/llvm/ProfileData/InstrProfWriter.h
@@ -237,6 +237,9 @@ private:
   uint64_t writeHeader(const IndexedInstrProf::Header &header,
                        const bool WritePrevVersion, ProfOStream &OS);
 
+  // Writes binary IDs.
+  Error writeBinaryIds(ProfOStream &OS);
+
   // Writes compressed vtable names to profiles.
   Error writeVTableNames(ProfOStream &OS);
 };


### PR DESCRIPTION
The patch makes InstrProfWriter::writeImpl less monolithic by adding
InstrProfWriter::writeBinaryIds to serialize binary IDs.  This way,
InstrProfWriter::writeImpl can simply call the new function instead of
handling all the details within writeImpl.
