### PR TITLE
Fix signal handling for platforms without SA_ONSTACK

### DIFF
--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -309,6 +309,12 @@ static void RegisterHandlers() { // Not signal-safe.
 
     struct sigaction NewHandler;
 
+#ifndef SA_ONSTACK
+    // Some platforms such as QNX do not define or implement SA_ONSTACK,
+    // so default that flag to 0 to just use the pre-existing stack there.
+    int SA_ONSTACK = 0;
+#endif
+
     switch (Kind) {
     case SignalKind::IsKill:
       NewHandler.sa_handler = SignalHandler;


### PR DESCRIPTION
Some platforms such as QNX do not define or implement SA_ONSTACK, so default that flag to 0 to just use the pre-existing stack there.