### PR TITLE
[offload] Remove bogus offload-tblgen check for standalone build

### DIFF
--- a/offload/cmake/OpenMPTesting.cmake
+++ b/offload/cmake/OpenMPTesting.cmake
@@ -37,17 +37,6 @@ function(find_standalone_test_dependencies)
     return()
   endif()
 
-  find_program(OFFLOAD_TBLGEN_EXECUTABLE
-    NAMES offload-tblgen
-    PATHS ${OPENMP_LLVM_TOOLS_DIR})
-  if (NOT OFFLOAD_TBLGEN_EXECUTABLE)
-    message(STATUS "Cannot find 'offload-tblgen'.")
-    message(STATUS "Please put 'not' in your PATH, set OFFLOAD_TBLGEN_EXECUTABLE to its full path, or point OPENMP_LLVM_TOOLS_DIR to its directory.")
-    message(WARNING "The check targets will not be available!")
-    set(ENABLE_CHECK_TARGETS FALSE PARENT_SCOPE)
-    return()
-  endif()
-
   find_program(OPENMP_NOT_EXECUTABLE
     NAMES not
     PATHS ${OPENMP_LLVM_TOOLS_DIR})


### PR DESCRIPTION
fd3907ccb583df99e9c19d2fe84e4e7c52d75de9 introduced a check for system offload-tblgen executable when doing a standalone build.  This check is bogus, since offload-tblgen is built as part of offload and not some other preinstalled component.  The path is also overwritten below, so the check only causes tests to be disabled unnecessarily.

CC @callumfare 