### PR TITLE
[libc++] Fix improper static_cast in std::deque and __split_buffer

### DIFF
--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -435,7 +435,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::emplace_fron
       __begin_            = std::move_backward(__begin_, __end_, __end_ + __d);
       __end_ += __d;
     } else {
-      size_type __c = std::max<size_type>(2 * static_cast<size_t>(__cap_ - __first_), 1);
+      size_type __c = std::max<size_type>(2 * static_cast<size_type>(__cap_ - __first_), 1);
       __split_buffer<value_type, __alloc_rr&> __t(__c, (__c + 3) / 4, __alloc_);
       __t.__construct_at_end(move_iterator<pointer>(__begin_), move_iterator<pointer>(__end_));
       std::swap(__first_, __t.__first_);
@@ -458,7 +458,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::emplace_back
       __end_              = std::move(__begin_, __end_, __begin_ - __d);
       __begin_ -= __d;
     } else {
-      size_type __c = std::max<size_type>(2 * static_cast<size_t>(__cap_ - __first_), 1);
+      size_type __c = std::max<size_type>(2 * static_cast<size_type>(__cap_ - __first_), 1);
       __split_buffer<value_type, __alloc_rr&> __t(__c, __c / 4, __alloc_);
       __t.__construct_at_end(move_iterator<pointer>(__begin_), move_iterator<pointer>(__end_));
       std::swap(__first_, __t.__first_);

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -2431,7 +2431,7 @@ typename deque<_Tp, _Allocator>::iterator deque<_Tp, _Allocator>::erase(const_it
   difference_type __pos = __f - __b;
   iterator __p          = __b + __pos;
   allocator_type& __a   = __alloc();
-  if (static_cast<size_t>(__pos) <= (size() - 1) / 2) { // erase from front
+  if (static_cast<size_type>(__pos) <= (size() - 1) / 2) { // erase from front
     std::move_backward(__b, __p, std::next(__p));
     __alloc_traits::destroy(__a, std::addressof(*__b));
     --__size();
@@ -2459,7 +2459,7 @@ typename deque<_Tp, _Allocator>::iterator deque<_Tp, _Allocator>::erase(const_it
   iterator __p          = __b + __pos;
   if (__n > 0) {
     allocator_type& __a = __alloc();
-    if (static_cast<size_t>(__pos) <= (size() - __n) / 2) { // erase from front
+    if (static_cast<size_type>(__pos) <= (size() - __n) / 2) { // erase from front
       iterator __i = std::move_backward(__b, __p, __p + __n);
       for (; __b != __i; ++__b)
         __alloc_traits::destroy(__a, std::addressof(*__b));


### PR DESCRIPTION
This PR addresses the improper use of `static_cast` to `size_t` where `size_type` is intended. Although the `size_type` member type of STL containers is usually a synonym of `std::size_t`, there is no guarantee that they are always equivalent. The C++ standard does not mandate this equivalence.

In libc++'s implementations of `std::deque`, `std::vector`, and `__split_buffer`, the `size_type` member type is defined as `std::allocator_traits<allocator_type>::size_type`, which is either `allocator_type::size_type` if available or `std::make_unsigned<difference_type>::type`. While it is true for `std::allocator` that the `size_type` member type is `std::size_t`, for user-defined allocator types, they may mismatch. This justifies the need to replace `static_cast<size_t>` with `static_cast<size_type>` in this PR.