### PR TITLE
[mlir][presburger] Preserve relative ordering of symbols and non-symbol vars when setting up SymbolicLexSimplex

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/Utils.h
+++ b/mlir/include/mlir/Analysis/Presburger/Utils.h
@@ -96,7 +96,8 @@ enum class ReprKind { Inequality, Equality, None };
 /// set to None.
 struct MaybeLocalRepr {
   ReprKind kind = ReprKind::None;
-  explicit operator bool() const { return kind != ReprKind::None; }
+  explicit operator bool() const { return hasRepr(); }
+  bool hasRepr() const { return kind != ReprKind::None; }
   union {
     unsigned equalityIdx;
     struct {

--- a/mlir/lib/Analysis/Presburger/Simplex.cpp
+++ b/mlir/lib/Analysis/Presburger/Simplex.cpp
@@ -64,13 +64,14 @@ SimplexBase::SimplexBase(unsigned nVar, bool mustUseBigM,
                          const llvm::SmallBitVector &isSymbol)
     : SimplexBase(nVar, mustUseBigM) {
   assert(isSymbol.size() == nVar && "invalid bitmask!");
-  // Invariant: nSymbol is the number of symbols that have been marked
-  // already and these occupy the columns
-  // [getNumFixedCols(), getNumFixedCols() + nSymbol).
-  for (unsigned symbolIdx : isSymbol.set_bits()) {
-    var[symbolIdx].isSymbol = true;
-    swapColumns(var[symbolIdx].pos, getNumFixedCols() + nSymbol);
-    ++nSymbol;
+  // Iterate through all the variables. Move symbols to the left and non-symbols
+  // to the right while preserving relative ordering.
+  for (unsigned i = 0; i < nVar; ++i) {
+    if (isSymbol[i]) {
+      var[i].isSymbol = true;
+      swapColumns(var[i].pos, getNumFixedCols() + nSymbol);
+      nSymbol++;
+    }
   }
 }
 

--- a/mlir/lib/Analysis/Presburger/Simplex.cpp
+++ b/mlir/lib/Analysis/Presburger/Simplex.cpp
@@ -68,9 +68,31 @@ SimplexBase::SimplexBase(unsigned nVar, bool mustUseBigM,
   // to the right while preserving relative ordering.
   for (unsigned i = 0; i < nVar; ++i) {
     if (isSymbol[i]) {
+
+      // Move the column from its current position to the end of
+      // the symbols segment and update the position metadata for each column
+      // unknown (which should all be vars at construction time). The
+      // segment of non-symbol up until the current variable's column are
+      // shifted to the right and the current column is then moved before the
+      // right-shifted segment.
+      tableau.moveColumns(var[i].pos, 1, getNumFixedCols() + nSymbol);
+
+      // Update the column position metadata for the unknowns associated with
+      // the right-shifted columns.
+      for (unsigned col = getNumFixedCols() + nSymbol; col < var[i].pos; ++col)
+        unknownFromColumn(col).pos = col + 1;
+
+      // Perform the equivalent rearrangement on the col-to-unknown
+      // mapping.
+      std::rotate(colUnknown.begin() + getNumFixedCols() + nSymbol,
+                  colUnknown.begin() + var[i].pos,
+                  colUnknown.begin() + var[i].pos + 1);
+
+      // Update the column mapping for the current variable.
+      var[i].pos = getNumFixedCols() + nSymbol;
       var[i].isSymbol = true;
-      swapColumns(var[i].pos, getNumFixedCols() + nSymbol);
-      nSymbol++;
+
+      ++nSymbol;
     }
   }
 }

--- a/mlir/unittests/Analysis/Presburger/PresburgerSetTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/PresburgerSetTest.cpp
@@ -855,6 +855,20 @@ TEST(SetTest, computeReprWithOnlyDivLocals) {
                   PresburgerSet(parseIntegerPolyhedron(
                       {"(x) : (x - 3*(x floordiv 3) == 0)"})),
                   /*numToProject=*/2);
+
+  testComputeRepr(
+      parseIntegerPolyhedron("(e, a, b, c)[] : ("
+                             "a >= 0,"
+                             "b >= 0,"
+                             "c >= 0,"
+                             "e >= 0,"
+                             "15 - a >= 0,"
+                             "7 - b >= 0,"
+                             "5 - c >= 0,"
+                             "e - a * 192 - c * 32 - b * 4 >= 0,"
+                             "3 - e + a * 192 + c * 32 + b * 4 >= 0)"),
+      parsePresburgerSet({"(i) : (i >= 0, i <= 3071)"}),
+      /*numToProject=*/3);
 }
 
 TEST(SetTest, subtractOutputSizeRegression) {


### PR DESCRIPTION
The Presburger library's SymbolicLexSimplex class organizes its tableau
so that symbols occuply the columns in the range `[3, 3 + num_symbols)`.

When creating the SymbolicLexOpt from an IntegerRelation, the API allows
the user to specify what variables of the system should be considered
as symbols. The constructor then reorders the coefficient when constructing
the initial constraint rows. This reordering was also manually at certain
users of SymbolicLexOpt, e.g. `IntegerRelation::computeReprWithOnlyDivLocals`.

Previously, at least one of the reordering implementations was not stable
(in `computeReprWithOnlyDivLocals`). If it considered the the second
variable to be a symbol in a 4 variable system:

```
var0 sym1 var2 var3
```

then the simplex would get arranged as

```
sym1 var3 var2 var0
```

I discovered tha, in certain cases, this reordering can cause
`SymbolicLexOpt::computeSymbolicLexMax` to become extremely inefficient
due to a large number of branches through the
context tableau as well as an explosion in the size of the coefficients.
See the additional test added.

So, this change updates the locations where the reordering logic
is implemented in order to ensure the partitioning is stable.

It is possible that this is just masking a more complicated bug (hard to
say for a non-expert on this code). My debugging efforts lead me to believe
that there is not a bug in the simplex solver, however.
Rather, some pre-processing procedures that rely on
heuristics/patterns (e.g. detection of division representations) can fail,
which can result in a sub-optimal problem description
being handed off to the simplex solver. In any case, a non-stable
partitioning of the variables is unexpected and makes it difficult to
proactively try to avoid problematic system descriptions by users of the
Presburger library.
