### PR TITLE
[Clang] Fix crash for incompatible types in inline assembly

### DIFF
--- a/clang/test/Sema/asm.c
+++ b/clang/test/Sema/asm.c
@@ -365,3 +365,24 @@ void test19(long long x)
   // FIXME: This case should be supported by codegen, but it fails now.
   asm ("" : "=rm" (x): "0" (e)); // expected-error {{unsupported inline asm: input with type 'st_size128' (aka 'struct _st_size128') matching output with type 'long long'}}
 }
+
+typedef int int2 __attribute__((ext_vector_type(2)));
+
+// GH118892
+void test20(char x) {
+  double d;
+  float f;
+
+  asm ("fabs" : "=t" (d): "0" (x)); // expected-error {{unsupported inline asm: input with type 'char' matching output with type 'double'}}
+  asm ("fabs" : "=t" (x): "0" (d)); // expected-error {{unsupported inline asm: input with type 'double' matching output with type 'char'}}
+  asm ("fabs" : "=t" (f): "0" (d)); // no-error
+  asm ("fabs" : "=t" (d): "0" (f)); // no-error
+
+  st_size64 a;
+  asm ("fabs" : "=t" (d): "0" (a)); // expected-error {{unsupported inline asm: input with type 'st_size64' (aka 'struct _st_size64') matching output with type 'double'}}
+  asm ("fabs" : "=t" (a): "0" (d)); // expected-error {{unsupported inline asm: input with type 'double' matching output with type 'st_size64' (aka 'struct _st_size64')}}
+
+  int2 v;
+  asm ("fabs" : "=t" (d): "0" (v)); // expected-error {{unsupported inline asm: input with type 'int2' (vector of 2 'int' values) matching output with type 'double'}}
+  asm ("fabs" : "=t" (v): "0" (d)); // expected-error {{unsupported inline asm: input with type 'double' matching output with type 'int2' (vector of 2 'int' values)}}
+}


### PR DESCRIPTION
Fixed issue #118892.