### PR TITLE
[InstCombine] Fold (trunc X to i1) & !iszero(X & Pow2)) -> (X & (1 | Pow2)) == (1 | Pow2)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -815,8 +815,11 @@ static Value *foldTruncAndOrICmpOfAndWithPow2(InstCombiner::BuilderTy &Builder,
                                               const SimplifyQuery &Q) {
   CmpInst::Predicate Pred = IsAnd ? CmpInst::ICMP_NE : CmpInst::ICMP_EQ;
 
-  if (isa<ICmpInst>(LHS))
+  bool Swapped = false;
+  if (isa<ICmpInst>(LHS)) {
     std::swap(LHS, RHS);
+    Swapped = true;
+  }
 
   Value *X, *Pow2;
 
@@ -828,7 +831,7 @@ static Value *foldTruncAndOrICmpOfAndWithPow2(InstCombiner::BuilderTy &Builder,
                              Q.CxtI, Q.DT)) {
     // If this is a logical and/or, then we must prevent propagation of a
     // poison value from the RHS by inserting freeze.
-    if (IsLogical)
+    if (!Swapped && IsLogical)
       Pow2 = Builder.CreateFreeze(Pow2);
     Value *Mask = Builder.CreateOr(ConstantInt::get(Pow2->getType(), 1), Pow2);
     Value *Masked = Builder.CreateAnd(X, Mask);

--- a/llvm/test/Transforms/InstCombine/onehot_merge.ll
+++ b/llvm/test/Transforms/InstCombine/onehot_merge.ll
@@ -1146,11 +1146,8 @@ define i1 @foo1_and_signbit_lshr_without_shifting_signbit_not_pwr2_logical(i32 %
 
 define i1 @trunc_or_icmp_consts(i8 %k) {
 ; CHECK-LABEL: @trunc_or_icmp_consts(
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K:%.*]] to i1
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[TRUNC]], true
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[K]], 8
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[AND]], 0
-; CHECK-NEXT:    [[OR:%.*]] = or i1 [[ICMP]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[K:%.*]], 9
+; CHECK-NEXT:    [[OR:%.*]] = icmp ne i8 [[TMP1]], 9
 ; CHECK-NEXT:    ret i1 [[OR]]
 ;
   %trunc = trunc i8 %k to i1
@@ -1163,11 +1160,8 @@ define i1 @trunc_or_icmp_consts(i8 %k) {
 
 define i1 @icmp_or_trunc_consts(i8 %k) {
 ; CHECK-LABEL: @icmp_or_trunc_consts(
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K:%.*]] to i1
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[TRUNC]], true
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[K]], 8
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[AND]], 0
-; CHECK-NEXT:    [[OR:%.*]] = or i1 [[ICMP]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[K:%.*]], 9
+; CHECK-NEXT:    [[OR:%.*]] = icmp ne i8 [[TMP1]], 9
 ; CHECK-NEXT:    ret i1 [[OR]]
 ;
   %trunc = trunc i8 %k to i1
