### PR TITLE
[libc] Fix multiply-defined global functions in ctype tests

### DIFF
--- a/libc/test/src/ctype/isalnum_test.cpp
+++ b/libc/test/src/ctype/isalnum_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcIsAlNum, SimpleTest) {
-  EXPECT_NE(LIBC_NAMESPACE::isalnum('a'), 0);
-  EXPECT_NE(LIBC_NAMESPACE::isalnum('B'), 0);
-  EXPECT_NE(LIBC_NAMESPACE::isalnum('3'), 0);
-
-  EXPECT_EQ(LIBC_NAMESPACE::isalnum(' '), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalnum('?'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalnum('\0'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalnum(-1), 0);
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 constexpr char ALNUM_ARRAY[] = {
@@ -36,6 +27,19 @@ bool in_span(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return true;
   return false;
+}
+
+} // namespace
+
+TEST(LlvmLibcIsAlNum, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::isalnum('a'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::isalnum('B'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::isalnum('3'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::isalnum(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalnum('?'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalnum('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalnum(-1), 0);
 }
 
 TEST(LlvmLibcIsAlNum, DefaultLocale) {

--- a/libc/test/src/ctype/isalpha_test.cpp
+++ b/libc/test/src/ctype/isalpha_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcIsAlpha, SimpleTest) {
-  EXPECT_NE(LIBC_NAMESPACE::isalpha('a'), 0);
-  EXPECT_NE(LIBC_NAMESPACE::isalpha('B'), 0);
-
-  EXPECT_EQ(LIBC_NAMESPACE::isalpha('3'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalpha(' '), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalpha('?'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalpha('\0'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isalpha(-1), 0);
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 constexpr char ALPHA_ARRAY[] = {
@@ -35,6 +26,19 @@ bool in_span(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return true;
   return false;
+}
+
+} // namespace
+
+TEST(LlvmLibcIsAlpha, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::isalpha('a'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::isalpha('B'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::isalpha('3'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalpha(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalpha('?'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalpha('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isalpha(-1), 0);
 }
 
 TEST(LlvmLibcIsAlpha, DefaultLocale) {

--- a/libc/test/src/ctype/isdigit_test.cpp
+++ b/libc/test/src/ctype/isdigit_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcIsDigit, SimpleTest) {
-  EXPECT_NE(LIBC_NAMESPACE::isdigit('3'), 0);
-
-  EXPECT_EQ(LIBC_NAMESPACE::isdigit('a'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isdigit('B'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isdigit(' '), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isdigit('?'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isdigit('\0'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isdigit(-1), 0);
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 constexpr char DIGIT_ARRAY[] = {
@@ -32,6 +23,19 @@ bool in_span(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return true;
   return false;
+}
+
+} // namespace
+
+TEST(LlvmLibcIsDigit, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::isdigit('3'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::isdigit('a'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isdigit('B'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isdigit(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isdigit('?'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isdigit('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isdigit(-1), 0);
 }
 
 TEST(LlvmLibcIsDigit, DefaultLocale) {

--- a/libc/test/src/ctype/islower_test.cpp
+++ b/libc/test/src/ctype/islower_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcIsLower, SimpleTest) {
-  EXPECT_NE(LIBC_NAMESPACE::islower('a'), 0);
-
-  EXPECT_EQ(LIBC_NAMESPACE::islower('B'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::islower('3'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::islower(' '), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::islower('?'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::islower('\0'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::islower(-1), 0);
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 constexpr char LOWER_ARRAY[] = {
@@ -33,6 +24,19 @@ bool in_span(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return true;
   return false;
+}
+
+} // namespace
+
+TEST(LlvmLibcIsLower, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::islower('a'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::islower('B'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::islower('3'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::islower(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::islower('?'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::islower('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::islower(-1), 0);
 }
 
 TEST(LlvmLibcIsLower, DefaultLocale) {

--- a/libc/test/src/ctype/isupper_test.cpp
+++ b/libc/test/src/ctype/isupper_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcIsUpper, SimpleTest) {
-  EXPECT_NE(LIBC_NAMESPACE::isupper('B'), 0);
-
-  EXPECT_EQ(LIBC_NAMESPACE::isupper('a'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isupper('3'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isupper(' '), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isupper('?'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isupper('\0'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isupper(-1), 0);
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 constexpr char UPPER_ARRAY[] = {
@@ -33,6 +24,19 @@ bool in_span(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return true;
   return false;
+}
+
+} // namespace
+
+TEST(LlvmLibcIsUpper, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::isupper('B'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::isupper('a'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isupper('3'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isupper(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isupper('?'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isupper('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isupper(-1), 0);
 }
 
 TEST(LlvmLibcIsUpper, DefaultLocale) {

--- a/libc/test/src/ctype/isxdigit_test.cpp
+++ b/libc/test/src/ctype/isxdigit_test.cpp
@@ -11,17 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcIsXdigit, SimpleTest) {
-  EXPECT_NE(LIBC_NAMESPACE::isxdigit('a'), 0);
-  EXPECT_NE(LIBC_NAMESPACE::isxdigit('B'), 0);
-  EXPECT_NE(LIBC_NAMESPACE::isxdigit('3'), 0);
-
-  EXPECT_EQ(LIBC_NAMESPACE::isxdigit('z'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isxdigit(' '), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isxdigit('?'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isxdigit('\0'), 0);
-  EXPECT_EQ(LIBC_NAMESPACE::isxdigit(-1), 0);
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 constexpr char XDIGIT_ARRAY[] = {
@@ -34,6 +24,20 @@ bool in_span(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return true;
   return false;
+}
+
+} // namespace
+
+TEST(LlvmLibcIsXdigit, SimpleTest) {
+  EXPECT_NE(LIBC_NAMESPACE::isxdigit('a'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::isxdigit('B'), 0);
+  EXPECT_NE(LIBC_NAMESPACE::isxdigit('3'), 0);
+
+  EXPECT_EQ(LIBC_NAMESPACE::isxdigit('z'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isxdigit(' '), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isxdigit('?'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isxdigit('\0'), 0);
+  EXPECT_EQ(LIBC_NAMESPACE::isxdigit(-1), 0);
 }
 
 TEST(LlvmLibcIsXdigit, DefaultLocale) {

--- a/libc/test/src/ctype/tolower_test.cpp
+++ b/libc/test/src/ctype/tolower_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcToLower, SimpleTest) {
-  EXPECT_EQ(LIBC_NAMESPACE::tolower('a'), int('a'));
-  EXPECT_EQ(LIBC_NAMESPACE::tolower('B'), int('b'));
-  EXPECT_EQ(LIBC_NAMESPACE::tolower('3'), int('3'));
-
-  EXPECT_EQ(LIBC_NAMESPACE::tolower(' '), int(' '));
-  EXPECT_EQ(LIBC_NAMESPACE::tolower('?'), int('?'));
-  EXPECT_EQ(LIBC_NAMESPACE::tolower('\0'), int('\0'));
-  EXPECT_EQ(LIBC_NAMESPACE::tolower(-1), int(-1));
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 // Invariant: UPPER_ARR and LOWER_ARR are both the complete alphabet in the same
@@ -43,6 +34,19 @@ int span_index(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return static_cast<int>(i);
   return -1;
+}
+
+} // namespace
+
+TEST(LlvmLibcToLower, SimpleTest) {
+  EXPECT_EQ(LIBC_NAMESPACE::tolower('a'), int('a'));
+  EXPECT_EQ(LIBC_NAMESPACE::tolower('B'), int('b'));
+  EXPECT_EQ(LIBC_NAMESPACE::tolower('3'), int('3'));
+
+  EXPECT_EQ(LIBC_NAMESPACE::tolower(' '), int(' '));
+  EXPECT_EQ(LIBC_NAMESPACE::tolower('?'), int('?'));
+  EXPECT_EQ(LIBC_NAMESPACE::tolower('\0'), int('\0'));
+  EXPECT_EQ(LIBC_NAMESPACE::tolower(-1), int(-1));
 }
 
 TEST(LlvmLibcToLower, DefaultLocale) {

--- a/libc/test/src/ctype/toupper_test.cpp
+++ b/libc/test/src/ctype/toupper_test.cpp
@@ -11,16 +11,7 @@
 
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcToUpper, SimpleTest) {
-  EXPECT_EQ(LIBC_NAMESPACE::toupper('a'), int('A'));
-  EXPECT_EQ(LIBC_NAMESPACE::toupper('B'), int('B'));
-  EXPECT_EQ(LIBC_NAMESPACE::toupper('3'), int('3'));
-
-  EXPECT_EQ(LIBC_NAMESPACE::toupper(' '), int(' '));
-  EXPECT_EQ(LIBC_NAMESPACE::toupper('?'), int('?'));
-  EXPECT_EQ(LIBC_NAMESPACE::toupper('\0'), int('\0'));
-  EXPECT_EQ(LIBC_NAMESPACE::toupper(-1), int(-1));
-}
+namespace {
 
 // TODO: Merge the ctype tests using this framework.
 // Invariant: UPPER_ARR and LOWER_ARR are both the complete alphabet in the same
@@ -43,6 +34,19 @@ int span_index(int ch, LIBC_NAMESPACE::cpp::span<const char> arr) {
     if (static_cast<int>(arr[i]) == ch)
       return static_cast<int>(i);
   return -1;
+}
+
+} // namespace
+
+TEST(LlvmLibcToUpper, SimpleTest) {
+  EXPECT_EQ(LIBC_NAMESPACE::toupper('a'), int('A'));
+  EXPECT_EQ(LIBC_NAMESPACE::toupper('B'), int('B'));
+  EXPECT_EQ(LIBC_NAMESPACE::toupper('3'), int('3'));
+
+  EXPECT_EQ(LIBC_NAMESPACE::toupper(' '), int(' '));
+  EXPECT_EQ(LIBC_NAMESPACE::toupper('?'), int('?'));
+  EXPECT_EQ(LIBC_NAMESPACE::toupper('\0'), int('\0'));
+  EXPECT_EQ(LIBC_NAMESPACE::toupper(-1), int(-1));
 }
 
 TEST(LlvmLibcToUpper, DefaultLocale) {


### PR DESCRIPTION
For whatever reason, each ctype test contains its own copy of
some identical helper source code.  These local helpers were
defined with external linkage for no apparent reason.  This leads
to multiple definition errors when linking these tests together.

This change moves each file's local helper code into an anonymous
namespace so it has internal linkage.  It's notable that the libc
test code does not follow the most common norm of gtest-style
code where all the `TEST(...)` cases themselves are defined
inside an anonymous namespace (along with whatever other local
helpers they use); whether libc's tests should follow that usual
convention can be addressed holistically in future discussion.

The replacement of numerous cut&paste'd copies of identical
helper code with sharing the source code in some usual fashion is
also left for later cleanup.

This change only makes the test code not straightforwardly have
multiple definition errors that prevent linking a test executable
at all.
