### PR TITLE
[libc++] Remove explicit mentions of __need_FOO macros

### DIFF
--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -2282,15 +2282,15 @@ module std_stdbool_h [system] {
   textual header "stdbool.h"
 }
 module std_stddef_h [system] {
-  // <stddef.h>'s __need_* macros require textual inclusion.
+  // <stddef.h> supports being included multiple times with different pre-defined macros
   textual header "stddef.h"
 }
 module std_stdio_h [system] {
-  // <stdio.h>'s __need_* macros require textual inclusion.
+  // <stdio.h> supports being included multiple times with different pre-defined macros
   textual header "stdio.h"
 }
 module std_stdlib_h [system] {
-  // <stdlib.h>'s __need_* macros require textual inclusion.
+  // <stdlib.h> supports being included multiple times with different pre-defined macros
   textual header "stdlib.h"
 }
 module std_string_h [system] {
@@ -2306,7 +2306,7 @@ module std_uchar_h [system] {
   export *
 }
 module std_wchar_h [system] {
-  // <wchar.h>'s __need_* macros require textual inclusion.
+  // <wchar.h> supports being included multiple times with different pre-defined macros
   textual header "wchar.h"
 }
 module std_wctype_h [system] {

--- a/libcxx/include/stdio.h
+++ b/libcxx/include/stdio.h
@@ -7,17 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(__need_FILE) || defined(__need___FILE)
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
-
-#  include_next <stdio.h>
-
-#elif !defined(_LIBCPP_STDIO_H)
-#  define _LIBCPP_STDIO_H
-
 /*
     stdio.h synopsis
 
@@ -98,13 +87,23 @@ int ferror(FILE* stream);
 void perror(const char* s);
 */
 
-#  if 0
-#  else // 0
-#    include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#      pragma GCC system_header
-#    endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+// The inclusion of the system's <stdio.h> is intentionally done once outside of any include
+// guards because some code expects to be able to include the underlying system header multiple
+// times to get different definitions based on the macros that are set before inclusion.
+#  if __has_include_next(<stdio.h>)
+#    include_next <stdio.h>
+#  endif
+
+#  ifndef _LIBCPP_STDIO_H
+#    define _LIBCPP_STDIO_H
 
 #    if __has_include_next(<stdio.h>)
 #      include_next <stdio.h>

--- a/libcxx/include/stdlib.h
+++ b/libcxx/include/stdlib.h
@@ -7,17 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(__need_malloc_and_calloc)
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
-
-#  include_next <stdlib.h>
-
-#elif !defined(_LIBCPP_STDLIB_H)
-#  define _LIBCPP_STDLIB_H
-
 /*
     stdlib.h synopsis
 
@@ -84,13 +73,23 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 
 */
 
-#  if 0
-#  else // 0
-#    include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#      pragma GCC system_header
-#    endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+// The inclusion of the system's <stdlib.h> is intentionally done once outside of any include
+// guards because some code expects to be able to include the underlying system header multiple
+// times to get different definitions based on the macros that are set before inclusion.
+#  if __has_include_next(<stdlib.h>)
+#    include_next <stdlib.h>
+#  endif
+
+#  if !defined(_LIBCPP_STDLIB_H)
+#    define _LIBCPP_STDLIB_H
 
 #    if __has_include_next(<stdlib.h>)
 #      include_next <stdlib.h>
@@ -148,7 +147,7 @@ inline _LIBCPP_HIDE_FROM_ABI lldiv_t div(long long __x, long long __y) _NOEXCEPT
 #        endif
 #      endif // _LIBCPP_MSVCRT
 } // extern "C++"
-#    endif   // __cplusplus
-#  endif     // 0
+#    endif // __cplusplus
+#  endif   // 0
 
 #endif // _LIBCPP_STDLIB_H

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -7,17 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(__need_wint_t) || defined(__need_mbstate_t)
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
-
-#  include_next <wchar.h>
-
-#elif !defined(_LIBCPP_WCHAR_H)
-#  define _LIBCPP_WCHAR_H
-
 /*
     wchar.h synopsis
 
@@ -105,25 +94,35 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 
 */
 
-#  if 0
-#  else // 0
-#    include <__config>
-#    include <stddef.h>
+#if 0
+#else // 0
+#  include <__config>
 
-#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#      pragma GCC system_header
-#    endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 // We define this here to support older versions of glibc <wchar.h> that do
 // not define this for clang.
-#    ifdef __cplusplus
-#      define __CORRECT_ISO_CPP_WCHAR_H_PROTO
-#    endif
+#  if defined(__cplusplus) && !defined(__CORRECT_ISO_CPP_WCHAR_H_PROTO)
+#    define __CORRECT_ISO_CPP_WCHAR_H_PROTO
+#  endif
+
+// The inclusion of the system's <wchar.h> is intentionally done once outside of any include
+// guards because some code expects to be able to include the underlying system header multiple
+// times to get different definitions based on the macros that are set before inclusion.
+#  if __has_include_next(<wchar.h>)
+#    include_next <wchar.h>
+#  endif
+
+#  ifndef _LIBCPP_WCHAR_H
+#    define _LIBCPP_WCHAR_H
+
+#    include <__mbstate_t.h> // provide mbstate_t
+#    include <stddef.h>      // provide size_t
 
 #    if __has_include_next(<wchar.h>)
 #      include_next <wchar.h>
-#    else
-#      include <__mbstate_t.h> // make sure we have mbstate_t regardless of the existence of <wchar.h>
 #    endif
 
 // Determine whether we have const-correct overloads for wcschr and friends.

--- a/libcxx/test/libcxx/clang_modules_include.gen.py
+++ b/libcxx/test/libcxx/clang_modules_include.gen.py
@@ -49,6 +49,9 @@ for header in public_headers:
 // TODO: Investigate why this doesn't work on Picolibc once the locale base API is refactored
 // UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
 
+// TODO: Fix seemingly circular inclusion or <wchar.h> on AIX
+// UNSUPPORTED: LIBCXX-AIX-FIXME
+
 {lit_header_restrictions.get(header, '')}
 {lit_header_undeprecations.get(header, '')}
 
@@ -82,6 +85,9 @@ print(
 
 // TODO: Investigate why this doesn't work on Picolibc once the locale base API is refactored
 // UNSUPPORTED: LIBCXX-PICOLIBC-FIXME
+
+// TODO: Fix seemingly circular inclusion or <wchar.h> on AIX
+// UNSUPPORTED: LIBCXX-AIX-FIXME
 
 @import std;
 


### PR DESCRIPTION
This change has a long history. It was first attempted naively in https://reviews.llvm.org/D131425, which didn't work because we broke the ability for code to include e.g. <stdio.h> multiple times and get different definitions based on the pre-defined macros.

However, in #86843 we managed to simplify <stddef.h> by including the underlying system header outside of any include guards, which worked.

This patch applies the same simplification we did to <stddef.h> to the other headers that currently mention __need_FOO macros explicitly.