### PR TITLE
[llvm] Pass FFI CMake options through to runtimes (for offload)

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -277,6 +277,7 @@ function(runtime_default_target)
                            PASSTHROUGH_PREFIXES LLVM_ENABLE_RUNTIMES
                                                 LLVM_USE_LINKER
                                                 CUDA # For runtimes that may look for the CUDA SDK (libc, offload)
+                                                FFI # offload uses libffi
                                                 ${ARG_PREFIXES}
                            EXTRA_TARGETS ${extra_targets}
                                          ${test_targets}


### PR DESCRIPTION
Pass the FFI-related CMake options through to runtimes, since offload is building against libffi.  This is needed when the system requires custom `LIBFFI_INCLUDE` to build (e.g. on Gentoo where the headers are installed to `/usr/lib*/libffi/include`).

(this one's for non-standalone builds)