### PR TITLE
[memprof] Drop memprof:: in unit tests (NFC)

### DIFF
--- a/llvm/unittests/ProfileData/InstrProfTest.cpp
+++ b/llvm/unittests/ProfileData/InstrProfTest.cpp
@@ -393,7 +393,7 @@ IndexedMemProfRecord
 makeRecordV2(std::initializer_list<::llvm::memprof::CallStackId> AllocFrames,
              std::initializer_list<::llvm::memprof::CallStackId> CallSiteFrames,
              const MemInfoBlock &Block, const memprof::MemProfSchema &Schema) {
-  llvm::memprof::IndexedMemProfRecord MR;
+  IndexedMemProfRecord MR;
   for (const auto &CSId : AllocFrames)
     MR.AllocSites.emplace_back(CSId, Block, Schema);
   for (const auto &CSId : CallSiteFrames)
@@ -533,7 +533,7 @@ TEST_F(InstrProfTest, test_caller_callee_pairs) {
       /*AllocFrames=*/{0x111, 0x222},
       /*CallSiteFrames=*/{}, MIB, memprof::getHotColdSchema());
 
-  memprof::IndexedMemProfData MemProfData;
+  IndexedMemProfData MemProfData;
   MemProfData.Frames.try_emplace(0, 0x123, 1, 2, false);
   MemProfData.Frames.try_emplace(1, 0x234, 3, 4, true);
   MemProfData.Frames.try_emplace(2, 0x123, 5, 6, false);

--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -277,9 +277,9 @@ TEST(MemProf, RecordSerializationRoundTripVerion2) {
                     /*dealloc_timestamp=*/2000, /*alloc_cpu=*/3,
                     /*dealloc_cpu=*/4, /*Histogram=*/0, /*HistogramSize=*/0);
 
-  llvm::SmallVector<llvm::memprof::CallStackId> CallStackIds = {0x123, 0x456};
+  llvm::SmallVector<CallStackId> CallStackIds = {0x123, 0x456};
 
-  llvm::SmallVector<llvm::memprof::CallStackId> CallSiteIds = {0x333, 0x444};
+  llvm::SmallVector<CallStackId> CallSiteIds = {0x333, 0x444};
 
   IndexedMemProfRecord Record;
   for (const auto &CSId : CallStackIds) {
@@ -308,9 +308,9 @@ TEST(MemProf, RecordSerializationRoundTripVersion2HotColdSchema) {
   Info.TotalLifetime = 33;
   Info.TotalLifetimeAccessDensity = 44;
 
-  llvm::SmallVector<llvm::memprof::CallStackId> CallStackIds = {0x123, 0x456};
+  llvm::SmallVector<CallStackId> CallStackIds = {0x123, 0x456};
 
-  llvm::SmallVector<llvm::memprof::CallStackId> CallSiteIds = {0x333, 0x444};
+  llvm::SmallVector<CallStackId> CallSiteIds = {0x333, 0x444};
 
   IndexedMemProfRecord Record;
   for (const auto &CSId : CallStackIds) {
@@ -422,7 +422,7 @@ TEST(MemProf, SymbolizationFilter) {
 }
 
 TEST(MemProf, BaseMemProfReader) {
-  llvm::memprof::IndexedMemProfData MemProfData;
+  IndexedMemProfData MemProfData;
   Frame F1(/*Hash=*/IndexedMemProfRecord::getGUID("foo"), /*LineOffset=*/20,
            /*Column=*/5, /*IsInlineFrame=*/true);
   Frame F2(/*Hash=*/IndexedMemProfRecord::getGUID("bar"), /*LineOffset=*/10,
@@ -455,7 +455,7 @@ TEST(MemProf, BaseMemProfReader) {
 }
 
 TEST(MemProf, BaseMemProfReaderWithCSIdMap) {
-  llvm::memprof::IndexedMemProfData MemProfData;
+  IndexedMemProfData MemProfData;
   Frame F1(/*Hash=*/IndexedMemProfRecord::getGUID("foo"), /*LineOffset=*/20,
            /*Column=*/5, /*IsInlineFrame=*/true);
   Frame F2(/*Hash=*/IndexedMemProfRecord::getGUID("bar"), /*LineOffset=*/10,
@@ -562,8 +562,8 @@ MemInfoBlock makePartialMIB() {
 TEST(MemProf, MissingCallStackId) {
   // Use a non-existent CallStackId to trigger a mapping error in
   // toMemProfRecord.
-  llvm::memprof::IndexedAllocationInfo AI(0xdeadbeefU, makePartialMIB(),
-                                          llvm::memprof::getHotColdSchema());
+  IndexedAllocationInfo AI(0xdeadbeefU, makePartialMIB(),
+                           llvm::memprof::getHotColdSchema());
 
   IndexedMemProfRecord IndexedMR;
   IndexedMR.AllocSites.push_back(AI);
@@ -584,8 +584,8 @@ TEST(MemProf, MissingCallStackId) {
 }
 
 TEST(MemProf, MissingFrameId) {
-  llvm::memprof::IndexedAllocationInfo AI(0x222, makePartialMIB(),
-                                          llvm::memprof::getHotColdSchema());
+  IndexedAllocationInfo AI(0x222, makePartialMIB(),
+                           llvm::memprof::getHotColdSchema());
 
   IndexedMemProfRecord IndexedMR;
   IndexedMR.AllocSites.push_back(AI);
@@ -611,9 +611,8 @@ TEST(MemProf, MissingFrameId) {
 TEST(MemProf, RadixTreeBuilderEmpty) {
   llvm::DenseMap<FrameId, llvm::memprof::LinearFrameId> MemProfFrameIndexes;
   llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>> MemProfCallStackData;
-  llvm::DenseMap<llvm::memprof::FrameId, llvm::memprof::FrameStat>
-      FrameHistogram =
-          llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
+  llvm::DenseMap<FrameId, llvm::memprof::FrameStat> FrameHistogram =
+      llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
   llvm::memprof::CallStackRadixTreeBuilder<FrameId> Builder;
   Builder.build(std::move(MemProfCallStackData), &MemProfFrameIndexes,
                 FrameHistogram);
@@ -626,12 +625,11 @@ TEST(MemProf, RadixTreeBuilderEmpty) {
 TEST(MemProf, RadixTreeBuilderOne) {
   llvm::DenseMap<FrameId, llvm::memprof::LinearFrameId> MemProfFrameIndexes = {
       {11, 1}, {12, 2}, {13, 3}};
-  llvm::SmallVector<llvm::memprof::FrameId> CS1 = {13, 12, 11};
+  llvm::SmallVector<FrameId> CS1 = {13, 12, 11};
   llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>> MemProfCallStackData;
   MemProfCallStackData.insert({hashCallStack(CS1), CS1});
-  llvm::DenseMap<llvm::memprof::FrameId, llvm::memprof::FrameStat>
-      FrameHistogram =
-          llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
+  llvm::DenseMap<FrameId, llvm::memprof::FrameStat> FrameHistogram =
+      llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
   llvm::memprof::CallStackRadixTreeBuilder<FrameId> Builder;
   Builder.build(std::move(MemProfCallStackData), &MemProfFrameIndexes,
                 FrameHistogram);
@@ -649,14 +647,13 @@ TEST(MemProf, RadixTreeBuilderOne) {
 TEST(MemProf, RadixTreeBuilderTwo) {
   llvm::DenseMap<FrameId, llvm::memprof::LinearFrameId> MemProfFrameIndexes = {
       {11, 1}, {12, 2}, {13, 3}};
-  llvm::SmallVector<llvm::memprof::FrameId> CS1 = {12, 11};
-  llvm::SmallVector<llvm::memprof::FrameId> CS2 = {13, 12, 11};
+  llvm::SmallVector<FrameId> CS1 = {12, 11};
+  llvm::SmallVector<FrameId> CS2 = {13, 12, 11};
   llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>> MemProfCallStackData;
   MemProfCallStackData.insert({hashCallStack(CS1), CS1});
   MemProfCallStackData.insert({hashCallStack(CS2), CS2});
-  llvm::DenseMap<llvm::memprof::FrameId, llvm::memprof::FrameStat>
-      FrameHistogram =
-          llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
+  llvm::DenseMap<FrameId, llvm::memprof::FrameStat> FrameHistogram =
+      llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
   llvm::memprof::CallStackRadixTreeBuilder<FrameId> Builder;
   Builder.build(std::move(MemProfCallStackData), &MemProfFrameIndexes,
                 FrameHistogram);
@@ -679,18 +676,17 @@ TEST(MemProf, RadixTreeBuilderSuccessiveJumps) {
   llvm::DenseMap<FrameId, llvm::memprof::LinearFrameId> MemProfFrameIndexes = {
       {11, 1}, {12, 2}, {13, 3}, {14, 4}, {15, 5}, {16, 6}, {17, 7}, {18, 8},
   };
-  llvm::SmallVector<llvm::memprof::FrameId> CS1 = {14, 13, 12, 11};
-  llvm::SmallVector<llvm::memprof::FrameId> CS2 = {15, 13, 12, 11};
-  llvm::SmallVector<llvm::memprof::FrameId> CS3 = {17, 16, 12, 11};
-  llvm::SmallVector<llvm::memprof::FrameId> CS4 = {18, 16, 12, 11};
+  llvm::SmallVector<FrameId> CS1 = {14, 13, 12, 11};
+  llvm::SmallVector<FrameId> CS2 = {15, 13, 12, 11};
+  llvm::SmallVector<FrameId> CS3 = {17, 16, 12, 11};
+  llvm::SmallVector<FrameId> CS4 = {18, 16, 12, 11};
   llvm::MapVector<CallStackId, llvm::SmallVector<FrameId>> MemProfCallStackData;
   MemProfCallStackData.insert({hashCallStack(CS1), CS1});
   MemProfCallStackData.insert({hashCallStack(CS2), CS2});
   MemProfCallStackData.insert({hashCallStack(CS3), CS3});
   MemProfCallStackData.insert({hashCallStack(CS4), CS4});
-  llvm::DenseMap<llvm::memprof::FrameId, llvm::memprof::FrameStat>
-      FrameHistogram =
-          llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
+  llvm::DenseMap<FrameId, llvm::memprof::FrameStat> FrameHistogram =
+      llvm::memprof::computeFrameHistogram<FrameId>(MemProfCallStackData);
   llvm::memprof::CallStackRadixTreeBuilder<FrameId> Builder;
   Builder.build(std::move(MemProfCallStackData), &MemProfFrameIndexes,
                 FrameHistogram);
@@ -746,7 +742,7 @@ HeapProfileRecords:
 
   llvm::memprof::YAMLMemProfReader YAMLReader;
   YAMLReader.parse(YAMLData);
-  llvm::memprof::IndexedMemProfData MemProfData = YAMLReader.takeMemProfData();
+  IndexedMemProfData MemProfData = YAMLReader.takeMemProfData();
 
   Frame F1(0x100, 11, 10, true);
   Frame F2(0x200, 22, 20, false);


### PR DESCRIPTION
This patch replaces memprof::Foo with Foo if we have corresponding:

  using llvm::memprof::Foo;
