### PR TITLE
Bump minimum MSVC version by one dot release to VS 2019 16.8

### DIFF
--- a/llvm/cmake/modules/CheckCompilerVersion.cmake
+++ b/llvm/cmake/modules/CheckCompilerVersion.cmake
@@ -12,9 +12,9 @@ set(APPLECLANG_MIN 10.0)
 set(APPLECLANG_SOFT_ERROR 10.0)
 
 # https://en.wikipedia.org/wiki/Microsoft_Visual_C#Internal_version_numbering
-# _MSC_VER == 1927 MSVC++ 14.27 Visual Studio 2019 Version 16.7
-set(MSVC_MIN 19.27)
-set(MSVC_SOFT_ERROR 19.27)
+# _MSC_VER == 1928 MSVC++ 19.27 Visual Studio 2019 Version 16.8 + 16.9
+set(MSVC_MIN 19.28)
+set(MSVC_SOFT_ERROR 19.28)
 
 set(LIBSTDCXX_MIN 7)
 set(LIBSTDCXX_SOFT_ERROR 7)

--- a/llvm/docs/GettingStarted.rst
+++ b/llvm/docs/GettingStarted.rst
@@ -356,7 +356,7 @@ popular host toolchains for specific minimum versions in our build systems:
 * Clang 5.0
 * Apple Clang 10.0
 * GCC 7.4
-* Visual Studio 2019 16.7
+* Visual Studio 2019 16.8
 
 Anything older than these toolchains *may* work, but will require forcing the
 build system with a special option and is not really a supported host platform.

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -113,6 +113,8 @@ Changes to LLVM infrastructure
 Changes to building LLVM
 ------------------------
 
+* Raised the minimum MSVC version to Visual Studio 2019 16.8.
+
 Changes to TableGen
 -------------------
 


### PR DESCRIPTION
This is a small change, but unblocks using longer string literals in LLVM's source code, and hopefully isn't disruptive.

Discussed in an RFC here: https://discourse.llvm.org/t/rfc-raising-minimum-msvc-version-by-one-dot-release/