### PR TITLE
[dsymutil] Emit a warning instead of an error when using fat64 header

### DIFF
--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -832,15 +832,15 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
       return EXIT_FAILURE;
 
     if (NeedsTempFiles) {
-      const bool Fat64 = Options.LinkOpts.Fat64;
+      bool Fat64 = Options.LinkOpts.Fat64;
       if (!Fat64) {
         // Universal Mach-O files can't have an archicture slice that starts
         // beyond the 4GB boundary. "lipo" can create a 64 bit universal
-        // header, but not all tools can parse these files so we want to return
-        // an error if the file can't be encoded as a file with a 32 bit
+        // header, but older tools may not support these files so we want to
+        // emit a warning if the file can't be encoded as a file with a 32 bit
         // universal header. To detect this, we check the size of each
         // architecture's skinny Mach-O file and add up the offsets. If they
-        // exceed 4GB, then we return an error.
+        // exceed 4GB, we emit a warning.
 
         // First we compute the right offset where the first architecture will
         // fit followin the 32 bit universal header. The 32 bit universal header
@@ -859,13 +859,15 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
           if (!stat)
             break;
           if (FileOffset > UINT32_MAX) {
-            WithColor::error()
-                << formatv("the universal binary has a slice with a starting "
-                           "offset ({0:x}) that exceeds 4GB and will produce "
-                           "an invalid Mach-O file. Use the -fat64 flag to "
-                           "generate a universal binary with a 64-bit header "
-                           "but note that not all tools support this format.",
-                           FileOffset);
+            Fat64 = true;
+            WithColor::warning() << formatv(
+                "the universal binary has a slice with a starting offset "
+                "({0:x}) that exceeds 4GB. To avoid producing an invalid "
+                "Mach-O file, a universal binary with a 64-bit header will be "
+                "generated, which may not be supported by older tools. Use the "
+                "-fat64 flag to force a 64-bit header and silence this "
+                "warning.",
+                FileOffset);
             return EXIT_FAILURE;
           }
           FileOffset += stat->getSize();


### PR DESCRIPTION
Universal Mach-O files can't have an archicture slice that starts beyond the 4GB boundary. However, we support generating universal binaries with a fat64 header, but older tools may not understand this format.

Currently, unless -fat64 is passed, dsymutil will error out when it encounters a slice that would exceeds the 4GB limit. Now that more tools (like LLDB and CoreSymbolication) understand the fat64 header format, this patch changes the default behavior to use the fat64 header and emits a warning instead. The warning can be silenced by passing the -fat64 flag. The goal is to eventually remove the warning altogether.

rdar://140998416