### PR TITLE
[mlir][docs] Fix typos in documentation for MLIR tensor dialect

### DIFF
--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
@@ -213,11 +213,11 @@ def Tensor_DimOp : Tensor_Op<"dim", [
 
     // Return the dynamic dimension of %A.
     %c1 = arith.constant 1 : index
-    %y = tensor.dim %A, %c1 : memref<4x?xf32>
+    %y = tensor.dim %A, %c1 : tensor<4x?xf32>
 
     // Equivalent generic form:
-    %x = "tensor.dim"(%A, %c0) : (memref<4x?xf32>, index) -> index
-    %y = "tensor.dim"(%A, %c1) : (memref<4x?xf32>, index) -> index
+    %x = "tensor.dim"(%A, %c0) : (tensor<4x?xf32>, index) -> index
+    %y = "tensor.dim"(%A, %c1) : (tensor<4x?xf32>, index) -> index
     ```
   }];
 

--- a/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
+++ b/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td
@@ -673,7 +673,7 @@ def Tensor_GatherOp : Tensor_Op<"gather", [
 
     At the tensor-level, the index tensor is specified in an AoS form (i.e.
     coordinate tuple is the most minor). It is the responsibility of further
-    lowerings and bufferiation to implement various concrete layouts.
+    lowerings and bufferization to implement various concrete layouts.
 
     Note: As currently specified, the operation must lower to an abstraction that
     performs copies to the output tensor. This is because the buffer type system
@@ -710,7 +710,7 @@ def Tensor_GatherOp : Tensor_Op<"gather", [
 
   let extraClassDeclaration = [{
     // TODO: InferTypeOpInterface once enough confidence is built with
-    // tensor<tensor> and its lwoering to memref<memref>.
+    // tensor<tensor> and its lowering to memref<memref>.
     static RankedTensorType inferResultType(RankedTensorType sourceType,
                                             RankedTensorType indicesType,
                                             ArrayRef<int64_t> gatherDims,
@@ -1673,7 +1673,7 @@ def Tensor_ScatterOp : Tensor_Op<"scatter", [
     source tensor has size `1`.
     I.e. if the dest type is `axbxcxd` and the coordinates are [1, 3], then
     the source type suffix is `ax1xcx1`.
-    Sactter also allows rank-reducing semantics where the shape `ax1xcx1` can be
+    Scatter also allows rank-reducing semantics where the shape `ax1xcx1` can be
     further simplified to `axc`.
 
     The elemental type of the indices tensor can be any integer type.
@@ -1693,7 +1693,7 @@ def Tensor_ScatterOp : Tensor_Op<"scatter", [
 
     At the tensor-level, the index tensor is specified in an AoS form (i.e.
     coordinate tuple is the most minor). It is the responsibility of further
-    lowerings and bufferiation to implement various concrete layouts.
+    lowerings and bufferization to implement various concrete layouts.
 
     Note: As currently specified, the operation must lower to an abstraction that
     performs copies to the output tensor. This is because the buffer type system
@@ -2115,7 +2115,7 @@ def Tensor_UnPackOp : Tensor_RelayoutOp<"unpack"> {
     /// Check if this UnPackOp is like a simple unpad operation.
     /// In other words, this operation:
     /// 1. drops useless dimensions (dimension of size 1), and
-    /// 2. reduces dimensions in place (i.e., no tranpose.)
+    /// 2. reduces dimensions in place (i.e., no transpose.)
     bool isLikeUnPad();
   }];
 


### PR DESCRIPTION
Fix typos in the tensor dialect documentation as referenced in [this discourse topic](https://discourse.llvm.org/t/question-typo-in-the-documentation-for-tensor-dim/83539?u=e3m3).

1. Typos/Copy-paste errors referencing invalid `memref` type for `tensor.dim` op.
2. Miscellaneous typos across other tensor dialect ops.