### PR TITLE
[clang-tidy] fix false positive in lambda expr for return-const-ref-from-parameter

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/ReturnConstRefFromParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ReturnConstRefFromParameterCheck.cpp
@@ -31,22 +31,20 @@ void ReturnConstRefFromParameterCheck::registerMatchers(MatchFinder *Finder) {
                              qualType(lValueReferenceType(pointee(
                                           qualType(isConstQualified()))))
                                  .bind("type"))),
-                         hasDeclContext(functionDecl().bind("owner")),
+                         hasDeclContext(functionDecl(
+                             equalsBoundNode("func"),
+                             hasReturnTypeLoc(loc(qualType(
+                                 hasCanonicalType(equalsBoundNode("type"))))))),
                          unless(hasLifetimeBoundAttr()))
                  .bind("param")))
           .bind("dref"));
-  const auto Func =
-      functionDecl(equalsBoundNode("owner"),
-                   hasReturnTypeLoc(loc(
-                       qualType(hasCanonicalType(equalsBoundNode("type"))))))
-          .bind("func");
 
   Finder->addMatcher(
       returnStmt(
+          hasAncestor(functionDecl().bind("func")),
           hasReturnValue(anyOf(
               DRef, ignoringParens(conditionalOperator(eachOf(
-                        hasTrueExpression(DRef), hasFalseExpression(DRef)))))),
-          hasAncestor(Func)),
+                        hasTrueExpression(DRef), hasFalseExpression(DRef))))))),
       this);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -183,8 +183,8 @@ Changes in existing checks
 - Improved :doc:`bugprone-return-const-ref-from-parameter
   <clang-tidy/checks/bugprone/return-const-ref-from-parameter>` check to
   diagnose potential dangling references when returning a ``const &`` parameter
-  by using the conditional operator ``cond ? var1 : var2`` and no longer giving
-  false positives for functions which contain lambda and ignore parameters
+  by using the conditional operator ``cond ? var1 : var2`` and fixing false
+  positives for functions which contain lambda and ignore parameters
   with ``[[clang::lifetimebound]]`` attribute.
   
 - Improved :doc:`bugprone-sizeof-expression

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/return-const-ref-from-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/return-const-ref-from-parameter.cpp
@@ -203,3 +203,26 @@ namespace use_lifetime_bound_attr {
 int const &f(int const &a [[clang::lifetimebound]]) { return a; }
 } // namespace use_lifetime_bound_attr
 } // namespace gh117696
+
+
+namespace lambda {
+using T = const int &;
+using K = const float &;
+T inner_valid_lambda(T a) {
+  [&]() -> T { return a; };
+  return a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: returning a constant reference parameter
+}
+T inner_invalid_lambda(T a) {
+  [&](T a) -> T { return a; };
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: returning a constant reference parameter
+  return a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: returning a constant reference parameter
+}
+T inner_invalid_lambda2(T a) {
+  [&](K a) -> K { return a; };
+  // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: returning a constant reference parameter
+  return a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: returning a constant reference parameter
+}
+} // namespace lambda


### PR DESCRIPTION
We should bind the node in `hasAncestor` matcher and `equalsBoundNode` in the other matcher because  `hasAncestor` will visit the ancestor until to find the matched result.