### PR TITLE
[memprof] Use gtest matchers at more places

### DIFF
--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -26,6 +26,7 @@
 
 using namespace llvm;
 using ::llvm::memprof::LineLocation;
+using ::testing::ElementsAre;
 using ::testing::EndsWith;
 using ::testing::IsSubsetOf;
 using ::testing::Pair;
@@ -564,19 +565,16 @@ TEST_F(InstrProfTest, test_caller_callee_pairs) {
 
   auto It = Pairs.find(0x123);
   ASSERT_NE(It, Pairs.end());
-  ASSERT_THAT(It->second, SizeIs(2));
-  EXPECT_THAT(It->second[0], Pair(LineLocation(1, 2), 0x234U));
-  EXPECT_THAT(It->second[1], Pair(LineLocation(5, 6), 0x345U));
+  EXPECT_THAT(It->second, ElementsAre(Pair(LineLocation(1, 2), 0x234U),
+                                      Pair(LineLocation(5, 6), 0x345U)));
 
   It = Pairs.find(0x234);
   ASSERT_NE(It, Pairs.end());
-  ASSERT_THAT(It->second, SizeIs(1));
-  EXPECT_THAT(It->second[0], Pair(LineLocation(3, 4), 0U));
+  EXPECT_THAT(It->second, ElementsAre(Pair(LineLocation(3, 4), 0U)));
 
   It = Pairs.find(0x345);
   ASSERT_NE(It, Pairs.end());
-  ASSERT_THAT(It->second, SizeIs(1));
-  EXPECT_THAT(It->second[0], Pair(LineLocation(7, 8), 0U));
+  EXPECT_THAT(It->second, ElementsAre(Pair(LineLocation(7, 8), 0U)));
 }
 
 TEST_F(InstrProfTest, test_memprof_getrecord_error) {

--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -221,31 +221,28 @@ TEST(MemProf, FillsValue) {
   EXPECT_THAT(Bar.AllocSites[0].CallStack[3],
               FrameContains("abc", 5U, 30U, false));
 
-  ASSERT_THAT(Bar.CallSites, SizeIs(1));
-  ASSERT_THAT(Bar.CallSites[0], SizeIs(2));
-  EXPECT_THAT(Bar.CallSites[0][0], FrameContains("foo", 5U, 30U, true));
-  EXPECT_THAT(Bar.CallSites[0][1], FrameContains("bar", 51U, 20U, false));
+  EXPECT_THAT(Bar.CallSites,
+              ElementsAre(ElementsAre(FrameContains("foo", 5U, 30U, true),
+                                      FrameContains("bar", 51U, 20U, false))));
 
   // Check the memprof record for xyz.
   const llvm::GlobalValue::GUID XyzId = IndexedMemProfRecord::getGUID("xyz");
   ASSERT_TRUE(Records.contains(XyzId));
   const MemProfRecord &Xyz = Records[XyzId];
-  ASSERT_THAT(Xyz.CallSites, SizeIs(1));
-  ASSERT_THAT(Xyz.CallSites[0], SizeIs(2));
   // Expect the entire frame even though in practice we only need the first
   // entry here.
-  EXPECT_THAT(Xyz.CallSites[0][0], FrameContains("xyz", 5U, 30U, true));
-  EXPECT_THAT(Xyz.CallSites[0][1], FrameContains("abc", 5U, 30U, false));
+  EXPECT_THAT(Xyz.CallSites,
+              ElementsAre(ElementsAre(FrameContains("xyz", 5U, 30U, true),
+                                      FrameContains("abc", 5U, 30U, false))));
 
   // Check the memprof record for abc.
   const llvm::GlobalValue::GUID AbcId = IndexedMemProfRecord::getGUID("abc");
   ASSERT_TRUE(Records.contains(AbcId));
   const MemProfRecord &Abc = Records[AbcId];
   EXPECT_TRUE(Abc.AllocSites.empty());
-  ASSERT_THAT(Abc.CallSites, SizeIs(1));
-  ASSERT_THAT(Abc.CallSites[0], SizeIs(2));
-  EXPECT_THAT(Abc.CallSites[0][0], FrameContains("xyz", 5U, 30U, true));
-  EXPECT_THAT(Abc.CallSites[0][1], FrameContains("abc", 5U, 30U, false));
+  EXPECT_THAT(Abc.CallSites,
+              ElementsAre(ElementsAre(FrameContains("xyz", 5U, 30U, true),
+                                      FrameContains("abc", 5U, 30U, false))));
 }
 
 TEST(MemProf, PortableWrapper) {
@@ -419,9 +416,8 @@ TEST(MemProf, SymbolizationFilter) {
 
   ASSERT_THAT(Records, SizeIs(1));
   ASSERT_THAT(Records[0].AllocSites, SizeIs(1));
-  ASSERT_THAT(Records[0].AllocSites[0].CallStack, SizeIs(1));
-  EXPECT_THAT(Records[0].AllocSites[0].CallStack[0],
-              FrameContains("foo", 5U, 30U, false));
+  EXPECT_THAT(Records[0].AllocSites[0].CallStack,
+              ElementsAre(FrameContains("foo", 5U, 30U, false)));
 }
 
 TEST(MemProf, BaseMemProfReader) {
@@ -452,11 +448,9 @@ TEST(MemProf, BaseMemProfReader) {
 
   ASSERT_THAT(Records, SizeIs(1));
   ASSERT_THAT(Records[0].AllocSites, SizeIs(1));
-  ASSERT_THAT(Records[0].AllocSites[0].CallStack, SizeIs(2));
-  EXPECT_THAT(Records[0].AllocSites[0].CallStack[0],
-              FrameContains("foo", 20U, 5U, true));
-  EXPECT_THAT(Records[0].AllocSites[0].CallStack[1],
-              FrameContains("bar", 10U, 2U, false));
+  EXPECT_THAT(Records[0].AllocSites[0].CallStack,
+              ElementsAre(FrameContains("foo", 20U, 5U, true),
+                          FrameContains("bar", 10U, 2U, false)));
 }
 
 TEST(MemProf, BaseMemProfReaderWithCSIdMap) {
@@ -489,11 +483,9 @@ TEST(MemProf, BaseMemProfReaderWithCSIdMap) {
 
   ASSERT_THAT(Records, SizeIs(1));
   ASSERT_THAT(Records[0].AllocSites, SizeIs(1));
-  ASSERT_THAT(Records[0].AllocSites[0].CallStack, SizeIs(2));
-  EXPECT_THAT(Records[0].AllocSites[0].CallStack[0],
-              FrameContains("foo", 20U, 5U, true));
-  EXPECT_THAT(Records[0].AllocSites[0].CallStack[1],
-              FrameContains("bar", 10U, 2U, false));
+  EXPECT_THAT(Records[0].AllocSites[0].CallStack,
+              ElementsAre(FrameContains("foo", 20U, 5U, true),
+                          FrameContains("bar", 10U, 2U, false)));
 }
 
 TEST(MemProf, IndexedMemProfRecordToMemProfRecord) {


### PR DESCRIPTION
These gtest matchers reduce the number of times we mention the
variables under examined.
