### PR TITLE
[lldb] Add lookup by name to SBValue through new member property

### DIFF
--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -24,7 +24,7 @@ STRING_EXTENSION_OUTSIDE(SBValue)
                         key %= count
                         return self.sbvalue.GetChildAtIndex(key)
                 elif isinstance(key, str):
-                    if child := self.sbvalue.GetChildMemberWithName(key)
+                    if child := self.sbvalue.GetChildMemberWithName(key):
                         return child
                     # Support base classes, which are children but not members.
                     for child in self.sbvalue:

--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -24,7 +24,12 @@ STRING_EXTENSION_OUTSIDE(SBValue)
                         key %= count
                         return self.sbvalue.GetChildAtIndex(key)
                 elif isinstance(key, str):
-                    return self.sbvalue.GetChildMemberWithName(key)
+                    if child := self.sbvalue.GetChildMemberWithName(key)
+                        return child
+                    # Support base classes, which are children but not members.
+                    for child in self.sbvalue:
+                        if child.name == key:
+                            return child
                 return None
 
         def get_child_access_object(self):

--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -38,7 +38,7 @@ STRING_EXTENSION_OUTSIDE(SBValue)
                 def __getitem__(self, key):
                     if isinstance(key, str):
                         return self.valobj.GetChildMemberWithName(key)
-                    raise TypeError("invalid subscript key")
+                    raise TypeError("member key must be a string")
 
             return member_access(self)
 

--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -7,7 +7,7 @@ STRING_EXTENSION_OUTSIDE(SBValue)
             return self.GetDynamicValue (eDynamicCanRunTarget)
 
         class children_access(object):
-            '''A helper object that will lazily hand out child values when supplied an index or name.'''
+            '''A helper object that will lazily hand out child values when supplied an index.'''
 
             def __init__(self, sbvalue):
                 self.sbvalue = sbvalue
@@ -23,18 +23,24 @@ STRING_EXTENSION_OUTSIDE(SBValue)
                     if -count <= key < count:
                         key %= count
                         return self.sbvalue.GetChildAtIndex(key)
-                elif isinstance(key, str):
-                    if child := self.sbvalue.GetChildMemberWithName(key):
-                        return child
-                    # Support base classes, which are children but not members.
-                    for child in self.sbvalue:
-                        if child.name == key:
-                            return child
                 return None
 
         def get_child_access_object(self):
             '''An accessor function that returns a children_access() object which allows lazy member variable access from a lldb.SBValue object.'''
             return self.children_access (self)
+
+        def get_member_access_object(self):
+            '''An accessor function that returns an interface which provides subscript based lookup of child members.'''
+            class member_access:
+                def __init__(self, valobj):
+                    self.valobj = valobj
+
+                def __getitem__(self, key):
+                    if isinstance(key, str):
+                        return self.valobj.GetChildMemberWithName(key)
+                    raise TypeError("invalid subscript key")
+
+            return member_access(self)
 
         def get_value_child_list(self):
             '''An accessor function that returns a list() that contains all children in a lldb.SBValue object.'''
@@ -56,7 +62,8 @@ STRING_EXTENSION_OUTSIDE(SBValue)
             return self.GetNumChildren()
 
         children = property(get_value_child_list, None, doc='''A read only property that returns a list() of lldb.SBValue objects for the children of the value.''')
-        child = property(get_child_access_object, None, doc='''A read only property that returns an object that can access children of a variable by index or by name.''')
+        child = property(get_child_access_object, None, doc='''A read only property that returns an object that can access children of a variable by index (child_value = value.children[12]).''')
+        member = property(get_member_access_object, None, doc='''A read only property that returns an object that can access child members by name.''')
         name = property(GetName, None, doc='''A read only property that returns the name of this value as a string.''')
         type = property(GetType, None, doc='''A read only property that returns a lldb.SBType object that represents the type for this value.''')
         size = property(GetByteSize, None, doc='''A read only property that returns the size in bytes of this value.''')

--- a/lldb/bindings/interface/SBValueExtensions.i
+++ b/lldb/bindings/interface/SBValueExtensions.i
@@ -7,7 +7,7 @@ STRING_EXTENSION_OUTSIDE(SBValue)
             return self.GetDynamicValue (eDynamicCanRunTarget)
 
         class children_access(object):
