### PR TITLE
[libc] Add unistd overlay

### DIFF
--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -126,10 +126,13 @@ add_proxy_header_library(
     libc.include.llvm-libc-macros.sys_stat_macros
 )
 
+add_header_library(unistd_overlay HDRS unistd_overlay.h)
 add_proxy_header_library(
   unistd_macros
   HDRS
     unistd_macros.h
+  DEPENDS
+    .unistd_overlay
   FULL_BUILD_DEPENDS
     libc.include.unistd
     libc.include.llvm-libc-macros.unistd_macros

--- a/libc/hdr/unistd_macros.h
+++ b/libc/hdr/unistd_macros.h
@@ -15,7 +15,7 @@
 
 #else // Overlay mode
 
-#include <unistd.h>
+#include "unistd_overlay.h"
 
 #endif // LLVM_LIBC_FULL_BUILD
 

--- a/libc/hdr/unistd_overlay.h
+++ b/libc/hdr/unistd_overlay.h
@@ -1,0 +1,69 @@
+//===-- Including unistd.h in overlay mode -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_UNISTD_OVERLAY_H
+#define LLVM_LIBC_HDR_UNISTD_OVERLAY_H
+
+#ifdef LIBC_FULL_BUILD
+#error "This header should only be included in overlay mode"
+#endif
+
+// Overlay mode
+
+// glibc <unistd.h> header might provide extern inline definitions for few
+// functions, causing external alias errors.  They are guarded by
+// `__USE_EXTERN_INLINES` macro.  We temporarily disable `__USE_EXTERN_INLINES`
+// macro by defining `__NO_INLINE__` before including <stdio.h>.
+// And the same with `__USE_FORTIFY_LEVEL`, which will be temporarily disabled
+// with `_FORTIFY_SOURCE`.
+
+#ifdef _FORTIFY_SOURCE
+#define LIBC_OLD_FORTIFY_SOURCE _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif
+
+#ifdef __USE_EXTERN_INLINES
+#define LIBC_OLD_USE_EXTERN_INLINES
+#undef __USE_EXTERN_INLINES
+#endif
+
+#ifdef __USE_FORTIFY_LEVEL
+#define LIBC_OLD_USE_FORTIFY_LEVEL __USE_FORTIFY_LEVEL
+#undef __USE_FORTIFY_LEVEL
+#define __USE_FORTIFY_LEVEL 0
+#endif
+
+#ifndef __NO_INLINE__
+#define __NO_INLINE__ 1
+#define LIBC_SET_NO_INLINE
+#endif
+
+#include <unistd.h>
+
+#ifdef LIBC_OLD_FORTIFY_SOURCE
+#define _FORTIFY_SOURCE LIBC_OLD_FORTIFY_SOURCE
+#undef LIBC_OLD_FORTIFY_SOURCE
+#endif
+
+#ifdef LIBC_SET_NO_INLINE
+#undef __NO_INLINE__
+#undef LIBC_SET_NO_INLINE
+#endif
+
+#ifdef LIBC_OLD_USE_FORTIFY_LEVEL
+#undef __USE_FORTIFY_LEVEL
+#define __USE_FORTIFY_LEVEL LIBC_OLD_USE_FORTIFY_LEVEL
+#undef LIBC_OLD_USE_FORTIFY_LEVEL
+#endif
+
+#ifdef LIBC_OLD_USE_EXTERN_INLINES
+#define __USE_EXTERN_INLINES
+#undef LIBC_OLD_USE_EXTERN_INLINES
+#endif
+
+#endif // LLVM_LIBC_HDR_UNISTD_OVERLAY_H

--- a/libc/src/unistd/dup.h
+++ b/libc/src/unistd/dup.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_DUP_H
 #define LLVM_LIBC_SRC_UNISTD_DUP_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/dup2.h
+++ b/libc/src/unistd/dup2.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_DUP2_H
 #define LLVM_LIBC_SRC_UNISTD_DUP2_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/dup3.h
+++ b/libc/src/unistd/dup3.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_DUP3_H
 #define LLVM_LIBC_SRC_UNISTD_DUP3_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/fork.h
+++ b/libc/src/unistd/fork.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_FORK_H
 #define LLVM_LIBC_SRC_UNISTD_FORK_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/ftruncate.h
+++ b/libc/src/unistd/ftruncate.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_FTRUNCATE_H
 #define LLVM_LIBC_SRC_UNISTD_FTRUNCATE_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/getcwd.h
+++ b/libc/src/unistd/getcwd.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETCWD_H
 #define LLVM_LIBC_SRC_UNISTD_GETCWD_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/geteuid.h
+++ b/libc/src/unistd/geteuid.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETEUID_H
 #define LLVM_LIBC_SRC_UNISTD_GETEUID_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/getopt.h
+++ b/libc/src/unistd/getopt.h
@@ -10,8 +10,8 @@
 #define LLVM_LIBC_SRC_UNISTD_GETOPT_H
 
 #include "hdr/types/FILE.h"
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/getpid.h
+++ b/libc/src/unistd/getpid.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETPID_H
 #define LLVM_LIBC_SRC_UNISTD_GETPID_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/getppid.h
+++ b/libc/src/unistd/getppid.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETPPID_H
 #define LLVM_LIBC_SRC_UNISTD_GETPPID_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/getuid.h
+++ b/libc/src/unistd/getuid.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_GETUID_H
 #define LLVM_LIBC_SRC_UNISTD_GETUID_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/isatty.h
+++ b/libc/src/unistd/isatty.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_ISATTY_H
 #define LLVM_LIBC_SRC_UNISTD_ISATTY_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/link.h
+++ b/libc/src/unistd/link.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_LINK_H
 #define LLVM_LIBC_SRC_UNISTD_LINK_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/linux/ftruncate.cpp
+++ b/libc/src/unistd/linux/ftruncate.cpp
@@ -11,11 +11,11 @@
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
 #include "src/errno/libc_errno.h"
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/linux/lseek.cpp
+++ b/libc/src/unistd/linux/lseek.cpp
@@ -14,8 +14,8 @@
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
 
+#include "hdr/types/off_t.h"
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>      // For off_t.
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -10,11 +10,11 @@
 
 #include "src/__support/common.h"
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
 #include "src/errno/libc_errno.h"
 #include "src/sys/auxv/getauxval.h"
 #include <sys/auxv.h>
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/linux/truncate.cpp
+++ b/libc/src/unistd/linux/truncate.cpp
@@ -13,9 +13,9 @@
 #include "src/__support/macros/config.h"
 #include "src/errno/libc_errno.h"
 
+#include "hdr/unistd_macros.h"
 #include <stdint.h>      // For uint64_t.
 #include <sys/syscall.h> // For syscall numbers.
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/lseek.h
+++ b/libc/src/unistd/lseek.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_LSEEK_H
 #define LLVM_LIBC_SRC_UNISTD_LSEEK_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/pread.h
+++ b/libc/src/unistd/pread.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_PREAD_H
 #define LLVM_LIBC_SRC_UNISTD_PREAD_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/pwrite.h
+++ b/libc/src/unistd/pwrite.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_PWRITE_H
 #define LLVM_LIBC_SRC_UNISTD_PWRITE_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/read.h
+++ b/libc/src/unistd/read.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_READ_H
 #define LLVM_LIBC_SRC_UNISTD_READ_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/readlink.h
+++ b/libc/src/unistd/readlink.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_READLINK_H
 #define LLVM_LIBC_SRC_UNISTD_READLINK_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/readlinkat.h
+++ b/libc/src/unistd/readlinkat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_READLINKAT_H
 #define LLVM_LIBC_SRC_UNISTD_READLINKAT_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/swab.h
+++ b/libc/src/unistd/swab.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SWAB_H
 #define LLVM_LIBC_SRC_UNISTD_SWAB_H
 
+#include "hdr/types/ssize_t.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h> // For ssize_t
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/symlink.h
+++ b/libc/src/unistd/symlink.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYMLINK_H
 #define LLVM_LIBC_SRC_UNISTD_SYMLINK_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/symlinkat.h
+++ b/libc/src/unistd/symlinkat.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYMLINKAT_H
 #define LLVM_LIBC_SRC_UNISTD_SYMLINKAT_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/syscall.h
+++ b/libc/src/unistd/syscall.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYSCALL_H
 #define LLVM_LIBC_SRC_UNISTD_SYSCALL_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
 #include <stdarg.h>
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/sysconf.h
+++ b/libc/src/unistd/sysconf.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_SYSCONF_H
 #define LLVM_LIBC_SRC_UNISTD_SYSCONF_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/truncate.h
+++ b/libc/src/unistd/truncate.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_TRUNCATE_H
 #define LLVM_LIBC_SRC_UNISTD_TRUNCATE_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/unistd/write.h
+++ b/libc/src/unistd/write.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_LIBC_SRC_UNISTD_WRITE_H
 #define LLVM_LIBC_SRC_UNISTD_WRITE_H
 
+#include "hdr/unistd_macros.h"
 #include "src/__support/macros/config.h"
-#include <unistd.h>
 
 namespace LIBC_NAMESPACE_DECL {
 


### PR DESCRIPTION
Fixes failures like this which I experienced:
```
FAILED: src/unistd/linux/CMakeFiles/libc.src.unistd.linux.read.dir/read.cpp.o
/nix/store/2r2xi5pbg29bsmqywsm5zgl8l7adky4i-gcc-wrapper-13.3.0/bin/g++ -DLIBC_NAMESPACE=__llvm_libc -D_DEBUG -I/build/libc-src-20.0.0-unstable-2024-12-05/libc -isystem /build/libc-src-20.0.0-unstable-2024-12-05/libc/build/include -g -std=gnu++17 -DLIBC_QSORT_IMPL=LIBC_QSORT_QUICK_SORT -DLIBC_ADD_NULL_CHECKS -DLIBC_COPT_PUBLIC_PACKAGING -MD -MT src/unistd/linux/CMakeFiles/libc.src.unistd.linux.read.dir/read.cpp.o -MF src/unistd/linux/CMakeFiles/libc.src.unistd.linux.read.dir/read.cpp.o.d -o src/unistd/linux/CMakeFiles/libc.src.unistd.linux.read.dir/read.cpp.o -c /build/libc-src-20.0.0-unstable-2024-12-05/libc/src/unistd/linux/read.cpp
次のファイルから読み込み:  /build/libc-src-20.0.0-unstable-2024-12-05/libc/src/__support/OSUtil/linux/syscall.h:13,
         次から読み込み:  /build/libc-src-20.0.0-unstable-2024-12-05/libc/src/__support/OSUtil/syscall.h:15,
         次から読み込み:  /build/libc-src-20.0.0-unstable-2024-12-05/libc/src/unistd/linux/read.cpp:11:
/build/libc-src-20.0.0-unstable-2024-12-05/libc/src/unistd/linux/read.cpp:20:29: エラー: ‘ssize_t __llvm_libc::read(int, void*, size_t)’ が外部シンボル ‘read’ の別名となっています
   20 | LLVM_LIBC_FUNCTION(ssize_t, read, (int fd, void *buf, size_t count)) {
      |                             ^~~~
/build/libc-src-20.0.0-unstable-2024-12-05/libc/src/__support/common.h:46:34: 備考: in definition of macro ‘LLVM_LIBC_FUNCTION_IMPL’
   46 |   decltype(LIBC_NAMESPACE::name) name [[gnu::alias(#name)]];                   \
      |                                  ^~~~
/build/libc-src-20.0.0-unstable-2024-12-05/libc/src/unistd/linux/read.cpp:20:1: 備考: in expansion of macro ‘LLVM_LIBC_FUNCTION’
   20 | LLVM_LIBC_FUNCTION(ssize_t, read, (int fd, void *buf, size_t count)) {
      | ^~~~~~~~~~~~~~~~~~
```