### PR TITLE
[lldb] do not show misleading error when there is no frame

### DIFF
--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -1012,33 +1012,26 @@ bool SBFrame::GetDescription(SBStream &description) {
 SBValue SBFrame::EvaluateExpression(const char *expr) {
   LLDB_INSTRUMENT_VA(this, expr);
 
-  SBValue result;
   std::unique_lock<std::recursive_mutex> lock;
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock);
 
   StackFrame *frame = exe_ctx.GetFramePtr();
   Target *target = exe_ctx.GetTargetPtr();
+  SBExpressionOptions options;
   if (frame && target) {
-    SBExpressionOptions options;
     lldb::DynamicValueType fetch_dynamic_value =
         frame->CalculateTarget()->GetPreferDynamicValue();
     options.SetFetchDynamicValue(fetch_dynamic_value);
-    options.SetUnwindOnError(true);
-    options.SetIgnoreBreakpoints(true);
-    SourceLanguage language = target->GetLanguage();
-    if (!language)
-      language = frame->GetLanguage();
-    options.SetLanguage((SBSourceLanguageName)language.name, language.version);
-    return EvaluateExpression(expr, options);
-  } else {
-    Status error;
-    error = Status::FromErrorString("can't evaluate expressions when the "
-                                    "process is running.");
-    ValueObjectSP error_val_sp =
-        ValueObjectConstResult::Create(nullptr, std::move(error));
-    result.SetSP(error_val_sp, false);
   }
-  return result;
+  options.SetUnwindOnError(true);
+  options.SetIgnoreBreakpoints(true);
+  SourceLanguage language;
+  if (target)
+    language = target->GetLanguage();
+  if (!language && frame)
+    language = frame->GetLanguage();
+  options.SetLanguage((SBSourceLanguageName)language.name, language.version);
+  return EvaluateExpression(expr, options);
 }
 
 SBValue

--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -107,6 +107,4 @@ class TestRunLocker(TestBase):
             "script var = lldb.frame.EvaluateExpression('SomethingToCall()'); var.GetError().GetCString()",
             result,
         )
-        self.assertIn(
-            "can't evaluate expressions when the process is running", result.GetOutput()
-        )
+        self.assertIn("sbframe object is not valid", result.GetOutput())


### PR DESCRIPTION
I am using VSCode with the official vscode-lldb extension. When I try to list the breakpoints in the debug console get the message:

```
br list
can't evaluate expressions when the process is running.
```

I know that this is wrong and you need to use
```
`br list
(lldb) br list
No breakpoints currently set.
```
but the error message is misleading. I cleaned up the code and now the error message is

```
br list
sbframe object is not valid.
```
which is still not perfect, but at least it's not misleading.