### PR TITLE
[LoopRotate] Use `poison` instead of `undef` as placeholder

### DIFF
--- a/llvm/lib/Transforms/Utils/LoopRotationUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopRotationUtils.cpp
@@ -171,14 +171,14 @@ static void RewriteUsesOfClonedInstructions(BasicBlock *OrigHeader,
       // Users in the OrigPreHeader need to use the value to which the
       // original definitions are mapped and anything else can be handled by
       // the SSAUpdater. To avoid adding PHINodes, check if the value is
-      // available in UserBB, if not substitute undef.
+      // available in UserBB, if not substitute poison.
       Value *NewVal;
       if (UserBB == OrigPreheader)
         NewVal = OrigPreHeaderVal;
       else if (SSA.HasValueForBlock(UserBB))
         NewVal = SSA.GetValueInMiddleOfBlock(UserBB);
       else
-        NewVal = UndefValue::get(OrigHeaderVal->getType());
+        NewVal = PoisonValue::get(OrigHeaderVal->getType());
       DbgValue->replaceVariableLocationOp(OrigHeaderVal, NewVal);
     }
 
@@ -194,14 +194,14 @@ static void RewriteUsesOfClonedInstructions(BasicBlock *OrigHeader,
       // Users in the OrigPreHeader need to use the value to which the
       // original definitions are mapped and anything else can be handled by
       // the SSAUpdater. To avoid adding PHINodes, check if the value is
-      // available in UserBB, if not substitute undef.
+      // available in UserBB, if not substitute poison.
       Value *NewVal;
       if (UserBB == OrigPreheader)
         NewVal = OrigPreHeaderVal;
       else if (SSA.HasValueForBlock(UserBB))
         NewVal = SSA.GetValueInMiddleOfBlock(UserBB);
       else
-        NewVal = UndefValue::get(OrigHeaderVal->getType());
+        NewVal = PoisonValue::get(OrigHeaderVal->getType());
       DVR->replaceVariableLocationOp(OrigHeaderVal, NewVal);
     }
   }

--- a/llvm/test/Transforms/LoopRotate/dbgvalue.ll
+++ b/llvm/test/Transforms/LoopRotate/dbgvalue.ll
@@ -113,7 +113,7 @@ return:                                           ; preds = %if.end
 
 ; Check that the dbg.values move up to being immediately below the PHIs,
 ; using their Values. However once we exit the loop, the x and y values
-; become irrelevant and undef, only z gets an LCSSA PHI to preserve it.
+; become irrelevant and poison, only z gets an LCSSA PHI to preserve it.
 ;
 ; Note that while the icmp is initially undominated by any dbg.value and thus
 ; shouldn't get a variable location, the first iteration is peeled off into the
@@ -138,8 +138,8 @@ define i32 @tak2(i32 %x, i32 %y, i32 %z) nounwind ssp !dbg !21 {
 ; CHECK:      tail call i32 @tak(i32
 ; CHECK: if.end:
 ; CHECK-NEXT: z.tr.lcssa = phi i32
-; CHECK-NEXT: #dbg_value(i32 undef
-; CHECK-NEXT: #dbg_value(i32 undef
+; CHECK-NEXT: #dbg_value(i32 poison
+; CHECK-NEXT: #dbg_value(i32 poison
 ; CHECK-NEXT: #dbg_value(i32 %z.tr.lcssa
 entry:
   br label %tailrecurse


### PR DESCRIPTION
The `poison` values are used to substitute debug information of values moved from the original header into the preheader that are no longer available in the former.