### PR TITLE
[libc] Remove unused target conditionals for Apple platforms

### DIFF
--- a/libc/src/__support/macros/properties/os.h
+++ b/libc/src/__support/macros/properties/os.h
@@ -25,18 +25,6 @@
 #define LIBC_TARGET_OS_IS_WINDOWS
 #endif
 
-#if (defined(__apple__) || defined(__APPLE__) || defined(__MACH__))
-// From https://stackoverflow.com/a/49560690
-#include "TargetConditionals.h"
-#if defined(TARGET_OS_OSX)
-#define LIBC_TARGET_OS_IS_MACOS
-#endif
-#if defined(TARGET_OS_IPHONE)
-// This is set for any non-Mac Apple products (IOS, TV, WATCH)
-#define LIBC_TARGET_OS_IS_IPHONE
-#endif
-#endif
-
 #if defined(__Fuchsia__)
 #define LIBC_TARGET_OS_IS_FUCHSIA
 #endif


### PR DESCRIPTION
It seems that LIBC_TARGET_OS_IS_MACOS and LIBC_TARGET_OS_IS_IPHONE were never actually used in the code, so these definitions can be removed.

I came across these because libc++ now depends on llvm-libc to build (for from_chars), and the unguarded use of TargetConditionals.h broke some of our downstream configurations. There are some platforms for which `__APPLE__` is defined but that don't provide TargetConditionals.h.

If there is a need to keep defining those, the compiler also provides some uglier macro definitions like `__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__` that do not require including any header.