### PR TITLE
[compiler-rt][AArch64] NFCI: Simplify __arm_get_current_vg.

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/sme-abi.S
+++ b/compiler-rt/lib/builtins/aarch64/sme-abi.S
@@ -8,6 +8,8 @@
 
 #include "../assembly.h"
 
+.set FEAT_SVE_BIT, 30
+.set SVCR_PSTATE_SM_BIT, 0
 
 #if !defined(__APPLE__)
 #define TPIDR2_SYMBOL SYMBOL_NAME(__aarch64_has_sme_and_tpidr2_el0)
@@ -188,39 +190,20 @@ DEFINE_COMPILERRT_OUTLINE_FUNCTION_UNMANGLED(__arm_get_current_vg)
   .variant_pcs __arm_get_current_vg
   BTI_C
 
-  stp     x29, x30, [sp, #-16]!
-  .cfi_def_cfa_offset 16
-  mov     x29, sp
-  .cfi_def_cfa w29, 16
-  .cfi_offset w30, -8
-  .cfi_offset w29, -16
   adrp    x17, CPU_FEATS_SYMBOL
   ldr     w17, [x17, CPU_FEATS_SYMBOL_OFFSET]
-  tbnz    w17, #30, 0f
-  adrp    x16, TPIDR2_SYMBOL
-  ldrb    w16, [x16, TPIDR2_SYMBOL_OFFSET]
-  cbz     w16, 1f
+  tbnz    w17, #FEAT_SVE_BIT, 1f
+  adrp    x17, TPIDR2_SYMBOL
+  ldrb    w17, [x17, TPIDR2_SYMBOL_OFFSET]
+  cbz     x17, 2f
 0:
-  mov     x18, x1
-  bl      __arm_sme_state
-  mov     x1, x18
-  and     x17, x17, #0x40000000
-  bfxil   x17, x0, #0, #1
-  cbz     x17, 1f
-  cntd    x0
-  .cfi_def_cfa wsp, 16
-  ldp     x29, x30, [sp], #16
-  .cfi_def_cfa_offset 0
-  .cfi_restore w30
-  .cfi_restore w29
-  ret
+  mrs     x17, SVCR
+  tbz     x17, #SVCR_PSTATE_SM_BIT, 2f
 1:
+  cntd    x0
+  ret
+2:
   mov     x0, xzr
-  .cfi_def_cfa wsp, 16
-  ldp     x29, x30, [sp], #16
-  .cfi_def_cfa_offset 0
-  .cfi_restore w30
-  .cfi_restore w29
   ret
 END_COMPILERRT_OUTLINE_FUNCTION(__arm_get_current_vg)
 


### PR DESCRIPTION
This patch simplifies the code in two different ways:
* When SVE is available, return `cntd` directly to avoid the need for bitfield insert.
* When SME is available, check the PSTATE.SM bit of `SVCR` directly rather than calling `__arm_sme_state`.