### PR TITLE
[IVDescriptors][NFC] Remove the number check of cmp select pattern for min/max reduction.

### DIFF
--- a/llvm/lib/Analysis/IVDescriptors.cpp
+++ b/llvm/lib/Analysis/IVDescriptors.cpp
@@ -244,9 +244,9 @@ bool RecurrenceDescriptor::AddReductionVar(
   // must include the original PHI.
   bool FoundStartPHI = false;
 
-  // To recognize min/max patterns formed by a icmp select sequence, we store
-  // the number of instruction we saw from the recognized min/max pattern,
-  //  to make sure we only see exactly the two instructions.
+  // Tracks the number of instructions (either cmp or select) observed in an
+  // AnyOf recurrence pattern to ensure it matches the expected instruction
+  // sequence.
   unsigned NumCmpSelectPatternInst = 0;
   InstDesc ReduxDesc(false, nullptr);
 
@@ -415,11 +415,9 @@ bool RecurrenceDescriptor::AddReductionVar(
     if (IsAPhi && Cur != Phi && !areAllUsesIn(Cur, VisitedInsts))
       return false;
 
-    if ((isIntMinMaxRecurrenceKind(Kind) || Kind == RecurKind::IAnyOf) &&
-        (isa<ICmpInst>(Cur) || isa<SelectInst>(Cur)))
+    if (Kind == RecurKind::IAnyOf && isa<ICmpInst, SelectInst>(Cur))
       ++NumCmpSelectPatternInst;
-    if ((isFPMinMaxRecurrenceKind(Kind) || Kind == RecurKind::FAnyOf) &&
-        (isa<FCmpInst>(Cur) || isa<SelectInst>(Cur)))
+    if (Kind == RecurKind::FAnyOf && isa<FCmpInst, SelectInst>(Cur))
       ++NumCmpSelectPatternInst;
 
     // Check  whether we found a reduction operator.
@@ -496,13 +494,6 @@ bool RecurrenceDescriptor::AddReductionVar(
     Worklist.append(PHIs.begin(), PHIs.end());
     Worklist.append(NonPHIs.begin(), NonPHIs.end());
   }
-
-  // This means we have seen one but not the other instruction of the
-  // pattern or more than just a select and cmp. Zero implies that we saw a
-  // llvm.min/max intrinsic, which is always OK.
-  if (isMinMaxRecurrenceKind(Kind) && NumCmpSelectPatternInst != 2 &&
-      NumCmpSelectPatternInst != 0)
-    return false;
 
   if (isAnyOfRecurrenceKind(Kind) && NumCmpSelectPatternInst != 1)
     return false;


### PR DESCRIPTION
In RecurrenceDescriptor::isMinMaxPattern, only cmp-select patterns that match the form select(cmp(X, Y), X, Y) are recognized as min/max patterns. This ensures that both the cmp and select instructions are visited, eliminating the need for confirmation via NumCmpSelectPatternInst.