### PR TITLE
[DSE] Enable initializes improvement

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -164,9 +164,9 @@ static cl::opt<bool>
     OptimizeMemorySSA("dse-optimize-memoryssa", cl::init(true), cl::Hidden,
                       cl::desc("Allow DSE to optimize memory accesses."));
 
-// TODO: turn on and remove this flag.
+// TODO: remove this flag.
 static cl::opt<bool> EnableInitializesImprovement(
-    "enable-dse-initializes-attr-improvement", cl::init(false), cl::Hidden,
+    "enable-dse-initializes-attr-improvement", cl::init(true), cl::Hidden,
     cl::desc("Enable the initializes attr improvement in DSE"));
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Tested with an internal search backend loadtest.

With `-ftrivial-auto-var-init`, this work has a 0.2%-0.3% total QPS improvement.

Note that, the metric is total QPS instead of cpu-time, even 1% improvement means a lot.

- Add the "initializes" attr: https://github.com/llvm/llvm-project/pull/97373 
- Apply the attr to DSE: https://github.com/llvm/llvm-project/pull/107282

