### PR TITLE
[libcxx][test] Silence nodiscard warnings for `std::expected`

### DIFF
--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/and_then.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/and_then.pass.cpp
@@ -263,8 +263,8 @@ constexpr void test_val_types() {
 constexpr void test_sfinae() {
   std::expected<NonConst, int> e(std::unexpected<int>(2));
   auto l = [](auto&& x) { return x.non_const(); };
-  e.and_then(l);
-  std::move(e).and_then(l);
+  (void)e.and_then(l);
+  (void)std::move(e).and_then(l);
 }
 
 constexpr void test_move_only_error_type() {
@@ -272,14 +272,14 @@ constexpr void test_move_only_error_type() {
   {
     std::expected<int, MoveOnlyErrorType> e;
     auto l = [](int) { return std::expected<int, MoveOnlyErrorType>{}; };
-    std::move(e).and_then(l);
+    (void)std::move(e).and_then(l);
   }
 
   // Test const&&
   {
     const std::expected<int, MoveOnlyErrorType> e;
     auto l = [](const int) { return std::expected<int, MoveOnlyErrorType>{}; };
-    std::move(e).and_then(l);
+    (void)std::move(e).and_then(l);
   }
 }
 
@@ -296,10 +296,10 @@ constexpr bool test() {
     return std::expected<int, int>();
   };
 
-  e.and_then(never_called);
-  std::move(e).and_then(never_called);
-  ce.and_then(never_called);
-  std::move(ce).and_then(never_called);
+  (void)e.and_then(never_called);
+  (void)std::move(e).and_then(never_called);
+  (void)ce.and_then(never_called);
+  (void)std::move(ce).and_then(never_called);
 
   return true;
 }

--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/or_else.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/or_else.pass.cpp
@@ -178,8 +178,8 @@ struct NonConst {
 constexpr void test_sfinae() {
   std::expected<int, NonConst> e{1};
   auto l = [](auto&& x) { return x.non_const(); };
-  e.or_else(l);
-  std::move(e).or_else(l);
+  (void)e.or_else(l);
+  (void)std::move(e).or_else(l);
 }
 
 constexpr void test_move_only_error_type() {
@@ -187,28 +187,28 @@ constexpr void test_move_only_error_type() {
   {
       std::expected<int, MoveOnlyErrorType> e;
       auto l = [](MoveOnlyErrorType&) { return std::expected<int, int>{}; };
-      e.or_else(l);
+      (void)e.or_else(l);
   }
 
   // Test const&
   {
       const std::expected<int, MoveOnlyErrorType> e;
       auto l = [](const MoveOnlyErrorType&) { return std::expected<int, int>{}; };
-      e.or_else(l);
+      (void)e.or_else(l);
   }
 
   // Test &&
   {
       std::expected<int, MoveOnlyErrorType> e;
       auto l = [](MoveOnlyErrorType&&) { return std::expected<int, int>{}; };
-      std::move(e).or_else(l);
+      (void)std::move(e).or_else(l);
   }
 
   // Test const&&
   {
       const std::expected<int, MoveOnlyErrorType> e;
       auto l = [](const MoveOnlyErrorType&&) { return std::expected<int, int>{}; };
-      std::move(e).or_else(l);
+      (void)std::move(e).or_else(l);
   }
 }
 
@@ -225,10 +225,10 @@ constexpr bool test() {
     return std::expected<int, int>();
   };
 
-  e.or_else(never_called);
-  std::move(e).or_else(never_called);
-  ce.or_else(never_called);
-  std::move(ce).or_else(never_called);
+  (void)e.or_else(never_called);
+  (void)std::move(e).or_else(never_called);
+  (void)ce.or_else(never_called);
+  (void)std::move(ce).or_else(never_called);
   return true;
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/transform.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/transform.pass.cpp
@@ -187,13 +187,13 @@ constexpr void test_val_types() {
 constexpr void test_take_val_return_void() {
   std::expected<int, int> e(1);
   int val = 0;
-  e.transform([&val]<typename T>(T&&) -> void {
+  (void)e.transform([&val]<typename T>(T&&) -> void {
     static_assert(std::is_same_v<T, int&>);
     assert(val == 0);
     val = 1;
   });
   assert(val == 1);
-  std::move(e).transform([&val]<typename T>(T&&) -> void {
+  (void)std::move(e).transform([&val]<typename T>(T&&) -> void {
     static_assert(std::is_same_v<T, int>);
     assert(val == 1);
     val = 2;
@@ -201,13 +201,13 @@ constexpr void test_take_val_return_void() {
 
   const auto& ce = e;
   assert(val == 2);
-  ce.transform([&val]<typename T>(T&&) -> void {
+  (void)ce.transform([&val]<typename T>(T&&) -> void {
     static_assert(std::is_same_v<T, const int&>);
     assert(val == 2);
     val = 3;
   });
   assert(val == 3);
-  std::move(ce).transform([&val]<typename T>(T&&) -> void {
+  (void)std::move(ce).transform([&val]<typename T>(T&&) -> void {
     static_assert(std::is_same_v<T, const int>);
     assert(val == 3);
     val = 4;
@@ -227,8 +227,8 @@ constexpr void test_direct_non_list_init() {
 constexpr void test_sfinae() {
   std::expected<NonConst, int> e(std::unexpected<int>(2));
   auto l = [](auto&& x) { return x.non_const(); };
-  e.transform(l);
-  std::move(e).transform(l);
+  (void)e.transform(l);
+  (void)std::move(e).transform(l);
 
   std::expected<int, int> e1(std::unexpected<int>(1));
   const auto& ce1         = e1;
@@ -237,10 +237,10 @@ constexpr void test_sfinae() {
     return std::expected<int, int>();
   };
 
-  e1.transform(never_called);
-  std::move(e1).transform(never_called);
-  ce1.and_then(never_called);
-  std::move(ce1).transform(never_called);
+  (void)e1.transform(never_called);
+  (void)std::move(e1).transform(never_called);
+  (void)ce1.and_then(never_called);
+  (void)std::move(ce1).transform(never_called);
 }
 
 constexpr void test_move_only_error_type() {
@@ -248,14 +248,14 @@ constexpr void test_move_only_error_type() {
   {
       std::expected<int, MoveOnlyErrorType> e;
       auto l = [](int) { return 0; };
-      std::move(e).transform(l);
+      (void)std::move(e).transform(l);
   }
 
   // Test const&&
   {
       const std::expected<int, MoveOnlyErrorType> e;
       auto l = [](const int) { return 0; };
-      std::move(e).transform(l);
+      (void)std::move(e).transform(l);
   }
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/transform.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/transform.pass.cpp
@@ -239,7 +239,7 @@ constexpr void test_sfinae() {
 
   (void)e1.transform(never_called);
   (void)std::move(e1).transform(never_called);
-  (void)ce1.and_then(never_called);
+  (void)ce1.transform(never_called);
   (void)std::move(ce1).transform(never_called);
 }
 

--- a/libcxx/test/std/utilities/expected/expected.expected/monadic/transform_error.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/monadic/transform_error.pass.cpp
@@ -197,8 +197,8 @@ constexpr void test_direct_non_list_init() {
 constexpr void test_sfinae() {
   std::expected<int, NonConst> e(2);
   auto l = [](auto&& x) { return x.non_const(); };
-  e.transform_error(l);
-  std::move(e).transform_error(l);
+  (void)e.transform_error(l);
+  (void)std::move(e).transform_error(l);
 
   std::expected<int, int> e1;
   const auto& ce1 = e1;
@@ -208,10 +208,10 @@ constexpr void test_sfinae() {
     return 0;
   };
 
-  e1.transform_error(never_called);
-  std::move(e1).transform_error(never_called);
-  ce1.transform_error(never_called);
-  std::move(ce1).transform_error(never_called);
+  (void)e1.transform_error(never_called);
+  (void)std::move(e1).transform_error(never_called);
+  (void)ce1.transform_error(never_called);
+  (void)std::move(ce1).transform_error(never_called);
 }
 
 constexpr void test_move_only_error_type() {
@@ -219,28 +219,28 @@ constexpr void test_move_only_error_type() {
   {
       std::expected<int, MoveOnlyErrorType> e;
       auto l = [](MoveOnlyErrorType&) { return 0; };
-      e.transform_error(l);
+      (void)e.transform_error(l);
   }
 
   // Test const&
   {
       const std::expected<int, MoveOnlyErrorType> e;
       auto l = [](const MoveOnlyErrorType&) { return 0; };
-      e.transform_error(l);
+      (void)e.transform_error(l);
   }
 
   // Test &&
   {
       std::expected<int, MoveOnlyErrorType> e;
       auto l = [](MoveOnlyErrorType&&) { return 0; };
-      std::move(e).transform_error(l);
+      (void)std::move(e).transform_error(l);
   }
 
   // Test const&&
   {
       const std::expected<int, MoveOnlyErrorType> e;
       auto l = [](const MoveOnlyErrorType&&) { return 0; };
-      std::move(e).transform_error(l);
+      (void)std::move(e).transform_error(l);
   }
 }
 


### PR DESCRIPTION
I'm exploring marking microsoft/STL's `std::expected` as `[[nodiscard]]`, which affects all functions returning `std::expected`, including its own monadic member functions.

As usual, libc++'s test suite contains calls to these member functions to make sure they compile, but it's discarding the returns. I'm adding `(void)` casts to silence the `[[nodiscard]]` warnings without altering what the test is covering.