### PR TITLE
[InstCombine]  Widen Sel width after Cmp to generate Max/Min intrinsics.

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8908,7 +8908,8 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
   Value *CastedTo = nullptr;
   if (*CastOp == Instruction::Trunc) {
     Value *ExtV;
-    if (match(CmpI->getOperand(1), m_SExt(m_Value(ExtV))) &&
+    if ((match(CmpI->getOperand(1), m_ZExt(m_Value(ExtV))) ||
+         match(CmpI->getOperand(1), m_SExt(m_Value(ExtV)))) &&
         ExtV->getType() == Cast1->getType() && ExtV == V2) {
       // Here we have the following case:
       //   %y_ext = sext iK %y to iN

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8784,17 +8784,11 @@ static SelectPatternResult matchSelectPattern(CmpInst::Predicate Pred,
 static Value *lookThroughCastConst(CmpInst *CmpI, Value *V1, Value *V2,
                                    Instruction::CastOps *CastOp) {
   auto *Cast1 = dyn_cast<CastInst>(V1);
-  if (!Cast1)
-    return nullptr;
+  auto *C = dyn_cast<Constant>(V2);
+  Type *SrcTy = Cast1->getSrcTy();
+  const DataLayout &DL = CmpI->getDataLayout();
 
   *CastOp = Cast1->getOpcode();
-  Type *SrcTy = Cast1->getSrcTy();
-
-  auto *C = dyn_cast<Constant>(V2);
-  if (!C)
-    return nullptr;
-
-  const DataLayout &DL = CmpI->getDataLayout();
   Constant *CastedTo = nullptr;
   switch (*CastOp) {
   case Instruction::ZExt:

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8907,10 +8907,8 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
 
   Value *CastedTo = nullptr;
   if (*CastOp == Instruction::Trunc) {
-    Value *ExtV;
-    if ((match(CmpI->getOperand(1), m_ZExt(m_Value(ExtV))) ||
-         match(CmpI->getOperand(1), m_SExt(m_Value(ExtV)))) &&
-        ExtV->getType() == Cast1->getType() && ExtV == V2) {
+    if (match(CmpI->getOperand(1), m_ZExtOrSExt(m_Specific(V2))) &&
+        V2->getType() == Cast1->getType()) {
       // Here we have the following case:
       //   %y_ext = sext iK %y to iN
       //   %cond = cmp iN %x, %y_ext

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8907,7 +8907,7 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
       // We can always move trunc after select operation:
       //   %y_ext = sext iK %y to iN
       //   %cond = cmp iN %x, %y_ext
-      //   %widesel = select i1 %cond, iN %x, iN%y_ext
+      //   %widesel = select i1 %cond, iN %x, iN %y_ext
       //   %tr = trunc iN %widesel to iK
       assert(V2->getType() == Cast1->getType() &&
              "V2 and Cast1 should be the same type.");

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8781,10 +8781,8 @@ static SelectPatternResult matchSelectPattern(CmpInst::Predicate Pred,
   return matchFastFloatClamp(Pred, CmpLHS, CmpRHS, TrueVal, FalseVal, LHS, RHS);
 }
 
-static Value *lookThroughCastConst(CmpInst *CmpI, Value *V1, Value *V2,
+static Value *lookThroughCastConst(CmpInst *CmpI, CastInst *Cast1, Constant *C,
                                    Instruction::CastOps *CastOp) {
-  auto *Cast1 = dyn_cast<CastInst>(V1);
-  auto *C = dyn_cast<Constant>(V2);
   Type *SrcTy = Cast1->getSrcTy();
   const DataLayout &DL = CmpI->getDataLayout();
 
@@ -8897,7 +8895,7 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
 
   auto *C = dyn_cast<Constant>(V2);
   if (C)
-    return lookThroughCastConst(CmpI, V1, V2, CastOp);
+    return lookThroughCastConst(CmpI, Cast1, C, CastOp);
 
   Value *CastedTo = nullptr;
   if (*CastOp == Instruction::Trunc) {

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8897,8 +8897,7 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
 
   Value *CastedTo = nullptr;
   if (*CastOp == Instruction::Trunc) {
-    if (match(CmpI->getOperand(1), m_ZExtOrSExt(m_Specific(V2))) &&
-        V2->getType() == Cast1->getType()) {
+    if (match(CmpI->getOperand(1), m_ZExtOrSExt(m_Specific(V2)))) {
       // Here we have the following case:
       //   %y_ext = sext iK %y to iN
       //   %cond = cmp iN %x, %y_ext
@@ -8910,6 +8909,8 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
       //   %cond = cmp iN %x, %y_ext
       //   %widesel = select i1 %cond, iN %x, iN%y_ext
       //   %tr = trunc iN %widesel to iK
+      assert(V2->getType() == Cast1->getType() &&
+             "V2 and Cast1 should be the same type.");
       CastedTo = CmpI->getOperand(1);
     }
   }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8781,12 +8781,10 @@ static SelectPatternResult matchSelectPattern(CmpInst::Predicate Pred,
   return matchFastFloatClamp(Pred, CmpLHS, CmpRHS, TrueVal, FalseVal, LHS, RHS);
 }
 
-static Value *lookThroughCastConst(CmpInst *CmpI, CastInst *Cast1, Constant *C,
+static Value *lookThroughCastConst(CmpInst *CmpI, Type *SrcTy, Constant *C,
                                    Instruction::CastOps *CastOp) {
-  Type *SrcTy = Cast1->getSrcTy();
   const DataLayout &DL = CmpI->getDataLayout();
 
-  *CastOp = Cast1->getOpcode();
   Constant *CastedTo = nullptr;
   switch (*CastOp) {
   case Instruction::ZExt:
@@ -8895,7 +8893,7 @@ static Value *lookThroughCast(CmpInst *CmpI, Value *V1, Value *V2,
 
   auto *C = dyn_cast<Constant>(V2);
   if (C)
-    return lookThroughCastConst(CmpI, Cast1, C, CastOp);
+    return lookThroughCastConst(CmpI, SrcTy, C, CastOp);
 
   Value *CastedTo = nullptr;
   if (*CastOp == Instruction::Trunc) {

--- a/llvm/test/Transforms/InstCombine/minmax-fold.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fold.ll
@@ -697,6 +697,34 @@ define zeroext i8 @look_through_cast2(i32 %x) {
   ret i8 %res
 }
 
+define zeroext i8 @look_through_cast_int_min(i8 %a, i32 %min) {
+; CHECK-LABEL: @look_through_cast_int_min(
+; CHECK-NEXT:    [[A32:%.*]] = sext i8 [[A:%.*]] to i32
+; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smin.i32(i32 [[MIN:%.*]], i32 [[A32]])
+; CHECK-NEXT:    [[SEL:%.*]] = trunc i32 [[SEL1]] to i8
+; CHECK-NEXT:    ret i8 [[SEL]]
+;
+  %a32 = sext i8 %a to i32
+  %cmp = icmp slt i32 %a32, %min
+  %min8 = trunc i32 %min to i8
+  %sel = select i1 %cmp, i8 %a, i8 %min8
+  ret i8 %sel
+}
+
+define zeroext i16 @look_through_cast_int_max(i16 %a, i32 %max) {
+; CHECK-LABEL: @look_through_cast_int_max(
+; CHECK-NEXT:    [[A32:%.*]] = sext i16 [[A:%.*]] to i32
+; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smax.i32(i32 [[MAX:%.*]], i32 [[A32]])
+; CHECK-NEXT:    [[SEL:%.*]] = trunc i32 [[SEL1]] to i16
+; CHECK-NEXT:    ret i16 [[SEL]]
+;
+  %a32 = sext i16 %a to i32
+  %cmp = icmp sgt i32 %max, %a32
+  %max8 = trunc i32 %max to i16
+  %sel = select i1 %cmp, i16 %max8, i16 %a
+  ret i16 %sel
+}
+
 define <2 x i8> @min_through_cast_vec1(<2 x i32> %x) {
 ; CHECK-LABEL: @min_through_cast_vec1(
 ; CHECK-NEXT:    [[RES1:%.*]] = call <2 x i32> @llvm.smin.v2i32(<2 x i32> [[X:%.*]], <2 x i32> <i32 510, i32 511>)
@@ -719,6 +747,34 @@ define <2 x i8> @min_through_cast_vec2(<2 x i32> %x) {
   %x_trunc = trunc <2 x i32> %x to <2 x i8>
   %res = select <2 x i1> %cmp, <2 x i8> %x_trunc, <2 x i8> <i8 255, i8 255>
   ret <2 x i8> %res
+}
+
+define <8 x i8> @look_through_cast_int_min_vec(<8 x i8> %a, <8 x i32> %min) {
+; CHECK-LABEL: @look_through_cast_int_min_vec(
+; CHECK-NEXT:    [[A32:%.*]] = sext <8 x i8> [[A:%.*]] to <8 x i32>
+; CHECK-NEXT:    [[SEL1:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[MIN:%.*]], <8 x i32> [[A32]])
+; CHECK-NEXT:    [[SEL:%.*]] = trunc <8 x i32> [[SEL1]] to <8 x i8>
+; CHECK-NEXT:    ret <8 x i8> [[SEL]]
+;
+  %a32 = sext <8 x i8> %a to <8 x i32>
+  %cmp = icmp slt <8 x i32> %a32, %min
+  %min8 = trunc <8 x i32> %min to <8 x i8>
+  %sel = select <8 x i1> %cmp, <8 x i8> %a, <8 x i8> %min8
+  ret <8 x i8> %sel
+}
+
+define <8 x i32> @look_through_cast_int_max_vec(<8 x i32> %a, <8 x i64> %max) {
+; CHECK-LABEL: @look_through_cast_int_max_vec(
+; CHECK-NEXT:    [[A32:%.*]] = sext <8 x i32> [[A:%.*]] to <8 x i64>
+; CHECK-NEXT:    [[SEL1:%.*]] = call <8 x i64> @llvm.smax.v8i64(<8 x i64> [[MAX:%.*]], <8 x i64> [[A32]])
+; CHECK-NEXT:    [[SEL:%.*]] = trunc <8 x i64> [[SEL1]] to <8 x i32>
+; CHECK-NEXT:    ret <8 x i32> [[SEL]]
+;
+  %a32 = sext <8 x i32> %a to <8 x i64>
+  %cmp = icmp sgt <8 x i64> %a32, %max
+  %max8 = trunc <8 x i64> %max to <8 x i32>
+  %sel = select <8 x i1> %cmp, <8 x i32> %a, <8 x i32> %max8
+  ret <8 x i32> %sel
 }
 
 ; Remove a min/max op in a sequence with a common operand.

--- a/llvm/test/Transforms/InstCombine/minmax-fold.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fold.ll
@@ -697,7 +697,7 @@ define zeroext i8 @look_through_cast2(i32 %x) {
   ret i8 %res
 }
 
-define zeroext i8 @look_through_cast_int_min(i8 %a, i32 %min) {
+define i8 @look_through_cast_int_min(i8 %a, i32 %min) {
 ; CHECK-LABEL: @look_through_cast_int_min(
 ; CHECK-NEXT:    [[A32:%.*]] = sext i8 [[A:%.*]] to i32
 ; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smin.i32(i32 [[MIN:%.*]], i32 [[A32]])
@@ -711,7 +711,7 @@ define zeroext i8 @look_through_cast_int_min(i8 %a, i32 %min) {
   ret i8 %sel
 }
 
-define zeroext i16 @look_through_cast_int_max(i16 %a, i32 %max) {
+define i16 @look_through_cast_int_max(i16 %a, i32 %max) {
 ; CHECK-LABEL: @look_through_cast_int_max(
 ; CHECK-NEXT:    [[A32:%.*]] = zext i16 [[A:%.*]] to i32
 ; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smax.i32(i32 [[MAX:%.*]], i32 [[A32]])

--- a/llvm/test/Transforms/InstCombine/minmax-fold.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fold.ll
@@ -713,12 +713,12 @@ define zeroext i8 @look_through_cast_int_min(i8 %a, i32 %min) {
 
 define zeroext i16 @look_through_cast_int_max(i16 %a, i32 %max) {
 ; CHECK-LABEL: @look_through_cast_int_max(
-; CHECK-NEXT:    [[A32:%.*]] = sext i16 [[A:%.*]] to i32
+; CHECK-NEXT:    [[A32:%.*]] = zext i16 [[A:%.*]] to i32
 ; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smax.i32(i32 [[MAX:%.*]], i32 [[A32]])
 ; CHECK-NEXT:    [[SEL:%.*]] = trunc i32 [[SEL1]] to i16
 ; CHECK-NEXT:    ret i16 [[SEL]]
 ;
-  %a32 = sext i16 %a to i32
+  %a32 = zext i16 %a to i32
   %cmp = icmp sgt i32 %max, %a32
   %max8 = trunc i32 %max to i16
   %sel = select i1 %cmp, i16 %max8, i16 %a
@@ -752,12 +752,12 @@ define <2 x i8> @min_through_cast_vec2(<2 x i32> %x) {
 define <8 x i8> @look_through_cast_int_min_vec(<8 x i8> %a, <8 x i32> %min) {
 ; CHECK-LABEL: @look_through_cast_int_min_vec(
 ; CHECK-NEXT:    [[A32:%.*]] = sext <8 x i8> [[A:%.*]] to <8 x i32>
-; CHECK-NEXT:    [[SEL1:%.*]] = call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[MIN:%.*]], <8 x i32> [[A32]])
+; CHECK-NEXT:    [[SEL1:%.*]] = call <8 x i32> @llvm.umin.v8i32(<8 x i32> [[MIN:%.*]], <8 x i32> [[A32]])
 ; CHECK-NEXT:    [[SEL:%.*]] = trunc <8 x i32> [[SEL1]] to <8 x i8>
 ; CHECK-NEXT:    ret <8 x i8> [[SEL]]
 ;
   %a32 = sext <8 x i8> %a to <8 x i32>
-  %cmp = icmp slt <8 x i32> %a32, %min
+  %cmp = icmp ult <8 x i32> %a32, %min
   %min8 = trunc <8 x i32> %min to <8 x i8>
   %sel = select <8 x i1> %cmp, <8 x i8> %a, <8 x i8> %min8
   ret <8 x i8> %sel
@@ -765,12 +765,12 @@ define <8 x i8> @look_through_cast_int_min_vec(<8 x i8> %a, <8 x i32> %min) {
 
 define <8 x i32> @look_through_cast_int_max_vec(<8 x i32> %a, <8 x i64> %max) {
 ; CHECK-LABEL: @look_through_cast_int_max_vec(
-; CHECK-NEXT:    [[A32:%.*]] = sext <8 x i32> [[A:%.*]] to <8 x i64>
+; CHECK-NEXT:    [[A32:%.*]] = zext <8 x i32> [[A:%.*]] to <8 x i64>
 ; CHECK-NEXT:    [[SEL1:%.*]] = call <8 x i64> @llvm.smax.v8i64(<8 x i64> [[MAX:%.*]], <8 x i64> [[A32]])
 ; CHECK-NEXT:    [[SEL:%.*]] = trunc <8 x i64> [[SEL1]] to <8 x i32>
 ; CHECK-NEXT:    ret <8 x i32> [[SEL]]
 ;
-  %a32 = sext <8 x i32> %a to <8 x i64>
+  %a32 = zext <8 x i32> %a to <8 x i64>
   %cmp = icmp sgt <8 x i64> %a32, %max
   %max8 = trunc <8 x i64> %max to <8 x i32>
   %sel = select <8 x i1> %cmp, <8 x i32> %a, <8 x i32> %max8


### PR DESCRIPTION
When Sel(Cmp) are in different integer type,

From: (K and N mean width, K < N; a and b are src operands.)
bN = Ext(bK)
cond = Cmp(aN, bN)
aK = Trunc aN
retK = Sel(cond, aK, bK)
To:
bN = Ext(bK)
cond = Cmp(aN, bN)
retN = Sel(cond, aN, bN)
retK = Trunc retN

Though Sel's operands width becomes larger, the benefit
of making type width in Sel the same as Cmp, is for combing
to max/min intrinsics, and also better performance for SIMD instructions.
References of correctness: https://alive2.llvm.org/ce/z/Y4Kegm
                           https://alive2.llvm.org/ce/z/qFtjtR
Reference of generated code comparision:
                           https://gcc.godbolt.org/z/o97svGvYM
                           https://gcc.godbolt.org/z/59Ynj91ov