-            '''A helper object that will lazily hand out thread for a process when supplied an index.'''
+            '''A helper object that will lazily hand out child values when supplied an index or name.'''
 
             def __init__(self, sbvalue):
                 self.sbvalue = sbvalue
@@ -23,6 +23,8 @@ STRING_EXTENSION_OUTSIDE(SBValue)
                     if -count <= key < count:
                         key %= count
                         return self.sbvalue.GetChildAtIndex(key)
+                elif isinstance(key, str):
+                    return self.sbvalue.GetChildMemberWithName(key)
                 return None
 
         def get_child_access_object(self):
@@ -49,7 +51,7 @@ STRING_EXTENSION_OUTSIDE(SBValue)
             return self.GetNumChildren()
 
         children = property(get_value_child_list, None, doc='''A read only property that returns a list() of lldb.SBValue objects for the children of the value.''')
-        child = property(get_child_access_object, None, doc='''A read only property that returns an object that can access children of a variable by index (child_value = value.children[12]).''')
+        child = property(get_child_access_object, None, doc='''A read only property that returns an object that can access children of a variable by index or by name.''')
         name = property(GetName, None, doc='''A read only property that returns the name of this value as a string.''')
         type = property(GetType, None, doc='''A read only property that returns a lldb.SBType object that represents the type for this value.''')
         size = property(GetByteSize, None, doc='''A read only property that returns the size in bytes of this value.''')

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -140,10 +140,8 @@ class ValueAPITestCase(TestBase):
         val_i = target.EvaluateExpression("i")
         val_s = target.EvaluateExpression("s")
         val_a = target.EvaluateExpression("a")
-        self.assertTrue(
-            val_s.GetChildMemberWithName("a").GetAddress().IsValid(), VALID_VARIABLE
-        )
-        self.assertTrue(val_s.GetChildMemberWithName("a").AddressOf(), VALID_VARIABLE)
+        self.assertTrue(val_s.child["a"].GetAddress().IsValid(), VALID_VARIABLE)
+        self.assertTrue(val_s.child["a"].AddressOf(), VALID_VARIABLE)
         self.assertTrue(val_a.Cast(val_i.GetType()).AddressOf(), VALID_VARIABLE)
 
         # Test some other cases of the Cast API.  We allow casts from one struct type
@@ -210,7 +208,7 @@ class ValueAPITestCase(TestBase):
         weird_cast = f_var.Cast(val_s.GetType())
         self.assertSuccess(weird_cast.GetError(), "Can cast from a larger to a smaller")
         self.assertEqual(
-            weird_cast.GetChildMemberWithName("a").GetValueAsSigned(0),
+            weird_cast.child["a"].GetValueAsSigned(0),
             33,
             "Got the right value",
         )

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -140,8 +140,8 @@ class ValueAPITestCase(TestBase):
         val_i = target.EvaluateExpression("i")
         val_s = target.EvaluateExpression("s")
         val_a = target.EvaluateExpression("a")
-        self.assertTrue(val_s.child["a"].GetAddress().IsValid(), VALID_VARIABLE)
-        self.assertTrue(val_s.child["a"].AddressOf(), VALID_VARIABLE)
+        self.assertTrue(val_s.member["a"].GetAddress().IsValid(), VALID_VARIABLE)
+        self.assertTrue(val_s.member["a"].AddressOf(), VALID_VARIABLE)
         self.assertTrue(val_a.Cast(val_i.GetType()).AddressOf(), VALID_VARIABLE)
 
         # Test some other cases of the Cast API.  We allow casts from one struct type
@@ -208,7 +208,7 @@ class ValueAPITestCase(TestBase):
         weird_cast = f_var.Cast(val_s.GetType())
         self.assertSuccess(weird_cast.GetError(), "Can cast from a larger to a smaller")
         self.assertEqual(
-            weird_cast.child["a"].GetValueAsSigned(0),
+            weird_cast.member["a"].GetValueAsSigned(0),
             33,
             "Got the right value",
         )


### PR DESCRIPTION
Introduces a `member` property to `SBValue`. This property provides pythonic access to a value's members, by name. The expression `value.member["name"]` will be an alternate form form of writing `value.GetChildMemberWithName("name")`.