### PR TITLE
[InstCombine] Fold trunc nuw/nsw X to i1 -> true IFF X != 0

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -934,6 +934,11 @@ Instruction *InstCombinerImpl::visitTrunc(TruncInst &Trunc) {
     }
   }
 
+  if (DestWidth == 1 &&
+      (Trunc.hasNoUnsignedWrap() || Trunc.hasNoSignedWrap()) &&
+      isKnownNonZero(Src, SQ.getWithInstruction(&Trunc)))
+    return replaceInstUsesWith(Trunc, ConstantInt::getTrue(DestTy));
+
   bool Changed = false;
   if (!Trunc.hasNoSignedWrap() &&
       ComputeMaxSignificantBits(Src, /*Depth=*/0, &Trunc) <= DestWidth) {

--- a/llvm/test/Transforms/InstCombine/trunc.ll
+++ b/llvm/test/Transforms/InstCombine/trunc.ll
@@ -1129,8 +1129,7 @@ define i1 @trunc_nuw_i1_non_zero(i8 %1) {
 ; CHECK-LABEL: @trunc_nuw_i1_non_zero(
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i8 [[TMP0:%.*]], 0
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[TMP2]])
-; CHECK-NEXT:    [[RET:%.*]] = trunc nuw i8 [[TMP0]] to i1
-; CHECK-NEXT:    ret i1 [[RET]]
+; CHECK-NEXT:    ret i1 true
 ;
   %3 = icmp ne i8 %1, 0
   tail call void @llvm.assume(i1 %3)
@@ -1177,8 +1176,7 @@ define i1 @trunc_nsw_i1_non_zero(i8 %1) {
 ; CHECK-LABEL: @trunc_nsw_i1_non_zero(
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp ne i8 [[TMP0:%.*]], 0
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[TMP2]])
-; CHECK-NEXT:    [[RET:%.*]] = trunc nsw i8 [[TMP0]] to i1
-; CHECK-NEXT:    ret i1 [[RET]]
+; CHECK-NEXT:    ret i1 true
 ;
   %3 = icmp ne i8 %1, 0
   tail call void @llvm.assume(i1 %3)


### PR DESCRIPTION
This is a fairly common pattern when I tried it on llvm-opt-benchmark over 100 files updated.

proof https://alive2.llvm.org/ce/z/prpPex