### PR TITLE
Add support for CHERI "purecap" as an environment in target triples.

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -270,6 +270,8 @@ public:
     MuslX32,
     LLVM,
 
+    CheriPureCap,
+
     MSVC,
     Itanium,
     Cygnus,

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -362,6 +362,8 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
     return "pauthtest";
   case LLVM:
     return "llvm";
+  case CheriPureCap:
+    return "purecap";
   }
 
   llvm_unreachable("Invalid EnvironmentType!");
@@ -743,6 +745,7 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
       .StartsWith("ohos", Triple::OpenHOS)
       .StartsWith("pauthtest", Triple::PAuthTest)
       .StartsWith("llvm", Triple::LLVM)
+      .StartsWith("purecap", Triple::CheriPureCap)
       .Default(Triple::UnknownEnvironment);
 }
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1347,6 +1347,12 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(Triple::Linux, T.getOS());
   EXPECT_EQ(Triple::LLVM, T.getEnvironment());
 
+  T = Triple("riscv64-unknown-linux-purecap");
+  EXPECT_EQ(Triple::riscv64, T.getArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::Linux, T.getOS());
+  EXPECT_EQ(Triple::CheriPureCap, T.getEnvironment());
+
   T = Triple("huh");
   EXPECT_EQ(Triple::UnknownArch, T.getArch());
 }


### PR DESCRIPTION
For context, CHERI architectures can support two modes:
* Hybrid mode, in which capabilities co-exist alongside normal pointers.
* Pure capability mode, in which all pointers are replaced with capabilities.

Hybrid mode does not require any indication in the target triple, as it
is treated the same as any other extension to the parent ISA. Pure cap mode,
however, is a different ABI from the native ABI of the parent architecture.
