### PR TITLE
[libc] Find Python 3 in standalone

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -8,6 +8,13 @@ endif()
 include(${LLVM_COMMON_CMAKE_UTILS}/Modules/CMakePolicy.cmake
   NO_POLICY_SCOPE)
 
+# If we are not building as a part of LLVM, build libc as an
+# standalone project, using LLVM as an external library:
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(libc)
+  set(LIBC_BUILT_STANDALONE TRUE)
+endif()
+
 if (LIBC_CMAKE_VERBOSE_LOGGING)
   get_directory_property(LIBC_OLD_PREPROCESSOR_DEFS COMPILE_DEFINITIONS)
   foreach(OLD_DEF ${LIBC_OLD_PREPROCESSOR_DEFS})
@@ -29,6 +36,14 @@ endif()
 
 # Default to C++17
 set(CMAKE_CXX_STANDARD 17)
+
+if(LIBC_BUILT_STANDALONE)
+  # Python 3 is required and needs to be manually imported in
+  # a standalone build.
+  # NOTE: We specifically need pyyaml in order for hdrgen to work.
+  find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
+    COMPONENTS Interpreter)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 


### PR DESCRIPTION
`Python3_Executable` wasn't defined when libc is trying to be built in standalone mode. Also adds a `project` define so CMake quits complaining.