### PR TITLE
[Clang][perf-training] Fix clean command in perf-helper.py

### DIFF
--- a/clang/utils/perf-training/perf-helper.py
+++ b/clang/utils/perf-training/perf-helper.py
@@ -36,7 +36,7 @@ def clean(args):
             + "\tRemoves all files with extension from <path>."
         )
         return 1
-    for path in args[1:-1]:
+    for path in args[0:-1]:
         for filename in findFilesWithExtension(path, args[-1]):
             os.remove(filename)
     return 0


### PR DESCRIPTION
The first path argument was always being ignored, and since most calls to this command only passed one path, it wasn't actually doing anything in most cases.

This bug was introduced by dd0356d741aefa25ece973d6cc4b55dcb73b84b4.