### PR TITLE
[WebAssembly] Handle symbols in `.init_array` sections

### DIFF
--- a/llvm/test/MC/WebAssembly/init-array-label.s
+++ b/llvm/test/MC/WebAssembly/init-array-label.s
@@ -1,0 +1,91 @@
+# RUN: llvm-mc -triple=wasm32-unknown-unknown -filetype=obj < %s | obj2yaml | FileCheck %s
+
+init1:
+	.functype	init1 () -> ()
+	end_function
+
+init2:
+	.functype	init2 () -> ()
+	end_function
+
+	.section	.init_array.42,"",@
+	.p2align	2, 0x0
+	.int32	init1
+
+	.section	.init_array,"",@
+	.globl	p_init1
+	.p2align	2, 0x0
+p_init1:
+	.int32	init1
+	.size	p_init1, 4
+
+	.section	.init_array,"",@
+	.globl	p_init2
+	.p2align	2, 0x0
+p_init2:
+	.int32	init1
+	.int32	init2
+	.size	p_init2, 8
+
+# CHECK:        - Type:            FUNCTION
+# CHECK-NEXT:     FunctionTypes:   [ 0, 0 ]
+# CHECK-NEXT:   - Type:            DATACOUNT
+# CHECK-NEXT:     Count:           1
+# CHECK-NEXT:   - Type:            CODE
+# CHECK-NEXT:     Functions:
+# CHECK-NEXT:       - Index:           0
+# CHECK-NEXT:         Locals:          []
+# CHECK-NEXT:         Body:            0B
+# CHECK-NEXT:       - Index:           1
+# CHECK-NEXT:         Locals:          []
+# CHECK-NEXT:         Body:            0B
+# CHECK-NEXT:   - Type:            DATA
+# CHECK-NEXT:     Segments:
+# CHECK-NEXT:       - SectionOffset:   6
+# CHECK-NEXT:         InitFlags:       0
+# CHECK-NEXT:         Offset:
+# CHECK-NEXT:           Opcode:          I32_CONST
+# CHECK-NEXT:           Value:           0
+# CHECK-NEXT:         Content:         '000000000000000000000000'
+# CHECK-NEXT:   - Type:            CUSTOM
+# CHECK-NEXT:     Name:            linking
+# CHECK-NEXT:     Version:         2
+# CHECK-NEXT:     SymbolTable:
+# CHECK-NEXT:       - Index:           0
+# CHECK-NEXT:         Kind:            FUNCTION
+# CHECK-NEXT:         Name:            init1
+# CHECK-NEXT:         Flags:           [ BINDING_LOCAL ]
+# CHECK-NEXT:         Function:        0
+# CHECK-NEXT:       - Index:           1
+# CHECK-NEXT:         Kind:            FUNCTION
+# CHECK-NEXT:         Name:            init2
+# CHECK-NEXT:         Flags:           [ BINDING_LOCAL ]
+# CHECK-NEXT:         Function:        1
+# CHECK-NEXT:       - Index:           2
+# CHECK-NEXT:         Kind:            DATA
+# CHECK-NEXT:         Name:            p_init1
+# CHECK-NEXT:         Flags:           [  ]
+# CHECK-NEXT:         Segment:         0
+# CHECK-NEXT:         Size:            4
+# CHECK-NEXT:       - Index:           3
+# CHECK-NEXT:         Kind:            DATA
+# CHECK-NEXT:         Name:            p_init2
+# CHECK-NEXT:         Flags:           [  ]
+# CHECK-NEXT:         Segment:         0
+# CHECK-NEXT:         Offset:          4
+# CHECK-NEXT:         Size:            8
+# CHECK-NEXT:     SegmentInfo:
+# CHECK-NEXT:       - Index:           0
+# CHECK-NEXT:         Name:            .init_array
+# CHECK-NEXT:         Alignment:       2
+# CHECK-NEXT:         Flags:           [  ]
+# CHECK-NEXT:     InitFunctions:
+# CHECK-NEXT:       - Priority:        42
+# CHECK-NEXT:         Symbol:          0
+# CHECK-NEXT:       - Priority:        65535
+# CHECK-NEXT:         Symbol:          0
+# CHECK-NEXT:       - Priority:        65535
+# CHECK-NEXT:         Symbol:          0
+# CHECK-NEXT:       - Priority:        65535
+# CHECK-NEXT:         Symbol:          1
+# CHECK-NEXT: ...


### PR DESCRIPTION
Follow on from #111008.

Consider the following C code, which supplies a function `init()` and an array written to the `.init_array` section so that the function runs before `main()`.

```c
void init() {}
typedef void (*fn)(void);
__attribute__((section(".init_array"))) fn p_init[1] = { &init };

int main() { return 0; }
```

Note that a label `p_init` is also provided for the array. I'm not sure if there exists a way to do this in C without additionally creating the `p_init` symbol.

In any case, compile this code to find:

```
$ EM_LLVM_ROOT=[...]/llvm-project/build/bin emcc bug.c -o bug.js
wasm-ld: error: [...]/emscripten_temp_fgsxu6w6/bug_0.o: invalid data segment index: 0
```

What is happening is the array to be written to `.init_array` is being handled specially by `WasmObjectWriter.cpp`:

https://github.com/llvm/llvm-project/blob/4e0ba801ea2267d80ff875bdc40984da32db774d/llvm/lib/MC/WasmObjectWriter.cpp#L1485-L1487

This existing code skips writing out the array in a data segment. Later this is indeed dealt with by writing each function in the array into a Wasm custom linking section, in the `InitFunctions` subsection.

Unfortunately, the symbol `p_init` is also written to the Wasm custom linking section as a `wasm::WASM_SYMBOL_TYPE_DATA`, pointing to a data segment that now does not exist. As far as I can tell, we don't really indend to ever reference this symbol, the pattern is just used in C (and a similar construct can be used in Rust) to ensure that the `.init_array` array exists. So, while we could just throw an error here it's not ideal as it breaks this useful pattern for life-before-main.

In #111008 I suggested a change to simply not write the `p_init` symbol to the custom linking section of the Wasm object. But, after some prompting by @sbc100 it seems this is not a good idea, since it breaks code that does happen to reference the `p_init` symbol for whatever reason.

In this patch I instead remove the skip, so that data segments are also written for `.init_array` sections. This works around the problem above, since the `p_init` entry now references a data section that exists. I don't think the data written there is useful, but the change at least avoids the error message above. It also fixes related issues when you have multiple `.init_array` sections.

Some tests related to the change have been modified to reflect the additional emitted data, and a new test `init-array-label.s` has been added to test the specific problem above.