### PR TITLE
[libc][docs] stub out assert, errno, and locale

### DIFF
--- a/libc/docs/headers/assert.rst
+++ b/libc/docs/headers/assert.rst
@@ -1,0 +1,27 @@
+.. include:: ../check.rst
+
+========
+assert.h
+========
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Macro
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - __STDC_VERSION_ASSERT_H__
+    - |check|
+    - 7.2.1
+    -
+  * - assert
+    -
+    - 7.2.1
+    -
+

--- a/libc/docs/headers/errno.rst
+++ b/libc/docs/headers/errno.rst
@@ -1,0 +1,35 @@
+.. include:: ../check.rst
+
+=======
+errno.h
+=======
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Macro
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - EDOM
+    -
+    - 7.5
+    -
+  * - EILSEQ
+    -
+    - 7.5
+    -
+  * - ERANGE
+    -
+    - 7.5
+    -
+  * - errno
+    -
+    - 7.5
+    -
+

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -4,9 +4,12 @@ Implementation Status
 .. toctree::
    :maxdepth: 1
 
+   assert
    complex
    ctype
+   errno
    fenv
+   locale
    math/index.rst
    search
    setjmp

--- a/libc/docs/headers/locale.rst
+++ b/libc/docs/headers/locale.rst
@@ -1,0 +1,63 @@
+.. include:: ../check.rst
+
+========
+locale.h
+========
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Macro
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - LC_ALL
+    - |check|
+    - 7.11
+    -
+  * - LC_COLLATE
+    - |check|
+    - 7.11
+    -
+  * - LC_CTYPE
+    - |check|
+    - 7.11
+    -
+  * - LC_MONETARY
+    - |check|
+    - 7.11
+    -
+  * - LC_NUMERIC
+    - |check|
+    - 7.11
+    -
+  * - LC_TIME
+    - |check|
+    - 7.11
+    -
+
+Functions
+=========
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - localeconv
+    - |check|
+    - 7.11.2.1
+    -
+  * - setlocale
+    - |check|
+    - 7.11.1.1
+    -

--- a/libc/utils/docgen/assert.json
+++ b/libc/utils/docgen/assert.json
@@ -1,0 +1,10 @@
+{
+  "macros": {
+    "__STDC_VERSION_ASSERT_H__": {
+      "c-definition": "7.2.1"
+    },
+    "assert": {
+      "c-definition": "7.2.1"
+    }
+  }
+}

--- a/libc/utils/docgen/errno.json
+++ b/libc/utils/docgen/errno.json
@@ -1,0 +1,16 @@
+{
+  "macros": {
+    "EDOM": {
+      "c-definition": "7.5"
+    },
+    "EILSEQ": {
+      "c-definition": "7.5"
+    },
+    "ERANGE": {
+      "c-definition": "7.5"
+    },
+    "errno": {
+      "c-definition": "7.5"
+    }
+  }
+}

--- a/libc/utils/docgen/locale.json
+++ b/libc/utils/docgen/locale.json
@@ -1,0 +1,30 @@
+{
+  "macros": {
+    "LC_ALL": {
+      "c-definition": "7.11"
+    },
+    "LC_COLLATE": {
+      "c-definition": "7.11"
+    },
+    "LC_CTYPE": {
+      "c-definition": "7.11"
+    },
+    "LC_MONETARY": {
+      "c-definition": "7.11"
+    },
+    "LC_NUMERIC": {
+      "c-definition": "7.11"
+    },
+    "LC_TIME": {
+      "c-definition": "7.11"
+    }
+  },
+  "functions": {
+    "setlocale": {
+      "c-definition": "7.11.1.1"
+    },
+    "localeconv": {
+      "c-definition": "7.11.2.1"
+    }
+  }
+}


### PR DESCRIPTION
[libc][docs] stub out assert, errno, and locale

These were the remaining c89 library headers (besides string.h and stdlib.h; I
will split strings.rst in a follow up commit).

The macro support detection in docgen doesn't quite work for some of these
headers.  Add the stubs for these headers for now, and fix up docgen later.

See the "NIST publication":
Link: https://www.open-std.org/jtc1/sc22/wg14/www/projects.html