### PR TITLE
[MC] Fix DWARF file table for files with empty DWARF (#119020)

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -162,8 +162,8 @@ private:
   };
   CppHashInfoTy CppHashInfo;
 
-  /// The filename from the first cpp hash file line comment, if any.
-  StringRef FirstCppHashFilename;
+  /// Have we seen any file line comment.
+  bool HadCppHashFilename = false;
 
   /// List of forward directional labels for diagnosis at the end.
   SmallVector<std::tuple<SMLoc, CppHashInfoTy, MCSymbol *>, 4> DirLabels;
@@ -952,12 +952,6 @@ bool AsmParser::enabledGenDwarfForAssembly() {
   // the assembler source was produced with debug info already) then emit one
   // describing the assembler source file itself.
   if (getContext().getGenDwarfFileNumber() == 0) {
-    // Use the first #line directive for this, if any. It's preprocessed, so
-    // there is no checksum, and of course no source directive.
-    if (!FirstCppHashFilename.empty())
-      getContext().setMCLineTableRootFile(
-          /*CUID=*/0, getContext().getCompilationDir(), FirstCppHashFilename,
-          /*Cksum=*/std::nullopt, /*Source=*/std::nullopt);
     const MCDwarfFile &RootFile =
         getContext().getMCDwarfLineTable(/*CUID=*/0).getRootFile();
     getContext().setGenDwarfFileNumber(getStreamer().emitDwarfFileDirective(
@@ -2440,8 +2434,19 @@ bool AsmParser::parseCppHashLineFilenameComment(SMLoc L, bool SaveLocInfo) {
   CppHashInfo.Filename = Filename;
   CppHashInfo.LineNumber = LineNumber;
   CppHashInfo.Buf = CurBuffer;
-  if (FirstCppHashFilename.empty())
-    FirstCppHashFilename = Filename;
+  if (!HadCppHashFilename) {
+    HadCppHashFilename = true;
+    // If we haven't encountered any .file directives, then the first #line
+    // directive describes the "root" file and directory of the compilation
+    // unit.
+    if (getContext().getGenDwarfFileNumber() == 0) {
+      // It's preprocessed, so there is no checksum, and of course no source
+      // directive.
+      getContext().setMCLineTableRootFile(
+          /*CUID=*/0, getContext().getCompilationDir(), Filename,
+          /*Cksum=*/std::nullopt, /*Source=*/std::nullopt);
+    }
+  }
   return false;
 }
 

--- a/llvm/test/MC/ELF/debug-hash-file-empty-dwarf.s
+++ b/llvm/test/MC/ELF/debug-hash-file-empty-dwarf.s
@@ -1,0 +1,26 @@
+// RUN: llvm-mc -triple x86_64-unknown-linux-gnu -filetype obj -g -dwarf-version 5 -o %t %s
+// RUN: llvm-dwarfdump -debug-info -debug-line %t | FileCheck %s
+
+// CHECK-NOT: DW_TAG_
+
+// CHECK:      include_directories[ 0] =
+// CHECK-NOT:  include_directories[ 1] =
+// CHECK:      file_names[ 0]:
+// CHECK-NEXT:           name: "/MyTest/Inputs/other.S"
+// CHECK-NEXT:      dir_index: 0
+// CHECK-NOT:  file_names[ 1]:
+
+// RUN: llvm-mc -triple=x86_64 -filetype=obj -g -dwarf-version=5 -fdebug-prefix-map=/MyTest=/src_root %s -o %t.5.o
+// RUN: llvm-dwarfdump -debug-info -debug-line %t.5.o | FileCheck %s --check-prefixes=MAP
+
+// MAP-NOT: DW_TAG_
+
+// MAP:      include_directories[  0] = "{{.*}}"
+// MAP-NEXT: file_names[  0]:
+// MAP-NEXT:            name: "/src_root/Inputs/other.S"
+// MAP-NEXT:       dir_index: 0
+
+# 1 "/MyTest/Inputs/other.S"
+
+.section .data
+.asciz "data"


### PR DESCRIPTION
Update root file in DWARF file/line table as soon as we see the first "#line" directive.

This was moved from "enabledGenDwarfForAssembly", which is called right before we emit DWARF information. But if the file is empty or contains expressions that doesn't need DWARF, it is never called, leaving an original root file and not the file in the "#line" directive.

Add a test checking for this case.

Fixes: #119020