### PR TITLE
[Polly] Disable vectorization for Polly's fallback loops

### DIFF
--- a/polly/lib/CodeGen/CodeGeneration.cpp
+++ b/polly/lib/CodeGen/CodeGeneration.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/LoopUtils.h"
 #include "isl/ast.h"
 #include <cassert>
 
@@ -232,6 +233,15 @@ static bool generateCode(Scop &S, IslAstInfo &AI, LoopInfo &LI,
   // ScopAnnotator::buildAliasScopes.
   NodeBuilder.allocateNewArrays(StartExitBlocks);
   Annotator.buildAliasScopes(S);
+
+  // The code below annotates the "llvm.loop.vectorize.enable" to false
+  // for the code flow taken when RTCs fail. Because we don't want the
+  // Loop Vectorizer to come in later and vectorize the original fall back
+  // loop when polly is enabled.
+  for (Loop *L : LI.getLoopsInPreorder()) {
+    if (S.contains(L))
+      addStringMetadataToLoop(L, "llvm.loop.vectorize.enable", 0);
+  }
 
   if (PerfMonitoring) {
     PerfMonitor P(S, EnteringBB->getParent()->getParent());

--- a/polly/lib/Support/ScopHelper.cpp
+++ b/polly/lib/Support/ScopHelper.cpp
@@ -604,7 +604,8 @@ bool polly::isHoistableLoad(LoadInst *LInst, Region &R, LoopInfo &LI,
 
   for (auto *User : Ptr->users()) {
     auto *UserI = dyn_cast<Instruction>(User);
-    if (!UserI || !R.contains(UserI))
+    if (!UserI || UserI->getFunction() != LInst->getFunction() ||
+        !R.contains(UserI))
       continue;
     if (!UserI->mayWriteToMemory())
       continue;

--- a/polly/test/CodeGen/LoopParallelMD/single_loop_param_parallel.ll
+++ b/polly/test/CodeGen/LoopParallelMD/single_loop_param_parallel.ll
@@ -36,7 +36,6 @@ ret:
 ; SEQUENTIAL-LABEL: @test-one
 ; SEQUENTIAL-NOT: !llvm.mem.parallel_loop_access
 ; SEQUENTIAL-NOT: !llvm.access.group
-; SEQUENTIAL-NOT: !llvm.loop
 
 ; PARALLEL: @test-one
 ; PARALLEL: store i32 1, ptr %scevgep1, {{[ ._!,a-zA-Z0-9]*}}, !llvm.access.group ![[GROUPID3:[0-9]+]]
@@ -81,13 +80,11 @@ ret:
 ; SEQUENTIAL-LABEL: @test-two
 ; SEQUENTIAL-NOT: !llvm.mem.parallel_loop_access
 ; SEQUENTIAL-NOT: !llvm.access.group
-; SEQUENTIAL-NOT: !llvm.loop
 
 ; PARALLEL: @test-two
 ; PARALLEL: %val_p_scalar_ = load i32, ptr %scevgep, {{[ ._!,a-zA-Z0-9]*}}, !llvm.access.group ![[GROUPID8:[0-9]*]]
 ; PARALLEL: store i32 %val_p_scalar_, ptr %scevgep1, {{[ ._!,a-zA-Z0-9]*}}, !llvm.access.group ![[GROUPID8]]
 ; PARALLEL:  br i1 %polly.loop_cond, label %polly.loop_header, label %polly.loop_exit, !llvm.loop ![[LoopID9:[0-9]*]]
-
 
 ; PARALLEL: ![[LoopID4]] = distinct !{![[LoopID4]], ![[PARACC5:[0-9]+]]}
 ; PARALLEL: ![[PARACC5]] = !{!"llvm.loop.parallel_accesses", ![[GROUPID3]]}

--- a/polly/test/CodeGen/MemAccess/codegen_address_space.ll
+++ b/polly/test/CodeGen/MemAccess/codegen_address_space.ll
@@ -40,4 +40,4 @@ for.end:                                          ; preds = %for.cond
 }
 
 ; CHECK: %polly.access.A = getelementptr i32, ptr addrspace(5) %A, i64 0
-; CHECK: %tmp2_p_scalar_ = load i32, ptr addrspace(5) %polly.access.A, align 4, !alias.scope !0, !noalias !3
+; CHECK: %tmp2_p_scalar_ = load i32, ptr addrspace(5) %polly.access.A, align 4, !alias.scope !2, !noalias !5

--- a/polly/test/CodeGen/MemAccess/create_arrays.ll
+++ b/polly/test/CodeGen/MemAccess/create_arrays.ll
@@ -28,19 +28,23 @@
 ; CODEGEN:  %beta.s2a.reload = load double, ptr %beta.s2a
 ; CODEGEN:  %polly.access.mul.E = mul nsw i64 %polly.indvar31, 200000
 ; CODEGEN:  %polly.access.add.E = add nsw i64 %polly.access.mul.E, %polly.indvar
-; CODEGEN:  {{%.*}} = load double, ptr %polly.access.E, align 8, !alias.scope !0, !noalias !3
-; CODEGEN:  store double {{%.*}}, ptr %scevgep34, align 8, !alias.scope !8, !noalias !9
+; CODEGEN:  {{%.*}} = load double, ptr %polly.access.E, align 8, !alias.scope !4, !noalias !7
+; CODEGEN:  store double {{%.*}}, ptr %scevgep34, align 8, !alias.scope !12, !noalias !13
 ;
-; CODEGEN: !0 = !{!1}
-; CODEGEN: !1 = distinct !{!1, !2, !"polly.alias.scope.E"}
-; CODEGEN: !2 = distinct !{!2, !"polly.alias.scope.domain"}
-; CODEGEN: !3 = !{!4, !5, !6, !7}
-; CODEGEN: !4 = distinct !{!4, !2, !"polly.alias.scope.MemRef_B"}
-; CODEGEN: !5 = distinct !{!5, !2, !"polly.alias.scope.MemRef_A"}
-; CODEGEN: !6 = distinct !{!6, !2, !"polly.alias.scope.D"}
-; CODEGEN: !7 = distinct !{!7, !2, !"polly.alias.scope.F"}
-; CODEGEN: !8 = !{!5}
-; CODEGEN: !9 = !{!4, !6, !1, !7}
+; CODEGEN: !0 = distinct !{!0, !1}
+; CODEGEN: !1 = !{!"llvm.loop.vectorize.enable", i32 0}
+; CODEGEN: !2 = distinct !{!2, !1}
+; CODEGEN: !3 = distinct !{!3, !1}
+; CODEGEN: !4 = !{!5}
+; CODEGEN: !5 = distinct !{!5, !6, !"polly.alias.scope.E"}
+; CODEGEN: !6 = distinct !{!6, !"polly.alias.scope.domain"}
+; CODEGEN: !7 = !{!8, !9, !10, !11}
+; CODEGEN: !8 = distinct !{!8, !6, !"polly.alias.scope.MemRef_B"}
+; CODEGEN: !9 = distinct !{!9, !6, !"polly.alias.scope.MemRef_A"}
+; CODEGEN: !10 = distinct !{!10, !6, !"polly.alias.scope.D"}
+; CODEGEN: !11 = distinct !{!11, !6, !"polly.alias.scope.F"}
+; CODEGEN: !12 = !{!9}
+; CODEGEN: !13 = !{!8, !10, !5, !11}
 ;
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-unknown"

--- a/polly/test/CodeGen/MemAccess/different_types.ll
+++ b/polly/test/CodeGen/MemAccess/different_types.ll
@@ -12,7 +12,7 @@
 ; CHECK: %[[R1:[._0-9]*]] = sub nsw i64 0, %polly.indvar7
 ; CHECK: %[[R2:[._0-9]*]] = add nsw i64 %[[R1]], 99
 ; CHECK: %polly.access.A10 = getelementptr i32, ptr %A, i64 %[[R2]]
-; CHECK: %tmp14_p_scalar_ = load float, ptr %polly.access.A10, align 4, !alias.scope !3, !noalias !0
+; CHECK: %tmp14_p_scalar_ = load float, ptr %polly.access.A10, align 4, !alias.scope !6, !noalias !3
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/polly/test/CodeGen/MemAccess/generate-all.ll
+++ b/polly/test/CodeGen/MemAccess/generate-all.ll
@@ -13,9 +13,9 @@
 ; SCEV-NEXT:   %1 = zext i2 %0 to i64
 ; SCEV-NEXT:   %2 = shl nuw nsw i64 %1, 2
 ; SCEV-NEXT:   %scevgep = getelementptr i8, ptr %A, i64 %2
-; SCEV-NEXT:   %tmp4_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !0, !noalias !3
+; SCEV-NEXT:   %tmp4_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !2, !noalias !5
 ; SCEV-NEXT:   %p_tmp5 = fadd float %tmp4_p_scalar_, 1.000000e+01
-; SCEV-NEXT:   store float %p_tmp5, ptr %scevgep, align 4, !alias.scope !0, !noalias !3
+; SCEV-NEXT:   store float %p_tmp5, ptr %scevgep, align 4, !alias.scope !2, !noalias !5
 ; SCEV-NEXT:   %polly.indvar_next = add nsw i64 %polly.indvar, 1
 ; SCEV-NEXT:   %polly.loop_cond = icmp sle i64 %polly.indvar_next, 99
 ; SCEV-NEXT:   br i1 %polly.loop_cond, label %polly.loop_header, label %polly.loop_exit
@@ -23,11 +23,11 @@
 ; ASTEXPR: 	polly.stmt.bb2:                                   ; preds = %polly.loop_header
 ; ASTEXPR-NEXT:   %pexp.pdiv_r = urem i64 %polly.indvar, 4
 ; ASTEXPR-NEXT:   %polly.access.A = getelementptr float, ptr %A, i64 %pexp.pdiv_r
-; ASTEXPR-NEXT:   %tmp4_p_scalar_ = load float, ptr %polly.access.A, align 4, !alias.scope !0, !noalias !3
+; ASTEXPR-NEXT:   %tmp4_p_scalar_ = load float, ptr %polly.access.A, align 4, !alias.scope !2, !noalias !5
 ; ASTEXPR-NEXT:   %p_tmp5 = fadd float %tmp4_p_scalar_, 1.000000e+01
 ; ASTEXPR-NEXT:   %pexp.pdiv_r1 = urem i64 %polly.indvar, 4
 ; ASTEXPR-NEXT:   %polly.access.A2 = getelementptr float, ptr %A, i64 %pexp.pdiv_r1
-; ASTEXPR-NEXT:   store float %p_tmp5, ptr %polly.access.A2, align 4, !alias.scope !0, !noalias !3
+; ASTEXPR-NEXT:   store float %p_tmp5, ptr %polly.access.A2, align 4, !alias.scope !2, !noalias !5
 ; ASTEXPR-NEXT:   %polly.indvar_next = add nsw i64 %polly.indvar, 1
 ; ASTEXPR-NEXT:   %polly.loop_cond = icmp sle i64 %polly.indvar_next, 99
 ; ASTEXPR-NEXT:   br i1 %polly.loop_cond, label %polly.loop_header, label %polly.loop_exit

--- a/polly/test/CodeGen/OpenMP/alias-metadata.ll
+++ b/polly/test/CodeGen/OpenMP/alias-metadata.ll
@@ -32,8 +32,8 @@ bb5:                                              ; preds = %bb4
   %tmp7 = getelementptr inbounds float, ptr %A, i64 %i.0
   %tmp6 = load float, ptr %tmp, align 4
   store float %tmp6, ptr %tmp7, align 4
-; CHECK: %tmp6_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !0, !noalias !3
-; CHECK: store float %tmp6_p_scalar_, ptr %scevgep7, align 4, !alias.scope !3, !noalias !0
+; CHECK: %tmp6_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !3, !noalias !6
+; CHECK: store float %tmp6_p_scalar_, ptr %scevgep7, align 4, !alias.scope !6, !noalias !3
   br label %bb8
 
 bb8:                                              ; preds = %bb5

--- a/polly/test/CodeGen/OpenMP/new_multidim_access.ll
+++ b/polly/test/CodeGen/OpenMP/new_multidim_access.ll
@@ -23,13 +23,13 @@
 ; IR: %6 = add nsw i64 %polly.indvar4, 13
 ; IR: %polly.access.add.polly.subfunc.arg.A = add nsw i64 %polly.access.mul.polly.subfunc.arg.A, %6
 ; IR: %polly.access.polly.subfunc.arg.A = getelementptr float, ptr %polly.subfunc.arg.A, i64 %polly.access.add.polly.subfunc.arg.A
-; IR: %tmp10_p_scalar_ = load float, ptr %polly.access.polly.subfunc.arg.A, align 4, !alias.scope !0, !noalias !3, !llvm.access.group !4
+; IR: %tmp10_p_scalar_ = load float, ptr %polly.access.polly.subfunc.arg.A, align 4, !alias.scope !3, !noalias !6, !llvm.access.group !7
 
 ; IR: %polly.access.mul.polly.subfunc.arg.A7 = mul nsw i64 %polly.indvar, %polly.subfunc.arg.m
 ; IR: %7 = add nsw i64 %polly.indvar4, 43
 ; IR: %polly.access.add.polly.subfunc.arg.A8 = add nsw i64 %polly.access.mul.polly.subfunc.arg.A7, %7
 ; IR: %polly.access.polly.subfunc.arg.A9 = getelementptr float, ptr %polly.subfunc.arg.A, i64 %polly.access.add.polly.subfunc.arg.A8
-; IR: store float %p_tmp11, ptr %polly.access.polly.subfunc.arg.A9, align 4, !alias.scope !0, !noalias !3, !llvm.access.group !4
+; IR: store float %p_tmp11, ptr %polly.access.polly.subfunc.arg.A9, align 4, !alias.scope !3, !noalias !6, !llvm.access.group !7
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 define void @new_multidim_access(i64 %n, i64 %m, ptr %A) {

--- a/polly/test/CodeGen/RuntimeDebugBuilder/combine_different_values.ll
+++ b/polly/test/CodeGen/RuntimeDebugBuilder/combine_different_values.ll
@@ -53,12 +53,12 @@
 
 ; CHECK: %0 = shl nuw nsw i64 %polly.indvar, 3
 ; CHECK: %scevgep = getelementptr i8, ptr %B, i64 %0
-; CHECK: %tmp3_p_scalar_ = load double, ptr %scevgep, align 8, !alias.scope !0, !noalias !3
+; CHECK: %tmp3_p_scalar_ = load double, ptr %scevgep, align 8, !alias.scope !2, !noalias !5
 ; CHECK: %1 = ptrtoint ptr %scevgep to i64
 ; CHECK: %2 = call i32 (...) @printf(ptr @3, ptr addrspace(4) @0, i64 %1, ptr addrspace(4) @1, double %tmp3_p_scalar_, ptr addrspace(4) @2)
 ; CHECK: %3 = call i32 @fflush(ptr null)
 ; CHECK: %scevgep1 = getelementptr i8, ptr %C, i64 %polly.indvar
-; CHECK: %tmp5_p_scalar_ = load i8, ptr %scevgep1, align 1, !alias.scope !8, !noalias !9
+; CHECK: %tmp5_p_scalar_ = load i8, ptr %scevgep1, align 1, !alias.scope !10, !noalias !11
 ; CHECK: %4 = ptrtoint ptr %scevgep1 to i64
 ; CHECK: %5 = sext i8 %tmp5_p_scalar_ to i64
 ; CHECK: %6 = call i32 (...) @printf(ptr @7, ptr addrspace(4) @4, i64 %4, ptr addrspace(4) @5, i64 %5, ptr addrspace(4) @6)
@@ -67,7 +67,7 @@
 ; CHECK: %p_tmp7 = fadd double %tmp3_p_scalar_, %p_tmp6
 ; CHECK: %8 = shl nuw nsw i64 %polly.indvar, 2
 ; CHECK: %scevgep2 = getelementptr i8, ptr %D, i64 %8
-; CHECK: %tmp9_p_scalar_ = load i32, ptr %scevgep2, align 4, !alias.scope !10, !noalias !11
+; CHECK: %tmp9_p_scalar_ = load i32, ptr %scevgep2, align 4, !alias.scope !12, !noalias !13
 ; CHECK: %9 = ptrtoint ptr %scevgep2 to i64
 ; CHECK: %10 = sext i32 %tmp9_p_scalar_ to i64
 ; CHECK: %11 = call i32 (...) @printf(ptr @11, ptr addrspace(4) @8, i64 %9, ptr addrspace(4) @9, i64 %10, ptr addrspace(4) @10)
@@ -76,7 +76,7 @@
 ; CHECK: %p_tmp11 = fadd double %p_tmp7, %p_tmp10
 ; CHECK: %13 = shl nuw nsw i64 %polly.indvar, 3
 ; CHECK: %scevgep3 = getelementptr i8, ptr %E, i64 %13
-; CHECK: %tmp13_p_scalar_ = load i64, ptr %scevgep3, align 8, !alias.scope !12, !noalias !13
+; CHECK: %tmp13_p_scalar_ = load i64, ptr %scevgep3, align 8, !alias.scope !14, !noalias !15
 ; CHECK: %14 = ptrtoint ptr %scevgep3 to i64
 ; CHECK: %15 = call i32 (...) @printf(ptr @15, ptr addrspace(4) @12, i64 %14, ptr addrspace(4) @13, i64 %tmp13_p_scalar_, ptr addrspace(4) @14)
 ; CHECK: %16 = call i32 @fflush(ptr null)
@@ -84,7 +84,7 @@
 ; CHECK: %p_tmp15 = fadd double %p_tmp11, %p_tmp14
 ; CHECK: %17 = shl nuw nsw i64 %polly.indvar, 2
 ; CHECK: %scevgep4 = getelementptr i8, ptr %A, i64 %17
-; CHECK: %tmp17_p_scalar_ = load float, ptr %scevgep4, align 4, !alias.scope !14, !noalias !15
+; CHECK: %tmp17_p_scalar_ = load float, ptr %scevgep4, align 4, !alias.scope !16, !noalias !17
 ; CHECK: %18 = ptrtoint ptr %scevgep4 to i64
 ; CHECK: %19 = fpext float %tmp17_p_scalar_ to double
 ; CHECK: %20 = call i32 (...) @printf(ptr @19, ptr addrspace(4) @16, i64 %18, ptr addrspace(4) @17, double %19, ptr addrspace(4) @18)

--- a/polly/test/CodeGen/annotated_alias_scopes.ll
+++ b/polly/test/CodeGen/annotated_alias_scopes.ll
@@ -4,22 +4,24 @@
 ;
 ; SCOPES-LABEL: polly.stmt.for.body:
 ; SCOPES:      %[[BIdx:[._a-zA-Z0-9]*]] = getelementptr{{.*}} ptr %B, i64 %{{.*}}
-; SCOPES:      load i32, ptr %[[BIdx]], align 4, !alias.scope !0, !noalias !3
+; SCOPES:      load i32, ptr %[[BIdx]], align 4, !alias.scope !2, !noalias !5
 ; SCOPES:      %[[CIdx:[._a-zA-Z0-9]*]] = getelementptr{{.*}} ptr %C, i64 %{{.*}}
-; SCOPES:      load float, ptr %[[CIdx]], align 4, !alias.scope !6, !noalias !7
+; SCOPES:      load float, ptr %[[CIdx]], align 4, !alias.scope !8, !noalias !9
 ; SCOPES:      %[[AIdx:[._a-zA-Z0-9]*]] = getelementptr{{.*}} ptr %A, i64 %{{.*}}
-; SCOPES:      store i32 %{{[._a-zA-Z0-9]*}}, ptr %[[AIdx]], align 4, !alias.scope !8, !noalias !9
+; SCOPES:      store i32 %{{[._a-zA-Z0-9]*}}, ptr %[[AIdx]], align 4, !alias.scope !10, !noalias !11
 ;
-; SCOPES: !0 = !{!1}
-; SCOPES: !1 = distinct !{!1, !2, !"polly.alias.scope.MemRef_B"}
-; SCOPES: !2 = distinct !{!2, !"polly.alias.scope.domain"}
-; SCOPES: !3 = !{!4, !5}
-; SCOPES: !4 = distinct !{!4, !2, !"polly.alias.scope.MemRef_C"}
-; SCOPES: !5 = distinct !{!5, !2, !"polly.alias.scope.MemRef_A"}
-; SCOPES: !6 = !{!4}
-; SCOPES: !7 = !{!1, !5}
-; SCOPES: !8 = !{!5}
-; SCOPES: !9 = !{!1, !4}
+; SCOPES: !0 = distinct !{!0, !1}
+; SCOPES: !1 = !{!"llvm.loop.vectorize.enable", i32 0}
+; SCOPES: !2 = !{!3}
+; SCOPES: !3 = distinct !{!3, !4, !"polly.alias.scope.MemRef_B"}
+; SCOPES: !4 = distinct !{!4, !"polly.alias.scope.domain"}
+; SCOPES: !5 = !{!6, !7}
+; SCOPES: !6 = distinct !{!6, !4, !"polly.alias.scope.MemRef_C"}
+; SCOPES: !7 = distinct !{!7, !4, !"polly.alias.scope.MemRef_A"}
+; SCOPES: !8 = !{!6}
+; SCOPES: !9 = !{!3, !7}
+; SCOPES: !10 = !{!7}
+; SCOPES: !11 = !{!3, !6}
 ;
 ;    void jd(int *A, int *B, float *C) {
 ;      for (int i = 0; i < 1024; i++)

--- a/polly/test/CodeGen/non-affine-phi-node-expansion-2.ll
+++ b/polly/test/CodeGen/non-affine-phi-node-expansion-2.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 
 ; CHECK: polly.stmt.bb3:                                   ; preds = %polly.stmt.bb3.entry
-; CHECK:   %tmp6_p_scalar_ = load double, ptr %arg1{{[0-9]*}}, align 8, !alias.scope !0, !noalias !3
+; CHECK:   %tmp6_p_scalar_ = load double, ptr %arg1{{[0-9]*}}, align 8, !alias.scope !2, !noalias !5
 ; CHECK:   %p_tmp7 = fadd double 1.000000e+00, %tmp6_p_scalar_
 ; CHECK:   %p_tmp8 = fcmp olt double 1.400000e+01, %p_tmp7
 ; CHECK:   br i1 %p_tmp8, label %polly.stmt.bb9, label %polly.stmt.bb10

--- a/polly/test/CodeGen/non_affine_float_compare.ll
+++ b/polly/test/CodeGen/non_affine_float_compare.ll
@@ -13,19 +13,19 @@
 ; CHECK: polly.stmt.bb2:
 ; CHECK:   %[[offset:.*]] = shl nuw nsw i64 %polly.indvar, 2
 ; CHECK:   %scevgep[[R0:[0-9]*]] = getelementptr i8, ptr %A, i64 %[[offset]]
-; CHECK:   %tmp3_p_scalar_ = load float, ptr %scevgep[[R0]], align 4, !alias.scope !0, !noalias !3
+; CHECK:   %tmp3_p_scalar_ = load float, ptr %scevgep[[R0]], align 4, !alias.scope !2, !noalias !5
 ; CHECK:   %[[offset2:.*]] = shl nuw nsw i64 %polly.indvar, 2
 ; CHECK:   %scevgep[[R2:[0-9]*]] = getelementptr i8, ptr %scevgep{{[0-9]*}}, i64 %[[offset2]]
-; CHECK:   %tmp6_p_scalar_ = load float, ptr %scevgep[[R2]], align 4, !alias.scope !0, !noalias !3
+; CHECK:   %tmp6_p_scalar_ = load float, ptr %scevgep[[R2]], align 4, !alias.scope !2, !noalias !5
 ; CHECK:   %p_tmp7 = fcmp oeq float %tmp3_p_scalar_, %tmp6_p_scalar_
 ; CHECK:   br i1 %p_tmp7, label %polly.stmt.bb8, label %polly.stmt.bb12.[[R:[a-zA-Z_.0-9]*]]
 
 ; CHECK: polly.stmt.bb8:
 ; CHECK:   %[[offset3:.*]] = shl nuw nsw i64 %polly.indvar, 2
 ; CHECK:   %scevgep[[R3:[0-9]*]] = getelementptr i8, ptr %A, i64 %[[offset3]]
-; CHECK:   %tmp10_p_scalar_ = load float, ptr %scevgep[[R3]], align 4, !alias.scope !0, !noalias !3
+; CHECK:   %tmp10_p_scalar_ = load float, ptr %scevgep[[R3]], align 4, !alias.scope !2, !noalias !5
 ; CHECK:   %p_tmp11 = fadd float %tmp10_p_scalar_, 1.000000e+00
-; CHECK:   store float %p_tmp11, ptr %scevgep[[R3]], align 4, !alias.scope !0, !noalias !3
+; CHECK:   store float %p_tmp11, ptr %scevgep[[R3]], align 4, !alias.scope !2, !noalias !5
 ; CHECK:   br label %polly.stmt.bb12.[[R]]
 
 ; CHECK: polly.stmt.bb12.[[R]]:
@@ -34,9 +34,9 @@
 ; CHECK: polly.stmt.bb12:
 ; CHECK:   %[[offset4:.*]] = shl nuw nsw i64 %polly.indvar, 2
 ; CHECK:   %scevgep[[R4:[0-9]*]] = getelementptr i8, ptr %A, i64 %[[offset4]]
-; CHECK:   %tmp10b_p_scalar_ = load float, ptr %scevgep[[R4]], align 4, !alias.scope !0, !noalias !3
+; CHECK:   %tmp10b_p_scalar_ = load float, ptr %scevgep[[R4]], align 4, !alias.scope !2, !noalias !5
 ; CHECK:   %p_tmp11b = fadd float %tmp10b_p_scalar_, 1.000000e+00
-; CHECK:   store float %p_tmp11b, ptr %scevgep[[R4]], align 4, !alias.scope !0, !noalias !3
+; CHECK:   store float %p_tmp11b, ptr %scevgep[[R4]], align 4, !alias.scope !2, !noalias !5
 ; CHECK:   %polly.indvar_next = add nsw i64 %polly.indvar, 1
 ; CHECK:   %polly.loop_cond = icmp sle i64 %polly.indvar_next, 1023
 ; CHECK:   br i1 %polly.loop_cond, label %polly.loop_header, label %polly.loop_exit

--- a/polly/test/CodeGen/partial_write_array.ll
+++ b/polly/test/CodeGen/partial_write_array.ll
@@ -38,7 +38,7 @@ return:
 
 ; CHECK:      polly.stmt.body.Stmt_body_Write0.partial:
 ; CHECK-NEXT:   %polly.access.A = getelementptr double, ptr %A, i64 0
-; CHECK-NEXT:   store double 4.200000e+01, ptr %polly.access.A, align 8, !alias.scope !0, !noalias !3
+; CHECK-NEXT:   store double 4.200000e+01, ptr %polly.access.A, align 8, !alias.scope !2, !noalias !5
 ; CHECK-NEXT:   br label %polly.stmt.body.cont
 
 ; CHECK:      polly.stmt.body.cont:

--- a/polly/test/CodeGen/partial_write_impossible_restriction.ll
+++ b/polly/test/CodeGen/partial_write_impossible_restriction.ll
@@ -49,10 +49,10 @@ if.then.i.i1141.loopexit:                         ; preds = %cond.end
 
 ; CHECK-LABEL: polly.stmt.cond.false:
 ; CHECK:         %polly.access..pn{{[0-9]*}} = getelementptr i32, ptr %.pn, i64 %polly.indvar
-; CHECK:         store i32 %cond.in.sroa.speculate.load.cond.false_p_scalar_, ptr %polly.access..pn{{[0-9]*}}, align 4, !alias.scope !0, !noalias !3
+; CHECK:         store i32 %cond.in.sroa.speculate.load.cond.false_p_scalar_, ptr %polly.access..pn{{[0-9]*}}, align 4, !alias.scope !2, !noalias !5
 ; CHECK:         br label %polly.merge
 
 ; CHECK-LABEL: polly.stmt.cond.false{{[0-9]*}}:
 ; CHECK:         %polly.access..pn{{[0-9]*}} = getelementptr i32, ptr %.pn, i64 0
-; CHECK:         store i32 %cond.in.sroa.speculate.load.cond.false_p_scalar_{{[0-9]*}}, ptr %polly.access..pn{{[0-9]*}}, align 4, !alias.scope !0, !noalias !3
+; CHECK:         store i32 %cond.in.sroa.speculate.load.cond.false_p_scalar_{{[0-9]*}}, ptr %polly.access..pn{{[0-9]*}}, align 4, !alias.scope !2, !noalias !5
 ; CHECK:         br label %polly.stmt.cond.end{{[0-9]*}}

--- a/polly/test/CodeGen/phi_loop_carried_float.ll
+++ b/polly/test/CodeGen/phi_loop_carried_float.ll
@@ -29,7 +29,7 @@
 
 ; CHECK-LABEL: polly.stmt.bb4:
 ; CHECK:         %tmp.0.s2a.reload[[R3:[0-9]*]] = load float, ptr %tmp.0.s2a
-; CHECK:         %tmp[[R5:[0-9]*]]_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !0, !noalias !3
+; CHECK:         %tmp[[R5:[0-9]*]]_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !2, !noalias !5
 ; CHECK:         %p_tmp[[R4:[0-9]*]] = fadd float %tmp.0.s2a.reload[[R3]], %tmp[[R5]]_p_scalar_
 ; CHECK:         store float %p_tmp[[R4]], ptr %tmp.0.phiops
 

--- a/polly/test/CodeGen/phi_loop_carried_float_escape.ll
+++ b/polly/test/CodeGen/phi_loop_carried_float_escape.ll
@@ -29,7 +29,7 @@
 
 ; CHECK-LABEL: polly.stmt.bb4:
 ; CHECK:         %tmp.0.s2a.reload[[R3:[0-9]*]] = load float, ptr %tmp.0.s2a
-; CHECK:         %tmp[[R5:[0-9]*]]_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !0, !noalias !3
+; CHECK:         %tmp[[R5:[0-9]*]]_p_scalar_ = load float, ptr %scevgep, align 4, !alias.scope !2, !noalias !5
 ; CHECK:         %p_tmp[[R4:[0-9]*]] = fadd float %tmp.0.s2a.reload[[R3]], %tmp[[R5]]_p_scalar_
 ; CHECK:         store float %p_tmp[[R4]], ptr %tmp.0.phiops
 

--- a/polly/test/CodeGen/scev-backedgetaken.ll
+++ b/polly/test/CodeGen/scev-backedgetaken.ll
@@ -41,9 +41,11 @@ for.cond.cleanup.loopexit:
 
 ; CHECK-LABEL: @func(
 ; CHECK:         polly.stmt.omp.inner.for.body.us.us.us.preheader:
-; CHECK:         load i32, ptr %scevgep, align 4, !alias.scope !0, !noalias !3
+; CHECK:         load i32, ptr %scevgep, align 4, !alias.scope !2, !noalias !5
 
-; CHECK:       !0 = !{!1}
-; CHECK:       !1 = distinct !{!1, !2, !"polly.alias.scope.MemRef_d"}
-; CHECK:       !2 = distinct !{!2, !"polly.alias.scope.domain"}
-; CHECK:       !3 = !{}
+; CHECK:       !0 = distinct !{!0, !1}
+; CHECK:       !1 = !{!"llvm.loop.vectorize.enable", i32 0}
+; CHECK:       !2 = !{!3}
+; CHECK:       !3 = distinct !{!3, !4, !"polly.alias.scope.MemRef_d"}
+; CHECK:       !4 = distinct !{!4, !"polly.alias.scope.domain"}
+; CHECK:       !5 = !{}

--- a/polly/test/CodeGen/stmt_split_no_dependence.ll
+++ b/polly/test/CodeGen/stmt_split_no_dependence.ll
@@ -1,7 +1,7 @@
 ; RUN: opt %loadNPMPolly -passes=polly-codegen -S < %s | FileCheck %s
 ;
-; CHECK:   store i32 %9, ptr %scevgep, align 4, !alias.scope !1, !noalias !4
-; CHECK:   store i32 %11, ptr %scevgep4, align 4, !alias.scope !4, !noalias !1
+; CHECK:   store i32 %9, ptr %scevgep, align 4, !alias.scope !3, !noalias !6
+; CHECK:   store i32 %11, ptr %scevgep4, align 4, !alias.scope !6, !noalias !3
 ;
 ;      void func(int *A, int *B){
 ;        for (int i = 0; i < 1024; i+=1) {

--- a/polly/test/ScopDetect/dom-tree-crash.ll
+++ b/polly/test/ScopDetect/dom-tree-crash.ll
@@ -1,0 +1,31 @@
+; RUN: opt %loadNPMPolly '-passes=print<polly-detect>' -disable-output < %s 2>&1 | FileCheck %s
+
+; CHECK: Detected Scops in Function foo
+
+; This unit test case is to check if the following IR does not crash in isHoistableLoad function during Scop Detection.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnueabi"
+
+define void @foo(ptr %block) {
+entry:
+  br label %for.body
+
+for.cond1.preheader:                              ; preds = %for.body
+  %0 = load ptr, ptr null, align 8
+  %1 = load i16, ptr %block, align 2
+  %2 = load i16, ptr %0, align 2
+  br label %foo.exit
+
+for.body:                                         ; preds = %for.body, %entry
+  br i1 false, label %for.cond1.preheader, label %for.body
+
+foo.exit:                                     ; preds = %for.cond1.preheader
+  ret void
+}
+
+define void @init_foo() {
+entry:
+  store ptr null, ptr null, align 8
+  ret void
+}

--- a/polly/test/ScopInfo/int2ptr_ptr2int.ll
+++ b/polly/test/ScopInfo/int2ptr_ptr2int.ll
@@ -24,10 +24,10 @@
 ; IR-NEXT:   %p_add.ptr2 = getelementptr inbounds i64, ptr %p_tmp1, i64 1
 ; IR-NEXT:   %p_tmp2 = ptrtoint ptr %p_add.ptr2 to i64
 ; IR-NEXT:   %p_arrayidx = getelementptr inbounds i64, ptr %A, i64 %p_tmp2
-; IR-NEXT:   %tmp3_p_scalar_ = load i64, ptr %p_arrayidx, align 8, !alias.scope !0, !noalias !3
-; IR-NEXT:   %tmp4_p_scalar_ = load i64, ptr %scevgep, align 8, !alias.scope !0, !noalias !3
+; IR-NEXT:   %tmp3_p_scalar_ = load i64, ptr %p_arrayidx, align 8, !alias.scope !2, !noalias !5
+; IR-NEXT:   %tmp4_p_scalar_ = load i64, ptr %scevgep, align 8, !alias.scope !2, !noalias !5
 ; IR-NEXT:   %p_add4 = add nsw i64 %tmp4_p_scalar_, %tmp3_p_scalar_
-; IR-NEXT:   store i64 %p_add4, ptr %scevgep, align 8, !alias.scope !0, !noalias !3
+; IR-NEXT:   store i64 %p_add4, ptr %scevgep, align 8, !alias.scope !2, !noalias !5
 ; IR-NEXT:   %polly.indvar_next = add nsw i64 %polly.indvar, 1
 ; IR-NEXT:   %polly.loop_cond = icmp sle i64 %polly.indvar_next, 99
 ; IR-NEXT:   br i1 %polly.loop_cond, label %polly.loop_header, label %polly.loop_exit

--- a/polly/test/ScopInfo/int2ptr_ptr2int_2.ll
+++ b/polly/test/ScopInfo/int2ptr_ptr2int_2.ll
@@ -24,9 +24,9 @@
 ; IR-NEXT:   %ptr13 = ptrtoint ptr %ptr to i16
 ;
 ; IR:      polly.stmt.for.body:
-; IR-NEXT:   %tmp4_p_scalar_ = load i64, ptr %scevgep, align 8, !alias.scope !3, !noalias !0
+; IR-NEXT:   %tmp4_p_scalar_ = load i64, ptr %scevgep, align 8, !alias.scope !5, !noalias !2
 ; IR-NEXT:   %p_add4 = add nsw i64 %tmp4_p_scalar_, %polly.preload.tmp3.merge
-; IR-NEXT:   store i64 %p_add4, ptr %scevgep, align 8, !alias.scope !3, !noalias !0
+; IR-NEXT:   store i64 %p_add4, ptr %scevgep, align 8, !alias.scope !5, !noalias !2
 ; IR-NEXT:   %polly.indvar_next = add nsw i64 %polly.indvar, 1
 ; IR-NEXT:   %polly.loop_cond = icmp sle i64 %polly.indvar_next, 99
 ; IR-NEXT:   br i1 %polly.loop_cond, label %polly.loop_header, label %polly.loop_exit


### PR DESCRIPTION
The patch sets the vectorization metadata to false for Polly's fallback loops. These are the loops executed when RTCs fail. This minimizes the multiple loop versioning carried out by Polly and subsequently by the Loop Vectorizer.