### PR TITLE
[InstCombine] Match range check pattern with SExt

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -698,20 +698,10 @@ Value *InstCombinerImpl::simplifyRangeCheck(ICmpInst *Cmp0, ICmpInst *Cmp1,
   Value *Cmp1Op0 = Cmp1->getOperand(0);
   Value *Cmp1Op1 = Cmp1->getOperand(1);
   Value *RangeEnd;
-  if (Cmp1Op0 == Input) {
-    // For the upper range compare we have: icmp x, n
-    RangeEnd = Cmp1Op1;
-  } else if (isa<SExtInst>(Cmp1Op0) &&
-             cast<SExtInst>(Cmp1Op0)->getOperand(0) == Input) {
-    // For the upper range compare we have: icmp (sext x), n
+  if (match(Cmp1Op0, m_SExtOrSelf(m_Specific(Input)))) {
     Input = Cmp1Op0;
     RangeEnd = Cmp1Op1;
-  } else if (Cmp1Op1 == Input) {
-    // For the upper range compare we have: icmp n, x
-    Pred1 = ICmpInst::getSwappedPredicate(Pred1);
-    RangeEnd = Cmp1Op0;
-  } else if (isa<SExtInst>(Cmp1Op1) &&
-             cast<SExtInst>(Cmp1Op1)->getOperand(0) == Input) {
+  } else if (match(Cmp1Op1, m_SExtOrSelf(m_Specific(Input)))) {
     // For the upper range compare we have: icmp n, (sext x)
     Pred1 = ICmpInst::getSwappedPredicate(Pred1);
     Input = Cmp1Op1;

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -695,14 +695,27 @@ Value *InstCombinerImpl::simplifyRangeCheck(ICmpInst *Cmp0, ICmpInst *Cmp1,
                                Cmp1->getPredicate());
 
   Value *Input = Cmp0->getOperand(0);
+  Value *Cmp1Op0 = Cmp1->getOperand(0);
+  Value *Cmp1Op1 = Cmp1->getOperand(1);
   Value *RangeEnd;
-  if (Cmp1->getOperand(0) == Input) {
+  if (Cmp1Op0 == Input) {
     // For the upper range compare we have: icmp x, n
-    RangeEnd = Cmp1->getOperand(1);
-  } else if (Cmp1->getOperand(1) == Input) {
+    RangeEnd = Cmp1Op1;
+  } else if (isa<SExtInst>(Cmp1Op0) &&
+             cast<SExtInst>(Cmp1Op0)->getOperand(0) == Input) {
+    // For the upper range compare we have: icmp (sext x), n
+    Input = Cmp1Op0;
+    RangeEnd = Cmp1Op1;
+  } else if (Cmp1Op1 == Input) {
     // For the upper range compare we have: icmp n, x
-    RangeEnd = Cmp1->getOperand(0);
     Pred1 = ICmpInst::getSwappedPredicate(Pred1);
+    RangeEnd = Cmp1Op0;
+  } else if (isa<SExtInst>(Cmp1Op1) &&
+             cast<SExtInst>(Cmp1Op1)->getOperand(0) == Input) {
+    // For the upper range compare we have: icmp n, (sext x)
+    Pred1 = ICmpInst::getSwappedPredicate(Pred1);
+    Input = Cmp1Op1;
+    RangeEnd = Cmp1Op0;
   } else {
     return nullptr;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -699,13 +699,14 @@ Value *InstCombinerImpl::simplifyRangeCheck(ICmpInst *Cmp0, ICmpInst *Cmp1,
   Value *Cmp1Op1 = Cmp1->getOperand(1);
   Value *RangeEnd;
   if (match(Cmp1Op0, m_SExtOrSelf(m_Specific(Input)))) {
+    // For the upper range compare we have: icmp x, n
     Input = Cmp1Op0;
     RangeEnd = Cmp1Op1;
   } else if (match(Cmp1Op1, m_SExtOrSelf(m_Specific(Input)))) {
     // For the upper range compare we have: icmp n, (sext x)
-    Pred1 = ICmpInst::getSwappedPredicate(Pred1);
     Input = Cmp1Op1;
     RangeEnd = Cmp1Op0;
+    Pred1 = ICmpInst::getSwappedPredicate(Pred1);
   } else {
     return nullptr;
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -703,7 +703,7 @@ Value *InstCombinerImpl::simplifyRangeCheck(ICmpInst *Cmp0, ICmpInst *Cmp1,
     Input = Cmp1Op0;
     RangeEnd = Cmp1Op1;
   } else if (match(Cmp1Op1, m_SExtOrSelf(m_Specific(Input)))) {
-    // For the upper range compare we have: icmp n, (sext x)
+    // For the upper range compare we have: icmp n, x
     Input = Cmp1Op1;
     RangeEnd = Cmp1Op0;
     Pred1 = ICmpInst::getSwappedPredicate(Pred1);

--- a/llvm/test/Transforms/InstCombine/range-check.ll
+++ b/llvm/test/Transforms/InstCombine/range-check.ll
@@ -34,15 +34,17 @@ define i1 @test_and1_logical(i32 %x, i32 %n) {
 
 define i1 @test_and1_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_and1_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp ugt i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
   %a = icmp sge i32 %x, 0
-  %b = icmp slt i64 %x_sext, %nn
+  %b = icmp slt i64 %x_sext, %n
   %c = and i1 %a, %b
   ret i1 %c
 }
@@ -77,15 +79,17 @@ define i1 @test_and2_logical(i32 %x, i32 %n) {
 
 define i1 @test_and2_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_and2_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp uge i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
   %a = icmp sgt i32 %x, -1
-  %b = icmp sle i64 %x_sext, %nn
+  %b = icmp sle i64 %x_sext, %n
   %c = and i1 %a, %b
   ret i1 %c
 }
@@ -118,14 +122,16 @@ define i1 @test_and3_logical(i32 %x, i32 %n) {
 
 define i1 @test_and3_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_and3_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp ugt i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
-  %a = icmp sgt i64 %nn, %x_sext
+  %a = icmp sgt i64 %n, %x_sext
   %b = icmp sge i32 %x, 0
   %c = and i1 %a, %b
   ret i1 %c
@@ -159,14 +165,16 @@ define i1 @test_and4_logical(i32 %x, i32 %n) {
 
 define i1 @test_and4_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_and4_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp uge i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
-  %a = icmp sge i64 %nn, %x_sext
+  %a = icmp sge i64 %n, %x_sext
   %b = icmp sge i32 %x, 0
   %c = and i1 %a, %b
   ret i1 %c
@@ -202,15 +210,17 @@ define i1 @test_or1_logical(i32 %x, i32 %n) {
 
 define i1 @test_or1_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_or1_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp ule i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
   %a = icmp slt i32 %x, 0
-  %b = icmp sge i64 %x_sext, %nn
+  %b = icmp sge i64 %x_sext, %n
   %c = or i1 %a, %b
   ret i1 %c
 }
@@ -245,15 +255,17 @@ define i1 @test_or2_logical(i32 %x, i32 %n) {
 
 define i1 @test_or2_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_or2_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp ult i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
   %a = icmp sle i32 %x, -1
-  %b = icmp sgt i64 %x_sext, %nn
+  %b = icmp sgt i64 %x_sext, %n
   %c = or i1 %a, %b
   ret i1 %c
 }
@@ -286,14 +298,16 @@ define i1 @test_or3_logical(i32 %x, i32 %n) {
 
 define i1 @test_or3_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_or3_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp ule i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
-  %a = icmp sle i64 %nn, %x_sext
+  %a = icmp sle i64 %n, %x_sext
   %b = icmp slt i32 %x, 0
   %c = or i1 %a, %b
   ret i1 %c
@@ -327,14 +341,16 @@ define i1 @test_or4_logical(i32 %x, i32 %n) {
 
 define i1 @test_or4_sext(i32 %x, i64 %n) {
 ; CHECK-LABEL: @test_or4_sext(
-; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[N_NOT_NEGATIVE:%.*]] = icmp sgt i64 [[NN:%.*]], -1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[N_NOT_NEGATIVE]])
 ; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
 ; CHECK-NEXT:    [[C:%.*]] = icmp ult i64 [[NN]], [[X_SEXT]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
-  %nn = and i64 %n, 2147483647
+  %n_not_negative = icmp sge i64 %n, 0
+  call void @llvm.assume(i1 %n_not_negative)
   %x_sext = sext i32 %x to i64
-  %a = icmp slt i64 %nn, %x_sext
+  %a = icmp slt i64 %n, %x_sext
   %b = icmp slt i32 %x, 0
   %c = or i1 %a, %b
   ret i1 %c

--- a/llvm/test/Transforms/InstCombine/range-check.ll
+++ b/llvm/test/Transforms/InstCombine/range-check.ll
@@ -32,6 +32,21 @@ define i1 @test_and1_logical(i32 %x, i32 %n) {
   ret i1 %c
 }
 
+define i1 @test_and1_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_and1_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp ugt i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp sge i32 %x, 0
+  %b = icmp slt i64 %x_sext, %nn
+  %c = and i1 %a, %b
+  ret i1 %c
+}
+
 define i1 @test_and2(i32 %x, i32 %n) {
 ; CHECK-LABEL: @test_and2(
 ; CHECK-NEXT:    [[NN:%.*]] = and i32 [[N:%.*]], 2147483647
@@ -57,6 +72,21 @@ define i1 @test_and2_logical(i32 %x, i32 %n) {
   %a = icmp sgt i32 %x, -1
   %b = icmp sle i32 %x, %nn
   %c = select i1 %a, i1 %b, i1 false
+  ret i1 %c
+}
+
+define i1 @test_and2_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_and2_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp uge i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp sgt i32 %x, -1
+  %b = icmp sle i64 %x_sext, %nn
+  %c = and i1 %a, %b
   ret i1 %c
 }
 
@@ -86,6 +116,21 @@ define i1 @test_and3_logical(i32 %x, i32 %n) {
   ret i1 %c
 }
 
+define i1 @test_and3_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_and3_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp ugt i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp sgt i64 %nn, %x_sext
+  %b = icmp sge i32 %x, 0
+  %c = and i1 %a, %b
+  ret i1 %c
+}
+
 define i1 @test_and4(i32 %x, i32 %n) {
 ; CHECK-LABEL: @test_and4(
 ; CHECK-NEXT:    [[NN:%.*]] = and i32 [[N:%.*]], 2147483647
@@ -109,6 +154,21 @@ define i1 @test_and4_logical(i32 %x, i32 %n) {
   %a = icmp sge i32 %nn, %x
   %b = icmp sge i32 %x, 0
   %c = select i1 %a, i1 %b, i1 false
+  ret i1 %c
+}
+
+define i1 @test_and4_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_and4_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp uge i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp sge i64 %nn, %x_sext
+  %b = icmp sge i32 %x, 0
+  %c = and i1 %a, %b
   ret i1 %c
 }
 
@@ -140,6 +200,21 @@ define i1 @test_or1_logical(i32 %x, i32 %n) {
   ret i1 %c
 }
 
+define i1 @test_or1_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_or1_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp ule i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp slt i32 %x, 0
+  %b = icmp sge i64 %x_sext, %nn
+  %c = or i1 %a, %b
+  ret i1 %c
+}
+
 define i1 @test_or2(i32 %x, i32 %n) {
 ; CHECK-LABEL: @test_or2(
 ; CHECK-NEXT:    [[NN:%.*]] = and i32 [[N:%.*]], 2147483647
@@ -165,6 +240,21 @@ define i1 @test_or2_logical(i32 %x, i32 %n) {
   %a = icmp sle i32 %x, -1
   %b = icmp sgt i32 %x, %nn
   %c = select i1 %a, i1 true, i1 %b
+  ret i1 %c
+}
+
+define i1 @test_or2_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_or2_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp ult i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp sle i32 %x, -1
+  %b = icmp sgt i64 %x_sext, %nn
+  %c = or i1 %a, %b
   ret i1 %c
 }
 
@@ -194,6 +284,21 @@ define i1 @test_or3_logical(i32 %x, i32 %n) {
   ret i1 %c
 }
 
+define i1 @test_or3_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_or3_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp ule i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp sle i64 %nn, %x_sext
+  %b = icmp slt i32 %x, 0
+  %c = or i1 %a, %b
+  ret i1 %c
+}
+
 define i1 @test_or4(i32 %x, i32 %n) {
 ; CHECK-LABEL: @test_or4(
 ; CHECK-NEXT:    [[NN:%.*]] = and i32 [[N:%.*]], 2147483647
@@ -217,6 +322,21 @@ define i1 @test_or4_logical(i32 %x, i32 %n) {
   %a = icmp slt i32 %nn, %x
   %b = icmp slt i32 %x, 0
   %c = select i1 %a, i1 true, i1 %b
+  ret i1 %c
+}
+
+define i1 @test_or4_sext(i32 %x, i64 %n) {
+; CHECK-LABEL: @test_or4_sext(
+; CHECK-NEXT:    [[NN:%.*]] = and i64 [[N:%.*]], 2147483647
+; CHECK-NEXT:    [[X_SEXT:%.*]] = sext i32 [[X:%.*]] to i64
+; CHECK-NEXT:    [[C:%.*]] = icmp ult i64 [[NN]], [[X_SEXT]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %nn = and i64 %n, 2147483647
+  %x_sext = sext i32 %x to i64
+  %a = icmp slt i64 %nn, %x_sext
+  %b = icmp slt i32 %x, 0
+  %c = or i1 %a, %b
   ret i1 %c
 }
 


### PR DESCRIPTION
= Background

We optimize range check patterns like the following:
```
  %n_not_negative = icmp sge i32 %n, 0
  call void @llvm.assume(i1 %n_not_negative)
  %a = icmp sge i32 %x, 0
  %b = icmp slt i32 %x, %n
  %c = and i1 %a, %b
```
to a single unsigned comparison:
```
  %n_not_negative = icmp sge i32 %n, 0
  call void @llvm.assume(i1 %n_not_negative)
  %c = icmp ult i32 %x, %n
```

= Extended Pattern

This adds support for a variant of this pattern where the upper range is compared with a sign extended value:

```
  %n_not_negative = icmp sge i64 %n, 0
  call void @llvm.assume(i1 %n_not_negative)
  %x_sext = sext i32 %x to i64
  %a = icmp sge i32 %x, 0
  %b = icmp slt i64 %x_sext, %n
  %c = and i1 %a, %b
```
is now optimized to:
```
  %n_not_negative = icmp sge i64 %n, 0
  call void @llvm.assume(i1 %n_not_negative)
  %x_sext = sext i32 %x to i64
  %c = icmp ult i64 %x_sext, %n
```

Alive2: https://alive2.llvm.org/ce/z/XVuz9L