### PR TITLE
[Hexagon] Add support for addrspacecast lowering

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.h
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.h
@@ -46,6 +46,10 @@ public:
   MachineFunctionInfo *
   createMachineFunctionInfo(BumpPtrAllocator &Allocator, const Function &F,
                             const TargetSubtargetInfo *STI) const override;
+
+  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override {
+    return true;
+  }
 };
 
 } // end namespace llvm

--- a/llvm/test/CodeGen/Hexagon/addrspacecast-crash.ll
+++ b/llvm/test/CodeGen/Hexagon/addrspacecast-crash.ll
@@ -1,0 +1,12 @@
+; Tests if addrspacecast is handled in Hexagon backend
+
+; REQUIRES: asserts
+
+; RUN: llc -march=hexagon %s -o /dev/null
+
+define double @f(ptr %G, ptr %x) {
+BB:
+  %Castaddrspacecast = addrspacecast ptr %x to ptr addrspace(1)
+  store ptr addrspace(1) %Castaddrspacecast, ptr %G, align 8
+  ret double 0.000000e+00
+}


### PR DESCRIPTION
This patch adds support for addrspacecast lowering. At the moment, there are no separate address spaces for Hexagon target, hence this instruction is treated as a noop.