### PR TITLE
[libc] document supported os ranges

### DIFF
--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -41,7 +41,7 @@ slowly replacing functions from its bundled libc with functions from this
 project.
 
 LLVM-libc does not guarantee backward compatibility with operating systems that have reached their EOL.
-Compatibility patch for obsolete operating systems will not be accepted.
+Compatibility patches for obsolete operating systems will not be accepted.
 
 For Linux, we support kernel versions as listed on `kernel.org <https://kernel.org/>`_, including
 ``longterm`` (not past EOL date), ``stable``, and ``mainline`` versions. We actively adopt new features

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -47,7 +47,7 @@ For Linux, we support kernel versions as listed on `kernel.org <https://kernel.o
 ``longterm`` (not past EOL date), ``stable``, and ``mainline`` versions. We actively adopt new features
 from ``linux-next``.
 
-For Windows, we support products within their lifecycle. Please refer to 
+For Windows, we plan to support products within their lifecycle. Please refer to 
 `Search Product and Services Lifecycle Information <https://learn.microsoft.com/en-us/lifecycle/products/?products=windows>`_ for more information.
 
 ABI Compatibility

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -40,7 +40,7 @@ and MacOS have limited support (may be broken).  The Fuchsia platform is
 slowly replacing functions from its bundled libc with functions from this
 project.
 
-LLVM-libc does not guarantee backward compatibility with operating systems that reaches their EOL.
+LLVM-libc does not guarantee backward compatibility with operating systems that have reached their EOL.
 Compatibility patch for obsolete operating systems will not be accepted.
 
 For Linux, we support kernel versions as listed on `kernel.org <https://kernel.org/>`_, including

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -40,6 +40,16 @@ and MacOS have limited support (may be broken).  The Fuchsia platform is
 slowly replacing functions from its bundled libc with functions from this
 project.
 
+LLVM-libc does not guarantee backward compatibility with operating systems that reaches their EOL.
+Compatibility patch for obsolete operating systems will not be accepted.
+
+For Linux, we support kernel versions as listed on `kernel.org <https://kernel.org/>`_, including
+``longterm``, ``stable``, and ``mainline`` versions. We actively adapt new features
+from ``linux-next``.
+
+For Windows, we support products within their lifecycle. Please refer to 
+`Search Product and Services Lifecycle Information <https://learn.microsoft.com/en-us/lifecycle/products/?products=windows>`_ for more information.
+
 ABI Compatibility
 =================
 

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -44,7 +44,7 @@ LLVM-libc does not guarantee backward compatibility with operating systems that 
 Compatibility patch for obsolete operating systems will not be accepted.
 
 For Linux, we support kernel versions as listed on `kernel.org <https://kernel.org/>`_, including
-``longterm``, ``stable``, and ``mainline`` versions. We actively adapt new features
+``longterm`` (not past EOL date), ``stable``, and ``mainline`` versions. We actively adopt new features
 from ``linux-next``.
 
 For Windows, we support products within their lifecycle. Please refer to 


### PR DESCRIPTION
LLVM-libc does not guarantee backward compatibility with operating systems that have reached their EOL.
Compatibility patches for obsolete operating systems will not be accepted.

For Linux, we support kernel versions as listed on [kernel.org](https://kernel.org/), including
``longterm`` (not passed EOL date), ``stable``, and ``mainline`` versions. We actively adapt new features
from ``linux-next``.

For Windows, we plan to support products within their lifecycle. Please refer to 
[Search Product and Services Lifecycle Information](https://learn.microsoft.com/en-us/lifecycle/products/?products=windows) for more information.