### PR TITLE
[MC][Mips] Fix wrong assumption about `Immediate` operand.

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
@@ -143,10 +143,13 @@ public:
     switch (Info->get(Inst.getOpcode()).operands()[NumOps - 1].OperandType) {
     case MCOI::OPERAND_UNKNOWN:
     case MCOI::OPERAND_IMMEDIATE: {
+      const MCOperand& Op = Inst.getOperand(NumOps - 1);
+      if (!Op.isImm())
+        return false;
       // j, jal, jalx, jals
       // Absolute branch within the current 256 MB-aligned region
       uint64_t Region = Addr & ~uint64_t(0xfffffff);
-      Target = Region + Inst.getOperand(NumOps - 1).getImm();
+      Target = Region + Op.getImm();
       return true;
     }
     case MCOI::OPERAND_PCREL:


### PR DESCRIPTION
While trying to evaluate the branch of this MIPS (EL) non-branch instruction: `ldxc1 $f2, $4($7)` the function fails on the assert: `assert(isImm() && ...)`.

This commit ensures that the operand is an immediate before accessing the value.

- Triple: `mipsel-unknown-linux-gnu-elf` with `+mips32r2`
- Instruction: `ldxc1 $f2, $4($7)`
- Raw instruction: `0x81, 0x0, 0xe4, 0x4c`