### PR TITLE
[NFC][SystemZ] Use SExt for signed constants

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZOperands.td
+++ b/llvm/lib/Target/SystemZ/SystemZOperands.td
@@ -220,7 +220,7 @@ def NEGLF32 : SDNodeXForm<imm, [{
 
 // Truncate an immediate to a 8-bit signed quantity.
 def SIMM8 : SDNodeXForm<imm, [{
-  return CurDAG->getSignedTargetConstant(int8_t(N->getZExtValue()), SDLoc(N),
+  return CurDAG->getSignedTargetConstant(int8_t(N->getSExtValue()), SDLoc(N),
                                          MVT::i64);
 }]>;
 
@@ -244,13 +244,13 @@ def UIMM12 : SDNodeXForm<imm, [{
 
 // Truncate an immediate to a 16-bit signed quantity.
 def SIMM16 : SDNodeXForm<imm, [{
-  return CurDAG->getSignedTargetConstant(int16_t(N->getZExtValue()), SDLoc(N),
+  return CurDAG->getSignedTargetConstant(int16_t(N->getSExtValue()), SDLoc(N),
                                          MVT::i64);
 }]>;
 
 // Negate and then truncate an immediate to a 16-bit signed quantity.
 def NEGSIMM16 : SDNodeXForm<imm, [{
-  return CurDAG->getSignedTargetConstant(int16_t(-N->getZExtValue()), SDLoc(N),
+  return CurDAG->getSignedTargetConstant(int16_t(-N->getSExtValue()), SDLoc(N),
                                          MVT::i64);
 }]>;
 
@@ -262,13 +262,13 @@ def UIMM16 : SDNodeXForm<imm, [{
 
 // Truncate an immediate to a 32-bit signed quantity.
 def SIMM32 : SDNodeXForm<imm, [{
-  return CurDAG->getSignedTargetConstant(int32_t(N->getZExtValue()), SDLoc(N),
+  return CurDAG->getSignedTargetConstant(int32_t(N->getSExtValue()), SDLoc(N),
                                          MVT::i64);
 }]>;
 
 // Negate and then truncate an immediate to a 32-bit unsigned quantity.
 def NEGSIMM32 : SDNodeXForm<imm, [{
-  return CurDAG->getSignedTargetConstant(int32_t(-N->getZExtValue()), SDLoc(N),
+  return CurDAG->getSignedTargetConstant(int32_t(-N->getSExtValue()), SDLoc(N),
                                          MVT::i64);
 }]>;
 


### PR DESCRIPTION
Use SExt instead of ZExt in XForms which produce a signed value. This is only to make it clear that the XForm handles a signed value.