### PR TITLE
[ARM] Error on invalid tokens in barrier insts

### DIFF
--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -5129,7 +5129,8 @@ ParseStatus ARMAsmParser::parseMemBarrierOptOperand(OperandVector &Operands) {
 
     Opt = ARM_MB::RESERVED_0 + Val;
   } else
-    return ParseStatus::Failure;
+    return Error(Parser.getTok().getLoc(),
+                 "expected an immediate or barrier type");
 
   Operands.push_back(
       ARMOperand::CreateMemBarrierOpt((ARM_MB::MemBOpt)Opt, S, *this));
@@ -5193,7 +5194,8 @@ ARMAsmParser::parseInstSyncBarrierOptOperand(OperandVector &Operands) {
 
     Opt = ARM_ISB::RESERVED_0 + Val;
   } else
-    return ParseStatus::Failure;
+    return Error(Parser.getTok().getLoc(),
+                 "expected an immediate or barrier type");
 
   Operands.push_back(ARMOperand::CreateInstSyncBarrierOpt(
       (ARM_ISB::InstSyncBOpt)Opt, S, *this));

--- a/llvm/test/MC/ARM/invalid-barrier.s
+++ b/llvm/test/MC/ARM/invalid-barrier.s
@@ -5,24 +5,46 @@
 @ DMB
 @------------------------------------------------------------------------------
         dmb #0x10
+@ CHECK: [[@LINE-1]]:{{.*}}: error: immediate value out of range
         dmb imaginary_scope
-
-@ CHECK: error: immediate value out of range
-@ CHECK: error: invalid operand for instruction
+@ CHECK: [[@LINE-1]]:{{.*}}: error: invalid operand for instruction
+        dmb [r0]
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        dmb [], @, -=_+
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        dmb ,,,,,
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        dmb 3.141
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
 
 @------------------------------------------------------------------------------
 @ DSB
 @------------------------------------------------------------------------------
         dsb #0x10
+@ CHECK: [[@LINE-1]]:{{.*}}: error: immediate value out of range
         dsb imaginary_scope
-@ CHECK: error: immediate value out of range
-@ CHECK: error: invalid operand for instruction
+@ CHECK: [[@LINE-1]]:{{.*}}: error: invalid operand for instruction
+        dsb [r0]
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        dsb [], @, -=_+
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        dsb ,,,,,
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        dsb 3.141
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
 
 @------------------------------------------------------------------------------
 @ ISB
 @------------------------------------------------------------------------------
         isb #0x1f
+@ CHECK: [[@LINE-1]]:{{.*}}: error: immediate value out of range
         isb imaginary_domain
-
-@ CHECK: error: immediate value out of range
-@ CHECK: error: invalid operand for instruction
+@ CHECK: [[@LINE-1]]:{{.*}}: error: invalid operand for instruction
+        isb [r0]
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        isb [], @, -=_+
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        isb ,,,,,
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type
+        isb 3.141
+@ CHECK: [[@LINE-1]]:{{.*}}: error: expected an immediate or barrier type


### PR DESCRIPTION
These operand parser functions for barrier instructions were returning ParseStatus::Failure for unexpected token kinds, but not outputting an error message, so these instructions with invalid operands were being rejected without an error being printed.

Fixes #67949 