### PR TITLE
[clangd] Do not show `aParam` parameter hint for argument spelled `param`

### DIFF
--- a/clang-tools-extra/clangd/InlayHints.cpp
+++ b/clang-tools-extra/clangd/InlayHints.cpp
@@ -867,13 +867,28 @@ private:
     }
   }
 
+  static bool argumentMatchesParamName(StringRef ArgName, StringRef ParamName) {
+    // Exact match.
+    if (ParamName == ArgName)
+      return true;
+
+    // Parameter name uses "a" prefix (e.g. "aParam").
+    if (ParamName.size() > 1 && ParamName[0] == 'a' &&
+        std::isupper(ParamName[1])) {
+      return ArgName.size() > 0 && ArgName[0] == std::tolower(ParamName[1]) &&
+             ArgName.drop_front() == ParamName.drop_front(2);
+    }
+
+    return false;
+  }
+
   bool shouldHintName(const Expr *Arg, StringRef ParamName) {
     if (ParamName.empty())
       return false;
 
     // If the argument expression is a single name and it matches the
     // parameter name exactly, omit the name hint.
-    if (ParamName == getSpelledIdentifier(Arg))
+    if (argumentMatchesParamName(getSpelledIdentifier(Arg), ParamName))
       return false;
 
     // Exclude argument expressions preceded by a /*paramName*/.

--- a/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
+++ b/clang-tools-extra/clangd/unittests/InlayHintTests.cpp
@@ -1011,6 +1011,7 @@ TEST(ParameterHints, FunctionPointer) {
 TEST(ParameterHints, ArgMatchesParam) {
   assertParameterHints(R"cpp(
     void foo(int param);
+    void prefixConvention(int aParam);
     struct S {
       static const int param = 42;
     };
@@ -1018,6 +1019,12 @@ TEST(ParameterHints, ArgMatchesParam) {
       int param = 42;
       // Do not show redundant "param: param".
       foo(param);
+      // Some codebases have a naming convention of prefixing
+      // parameter names with "a", e.g. "aParam". (The "a"
+      // stands for "argument", used as an (imprecise) synonym
+      // for "parameter".)
+      // Do not show "aParam: param" either.
+      prefixConvention(param);
       // But show it if the argument is qualified.
       foo($param[[S::param]]);
     }
@@ -1026,6 +1033,8 @@ TEST(ParameterHints, ArgMatchesParam) {
       void bar() {
         // Do not show "param: param" for member-expr.
         foo(param);
+        // Nor "aParam: param"
+        prefixConvention(param);
       }
     };
   )cpp",


### PR DESCRIPTION
Fixes https://github.com/clangd/clangd/issues/2248