### PR TITLE
[memprof] Remove a stale comment in a unit test

### DIFF
--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -401,8 +401,6 @@ makeRecordV2(std::initializer_list<::llvm::memprof::CallStackId> AllocFrames,
              const MemInfoBlock &Block, const memprof::MemProfSchema &Schema) {
   llvm::memprof::IndexedMemProfRecord MR;
   for (const auto &CSId : AllocFrames)
-    // We don't populate IndexedAllocationInfo::CallStack because we use it only
-    // in Version1.
     MR.AllocSites.emplace_back(CSId, Block, Schema);
   for (const auto &CSId : CallSiteFrames)
     MR.CallSiteIds.push_back(CSId);


### PR DESCRIPTION
We've removed IndexedAllocationInfo::CallStack, so we don't need to
mention it.
