### PR TITLE
[MachineLICM] Fix the check for high register pressure

### DIFF
--- a/llvm/lib/CodeGen/MachineLICM.cpp
+++ b/llvm/lib/CodeGen/MachineLICM.cpp
@@ -1250,6 +1250,8 @@ bool MachineLICMImpl::CanCauseHighRegPressure(
     if (CheapInstr && !HoistCheapInsts)
       return true;
 
+    if (static_cast<int>(RegPressure[Class]) + RPIdAndCost.second >= Limit)
+      return true;
     for (const auto &RP : BackTrace)
       if (static_cast<int>(RP[Class]) + RPIdAndCost.second >= Limit)
         return true;


### PR DESCRIPTION
We should be checking the register pressure change in MI's parent block before hoisting the instruction.