### PR TITLE
[Offload][AMDGPU] accept generic target

### DIFF
--- a/offload/DeviceRTL/CMakeLists.txt
+++ b/offload/DeviceRTL/CMakeLists.txt
@@ -42,11 +42,16 @@ set(devicertl_base_directory ${CMAKE_CURRENT_SOURCE_DIR})
 set(include_directory ${devicertl_base_directory}/include)
 set(source_directory ${devicertl_base_directory}/src)
 
-set(all_amdgpu_architectures "gfx700;gfx701;gfx801;gfx803;gfx900;gfx902;gfx906"
-                             "gfx908;gfx90a;gfx90c;gfx940;gfx941;gfx942;gfx950;gfx1010"
-                             "gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035"
-                             "gfx1036;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150"
-                             "gfx1151;gfx1152;gfx1153")
+set(all_amdgpu_architectures "gfx700;gfx701;gfx801;gfx803"
+                             "gfx9-generic;gfx900;gfx902;gfx906;gfx908"
+                             "gfx90a;gfx90c"
+                             "gfx9-4-generic;gfx940;gfx941;gfx942;gfx950"
+                             "gfx10-1-generic;gfx1010;gfx1012"
+                             "gfx10-3-generic;gfx1030;gfx1031;gfx1032;gfx1033"
+                             "gfx1034;gfx1035;gfx1036"
+                             "gfx11-generic;gfx1100;gfx1101;gfx1102;gfx1103"
+                             "gfx1150;gfx1151;gfx1152;gfx1153"
+                             "gfx12-generic")
 set(all_nvptx_architectures "sm_35;sm_37;sm_50;sm_52;sm_53;sm_60;sm_61;sm_62"
                             "sm_70;sm_72;sm_75;sm_80;sm_86;sm_87;sm_89;sm_90")
 set(all_gpu_architectures

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -191,7 +191,7 @@ Error asyncMemCopy(bool UseMultipleSdmaEngines, void *Dst, hsa_agent_t DstAgent,
 }
 
 Error getTargetTripleAndFeatures(hsa_agent_t Agent,
-                                 SmallVector<StringRef> &Targets) {
+                                 SmallVector<SmallString<32>> &Targets) {
   auto Err = hsa_utils::iterateAgentISAs(Agent, [&](hsa_isa_t ISA) {
     uint32_t Length;
     hsa_status_t Status;
@@ -1988,10 +1988,10 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
       return Err;
 
     // Detect if XNACK is enabled
-    SmallVector<StringRef> Targets;
+    SmallVector<SmallString<32>> Targets;
     if (auto Err = hsa_utils::getTargetTripleAndFeatures(Agent, Targets))
       return Err;
-    if (!Targets.empty() && Targets[0].contains("xnack+"))
+    if (!Targets.empty() && Targets[0].str().contains("xnack+"))
       IsXnackEnabled = true;
 
     // detect if device is an APU.
@@ -3205,7 +3205,7 @@ struct AMDGPUPluginTy final : public GenericPluginTy {
     if (!Processor)
       return false;
 
-    SmallVector<StringRef> Targets;
+    SmallVector<SmallString<32>> Targets;
     if (auto Err = hsa_utils::getTargetTripleAndFeatures(
             getKernelAgent(DeviceId), Targets))
       return Err;

--- a/offload/plugins-nextgen/common/src/Utils/ELF.cpp
+++ b/offload/plugins-nextgen/common/src/Utils/ELF.cpp
@@ -68,7 +68,8 @@ checkMachineImpl(const object::ELFObjectFile<ELFT> &ELFObj, uint16_t EMachine) {
         Header.e_ident[EI_ABIVERSION] != ELFABIVERSION_AMDGPU_HSA_V6)
       return createError("Invalid AMD ABI version, must be version 4 or above");
     if ((Header.e_flags & EF_AMDGPU_MACH) < EF_AMDGPU_MACH_AMDGCN_GFX700 ||
-        (Header.e_flags & EF_AMDGPU_MACH) > EF_AMDGPU_MACH_AMDGCN_GFX1201)
+        (Header.e_flags & EF_AMDGPU_MACH) >
+            EF_AMDGPU_MACH_AMDGCN_GFX9_4_GENERIC)
       return createError("Unsupported AMDGPU architecture");
   } else if (Header.e_machine == EM_CUDA) {
     if (~Header.e_flags & EF_CUDA_64BIT_ADDRESS)


### PR DESCRIPTION
Enables generic ISA, e.g., "--offload-arch=gfx11-generic" device code to run on gfx11-generic ISA capable device.

Executable may contain one ELF that has specific target ISA and another ELF that has compatible generic ISA.
Under that circumstance, this code should say both ELFs are compatible, leaving the rest to PluginManager to handle.
Suggestions on how best to address that is welcome.