### PR TITLE
[SPARC][IAS] Add support for `call dest, imm` form

### DIFF
--- a/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
+++ b/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
@@ -220,6 +220,7 @@ private:
     k_MemoryImm,
     k_ASITag,
     k_PrefetchTag,
+    k_TailRelocSym, // Special kind of immediate for TLS relocation purposes.
   } Kind;
 
   SMLoc StartLoc, EndLoc;
@@ -265,7 +266,7 @@ public:
   bool isMembarTag() const { return Kind == k_Immediate; }
   bool isASITag() const { return Kind == k_ASITag; }
   bool isPrefetchTag() const { return Kind == k_PrefetchTag; }
-  bool isTailRelocSym() const { return Kind == k_Immediate; }
+  bool isTailRelocSym() const { return Kind == k_TailRelocSym; }
 
   bool isCallTarget() const {
     if (!isImm())
@@ -354,6 +355,11 @@ public:
     return Prefetch;
   }
 
+  const MCExpr *getTailRelocSym() const {
+    assert((Kind == k_TailRelocSym) && "Invalid access!");
+    return Imm.Val;
+  }
+
   /// getStartLoc - Get the location of the first token of this operand.
   SMLoc getStartLoc() const override {
     return StartLoc;
@@ -379,6 +385,9 @@ public:
       break;
     case k_PrefetchTag:
       OS << "Prefetch tag: " << getPrefetchTag() << "\n";
+      break;
+    case k_TailRelocSym:
+      OS << "TailReloc: " << getTailRelocSym() << "\n";
       break;
     }
   }
