### PR TITLE
[libc] Add missing casts in StrtolTest

### DIFF
--- a/libc/test/src/stdlib/StrtolTest.h
+++ b/libc/test/src/stdlib/StrtolTest.h
@@ -200,8 +200,8 @@ struct StrtoTest : public LIBC_NAMESPACE::testing::Test {
     char small_string[4] = {'\0', '\0', '\0', '\0'};
     for (int base = 2; base <= 36; ++base) {
       for (int first_digit = 0; first_digit <= 36; ++first_digit) {
-        small_string[0] =
-            LIBC_NAMESPACE::internal::int_to_b36_char(first_digit);
+        small_string[0] = static_cast<char>(
+            LIBC_NAMESPACE::internal::int_to_b36_char(first_digit));
         if (first_digit < base) {
           LIBC_NAMESPACE::libc_errno = 0;
           ASSERT_EQ(func(small_string, nullptr, base),
@@ -217,11 +217,11 @@ struct StrtoTest : public LIBC_NAMESPACE::testing::Test {
 
     for (int base = 2; base <= 36; ++base) {
       for (int first_digit = 0; first_digit <= 36; ++first_digit) {
-        small_string[0] =
-            LIBC_NAMESPACE::internal::int_to_b36_char(first_digit);
+        small_string[0] = static_cast<char>(
+            LIBC_NAMESPACE::internal::int_to_b36_char(first_digit));
         for (int second_digit = 0; second_digit <= 36; ++second_digit) {
-          small_string[1] =
-              LIBC_NAMESPACE::internal::int_to_b36_char(second_digit);
+          small_string[1] = static_cast<char>(
+              LIBC_NAMESPACE::internal::int_to_b36_char(second_digit));
           if (first_digit < base && second_digit < base) {
             LIBC_NAMESPACE::libc_errno = 0;
             ASSERT_EQ(
@@ -244,14 +244,14 @@ struct StrtoTest : public LIBC_NAMESPACE::testing::Test {
 
     for (int base = 2; base <= 36; ++base) {
       for (int first_digit = 0; first_digit <= 36; ++first_digit) {
-        small_string[0] =
-            LIBC_NAMESPACE::internal::int_to_b36_char(first_digit);
+        small_string[0] = static_cast<char>(
+            LIBC_NAMESPACE::internal::int_to_b36_char(first_digit));
         for (int second_digit = 0; second_digit <= 36; ++second_digit) {
-          small_string[1] =
-              LIBC_NAMESPACE::internal::int_to_b36_char(second_digit);
+          small_string[1] = static_cast<char>(
+              LIBC_NAMESPACE::internal::int_to_b36_char(second_digit));
           for (int third_digit = 0; third_digit <= limit; ++third_digit) {
-            small_string[2] =
-                LIBC_NAMESPACE::internal::int_to_b36_char(third_digit);
+            small_string[2] = static_cast<char>(
+                LIBC_NAMESPACE::internal::int_to_b36_char(third_digit));
 
             if (first_digit < base && second_digit < base &&
                 third_digit < base) {


### PR DESCRIPTION
The a0c4f854cad2b97e44a1b58dc1fd982e1c4d60f3 change replaced the
local int_to_b36_char function returning `char` with uses of the
__support function of the same name that returns `int`.  The uses
of the old local function lacked the casts that all other uses of
the shared function of the same name had.  Add them.