@@ -1181,11 +1175,9 @@ define i1 @icmp_or_trunc_consts(i8 %k) {
 define i1 @trunc_or_icmp(i8 %k, i8 %c1) {
 ; CHECK-LABEL: @trunc_or_icmp(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw i8 1, [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and i8 [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[T1]], 0
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K]] to i1
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[TRUNC]], true
-; CHECK-NEXT:    [[RET:%.*]] = or i1 [[ICMP]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[T]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[K:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp ne i8 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %t = shl i8 1, %c1
@@ -1200,11 +1192,9 @@ define i1 @trunc_or_icmp(i8 %k, i8 %c1) {
 define i1 @trunc_logical_or_icmp(i8 %k, i8 %c1) {
 ; CHECK-LABEL: @trunc_logical_or_icmp(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw i8 1, [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and i8 [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[T1]], 0
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K]] to i1
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[TRUNC]], true
-; CHECK-NEXT:    [[RET:%.*]] = or i1 [[ICMP]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[T]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[K:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp ne i8 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %t = shl i8 1, %c1
@@ -1219,11 +1209,10 @@ define i1 @trunc_logical_or_icmp(i8 %k, i8 %c1) {
 define i1 @icmp_logical_or_trunc(i8 %k, i8 %c1) {
 ; CHECK-LABEL: @icmp_logical_or_trunc(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw i8 1, [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and i8 [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[T1]], 0
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K]] to i1
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[TRUNC]], true
-; CHECK-NEXT:    [[RET:%.*]] = select i1 [[NOT]], i1 true, i1 [[ICMP]]
+; CHECK-NEXT:    [[TMP1:%.*]] = freeze i8 [[T]]
+; CHECK-NEXT:    [[TMP2:%.*]] = or i8 [[TMP1]], 1
+; CHECK-NEXT:    [[TMP3:%.*]] = and i8 [[K:%.*]], [[TMP2]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp ne i8 [[TMP3]], [[TMP2]]
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %t = shl i8 1, %c1
@@ -1238,11 +1227,9 @@ define i1 @icmp_logical_or_trunc(i8 %k, i8 %c1) {
 define <2 x i1> @trunc_or_icmp_vec(<2 x i8> %k, <2 x i8> %c1) {
 ; CHECK-LABEL: @trunc_or_icmp_vec(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw <2 x i8> splat (i8 1), [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and <2 x i8> [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <2 x i8> [[T1]], zeroinitializer
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc <2 x i8> [[K]] to <2 x i1>
-; CHECK-NEXT:    [[NOT:%.*]] = xor <2 x i1> [[TRUNC]], splat (i1 true)
-; CHECK-NEXT:    [[RET:%.*]] = or <2 x i1> [[ICMP]], [[NOT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or <2 x i8> [[T]], splat (i8 1)
+; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i8> [[K:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp ne <2 x i8> [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    ret <2 x i1> [[RET]]
 ;
   %t = shl <2 x i8> <i8 1, i8 1>, %c1
@@ -1309,10 +1296,8 @@ define i1 @neg_trunc_or_icmp_ne(i8 %k, i8 %c1) {
 
 define i1 @trunc_and_icmp_consts(i8 %k) {
 ; CHECK-LABEL: @trunc_and_icmp_consts(
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K:%.*]] to i1
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[K]], 8
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i8 [[AND]], 0
-; CHECK-NEXT:    [[RET:%.*]] = and i1 [[ICMP]], [[TRUNC]]
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[K:%.*]], 9
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq i8 [[TMP1]], 9
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %trunc = trunc i8 %k to i1
@@ -1324,10 +1309,8 @@ define i1 @trunc_and_icmp_consts(i8 %k) {
 
 define i1 @icmp_and_trunc_consts(i8 %k) {
 ; CHECK-LABEL: @icmp_and_trunc_consts(
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K:%.*]] to i1
-; CHECK-NEXT:    [[AND:%.*]] = and i8 [[K]], 8
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i8 [[AND]], 0
-; CHECK-NEXT:    [[RET:%.*]] = and i1 [[ICMP]], [[TRUNC]]
+; CHECK-NEXT:    [[TMP1:%.*]] = and i8 [[K:%.*]], 9
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq i8 [[TMP1]], 9
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %trunc = trunc i8 %k to i1
@@ -1340,10 +1323,9 @@ define i1 @icmp_and_trunc_consts(i8 %k) {
 define i1 @trunc_and_icmp(i8 %k, i8 %c1) {
 ; CHECK-LABEL: @trunc_and_icmp(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw i8 1, [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and i8 [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i8 [[T1]], 0
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K]] to i1
-; CHECK-NEXT:    [[RET:%.*]] = and i1 [[ICMP]], [[TRUNC]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[T]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[K:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq i8 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %t = shl i8 1, %c1
@@ -1357,10 +1339,9 @@ define i1 @trunc_and_icmp(i8 %k, i8 %c1) {
 define i1 @trunc_logical_and_icmp(i8 %k, i8 %c1) {
 ; CHECK-LABEL: @trunc_logical_and_icmp(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw i8 1, [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and i8 [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i8 [[T1]], 0
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K]] to i1
-; CHECK-NEXT:    [[RET:%.*]] = and i1 [[ICMP]], [[TRUNC]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[T]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[K:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq i8 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %t = shl i8 1, %c1
@@ -1374,10 +1355,10 @@ define i1 @trunc_logical_and_icmp(i8 %k, i8 %c1) {
 define i1 @icmp_logical_and_trunc(i8 %k, i8 %c1) {
 ; CHECK-LABEL: @icmp_logical_and_trunc(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw i8 1, [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and i8 [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne i8 [[T1]], 0
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[K]] to i1
-; CHECK-NEXT:    [[RET:%.*]] = select i1 [[TRUNC]], i1 [[ICMP]], i1 false
+; CHECK-NEXT:    [[TMP1:%.*]] = freeze i8 [[T]]
+; CHECK-NEXT:    [[TMP2:%.*]] = or i8 [[TMP1]], 1
+; CHECK-NEXT:    [[TMP3:%.*]] = and i8 [[K:%.*]], [[TMP2]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq i8 [[TMP3]], [[TMP2]]
 ; CHECK-NEXT:    ret i1 [[RET]]
 ;
   %t = shl i8 1, %c1
@@ -1391,10 +1372,9 @@ define i1 @icmp_logical_and_trunc(i8 %k, i8 %c1) {
 define <2 x i1> @trunc_and_icmp_vec(<2 x i8> %k, <2 x i8> %c1) {
 ; CHECK-LABEL: @trunc_and_icmp_vec(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw <2 x i8> splat (i8 1), [[C1:%.*]]
-; CHECK-NEXT:    [[T1:%.*]] = and <2 x i8> [[T]], [[K:%.*]]
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp ne <2 x i8> [[T1]], zeroinitializer
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc <2 x i8> [[K]] to <2 x i1>
-; CHECK-NEXT:    [[RET:%.*]] = and <2 x i1> [[ICMP]], [[TRUNC]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or <2 x i8> [[T]], splat (i8 1)
+; CHECK-NEXT:    [[TMP2:%.*]] = and <2 x i8> [[K:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[RET:%.*]] = icmp eq <2 x i8> [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    ret <2 x i1> [[RET]]
 ;
   %t = shl <2 x i8> <i8 1, i8 1>, %c1

--- a/llvm/test/Transforms/InstCombine/onehot_merge.ll
+++ b/llvm/test/Transforms/InstCombine/onehot_merge.ll
@@ -1373,8 +1373,7 @@ define i1 @trunc_logical_and_icmp_and_icmps(i8 %x, i8 %y, i8 %c1) {
 ; CHECK-LABEL: @trunc_logical_and_icmp_and_icmps(
 ; CHECK-NEXT:    [[Z_SHIFT:%.*]] = shl nuw i8 1, [[Z:%.*]]
 ; CHECK-NEXT:    [[C1:%.*]] = icmp eq i8 [[Y:%.*]], 42
-; CHECK-NEXT:    [[TMP4:%.*]] = freeze i8 [[Z_SHIFT]]
-; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[TMP4]], 1
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[Z_SHIFT]], 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[X:%.*]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i8 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    [[AND2:%.*]] = select i1 [[TMP3]], i1 [[C1]], i1 false

--- a/llvm/test/Transforms/InstCombine/onehot_merge.ll
+++ b/llvm/test/Transforms/InstCombine/onehot_merge.ll
@@ -1369,6 +1369,27 @@ define i1 @icmp_logical_and_trunc(i8 %k, i8 %c1) {
   ret i1 %ret
 }
 
+define i1 @trunc_logical_and_icmp_and_icmps(i8 %x, i8 %y, i8 %c1) {
+; CHECK-LABEL: @trunc_logical_and_icmp_and_icmps(
+; CHECK-NEXT:    [[Z_SHIFT:%.*]] = shl nuw i8 1, [[Z:%.*]]
+; CHECK-NEXT:    [[C1:%.*]] = icmp eq i8 [[Y:%.*]], 42
+; CHECK-NEXT:    [[TMP4:%.*]] = freeze i8 [[Z_SHIFT]]
+; CHECK-NEXT:    [[TMP1:%.*]] = or i8 [[TMP4]], 1
+; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[X:%.*]], [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = icmp eq i8 [[TMP2]], [[TMP1]]
+; CHECK-NEXT:    [[AND2:%.*]] = select i1 [[TMP3]], i1 [[C1]], i1 false
+; CHECK-NEXT:    ret i1 [[AND2]]
+;
+  %t = shl i8 1, %c1
+  %t1 = and i8 %x, %t
+  %trunc = trunc i8 %x to i1
+  %icmp1 = icmp eq i8 %y, 42
+  %and1 = select i1 %trunc, i1 %icmp1, i1 false
+  %icmp2 = icmp ne i8 %t1, 0
+  %and2 = and i1 %icmp2, %and1
+  ret i1 %and2
+}
+
 define <2 x i1> @trunc_and_icmp_vec(<2 x i8> %k, <2 x i8> %c1) {
 ; CHECK-LABEL: @trunc_and_icmp_vec(
 ; CHECK-NEXT:    [[T:%.*]] = shl nuw <2 x i8> splat (i8 1), [[C1:%.*]]


### PR DESCRIPTION
Folds the patterns:
not(trunc X to i1) | iszero(X & Pow2) -> (X & (1 | Pow2)) != (1 | Pow2)
(trunc X to i1) & !iszero(X & Pow2)) -> (X & (1 | Pow2)) == (1 | Pow2)

this is the same pattern that foldAndOrOfICmpsOfAndWithPow2 handles but one `!iszero(X & 1)` have been folded to a `trunc X to i1` or `iszero(X & 1)` folded to `not(trunc X to i1)`
around 100 files updated for the llvm-opt-benchmark with like 6 files with some regressions 
like https://alive2.llvm.org/ce/z/SQLjda and https://alive2.llvm.org/ce/z/_Vu4yB
do not know how to handle the regressions feels like for every fold that I add to handle one regressions i gett new regressions.

proof: https://alive2.llvm.org/ce/z/ofzAyQ