### PR TITLE
[Clang] allow usage of placement new operator in [[msvc::constexpr]] context outside of the std namespace

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -525,7 +525,8 @@ Attribute Changes in Clang
 
 - The ``target_version`` attribute is now only supported for AArch64 and RISC-V architectures.
 
-- Clang now permits ``[[msvc::constexpr]]`` usage outside of the std namespace. (#GH74924)
+- Clang now permits the usage of the placement new operator in ``[[msvc::constexpr]]``
+  context outside of the std namespace. (#GH74924)
 
 Improvements to Clang's diagnostics
 -----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -525,6 +525,8 @@ Attribute Changes in Clang
 
 - The ``target_version`` attribute is now only supported for AArch64 and RISC-V architectures.
 
+- Clang now permits ``[[msvc::constexpr]]`` usage outside of the std namespace. (#GH74924)
+
 Improvements to Clang's diagnostics
 -----------------------------------
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -10172,7 +10172,9 @@ bool PointerExprEvaluator::VisitCXXNewExpr(const CXXNewExpr *E) {
       return false;
     IsNothrow = true;
   } else if (OperatorNew->isReservedGlobalPlacementOperator()) {
-    if (Info.CurrentCall->isStdFunction() || Info.getLangOpts().CPlusPlus26) {
+    if (Info.CurrentCall->isStdFunction() || Info.getLangOpts().CPlusPlus26 ||
+        (Info.CurrentCall->CanEvalMSConstexpr &&
+         OperatorNew->hasAttr<MSConstexprAttr>())) {
       if (!EvaluatePointer(E->getPlacementArg(0), Result, Info))
         return false;
       if (Result.Designator.Invalid)

--- a/clang/test/AST/ms-constexpr-new.cpp
+++ b/clang/test/AST/ms-constexpr-new.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fms-compatibility -fms-compatibility-version=19.33 -std=c++20 -ast-dump %s | FileCheck %s
+
+// CHECK: used operator new
+// CHECK: MSConstexprAttr 0x{{[0-9a-f]+}} <col:17, col:23>
+[[nodiscard]] [[msvc::constexpr]] inline void* __cdecl operator new(decltype(sizeof(void*)), void* p) noexcept { return p; }
+
+// CHECK: used constexpr construct_at
+// CHECK: AttributedStmt 0x{{[0-9a-f]+}} <col:46, col:88>
+// CHECK-NEXT: MSConstexprAttr 0x{{[0-9a-f]+}} <col:48, col:54>
+// CHECK-NEXT: ReturnStmt 0x{{[0-9a-f]+}} <col:66, col:88>
+constexpr int* construct_at(int* p, int v) { [[msvc::constexpr]] return ::new (p) int(v); }
+constexpr bool check_construct_at() { int x; return *construct_at(&x, 42) == 42; }
+static_assert(check_construct_at());

--- a/clang/test/SemaCXX/ms-constexpr-new.cpp
+++ b/clang/test/SemaCXX/ms-constexpr-new.cpp
@@ -12,5 +12,12 @@ namespace std {
   }
 }
 
-constexpr bool check_construct_at() { int x; return *std::construct_at(&x, 42) == 42; }
-static_assert(check_construct_at());
+constexpr bool check_std_construct_at() { int x; return *std::construct_at(&x, 42) == 42; }
+static_assert(check_std_construct_at());
+
+constexpr int* construct_at(int* p, int v) { [[msvc::constexpr]] return ::new (p) int(v); } // unsupported-error {{constexpr function never produces a constant expression}} \
+                                                                                            // unsupported-warning {{unknown attribute 'constexpr' ignored}} \
+                                                                                            // unsupported-note 2{{this placement new expression is not supported in constant expressions before C++2c}}
+constexpr bool check_construct_at() { int x; return *construct_at(&x, 42) == 42; }          // unsupported-note {{in call to 'construct_at(&x, 42)'}}
+static_assert(check_construct_at());                                                        // unsupported-error {{static assertion expression is not an integral constant expression}}\
+                                                                                            // unsupported-note {{in call to 'check_construct_at()'}}


### PR DESCRIPTION
Fixes #74924