### PR TITLE
[docs] Add a more detailed description in CXString.h.

### DIFF
--- a/clang/include/clang-c/CXString.h
+++ b/clang/include/clang-c/CXString.h
@@ -46,6 +46,9 @@ typedef struct {
 
 /**
  * Retrieve the character data associated with the given string.
+ *
+ * The caller shouldn't free the returned string data, and the returned string
+ * data shouldn't be accessed after the \c CXString disposed.
  */
 CINDEX_LINKAGE const char *clang_getCString(CXString string);
 

--- a/clang/include/clang-c/CXString.h
+++ b/clang/include/clang-c/CXString.h
@@ -47,8 +47,9 @@ typedef struct {
 /**
  * Retrieve the character data associated with the given string.
  *
- * The caller shouldn't free the returned string data, and the returned string
- * data shouldn't be accessed after the \c CXString disposed.
+ * The returned data is a reference and not owned by the user. This data
+ * is only valid while the `CXString` is valid. This function is similar
+ * to `std::string::c_str()`.
  */
 CINDEX_LINKAGE const char *clang_getCString(CXString string);
 


### PR DESCRIPTION
Emmm... Maybe I'm splitting hairs. But I really think the paragraph should be more detailed. The orginal document makes me confused. Do I take the ownership of the string data? 
Here I don't refer the `clang_disposeString` function, because here's a `clang_disposeStringSet`. 