### PR TITLE
[clang][bytecode] Pass (float) BitWidth to DoBitCast

### DIFF
--- a/clang/lib/AST/ByteCode/BitcastBuffer.h
+++ b/clang/lib/AST/ByteCode/BitcastBuffer.h
@@ -45,6 +45,7 @@ struct Bits {
   bool operator>=(Bits Other) const { return N >= Other.N; }
   bool operator<=(Bits Other) const { return N <= Other.N; }
   bool operator==(Bits Other) const { return N == Other.N; }
+  bool operator!=(Bits Other) const { return N != Other.N; }
 };
 
 /// A quantity in bytes.

--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.h
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_AST_INTERP_BUILITN_BIT_CAST_H
 #define LLVM_CLANG_AST_INTERP_BUILITN_BIT_CAST_H
 
+#include "BitcastBuffer.h"
 #include <cstddef>
 
 namespace clang {
@@ -18,7 +19,8 @@ class InterpState;
 class CodePtr;
 
 bool DoBitCast(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
-               std::byte *Buff, size_t BuffSize, bool &HasIndeterminateBits);
+               std::byte *Buff, Bits BitWidth, Bits FullBitWidth,
+               bool &HasIndeterminateBits);
 bool DoBitCastPtr(InterpState &S, CodePtr OpPC, const Pointer &FromPtr,
                   Pointer &ToPtr);
 bool DoBitCastPtr(InterpState &S, CodePtr OpPC, const Pointer &FromPtr,


### PR DESCRIPTION
In certain cases (i.e. long double on x86), the bit with we get from the floating point semantics is different than the type size we compute for the BitCast instruction. Pass this along to DoBitCast, so in there we can check only the relevant bits for being initialized.

This also fixes a weirdness we still had in DoBitCast.