### PR TITLE
[lldb][test] Link certain libc++ tests with the whole library

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -368,7 +368,7 @@ ifeq (,$(filter 1, $(USE_LIBSTDCPP) $(USE_LIBCPP) $(USE_SYSTEM_STDLIB)))
     ifneq "$(LIBCPP_INCLUDE_TARGET_DIR)" ""
       CXXFLAGS += -cxx-isystem $(LIBCPP_INCLUDE_TARGET_DIR)
     endif
-    LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++
+    LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++ -lc++abi
   else
     USE_SYSTEM_STDLIB := 1
   endif
@@ -389,7 +389,7 @@ ifeq (1,$(USE_LIBCPP))
 		ifneq "$(LIBCPP_INCLUDE_TARGET_DIR)" ""
 				CXXFLAGS += -cxx-isystem $(LIBCPP_INCLUDE_TARGET_DIR)
 		endif
-		LDFLAGS += -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++
+		LDFLAGS += -nostdlib++ -nostdinc -L$(LIBCPP_LIBRARY_DIR) -Wl,-rpath,$(LIBCPP_LIBRARY_DIR) -lc++ -lc++abi
 	else
 		ifeq "$(OS)" "Android"
 				# Nothing to do, this is already handled in

--- a/lldb/test/API/commands/expression/import-std-module/array/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/array/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LDFLAGS := -Xlinker --push-state -Xlinker --whole-archive -lc++ -lc++abi -Xlinker --pop-state
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LDFLAGS := -Xlinker --push-state -Xlinker --whole-archive -lc++ -lc++abi -Xlinker --pop-state
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LDFLAGS := -Xlinker --push-state -Xlinker --whole-archive -lc++ -lc++abi -Xlinker --pop-state
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LDFLAGS := -Xlinker --push-state -Xlinker --whole-archive -lc++ -lc++abi -Xlinker --pop-state
+endif
+
 include Makefile.rules

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/Makefile
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/Makefile
@@ -1,3 +1,8 @@
 USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
+
+ifneq ($(OS),Darwin)
+	LDFLAGS := -Xlinker --push-state -Xlinker --whole-archive -lc++ -lc++abi -Xlinker --pop-state
+endif
+
 include Makefile.rules

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -4,6 +4,7 @@
 
 import os
 import platform
+import re
 import shlex
 import shutil
 import subprocess
@@ -211,7 +212,7 @@ if is_configured("llvm_tools_dir"):
 
 # If we have a just-built libcxx, prefer it over the system one.
 if is_configured("has_libcxx") and config.has_libcxx:
-    if platform.system() != "Windows":
+    if platform.system() != "Windows" or re.match(r".*-linux.*", config.target_triple):
         if is_configured("libcxx_include_dir") and is_configured("libcxx_libs_dir"):
             dotest_cmd += ["--libcxx-include-dir", config.libcxx_include_dir]
             if is_configured("libcxx_include_target_dir"):

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -239,6 +239,7 @@ def use_support_substitutions(config):
         host_flags += [
             "-L{}".format(config.libcxx_libs_dir),
             "-lc++",
+            "-lc++abi",
         ]
 
     host_flags = " ".join(host_flags)


### PR DESCRIPTION
Some tests from 'import-std-module' used to fail on the builder https://lab.llvm.org/staging/#/builders/195/builds/4470, since libcxx is set up to be linked statically with test binaries on it.

Thus, they were temporarily disabled in #112530. Here, this commit is reverted.

When libcxx is linked with a program as an archive of static libraries, functions that aren't used in the program are omitted. Then, jitted expressions from the tests try calling several functions that aren't present in the process image, which causes the failure.

Here, --whole-archive linker flags are added to tests' Makefiles to ensure that the whole libc++ is included during static linking. It's applied only to -lc++ and -lc++abi (via --push-state/--pop-state), since for some reason clang Gnu toolchain driver on certain Linux configurations adds -libclang_rt.builtins twice, so we can't just apply --whole-archive to all static libraries.

Flags in Makefile.rules and tests' Makefiles are changed to supported the configuration when libc++, libc++abi and libunwind are linked separately (this configuration will be enabled on lldb remote buildbots to be able to control what we link with and avoid duplicate symbols errors).

'-nostdlib++ -nostdinc' are added to LDFLAGS in Makefile.rules to avoid duplicate symbols error. Applying them only to CXXFLAGS is not enough since thus they are not passed to the linker call.

'--libcxx-include-dir' flag passing has been fixed on Windows host for remote platform in lldb/test/API/lit.cfg.py.