@@ -454,7 +463,7 @@ public:
 
   void addTailRelocSymOperands(MCInst &Inst, unsigned N) const {
     assert(N == 1 && "Invalid number of operands!");
-    addExpr(Inst, getImm());
+    addExpr(Inst, getTailRelocSym());
   }
 
   static std::unique_ptr<SparcOperand> CreateToken(StringRef Str, SMLoc S) {
@@ -498,6 +507,15 @@ public:
                                                          SMLoc E) {
     auto Op = std::make_unique<SparcOperand>(k_PrefetchTag);
     Op->Prefetch = Val;
+    Op->StartLoc = S;
+    Op->EndLoc = E;
+    return Op;
+  }
+
+  static std::unique_ptr<SparcOperand> CreateTailRelocSym(const MCExpr *Val,
+                                                          SMLoc S, SMLoc E) {
+    auto Op = std::make_unique<SparcOperand>(k_TailRelocSym);
+    Op->Imm.Val = Val;
     Op->StartLoc = S;
     Op->EndLoc = E;
     return Op;
@@ -1070,7 +1088,7 @@ ParseStatus SparcAsmParser::parseTailRelocSym(OperandVector &Operands) {
   };
 
   if (getLexer().getKind() != AsmToken::Percent)
-    return Error(getLoc(), "expected '%' for operand modifier");
+    return ParseStatus::NoMatch;
 
   const AsmToken Tok = Parser.getTok();
   getParser().Lex(); // Eat '%'
@@ -1099,7 +1117,7 @@ ParseStatus SparcAsmParser::parseTailRelocSym(OperandVector &Operands) {
     return ParseStatus::Failure;
 
   const MCExpr *Val = adjustPICRelocation(VK, SubExpr);
-  Operands.push_back(SparcOperand::CreateImm(Val, S, E));
+  Operands.push_back(SparcOperand::CreateTailRelocSym(Val, S, E));
   return ParseStatus::Success;
 }
 

--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -375,13 +375,12 @@ bool Filler::needsUnimp(MachineBasicBlock::iterator I, unsigned &StructSize)
   unsigned structSizeOpNum = 0;
   switch (I->getOpcode()) {
   default: llvm_unreachable("Unknown call opcode.");
-  case SP::CALL: structSizeOpNum = 1; break;
-  case SP::CALLi:
+  case SP::CALL:
+    structSizeOpNum = 1;
+    break;
   case SP::CALLrr:
-  case SP::CALLri: structSizeOpNum = 2; break;
-  case SP::CALLrri:
-  case SP::CALLrii:
-    structSizeOpNum = 3;
+  case SP::CALLri:
+    structSizeOpNum = 2;
     break;
   case SP::TLS_CALL: return false;
   case SP::TAIL_CALLri:

--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -310,12 +310,9 @@ void Filler::insertCallDefsUses(MachineBasicBlock::iterator MI,
   switch(MI->getOpcode()) {
   default: llvm_unreachable("Unknown opcode.");
   case SP::CALL:
-  case SP::CALLi:
     break;
   case SP::CALLrr:
   case SP::CALLri:
-  case SP::CALLrri:
-  case SP::CALLrii:
     assert(MI->getNumOperands() >= 2);
     const MachineOperand &Reg = MI->getOperand(0);
     assert(Reg.isReg() && "CALL first operand is not a register.");

--- a/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
+++ b/llvm/lib/Target/Sparc/DelaySlotFiller.cpp
@@ -309,9 +309,13 @@ void Filler::insertCallDefsUses(MachineBasicBlock::iterator MI,
 
   switch(MI->getOpcode()) {
   default: llvm_unreachable("Unknown opcode.");
-  case SP::CALL: break;
+  case SP::CALL:
+  case SP::CALLi:
+    break;
   case SP::CALLrr:
   case SP::CALLri:
+  case SP::CALLrri:
+  case SP::CALLrii:
     assert(MI->getNumOperands() >= 2);
     const MachineOperand &Reg = MI->getOperand(0);
     assert(Reg.isReg() && "CALL first operand is not a register.");
@@ -372,8 +376,13 @@ bool Filler::needsUnimp(MachineBasicBlock::iterator I, unsigned &StructSize)
   switch (I->getOpcode()) {
   default: llvm_unreachable("Unknown call opcode.");
   case SP::CALL: structSizeOpNum = 1; break;
+  case SP::CALLi:
   case SP::CALLrr:
   case SP::CALLri: structSizeOpNum = 2; break;
+  case SP::CALLrri:
+  case SP::CALLrii:
+    structSizeOpNum = 3;
+    break;
   case SP::TLS_CALL: return false;
   case SP::TAIL_CALLri:
   case SP::TAIL_CALL: return false;

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.td
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.td
@@ -1039,10 +1039,8 @@ let Uses = [O6],
   // call with trailing imm argument.
   // The imm argument is discarded.
   let isAsmParserOnly = 1 in {
-    def CALLi : InstSP<(outs), (ins calltarget:$disp, i32imm:$imm, variable_ops),
-                    "call $disp, $imm",
-                    [],
-                    IIC_jmp_or_call> {
+    def CALLi : InstSP<(outs), (ins calltarget:$disp, i32imm:$imm),
+                    "call $disp, $imm", []> {
       bits<30> disp;
       let op = 1;
       let Inst{29-0} = disp;
@@ -1065,15 +1063,11 @@ let Uses = [O6],
 
   let isAsmParserOnly = 1, rd = 15 in {
     def CALLrri : F3_1<2, 0b111000,
-                      (outs), (ins (MEMrr $rs1, $rs2):$addr, i32imm:$imm, variable_ops),
-                      "call $addr, $imm",
-                      [],
-                      IIC_jmp_or_call>;
+                      (outs), (ins (MEMrr $rs1, $rs2):$addr, i32imm:$imm),
+                      "call $addr, $imm", []>;
     def CALLrii : F3_2<2, 0b111000,
-                      (outs), (ins (MEMri $rs1, $simm13):$addr, i32imm:$imm, variable_ops),
-                      "call $addr, $imm",
-                      [],
-                      IIC_jmp_or_call>;
+                      (outs), (ins (MEMri $rs1, $simm13):$addr, i32imm:$imm),
+                      "call $addr, $imm", []>;
   }
 }
 

--- a/llvm/lib/Target/Sparc/SparcInstrInfo.td
+++ b/llvm/lib/Target/Sparc/SparcInstrInfo.td
@@ -1036,6 +1036,19 @@ let Uses = [O6],
     let Inst{29-0} = disp;
   }
 
+  // call with trailing imm argument.
+  // The imm argument is discarded.
+  let isAsmParserOnly = 1 in {
+    def CALLi : InstSP<(outs), (ins calltarget:$disp, i32imm:$imm, variable_ops),
+                    "call $disp, $imm",
+                    [],
+                    IIC_jmp_or_call> {
+      bits<30> disp;
+      let op = 1;
+      let Inst{29-0} = disp;
+    }
+  }
+
   // indirect calls: special cases of JMPL.
   let isCodeGenOnly = 1, rd = 15 in {
     def CALLrr : F3_1<2, 0b111000,
@@ -1047,6 +1060,19 @@ let Uses = [O6],
                       (outs), (ins (MEMri $rs1, $simm13):$addr, variable_ops),
                       "call $addr",
                       [(call ADDRri:$addr)],
+                      IIC_jmp_or_call>;
+  }
+
+  let isAsmParserOnly = 1, rd = 15 in {
+    def CALLrri : F3_1<2, 0b111000,
+                      (outs), (ins (MEMrr $rs1, $rs2):$addr, i32imm:$imm, variable_ops),
+                      "call $addr, $imm",
+                      [],
+                      IIC_jmp_or_call>;
+    def CALLrii : F3_2<2, 0b111000,
+                      (outs), (ins (MEMri $rs1, $simm13):$addr, i32imm:$imm, variable_ops),
+                      "call $addr, $imm",
+                      [],
                       IIC_jmp_or_call>;
   }
 }

--- a/llvm/test/MC/Sparc/sparc-ctrl-instructions.s
+++ b/llvm/test/MC/Sparc/sparc-ctrl-instructions.s
@@ -5,22 +5,43 @@
         ! CHECK:              !   fixup A - offset: 0, value: foo, kind: fixup_sparc_call30
         call foo
 
+        ! CHECK: call foo, 0  ! encoding: [0b01AAAAAA,A,A,A]
+        ! CHECK:              !   fixup A - offset: 0, value: foo, kind: fixup_sparc_call30
+        call foo, 0
+
         ! CHECK: call %g1+%i2 ! encoding: [0x9f,0xc0,0x40,0x1a]
         call %g1 + %i2
+
+        ! CHECK: call %g1+%i2, 1 ! encoding: [0x9f,0xc0,0x40,0x1a]
+        call %g1 + %i2, 1
 
         ! CHECK: call %o1+8   ! encoding: [0x9f,0xc2,0x60,0x08]
         call %o1 + 8
 
+        ! CHECK: call %o1+8, 2   ! encoding: [0x9f,0xc2,0x60,0x08]
+        call %o1 + 8, 2
+
         ! CHECK: call %g1     ! encoding: [0x9f,0xc0,0x40,0x00]
         call %g1
+
+        ! CHECK: call %g1, 3     ! encoding: [0x9f,0xc0,0x40,0x00]
+        call %g1, 3
 
         ! CHECK: call %g1+%lo(sym)   ! encoding: [0x9f,0xc0,0b011000AA,A]
         ! CHECK-NEXT:                ! fixup A - offset: 0, value: %lo(sym), kind: fixup_sparc_lo10
         call %g1+%lo(sym)
 
+        ! CHECK: call %g1+%lo(sym), 4   ! encoding: [0x9f,0xc0,0b011000AA,A]
+        ! CHECK-NEXT:                ! fixup A - offset: 0, value: %lo(sym), kind: fixup_sparc_lo10
+        call %g1+%lo(sym), 4
+
         ! CHECK-LABEL: .Ltmp0:
         ! CHECK: call .Ltmp0-4 ! encoding: [0b01AAAAAA,A,A,A]
         call . - 4
+
+        ! CHECK-LABEL: .Ltmp1:
+        ! CHECK: call .Ltmp1-4, 5 ! encoding: [0b01AAAAAA,A,A,A]
+        call . - 4, 5
 
         ! CHECK: jmp %g1+%i2  ! encoding: [0x81,0xc0,0x40,0x1a]
         jmp %g1 + %i2


### PR DESCRIPTION
This follows GCC behavior of allowing a trailing immediate, that is ignored by the assembler.