### PR TITLE
[libc++] Add #if 0 block to all the top-level headers

### DIFF
--- a/libcxx/include/algorithm
+++ b/libcxx/include/algorithm
@@ -1827,232 +1827,235 @@ template <class BidirectionalIterator, class Compare>
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__algorithm/adjacent_find.h>
-#include <__algorithm/all_of.h>
-#include <__algorithm/any_of.h>
-#include <__algorithm/binary_search.h>
-#include <__algorithm/copy.h>
-#include <__algorithm/copy_backward.h>
-#include <__algorithm/copy_if.h>
-#include <__algorithm/copy_n.h>
-#include <__algorithm/count.h>
-#include <__algorithm/count_if.h>
-#include <__algorithm/equal.h>
-#include <__algorithm/equal_range.h>
-#include <__algorithm/fill.h>
-#include <__algorithm/fill_n.h>
-#include <__algorithm/find.h>
-#include <__algorithm/find_end.h>
-#include <__algorithm/find_first_of.h>
-#include <__algorithm/find_if.h>
-#include <__algorithm/find_if_not.h>
-#include <__algorithm/for_each.h>
-#include <__algorithm/generate.h>
-#include <__algorithm/generate_n.h>
-#include <__algorithm/includes.h>
-#include <__algorithm/inplace_merge.h>
-#include <__algorithm/is_heap.h>
-#include <__algorithm/is_heap_until.h>
-#include <__algorithm/is_partitioned.h>
-#include <__algorithm/is_permutation.h>
-#include <__algorithm/is_sorted.h>
-#include <__algorithm/is_sorted_until.h>
-#include <__algorithm/iter_swap.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lower_bound.h>
-#include <__algorithm/make_heap.h>
-#include <__algorithm/max.h>
-#include <__algorithm/max_element.h>
-#include <__algorithm/merge.h>
-#include <__algorithm/min.h>
-#include <__algorithm/min_element.h>
-#include <__algorithm/minmax.h>
-#include <__algorithm/minmax_element.h>
-#include <__algorithm/mismatch.h>
-#include <__algorithm/move.h>
-#include <__algorithm/move_backward.h>
-#include <__algorithm/next_permutation.h>
-#include <__algorithm/none_of.h>
-#include <__algorithm/nth_element.h>
-#include <__algorithm/partial_sort.h>
-#include <__algorithm/partial_sort_copy.h>
-#include <__algorithm/partition.h>
-#include <__algorithm/partition_copy.h>
-#include <__algorithm/partition_point.h>
-#include <__algorithm/pop_heap.h>
-#include <__algorithm/prev_permutation.h>
-#include <__algorithm/push_heap.h>
-#include <__algorithm/remove.h>
-#include <__algorithm/remove_copy.h>
-#include <__algorithm/remove_copy_if.h>
-#include <__algorithm/remove_if.h>
-#include <__algorithm/replace.h>
-#include <__algorithm/replace_copy.h>
-#include <__algorithm/replace_copy_if.h>
-#include <__algorithm/replace_if.h>
-#include <__algorithm/reverse.h>
-#include <__algorithm/reverse_copy.h>
-#include <__algorithm/rotate.h>
-#include <__algorithm/rotate_copy.h>
-#include <__algorithm/search.h>
-#include <__algorithm/search_n.h>
-#include <__algorithm/set_difference.h>
-#include <__algorithm/set_intersection.h>
-#include <__algorithm/set_symmetric_difference.h>
-#include <__algorithm/set_union.h>
-#include <__algorithm/shuffle.h>
-#include <__algorithm/sort.h>
-#include <__algorithm/sort_heap.h>
-#include <__algorithm/stable_partition.h>
-#include <__algorithm/stable_sort.h>
-#include <__algorithm/swap_ranges.h>
-#include <__algorithm/transform.h>
-#include <__algorithm/unique.h>
-#include <__algorithm/unique_copy.h>
-#include <__algorithm/upper_bound.h>
+#  include <__algorithm/adjacent_find.h>
+#  include <__algorithm/all_of.h>
+#  include <__algorithm/any_of.h>
+#  include <__algorithm/binary_search.h>
+#  include <__algorithm/copy.h>
+#  include <__algorithm/copy_backward.h>
+#  include <__algorithm/copy_if.h>
+#  include <__algorithm/copy_n.h>
+#  include <__algorithm/count.h>
+#  include <__algorithm/count_if.h>
+#  include <__algorithm/equal.h>
+#  include <__algorithm/equal_range.h>
+#  include <__algorithm/fill.h>
+#  include <__algorithm/fill_n.h>
+#  include <__algorithm/find.h>
+#  include <__algorithm/find_end.h>
+#  include <__algorithm/find_first_of.h>
+#  include <__algorithm/find_if.h>
+#  include <__algorithm/find_if_not.h>
+#  include <__algorithm/for_each.h>
+#  include <__algorithm/generate.h>
+#  include <__algorithm/generate_n.h>
+#  include <__algorithm/includes.h>
+#  include <__algorithm/inplace_merge.h>
+#  include <__algorithm/is_heap.h>
+#  include <__algorithm/is_heap_until.h>
+#  include <__algorithm/is_partitioned.h>
+#  include <__algorithm/is_permutation.h>
+#  include <__algorithm/is_sorted.h>
+#  include <__algorithm/is_sorted_until.h>
+#  include <__algorithm/iter_swap.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lower_bound.h>
+#  include <__algorithm/make_heap.h>
+#  include <__algorithm/max.h>
+#  include <__algorithm/max_element.h>
+#  include <__algorithm/merge.h>
+#  include <__algorithm/min.h>
+#  include <__algorithm/min_element.h>
+#  include <__algorithm/minmax.h>
+#  include <__algorithm/minmax_element.h>
+#  include <__algorithm/mismatch.h>
+#  include <__algorithm/move.h>
+#  include <__algorithm/move_backward.h>
+#  include <__algorithm/next_permutation.h>
+#  include <__algorithm/none_of.h>
+#  include <__algorithm/nth_element.h>
+#  include <__algorithm/partial_sort.h>
+#  include <__algorithm/partial_sort_copy.h>
+#  include <__algorithm/partition.h>
+#  include <__algorithm/partition_copy.h>
+#  include <__algorithm/partition_point.h>
+#  include <__algorithm/pop_heap.h>
+#  include <__algorithm/prev_permutation.h>
+#  include <__algorithm/push_heap.h>
+#  include <__algorithm/remove.h>
+#  include <__algorithm/remove_copy.h>
+#  include <__algorithm/remove_copy_if.h>
+#  include <__algorithm/remove_if.h>
+#  include <__algorithm/replace.h>
+#  include <__algorithm/replace_copy.h>
+#  include <__algorithm/replace_copy_if.h>
+#  include <__algorithm/replace_if.h>
+#  include <__algorithm/reverse.h>
+#  include <__algorithm/reverse_copy.h>
+#  include <__algorithm/rotate.h>
+#  include <__algorithm/rotate_copy.h>
+#  include <__algorithm/search.h>
+#  include <__algorithm/search_n.h>
+#  include <__algorithm/set_difference.h>
+#  include <__algorithm/set_intersection.h>
+#  include <__algorithm/set_symmetric_difference.h>
+#  include <__algorithm/set_union.h>
+#  include <__algorithm/shuffle.h>
+#  include <__algorithm/sort.h>
+#  include <__algorithm/sort_heap.h>
+#  include <__algorithm/stable_partition.h>
+#  include <__algorithm/stable_sort.h>
+#  include <__algorithm/swap_ranges.h>
+#  include <__algorithm/transform.h>
+#  include <__algorithm/unique.h>
+#  include <__algorithm/unique_copy.h>
+#  include <__algorithm/upper_bound.h>
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__algorithm/clamp.h>
-#  include <__algorithm/for_each_n.h>
-#  include <__algorithm/pstl.h>
-#  include <__algorithm/sample.h>
-#endif // _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
+#    include <__algorithm/clamp.h>
+#    include <__algorithm/for_each_n.h>
+#    include <__algorithm/pstl.h>
+#    include <__algorithm/sample.h>
+#  endif // _LIBCPP_STD_VER >= 17
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__algorithm/in_found_result.h>
-#  include <__algorithm/in_fun_result.h>
-#  include <__algorithm/in_in_out_result.h>
-#  include <__algorithm/in_in_result.h>
-#  include <__algorithm/in_out_out_result.h>
-#  include <__algorithm/in_out_result.h>
-#  include <__algorithm/lexicographical_compare_three_way.h>
-#  include <__algorithm/min_max_result.h>
-#  include <__algorithm/ranges_adjacent_find.h>
-#  include <__algorithm/ranges_all_of.h>
-#  include <__algorithm/ranges_any_of.h>
-#  include <__algorithm/ranges_binary_search.h>
-#  include <__algorithm/ranges_clamp.h>
-#  include <__algorithm/ranges_contains.h>
-#  include <__algorithm/ranges_copy.h>
-#  include <__algorithm/ranges_copy_backward.h>
-#  include <__algorithm/ranges_copy_if.h>
-#  include <__algorithm/ranges_copy_n.h>
-#  include <__algorithm/ranges_count.h>
-#  include <__algorithm/ranges_count_if.h>
-#  include <__algorithm/ranges_equal.h>
-#  include <__algorithm/ranges_equal_range.h>
-#  include <__algorithm/ranges_fill.h>
-#  include <__algorithm/ranges_fill_n.h>
-#  include <__algorithm/ranges_find.h>
-#  include <__algorithm/ranges_find_end.h>
-#  include <__algorithm/ranges_find_first_of.h>
-#  include <__algorithm/ranges_find_if.h>
-#  include <__algorithm/ranges_find_if_not.h>
-#  include <__algorithm/ranges_for_each.h>
-#  include <__algorithm/ranges_for_each_n.h>
-#  include <__algorithm/ranges_generate.h>
-#  include <__algorithm/ranges_generate_n.h>
-#  include <__algorithm/ranges_includes.h>
-#  include <__algorithm/ranges_inplace_merge.h>
-#  include <__algorithm/ranges_is_heap.h>
-#  include <__algorithm/ranges_is_heap_until.h>
-#  include <__algorithm/ranges_is_partitioned.h>
-#  include <__algorithm/ranges_is_permutation.h>
-#  include <__algorithm/ranges_is_sorted.h>
-#  include <__algorithm/ranges_is_sorted_until.h>
-#  include <__algorithm/ranges_lexicographical_compare.h>
-#  include <__algorithm/ranges_lower_bound.h>
-#  include <__algorithm/ranges_make_heap.h>
-#  include <__algorithm/ranges_max.h>
-#  include <__algorithm/ranges_max_element.h>
-#  include <__algorithm/ranges_merge.h>
-#  include <__algorithm/ranges_min.h>
-#  include <__algorithm/ranges_min_element.h>
-#  include <__algorithm/ranges_minmax.h>
-#  include <__algorithm/ranges_minmax_element.h>
-#  include <__algorithm/ranges_mismatch.h>
-#  include <__algorithm/ranges_move.h>
-#  include <__algorithm/ranges_move_backward.h>
-#  include <__algorithm/ranges_next_permutation.h>
-#  include <__algorithm/ranges_none_of.h>
-#  include <__algorithm/ranges_nth_element.h>
-#  include <__algorithm/ranges_partial_sort.h>
-#  include <__algorithm/ranges_partial_sort_copy.h>
-#  include <__algorithm/ranges_partition.h>
-#  include <__algorithm/ranges_partition_copy.h>
-#  include <__algorithm/ranges_partition_point.h>
-#  include <__algorithm/ranges_pop_heap.h>
-#  include <__algorithm/ranges_prev_permutation.h>
-#  include <__algorithm/ranges_push_heap.h>
-#  include <__algorithm/ranges_remove.h>
-#  include <__algorithm/ranges_remove_copy.h>
-#  include <__algorithm/ranges_remove_copy_if.h>
-#  include <__algorithm/ranges_remove_if.h>
-#  include <__algorithm/ranges_replace.h>
-#  include <__algorithm/ranges_replace_copy.h>
-#  include <__algorithm/ranges_replace_copy_if.h>
-#  include <__algorithm/ranges_replace_if.h>
-#  include <__algorithm/ranges_reverse.h>
-#  include <__algorithm/ranges_reverse_copy.h>
-#  include <__algorithm/ranges_rotate.h>
-#  include <__algorithm/ranges_rotate_copy.h>
-#  include <__algorithm/ranges_sample.h>
-#  include <__algorithm/ranges_search.h>
-#  include <__algorithm/ranges_search_n.h>
-#  include <__algorithm/ranges_set_difference.h>
-#  include <__algorithm/ranges_set_intersection.h>
-#  include <__algorithm/ranges_set_symmetric_difference.h>
-#  include <__algorithm/ranges_set_union.h>
-#  include <__algorithm/ranges_shuffle.h>
-#  include <__algorithm/ranges_sort.h>
-#  include <__algorithm/ranges_sort_heap.h>
-#  include <__algorithm/ranges_stable_partition.h>
-#  include <__algorithm/ranges_stable_sort.h>
-#  include <__algorithm/ranges_swap_ranges.h>
-#  include <__algorithm/ranges_transform.h>
-#  include <__algorithm/ranges_unique.h>
-#  include <__algorithm/ranges_unique_copy.h>
-#  include <__algorithm/ranges_upper_bound.h>
-#  include <__algorithm/shift_left.h>
-#  include <__algorithm/shift_right.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__algorithm/in_found_result.h>
+#    include <__algorithm/in_fun_result.h>
+#    include <__algorithm/in_in_out_result.h>
+#    include <__algorithm/in_in_result.h>
+#    include <__algorithm/in_out_out_result.h>
+#    include <__algorithm/in_out_result.h>
+#    include <__algorithm/lexicographical_compare_three_way.h>
+#    include <__algorithm/min_max_result.h>
+#    include <__algorithm/ranges_adjacent_find.h>
+#    include <__algorithm/ranges_all_of.h>
+#    include <__algorithm/ranges_any_of.h>
+#    include <__algorithm/ranges_binary_search.h>
+#    include <__algorithm/ranges_clamp.h>
+#    include <__algorithm/ranges_contains.h>
+#    include <__algorithm/ranges_copy.h>
+#    include <__algorithm/ranges_copy_backward.h>
+#    include <__algorithm/ranges_copy_if.h>
+#    include <__algorithm/ranges_copy_n.h>
+#    include <__algorithm/ranges_count.h>
+#    include <__algorithm/ranges_count_if.h>
+#    include <__algorithm/ranges_equal.h>
+#    include <__algorithm/ranges_equal_range.h>
+#    include <__algorithm/ranges_fill.h>
+#    include <__algorithm/ranges_fill_n.h>
+#    include <__algorithm/ranges_find.h>
+#    include <__algorithm/ranges_find_end.h>
+#    include <__algorithm/ranges_find_first_of.h>
+#    include <__algorithm/ranges_find_if.h>
+#    include <__algorithm/ranges_find_if_not.h>
+#    include <__algorithm/ranges_for_each.h>
+#    include <__algorithm/ranges_for_each_n.h>
+#    include <__algorithm/ranges_generate.h>
+#    include <__algorithm/ranges_generate_n.h>
+#    include <__algorithm/ranges_includes.h>
+#    include <__algorithm/ranges_inplace_merge.h>
+#    include <__algorithm/ranges_is_heap.h>
+#    include <__algorithm/ranges_is_heap_until.h>
+#    include <__algorithm/ranges_is_partitioned.h>
+#    include <__algorithm/ranges_is_permutation.h>
+#    include <__algorithm/ranges_is_sorted.h>
+#    include <__algorithm/ranges_is_sorted_until.h>
+#    include <__algorithm/ranges_lexicographical_compare.h>
+#    include <__algorithm/ranges_lower_bound.h>
+#    include <__algorithm/ranges_make_heap.h>
+#    include <__algorithm/ranges_max.h>
+#    include <__algorithm/ranges_max_element.h>
+#    include <__algorithm/ranges_merge.h>
+#    include <__algorithm/ranges_min.h>
+#    include <__algorithm/ranges_min_element.h>
+#    include <__algorithm/ranges_minmax.h>
+#    include <__algorithm/ranges_minmax_element.h>
+#    include <__algorithm/ranges_mismatch.h>
+#    include <__algorithm/ranges_move.h>
+#    include <__algorithm/ranges_move_backward.h>
+#    include <__algorithm/ranges_next_permutation.h>
+#    include <__algorithm/ranges_none_of.h>
+#    include <__algorithm/ranges_nth_element.h>
+#    include <__algorithm/ranges_partial_sort.h>
+#    include <__algorithm/ranges_partial_sort_copy.h>
+#    include <__algorithm/ranges_partition.h>
+#    include <__algorithm/ranges_partition_copy.h>
+#    include <__algorithm/ranges_partition_point.h>
+#    include <__algorithm/ranges_pop_heap.h>
+#    include <__algorithm/ranges_prev_permutation.h>
+#    include <__algorithm/ranges_push_heap.h>
+#    include <__algorithm/ranges_remove.h>
+#    include <__algorithm/ranges_remove_copy.h>
+#    include <__algorithm/ranges_remove_copy_if.h>
+#    include <__algorithm/ranges_remove_if.h>
+#    include <__algorithm/ranges_replace.h>
+#    include <__algorithm/ranges_replace_copy.h>
+#    include <__algorithm/ranges_replace_copy_if.h>
+#    include <__algorithm/ranges_replace_if.h>
+#    include <__algorithm/ranges_reverse.h>
+#    include <__algorithm/ranges_reverse_copy.h>
+#    include <__algorithm/ranges_rotate.h>
+#    include <__algorithm/ranges_rotate_copy.h>
+#    include <__algorithm/ranges_sample.h>
+#    include <__algorithm/ranges_search.h>
+#    include <__algorithm/ranges_search_n.h>
+#    include <__algorithm/ranges_set_difference.h>
+#    include <__algorithm/ranges_set_intersection.h>
+#    include <__algorithm/ranges_set_symmetric_difference.h>
+#    include <__algorithm/ranges_set_union.h>
+#    include <__algorithm/ranges_shuffle.h>
+#    include <__algorithm/ranges_sort.h>
+#    include <__algorithm/ranges_sort_heap.h>
+#    include <__algorithm/ranges_stable_partition.h>
+#    include <__algorithm/ranges_stable_sort.h>
+#    include <__algorithm/ranges_swap_ranges.h>
+#    include <__algorithm/ranges_transform.h>
+#    include <__algorithm/ranges_unique.h>
+#    include <__algorithm/ranges_unique_copy.h>
+#    include <__algorithm/ranges_upper_bound.h>
+#    include <__algorithm/shift_left.h>
+#    include <__algorithm/shift_right.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__algorithm/ranges_contains_subrange.h>
-#  include <__algorithm/ranges_ends_with.h>
-#  include <__algorithm/ranges_find_last.h>
-#  include <__algorithm/ranges_fold.h>
-#  include <__algorithm/ranges_starts_with.h>
-#endif // _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
+#    include <__algorithm/ranges_contains_subrange.h>
+#    include <__algorithm/ranges_ends_with.h>
+#    include <__algorithm/ranges_find_last.h>
+#    include <__algorithm/ranges_fold.h>
+#    include <__algorithm/ranges_starts_with.h>
+#  endif // _LIBCPP_STD_VER >= 23
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [algorithm.syn]
-#include <initializer_list>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 14
-#  include <execution>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 14
+#    include <execution>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <bit>
-#  include <concepts>
-#  include <cstdlib>
-#  include <cstring>
-#  include <iterator>
-#  include <memory>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <bit>
+#    include <concepts>
+#    include <cstdlib>
+#    include <cstring>
+#    include <iterator>
+#    include <memory>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_ALGORITHM

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -80,41 +80,43 @@ namespace std {
 
 */
 
-#include <__config>
-#include <__memory/allocator.h>
-#include <__memory/allocator_destructor.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/unique_ptr.h>
-#include <__type_traits/add_cv_quals.h>
-#include <__type_traits/add_pointer.h>
-#include <__type_traits/aligned_storage.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/decay.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_function.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_void.h>
-#include <__type_traits/remove_cv.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
-#include <__utility/forward.h>
-#include <__utility/in_place.h>
-#include <__utility/move.h>
-#include <__utility/unreachable.h>
-#include <__verbose_abort>
-#include <initializer_list>
-#include <typeinfo>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_destructor.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/unique_ptr.h>
+#  include <__type_traits/add_cv_quals.h>
+#  include <__type_traits/add_pointer.h>
+#  include <__type_traits/aligned_storage.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/decay.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_function.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_reference.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_void.h>
+#  include <__type_traits/remove_cv.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__utility/forward.h>
+#  include <__utility/in_place.h>
+#  include <__utility/move.h>
+#  include <__utility/unreachable.h>
+#  include <__verbose_abort>
+#  include <initializer_list>
+#  include <typeinfo>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 namespace std {
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_AVAILABILITY_BAD_ANY_CAST bad_any_cast : public bad_cast {
@@ -125,14 +127,14 @@ public:
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 
 [[noreturn]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_ANY_CAST void __throw_bad_any_cast() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   throw bad_any_cast();
-#  else
+#    else
   _LIBCPP_VERBOSE_ABORT("bad_any_cast was thrown in -fno-exceptions mode");
-#  endif
+#    endif
 }
 
 // Forward declarations
@@ -174,10 +176,10 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr const void* __get_fallback_typeid() {
 
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI bool __compare_typeid(type_info const* __id, const void* __fallback_id) {
-#  if _LIBCPP_HAS_RTTI
+#    if _LIBCPP_HAS_RTTI
   if (__id && *__id == typeid(_Tp))
     return true;
-#  endif
+#    endif
   return !__id && __fallback_id == __any_imp::__get_fallback_typeid<_Tp>();
 }
 
@@ -264,7 +266,7 @@ public:
   // 6.3.4 any observers
   _LIBCPP_HIDE_FROM_ABI bool has_value() const _NOEXCEPT { return __h_ != nullptr; }
 
-#  if _LIBCPP_HAS_RTTI
+#    if _LIBCPP_HAS_RTTI
   _LIBCPP_HIDE_FROM_ABI const type_info& type() const _NOEXCEPT {
     if (__h_) {
       return *static_cast<type_info const*>(this->__call(_Action::_TypeInfo));
@@ -272,7 +274,7 @@ public:
       return typeid(void);
     }
   }
-#  endif
+#    endif
 
 private:
   typedef __any_imp::_Action _Action;
@@ -370,11 +372,11 @@ private:
   }
 
   _LIBCPP_HIDE_FROM_ABI static void* __type_info() {
-#  if _LIBCPP_HAS_RTTI
+#    if _LIBCPP_HAS_RTTI
     return const_cast<void*>(static_cast<void const*>(&typeid(_Tp)));
-#  else
+#    else
     return nullptr;
-#  endif
+#    endif
   }
 };
 
@@ -442,11 +444,11 @@ private:
   }
 
   _LIBCPP_HIDE_FROM_ABI static void* __type_info() {
-#  if _LIBCPP_HAS_RTTI
+#    if _LIBCPP_HAS_RTTI
     return const_cast<void*>(static_cast<void const*>(&typeid(_Tp)));
-#  else
+#    else
     return nullptr;
-#  endif
+#    endif
   }
 };
 
@@ -577,37 +579,38 @@ _LIBCPP_HIDE_FROM_ABI add_pointer_t<_ValueType> any_cast(any* __any) _NOEXCEPT {
     void* __p = __any->__call(
         _Action::_Get,
         nullptr,
-#  if _LIBCPP_HAS_RTTI
+#    if _LIBCPP_HAS_RTTI
         &typeid(_ValueType),
-#  else
+#    else
         nullptr,
-#  endif
+#    endif
         __any_imp::__get_fallback_typeid<_ValueType>());
     return std::__pointer_or_func_cast<_ReturnType>(__p, is_function<_ValueType>{});
   }
   return nullptr;
 }
 
-#endif // _LIBCPP_STD_VER >= 17
+#  endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
-#  include <chrono>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#    include <chrono>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <iterator>
-#  include <memory>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <variant>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <iterator>
+#    include <memory>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <variant>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_ANY

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -111,60 +111,62 @@ template <size_t I, class T, size_t N> const T&& get(const array<T, N>&&) noexce
 
 */
 
-#include <__algorithm/equal.h>
-#include <__algorithm/fill_n.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lexicographical_compare_three_way.h>
-#include <__algorithm/swap_ranges.h>
-#include <__assert>
-#include <__config>
-#include <__cstddef/ptrdiff_t.h>
-#include <__fwd/array.h>
-#include <__iterator/reverse_iterator.h>
-#include <__iterator/static_bounded_iter.h>
-#include <__iterator/wrap_iter.h>
-#include <__tuple/sfinae_helpers.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/conjunction.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_const.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/is_trivially_relocatable.h>
-#include <__type_traits/remove_cv.h>
-#include <__utility/empty.h>
-#include <__utility/integer_sequence.h>
-#include <__utility/move.h>
-#include <__utility/unreachable.h>
-#include <stdexcept>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/equal.h>
+#  include <__algorithm/fill_n.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lexicographical_compare_three_way.h>
+#  include <__algorithm/swap_ranges.h>
+#  include <__assert>
+#  include <__config>
+#  include <__cstddef/ptrdiff_t.h>
+#  include <__fwd/array.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__iterator/static_bounded_iter.h>
+#  include <__iterator/wrap_iter.h>
+#  include <__tuple/sfinae_helpers.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/conjunction.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_const.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/is_trivially_relocatable.h>
+#  include <__type_traits/remove_cv.h>
+#  include <__utility/empty.h>
+#  include <__utility/integer_sequence.h>
+#  include <__utility/move.h>
+#  include <__utility/unreachable.h>
+#  include <stdexcept>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [array.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
 // [tuple.helper]
-#include <__tuple/tuple_element.h>
-#include <__tuple/tuple_size.h>
+#  include <__tuple/tuple_element.h>
+#  include <__tuple/tuple_size.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -179,16 +181,16 @@ struct _LIBCPP_TEMPLATE_VIS array {
   using const_reference = const value_type&;
   using pointer         = value_type*;
   using const_pointer   = const value_type*;
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
   using iterator       = __static_bounded_iter<pointer, _Size>;
   using const_iterator = __static_bounded_iter<const_pointer, _Size>;
-#elif defined(_LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY)
+#  elif defined(_LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY)
   using iterator       = __wrap_iter<pointer>;
   using const_iterator = __wrap_iter<const_pointer>;
-#else
+#  else
   using iterator       = pointer;
   using const_iterator = const_pointer;
-#endif
+#  endif
   using size_type              = size_t;
   using difference_type        = ptrdiff_t;
   using reverse_iterator       = std::reverse_iterator<iterator>;
@@ -207,32 +209,32 @@ struct _LIBCPP_TEMPLATE_VIS array {
 
   // iterators:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 iterator begin() _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<_Size>(data(), data());
-#else
+#  else
     return iterator(data());
-#endif
+#  endif
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 const_iterator begin() const _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<_Size>(data(), data());
-#else
+#  else
     return const_iterator(data());
-#endif
+#  endif
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 iterator end() _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<_Size>(data() + _Size, data());
-#else
+#  else
     return iterator(data() + _Size);
-#endif
+#  endif
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 const_iterator end() const _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<_Size>(data() + _Size, data());
-#else
+#  else
     return const_iterator(data() + _Size);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator rbegin() _NOEXCEPT {
@@ -302,16 +304,16 @@ struct _LIBCPP_TEMPLATE_VIS array<_Tp, 0> {
   using const_reference = const value_type&;
   using pointer         = value_type*;
   using const_pointer   = const value_type*;
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
   using iterator       = __static_bounded_iter<pointer, 0>;
   using const_iterator = __static_bounded_iter<const_pointer, 0>;
-#elif defined(_LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY)
+#  elif defined(_LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY)
   using iterator       = __wrap_iter<pointer>;
   using const_iterator = __wrap_iter<const_pointer>;
-#else
+#  else
   using iterator       = pointer;
   using const_iterator = const_pointer;
-#endif
+#  endif
   using size_type              = size_t;
   using difference_type        = ptrdiff_t;
   using reverse_iterator       = std::reverse_iterator<iterator>;
@@ -338,32 +340,32 @@ struct _LIBCPP_TEMPLATE_VIS array<_Tp, 0> {
 
   // iterators:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 iterator begin() _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<0>(data(), data());
-#else
+#  else
     return iterator(data());
-#endif
+#  endif
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 const_iterator begin() const _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<0>(data(), data());
-#else
+#  else
     return const_iterator(data());
-#endif
+#  endif
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 iterator end() _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<0>(data(), data());
-#else
+#  else
     return iterator(data());
-#endif
+#  endif
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 const_iterator end() const _NOEXCEPT {
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS_IN_STD_ARRAY)
     return std::__make_static_bounded_iter<0>(data(), data());
-#else
+#  else
     return const_iterator(data());
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 reverse_iterator rbegin() _NOEXCEPT {
@@ -433,10 +435,10 @@ struct _LIBCPP_TEMPLATE_VIS array<_Tp, 0> {
   }
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _Tp, class... _Args, class = enable_if_t<__all<_IsSame<_Tp, _Args>::value...>::value> >
 array(_Tp, _Args...) -> array<_Tp, 1 + sizeof...(_Args)>;
-#endif
+#  endif
 
 template <class _Tp, size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool
@@ -444,7 +446,7 @@ operator==(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y) {
   return std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Tp, size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y) {
@@ -471,7 +473,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator>=(const array<_Tp, _Size>& __x, const
   return !(__x < __y);
 }
 
-#else // _LIBCPP_STD_VER <= 17
+#  else // _LIBCPP_STD_VER <= 17
 
 template <class _Tp, size_t _Size>
 _LIBCPP_HIDE_FROM_ABI constexpr __synth_three_way_result<_Tp>
@@ -479,7 +481,7 @@ operator<=>(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y) {
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
-#endif // _LIBCPP_STD_VER <= 17
+#  endif // _LIBCPP_STD_VER <= 17
 
 template <class _Tp, size_t _Size, __enable_if_t<_Size == 0 || __is_swappable_v<_Tp>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(array<_Tp, _Size>& __x, array<_Tp, _Size>& __y)
@@ -520,7 +522,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp&& get(const
   return std::move(__a.__elems_[_Ip]);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 template <typename _Tp, size_t _Size, size_t... _Index>
 _LIBCPP_HIDE_FROM_ABI constexpr array<remove_cv_t<_Tp>, _Size>
@@ -550,19 +552,20 @@ to_array(_Tp (&&__arr)[_Size]) noexcept(is_nothrow_move_constructible_v<_Tp>) {
   return std::__to_array_rvalue_impl(std::move(__arr), make_index_sequence<_Size>());
 }
 
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iterator>
-#  include <type_traits>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iterator>
+#    include <type_traits>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_ARRAY

--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -587,41 +587,44 @@ template <class T>
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__atomic/aliases.h>
-#include <__atomic/atomic.h>
-#include <__atomic/atomic_flag.h>
-#include <__atomic/atomic_init.h>
-#include <__atomic/atomic_lock_free.h>
-#include <__atomic/atomic_sync.h>
-#include <__atomic/check_memory_order.h>
-#include <__atomic/contention_t.h>
-#include <__atomic/fence.h>
-#include <__atomic/is_always_lock_free.h>
-#include <__atomic/kill_dependency.h>
-#include <__atomic/memory_order.h>
-#include <version>
+#  include <__atomic/aliases.h>
+#  include <__atomic/atomic.h>
+#  include <__atomic/atomic_flag.h>
+#  include <__atomic/atomic_init.h>
+#  include <__atomic/atomic_lock_free.h>
+#  include <__atomic/atomic_sync.h>
+#  include <__atomic/check_memory_order.h>
+#  include <__atomic/contention_t.h>
+#  include <__atomic/fence.h>
+#  include <__atomic/is_always_lock_free.h>
+#  include <__atomic/kill_dependency.h>
+#  include <__atomic/memory_order.h>
+#  include <version>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__atomic/atomic_ref.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__atomic/atomic_ref.h>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !_LIBCPP_HAS_ATOMIC_HEADER
-#  error <atomic> is not implemented
-#endif
+#  if !_LIBCPP_HAS_ATOMIC_HEADER
+#    error <atomic> is not implemented
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cmath>
-#  include <compare>
-#  include <cstddef>
-#  include <cstdlib>
-#  include <cstring>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cmath>
+#    include <compare>
+#    include <cstddef>
+#    include <cstdlib>
+#    include <cstring>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_ATOMIC

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -45,30 +45,32 @@ namespace std
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  include <__assert>
-#  include <__atomic/atomic.h>
-#  include <__atomic/memory_order.h>
-#  include <__cstddef/ptrdiff_t.h>
-#  include <__memory/unique_ptr.h>
-#  include <__thread/poll_with_backoff.h>
-#  include <__thread/timed_backoff_policy.h>
-#  include <__utility/move.h>
-#  include <cstdint>
-#  include <limits>
-#  include <version>
+#    include <__assert>
+#    include <__atomic/atomic.h>
+#    include <__atomic/memory_order.h>
+#    include <__cstddef/ptrdiff_t.h>
+#    include <__memory/unique_ptr.h>
+#    include <__thread/poll_with_backoff.h>
+#    include <__thread/timed_backoff_policy.h>
+#    include <__utility/move.h>
+#    include <cstdint>
+#    include <limits>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -76,7 +78,7 @@ struct __empty_completion {
   inline _LIBCPP_HIDE_FROM_ABI void operator()() noexcept {}
 };
 
-#    ifndef _LIBCPP_HAS_NO_TREE_BARRIER
+#      ifndef _LIBCPP_HAS_NO_TREE_BARRIER
 
 /*
 
@@ -150,7 +152,7 @@ public:
   }
 };
 
-#    else
+#      else
 
 /*
 
@@ -251,7 +253,7 @@ public:
   }
 };
 
-#    endif // !_LIBCPP_HAS_NO_TREE_BARRIER
+#      endif // !_LIBCPP_HAS_NO_TREE_BARRIER
 
 template <class _CompletionF = __empty_completion>
 class barrier {
@@ -290,19 +292,20 @@ public:
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_THREADS
+#  endif // _LIBCPP_HAS_THREADS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <iterator>
-#  include <memory>
-#  include <stdexcept>
-#  include <variant>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <iterator>
+#    include <memory>
+#    include <stdexcept>
+#    include <variant>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_BARRIER

--- a/libcxx/include/bit
+++ b/libcxx/include/bit
@@ -61,37 +61,40 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__bit/bit_cast.h>
-#  include <__bit/bit_ceil.h>
-#  include <__bit/bit_floor.h>
-#  include <__bit/bit_log2.h>
-#  include <__bit/bit_width.h>
-#  include <__bit/countl.h>
-#  include <__bit/countr.h>
-#  include <__bit/endian.h>
-#  include <__bit/has_single_bit.h>
-#  include <__bit/popcount.h>
-#  include <__bit/rotate.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__bit/bit_cast.h>
+#    include <__bit/bit_ceil.h>
+#    include <__bit/bit_floor.h>
+#    include <__bit/bit_log2.h>
+#    include <__bit/bit_width.h>
+#    include <__bit/countl.h>
+#    include <__bit/countr.h>
+#    include <__bit/endian.h>
+#    include <__bit/has_single_bit.h>
+#    include <__bit/popcount.h>
+#    include <__bit/rotate.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__bit/byteswap.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__bit/byteswap.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <limits>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <limits>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_BIT

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -126,32 +126,34 @@ template <size_t N> struct hash<std::bitset<N>>;
 
 // clang-format on
 
-#include <__algorithm/count.h>
-#include <__algorithm/fill.h>
-#include <__algorithm/fill_n.h>
-#include <__algorithm/find.h>
-#include <__bit_reference>
-#include <__config>
-#include <__functional/hash.h>
-#include <__functional/unary_function.h>
-#include <__type_traits/is_char_like_type.h>
-#include <climits>
-#include <stdexcept>
-#include <string_view>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/count.h>
+#  include <__algorithm/fill.h>
+#  include <__algorithm/fill_n.h>
+#  include <__algorithm/find.h>
+#  include <__bit_reference>
+#  include <__config>
+#  include <__functional/hash.h>
+#  include <__functional/unary_function.h>
+#  include <__type_traits/is_char_like_type.h>
+#  include <climits>
+#  include <stdexcept>
+#  include <string_view>
+#  include <version>
 
 // standard-mandated includes
 
 // [bitset.syn]
-#include <iosfwd>
-#include <string>
+#  include <iosfwd>
+#  include <string>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -222,10 +224,10 @@ protected:
   _LIBCPP_HIDE_FROM_ABI size_t __hash_code() const _NOEXCEPT;
 
 private:
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
   void __init(unsigned long long __v, false_type) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI void __init(unsigned long long __v, true_type) _NOEXCEPT;
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long to_ulong(false_type) const;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long to_ulong(true_type) const;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unsigned long long to_ullong(false_type) const;
@@ -236,16 +238,16 @@ private:
 
 template <size_t _N_words, size_t _Size>
 inline _LIBCPP_CONSTEXPR __bitset<_N_words, _Size>::__bitset() _NOEXCEPT
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     : __first_{0}
-#endif
+#  endif
 {
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
   std::fill_n(__first_, _N_words, __storage_type(0));
-#endif
+#  endif
 }
 
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
 
 template <size_t _N_words, size_t _Size>
 void __bitset<_N_words, _Size>::__init(unsigned long long __v, false_type) _NOEXCEPT {
@@ -271,27 +273,27 @@ inline _LIBCPP_HIDE_FROM_ABI void __bitset<_N_words, _Size>::__init(unsigned lon
   std::fill(__first_ + 1, __first_ + sizeof(__first_) / sizeof(__first_[0]), __storage_type(0));
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <size_t _N_words, size_t _Size>
 inline _LIBCPP_CONSTEXPR __bitset<_N_words, _Size>::__bitset(unsigned long long __v) _NOEXCEPT
-#ifndef _LIBCPP_CXX03_LANG
-#  if __SIZEOF_SIZE_T__ == 8
+#  ifndef _LIBCPP_CXX03_LANG
+#    if __SIZEOF_SIZE_T__ == 8
     : __first_{__v}
-#  elif __SIZEOF_SIZE_T__ == 4
+#    elif __SIZEOF_SIZE_T__ == 4
     : __first_{static_cast<__storage_type>(__v),
                _Size >= 2 * __bits_per_word
                    ? static_cast<__storage_type>(__v >> __bits_per_word)
                    : static_cast<__storage_type>((__v >> __bits_per_word) &
                                                  (__storage_type(1) << (_Size - __bits_per_word)) - 1)}
-#  else
-#    error This constructor has not been ported to this platform
+#    else
+#      error This constructor has not been ported to this platform
+#    endif
 #  endif
-#endif
 {
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
   __init(__v, integral_constant<bool, sizeof(unsigned long long) == sizeof(__storage_type)>());
-#endif
+#  endif
 }
 
 template <size_t _N_words, size_t _Size>
@@ -623,18 +625,18 @@ public:
   template <class _CharT, __enable_if_t<_IsCharLikeType<_CharT>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit bitset(
       const _CharT* __str,
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
       typename basic_string_view<_CharT>::size_type __n = basic_string_view<_CharT>::npos,
-#else
+#  else
       typename basic_string<_CharT>::size_type __n = basic_string<_CharT>::npos,
-#endif
+#  endif
       _CharT __zero = _CharT('0'),
       _CharT __one  = _CharT('1')) {
 
     size_t __rlen = std::min(__n, char_traits<_CharT>::length(__str));
     __init_from_string_view(basic_string_view<_CharT>(__str, __rlen), __zero, __one);
   }
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
   template <class _CharT, class _Traits>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit bitset(
       basic_string_view<_CharT, _Traits> __str,
@@ -648,7 +650,7 @@ public:
     size_t __rlen = std::min(__n, __str.size() - __pos);
     __init_from_string_view(basic_string_view<_CharT, _Traits>(__str.data() + __pos, __rlen), __zero, __one);
   }
-#endif
+#  endif
   template <class _CharT, class _Traits, class _Allocator>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 explicit bitset(
       const basic_string<_CharT, _Traits, _Allocator>& __str,
@@ -679,13 +681,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bitset& flip(size_t __pos);
 
   // element access:
-#ifdef _LIBCPP_ABI_BITSET_VECTOR_BOOL_CONST_SUBSCRIPT_RETURN_BOOL
+#  ifdef _LIBCPP_ABI_BITSET_VECTOR_BOOL_CONST_SUBSCRIPT_RETURN_BOOL
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool operator[](size_t __p) const { return __base::__make_ref(__p); }
-#else
+#  else
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR const_reference operator[](size_t __p) const {
     return __base::__make_ref(__p);
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 reference operator[](size_t __p) {
     return __base::__make_ref(__p);
   }
@@ -705,9 +707,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 size_t count() const _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR size_t size() const _NOEXCEPT { return _Size; }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool operator==(const bitset& __rhs) const _NOEXCEPT;
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const bitset& __rhs) const _NOEXCEPT;
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool test(size_t __pos) const;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool all() const _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool any() const _NOEXCEPT;
@@ -880,14 +882,14 @@ bitset<_Size>::operator==(const bitset& __rhs) const _NOEXCEPT {
   return std::equal(__base::__make_iter(0), __base::__make_iter(_Size), __rhs.__make_iter(0));
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <size_t _Size>
 inline _LIBCPP_HIDE_FROM_ABI bool bitset<_Size>::operator!=(const bitset& __rhs) const _NOEXCEPT {
   return !(*this == __rhs);
 }
 
-#endif
+#  endif
 
 template <size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool bitset<_Size>::test(size_t __pos) const {
@@ -964,10 +966,11 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <cstdlib>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <cstdlib>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_BITSET

--- a/libcxx/include/cassert
+++ b/libcxx/include/cassert
@@ -16,16 +16,19 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
 // <assert.h> is not provided by libc++
-#if __has_include(<assert.h>)
-#  include <assert.h>
-#  ifdef _LIBCPP_ASSERT_H
-#    error "If libc++ starts defining <assert.h>, the __has_include check should move to libc++'s <assert.h>"
+#  if __has_include(<assert.h>)
+#    include <assert.h>
+#    ifdef _LIBCPP_ASSERT_H
+#      error "If libc++ starts defining <assert.h>, the __has_include check should move to libc++'s <assert.h>"
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0

--- a/libcxx/include/ccomplex
+++ b/libcxx/include/ccomplex
@@ -17,22 +17,25 @@
 
 */
 
-#include <complex>
+#if 0
+#else // 0
+#  include <complex>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 using __standard_header_ccomplex _LIBCPP_DEPRECATED_("removed in C++20. Include <complex> instead.") = void;
 using __use_standard_header_ccomplex = __standard_header_ccomplex;
 
-#elif _LIBCPP_STD_VER >= 17
+#  elif _LIBCPP_STD_VER >= 17
 
 using __standard_header_ccomplex _LIBCPP_DEPRECATED_("Include <complex> instead.") = void;
 using __use_standard_header_ccomplex                                               = __standard_header_ccomplex;
 
-#endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CCOMPLEX

--- a/libcxx/include/cctype
+++ b/libcxx/include/cctype
@@ -34,78 +34,80 @@ int toupper(int c);
 }  // std
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <ctype.h>
+#  include <ctype.h>
 
-#ifndef _LIBCPP_CTYPE_H
+#  ifndef _LIBCPP_CTYPE_H
 #   error <cctype> tried including <ctype.h> but didn't find libc++'s <ctype.h> header. \
           This usually means that your header search paths are not configured properly.  \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#ifdef isalnum
-#  undef isalnum
-#endif
+#  ifdef isalnum
+#    undef isalnum
+#  endif
 
-#ifdef isalpha
-#  undef isalpha
-#endif
+#  ifdef isalpha
+#    undef isalpha
+#  endif
 
-#ifdef isblank
-#  undef isblank
-#endif
+#  ifdef isblank
+#    undef isblank
+#  endif
 
-#ifdef iscntrl
-#  undef iscntrl
-#endif
+#  ifdef iscntrl
+#    undef iscntrl
+#  endif
 
-#ifdef isdigit
-#  undef isdigit
-#endif
+#  ifdef isdigit
+#    undef isdigit
+#  endif
 
-#ifdef isgraph
-#  undef isgraph
-#endif
+#  ifdef isgraph
+#    undef isgraph
+#  endif
 
-#ifdef islower
-#  undef islower
-#endif
+#  ifdef islower
+#    undef islower
+#  endif
 
-#ifdef isprint
-#  undef isprint
-#endif
+#  ifdef isprint
+#    undef isprint
+#  endif
 
-#ifdef ispunct
-#  undef ispunct
-#endif
+#  ifdef ispunct
+#    undef ispunct
+#  endif
 
-#ifdef isspace
-#  undef isspace
-#endif
+#  ifdef isspace
+#    undef isspace
+#  endif
 
-#ifdef isupper
-#  undef isupper
-#endif
+#  ifdef isupper
+#    undef isupper
+#  endif
 
-#ifdef isxdigit
-#  undef isxdigit
-#endif
+#  ifdef isxdigit
+#    undef isxdigit
+#  endif
 
-#ifdef tolower
-#  undef tolower
-#endif
+#  ifdef tolower
+#    undef tolower
+#  endif
 
-#ifdef toupper
-#  undef toupper
-#endif
+#  ifdef toupper
+#    undef toupper
+#  endif
 
 using ::isalnum _LIBCPP_USING_IF_EXISTS;
 using ::isalpha _LIBCPP_USING_IF_EXISTS;
@@ -123,5 +125,6 @@ using ::tolower _LIBCPP_USING_IF_EXISTS;
 using ::toupper _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+#endif // 0
 
 #endif // _LIBCPP_CCTYPE

--- a/libcxx/include/cerrno
+++ b/libcxx/include/cerrno
@@ -22,21 +22,23 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <errno.h>
+#  include <errno.h>
 
-#ifndef _LIBCPP_ERRNO_H
+#  ifndef _LIBCPP_ERRNO_H
 #   error <cerrno> tried including <errno.h> but didn't find libc++'s <errno.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 // LWG3869 Deprecate std::errc constants related to UNIX STREAMS
 //
@@ -44,5 +46,6 @@ Macros:
 // deprecated in libc++ in https://github.com/llvm/llvm-project/pull/80542.
 // Based on the post commit feedback the macro are no longer deprecated.
 // Instead libc++ leaves the deprecation to the provider of errno.h.
+#endif // 0
 
 #endif // _LIBCPP_CERRNO

--- a/libcxx/include/cfenv
+++ b/libcxx/include/cfenv
@@ -52,21 +52,23 @@ int feupdateenv(const fenv_t* envp);
 }  // std
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <fenv.h>
+#  include <fenv.h>
 
-#ifndef _LIBCPP_FENV_H
+#  ifndef _LIBCPP_FENV_H
 #   error <cfenv> tried including <fenv.h> but didn't find libc++'s <fenv.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -84,6 +86,7 @@ using ::fegetenv _LIBCPP_USING_IF_EXISTS;
 using ::feholdexcept _LIBCPP_USING_IF_EXISTS;
 using ::fesetenv _LIBCPP_USING_IF_EXISTS;
 using ::feupdateenv _LIBCPP_USING_IF_EXISTS;
+#endif // 0
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/cfloat
+++ b/libcxx/include/cfloat
@@ -69,20 +69,23 @@ Macros:
     LDBL_TRUE_MIN       // C11
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <float.h>
+#  include <float.h>
 
-#ifndef _LIBCPP_FLOAT_H
+#  ifndef _LIBCPP_FLOAT_H
 #   error <cfloat> tried including <float.h> but didn't find libc++'s <float.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CFLOAT

--- a/libcxx/include/charconv
+++ b/libcxx/include/charconv
@@ -75,42 +75,45 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__charconv/chars_format.h>
-#  include <__charconv/from_chars_floating_point.h>
-#  include <__charconv/from_chars_integral.h>
-#  include <__charconv/from_chars_result.h>
-#  include <__charconv/tables.h>
-#  include <__charconv/to_chars.h>
-#  include <__charconv/to_chars_base_10.h>
-#  include <__charconv/to_chars_floating_point.h>
-#  include <__charconv/to_chars_integral.h>
-#  include <__charconv/to_chars_result.h>
-#  include <__charconv/traits.h>
-#endif // _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
+#    include <__charconv/chars_format.h>
+#    include <__charconv/from_chars_floating_point.h>
+#    include <__charconv/from_chars_integral.h>
+#    include <__charconv/from_chars_result.h>
+#    include <__charconv/tables.h>
+#    include <__charconv/to_chars.h>
+#    include <__charconv/to_chars_base_10.h>
+#    include <__charconv/to_chars_floating_point.h>
+#    include <__charconv/to_chars_integral.h>
+#    include <__charconv/to_chars_result.h>
+#    include <__charconv/traits.h>
+#  endif // _LIBCPP_STD_VER >= 17
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cmath>
-#  include <concepts>
-#  include <cstddef>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <cstring>
-#  include <iosfwd>
-#  include <limits>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cmath>
+#    include <concepts>
+#    include <cstddef>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <cstring>
+#    include <iosfwd>
+#    include <limits>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CHARCONV

--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -939,83 +939,86 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 
 // clang-format on
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__chrono/duration.h>
-#include <__chrono/file_clock.h>
-#include <__chrono/high_resolution_clock.h>
-#include <__chrono/steady_clock.h>
-#include <__chrono/system_clock.h>
-#include <__chrono/time_point.h>
+#  include <__chrono/duration.h>
+#  include <__chrono/file_clock.h>
+#  include <__chrono/high_resolution_clock.h>
+#  include <__chrono/steady_clock.h>
+#  include <__chrono/system_clock.h>
+#  include <__chrono/time_point.h>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__chrono/calendar.h>
-#  include <__chrono/day.h>
-#  include <__chrono/exception.h>
-#  include <__chrono/hh_mm_ss.h>
-#  include <__chrono/literals.h>
-#  include <__chrono/local_info.h>
-#  include <__chrono/month.h>
-#  include <__chrono/month_weekday.h>
-#  include <__chrono/monthday.h>
-#  include <__chrono/sys_info.h>
-#  include <__chrono/weekday.h>
-#  include <__chrono/year.h>
-#  include <__chrono/year_month.h>
-#  include <__chrono/year_month_day.h>
-#  include <__chrono/year_month_weekday.h>
+#  if _LIBCPP_STD_VER >= 20
+#    include <__chrono/calendar.h>
+#    include <__chrono/day.h>
+#    include <__chrono/exception.h>
+#    include <__chrono/hh_mm_ss.h>
+#    include <__chrono/literals.h>
+#    include <__chrono/local_info.h>
+#    include <__chrono/month.h>
+#    include <__chrono/month_weekday.h>
+#    include <__chrono/monthday.h>
+#    include <__chrono/sys_info.h>
+#    include <__chrono/weekday.h>
+#    include <__chrono/year.h>
+#    include <__chrono/year_month.h>
+#    include <__chrono/year_month_day.h>
+#    include <__chrono/year_month_weekday.h>
 
-#  if _LIBCPP_HAS_LOCALIZATION
-#    include <__chrono/formatter.h>
-#    include <__chrono/ostream.h>
-#    include <__chrono/parser_std_format_spec.h>
-#    include <__chrono/statically_widen.h>
+#    if _LIBCPP_HAS_LOCALIZATION
+#      include <__chrono/formatter.h>
+#      include <__chrono/ostream.h>
+#      include <__chrono/parser_std_format_spec.h>
+#      include <__chrono/statically_widen.h>
+#    endif
+
+#    if _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+#      include <__chrono/leap_second.h>
+#      include <__chrono/time_zone.h>
+#      include <__chrono/time_zone_link.h>
+#      include <__chrono/tzdb.h>
+#      include <__chrono/tzdb_list.h>
+#      include <__chrono/zoned_time.h>
+#    endif
+
 #  endif
 
-#  if _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
-#    include <__chrono/leap_second.h>
-#    include <__chrono/time_zone.h>
-#    include <__chrono/time_zone_link.h>
-#    include <__chrono/tzdb.h>
-#    include <__chrono/tzdb_list.h>
-#    include <__chrono/zoned_time.h>
-#  endif
-
-#endif
-
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [time.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
-#  include <cstdint>
-#  include <stdexcept>
-#  include <string_view>
-#endif
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <bit>
-#  include <concepts>
-#  include <cstring>
-#  include <forward_list>
-#  include <string>
-#  include <tuple>
-#  include <vector>
-#endif
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 20
-#  include <charconv>
-#  if _LIBCPP_HAS_LOCALIZATION
-#    include <locale>
-#    include <ostream>
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
 #  endif
-#endif
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#    include <cstdint>
+#    include <stdexcept>
+#    include <string_view>
+#  endif
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <bit>
+#    include <concepts>
+#    include <cstring>
+#    include <forward_list>
+#    include <string>
+#    include <tuple>
+#    include <vector>
+#  endif
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER == 20
+#    include <charconv>
+#    if _LIBCPP_HAS_LOCALIZATION
+#      include <locale>
+#      include <ostream>
+#    endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CHRONO

--- a/libcxx/include/cinttypes
+++ b/libcxx/include/cinttypes
@@ -234,26 +234,28 @@ uintmax_t wcstoumax(const wchar_t* restrict nptr, wchar_t** restrict endptr, int
 }  // std
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
 // standard-mandated includes
 
 // [cinttypes.syn]
-#include <cstdint>
+#  include <cstdint>
 
-#include <inttypes.h>
+#  include <inttypes.h>
 
-#ifndef _LIBCPP_INTTYPES_H
+#  ifndef _LIBCPP_INTTYPES_H
 #   error <cinttypes> tried including <inttypes.h> but didn't find libc++'s <inttypes.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -266,5 +268,7 @@ using ::wcstoimax _LIBCPP_USING_IF_EXISTS;
 using ::wcstoumax _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CINTTYPES

--- a/libcxx/include/ciso646
+++ b/libcxx/include/ciso646
@@ -15,17 +15,20 @@
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 using __standard_header_ciso646 _LIBCPP_DEPRECATED_("removed in C++20. Include <version> instead.") = void;
 using __use_standard_header_ciso646 = __standard_header_ciso646;
 
-#endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CISO646

--- a/libcxx/include/climits
+++ b/libcxx/include/climits
@@ -37,12 +37,16 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <limits.h>
+#  include <limits.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+#endif // 0
 
 #endif // _LIBCPP_CLIMITS

--- a/libcxx/include/clocale
+++ b/libcxx/include/clocale
@@ -34,15 +34,17 @@ lconv* localeconv();
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if __has_include(<locale.h>)
-#  include <locale.h>
-#endif
+#  if __has_include(<locale.h>)
+#    include <locale.h>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -51,5 +53,7 @@ using ::setlocale _LIBCPP_USING_IF_EXISTS;
 using ::localeconv _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CLOCALE

--- a/libcxx/include/cmath
+++ b/libcxx/include/cmath
@@ -312,35 +312,37 @@ constexpr long double lerp(long double a, long double b, long double t) noexcept
 
 */
 
-#include <__config>
-#include <__math/hypot.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_arithmetic.h>
-#include <__type_traits/is_constant_evaluated.h>
-#include <__type_traits/is_floating_point.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/promote.h>
-#include <__type_traits/remove_cv.h>
-#include <limits>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__math/hypot.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_arithmetic.h>
+#  include <__type_traits/is_constant_evaluated.h>
+#  include <__type_traits/is_floating_point.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/promote.h>
+#  include <__type_traits/remove_cv.h>
+#  include <limits>
+#  include <version>
 
-#include <__math/special_functions.h>
-#include <math.h>
+#  include <__math/special_functions.h>
+#  include <math.h>
 
-#ifndef _LIBCPP_MATH_H
+#  ifndef _LIBCPP_MATH_H
 #   error <cmath> tried including <math.h> but didn't find libc++'s <math.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -556,11 +558,11 @@ using ::truncl _LIBCPP_USING_IF_EXISTS;
 
 template <class _A1, __enable_if_t<is_floating_point<_A1>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool __constexpr_isinf(_A1 __lcpp_x) _NOEXCEPT {
-#if __has_builtin(__builtin_isinf)
+#  if __has_builtin(__builtin_isinf)
   return __builtin_isinf(__lcpp_x);
-#else
+#  else
   return isinf(__lcpp_x);
-#endif
+#  endif
 }
 
 template <class _A1, __enable_if_t<!is_floating_point<_A1>::value, int> = 0>
@@ -568,7 +570,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR bool __constexpr_isinf(_A1 __lcpp_x) _NO
   return std::isinf(__lcpp_x);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <typename _Fp>
 _LIBCPP_HIDE_FROM_ABI constexpr _Fp __lerp(_Fp __a, _Fp __b, _Fp __t) noexcept {
   if ((__a <= 0 && __b >= 0) || (__a >= 0 && __b <= 0))
@@ -605,14 +607,15 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr
       _IsSame<_A1, __result_type>::value && _IsSame<_A2, __result_type>::value && _IsSame<_A3, __result_type>::value));
   return std::__lerp((__result_type)__a, (__result_type)__b, (__result_type)__t);
 }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CMATH

--- a/libcxx/include/codecvt
+++ b/libcxx/include/codecvt
@@ -54,15 +54,17 @@ class codecvt_utf8_utf16
 
 */
 
-#include <__config>
-#include <__locale>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__locale>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
+#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -73,7 +75,7 @@ enum _LIBCPP_DEPRECATED_IN_CXX17 codecvt_mode { consume_header = 4, generate_hea
 template <class _Elem>
 class __codecvt_utf8;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI __codecvt_utf8<wchar_t> : public codecvt<wchar_t, char, mbstate_t> {
   unsigned long __maxcode_;
@@ -112,7 +114,7 @@ protected:
   int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const override;
   int do_max_length() const _NOEXCEPT override;
 };
-#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <>
@@ -203,7 +205,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 template <class _Elem, bool _LittleEndian>
 class __codecvt_utf16;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI __codecvt_utf16<wchar_t, false> : public codecvt<wchar_t, char, mbstate_t> {
   unsigned long __maxcode_;
@@ -281,7 +283,7 @@ protected:
   int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const override;
   int do_max_length() const _NOEXCEPT override;
 };
-#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <>
@@ -448,7 +450,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 template <class _Elem>
 class __codecvt_utf8_utf16;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI __codecvt_utf8_utf16<wchar_t> : public codecvt<wchar_t, char, mbstate_t> {
   unsigned long __maxcode_;
@@ -487,7 +489,7 @@ protected:
   int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const override;
   int do_max_length() const _NOEXCEPT override;
 };
-#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <>
@@ -576,22 +578,23 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
+#  endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstddef>
-#  include <cstdlib>
-#  include <cstring>
-#  include <initializer_list>
-#  include <iosfwd>
-#  include <limits>
-#  include <mutex>
-#  include <new>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstddef>
+#    include <cstdlib>
+#    include <cstring>
+#    include <initializer_list>
+#    include <iosfwd>
+#    include <limits>
+#    include <mutex>
+#    include <new>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CODECVT

--- a/libcxx/include/compare
+++ b/libcxx/include/compare
@@ -140,34 +140,37 @@ namespace std {
 }
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__compare/common_comparison_category.h>
-#  include <__compare/compare_partial_order_fallback.h>
-#  include <__compare/compare_strong_order_fallback.h>
-#  include <__compare/compare_three_way.h>
-#  include <__compare/compare_three_way_result.h>
-#  include <__compare/compare_weak_order_fallback.h>
-#  include <__compare/is_eq.h>
-#  include <__compare/ordering.h>
-#  include <__compare/partial_order.h>
-#  include <__compare/strong_order.h>
-#  include <__compare/synth_three_way.h>
-#  include <__compare/three_way_comparable.h>
-#  include <__compare/weak_order.h>
-#endif // _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
+#    include <__compare/common_comparison_category.h>
+#    include <__compare/compare_partial_order_fallback.h>
+#    include <__compare/compare_strong_order_fallback.h>
+#    include <__compare/compare_three_way.h>
+#    include <__compare/compare_three_way_result.h>
+#    include <__compare/compare_weak_order_fallback.h>
+#    include <__compare/is_eq.h>
+#    include <__compare/ordering.h>
+#    include <__compare/partial_order.h>
+#    include <__compare/strong_order.h>
+#    include <__compare/synth_three_way.h>
+#    include <__compare/three_way_comparable.h>
+#    include <__compare/weak_order.h>
+#  endif // _LIBCPP_STD_VER >= 20
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cmath>
-#  include <cstddef>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cmath>
+#    include <cstddef>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_COMPARE

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -256,26 +256,28 @@ template<class T> complex<T> tanh (const complex<T>&);
 
 */
 
-#include <__config>
-#include <__fwd/complex.h>
-#include <__fwd/tuple.h>
-#include <__tuple/tuple_element.h>
-#include <__tuple/tuple_size.h>
-#include <__type_traits/conditional.h>
-#include <__utility/move.h>
-#include <cmath>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__fwd/complex.h>
+#  include <__fwd/tuple.h>
+#  include <__tuple/tuple_element.h>
+#  include <__tuple/tuple_size.h>
+#  include <__type_traits/conditional.h>
+#  include <__utility/move.h>
+#  include <cmath>
+#  include <version>
 
-#if _LIBCPP_HAS_LOCALIZATION
-#  include <sstream> // for std::basic_ostringstream
-#endif
+#  if _LIBCPP_HAS_LOCALIZATION
+#    include <sstream> // for std::basic_ostringstream
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -374,7 +376,7 @@ public:
     return *this;
   }
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr _Xp& get(complex<_Xp>&) noexcept;
 
@@ -386,7 +388,7 @@ public:
 
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr const _Xp&& get(const complex<_Xp>&&) noexcept;
-#endif
+#  endif
 };
 
 template <>
@@ -404,11 +406,11 @@ using __complex_t =
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __complex_t<_Tp> __make_complex(_Tp __re, _Tp __im) {
-#if __has_builtin(__builtin_complex)
+#  if __has_builtin(__builtin_complex)
   return __builtin_complex(__re, __im);
-#else
+#  else
   return __complex_t<_Tp>{__re, __im};
-#endif
+#  endif
 }
 
 template <>
@@ -493,7 +495,7 @@ public:
     return *this;
   }
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr _Xp& get(complex<_Xp>&) noexcept;
 
@@ -505,7 +507,7 @@ public:
 
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr const _Xp&& get(const complex<_Xp>&&) noexcept;
-#endif
+#  endif
 };
 
 template <>
@@ -593,7 +595,7 @@ public:
     return *this;
   }
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr _Xp& get(complex<_Xp>&) noexcept;
 
@@ -605,7 +607,7 @@ public:
 
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr const _Xp&& get(const complex<_Xp>&&) noexcept;
-#endif
+#  endif
 };
 
 template <>
@@ -694,7 +696,7 @@ public:
     return *this;
   }
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr _Xp& get(complex<_Xp>&) noexcept;
 
@@ -706,7 +708,7 @@ public:
 
   template <size_t _Ip, class _Xp>
   friend _LIBCPP_HIDE_FROM_ABI constexpr const _Xp&& get(const complex<_Xp>&&) noexcept;
-#endif
+#  endif
 };
 
 inline _LIBCPP_CONSTEXPR complex<float>::complex(const complex<double>& __c) : __re_(__c.real()), __im_(__c.imag()) {}
@@ -861,7 +863,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator==(const
   return __x.real() == __y && __x.imag() == 0;
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator==(const _Tp& __x, const complex<_Tp>& __y) {
@@ -884,7 +886,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool operator!=(const
   return !(__x == __y);
 }
 
-#endif
+#  endif
 
 // 26.3.7 values:
 
@@ -1322,7 +1324,7 @@ _LIBCPP_HIDE_FROM_ABI complex<_Tp> tan(const complex<_Tp>& __x) {
   return complex<_Tp>(__z.imag(), -__z.real());
 }
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 template <class _Tp, class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, complex<_Tp>& __x) {
@@ -1379,9 +1381,9 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x) {
   __s << '(' << __x.real() << ',' << __x.imag() << ')';
   return __os << __s.str();
 }
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
 
 // [complex.tuple], tuple interface
 
@@ -1434,9 +1436,9 @@ _LIBCPP_HIDE_FROM_ABI constexpr const _Xp&& get(const complex<_Xp>&& __z) noexce
   }
 }
 
-#endif // _LIBCPP_STD_VER >= 26
+#  endif // _LIBCPP_STD_VER >= 26
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 // Literal suffix for complex number literals [complex.literals]
 inline namespace literals {
 inline namespace complex_literals {
@@ -1463,16 +1465,17 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr complex<float> operator""if(unsigned long
 }
 } // namespace complex_literals
 } // namespace literals
-#endif
+#  endif
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <iosfwd>
-#  include <stdexcept>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <iosfwd>
+#    include <stdexcept>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_COMPLEX

--- a/libcxx/include/complex.h
+++ b/libcxx/include/complex.h
@@ -17,16 +17,19 @@
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#ifdef __cplusplus
-#  include <complex>
-#elif __has_include_next(<complex.h>)
-#  include_next <complex.h>
-#endif
+#  ifdef __cplusplus
+#    include <complex>
+#  elif __has_include_next(<complex.h>)
+#    include_next <complex.h>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_COMPLEX_H

--- a/libcxx/include/concepts
+++ b/libcxx/include/concepts
@@ -129,42 +129,45 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__concepts/arithmetic.h>
-#  include <__concepts/assignable.h>
-#  include <__concepts/boolean_testable.h>
-#  include <__concepts/class_or_enum.h>
-#  include <__concepts/common_reference_with.h>
-#  include <__concepts/common_with.h>
-#  include <__concepts/constructible.h>
-#  include <__concepts/convertible_to.h>
-#  include <__concepts/copyable.h>
-#  include <__concepts/derived_from.h>
-#  include <__concepts/destructible.h>
-#  include <__concepts/different_from.h>
-#  include <__concepts/equality_comparable.h>
-#  include <__concepts/invocable.h>
-#  include <__concepts/movable.h>
-#  include <__concepts/predicate.h>
-#  include <__concepts/regular.h>
-#  include <__concepts/relation.h>
-#  include <__concepts/same_as.h>
-#  include <__concepts/semiregular.h>
-#  include <__concepts/swappable.h>
-#  include <__concepts/totally_ordered.h>
-#endif // _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
+#    include <__concepts/arithmetic.h>
+#    include <__concepts/assignable.h>
+#    include <__concepts/boolean_testable.h>
+#    include <__concepts/class_or_enum.h>
+#    include <__concepts/common_reference_with.h>
+#    include <__concepts/common_with.h>
+#    include <__concepts/constructible.h>
+#    include <__concepts/convertible_to.h>
+#    include <__concepts/copyable.h>
+#    include <__concepts/derived_from.h>
+#    include <__concepts/destructible.h>
+#    include <__concepts/different_from.h>
+#    include <__concepts/equality_comparable.h>
+#    include <__concepts/invocable.h>
+#    include <__concepts/movable.h>
+#    include <__concepts/predicate.h>
+#    include <__concepts/regular.h>
+#    include <__concepts/relation.h>
+#    include <__concepts/same_as.h>
+#    include <__concepts/semiregular.h>
+#    include <__concepts/swappable.h>
+#    include <__concepts/totally_ordered.h>
+#  endif // _LIBCPP_STD_VER >= 20
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <type_traits>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CONCEPTS

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -118,29 +118,31 @@ public:
 
 */
 
-#include <__chrono/duration.h>
-#include <__chrono/steady_clock.h>
-#include <__chrono/time_point.h>
-#include <__condition_variable/condition_variable.h>
-#include <__config>
-#include <__memory/shared_ptr.h>
-#include <__mutex/lock_guard.h>
-#include <__mutex/mutex.h>
-#include <__mutex/tag_types.h>
-#include <__mutex/unique_lock.h>
-#include <__stop_token/stop_callback.h>
-#include <__stop_token/stop_token.h>
-#include <__utility/move.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__chrono/duration.h>
+#  include <__chrono/steady_clock.h>
+#  include <__chrono/time_point.h>
+#  include <__condition_variable/condition_variable.h>
+#  include <__config>
+#  include <__memory/shared_ptr.h>
+#  include <__mutex/lock_guard.h>
+#  include <__mutex/mutex.h>
+#  include <__mutex/tag_types.h>
+#  include <__mutex/unique_lock.h>
+#  include <__stop_token/stop_callback.h>
+#  include <__stop_token/stop_token.h>
+#  include <__utility/move.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -173,7 +175,7 @@ public:
   template <class _Lock, class _Rep, class _Period, class _Predicate>
   bool _LIBCPP_HIDE_FROM_ABI wait_for(_Lock& __lock, const chrono::duration<_Rep, _Period>& __d, _Predicate __pred);
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
   template <class _Lock, class _Predicate>
   _LIBCPP_AVAILABILITY_SYNC _LIBCPP_HIDE_FROM_ABI bool wait(_Lock& __lock, stop_token __stoken, _Predicate __pred);
@@ -186,7 +188,7 @@ public:
   _LIBCPP_AVAILABILITY_SYNC _LIBCPP_HIDE_FROM_ABI bool
   wait_for(_Lock& __lock, stop_token __stoken, const chrono::duration<_Rep, _Period>& __rel_time, _Predicate __pred);
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 };
 
 inline condition_variable_any::condition_variable_any() : __mut_(make_shared<mutex>()) {}
@@ -260,7 +262,7 @@ condition_variable_any::wait_for(_Lock& __lock, const chrono::duration<_Rep, _Pe
   return wait_until(__lock, chrono::steady_clock::now() + __d, std::move(__pred));
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 template <class _Lock, class _Predicate>
 bool condition_variable_any::wait(_Lock& __user_lock, stop_token __stoken, _Predicate __pred) {
@@ -341,29 +343,30 @@ bool condition_variable_any::wait_for(
   return wait_until(__lock, std::move(__stoken), chrono::steady_clock::now() + __rel_time, std::move(__pred));
 }
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_EXPORTED_FROM_ABI void notify_all_at_thread_exit(condition_variable&, unique_lock<mutex>);
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_HAS_THREADS
+#  endif // _LIBCPP_HAS_THREADS
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <cstring>
-#  include <initializer_list>
-#  include <iosfwd>
-#  include <new>
-#  include <stdexcept>
-#  include <system_error>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <cstring>
+#    include <initializer_list>
+#    include <iosfwd>
+#    include <new>
+#    include <stdexcept>
+#    include <system_error>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CONDITION_VARIABLE

--- a/libcxx/include/coroutine
+++ b/libcxx/include/coroutine
@@ -38,31 +38,34 @@ struct suspend_always;
 
  */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__coroutine/coroutine_handle.h>
-#  include <__coroutine/coroutine_traits.h>
-#  include <__coroutine/noop_coroutine_handle.h>
-#  include <__coroutine/trivial_awaitables.h>
-#endif // _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
+#    include <__coroutine/coroutine_handle.h>
+#    include <__coroutine/coroutine_traits.h>
+#    include <__coroutine/noop_coroutine_handle.h>
+#    include <__coroutine/trivial_awaitables.h>
+#  endif // _LIBCPP_STD_VER >= 20
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [coroutine.syn]
-#include <compare>
+#  include <compare>
 
-#ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
-#  pragma GCC system_header
-#endif
+#  ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <iosfwd>
-#  include <limits>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <iosfwd>
+#    include <limits>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_COROUTINE

--- a/libcxx/include/csetjmp
+++ b/libcxx/include/csetjmp
@@ -30,19 +30,21 @@ void longjmp(jmp_buf env, int val);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
 // <setjmp.h> is not provided by libc++
-#if __has_include(<setjmp.h>)
-#  include <setjmp.h>
-#  ifdef _LIBCPP_SETJMP_H
-#    error "If libc++ starts defining <setjmp.h>, the __has_include check should move to libc++'s <setjmp.h>"
+#  if __has_include(<setjmp.h>)
+#    include <setjmp.h>
+#    ifdef _LIBCPP_SETJMP_H
+#      error "If libc++ starts defining <setjmp.h>, the __has_include check should move to libc++'s <setjmp.h>"
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -50,5 +52,7 @@ using ::jmp_buf _LIBCPP_USING_IF_EXISTS;
 using ::longjmp _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSETJMP

--- a/libcxx/include/csignal
+++ b/libcxx/include/csignal
@@ -39,19 +39,21 @@ int raise(int sig);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
 // <signal.h> is not provided by libc++
-#if __has_include(<signal.h>)
-#  include <signal.h>
-#  ifdef _LIBCPP_SIGNAL_H
-#    error "If libc++ starts defining <signal.h>, the __has_include check should move to libc++'s <signal.h>"
+#  if __has_include(<signal.h>)
+#    include <signal.h>
+#    ifdef _LIBCPP_SIGNAL_H
+#      error "If libc++ starts defining <signal.h>, the __has_include check should move to libc++'s <signal.h>"
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -60,5 +62,7 @@ using ::signal _LIBCPP_USING_IF_EXISTS;
 using ::raise _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSIGNAL

--- a/libcxx/include/cstdalign
+++ b/libcxx/include/cstdalign
@@ -20,36 +20,39 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
 // <stdalign.h> is not provided by libc++
-#if __has_include(<stdalign.h>)
-#  include <stdalign.h>
-#  ifdef _LIBCPP_STDALIGN_H
-#    error "If libc++ starts defining <stdalign.h>, the __has_include check should move to libc++'s <stdalign.h>"
+#  if __has_include(<stdalign.h>)
+#    include <stdalign.h>
+#    ifdef _LIBCPP_STDALIGN_H
+#      error "If libc++ starts defining <stdalign.h>, the __has_include check should move to libc++'s <stdalign.h>"
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#undef __alignas_is_defined
-#define __alignas_is_defined 1
+#  undef __alignas_is_defined
+#  define __alignas_is_defined 1
 
-#undef __alignof_is_defined
-#define __alignof_is_defined 1
+#  undef __alignof_is_defined
+#  define __alignof_is_defined 1
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 using __standard_header_cstdalign _LIBCPP_DEPRECATED_("removed in C++20.") = void;
 using __use_standard_header_cstdalign                                      = __standard_header_cstdalign;
 
-#elif _LIBCPP_STD_VER >= 17
+#  elif _LIBCPP_STD_VER >= 17
 
 using __standard_header_cstdalign _LIBCPP_DEPRECATED = void;
 using __use_standard_header_cstdalign                = __standard_header_cstdalign;
 
-#endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CSTDALIGN

--- a/libcxx/include/cstdarg
+++ b/libcxx/include/cstdarg
@@ -31,24 +31,28 @@ Types:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
 // <stdarg.h> is not provided by libc++
-#if __has_include(<stdarg.h>)
-#  include <stdarg.h>
-#  ifdef _LIBCPP_STDARG_H
-#    error "If libc++ starts defining <stdarg.h>, the __has_include check should move to libc++'s <stdarg.h>"
+#  if __has_include(<stdarg.h>)
+#    include <stdarg.h>
+#    ifdef _LIBCPP_STDARG_H
+#      error "If libc++ starts defining <stdarg.h>, the __has_include check should move to libc++'s <stdarg.h>"
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 using ::va_list _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSTDARG

--- a/libcxx/include/cstdbool
+++ b/libcxx/include/cstdbool
@@ -19,25 +19,28 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#undef __bool_true_false_are_defined
-#define __bool_true_false_are_defined 1
+#  undef __bool_true_false_are_defined
+#  define __bool_true_false_are_defined 1
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 using __standard_header_cstdbool _LIBCPP_DEPRECATED_("removed in C++20.") = void;
 using __use_standard_header_cstdbool                                      = __standard_header_cstdbool;
 
-#elif _LIBCPP_STD_VER >= 17
+#  elif _LIBCPP_STD_VER >= 17
 
 using __standard_header_cstdbool _LIBCPP_DEPRECATED = void;
 using __use_standard_header_cstdbool                = __standard_header_cstdbool;
 
-#endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CSTDBOOL

--- a/libcxx/include/cstddef
+++ b/libcxx/include/cstddef
@@ -33,27 +33,30 @@ Types:
 
 */
 
-#include <__config>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <version>
 
-#include <stddef.h>
+#  include <stddef.h>
 
-#ifndef _LIBCPP_STDDEF_H
+#  ifndef _LIBCPP_STDDEF_H
 #   error <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#include <__cstddef/byte.h>
-#include <__cstddef/max_align_t.h>
-#include <__cstddef/nullptr_t.h>
-#include <__cstddef/ptrdiff_t.h>
-#include <__cstddef/size_t.h>
+#  include <__cstddef/byte.h>
+#  include <__cstddef/max_align_t.h>
+#  include <__cstddef/nullptr_t.h>
+#  include <__cstddef/ptrdiff_t.h>
+#  include <__cstddef/size_t.h>
+#endif // 0
 
 #endif // _LIBCPP_CSTDDEF

--- a/libcxx/include/cstdint
+++ b/libcxx/include/cstdint
@@ -140,15 +140,17 @@ Types:
 }  // std
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if __has_include(<stdint.h>)
-#  include <stdint.h>
-#endif
+#  if __has_include(<stdint.h>)
+#    include <stdint.h>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -189,5 +191,7 @@ using ::intmax_t _LIBCPP_USING_IF_EXISTS;
 using ::uintmax_t _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSTDINT

--- a/libcxx/include/cstdio
+++ b/libcxx/include/cstdio
@@ -95,22 +95,24 @@ void perror(const char* s);
 }  // std
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
 
-#include <stdio.h>
+#  include <stdio.h>
 
-#ifndef _LIBCPP_STDIO_H
+#  ifndef _LIBCPP_STDIO_H
 #   error <cstdio> tried including <stdio.h> but didn't find libc++'s <stdio.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -158,9 +160,9 @@ using ::tmpfile _LIBCPP_USING_IF_EXISTS;
 using ::tmpnam _LIBCPP_USING_IF_EXISTS;
 
 using ::getchar _LIBCPP_USING_IF_EXISTS;
-#if _LIBCPP_STD_VER <= 11
+#  if _LIBCPP_STD_VER <= 11
 using ::gets _LIBCPP_USING_IF_EXISTS;
-#endif
+#  endif
 using ::scanf _LIBCPP_USING_IF_EXISTS;
 using ::vscanf _LIBCPP_USING_IF_EXISTS;
 
@@ -170,5 +172,7 @@ using ::puts _LIBCPP_USING_IF_EXISTS;
 using ::vprintf _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSTDIO

--- a/libcxx/include/cstdlib
+++ b/libcxx/include/cstdlib
@@ -81,22 +81,24 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
 
-#include <stdlib.h>
+#  include <stdlib.h>
 
-#ifndef _LIBCPP_STDLIB_H
+#  ifndef _LIBCPP_STDLIB_H
 #   error <cstdlib> tried including <stdlib.h> but didn't find libc++'s <stdlib.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -135,20 +137,22 @@ using ::div _LIBCPP_USING_IF_EXISTS;
 using ::ldiv _LIBCPP_USING_IF_EXISTS;
 using ::lldiv _LIBCPP_USING_IF_EXISTS;
 using ::mblen _LIBCPP_USING_IF_EXISTS;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 using ::mbtowc _LIBCPP_USING_IF_EXISTS;
 using ::wctomb _LIBCPP_USING_IF_EXISTS;
 using ::mbstowcs _LIBCPP_USING_IF_EXISTS;
 using ::wcstombs _LIBCPP_USING_IF_EXISTS;
-#endif
-#if !defined(_LIBCPP_CXX03_LANG)
+#  endif
+#  if !defined(_LIBCPP_CXX03_LANG)
 using ::at_quick_exit _LIBCPP_USING_IF_EXISTS;
 using ::quick_exit _LIBCPP_USING_IF_EXISTS;
-#endif
-#if _LIBCPP_STD_VER >= 17
+#  endif
+#  if _LIBCPP_STD_VER >= 17
 using ::aligned_alloc _LIBCPP_USING_IF_EXISTS;
-#endif
+#  endif
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSTDLIB

--- a/libcxx/include/cstring
+++ b/libcxx/include/cstring
@@ -56,23 +56,25 @@ size_t strlen(const char* s);
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
-#include <__type_traits/is_constant_evaluated.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
+#  include <__type_traits/is_constant_evaluated.h>
 
-#include <string.h>
+#  include <string.h>
 
-#ifndef _LIBCPP_STRING_H
+#  ifndef _LIBCPP_STRING_H
 #   error <cstring> tried including <string.h> but didn't find libc++'s <string.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -100,5 +102,7 @@ using ::strerror _LIBCPP_USING_IF_EXISTS;
 using ::strlen _LIBCPP_USING_IF_EXISTS;
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CSTRING

--- a/libcxx/include/ctgmath
+++ b/libcxx/include/ctgmath
@@ -18,23 +18,27 @@
 
 */
 
-#include <cmath>
-#include <complex>
+#if 0
+#else // 0
+#  include <cmath>
+#  include <complex>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 using __standard_header_ctgmath _LIBCPP_DEPRECATED_("removed in C++20. Include <cmath> and <complex> instead.") = void;
 using __use_standard_header_ctgmath = __standard_header_ctgmath;
 
-#elif _LIBCPP_STD_VER >= 17
+#  elif _LIBCPP_STD_VER >= 17
 
 using __standard_header_ctgmath _LIBCPP_DEPRECATED_("Include <cmath> and <complex> instead.") = void;
 using __use_standard_header_ctgmath = __standard_header_ctgmath;
 
-#endif
+#  endif
+
+#endif // 0
 
 #endif // _LIBCPP_CTGMATH

--- a/libcxx/include/ctime
+++ b/libcxx/include/ctime
@@ -45,29 +45,31 @@ int timespec_get( struct timespec *ts, int base); // C++17
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
 
 // <time.h> is not provided by libc++
-#if __has_include(<time.h>)
-#  include <time.h>
-#  ifdef _LIBCPP_TIME_H
-#    error "If libc++ starts defining <time.h>, the __has_include check should move to libc++'s <time.h>"
+#  if __has_include(<time.h>)
+#    include <time.h>
+#    ifdef _LIBCPP_TIME_H
+#      error "If libc++ starts defining <time.h>, the __has_include check should move to libc++'s <time.h>"
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 using ::clock_t _LIBCPP_USING_IF_EXISTS;
 using ::time_t _LIBCPP_USING_IF_EXISTS;
 using ::tm _LIBCPP_USING_IF_EXISTS;
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 using ::timespec _LIBCPP_USING_IF_EXISTS;
-#endif
+#  endif
 using ::clock _LIBCPP_USING_IF_EXISTS;
 using ::difftime _LIBCPP_USING_IF_EXISTS;
 using ::mktime _LIBCPP_USING_IF_EXISTS;
@@ -77,10 +79,12 @@ using ::ctime _LIBCPP_USING_IF_EXISTS;
 using ::gmtime _LIBCPP_USING_IF_EXISTS;
 using ::localtime _LIBCPP_USING_IF_EXISTS;
 using ::strftime _LIBCPP_USING_IF_EXISTS;
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 using ::timespec_get _LIBCPP_USING_IF_EXISTS;
-#endif
+#  endif
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CTIME

--- a/libcxx/include/ctype.h
+++ b/libcxx/include/ctype.h
@@ -29,33 +29,36 @@ int tolower(int c);
 int toupper(int c);
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if __has_include_next(<ctype.h>)
-#  include_next <ctype.h>
-#endif
+#  if __has_include_next(<ctype.h>)
+#    include_next <ctype.h>
+#  endif
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 
-#  undef isalnum
-#  undef isalpha
-#  undef isblank
-#  undef iscntrl
-#  undef isdigit
-#  undef isgraph
-#  undef islower
-#  undef isprint
-#  undef ispunct
-#  undef isspace
-#  undef isupper
-#  undef isxdigit
-#  undef tolower
-#  undef toupper
+#    undef isalnum
+#    undef isalpha
+#    undef isblank
+#    undef iscntrl
+#    undef isdigit
+#    undef isgraph
+#    undef islower
+#    undef isprint
+#    undef ispunct
+#    undef isspace
+#    undef isupper
+#    undef isxdigit
+#    undef tolower
+#    undef toupper
 
-#endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CTYPE_H

--- a/libcxx/include/cuchar
+++ b/libcxx/include/cuchar
@@ -36,39 +36,42 @@ size_t c32rtomb(char* s, char32_t c32, mbstate_t* ps);
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
 
-#include <uchar.h>
+#  include <uchar.h>
 
-#ifndef _LIBCPP_UCHAR_H
+#  ifndef _LIBCPP_UCHAR_H
 #   error <cuchar> tried including <uchar.h> but didn't find libc++'s <uchar.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if !defined(_LIBCPP_CXX03_LANG)
+#  if !defined(_LIBCPP_CXX03_LANG)
 
 using ::mbstate_t _LIBCPP_USING_IF_EXISTS;
 
-#  if _LIBCPP_HAS_C8RTOMB_MBRTOC8
+#    if _LIBCPP_HAS_C8RTOMB_MBRTOC8
 using ::mbrtoc8 _LIBCPP_USING_IF_EXISTS;
 using ::c8rtomb _LIBCPP_USING_IF_EXISTS;
-#  endif
+#    endif
 using ::mbrtoc16 _LIBCPP_USING_IF_EXISTS;
 using ::c16rtomb _LIBCPP_USING_IF_EXISTS;
 using ::mbrtoc32 _LIBCPP_USING_IF_EXISTS;
 using ::c32rtomb _LIBCPP_USING_IF_EXISTS;
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
+#endif   // 0
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -102,28 +102,30 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
-#include <__type_traits/copy_cv.h>
-#include <__type_traits/is_constant_evaluated.h>
-#include <__type_traits/is_equality_comparable.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/remove_cv.h>
-#include <cwctype>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
+#  include <__type_traits/copy_cv.h>
+#  include <__type_traits/is_constant_evaluated.h>
+#  include <__type_traits/is_equality_comparable.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/remove_cv.h>
+#  include <cwctype>
 
-#include <wchar.h>
+#  include <wchar.h>
 
-#ifndef _LIBCPP_WCHAR_H
+#  ifndef _LIBCPP_WCHAR_H
 #   error <cwchar> tried including <wchar.h> but didn't find libc++'s <wchar.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -194,9 +196,9 @@ using ::vwprintf _LIBCPP_USING_IF_EXISTS;
 using ::wprintf _LIBCPP_USING_IF_EXISTS;
 
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 size_t __constexpr_wcslen(const wchar_t* __str) {
-#if __has_builtin(__builtin_wcslen)
+#  if __has_builtin(__builtin_wcslen)
   return __builtin_wcslen(__str);
-#else
+#  else
   if (!__libcpp_is_constant_evaluated())
     return std::wcslen(__str);
 
@@ -204,14 +206,14 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 size_t __constexpr_wc
   for (; *__str != L'\0'; ++__str)
     ++__len;
   return __len;
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int
 __constexpr_wmemcmp(const wchar_t* __lhs, const wchar_t* __rhs, size_t __count) {
-#if __has_builtin(__builtin_wmemcmp)
+#  if __has_builtin(__builtin_wmemcmp)
   return __builtin_wmemcmp(__lhs, __rhs, __count);
-#else
+#  else
   if (!__libcpp_is_constant_evaluated())
     return std::wmemcmp(__lhs, __rhs, __count);
 
@@ -222,7 +224,7 @@ __constexpr_wmemcmp(const wchar_t* __lhs, const wchar_t* __rhs, size_t __count) 
       return 1;
   }
   return 0;
-#endif
+#  endif
 }
 
 template <class _Tp, class _Up>
@@ -231,18 +233,18 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp
                     __libcpp_is_trivially_equality_comparable<_Tp, _Tp>::value,
                 "Calling wmemchr on non-trivially equality comparable types is unsafe.");
 
-#if __has_builtin(__builtin_wmemchr)
+#  if __has_builtin(__builtin_wmemchr)
   if (!__libcpp_is_constant_evaluated()) {
     wchar_t __value_buffer = 0;
     __builtin_memcpy(&__value_buffer, &__value, sizeof(wchar_t));
     return reinterpret_cast<_Tp*>(
         __builtin_wmemchr(reinterpret_cast<__copy_cv_t<_Tp, wchar_t>*>(__str), __value_buffer, __count));
   }
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   else if constexpr (is_same_v<remove_cv_t<_Tp>, wchar_t>)
     return __builtin_wmemchr(__str, __value, __count);
-#  endif
-#endif // __has_builtin(__builtin_wmemchr)
+#    endif
+#  endif // __has_builtin(__builtin_wmemchr)
 
   for (; __count; --__count) {
     if (*__str == __value)
@@ -254,8 +256,9 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_CWCHAR

--- a/libcxx/include/cwctype
+++ b/libcxx/include/cwctype
@@ -49,26 +49,28 @@ wctrans_t wctrans(const char* property);
 
 */
 
-#include <__config>
-#include <cctype>
+#if 0
+#else // 0
+#  include <__config>
+#  include <cctype>
 
-#include <wctype.h>
+#  include <wctype.h>
 
-#ifndef _LIBCPP_WCTYPE_H
+#  ifndef _LIBCPP_WCTYPE_H
 #   error <cwctype> tried including <wctype.h> but didn't find libc++'s <wctype.h> header. \
           This usually means that your header search paths are not configured properly. \
           The header search paths should contain the C++ Standard Library headers before \
           any C Standard Library, and you are probably using compiler flags that make that \
           not be the case.
-#endif
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if defined(_LIBCPP_INCLUDED_C_LIBRARY_WCTYPE_H)
+#  if defined(_LIBCPP_INCLUDED_C_LIBRARY_WCTYPE_H)
 using ::wint_t _LIBCPP_USING_IF_EXISTS;
 using ::wctrans_t _LIBCPP_USING_IF_EXISTS;
 using ::wctype_t _LIBCPP_USING_IF_EXISTS;
@@ -90,8 +92,10 @@ using ::towlower _LIBCPP_USING_IF_EXISTS;
 using ::towupper _LIBCPP_USING_IF_EXISTS;
 using ::towctrans _LIBCPP_USING_IF_EXISTS;
 using ::wctrans _LIBCPP_USING_IF_EXISTS;
-#endif // _LIBCPP_INCLUDED_C_LIBRARY_WCTYPE_H
+#  endif // _LIBCPP_INCLUDED_C_LIBRARY_WCTYPE_H
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_CWCTYPE

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -177,87 +177,89 @@ template <class T, class Allocator, class Predicate>
 
 */
 
-#include <__algorithm/copy.h>
-#include <__algorithm/copy_backward.h>
-#include <__algorithm/copy_n.h>
-#include <__algorithm/equal.h>
-#include <__algorithm/fill_n.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lexicographical_compare_three_way.h>
-#include <__algorithm/max.h>
-#include <__algorithm/min.h>
-#include <__algorithm/move.h>
-#include <__algorithm/move_backward.h>
-#include <__algorithm/remove.h>
-#include <__algorithm/remove_if.h>
-#include <__algorithm/unwrap_iter.h>
-#include <__assert>
-#include <__config>
-#include <__debug_utils/sanitizers.h>
-#include <__format/enable_insertable.h>
-#include <__fwd/deque.h>
-#include <__iterator/distance.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/move_iterator.h>
-#include <__iterator/next.h>
-#include <__iterator/prev.h>
-#include <__iterator/reverse_iterator.h>
-#include <__iterator/segmented_iterator.h>
-#include <__memory/addressof.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_destructor.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/compressed_pair.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/swap_allocator.h>
-#include <__memory/temp_value.h>
-#include <__memory/unique_ptr.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__ranges/size.h>
-#include <__split_buffer>
-#include <__type_traits/conditional.h>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/disjunction.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/is_trivially_relocatable.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/pair.h>
-#include <__utility/swap.h>
-#include <limits>
-#include <stdexcept>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/copy.h>
+#  include <__algorithm/copy_backward.h>
+#  include <__algorithm/copy_n.h>
+#  include <__algorithm/equal.h>
+#  include <__algorithm/fill_n.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lexicographical_compare_three_way.h>
+#  include <__algorithm/max.h>
+#  include <__algorithm/min.h>
+#  include <__algorithm/move.h>
+#  include <__algorithm/move_backward.h>
+#  include <__algorithm/remove.h>
+#  include <__algorithm/remove_if.h>
+#  include <__algorithm/unwrap_iter.h>
+#  include <__assert>
+#  include <__config>
+#  include <__debug_utils/sanitizers.h>
+#  include <__format/enable_insertable.h>
+#  include <__fwd/deque.h>
+#  include <__iterator/distance.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/move_iterator.h>
+#  include <__iterator/next.h>
+#  include <__iterator/prev.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__iterator/segmented_iterator.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_destructor.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/compressed_pair.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/swap_allocator.h>
+#  include <__memory/temp_value.h>
+#  include <__memory/unique_ptr.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__ranges/access.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__ranges/size.h>
+#  include <__split_buffer>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/disjunction.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/is_trivially_relocatable.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/pair.h>
+#  include <__utility/swap.h>
+#  include <limits>
+#  include <stdexcept>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [deque.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -272,13 +274,13 @@ template <class _ValueType,
           class _MapPointer,
           class _DiffType,
           _DiffType _BS =
-#ifdef _LIBCPP_ABI_INCOMPLETE_TYPES_IN_DEQUE
+#  ifdef _LIBCPP_ABI_INCOMPLETE_TYPES_IN_DEQUE
               // Keep template parameter to avoid changing all template declarations thoughout
               // this file.
           0
-#else
+#  else
               __deque_block_size<_ValueType, _DiffType>::value
-#endif
+#  endif
           >
 class _LIBCPP_TEMPLATE_VIS __deque_iterator {
   typedef _MapPointer __map_iterator;
@@ -299,10 +301,10 @@ public:
   typedef _Reference reference;
 
   _LIBCPP_HIDE_FROM_ABI __deque_iterator() _NOEXCEPT
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       : __m_iter_(nullptr),
         __ptr_(nullptr)
-#endif
+#  endif
   {
   }
 
@@ -391,7 +393,7 @@ public:
     return __x.__ptr_ == __y.__ptr_;
   }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
   _LIBCPP_HIDE_FROM_ABI friend bool operator!=(const __deque_iterator& __x, const __deque_iterator& __y) {
     return !(__x == __y);
   }
@@ -411,7 +413,7 @@ public:
     return !(__x < __y);
   }
 
-#else
+#  else
 
   _LIBCPP_HIDE_FROM_ABI friend strong_ordering operator<=>(const __deque_iterator& __x, const __deque_iterator& __y) {
     if (__x.__m_iter_ < __y.__m_iter_)
@@ -433,7 +435,7 @@ public:
 
     return strong_ordering::greater;
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 private:
   _LIBCPP_HIDE_FROM_ABI explicit __deque_iterator(__map_iterator __m, pointer __p) _NOEXCEPT
@@ -621,9 +623,9 @@ public:
   }
 
   explicit _LIBCPP_HIDE_FROM_ABI deque(size_type __n);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   explicit _LIBCPP_HIDE_FROM_ABI deque(size_type __n, const _Allocator& __a);
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI deque(size_type __n, const value_type& __v);
 
   template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
@@ -639,7 +641,7 @@ public:
   template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI deque(_InputIter __f, _InputIter __l, const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI deque(from_range_t, _Range&& __range, const allocator_type& __a = allocator_type())
       : __map_(__pointer_allocator(__a)), __start_(0), __size_(0), __alloc_(__a) {
@@ -652,14 +654,14 @@ public:
       }
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI deque(const deque& __c);
   _LIBCPP_HIDE_FROM_ABI deque(const deque& __c, const __type_identity_t<allocator_type>& __a);
 
   _LIBCPP_HIDE_FROM_ABI deque& operator=(const deque& __c);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI deque(initializer_list<value_type> __il);
   _LIBCPP_HIDE_FROM_ABI deque(initializer_list<value_type> __il, const allocator_type& __a);
 
@@ -675,7 +677,7 @@ public:
                                   is_nothrow_move_assignable<allocator_type>::value);
 
   _LIBCPP_HIDE_FROM_ABI void assign(initializer_list<value_type> __il) { assign(__il.begin(), __il.end()); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <class _InputIter,
             __enable_if_t<__has_input_iterator_category<_InputIter>::value &&
@@ -685,7 +687,7 @@ public:
   template <class _RAIter, __enable_if_t<__has_random_access_iterator_category<_RAIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void assign(_RAIter __f, _RAIter __l);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void assign_range(_Range&& __range) {
     if constexpr (ranges::random_access_range<_Range>) {
@@ -700,7 +702,7 @@ public:
       __assign_with_sentinel(ranges::begin(__range), ranges::end(__range));
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void assign(size_type __n, const value_type& __v);
 
@@ -769,25 +771,25 @@ public:
   // 23.2.2.3 modifiers:
   _LIBCPP_HIDE_FROM_ABI void push_front(const value_type& __v);
   _LIBCPP_HIDE_FROM_ABI void push_back(const value_type& __v);
-#ifndef _LIBCPP_CXX03_LANG
-#  if _LIBCPP_STD_VER >= 17
+#  ifndef _LIBCPP_CXX03_LANG
+#    if _LIBCPP_STD_VER >= 17
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI reference emplace_front(_Args&&... __args);
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI reference emplace_back(_Args&&... __args);
-#  else
+#    else
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI void emplace_front(_Args&&... __args);
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI void emplace_back(_Args&&... __args);
-#  endif
+#    endif
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator emplace(const_iterator __p, _Args&&... __args);
 
   _LIBCPP_HIDE_FROM_ABI void push_front(value_type&& __v);
   _LIBCPP_HIDE_FROM_ABI void push_back(value_type&& __v);
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void prepend_range(_Range&& __range) {
     insert_range(begin(), std::forward<_Range>(__range));
@@ -797,14 +799,14 @@ public:
   _LIBCPP_HIDE_FROM_ABI void append_range(_Range&& __range) {
     insert_range(end(), std::forward<_Range>(__range));
   }
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, value_type&& __v);
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, initializer_list<value_type> __il) {
     return insert(__p, __il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, const value_type& __v);
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, size_type __n, const value_type& __v);
   template <class _InputIter, __enable_if_t<__has_exactly_input_iterator_category<_InputIter>::value, int> = 0>
@@ -815,7 +817,7 @@ public:
   template <class _BiIter, __enable_if_t<__has_bidirectional_iterator_category<_BiIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, _BiIter __f, _BiIter __l);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI iterator insert_range(const_iterator __position, _Range&& __range) {
     if constexpr (ranges::bidirectional_range<_Range>) {
@@ -830,7 +832,7 @@ public:
       return __insert_with_sentinel(__position, ranges::begin(__range), ranges::end(__range));
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void pop_front();
   _LIBCPP_HIDE_FROM_ABI void pop_back();
@@ -838,11 +840,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __f, const_iterator __l);
 
   _LIBCPP_HIDE_FROM_ABI void swap(deque& __c)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
-#else
+#  else
       _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT;
 
   _LIBCPP_HIDE_FROM_ABI bool __invariants() const {
@@ -920,7 +922,7 @@ private:
     (void)__end;
     (void)__annotation_type;
     (void)__place;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     // __beg - index of the first item to annotate
     // __end - index behind the last item to annotate (so last item + 1)
     // __annotation_type - __asan_unposion or __asan_poison
@@ -1013,23 +1015,23 @@ private:
       std::__annotate_double_ended_contiguous_container<_Allocator>(
           __mem_beg, __mem_end, __old_beg, __old_end, __new_beg, __new_end);
     }
-#endif // _LIBCPP_HAS_ASAN
+#  endif // _LIBCPP_HAS_ASAN
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_new(size_type __current_size) const _NOEXCEPT {
     (void)__current_size;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     if (__current_size == 0)
       __annotate_from_to(0, __map_.size() * __block_size, __asan_poison, __asan_back_moved);
     else {
       __annotate_from_to(0, __start_, __asan_poison, __asan_front_moved);
       __annotate_from_to(__start_ + __current_size, __map_.size() * __block_size, __asan_poison, __asan_back_moved);
     }
-#endif // _LIBCPP_HAS_ASAN
+#  endif // _LIBCPP_HAS_ASAN
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_delete() const _NOEXCEPT {
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     if (empty()) {
       for (size_t __i = 0; __i < __map_.size(); ++__i) {
         __annotate_whole_block(__i, __asan_unposion);
@@ -1038,37 +1040,37 @@ private:
       __annotate_from_to(0, __start_, __asan_unposion, __asan_front_moved);
       __annotate_from_to(__start_ + size(), __map_.size() * __block_size, __asan_unposion, __asan_back_moved);
     }
-#endif // _LIBCPP_HAS_ASAN
+#  endif // _LIBCPP_HAS_ASAN
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_increase_front(size_type __n) const _NOEXCEPT {
     (void)__n;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     __annotate_from_to(__start_ - __n, __start_, __asan_unposion, __asan_front_moved);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_increase_back(size_type __n) const _NOEXCEPT {
     (void)__n;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     __annotate_from_to(__start_ + size(), __start_ + size() + __n, __asan_unposion, __asan_back_moved);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_shrink_front(size_type __old_size, size_type __old_start) const _NOEXCEPT {
     (void)__old_size;
     (void)__old_start;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     __annotate_from_to(__old_start, __old_start + (__old_size - size()), __asan_poison, __asan_front_moved);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_shrink_back(size_type __old_size, size_type __old_start) const _NOEXCEPT {
     (void)__old_size;
     (void)__old_start;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     __annotate_from_to(__old_start + size(), __old_start + __old_size, __asan_poison, __asan_back_moved);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI void __annotate_poison_block(const void* __beginning, const void* __end) const _NOEXCEPT {
@@ -1079,7 +1081,7 @@ private:
   __annotate_whole_block(size_t __block_index, __asan_annotation_type __annotation_type) const _NOEXCEPT {
     (void)__block_index;
     (void)__annotation_type;
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
     __map_const_iterator __block_it = __map_.begin() + __block_index;
     const void* __block_start       = std::__to_address(*__block_it);
     const void* __block_end         = std::__to_address(*__block_it + __block_size);
@@ -1090,9 +1092,9 @@ private:
       std::__annotate_double_ended_contiguous_container<_Allocator>(
           __block_start, __block_end, __block_start, __block_start, __block_start, __block_end);
     }
-#endif
+#  endif
   }
-#if _LIBCPP_HAS_ASAN
+#  if _LIBCPP_HAS_ASAN
 
 public:
   _LIBCPP_HIDE_FROM_ABI bool __verify_asan_annotations() const _NOEXCEPT {
@@ -1154,7 +1156,7 @@ public:
   }
 
 private:
-#endif // _LIBCPP_HAS_ASAN
+#  endif // _LIBCPP_HAS_ASAN
   _LIBCPP_HIDE_FROM_ABI bool __maybe_remove_front_spare(bool __keep_one = true) {
     if (__front_spare_blocks() >= 2 || (!__keep_one && __front_spare_blocks())) {
       __annotate_whole_block(0, __asan_unposion);
@@ -1244,7 +1246,7 @@ template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR const typename allocator_traits<_Alloc>::difference_type deque<_Tp, _Alloc>::__block_size =
     __deque_block_size<value_type, difference_type>::value;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Alloc = allocator<__iter_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
@@ -1256,14 +1258,14 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator<_Alloc>::value> >
 deque(_InputIterator, _InputIterator, _Alloc) -> deque<__iter_value_type<_InputIterator>, _Alloc>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
           class        = enable_if_t<__is_allocator<_Alloc>::value> >
 deque(from_range_t, _Range&&, _Alloc = _Alloc()) -> deque<ranges::range_value_t<_Range>, _Alloc>;
-#endif
+#  endif
 
 template <class _Tp, class _Allocator>
 deque<_Tp, _Allocator>::deque(size_type __n) : __start_(0), __size_(0) {
@@ -1272,7 +1274,7 @@ deque<_Tp, _Allocator>::deque(size_type __n) : __start_(0), __size_(0) {
     __append(__n);
 }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 template <class _Tp, class _Allocator>
 deque<_Tp, _Allocator>::deque(size_type __n, const _Allocator& __a)
     : __map_(__pointer_allocator(__a)), __start_(0), __size_(0), __alloc_(__a) {
@@ -1280,7 +1282,7 @@ deque<_Tp, _Allocator>::deque(size_type __n, const _Allocator& __a)
   if (__n > 0)
     __append(__n);
 }
-#endif
+#  endif
 
 template <class _Tp, class _Allocator>
 deque<_Tp, _Allocator>::deque(size_type __n, const value_type& __v) : __start_(0), __size_(0) {
@@ -1330,7 +1332,7 @@ deque<_Tp, _Allocator>& deque<_Tp, _Allocator>::operator=(const deque& __c) {
   return *this;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Allocator>
 deque<_Tp, _Allocator>::deque(initializer_list<value_type> __il) : __start_(0), __size_(0) {
@@ -1398,7 +1400,7 @@ void deque<_Tp, _Allocator>::__move_assign(deque& __c,
   __move_assign(__c);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Allocator>
 template <class _InputIter,
@@ -1586,7 +1588,7 @@ void deque<_Tp, _Allocator>::push_front(const value_type& __v) {
   ++__size();
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Allocator>
 void deque<_Tp, _Allocator>::push_back(value_type&& __v) {
   allocator_type& __a = __alloc();
@@ -1600,11 +1602,11 @@ void deque<_Tp, _Allocator>::push_back(value_type&& __v) {
 
 template <class _Tp, class _Allocator>
 template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 typename deque<_Tp, _Allocator>::reference
-#  else
+#    else
 void
-#  endif
+#    endif
 deque<_Tp, _Allocator>::emplace_back(_Args&&... __args) {
   allocator_type& __a = __alloc();
   if (__back_spare() == 0)
@@ -1613,9 +1615,9 @@ deque<_Tp, _Allocator>::emplace_back(_Args&&... __args) {
   __annotate_increase_back(1);
   __alloc_traits::construct(__a, std::addressof(*end()), std::forward<_Args>(__args)...);
   ++__size();
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   return *--end();
-#  endif
+#    endif
 }
 
 template <class _Tp, class _Allocator>
@@ -1632,11 +1634,11 @@ void deque<_Tp, _Allocator>::push_front(value_type&& __v) {
 
 template <class _Tp, class _Allocator>
 template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 typename deque<_Tp, _Allocator>::reference
-#  else
+#    else
 void
-#  endif
+#    endif
 deque<_Tp, _Allocator>::emplace_front(_Args&&... __args) {
   allocator_type& __a = __alloc();
   if (__front_spare() == 0)
@@ -1646,9 +1648,9 @@ deque<_Tp, _Allocator>::emplace_front(_Args&&... __args) {
   __alloc_traits::construct(__a, std::addressof(*--begin()), std::forward<_Args>(__args)...);
   --__start_;
   ++__size();
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   return *begin();
-#  endif
+#    endif
 }
 
 template <class _Tp, class _Allocator>
@@ -1746,7 +1748,7 @@ typename deque<_Tp, _Allocator>::iterator deque<_Tp, _Allocator>::emplace(const_
   return begin() + __pos;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Allocator>
 typename deque<_Tp, _Allocator>::iterator deque<_Tp, _Allocator>::insert(const_iterator __p, const value_type& __v) {
@@ -1969,11 +1971,11 @@ template <class _Tp, class _Allocator>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_HIDE_FROM_ABI void deque<_Tp, _Allocator>::__append_with_sentinel(_InputIterator __f, _Sentinel __l) {
   for (; __f != __l; ++__f)
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
     push_back(*__f);
-#else
+#  else
     emplace_back(*__f);
-#endif
+#  endif
 }
 
 template <class _Tp, class _Allocator>
@@ -2125,22 +2127,22 @@ void deque<_Tp, _Allocator>::__add_front_capacity(size_type __n) {
     size_type __ds = (__nb + __back_capacity) * __block_size - __map_.empty();
     __split_buffer<pointer, __pointer_allocator&> __buf(
         std::max<size_type>(2 * __map_.capacity(), __nb + __map_.size()), 0, __map_.__alloc_);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (; __nb > 0; --__nb) {
         __buf.emplace_back(__alloc_traits::allocate(__a, __block_size));
         // ASan: this is empty container, we have to poison whole block
         __annotate_poison_block(std::__to_address(__buf.back()), std::__to_address(__buf.back() + __block_size));
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __annotate_delete();
       for (__map_pointer __i = __buf.begin(); __i != __buf.end(); ++__i)
         __alloc_traits::deallocate(__a, *__i, __block_size);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     for (; __back_capacity > 0; --__back_capacity) {
       __buf.emplace_back(__map_.back());
       __map_.pop_back();
@@ -2250,22 +2252,22 @@ void deque<_Tp, _Allocator>::__add_back_capacity(size_type __n) {
         std::max<size_type>(2 * __map_.capacity(), __nb + __map_.size()),
         __map_.size() - __front_capacity,
         __map_.__alloc_);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (; __nb > 0; --__nb) {
         __buf.emplace_back(__alloc_traits::allocate(__a, __block_size));
         // ASan: this is an empty container, we have to poison the whole block
         __annotate_poison_block(std::__to_address(__buf.back()), std::__to_address(__buf.back() + __block_size));
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __annotate_delete();
       for (__map_pointer __i = __buf.begin(); __i != __buf.end(); ++__i)
         __alloc_traits::deallocate(__a, *__i, __block_size);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     for (; __front_capacity > 0; --__front_capacity) {
       __buf.emplace_back(__map_.front());
       __map_.pop_front();
@@ -2502,11 +2504,11 @@ void deque<_Tp, _Allocator>::__erase_to_end(const_iterator __f) {
 
 template <class _Tp, class _Allocator>
 inline void deque<_Tp, _Allocator>::swap(deque& __c)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
-#else
+#  else
     _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
-#endif
+#  endif
 {
   __map_.swap(__c.__map_);
   std::swap(__start_, __c.__start_);
@@ -2542,7 +2544,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator==(const deque<_Tp, _Allocator>& __x, 
   return __sz == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const deque<_Tp, _Allocator>& __x, const deque<_Tp, _Allocator>& __y) {
@@ -2569,7 +2571,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator<=(const deque<_Tp, _Allocator>& __x, 
   return !(__y < __x);
 }
 
-#else // _LIBCPP_STD_VER <= 17
+#  else // _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Tp>
@@ -2577,7 +2579,7 @@ operator<=>(const deque<_Tp, _Allocator>& __x, const deque<_Tp, _Allocator>& __y
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
-#endif // _LIBCPP_STD_VER <= 17
+#  endif // _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void swap(deque<_Tp, _Allocator>& __x, deque<_Tp, _Allocator>& __y)
@@ -2585,7 +2587,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(deque<_Tp, _Allocator>& __x, deque<_Tp, _
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Tp, class _Allocator, class _Up>
 inline _LIBCPP_HIDE_FROM_ABI typename deque<_Tp, _Allocator>::size_type
 erase(deque<_Tp, _Allocator>& __c, const _Up& __v) {
@@ -2604,12 +2606,12 @@ erase_if(deque<_Tp, _Allocator>& __c, _Predicate __pred) {
 
 template <>
 inline constexpr bool __format::__enable_insertable<std::deque<char>> = true;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 inline constexpr bool __format::__enable_insertable<std::deque<wchar_t>> = true;
-#  endif
+#    endif
 
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp, class _Allocator>
 struct __container_traits<deque<_Tp, _Allocator> > {
@@ -2624,27 +2626,28 @@ struct __container_traits<deque<_Tp, _Allocator> > {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _ValueT>
 using deque _LIBCPP_AVAILABILITY_PMR = std::deque<_ValueT, polymorphic_allocator<_ValueT>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <atomic>
-#  include <concepts>
-#  include <cstdlib>
-#  include <functional>
-#  include <iosfwd>
-#  include <iterator>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <atomic>
+#    include <concepts>
+#    include <cstdlib>
+#    include <functional>
+#    include <iosfwd>
+#    include <iterator>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_DEQUE

--- a/libcxx/include/errno.h
+++ b/libcxx/include/errno.h
@@ -22,378 +22,381 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if __has_include_next(<errno.h>)
-#  include_next <errno.h>
-#endif
+#  if __has_include_next(<errno.h>)
+#    include_next <errno.h>
+#  endif
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 
-#  if !defined(EOWNERDEAD) || !defined(ENOTRECOVERABLE)
+#    if !defined(EOWNERDEAD) || !defined(ENOTRECOVERABLE)
 
-#    ifdef ELAST
+#      ifdef ELAST
 
 static const int __elast1 = ELAST + 1;
 static const int __elast2 = ELAST + 2;
 
-#    else
+#      else
 
 static const int __elast1 = 104;
 static const int __elast2 = 105;
 
-#    endif
-
-#    ifdef ENOTRECOVERABLE
-
-#      define EOWNERDEAD __elast1
-
-#      ifdef ELAST
-#        undef ELAST
-#        define ELAST EOWNERDEAD
 #      endif
 
-#    elif defined(EOWNERDEAD)
+#      ifdef ENOTRECOVERABLE
 
-#      define ENOTRECOVERABLE __elast1
-#      ifdef ELAST
-#        undef ELAST
-#        define ELAST ENOTRECOVERABLE
-#      endif
+#        define EOWNERDEAD __elast1
 
-#    else // defined(EOWNERDEAD)
+#        ifdef ELAST
+#          undef ELAST
+#          define ELAST EOWNERDEAD
+#        endif
 
-#      define EOWNERDEAD __elast1
-#      define ENOTRECOVERABLE __elast2
-#      ifdef ELAST
-#        undef ELAST
-#        define ELAST ENOTRECOVERABLE
-#      endif
+#      elif defined(EOWNERDEAD)
 
-#    endif // defined(EOWNERDEAD)
+#        define ENOTRECOVERABLE __elast1
+#        ifdef ELAST
+#          undef ELAST
+#          define ELAST ENOTRECOVERABLE
+#        endif
 
-#  endif // !defined(EOWNERDEAD) || !defined(ENOTRECOVERABLE)
+#      else // defined(EOWNERDEAD)
+
+#        define EOWNERDEAD __elast1
+#        define ENOTRECOVERABLE __elast2
+#        ifdef ELAST
+#          undef ELAST
+#          define ELAST ENOTRECOVERABLE
+#        endif
+
+#      endif // defined(EOWNERDEAD)
+
+#    endif // !defined(EOWNERDEAD) || !defined(ENOTRECOVERABLE)
 
 //  supply errno values likely to be missing, particularly on Windows
 
-#  ifndef EAFNOSUPPORT
-#    define EAFNOSUPPORT 9901
-#  endif
+#    ifndef EAFNOSUPPORT
+#      define EAFNOSUPPORT 9901
+#    endif
 
-#  ifndef EADDRINUSE
-#    define EADDRINUSE 9902
-#  endif
+#    ifndef EADDRINUSE
+#      define EADDRINUSE 9902
+#    endif
 
-#  ifndef EADDRNOTAVAIL
-#    define EADDRNOTAVAIL 9903
-#  endif
+#    ifndef EADDRNOTAVAIL
+#      define EADDRNOTAVAIL 9903
+#    endif
 
-#  ifndef EISCONN
-#    define EISCONN 9904
-#  endif
+#    ifndef EISCONN
+#      define EISCONN 9904
+#    endif
 
-#  ifndef EBADMSG
-#    define EBADMSG 9905
-#  endif
+#    ifndef EBADMSG
+#      define EBADMSG 9905
+#    endif
 
-#  ifndef ECONNABORTED
-#    define ECONNABORTED 9906
-#  endif
+#    ifndef ECONNABORTED
+#      define ECONNABORTED 9906
+#    endif
 
-#  ifndef EALREADY
-#    define EALREADY 9907
-#  endif
+#    ifndef EALREADY
+#      define EALREADY 9907
+#    endif
 
-#  ifndef ECONNREFUSED
-#    define ECONNREFUSED 9908
-#  endif
+#    ifndef ECONNREFUSED
+#      define ECONNREFUSED 9908
+#    endif
 
-#  ifndef ECONNRESET
-#    define ECONNRESET 9909
-#  endif
+#    ifndef ECONNRESET
+#      define ECONNRESET 9909
+#    endif
 
-#  ifndef EDESTADDRREQ
-#    define EDESTADDRREQ 9910
-#  endif
+#    ifndef EDESTADDRREQ
+#      define EDESTADDRREQ 9910
+#    endif
 
-#  ifndef EHOSTUNREACH
-#    define EHOSTUNREACH 9911
-#  endif
+#    ifndef EHOSTUNREACH
+#      define EHOSTUNREACH 9911
+#    endif
 
-#  ifndef EIDRM
-#    define EIDRM 9912
-#  endif
+#    ifndef EIDRM
+#      define EIDRM 9912
+#    endif
 
-#  ifndef EMSGSIZE
-#    define EMSGSIZE 9913
-#  endif
+#    ifndef EMSGSIZE
+#      define EMSGSIZE 9913
+#    endif
 
-#  ifndef ENETDOWN
-#    define ENETDOWN 9914
-#  endif
+#    ifndef ENETDOWN
+#      define ENETDOWN 9914
+#    endif
 
-#  ifndef ENETRESET
-#    define ENETRESET 9915
-#  endif
+#    ifndef ENETRESET
+#      define ENETRESET 9915
+#    endif
 
-#  ifndef ENETUNREACH
-#    define ENETUNREACH 9916
-#  endif
+#    ifndef ENETUNREACH
+#      define ENETUNREACH 9916
+#    endif
 
-#  ifndef ENOBUFS
-#    define ENOBUFS 9917
-#  endif
+#    ifndef ENOBUFS
+#      define ENOBUFS 9917
+#    endif
 
-#  ifndef ENOLINK
-#    define ENOLINK 9918
-#  endif
+#    ifndef ENOLINK
+#      define ENOLINK 9918
+#    endif
 
-#  ifndef ENODATA
-#    define ENODATA 9919
-#  endif
+#    ifndef ENODATA
+#      define ENODATA 9919
+#    endif
 
-#  ifndef ENOMSG
-#    define ENOMSG 9920
-#  endif
+#    ifndef ENOMSG
+#      define ENOMSG 9920
+#    endif
 
-#  ifndef ENOPROTOOPT
-#    define ENOPROTOOPT 9921
-#  endif
+#    ifndef ENOPROTOOPT
+#      define ENOPROTOOPT 9921
+#    endif
 
-#  ifndef ENOSR
-#    define ENOSR 9922
-#  endif
+#    ifndef ENOSR
+#      define ENOSR 9922
+#    endif
 
-#  ifndef ENOTSOCK
-#    define ENOTSOCK 9923
-#  endif
+#    ifndef ENOTSOCK
+#      define ENOTSOCK 9923
+#    endif
 
-#  ifndef ENOSTR
-#    define ENOSTR 9924
-#  endif
+#    ifndef ENOSTR
+#      define ENOSTR 9924
+#    endif
 
-#  ifndef ENOTCONN
-#    define ENOTCONN 9925
-#  endif
+#    ifndef ENOTCONN
+#      define ENOTCONN 9925
+#    endif
 
-#  ifndef ENOTSUP
-#    define ENOTSUP 9926
-#  endif
+#    ifndef ENOTSUP
+#      define ENOTSUP 9926
+#    endif
 
-#  ifndef ECANCELED
-#    define ECANCELED 9927
-#  endif
+#    ifndef ECANCELED
+#      define ECANCELED 9927
+#    endif
 
-#  ifndef EINPROGRESS
-#    define EINPROGRESS 9928
-#  endif
+#    ifndef EINPROGRESS
+#      define EINPROGRESS 9928
+#    endif
 
-#  ifndef EOPNOTSUPP
-#    define EOPNOTSUPP 9929
-#  endif
+#    ifndef EOPNOTSUPP
+#      define EOPNOTSUPP 9929
+#    endif
 
-#  ifndef EWOULDBLOCK
-#    define EWOULDBLOCK 9930
-#  endif
+#    ifndef EWOULDBLOCK
+#      define EWOULDBLOCK 9930
+#    endif
 
-#  ifndef EOWNERDEAD
-#    define EOWNERDEAD 9931
-#  endif
+#    ifndef EOWNERDEAD
+#      define EOWNERDEAD 9931
+#    endif
 
-#  ifndef EPROTO
-#    define EPROTO 9932
-#  endif
+#    ifndef EPROTO
+#      define EPROTO 9932
+#    endif
 
-#  ifndef EPROTONOSUPPORT
-#    define EPROTONOSUPPORT 9933
-#  endif
+#    ifndef EPROTONOSUPPORT
+#      define EPROTONOSUPPORT 9933
+#    endif
 
-#  ifndef ENOTRECOVERABLE
-#    define ENOTRECOVERABLE 9934
-#  endif
+#    ifndef ENOTRECOVERABLE
+#      define ENOTRECOVERABLE 9934
+#    endif
 
-#  ifndef ETIME
-#    define ETIME 9935
-#  endif
+#    ifndef ETIME
+#      define ETIME 9935
+#    endif
 
-#  ifndef ETXTBSY
-#    define ETXTBSY 9936
-#  endif
+#    ifndef ETXTBSY
+#      define ETXTBSY 9936
+#    endif
 
-#  ifndef ETIMEDOUT
-#    define ETIMEDOUT 9938
-#  endif
+#    ifndef ETIMEDOUT
+#      define ETIMEDOUT 9938
+#    endif
 
-#  ifndef ELOOP
-#    define ELOOP 9939
-#  endif
+#    ifndef ELOOP
+#      define ELOOP 9939
+#    endif
 
-#  ifndef EOVERFLOW
-#    define EOVERFLOW 9940
-#  endif
+#    ifndef EOVERFLOW
+#      define EOVERFLOW 9940
+#    endif
 
-#  ifndef EPROTOTYPE
-#    define EPROTOTYPE 9941
-#  endif
+#    ifndef EPROTOTYPE
+#      define EPROTOTYPE 9941
+#    endif
 
-#  ifndef ENOSYS
-#    define ENOSYS 9942
-#  endif
+#    ifndef ENOSYS
+#      define ENOSYS 9942
+#    endif
 
-#  ifndef EINVAL
-#    define EINVAL 9943
-#  endif
+#    ifndef EINVAL
+#      define EINVAL 9943
+#    endif
 
-#  ifndef ERANGE
-#    define ERANGE 9944
-#  endif
+#    ifndef ERANGE
+#      define ERANGE 9944
+#    endif
 
-#  ifndef EILSEQ
-#    define EILSEQ 9945
-#  endif
+#    ifndef EILSEQ
+#      define EILSEQ 9945
+#    endif
 
 //  Windows Mobile doesn't appear to define these:
 
-#  ifndef E2BIG
-#    define E2BIG 9946
-#  endif
+#    ifndef E2BIG
+#      define E2BIG 9946
+#    endif
 
-#  ifndef EDOM
-#    define EDOM 9947
-#  endif
+#    ifndef EDOM
+#      define EDOM 9947
+#    endif
 
-#  ifndef EFAULT
-#    define EFAULT 9948
-#  endif
+#    ifndef EFAULT
+#      define EFAULT 9948
+#    endif
 
-#  ifndef EBADF
-#    define EBADF 9949
-#  endif
+#    ifndef EBADF
+#      define EBADF 9949
+#    endif
 
-#  ifndef EPIPE
-#    define EPIPE 9950
-#  endif
+#    ifndef EPIPE
+#      define EPIPE 9950
+#    endif
 
-#  ifndef EXDEV
-#    define EXDEV 9951
-#  endif
+#    ifndef EXDEV
+#      define EXDEV 9951
+#    endif
 
-#  ifndef EBUSY
-#    define EBUSY 9952
-#  endif
+#    ifndef EBUSY
+#      define EBUSY 9952
+#    endif
 
-#  ifndef ENOTEMPTY
-#    define ENOTEMPTY 9953
-#  endif
+#    ifndef ENOTEMPTY
+#      define ENOTEMPTY 9953
+#    endif
 
-#  ifndef ENOEXEC
-#    define ENOEXEC 9954
-#  endif
+#    ifndef ENOEXEC
+#      define ENOEXEC 9954
+#    endif
 
-#  ifndef EEXIST
-#    define EEXIST 9955
-#  endif
+#    ifndef EEXIST
+#      define EEXIST 9955
+#    endif
 
-#  ifndef EFBIG
-#    define EFBIG 9956
-#  endif
+#    ifndef EFBIG
+#      define EFBIG 9956
+#    endif
 
-#  ifndef ENAMETOOLONG
-#    define ENAMETOOLONG 9957
-#  endif
+#    ifndef ENAMETOOLONG
+#      define ENAMETOOLONG 9957
+#    endif
 
-#  ifndef ENOTTY
-#    define ENOTTY 9958
-#  endif
+#    ifndef ENOTTY
+#      define ENOTTY 9958
+#    endif
 
-#  ifndef EINTR
-#    define EINTR 9959
-#  endif
+#    ifndef EINTR
+#      define EINTR 9959
+#    endif
 
-#  ifndef ESPIPE
-#    define ESPIPE 9960
-#  endif
+#    ifndef ESPIPE
+#      define ESPIPE 9960
+#    endif
 
-#  ifndef EIO
-#    define EIO 9961
-#  endif
+#    ifndef EIO
+#      define EIO 9961
+#    endif
 
-#  ifndef EISDIR
-#    define EISDIR 9962
-#  endif
+#    ifndef EISDIR
+#      define EISDIR 9962
+#    endif
 
-#  ifndef ECHILD
-#    define ECHILD 9963
-#  endif
+#    ifndef ECHILD
+#      define ECHILD 9963
+#    endif
 
-#  ifndef ENOLCK
-#    define ENOLCK 9964
-#  endif
+#    ifndef ENOLCK
+#      define ENOLCK 9964
+#    endif
 
-#  ifndef ENOSPC
-#    define ENOSPC 9965
-#  endif
+#    ifndef ENOSPC
+#      define ENOSPC 9965
+#    endif
 
-#  ifndef ENXIO
-#    define ENXIO 9966
-#  endif
+#    ifndef ENXIO
+#      define ENXIO 9966
+#    endif
 
-#  ifndef ENODEV
-#    define ENODEV 9967
-#  endif
+#    ifndef ENODEV
+#      define ENODEV 9967
+#    endif
 
-#  ifndef ENOENT
-#    define ENOENT 9968
-#  endif
+#    ifndef ENOENT
+#      define ENOENT 9968
+#    endif
 
-#  ifndef ESRCH
-#    define ESRCH 9969
-#  endif
+#    ifndef ESRCH
+#      define ESRCH 9969
+#    endif
 
-#  ifndef ENOTDIR
-#    define ENOTDIR 9970
-#  endif
+#    ifndef ENOTDIR
+#      define ENOTDIR 9970
+#    endif
 
-#  ifndef ENOMEM
-#    define ENOMEM 9971
-#  endif
+#    ifndef ENOMEM
+#      define ENOMEM 9971
+#    endif
 
-#  ifndef EPERM
-#    define EPERM 9972
-#  endif
+#    ifndef EPERM
+#      define EPERM 9972
+#    endif
 
-#  ifndef EACCES
-#    define EACCES 9973
-#  endif
+#    ifndef EACCES
+#      define EACCES 9973
+#    endif
 
-#  ifndef EROFS
-#    define EROFS 9974
-#  endif
+#    ifndef EROFS
+#      define EROFS 9974
+#    endif
 
-#  ifndef EDEADLK
-#    define EDEADLK 9975
-#  endif
+#    ifndef EDEADLK
+#      define EDEADLK 9975
+#    endif
 
-#  ifndef EAGAIN
-#    define EAGAIN 9976
-#  endif
+#    ifndef EAGAIN
+#      define EAGAIN 9976
+#    endif
 
-#  ifndef ENFILE
-#    define ENFILE 9977
-#  endif
+#    ifndef ENFILE
+#      define ENFILE 9977
+#    endif
 
-#  ifndef EMFILE
-#    define EMFILE 9978
-#  endif
+#    ifndef EMFILE
+#      define EMFILE 9978
+#    endif
 
-#  ifndef EMLINK
-#    define EMLINK 9979
-#  endif
+#    ifndef EMLINK
+#      define EMLINK 9979
+#    endif
 
-#endif // __cplusplus
+#  endif // __cplusplus
+#endif   // 0
 
 #endif // _LIBCPP_ERRNO_H

--- a/libcxx/include/exception
+++ b/libcxx/include/exception
@@ -76,22 +76,25 @@ template <class E> void rethrow_if_nested(const E& e);
 
 */
 
-#include <__config>
-#include <__exception/exception.h>
-#include <__exception/exception_ptr.h>
-#include <__exception/nested_exception.h>
-#include <__exception/operations.h>
-#include <__exception/terminate.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__exception/exception.h>
+#  include <__exception/exception_ptr.h>
+#  include <__exception/nested_exception.h>
+#  include <__exception/operations.h>
+#  include <__exception/terminate.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <cstdlib>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <cstdlib>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_EXCEPTION

--- a/libcxx/include/execution
+++ b/libcxx/include/execution
@@ -32,17 +32,19 @@ namespace std {
 }
 */
 
-#include <__config>
-#include <__type_traits/is_execution_policy.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/remove_cvref.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__type_traits/is_execution_policy.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_INCOMPLETE_PSTL) && _LIBCPP_STD_VER >= 17
+#  if !defined(_LIBCPP_HAS_NO_INCOMPLETE_PSTL) && _LIBCPP_STD_VER >= 17
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -79,7 +81,7 @@ struct __unsequenced_policy {
 
 constexpr __unsequenced_policy __unseq{__disable_user_instantiations_tag{}};
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 struct unsequenced_policy {
   _LIBCPP_HIDE_FROM_ABI constexpr explicit unsequenced_policy(__disable_user_instantiations_tag) {}
@@ -89,7 +91,7 @@ struct unsequenced_policy {
 
 inline constexpr unsequenced_policy unseq{__disable_user_instantiations_tag{}};
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 } // namespace execution
 
@@ -117,14 +119,14 @@ inline constexpr bool __is_unsequenced_execution_policy_impl<execution::__unsequ
 template <>
 inline constexpr bool __is_unsequenced_execution_policy_impl<execution::parallel_unsequenced_policy> = true;
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <>
 inline constexpr bool is_execution_policy_v<execution::unsequenced_policy> = true;
 
 template <>
 inline constexpr bool __is_unsequenced_execution_policy_impl<execution::unsequenced_policy> = true;
 
-#  endif
+#    endif
 
 template <class _Tp>
 struct is_execution_policy : bool_constant<is_execution_policy_v<_Tp>> {};
@@ -140,10 +142,11 @@ _LIBCPP_HIDE_FROM_ABI auto __remove_parallel_policy(const _ExecutionPolicy&) {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // !defined(_LIBCPP_HAS_NO_INCOMPLETE_PSTL) && _LIBCPP_STD_VER >= 17
+#  endif // !defined(_LIBCPP_HAS_NO_INCOMPLETE_PSTL) && _LIBCPP_STD_VER >= 17
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_EXECUTION

--- a/libcxx/include/expected
+++ b/libcxx/include/expected
@@ -38,19 +38,22 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__expected/bad_expected_access.h>
-#  include <__expected/expected.h>
-#  include <__expected/unexpect.h>
-#  include <__expected/unexpected.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__expected/bad_expected_access.h>
+#    include <__expected/expected.h>
+#    include <__expected/unexpect.h>
+#    include <__expected/unexpected.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_EXPECTED

--- a/libcxx/include/fenv.h
+++ b/libcxx/include/fenv.h
@@ -49,66 +49,69 @@ int feupdateenv(const fenv_t* envp);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if __has_include_next(<fenv.h>)
-#  include_next <fenv.h>
-#endif
+#  if __has_include_next(<fenv.h>)
+#    include_next <fenv.h>
+#  endif
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 
 extern "C++" {
 
-#  ifdef feclearexcept
-#    undef feclearexcept
-#  endif
+#    ifdef feclearexcept
+#      undef feclearexcept
+#    endif
 
-#  ifdef fegetexceptflag
-#    undef fegetexceptflag
-#  endif
+#    ifdef fegetexceptflag
+#      undef fegetexceptflag
+#    endif
 
-#  ifdef feraiseexcept
-#    undef feraiseexcept
-#  endif
+#    ifdef feraiseexcept
+#      undef feraiseexcept
+#    endif
 
-#  ifdef fesetexceptflag
-#    undef fesetexceptflag
-#  endif
+#    ifdef fesetexceptflag
+#      undef fesetexceptflag
+#    endif
 
-#  ifdef fetestexcept
-#    undef fetestexcept
-#  endif
+#    ifdef fetestexcept
+#      undef fetestexcept
+#    endif
 
-#  ifdef fegetround
-#    undef fegetround
-#  endif
+#    ifdef fegetround
+#      undef fegetround
+#    endif
 
-#  ifdef fesetround
-#    undef fesetround
-#  endif
+#    ifdef fesetround
+#      undef fesetround
+#    endif
 
-#  ifdef fegetenv
-#    undef fegetenv
-#  endif
+#    ifdef fegetenv
+#      undef fegetenv
+#    endif
 
-#  ifdef feholdexcept
-#    undef feholdexcept
-#  endif
+#    ifdef feholdexcept
+#      undef feholdexcept
+#    endif
 
-#  ifdef fesetenv
-#    undef fesetenv
-#  endif
+#    ifdef fesetenv
+#      undef fesetenv
+#    endif
 
-#  ifdef feupdateenv
-#    undef feupdateenv
-#  endif
+#    ifdef feupdateenv
+#      undef feupdateenv
+#    endif
 
 } // extern "C++"
 
-#endif // defined(__cplusplus)
+#  endif // defined(__cplusplus)
+#endif   // 0
 
 #endif // _LIBCPP_FENV_H

--- a/libcxx/include/filesystem
+++ b/libcxx/include/filesystem
@@ -533,45 +533,48 @@ inline constexpr bool std::ranges::enable_view<std::filesystem::recursive_direct
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__filesystem/copy_options.h>
-#  include <__filesystem/directory_entry.h>
-#  include <__filesystem/directory_iterator.h>
-#  include <__filesystem/directory_options.h>
-#  include <__filesystem/file_status.h>
-#  include <__filesystem/file_time_type.h>
-#  include <__filesystem/file_type.h>
-#  include <__filesystem/filesystem_error.h>
-#  include <__filesystem/operations.h>
-#  include <__filesystem/path.h>
-#  include <__filesystem/path_iterator.h>
-#  include <__filesystem/perm_options.h>
-#  include <__filesystem/perms.h>
-#  include <__filesystem/recursive_directory_iterator.h>
-#  include <__filesystem/space_info.h>
-#  include <__filesystem/u8path.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__filesystem/copy_options.h>
+#    include <__filesystem/directory_entry.h>
+#    include <__filesystem/directory_iterator.h>
+#    include <__filesystem/directory_options.h>
+#    include <__filesystem/file_status.h>
+#    include <__filesystem/file_time_type.h>
+#    include <__filesystem/file_type.h>
+#    include <__filesystem/filesystem_error.h>
+#    include <__filesystem/operations.h>
+#    include <__filesystem/path.h>
+#    include <__filesystem/path_iterator.h>
+#    include <__filesystem/perm_options.h>
+#    include <__filesystem/perms.h>
+#    include <__filesystem/recursive_directory_iterator.h>
+#    include <__filesystem/space_info.h>
+#    include <__filesystem/u8path.h>
+#  endif
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [fs.filesystem.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <cstdlib>
-#  include <cstring>
-#  include <iosfwd>
-#  include <new>
-#  include <system_error>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <cstdlib>
+#    include <cstring>
+#    include <iosfwd>
+#    include <new>
+#    include <system_error>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FILESYSTEM

--- a/libcxx/include/flat_map
+++ b/libcxx/include/flat_map
@@ -37,18 +37,21 @@ namespace std {
       erase_if(flat_map<Key, T, Compare, KeyContainer, MappedContainer>& c, Predicate pred);
 */
 
-#include <__assert> // all public C++ headers provide the assertion handler
-#include <__config>
-#include <__flat_map/flat_map.h>
-#include <__flat_map/sorted_unique.h>
-#include <version>
+#if 0
+#else                 // 0
+#  include <__assert> // all public C++ headers provide the assertion handler
+#  include <__config>
+#  include <__flat_map/flat_map.h>
+#  include <__flat_map/sorted_unique.h>
+#  include <version>
 
 // standard required includes
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FLAT_MAP

--- a/libcxx/include/float.h
+++ b/libcxx/include/float.h
@@ -70,26 +70,29 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
-
-#if __has_include_next(<float.h>)
-#  include_next <float.h>
-#endif
-
-#ifdef __cplusplus
-
-#  ifndef FLT_EVAL_METHOD
-#    define FLT_EVAL_METHOD __FLT_EVAL_METHOD__
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
 #  endif
 
-#  ifndef DECIMAL_DIG
-#    define DECIMAL_DIG __DECIMAL_DIG__
+#  if __has_include_next(<float.h>)
+#    include_next <float.h>
 #  endif
 
-#endif // __cplusplus
+#  ifdef __cplusplus
+
+#    ifndef FLT_EVAL_METHOD
+#      define FLT_EVAL_METHOD __FLT_EVAL_METHOD__
+#    endif
+
+#    ifndef DECIMAL_DIG
+#      define DECIMAL_DIG __DECIMAL_DIG__
+#    endif
+
+#  endif // __cplusplus
+#endif   // 0
 
 #endif // _LIBCPP_FLOAT_H

--- a/libcxx/include/format
+++ b/libcxx/include/format
@@ -191,70 +191,73 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__format/buffer.h>
-#  include <__format/concepts.h>
-#  include <__format/container_adaptor.h>
-#  include <__format/enable_insertable.h>
-#  include <__format/escaped_output_table.h>
-#  include <__format/extended_grapheme_cluster_table.h>
-#  include <__format/format_arg.h>
-#  include <__format/format_arg_store.h>
-#  include <__format/format_args.h>
-#  include <__format/format_context.h>
-#  include <__format/format_error.h>
-#  include <__format/format_functions.h>
-#  include <__format/format_parse_context.h>
-#  include <__format/format_string.h>
-#  include <__format/format_to_n_result.h>
-#  include <__format/formatter.h>
-#  include <__format/formatter_bool.h>
-#  include <__format/formatter_char.h>
-#  include <__format/formatter_floating_point.h>
-#  include <__format/formatter_integer.h>
-#  include <__format/formatter_pointer.h>
-#  include <__format/formatter_string.h>
-#  include <__format/formatter_tuple.h>
-#  include <__format/parser_std_format_spec.h>
-#  include <__format/range_default_formatter.h>
-#  include <__format/range_formatter.h>
-#  include <__format/unicode.h>
-#  include <__fwd/format.h>
-#endif
-
-#include <version>
-
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <array>
-#  include <cctype>
-#  include <cerrno>
-#  include <clocale>
-#  include <cmath>
-#  include <cstddef>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <cstring>
-#  include <initializer_list>
-#  include <limits>
-#  include <locale>
-#  include <new>
-#  include <optional>
-#  include <queue>
-#  include <stack>
-#  include <stdexcept>
-#  include <string>
-#  include <string_view>
-#  include <tuple>
-
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
-#    include <cwchar>
+#  if _LIBCPP_STD_VER >= 20
+#    include <__format/buffer.h>
+#    include <__format/concepts.h>
+#    include <__format/container_adaptor.h>
+#    include <__format/enable_insertable.h>
+#    include <__format/escaped_output_table.h>
+#    include <__format/extended_grapheme_cluster_table.h>
+#    include <__format/format_arg.h>
+#    include <__format/format_arg_store.h>
+#    include <__format/format_args.h>
+#    include <__format/format_context.h>
+#    include <__format/format_error.h>
+#    include <__format/format_functions.h>
+#    include <__format/format_parse_context.h>
+#    include <__format/format_string.h>
+#    include <__format/format_to_n_result.h>
+#    include <__format/formatter.h>
+#    include <__format/formatter_bool.h>
+#    include <__format/formatter_char.h>
+#    include <__format/formatter_floating_point.h>
+#    include <__format/formatter_integer.h>
+#    include <__format/formatter_pointer.h>
+#    include <__format/formatter_string.h>
+#    include <__format/formatter_tuple.h>
+#    include <__format/parser_std_format_spec.h>
+#    include <__format/range_default_formatter.h>
+#    include <__format/range_formatter.h>
+#    include <__format/unicode.h>
+#    include <__fwd/format.h>
 #  endif
-#endif
+
+#  include <version>
+
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <array>
+#    include <cctype>
+#    include <cerrno>
+#    include <clocale>
+#    include <cmath>
+#    include <cstddef>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <cstring>
+#    include <initializer_list>
+#    include <limits>
+#    include <locale>
+#    include <new>
+#    include <optional>
+#    include <queue>
+#    include <stack>
+#    include <stdexcept>
+#    include <string>
+#    include <string_view>
+#    include <tuple>
+
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      include <cwchar>
+#    endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FORMAT

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -195,66 +195,68 @@ template <class T, class Allocator, class Predicate>
 
 */
 
-#include <__algorithm/comp.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lexicographical_compare_three_way.h>
-#include <__algorithm/min.h>
-#include <__config>
-#include <__cstddef/nullptr_t.h>
-#include <__iterator/distance.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/move_iterator.h>
-#include <__iterator/next.h>
-#include <__memory/addressof.h>
-#include <__memory/allocation_guard.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/compressed_pair.h>
-#include <__memory/construct_at.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/swap_allocator.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_const.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_pointer.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <limits>
-#include <new> // __launder
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/comp.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lexicographical_compare_three_way.h>
+#  include <__algorithm/min.h>
+#  include <__config>
+#  include <__cstddef/nullptr_t.h>
+#  include <__iterator/distance.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/move_iterator.h>
+#  include <__iterator/next.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocation_guard.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/compressed_pair.h>
+#  include <__memory/construct_at.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/swap_allocator.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__ranges/access.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_const.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_pointer.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <limits>
+#  include <new> // __launder
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [forward.list.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -281,7 +283,7 @@ struct __forward_node_traits {
   typedef __rebind_pointer_t<_NodePtr, void> __void_pointer;
 
 // TODO(LLVM 22): Remove this check
-#ifndef _LIBCPP_ABI_FORWARD_LIST_REMOVE_NODE_POINTER_UB
+#  ifndef _LIBCPP_ABI_FORWARD_LIST_REMOVE_NODE_POINTER_UB
   static_assert(sizeof(__begin_node_pointer) == sizeof(__node_pointer) && _LIBCPP_ALIGNOF(__begin_node_pointer) ==
                     _LIBCPP_ALIGNOF(__node_pointer),
                 "It looks like you are using std::forward_list with a fancy pointer type that thas a different "
@@ -289,7 +291,7 @@ struct __forward_node_traits {
                 "pointer (both of which are implementation details of the standard library). This means that your ABI "
                 "is being broken between LLVM 19 and LLVM 20. If you don't care about your ABI being broken, define "
                 "the _LIBCPP_ABI_FORWARD_LIST_REMOVE_NODE_POINTER_UB macro to silence this diagnostic.");
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI static __begin_node_pointer __as_iter_node(__begin_node_pointer __p) { return __p; }
   _LIBCPP_HIDE_FROM_ABI static __begin_node_pointer __as_iter_node(__node_pointer __p) {
@@ -323,7 +325,7 @@ struct __forward_list_node : public __begin_node_of<_Tp, _VoidPtr> {
 
   // We allow starting the lifetime of nodes without initializing the value held by the node,
   // since that is handled by the list itself in order to be allocator-aware.
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 private:
   union {
@@ -332,14 +334,14 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI _Tp& __get_value() { return __value_; }
-#else
+#  else
 
 private:
   _ALIGNAS_TYPE(_Tp) char __buffer_[sizeof(_Tp)];
 
 public:
   _LIBCPP_HIDE_FROM_ABI _Tp& __get_value() { return *std::__launder(reinterpret_cast<_Tp*>(&__buffer_)); }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI explicit __forward_list_node(_NodePtr __next) : _Base(__next) {}
   _LIBCPP_HIDE_FROM_ABI ~__forward_list_node() {}
@@ -514,11 +516,11 @@ protected:
       : __before_begin_(__begin_node()), __alloc_(__a) {}
 
 public:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI
   __forward_list_base(__forward_list_base&& __x) noexcept(is_nothrow_move_constructible<__node_allocator>::value);
   _LIBCPP_HIDE_FROM_ABI __forward_list_base(__forward_list_base&& __x, const allocator_type& __a);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   __forward_list_base(const __forward_list_base&)            = delete;
   __forward_list_base& operator=(const __forward_list_base&) = delete;
@@ -562,11 +564,11 @@ protected:
 
 public:
   _LIBCPP_HIDE_FROM_ABI void swap(__forward_list_base& __x)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
-#else
+#  else
       _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>);
-#endif
+#  endif
 
 protected:
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT;
@@ -586,7 +588,7 @@ private:
   }
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 inline __forward_list_base<_Tp, _Alloc>::__forward_list_base(__forward_list_base&& __x) noexcept(
@@ -604,7 +606,7 @@ inline __forward_list_base<_Tp, _Alloc>::__forward_list_base(__forward_list_base
   }
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 __forward_list_base<_Tp, _Alloc>::~__forward_list_base() {
@@ -613,11 +615,11 @@ __forward_list_base<_Tp, _Alloc>::~__forward_list_base() {
 
 template <class _Tp, class _Alloc>
 inline void __forward_list_base<_Tp, _Alloc>::swap(__forward_list_base& __x)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
-#else
+#  else
     _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
-#endif
+#  endif
 {
   std::__swap_allocator(__alloc_, __x.__alloc_);
   using std::swap;
@@ -664,19 +666,19 @@ public:
 
   typedef typename __base::iterator iterator;
   typedef typename __base::const_iterator const_iterator;
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   typedef size_type __remove_return_type;
-#else
+#  else
   typedef void __remove_return_type;
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI forward_list() _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value) {
   } // = default;
   _LIBCPP_HIDE_FROM_ABI explicit forward_list(const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI explicit forward_list(size_type __n);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI explicit forward_list(size_type __n, const allocator_type& __a);
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI forward_list(size_type __n, const value_type& __v);
 
   template <__enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
@@ -690,20 +692,20 @@ public:
   template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI forward_list(_InputIterator __f, _InputIterator __l, const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI forward_list(from_range_t, _Range&& __range, const allocator_type& __a = allocator_type())
       : __base(__a) {
     prepend_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI forward_list(const forward_list& __x);
   _LIBCPP_HIDE_FROM_ABI forward_list(const forward_list& __x, const __type_identity_t<allocator_type>& __a);
 
   _LIBCPP_HIDE_FROM_ABI forward_list& operator=(const forward_list& __x);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI forward_list(forward_list&& __x) noexcept(is_nothrow_move_constructible<__base>::value)
       : __base(std::move(__x)) {}
   _LIBCPP_HIDE_FROM_ABI forward_list(forward_list&& __x, const __type_identity_t<allocator_type>& __a);
@@ -718,19 +720,19 @@ public:
   _LIBCPP_HIDE_FROM_ABI forward_list& operator=(initializer_list<value_type> __il);
 
   _LIBCPP_HIDE_FROM_ABI void assign(initializer_list<value_type> __il);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   // ~forward_list() = default;
 
   template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   void _LIBCPP_HIDE_FROM_ABI assign(_InputIterator __f, _InputIterator __l);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void assign_range(_Range&& __range) {
     __assign_with_sentinel(ranges::begin(__range), ranges::end(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void assign(size_type __n, const value_type& __v);
 
@@ -766,28 +768,28 @@ public:
   _LIBCPP_HIDE_FROM_ABI reference front() { return __base::__before_begin()->__next_->__get_value(); }
   _LIBCPP_HIDE_FROM_ABI const_reference front() const { return __base::__before_begin()->__next_->__get_value(); }
 
-#ifndef _LIBCPP_CXX03_LANG
-#  if _LIBCPP_STD_VER >= 17
+#  ifndef _LIBCPP_CXX03_LANG
+#    if _LIBCPP_STD_VER >= 17
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI reference emplace_front(_Args&&... __args);
-#  else
+#    else
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI void emplace_front(_Args&&... __args);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI void push_front(value_type&& __v);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void push_front(const value_type& __v);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void prepend_range(_Range&& __range) {
     insert_range_after(cbefore_begin(), std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void pop_front();
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator emplace_after(const_iterator __p, _Args&&... __args);
 
@@ -795,18 +797,18 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator insert_after(const_iterator __p, initializer_list<value_type> __il) {
     return insert_after(__p, __il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI iterator insert_after(const_iterator __p, const value_type& __v);
   _LIBCPP_HIDE_FROM_ABI iterator insert_after(const_iterator __p, size_type __n, const value_type& __v);
   template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert_after(const_iterator __p, _InputIterator __f, _InputIterator __l);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI iterator insert_range_after(const_iterator __position, _Range&& __range) {
     return __insert_after_with_sentinel(__position, ranges::begin(__range), ranges::end(__range));
   }
-#endif
+#  endif
 
   template <class _InputIterator, class _Sentinel>
   _LIBCPP_HIDE_FROM_ABI iterator __insert_after_with_sentinel(const_iterator __p, _InputIterator __f, _Sentinel __l);
@@ -815,11 +817,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator erase_after(const_iterator __f, const_iterator __l);
 
   _LIBCPP_HIDE_FROM_ABI void swap(forward_list& __x)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       _NOEXCEPT
-#else
+#  else
       _NOEXCEPT_(!__node_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
-#endif
+#  endif
   {
     __base::swap(__x);
   }
@@ -842,13 +844,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI __remove_return_type unique() { return unique(__equal_to()); }
   template <class _BinaryPredicate>
   _LIBCPP_HIDE_FROM_ABI __remove_return_type unique(_BinaryPredicate __binary_pred);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void merge(forward_list&& __x) { merge(__x, __less<>()); }
   template <class _Compare>
   _LIBCPP_HIDE_FROM_ABI void merge(forward_list&& __x, _Compare __comp) {
     merge(__x, std::move(__comp));
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void merge(forward_list& __x) { merge(__x, __less<>()); }
   template <class _Compare>
   _LIBCPP_HIDE_FROM_ABI void merge(forward_list& __x, _Compare __comp);
@@ -858,11 +860,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reverse() _NOEXCEPT;
 
 private:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void __move_assign(forward_list& __x, true_type)
       _NOEXCEPT_(is_nothrow_move_assignable<allocator_type>::value);
   _LIBCPP_HIDE_FROM_ABI void __move_assign(forward_list& __x, false_type);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <class _Iter, class _Sent>
   _LIBCPP_HIDE_FROM_ABI void __assign_with_sentinel(_Iter __f, _Sent __l);
@@ -875,7 +877,7 @@ private:
   static _LIBCPP_HIDDEN __node_pointer __sort(__node_pointer __f, difference_type __sz, _Compare& __comp);
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Alloc = allocator<__iter_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
@@ -887,14 +889,14 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator<_Alloc>::value> >
 forward_list(_InputIterator, _InputIterator, _Alloc) -> forward_list<__iter_value_type<_InputIterator>, _Alloc>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
           class        = enable_if_t<__is_allocator<_Alloc>::value> >
 forward_list(from_range_t, _Range&&, _Alloc = _Alloc()) -> forward_list<ranges::range_value_t<_Range>, _Alloc>;
-#endif
+#  endif
 
 template <class _Tp, class _Alloc>
 inline forward_list<_Tp, _Alloc>::forward_list(const allocator_type& __a) : __base(__a) {}
@@ -908,7 +910,7 @@ forward_list<_Tp, _Alloc>::forward_list(size_type __n) {
   }
 }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(size_type __n, const allocator_type& __base_alloc) : __base(__base_alloc) {
   if (__n > 0) {
@@ -917,7 +919,7 @@ forward_list<_Tp, _Alloc>::forward_list(size_type __n, const allocator_type& __b
     }
   }
 }
-#endif
+#  endif
 
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(size_type __n, const value_type& __v) {
@@ -958,7 +960,7 @@ forward_list<_Tp, _Alloc>& forward_list<_Tp, _Alloc>::operator=(const forward_li
   return *this;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Alloc>
 forward_list<_Tp, _Alloc>::forward_list(forward_list&& __x, const __type_identity_t<allocator_type>& __a)
     : __base(std::move(__x), __a) {
@@ -1010,7 +1012,7 @@ inline forward_list<_Tp, _Alloc>& forward_list<_Tp, _Alloc>::operator=(initializ
   return *this;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> >
@@ -1045,7 +1047,7 @@ void forward_list<_Tp, _Alloc>::assign(size_type __n, const value_type& __v) {
     erase_after(__i, __e);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 inline void forward_list<_Tp, _Alloc>::assign(initializer_list<value_type> __il) {
@@ -1054,17 +1056,17 @@ inline void forward_list<_Tp, _Alloc>::assign(initializer_list<value_type> __il)
 
 template <class _Tp, class _Alloc>
 template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 typename forward_list<_Tp, _Alloc>::reference
-#  else
+#    else
 void
-#  endif
+#    endif
 forward_list<_Tp, _Alloc>::emplace_front(_Args&&... __args) {
   __base::__before_begin()->__next_ =
       this->__create_node(/* next = */ __base::__before_begin()->__next_, std::forward<_Args>(__args)...);
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   return __base::__before_begin()->__next_->__get_value();
-#  endif
+#    endif
 }
 
 template <class _Tp, class _Alloc>
@@ -1073,7 +1075,7 @@ void forward_list<_Tp, _Alloc>::push_front(value_type&& __v) {
       this->__create_node(/* next = */ __base::__before_begin()->__next_, std::move(__v));
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 void forward_list<_Tp, _Alloc>::push_front(const value_type& __v) {
@@ -1087,7 +1089,7 @@ void forward_list<_Tp, _Alloc>::pop_front() {
   this->__delete_node(__p);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 template <class... _Args>
@@ -1106,7 +1108,7 @@ forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, value_type&& __v) {
   return iterator(__r->__next_);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 typename forward_list<_Tp, _Alloc>::iterator
@@ -1123,13 +1125,13 @@ forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, size_type __n, const
   if (__n > 0) {
     __node_pointer __first = this->__create_node(/* next = */ nullptr, __v);
     __node_pointer __last  = __first;
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (--__n; __n != 0; --__n, __last = __last->__next_) {
         __last->__next_ = this->__create_node(/* next = */ nullptr, __v);
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       while (__first != nullptr) {
         __node_pointer __next = __first->__next_;
@@ -1138,7 +1140,7 @@ forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, size_type __n, const
       }
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     __last->__next_ = __r->__next_;
     __r->__next_    = __first;
     __r             = static_cast<__begin_node_pointer>(__last);
@@ -1163,13 +1165,13 @@ forward_list<_Tp, _Alloc>::__insert_after_with_sentinel(const_iterator __p, _Inp
     __node_pointer __first = this->__create_node(/* next = */ nullptr, *__f);
     __node_pointer __last  = __first;
 
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (++__f; __f != __l; ++__f, ((void)(__last = __last->__next_))) {
         __last->__next_ = this->__create_node(/* next = */ nullptr, *__f);
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       while (__first != nullptr) {
         __node_pointer __next = __first->__next_;
@@ -1178,7 +1180,7 @@ forward_list<_Tp, _Alloc>::__insert_after_with_sentinel(const_iterator __p, _Inp
       }
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
 
     __last->__next_ = __r->__next_;
     __r->__next_    = __first;
@@ -1484,7 +1486,7 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const forward_list<_Tp, _Alloc>& __x, cons
   return (__ix == __ex) == (__iy == __ey);
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -1516,7 +1518,7 @@ operator<=(const forward_list<_Tp, _Alloc>& __x, const forward_list<_Tp, _Alloc>
   return !(__y < __x);
 }
 
-#else // #if _LIBCPP_STD_VER <= 17
+#  else // #if _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Tp>
@@ -1524,7 +1526,7 @@ operator<=>(const forward_list<_Tp, _Allocator>& __x, const forward_list<_Tp, _A
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
-#endif // #if _LIBCPP_STD_VER <= 17
+#  endif // #if _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI void swap(forward_list<_Tp, _Alloc>& __x, forward_list<_Tp, _Alloc>& __y)
@@ -1532,7 +1534,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(forward_list<_Tp, _Alloc>& __x, forward_l
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Tp, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename forward_list<_Tp, _Allocator>::size_type
 erase_if(forward_list<_Tp, _Allocator>& __c, _Predicate __pred) {
@@ -1544,7 +1546,7 @@ inline _LIBCPP_HIDE_FROM_ABI typename forward_list<_Tp, _Allocator>::size_type
 erase(forward_list<_Tp, _Allocator>& __c, const _Up& __v) {
   return std::erase_if(__c, [&](auto& __elem) { return __elem == __v; });
 }
-#endif
+#  endif
 
 template <class _Tp, class _Allocator>
 struct __container_traits<forward_list<_Tp, _Allocator> > {
@@ -1559,30 +1561,31 @@ struct __container_traits<forward_list<_Tp, _Allocator> > {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _ValueT>
 using forward_list _LIBCPP_AVAILABILITY_PMR = std::forward_list<_ValueT, polymorphic_allocator<_ValueT>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <atomic>
-#  include <concepts>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <cstring>
-#  include <functional>
-#  include <iosfwd>
-#  include <iterator>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <atomic>
+#    include <concepts>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <cstring>
+#    include <functional>
+#    include <iosfwd>
+#    include <iterator>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FORWARD_LIST

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -186,46 +186,48 @@ typedef basic_fstream<wchar_t> wfstream;
 
 */
 
-#include <__algorithm/max.h>
-#include <__assert>
-#include <__config>
-#include <__filesystem/path.h>
-#include <__fwd/fstream.h>
-#include <__locale>
-#include <__memory/addressof.h>
-#include <__memory/unique_ptr.h>
-#include <__ostream/basic_ostream.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_same.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <__utility/unreachable.h>
-#include <cstdio>
-#include <istream>
-#include <streambuf>
-#include <typeinfo>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/max.h>
+#  include <__assert>
+#  include <__config>
+#  include <__filesystem/path.h>
+#  include <__fwd/fstream.h>
+#  include <__locale>
+#  include <__memory/addressof.h>
+#  include <__memory/unique_ptr.h>
+#  include <__ostream/basic_ostream.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_same.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <__utility/unreachable.h>
+#  include <cstdio>
+#  include <istream>
+#  include <streambuf>
+#  include <typeinfo>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if !defined(_LIBCPP_MSVCRT) && !defined(_NEWLIB_VERSION)
-#  define _LIBCPP_HAS_OFF_T_FUNCTIONS 1
-#else
-#  define _LIBCPP_HAS_OFF_T_FUNCTIONS 0
-#endif
+#  if !defined(_LIBCPP_MSVCRT) && !defined(_NEWLIB_VERSION)
+#    define _LIBCPP_HAS_OFF_T_FUNCTIONS 1
+#  else
+#    define _LIBCPP_HAS_OFF_T_FUNCTIONS 0
+#  endif
 
-#if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#  if _LIBCPP_STD_VER >= 26 && defined(_LIBCPP_WIN32API)
+#    if _LIBCPP_STD_VER >= 26 && defined(_LIBCPP_WIN32API)
 _LIBCPP_EXPORTED_FROM_ABI void* __filebuf_windows_native_handle(FILE* __file) noexcept;
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 class _LIBCPP_TEMPLATE_VIS basic_filebuf : public basic_streambuf<_CharT, _Traits> {
@@ -236,15 +238,15 @@ public:
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
   typedef typename traits_type::state_type state_type;
-#  if _LIBCPP_STD_VER >= 26
-#    if defined(_LIBCPP_WIN32API)
+#    if _LIBCPP_STD_VER >= 26
+#      if defined(_LIBCPP_WIN32API)
   using native_handle_type = void*; // HANDLE
-#    elif __has_include(<unistd.h>)
+#      elif __has_include(<unistd.h>)
   using native_handle_type = int; // POSIX file descriptor
-#    else
-#      error "Provide a native file handle!"
+#      else
+#        error "Provide a native file handle!"
+#      endif
 #    endif
-#  endif
 
   // 27.9.1.2 Constructors/destructor:
   basic_filebuf();
@@ -258,36 +260,36 @@ public:
   // 27.9.1.4 Members:
   _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   basic_filebuf* open(const char* __s, ios_base::openmode __mode);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   basic_filebuf* open(const wchar_t* __s, ios_base::openmode __mode);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* open(const string& __s, ios_base::openmode __mode);
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI basic_filebuf*
   open(const filesystem::path& __p, ios_base::openmode __mode) {
     return open(__p.c_str(), __mode);
   }
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI basic_filebuf* __open(int __fd, ios_base::openmode __mode);
   basic_filebuf* close();
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() const noexcept {
     _LIBCPP_ASSERT_UNCATEGORIZED(this->is_open(), "File must be opened");
-#    if defined(_LIBCPP_WIN32API)
+#      if defined(_LIBCPP_WIN32API)
     return std::__filebuf_windows_native_handle(__file_);
-#    elif __has_include(<unistd.h>)
+#      elif __has_include(<unistd.h>)
     return fileno(__file_);
-#    else
-#      error "Provide a way to determine the file native handle!"
-#    endif
+#      else
+#        error "Provide a way to determine the file native handle!"
+#      endif
   }
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 
   _LIBCPP_HIDE_FROM_ABI inline static const char* __make_mdstring(ios_base::openmode __mode) _NOEXCEPT;
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   _LIBCPP_HIDE_FROM_ABI inline static const wchar_t* __make_mdwstring(ios_base::openmode __mode) _NOEXCEPT;
-#  endif
+#    endif
 
 protected:
   // 27.9.1.5 Overridden virtual functions:
@@ -489,14 +491,14 @@ inline basic_filebuf<_CharT, _Traits>& basic_filebuf<_CharT, _Traits>::operator=
 
 template <class _CharT, class _Traits>
 basic_filebuf<_CharT, _Traits>::~basic_filebuf() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     close();
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   if (__owns_eb_)
     delete[] __extbuf_;
   if (__owns_ib_)
@@ -616,7 +618,7 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
   case ios_base::in | ios_base::out | ios_base::app | ios_base::binary:
   case ios_base::in | ios_base::app | ios_base::binary:
     return "a+b" _LIBCPP_FOPEN_CLOEXEC_MODE;
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:
     return "wx" _LIBCPP_FOPEN_CLOEXEC_MODE;
@@ -627,14 +629,14 @@ const char* basic_filebuf<_CharT, _Traits>::__make_mdstring(ios_base::openmode _
     return "wbx" _LIBCPP_FOPEN_CLOEXEC_MODE;
   case ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary | ios_base::noreplace:
     return "w+bx" _LIBCPP_FOPEN_CLOEXEC_MODE;
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
   default:
     return nullptr;
   }
   __libcpp_unreachable();
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmode __mode) _NOEXCEPT {
   switch (__mode & ~ios_base::ate) {
@@ -668,7 +670,7 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
   case ios_base::in | ios_base::out | ios_base::app | ios_base::binary:
   case ios_base::in | ios_base::app | ios_base::binary:
     return L"a+b";
-#    if _LIBCPP_STD_VER >= 23
+#      if _LIBCPP_STD_VER >= 23
   case ios_base::out | ios_base::noreplace:
   case ios_base::out | ios_base::trunc | ios_base::noreplace:
     return L"wx";
@@ -679,13 +681,13 @@ const wchar_t* basic_filebuf<_CharT, _Traits>::__make_mdwstring(ios_base::openmo
     return L"wbx";
   case ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary | ios_base::noreplace:
     return L"w+bx";
-#    endif // _LIBCPP_STD_VER >= 23
+#      endif // _LIBCPP_STD_VER >= 23
   default:
     return nullptr;
   }
   __libcpp_unreachable();
 }
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const char* __s, ios_base::openmode __mode) {
@@ -709,7 +711,7 @@ inline basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::__open(in
   return __do_open(fdopen(__fd, __mdstr), __mode);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 // This is basically the same as the char* overload except that it uses _wfopen
 // and long mode strings.
 template <class _CharT, class _Traits>
@@ -722,7 +724,7 @@ basic_filebuf<_CharT, _Traits>* basic_filebuf<_CharT, _Traits>::open(const wchar
 
   return __do_open(_wfopen(__s, __mdstr), __mode);
 }
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 inline basic_filebuf<_CharT, _Traits>*
@@ -933,15 +935,15 @@ basic_filebuf<_CharT, _Traits>::seekoff(off_type __off, ios_base::seekdir __way,
   default:
     return pos_type(off_type(-1));
   }
-#  if !_LIBCPP_HAS_OFF_T_FUNCTIONS
+#    if !_LIBCPP_HAS_OFF_T_FUNCTIONS
   if (fseek(__file_, __width > 0 ? __width * __off : 0, __whence))
     return pos_type(off_type(-1));
   pos_type __r = ftell(__file_);
-#  else
+#    else
   if (::fseeko(__file_, __width > 0 ? __width * __off : 0, __whence))
     return pos_type(off_type(-1));
   pos_type __r = ftello(__file_);
-#  endif
+#    endif
   __r.state(__st_);
   return __r;
 }
@@ -951,13 +953,13 @@ typename basic_filebuf<_CharT, _Traits>::pos_type
 basic_filebuf<_CharT, _Traits>::seekpos(pos_type __sp, ios_base::openmode) {
   if (__file_ == nullptr || sync())
     return pos_type(off_type(-1));
-#  if !_LIBCPP_HAS_OFF_T_FUNCTIONS
+#    if !_LIBCPP_HAS_OFF_T_FUNCTIONS
   if (fseek(__file_, __sp, SEEK_SET))
     return pos_type(off_type(-1));
-#  else
+#    else
   if (::fseeko(__file_, __sp, SEEK_SET))
     return pos_type(off_type(-1));
-#  endif
+#    endif
   __st_ = __sp.state();
   return __sp;
 }
@@ -1004,13 +1006,13 @@ int basic_filebuf<_CharT, _Traits>::sync() {
         }
       }
     }
-#  if !_LIBCPP_HAS_OFF_T_FUNCTIONS
+#    if !_LIBCPP_HAS_OFF_T_FUNCTIONS
     if (fseek(__file_, -__c, SEEK_CUR))
       return -1;
-#  else
+#    else
     if (::fseeko(__file_, -__c, SEEK_CUR))
       return -1;
-#  endif
+#    endif
     if (__update_st)
       __st_ = __state;
     __extbufnext_ = __extbufend_ = __extbuf_;
@@ -1096,42 +1098,42 @@ public:
   typedef typename traits_type::int_type int_type;
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   using native_handle_type = typename basic_filebuf<_CharT, _Traits>::native_handle_type;
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI basic_ifstream();
   _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(const wchar_t* __s, ios_base::openmode __mode = ios_base::in);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(const string& __s, ios_base::openmode __mode = ios_base::in);
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   template <class _Tp, class = enable_if_t<is_same_v<_Tp, filesystem::path>>>
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
       _LIBCPP_HIDE_FROM_ABI explicit basic_ifstream(const _Tp& __p, ios_base::openmode __mode = ios_base::in)
       : basic_ifstream(__p.c_str(), __mode) {}
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI basic_ifstream(basic_ifstream&& __rhs);
   _LIBCPP_HIDE_FROM_ABI basic_ifstream& operator=(basic_ifstream&& __rhs);
   _LIBCPP_HIDE_FROM_ABI void swap(basic_ifstream& __rhs);
 
   _LIBCPP_HIDE_FROM_ABI basic_filebuf<char_type, traits_type>* rdbuf() const;
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() const noexcept { return rdbuf()->native_handle(); }
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   void open(const char* __s, ios_base::openmode __mode = ios_base::in);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in);
-#  endif
+#    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::in);
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI void
   open(const filesystem::path& __p, ios_base::openmode __mode = ios_base::in) {
     return open(__p.c_str(), __mode);
   }
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI void __open(int __fd, ios_base::openmode __mode);
   _LIBCPP_HIDE_FROM_ABI void close();
@@ -1151,14 +1153,14 @@ inline basic_ifstream<_CharT, _Traits>::basic_ifstream(const char* __s, ios_base
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 inline basic_ifstream<_CharT, _Traits>::basic_ifstream(const wchar_t* __s, ios_base::openmode __mode)
     : basic_istream<char_type, traits_type>(std::addressof(__sb_)) {
   if (__sb_.open(__s, __mode | ios_base::in) == nullptr)
     this->setstate(ios_base::failbit);
 }
-#  endif
+#    endif
 
 // extension
 template <class _CharT, class _Traits>
@@ -1210,7 +1212,7 @@ void basic_ifstream<_CharT, _Traits>::open(const char* __s, ios_base::openmode _
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 void basic_ifstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmode __mode) {
   if (__sb_.open(__s, __mode | ios_base::in))
@@ -1218,7 +1220,7 @@ void basic_ifstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmod
   else
     this->setstate(ios_base::failbit);
 }
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 void basic_ifstream<_CharT, _Traits>::open(const string& __s, ios_base::openmode __mode) {
@@ -1252,45 +1254,45 @@ public:
   typedef typename traits_type::int_type int_type;
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   using native_handle_type = typename basic_filebuf<_CharT, _Traits>::native_handle_type;
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI basic_ofstream();
   _LIBCPP_HIDE_FROM_ABI explicit basic_ofstream(const char* __s, ios_base::openmode __mode = ios_base::out);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   _LIBCPP_HIDE_FROM_ABI explicit basic_ofstream(const wchar_t* __s, ios_base::openmode __mode = ios_base::out);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI explicit basic_ofstream(const string& __s, ios_base::openmode __mode = ios_base::out);
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   template <class _Tp, class = enable_if_t<is_same_v<_Tp, filesystem::path>>>
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY
       _LIBCPP_HIDE_FROM_ABI explicit basic_ofstream(const _Tp& __p, ios_base::openmode __mode = ios_base::out)
       : basic_ofstream(__p.c_str(), __mode) {}
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI basic_ofstream(basic_ofstream&& __rhs);
   _LIBCPP_HIDE_FROM_ABI basic_ofstream& operator=(basic_ofstream&& __rhs);
   _LIBCPP_HIDE_FROM_ABI void swap(basic_ofstream& __rhs);
 
   _LIBCPP_HIDE_FROM_ABI basic_filebuf<char_type, traits_type>* rdbuf() const;
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() const noexcept { return rdbuf()->native_handle(); }
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   void open(const char* __s, ios_base::openmode __mode = ios_base::out);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::out);
-#  endif
+#    endif
   void open(const string& __s, ios_base::openmode __mode = ios_base::out);
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI void
   open(const filesystem::path& __p, ios_base::openmode __mode = ios_base::out) {
     return open(__p.c_str(), __mode);
   }
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI void __open(int __fd, ios_base::openmode __mode);
   _LIBCPP_HIDE_FROM_ABI void close();
@@ -1310,14 +1312,14 @@ inline basic_ofstream<_CharT, _Traits>::basic_ofstream(const char* __s, ios_base
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 inline basic_ofstream<_CharT, _Traits>::basic_ofstream(const wchar_t* __s, ios_base::openmode __mode)
     : basic_ostream<char_type, traits_type>(std::addressof(__sb_)) {
   if (__sb_.open(__s, __mode | ios_base::out) == nullptr)
     this->setstate(ios_base::failbit);
 }
-#  endif
+#    endif
 
 // extension
 template <class _CharT, class _Traits>
@@ -1369,7 +1371,7 @@ void basic_ofstream<_CharT, _Traits>::open(const char* __s, ios_base::openmode _
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 void basic_ofstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmode __mode) {
   if (__sb_.open(__s, __mode | ios_base::out))
@@ -1377,7 +1379,7 @@ void basic_ofstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmod
   else
     this->setstate(ios_base::failbit);
 }
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 void basic_ofstream<_CharT, _Traits>::open(const string& __s, ios_base::openmode __mode) {
@@ -1411,26 +1413,26 @@ public:
   typedef typename traits_type::int_type int_type;
   typedef typename traits_type::pos_type pos_type;
   typedef typename traits_type::off_type off_type;
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   using native_handle_type = typename basic_filebuf<_CharT, _Traits>::native_handle_type;
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI basic_fstream();
   _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(const char* __s,
                                                ios_base::openmode __mode = ios_base::in | ios_base::out);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(const wchar_t* __s,
                                                ios_base::openmode __mode = ios_base::in | ios_base::out);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(const string& __s,
                                                ios_base::openmode __mode = ios_base::in | ios_base::out);
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   template <class _Tp, class = enable_if_t<is_same_v<_Tp, filesystem::path>>>
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI explicit basic_fstream(
       const _Tp& __p, ios_base::openmode __mode = ios_base::in | ios_base::out)
       : basic_fstream(__p.c_str(), __mode) {}
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI basic_fstream(basic_fstream&& __rhs);
 
@@ -1439,22 +1441,22 @@ public:
   _LIBCPP_HIDE_FROM_ABI void swap(basic_fstream& __rhs);
 
   _LIBCPP_HIDE_FROM_ABI basic_filebuf<char_type, traits_type>* rdbuf() const;
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() const noexcept { return rdbuf()->native_handle(); }
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI bool is_open() const;
   _LIBCPP_HIDE_FROM_ABI void open(const char* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
   void open(const wchar_t* __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI void open(const string& __s, ios_base::openmode __mode = ios_base::in | ios_base::out);
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_AVAILABILITY_FILESYSTEM_LIBRARY _LIBCPP_HIDE_FROM_ABI void
   open(const filesystem::path& __p, ios_base::openmode __mode = ios_base::in | ios_base::out) {
     return open(__p.c_str(), __mode);
   }
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI void close();
 
@@ -1473,14 +1475,14 @@ inline basic_fstream<_CharT, _Traits>::basic_fstream(const char* __s, ios_base::
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 inline basic_fstream<_CharT, _Traits>::basic_fstream(const wchar_t* __s, ios_base::openmode __mode)
     : basic_iostream<char_type, traits_type>(std::addressof(__sb_)) {
   if (__sb_.open(__s, __mode) == nullptr)
     this->setstate(ios_base::failbit);
 }
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 inline basic_fstream<_CharT, _Traits>::basic_fstream(const string& __s, ios_base::openmode __mode)
@@ -1532,7 +1534,7 @@ void basic_fstream<_CharT, _Traits>::open(const char* __s, ios_base::openmode __
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_HAS_OPEN_WITH_WCHAR
+#    if _LIBCPP_HAS_OPEN_WITH_WCHAR
 template <class _CharT, class _Traits>
 void basic_fstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmode __mode) {
   if (__sb_.open(__s, __mode))
@@ -1540,7 +1542,7 @@ void basic_fstream<_CharT, _Traits>::open(const wchar_t* __s, ios_base::openmode
   else
     this->setstate(ios_base::failbit);
 }
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 void basic_fstream<_CharT, _Traits>::open(const string& __s, ios_base::openmode __mode) {
@@ -1556,32 +1558,33 @@ inline void basic_fstream<_CharT, _Traits>::close() {
     this->setstate(ios_base::failbit);
 }
 
-#  if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
+#    if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ifstream<char>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ofstream<char>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_filebuf<char>;
-#  endif
+#    endif
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <limits>
-#  include <mutex>
-#  include <new>
-#  include <stdexcept>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <limits>
+#    include <mutex>
+#    include <new>
+#    include <stdexcept>
+#    include <type_traits>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
-#  include <filesystem>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#    include <filesystem>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FSTREAM

--- a/libcxx/include/functional
+++ b/libcxx/include/functional
@@ -527,72 +527,75 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__functional/binary_function.h>
-#include <__functional/binary_negate.h>
-#include <__functional/bind.h>
-#include <__functional/binder1st.h>
-#include <__functional/binder2nd.h>
-#include <__functional/hash.h>
-#include <__functional/mem_fn.h> // TODO: deprecate
-#include <__functional/mem_fun_ref.h>
-#include <__functional/operations.h>
-#include <__functional/pointer_to_binary_function.h>
-#include <__functional/pointer_to_unary_function.h>
-#include <__functional/reference_wrapper.h>
-#include <__functional/unary_function.h>
-#include <__functional/unary_negate.h>
+#  include <__functional/binary_function.h>
+#  include <__functional/binary_negate.h>
+#  include <__functional/bind.h>
+#  include <__functional/binder1st.h>
+#  include <__functional/binder2nd.h>
+#  include <__functional/hash.h>
+#  include <__functional/mem_fn.h> // TODO: deprecate
+#  include <__functional/mem_fun_ref.h>
+#  include <__functional/operations.h>
+#  include <__functional/pointer_to_binary_function.h>
+#  include <__functional/pointer_to_unary_function.h>
+#  include <__functional/reference_wrapper.h>
+#  include <__functional/unary_function.h>
+#  include <__functional/unary_negate.h>
 
-#ifndef _LIBCPP_CXX03_LANG
-#  include <__functional/function.h>
-#endif
+#  ifndef _LIBCPP_CXX03_LANG
+#    include <__functional/function.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__functional/boyer_moore_searcher.h>
-#  include <__functional/default_searcher.h>
-#  include <__functional/invoke.h>
-#  include <__functional/not_fn.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__functional/boyer_moore_searcher.h>
+#    include <__functional/default_searcher.h>
+#    include <__functional/invoke.h>
+#    include <__functional/not_fn.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__functional/bind_back.h>
-#  include <__functional/bind_front.h>
-#  include <__functional/identity.h>
-#  include <__functional/ranges_operations.h>
-#  include <__type_traits/unwrap_ref.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__functional/bind_back.h>
+#    include <__functional/bind_front.h>
+#    include <__functional/identity.h>
+#    include <__functional/ranges_operations.h>
+#    include <__type_traits/unwrap_ref.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && defined(_LIBCPP_CXX03_LANG)
-#  include <limits>
-#  include <new>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && defined(_LIBCPP_CXX03_LANG)
+#    include <limits>
+#    include <new>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 14
-#  include <array>
-#  include <initializer_list>
-#  include <unordered_map>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 14
+#    include <array>
+#    include <initializer_list>
+#    include <unordered_map>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdlib>
-#  include <exception>
-#  include <iosfwd>
-#  include <memory>
-#  include <stdexcept>
-#  include <tuple>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#  include <vector>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdlib>
+#    include <exception>
+#    include <iosfwd>
+#    include <memory>
+#    include <stdexcept>
+#    include <tuple>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#    include <vector>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FUNCTIONAL

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -362,59 +362,61 @@ template <class R, class Alloc> struct uses_allocator<packaged_task<R>, Alloc>; 
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  include <__assert>
-#  include <__chrono/duration.h>
-#  include <__chrono/steady_clock.h>
-#  include <__chrono/time_point.h>
-#  include <__condition_variable/condition_variable.h>
-#  include <__exception/exception_ptr.h>
-#  include <__memory/addressof.h>
-#  include <__memory/allocator.h>
-#  include <__memory/allocator_arg_t.h>
-#  include <__memory/allocator_destructor.h>
-#  include <__memory/allocator_traits.h>
-#  include <__memory/compressed_pair.h>
-#  include <__memory/pointer_traits.h>
-#  include <__memory/shared_count.h>
-#  include <__memory/unique_ptr.h>
-#  include <__memory/uses_allocator.h>
-#  include <__mutex/lock_guard.h>
-#  include <__mutex/mutex.h>
-#  include <__mutex/unique_lock.h>
-#  include <__system_error/error_category.h>
-#  include <__system_error/error_code.h>
-#  include <__system_error/error_condition.h>
-#  include <__thread/thread.h>
-#  include <__type_traits/add_lvalue_reference.h>
-#  include <__type_traits/aligned_storage.h>
-#  include <__type_traits/conditional.h>
-#  include <__type_traits/decay.h>
-#  include <__type_traits/enable_if.h>
-#  include <__type_traits/invoke.h>
-#  include <__type_traits/is_same.h>
-#  include <__type_traits/remove_cvref.h>
-#  include <__type_traits/remove_reference.h>
-#  include <__type_traits/strip_signature.h>
-#  include <__type_traits/underlying_type.h>
-#  include <__utility/auto_cast.h>
-#  include <__utility/forward.h>
-#  include <__utility/move.h>
-#  include <__utility/swap.h>
-#  include <new>
-#  include <stdexcept>
-#  include <tuple>
-#  include <version>
+#    include <__assert>
+#    include <__chrono/duration.h>
+#    include <__chrono/steady_clock.h>
+#    include <__chrono/time_point.h>
+#    include <__condition_variable/condition_variable.h>
+#    include <__exception/exception_ptr.h>
+#    include <__memory/addressof.h>
+#    include <__memory/allocator.h>
+#    include <__memory/allocator_arg_t.h>
+#    include <__memory/allocator_destructor.h>
+#    include <__memory/allocator_traits.h>
+#    include <__memory/compressed_pair.h>
+#    include <__memory/pointer_traits.h>
+#    include <__memory/shared_count.h>
+#    include <__memory/unique_ptr.h>
+#    include <__memory/uses_allocator.h>
+#    include <__mutex/lock_guard.h>
+#    include <__mutex/mutex.h>
+#    include <__mutex/unique_lock.h>
+#    include <__system_error/error_category.h>
+#    include <__system_error/error_code.h>
+#    include <__system_error/error_condition.h>
+#    include <__thread/thread.h>
+#    include <__type_traits/add_lvalue_reference.h>
+#    include <__type_traits/aligned_storage.h>
+#    include <__type_traits/conditional.h>
+#    include <__type_traits/decay.h>
+#    include <__type_traits/enable_if.h>
+#    include <__type_traits/invoke.h>
+#    include <__type_traits/is_same.h>
+#    include <__type_traits/remove_cvref.h>
+#    include <__type_traits/remove_reference.h>
+#    include <__type_traits/strip_signature.h>
+#    include <__type_traits/underlying_type.h>
+#    include <__utility/auto_cast.h>
+#    include <__utility/forward.h>
+#    include <__utility/move.h>
+#    include <__utility/swap.h>
+#    include <new>
+#    include <stdexcept>
+#    include <tuple>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -426,16 +428,16 @@ _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(future_errc)
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<future_errc> : public true_type {};
 
-#  ifdef _LIBCPP_CXX03_LANG
+#    ifdef _LIBCPP_CXX03_LANG
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<future_errc::__lx> : public true_type {};
-#  endif
+#    endif
 
 // enum class launch
 _LIBCPP_DECLARE_STRONG_ENUM(launch){async = 1, deferred = 2, any = async | deferred};
 _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(launch)
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 typedef underlying_type<launch>::type __launch_underlying_type;
 
@@ -470,7 +472,7 @@ inline _LIBCPP_HIDE_FROM_ABI launch& operator^=(launch& __x, launch __y) {
   return __x;
 }
 
-#  endif // !_LIBCPP_CXX03_LANG
+#    endif // !_LIBCPP_CXX03_LANG
 
 // enum class future_status
 _LIBCPP_DECLARE_STRONG_ENUM(future_status){ready, timeout, deferred};
@@ -497,9 +499,9 @@ class _LIBCPP_EXPORTED_FROM_ABI future_error : public logic_error {
   friend class promise;
 
 public:
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI explicit future_error(future_errc __ec) : future_error(std::make_error_code(__ec)) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI const error_code& code() const _NOEXCEPT { return __ec_; }
 
@@ -509,12 +511,12 @@ public:
 
 // Declared above std::future_error
 void __throw_future_error(future_errc __ev) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   throw future_error(make_error_code(__ev));
-#  else
+#    else
   (void)__ev;
   _LIBCPP_VERBOSE_ABORT("future_error was thrown in -fno-exceptions mode");
-#  endif
+#    endif
 }
 
 class _LIBCPP_EXPORTED_FROM_ABI __assoc_sub_state : public __shared_count {
@@ -788,15 +790,15 @@ inline __deferred_assoc_state<_Rp, _Fp>::__deferred_assoc_state(_Fp&& __f) : __f
 
 template <class _Rp, class _Fp>
 void __deferred_assoc_state<_Rp, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->set_value(__func_());
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Fp>
@@ -818,16 +820,16 @@ inline __deferred_assoc_state<void, _Fp>::__deferred_assoc_state(_Fp&& __f) : __
 
 template <class _Fp>
 void __deferred_assoc_state<void, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __func_();
     this->set_value();
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class _Fp>
@@ -849,15 +851,15 @@ inline __async_assoc_state<_Rp, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(s
 
 template <class _Rp, class _Fp>
 void __async_assoc_state<_Rp, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->set_value(__func_());
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class _Fp>
@@ -885,16 +887,16 @@ inline __async_assoc_state<void, _Fp>::__async_assoc_state(_Fp&& __f) : __func_(
 
 template <class _Fp>
 void __async_assoc_state<void, _Fp>::__execute() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __func_();
     this->set_value();
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     this->set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Fp>
@@ -1622,11 +1624,11 @@ public:
   template <class _Fp, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
 
-#  if _LIBCPP_STD_VER <= 14
+#    if _LIBCPP_STD_VER <= 14
   template <class _Fp, class _Allocator, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
       : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)), __p_(allocator_arg_t(), __a) {}
-#  endif
+#    endif
   // ~packaged_task() = default;
 
   // no copy
@@ -1665,15 +1667,15 @@ void packaged_task<_Rp(_ArgTypes...)>::operator()(_ArgTypes... __args) {
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __p_.set_value(__f_(std::forward<_ArgTypes>(__args)...));
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __p_.set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class... _ArgTypes>
@@ -1682,15 +1684,15 @@ void packaged_task<_Rp(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... __
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __p_.set_value_at_thread_exit(__f_(std::forward<_ArgTypes>(__args)...));
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __p_.set_exception_at_thread_exit(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _Rp, class... _ArgTypes>
@@ -1714,11 +1716,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI packaged_task() _NOEXCEPT : __p_(nullptr) {}
   template <class _Fp, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit packaged_task(_Fp&& __f) : __f_(std::forward<_Fp>(__f)) {}
-#  if _LIBCPP_STD_VER <= 14
+#    if _LIBCPP_STD_VER <= 14
   template <class _Fp, class _Allocator, __enable_if_t<!is_same<__remove_cvref_t<_Fp>, packaged_task>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI packaged_task(allocator_arg_t, const _Allocator& __a, _Fp&& __f)
       : __f_(allocator_arg_t(), __a, std::forward<_Fp>(__f)), __p_(allocator_arg_t(), __a) {}
-#  endif
+#    endif
   // ~packaged_task() = default;
 
   // no copy
@@ -1751,7 +1753,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reset();
 };
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 
 template <class _Rp, class... _Args>
 packaged_task(_Rp (*)(_Args...)) -> packaged_task<_Rp(_Args...)>;
@@ -1759,7 +1761,7 @@ packaged_task(_Rp (*)(_Args...)) -> packaged_task<_Rp(_Args...)>;
 template <class _Fp, class _Stripped = typename __strip_signature<decltype(&_Fp::operator())>::type>
 packaged_task(_Fp) -> packaged_task<_Stripped>;
 
-#  endif
+#    endif
 
 template <class... _ArgTypes>
 void packaged_task<void(_ArgTypes...)>::operator()(_ArgTypes... __args) {
@@ -1767,16 +1769,16 @@ void packaged_task<void(_ArgTypes...)>::operator()(_ArgTypes... __args) {
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __f_(std::forward<_ArgTypes>(__args)...);
     __p_.set_value();
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __p_.set_exception(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class... _ArgTypes>
@@ -1785,16 +1787,16 @@ void packaged_task<void(_ArgTypes...)>::make_ready_at_thread_exit(_ArgTypes... _
     __throw_future_error(future_errc::no_state);
   if (__p_.__state_->__has_value())
     __throw_future_error(future_errc::promise_already_satisfied);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __f_(std::forward<_ArgTypes>(__args)...);
     __p_.set_value_at_thread_exit();
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __p_.set_exception_at_thread_exit(current_exception());
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class... _ArgTypes>
@@ -1810,10 +1812,10 @@ swap(packaged_task<_Rp(_ArgTypes...)>& __x, packaged_task<_Rp(_ArgTypes...)>& __
   __x.swap(__y);
 }
 
-#  if _LIBCPP_STD_VER <= 14
+#    if _LIBCPP_STD_VER <= 14
 template <class _Callable, class _Alloc>
 struct _LIBCPP_TEMPLATE_VIS uses_allocator<packaged_task<_Callable>, _Alloc> : public true_type {};
-#  endif
+#    endif
 
 template <class _Rp, class _Fp>
 _LIBCPP_HIDE_FROM_ABI future<_Rp> __make_deferred_assoc_state(_Fp&& __f) {
@@ -1830,7 +1832,7 @@ _LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Fp&& __f) {
   return future<_Rp>(__h.get());
 }
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 template <class _Fp, class... _Args>
 class _LIBCPP_HIDDEN __async_func {
@@ -1866,18 +1868,18 @@ async(launch __policy, _Fp&& __f, _Args&&... __args) {
   typedef __async_func<__decay_t<_Fp>, __decay_t<_Args>...> _BF;
   typedef typename _BF::_Rp _Rp;
 
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
   try {
-#    endif
+#      endif
     if (__does_policy_contain(__policy, launch::async))
       return std::__make_async_assoc_state<_Rp>(
           _BF(_LIBCPP_AUTO_CAST(std::forward<_Fp>(__f)), _LIBCPP_AUTO_CAST(std::forward<_Args>(__args))...));
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     if (__policy == launch::async)
       throw;
   }
-#    endif
+#      endif
 
   if (__does_policy_contain(__policy, launch::deferred))
     return std::__make_deferred_assoc_state<_Rp>(
@@ -1891,7 +1893,7 @@ async(_Fp&& __f, _Args&&... __args) {
   return std::async(launch::any, std::forward<_Fp>(__f), std::forward<_Args>(__args)...);
 }
 
-#  endif // C++03
+#    endif // C++03
 
 // shared_future
 
@@ -2068,19 +2070,20 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_THREADS
+#  endif // _LIBCPP_HAS_THREADS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
-#  include <chrono>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#    include <chrono>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <cstdlib>
-#  include <exception>
-#  include <iosfwd>
-#  include <system_error>
-#  include <thread>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <cstdlib>
+#    include <exception>
+#    include <iosfwd>
+#    include <system_error>
+#    include <thread>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_FUTURE

--- a/libcxx/include/initializer_list
+++ b/libcxx/include/initializer_list
@@ -42,18 +42,20 @@ template<class E> const E* end(initializer_list<E> il) noexcept; // constexpr in
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 namespace std // purposefully not versioned
 {
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Ep>
 class _LIBCPP_TEMPLATE_VIS initializer_list {
@@ -92,12 +94,13 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ep* end(initia
   return __il.end();
 }
 
-#endif // !defined(_LIBCPP_CXX03_LANG)
+#  endif // !defined(_LIBCPP_CXX03_LANG)
 
 } // namespace std
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_INITIALIZER_LIST

--- a/libcxx/include/inttypes.h
+++ b/libcxx/include/inttypes.h
@@ -235,30 +235,33 @@ uintmax_t wcstoumax(const wchar_t* restrict nptr, wchar_t** restrict endptr, int
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 /* C99 stdlib (e.g. glibc < 2.18) does not provide format macros needed
    for C++11 unless __STDC_FORMAT_MACROS is defined
 */
-#if defined(__cplusplus) && !defined(__STDC_FORMAT_MACROS)
-#  define __STDC_FORMAT_MACROS
-#endif
+#  if defined(__cplusplus) && !defined(__STDC_FORMAT_MACROS)
+#    define __STDC_FORMAT_MACROS
+#  endif
 
-#if __has_include_next(<inttypes.h>)
-#  include_next <inttypes.h>
-#endif
+#  if __has_include_next(<inttypes.h>)
+#    include_next <inttypes.h>
+#  endif
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 
-#  include <stdint.h>
+#    include <stdint.h>
 
-#  undef imaxabs
-#  undef imaxdiv
+#    undef imaxabs
+#    undef imaxdiv
 
-#endif // __cplusplus
+#  endif // __cplusplus
+#endif   // 0
 
 #endif // _LIBCPP_INTTYPES_H

--- a/libcxx/include/iomanip
+++ b/libcxx/include/iomanip
@@ -42,19 +42,21 @@ template <class charT, class traits, class Allocator>
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__ostream/put_character_sequence.h>
-#  include <ios>
-#  include <iosfwd>
-#  include <locale>
-#  include <version>
+#    include <__ostream/put_character_sequence.h>
+#    include <ios>
+#    include <iosfwd>
+#    include <locale>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -237,9 +239,9 @@ public:
 template <class _CharT, class _Traits, class _MoneyT>
 _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t7<_MoneyT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     typename basic_istream<_CharT, _Traits>::sentry __s(__is);
     if (__s) {
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
@@ -249,11 +251,11 @@ operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t7<_MoneyT>& __x) {
       __mf.get(_Ip(__is), _Ip(), __x.__intl_, __is, __err, __x.__mon_);
       __is.setstate(__err);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __is.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   return __is;
 }
 
@@ -286,9 +288,9 @@ public:
 template <class _CharT, class _Traits, class _MoneyT>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t8<_MoneyT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Op;
@@ -297,11 +299,11 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t8<_MoneyT>& __x) {
       if (__mf.put(_Op(__os), __x.__intl_, __os, __os.fill(), __x.__mon_).failed())
         __os.setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 
@@ -334,9 +336,9 @@ public:
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t9<_CharT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     typename basic_istream<_CharT, _Traits>::sentry __s(__is);
     if (__s) {
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
@@ -346,11 +348,11 @@ operator>>(basic_istream<_CharT, _Traits>& __is, const __iom_t9<_CharT>& __x) {
       __tf.get(_Ip(__is), _Ip(), __is, __err, __x.__tm_, __x.__fmt_, __x.__fmt_ + _Traits::length(__x.__fmt_));
       __is.setstate(__err);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __is.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   return __is;
 }
 
@@ -383,9 +385,9 @@ public:
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
 operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t10<_CharT>& __x) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     typename basic_ostream<_CharT, _Traits>::sentry __s(__os);
     if (__s) {
       typedef ostreambuf_iterator<_CharT, _Traits> _Op;
@@ -395,11 +397,11 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const __iom_t10<_CharT>& __x) {
               .failed())
         __os.setstate(ios_base::badbit);
     }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __os.__set_badbit_and_consider_rethrow();
   }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   return __os;
 }
 
@@ -511,7 +513,7 @@ __quoted(basic_string<_CharT, _Traits, _Allocator>& __s, _CharT __delim = _CharT
   return __quoted_proxy<_CharT, _Traits, _Allocator>(__s, __delim, __escape);
 }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
 
 template <class _CharT>
 _LIBCPP_HIDE_FROM_ABI auto quoted(const _CharT* __s, _CharT __delim = _CharT('"'), _CharT __escape = _CharT('\\')) {
@@ -541,25 +543,26 @@ quoted(basic_string_view<_CharT, _Traits> __sv, _CharT __delim = _CharT('"'), _C
   return __quoted_output_proxy<_CharT, _Traits>(__sv.data(), __sv.data() + __sv.size(), __delim, __escape);
 }
 
-#  endif // _LIBCPP_STD_VER >= 14
+#    endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <array>
-#  include <bitset>
-#  include <deque>
-#  include <format>
-#  include <functional>
-#  include <istream>
-#  include <ostream>
-#  include <print>
-#  include <queue>
-#  include <stack>
-#  include <unordered_map>
-#  include <vector>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <array>
+#    include <bitset>
+#    include <deque>
+#    include <format>
+#    include <functional>
+#    include <istream>
+#    include <ostream>
+#    include <print>
+#    include <queue>
+#    include <stack>
+#    include <unordered_map>
+#    include <vector>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_IOMANIP

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -211,37 +211,39 @@ storage-class-specifier const error_category& iostream_category() noexcept;
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__fwd/ios.h>
-#  include <__ios/fpos.h>
-#  include <__locale>
-#  include <__memory/addressof.h>
-#  include <__system_error/error_category.h>
-#  include <__system_error/error_code.h>
-#  include <__system_error/error_condition.h>
-#  include <__system_error/system_error.h>
-#  include <__utility/swap.h>
-#  include <__verbose_abort>
-#  include <version>
+#    include <__fwd/ios.h>
+#    include <__ios/fpos.h>
+#    include <__locale>
+#    include <__memory/addressof.h>
+#    include <__system_error/error_category.h>
+#    include <__system_error/error_code.h>
+#    include <__system_error/error_condition.h>
+#    include <__system_error/system_error.h>
+#    include <__utility/swap.h>
+#    include <__verbose_abort>
+#    include <version>
 
 // standard-mandated includes
 
 // [ios.syn]
-#  include <iosfwd>
+#    include <iosfwd>
 
-#  if _LIBCPP_HAS_ATOMIC_HEADER
-#    include <__atomic/atomic.h> // for __xindex_
-#  endif
+#    if _LIBCPP_HAS_ATOMIC_HEADER
+#      include <__atomic/atomic.h> // for __xindex_
+#    endif
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -284,20 +286,20 @@ public:
   static const openmode in     = 0x08;
   static const openmode out    = 0x10;
   static const openmode trunc  = 0x20;
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   static const openmode noreplace = 0x40;
-#  endif
+#    endif
 
   enum seekdir { beg, cur, end };
 
-#  if _LIBCPP_STD_VER <= 14
+#    if _LIBCPP_STD_VER <= 14
   typedef iostate io_state;
   typedef openmode open_mode;
   typedef seekdir seek_dir;
 
   typedef std::streamoff streamoff;
   typedef std::streampos streampos;
-#  endif
+#    endif
 
   class _LIBCPP_EXPORTED_FROM_ABI Init;
 
@@ -397,11 +399,11 @@ private:
   size_t __event_cap_;
 // TODO(EricWF): Enable this for both Clang and GCC. Currently it is only
 // enabled with clang.
-#  if _LIBCPP_HAS_C_ATOMIC_IMP && _LIBCPP_HAS_THREADS
+#    if _LIBCPP_HAS_C_ATOMIC_IMP && _LIBCPP_HAS_THREADS
   static atomic<int> __xindex_;
-#  else
+#    else
   static int __xindex_;
-#  endif
+#    endif
   long* __iarray_;
   size_t __iarray_size_;
   size_t __iarray_cap_;
@@ -417,10 +419,10 @@ _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(io_errc)
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<io_errc> : public true_type {};
 
-#  ifdef _LIBCPP_CXX03_LANG
+#    ifdef _LIBCPP_CXX03_LANG
 template <>
 struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<io_errc::__lx> : public true_type {};
-#  endif
+#    endif
 
 _LIBCPP_EXPORTED_FROM_ABI const error_category& iostream_category() _NOEXCEPT;
 
@@ -441,11 +443,11 @@ public:
 };
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_failure(char const* __msg) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   throw ios_base::failure(__msg);
-#  else
+#    else
   _LIBCPP_VERBOSE_ABORT("ios_base::failure was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#  endif
+#    endif
 }
 
 class _LIBCPP_EXPORTED_FROM_ABI ios_base::Init {
@@ -569,13 +571,13 @@ public:
   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
                 "traits_type::char_type must be the same type as CharT");
 
-#  ifdef _LIBCPP_CXX03_LANG
+#    ifdef _LIBCPP_CXX03_LANG
   // Preserve the ability to compare with literal 0,
   // and implicitly convert to bool, but not implicitly convert to int.
   _LIBCPP_HIDE_FROM_ABI operator void*() const { return fail() ? nullptr : (void*)this; }
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI explicit operator bool() const { return !fail(); }
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI bool operator!() const { return fail(); }
   _LIBCPP_HIDE_FROM_ABI iostate rdstate() const { return ios_base::rdstate(); }
@@ -625,11 +627,11 @@ protected:
 private:
   basic_ostream<char_type, traits_type>* __tie_;
 
-#  if defined(_LIBCPP_ABI_IOS_ALLOW_ARBITRARY_FILL_VALUE)
+#    if defined(_LIBCPP_ABI_IOS_ALLOW_ARBITRARY_FILL_VALUE)
   using _FillType = _FillHelper<traits_type>;
-#  else
+#    else
   using _FillType = _SentinelValueFill<traits_type>;
-#  endif
+#    endif
   mutable _FillType __fill_;
 };
 
@@ -744,9 +746,9 @@ inline _LIBCPP_HIDE_FROM_ABI void basic_ios<_CharT, _Traits>::set_rdbuf(basic_st
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ios<char>;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ios<wchar_t>;
-#  endif
+#    endif
 
 _LIBCPP_HIDE_FROM_ABI inline ios_base& boolalpha(ios_base& __str) {
   __str.setf(ios_base::boolalpha);
@@ -872,22 +874,23 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstddef>
-#  include <cstdlib>
-#  include <cstring>
-#  include <initializer_list>
-#  include <limits>
-#  include <mutex>
-#  include <new>
-#  include <stdexcept>
-#  include <system_error>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstddef>
+#    include <cstdlib>
+#    include <cstring>
+#    include <initializer_list>
+#    include <limits>
+#    include <mutex>
+#    include <new>
+#    include <stdexcept>
+#    include <system_error>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_IOS

--- a/libcxx/include/iosfwd
+++ b/libcxx/include/iosfwd
@@ -105,21 +105,23 @@ using wosyncstream = basic_osyncstream<wchar_t>;  // C++20
 
 */
 
-#include <__config>
-#include <__fwd/fstream.h>
-#include <__fwd/ios.h>
-#include <__fwd/istream.h>
-#include <__fwd/memory.h>
-#include <__fwd/ostream.h>
-#include <__fwd/sstream.h>
-#include <__fwd/streambuf.h>
-#include <__fwd/string.h>
-#include <__std_mbstate_t.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__fwd/fstream.h>
+#  include <__fwd/ios.h>
+#  include <__fwd/istream.h>
+#  include <__fwd/memory.h>
+#  include <__fwd/ostream.h>
+#  include <__fwd/sstream.h>
+#  include <__fwd/streambuf.h>
+#  include <__fwd/string.h>
+#  include <__std_mbstate_t.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -131,34 +133,34 @@ class _LIBCPP_TEMPLATE_VIS ostreambuf_iterator;
 template <class _State>
 class _LIBCPP_TEMPLATE_VIS fpos;
 typedef fpos<mbstate_t> streampos;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef fpos<mbstate_t> wstreampos;
-#endif
-#if _LIBCPP_HAS_CHAR8_T
+#  endif
+#  if _LIBCPP_HAS_CHAR8_T
 typedef fpos<mbstate_t> u8streampos;
-#endif
+#  endif
 typedef fpos<mbstate_t> u16streampos;
 typedef fpos<mbstate_t> u32streampos;
 
-#if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
+#  if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
 
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT>>
 class basic_syncbuf;
 
 using syncbuf = basic_syncbuf<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 using wsyncbuf = basic_syncbuf<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT>>
 class basic_osyncstream;
 
 using osyncstream = basic_osyncstream<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 using wosyncstream = basic_osyncstream<wchar_t>;
-#  endif
+#    endif
 
-#endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
+#  endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
 
 template <class _CharT, class _Traits>
 class __save_flags {
@@ -182,5 +184,7 @@ public:
 };
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_IOSFWD

--- a/libcxx/include/iostream
+++ b/libcxx/include/iostream
@@ -33,20 +33,22 @@ extern wostream wclog;
 
 */
 
-#include <__config>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <version>
 
 // standard-mandated includes
 
 // [iostream.syn]
-#include <ios>
-#include <istream>
-#include <ostream>
-#include <streambuf>
+#  include <ios>
+#  include <istream>
+#  include <ostream>
+#  include <streambuf>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -55,13 +57,15 @@ extern _LIBCPP_EXPORTED_FROM_ABI ostream cout;
 extern _LIBCPP_EXPORTED_FROM_ABI ostream cerr;
 extern _LIBCPP_EXPORTED_FROM_ABI ostream clog;
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 extern _LIBCPP_EXPORTED_FROM_ABI wistream wcin;
 extern _LIBCPP_EXPORTED_FROM_ABI wostream wcout;
 extern _LIBCPP_EXPORTED_FROM_ABI wostream wcerr;
 extern _LIBCPP_EXPORTED_FROM_ABI wostream wclog;
-#endif
+#  endif
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_IOSTREAM

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -158,30 +158,32 @@ template <class Stream, class T>
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__fwd/istream.h>
-#  include <__iterator/istreambuf_iterator.h>
-#  include <__ostream/basic_ostream.h>
-#  include <__type_traits/conjunction.h>
-#  include <__type_traits/enable_if.h>
-#  include <__type_traits/is_base_of.h>
-#  include <__type_traits/make_unsigned.h>
-#  include <__utility/declval.h>
-#  include <__utility/forward.h>
-#  include <bitset>
-#  include <ios>
-#  include <locale>
-#  include <version>
+#    include <__fwd/istream.h>
+#    include <__iterator/istreambuf_iterator.h>
+#    include <__ostream/basic_ostream.h>
+#    include <__type_traits/conjunction.h>
+#    include <__type_traits/enable_if.h>
+#    include <__type_traits/is_base_of.h>
+#    include <__type_traits/make_unsigned.h>
+#    include <__utility/declval.h>
+#    include <__utility/forward.h>
+#    include <bitset>
+#    include <ios>
+#    include <locale>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -357,13 +359,13 @@ __input_arithmetic(basic_istream<_CharT, _Traits>& __is, _Tp& __n) {
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __s(__is);
   if (__s) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
       typedef num_get<_CharT, _Ip> _Fp;
       std::use_facet<_Fp>(__is.getloc()).get(_Ip(__is), _Ip(), __is, __state, __n);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -371,7 +373,7 @@ __input_arithmetic(basic_istream<_CharT, _Traits>& __is, _Tp& __n) {
         throw;
       }
     }
-#  endif
+#    endif
     __is.setstate(__state);
   }
   return __is;
@@ -438,9 +440,9 @@ __input_arithmetic_with_numeric_limits(basic_istream<_CharT, _Traits>& __is, _Tp
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __s(__is);
   if (__s) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       typedef istreambuf_iterator<_CharT, _Traits> _Ip;
       typedef num_get<_CharT, _Ip> _Fp;
       long __temp;
@@ -454,7 +456,7 @@ __input_arithmetic_with_numeric_limits(basic_istream<_CharT, _Traits>& __is, _Tp
       } else {
         __n = static_cast<_Tp>(__temp);
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -462,7 +464,7 @@ __input_arithmetic_with_numeric_limits(basic_istream<_CharT, _Traits>& __is, _Tp
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __is.setstate(__state);
   }
   return __is;
@@ -484,9 +486,9 @@ __input_c_string(basic_istream<_CharT, _Traits>& __is, _CharT* __p, size_t __n) 
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif
+#    endif
       _CharT* __s               = __p;
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
       while (__s != __p + (__n - 1)) {
@@ -505,7 +507,7 @@ __input_c_string(basic_istream<_CharT, _Traits>& __is, _CharT* __p, size_t __n) 
       __is.width(0);
       if (__s == __p)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -513,13 +515,13 @@ __input_c_string(basic_istream<_CharT, _Traits>& __is, _CharT* __p, size_t __n) 
         throw;
       }
     }
-#  endif
+#    endif
     __is.setstate(__state);
   }
   return __is;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits, size_t _Np>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
@@ -542,7 +544,7 @@ operator>>(basic_istream<char, _Traits>& __is, signed char (&__buf)[_Np]) {
   return __is >> (char(&)[_Np])__buf;
 }
 
-#  else
+#    else
 
 template <class _CharT, class _Traits>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
@@ -565,22 +567,22 @@ operator>>(basic_istream<char, _Traits>& __is, signed char* __s) {
   return __is >> (char*)__s;
 }
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& operator>>(basic_istream<_CharT, _Traits>& __is, _CharT& __c) {
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif
+#    endif
       typename _Traits::int_type __i = __is.rdbuf()->sbumpc();
       if (_Traits::eq_int_type(__i, _Traits::eof()))
         __state |= ios_base::eofbit | ios_base::failbit;
       else
         __c = _Traits::to_char_type(__i);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -588,7 +590,7 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& operator>>(basic_istream<_
         throw;
       }
     }
-#  endif
+#    endif
     __is.setstate(__state);
   }
   return __is;
@@ -614,9 +616,9 @@ basic_istream<_CharT, _Traits>::operator>>(basic_streambuf<char_type, traits_typ
   sentry __s(*this, true);
   if (__s) {
     if (__sb) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
         while (true) {
           typename traits_type::int_type __i = this->rdbuf()->sgetc();
           if (traits_type::eq_int_type(__i, _Traits::eof())) {
@@ -630,7 +632,7 @@ basic_istream<_CharT, _Traits>::operator>>(basic_streambuf<char_type, traits_typ
         }
         if (__gc_ == 0)
           __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       } catch (...) {
         __state |= ios_base::badbit;
         if (__gc_ == 0)
@@ -641,7 +643,7 @@ basic_istream<_CharT, _Traits>::operator>>(basic_streambuf<char_type, traits_typ
           throw;
         }
       }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     } else {
       __state |= ios_base::failbit;
     }
@@ -657,22 +659,22 @@ typename basic_istream<_CharT, _Traits>::int_type basic_istream<_CharT, _Traits>
   int_type __r              = traits_type::eof();
   sentry __s(*this, true);
   if (__s) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif
+#    endif
       __r = this->rdbuf()->sbumpc();
       if (traits_type::eq_int_type(__r, traits_type::eof()))
         __state |= ios_base::failbit | ios_base::eofbit;
       else
         __gc_ = 1;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       this->__setstate_nothrow(this->rdstate() | ios_base::badbit);
       if (this->exceptions() & ios_base::badbit) {
         throw;
       }
     }
-#  endif
+#    endif
     this->setstate(__state);
   }
   return __r;
@@ -685,9 +687,9 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::get(char_type* _
   sentry __sen(*this, true);
   if (__sen) {
     if (__n > 0) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       try {
-#  endif
+#    endif
         while (__gc_ < __n - 1) {
           int_type __i = this->rdbuf()->sgetc();
           if (traits_type::eq_int_type(__i, traits_type::eof())) {
@@ -703,7 +705,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::get(char_type* _
         }
         if (__gc_ == 0)
           __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       } catch (...) {
         __state |= ios_base::badbit;
         this->__setstate_nothrow(__state);
@@ -713,7 +715,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::get(char_type* _
           throw;
         }
       }
-#  endif
+#    endif
     } else {
       __state |= ios_base::failbit;
     }
@@ -734,9 +736,9 @@ basic_istream<_CharT, _Traits>::get(basic_streambuf<char_type, traits_type>& __s
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       while (true) {
         typename traits_type::int_type __i = this->rdbuf()->sgetc();
         if (traits_type::eq_int_type(__i, traits_type::eof())) {
@@ -751,12 +753,12 @@ basic_istream<_CharT, _Traits>::get(basic_streambuf<char_type, traits_type>& __s
         __inc_gcount();
         this->rdbuf()->sbumpc();
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       // according to the spec, exceptions here are caught but not rethrown
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     if (__gc_ == 0)
       __state |= ios_base::failbit;
     this->setstate(__state);
@@ -771,9 +773,9 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       while (true) {
         typename traits_type::int_type __i = this->rdbuf()->sgetc();
         if (traits_type::eq_int_type(__i, traits_type::eof())) {
@@ -794,7 +796,7 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
         this->rdbuf()->sbumpc();
         __inc_gcount();
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -806,7 +808,7 @@ basic_istream<_CharT, _Traits>::getline(char_type* __s, streamsize __n, char_typ
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   }
   if (__n > 0)
     *__s = char_type();
@@ -822,9 +824,9 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::ignore(streamsiz
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       if (__n == numeric_limits<streamsize>::max()) {
         while (true) {
           typename traits_type::int_type __i = this->rdbuf()->sbumpc();
@@ -848,7 +850,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::ignore(streamsiz
             break;
         }
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -856,7 +858,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::ignore(streamsiz
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return *this;
@@ -869,13 +871,13 @@ typename basic_istream<_CharT, _Traits>::int_type basic_istream<_CharT, _Traits>
   int_type __r              = traits_type::eof();
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       __r = this->rdbuf()->sgetc();
       if (traits_type::eq_int_type(__r, traits_type::eof()))
         __state |= ios_base::eofbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -883,7 +885,7 @@ typename basic_istream<_CharT, _Traits>::int_type basic_istream<_CharT, _Traits>
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return __r;
@@ -895,13 +897,13 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::read(char_type* 
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       __gc_ = this->rdbuf()->sgetn(__s, __n);
       if (__gc_ != __n)
         __state |= ios_base::failbit | ios_base::eofbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -909,7 +911,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::read(char_type* 
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -923,9 +925,9 @@ streamsize basic_istream<_CharT, _Traits>::readsome(char_type* __s, streamsize _
   __gc_                     = 0;
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       streamsize __c = this->rdbuf()->in_avail();
       switch (__c) {
       case -1:
@@ -940,7 +942,7 @@ streamsize basic_istream<_CharT, _Traits>::readsome(char_type* __s, streamsize _
           __state |= ios_base::failbit | ios_base::eofbit;
         break;
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -948,7 +950,7 @@ streamsize basic_istream<_CharT, _Traits>::readsome(char_type* __s, streamsize _
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -963,12 +965,12 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::putback(char_typ
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       if (this->rdbuf() == nullptr || this->rdbuf()->sputbackc(__c) == traits_type::eof())
         __state |= ios_base::badbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -976,7 +978,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::putback(char_typ
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -991,12 +993,12 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::unget() {
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       if (this->rdbuf() == nullptr || this->rdbuf()->sungetc() == traits_type::eof())
         __state |= ios_base::badbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -1004,7 +1006,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::unget() {
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   } else {
     __state |= ios_base::failbit;
   }
@@ -1021,14 +1023,14 @@ int basic_istream<_CharT, _Traits>::sync() {
 
   int __r = 0;
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       if (this->rdbuf()->pubsync() == -1) {
         __state |= ios_base::badbit;
         __r = -1;
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -1036,7 +1038,7 @@ int basic_istream<_CharT, _Traits>::sync() {
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return __r;
@@ -1048,11 +1050,11 @@ typename basic_istream<_CharT, _Traits>::pos_type basic_istream<_CharT, _Traits>
   pos_type __r(-1);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       __r = this->rdbuf()->pubseekoff(0, ios_base::cur, ios_base::in);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -1060,7 +1062,7 @@ typename basic_istream<_CharT, _Traits>::pos_type basic_istream<_CharT, _Traits>
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return __r;
@@ -1072,12 +1074,12 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::seekg(pos_type _
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       if (this->rdbuf()->pubseekpos(__pos, ios_base::in) == pos_type(-1))
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -1085,7 +1087,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::seekg(pos_type _
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return *this;
@@ -1097,12 +1099,12 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::seekg(off_type _
   this->clear(__state);
   sentry __sen(*this, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       if (this->rdbuf()->pubseekoff(__off, __dir, ios_base::in) == pos_type(-1))
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       this->__setstate_nothrow(__state);
@@ -1110,7 +1112,7 @@ basic_istream<_CharT, _Traits>& basic_istream<_CharT, _Traits>::seekg(off_type _
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     this->setstate(__state);
   }
   return *this;
@@ -1121,9 +1123,9 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& ws(basic_istream<_CharT, _
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
       while (true) {
         typename _Traits::int_type __i = __is.rdbuf()->sgetc();
@@ -1135,7 +1137,7 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& ws(basic_istream<_CharT, _
           break;
         __is.rdbuf()->sbumpc();
       }
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -1143,7 +1145,7 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>& ws(basic_istream<_CharT, _
         throw;
       }
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     __is.setstate(__state);
   }
   return __is;
@@ -1211,9 +1213,9 @@ operator>>(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif
+#    endif
       __str.clear();
       using _Size              = typename basic_string<_CharT, _Traits, _Allocator>::size_type;
       streamsize const __width = __is.width();
@@ -1243,7 +1245,7 @@ operator>>(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _
       __is.width(0);
       if (__c == 0)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -1251,7 +1253,7 @@ operator>>(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _
         throw;
       }
     }
-#  endif
+#    endif
     __is.setstate(__state);
   }
   return __is;
@@ -1263,9 +1265,9 @@ getline(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _All
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is, true);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif
+#    endif
       __str.clear();
       streamsize __extr = 0;
       while (true) {
@@ -1286,7 +1288,7 @@ getline(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _All
       }
       if (__extr == 0)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -1294,7 +1296,7 @@ getline(basic_istream<_CharT, _Traits>& __is, basic_string<_CharT, _Traits, _All
         throw;
       }
     }
-#  endif
+#    endif
     __is.setstate(__state);
   }
   return __is;
@@ -1324,9 +1326,9 @@ operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x) {
   ios_base::iostate __state = ios_base::goodbit;
   typename basic_istream<_CharT, _Traits>::sentry __sen(__is);
   if (__sen) {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif
+#    endif
       basic_string<_CharT, _Traits> __str;
       const ctype<_CharT>& __ct = std::use_facet<ctype<_CharT> >(__is.getloc());
       size_t __c                = 0;
@@ -1348,7 +1350,7 @@ operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x) {
       __x = bitset<_Size>(__str);
       if (_Size > 0 && __c == 0)
         __state |= ios_base::failbit;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __state |= ios_base::badbit;
       __is.__setstate_nothrow(__state);
@@ -1356,29 +1358,31 @@ operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x) {
         throw;
       }
     }
-#  endif
+#    endif
     __is.setstate(__state);
   }
   return __is;
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_istream<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_istream<wchar_t>;
-#  endif
+#    endif
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_iostream<char>;
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <iosfwd>
-#  include <ostream>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <iosfwd>
+#    include <ostream>
+#    include <type_traits>
+#  endif
 
 _LIBCPP_POP_MACROS
+
+#endif // 0
 
 #endif // _LIBCPP_ISTREAM

--- a/libcxx/include/iterator
+++ b/libcxx/include/iterator
@@ -679,77 +679,80 @@ template <class E> constexpr const E* data(initializer_list<E> il) noexcept;    
 
 */
 
-#include <__config>
-#include <__iterator/access.h>
-#include <__iterator/advance.h>
-#include <__iterator/back_insert_iterator.h>
-#include <__iterator/distance.h>
-#include <__iterator/front_insert_iterator.h>
-#include <__iterator/insert_iterator.h>
-#include <__iterator/istream_iterator.h>
-#include <__iterator/istreambuf_iterator.h>
-#include <__iterator/iterator.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/move_iterator.h>
-#include <__iterator/next.h>
-#include <__iterator/ostream_iterator.h>
-#include <__iterator/ostreambuf_iterator.h>
-#include <__iterator/prev.h>
-#include <__iterator/reverse_iterator.h>
-#include <__iterator/wrap_iter.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__iterator/access.h>
+#  include <__iterator/advance.h>
+#  include <__iterator/back_insert_iterator.h>
+#  include <__iterator/distance.h>
+#  include <__iterator/front_insert_iterator.h>
+#  include <__iterator/insert_iterator.h>
+#  include <__iterator/istream_iterator.h>
+#  include <__iterator/istreambuf_iterator.h>
+#  include <__iterator/iterator.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/move_iterator.h>
+#  include <__iterator/next.h>
+#  include <__iterator/ostream_iterator.h>
+#  include <__iterator/ostreambuf_iterator.h>
+#  include <__iterator/prev.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__iterator/wrap_iter.h>
 
-#if _LIBCPP_STD_VER >= 14
-#  include <__iterator/reverse_access.h>
-#endif
+#  if _LIBCPP_STD_VER >= 14
+#    include <__iterator/reverse_access.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__iterator/data.h>
-#  include <__iterator/empty.h>
-#  include <__iterator/size.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__iterator/data.h>
+#    include <__iterator/empty.h>
+#    include <__iterator/size.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__iterator/common_iterator.h>
-#  include <__iterator/concepts.h>
-#  include <__iterator/counted_iterator.h>
-#  include <__iterator/default_sentinel.h>
-#  include <__iterator/incrementable_traits.h>
-#  include <__iterator/indirectly_comparable.h>
-#  include <__iterator/iter_move.h>
-#  include <__iterator/iter_swap.h>
-#  include <__iterator/mergeable.h>
-#  include <__iterator/move_sentinel.h>
-#  include <__iterator/permutable.h>
-#  include <__iterator/projected.h>
-#  include <__iterator/readable_traits.h>
-#  include <__iterator/sortable.h>
-#  include <__iterator/unreachable_sentinel.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__iterator/common_iterator.h>
+#    include <__iterator/concepts.h>
+#    include <__iterator/counted_iterator.h>
+#    include <__iterator/default_sentinel.h>
+#    include <__iterator/incrementable_traits.h>
+#    include <__iterator/indirectly_comparable.h>
+#    include <__iterator/iter_move.h>
+#    include <__iterator/iter_swap.h>
+#    include <__iterator/mergeable.h>
+#    include <__iterator/move_sentinel.h>
+#    include <__iterator/permutable.h>
+#    include <__iterator/projected.h>
+#    include <__iterator/readable_traits.h>
+#    include <__iterator/sortable.h>
+#    include <__iterator/unreachable_sentinel.h>
+#  endif
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.synopsis]
-#include <compare>
-#include <concepts>
+#  include <compare>
+#  include <concepts>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
-#  include <variant>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#    include <variant>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <cstdlib>
-#  include <exception>
-#  include <new>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <cstdlib>
+#    include <exception>
+#    include <new>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_ITERATOR

--- a/libcxx/include/latch
+++ b/libcxx/include/latch
@@ -40,26 +40,28 @@ namespace std
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  include <__assert>
-#  include <__atomic/atomic.h>
-#  include <__atomic/atomic_sync.h>
-#  include <__atomic/memory_order.h>
-#  include <__cstddef/ptrdiff_t.h>
-#  include <limits>
-#  include <version>
+#    include <__assert>
+#    include <__atomic/atomic.h>
+#    include <__atomic/atomic_sync.h>
+#    include <__atomic/memory_order.h>
+#    include <__cstddef/ptrdiff_t.h>
+#    include <limits>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -117,15 +119,16 @@ private:
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_THREADS
+#  endif // _LIBCPP_HAS_THREADS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_LATCH

--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -102,18 +102,20 @@ template<> class numeric_limits<cv long double>;
 
 */
 
-#include <__config>
-#include <__type_traits/is_arithmetic.h>
-#include <__type_traits/is_signed.h>
-#include <__type_traits/remove_cv.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__type_traits/is_arithmetic.h>
+#  include <__type_traits/is_signed.h>
+#  include <__type_traits/remove_cv.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
-#include <version>
+#  include <__undef_macros>
+#  include <version>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -227,11 +229,11 @@ protected:
   static _LIBCPP_CONSTEXPR const bool is_bounded = true;
   static _LIBCPP_CONSTEXPR const bool is_modulo  = !std::is_signed<_Tp>::value;
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || defined(__wasm__)
+#  if defined(__i386__) || defined(__x86_64__) || defined(__pnacl__) || defined(__wasm__)
   static _LIBCPP_CONSTEXPR const bool traps = true;
-#else
+#  else
   static _LIBCPP_CONSTEXPR const bool traps = false;
-#endif
+#  endif
   static _LIBCPP_CONSTEXPR const bool tinyness_before          = false;
   static _LIBCPP_CONSTEXPR const float_round_style round_style = round_toward_zero;
 };
@@ -332,11 +334,11 @@ protected:
   static _LIBCPP_CONSTEXPR const bool is_modulo  = false;
 
   static _LIBCPP_CONSTEXPR const bool traps = false;
-#if (defined(__arm__) || defined(__aarch64__))
+#  if (defined(__arm__) || defined(__aarch64__))
   static _LIBCPP_CONSTEXPR const bool tinyness_before = true;
-#else
+#  else
   static _LIBCPP_CONSTEXPR const bool tinyness_before = false;
-#endif
+#  endif
   static _LIBCPP_CONSTEXPR const float_round_style round_style = round_to_nearest;
 };
 
@@ -389,11 +391,11 @@ protected:
   static _LIBCPP_CONSTEXPR const bool is_modulo  = false;
 
   static _LIBCPP_CONSTEXPR const bool traps = false;
-#if (defined(__arm__) || defined(__aarch64__))
+#  if (defined(__arm__) || defined(__aarch64__))
   static _LIBCPP_CONSTEXPR const bool tinyness_before = true;
-#else
+#  else
   static _LIBCPP_CONSTEXPR const bool tinyness_before = false;
-#endif
+#  endif
   static _LIBCPP_CONSTEXPR const float_round_style round_style = round_to_nearest;
 };
 
@@ -441,20 +443,20 @@ protected:
     return __LDBL_DENORM_MIN__;
   }
 
-#if defined(__powerpc__) && defined(__LONG_DOUBLE_IBM128__)
+#  if defined(__powerpc__) && defined(__LONG_DOUBLE_IBM128__)
   static _LIBCPP_CONSTEXPR const bool is_iec559 = false;
-#else
+#  else
   static _LIBCPP_CONSTEXPR const bool is_iec559 = true;
-#endif
+#  endif
   static _LIBCPP_CONSTEXPR const bool is_bounded = true;
   static _LIBCPP_CONSTEXPR const bool is_modulo  = false;
 
   static _LIBCPP_CONSTEXPR const bool traps = false;
-#if (defined(__arm__) || defined(__aarch64__))
+#  if (defined(__arm__) || defined(__aarch64__))
   static _LIBCPP_CONSTEXPR const bool tinyness_before = true;
-#else
+#  else
   static _LIBCPP_CONSTEXPR const bool tinyness_before = false;
-#endif
+#  endif
   static _LIBCPP_CONSTEXPR const float_round_style round_style = round_to_nearest;
 };
 
@@ -530,8 +532,9 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_LIMITS

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -197,69 +197,71 @@ template <class T, class Allocator, class Predicate>
 
 */
 
-#include <__algorithm/comp.h>
-#include <__algorithm/equal.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lexicographical_compare_three_way.h>
-#include <__algorithm/min.h>
-#include <__assert>
-#include <__config>
-#include <__format/enable_insertable.h>
-#include <__iterator/distance.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/move_iterator.h>
-#include <__iterator/next.h>
-#include <__iterator/prev.h>
-#include <__iterator/reverse_iterator.h>
-#include <__memory/addressof.h>
-#include <__memory/allocation_guard.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/compressed_pair.h>
-#include <__memory/construct_at.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/swap_allocator.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_pointer.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <cstring>
-#include <limits>
-#include <new> // __launder
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/comp.h>
+#  include <__algorithm/equal.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lexicographical_compare_three_way.h>
+#  include <__algorithm/min.h>
+#  include <__assert>
+#  include <__config>
+#  include <__format/enable_insertable.h>
+#  include <__iterator/distance.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/move_iterator.h>
+#  include <__iterator/next.h>
+#  include <__iterator/prev.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocation_guard.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/compressed_pair.h>
+#  include <__memory/construct_at.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/swap_allocator.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__ranges/access.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_pointer.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <cstring>
+#  include <limits>
+#  include <new> // __launder
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [list.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -274,7 +276,7 @@ struct __list_node_pointer_traits {
   typedef __rebind_pointer_t<_VoidPtr, __list_node_base<_Tp, _VoidPtr> > __base_pointer;
 
 // TODO(LLVM 22): Remove this check
-#ifndef _LIBCPP_ABI_LIST_REMOVE_NODE_POINTER_UB
+#  ifndef _LIBCPP_ABI_LIST_REMOVE_NODE_POINTER_UB
   static_assert(sizeof(__node_pointer) == sizeof(__node_pointer) && _LIBCPP_ALIGNOF(__base_pointer) ==
                     _LIBCPP_ALIGNOF(__node_pointer),
                 "It looks like you are using std::list with a fancy pointer type that thas a different representation "
@@ -282,7 +284,7 @@ struct __list_node_pointer_traits {
                 "implementation details of the standard library). This means that your ABI is being broken between "
                 "LLVM 19 and LLVM 20. If you don't care about your ABI being broken, define the "
                 "_LIBCPP_ABI_LIST_REMOVE_NODE_POINTER_UB macro to silence this diagnostic.");
-#endif
+#  endif
 
   static _LIBCPP_HIDE_FROM_ABI __base_pointer __unsafe_link_pointer_cast(__base_pointer __p) { return __p; }
 
@@ -314,7 +316,7 @@ template <class _Tp, class _VoidPtr>
 struct __list_node : public __list_node_base<_Tp, _VoidPtr> {
   // We allow starting the lifetime of nodes without initializing the value held by the node,
   // since that is handled by the list itself in order to be allocator-aware.
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 private:
   union {
@@ -323,14 +325,14 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI _Tp& __get_value() { return __value_; }
-#else
+#  else
 
 private:
   _ALIGNAS_TYPE(_Tp) char __buffer_[sizeof(_Tp)];
 
 public:
   _LIBCPP_HIDE_FROM_ABI _Tp& __get_value() { return *std::__launder(reinterpret_cast<_Tp*>(&__buffer_)); }
-#endif
+#  endif
 
   typedef __list_node_base<_Tp, _VoidPtr> __base;
   typedef typename __base::__base_pointer __base_pointer;
@@ -512,9 +514,9 @@ protected:
   _LIBCPP_HIDE_FROM_ABI __list_imp() _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value);
   _LIBCPP_HIDE_FROM_ABI __list_imp(const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI __list_imp(const __node_allocator& __a);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __list_imp(__node_allocator&& __a) _NOEXCEPT;
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI ~__list_imp();
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI bool empty() const _NOEXCEPT { return __size_ == 0; }
@@ -525,11 +527,11 @@ protected:
   _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT { return const_iterator(__end_as_link()); }
 
   _LIBCPP_HIDE_FROM_ABI void swap(__list_imp& __c)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
-#else
+#  else
       _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void __copy_assign_alloc(const __list_imp& __c) {
     __copy_assign_alloc(
@@ -603,12 +605,12 @@ inline __list_imp<_Tp, _Alloc>::__list_imp(const allocator_type& __a)
 template <class _Tp, class _Alloc>
 inline __list_imp<_Tp, _Alloc>::__list_imp(const __node_allocator& __a) : __size_(0), __node_alloc_(__a) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Alloc>
 inline __list_imp<_Tp, _Alloc>::__list_imp(__node_allocator&& __a) _NOEXCEPT
     : __size_(0),
       __node_alloc_(std::move(__a)) {}
-#endif
+#  endif
 
 template <class _Tp, class _Alloc>
 __list_imp<_Tp, _Alloc>::~__list_imp() {
@@ -632,11 +634,11 @@ void __list_imp<_Tp, _Alloc>::clear() _NOEXCEPT {
 
 template <class _Tp, class _Alloc>
 void __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
-#else
+#  else
     _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
-#endif
+#  endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
       __alloc_traits::propagate_on_container_swap::value || this->__node_alloc_ == __c.__node_alloc_,
@@ -683,18 +685,18 @@ public:
   typedef typename __base::const_iterator const_iterator;
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   typedef size_type __remove_return_type;
-#else
+#  else
   typedef void __remove_return_type;
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI list() _NOEXCEPT_(is_nothrow_default_constructible<__node_allocator>::value) {}
   _LIBCPP_HIDE_FROM_ABI explicit list(const allocator_type& __a) : __base(__a) {}
   _LIBCPP_HIDE_FROM_ABI explicit list(size_type __n);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI explicit list(size_type __n, const allocator_type& __a);
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x);
   template <__enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI list(size_type __n, const value_type& __x, const allocator_type& __a) : __base(__a) {
@@ -708,18 +710,18 @@ public:
   template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI list(_InpIter __f, _InpIter __l, const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI list(from_range_t, _Range&& __range, const allocator_type& __a = allocator_type())
       : __base(__a) {
     prepend_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI list(const list& __c);
   _LIBCPP_HIDE_FROM_ABI list(const list& __c, const __type_identity_t<allocator_type>& __a);
   _LIBCPP_HIDE_FROM_ABI list& operator=(const list& __c);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI list(initializer_list<value_type> __il);
   _LIBCPP_HIDE_FROM_ABI list(initializer_list<value_type> __il, const allocator_type& __a);
 
@@ -735,17 +737,17 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI void assign(initializer_list<value_type> __il) { assign(__il.begin(), __il.end()); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI void assign(_InpIter __f, _InpIter __l);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void assign_range(_Range&& __range) {
     __assign_with_sentinel(ranges::begin(__range), ranges::end(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void assign(size_type __n, const value_type& __x);
 
@@ -788,11 +790,11 @@ public:
     return __base::__end_.__prev_->__as_node()->__get_value();
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void push_front(value_type&& __x);
   _LIBCPP_HIDE_FROM_ABI void push_back(value_type&& __x);
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void prepend_range(_Range&& __range) {
     insert_range(begin(), std::forward<_Range>(__range));
@@ -802,20 +804,20 @@ public:
   _LIBCPP_HIDE_FROM_ABI void append_range(_Range&& __range) {
     insert_range(end(), std::forward<_Range>(__range));
   }
-#  endif
+#    endif
 
   template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI reference emplace_front(_Args&&... __args);
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI void emplace_front(_Args&&... __args);
-#  endif
+#    endif
   template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI reference emplace_back(_Args&&... __args);
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI void emplace_back(_Args&&... __args);
-#  endif
+#    endif
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator emplace(const_iterator __p, _Args&&... __args);
 
@@ -824,19 +826,19 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, initializer_list<value_type> __il) {
     return insert(__p, __il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI void push_front(const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI void push_back(const value_type& __x);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class _Arg>
   _LIBCPP_HIDE_FROM_ABI void __emplace_back(_Arg&& __arg) {
     emplace_back(std::forward<_Arg>(__arg));
   }
-#else
+#  else
   _LIBCPP_HIDE_FROM_ABI void __emplace_back(value_type const& __arg) { push_back(__arg); }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, size_type __n, const value_type& __x);
@@ -844,19 +846,19 @@ public:
   template <class _InpIter, __enable_if_t<__has_input_iterator_category<_InpIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, _InpIter __f, _InpIter __l);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI iterator insert_range(const_iterator __position, _Range&& __range) {
     return __insert_with_sentinel(__position, ranges::begin(__range), ranges::end(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(list& __c)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       _NOEXCEPT
-#else
+#  else
       _NOEXCEPT_(!__node_alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<__node_allocator>)
-#endif
+#  endif
   {
     __base::swap(__c);
   }
@@ -872,13 +874,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI void resize(size_type __n, const value_type& __x);
 
   _LIBCPP_HIDE_FROM_ABI void splice(const_iterator __p, list& __c);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void splice(const_iterator __p, list&& __c) { splice(__p, __c); }
   _LIBCPP_HIDE_FROM_ABI void splice(const_iterator __p, list&& __c, const_iterator __i) { splice(__p, __c, __i); }
   _LIBCPP_HIDE_FROM_ABI void splice(const_iterator __p, list&& __c, const_iterator __f, const_iterator __l) {
     splice(__p, __c, __f, __l);
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI void splice(const_iterator __p, list& __c, const_iterator __i);
   _LIBCPP_HIDE_FROM_ABI void splice(const_iterator __p, list& __c, const_iterator __f, const_iterator __l);
 
@@ -889,14 +891,14 @@ public:
   template <class _BinaryPred>
   _LIBCPP_HIDE_FROM_ABI __remove_return_type unique(_BinaryPred __binary_pred);
   _LIBCPP_HIDE_FROM_ABI void merge(list& __c);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void merge(list&& __c) { merge(__c); }
 
   template <class _Comp>
   _LIBCPP_HIDE_FROM_ABI void merge(list&& __c, _Comp __comp) {
     merge(__c, __comp);
   }
-#endif
+#  endif
   template <class _Comp>
   _LIBCPP_HIDE_FROM_ABI void merge(list& __c, _Comp __comp);
 
@@ -928,7 +930,7 @@ private:
   _LIBCPP_HIDE_FROM_ABI void __move_assign(list& __c, false_type);
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Alloc = allocator<__iter_value_type<_InputIterator>>,
           class        = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
@@ -940,14 +942,14 @@ template <class _InputIterator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value>,
           class = enable_if_t<__is_allocator<_Alloc>::value> >
 list(_InputIterator, _InputIterator, _Alloc) -> list<__iter_value_type<_InputIterator>, _Alloc>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Alloc = allocator<ranges::range_value_t<_Range>>,
           class        = enable_if_t<__is_allocator<_Alloc>::value> >
 list(from_range_t, _Range&&, _Alloc = _Alloc()) -> list<ranges::range_value_t<_Range>, _Alloc>;
-#endif
+#  endif
 
 // Link in nodes [__f, __l] just prior to __p
 template <class _Tp, class _Alloc>
@@ -984,20 +986,20 @@ inline typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::__iterator(size_t
 template <class _Tp, class _Alloc>
 list<_Tp, _Alloc>::list(size_type __n) {
   for (; __n > 0; --__n)
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     emplace_back();
-#else
+#  else
     push_back(value_type());
-#endif
+#  endif
 }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 template <class _Tp, class _Alloc>
 list<_Tp, _Alloc>::list(size_type __n, const allocator_type& __a) : __base(__a) {
   for (; __n > 0; --__n)
     emplace_back();
 }
-#endif
+#  endif
 
 template <class _Tp, class _Alloc>
 list<_Tp, _Alloc>::list(size_type __n, const value_type& __x) {
@@ -1032,7 +1034,7 @@ list<_Tp, _Alloc>::list(const list& __c, const __type_identity_t<allocator_type>
     push_back(*__i);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 list<_Tp, _Alloc>::list(initializer_list<value_type> __il, const allocator_type& __a) : __base(__a) {
@@ -1087,7 +1089,7 @@ void list<_Tp, _Alloc>::__move_assign(list& __c,
   splice(end(), __c);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 inline list<_Tp, _Alloc>& list<_Tp, _Alloc>::operator=(const list& __c) {
@@ -1152,13 +1154,13 @@ list<_Tp, _Alloc>::insert(const_iterator __p, size_type __n, const value_type& _
     ++__ds;
     __r          = iterator(__node->__as_link());
     iterator __e = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (--__n; __n != 0; --__n, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr, __x)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
@@ -1170,7 +1172,7 @@ list<_Tp, _Alloc>::insert(const_iterator __p, size_type __n, const value_type& _
       }
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__p.__ptr_, __r.__ptr_, __e.__ptr_);
     this->__size_ += __ds;
   }
@@ -1194,13 +1196,13 @@ list<_Tp, _Alloc>::__insert_with_sentinel(const_iterator __p, _Iterator __f, _Se
     ++__ds;
     __r          = iterator(__node->__as_link());
     iterator __e = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (++__f; __f != __l; ++__f, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr, *__f)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
@@ -1212,7 +1214,7 @@ list<_Tp, _Alloc>::__insert_with_sentinel(const_iterator __p, _Iterator __f, _Se
       }
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__p.__ptr_, __r.__ptr_, __e.__ptr_);
     this->__size_ += __ds;
   }
@@ -1235,7 +1237,7 @@ void list<_Tp, _Alloc>::push_back(const value_type& __x) {
   ++this->__size_;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::push_front(value_type&& __x) {
@@ -1255,38 +1257,38 @@ void list<_Tp, _Alloc>::push_back(value_type&& __x) {
 
 template <class _Tp, class _Alloc>
 template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 typename list<_Tp, _Alloc>::reference
-#  else
+#    else
 void
-#  endif
+#    endif
 list<_Tp, _Alloc>::emplace_front(_Args&&... __args) {
   __node_pointer __node =
       this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::forward<_Args>(__args)...);
   __base_pointer __nl = __node->__as_link();
   __link_nodes_at_front(__nl, __nl);
   ++this->__size_;
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   return __node->__get_value();
-#  endif
+#    endif
 }
 
 template <class _Tp, class _Alloc>
 template <class... _Args>
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 typename list<_Tp, _Alloc>::reference
-#  else
+#    else
 void
-#  endif
+#    endif
 list<_Tp, _Alloc>::emplace_back(_Args&&... __args) {
   __node_pointer __node =
       this->__create_node(/* prev = */ nullptr, /* next = */ nullptr, std::forward<_Args>(__args)...);
   __base_pointer __nl = __node->__as_link();
   __link_nodes_at_back(__nl, __nl);
   ++this->__size_;
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   return __node->__get_value();
-#  endif
+#    endif
 }
 
 template <class _Tp, class _Alloc>
@@ -1309,7 +1311,7 @@ typename list<_Tp, _Alloc>::iterator list<_Tp, _Alloc>::insert(const_iterator __
   return iterator(__nl);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Alloc>
 void list<_Tp, _Alloc>::pop_front() {
@@ -1365,13 +1367,13 @@ void list<_Tp, _Alloc>::resize(size_type __n) {
     ++__ds;
     iterator __r = iterator(__node->__as_link());
     iterator __e = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (--__n; __n != 0; --__n, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
@@ -1383,7 +1385,7 @@ void list<_Tp, _Alloc>::resize(size_type __n) {
       }
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes_at_back(__r.__ptr_, __e.__ptr_);
     this->__size_ += __ds;
   }
@@ -1401,13 +1403,13 @@ void list<_Tp, _Alloc>::resize(size_type __n, const value_type& __x) {
     __base_pointer __nl = __node->__as_link();
     iterator __r        = iterator(__nl);
     iterator __e        = __r;
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (--__n; __n != 0; --__n, (void)++__e, ++__ds) {
         __e.__ptr_->__next_ = this->__create_node(/* prev = */ __e.__ptr_, /* next = */ nullptr, __x)->__as_link();
       }
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       while (true) {
         __base_pointer __prev    = __e.__ptr_->__prev_;
@@ -1419,7 +1421,7 @@ void list<_Tp, _Alloc>::resize(size_type __n, const value_type& __x) {
       }
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     __link_nodes(__base::__end_as_link(), __r.__ptr_, __e.__ptr_);
     this->__size_ += __ds;
   }
@@ -1645,7 +1647,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator==(const list<_Tp, _Alloc>& __x, const
   return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI bool operator<(const list<_Tp, _Alloc>& __x, const list<_Tp, _Alloc>& __y) {
@@ -1672,7 +1674,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator<=(const list<_Tp, _Alloc>& __x, const
   return !(__y < __x);
 }
 
-#else // _LIBCPP_STD_VER <= 17
+#  else // _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Tp>
@@ -1680,7 +1682,7 @@ operator<=>(const list<_Tp, _Allocator>& __x, const list<_Tp, _Allocator>& __y) 
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
-#endif // _LIBCPP_STD_VER <= 17
+#  endif // _LIBCPP_STD_VER <= 17
 
 template <class _Tp, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI void swap(list<_Tp, _Alloc>& __x, list<_Tp, _Alloc>& __y)
@@ -1688,7 +1690,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(list<_Tp, _Alloc>& __x, list<_Tp, _Alloc>
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Tp, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename list<_Tp, _Allocator>::size_type
 erase_if(list<_Tp, _Allocator>& __c, _Predicate __pred) {
@@ -1703,12 +1705,12 @@ erase(list<_Tp, _Allocator>& __c, const _Up& __v) {
 
 template <>
 inline constexpr bool __format::__enable_insertable<std::list<char>> = true;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 inline constexpr bool __format::__enable_insertable<std::list<wchar_t>> = true;
-#  endif
+#    endif
 
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp, class _Allocator>
 struct __container_traits<list<_Tp, _Allocator> > {
@@ -1723,29 +1725,30 @@ struct __container_traits<list<_Tp, _Allocator> > {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _ValueT>
 using list _LIBCPP_AVAILABILITY_PMR = std::list<_ValueT, polymorphic_allocator<_ValueT>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <atomic>
-#  include <concepts>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <functional>
-#  include <iosfwd>
-#  include <iterator>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <atomic>
+#    include <concepts>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <functional>
+#    include <iosfwd>
+#    include <iterator>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_LIST

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -187,69 +187,71 @@ template <class charT> class messages_byname;
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__algorithm/copy.h>
-#  include <__algorithm/equal.h>
-#  include <__algorithm/find.h>
-#  include <__algorithm/max.h>
-#  include <__algorithm/reverse.h>
-#  include <__algorithm/unwrap_iter.h>
-#  include <__assert>
-#  include <__iterator/access.h>
-#  include <__iterator/back_insert_iterator.h>
-#  include <__iterator/istreambuf_iterator.h>
-#  include <__iterator/ostreambuf_iterator.h>
-#  include <__locale>
-#  include <__locale_dir/pad_and_output.h>
-#  include <__memory/unique_ptr.h>
-#  include <__type_traits/make_unsigned.h>
-#  include <cerrno>
-#  include <cstdio>
-#  include <cstdlib>
-#  include <ctime>
-#  include <ios>
-#  include <limits>
-#  include <new>
-#  include <streambuf>
-#  include <version>
+#    include <__algorithm/copy.h>
+#    include <__algorithm/equal.h>
+#    include <__algorithm/find.h>
+#    include <__algorithm/max.h>
+#    include <__algorithm/reverse.h>
+#    include <__algorithm/unwrap_iter.h>
+#    include <__assert>
+#    include <__iterator/access.h>
+#    include <__iterator/back_insert_iterator.h>
+#    include <__iterator/istreambuf_iterator.h>
+#    include <__iterator/ostreambuf_iterator.h>
+#    include <__locale>
+#    include <__locale_dir/pad_and_output.h>
+#    include <__memory/unique_ptr.h>
+#    include <__type_traits/make_unsigned.h>
+#    include <cerrno>
+#    include <cstdio>
+#    include <cstdlib>
+#    include <ctime>
+#    include <ios>
+#    include <limits>
+#    include <new>
+#    include <streambuf>
+#    include <version>
 
 // TODO: Properly qualify calls now that __bsd_locale_defaults.h defines functions instead of macros
 // NOLINTBEGIN(libcpp-robust-against-adl)
 
-#  if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#    if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 // Most unix variants have catopen.  These are the specific ones that don't.
-#    if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__)
-#      define _LIBCPP_HAS_CATOPEN 1
-#      include <nl_types.h>
+#      if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__)
+#        define _LIBCPP_HAS_CATOPEN 1
+#        include <nl_types.h>
+#      else
+#        define _LIBCPP_HAS_CATOPEN 0
+#      endif
 #    else
 #      define _LIBCPP_HAS_CATOPEN 0
 #    endif
-#  else
-#    define _LIBCPP_HAS_CATOPEN 0
-#  endif
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#  if defined(__APPLE__) || defined(__FreeBSD__)
-#    define _LIBCPP_GET_C_LOCALE 0
-#  elif defined(__NetBSD__)
-#    define _LIBCPP_GET_C_LOCALE LC_C_LOCALE
-#  else
-#    define _LIBCPP_GET_C_LOCALE __cloc()
+#    if defined(__APPLE__) || defined(__FreeBSD__)
+#      define _LIBCPP_GET_C_LOCALE 0
+#    elif defined(__NetBSD__)
+#      define _LIBCPP_GET_C_LOCALE LC_C_LOCALE
+#    else
+#      define _LIBCPP_GET_C_LOCALE __cloc()
 // Get the C locale object
 _LIBCPP_EXPORTED_FROM_ABI __locale::__locale_t __cloc();
-#    define __cloc_defined
-#  endif
+#      define __cloc_defined
+#    endif
 
 // __scan_keyword
 // Scans [__b, __e) until a match is found in the basic_strings range
@@ -397,7 +399,7 @@ struct __num_get : protected __num_get_base {
       unsigned*& __g_end,
       unsigned& __dc,
       _CharT* __atoms);
-#  ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#    ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
   static string __stage2_int_prep(ios_base& __iob, _CharT* __atoms, _CharT& __thousands_sep);
   static int __stage2_int_loop(
       _CharT __ct,
@@ -411,7 +413,7 @@ struct __num_get : protected __num_get_base {
       unsigned*& __g_end,
       _CharT* __atoms);
 
-#  else
+#    else
   static string __stage2_int_prep(ios_base& __iob, _CharT& __thousands_sep) {
     locale __loc                 = __iob.getloc();
     const numpunct<_CharT>& __np = use_facet<numpunct<_CharT> >(__loc);
@@ -446,10 +448,10 @@ private:
     (void)__atoms;
     return __src;
   }
-#  endif
+#    endif
 };
 
-#  ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#    ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
 template <class _CharT>
 string __num_get<_CharT>::__stage2_int_prep(ios_base& __iob, _CharT* __atoms, _CharT& __thousands_sep) {
   locale __loc = __iob.getloc();
@@ -458,7 +460,7 @@ string __num_get<_CharT>::__stage2_int_prep(ios_base& __iob, _CharT* __atoms, _C
   __thousands_sep              = __np.thousands_sep();
   return __np.grouping();
 }
-#  endif
+#    endif
 
 template <class _CharT>
 string __num_get<_CharT>::__stage2_float_prep(
@@ -473,16 +475,16 @@ string __num_get<_CharT>::__stage2_float_prep(
 
 template <class _CharT>
 int
-#  ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#    ifndef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
 __num_get<_CharT>::__stage2_int_loop(_CharT __ct, int __base, char* __a, char*& __a_end,
                   unsigned& __dc, _CharT __thousands_sep, const string& __grouping,
                   unsigned* __g, unsigned*& __g_end, _CharT* __atoms)
-#  else
+#    else
 __num_get<_CharT>::__stage2_int_loop(_CharT __ct, int __base, char* __a, char*& __a_end,
                   unsigned& __dc, _CharT __thousands_sep, const string& __grouping,
                   unsigned* __g, unsigned*& __g_end, const _CharT* __atoms)
 
-#  endif
+#    endif
 {
   if (__a_end == __a && (__ct == __atoms[24] || __ct == __atoms[25])) {
     *__a_end++ = __ct == __atoms[24] ? '+' : '-';
@@ -581,9 +583,9 @@ int __num_get<_CharT>::__stage2_float_loop(
 }
 
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS num_get : public locale::facet, private __num_get<_CharT> {
@@ -853,14 +855,14 @@ _InputIterator num_get<_CharT, _InputIterator>::__do_get_signed(
   // Stage 2
   char_type __thousands_sep;
   const int __atoms_size = __num_get_base::__int_chr_cnt;
-#  ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#    ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
   char_type __atoms1[__atoms_size];
   const char_type* __atoms = this->__do_widen(__iob, __atoms1);
   string __grouping        = this->__stage2_int_prep(__iob, __thousands_sep);
-#  else
+#    else
   char_type __atoms[__atoms_size];
   string __grouping = this->__stage2_int_prep(__iob, __atoms, __thousands_sep);
-#  endif
+#    endif
   string __buf;
   __buf.resize(__buf.capacity());
   char* __a     = &__buf[0];
@@ -902,14 +904,14 @@ _InputIterator num_get<_CharT, _InputIterator>::__do_get_unsigned(
   // Stage 2
   char_type __thousands_sep;
   const int __atoms_size = __num_get_base::__int_chr_cnt;
-#  ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
+#    ifdef _LIBCPP_ABI_OPTIMIZED_LOCALE_NUM_GET
   char_type __atoms1[__atoms_size];
   const char_type* __atoms = this->__do_widen(__iob, __atoms1);
   string __grouping        = this->__stage2_int_prep(__iob, __thousands_sep);
-#  else
+#    else
   char_type __atoms[__atoms_size];
   string __grouping = this->__stage2_int_prep(__iob, __atoms, __thousands_sep);
-#  endif
+#    endif
   string __buf;
   __buf.resize(__buf.capacity());
   char* __a     = &__buf[0];
@@ -1052,9 +1054,9 @@ _InputIterator num_get<_CharT, _InputIterator>::do_get(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_get<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_get<wchar_t>;
-#  endif
+#    endif
 
 struct _LIBCPP_EXPORTED_FROM_ABI __num_put_base {
 protected:
@@ -1170,9 +1172,9 @@ void __num_put<_CharT>::__widen_and_group_float(
 }
 
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS num_put : public locale::facet, private __num_put<_CharT> {
@@ -1397,9 +1399,9 @@ num_put<_CharT, _OutputIterator>::do_put(iter_type __s, ios_base& __iob, char_ty
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_put<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_put<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _InputIterator>
 _LIBCPP_HIDE_FROM_ABI int __get_up_to_n_digits(
@@ -1464,7 +1466,7 @@ _LIBCPP_EXPORTED_FROM_ABI const string& __time_get_c_storage<char>::__x() const;
 template <>
 _LIBCPP_EXPORTED_FROM_ABI const string& __time_get_c_storage<char>::__X() const;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI const wstring* __time_get_c_storage<wchar_t>::__weeks() const;
 template <>
@@ -1479,7 +1481,7 @@ template <>
 _LIBCPP_EXPORTED_FROM_ABI const wstring& __time_get_c_storage<wchar_t>::__x() const;
 template <>
 _LIBCPP_EXPORTED_FROM_ABI const wstring& __time_get_c_storage<wchar_t>::__X() const;
-#  endif
+#    endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS time_get : public locale::facet, public time_base, private __time_get_c_storage<_CharT> {
@@ -1933,9 +1935,9 @@ _InputIterator time_get<_CharT, _InputIterator>::do_get(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<wchar_t>;
-#  endif
+#    endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_get {
 protected:
@@ -1971,32 +1973,32 @@ private:
   string_type __analyze(char __fmt, const ctype<_CharT>&);
 };
 
-#  define _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(_CharT)                                                      \
-    template <>                                                                                                        \
-    _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order() const;                \
-    template <>                                                                                                        \
-    _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);                             \
-    template <>                                                                                                        \
-    _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);                           \
-    template <>                                                                                                        \
-    _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);                             \
-    template <>                                                                                                        \
-    _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type __time_get_storage<_CharT>::__analyze(           \
-        char, const ctype<_CharT>&);                                                                                   \
-    extern template _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order()       \
-        const;                                                                                                         \
-    extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);             \
-    extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);           \
-    extern template _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);             \
-    extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type                                  \
-    __time_get_storage<_CharT>::__analyze(char, const ctype<_CharT>&);                                                 \
-    /**/
+#    define _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(_CharT)                                                    \
+      template <>                                                                                                      \
+      _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order() const;              \
+      template <>                                                                                                      \
+      _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);                           \
+      template <>                                                                                                      \
+      _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);                         \
+      template <>                                                                                                      \
+      _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);                           \
+      template <>                                                                                                      \
+      _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type __time_get_storage<_CharT>::__analyze(         \
+          char, const ctype<_CharT>&);                                                                                 \
+      extern template _LIBCPP_EXPORTED_FROM_ABI time_base::dateorder __time_get_storage<_CharT>::__do_date_order()     \
+          const;                                                                                                       \
+      extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const char*);           \
+      extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::__time_get_storage(const string&);         \
+      extern template _LIBCPP_EXPORTED_FROM_ABI void __time_get_storage<_CharT>::init(const ctype<_CharT>&);           \
+      extern template _LIBCPP_EXPORTED_FROM_ABI __time_get_storage<_CharT>::string_type                                \
+      __time_get_storage<_CharT>::__analyze(char, const ctype<_CharT>&);                                               \
+      /**/
 
 _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(char)
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(wchar_t)
-#  endif
-#  undef _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION
+#    endif
+#    undef _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS time_get_byname
@@ -2029,9 +2031,9 @@ private:
 };
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<wchar_t>;
-#  endif
+#    endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_put {
   __locale::__locale_t __loc_;
@@ -2042,9 +2044,9 @@ protected:
   __time_put(const string& __nm);
   ~__time_put();
   void __do_put(char* __nb, char*& __ne, const tm* __tm, char __fmt, char __mod) const;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
   void __do_put(wchar_t* __wb, wchar_t*& __we, const tm* __tm, char __fmt, char __mod) const;
-#  endif
+#    endif
 };
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
@@ -2118,9 +2120,9 @@ _OutputIterator time_put<_CharT, _OutputIterator>::do_put(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS time_put_byname : public time_put<_CharT, _OutputIterator> {
@@ -2136,9 +2138,9 @@ protected:
 };
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put_byname<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put_byname<wchar_t>;
-#  endif
+#    endif
 
 // money_base
 
@@ -2203,10 +2205,10 @@ const bool moneypunct<_CharT, _International>::intl;
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<char, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<char, true>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, true>;
-#  endif
+#    endif
 
 // moneypunct_byname
 
@@ -2261,14 +2263,14 @@ _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<char, true>::init(const char*);
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<char, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<char, true>;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<wchar_t, false>::init(const char*);
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<wchar_t, true>::init(const char*);
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<wchar_t, false>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<wchar_t, true>;
-#  endif
+#    endif
 
 // money_get
 
@@ -2329,9 +2331,9 @@ void __money_get<_CharT>::__gather_info(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS money_get : public locale::facet, private __money_get<_CharT> {
@@ -2639,9 +2641,9 @@ _InputIterator money_get<_CharT, _InputIterator>::do_get(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_get<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_get<wchar_t>;
-#  endif
+#    endif
 
 // money_put
 
@@ -2817,9 +2819,9 @@ void __money_put<_CharT>::__format(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
 class _LIBCPP_TEMPLATE_VIS money_put : public locale::facet, private __money_put<_CharT> {
@@ -2963,9 +2965,9 @@ _OutputIterator money_put<_CharT, _OutputIterator>::do_put(
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_put<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_put<wchar_t>;
-#  endif
+#    endif
 
 // messages
 
@@ -3009,18 +3011,18 @@ locale::id messages<_CharT>::id;
 
 template <class _CharT>
 typename messages<_CharT>::catalog messages<_CharT>::do_open(const basic_string<char>& __nm, const locale&) const {
-#  if _LIBCPP_HAS_CATOPEN
+#    if _LIBCPP_HAS_CATOPEN
   return (catalog)catopen(__nm.c_str(), NL_CAT_LOCALE);
-#  else  // !_LIBCPP_HAS_CATOPEN
+#    else  // !_LIBCPP_HAS_CATOPEN
   (void)__nm;
   return -1;
-#  endif // _LIBCPP_HAS_CATOPEN
+#    endif // _LIBCPP_HAS_CATOPEN
 }
 
 template <class _CharT>
 typename messages<_CharT>::string_type
 messages<_CharT>::do_get(catalog __c, int __set, int __msgid, const string_type& __dflt) const {
-#  if _LIBCPP_HAS_CATOPEN
+#    if _LIBCPP_HAS_CATOPEN
   string __ndflt;
   __narrow_to_utf8<sizeof(char_type) * __CHAR_BIT__>()(
       std::back_inserter(__ndflt), __dflt.c_str(), __dflt.c_str() + __dflt.size());
@@ -3030,27 +3032,27 @@ messages<_CharT>::do_get(catalog __c, int __set, int __msgid, const string_type&
   string_type __w;
   __widen_from_utf8<sizeof(char_type) * __CHAR_BIT__>()(std::back_inserter(__w), __n, __n + std::strlen(__n));
   return __w;
-#  else  // !_LIBCPP_HAS_CATOPEN
+#    else  // !_LIBCPP_HAS_CATOPEN
   (void)__c;
   (void)__set;
   (void)__msgid;
   return __dflt;
-#  endif // _LIBCPP_HAS_CATOPEN
+#    endif // _LIBCPP_HAS_CATOPEN
 }
 
 template <class _CharT>
 void messages<_CharT>::do_close(catalog __c) const {
-#  if _LIBCPP_HAS_CATOPEN
+#    if _LIBCPP_HAS_CATOPEN
   catclose((nl_catd)__c);
-#  else  // !_LIBCPP_HAS_CATOPEN
+#    else  // !_LIBCPP_HAS_CATOPEN
   (void)__c;
-#  endif // _LIBCPP_HAS_CATOPEN
+#    endif // _LIBCPP_HAS_CATOPEN
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<wchar_t>;
-#  endif
+#    endif
 
 template <class _CharT>
 class _LIBCPP_TEMPLATE_VIS messages_byname : public messages<_CharT> {
@@ -3067,11 +3069,11 @@ protected:
 };
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages_byname<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages_byname<wchar_t>;
-#  endif
+#    endif
 
-#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
+#    if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
 
 template <class _Codecvt,
           class _Elem      = wchar_t,
@@ -3092,19 +3094,19 @@ private:
   size_t __cvtcount_;
 
 public:
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert() : wstring_convert(new _Codecvt) {}
   _LIBCPP_HIDE_FROM_ABI explicit wstring_convert(_Codecvt* __pcvt);
-#    else
+#      else
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_EXPLICIT_SINCE_CXX14 wstring_convert(_Codecvt* __pcvt = new _Codecvt);
-#    endif
+#      endif
 
   _LIBCPP_HIDE_FROM_ABI wstring_convert(_Codecvt* __pcvt, state_type __state);
   _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
   wstring_convert(const byte_string& __byte_err, const wide_string& __wide_err = wide_string());
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wstring_convert(wstring_convert&& __wc);
-#    endif
+#      endif
   _LIBCPP_HIDE_FROM_ABI ~wstring_convert();
 
   wstring_convert(const wstring_convert& __wc)            = delete;
@@ -3149,7 +3151,7 @@ wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert(
   __cvtptr_ = new _Codecvt;
 }
 
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
 
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
 inline wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert(wstring_convert&& __wc)
@@ -3161,7 +3163,7 @@ inline wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::wstring_convert
   __wc.__cvtptr_ = nullptr;
 }
 
-#    endif // _LIBCPP_CXX03_LANG
+#      endif // _LIBCPP_CXX03_LANG
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Codecvt, class _Elem, class _WideAlloc, class _ByteAlloc>
@@ -3315,14 +3317,14 @@ private:
   bool __always_noconv_;
 
 public:
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI wbuffer_convert() : wbuffer_convert(nullptr) {}
   explicit _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
-#    else
+#      else
   _LIBCPP_EXPLICIT_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI
   wbuffer_convert(streambuf* __bytebuf = nullptr, _Codecvt* __pcvt = new _Codecvt, state_type __state = state_type());
-#    endif
+#      endif
 
   _LIBCPP_HIDE_FROM_ABI ~wbuffer_convert();
 
@@ -3678,7 +3680,7 @@ wbuffer_convert<_Codecvt, _Elem, _Tr>* wbuffer_convert<_Codecvt, _Elem, _Tr>::__
 
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 
-#  endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
+#    endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_WSTRING_CONVERT)
 
 _LIBCPP_END_NAMESPACE_STD
 
@@ -3686,17 +3688,18 @@ _LIBCPP_POP_MACROS
 
 // NOLINTEND(libcpp-robust-against-adl)
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdarg>
-#  include <iterator>
-#  include <mutex>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdarg>
+#    include <iterator>
+#    include <mutex>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_LOCALE

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -571,61 +571,63 @@ erase_if(multimap<Key, T, Compare, Allocator>& c, Predicate pred);  // C++20
 
 */
 
-#include <__algorithm/equal.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lexicographical_compare_three_way.h>
-#include <__assert>
-#include <__config>
-#include <__functional/binary_function.h>
-#include <__functional/is_transparent.h>
-#include <__functional/operations.h>
-#include <__iterator/erase_if_container.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/ranges_iterator_traits.h>
-#include <__iterator/reverse_iterator.h>
-#include <__memory/addressof.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/unique_ptr.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__node_handle>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__tree>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/remove_const.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/pair.h>
-#include <__utility/piecewise_construct.h>
-#include <__utility/swap.h>
-#include <new> // for std::launder
-#include <stdexcept>
-#include <tuple>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/equal.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lexicographical_compare_three_way.h>
+#  include <__assert>
+#  include <__config>
+#  include <__functional/binary_function.h>
+#  include <__functional/is_transparent.h>
+#  include <__functional/operations.h>
+#  include <__iterator/erase_if_container.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/ranges_iterator_traits.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/unique_ptr.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__node_handle>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__tree>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/remove_const.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/pair.h>
+#  include <__utility/piecewise_construct.h>
+#  include <__utility/swap.h>
+#  include <new> // for std::launder
+#  include <stdexcept>
+#  include <tuple>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [associative.map.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -654,7 +656,7 @@ public:
     swap(static_cast<_Compare&>(*this), static_cast<_Compare&>(__y));
   }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2>
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _K2& __x, const _CP& __y) const {
     return static_cast<const _Compare&>(*this)(__x, __y.__get_value().first);
@@ -664,7 +666,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _CP& __x, const _K2& __y) const {
     return static_cast<const _Compare&>(*this)(__x.__get_value().first, __y);
   }
-#endif
+#  endif
 };
 
 template <class _Key, class _CP, class _Compare>
@@ -692,7 +694,7 @@ public:
     swap(__comp_, __y.__comp_);
   }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2>
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _K2& __x, const _CP& __y) const {
     return __comp_(__x, __y.__get_value().first);
@@ -702,7 +704,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _CP& __x, const _K2& __y) const {
     return __comp_(__x.__get_value().first, __y);
   }
-#endif
+#  endif
 };
 
 template <class _Key, class _CP, class _Compare, bool __b>
@@ -732,14 +734,14 @@ public:
         __first_constructed(false),
         __second_constructed(false) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __map_node_destructor(__tree_node_destructor<allocator_type>&& __x) _NOEXCEPT
       : __na_(__x.__na_),
         __first_constructed(__x.__value_constructed),
         __second_constructed(__x.__value_constructed) {
     __x.__value_constructed = false;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   __map_node_destructor& operator=(const __map_node_destructor&) = delete;
 
@@ -760,7 +762,7 @@ class multimap;
 template <class _TreeIterator>
 class __map_const_iterator;
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp>
 struct _LIBCPP_STANDALONE_DEBUG __value_type {
@@ -775,19 +777,19 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI value_type& __get_value() {
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
     return *std::launder(std::addressof(__cc_));
-#  else
+#    else
     return __cc_;
-#  endif
+#    endif
   }
 
   _LIBCPP_HIDE_FROM_ABI const value_type& __get_value() const {
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
     return *std::launder(std::addressof(__cc_));
-#  else
+#    else
     return __cc_;
-#  endif
+#    endif
   }
 
   _LIBCPP_HIDE_FROM_ABI __nc_ref_pair_type __ref() {
@@ -822,7 +824,7 @@ public:
   __value_type(__value_type&&)      = delete;
 };
 
-#else
+#  else
 
 template <class _Key, class _Tp>
 struct __value_type {
@@ -843,7 +845,7 @@ public:
   ~__value_type()                              = delete;
 };
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 struct __extract_key_value_types;
@@ -1019,10 +1021,10 @@ public:
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __map_node_handle<typename __base::__node, allocator_type> node_type;
   typedef __insert_return_type<iterator, node_type> insert_return_type;
-#endif
+#  endif
 
   template <class _Key2, class _Value2, class _Comp2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS map;
@@ -1054,7 +1056,7 @@ public:
     insert(__f, __l);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI
   map(from_range_t,
@@ -1064,37 +1066,37 @@ public:
       : __tree_(__vc(__comp), typename __base::allocator_type(__a)) {
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI map(_InputIterator __f, _InputIterator __l, const allocator_type& __a)
       : map(__f, __l, key_compare(), __a) {}
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI map(from_range_t, _Range&& __range, const allocator_type& __a)
       : map(from_range, std::forward<_Range>(__range), key_compare(), __a) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI map(const map& __m) : __tree_(__m.__tree_) { insert(__m.begin(), __m.end()); }
 
   _LIBCPP_HIDE_FROM_ABI map& operator=(const map& __m) {
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     __tree_ = __m.__tree_;
-#else
+#  else
     if (this != std::addressof(__m)) {
       __tree_.clear();
       __tree_.value_comp() = __m.__tree_.value_comp();
       __tree_.__copy_assign_alloc(__m.__tree_);
       insert(__m.begin(), __m.end());
     }
-#endif
+#  endif
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI map(map&& __m) noexcept(is_nothrow_move_constructible<__base>::value)
       : __tree_(std::move(__m.__tree_)) {}
@@ -1116,17 +1118,17 @@ public:
     insert(__il.begin(), __il.end());
   }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI map(initializer_list<value_type> __il, const allocator_type& __a)
       : map(__il, key_compare(), __a) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI map& operator=(initializer_list<value_type> __il) {
     __tree_.__assign_unique(__il.begin(), __il.end());
     return *this;
   }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI explicit map(const allocator_type& __a) : __tree_(typename __base::allocator_type(__a)) {}
 
@@ -1157,9 +1159,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT { return __tree_.max_size(); }
 
   _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](const key_type& __k);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](key_type&& __k);
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI mapped_type& at(const key_type& __k);
   _LIBCPP_HIDE_FROM_ABI const mapped_type& at(const key_type& __k) const;
@@ -1168,7 +1170,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI key_compare key_comp() const { return __tree_.value_comp().key_comp(); }
   _LIBCPP_HIDE_FROM_ABI value_compare value_comp() const { return value_compare(__tree_.value_comp().key_comp()); }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> emplace(_Args&&... __args) {
     return __tree_.__emplace_unique(std::forward<_Args>(__args)...);
@@ -1189,7 +1191,7 @@ public:
     return __tree_.__insert_unique(__pos.__i_, std::forward<_Pp>(__p));
   }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(const value_type& __v) { return __tree_.__insert_unique(__v); }
 
@@ -1197,7 +1199,7 @@ public:
     return __tree_.__insert_unique(__p.__i_, __v);
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(value_type&& __v) {
     return __tree_.__insert_unique(std::move(__v));
   }
@@ -1207,7 +1209,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
-#endif
+#  endif
 
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI void insert(_InputIterator __f, _InputIterator __l) {
@@ -1215,7 +1217,7 @@ public:
       insert(__e.__i_, *__f);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     const_iterator __end = cend();
@@ -1223,9 +1225,9 @@ public:
       insert(__end.__i_, std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> try_emplace(const key_type& __k, _Args&&... __args) {
@@ -1310,7 +1312,7 @@ public:
     return __r;
   }
 
-#endif // _LIBCPP_STD_VER >= 17
+#  endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __tree_.erase(__p.__i_); }
   _LIBCPP_HIDE_FROM_ABI iterator erase(iterator __p) { return __tree_.erase(__p.__i_); }
@@ -1320,7 +1322,7 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __tree_.clear(); }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI insert_return_type insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to map::insert()");
@@ -1361,13 +1363,13 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     __tree_.__node_handle_merge_unique(__source.__tree_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(map& __m) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) { __tree_.swap(__m.__tree_); }
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
@@ -1376,27 +1378,27 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __tree_.__count_unique(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const key_type& __k) { return __tree_.lower_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const key_type& __k) const { return __tree_.lower_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.lower_bound(__k);
@@ -1406,11 +1408,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.lower_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const key_type& __k) { return __tree_.upper_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const key_type& __k) const { return __tree_.upper_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.upper_bound(__k);
@@ -1419,7 +1421,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.upper_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __tree_.__equal_range_unique(__k);
@@ -1427,7 +1429,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __tree_.__equal_range_unique(__k);
   }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
@@ -1436,7 +1438,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
-#endif
+#  endif
 
 private:
   typedef typename __base::__node __node;
@@ -1448,12 +1450,12 @@ private:
   typedef __map_node_destructor<__node_allocator> _Dp;
   typedef unique_ptr<__node, _Dp> __node_holder;
 
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __node_holder __construct_node_with_key(const key_type& __k);
-#endif
+#  endif
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Compare   = less<__iter_key_type<_InputIterator>>,
           class _Allocator = allocator<__iter_to_alloc_type<_InputIterator>>,
@@ -1463,7 +1465,7 @@ template <class _InputIterator,
 map(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
     -> map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Compare, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Compare   = less<__range_key_type<_Range>>,
           class _Allocator = allocator<__range_to_alloc_type<_Range>>,
@@ -1471,7 +1473,7 @@ template <ranges::input_range _Range,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
 map(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
     -> map<__range_key_type<_Range>, __range_mapped_type<_Range>, _Compare, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key,
           class _Tp,
@@ -1493,18 +1495,18 @@ map(_InputIterator, _InputIterator, _Allocator)
            less<__iter_key_type<_InputIterator>>,
            _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 map(from_range_t, _Range&&, _Allocator)
     -> map<__range_key_type<_Range>, __range_mapped_type<_Range>, less<__range_key_type<_Range>>, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 map(initializer_list<pair<_Key, _Tp>>,
     _Allocator) -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 map<_Key, _Tp, _Compare, _Allocator>::map(map&& __m, const allocator_type& __a)
     : __tree_(std::move(__m.__tree_), typename __base::allocator_type(__a)) {
@@ -1535,7 +1537,7 @@ _Tp& map<_Key, _Tp, _Compare, _Allocator>::operator[](key_type&& __k) {
   // NOLINTEND(bugprone-use-after-move)
 }
 
-#else // _LIBCPP_CXX03_LANG
+#  else // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 typename map<_Key, _Tp, _Compare, _Allocator>::__node_holder
@@ -1562,7 +1564,7 @@ _Tp& map<_Key, _Tp, _Compare, _Allocator>::operator[](const key_type& __k) {
   return __r->__value_.__get_value().second;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 _Tp& map<_Key, _Tp, _Compare, _Allocator>::at(const key_type& __k) {
@@ -1588,7 +1590,7 @@ operator==(const map<_Key, _Tp, _Compare, _Allocator>& __x, const map<_Key, _Tp,
   return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -1620,7 +1622,7 @@ operator<=(const map<_Key, _Tp, _Compare, _Allocator>& __x, const map<_Key, _Tp,
   return !(__y < __x);
 }
 
-#else // #if _LIBCPP_STD_VER <= 17
+#  else // #if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<pair<const _Key, _Tp>>
@@ -1628,7 +1630,7 @@ operator<=>(const map<_Key, _Tp, _Compare, _Allocator>& __x, const map<_Key, _Tp
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
-#endif // #if _LIBCPP_STD_VER <= 17
+#  endif // #if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void
@@ -1637,13 +1639,13 @@ swap(map<_Key, _Tp, _Compare, _Allocator>& __x, map<_Key, _Tp, _Compare, _Alloca
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Key, class _Tp, class _Compare, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename map<_Key, _Tp, _Compare, _Allocator>::size_type
 erase_if(map<_Key, _Tp, _Compare, _Allocator>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 struct __container_traits<map<_Key, _Tp, _Compare, _Allocator> > {
@@ -1703,9 +1705,9 @@ public:
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __map_node_handle<typename __base::__node, allocator_type> node_type;
-#endif
+#  endif
 
   template <class _Key2, class _Value2, class _Comp2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS map;
@@ -1737,7 +1739,7 @@ public:
     insert(__f, __l);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI
   multimap(from_range_t,
@@ -1747,19 +1749,19 @@ public:
       : __tree_(__vc(__comp), typename __base::allocator_type(__a)) {
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI multimap(_InputIterator __f, _InputIterator __l, const allocator_type& __a)
       : multimap(__f, __l, key_compare(), __a) {}
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI multimap(from_range_t, _Range&& __range, const allocator_type& __a)
       : multimap(from_range, std::forward<_Range>(__range), key_compare(), __a) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI multimap(const multimap& __m)
       : __tree_(__m.__tree_.value_comp(),
@@ -1768,20 +1770,20 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI multimap& operator=(const multimap& __m) {
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     __tree_ = __m.__tree_;
-#else
+#  else
     if (this != std::addressof(__m)) {
       __tree_.clear();
       __tree_.value_comp() = __m.__tree_.value_comp();
       __tree_.__copy_assign_alloc(__m.__tree_);
       insert(__m.begin(), __m.end());
     }
-#endif
+#  endif
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI multimap(multimap&& __m) noexcept(is_nothrow_move_constructible<__base>::value)
       : __tree_(std::move(__m.__tree_)) {}
@@ -1804,17 +1806,17 @@ public:
     insert(__il.begin(), __il.end());
   }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI multimap(initializer_list<value_type> __il, const allocator_type& __a)
       : multimap(__il, key_compare(), __a) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI multimap& operator=(initializer_list<value_type> __il) {
     __tree_.__assign_multi(__il.begin(), __il.end());
     return *this;
   }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI explicit multimap(const allocator_type& __a) : __tree_(typename __base::allocator_type(__a)) {}
 
@@ -1848,7 +1850,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI key_compare key_comp() const { return __tree_.value_comp().key_comp(); }
   _LIBCPP_HIDE_FROM_ABI value_compare value_comp() const { return value_compare(__tree_.value_comp().key_comp()); }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator emplace(_Args&&... __args) {
@@ -1878,7 +1880,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const value_type& __v) { return __tree_.__insert_multi(__v); }
 
@@ -1892,7 +1894,7 @@ public:
       __tree_.__insert_multi(__e.__i_, *__f);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     const_iterator __end = cend();
@@ -1900,7 +1902,7 @@ public:
       __tree_.__insert_multi(__end.__i_, std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __tree_.erase(__p.__i_); }
   _LIBCPP_HIDE_FROM_ABI iterator erase(iterator __p) { return __tree_.erase(__p.__i_); }
@@ -1909,7 +1911,7 @@ public:
     return __tree_.erase(__f.__i_, __l.__i_);
   }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI iterator insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to multimap::insert()");
@@ -1950,7 +1952,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     return __tree_.__node_handle_merge_multi(__source.__tree_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __tree_.clear(); }
 
@@ -1960,7 +1962,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
@@ -1969,27 +1971,27 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __tree_.__count_multi(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const key_type& __k) { return __tree_.lower_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const key_type& __k) const { return __tree_.lower_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.lower_bound(__k);
@@ -1999,11 +2001,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.lower_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const key_type& __k) { return __tree_.upper_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const key_type& __k) const { return __tree_.upper_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.upper_bound(__k);
@@ -2012,7 +2014,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.upper_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __tree_.__equal_range_multi(__k);
@@ -2020,7 +2022,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
@@ -2029,7 +2031,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
-#endif
+#  endif
 
 private:
   typedef typename __base::__node __node;
@@ -2040,7 +2042,7 @@ private:
   typedef unique_ptr<__node, _Dp> __node_holder;
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Compare   = less<__iter_key_type<_InputIterator>>,
           class _Allocator = allocator<__iter_to_alloc_type<_InputIterator>>,
@@ -2050,7 +2052,7 @@ template <class _InputIterator,
 multimap(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
     -> multimap<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Compare, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Compare   = less<__range_key_type<_Range>>,
           class _Allocator = allocator<__range_to_alloc_type<_Range>>,
@@ -2058,7 +2060,7 @@ template <ranges::input_range _Range,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
 multimap(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
     -> multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, _Compare, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key,
           class _Tp,
@@ -2080,18 +2082,18 @@ multimap(_InputIterator, _InputIterator, _Allocator)
                 less<__iter_key_type<_InputIterator>>,
                 _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 multimap(from_range_t, _Range&&, _Allocator)
     -> multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, less<__range_key_type<_Range>>, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 multimap(initializer_list<pair<_Key, _Tp>>,
          _Allocator) -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 multimap<_Key, _Tp, _Compare, _Allocator>::multimap(multimap&& __m, const allocator_type& __a)
     : __tree_(std::move(__m.__tree_), typename __base::allocator_type(__a)) {
@@ -2101,7 +2103,7 @@ multimap<_Key, _Tp, _Compare, _Allocator>::multimap(multimap&& __m, const alloca
       __tree_.__insert_multi(__e.__i_, std::move(__m.__tree_.remove(__m.begin().__i_)->__value_.__move()));
   }
 }
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -2109,7 +2111,7 @@ operator==(const multimap<_Key, _Tp, _Compare, _Allocator>& __x, const multimap<
   return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -2141,7 +2143,7 @@ operator<=(const multimap<_Key, _Tp, _Compare, _Allocator>& __x, const multimap<
   return !(__y < __x);
 }
 
-#else // #if _LIBCPP_STD_VER <= 17
+#  else // #if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<pair<const _Key, _Tp>>
@@ -2150,7 +2152,7 @@ operator<=>(const multimap<_Key, _Tp, _Compare, _Allocator>& __x,
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), __synth_three_way);
 }
 
-#endif // #if _LIBCPP_STD_VER <= 17
+#  endif // #if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void
@@ -2159,13 +2161,13 @@ swap(multimap<_Key, _Tp, _Compare, _Allocator>& __x, multimap<_Key, _Tp, _Compar
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Key, class _Tp, class _Compare, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename multimap<_Key, _Tp, _Compare, _Allocator>::size_type
 erase_if(multimap<_Key, _Tp, _Compare, _Allocator>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
 struct __container_traits<multimap<_Key, _Tp, _Compare, _Allocator> > {
@@ -2177,7 +2179,7 @@ struct __container_traits<multimap<_Key, _Tp, _Compare, _Allocator> > {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _KeyT, class _ValueT, class _CompareT = std::less<_KeyT>>
@@ -2189,17 +2191,18 @@ using multimap _LIBCPP_AVAILABILITY_PMR =
     std::multimap<_KeyT, _ValueT, _CompareT, polymorphic_allocator<std::pair<const _KeyT, _ValueT>>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <cstdlib>
-#  include <functional>
-#  include <iterator>
-#  include <type_traits>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <cstdlib>
+#    include <functional>
+#    include <iterator>
+#    include <type_traits>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_MAP

--- a/libcxx/include/math.h
+++ b/libcxx/include/math.h
@@ -291,93 +291,95 @@ long double    truncl(long double x);
 
 */
 
-#  include <__config>
+#  if 0
+#  else // 0
+#    include <__config>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
-#  if __has_include_next(<math.h>)
-#    include_next <math.h>
-#  endif
+#    if __has_include_next(<math.h>)
+#      include_next <math.h>
+#    endif
 
-#  ifdef __cplusplus
+#    ifdef __cplusplus
 
 // We support including .h headers inside 'extern "C"' contexts, so switch
 // back to C++ linkage before including these C++ headers.
 extern "C++" {
 
-#    ifdef fpclassify
-#      undef fpclassify
-#    endif
+#      ifdef fpclassify
+#        undef fpclassify
+#      endif
 
-#    ifdef signbit
-#      undef signbit
-#    endif
+#      ifdef signbit
+#        undef signbit
+#      endif
 
-#    ifdef isfinite
-#      undef isfinite
-#    endif
+#      ifdef isfinite
+#        undef isfinite
+#      endif
 
-#    ifdef isinf
-#      undef isinf
-#    endif
+#      ifdef isinf
+#        undef isinf
+#      endif
 
-#    ifdef isnan
-#      undef isnan
-#    endif
+#      ifdef isnan
+#        undef isnan
+#      endif
 
-#    ifdef isnormal
-#      undef isnormal
-#    endif
+#      ifdef isnormal
+#        undef isnormal
+#      endif
 
-#    ifdef isgreater
-#      undef isgreater
-#    endif
+#      ifdef isgreater
+#        undef isgreater
+#      endif
 
-#    ifdef isgreaterequal
-#      undef isgreaterequal
-#    endif
+#      ifdef isgreaterequal
+#        undef isgreaterequal
+#      endif
 
-#    ifdef isless
-#      undef isless
-#    endif
+#      ifdef isless
+#        undef isless
+#      endif
 
-#    ifdef islessequal
-#      undef islessequal
-#    endif
+#      ifdef islessequal
+#        undef islessequal
+#      endif
 
-#    ifdef islessgreater
-#      undef islessgreater
-#    endif
+#      ifdef islessgreater
+#        undef islessgreater
+#      endif
 
-#    ifdef isunordered
-#      undef isunordered
-#    endif
+#      ifdef isunordered
+#        undef isunordered
+#      endif
 
-#    include <__math/abs.h>
-#    include <__math/copysign.h>
-#    include <__math/error_functions.h>
-#    include <__math/exponential_functions.h>
-#    include <__math/fdim.h>
-#    include <__math/fma.h>
-#    include <__math/gamma.h>
-#    include <__math/hyperbolic_functions.h>
-#    include <__math/hypot.h>
-#    include <__math/inverse_hyperbolic_functions.h>
-#    include <__math/inverse_trigonometric_functions.h>
-#    include <__math/logarithms.h>
-#    include <__math/min_max.h>
-#    include <__math/modulo.h>
-#    include <__math/remainder.h>
-#    include <__math/roots.h>
-#    include <__math/rounding_functions.h>
-#    include <__math/traits.h>
-#    include <__math/trigonometric_functions.h>
-#    include <__type_traits/enable_if.h>
-#    include <__type_traits/is_floating_point.h>
-#    include <__type_traits/is_integral.h>
-#    include <stdlib.h>
+#      include <__math/abs.h>
+#      include <__math/copysign.h>
+#      include <__math/error_functions.h>
+#      include <__math/exponential_functions.h>
+#      include <__math/fdim.h>
+#      include <__math/fma.h>
+#      include <__math/gamma.h>
+#      include <__math/hyperbolic_functions.h>
+#      include <__math/hypot.h>
+#      include <__math/inverse_hyperbolic_functions.h>
+#      include <__math/inverse_trigonometric_functions.h>
+#      include <__math/logarithms.h>
+#      include <__math/min_max.h>
+#      include <__math/modulo.h>
+#      include <__math/remainder.h>
+#      include <__math/roots.h>
+#      include <__math/rounding_functions.h>
+#      include <__math/traits.h>
+#      include <__math/trigonometric_functions.h>
+#      include <__type_traits/enable_if.h>
+#      include <__type_traits/is_floating_point.h>
+#      include <__type_traits/is_integral.h>
+#      include <stdlib.h>
 
 // fpclassify relies on implementation-defined constants, so we can't move it to a detail header
 _LIBCPP_BEGIN_NAMESPACE_STD
@@ -415,7 +417,7 @@ using std::__math::fpclassify;
 using std::__math::signbit;
 
 // The MSVC runtime already provides these functions as templates
-#    ifndef _LIBCPP_MSVCRT
+#      ifndef _LIBCPP_MSVCRT
 using std::__math::isfinite;
 using std::__math::isgreater;
 using std::__math::isgreaterequal;
@@ -426,7 +428,7 @@ using std::__math::islessgreater;
 using std::__math::isnan;
 using std::__math::isnormal;
 using std::__math::isunordered;
-#    endif // _LIBCPP_MSVCRT
+#      endif // _LIBCPP_MSVCRT
 
 // abs
 //
@@ -501,7 +503,8 @@ using std::__math::trunc;
 
 } // extern "C++"
 
-#  endif // __cplusplus
+#    endif // __cplusplus
+#  endif   // 0
 
 #else // _LIBCPP_MATH_H
 

--- a/libcxx/include/mdspan
+++ b/libcxx/include/mdspan
@@ -408,22 +408,25 @@ namespace std {
 #ifndef _LIBCPP_MDSPAN
 #define _LIBCPP_MDSPAN
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__fwd/mdspan.h>
-#  include <__mdspan/default_accessor.h>
-#  include <__mdspan/extents.h>
-#  include <__mdspan/layout_left.h>
-#  include <__mdspan/layout_right.h>
-#  include <__mdspan/layout_stride.h>
-#  include <__mdspan/mdspan.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__fwd/mdspan.h>
+#    include <__mdspan/default_accessor.h>
+#    include <__mdspan/extents.h>
+#    include <__mdspan/layout_left.h>
+#    include <__mdspan/layout_right.h>
+#    include <__mdspan/layout_stride.h>
+#    include <__mdspan/mdspan.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_MDSPAN

--- a/libcxx/include/memory
+++ b/libcxx/include/memory
@@ -934,65 +934,68 @@ template<class Pointer = void, class Smart, class... Args>
 
 // clang-format on
 
-#include <__config>
-#include <__memory/addressof.h>
-#include <__memory/align.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_arg_t.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/auto_ptr.h>
-#include <__memory/inout_ptr.h>
-#include <__memory/out_ptr.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/raw_storage_iterator.h>
-#include <__memory/shared_ptr.h>
-#include <__memory/temporary_buffer.h>
-#include <__memory/uninitialized_algorithms.h>
-#include <__memory/unique_ptr.h>
-#include <__memory/uses_allocator.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__memory/addressof.h>
+#  include <__memory/align.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_arg_t.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/auto_ptr.h>
+#  include <__memory/inout_ptr.h>
+#  include <__memory/out_ptr.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/raw_storage_iterator.h>
+#  include <__memory/shared_ptr.h>
+#  include <__memory/temporary_buffer.h>
+#  include <__memory/uninitialized_algorithms.h>
+#  include <__memory/unique_ptr.h>
+#  include <__memory/uses_allocator.h>
 
 // standard-mandated includes
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__memory/construct_at.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__memory/construct_at.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__memory/assume_aligned.h>
-#  include <__memory/concepts.h>
-#  include <__memory/ranges_construct_at.h>
-#  include <__memory/ranges_uninitialized_algorithms.h>
-#  include <__memory/uses_allocator_construction.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__memory/assume_aligned.h>
+#    include <__memory/concepts.h>
+#    include <__memory/ranges_construct_at.h>
+#    include <__memory/ranges_uninitialized_algorithms.h>
+#    include <__memory/uses_allocator_construction.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__memory/allocate_at_least.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__memory/allocate_at_least.h>
+#  endif
 
-#include <version>
+#  include <version>
 
 // [memory.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstddef>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <cstring>
-#  include <iosfwd>
-#  include <iterator>
-#  include <new>
-#  include <stdexcept>
-#  include <tuple>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstddef>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <cstring>
+#    include <iosfwd>
+#    include <iterator>
+#    include <new>
+#    include <stdexcept>
+#    include <tuple>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_MEMORY

--- a/libcxx/include/memory_resource
+++ b/libcxx/include/memory_resource
@@ -49,29 +49,32 @@ namespace std::pmr {
 
  */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__memory_resource/memory_resource.h>
-#  include <__memory_resource/monotonic_buffer_resource.h>
-#  include <__memory_resource/polymorphic_allocator.h>
-#  include <__memory_resource/pool_options.h>
-#  include <__memory_resource/synchronized_pool_resource.h>
-#  include <__memory_resource/unsynchronized_pool_resource.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__memory_resource/memory_resource.h>
+#    include <__memory_resource/monotonic_buffer_resource.h>
+#    include <__memory_resource/polymorphic_allocator.h>
+#    include <__memory_resource/pool_options.h>
+#    include <__memory_resource/synchronized_pool_resource.h>
+#    include <__memory_resource/unsynchronized_pool_resource.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER >= 17 && _LIBCPP_STD_VER <= 20
-#  include <mutex>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER >= 17 && _LIBCPP_STD_VER <= 20
+#    include <mutex>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <stdexcept>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <stdexcept>
+#  endif
+#endif // 0
 
 #endif /* _LIBCPP_MEMORY_RESOURCE */

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -186,34 +186,36 @@ template<class Callable, class ...Args>
 
 */
 
-#include <__chrono/steady_clock.h>
-#include <__chrono/time_point.h>
-#include <__condition_variable/condition_variable.h>
-#include <__config>
-#include <__mutex/lock_guard.h>
-#include <__mutex/mutex.h>
-#include <__mutex/once_flag.h>
-#include <__mutex/tag_types.h>
-#include <__mutex/unique_lock.h>
-#include <__thread/id.h>
-#include <__thread/support.h>
-#include <__utility/forward.h>
-#include <limits>
-#ifndef _LIBCPP_CXX03_LANG
-#  include <tuple>
-#endif
-#include <version>
+#if 0
+#else // 0
+#  include <__chrono/steady_clock.h>
+#  include <__chrono/time_point.h>
+#  include <__condition_variable/condition_variable.h>
+#  include <__config>
+#  include <__mutex/lock_guard.h>
+#  include <__mutex/mutex.h>
+#  include <__mutex/once_flag.h>
+#  include <__mutex/tag_types.h>
+#  include <__mutex/unique_lock.h>
+#  include <__thread/id.h>
+#  include <__thread/support.h>
+#  include <__utility/forward.h>
+#  include <limits>
+#  ifndef _LIBCPP_CXX03_LANG
+#    include <tuple>
+#  endif
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
 class _LIBCPP_EXPORTED_FROM_ABI recursive_mutex {
   __libcpp_recursive_mutex_t __m_;
@@ -333,7 +335,7 @@ _LIBCPP_HIDE_FROM_ABI int try_lock(_L0& __l0, _L1& __l1) {
   return 0;
 }
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 template <class _L0, class _L1, class _L2, class... _L3>
 _LIBCPP_HIDE_FROM_ABI int try_lock(_L0& __l0, _L1& __l1, _L2& __l2, _L3&... __l3) {
@@ -349,7 +351,7 @@ _LIBCPP_HIDE_FROM_ABI int try_lock(_L0& __l0, _L1& __l1, _L2& __l2, _L3&... __l3
   return __r;
 }
 
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
 template <class _L0, class _L1>
 _LIBCPP_HIDE_FROM_ABI void lock(_L0& __l0, _L1& __l1) {
@@ -373,7 +375,7 @@ _LIBCPP_HIDE_FROM_ABI void lock(_L0& __l0, _L1& __l1) {
   }
 }
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 template <class _L0, class _L1, class _L2, class... _L3>
 void __lock_first(int __i, _L0& __l0, _L1& __l1, _L2& __l2, _L3&... __l3) {
@@ -416,9 +418,9 @@ inline _LIBCPP_HIDE_FROM_ABI void lock(_L0& __l0, _L1& __l1, _L2& __l2, _L3&... 
   std::__lock_first(0, __l0, __l1, __l2, __l3...);
 }
 
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 template <class... _Mutexes>
 class _LIBCPP_TEMPLATE_VIS scoped_lock;
 
@@ -489,26 +491,27 @@ private:
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(scoped_lock);
 
-#  endif // _LIBCPP_STD_VER >= 17
-#endif   // _LIBCPP_HAS_THREADS
+#    endif // _LIBCPP_STD_VER >= 17
+#  endif   // _LIBCPP_HAS_THREADS
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdlib>
-#  include <cstring>
-#  include <ctime>
-#  include <initializer_list>
-#  include <iosfwd>
-#  include <new>
-#  include <stdexcept>
-#  include <system_error>
-#  include <type_traits>
-#  include <typeinfo>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdlib>
+#    include <cstring>
+#    include <ctime>
+#    include <initializer_list>
+#    include <iosfwd>
+#    include <new>
+#    include <stdexcept>
+#    include <system_error>
+#    include <type_traits>
+#    include <typeinfo>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_MUTEX

--- a/libcxx/include/new
+++ b/libcxx/include/new
@@ -86,45 +86,47 @@ void  operator delete[](void* ptr, void*) noexcept;
 
 */
 
-#include <__config>
-#include <__cstddef/max_align_t.h>
-#include <__cstddef/size_t.h>
-#include <__exception/exception.h>
-#include <__type_traits/is_function.h>
-#include <__type_traits/is_void.h>
-#include <__verbose_abort>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/max_align_t.h>
+#  include <__cstddef/size_t.h>
+#  include <__exception/exception.h>
+#  include <__type_traits/is_function.h>
+#  include <__type_traits/is_void.h>
+#  include <__verbose_abort>
+#  include <version>
 
-#if defined(_LIBCPP_ABI_VCRUNTIME)
-#  include <new.h>
-#endif
+#  if defined(_LIBCPP_ABI_VCRUNTIME)
+#    include <new.h>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
-#  define _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION 1
-#else
-#  define _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION 0
-#endif
+#  if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
+#    define _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION 1
+#  else
+#    define _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION 0
+#  endif
 
-#if _LIBCPP_STD_VER >= 14 || _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION
-#  define _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION 1
-#else
-#  define _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION 0
-#endif
+#  if _LIBCPP_STD_VER >= 14 || _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION
+#    define _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION 1
+#  else
+#    define _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION 0
+#  endif
 
-#if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION && _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION
-#  define _LIBCPP_HAS_SIZED_DEALLOCATION 1
-#else
-#  define _LIBCPP_HAS_SIZED_DEALLOCATION 0
-#endif
+#  if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION && _LIBCPP_HAS_LANGUAGE_SIZED_DEALLOCATION
+#    define _LIBCPP_HAS_SIZED_DEALLOCATION 1
+#  else
+#    define _LIBCPP_HAS_SIZED_DEALLOCATION 0
+#  endif
 
 namespace std // purposefully not using versioning namespace
 {
 
-#if !defined(_LIBCPP_ABI_VCRUNTIME)
+#  if !defined(_LIBCPP_ABI_VCRUNTIME)
 struct _LIBCPP_EXPORTED_FROM_ABI nothrow_t {
   explicit nothrow_t() = default;
 };
@@ -152,7 +154,7 @@ typedef void (*new_handler)();
 _LIBCPP_EXPORTED_FROM_ABI new_handler set_new_handler(new_handler) _NOEXCEPT;
 _LIBCPP_EXPORTED_FROM_ABI new_handler get_new_handler() _NOEXCEPT;
 
-#elif defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0 // !_LIBCPP_ABI_VCRUNTIME
+#  elif defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0 // !_LIBCPP_ABI_VCRUNTIME
 
 // When _HAS_EXCEPTIONS == 0, these complete definitions are needed,
 // since they would normally be provided in vcruntime_exception.h
@@ -170,72 +172,72 @@ class bad_array_new_length : public bad_alloc {
 public:
   bad_array_new_length() noexcept : bad_alloc("bad array new length") {}
 };
-#endif // defined(_LIBCPP_ABI_VCRUNTIME) && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0
+#  endif // defined(_LIBCPP_ABI_VCRUNTIME) && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0
 
 [[__noreturn__]] _LIBCPP_EXPORTED_FROM_ABI void __throw_bad_alloc(); // not in C++ spec
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_bad_array_new_length() {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw bad_array_new_length();
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("bad_array_new_length was thrown in -fno-exceptions mode");
-#endif
+#  endif
 }
 
-#if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && !defined(_LIBCPP_ABI_VCRUNTIME)
-#  ifndef _LIBCPP_CXX03_LANG
+#  if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && !defined(_LIBCPP_ABI_VCRUNTIME)
+#    ifndef _LIBCPP_CXX03_LANG
 enum class align_val_t : size_t {};
-#  else
+#    else
 enum align_val_t { __zero = 0, __max = (size_t)-1 };
+#    endif
 #  endif
-#endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 // Enable the declaration even if the compiler doesn't support the language
 // feature.
 struct destroying_delete_t {
   explicit destroying_delete_t() = default;
 };
 inline constexpr destroying_delete_t destroying_delete{};
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 } // namespace std
 
-#if defined(_LIBCPP_CXX03_LANG)
-#  define _THROW_BAD_ALLOC throw(std::bad_alloc)
-#else
-#  define _THROW_BAD_ALLOC
-#endif
+#  if defined(_LIBCPP_CXX03_LANG)
+#    define _THROW_BAD_ALLOC throw(std::bad_alloc)
+#  else
+#    define _THROW_BAD_ALLOC
+#  endif
 
-#if !defined(_LIBCPP_ABI_VCRUNTIME)
+#  if !defined(_LIBCPP_ABI_VCRUNTIME)
 
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz) _THROW_BAD_ALLOC;
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT
     _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, const std::nothrow_t&) _NOEXCEPT;
-#  if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
+#    if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::size_t __sz) _NOEXCEPT;
-#  endif
+#    endif
 
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz) _THROW_BAD_ALLOC;
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT
     _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, const std::nothrow_t&) _NOEXCEPT;
-#  if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
+#    if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::size_t __sz) _NOEXCEPT;
-#  endif
+#    endif
 
-#  if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
+#    if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void*
 operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::align_val_t) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
-#    if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
+#      if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
-#    endif
+#      endif
 
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void*
 operator new[](std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
@@ -243,10 +245,10 @@ operator new[](std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
 operator new[](std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::align_val_t) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
-#    if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
+#      if _LIBCPP_HAS_LIBRARY_SIZED_DEALLOCATION
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::size_t __sz, std::align_val_t) _NOEXCEPT;
+#      endif
 #    endif
-#  endif
 
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX26 void*
 operator new(std::size_t, void* __p) _NOEXCEPT {
@@ -259,43 +261,43 @@ operator new[](std::size_t, void* __p) _NOEXCEPT {
 inline _LIBCPP_HIDE_FROM_ABI void operator delete(void*, void*) _NOEXCEPT {}
 inline _LIBCPP_HIDE_FROM_ABI void operator delete[](void*, void*) _NOEXCEPT {}
 
-#endif // !_LIBCPP_ABI_VCRUNTIME
+#  endif // !_LIBCPP_ABI_VCRUNTIME
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_CONSTEXPR inline _LIBCPP_HIDE_FROM_ABI bool __is_overaligned_for_new(size_t __align) _NOEXCEPT {
-#ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
+#  ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
   return __align > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
-#else
+#  else
   return __align > _LIBCPP_ALIGNOF(max_align_t);
-#endif
+#  endif
 }
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI void* __libcpp_operator_new(_Args... __args) {
-#if __has_builtin(__builtin_operator_new) && __has_builtin(__builtin_operator_delete)
+#  if __has_builtin(__builtin_operator_new) && __has_builtin(__builtin_operator_delete)
   return __builtin_operator_new(__args...);
-#else
+#  else
   return ::operator new(__args...);
-#endif
+#  endif
 }
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI void __libcpp_operator_delete(_Args... __args) _NOEXCEPT {
-#if __has_builtin(__builtin_operator_new) && __has_builtin(__builtin_operator_delete)
+#  if __has_builtin(__builtin_operator_new) && __has_builtin(__builtin_operator_delete)
   __builtin_operator_delete(__args...);
-#else
+#  else
   ::operator delete(__args...);
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI void* __libcpp_allocate(size_t __size, size_t __align) {
-#if _LIBCPP_HAS_ALIGNED_ALLOCATION
+#  if _LIBCPP_HAS_ALIGNED_ALLOCATION
   if (__is_overaligned_for_new(__align)) {
     const align_val_t __align_val = static_cast<align_val_t>(__align);
     return __libcpp_operator_new(__size, __align_val);
   }
-#endif
+#  endif
 
   (void)__align;
   return __libcpp_operator_new(__size);
@@ -303,40 +305,40 @@ inline _LIBCPP_HIDE_FROM_ABI void* __libcpp_allocate(size_t __size, size_t __ali
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI void __do_deallocate_handle_size(void* __ptr, size_t __size, _Args... __args) _NOEXCEPT {
-#if !_LIBCPP_HAS_SIZED_DEALLOCATION
+#  if !_LIBCPP_HAS_SIZED_DEALLOCATION
   (void)__size;
   return std::__libcpp_operator_delete(__ptr, __args...);
-#else
+#  else
   return std::__libcpp_operator_delete(__ptr, __size, __args...);
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI void __libcpp_deallocate(void* __ptr, size_t __size, size_t __align) _NOEXCEPT {
-#if !_LIBCPP_HAS_ALIGNED_ALLOCATION
+#  if !_LIBCPP_HAS_ALIGNED_ALLOCATION
   (void)__align;
   return __do_deallocate_handle_size(__ptr, __size);
-#else
+#  else
   if (__is_overaligned_for_new(__align)) {
     const align_val_t __align_val = static_cast<align_val_t>(__align);
     return __do_deallocate_handle_size(__ptr, __size, __align_val);
   } else {
     return __do_deallocate_handle_size(__ptr, __size);
   }
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI void __libcpp_deallocate_unsized(void* __ptr, size_t __align) _NOEXCEPT {
-#if !_LIBCPP_HAS_ALIGNED_ALLOCATION
+#  if !_LIBCPP_HAS_ALIGNED_ALLOCATION
   (void)__align;
   return __libcpp_operator_delete(__ptr);
-#else
+#  else
   if (__is_overaligned_for_new(__align)) {
     const align_val_t __align_val = static_cast<align_val_t>(__align);
     return __libcpp_operator_delete(__ptr, __align_val);
   } else {
     return __libcpp_operator_delete(__ptr);
   }
-#endif
+#  endif
 }
 
 template <class _Tp>
@@ -346,30 +348,31 @@ template <class _Tp>
   return __builtin_launder(__p);
 }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
 [[nodiscard]] inline _LIBCPP_HIDE_FROM_ABI constexpr _Tp* launder(_Tp* __p) noexcept {
   return std::__launder(__p);
 }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 
-#  if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
+#    if defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
 
 inline constexpr size_t hardware_destructive_interference_size  = __GCC_DESTRUCTIVE_SIZE;
 inline constexpr size_t hardware_constructive_interference_size = __GCC_CONSTRUCTIVE_SIZE;
 
-#  endif // defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
+#    endif // defined(__GCC_DESTRUCTIVE_SIZE) && defined(__GCC_CONSTRUCTIVE_SIZE)
 
-#endif // _LIBCPP_STD_VER >= 17
+#  endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <cstdlib>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <cstdlib>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_NEW

--- a/libcxx/include/numbers
+++ b/libcxx/include/numbers
@@ -58,15 +58,17 @@ namespace std::numbers {
 }
 */
 
-#include <__concepts/arithmetic.h>
-#include <__config>
-#include <version>
+#if 0
+#else // 0
+#  include <__concepts/arithmetic.h>
+#  include <__config>
+#  include <version>
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -154,12 +156,13 @@ inline constexpr double phi        = phi_v<double>;
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <cstddef>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <cstddef>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_NUMBERS

--- a/libcxx/include/numeric
+++ b/libcxx/include/numeric
@@ -156,52 +156,55 @@ constexpr T saturate_cast(U x) noexcept;                    // freestanding, Sin
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__numeric/accumulate.h>
-#include <__numeric/adjacent_difference.h>
-#include <__numeric/inner_product.h>
-#include <__numeric/iota.h>
-#include <__numeric/partial_sum.h>
+#  include <__numeric/accumulate.h>
+#  include <__numeric/adjacent_difference.h>
+#  include <__numeric/inner_product.h>
+#  include <__numeric/iota.h>
+#  include <__numeric/partial_sum.h>
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__numeric/exclusive_scan.h>
-#  include <__numeric/gcd_lcm.h>
-#  include <__numeric/inclusive_scan.h>
-#  include <__numeric/pstl.h>
-#  include <__numeric/reduce.h>
-#  include <__numeric/transform_exclusive_scan.h>
-#  include <__numeric/transform_inclusive_scan.h>
-#  include <__numeric/transform_reduce.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__numeric/exclusive_scan.h>
+#    include <__numeric/gcd_lcm.h>
+#    include <__numeric/inclusive_scan.h>
+#    include <__numeric/pstl.h>
+#    include <__numeric/reduce.h>
+#    include <__numeric/transform_exclusive_scan.h>
+#    include <__numeric/transform_inclusive_scan.h>
+#    include <__numeric/transform_reduce.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__numeric/midpoint.h>
-#  include <__numeric/saturation_arithmetic.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__numeric/midpoint.h>
+#    include <__numeric/saturation_arithmetic.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 14
-#  include <initializer_list>
-#  include <limits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 14
+#    include <initializer_list>
+#    include <limits>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <climits>
-#  include <cmath>
-#  include <concepts>
-#  include <cstdint>
-#  include <execution>
-#  include <functional>
-#  include <iterator>
-#  include <new>
-#  include <optional>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <climits>
+#    include <cmath>
+#    include <concepts>
+#    include <cstdint>
+#    include <execution>
+#    include <functional>
+#    include <iterator>
+#    include <new>
+#    include <optional>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_NUMERIC

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -177,69 +177,71 @@ namespace std {
 
 */
 
-#include <__assert>
-#include <__compare/compare_three_way_result.h>
-#include <__compare/ordering.h>
-#include <__compare/three_way_comparable.h>
-#include <__concepts/invocable.h>
-#include <__config>
-#include <__exception/exception.h>
-#include <__functional/hash.h>
-#include <__functional/invoke.h>
-#include <__functional/unary_function.h>
-#include <__fwd/functional.h>
-#include <__memory/addressof.h>
-#include <__memory/construct_at.h>
-#include <__tuple/sfinae_helpers.h>
-#include <__type_traits/add_pointer.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/conjunction.h>
-#include <__type_traits/decay.h>
-#include <__type_traits/disjunction.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/invoke.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_assignable.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_destructible.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_object.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_scalar.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/is_trivially_assignable.h>
-#include <__type_traits/is_trivially_constructible.h>
-#include <__type_traits/is_trivially_destructible.h>
-#include <__type_traits/is_trivially_relocatable.h>
-#include <__type_traits/negation.h>
-#include <__type_traits/remove_const.h>
-#include <__type_traits/remove_cv.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/in_place.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <__verbose_abort>
-#include <initializer_list>
-#include <new>
-#include <version>
+#if 0
+#else // 0
+#  include <__assert>
+#  include <__compare/compare_three_way_result.h>
+#  include <__compare/ordering.h>
+#  include <__compare/three_way_comparable.h>
+#  include <__concepts/invocable.h>
+#  include <__config>
+#  include <__exception/exception.h>
+#  include <__functional/hash.h>
+#  include <__functional/invoke.h>
+#  include <__functional/unary_function.h>
+#  include <__fwd/functional.h>
+#  include <__memory/addressof.h>
+#  include <__memory/construct_at.h>
+#  include <__tuple/sfinae_helpers.h>
+#  include <__type_traits/add_pointer.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/conjunction.h>
+#  include <__type_traits/decay.h>
+#  include <__type_traits/disjunction.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/invoke.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_assignable.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_destructible.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_object.h>
+#  include <__type_traits/is_reference.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_scalar.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/is_trivially_assignable.h>
+#  include <__type_traits/is_trivially_constructible.h>
+#  include <__type_traits/is_trivially_destructible.h>
+#  include <__type_traits/is_trivially_relocatable.h>
+#  include <__type_traits/negation.h>
+#  include <__type_traits/remove_const.h>
+#  include <__type_traits/remove_cv.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/in_place.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <__verbose_abort>
+#  include <initializer_list>
+#  include <new>
+#  include <version>
 
 // standard-mandated includes
 
 // [optional.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 namespace std // purposefully not using versioning namespace
 {
@@ -256,17 +258,17 @@ public:
 
 } // namespace std
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 [[noreturn]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_OPTIONAL_ACCESS void
 __throw_bad_optional_access() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   throw bad_optional_access();
-#  else
+#    else
   _LIBCPP_VERBOSE_ABORT("bad_optional_access was thrown in -fno-exceptions mode");
-#  endif
+#    endif
 }
 
 struct nullopt_t {
@@ -304,12 +306,12 @@ struct __optional_destruct_base<_Tp, false> {
   _LIBCPP_HIDE_FROM_ABI constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args)
       : __val_(std::forward<_Args>(__args)...), __engaged_(true) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <class _Fp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit __optional_destruct_base(
       __optional_construct_from_invoke_tag, _Fp&& __f, _Args&&... __args)
       : __val_(std::invoke(std::forward<_Fp>(__f), std::forward<_Args>(__args)...)), __engaged_(true) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void reset() noexcept {
     if (__engaged_) {
@@ -335,12 +337,12 @@ struct __optional_destruct_base<_Tp, true> {
   _LIBCPP_HIDE_FROM_ABI constexpr explicit __optional_destruct_base(in_place_t, _Args&&... __args)
       : __val_(std::forward<_Args>(__args)...), __engaged_(true) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <class _Fp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI constexpr __optional_destruct_base(
       __optional_construct_from_invoke_tag, _Fp&& __f, _Args&&... __args)
       : __val_(std::invoke(std::forward<_Fp>(__f), std::forward<_Args>(__args)...)), __engaged_(true) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void reset() noexcept {
     if (__engaged_) {
@@ -564,12 +566,12 @@ using __optional_sfinae_assign_base_t =
 template <class _Tp>
 class optional;
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
 concept __is_derived_from_optional = requires(const _Tp& __t) { []<class _Up>(const optional<_Up>&) {}(__t); };
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
 struct __is_std_optional : false_type {};
@@ -711,14 +713,14 @@ public:
     this->__construct_from(std::move(__v));
   }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <class _Tag,
             class _Fp,
             class... _Args,
             __enable_if_t<_IsSame<_Tag, __optional_construct_from_invoke_tag>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI constexpr explicit optional(_Tag, _Fp&& __f, _Args&&... __args)
       : __base(__optional_construct_from_invoke_tag{}, std::forward<_Fp>(__f), std::forward<_Args>(__args)...) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 optional& operator=(nullopt_t) noexcept {
     reset();
@@ -864,7 +866,7 @@ public:
     return this->has_value() ? std::move(this->__get()) : static_cast<value_type>(std::forward<_Up>(__v));
   }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <class _Func>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_OPTIONAL_ACCESS constexpr auto and_then(_Func&& __f) & {
     using _Up = invoke_result_t<_Func, value_type&>;
@@ -974,15 +976,15 @@ public:
       return std::move(*this);
     return std::forward<_Func>(__f)();
   }
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   using __base::reset;
 };
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 template <class _Tp>
 optional(_Tp) -> optional<_Tp>;
-#  endif
+#    endif
 
 // Comparisons between optionals
 template <class _Tp, class _Up>
@@ -1057,7 +1059,7 @@ operator>=(const optional<_Tp>& __x, const optional<_Up>& __y) {
   return *__x >= *__y;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 template <class _Tp, three_way_comparable_with<_Tp> _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr compare_three_way_result_t<_Tp, _Up>
@@ -1067,7 +1069,7 @@ operator<=>(const optional<_Tp>& __x, const optional<_Up>& __y) {
   return __x.has_value() <=> __y.has_value();
 }
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 // Comparisons with nullopt
 template <class _Tp>
@@ -1075,7 +1077,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool operator==(const optional<_Tp>& __x, nullop
   return !static_cast<bool>(__x);
 }
 
-#  if _LIBCPP_STD_VER <= 17
+#    if _LIBCPP_STD_VER <= 17
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI constexpr bool operator==(nullopt_t, const optional<_Tp>& __x) noexcept {
@@ -1132,14 +1134,14 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool operator>=(nullopt_t, const optional<_Tp>& 
   return !static_cast<bool>(__x);
 }
 
-#  else // _LIBCPP_STD_VER <= 17
+#    else // _LIBCPP_STD_VER <= 17
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI constexpr strong_ordering operator<=>(const optional<_Tp>& __x, nullopt_t) noexcept {
   return __x.has_value() <=> false;
 }
 
-#  endif // _LIBCPP_STD_VER <= 17
+#    endif // _LIBCPP_STD_VER <= 17
 
 // Comparisons with T
 template <class _Tp, class _Up>
@@ -1238,7 +1240,7 @@ operator>=(const _Tp& __v, const optional<_Up>& __x) {
   return static_cast<bool>(__x) ? __v >= *__x : true;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 template <class _Tp, class _Up>
   requires(!__is_derived_from_optional<_Up>) && three_way_comparable_with<_Tp, _Up>
@@ -1247,7 +1249,7 @@ operator<=>(const optional<_Tp>& __x, const _Up& __v) {
   return __x.has_value() ? *__x <=> __v : strong_ordering::less;
 }
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI
@@ -1273,10 +1275,10 @@ _LIBCPP_HIDE_FROM_ABI constexpr optional<_Tp> make_optional(initializer_list<_Up
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS hash< __enable_hash_helper<optional<_Tp>, remove_const_t<_Tp>> > {
-#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
   _LIBCPP_DEPRECATED_IN_CXX17 typedef optional<_Tp> argument_type;
   _LIBCPP_DEPRECATED_IN_CXX17 typedef size_t result_type;
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const optional<_Tp>& __opt) const {
     return static_cast<bool>(__opt) ? hash<remove_const_t<_Tp>>()(*__opt) : 0;
@@ -1285,25 +1287,26 @@ struct _LIBCPP_TEMPLATE_VIS hash< __enable_hash_helper<optional<_Tp>, remove_con
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 17
+#  endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <climits>
-#  include <concepts>
-#  include <ctime>
-#  include <iterator>
-#  include <limits>
-#  include <memory>
-#  include <ratio>
-#  include <stdexcept>
-#  include <tuple>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#  include <variant>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <climits>
+#    include <concepts>
+#    include <ctime>
+#    include <iterator>
+#    include <limits>
+#    include <memory>
+#    include <ratio>
+#    include <stdexcept>
+#    include <tuple>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#    include <variant>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_OPTIONAL

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -172,35 +172,38 @@ void vprint_nonunicode(ostream& os, string_view fmt, format_args args);         
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__ostream/basic_ostream.h>
+#    include <__ostream/basic_ostream.h>
 
-#  if _LIBCPP_STD_VER >= 23
-#    include <__ostream/print.h>
+#    if _LIBCPP_STD_VER >= 23
+#      include <__ostream/print.h>
+#    endif
+
+#    include <version>
+
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
+
+#  endif // _LIBCPP_HAS_LOCALIZATION
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdio>
+#    include <cstdlib>
+#    include <format>
+#    include <iosfwd>
+#    include <iterator>
+#    include <print>
+#    include <stdexcept>
+#    include <type_traits>
 #  endif
-
-#  include <version>
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
-
-#endif // _LIBCPP_HAS_LOCALIZATION
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdio>
-#  include <cstdlib>
-#  include <format>
-#  include <iosfwd>
-#  include <iterator>
-#  include <print>
-#  include <stdexcept>
-#  include <type_traits>
-#endif
+#endif // 0
 
 #endif // _LIBCPP_OSTREAM

--- a/libcxx/include/print
+++ b/libcxx/include/print
@@ -33,28 +33,30 @@ namespace std {
 }
 */
 
-#include <__assert>
-#include <__concepts/same_as.h>
-#include <__config>
-#include <__system_error/throw_system_error.h>
-#include <__utility/forward.h>
-#include <cerrno>
-#include <cstdio>
-#include <format>
-#include <string>
-#include <string_view>
-#include <version>
+#if 0
+#else // 0
+#  include <__assert>
+#  include <__concepts/same_as.h>
+#  include <__config>
+#  include <__system_error/throw_system_error.h>
+#  include <__utility/forward.h>
+#  include <cerrno>
+#  include <cstdio>
+#  include <format>
+#  include <string>
+#  include <string_view>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#ifdef _LIBCPP_WIN32API
+#  ifdef _LIBCPP_WIN32API
 _LIBCPP_EXPORTED_FROM_ABI bool __is_windows_terminal(FILE* __stream);
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 // A wrapper for WriteConsoleW which is used to write to the Windows
 // console. This function is in the dylib to avoid pulling in windows.h
 // in the library headers. The function itself uses some private parts
@@ -65,14 +67,14 @@ _LIBCPP_EXPORTED_FROM_ABI bool __is_windows_terminal(FILE* __stream);
 //
 // Note the function is only implemented on the Windows platform.
 _LIBCPP_EXPORTED_FROM_ABI void __write_to_windows_console(FILE* __stream, wstring_view __view);
-#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
-#elif __has_include(<unistd.h>)
+#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  elif __has_include(<unistd.h>)
 _LIBCPP_EXPORTED_FROM_ABI bool __is_posix_terminal(FILE* __stream);
-#endif // _LIBCPP_WIN32API
+#  endif // _LIBCPP_WIN32API
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 
-#  if _LIBCPP_HAS_UNICODE
+#    if _LIBCPP_HAS_UNICODE
 // This is the code to transcode UTF-8 to UTF-16. This is used on
 // Windows for the native Unicode API. The code is modeled to make it
 // easier to extend to
@@ -86,27 +88,27 @@ namespace __unicode {
 // The names of these concepts are modelled after P2728R0, but the
 // implementation is not. char16_t may contain 32-bits so depending on the
 // number of bits is an issue.
-#    ifdef _LIBCPP_SHORT_WCHAR
+#      ifdef _LIBCPP_SHORT_WCHAR
 template <class _Tp>
 concept __utf16_code_unit =
     same_as<_Tp, char16_t>
-#      if _LIBCPP_HAS_WIDE_CHARACTERS
+#        if _LIBCPP_HAS_WIDE_CHARACTERS
     || same_as<_Tp, wchar_t>
-#      endif
+#        endif
     ;
 template <class _Tp>
 concept __utf32_code_unit = same_as<_Tp, char32_t>;
-#    else // _LIBCPP_SHORT_WCHAR
+#      else // _LIBCPP_SHORT_WCHAR
 template <class _Tp>
 concept __utf16_code_unit = same_as<_Tp, char16_t>;
 template <class _Tp>
 concept __utf32_code_unit =
     same_as<_Tp, char32_t>
-#      if _LIBCPP_HAS_WIDE_CHARACTERS
+#        if _LIBCPP_HAS_WIDE_CHARACTERS
     || same_as<_Tp, wchar_t>
-#      endif
+#        endif
     ;
-#    endif // _LIBCPP_SHORT_WCHAR
+#      endif // _LIBCPP_SHORT_WCHAR
 
 // Pass by reference since an output_iterator may not be copyable.
 template <class _OutIt>
@@ -164,7 +166,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr _OutIt __transcode(_InIt __first, _InIt __last, 
 
 } // namespace __unicode
 
-#  endif //  _LIBCPP_HAS_UNICODE
+#    endif //  _LIBCPP_HAS_UNICODE
 
 namespace __print {
 
@@ -184,30 +186,30 @@ namespace __print {
 //   (note at the time of writing Clang is hard-coded to UTF-8.)
 //
 
-#  if !_LIBCPP_HAS_UNICODE
+#    if !_LIBCPP_HAS_UNICODE
 inline constexpr bool __use_unicode_execution_charset = false;
-#  elif defined(_MSVC_EXECUTION_CHARACTER_SET)
+#    elif defined(_MSVC_EXECUTION_CHARACTER_SET)
 // This is the same test MSVC STL uses in their implementation of <print>
 // See: https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
 inline constexpr bool __use_unicode_execution_charset = _MSVC_EXECUTION_CHARACTER_SET == 65001;
-#  else
+#    else
 inline constexpr bool __use_unicode_execution_charset = true;
-#  endif
+#    endif
 
 _LIBCPP_HIDE_FROM_ABI inline bool __is_terminal([[maybe_unused]] FILE* __stream) {
   // The macro _LIBCPP_TESTING_PRINT_IS_TERMINAL is used to change
   // the behavior in the test. This is not part of the public API.
-#  ifdef _LIBCPP_TESTING_PRINT_IS_TERMINAL
+#    ifdef _LIBCPP_TESTING_PRINT_IS_TERMINAL
   return _LIBCPP_TESTING_PRINT_IS_TERMINAL(__stream);
-#  elif _LIBCPP_AVAILABILITY_HAS_PRINT == 0 || !_LIBCPP_HAS_TERMINAL
+#    elif _LIBCPP_AVAILABILITY_HAS_PRINT == 0 || !_LIBCPP_HAS_TERMINAL
   return false;
-#  elif defined(_LIBCPP_WIN32API)
+#    elif defined(_LIBCPP_WIN32API)
   return std::__is_windows_terminal(__stream);
-#  elif __has_include(<unistd.h>)
+#    elif __has_include(<unistd.h>)
   return std::__is_posix_terminal(__stream);
-#  else
-#    error "Provide a way to determine whether a FILE* is a terminal"
-#  endif
+#    else
+#      error "Provide a way to determine whether a FILE* is a terminal"
+#    endif
 }
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
@@ -226,7 +228,7 @@ __vprint_nonunicode(FILE* __stream, string_view __fmt, format_args __args, bool 
   }
 }
 
-#  if _LIBCPP_HAS_UNICODE
+#    if _LIBCPP_HAS_UNICODE
 
 // Note these helper functions are mainly used to aid testing.
 // On POSIX systems and Windows the output is no longer considered a
@@ -243,7 +245,7 @@ __vprint_unicode_posix(FILE* __stream, string_view __fmt, format_args __args, bo
   __print::__vprint_nonunicode(__stream, __fmt, __args, __write_nl);
 }
 
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void
 __vprint_unicode_windows(FILE* __stream, string_view __fmt, format_args __args, bool __write_nl, bool __is_terminal) {
@@ -272,16 +274,16 @@ __vprint_unicode_windows(FILE* __stream, string_view __fmt, format_args __args, 
 
   // The macro _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION is used to change
   // the behavior in the test. This is not part of the public API.
-#      ifdef _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION
+#        ifdef _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION
   _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION(__stream, __view);
-#      elif defined(_LIBCPP_WIN32API)
+#        elif defined(_LIBCPP_WIN32API)
   std::__write_to_windows_console(__stream, __view);
-#      else
+#        else
   std::__throw_runtime_error("No defintion of _LIBCPP_TESTING_PRINT_WRITE_TO_WINDOWS_CONSOLE_FUNCTION and "
                              "__write_to_windows_console is not available.");
-#      endif
+#        endif
 }
-#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#      endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void
@@ -312,29 +314,29 @@ __vprint_unicode([[maybe_unused]] FILE* __stream,
   // so there the call can be forwarded to the non_unicode API. On
   // Windows there is a different API. This API requires transcoding.
 
-#    ifndef _LIBCPP_WIN32API
+#      ifndef _LIBCPP_WIN32API
   __print::__vprint_unicode_posix(__stream, __fmt, __args, __write_nl, __print::__is_terminal(__stream));
-#    elif _LIBCPP_HAS_WIDE_CHARACTERS
+#      elif _LIBCPP_HAS_WIDE_CHARACTERS
   __print::__vprint_unicode_windows(__stream, __fmt, __args, __write_nl, __print::__is_terminal(__stream));
-#    else
-#      error "Windows builds with wchar_t disabled are not supported."
-#    endif
+#      else
+#        error "Windows builds with wchar_t disabled are not supported."
+#      endif
 }
 
-#  endif // _LIBCPP_HAS_UNICODE
+#    endif // _LIBCPP_HAS_UNICODE
 
 } // namespace __print
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI void print(FILE* __stream, format_string<_Args...> __fmt, _Args&&... __args) {
-#  if _LIBCPP_HAS_UNICODE
+#    if _LIBCPP_HAS_UNICODE
   if constexpr (__print::__use_unicode_execution_charset)
     __print::__vprint_unicode(__stream, __fmt.get(), std::make_format_args(__args...), false);
   else
     __print::__vprint_nonunicode(__stream, __fmt.get(), std::make_format_args(__args...), false);
-#  else  // _LIBCPP_HAS_UNICODE
+#    else  // _LIBCPP_HAS_UNICODE
   __print::__vprint_nonunicode(__stream, __fmt.get(), std::make_format_args(__args...), false);
-#  endif // _LIBCPP_HAS_UNICODE
+#    endif // _LIBCPP_HAS_UNICODE
 }
 
 template <class... _Args>
@@ -344,7 +346,7 @@ _LIBCPP_HIDE_FROM_ABI void print(format_string<_Args...> __fmt, _Args&&... __arg
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI void println(FILE* __stream, format_string<_Args...> __fmt, _Args&&... __args) {
-#  if _LIBCPP_HAS_UNICODE
+#    if _LIBCPP_HAS_UNICODE
   // Note the wording in the Standard is inefficient. The output of
   // std::format is a std::string which is then copied. This solution
   // just appends a newline at the end of the output.
@@ -352,9 +354,9 @@ _LIBCPP_HIDE_FROM_ABI void println(FILE* __stream, format_string<_Args...> __fmt
     __print::__vprint_unicode(__stream, __fmt.get(), std::make_format_args(__args...), true);
   else
     __print::__vprint_nonunicode(__stream, __fmt.get(), std::make_format_args(__args...), true);
-#  else  // _LIBCPP_HAS_UNICODE
+#    else  // _LIBCPP_HAS_UNICODE
   __print::__vprint_nonunicode(__stream, __fmt.get(), std::make_format_args(__args...), true);
-#  endif // _LIBCPP_HAS_UNICODE
+#    endif // _LIBCPP_HAS_UNICODE
 }
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
@@ -372,7 +374,7 @@ _LIBCPP_HIDE_FROM_ABI void println(format_string<_Args...> __fmt, _Args&&... __a
   std::println(stdout, __fmt, std::forward<_Args>(__args)...);
 }
 
-#  if _LIBCPP_HAS_UNICODE
+#    if _LIBCPP_HAS_UNICODE
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void vprint_unicode(FILE* __stream, string_view __fmt, format_args __args) {
   __print::__vprint_unicode(__stream, __fmt, __args, false);
@@ -383,7 +385,7 @@ _LIBCPP_HIDE_FROM_ABI inline void vprint_unicode(string_view __fmt, format_args 
   std::vprint_unicode(stdout, __fmt, __args);
 }
 
-#  endif // _LIBCPP_HAS_UNICODE
+#    endif // _LIBCPP_HAS_UNICODE
 
 template <class = void> // TODO PRINT template or availability markup fires too eagerly (http://llvm.org/PR61563).
 _LIBCPP_HIDE_FROM_ABI inline void vprint_nonunicode(FILE* __stream, string_view __fmt, format_args __args) {
@@ -395,8 +397,10 @@ _LIBCPP_HIDE_FROM_ABI inline void vprint_nonunicode(string_view __fmt, format_ar
   std::vprint_nonunicode(stdout, __fmt, __args);
 }
 
-#endif // _LIBCPP_STD_VER >= 23
+#  endif // _LIBCPP_STD_VER >= 23
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_PRINT

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -254,38 +254,40 @@ template <class T, class Container, class Compare>
 
 */
 
-#include <__algorithm/make_heap.h>
-#include <__algorithm/pop_heap.h>
-#include <__algorithm/push_heap.h>
-#include <__algorithm/ranges_copy.h>
-#include <__config>
-#include <__functional/operations.h>
-#include <__fwd/deque.h>
-#include <__fwd/queue.h>
-#include <__iterator/back_insert_iterator.h>
-#include <__iterator/iterator_traits.h>
-#include <__memory/uses_allocator.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__utility/forward.h>
-#include <deque>
-#include <vector>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/make_heap.h>
+#  include <__algorithm/pop_heap.h>
+#  include <__algorithm/push_heap.h>
+#  include <__algorithm/ranges_copy.h>
+#  include <__config>
+#  include <__functional/operations.h>
+#  include <__fwd/deque.h>
+#  include <__fwd/queue.h>
+#  include <__iterator/back_insert_iterator.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__memory/uses_allocator.h>
+#  include <__ranges/access.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__utility/forward.h>
+#  include <deque>
+#  include <vector>
+#  include <version>
 
 // standard-mandated includes
 
 // [queue.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -313,7 +315,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI queue(const queue& __q) : c(__q.c) {}
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI queue(_InputIterator __first, _InputIterator __last) : c(__first, __last) {}
 
@@ -333,14 +335,14 @@ public:
   _LIBCPP_HIDE_FROM_ABI queue(from_range_t, _Range&& __range, const _Alloc& __alloc)
       : c(from_range, std::forward<_Range>(__range), __alloc) {}
 
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI queue& operator=(const queue& __q) {
     c = __q.c;
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI queue(queue&& __q) noexcept(is_nothrow_move_constructible<container_type>::value)
       : c(std::move(__q.c)) {}
 
@@ -348,12 +350,12 @@ public:
     c = std::move(__q.c);
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI explicit queue(const container_type& __c) : c(__c) {}
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI explicit queue(container_type&& __c) : c(std::move(__c)) {}
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit queue(const _Alloc& __a) : c(__a) {}
@@ -364,13 +366,13 @@ public:
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI queue(const container_type& __c, const _Alloc& __a) : c(__c, __a) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI queue(container_type&& __c, const _Alloc& __a) : c(std::move(__c), __a) {}
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI queue(queue&& __q, const _Alloc& __a) : c(std::move(__q.c), __a) {}
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
   _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
@@ -381,10 +383,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_reference back() const { return c.back(); }
 
   _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v) { c.push_back(__v); }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void push(value_type&& __v) { c.push_back(std::move(__v)); }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void push_range(_Range&& __range) {
     if constexpr (requires(container_type& __c) { __c.append_range(std::forward<_Range>(__range)); }) {
@@ -393,22 +395,22 @@ public:
       ranges::copy(std::forward<_Range>(__range), std::back_inserter(c));
     }
   }
-#  endif
+#    endif
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   decltype(auto)
   emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
-#  else
+#    else
   void
   emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
-#  endif
-#endif // _LIBCPP_CXX03_LANG
+#    endif
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void pop() { c.pop_front(); }
 
   _LIBCPP_HIDE_FROM_ABI void swap(queue& __q) _NOEXCEPT_(__is_nothrow_swappable_v<container_type>) {
@@ -427,7 +429,7 @@ public:
   operator<(const queue<_T1, _OtherContainer>& __x, const queue<_T1, _OtherContainer>& __y);
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _Container, class = enable_if_t<!__is_allocator<_Container>::value> >
 queue(_Container) -> queue<typename _Container::value_type, _Container>;
 
@@ -436,9 +438,9 @@ template <class _Container,
           class = enable_if_t<!__is_allocator<_Container>::value>,
           class = enable_if_t<uses_allocator<_Container, _Alloc>::value> >
 queue(_Container, _Alloc) -> queue<typename _Container::value_type, _Container>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
 queue(_InputIterator, _InputIterator) -> queue<__iter_value_type<_InputIterator>>;
 
@@ -457,7 +459,7 @@ template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator
 queue(from_range_t,
       _Range&&,
       _Alloc) -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
-#endif
+#  endif
 
 template <class _Tp, class _Container>
 inline _LIBCPP_HIDE_FROM_ABI bool operator==(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y) {
@@ -489,7 +491,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator<=(const queue<_Tp, _Container>& __x, 
   return !(__y < __x);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 template <class _Tp, three_way_comparable _Container>
 _LIBCPP_HIDE_FROM_ABI compare_three_way_result_t<_Container>
@@ -498,7 +500,7 @@ operator<=>(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y
   return __x.__get_container() <=> __y.__get_container();
 }
 
-#endif
+#  endif
 
 template <class _Tp, class _Container, __enable_if_t<__is_swappable_v<_Container>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI void swap(queue<_Tp, _Container>& __x, queue<_Tp, _Container>& __y)
@@ -538,7 +540,7 @@ public:
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI priority_queue(priority_queue&& __q) noexcept(
       is_nothrow_move_constructible<container_type>::value && is_nothrow_move_constructible<value_compare>::value)
       : c(std::move(__q.c)), comp(std::move(__q.comp)) {}
@@ -549,13 +551,13 @@ public:
     comp = std::move(__q.comp);
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI explicit priority_queue(const value_compare& __comp) : c(), comp(__comp) {}
   _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, const container_type& __c);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, container_type&& __c);
-#endif
+#  endif
   template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp = value_compare());
 
@@ -563,19 +565,19 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, const container_type& __c);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, container_type&& __c);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI priority_queue(from_range_t, _Range&& __range, const value_compare& __comp = value_compare())
       : c(from_range, std::forward<_Range>(__range)), comp(__comp) {
     std::make_heap(c.begin(), c.end(), comp);
   }
-#endif
+#  endif
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI explicit priority_queue(const _Alloc& __a);
@@ -589,13 +591,13 @@ public:
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI priority_queue(const priority_queue& __q, const _Alloc& __a);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI priority_queue(const value_compare& __comp, container_type&& __c, const _Alloc& __a);
 
   template <class _Alloc, __enable_if_t<uses_allocator<container_type, _Alloc>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI priority_queue(priority_queue&& __q, const _Alloc& __a);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <
       class _InputIter,
@@ -619,7 +621,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI priority_queue(
       _InputIter __f, _InputIter __l, const value_compare& __comp, const container_type& __c, const _Alloc& __a);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <
       class _InputIter,
       class _Alloc,
@@ -627,9 +629,9 @@ public:
                     int> = 0>
   _LIBCPP_HIDE_FROM_ABI
   priority_queue(_InputIter __f, _InputIter __l, const value_compare& __comp, container_type&& __c, const _Alloc& __a);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 
   template <_ContainerCompatibleRange<_Tp> _Range,
             class _Alloc,
@@ -647,17 +649,17 @@ public:
     std::make_heap(c.begin(), c.end(), comp);
   }
 
-#endif
+#  endif
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
   _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
   _LIBCPP_HIDE_FROM_ABI const_reference top() const { return c.front(); }
 
   _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void push(value_type&& __v);
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void push_range(_Range&& __range) {
     if constexpr (requires(container_type& __c) { __c.append_range(std::forward<_Range>(__range)); }) {
@@ -668,11 +670,11 @@ public:
 
     std::make_heap(c.begin(), c.end(), comp);
   }
-#  endif
+#    endif
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI void emplace(_Args&&... __args);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void pop();
 
   _LIBCPP_HIDE_FROM_ABI void swap(priority_queue& __q)
@@ -681,7 +683,7 @@ public:
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI const _Container& __get_container() const { return c; }
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _Compare,
           class _Container,
           class = enable_if_t<!__is_allocator<_Compare>::value>,
@@ -735,9 +737,9 @@ template <class _InputIterator,
           class = enable_if_t<uses_allocator<_Container, _Alloc>::value> >
 priority_queue(_InputIterator, _InputIterator, _Compare, _Container, _Alloc)
     -> priority_queue<typename _Container::value_type, _Container, _Compare>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range,
           class _Compare = less<ranges::range_value_t<_Range>>,
@@ -757,7 +759,7 @@ template <ranges::input_range _Range, class _Alloc, class = enable_if_t<__is_all
 priority_queue(from_range_t, _Range&&, _Alloc)
     -> priority_queue<ranges::range_value_t<_Range>, vector<ranges::range_value_t<_Range>, _Alloc>>;
 
-#endif
+#  endif
 
 template <class _Tp, class _Container, class _Compare>
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const _Compare& __comp, const container_type& __c)
@@ -765,7 +767,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const _Compare&
   std::make_heap(c.begin(), c.end(), comp);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_compare& __comp, container_type&& __c)
@@ -773,7 +775,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const value_com
   std::make_heap(c.begin(), c.end(), comp);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> >
@@ -792,7 +794,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
   std::make_heap(c.begin(), c.end(), comp);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 template <class _InputIter, __enable_if_t<__has_input_iterator_category<_InputIter>::value, int> >
@@ -803,7 +805,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
   std::make_heap(c.begin(), c.end(), comp);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
@@ -827,7 +829,7 @@ template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value,
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(const priority_queue& __q, const _Alloc& __a)
     : c(__q.c, __a), comp(__q.comp) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value, int> >
@@ -842,7 +844,7 @@ template <class _Alloc, __enable_if_t<uses_allocator<_Container, _Alloc>::value,
 inline priority_queue<_Tp, _Container, _Compare>::priority_queue(priority_queue&& __q, const _Alloc& __a)
     : c(std::move(__q.c), __a), comp(std::move(__q.comp)) {}
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 template <
@@ -877,7 +879,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
   std::make_heap(c.begin(), c.end(), comp);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Tp, class _Container, class _Compare>
 template <
     class _InputIter,
@@ -889,7 +891,7 @@ inline priority_queue<_Tp, _Container, _Compare>::priority_queue(
   c.insert(c.end(), __f, __l);
   std::make_heap(c.begin(), c.end(), comp);
 }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 inline void priority_queue<_Tp, _Container, _Compare>::push(const value_type& __v) {
@@ -897,7 +899,7 @@ inline void priority_queue<_Tp, _Container, _Compare>::push(const value_type& __
   std::push_heap(c.begin(), c.end(), comp);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 inline void priority_queue<_Tp, _Container, _Compare>::push(value_type&& __v) {
@@ -912,7 +914,7 @@ inline void priority_queue<_Tp, _Container, _Compare>::emplace(_Args&&... __args
   std::push_heap(c.begin(), c.end(), comp);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp, class _Container, class _Compare>
 inline void priority_queue<_Tp, _Container, _Compare>::pop() {
@@ -946,11 +948,12 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <cstdlib>
-#  include <functional>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <cstdlib>
+#    include <functional>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_QUEUE

--- a/libcxx/include/random
+++ b/libcxx/include/random
@@ -1677,66 +1677,69 @@ class piecewise_linear_distribution
 } // std
 */
 
-#include <__config>
-#include <__random/bernoulli_distribution.h>
-#include <__random/binomial_distribution.h>
-#include <__random/cauchy_distribution.h>
-#include <__random/chi_squared_distribution.h>
-#include <__random/default_random_engine.h>
-#include <__random/discard_block_engine.h>
-#include <__random/discrete_distribution.h>
-#include <__random/exponential_distribution.h>
-#include <__random/extreme_value_distribution.h>
-#include <__random/fisher_f_distribution.h>
-#include <__random/gamma_distribution.h>
-#include <__random/generate_canonical.h>
-#include <__random/geometric_distribution.h>
-#include <__random/independent_bits_engine.h>
-#include <__random/is_seed_sequence.h>
-#include <__random/knuth_b.h>
-#include <__random/linear_congruential_engine.h>
-#include <__random/lognormal_distribution.h>
-#include <__random/mersenne_twister_engine.h>
-#include <__random/negative_binomial_distribution.h>
-#include <__random/normal_distribution.h>
-#include <__random/piecewise_constant_distribution.h>
-#include <__random/piecewise_linear_distribution.h>
-#include <__random/poisson_distribution.h>
-#include <__random/random_device.h>
-#include <__random/ranlux.h>
-#include <__random/seed_seq.h>
-#include <__random/shuffle_order_engine.h>
-#include <__random/student_t_distribution.h>
-#include <__random/subtract_with_carry_engine.h>
-#include <__random/uniform_int_distribution.h>
-#include <__random/uniform_random_bit_generator.h>
-#include <__random/uniform_real_distribution.h>
-#include <__random/weibull_distribution.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__random/bernoulli_distribution.h>
+#  include <__random/binomial_distribution.h>
+#  include <__random/cauchy_distribution.h>
+#  include <__random/chi_squared_distribution.h>
+#  include <__random/default_random_engine.h>
+#  include <__random/discard_block_engine.h>
+#  include <__random/discrete_distribution.h>
+#  include <__random/exponential_distribution.h>
+#  include <__random/extreme_value_distribution.h>
+#  include <__random/fisher_f_distribution.h>
+#  include <__random/gamma_distribution.h>
+#  include <__random/generate_canonical.h>
+#  include <__random/geometric_distribution.h>
+#  include <__random/independent_bits_engine.h>
+#  include <__random/is_seed_sequence.h>
+#  include <__random/knuth_b.h>
+#  include <__random/linear_congruential_engine.h>
+#  include <__random/lognormal_distribution.h>
+#  include <__random/mersenne_twister_engine.h>
+#  include <__random/negative_binomial_distribution.h>
+#  include <__random/normal_distribution.h>
+#  include <__random/piecewise_constant_distribution.h>
+#  include <__random/piecewise_linear_distribution.h>
+#  include <__random/poisson_distribution.h>
+#  include <__random/random_device.h>
+#  include <__random/ranlux.h>
+#  include <__random/seed_seq.h>
+#  include <__random/shuffle_order_engine.h>
+#  include <__random/student_t_distribution.h>
+#  include <__random/subtract_with_carry_engine.h>
+#  include <__random/uniform_int_distribution.h>
+#  include <__random/uniform_random_bit_generator.h>
+#  include <__random/uniform_real_distribution.h>
+#  include <__random/weibull_distribution.h>
+#  include <version>
 
 // standard-mandated includes
 
 // [rand.synopsis]
-#include <initializer_list>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <climits>
-#  include <cmath>
-#  include <concepts>
-#  include <cstddef>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <limits>
-#  include <numeric>
-#  include <string>
-#  include <type_traits>
-#  include <vector>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <climits>
+#    include <cmath>
+#    include <concepts>
+#    include <cstddef>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <limits>
+#    include <numeric>
+#    include <string>
+#    include <type_traits>
+#    include <vector>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_RANDOM

--- a/libcxx/include/ranges
+++ b/libcxx/include/ranges
@@ -380,76 +380,79 @@ namespace std {
 }
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__ranges/access.h>
-#  include <__ranges/all.h>
-#  include <__ranges/common_view.h>
-#  include <__ranges/concepts.h>
-#  include <__ranges/counted.h>
-#  include <__ranges/dangling.h>
-#  include <__ranges/data.h>
-#  include <__ranges/drop_view.h>
-#  include <__ranges/drop_while_view.h>
-#  include <__ranges/elements_view.h>
-#  include <__ranges/empty.h>
-#  include <__ranges/empty_view.h>
-#  include <__ranges/enable_borrowed_range.h>
-#  include <__ranges/enable_view.h>
-#  include <__ranges/filter_view.h>
-#  include <__ranges/iota_view.h>
-#  include <__ranges/join_view.h>
-#  include <__ranges/lazy_split_view.h>
-#  include <__ranges/rbegin.h>
-#  include <__ranges/ref_view.h>
-#  include <__ranges/rend.h>
-#  include <__ranges/reverse_view.h>
-#  include <__ranges/single_view.h>
-#  include <__ranges/size.h>
-#  include <__ranges/split_view.h>
-#  include <__ranges/subrange.h>
-#  include <__ranges/take_view.h>
-#  include <__ranges/take_while_view.h>
-#  include <__ranges/transform_view.h>
-#  include <__ranges/view_interface.h>
-#  include <__ranges/views.h>
+#  if _LIBCPP_STD_VER >= 20
+#    include <__ranges/access.h>
+#    include <__ranges/all.h>
+#    include <__ranges/common_view.h>
+#    include <__ranges/concepts.h>
+#    include <__ranges/counted.h>
+#    include <__ranges/dangling.h>
+#    include <__ranges/data.h>
+#    include <__ranges/drop_view.h>
+#    include <__ranges/drop_while_view.h>
+#    include <__ranges/elements_view.h>
+#    include <__ranges/empty.h>
+#    include <__ranges/empty_view.h>
+#    include <__ranges/enable_borrowed_range.h>
+#    include <__ranges/enable_view.h>
+#    include <__ranges/filter_view.h>
+#    include <__ranges/iota_view.h>
+#    include <__ranges/join_view.h>
+#    include <__ranges/lazy_split_view.h>
+#    include <__ranges/rbegin.h>
+#    include <__ranges/ref_view.h>
+#    include <__ranges/rend.h>
+#    include <__ranges/reverse_view.h>
+#    include <__ranges/single_view.h>
+#    include <__ranges/size.h>
+#    include <__ranges/split_view.h>
+#    include <__ranges/subrange.h>
+#    include <__ranges/take_view.h>
+#    include <__ranges/take_while_view.h>
+#    include <__ranges/transform_view.h>
+#    include <__ranges/view_interface.h>
+#    include <__ranges/views.h>
 
-#  if _LIBCPP_HAS_LOCALIZATION
-#    include <__ranges/istream_view.h>
+#    if _LIBCPP_HAS_LOCALIZATION
+#      include <__ranges/istream_view.h>
+#    endif
 #  endif
-#endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__ranges/as_rvalue_view.h>
-#  include <__ranges/chunk_by_view.h>
-#  include <__ranges/from_range.h>
-#  include <__ranges/repeat_view.h>
-#  include <__ranges/to.h>
-#  include <__ranges/zip_view.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__ranges/as_rvalue_view.h>
+#    include <__ranges/chunk_by_view.h>
+#    include <__ranges/from_range.h>
+#    include <__ranges/repeat_view.h>
+#    include <__ranges/to.h>
+#    include <__ranges/zip_view.h>
+#  endif
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [ranges.syn]
-#include <compare>
-#include <initializer_list>
-#include <iterator>
+#  include <compare>
+#  include <initializer_list>
+#  include <iterator>
 
 // [tuple.helper]
-#include <__tuple/tuple_element.h>
-#include <__tuple/tuple_size.h>
+#  include <__tuple/tuple_element.h>
+#  include <__tuple/tuple_size.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_RANGES

--- a/libcxx/include/ratio
+++ b/libcxx/include/ratio
@@ -81,18 +81,20 @@ using quetta = ratio <1'000'000'000'000'000'000'000'000'000'000, 1>; // Since C+
 }
 */
 
-#include <__config>
-#include <__type_traits/integral_constant.h>
-#include <climits>
-#include <cstdint>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__type_traits/integral_constant.h>
+#  include <climits>
+#  include <cstdint>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -279,17 +281,17 @@ public:
                           __ll_mul<_R2::den / __gcd_n1_d2, _R1::den / __gcd_d1_n2>::value >::type type;
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 using ratio_multiply = typename __ratio_multiply<_R1, _R2>::type;
 
-#else // _LIBCPP_CXX03_LANG
+#  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_multiply : public __ratio_multiply<_R1, _R2>::type {};
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct __ratio_divide {
@@ -305,17 +307,17 @@ public:
                           __ll_mul<_R2::num / __gcd_n1_n2, _R1::den / __gcd_d1_d2>::value >::type type;
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 using ratio_divide = typename __ratio_divide<_R1, _R2>::type;
 
-#else // _LIBCPP_CXX03_LANG
+#  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_divide : public __ratio_divide<_R1, _R2>::type {};
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct __ratio_add {
@@ -334,17 +336,17 @@ public:
              _R2::den > >::type type;
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 using ratio_add = typename __ratio_add<_R1, _R2>::type;
 
-#else // _LIBCPP_CXX03_LANG
+#  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_add : public __ratio_add<_R1, _R2>::type {};
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct __ratio_subtract {
@@ -363,17 +365,17 @@ public:
              _R2::den > >::type type;
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 using ratio_subtract = typename __ratio_subtract<_R1, _R2>::type;
 
-#else // _LIBCPP_CXX03_LANG
+#  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
 struct _LIBCPP_TEMPLATE_VIS ratio_subtract : public __ratio_subtract<_R1, _R2>::type {};
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 // ratio_equal
 
@@ -464,7 +466,7 @@ struct _LIBCPP_TEMPLATE_VIS ratio_greater_equal : _BoolConstant<!ratio_less<_R1,
 template <class _R1, class _R2>
 using __ratio_gcd = ratio<__static_gcd<_R1::num, _R2::num>, __static_lcm<_R1::den, _R2::den> >;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _R1, class _R2>
 inline constexpr bool ratio_equal_v = ratio_equal<_R1, _R2>::value;
 
@@ -482,14 +484,15 @@ inline constexpr bool ratio_greater_v = ratio_greater<_R1, _R2>::value;
 
 template <class _R1, class _R2>
 inline constexpr bool ratio_greater_equal_v = ratio_greater_equal<_R1, _R2>::value;
-#endif
+#  endif
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_RATIO

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -789,48 +789,50 @@ typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
 } // std
 */
 
-#include <__algorithm/find.h>
-#include <__algorithm/search.h>
-#include <__assert>
-#include <__config>
-#include <__iterator/back_insert_iterator.h>
-#include <__iterator/default_sentinel.h>
-#include <__iterator/wrap_iter.h>
-#include <__locale>
-#include <__memory/shared_ptr.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__type_traits/is_swappable.h>
-#include <__utility/move.h>
-#include <__utility/pair.h>
-#include <__utility/swap.h>
-#include <__verbose_abort>
-#include <deque>
-#include <stdexcept>
-#include <string>
-#include <vector>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/find.h>
+#  include <__algorithm/search.h>
+#  include <__assert>
+#  include <__config>
+#  include <__iterator/back_insert_iterator.h>
+#  include <__iterator/default_sentinel.h>
+#  include <__iterator/wrap_iter.h>
+#  include <__locale>
+#  include <__memory/shared_ptr.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__utility/move.h>
+#  include <__utility/pair.h>
+#  include <__utility/swap.h>
+#  include <__verbose_abort>
+#  include <deque>
+#  include <stdexcept>
+#  include <string>
+#  include <vector>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [re.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#define _LIBCPP_REGEX_COMPLEXITY_FACTOR 4096
+#  define _LIBCPP_REGEX_COMPLEXITY_FACTOR 4096
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -843,11 +845,11 @@ enum syntax_option_type {
   nosubs   = 1 << 1,
   optimize = 1 << 2,
   collate  = 1 << 3,
-#ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
+#  ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
   ECMAScript = 1 << 9,
-#else
+#  else
   ECMAScript = 0,
-#endif
+#  endif
   basic    = 1 << 4,
   extended = 1 << 5,
   awk      = 1 << 6,
@@ -858,11 +860,11 @@ enum syntax_option_type {
 };
 
 _LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR syntax_option_type __get_grammar(syntax_option_type __g) {
-#ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
+#  ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
   return static_cast<syntax_option_type>(__g & 0x3F0);
-#else
+#  else
   return static_cast<syntax_option_type>(__g & 0x1F0);
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR syntax_option_type operator~(syntax_option_type __x) {
@@ -984,11 +986,11 @@ public:
 
 template <regex_constants::error_type _Ev>
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_regex_error() {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw regex_error(_Ev);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("regex_error was thrown in -fno-exceptions mode");
-#endif
+#  endif
 }
 
 template <class _CharT>
@@ -997,7 +999,7 @@ public:
   typedef _CharT char_type;
   typedef basic_string<char_type> string_type;
   typedef locale locale_type;
-#if defined(__BIONIC__) || defined(_NEWLIB_VERSION)
+#  if defined(__BIONIC__) || defined(_NEWLIB_VERSION)
   // Originally bionic's ctype_base used its own ctype masks because the
   // builtin ctype implementation wasn't in libc++ yet. Bionic's ctype mask
   // was only 8 bits wide and already saturated, so it used a wider type here
@@ -1012,9 +1014,9 @@ public:
   // often used for space constrained environments, so it makes sense not to
   // duplicate the ctype table.
   typedef uint16_t char_class_type;
-#else
+#  else
   typedef ctype_base::mask char_class_type;
-#endif
+#  endif
 
   static const char_class_type __regex_word = ctype_base::__regex_word;
 
@@ -1054,30 +1056,30 @@ private:
 
   template <class _ForwardIterator>
   string_type __transform_primary(_ForwardIterator __f, _ForwardIterator __l, char) const;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
   template <class _ForwardIterator>
   string_type __transform_primary(_ForwardIterator __f, _ForwardIterator __l, wchar_t) const;
-#endif
+#  endif
   template <class _ForwardIterator>
   string_type __lookup_collatename(_ForwardIterator __f, _ForwardIterator __l, char) const;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
   template <class _ForwardIterator>
   string_type __lookup_collatename(_ForwardIterator __f, _ForwardIterator __l, wchar_t) const;
-#endif
+#  endif
   template <class _ForwardIterator>
   char_class_type __lookup_classname(_ForwardIterator __f, _ForwardIterator __l, bool __icase, char) const;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
   template <class _ForwardIterator>
   char_class_type __lookup_classname(_ForwardIterator __f, _ForwardIterator __l, bool __icase, wchar_t) const;
-#endif
+#  endif
 
   static int __regex_traits_value(unsigned char __ch, int __radix);
   _LIBCPP_HIDE_FROM_ABI int __regex_traits_value(char __ch, int __radix) const {
     return __regex_traits_value(static_cast<unsigned char>(__ch), __radix);
   }
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
   _LIBCPP_HIDE_FROM_ABI int __regex_traits_value(wchar_t __ch, int __radix) const;
-#endif
+#  endif
 };
 
 template <class _CharT>
@@ -1136,7 +1138,7 @@ regex_traits<_CharT>::__transform_primary(_ForwardIterator __f, _ForwardIterator
   return __d;
 }
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 template <class _ForwardIterator>
 typename regex_traits<_CharT>::string_type
@@ -1155,7 +1157,7 @@ regex_traits<_CharT>::__transform_primary(_ForwardIterator __f, _ForwardIterator
   }
   return __d;
 }
-#endif
+#  endif
 
 // lookup_collatename is very FreeBSD-specific
 
@@ -1180,7 +1182,7 @@ regex_traits<_CharT>::__lookup_collatename(_ForwardIterator __f, _ForwardIterato
   return __r;
 }
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 template <class _ForwardIterator>
 typename regex_traits<_CharT>::string_type
@@ -1208,7 +1210,7 @@ regex_traits<_CharT>::__lookup_collatename(_ForwardIterator __f, _ForwardIterato
   }
   return __r;
 }
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 // lookup_classname
 
@@ -1223,7 +1225,7 @@ regex_traits<_CharT>::__lookup_classname(_ForwardIterator __f, _ForwardIterator 
   return std::__get_classname(__s.c_str(), __icase);
 }
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 template <class _ForwardIterator>
 typename regex_traits<_CharT>::char_class_type
@@ -1239,7 +1241,7 @@ regex_traits<_CharT>::__lookup_classname(_ForwardIterator __f, _ForwardIterator 
   }
   return __get_classname(__n.c_str(), __icase);
 }
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 template <class _CharT>
 bool regex_traits<_CharT>::isctype(char_type __c, char_class_type __m) const {
@@ -1250,28 +1252,28 @@ bool regex_traits<_CharT>::isctype(char_type __c, char_class_type __m) const {
 
 inline _LIBCPP_HIDE_FROM_ABI bool __is_07(unsigned char __c) {
   return (__c & 0xF8u) ==
-#if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
+#  if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
          0xF0;
-#else
+#  else
          0x30;
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI bool __is_89(unsigned char __c) {
   return (__c & 0xFEu) ==
-#if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
+#  if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
          0xF8;
-#else
+#  else
          0x38;
-#endif
+#  endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI unsigned char __to_lower(unsigned char __c) {
-#if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
+#  if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
   return __c & 0xBF;
-#else
+#  else
   return __c | 0x20;
-#endif
+#  endif
 }
 
 template <class _CharT>
@@ -1290,12 +1292,12 @@ int regex_traits<_CharT>::__regex_traits_value(unsigned char __ch, int __radix) 
   return -1;
 }
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 inline int regex_traits<_CharT>::__regex_traits_value(wchar_t __ch, int __radix) const {
   return __regex_traits_value(static_cast<unsigned char>(__ct_->narrow(__ch, char_type())), __radix);
 }
-#endif
+#  endif
 
 template <class _CharT>
 class __node;
@@ -1938,10 +1940,10 @@ public:
 
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void __match_any_but_newline<char>::__exec(__state&) const;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void __match_any_but_newline<wchar_t>::__exec(__state&) const;
-#endif
+#  endif
 
 // __match_char
 
@@ -2262,9 +2264,9 @@ template <class _CharT, class _Traits = regex_traits<_CharT> >
 class _LIBCPP_TEMPLATE_VIS basic_regex;
 
 typedef basic_regex<char> regex;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef basic_regex<wchar_t> wregex;
-#endif
+#  endif
 
 template <class _CharT, class _Traits>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex)
@@ -2335,21 +2337,21 @@ public:
       : __flags_(__f), __marked_count_(0), __loop_count_(0), __open_count_(0), __end_(nullptr) {
     __init(__first, __last);
   }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI basic_regex(initializer_list<value_type> __il, flag_type __f = regex_constants::ECMAScript)
       : __flags_(__f), __marked_count_(0), __loop_count_(0), __open_count_(0), __end_(nullptr) {
     __init(__il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   //    ~basic_regex() = default;
 
   //     basic_regex& operator=(const basic_regex&) = default;
   //     basic_regex& operator=(basic_regex&&) = default;
   _LIBCPP_HIDE_FROM_ABI basic_regex& operator=(const value_type* __p) { return assign(__p); }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI basic_regex& operator=(initializer_list<value_type> __il) { return assign(__il); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   template <class _ST, class _SA>
   _LIBCPP_HIDE_FROM_ABI basic_regex& operator=(const basic_string<value_type, _ST, _SA>& __p) {
     return assign(__p);
@@ -2357,9 +2359,9 @@ public:
 
   // assign:
   _LIBCPP_HIDE_FROM_ABI basic_regex& assign(const basic_regex& __that) { return *this = __that; }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI basic_regex& assign(basic_regex&& __that) _NOEXCEPT { return *this = std::move(__that); }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI basic_regex& assign(const value_type* __p, flag_type __f = regex_constants::ECMAScript) {
     return assign(__p, __p + __traits_.length(__p), __f);
   }
@@ -2396,14 +2398,14 @@ public:
     return assign(basic_regex(__first, __last, __f));
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI basic_regex&
   assign(initializer_list<value_type> __il, flag_type __f = regex_constants::ECMAScript) {
     return assign(__il.begin(), __il.end(), __f);
   }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   // const operations:
   _LIBCPP_HIDE_FROM_ABI unsigned mark_count() const { return __marked_count_; }
@@ -2644,11 +2646,11 @@ private:
   friend class __lookahead;
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _ForwardIterator, __enable_if_t<__has_forward_iterator_category<_ForwardIterator>::value, int> = 0>
 basic_regex(_ForwardIterator, _ForwardIterator, regex_constants::syntax_option_type = regex_constants::ECMAScript)
     -> basic_regex<typename iterator_traits<_ForwardIterator>::value_type>;
-#endif
+#  endif
 
 template <class _CharT, class _Traits>
 const regex_constants::syntax_option_type basic_regex<_CharT, _Traits>::icase;
@@ -4181,10 +4183,10 @@ void basic_regex<_CharT, _Traits>::__push_lookahead(const basic_regex& __exp, bo
 
 typedef sub_match<const char*> csub_match;
 typedef sub_match<string::const_iterator> ssub_match;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef sub_match<const wchar_t*> wcsub_match;
 typedef sub_match<wstring::const_iterator> wssub_match;
-#endif
+#  endif
 
 template <class _BidirectionalIterator>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(csub_match)
@@ -4224,7 +4226,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator==(const sub_match<_BiIter>& __x, cons
   return __x.compare(__y) == 0;
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 using __sub_match_cat = compare_three_way_result_t<basic_string<typename iterator_traits<_BiIter>::value_type>>;
 
@@ -4232,7 +4234,7 @@ template <class _BiIter>
 _LIBCPP_HIDE_FROM_ABI auto operator<=>(const sub_match<_BiIter>& __x, const sub_match<_BiIter>& __y) {
   return static_cast<__sub_match_cat<_BiIter>>(__x.compare(__y) <=> 0);
 }
-#else  // _LIBCPP_STD_VER >= 20
+#  else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const sub_match<_BiIter>& __x, const sub_match<_BiIter>& __y) {
   return !(__x == __y);
@@ -4299,7 +4301,7 @@ operator<=(const basic_string<typename iterator_traits<_BiIter>::value_type, _ST
            const sub_match<_BiIter>& __y) {
   return !(__y < __x);
 }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 template <class _BiIter, class _ST, class _SA>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -4308,7 +4310,7 @@ operator==(const sub_match<_BiIter>& __x,
   return __x.compare(typename sub_match<_BiIter>::string_type(__y.data(), __y.size())) == 0;
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _BiIter, class _ST, class _SA>
 _LIBCPP_HIDE_FROM_ABI auto
 operator<=>(const sub_match<_BiIter>& __x,
@@ -4316,7 +4318,7 @@ operator<=>(const sub_match<_BiIter>& __x,
   return static_cast<__sub_match_cat<_BiIter>>(
       __x.compare(typename sub_match<_BiIter>::string_type(__y.data(), __y.size())) <=> 0);
 }
-#else  // _LIBCPP_STD_VER >= 20
+#  else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter, class _ST, class _SA>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator!=(const sub_match<_BiIter>& __x,
@@ -4387,7 +4389,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator<=(typename iterator_traits<_BiIter>::value_type const* __x, const sub_match<_BiIter>& __y) {
   return !(__y < __x);
 }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -4395,13 +4397,13 @@ operator==(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::val
   return __x.compare(__y) == 0;
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 _LIBCPP_HIDE_FROM_ABI auto
 operator<=>(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const* __y) {
   return static_cast<__sub_match_cat<_BiIter>>(__x.compare(__y) <=> 0);
 }
-#else  // _LIBCPP_STD_VER >= 20
+#  else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator!=(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const* __y) {
@@ -4469,7 +4471,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator<=(typename iterator_traits<_BiIter>::value_type const& __x, const sub_match<_BiIter>& __y) {
   return !(__y < __x);
 }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -4478,14 +4480,14 @@ operator==(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::val
   return __x.compare(string_type(1, __y)) == 0;
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 _LIBCPP_HIDE_FROM_ABI auto
 operator<=>(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const& __y) {
   using string_type = basic_string<typename iterator_traits<_BiIter>::value_type>;
   return static_cast<__sub_match_cat<_BiIter>>(__x.compare(string_type(1, __y)) <=> 0);
 }
-#else  // _LIBCPP_STD_VER >= 20
+#  else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator!=(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const& __y) {
@@ -4516,7 +4518,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator<=(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const& __y) {
   return !(__y < __x);
 }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _ST, class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _ST>&
@@ -4526,10 +4528,10 @@ operator<<(basic_ostream<_CharT, _ST>& __os, const sub_match<_BiIter>& __m) {
 
 typedef match_results<const char*> cmatch;
 typedef match_results<string::const_iterator> smatch;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef match_results<const wchar_t*> wcmatch;
 typedef match_results<wstring::const_iterator> wsmatch;
-#endif
+#  endif
 
 template <class _BidirectionalIterator, class _Allocator>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cmatch) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcmatch))
@@ -4559,12 +4561,12 @@ public:
   typedef basic_string<char_type> string_type;
 
   // construct/copy/destroy:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   match_results() : match_results(allocator_type()) {}
   explicit match_results(const allocator_type& __a);
-#else
+#  else
   explicit match_results(const allocator_type& __a = allocator_type());
-#endif
+#  endif
 
   //    match_results(const match_results&) = default;
   //    match_results& operator=(const match_results&) = default;
@@ -4814,13 +4816,13 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const match_results<_BidirectionalIterator
   return __x.__matches_ == __y.__matches_ && __x.__prefix_ == __y.__prefix_ && __x.__suffix_ == __y.__suffix_;
 }
 
-#if _LIBCPP_STD_VER < 20
+#  if _LIBCPP_STD_VER < 20
 template <class _BidirectionalIterator, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const match_results<_BidirectionalIterator, _Allocator>& __x,
                                              const match_results<_BidirectionalIterator, _Allocator>& __y) {
   return !(__x == __y);
 }
-#endif
+#  endif
 
 template <class _BidirectionalIterator, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void
@@ -5232,13 +5234,13 @@ regex_search(const basic_string<_CharT, _ST, _SA>& __s,
   return __r;
 }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 template <class _ST, class _SA, class _Ap, class _Cp, class _Tp>
 bool regex_search(const basic_string<_Cp, _ST, _SA>&& __s,
                   match_results<typename basic_string<_Cp, _ST, _SA>::const_iterator, _Ap>&,
                   const basic_regex<_Cp, _Tp>& __e,
                   regex_constants::match_flag_type __flags = regex_constants::match_default) = delete;
-#endif
+#  endif
 
 // regex_match
 
@@ -5287,14 +5289,14 @@ regex_match(const basic_string<_CharT, _ST, _SA>& __s,
   return std::regex_match(__s.begin(), __s.end(), __m, __e, __flags);
 }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 template <class _ST, class _SA, class _Allocator, class _CharT, class _Traits>
 inline _LIBCPP_HIDE_FROM_ABI bool
 regex_match(const basic_string<_CharT, _ST, _SA>&& __s,
             match_results<typename basic_string<_CharT, _ST, _SA>::const_iterator, _Allocator>& __m,
             const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default) = delete;
-#endif
+#  endif
 
 template <class _CharT, class _Traits>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -5321,10 +5323,10 @@ class _LIBCPP_TEMPLATE_VIS regex_iterator;
 
 typedef regex_iterator<const char*> cregex_iterator;
 typedef regex_iterator<string::const_iterator> sregex_iterator;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef regex_iterator<const wchar_t*> wcregex_iterator;
 typedef regex_iterator<wstring::const_iterator> wsregex_iterator;
-#endif
+#  endif
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cregex_iterator)
@@ -5337,9 +5339,9 @@ public:
   typedef const value_type* pointer;
   typedef const value_type& reference;
   typedef forward_iterator_tag iterator_category;
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   typedef input_iterator_tag iterator_concept;
-#endif
+#  endif
 
 private:
   _BidirectionalIterator __begin_;
@@ -5354,20 +5356,20 @@ public:
                  _BidirectionalIterator __b,
                  const regex_type& __re,
                  regex_constants::match_flag_type __m = regex_constants::match_default);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   regex_iterator(_BidirectionalIterator __a,
                  _BidirectionalIterator __b,
                  const regex_type&& __re,
                  regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI bool operator==(const regex_iterator& __x) const;
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool operator==(default_sentinel_t) const { return *this == regex_iterator(); }
-#endif
-#if _LIBCPP_STD_VER < 20
+#  endif
+#  if _LIBCPP_STD_VER < 20
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const regex_iterator& __x) const { return !(*this == __x); }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI reference operator*() const { return __match_; }
   _LIBCPP_HIDE_FROM_ABI pointer operator->() const { return std::addressof(__match_); }
@@ -5451,10 +5453,10 @@ class _LIBCPP_TEMPLATE_VIS regex_token_iterator;
 
 typedef regex_token_iterator<const char*> cregex_token_iterator;
 typedef regex_token_iterator<string::const_iterator> sregex_token_iterator;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef regex_token_iterator<const wchar_t*> wcregex_token_iterator;
 typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
-#endif
+#  endif
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cregex_token_iterator)
@@ -5468,9 +5470,9 @@ public:
   typedef const value_type* pointer;
   typedef const value_type& reference;
   typedef forward_iterator_tag iterator_category;
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   typedef input_iterator_tag iterator_concept;
-#endif
+#  endif
 
 private:
   typedef regex_iterator<_BidirectionalIterator, _CharT, _Traits> _Position;
@@ -5488,69 +5490,69 @@ public:
                        const regex_type& __re,
                        int __submatch                       = 0,
                        regex_constants::match_flag_type __m = regex_constants::match_default);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type&& __re,
                        int __submatch                       = 0,
                        regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#endif
+#  endif
 
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type& __re,
                        const vector<int>& __submatches,
                        regex_constants::match_flag_type __m = regex_constants::match_default);
-#if _LIBCPP_STD_VER >= 14
-  regex_token_iterator(_BidirectionalIterator __a,
-                       _BidirectionalIterator __b,
-                       const regex_type&& __re,
-                       const vector<int>& __submatches,
-                       regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#endif
-
-#ifndef _LIBCPP_CXX03_LANG
-  regex_token_iterator(_BidirectionalIterator __a,
-                       _BidirectionalIterator __b,
-                       const regex_type& __re,
-                       initializer_list<int> __submatches,
-                       regex_constants::match_flag_type __m = regex_constants::match_default);
-
 #  if _LIBCPP_STD_VER >= 14
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type&& __re,
-                       initializer_list<int> __submatches,
+                       const vector<int>& __submatches,
                        regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
 #  endif
-#endif // _LIBCPP_CXX03_LANG
+
+#  ifndef _LIBCPP_CXX03_LANG
+  regex_token_iterator(_BidirectionalIterator __a,
+                       _BidirectionalIterator __b,
+                       const regex_type& __re,
+                       initializer_list<int> __submatches,
+                       regex_constants::match_flag_type __m = regex_constants::match_default);
+
+#    if _LIBCPP_STD_VER >= 14
+  regex_token_iterator(_BidirectionalIterator __a,
+                       _BidirectionalIterator __b,
+                       const regex_type&& __re,
+                       initializer_list<int> __submatches,
+                       regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
+#    endif
+#  endif // _LIBCPP_CXX03_LANG
   template <size_t _Np>
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type& __re,
                        const int (&__submatches)[_Np],
                        regex_constants::match_flag_type __m = regex_constants::match_default);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <size_t _Np>
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type&& __re,
                        const int (&__submatches)[_Np],
                        regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#endif
+#  endif
 
   regex_token_iterator(const regex_token_iterator&);
   regex_token_iterator& operator=(const regex_token_iterator&);
 
   _LIBCPP_HIDE_FROM_ABI bool operator==(const regex_token_iterator& __x) const;
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_HIDE_FROM_ABI bool operator==(default_sentinel_t) const {
     return *this == regex_token_iterator();
   }
-#endif
-#if _LIBCPP_STD_VER < 20
+#  endif
+#  if _LIBCPP_STD_VER < 20
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const regex_token_iterator& __x) const { return !(*this == __x); }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI const value_type& operator*() const { return *__result_; }
   _LIBCPP_HIDE_FROM_ABI const value_type* operator->() const { return __result_; }
@@ -5612,7 +5614,7 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_itera
   __init(__a, __b);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_iterator(
@@ -5625,7 +5627,7 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_itera
   __init(__a, __b);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 template <size_t _Np>
@@ -5800,7 +5802,7 @@ regex_replace(const _CharT* __s,
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _BidirT>
@@ -5810,27 +5812,28 @@ using match_results _LIBCPP_AVAILABILITY_PMR =
 using cmatch _LIBCPP_AVAILABILITY_PMR = match_results<const char*>;
 using smatch _LIBCPP_AVAILABILITY_PMR = match_results<std::pmr::string::const_iterator>;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 using wcmatch _LIBCPP_AVAILABILITY_PMR = match_results<const wchar_t*>;
 using wsmatch _LIBCPP_AVAILABILITY_PMR = match_results<std::pmr::wstring::const_iterator>;
-#  endif
+#    endif
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <iterator>
-#  include <mutex>
-#  include <new>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <iterator>
+#    include <mutex>
+#    include <new>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_REGEX

--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -109,32 +109,34 @@ template <class OuterA1, class OuterA2, class... InnerAllocs>
 
 */
 
-#include <__config>
-#include <__memory/allocator_traits.h>
-#include <__memory/uses_allocator_construction.h>
-#include <__type_traits/common_type.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/remove_reference.h>
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/pair.h>
-#include <__utility/piecewise_construct.h>
-#include <tuple>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/uses_allocator_construction.h>
+#  include <__type_traits/common_type.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/integral_constant.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/pair.h>
+#  include <__utility/piecewise_construct.h>
+#  include <tuple>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if !defined(_LIBCPP_CXX03_LANG)
+#  if !defined(_LIBCPP_CXX03_LANG)
 
 // scoped_allocator_adaptor
 
@@ -404,7 +406,7 @@ public:
     return allocator_traits<outer_allocator_type>::max_size(outer_allocator());
   }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _Type, class... _Args>
   _LIBCPP_HIDE_FROM_ABI void construct(_Type* __ptr, _Args&&... __args) {
     using _OM = __outermost<outer_allocator_type>;
@@ -415,7 +417,7 @@ public:
         },
         std::uses_allocator_construction_args<_Type>(inner_allocator(), std::forward<_Args>(__args)...));
   }
-#  else
+#    else
   template <class _Tp, class... _Args>
   _LIBCPP_HIDE_FROM_ABI void construct(_Tp* __p, _Args&&... __args) {
     __construct(__uses_alloc_ctor<_Tp, inner_allocator_type&, _Args...>(), __p, std::forward<_Args>(__args)...);
@@ -462,7 +464,7 @@ public:
               std::forward_as_tuple(std::forward<_Up>(__x.first)),
               std::forward_as_tuple(std::forward<_Vp>(__x.second)));
   }
-#  endif
+#    endif
 
   template <class _Tp>
   _LIBCPP_HIDE_FROM_ABI void destroy(_Tp* __p) {
@@ -522,10 +524,10 @@ private:
   friend class __scoped_allocator_storage;
 };
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 template <class _OuterAlloc, class... _InnerAllocs>
 scoped_allocator_adaptor(_OuterAlloc, _InnerAllocs...) -> scoped_allocator_adaptor<_OuterAlloc, _InnerAllocs...>;
-#  endif
+#    endif
 
 template <class _OuterA1, class _OuterA2>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -540,7 +542,7 @@ operator==(const scoped_allocator_adaptor<_OuterA1, _InnerA0, _InnerAllocs...>& 
   return __a.outer_allocator() == __b.outer_allocator() && __a.inner_allocator() == __b.inner_allocator();
 }
 
-#  if _LIBCPP_STD_VER <= 17
+#    if _LIBCPP_STD_VER <= 17
 
 template <class _OuterA1, class _OuterA2, class... _InnerAllocs>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const scoped_allocator_adaptor<_OuterA1, _InnerAllocs...>& __a,
@@ -548,26 +550,27 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const scoped_allocator_adaptor<_Out
   return !(__a == __b);
 }
 
-#  endif // _LIBCPP_STD_VER <= 17
+#    endif // _LIBCPP_STD_VER <= 17
 
-#endif // !defined(_LIBCPP_CXX03_LANG)
+#  endif // !defined(_LIBCPP_CXX03_LANG)
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <climits>
-#  include <concepts>
-#  include <cstring>
-#  include <ctime>
-#  include <iterator>
-#  include <memory>
-#  include <ratio>
-#  include <stdexcept>
-#  include <type_traits>
-#  include <variant>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <climits>
+#    include <concepts>
+#    include <cstring>
+#    include <ctime>
+#    include <iterator>
+#    include <memory>
+#    include <ratio>
+#    include <stdexcept>
+#    include <type_traits>
+#    include <variant>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SCOPED_ALLOCATOR

--- a/libcxx/include/semaphore
+++ b/libcxx/include/semaphore
@@ -45,30 +45,32 @@ using binary_semaphore = counting_semaphore<1>; // since C++20
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  include <__assert>
-#  include <__atomic/atomic.h>
-#  include <__atomic/atomic_sync.h>
-#  include <__atomic/memory_order.h>
-#  include <__chrono/time_point.h>
-#  include <__cstddef/ptrdiff_t.h>
-#  include <__thread/poll_with_backoff.h>
-#  include <__thread/support.h>
-#  include <__thread/timed_backoff_policy.h>
-#  include <limits>
-#  include <version>
+#    include <__assert>
+#    include <__atomic/atomic.h>
+#    include <__atomic/atomic_sync.h>
+#    include <__atomic/memory_order.h>
+#    include <__chrono/time_point.h>
+#    include <__cstddef/ptrdiff_t.h>
+#    include <__thread/poll_with_backoff.h>
+#    include <__thread/support.h>
+#    include <__thread/timed_backoff_policy.h>
+#    include <limits>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -80,7 +82,7 @@ functions. It avoids contention against users' own use of those facilities.
 
 */
 
-#    define _LIBCPP_SEMAPHORE_MAX (numeric_limits<ptrdiff_t>::max())
+#      define _LIBCPP_SEMAPHORE_MAX (numeric_limits<ptrdiff_t>::max())
 
 class __atomic_semaphore_base {
   atomic<ptrdiff_t> __a_;
@@ -174,15 +176,16 @@ using binary_semaphore = counting_semaphore<1>;
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_THREADS
+#  endif // _LIBCPP_HAS_THREADS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <atomic>
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <atomic>
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SEMAPHORE

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -512,57 +512,59 @@ erase_if(multiset<Key, Compare, Allocator>& c, Predicate pred);  // C++20
 
 */
 
-#include <__algorithm/equal.h>
-#include <__algorithm/lexicographical_compare.h>
-#include <__algorithm/lexicographical_compare_three_way.h>
-#include <__assert>
-#include <__config>
-#include <__functional/is_transparent.h>
-#include <__functional/operations.h>
-#include <__iterator/erase_if_container.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/ranges_iterator_traits.h>
-#include <__iterator/reverse_iterator.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__node_handle>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__tree>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/pair.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/equal.h>
+#  include <__algorithm/lexicographical_compare.h>
+#  include <__algorithm/lexicographical_compare_three_way.h>
+#  include <__assert>
+#  include <__config>
+#  include <__functional/is_transparent.h>
+#  include <__functional/operations.h>
+#  include <__iterator/erase_if_container.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/ranges_iterator_traits.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__node_handle>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__tree>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/pair.h>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [associative.set.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -602,10 +604,10 @@ public:
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __set_node_handle<typename __base::__node, allocator_type> node_type;
   typedef __insert_return_type<iterator, node_type> insert_return_type;
-#endif
+#  endif
 
   template <class _Key2, class _Compare2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS set;
@@ -635,7 +637,7 @@ public:
     insert(__f, __l);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI
   set(from_range_t,
@@ -645,19 +647,19 @@ public:
       : __tree_(__comp, __a) {
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI set(_InputIterator __f, _InputIterator __l, const allocator_type& __a)
       : set(__f, __l, key_compare(), __a) {}
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI set(from_range_t, _Range&& __range, const allocator_type& __a)
       : set(from_range, std::forward<_Range>(__range), key_compare(), __a) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI set(const set& __s) : __tree_(__s.__tree_) { insert(__s.begin(), __s.end()); }
 
@@ -666,10 +668,10 @@ public:
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI set(set&& __s) noexcept(is_nothrow_move_constructible<__base>::value)
       : __tree_(std::move(__s.__tree_)) {}
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI explicit set(const allocator_type& __a) : __tree_(__a) {}
 
@@ -677,7 +679,7 @@ public:
     insert(__s.begin(), __s.end());
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI set(set&& __s, const allocator_type& __a);
 
   _LIBCPP_HIDE_FROM_ABI set(initializer_list<value_type> __il, const value_compare& __comp = value_compare())
@@ -690,10 +692,10 @@ public:
     insert(__il.begin(), __il.end());
   }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI set(initializer_list<value_type> __il, const allocator_type& __a)
       : set(__il, key_compare(), __a) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI set& operator=(initializer_list<value_type> __il) {
     __tree_.__assign_unique(__il.begin(), __il.end());
@@ -704,7 +706,7 @@ public:
     __tree_ = std::move(__s.__tree_);
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI ~set() { static_assert(sizeof(__diagnose_non_const_comparator<_Key, _Compare>()), ""); }
 
@@ -728,7 +730,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT { return __tree_.max_size(); }
 
   // modifiers:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> emplace(_Args&&... __args) {
     return __tree_.__emplace_unique(std::forward<_Args>(__args)...);
@@ -737,7 +739,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator emplace_hint(const_iterator __p, _Args&&... __args) {
     return __tree_.__emplace_hint_unique(__p, std::forward<_Args>(__args)...);
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(const value_type& __v) { return __tree_.__insert_unique(__v); }
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, const value_type& __v) {
@@ -750,7 +752,7 @@ public:
       __tree_.__insert_unique(__e, *__f);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     const_iterator __end = cend();
@@ -758,9 +760,9 @@ public:
       __tree_.__insert_unique(__end, std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(value_type&& __v) {
     return __tree_.__insert_unique(std::move(__v));
   }
@@ -770,14 +772,14 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __tree_.erase(__p); }
   _LIBCPP_HIDE_FROM_ABI size_type erase(const key_type& __k) { return __tree_.__erase_unique(__k); }
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __f, const_iterator __l) { return __tree_.erase(__f, __l); }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __tree_.clear(); }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI insert_return_type insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to set::insert()");
@@ -818,7 +820,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     __tree_.__node_handle_merge_unique(__source.__tree_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(set& __s) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) { __tree_.swap(__s.__tree_); }
 
@@ -829,7 +831,7 @@ public:
   // set operations:
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
@@ -838,27 +840,27 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __tree_.__count_unique(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const key_type& __k) { return __tree_.lower_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const key_type& __k) const { return __tree_.lower_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.lower_bound(__k);
@@ -868,11 +870,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.lower_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const key_type& __k) { return __tree_.upper_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const key_type& __k) const { return __tree_.upper_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.upper_bound(__k);
@@ -881,7 +883,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.upper_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __tree_.__equal_range_unique(__k);
@@ -889,7 +891,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __tree_.__equal_range_unique(__k);
   }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
@@ -898,10 +900,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
-#endif
+#  endif
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Compare   = less<__iter_value_type<_InputIterator>>,
           class _Allocator = allocator<__iter_value_type<_InputIterator>>,
@@ -911,7 +913,7 @@ template <class _InputIterator,
 set(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
     -> set<__iter_value_type<_InputIterator>, _Compare, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Compare   = less<ranges::range_value_t<_Range>>,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
@@ -919,7 +921,7 @@ template <ranges::input_range _Range,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>>
 set(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
     -> set<ranges::range_value_t<_Range>, _Compare, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key,
           class _Compare   = less<_Key>,
@@ -936,18 +938,18 @@ set(_InputIterator,
     _InputIterator,
     _Allocator) -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 set(from_range_t,
     _Range&&,
     _Allocator) -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 set(initializer_list<_Key>, _Allocator) -> set<_Key, less<_Key>, _Allocator>;
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Compare, class _Allocator>
 set<_Key, _Compare, _Allocator>::set(set&& __s, const allocator_type& __a) : __tree_(std::move(__s.__tree_), __a) {
@@ -958,7 +960,7 @@ set<_Key, _Compare, _Allocator>::set(set&& __s, const allocator_type& __a) : __t
   }
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -966,7 +968,7 @@ operator==(const set<_Key, _Compare, _Allocator>& __x, const set<_Key, _Compare,
   return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -998,7 +1000,7 @@ operator<=(const set<_Key, _Compare, _Allocator>& __x, const set<_Key, _Compare,
   return !(__y < __x);
 }
 
-#else // _LIBCPP_STD_VER <= 17
+#  else // _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Key>
@@ -1006,7 +1008,7 @@ operator<=>(const set<_Key, _Allocator>& __x, const set<_Key, _Allocator>& __y) 
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
-#endif // _LIBCPP_STD_VER <= 17
+#  endif // _LIBCPP_STD_VER <= 17
 
 // specialized algorithms:
 template <class _Key, class _Compare, class _Allocator>
@@ -1015,13 +1017,13 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(set<_Key, _Compare, _Allocator>& __x, set
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Key, class _Compare, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename set<_Key, _Compare, _Allocator>::size_type
 erase_if(set<_Key, _Compare, _Allocator>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Key, class _Compare, class _Allocator>
 struct __container_traits<set<_Key, _Compare, _Allocator> > {
@@ -1064,9 +1066,9 @@ public:
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __set_node_handle<typename __base::__node, allocator_type> node_type;
-#endif
+#  endif
 
   template <class _Key2, class _Compare2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS set;
@@ -1091,11 +1093,11 @@ public:
     insert(__f, __l);
   }
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI multiset(_InputIterator __f, _InputIterator __l, const allocator_type& __a)
       : multiset(__f, __l, key_compare(), __a) {}
-#endif
+#  endif
 
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI
@@ -1104,7 +1106,7 @@ public:
     insert(__f, __l);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI
   multiset(from_range_t,
@@ -1118,7 +1120,7 @@ public:
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI multiset(from_range_t, _Range&& __range, const allocator_type& __a)
       : multiset(from_range, std::forward<_Range>(__range), key_compare(), __a) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI multiset(const multiset& __s)
       : __tree_(__s.__tree_.value_comp(),
@@ -1131,19 +1133,19 @@ public:
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI multiset(multiset&& __s) noexcept(is_nothrow_move_constructible<__base>::value)
       : __tree_(std::move(__s.__tree_)) {}
 
   _LIBCPP_HIDE_FROM_ABI multiset(multiset&& __s, const allocator_type& __a);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI explicit multiset(const allocator_type& __a) : __tree_(__a) {}
   _LIBCPP_HIDE_FROM_ABI multiset(const multiset& __s, const allocator_type& __a)
       : __tree_(__s.__tree_.value_comp(), __a) {
     insert(__s.begin(), __s.end());
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI multiset(initializer_list<value_type> __il, const value_compare& __comp = value_compare())
       : __tree_(__comp) {
     insert(__il.begin(), __il.end());
@@ -1155,10 +1157,10 @@ public:
     insert(__il.begin(), __il.end());
   }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI multiset(initializer_list<value_type> __il, const allocator_type& __a)
       : multiset(__il, key_compare(), __a) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI multiset& operator=(initializer_list<value_type> __il) {
     __tree_.__assign_multi(__il.begin(), __il.end());
@@ -1169,7 +1171,7 @@ public:
     __tree_ = std::move(__s.__tree_);
     return *this;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI ~multiset() { static_assert(sizeof(__diagnose_non_const_comparator<_Key, _Compare>()), ""); }
 
@@ -1193,7 +1195,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI size_type max_size() const _NOEXCEPT { return __tree_.max_size(); }
 
   // modifiers:
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator emplace(_Args&&... __args) {
     return __tree_.__emplace_multi(std::forward<_Args>(__args)...);
@@ -1202,7 +1204,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator emplace_hint(const_iterator __p, _Args&&... __args) {
     return __tree_.__emplace_hint_multi(__p, std::forward<_Args>(__args)...);
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const value_type& __v) { return __tree_.__insert_multi(__v); }
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, const value_type& __v) {
@@ -1215,7 +1217,7 @@ public:
       __tree_.__insert_multi(__e, *__f);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     const_iterator __end = cend();
@@ -1223,9 +1225,9 @@ public:
       __tree_.__insert_multi(__end, std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI iterator insert(value_type&& __v) { return __tree_.__insert_multi(std::move(__v)); }
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator __p, value_type&& __v) {
@@ -1233,14 +1235,14 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __tree_.erase(__p); }
   _LIBCPP_HIDE_FROM_ABI size_type erase(const key_type& __k) { return __tree_.__erase_multi(__k); }
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __f, const_iterator __l) { return __tree_.erase(__f, __l); }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __tree_.clear(); }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI iterator insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to multiset::insert()");
@@ -1281,7 +1283,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     __tree_.__node_handle_merge_multi(__source.__tree_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(multiset& __s) _NOEXCEPT_(__is_nothrow_swappable_v<__base>) {
     __tree_.swap(__s.__tree_);
@@ -1294,7 +1296,7 @@ public:
   // set operations:
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __tree_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __tree_.find(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __tree_.find(__k);
@@ -1303,27 +1305,27 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __tree_.find(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __tree_.__count_multi(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __tree_.__count_multi(__k);
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const key_type& __k) { return __tree_.lower_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const key_type& __k) const { return __tree_.lower_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator lower_bound(const _K2& __k) {
     return __tree_.lower_bound(__k);
@@ -1333,11 +1335,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator lower_bound(const _K2& __k) const {
     return __tree_.lower_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const key_type& __k) { return __tree_.upper_bound(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const key_type& __k) const { return __tree_.upper_bound(__k); }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI iterator upper_bound(const _K2& __k) {
     return __tree_.upper_bound(__k);
@@ -1346,7 +1348,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator upper_bound(const _K2& __k) const {
     return __tree_.upper_bound(__k);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __tree_.__equal_range_multi(__k);
@@ -1354,7 +1356,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <typename _K2, enable_if_t<__is_transparent_v<_Compare, _K2>, int> = 0>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __tree_.__equal_range_multi(__k);
@@ -1363,10 +1365,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __tree_.__equal_range_multi(__k);
   }
-#endif
+#  endif
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Compare   = less<__iter_value_type<_InputIterator>>,
           class _Allocator = allocator<__iter_value_type<_InputIterator>>,
@@ -1376,7 +1378,7 @@ template <class _InputIterator,
 multiset(_InputIterator, _InputIterator, _Compare = _Compare(), _Allocator = _Allocator())
     -> multiset<__iter_value_type<_InputIterator>, _Compare, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Compare   = less<ranges::range_value_t<_Range>>,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
@@ -1384,7 +1386,7 @@ template <ranges::input_range _Range,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>>
 multiset(from_range_t, _Range&&, _Compare = _Compare(), _Allocator = _Allocator())
     -> multiset<ranges::range_value_t<_Range>, _Compare, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key,
           class _Compare   = less<_Key>,
@@ -1402,18 +1404,18 @@ template <class _InputIterator,
 multiset(_InputIterator, _InputIterator, _Allocator)
     -> multiset<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 multiset(from_range_t,
          _Range&&,
          _Allocator) -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
 multiset(initializer_list<_Key>, _Allocator) -> multiset<_Key, less<_Key>, _Allocator>;
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Compare, class _Allocator>
 multiset<_Key, _Compare, _Allocator>::multiset(multiset&& __s, const allocator_type& __a)
@@ -1425,7 +1427,7 @@ multiset<_Key, _Compare, _Allocator>::multiset(multiset&& __s, const allocator_t
   }
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -1433,7 +1435,7 @@ operator==(const multiset<_Key, _Compare, _Allocator>& __x, const multiset<_Key,
   return __x.size() == __y.size() && std::equal(__x.begin(), __x.end(), __y.begin());
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -1465,7 +1467,7 @@ operator<=(const multiset<_Key, _Compare, _Allocator>& __x, const multiset<_Key,
   return !(__y < __x);
 }
 
-#else // _LIBCPP_STD_VER <= 17
+#  else // _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Key>
@@ -1473,7 +1475,7 @@ operator<=>(const multiset<_Key, _Allocator>& __x, const multiset<_Key, _Allocat
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), __synth_three_way);
 }
 
-#endif // _LIBCPP_STD_VER <= 17
+#  endif // _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Compare, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void
@@ -1482,13 +1484,13 @@ swap(multiset<_Key, _Compare, _Allocator>& __x, multiset<_Key, _Compare, _Alloca
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Key, class _Compare, class _Allocator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename multiset<_Key, _Compare, _Allocator>::size_type
 erase_if(multiset<_Key, _Compare, _Allocator>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Key, class _Compare, class _Allocator>
 struct __container_traits<multiset<_Key, _Compare, _Allocator> > {
@@ -1500,7 +1502,7 @@ struct __container_traits<multiset<_Key, _Compare, _Allocator> > {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _KeyT, class _CompareT = std::less<_KeyT>>
@@ -1510,17 +1512,18 @@ template <class _KeyT, class _CompareT = std::less<_KeyT>>
 using multiset _LIBCPP_AVAILABILITY_PMR = std::multiset<_KeyT, _CompareT, polymorphic_allocator<_KeyT>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <cstdlib>
-#  include <functional>
-#  include <iterator>
-#  include <stdexcept>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <cstdlib>
+#    include <functional>
+#    include <iterator>
+#    include <stdexcept>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SET

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -122,31 +122,33 @@ template <class Mutex>
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  include <__chrono/duration.h>
-#  include <__chrono/steady_clock.h>
-#  include <__chrono/time_point.h>
-#  include <__condition_variable/condition_variable.h>
-#  include <__memory/addressof.h>
-#  include <__mutex/mutex.h>
-#  include <__mutex/tag_types.h>
-#  include <__mutex/unique_lock.h>
-#  include <__system_error/throw_system_error.h>
-#  include <__utility/swap.h>
-#  include <cerrno>
-#  include <version>
+#    include <__chrono/duration.h>
+#    include <__chrono/steady_clock.h>
+#    include <__chrono/time_point.h>
+#    include <__condition_variable/condition_variable.h>
+#    include <__memory/addressof.h>
+#    include <__mutex/mutex.h>
+#    include <__mutex/tag_types.h>
+#    include <__mutex/unique_lock.h>
+#    include <__system_error/throw_system_error.h>
+#    include <__utility/swap.h>
+#    include <cerrno>
+#    include <version>
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
 
-#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#      pragma GCC system_header
-#    endif
+#      if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#        pragma GCC system_header
+#      endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -179,7 +181,7 @@ struct _LIBCPP_EXPORTED_FROM_ABI __shared_mutex_base {
   //     native_handle_type native_handle(); // See 30.2.3
 };
 
-#    if _LIBCPP_STD_VER >= 17
+#      if _LIBCPP_STD_VER >= 17
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_mutex")) shared_mutex {
   __shared_mutex_base __base_;
 
@@ -216,7 +218,7 @@ public:
   //     typedef __shared_mutex_base::native_handle_type native_handle_type;
   //     _LIBCPP_HIDE_FROM_ABI native_handle_type native_handle() { return __base::unlock_shared(); }
 };
-#    endif
+#      endif
 
 class _LIBCPP_EXPORTED_FROM_ABI
 _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex")) shared_timed_mutex {
@@ -451,14 +453,15 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(shared_lock<_Mutex>& __x, shared_lock<_Mu
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  endif // _LIBCPP_STD_VER >= 14
+#    endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_THREADS
+#  endif // _LIBCPP_HAS_THREADS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <system_error>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <system_error>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SHARED_MUTEX

--- a/libcxx/include/source_location
+++ b/libcxx/include/source_location
@@ -25,17 +25,19 @@ namespace std {
 }
 */
 
-#include <__config>
-#include <cstdint>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <cstdint>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 class source_location {
   // The names source_location::__impl, _M_file_name, _M_function_name, _M_line, and _M_column
@@ -78,8 +80,10 @@ public:
   }
 };
 
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // 0
 
 #endif // _LIBCPP_SOURCE_LOCATION

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -144,60 +144,62 @@ template<class R>
 
 */
 
-#include <__assert>
-#include <__concepts/convertible_to.h>
-#include <__concepts/equality_comparable.h>
-#include <__config>
-#include <__cstddef/byte.h>
-#include <__cstddef/ptrdiff_t.h>
-#include <__fwd/array.h>
-#include <__fwd/span.h>
-#include <__iterator/bounded_iter.h>
-#include <__iterator/concepts.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/reverse_iterator.h>
-#include <__iterator/wrap_iter.h>
-#include <__memory/pointer_traits.h>
-#include <__ranges/concepts.h>
-#include <__ranges/data.h>
-#include <__ranges/enable_borrowed_range.h>
-#include <__ranges/enable_view.h>
-#include <__ranges/size.h>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_const.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_integral.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/remove_const.h>
-#include <__type_traits/remove_cv.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <initializer_list>
-#include <stdexcept>
-#include <version>
+#if 0
+#else // 0
+#  include <__assert>
+#  include <__concepts/convertible_to.h>
+#  include <__concepts/equality_comparable.h>
+#  include <__config>
+#  include <__cstddef/byte.h>
+#  include <__cstddef/ptrdiff_t.h>
+#  include <__fwd/array.h>
+#  include <__fwd/span.h>
+#  include <__iterator/bounded_iter.h>
+#  include <__iterator/concepts.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__iterator/wrap_iter.h>
+#  include <__memory/pointer_traits.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/data.h>
+#  include <__ranges/enable_borrowed_range.h>
+#  include <__ranges/enable_view.h>
+#  include <__ranges/size.h>
+#  include <__type_traits/integral_constant.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_const.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_integral.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/remove_const.h>
+#  include <__type_traits/remove_cv.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <initializer_list>
+#  include <stdexcept>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
 struct __is_std_span : false_type {};
@@ -237,11 +239,11 @@ public:
   using const_pointer   = const _Tp*;
   using reference       = _Tp&;
   using const_reference = const _Tp&;
-#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#    ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
   using iterator = __bounded_iter<pointer>;
-#  else
+#    else
   using iterator = __wrap_iter<pointer>;
-#  endif
+#    endif
   using reverse_iterator = std::reverse_iterator<iterator>;
 
   static constexpr size_type extent = _Extent;
@@ -251,14 +253,14 @@ public:
     requires(_Sz == 0)
   _LIBCPP_HIDE_FROM_ABI constexpr span() noexcept : __data_{nullptr} {}
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI constexpr explicit span(std::initializer_list<value_type> __il)
     requires is_const_v<element_type>
       : __data_{__il.begin()} {
     _LIBCPP_ASSERT_VALID_INPUT_RANGE(
         _Extent == __il.size(), "Size mismatch in span's constructor _Extent != __il.size().");
   }
-#  endif
+#    endif
 
   constexpr span(const span&) noexcept            = default;
   constexpr span& operator=(const span&) noexcept = default;
@@ -356,13 +358,13 @@ public:
     return __data_[__idx];
   }
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI constexpr reference at(size_type __index) const {
     if (__index >= size())
       std::__throw_out_of_range("span");
     return __data_[__index];
   }
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI constexpr reference front() const noexcept {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "span<T, N>::front() on empty span");
@@ -378,18 +380,18 @@ public:
 
   // [span.iter], span iterator support
   _LIBCPP_HIDE_FROM_ABI constexpr iterator begin() const noexcept {
-#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#    ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data(), data(), data() + size());
-#  else
+#    else
     return iterator(data());
-#  endif
+#    endif
   }
   _LIBCPP_HIDE_FROM_ABI constexpr iterator end() const noexcept {
-#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#    ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data() + size(), data(), data() + size());
-#  else
+#    else
     return iterator(data() + size());
-#  endif
+#    endif
   }
   _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator rbegin() const noexcept { return reverse_iterator(end()); }
   _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator rend() const noexcept { return reverse_iterator(begin()); }
@@ -418,11 +420,11 @@ public:
   using const_pointer   = const _Tp*;
   using reference       = _Tp&;
   using const_reference = const _Tp&;
-#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#    ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
   using iterator = __bounded_iter<pointer>;
-#  else
+#    else
   using iterator = __wrap_iter<pointer>;
-#  endif
+#    endif
   using reverse_iterator = std::reverse_iterator<iterator>;
 
   static constexpr size_type extent = dynamic_extent;
@@ -430,11 +432,11 @@ public:
   // [span.cons], span constructors, copy, assignment, and destructor
   _LIBCPP_HIDE_FROM_ABI constexpr span() noexcept : __data_{nullptr}, __size_{0} {}
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI constexpr span(std::initializer_list<value_type> __il)
     requires is_const_v<element_type>
       : __data_{__il.begin()}, __size_{__il.size()} {}
-#  endif
+#    endif
 
   constexpr span(const span&) noexcept            = default;
   constexpr span& operator=(const span&) noexcept = default;
@@ -518,13 +520,13 @@ public:
     return __data_[__idx];
   }
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   _LIBCPP_HIDE_FROM_ABI constexpr reference at(size_type __index) const {
     if (__index >= size())
       std::__throw_out_of_range("span");
     return __data_[__index];
   }
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI constexpr reference front() const noexcept {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(!empty(), "span<T>::front() on empty span");
@@ -540,18 +542,18 @@ public:
 
   // [span.iter], span iterator support
   _LIBCPP_HIDE_FROM_ABI constexpr iterator begin() const noexcept {
-#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#    ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data(), data(), data() + size());
-#  else
+#    else
     return iterator(data());
-#  endif
+#    endif
   }
   _LIBCPP_HIDE_FROM_ABI constexpr iterator end() const noexcept {
-#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#    ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data() + size(), data(), data() + size());
-#  else
+#    else
     return iterator(data() + size());
-#  endif
+#    endif
   }
   _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator rbegin() const noexcept { return reverse_iterator(end()); }
   _LIBCPP_HIDE_FROM_ABI constexpr reverse_iterator rend() const noexcept { return reverse_iterator(begin()); }
@@ -587,7 +589,7 @@ _LIBCPP_HIDE_FROM_ABI auto as_writable_bytes(span<_Tp, _Extent> __s) noexcept {
   return __s.__as_writable_bytes();
 }
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
 template <class _Tp>
 concept __integral_constant_like =
     is_integral_v<decltype(_Tp::value)> && !is_same_v<bool, remove_const_t<decltype(_Tp::value)>> &&
@@ -603,10 +605,10 @@ inline constexpr size_t __maybe_static_ext<_Tp> = {_Tp::value};
 
 template <contiguous_iterator _It, class _EndOrSize>
 span(_It, _EndOrSize) -> span<remove_reference_t<iter_reference_t<_It>>, __maybe_static_ext<_EndOrSize>>;
-#  else
+#    else
 template <contiguous_iterator _It, class _EndOrSize>
 span(_It, _EndOrSize) -> span<remove_reference_t<iter_reference_t<_It>>>;
-#  endif
+#    endif
 
 template <class _Tp, size_t _Sz>
 span(_Tp (&)[_Sz]) -> span<_Tp, _Sz>;
@@ -620,18 +622,19 @@ span(const array<_Tp, _Sz>&) -> span<const _Tp, _Sz>;
 template <ranges::contiguous_range _Range>
 span(_Range&&) -> span<remove_reference_t<ranges::range_reference_t<_Range>>>;
 
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <array>
-#  include <concepts>
-#  include <functional>
-#  include <iterator>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <array>
+#    include <concepts>
+#    include <functional>
+#    include <iterator>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SPAN

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -312,27 +312,29 @@ typedef basic_stringstream<wchar_t> wstringstream;
 
 // clang-format on
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__fwd/sstream.h>
-#  include <__ostream/basic_ostream.h>
-#  include <__type_traits/is_convertible.h>
-#  include <__utility/swap.h>
-#  include <ios>
-#  include <istream>
-#  include <locale>
-#  include <string>
-#  include <string_view>
-#  include <version>
+#    include <__fwd/sstream.h>
+#    include <__ostream/basic_ostream.h>
+#    include <__type_traits/is_convertible.h>
+#    include <__utility/swap.h>
+#    include <ios>
+#    include <istream>
+#    include <locale>
+#    include <string>
+#    include <string_view>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -375,7 +377,7 @@ public:
     str(__s);
   }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI explicit basic_stringbuf(const allocator_type& __a)
       : basic_stringbuf(ios_base::in | ios_base::out, __a) {}
 
@@ -409,9 +411,9 @@ public:
       : __str_(__s), __hm_(nullptr), __mode_(__wch) {
     __init_buf_ptrs();
   }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
 
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
@@ -433,37 +435,37 @@ public:
     __init_buf_ptrs();
   }
 
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 
   basic_stringbuf(const basic_stringbuf&) = delete;
   basic_stringbuf(basic_stringbuf&& __rhs) : __mode_(__rhs.__mode_) { __move_init(std::move(__rhs)); }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI basic_stringbuf(basic_stringbuf&& __rhs, const allocator_type& __a)
       : basic_stringbuf(__rhs.__mode_, __a) {
     __move_init(std::move(__rhs));
   }
-#  endif
+#    endif
 
   // [stringbuf.assign] Assign and swap:
   basic_stringbuf& operator=(const basic_stringbuf&) = delete;
   basic_stringbuf& operator=(basic_stringbuf&& __rhs);
   void swap(basic_stringbuf& __rhs)
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
       noexcept(allocator_traits<allocator_type>::propagate_on_container_swap::value ||
                allocator_traits<allocator_type>::is_always_equal::value)
-#  endif
+#    endif
           ;
 
   // [stringbuf.members] Member functions:
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const noexcept { return __str_.get_allocator(); }
-#  endif
+#    endif
 
-#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
   string_type str() const;
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI string_type str() const& { return str(__str_.get_allocator()); }
 
   _LIBCPP_HIDE_FROM_ABI string_type str() && {
@@ -477,9 +479,9 @@ public:
     __init_buf_ptrs();
     return __result;
   }
-#  endif // _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    endif // _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
     requires __is_allocator<_SAlloc>::value
   _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
@@ -487,14 +489,14 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI basic_string_view<char_type, traits_type> view() const noexcept;
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
   void str(const string_type& __s) {
     __str_ = __s;
     __init_buf_ptrs();
   }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
     requires(!is_same_v<_SAlloc, allocator_type>)
   _LIBCPP_HIDE_FROM_ABI void str(const basic_string<char_type, traits_type, _SAlloc>& __s) {
@@ -506,9 +508,9 @@ public:
     __str_ = std::move(__s);
     __init_buf_ptrs();
   }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
 
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
@@ -518,7 +520,7 @@ public:
     __init_buf_ptrs();
   }
 
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 
 protected:
   // [stringbuf.virtuals] Overridden virtual functions:
@@ -614,10 +616,10 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::operator=(basic_stringbuf&& __rhs)
 
 template <class _CharT, class _Traits, class _Allocator>
 void basic_stringbuf<_CharT, _Traits, _Allocator>::swap(basic_stringbuf& __rhs)
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
     noexcept(allocator_traits<_Allocator>::propagate_on_container_swap::value ||
              allocator_traits<_Allocator>::is_always_equal::value)
-#  endif
+#    endif
 {
   char_type* __p    = const_cast<char_type*>(__rhs.__str_.data());
   ptrdiff_t __rbinp = -1;
@@ -687,14 +689,14 @@ void basic_stringbuf<_CharT, _Traits, _Allocator>::swap(basic_stringbuf& __rhs)
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void
 swap(basic_stringbuf<_CharT, _Traits, _Allocator>& __x, basic_stringbuf<_CharT, _Traits, _Allocator>& __y)
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
     noexcept(noexcept(__x.swap(__y)))
-#  endif
+#    endif
 {
   __x.swap(__y);
 }
 
-#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
 template <class _CharT, class _Traits, class _Allocator>
 basic_string<_CharT, _Traits, _Allocator> basic_stringbuf<_CharT, _Traits, _Allocator>::str() const {
   if (__mode_ & ios_base::out) {
@@ -705,7 +707,7 @@ basic_string<_CharT, _Traits, _Allocator> basic_stringbuf<_CharT, _Traits, _Allo
     return string_type(this->eback(), this->egptr(), __str_.get_allocator());
   return string_type(__str_.get_allocator());
 }
-#  endif // _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    endif // _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI void basic_stringbuf<_CharT, _Traits, _Allocator>::__init_buf_ptrs() {
@@ -731,7 +733,7 @@ _LIBCPP_HIDE_FROM_ABI void basic_stringbuf<_CharT, _Traits, _Allocator>::__init_
   }
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI basic_string_view<_CharT, _Traits>
 basic_stringbuf<_CharT, _Traits, _Allocator>::view() const noexcept {
@@ -743,7 +745,7 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::view() const noexcept {
     return basic_string_view<_CharT, _Traits>(this->eback(), this->egptr());
   return basic_string_view<_CharT, _Traits>();
 }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits, class _Allocator>
 typename basic_stringbuf<_CharT, _Traits, _Allocator>::int_type
@@ -786,9 +788,9 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::overflow(int_type __c) {
     if (this->pptr() == this->epptr()) {
       if (!(__mode_ & ios_base::out))
         return traits_type::eof();
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
         ptrdiff_t __nout = this->pptr() - this->pbase();
         ptrdiff_t __hm   = __hm_ - this->pbase();
         __str_.push_back(char_type());
@@ -797,11 +799,11 @@ basic_stringbuf<_CharT, _Traits, _Allocator>::overflow(int_type __c) {
         this->setp(__p, __p + __str_.size());
         this->__pbump(__nout);
         __hm_ = this->pbase() + __hm;
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       } catch (...) {
         return traits_type::eof();
       }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
     }
     __hm_ = std::max(this->pptr() + 1, __hm_);
     if (__mode_ & ios_base::in) {
@@ -886,7 +888,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit basic_istringstream(const string_type& __s, ios_base::openmode __wch = ios_base::in)
       : basic_istream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__s, __wch | ios_base::in) {}
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI basic_istringstream(ios_base::openmode __wch, const _Allocator& __a)
       : basic_istream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__wch | ios_base::in, __a) {}
 
@@ -906,9 +908,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit basic_istringstream(const basic_string<_CharT, _Traits, _SAlloc>& __s,
                                                      ios_base::openmode __wch = ios_base::in)
       : basic_istream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__s, __wch | ios_base::in) {}
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
 
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
@@ -925,7 +927,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI basic_istringstream(const _Tp& __t, ios_base::openmode __which, const _Allocator& __a)
       : basic_istream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__t, __which | ios_base::in, __a) {}
 
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 
   basic_istringstream(const basic_istringstream&) = delete;
   _LIBCPP_HIDE_FROM_ABI basic_istringstream(basic_istringstream&& __rhs)
@@ -950,15 +952,15 @@ public:
     return const_cast<basic_stringbuf<char_type, traits_type, allocator_type>*>(std::addressof(__sb_));
   }
 
-#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
   _LIBCPP_HIDE_FROM_ABI string_type str() const { return __sb_.str(); }
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI string_type str() const& { return __sb_.str(); }
 
   _LIBCPP_HIDE_FROM_ABI string_type str() && { return std::move(__sb_).str(); }
-#  endif
+#    endif
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
     requires __is_allocator<_SAlloc>::value
   _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
@@ -966,26 +968,26 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI basic_string_view<char_type, traits_type> view() const noexcept { return __sb_.view(); }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI void str(const string_type& __s) { __sb_.str(__s); }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
   _LIBCPP_HIDE_FROM_ABI void str(const basic_string<char_type, traits_type, _SAlloc>& __s) {
     __sb_.str(__s);
   }
 
   _LIBCPP_HIDE_FROM_ABI void str(string_type&& __s) { __sb_.str(std::move(__s)); }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
   _LIBCPP_HIDE_FROM_ABI void str(const _Tp& __t) {
     rdbuf()->str(__t);
   }
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 };
 
 template <class _CharT, class _Traits, class _Allocator>
@@ -1022,7 +1024,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit basic_ostringstream(const string_type& __s, ios_base::openmode __wch = ios_base::out)
       : basic_ostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__s, __wch | ios_base::out) {}
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI basic_ostringstream(ios_base::openmode __wch, const _Allocator& __a)
       : basic_ostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__wch | ios_base::out, __a) {}
 
@@ -1043,9 +1045,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit basic_ostringstream(const basic_string<_CharT, _Traits, _SAlloc>& __s,
                                                      ios_base::openmode __wch = ios_base::out)
       : basic_ostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__s, __wch | ios_base::out) {}
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
 
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
@@ -1062,7 +1064,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI basic_ostringstream(const _Tp& __t, ios_base::openmode __which, const _Allocator& __a)
       : basic_ostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__t, __which | ios_base::out, __a) {}
 
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 
   basic_ostringstream(const basic_ostringstream&) = delete;
   _LIBCPP_HIDE_FROM_ABI basic_ostringstream(basic_ostringstream&& __rhs)
@@ -1088,15 +1090,15 @@ public:
     return const_cast<basic_stringbuf<char_type, traits_type, allocator_type>*>(std::addressof(__sb_));
   }
 
-#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
   _LIBCPP_HIDE_FROM_ABI string_type str() const { return __sb_.str(); }
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI string_type str() const& { return __sb_.str(); }
 
   _LIBCPP_HIDE_FROM_ABI string_type str() && { return std::move(__sb_).str(); }
-#  endif
+#    endif
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
     requires __is_allocator<_SAlloc>::value
   _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
@@ -1104,26 +1106,26 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI basic_string_view<char_type, traits_type> view() const noexcept { return __sb_.view(); }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI void str(const string_type& __s) { __sb_.str(__s); }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
   _LIBCPP_HIDE_FROM_ABI void str(const basic_string<char_type, traits_type, _SAlloc>& __s) {
     __sb_.str(__s);
   }
 
   _LIBCPP_HIDE_FROM_ABI void str(string_type&& __s) { __sb_.str(std::move(__s)); }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
   _LIBCPP_HIDE_FROM_ABI void str(const _Tp& __t) {
     rdbuf()->str(__t);
   }
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 };
 
 template <class _CharT, class _Traits, class _Allocator>
@@ -1161,7 +1163,7 @@ public:
                                                     ios_base::openmode __wch = ios_base::in | ios_base::out)
       : basic_iostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__s, __wch) {}
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI basic_stringstream(ios_base::openmode __wch, const _Allocator& __a)
       : basic_iostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__wch, __a) {}
 
@@ -1183,9 +1185,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit basic_stringstream(const basic_string<_CharT, _Traits, _SAlloc>& __s,
                                                     ios_base::openmode __wch = ios_base::out | ios_base::in)
       : basic_iostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__s, __wch) {}
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
 
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
@@ -1203,7 +1205,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI basic_stringstream(const _Tp& __t, ios_base::openmode __which, const _Allocator& __a)
       : basic_iostream<_CharT, _Traits>(std::addressof(__sb_)), __sb_(__t, __which, __a) {}
 
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 
   basic_stringstream(const basic_stringstream&) = delete;
   _LIBCPP_HIDE_FROM_ABI basic_stringstream(basic_stringstream&& __rhs)
@@ -1228,15 +1230,15 @@ public:
     return const_cast<basic_stringbuf<char_type, traits_type, allocator_type>*>(std::addressof(__sb_));
   }
 
-#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_BUILDING_LIBRARY)
   _LIBCPP_HIDE_FROM_ABI string_type str() const { return __sb_.str(); }
-#  else
+#    else
   _LIBCPP_HIDE_FROM_ABI string_type str() const& { return __sb_.str(); }
 
   _LIBCPP_HIDE_FROM_ABI string_type str() && { return std::move(__sb_).str(); }
-#  endif
+#    endif
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
     requires __is_allocator<_SAlloc>::value
   _LIBCPP_HIDE_FROM_ABI basic_string<char_type, traits_type, _SAlloc> str(const _SAlloc& __sa) const {
@@ -1244,26 +1246,26 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI basic_string_view<char_type, traits_type> view() const noexcept { return __sb_.view(); }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI void str(const string_type& __s) { __sb_.str(__s); }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _SAlloc>
   _LIBCPP_HIDE_FROM_ABI void str(const basic_string<char_type, traits_type, _SAlloc>& __s) {
     __sb_.str(__s);
   }
 
   _LIBCPP_HIDE_FROM_ABI void str(string_type&& __s) { __sb_.str(std::move(__s)); }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
-#  if _LIBCPP_STD_VER >= 26
+#    if _LIBCPP_STD_VER >= 26
   template <class _Tp>
     requires is_convertible_v<const _Tp&, basic_string_view<_CharT, _Traits>>
   _LIBCPP_HIDE_FROM_ABI void str(const _Tp& __t) {
     rdbuf()->str(__t);
   }
-#  endif //  _LIBCPP_STD_VER >= 26
+#    endif //  _LIBCPP_STD_VER >= 26
 };
 
 template <class _CharT, class _Traits, class _Allocator>
@@ -1272,22 +1274,23 @@ swap(basic_stringstream<_CharT, _Traits, _Allocator>& __x, basic_stringstream<_C
   __x.swap(__y);
 }
 
-#  if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
+#    if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_stringbuf<char>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_stringstream<char>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ostringstream<char>;
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_istringstream<char>;
-#  endif
+#    endif
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if _LIBCPP_STD_VER <= 20 && !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
-#  include <ostream>
-#  include <type_traits>
-#endif
+#  if _LIBCPP_STD_VER <= 20 && !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES)
+#    include <ostream>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SSTREAM

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -113,33 +113,35 @@ template <class T, class Container>
 
 */
 
-#include <__algorithm/ranges_copy.h>
-#include <__config>
-#include <__fwd/stack.h>
-#include <__iterator/back_insert_iterator.h>
-#include <__iterator/iterator_traits.h>
-#include <__memory/uses_allocator.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__type_traits/is_same.h>
-#include <__utility/forward.h>
-#include <deque>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/ranges_copy.h>
+#  include <__config>
+#  include <__fwd/stack.h>
+#  include <__iterator/back_insert_iterator.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__memory/uses_allocator.h>
+#  include <__ranges/access.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__type_traits/is_same.h>
+#  include <__utility/forward.h>
+#  include <deque>
+#  include <version>
 
 // standard-mandated includes
 
 // [stack.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -172,7 +174,7 @@ public:
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI stack(stack&& __q) noexcept(is_nothrow_move_constructible<container_type>::value)
       : c(std::move(__q.c)) {}
 
@@ -182,7 +184,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI explicit stack(container_type&& __c) : c(std::move(__c)) {}
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI explicit stack(const container_type& __c) : c(__c) {}
 
@@ -198,7 +200,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   stack(const stack& __s, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
       : c(__s.c, __a) {}
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class _Alloc>
   _LIBCPP_HIDE_FROM_ABI
   stack(container_type&& __c, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
@@ -207,9 +209,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   stack(stack&& __s, const _Alloc& __a, __enable_if_t<uses_allocator<container_type, _Alloc>::value>* = 0)
       : c(std::move(__s.c), __a) {}
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI stack(_InputIterator __first, _InputIterator __last) : c(__first, __last) {}
 
@@ -229,7 +231,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI stack(from_range_t, _Range&& __range, const _Alloc& __alloc)
       : c(from_range, std::forward<_Range>(__range), __alloc) {}
 
-#endif
+#  endif
 
   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI bool empty() const { return c.empty(); }
   _LIBCPP_HIDE_FROM_ABI size_type size() const { return c.size(); }
@@ -237,10 +239,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_reference top() const { return c.back(); }
 
   _LIBCPP_HIDE_FROM_ABI void push(const value_type& __v) { c.push_back(__v); }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void push(value_type&& __v) { c.push_back(std::move(__v)); }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_Tp> _Range>
   _LIBCPP_HIDE_FROM_ABI void push_range(_Range&& __range) {
     if constexpr (requires(container_type& __c) { __c.append_range(std::forward<_Range>(__range)); }) {
@@ -249,22 +251,22 @@ public:
       ranges::copy(std::forward<_Range>(__range), std::back_inserter(c));
     }
   }
-#  endif
+#    endif
 
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
   decltype(auto)
   emplace(_Args&&... __args) {
     return c.emplace_back(std::forward<_Args>(__args)...);
   }
-#  else
+#    else
   void
   emplace(_Args&&... __args) {
     c.emplace_back(std::forward<_Args>(__args)...);
   }
-#  endif
-#endif // _LIBCPP_CXX03_LANG
+#    endif
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI void pop() { c.pop_back(); }
 
@@ -282,7 +284,7 @@ public:
   friend bool operator<(const stack<_T1, _OtherContainer>& __x, const stack<_T1, _OtherContainer>& __y);
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _Container, class = enable_if_t<!__is_allocator<_Container>::value> >
 stack(_Container) -> stack<typename _Container::value_type, _Container>;
 
@@ -291,9 +293,9 @@ template <class _Container,
           class = enable_if_t<!__is_allocator<_Container>::value>,
           class = enable_if_t<uses_allocator<_Container, _Alloc>::value> >
 stack(_Container, _Alloc) -> stack<typename _Container::value_type, _Container>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <class _InputIterator, __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0>
 stack(_InputIterator, _InputIterator) -> stack<__iter_value_type<_InputIterator>>;
 
@@ -313,7 +315,7 @@ stack(from_range_t,
       _Range&&,
       _Alloc) -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 
-#endif
+#  endif
 
 template <class _Tp, class _Container>
 inline _LIBCPP_HIDE_FROM_ABI bool operator==(const stack<_Tp, _Container>& __x, const stack<_Tp, _Container>& __y) {
@@ -345,7 +347,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator<=(const stack<_Tp, _Container>& __x, 
   return !(__y < __x);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 template <class _Tp, three_way_comparable _Container>
 _LIBCPP_HIDE_FROM_ABI compare_three_way_result_t<_Container>
@@ -354,7 +356,7 @@ operator<=>(const stack<_Tp, _Container>& __x, const stack<_Tp, _Container>& __y
   return __x.__get_container() <=> __y.__get_container();
 }
 
-#endif
+#  endif
 
 template <class _Tp, class _Container, __enable_if_t<__is_swappable_v<_Container>, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI void swap(stack<_Tp, _Container>& __x, stack<_Tp, _Container>& __y)
@@ -370,10 +372,11 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <functional>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <functional>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STACK

--- a/libcxx/include/stdatomic.h
+++ b/libcxx/include/stdatomic.h
@@ -117,22 +117,24 @@ using std::atomic_signal_fence                         // see below
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
-
-#if defined(__cplusplus)
-
-#  include <atomic>
-#  include <version>
-
-#  ifdef _Atomic
-#    undef _Atomic
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
 #  endif
 
-#  define _Atomic(_Tp) ::std::atomic<_Tp>
+#  if defined(__cplusplus)
+
+#    include <atomic>
+#    include <version>
+
+#    ifdef _Atomic
+#      undef _Atomic
+#    endif
+
+#    define _Atomic(_Tp) ::std::atomic<_Tp>
 
 using std::memory_order _LIBCPP_USING_IF_EXISTS;
 using std::memory_order_relaxed _LIBCPP_USING_IF_EXISTS;
@@ -156,14 +158,14 @@ using std::atomic_long _LIBCPP_USING_IF_EXISTS;
 using std::atomic_ulong _LIBCPP_USING_IF_EXISTS;
 using std::atomic_llong _LIBCPP_USING_IF_EXISTS;
 using std::atomic_ullong _LIBCPP_USING_IF_EXISTS;
-#  if _LIBCPP_HAS_CHAR8_T
+#    if _LIBCPP_HAS_CHAR8_T
 using std::atomic_char8_t _LIBCPP_USING_IF_EXISTS;
-#  endif
+#    endif
 using std::atomic_char16_t _LIBCPP_USING_IF_EXISTS;
 using std::atomic_char32_t _LIBCPP_USING_IF_EXISTS;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 using std::atomic_wchar_t _LIBCPP_USING_IF_EXISTS;
-#  endif
+#    endif
 
 using std::atomic_int8_t _LIBCPP_USING_IF_EXISTS;
 using std::atomic_uint8_t _LIBCPP_USING_IF_EXISTS;
@@ -228,12 +230,13 @@ using std::atomic_store_explicit _LIBCPP_USING_IF_EXISTS;
 using std::atomic_signal_fence _LIBCPP_USING_IF_EXISTS;
 using std::atomic_thread_fence _LIBCPP_USING_IF_EXISTS;
 
-#else
+#  else
 
-#  if __has_include_next(<stdatomic.h>)
-#    include_next <stdatomic.h>
-#  endif
+#    if __has_include_next(<stdatomic.h>)
+#      include_next <stdatomic.h>
+#    endif
 
-#endif // defined(__cplusplus)
+#  endif // defined(__cplusplus)
+#endif   // 0
 
 #endif // _LIBCPP_STDATOMIC_H

--- a/libcxx/include/stdbool.h
+++ b/libcxx/include/stdbool.h
@@ -19,22 +19,25 @@ Macros:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if __has_include_next(<stdbool.h>)
-#  include_next <stdbool.h>
-#endif
+#  if __has_include_next(<stdbool.h>)
+#    include_next <stdbool.h>
+#  endif
 
-#ifdef __cplusplus
-#  undef bool
-#  undef true
-#  undef false
-#  undef __bool_true_false_are_defined
-#  define __bool_true_false_are_defined 1
-#endif
+#  ifdef __cplusplus
+#    undef bool
+#    undef true
+#    undef false
+#    undef __bool_true_false_are_defined
+#    define __bool_true_false_are_defined 1
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STDBOOL_H

--- a/libcxx/include/stddef.h
+++ b/libcxx/include/stddef.h
@@ -24,21 +24,24 @@ Types:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 // Note: This include is outside of header guards because we sometimes get included multiple times
 //       with different defines and the underlying <stddef.h> will know how to deal with that.
-#include_next <stddef.h>
+#  include_next <stddef.h>
 
-#ifndef _LIBCPP_STDDEF_H
-#  define _LIBCPP_STDDEF_H
+#  ifndef _LIBCPP_STDDEF_H
+#    define _LIBCPP_STDDEF_H
 
-#  ifdef __cplusplus
+#    ifdef __cplusplus
 typedef decltype(nullptr) nullptr_t;
-#  endif
+#    endif
+#  endif // 0
 
 #endif // _LIBCPP_STDDEF_H

--- a/libcxx/include/stdexcept
+++ b/libcxx/include/stdexcept
@@ -41,18 +41,20 @@ public:
 
 */
 
-#include <__config>
-#include <__exception/exception.h>
-#include <__fwd/string.h>
-#include <__verbose_abort>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__exception/exception.h>
+#  include <__fwd/string.h>
+#  include <__verbose_abort>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
 class _LIBCPP_HIDDEN __libcpp_refstring {
   const char* __imp_;
 
@@ -66,7 +68,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI const char* c_str() const _NOEXCEPT { return __imp_; }
 };
-#endif // !_LIBCPP_ABI_VCRUNTIME
+#  endif // !_LIBCPP_ABI_VCRUNTIME
 
 _LIBCPP_END_NAMESPACE_STD
 
@@ -74,7 +76,7 @@ namespace std // purposefully not using versioning namespace
 {
 
 class _LIBCPP_EXPORTED_FROM_ABI logic_error : public exception {
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
 
 private:
   std::__libcpp_refstring __imp_;
@@ -89,16 +91,16 @@ public:
   ~logic_error() _NOEXCEPT override;
 
   const char* what() const _NOEXCEPT override;
-#else
+#  else
 
 public:
   explicit logic_error(const std::string&); // Symbol uses versioned std::string
   _LIBCPP_HIDE_FROM_ABI explicit logic_error(const char* __s) : exception(__s) {}
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI runtime_error : public exception {
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
 
 private:
   std::__libcpp_refstring __imp_;
@@ -113,12 +115,12 @@ public:
   ~runtime_error() _NOEXCEPT override;
 
   const char* what() const _NOEXCEPT override;
-#else
+#  else
 
 public:
   explicit runtime_error(const std::string&); // Symbol uses versioned std::string
   _LIBCPP_HIDE_FROM_ABI explicit runtime_error(const char* __s) : exception(__s) {}
-#endif // _LIBCPP_ABI_VCRUNTIME
+#  endif // _LIBCPP_ABI_VCRUNTIME
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI domain_error : public logic_error {
@@ -126,11 +128,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit domain_error(const string& __s) : logic_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit domain_error(const char* __s) : logic_error(__s) {}
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI domain_error(const domain_error&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI domain_error& operator=(const domain_error&) _NOEXCEPT = default;
   ~domain_error() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI invalid_argument : public logic_error {
@@ -138,22 +140,22 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit invalid_argument(const string& __s) : logic_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit invalid_argument(const char* __s) : logic_error(__s) {}
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI invalid_argument(const invalid_argument&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI invalid_argument& operator=(const invalid_argument&) _NOEXCEPT = default;
   ~invalid_argument() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI length_error : public logic_error {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit length_error(const string& __s) : logic_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit length_error(const char* __s) : logic_error(__s) {}
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI length_error(const length_error&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI length_error& operator=(const length_error&) _NOEXCEPT = default;
   ~length_error() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI out_of_range : public logic_error {
@@ -161,11 +163,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit out_of_range(const string& __s) : logic_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit out_of_range(const char* __s) : logic_error(__s) {}
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI out_of_range(const out_of_range&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI out_of_range& operator=(const out_of_range&) _NOEXCEPT = default;
   ~out_of_range() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI range_error : public runtime_error {
@@ -173,11 +175,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit range_error(const string& __s) : runtime_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit range_error(const char* __s) : runtime_error(__s) {}
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI range_error(const range_error&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI range_error& operator=(const range_error&) _NOEXCEPT = default;
   ~range_error() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI overflow_error : public runtime_error {
@@ -185,11 +187,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit overflow_error(const string& __s) : runtime_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit overflow_error(const char* __s) : runtime_error(__s) {}
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI overflow_error(const overflow_error&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI overflow_error& operator=(const overflow_error&) _NOEXCEPT = default;
   ~overflow_error() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI underflow_error : public runtime_error {
@@ -197,11 +199,11 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit underflow_error(const string& __s) : runtime_error(__s) {}
   _LIBCPP_HIDE_FROM_ABI explicit underflow_error(const char* __s) : runtime_error(__s) {}
 
-#ifndef _LIBCPP_ABI_VCRUNTIME
+#  ifndef _LIBCPP_ABI_VCRUNTIME
   _LIBCPP_HIDE_FROM_ABI underflow_error(const underflow_error&) _NOEXCEPT            = default;
   _LIBCPP_HIDE_FROM_ABI underflow_error& operator=(const underflow_error&) _NOEXCEPT = default;
   ~underflow_error() _NOEXCEPT override;
-#endif
+#  endif
 };
 
 } // namespace std
@@ -212,76 +214,77 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 [[__noreturn__]] _LIBCPP_EXPORTED_FROM_ABI void __throw_runtime_error(const char*);
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_logic_error(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw logic_error(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("logic_error was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_domain_error(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw domain_error(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("domain_error was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_invalid_argument(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw invalid_argument(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("invalid_argument was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_length_error(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw length_error(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("length_error was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_out_of_range(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw out_of_range(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("out_of_range was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_range_error(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw range_error(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("range_error was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_overflow_error(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw overflow_error(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("overflow_error was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_underflow_error(const char* __msg) {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw underflow_error(__msg);
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("underflow_error was thrown in -fno-exceptions mode with message \"%s\"", __msg);
-#endif
+#  endif
 }
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <cstdlib>
-#  include <exception>
-#  include <iosfwd>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <cstdlib>
+#    include <exception>
+#    include <iosfwd>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STDEXCEPT

--- a/libcxx/include/stdio.h
+++ b/libcxx/include/stdio.h
@@ -98,26 +98,29 @@ int ferror(FILE* stream);
 void perror(const char* s);
 */
 
-#  include <__config>
+#  if 0
+#  else // 0
+#    include <__config>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
-#  if __has_include_next(<stdio.h>)
-#    include_next <stdio.h>
-#  endif
+#    if __has_include_next(<stdio.h>)
+#      include_next <stdio.h>
+#    endif
 
-#  ifdef __cplusplus
+#    ifdef __cplusplus
 
-#    undef getc
-#    undef putc
-#    undef clearerr
-#    undef feof
-#    undef ferror
-#    undef putchar
-#    undef getchar
+#      undef getc
+#      undef putc
+#      undef clearerr
+#      undef feof
+#      undef ferror
+#      undef putchar
+#      undef getchar
 
-#  endif
+#    endif
+#  endif // 0
 
 #endif // _LIBCPP_STDIO_H

--- a/libcxx/include/stdlib.h
+++ b/libcxx/include/stdlib.h
@@ -84,35 +84,37 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 
 */
 
-#  include <__config>
+#  if 0
+#  else // 0
+#    include <__config>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
-#  if __has_include_next(<stdlib.h>)
-#    include_next <stdlib.h>
-#  endif
+#    if __has_include_next(<stdlib.h>)
+#      include_next <stdlib.h>
+#    endif
 
-#  ifdef __cplusplus
+#    ifdef __cplusplus
 extern "C++" {
 // abs
 
-#    ifdef abs
-#      undef abs
-#    endif
-#    ifdef labs
-#      undef labs
-#    endif
-#    ifdef llabs
-#      undef llabs
-#    endif
+#      ifdef abs
+#        undef abs
+#      endif
+#      ifdef labs
+#        undef labs
+#      endif
+#      ifdef llabs
+#        undef llabs
+#      endif
 
 // MSVCRT already has the correct prototype in <stdlib.h> if __cplusplus is defined
-#    if !defined(_LIBCPP_MSVCRT)
+#      if !defined(_LIBCPP_MSVCRT)
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long abs(long __x) _NOEXCEPT { return __builtin_labs(__x); }
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI long long abs(long long __x) _NOEXCEPT { return __builtin_llabs(__x); }
-#    endif // !defined(_LIBCPP_MSVCRT)
+#      endif // !defined(_LIBCPP_MSVCRT)
 
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI float abs(float __lcpp_x) _NOEXCEPT {
   return __builtin_fabsf(__lcpp_x); // Use builtins to prevent needing math.h
@@ -128,24 +130,25 @@ extern "C++" {
 
 // div
 
-#    ifdef div
-#      undef div
-#    endif
-#    ifdef ldiv
-#      undef ldiv
-#    endif
-#    ifdef lldiv
-#      undef lldiv
-#    endif
+#      ifdef div
+#        undef div
+#      endif
+#      ifdef ldiv
+#        undef ldiv
+#      endif
+#      ifdef lldiv
+#        undef lldiv
+#      endif
 
 // MSVCRT already has the correct prototype in <stdlib.h> if __cplusplus is defined
-#    if !defined(_LIBCPP_MSVCRT)
+#      if !defined(_LIBCPP_MSVCRT)
 inline _LIBCPP_HIDE_FROM_ABI ldiv_t div(long __x, long __y) _NOEXCEPT { return ::ldiv(__x, __y); }
-#      if !(defined(__FreeBSD__) && !defined(__LONG_LONG_SUPPORTED))
+#        if !(defined(__FreeBSD__) && !defined(__LONG_LONG_SUPPORTED))
 inline _LIBCPP_HIDE_FROM_ABI lldiv_t div(long long __x, long long __y) _NOEXCEPT { return ::lldiv(__x, __y); }
-#      endif
-#    endif // _LIBCPP_MSVCRT
+#        endif
+#      endif // _LIBCPP_MSVCRT
 } // extern "C++"
-#  endif   // __cplusplus
+#    endif   // __cplusplus
+#  endif     // 0
 
 #endif // _LIBCPP_STDLIB_H

--- a/libcxx/include/stop_token
+++ b/libcxx/include/stop_token
@@ -31,27 +31,30 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  if _LIBCPP_STD_VER >= 20
-#    include <__stop_token/stop_callback.h>
-#    include <__stop_token/stop_source.h>
-#    include <__stop_token/stop_token.h>
+#    if _LIBCPP_STD_VER >= 20
+#      include <__stop_token/stop_callback.h>
+#      include <__stop_token/stop_source.h>
+#      include <__stop_token/stop_token.h>
+#    endif
+
+#    include <version>
+
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
+
+#  endif // _LIBCPP_HAS_THREADS
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <iosfwd>
 #  endif
-
-#  include <version>
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
-
-#endif // _LIBCPP_HAS_THREADS
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <iosfwd>
-#endif
+#endif // 0
 
 #endif // _LIBCPP_STOP_TOKEN

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -107,26 +107,28 @@ protected:
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__assert>
-#  include <__fwd/streambuf.h>
-#  include <__locale>
-#  include <__type_traits/is_same.h>
-#  include <__utility/is_valid_range.h>
-#  include <climits>
-#  include <ios>
-#  include <iosfwd>
-#  include <version>
+#    include <__assert>
+#    include <__fwd/streambuf.h>
+#    include <__locale>
+#    include <__type_traits/is_same.h>
+#    include <__utility/is_valid_range.h>
+#    include <climits>
+#    include <ios>
+#    include <iosfwd>
+#    include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -433,18 +435,19 @@ typename basic_streambuf<_CharT, _Traits>::int_type basic_streambuf<_CharT, _Tra
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_streambuf<char>;
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_streambuf<wchar_t>;
-#  endif
+#    endif
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstdint>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstdint>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STREAMBUF

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -586,103 +586,105 @@ basic_string<char32_t> operator""s( const char32_t *str, size_t len );          
 
 // clang-format on
 
-#include <__algorithm/max.h>
-#include <__algorithm/min.h>
-#include <__algorithm/remove.h>
-#include <__algorithm/remove_if.h>
-#include <__assert>
-#include <__config>
-#include <__debug_utils/sanitizers.h>
-#include <__format/enable_insertable.h>
-#include <__functional/hash.h>
-#include <__functional/unary_function.h>
-#include <__fwd/string.h>
-#include <__ios/fpos.h>
-#include <__iterator/bounded_iter.h>
-#include <__iterator/distance.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/reverse_iterator.h>
-#include <__iterator/wrap_iter.h>
-#include <__memory/addressof.h>
-#include <__memory/allocate_at_least.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/compressed_pair.h>
-#include <__memory/construct_at.h>
-#include <__memory/noexcept_move_assign_container.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/swap_allocator.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__ranges/access.h>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__ranges/size.h>
-#include <__string/char_traits.h>
-#include <__string/extern_template_lists.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_standard_layout.h>
-#include <__type_traits/is_trivial.h>
-#include <__type_traits/is_trivially_relocatable.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/void_t.h>
-#include <__utility/auto_cast.h>
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/is_pointer_in_range.h>
-#include <__utility/move.h>
-#include <__utility/scope_guard.h>
-#include <__utility/swap.h>
-#include <__utility/unreachable.h>
-#include <climits>
-#include <cstdio> // EOF
-#include <cstring>
-#include <limits>
-#include <stdexcept>
-#include <string_view>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/max.h>
+#  include <__algorithm/min.h>
+#  include <__algorithm/remove.h>
+#  include <__algorithm/remove_if.h>
+#  include <__assert>
+#  include <__config>
+#  include <__debug_utils/sanitizers.h>
+#  include <__format/enable_insertable.h>
+#  include <__functional/hash.h>
+#  include <__functional/unary_function.h>
+#  include <__fwd/string.h>
+#  include <__ios/fpos.h>
+#  include <__iterator/bounded_iter.h>
+#  include <__iterator/distance.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__iterator/wrap_iter.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocate_at_least.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/compressed_pair.h>
+#  include <__memory/construct_at.h>
+#  include <__memory/noexcept_move_assign_container.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/swap_allocator.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__ranges/access.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__ranges/size.h>
+#  include <__string/char_traits.h>
+#  include <__string/extern_template_lists.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_standard_layout.h>
+#  include <__type_traits/is_trivial.h>
+#  include <__type_traits/is_trivially_relocatable.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/void_t.h>
+#  include <__utility/auto_cast.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/is_pointer_in_range.h>
+#  include <__utility/move.h>
+#  include <__utility/scope_guard.h>
+#  include <__utility/swap.h>
+#  include <__utility/unreachable.h>
+#  include <climits>
+#  include <cstdio> // EOF
+#  include <cstring>
+#  include <limits>
+#  include <stdexcept>
+#  include <string_view>
+#  include <version>
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
-#  include <cwchar>
-#endif
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    include <cwchar>
+#  endif
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [string.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
-#  define _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS __attribute__((__no_sanitize__("address")))
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#    define _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS __attribute__((__no_sanitize__("address")))
 // This macro disables AddressSanitizer (ASan) instrumentation for a specific function,
 // allowing memory accesses that would normally trigger ASan errors to proceed without crashing.
 // This is useful for accessing parts of objects memory, which should not be accessed,
 // such as unused bytes in short strings, that should never be accessed
 // by other parts of the program.
-#else
-#  define _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS
-#endif
+#  else
+#    define _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -708,7 +710,7 @@ template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>
 operator+(const basic_string<_CharT, _Traits, _Allocator>& __x, _CharT __y);
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI constexpr basic_string<_CharT, _Traits, _Allocator>
@@ -728,7 +730,7 @@ template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI constexpr basic_string<_CharT, _Traits, _Allocator>
 operator+(type_identity_t<basic_string_view<_CharT, _Traits>> __lhs, basic_string<_CharT, _Traits, _Allocator>&& __rhs);
 
-#endif
+#  endif
 
 extern template _LIBCPP_EXPORTED_FROM_ABI string operator+
     <char, char_traits<char>, allocator<char> >(char const*, string const&);
@@ -786,7 +788,7 @@ public:
   //
   // This string implementation doesn't contain any references into itself. It only contains a bit that says whether
   // it is in small or large string mode, so the entire structure is trivially relocatable if its members are.
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
   // When compiling with AddressSanitizer (ASan), basic_string cannot be trivially
   // relocatable. Because the object's memory might be poisoned when its content
   // is kept inside objects memory (short string optimization), instead of in allocated
@@ -794,14 +796,14 @@ public:
   // the memory to avoid triggering false positives.
   // Therefore it's crucial to ensure the destructor is called.
   using __trivially_relocatable = void;
-#else
+#  else
   using __trivially_relocatable = __conditional_t<
       __libcpp_is_trivially_relocatable<allocator_type>::value && __libcpp_is_trivially_relocatable<pointer>::value,
       basic_string,
       void>;
-#endif
+#  endif
 
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pointer __asan_volatile_wrapper(pointer const& __ptr) const {
     if (__libcpp_is_constant_evaluated())
       return __ptr;
@@ -820,10 +822,10 @@ public:
 
     return const_cast<const_pointer&>(__copy_ptr);
   }
-#  define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) __asan_volatile_wrapper(PTR)
-#else
-#  define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) PTR
-#endif
+#    define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) __asan_volatile_wrapper(PTR)
+#  else
+#    define _LIBCPP_ASAN_VOLATILE_WRAPPER(PTR) PTR
+#  endif
 
   static_assert(!is_array<value_type>::value, "Character type of basic_string must not be an array");
   static_assert(is_standard_layout<value_type>::value, "Character type of basic_string must be standard-layout");
@@ -834,23 +836,23 @@ public:
                 "Allocator::value_type must be same type as value_type");
   static_assert(__check_valid_allocator<allocator_type>::value, "");
 
-#ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
+#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
   // Users might provide custom allocators, and prior to C++20 we have no existing way to detect whether the allocator's
   // pointer type is contiguous (though it has to be by the Standard). Using the wrapper type ensures the iterator is
   // considered contiguous.
   typedef __bounded_iter<__wrap_iter<pointer> > iterator;
   typedef __bounded_iter<__wrap_iter<const_pointer> > const_iterator;
-#else
+#  else
   typedef __wrap_iter<pointer> iterator;
   typedef __wrap_iter<const_pointer> const_iterator;
-#endif
+#  endif
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
 private:
   static_assert(CHAR_BIT == 8, "This implementation assumes that one byte contains 8 bits");
 
-#ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+#  ifdef _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 
   struct __long {
     pointer __data_;
@@ -881,19 +883,19 @@ private:
   // This does not impact the short string representation, since we never need the MSB
   // for representing the size of a short string anyway.
 
-#  ifdef _LIBCPP_BIG_ENDIAN
+#    ifdef _LIBCPP_BIG_ENDIAN
   static const size_type __endian_factor = 2;
-#  else
+#    else
   static const size_type __endian_factor = 1;
-#  endif
+#    endif
 
-#else // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+#  else // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 
-#  ifdef _LIBCPP_BIG_ENDIAN
+#    ifdef _LIBCPP_BIG_ENDIAN
   static const size_type __endian_factor = 1;
-#  else
+#    else
   static const size_type __endian_factor = 2;
-#  endif
+#    endif
 
   // Attribute 'packed' is used to keep the layout compatible with the
   // previous definition that did not use bit fields. This is because on
@@ -919,7 +921,7 @@ private:
     value_type __data_[__min_cap];
   };
 
-#endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
+#  endif // _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT
 
   static_assert(sizeof(__short) == (sizeof(value_type) * (__min_cap + 1)), "__short has an unexpected size.");
 
@@ -969,7 +971,7 @@ private:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator __make_iterator(pointer __p) {
-#ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
+#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
     // Bound the iterator according to the size (and not the capacity, unlike vector).
     //
     // By the Standard, string iterators are generally not guaranteed to stay valid when the container is modified,
@@ -980,21 +982,21 @@ private:
         std::__wrap_iter<pointer>(__p),
         std::__wrap_iter<pointer>(__get_pointer()),
         std::__wrap_iter<pointer>(__get_pointer() + size()));
-#else
+#  else
     return iterator(__p);
-#endif // _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
+#  endif // _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_iterator __make_const_iterator(const_pointer __p) const {
-#ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
+#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
     // Bound the iterator according to the size (and not the capacity, unlike vector).
     return std::__make_bounded_iter(
         std::__wrap_iter<const_pointer>(__p),
         std::__wrap_iter<const_pointer>(__get_pointer()),
         std::__wrap_iter<const_pointer>(__get_pointer() + size()));
-#else
+#  else
     return const_iterator(__p);
-#endif // _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
+#  endif // _LIBCPP_ABI_BOUNDED_ITERATORS_IN_STRING
   }
 
 public:
@@ -1007,11 +1009,11 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit basic_string(const allocator_type& __a)
-#if _LIBCPP_STD_VER <= 14
+#  if _LIBCPP_STD_VER <= 14
       _NOEXCEPT_(is_nothrow_copy_constructible<allocator_type>::value)
-#else
+#  else
       _NOEXCEPT
-#endif
+#  endif
       : __rep_(), __alloc_(__a) {
     __annotate_new(0);
   }
@@ -1035,13 +1037,13 @@ public:
       __init_copy_ctor_external(std::__to_address(__str.__get_long_pointer()), __str.__get_long_size());
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(basic_string&& __str)
-#  if _LIBCPP_STD_VER <= 14
+#    if _LIBCPP_STD_VER <= 14
       _NOEXCEPT_(is_nothrow_move_constructible<allocator_type>::value)
-#  else
+#    else
       _NOEXCEPT
-#  endif
+#    endif
       // Turning off ASan instrumentation for variable initialization with _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS
       // does not work consistently during initialization of __r_, so we instead unpoison __str's memory manually first.
       // __str's memory needs to be unpoisoned only in the case where it's a short string.
@@ -1073,7 +1075,7 @@ public:
         __annotate_new(size());
     }
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(const _CharT* __s) {
@@ -1088,9 +1090,9 @@ public:
     __init(__s, traits_type::length(__s));
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   basic_string(nullptr_t) = delete;
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(const _CharT* __s, size_type __n) {
     _LIBCPP_ASSERT_NON_NULL(__n == 0 || __s != nullptr, "basic_string(const char*, n) detected nullptr");
@@ -1106,7 +1108,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(size_type __n, _CharT __c) { __init(__n, __c); }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string(
       basic_string&& __str, size_type __pos, const _Allocator& __alloc = _Allocator())
       : basic_string(std::move(__str), __pos, npos, __alloc) {}
@@ -1125,7 +1127,7 @@ public:
       __init(__str.data() + __pos, __len);
     }
   }
-#endif
+#  endif
 
   template <__enable_if_t<__is_allocator<_Allocator>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(size_type __n, _CharT __c, const _Allocator& __a)
@@ -1196,7 +1198,7 @@ public:
     __init(__first, __last);
   }
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_CharT> _Range>
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string(
       from_range_t, _Range&& __range, const allocator_type& __a = allocator_type())
@@ -1207,9 +1209,9 @@ public:
       __init_with_sentinel(ranges::begin(__range), ranges::end(__range));
     }
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string(initializer_list<_CharT> __il) {
     __init(__il.begin(), __il.end());
   }
@@ -1218,7 +1220,7 @@ public:
       : __alloc_(__a) {
     __init(__il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   inline _LIBCPP_CONSTEXPR_SINCE_CXX20 ~basic_string() {
     __annotate_delete();
@@ -1242,7 +1244,7 @@ public:
     return assign(__sv);
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   operator=(basic_string&& __str) noexcept(__noexcept_move_assign_container<_Allocator, __alloc_traits>::value) {
     __move_assign(__str, integral_constant<bool, __alloc_traits::propagate_on_container_move_assignment::value>());
@@ -1252,13 +1254,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(initializer_list<value_type> __il) {
     return assign(__il.begin(), __il.size());
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(const value_type* __s) {
     return assign(__s);
   }
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   basic_string& operator=(nullptr_t) = delete;
-#endif
+#  endif
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator=(value_type __c);
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator begin() _NOEXCEPT {
@@ -1318,19 +1320,19 @@ public:
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 void reserve(size_type __requested_capacity);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <class _Op>
   _LIBCPP_HIDE_FROM_ABI constexpr void resize_and_overwrite(size_type __n, _Op __op) {
     __resize_default_init(__n);
     __erase_to_end(std::move(__op)(data(), _LIBCPP_AUTO_CAST(__n)));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __resize_default_init(size_type __n);
 
-#if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE)
+#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRING_RESERVE)
   _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_HIDE_FROM_ABI void reserve() _NOEXCEPT { shrink_to_fit(); }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void shrink_to_fit() _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void clear() _NOEXCEPT;
 
@@ -1380,11 +1382,11 @@ public:
     return *this;
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& operator+=(initializer_list<value_type> __il) {
     return append(__il);
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(const basic_string& __str) {
     return append(__str.data(), __str.size());
@@ -1429,19 +1431,19 @@ public:
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   append(_ForwardIterator __first, _ForwardIterator __last);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_CharT> _Range>
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string& append_range(_Range&& __range) {
     insert_range(end(), std::forward<_Range>(__range));
     return *this;
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& append(initializer_list<value_type> __il) {
     return append(__il.begin(), __il.size());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 void push_back(value_type __c);
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void pop_back();
@@ -1473,7 +1475,7 @@ public:
     return assign(__sv.data(), __sv.size());
   }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI constexpr void __move_assign(basic_string&& __str, size_type __pos, size_type __len) {
     // Pilfer the allocation from __str.
     _LIBCPP_ASSERT_INTERNAL(__alloc_ == __str.__alloc_, "__move_assign called with wrong allocator");
@@ -1494,18 +1496,18 @@ public:
       __annotate_shrink(__old_sz);
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(const basic_string& __str) {
     return *this = __str;
   }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   assign(basic_string&& __str) noexcept(__noexcept_move_assign_container<_Allocator, __alloc_traits>::value) {
     *this = std::move(__str);
     return *this;
   }
-#endif
+#  endif
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(const basic_string& __str, size_type __pos, size_type __n = npos);
 
   template <class _Tp,
@@ -1526,7 +1528,7 @@ public:
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   assign(_ForwardIterator __first, _ForwardIterator __last);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_CharT> _Range>
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string& assign_range(_Range&& __range) {
     if constexpr (__string_is_trivial_iterator<ranges::iterator_t<_Range>>::value &&
@@ -1540,13 +1542,13 @@ public:
 
     return *this;
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& assign(initializer_list<value_type> __il) {
     return assign(__il.begin(), __il.size());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   insert(size_type __pos1, const basic_string& __str) {
@@ -1574,7 +1576,7 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& insert(size_type __pos, size_type __n, value_type __c);
   _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator insert(const_iterator __pos, value_type __c);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_CharT> _Range>
   _LIBCPP_HIDE_FROM_ABI constexpr iterator insert_range(const_iterator __position, _Range&& __range) {
     if constexpr (ranges::forward_range<_Range> || ranges::sized_range<_Range>) {
@@ -1586,7 +1588,7 @@ public:
       return insert(__position, __temp.data(), __temp.data() + __temp.size());
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator
   insert(const_iterator __pos, size_type __n, value_type __c) {
@@ -1603,12 +1605,12 @@ public:
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator
   insert(const_iterator __pos, _ForwardIterator __first, _ForwardIterator __last);
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator
   insert(const_iterator __pos, initializer_list<value_type> __il) {
     return insert(__pos, __il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& erase(size_type __pos = 0, size_type __n = npos);
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 iterator erase(const_iterator __pos);
@@ -1673,30 +1675,30 @@ public:
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   replace(const_iterator __i1, const_iterator __i2, _InputIterator __j1, _InputIterator __j2);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<_CharT> _Range>
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string&
   replace_with_range(const_iterator __i1, const_iterator __i2, _Range&& __range) {
     basic_string __temp(from_range, std::forward<_Range>(__range), __alloc_);
     return replace(__i1, __i2, __temp);
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string&
   replace(const_iterator __i1, const_iterator __i2, initializer_list<value_type> __il) {
     return replace(__i1, __i2, __il.begin(), __il.end());
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20 size_type copy(value_type* __s, size_type __n, size_type __pos = 0) const;
 
-#if _LIBCPP_STD_VER <= 20
+#  if _LIBCPP_STD_VER <= 20
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string
   substr(size_type __pos = 0, size_type __n = npos) const {
     return basic_string(*this, __pos, __n);
   }
-#else
+#  else
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string substr(size_type __pos = 0, size_type __n = npos) const& {
     return basic_string(*this, __pos, __n);
   }
@@ -1704,24 +1706,24 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr basic_string substr(size_type __pos = 0, size_type __n = npos) && {
     return basic_string(std::move(*this), __pos, __n);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(basic_string& __str)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
       _NOEXCEPT;
-#else
+#  else
       _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>);
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const value_type* c_str() const _NOEXCEPT { return data(); }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const value_type* data() const _NOEXCEPT {
     return std::__to_address(__get_pointer());
   }
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 value_type* data() _NOEXCEPT {
     return std::__to_address(__get_pointer());
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 allocator_type get_allocator() const _NOEXCEPT {
     return __alloc_;
@@ -1834,7 +1836,7 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 int
   compare(size_type __pos1, size_type __n1, const value_type* __s, size_type __n2) const;
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   constexpr _LIBCPP_HIDE_FROM_ABI bool starts_with(__self_view __sv) const noexcept {
     return __self_view(typename __self_view::__assume_valid(), data(), size()).starts_with(__sv);
   }
@@ -1858,9 +1860,9 @@ public:
   constexpr _LIBCPP_HIDE_FROM_ABI bool ends_with(const value_type* __s) const noexcept {
     return ends_with(__self_view(__s));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   constexpr _LIBCPP_HIDE_FROM_ABI bool contains(__self_view __sv) const noexcept {
     return __self_view(typename __self_view::__assume_valid(), data(), size()).contains(__sv);
   }
@@ -1872,7 +1874,7 @@ public:
   constexpr _LIBCPP_HIDE_FROM_ABI bool contains(const value_type* __s) const {
     return __self_view(typename __self_view::__assume_valid(), data(), size()).contains(__s);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __invariants() const;
 
@@ -1895,15 +1897,15 @@ private:
   }
 
   static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __begin_lifetime(pointer __begin, size_type __n) {
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
     if (__libcpp_is_constant_evaluated()) {
       for (size_type __i = 0; __i != __n; ++__i)
         std::construct_at(std::addressof(__begin[__i]));
     }
-#else
+#  else
     (void)__begin;
     (void)__n;
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
   }
 
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI static bool __fits_in_sso(size_type __sz) { return __sz < __min_cap; }
@@ -1919,7 +1921,7 @@ private:
   template <class _ForwardIter, class _Sent>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static value_type*
   __copy_non_overlapping_range(_ForwardIter __first, _Sent __last, value_type* __dest) {
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     if constexpr (__libcpp_is_contiguous_iterator<_ForwardIter>::value &&
                   is_same<value_type, __iter_value_type<_ForwardIter>>::value && is_same<_ForwardIter, _Sent>::value) {
       _LIBCPP_ASSERT_INTERNAL(
@@ -1928,7 +1930,7 @@ private:
       traits_type::copy(__dest, std::__to_address(__first), __last - __first);
       return __dest + (__last - __first);
     }
-#endif
+#  endif
 
     for (; __first != __last; ++__first)
       traits_type::assign(*__dest++, *__first);
@@ -2039,45 +2041,45 @@ private:
   __annotate_contiguous_container(const void* __old_mid, const void* __new_mid) const {
     (void)__old_mid;
     (void)__new_mid;
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
-#  if defined(__APPLE__)
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#    if defined(__APPLE__)
     // TODO: remove after addressing issue #96099 (https://github.com/llvm/llvm-project/issues/96099)
     if (!__is_long())
       return;
-#  endif
+#    endif
     std::__annotate_contiguous_container<_Allocator>(data(), data() + capacity() + 1, __old_mid, __new_mid);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_new(size_type __current_size) const _NOEXCEPT {
     (void)__current_size;
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
     if (!__libcpp_is_constant_evaluated())
       __annotate_contiguous_container(data() + capacity() + 1, data() + __current_size + 1);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_delete() const _NOEXCEPT {
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
     if (!__libcpp_is_constant_evaluated())
       __annotate_contiguous_container(data() + size() + 1, data() + capacity() + 1);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_increase(size_type __n) const _NOEXCEPT {
     (void)__n;
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
     if (!__libcpp_is_constant_evaluated())
       __annotate_contiguous_container(data() + size() + 1, data() + size() + 1 + __n);
-#endif
+#  endif
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __annotate_shrink(size_type __old_size) const _NOEXCEPT {
     (void)__old_size;
-#if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
+#  if _LIBCPP_HAS_ASAN && _LIBCPP_INSTRUMENTED_WITH_ASAN
     if (!__libcpp_is_constant_evaluated())
       __annotate_contiguous_container(data() + __old_size + 1, data() + size() + 1);
-#endif
+#  endif
   }
 
   template <size_type __a>
@@ -2126,9 +2128,9 @@ private:
   __init_with_size(_InputIterator __first, _Sentinel __last, size_type __sz);
 
   _LIBCPP_CONSTEXPR_SINCE_CXX20
-#if _LIBCPP_ABI_VERSION >= 2 //  We want to use the function in the dylib in ABIv1
+#  if _LIBCPP_ABI_VERSION >= 2 //  We want to use the function in the dylib in ABIv1
   _LIBCPP_HIDE_FROM_ABI
-#endif
+#  endif
   _LIBCPP_DEPRECATED_("use __grow_by_without_replace") void __grow_by(
       size_type __old_cap,
       size_type __delta_cap,
@@ -2198,17 +2200,17 @@ private:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __copy_assign_alloc(const basic_string&, false_type) _NOEXCEPT {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __move_assign(basic_string& __str, false_type) noexcept(__alloc_traits::is_always_equal::value);
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS void
   __move_assign(basic_string& __str, true_type)
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
       noexcept;
-#  else
+#    else
       noexcept(is_nothrow_move_assignable<allocator_type>::value);
+#    endif
 #  endif
-#endif
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign_alloc(basic_string& __str)
       _NOEXCEPT_(!__alloc_traits::propagate_on_container_move_assignment::value ||
@@ -2271,10 +2273,10 @@ private:
   friend _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string operator+ <>(value_type, const basic_string&);
   friend _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string operator+ <>(const basic_string&, const value_type*);
   friend _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string operator+ <>(const basic_string&, value_type);
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
   friend constexpr basic_string operator+ <>(const basic_string&, type_identity_t<__self_view>);
   friend constexpr basic_string operator+ <>(type_identity_t<__self_view>, const basic_string&);
-#endif
+#  endif
 
   template <class _CharT2, class _Traits2, class _Allocator2>
   friend inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool
@@ -2283,21 +2285,21 @@ private:
 
 // These declarations must appear before any functions are implicitly used
 // so that they have the correct visibility specifier.
-#define _LIBCPP_DECLARE(...) extern template __VA_ARGS__;
-#ifdef _LIBCPP_ABI_STRING_OPTIMIZED_EXTERNAL_INSTANTIATION
+#  define _LIBCPP_DECLARE(...) extern template __VA_ARGS__;
+#  ifdef _LIBCPP_ABI_STRING_OPTIMIZED_EXTERNAL_INSTANTIATION
 _LIBCPP_STRING_UNSTABLE_EXTERN_TEMPLATE_LIST(_LIBCPP_DECLARE, char)
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 _LIBCPP_STRING_UNSTABLE_EXTERN_TEMPLATE_LIST(_LIBCPP_DECLARE, wchar_t)
-#  endif
-#else
+#    endif
+#  else
 _LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST(_LIBCPP_DECLARE, char)
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 _LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST(_LIBCPP_DECLARE, wchar_t)
+#    endif
 #  endif
-#endif
-#undef _LIBCPP_DECLARE
+#  undef _LIBCPP_DECLARE
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _CharT     = __iter_value_type<_InputIterator>,
           class _Allocator = allocator<_CharT>,
@@ -2320,15 +2322,15 @@ template <class _CharT,
           class _Sz        = typename allocator_traits<_Allocator>::size_type >
 basic_string(basic_string_view<_CharT, _Traits>, _Sz, _Sz, const _Allocator& = _Allocator())
     -> basic_string<_CharT, _Traits, _Allocator>;
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Allocator = allocator<ranges::range_value_t<_Range>>,
           class            = enable_if_t<__is_allocator<_Allocator>::value> >
 basic_string(from_range_t, _Range&&, _Allocator = _Allocator())
     -> basic_string<ranges::range_value_t<_Range>, char_traits<ranges::range_value_t<_Range>>, _Allocator>;
-#endif
+#  endif
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
@@ -2440,19 +2442,19 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_sentinel(_InputIterator _
   __rep_ = __rep();
   __annotate_new(0);
 
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     for (; __first != __last; ++__first)
       push_back(*__first);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     __annotate_delete();
     if (__is_long())
       __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
     throw;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
 }
 
 template <class _CharT, class _Traits, class _Allocator>
@@ -2487,18 +2489,18 @@ basic_string<_CharT, _Traits, _Allocator>::__init_with_size(_InputIterator __fir
     __set_long_size(__sz);
   }
 
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     auto __end = __copy_non_overlapping_range(__first, __last, std::__to_address(__p));
     traits_type::assign(*__end, value_type());
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   } catch (...) {
     if (__is_long())
       __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
     throw;
   }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   __annotate_new(__sz);
 }
 
@@ -2544,9 +2546,9 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__
 // not removed or changed to avoid breaking the ABI.
 template <class _CharT, class _Traits, class _Allocator>
 void _LIBCPP_CONSTEXPR_SINCE_CXX20
-#if _LIBCPP_ABI_VERSION >= 2 // We want to use the function in the dylib in ABIv1
+#  if _LIBCPP_ABI_VERSION >= 2 // We want to use the function in the dylib in ABIv1
 _LIBCPP_HIDE_FROM_ABI
-#endif
+#  endif
 _LIBCPP_DEPRECATED_("use __grow_by_without_replace") basic_string<_CharT, _Traits, _Allocator>::__grow_by(
     size_type __old_cap,
     size_type __delta_cap,
@@ -2701,7 +2703,7 @@ basic_string<_CharT, _Traits, _Allocator>::operator=(const basic_string& __str) 
   return *this;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::__move_assign(
@@ -2715,22 +2717,22 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocat
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_STRING_INTERNAL_MEMORY_ACCESS void
 basic_string<_CharT, _Traits, _Allocator>::__move_assign(basic_string& __str, true_type)
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
     noexcept
-#  else
+#    else
     noexcept(is_nothrow_move_assignable<allocator_type>::value)
-#  endif
+#    endif
 {
   __annotate_delete();
   if (__is_long()) {
     __alloc_traits::deallocate(__alloc_, __get_long_pointer(), __get_long_cap());
-#  if _LIBCPP_STD_VER <= 14
+#    if _LIBCPP_STD_VER <= 14
     if (!is_nothrow_move_assignable<allocator_type>::value) {
       __set_short_size(0);
       traits_type::assign(__get_short_pointer()[0], value_type());
       __annotate_new(0);
     }
-#  endif
+#    endif
   }
   size_type __str_old_size = __str.size();
   bool __str_was_short     = !__str.__is_long();
@@ -2759,7 +2761,7 @@ basic_string<_CharT, _Traits, _Allocator>::__move_assign(basic_string& __str, tr
     __annotate_new(__get_short_size());
 }
 
-#endif
+#  endif
 
 template <class _CharT, class _Traits, class _Allocator>
 template <class _InputIterator, __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> >
@@ -3396,9 +3398,9 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
       // Shrink
       // - called from shrink_to_fit should not throw.
       // - called from reserve may throw but is not required to.
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
       try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
         auto __allocation = std::__allocate_at_least(__alloc_, __target_capacity + 1);
 
         // The Standard mandates shrink_to_fit() does not increase the capacity.
@@ -3410,11 +3412,11 @@ basic_string<_CharT, _Traits, _Allocator>::__shrink_or_extend(size_type __target
         }
         __new_data        = __allocation.ptr;
         __target_capacity = __allocation.count - 1;
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
       } catch (...) {
         return;
       }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
     }
     __begin_lifetime(__new_data, __target_capacity + 1);
     __now_long = true;
@@ -3461,11 +3463,11 @@ basic_string<_CharT, _Traits, _Allocator>::copy(value_type* __s, size_type __n, 
 
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocator>::swap(basic_string& __str)
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
     _NOEXCEPT
-#else
+#  else
     _NOEXCEPT_(!__alloc_traits::propagate_on_container_swap::value || __is_nothrow_swappable_v<allocator_type>)
-#endif
+#  endif
 {
   _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(
       __alloc_traits::propagate_on_container_swap::value || __alloc_traits::is_always_equal::value ||
@@ -3840,12 +3842,12 @@ template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool
 operator==(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
            const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT {
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   return basic_string_view<_CharT, _Traits>(__lhs) == basic_string_view<_CharT, _Traits>(__rhs);
-#else
+#  else
   size_t __lhs_sz = __lhs.size();
   return __lhs_sz == __rhs.size() && _Traits::compare(__lhs.data(), __rhs.data(), __lhs_sz) == 0;
-#endif
+#  endif
 }
 
 template <class _Allocator>
@@ -3858,7 +3860,7 @@ operator==(const basic_string<char, char_traits<char>, _Allocator>& __lhs,
   return char_traits<char>::compare(__lhs.data(), __rhs.data(), __sz) == 0;
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator==(const _CharT* __lhs, const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT {
@@ -3869,7 +3871,7 @@ operator==(const _CharT* __lhs, const basic_string<_CharT, _Traits, _Allocator>&
     return false;
   return __rhs.compare(0, _String::npos, __lhs, __lhs_len) == 0;
 }
-#endif // _LIBCPP_STD_VER <= 17
+#  endif // _LIBCPP_STD_VER <= 17
 
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI bool
@@ -3888,7 +3890,7 @@ operator==(const basic_string<_CharT, _Traits, _Allocator>& __lhs, const _CharT*
   return __lhs.compare(0, _String::npos, __rhs, __rhs_len) == 0;
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI constexpr auto operator<=>(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
@@ -3902,7 +3904,7 @@ operator<=>(const basic_string<_CharT, _Traits, _Allocator>& __lhs, const _CharT
   return basic_string_view<_CharT, _Traits>(__lhs) <=> basic_string_view<_CharT, _Traits>(__rhs);
 }
 
-#else  // _LIBCPP_STD_VER >= 20
+#  else  // _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const basic_string<_CharT, _Traits, _Allocator>& __lhs,
@@ -4001,7 +4003,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator>=(const _CharT* __lhs, const basic_string<_CharT, _Traits, _Allocator>& __rhs) _NOEXCEPT {
   return !(__lhs < __rhs);
 }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 // operator +
 
@@ -4084,7 +4086,7 @@ operator+(const basic_string<_CharT, _Traits, _Allocator>& __lhs, _CharT __rhs) 
   return __r;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>
@@ -4130,9 +4132,9 @@ operator+(basic_string<_CharT, _Traits, _Allocator>&& __lhs, _CharT __rhs) {
   return std::move(__lhs);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
-#if _LIBCPP_STD_VER >= 26
+#  if _LIBCPP_STD_VER >= 26
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI constexpr basic_string<_CharT, _Traits, _Allocator>
@@ -4184,7 +4186,7 @@ operator+(type_identity_t<basic_string_view<_CharT, _Traits>> __lhs,
   return std::move(__rhs);
 }
 
-#endif // _LIBCPP_STD_VER >= 26
+#  endif // _LIBCPP_STD_VER >= 26
 
 // swap
 
@@ -4215,7 +4217,7 @@ _LIBCPP_EXPORTED_FROM_ABI string to_string(float __val);
 _LIBCPP_EXPORTED_FROM_ABI string to_string(double __val);
 _LIBCPP_EXPORTED_FROM_ABI string to_string(long double __val);
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 _LIBCPP_EXPORTED_FROM_ABI int stoi(const wstring& __str, size_t* __idx = nullptr, int __base = 10);
 _LIBCPP_EXPORTED_FROM_ABI long stol(const wstring& __str, size_t* __idx = nullptr, int __base = 10);
 _LIBCPP_EXPORTED_FROM_ABI unsigned long stoul(const wstring& __str, size_t* __idx = nullptr, int __base = 10);
@@ -4235,7 +4237,7 @@ _LIBCPP_EXPORTED_FROM_ABI wstring to_wstring(unsigned long long __val);
 _LIBCPP_EXPORTED_FROM_ABI wstring to_wstring(float __val);
 _LIBCPP_EXPORTED_FROM_ABI wstring to_wstring(double __val);
 _LIBCPP_EXPORTED_FROM_ABI wstring to_wstring(long double __val);
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_TEMPLATE_DATA_VIS const typename basic_string<_CharT, _Traits, _Allocator>::size_type
@@ -4252,10 +4254,10 @@ struct __string_hash : public __unary_function<basic_string<_CharT, char_traits<
 template <class _Allocator>
 struct hash<basic_string<char, char_traits<char>, _Allocator> > : __string_hash<char, _Allocator> {};
 
-#if _LIBCPP_HAS_CHAR8_T
+#  if _LIBCPP_HAS_CHAR8_T
 template <class _Allocator>
 struct hash<basic_string<char8_t, char_traits<char8_t>, _Allocator> > : __string_hash<char8_t, _Allocator> {};
-#endif
+#  endif
 
 template <class _Allocator>
 struct hash<basic_string<char16_t, char_traits<char16_t>, _Allocator> > : __string_hash<char16_t, _Allocator> {};
@@ -4263,10 +4265,10 @@ struct hash<basic_string<char16_t, char_traits<char16_t>, _Allocator> > : __stri
 template <class _Allocator>
 struct hash<basic_string<char32_t, char_traits<char32_t>, _Allocator> > : __string_hash<char32_t, _Allocator> {};
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _Allocator>
 struct hash<basic_string<wchar_t, char_traits<wchar_t>, _Allocator> > : __string_hash<wchar_t, _Allocator> {};
-#endif
+#  endif
 
 template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
@@ -4292,7 +4294,7 @@ template <class _CharT, class _Traits, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 getline(basic_istream<_CharT, _Traits>&& __is, basic_string<_CharT, _Traits, _Allocator>& __str);
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _CharT, class _Traits, class _Allocator, class _Up>
 inline _LIBCPP_HIDE_FROM_ABI typename basic_string<_CharT, _Traits, _Allocator>::size_type
 erase(basic_string<_CharT, _Traits, _Allocator>& __str, const _Up& __v) {
@@ -4308,9 +4310,9 @@ erase_if(basic_string<_CharT, _Traits, _Allocator>& __str, _Predicate __pred) {
   __str.erase(std::remove_if(__str.begin(), __str.end(), __pred), __str.end());
   return __old_size - __str.size();
 }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 // Literal suffixes for basic_string [basic.string.literals]
 inline namespace literals {
 inline namespace string_literals {
@@ -4319,18 +4321,18 @@ operator""s(const char* __str, size_t __len) {
   return basic_string<char>(__str, __len);
 }
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<wchar_t>
 operator""s(const wchar_t* __str, size_t __len) {
   return basic_string<wchar_t>(__str, __len);
 }
-#  endif
+#    endif
 
-#  if _LIBCPP_HAS_CHAR8_T
+#    if _LIBCPP_HAS_CHAR8_T
 inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string<char8_t> operator""s(const char8_t* __str, size_t __len) {
   return basic_string<char8_t>(__str, __len);
 }
-#  endif
+#    endif
 
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<char16_t>
 operator""s(const char16_t* __str, size_t __len) {
@@ -4344,30 +4346,31 @@ operator""s(const char32_t* __str, size_t __len) {
 } // namespace string_literals
 } // namespace literals
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <>
 inline constexpr bool __format::__enable_insertable<std::basic_string<char>> = true;
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 inline constexpr bool __format::__enable_insertable<std::basic_string<wchar_t>> = true;
+#      endif
 #    endif
-#  endif
 
-#endif
+#  endif
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iterator>
-#  include <new>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iterator>
+#    include <new>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STRING

--- a/libcxx/include/string.h
+++ b/libcxx/include/string.h
@@ -51,24 +51,27 @@ size_t strlen(const char* s);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if __has_include_next(<string.h>)
-#  include_next <string.h>
-#endif
+#  if __has_include_next(<string.h>)
+#    include_next <string.h>
+#  endif
 
 // MSVCRT, GNU libc and its derivates may already have the correct prototype in
 // <string.h>. This macro can be defined by users if their C library provides
 // the right signature.
-#if defined(__CORRECT_ISO_CPP_STRING_H_PROTO) || defined(_LIBCPP_MSVCRT) || defined(_STRING_H_CPLUSPLUS_98_CONFORMANCE_)
-#  define _LIBCPP_STRING_H_HAS_CONST_OVERLOADS
-#endif
+#  if defined(__CORRECT_ISO_CPP_STRING_H_PROTO) || defined(_LIBCPP_MSVCRT) ||                                          \
+      defined(_STRING_H_CPLUSPLUS_98_CONFORMANCE_)
+#    define _LIBCPP_STRING_H_HAS_CONST_OVERLOADS
+#  endif
 
-#if defined(__cplusplus) && !defined(_LIBCPP_STRING_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
+#  if defined(__cplusplus) && !defined(_LIBCPP_STRING_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
 extern "C++" {
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD const char* strchr(const char* __s, int __c) {
   return __builtin_strchr(__s, __c);
@@ -105,6 +108,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD char* strstr(char* __s1,
   return __builtin_strstr(__s1, __s2);
 }
 } // extern "C++"
-#endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STRING_H

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -205,60 +205,62 @@ namespace std {
 
 // clang-format on
 
-#include <__algorithm/min.h>
-#include <__assert>
-#include <__config>
-#include <__cstddef/nullptr_t.h>
-#include <__cstddef/ptrdiff_t.h>
-#include <__cstddef/size_t.h>
-#include <__functional/hash.h>
-#include <__functional/unary_function.h>
-#include <__fwd/ostream.h>
-#include <__fwd/string.h>
-#include <__fwd/string_view.h>
-#include <__iterator/bounded_iter.h>
-#include <__iterator/concepts.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/reverse_iterator.h>
-#include <__iterator/wrap_iter.h>
-#include <__memory/pointer_traits.h>
-#include <__ranges/concepts.h>
-#include <__ranges/data.h>
-#include <__ranges/enable_borrowed_range.h>
-#include <__ranges/enable_view.h>
-#include <__ranges/size.h>
-#include <__string/char_traits.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_standard_layout.h>
-#include <__type_traits/is_trivial.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
-#include <__type_traits/type_identity.h>
-#include <iosfwd>
-#include <limits>
-#include <stdexcept>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/min.h>
+#  include <__assert>
+#  include <__config>
+#  include <__cstddef/nullptr_t.h>
+#  include <__cstddef/ptrdiff_t.h>
+#  include <__cstddef/size_t.h>
+#  include <__functional/hash.h>
+#  include <__functional/unary_function.h>
+#  include <__fwd/ostream.h>
+#  include <__fwd/string.h>
+#  include <__fwd/string_view.h>
+#  include <__iterator/bounded_iter.h>
+#  include <__iterator/concepts.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/reverse_iterator.h>
+#  include <__iterator/wrap_iter.h>
+#  include <__memory/pointer_traits.h>
+#  include <__ranges/concepts.h>
+#  include <__ranges/data.h>
+#  include <__ranges/enable_borrowed_range.h>
+#  include <__ranges/enable_view.h>
+#  include <__ranges/size.h>
+#  include <__string/char_traits.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_standard_layout.h>
+#  include <__type_traits/is_trivial.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__type_traits/type_identity.h>
+#  include <iosfwd>
+#  include <limits>
+#  include <stdexcept>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [string.view.synop]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -283,13 +285,13 @@ public:
   using const_pointer   = const _CharT*;
   using reference       = _CharT&;
   using const_reference = const _CharT&;
-#if defined(_LIBCPP_ABI_BOUNDED_ITERATORS)
+#  if defined(_LIBCPP_ABI_BOUNDED_ITERATORS)
   using const_iterator = __bounded_iter<const_pointer>;
-#elif defined(_LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW)
+#  elif defined(_LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW)
   using const_iterator = __wrap_iter<const_pointer>;
-#else
+#  else
   using const_iterator = const_pointer;
-#endif
+#  endif
   using iterator                                = const_iterator;
   using const_reverse_iterator                  = std::reverse_iterator<const_iterator>;
   using reverse_iterator                        = const_reverse_iterator;
@@ -313,7 +315,7 @@ public:
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view(const _CharT* __s, size_type __len) _NOEXCEPT
       : __data_(__s),
         __size_(__len) {
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
     // Allocations must fit in `ptrdiff_t` for pointer arithmetic to work. If `__len` exceeds it, the input
     // range could not have been valid. Most likely the caller underflowed some arithmetic and inadvertently
     // passed in a negative length.
@@ -322,10 +324,10 @@ public:
         "string_view::string_view(_CharT *, size_t): length does not fit in difference_type");
     _LIBCPP_ASSERT_NON_NULL(
         __len == 0 || __s != nullptr, "string_view::string_view(_CharT *, size_t): received nullptr");
-#endif
+#  endif
   }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <contiguous_iterator _It, sized_sentinel_for<_It> _End>
     requires(is_same_v<iter_value_t<_It>, _CharT> && !is_convertible_v<_End, size_type>)
   constexpr _LIBCPP_HIDE_FROM_ABI basic_string_view(_It __begin, _End __end)
@@ -333,9 +335,9 @@ public:
     _LIBCPP_ASSERT_VALID_INPUT_RANGE(
         (__end - __begin) >= 0, "std::string_view::string_view(iterator, sentinel) received invalid range");
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <class _Range>
     requires(!is_same_v<remove_cvref_t<_Range>, basic_string_view> && ranges::contiguous_range<_Range> &&
              ranges::sized_range<_Range> && is_same_v<ranges::range_value_t<_Range>, _CharT> &&
@@ -343,14 +345,14 @@ public:
              (!requires(remove_cvref_t<_Range>& __d) { __d.operator std::basic_string_view<_CharT, _Traits>(); }))
   constexpr explicit _LIBCPP_HIDE_FROM_ABI basic_string_view(_Range&& __r)
       : __data_(ranges::data(__r)), __size_(ranges::size(__r)) {}
-#endif // _LIBCPP_STD_VER >= 23
+#  endif // _LIBCPP_STD_VER >= 23
 
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view(const _CharT* __s)
       : __data_(__s), __size_(std::__char_traits_length_checked<_Traits>(__s)) {}
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   basic_string_view(nullptr_t) = delete;
-#endif
+#  endif
 
   // [string.view.iterators], iterators
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator begin() const _NOEXCEPT { return cbegin(); }
@@ -358,19 +360,19 @@ public:
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator end() const _NOEXCEPT { return cend(); }
 
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT {
-#ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data(), data(), data() + size());
-#else
+#  else
     return const_iterator(__data_);
-#endif
+#  endif
   }
 
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT {
-#ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+#  ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
     return std::__make_bounded_iter(data() + size(), data(), data() + size());
-#else
+#  else
     return const_iterator(__data_ + __size_);
-#endif
+#  endif
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI const_reverse_iterator rbegin() const _NOEXCEPT {
@@ -645,7 +647,7 @@ public:
         data(), size(), __s, __pos, traits_type::length(__s));
   }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   constexpr _LIBCPP_HIDE_FROM_ABI bool starts_with(basic_string_view __s) const noexcept {
     return size() >= __s.size() && compare(0, __s.size(), __s) == 0;
   }
@@ -669,15 +671,15 @@ public:
   constexpr _LIBCPP_HIDE_FROM_ABI bool ends_with(const value_type* __s) const noexcept {
     return ends_with(basic_string_view(__s));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   constexpr _LIBCPP_HIDE_FROM_ABI bool contains(basic_string_view __sv) const noexcept { return find(__sv) != npos; }
 
   constexpr _LIBCPP_HIDE_FROM_ABI bool contains(value_type __c) const noexcept { return find(__c) != npos; }
 
   constexpr _LIBCPP_HIDE_FROM_ABI bool contains(const value_type* __s) const { return find(__s) != npos; }
-#endif
+#  endif
 
 private:
   struct __assume_valid {};
@@ -698,29 +700,29 @@ private:
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(basic_string_view);
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _CharT, class _Traits>
 inline constexpr bool ranges::enable_view<basic_string_view<_CharT, _Traits>> = true;
 
 template <class _CharT, class _Traits>
 inline constexpr bool ranges::enable_borrowed_range<basic_string_view<_CharT, _Traits> > = true;
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
 // [string.view.deduct]
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <contiguous_iterator _It, sized_sentinel_for<_It> _End>
 basic_string_view(_It, _End) -> basic_string_view<iter_value_t<_It>>;
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
 template <ranges::contiguous_range _Range>
 basic_string_view(_Range) -> basic_string_view<ranges::range_value_t<_Range>>;
-#endif
+#  endif
 
 // [string.view.comparison]
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI constexpr bool operator==(basic_string_view<_CharT, _Traits> __lhs,
@@ -743,7 +745,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto operator<=>(basic_string_view<_CharT, _Trai
   }
 }
 
-#else
+#  else
 
 // operator ==
 
@@ -886,7 +888,7 @@ operator>=(__type_identity_t<basic_string_view<_CharT, _Traits> > __lhs,
   return __lhs.compare(__rhs) >= 0;
 }
 
-#endif //  _LIBCPP_STD_VER >= 20
+#  endif //  _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
@@ -903,10 +905,10 @@ struct __string_view_hash : public __unary_function<basic_string_view<_CharT, ch
 template <>
 struct hash<basic_string_view<char, char_traits<char> > > : __string_view_hash<char> {};
 
-#if _LIBCPP_HAS_CHAR8_T
+#  if _LIBCPP_HAS_CHAR8_T
 template <>
 struct hash<basic_string_view<char8_t, char_traits<char8_t> > > : __string_view_hash<char8_t> {};
-#endif
+#  endif
 
 template <>
 struct hash<basic_string_view<char16_t, char_traits<char16_t> > > : __string_view_hash<char16_t> {};
@@ -914,31 +916,31 @@ struct hash<basic_string_view<char16_t, char_traits<char16_t> > > : __string_vie
 template <>
 struct hash<basic_string_view<char32_t, char_traits<char32_t> > > : __string_view_hash<char32_t> {};
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 struct hash<basic_string_view<wchar_t, char_traits<wchar_t> > > : __string_view_hash<wchar_t> {};
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 inline namespace literals {
 inline namespace string_view_literals {
 inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char> operator""sv(const char* __str, size_t __len) noexcept {
   return basic_string_view<char>(__str, __len);
 }
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<wchar_t>
 operator""sv(const wchar_t* __str, size_t __len) noexcept {
   return basic_string_view<wchar_t>(__str, __len);
 }
-#  endif
+#    endif
 
-#  if _LIBCPP_HAS_CHAR8_T
+#    if _LIBCPP_HAS_CHAR8_T
 inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char8_t>
 operator""sv(const char8_t* __str, size_t __len) noexcept {
   return basic_string_view<char8_t>(__str, __len);
 }
-#  endif
+#    endif
 
 inline _LIBCPP_HIDE_FROM_ABI constexpr basic_string_view<char16_t>
 operator""sv(const char16_t* __str, size_t __len) noexcept {
@@ -951,17 +953,18 @@ operator""sv(const char32_t* __str, size_t __len) noexcept {
 }
 } // namespace string_view_literals
 } // namespace literals
-#endif
+#  endif
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iterator>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iterator>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_STRING_VIEW

--- a/libcxx/include/strstream
+++ b/libcxx/include/strstream
@@ -129,31 +129,33 @@ private:
 
 */
 
-#include <__config>
-#include <__ostream/basic_ostream.h>
-#include <istream>
-#include <streambuf>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__ostream/basic_ostream.h>
+#  include <istream>
+#  include <streambuf>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
+#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 class _LIBCPP_DEPRECATED _LIBCPP_EXPORTED_FROM_ABI strstreambuf : public streambuf {
 public:
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstreambuf() : strstreambuf(0) {}
   explicit strstreambuf(streamsize __alsize);
-#  else
+#    else
   explicit strstreambuf(streamsize __alsize = 0);
-#  endif
+#    endif
   strstreambuf(void* (*__palloc)(size_t), void (*__pfree)(void*));
   strstreambuf(char* __gnext, streamsize __n, char* __pbeg = nullptr);
   strstreambuf(const char* __gnext, streamsize __n);
@@ -163,10 +165,10 @@ public:
   strstreambuf(unsigned char* __gnext, streamsize __n, unsigned char* __pbeg = nullptr);
   strstreambuf(const unsigned char* __gnext, streamsize __n);
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstreambuf(strstreambuf&& __rhs);
   _LIBCPP_HIDE_FROM_ABI strstreambuf& operator=(strstreambuf&& __rhs);
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
   ~strstreambuf() override;
 
@@ -200,7 +202,7 @@ private:
   void __init(char* __gnext, streamsize __n, char* __pbeg);
 };
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 inline _LIBCPP_HIDE_FROM_ABI strstreambuf::strstreambuf(strstreambuf&& __rhs)
     : streambuf(__rhs),
@@ -229,7 +231,7 @@ inline _LIBCPP_HIDE_FROM_ABI strstreambuf& strstreambuf::operator=(strstreambuf&
   return *this;
 }
 
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
 class _LIBCPP_DEPRECATED _LIBCPP_EXPORTED_FROM_ABI istrstream : public istream {
 public:
@@ -238,7 +240,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI istrstream(const char* __s, streamsize __n) : istream(&__sb_), __sb_(__s, __n) {}
   _LIBCPP_HIDE_FROM_ABI istrstream(char* __s, streamsize __n) : istream(&__sb_), __sb_(__s, __n) {}
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI istrstream(istrstream&& __rhs) // extension
       : istream(std::move(static_cast<istream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     istream::set_rdbuf(&__sb_);
@@ -249,7 +251,7 @@ public:
     istream::operator=(std::move(__rhs));
     return *this;
   }
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
   ~istrstream() override;
 
@@ -271,7 +273,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI ostrstream(char* __s, int __n, ios_base::openmode __mode = ios_base::out)
       : ostream(&__sb_), __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0)) {}
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI ostrstream(ostrstream&& __rhs) // extension
       : ostream(std::move(static_cast<ostream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     ostream::set_rdbuf(&__sb_);
@@ -282,7 +284,7 @@ public:
     ostream::operator=(std::move(__rhs));
     return *this;
   }
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
   ~ostrstream() override;
 
@@ -313,7 +315,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI strstream(char* __s, int __n, ios_base::openmode __mode = ios_base::in | ios_base::out)
       : iostream(&__sb_), __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0)) {}
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstream(strstream&& __rhs) // extension
       : iostream(std::move(static_cast<iostream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     iostream::set_rdbuf(&__sb_);
@@ -324,7 +326,7 @@ public:
     iostream::operator=(std::move(__rhs));
     return *this;
   }
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
   ~strstream() override;
 
@@ -347,6 +349,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
+#  endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
+#endif   // 0
 
 #endif // _LIBCPP_STRSTREAM

--- a/libcxx/include/syncstream
+++ b/libcxx/include/syncstream
@@ -117,37 +117,39 @@ namespace std {
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  include <__mutex/lock_guard.h>
-#  include <__utility/move.h>
-#  include <ios>
-#  include <iosfwd> // required for declaration of default arguments
-#  include <streambuf>
-#  include <string>
+#    include <__mutex/lock_guard.h>
+#    include <__utility/move.h>
+#    include <ios>
+#    include <iosfwd> // required for declaration of default arguments
+#    include <streambuf>
+#    include <string>
 
-#  if _LIBCPP_HAS_THREADS
-#    include <map>
-#    include <shared_mutex>
-#  endif
+#    if _LIBCPP_HAS_THREADS
+#      include <map>
+#      include <shared_mutex>
+#    endif
 
 // standard-mandated includes
 
 // [syncstream.syn]
-#  include <ostream>
+#    include <ostream>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#  if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
+#    if _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
 
 // [syncstream.syncbuf.overview]/1
 //   Class template basic_syncbuf stores character data written to it,
@@ -160,7 +162,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 //
 // This helper singleton is used to implement the required
 // synchronisation guarantees.
-#    if _LIBCPP_HAS_THREADS
+#      if _LIBCPP_HAS_THREADS
 class __wrapped_streambuf_mutex {
   _LIBCPP_HIDE_FROM_ABI __wrapped_streambuf_mutex() = default;
 
@@ -233,7 +235,7 @@ private:
     return __it;
   }
 };
-#    endif // _LIBCPP_HAS_THREADS
+#      endif // _LIBCPP_HAS_THREADS
 
 // basic_syncbuf
 
@@ -273,14 +275,14 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI ~basic_syncbuf() {
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
     try {
-#    endif // _LIBCPP_HAS_EXCEPTIONS
+#      endif // _LIBCPP_HAS_EXCEPTIONS
       emit();
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
     }
-#    endif // _LIBCPP_HAS_EXCEPTIONS
+#      endif // _LIBCPP_HAS_EXCEPTIONS
     __dec_reference();
   }
 
@@ -337,9 +339,9 @@ protected:
       return traits_type::not_eof(__c);
 
     if (this->pptr() == this->epptr()) {
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
       try {
-#    endif
+#      endif
         size_t __size = __str_.size();
         __str_.resize(__str_.capacity() + 1);
         _LIBCPP_ASSERT_INTERNAL(__str_.size() > __size, "the buffer hasn't grown");
@@ -348,11 +350,11 @@ protected:
         this->setp(__p, __p + __str_.size());
         this->pbump(__size);
 
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
       } catch (...) {
         return traits_type::eof();
       }
-#    endif
+#      endif
     }
 
     return this->sputc(traits_type::to_char_type(__c));
@@ -373,9 +375,9 @@ private:
     if (!__wrapped_)
       return false;
 
-#    if _LIBCPP_HAS_THREADS
+#      if _LIBCPP_HAS_THREADS
     lock_guard<mutex> __lock = __wrapped_streambuf_mutex::__instance().__get_lock(__wrapped_);
-#    endif
+#      endif
 
     bool __result = true;
     if (this->pptr() != this->pbase()) {
@@ -407,24 +409,24 @@ private:
   }
 
   _LIBCPP_HIDE_FROM_ABI void __inc_reference() {
-#    if _LIBCPP_HAS_THREADS
+#      if _LIBCPP_HAS_THREADS
     if (__wrapped_)
       __wrapped_streambuf_mutex::__instance().__inc_reference(__wrapped_);
-#    endif
+#      endif
   }
 
   _LIBCPP_HIDE_FROM_ABI void __dec_reference() noexcept {
-#    if _LIBCPP_HAS_THREADS
+#      if _LIBCPP_HAS_THREADS
     if (__wrapped_)
       __wrapped_streambuf_mutex::__instance().__dec_reference(__wrapped_);
-#    endif
+#      endif
   }
 };
 
 using std::syncbuf;
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 using std::wsyncbuf;
-#    endif
+#      endif
 
 // [syncstream.syncbuf.special], specialized algorithms
 template <class _CharT, class _Traits, class _Allocator>
@@ -480,17 +482,17 @@ public:
     // TODO validate other unformatted output functions.
     typename basic_ostream<char_type, traits_type>::sentry __s(*this);
     if (__s) {
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
       try {
-#    endif
+#      endif
 
         if (__sb_.emit() == false)
           this->setstate(ios::badbit);
-#    if _LIBCPP_HAS_EXCEPTIONS
+#      if _LIBCPP_HAS_EXCEPTIONS
       } catch (...) {
         this->__set_badbit_and_consider_rethrow();
       }
-#    endif
+#      endif
     }
   }
 
@@ -505,16 +507,17 @@ private:
 };
 
 using std::osyncstream;
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 using std::wosyncstream;
-#    endif
+#      endif
 
-#  endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
+#    endif // _LIBCPP_STD_VER >= 20 && !defined(_LIBCPP_HAS_NO_EXPERIMENTAL_SYNCSTREAM)
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#endif // _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_LOCALIZATION
+#endif   // 0
 
 #endif // _LIBCPP_SYNCSTREAM

--- a/libcxx/include/system_error
+++ b/libcxx/include/system_error
@@ -144,28 +144,31 @@ template <> struct hash<std::error_condition>;
 
 */
 
-#include <__config>
-#include <__system_error/errc.h>
-#include <__system_error/error_category.h>
-#include <__system_error/error_code.h>
-#include <__system_error/error_condition.h>
-#include <__system_error/system_error.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__system_error/errc.h>
+#  include <__system_error/error_category.h>
+#  include <__system_error/error_code.h>
+#  include <__system_error/error_condition.h>
+#  include <__system_error/system_error.h>
+#  include <version>
 
 // standard-mandated includes
 
 // [system.error.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstdint>
-#  include <cstring>
-#  include <limits>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstdint>
+#    include <cstring>
+#    include <limits>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_SYSTEM_ERROR

--- a/libcxx/include/tgmath.h
+++ b/libcxx/include/tgmath.h
@@ -17,19 +17,22 @@
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
-
-#ifdef __cplusplus
-#  include <cmath>
-#  include <complex>
-#else
-#  if __has_include_next(<tgmath.h>)
-#    include_next <tgmath.h>
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
 #  endif
-#endif
+
+#  ifdef __cplusplus
+#    include <cmath>
+#    include <complex>
+#  else
+#    if __has_include_next(<tgmath.h>)
+#      include_next <tgmath.h>
+#    endif
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_TGMATH_H

--- a/libcxx/include/thread
+++ b/libcxx/include/thread
@@ -86,44 +86,47 @@ void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_HAS_THREADS
+#  if _LIBCPP_HAS_THREADS
 
-#  include <__thread/this_thread.h>
-#  include <__thread/thread.h>
+#    include <__thread/this_thread.h>
+#    include <__thread/thread.h>
 
-#  if _LIBCPP_STD_VER >= 20
-#    include <__thread/jthread.h>
-#  endif
+#    if _LIBCPP_STD_VER >= 20
+#      include <__thread/jthread.h>
+#    endif
 
-#  if _LIBCPP_STD_VER >= 23
-#    include <__thread/formatter.h>
-#  endif
+#    if _LIBCPP_STD_VER >= 23
+#      include <__thread/formatter.h>
+#    endif
 
-#  include <version>
+#    include <version>
 
 // standard-mandated includes
 
 // [thread.syn]
-#  include <compare>
+#    include <compare>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
+
+#  endif // _LIBCPP_HAS_THREADS
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
+#    include <chrono>
 #  endif
 
-#endif // _LIBCPP_HAS_THREADS
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 17
-#  include <chrono>
-#endif
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstring>
-#  include <functional>
-#  include <new>
-#  include <system_error>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstring>
+#    include <functional>
+#    include <new>
+#    include <system_error>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_THREAD

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -210,76 +210,78 @@ template <class... Types>
 
 // clang-format on
 
-#include <__compare/common_comparison_category.h>
-#include <__compare/ordering.h>
-#include <__compare/synth_three_way.h>
-#include <__config>
-#include <__cstddef/size_t.h>
-#include <__fwd/array.h>
-#include <__fwd/pair.h>
-#include <__fwd/tuple.h>
-#include <__memory/allocator_arg_t.h>
-#include <__memory/uses_allocator.h>
-#include <__tuple/find_index.h>
-#include <__tuple/ignore.h>
-#include <__tuple/make_tuple_types.h>
-#include <__tuple/sfinae_helpers.h>
-#include <__tuple/tuple_element.h>
-#include <__tuple/tuple_indices.h>
-#include <__tuple/tuple_like_ext.h>
-#include <__tuple/tuple_size.h>
-#include <__tuple/tuple_types.h>
-#include <__type_traits/common_reference.h>
-#include <__type_traits/common_type.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/conjunction.h>
-#include <__type_traits/copy_cvref.h>
-#include <__type_traits/disjunction.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/invoke.h>
-#include <__type_traits/is_arithmetic.h>
-#include <__type_traits/is_assignable.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_empty.h>
-#include <__type_traits/is_final.h>
-#include <__type_traits/is_implicitly_default_constructible.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/is_trivially_relocatable.h>
-#include <__type_traits/lazy.h>
-#include <__type_traits/maybe_const.h>
-#include <__type_traits/nat.h>
-#include <__type_traits/negation.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
-#include <__type_traits/unwrap_ref.h>
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/integer_sequence.h>
-#include <__utility/move.h>
-#include <__utility/piecewise_construct.h>
-#include <__utility/swap.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__compare/common_comparison_category.h>
+#  include <__compare/ordering.h>
+#  include <__compare/synth_three_way.h>
+#  include <__config>
+#  include <__cstddef/size_t.h>
+#  include <__fwd/array.h>
+#  include <__fwd/pair.h>
+#  include <__fwd/tuple.h>
+#  include <__memory/allocator_arg_t.h>
+#  include <__memory/uses_allocator.h>
+#  include <__tuple/find_index.h>
+#  include <__tuple/ignore.h>
+#  include <__tuple/make_tuple_types.h>
+#  include <__tuple/sfinae_helpers.h>
+#  include <__tuple/tuple_element.h>
+#  include <__tuple/tuple_indices.h>
+#  include <__tuple/tuple_like_ext.h>
+#  include <__tuple/tuple_size.h>
+#  include <__tuple/tuple_types.h>
+#  include <__type_traits/common_reference.h>
+#  include <__type_traits/common_type.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/conjunction.h>
+#  include <__type_traits/copy_cvref.h>
+#  include <__type_traits/disjunction.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/invoke.h>
+#  include <__type_traits/is_arithmetic.h>
+#  include <__type_traits/is_assignable.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_empty.h>
+#  include <__type_traits/is_final.h>
+#  include <__type_traits/is_implicitly_default_constructible.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_reference.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/is_trivially_relocatable.h>
+#  include <__type_traits/lazy.h>
+#  include <__type_traits/maybe_const.h>
+#  include <__type_traits/nat.h>
+#  include <__type_traits/negation.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__type_traits/unwrap_ref.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/integer_sequence.h>
+#  include <__utility/move.h>
+#  include <__utility/piecewise_construct.h>
+#  include <__utility/swap.h>
+#  include <version>
 
 // standard-mandated includes
 
 // [tuple.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 // __tuple_leaf
 
@@ -305,11 +307,11 @@ class __tuple_leaf {
 
   template <class _Tp>
   static _LIBCPP_HIDE_FROM_ABI constexpr bool __can_bind_reference() {
-#  if __has_keyword(__reference_binds_to_temporary)
+#    if __has_keyword(__reference_binds_to_temporary)
     return !__reference_binds_to_temporary(_Hp, _Tp);
-#  else
+#    else
     return true;
-#  endif
+#    endif
   }
 
 public:
@@ -693,7 +695,7 @@ public:
       tuple(allocator_arg_t, const _Alloc& __a, const tuple<_Up...>& __t)
       : __base_(allocator_arg_t(), __a, __t) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   // tuple(tuple<U...>&) constructors (including allocator_arg_t variants)
 
   template <class... _Up, enable_if_t< _EnableCtorFromUTypesTuple<tuple<_Up...>&>::value>* = nullptr>
@@ -704,7 +706,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_Lazy<_And, is_convertible<_Up&, _Tp>...>::value)
       tuple(allocator_arg_t, const _Alloc& __alloc, tuple<_Up...>& __t)
       : __base_(allocator_arg_t(), __alloc, __t) {}
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   // tuple(tuple<U...>&&) constructors (including allocator_arg_t variants)
   template <class... _Up, __enable_if_t< _And< _EnableCtorFromUTypesTuple<tuple<_Up...>&&> >::value, int> = 0>
@@ -719,7 +721,7 @@ public:
       tuple(allocator_arg_t, const _Alloc& __a, tuple<_Up...>&& __t)
       : __base_(allocator_arg_t(), __a, std::move(__t)) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   // tuple(const tuple<U...>&&) constructors (including allocator_arg_t variants)
 
   template <class... _Up, enable_if_t< _EnableCtorFromUTypesTuple<const tuple<_Up...>&&>::value>* = nullptr>
@@ -733,7 +735,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_Lazy<_And, is_convertible<const _Up&&, _Tp>...>::value)
       tuple(allocator_arg_t, const _Alloc& __alloc, const tuple<_Up...>&& __t)
       : __base_(allocator_arg_t(), __alloc, std::move(__t)) {}
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   // tuple(const pair<U1, U2>&) constructors (including allocator_arg_t variants)
 
@@ -779,7 +781,7 @@ public:
       tuple(allocator_arg_t, const _Alloc& __a, const pair<_Up1, _Up2>& __p)
       : __base_(allocator_arg_t(), __a, __p) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   // tuple(pair<U1, U2>&) constructors (including allocator_arg_t variants)
 
   template <class _U1, class _U2, enable_if_t< _EnableCtorFromPair<pair<_U1, _U2>&>::value>* = nullptr>
@@ -794,7 +796,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_BothImplicitlyConvertible<pair<_U1, _U2>&>::value)
       tuple(allocator_arg_t, const _Alloc& __alloc, pair<_U1, _U2>& __p)
       : __base_(allocator_arg_t(), __alloc, __p) {}
-#  endif
+#    endif
 
   // tuple(pair<U1, U2>&&) constructors (including allocator_arg_t variants)
 
@@ -817,7 +819,7 @@ public:
       tuple(allocator_arg_t, const _Alloc& __a, pair<_Up1, _Up2>&& __p)
       : __base_(allocator_arg_t(), __a, std::move(__p)) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   // tuple(const pair<U1, U2>&&) constructors (including allocator_arg_t variants)
 
   template <class _U1, class _U2, enable_if_t< _EnableCtorFromPair<const pair<_U1, _U2>&&>::value>* = nullptr>
@@ -832,7 +834,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr explicit(!_BothImplicitlyConvertible<const pair<_U1, _U2>&&>::value)
       tuple(allocator_arg_t, const _Alloc& __alloc, const pair<_U1, _U2>&& __p)
       : __base_(allocator_arg_t(), __alloc, std::move(__p)) {}
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   // [tuple.assign]
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple&
@@ -842,7 +844,7 @@ public:
     return *this;
   }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   _LIBCPP_HIDE_FROM_ABI constexpr const tuple& operator=(tuple const& __tuple) const
     requires(_And<is_copy_assignable<const _Tp>...>::value)
   {
@@ -857,7 +859,7 @@ public:
         *this, std::move(__tuple), __tuple_types<_Tp...>(), typename __make_tuple_indices<sizeof...(_Tp)>::type());
     return *this;
   }
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple&
   operator=(_If<_And<is_move_assignable<_Tp>...>::value, tuple, __nat>&& __tuple) noexcept(
@@ -887,7 +889,7 @@ public:
     return *this;
   }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <class... _UTypes,
             enable_if_t< _And<_BoolConstant<sizeof...(_Tp) == sizeof...(_UTypes)>,
                               is_assignable<const _Tp&, const _UTypes&>...>::value>* = nullptr>
@@ -904,7 +906,7 @@ public:
         *this, __u, __tuple_types<_UTypes...>(), typename __make_tuple_indices<sizeof...(_Tp)>::type());
     return *this;
   }
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   template <template <class...> class _Pred,
             bool _Const,
@@ -924,7 +926,7 @@ public:
   template <bool _Const, class _Pair>
   struct _NothrowAssignFromPair : _AssignPredicateFromPair<is_nothrow_assignable, _Const, _Pair> {};
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <class _U1, class _U2, enable_if_t< _EnableAssignFromPair<true, const pair<_U1, _U2>&>::value>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI constexpr const tuple& operator=(const pair<_U1, _U2>& __pair) const
       noexcept(_NothrowAssignFromPair<true, const pair<_U1, _U2>&>::value) {
@@ -940,7 +942,7 @@ public:
     std::get<1>(*this) = std::move(__pair.second);
     return *this;
   }
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
   template <class _Up1,
             class _Up2,
@@ -992,12 +994,12 @@ public:
     __base_.swap(__t.__base_);
   }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   _LIBCPP_HIDE_FROM_ABI constexpr void swap(const tuple& __t) const
       noexcept(__all<is_nothrow_swappable_v<const _Tp&>...>::value) {
     __base_.swap(__t.__base_);
   }
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 };
 
 template <>
@@ -1013,12 +1015,12 @@ public:
   template <class _Alloc, class _Up>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 tuple(allocator_arg_t, const _Alloc&, array<_Up, 0>) _NOEXCEPT {}
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(tuple&) _NOEXCEPT {}
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   _LIBCPP_HIDE_FROM_ABI constexpr void swap(const tuple&) const noexcept {}
-#  endif
+#    endif
 };
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <class... _TTypes, class... _UTypes, template <class> class _TQual, template <class> class _UQual>
   requires requires { typename tuple<common_reference_t<_TQual<_TTypes>, _UQual<_UTypes>>...>; }
 struct basic_common_reference<tuple<_TTypes...>, tuple<_UTypes...>, _TQual, _UQual> {
@@ -1030,9 +1032,9 @@ template <class... _TTypes, class... _UTypes>
 struct common_type<tuple<_TTypes...>, tuple<_UTypes...>> {
   using type = tuple<common_type_t<_TTypes, _UTypes>...>;
 };
-#  endif // _LIBCPP_STD_VER >= 23
+#    endif // _LIBCPP_STD_VER >= 23
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 template <class... _Tp>
 tuple(_Tp...) -> tuple<_Tp...>;
 template <class _Tp1, class _Tp2>
@@ -1043,7 +1045,7 @@ template <class _Alloc, class _Tp1, class _Tp2>
 tuple(allocator_arg_t, _Alloc, pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
 template <class _Alloc, class... _Tp>
 tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
-#  endif
+#    endif
 
 template <class... _Tp, __enable_if_t<__all<__is_swappable_v<_Tp>...>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
@@ -1051,14 +1053,14 @@ swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<__is_nothrow_swappab
   __t.swap(__u);
 }
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <class... _Tp>
 _LIBCPP_HIDE_FROM_ABI constexpr enable_if_t<__all<is_swappable_v<const _Tp>...>::value, void>
 swap(const tuple<_Tp...>& __lhs,
      const tuple<_Tp...>& __rhs) noexcept(__all<is_nothrow_swappable_v<const _Tp>...>::value) {
   __lhs.swap(__rhs);
 }
-#  endif
+#    endif
 
 // get
 
@@ -1090,7 +1092,7 @@ get(const tuple<_Tp...>&& __t) _NOEXCEPT {
   return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__t.__base_).get());
 }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
 
 template <class _T1, class... _Args>
 inline _LIBCPP_HIDE_FROM_ABI constexpr _T1& get(tuple<_Args...>& __tup) noexcept {
@@ -1112,7 +1114,7 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr _T1 const&& get(tuple<_Args...> const&& _
   return std::get<__find_exactly_one_t<_T1, _Args...>::value>(std::move(__tup));
 }
 
-#  endif
+#    endif
 
 // tie
 
@@ -1155,7 +1157,7 @@ operator==(const tuple<_Tp...>& __x, const tuple<_Up...>& __y) {
   return __tuple_equal<sizeof...(_Tp)>()(__x, __y);
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 // operator<=>
 
@@ -1175,7 +1177,7 @@ operator<=>(const tuple<_Tp...>& __x, const tuple<_Up...>& __y) {
   return std::__tuple_compare_three_way(__x, __y, index_sequence_for<_Tp...>{});
 }
 
-#  else // _LIBCPP_STD_VER >= 20
+#    else // _LIBCPP_STD_VER >= 20
 
 template <class... _Tp, class... _Up>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 bool
@@ -1229,7 +1231,7 @@ operator<=(const tuple<_Tp...>& __x, const tuple<_Up...>& __y) {
   return !(__y < __x);
 }
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 // tuple_cat
 
@@ -1345,9 +1347,9 @@ tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls) {
 template <class... _Tp, class _Alloc>
 struct _LIBCPP_TEMPLATE_VIS uses_allocator<tuple<_Tp...>, _Alloc> : true_type {};
 
-#  if _LIBCPP_STD_VER >= 17
-#    define _LIBCPP_NOEXCEPT_RETURN(...)                                                                               \
-      noexcept(noexcept(__VA_ARGS__)) { return __VA_ARGS__; }
+#    if _LIBCPP_STD_VER >= 17
+#      define _LIBCPP_NOEXCEPT_RETURN(...)                                                                             \
+        noexcept(noexcept(__VA_ARGS__)) { return __VA_ARGS__; }
 
 // The _LIBCPP_NOEXCEPT_RETURN macro breaks formatting.
 // clang-format off
@@ -1410,14 +1412,15 @@ _LIBCPP_POP_MACROS
 
 // clang-format on
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <exception>
-#  include <iosfwd>
-#  include <new>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <exception>
+#    include <iosfwd>
+#    include <new>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_TUPLE

--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -424,108 +424,111 @@ namespace std
 
 */
 
-#include <__config>
-#include <__type_traits/add_cv_quals.h>
-#include <__type_traits/add_lvalue_reference.h>
-#include <__type_traits/add_pointer.h>
-#include <__type_traits/add_rvalue_reference.h>
-#include <__type_traits/aligned_storage.h>
-#include <__type_traits/aligned_union.h>
-#include <__type_traits/alignment_of.h>
-#include <__type_traits/common_type.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/decay.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/extent.h>
-#include <__type_traits/has_virtual_destructor.h>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_abstract.h>
-#include <__type_traits/is_arithmetic.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_assignable.h>
-#include <__type_traits/is_base_of.h>
-#include <__type_traits/is_class.h>
-#include <__type_traits/is_compound.h>
-#include <__type_traits/is_const.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_destructible.h>
-#include <__type_traits/is_empty.h>
-#include <__type_traits/is_enum.h>
-#include <__type_traits/is_floating_point.h>
-#include <__type_traits/is_function.h>
-#include <__type_traits/is_fundamental.h>
-#include <__type_traits/is_integral.h>
-#include <__type_traits/is_literal_type.h>
-#include <__type_traits/is_member_pointer.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_nothrow_destructible.h>
-#include <__type_traits/is_object.h>
-#include <__type_traits/is_pod.h>
-#include <__type_traits/is_pointer.h>
-#include <__type_traits/is_polymorphic.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_scalar.h>
-#include <__type_traits/is_signed.h>
-#include <__type_traits/is_standard_layout.h>
-#include <__type_traits/is_trivial.h>
-#include <__type_traits/is_trivially_assignable.h>
-#include <__type_traits/is_trivially_constructible.h>
-#include <__type_traits/is_trivially_copyable.h>
-#include <__type_traits/is_trivially_destructible.h>
-#include <__type_traits/is_union.h>
-#include <__type_traits/is_unsigned.h>
-#include <__type_traits/is_void.h>
-#include <__type_traits/is_volatile.h>
-#include <__type_traits/make_signed.h>
-#include <__type_traits/make_unsigned.h>
-#include <__type_traits/rank.h>
-#include <__type_traits/remove_all_extents.h>
-#include <__type_traits/remove_const.h>
-#include <__type_traits/remove_cv.h>
-#include <__type_traits/remove_extent.h>
-#include <__type_traits/remove_pointer.h>
-#include <__type_traits/remove_reference.h>
-#include <__type_traits/remove_volatile.h>
-#include <__type_traits/result_of.h>
-#include <__type_traits/underlying_type.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__type_traits/add_cv_quals.h>
+#  include <__type_traits/add_lvalue_reference.h>
+#  include <__type_traits/add_pointer.h>
+#  include <__type_traits/add_rvalue_reference.h>
+#  include <__type_traits/aligned_storage.h>
+#  include <__type_traits/aligned_union.h>
+#  include <__type_traits/alignment_of.h>
+#  include <__type_traits/common_type.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/decay.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/extent.h>
+#  include <__type_traits/has_virtual_destructor.h>
+#  include <__type_traits/integral_constant.h>
+#  include <__type_traits/is_abstract.h>
+#  include <__type_traits/is_arithmetic.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_assignable.h>
+#  include <__type_traits/is_base_of.h>
+#  include <__type_traits/is_class.h>
+#  include <__type_traits/is_compound.h>
+#  include <__type_traits/is_const.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_destructible.h>
+#  include <__type_traits/is_empty.h>
+#  include <__type_traits/is_enum.h>
+#  include <__type_traits/is_floating_point.h>
+#  include <__type_traits/is_function.h>
+#  include <__type_traits/is_fundamental.h>
+#  include <__type_traits/is_integral.h>
+#  include <__type_traits/is_literal_type.h>
+#  include <__type_traits/is_member_pointer.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_nothrow_destructible.h>
+#  include <__type_traits/is_object.h>
+#  include <__type_traits/is_pod.h>
+#  include <__type_traits/is_pointer.h>
+#  include <__type_traits/is_polymorphic.h>
+#  include <__type_traits/is_reference.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_scalar.h>
+#  include <__type_traits/is_signed.h>
+#  include <__type_traits/is_standard_layout.h>
+#  include <__type_traits/is_trivial.h>
+#  include <__type_traits/is_trivially_assignable.h>
+#  include <__type_traits/is_trivially_constructible.h>
+#  include <__type_traits/is_trivially_copyable.h>
+#  include <__type_traits/is_trivially_destructible.h>
+#  include <__type_traits/is_union.h>
+#  include <__type_traits/is_unsigned.h>
+#  include <__type_traits/is_void.h>
+#  include <__type_traits/is_volatile.h>
+#  include <__type_traits/make_signed.h>
+#  include <__type_traits/make_unsigned.h>
+#  include <__type_traits/rank.h>
+#  include <__type_traits/remove_all_extents.h>
+#  include <__type_traits/remove_const.h>
+#  include <__type_traits/remove_cv.h>
+#  include <__type_traits/remove_extent.h>
+#  include <__type_traits/remove_pointer.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__type_traits/remove_volatile.h>
+#  include <__type_traits/result_of.h>
+#  include <__type_traits/underlying_type.h>
 
-#if _LIBCPP_STD_VER >= 14
-#  include <__type_traits/is_final.h>
-#  include <__type_traits/is_null_pointer.h>
-#endif
+#  if _LIBCPP_STD_VER >= 14
+#    include <__type_traits/is_final.h>
+#    include <__type_traits/is_null_pointer.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__type_traits/conjunction.h>
-#  include <__type_traits/disjunction.h>
-#  include <__type_traits/has_unique_object_representation.h>
-#  include <__type_traits/invoke.h>
-#  include <__type_traits/is_aggregate.h>
-#  include <__type_traits/is_swappable.h>
-#  include <__type_traits/negation.h>
-#  include <__type_traits/void_t.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__type_traits/conjunction.h>
+#    include <__type_traits/disjunction.h>
+#    include <__type_traits/has_unique_object_representation.h>
+#    include <__type_traits/invoke.h>
+#    include <__type_traits/is_aggregate.h>
+#    include <__type_traits/is_swappable.h>
+#    include <__type_traits/negation.h>
+#    include <__type_traits/void_t.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__type_traits/common_reference.h>
-#  include <__type_traits/is_bounded_array.h>
-#  include <__type_traits/is_constant_evaluated.h>
-#  include <__type_traits/is_nothrow_convertible.h>
-#  include <__type_traits/is_unbounded_array.h>
-#  include <__type_traits/type_identity.h>
-#  include <__type_traits/unwrap_ref.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__type_traits/common_reference.h>
+#    include <__type_traits/is_bounded_array.h>
+#    include <__type_traits/is_constant_evaluated.h>
+#    include <__type_traits/is_nothrow_convertible.h>
+#    include <__type_traits/is_unbounded_array.h>
+#    include <__type_traits/type_identity.h>
+#    include <__type_traits/unwrap_ref.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__type_traits/is_implicit_lifetime.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__type_traits/is_implicit_lifetime.h>
+#  endif
 
-#include <version>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_TYPE_TRAITS

--- a/libcxx/include/typeindex
+++ b/libcxx/include/typeindex
@@ -45,17 +45,19 @@ struct hash<type_index>
 
 */
 
-#include <__config>
-#include <__functional/unary_function.h>
-#include <typeinfo>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__functional/unary_function.h>
+#  include <typeinfo>
+#  include <version>
 
 // standard-mandated includes
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -66,14 +68,14 @@ public:
   _LIBCPP_HIDE_FROM_ABI type_index(const type_info& __y) _NOEXCEPT : __t_(&__y) {}
 
   _LIBCPP_HIDE_FROM_ABI bool operator==(const type_index& __y) const _NOEXCEPT { return *__t_ == *__y.__t_; }
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const type_index& __y) const _NOEXCEPT { return *__t_ != *__y.__t_; }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI bool operator<(const type_index& __y) const _NOEXCEPT { return __t_->before(*__y.__t_); }
   _LIBCPP_HIDE_FROM_ABI bool operator<=(const type_index& __y) const _NOEXCEPT { return !__y.__t_->before(*__t_); }
   _LIBCPP_HIDE_FROM_ABI bool operator>(const type_index& __y) const _NOEXCEPT { return __y.__t_->before(*__t_); }
   _LIBCPP_HIDE_FROM_ABI bool operator>=(const type_index& __y) const _NOEXCEPT { return !__t_->before(*__y.__t_); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI strong_ordering operator<=>(const type_index& __y) const noexcept {
     if (*__t_ == *__y.__t_)
       return strong_ordering::equal;
@@ -81,7 +83,7 @@ public:
       return strong_ordering::less;
     return strong_ordering::greater;
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI size_t hash_code() const _NOEXCEPT { return __t_->hash_code(); }
   _LIBCPP_HIDE_FROM_ABI const char* name() const _NOEXCEPT { return __t_->name(); }
@@ -97,11 +99,12 @@ struct _LIBCPP_TEMPLATE_VIS hash<type_index> : public __unary_function<type_inde
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <iosfwd>
-#  include <new>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <iosfwd>
+#    include <new>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_TYPEINDEX

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -56,27 +56,29 @@ public:
 
 */
 
-#include <__config>
-#include <__cstddef/size_t.h>
-#include <__exception/exception.h>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_constant_evaluated.h>
-#include <__verbose_abort>
-#include <cstdint>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/size_t.h>
+#  include <__exception/exception.h>
+#  include <__type_traits/integral_constant.h>
+#  include <__type_traits/is_constant_evaluated.h>
+#  include <__verbose_abort>
+#  include <cstdint>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if defined(_LIBCPP_ABI_VCRUNTIME)
-#  include <vcruntime_typeinfo.h>
-#else
+#  if defined(_LIBCPP_ABI_VCRUNTIME)
+#    include <vcruntime_typeinfo.h>
+#  else
 
 namespace std // purposefully not using versioning namespace
 {
 
-#  if defined(_LIBCPP_ABI_MICROSOFT)
+#    if defined(_LIBCPP_ABI_MICROSOFT)
 
 class _LIBCPP_EXPORTED_FROM_ABI type_info {
   type_info& operator=(const type_info&);
@@ -107,12 +109,12 @@ public:
     return __compare(__arg) == 0;
   }
 
-#    if _LIBCPP_STD_VER <= 17
+#      if _LIBCPP_STD_VER <= 17
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const type_info& __arg) const _NOEXCEPT { return !operator==(__arg); }
-#    endif
+#      endif
 };
 
-#  else // !defined(_LIBCPP_ABI_MICROSOFT)
+#    else // !defined(_LIBCPP_ABI_MICROSOFT)
 
 // ========================================================================== //
 //                           Implementations
@@ -167,21 +169,21 @@ public:
 
 // This value can be overriden in the __config_site. When it's not overriden,
 // we pick a default implementation based on the platform here.
-#    ifndef _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION
+#      ifndef _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION
 
 // Windows and AIX binaries can't merge typeinfos, so use the NonUnique implementation.
-#      if defined(_LIBCPP_OBJECT_FORMAT_COFF) || defined(_LIBCPP_OBJECT_FORMAT_XCOFF)
-#        define _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION 2
+#        if defined(_LIBCPP_OBJECT_FORMAT_COFF) || defined(_LIBCPP_OBJECT_FORMAT_XCOFF)
+#          define _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION 2
 
 // On arm64 on Apple platforms, use the special NonUniqueARMRTTIBit implementation.
-#      elif defined(__APPLE__) && defined(__LP64__) && !defined(__x86_64__)
-#        define _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION 3
+#        elif defined(__APPLE__) && defined(__LP64__) && !defined(__x86_64__)
+#          define _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION 3
 
 // On all other platforms, assume the Itanium C++ ABI and use the Unique implementation.
-#      else
-#        define _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION 1
+#        else
+#          define _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION 1
+#        endif
 #      endif
-#    endif
 
 struct __type_info_implementations {
   struct __string_impl_base {
@@ -265,30 +267,30 @@ struct __type_info_implementations {
   };
 
   typedef
-#    if _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION == 1
+#      if _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION == 1
       __unique_impl
-#    elif _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION == 2
+#      elif _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION == 2
       __non_unique_impl
-#    elif _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION == 3
+#      elif _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION == 3
       __non_unique_arm_rtti_bit_impl
-#    else
-#      error invalid configuration for _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION
-#    endif
+#      else
+#        error invalid configuration for _LIBCPP_TYPEINFO_COMPARISON_IMPLEMENTATION
+#      endif
           __impl;
 };
 
-#    if __has_cpp_attribute(_Clang::__ptrauth_vtable_pointer__)
-#      if __has_feature(ptrauth_type_info_vtable_pointer_discrimination)
-#        define _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH                                                                  \
-          [[_Clang::__ptrauth_vtable_pointer__(process_independent, address_discrimination, type_discrimination)]]
+#      if __has_cpp_attribute(_Clang::__ptrauth_vtable_pointer__)
+#        if __has_feature(ptrauth_type_info_vtable_pointer_discrimination)
+#          define _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH                                                                \
+            [[_Clang::__ptrauth_vtable_pointer__(process_independent, address_discrimination, type_discrimination)]]
+#        else
+#          define _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH                                                                \
+            [[_Clang::__ptrauth_vtable_pointer__(                                                                      \
+                process_independent, no_address_discrimination, no_extra_discrimination)]]
+#        endif
 #      else
-#        define _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH                                                                  \
-          [[_Clang::__ptrauth_vtable_pointer__(                                                                        \
-              process_independent, no_address_discrimination, no_extra_discrimination)]]
+#        define _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH
 #      endif
-#    else
-#      define _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH
-#    endif
 
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_TYPE_INFO_VTABLE_POINTER_AUTH type_info {
   type_info& operator=(const type_info&);
@@ -321,11 +323,11 @@ public:
     return __impl::__eq(__type_name, __arg.__type_name);
   }
 
-#    if _LIBCPP_STD_VER <= 17
+#      if _LIBCPP_STD_VER <= 17
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const type_info& __arg) const _NOEXCEPT { return !operator==(__arg); }
-#    endif
+#      endif
 };
-#  endif // defined(_LIBCPP_ABI_MICROSOFT)
+#    endif // defined(_LIBCPP_ABI_MICROSOFT)
 
 class _LIBCPP_EXPORTED_FROM_ABI bad_cast : public exception {
 public:
@@ -347,9 +349,9 @@ public:
 
 } // namespace std
 
-#endif // defined(_LIBCPP_ABI_VCRUNTIME)
+#  endif // defined(_LIBCPP_ABI_VCRUNTIME)
 
-#if defined(_LIBCPP_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
+#  if defined(_LIBCPP_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
 
 namespace std {
 
@@ -371,22 +373,23 @@ private:
 
 } // namespace std
 
-#endif // defined(_LIBCPP_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
+#  endif // defined(_LIBCPP_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_bad_cast() {
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
   throw bad_cast();
-#else
+#  else
   _LIBCPP_VERBOSE_ABORT("bad_cast was thrown in -fno-exceptions mode");
-#endif
+#  endif
 }
 _LIBCPP_END_NAMESPACE_STD
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <cstdlib>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <cstdlib>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_TYPEINFO

--- a/libcxx/include/uchar.h
+++ b/libcxx/include/uchar.h
@@ -32,25 +32,28 @@ size_t c32rtomb(char* s, char32_t c32, mbstate_t* ps);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_CXX03_LANG)
+#  if !defined(_LIBCPP_CXX03_LANG)
 
 // Some platforms don't implement <uchar.h> and we don't want to give a hard
 // error on those platforms. When the platform doesn't provide <uchar.h>, at
 // least include <stddef.h> so we get the declaration for size_t, and try to
 // get the declaration of mbstate_t too.
-#  if __has_include_next(<uchar.h>)
-#    include_next <uchar.h>
-#  else
-#    include <__mbstate_t.h>
-#    include <stddef.h>
-#  endif
+#    if __has_include_next(<uchar.h>)
+#      include_next <uchar.h>
+#    else
+#      include <__mbstate_t.h>
+#      include <stddef.h>
+#    endif
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
+#endif   // 0
 
 #endif // _LIBCPP_UCHAR_H

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -583,60 +583,62 @@ template <class Key, class T, class Hash, class Pred, class Alloc>
 
 */
 
-#include <__algorithm/is_permutation.h>
-#include <__assert>
-#include <__config>
-#include <__functional/hash.h>
-#include <__functional/is_transparent.h>
-#include <__functional/operations.h>
-#include <__hash_table>
-#include <__iterator/distance.h>
-#include <__iterator/erase_if_container.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/ranges_iterator_traits.h>
-#include <__memory/addressof.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory/pointer_traits.h>
-#include <__memory/unique_ptr.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__node_handle>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/invoke.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_integral.h>
-#include <__type_traits/remove_const.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/pair.h>
-#include <new> // launder
-#include <stdexcept>
-#include <tuple>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/is_permutation.h>
+#  include <__assert>
+#  include <__config>
+#  include <__functional/hash.h>
+#  include <__functional/is_transparent.h>
+#  include <__functional/operations.h>
+#  include <__hash_table>
+#  include <__iterator/distance.h>
+#  include <__iterator/erase_if_container.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/ranges_iterator_traits.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory/pointer_traits.h>
+#  include <__memory/unique_ptr.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__node_handle>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/invoke.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_integral.h>
+#  include <__type_traits/remove_const.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/pair.h>
+#  include <new> // launder
+#  include <stdexcept>
+#  include <tuple>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [unord.map.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -655,12 +657,12 @@ public:
     return static_cast<const _Hash&>(*this)(__x.__get_value().first);
   }
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const _Key& __x) const { return static_cast<const _Hash&>(*this)(__x); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <typename _K2>
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const _K2& __x) const {
     return static_cast<const _Hash&>(*this)(__x);
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_hasher& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Hash>) {
     using std::swap;
     swap(static_cast<_Hash&>(*this), static_cast<_Hash&>(__y));
@@ -679,12 +681,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI const _Hash& hash_function() const _NOEXCEPT { return __hash_; }
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const _Cp& __x) const { return __hash_(__x.__get_value().first); }
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const _Key& __x) const { return __hash_(__x); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <typename _K2>
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const _K2& __x) const {
     return __hash_(__x);
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_hasher& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Hash>) {
     using std::swap;
     swap(__hash_, __y.__hash_);
@@ -718,7 +720,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _Key& __x, const _Cp& __y) const {
     return static_cast<const _Pred&>(*this)(__x, __y.__get_value().first);
   }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <typename _K2>
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _Cp& __x, const _K2& __y) const {
     return static_cast<const _Pred&>(*this)(__x.__get_value().first, __y);
@@ -735,7 +737,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _K2& __x, const _Key& __y) const {
     return static_cast<const _Pred&>(*this)(__x, __y);
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_equal& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Pred>) {
     using std::swap;
     swap(static_cast<_Pred&>(*this), static_cast<_Pred&>(__y));
@@ -761,7 +763,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _Key& __x, const _Cp& __y) const {
     return __pred_(__x, __y.__get_value().first);
   }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <typename _K2>
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _Cp& __x, const _K2& __y) const {
     return __pred_(__x.__get_value().first, __y);
@@ -778,7 +780,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI bool operator()(const _K2& __x, const _Key& __y) const {
     return __pred_(__x, __y);
   }
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI void swap(__unordered_map_equal& __y) _NOEXCEPT_(__is_nothrow_swappable_v<_Pred>) {
     using std::swap;
     swap(__pred_, __y.__pred_);
@@ -814,19 +816,19 @@ public:
         __first_constructed(false),
         __second_constructed(false) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __hash_map_node_destructor(__hash_node_destructor<allocator_type>&& __x) _NOEXCEPT
       : __na_(__x.__na_),
         __first_constructed(__x.__value_constructed),
         __second_constructed(__x.__value_constructed) {
     __x.__value_constructed = false;
   }
-#else  // _LIBCPP_CXX03_LANG
+#  else  // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __hash_map_node_destructor(const __hash_node_destructor<allocator_type>& __x)
       : __na_(__x.__na_), __first_constructed(__x.__value_constructed), __second_constructed(__x.__value_constructed) {
     const_cast<bool&>(__x.__value_constructed) = false;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI void operator()(pointer __p) _NOEXCEPT {
     if (__second_constructed)
@@ -838,7 +840,7 @@ public:
   }
 };
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 template <class _Key, class _Tp>
 struct _LIBCPP_STANDALONE_DEBUG __hash_value_type {
   typedef _Key key_type;
@@ -852,19 +854,19 @@ private:
 
 public:
   _LIBCPP_HIDE_FROM_ABI value_type& __get_value() {
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
     return *std::launder(std::addressof(__cc_));
-#  else
+#    else
     return __cc_;
-#  endif
+#    endif
   }
 
   _LIBCPP_HIDE_FROM_ABI const value_type& __get_value() const {
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
     return *std::launder(std::addressof(__cc_));
-#  else
+#    else
     return __cc_;
-#  endif
+#    endif
   }
 
   _LIBCPP_HIDE_FROM_ABI __nc_ref_pair_type __ref() {
@@ -901,7 +903,7 @@ public:
   ~__hash_value_type() = delete;
 };
 
-#else
+#  else
 
 template <class _Key, class _Tp>
 struct __hash_value_type {
@@ -919,7 +921,7 @@ public:
   ~__hash_value_type() = delete;
 };
 
-#endif
+#  endif
 
 template <class _HashIterator>
 class _LIBCPP_TEMPLATE_VIS __hash_map_iterator {
@@ -954,11 +956,11 @@ public:
   friend _LIBCPP_HIDE_FROM_ABI bool operator==(const __hash_map_iterator& __x, const __hash_map_iterator& __y) {
     return __x.__i_ == __y.__i_;
   }
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
   friend _LIBCPP_HIDE_FROM_ABI bool operator!=(const __hash_map_iterator& __x, const __hash_map_iterator& __y) {
     return __x.__i_ != __y.__i_;
   }
-#endif
+#  endif
 
   template <class, class, class, class, class>
   friend class _LIBCPP_TEMPLATE_VIS unordered_map;
@@ -1009,12 +1011,12 @@ public:
   operator==(const __hash_map_const_iterator& __x, const __hash_map_const_iterator& __y) {
     return __x.__i_ == __y.__i_;
   }
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
   friend _LIBCPP_HIDE_FROM_ABI bool
   operator!=(const __hash_map_const_iterator& __x, const __hash_map_const_iterator& __y) {
     return __x.__i_ != __y.__i_;
   }
-#endif
+#  endif
 
   template <class, class, class, class, class>
   friend class _LIBCPP_TEMPLATE_VIS unordered_map;
@@ -1084,10 +1086,10 @@ public:
   typedef __hash_map_iterator<typename __table::local_iterator> local_iterator;
   typedef __hash_map_const_iterator<typename __table::const_local_iterator> const_local_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __map_node_handle<__node, allocator_type> node_type;
   typedef __insert_return_type<iterator, node_type> insert_return_type;
-#endif
+#  endif
 
   template <class _Key2, class _Tp2, class _Hash2, class _Pred2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS unordered_map;
@@ -1117,7 +1119,7 @@ public:
       const key_equal& __eql,
       const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_map(
       from_range_t,
@@ -1132,12 +1134,12 @@ public:
     }
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI explicit unordered_map(const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI unordered_map(const unordered_map& __u);
   _LIBCPP_HIDE_FROM_ABI unordered_map(const unordered_map& __u, const allocator_type& __a);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_map(unordered_map&& __u) _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_map(unordered_map&& __u, const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI unordered_map(initializer_list<value_type> __il);
@@ -1152,8 +1154,8 @@ public:
       const hasher& __hf,
       const key_equal& __eql,
       const allocator_type& __a);
-#endif // _LIBCPP_CXX03_LANG
-#if _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_CXX03_LANG
+#  if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI unordered_map(size_type __n, const allocator_type& __a)
       : unordered_map(__n, hasher(), key_equal(), __a) {}
   _LIBCPP_HIDE_FROM_ABI unordered_map(size_type __n, const hasher& __hf, const allocator_type& __a)
@@ -1167,7 +1169,7 @@ public:
       _InputIterator __first, _InputIterator __last, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_map(__first, __last, __n, __hf, key_equal(), __a) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_map(from_range_t, _Range&& __range, size_type __n, const allocator_type& __a)
       : unordered_map(from_range, std::forward<_Range>(__range), __n, hasher(), key_equal(), __a) {}
@@ -1176,22 +1178,22 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   unordered_map(from_range_t, _Range&& __range, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_map(from_range, std::forward<_Range>(__range), __n, __hf, key_equal(), __a) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI unordered_map(initializer_list<value_type> __il, size_type __n, const allocator_type& __a)
       : unordered_map(__il, __n, hasher(), key_equal(), __a) {}
   _LIBCPP_HIDE_FROM_ABI
   unordered_map(initializer_list<value_type> __il, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_map(__il, __n, __hf, key_equal(), __a) {}
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI ~unordered_map() {
     static_assert(sizeof(std::__diagnose_unordered_container_requirements<_Key, _Hash, _Pred>(0)), "");
   }
 
   _LIBCPP_HIDE_FROM_ABI unordered_map& operator=(const unordered_map& __u) {
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     __table_ = __u.__table_;
-#else
+#  else
     if (this != std::addressof(__u)) {
       __table_.clear();
       __table_.hash_function()   = __u.__table_.hash_function();
@@ -1200,14 +1202,14 @@ public:
       __table_.__copy_assign_alloc(__u.__table_);
       insert(__u.begin(), __u.end());
     }
-#endif
+#  endif
     return *this;
   }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_map& operator=(unordered_map&& __u)
       _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_map& operator=(initializer_list<value_type> __il);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT {
     return allocator_type(__table_.__node_alloc());
@@ -1231,16 +1233,16 @@ public:
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI void insert(_InputIterator __first, _InputIterator __last);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     for (auto&& __element : __range) {
       __table_.__insert_unique(std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(value_type&& __x) {
@@ -1271,9 +1273,9 @@ public:
     return __table_.__emplace_unique(std::forward<_Args>(__args)...).first;
   }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> try_emplace(const key_type& __k, _Args&&... __args) {
     return __table_.__emplace_unique_key_args(
@@ -1326,7 +1328,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator insert_or_assign(const_iterator, key_type&& __k, _Vp&& __v) {
     return insert_or_assign(std::move(__k), std::forward<_Vp>(__v)).first;
   }
-#endif // _LIBCPP_STD_VER >= 17
+#  endif // _LIBCPP_STD_VER >= 17
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __table_.erase(__p.__i_); }
   _LIBCPP_HIDE_FROM_ABI iterator erase(iterator __p) { return __table_.erase(__p.__i_); }
@@ -1336,7 +1338,7 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __table_.clear(); }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI insert_return_type insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to unordered_map::insert()");
@@ -1378,7 +1380,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     return __table_.__node_handle_merge_unique(__source.__table_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(unordered_map& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
@@ -1389,7 +1391,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
@@ -1398,24 +1400,24 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __table_.__count_unique(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_unique(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __table_.__equal_range_unique(__k);
@@ -1423,7 +1425,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __table_.__equal_range_unique(__k);
   }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
@@ -1432,12 +1434,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](const key_type& __k);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI mapped_type& operator[](key_type&& __k);
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI mapped_type& at(const key_type& __k);
   _LIBCPP_HIDE_FROM_ABI const mapped_type& at(const key_type& __k) const;
@@ -1462,12 +1464,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reserve(size_type __n) { __table_.__reserve_unique(__n); }
 
 private:
-#ifdef _LIBCPP_CXX03_LANG
+#  ifdef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __node_holder __construct_node_with_key(const key_type& __k);
-#endif
+#  endif
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Hash      = hash<__iter_key_type<_InputIterator>>,
           class _Pred      = equal_to<__iter_key_type<_InputIterator>>,
@@ -1485,7 +1487,7 @@ unordered_map(_InputIterator,
               _Allocator                                       = _Allocator())
     -> unordered_map<__iter_key_type<_InputIterator>, __iter_mapped_type<_InputIterator>, _Hash, _Pred, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Hash      = hash<__range_key_type<_Range>>,
           class _Pred      = equal_to<__range_key_type<_Range>>,
@@ -1501,7 +1503,7 @@ unordered_map(from_range_t,
               _Pred                                            = _Pred(),
               _Allocator                                       = _Allocator())
     -> unordered_map<__range_key_type<_Range>, __range_mapped_type<_Range>, _Hash, _Pred, _Allocator>; // C++23
-#  endif
+#    endif
 
 template <class _Key,
           class _Tp,
@@ -1554,7 +1556,7 @@ unordered_map(_InputIterator, _InputIterator, typename allocator_traits<_Allocat
                      equal_to<__iter_key_type<_InputIterator>>,
                      _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -1585,7 +1587,7 @@ unordered_map(from_range_t, _Range&&, typename allocator_traits<_Allocator>::siz
                      equal_to<__range_key_type<_Range>>,
                      _Allocator>;
 
-#  endif
+#    endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_map(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -1604,7 +1606,7 @@ template <class _Key,
           class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_map(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_map<remove_const_t<_Key>, _Tp, _Hash, equal_to<remove_const_t<_Key>>, _Allocator>;
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(size_type __n, const hasher& __hf, const key_equal& __eql)
@@ -1665,7 +1667,7 @@ unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(const unordered_ma
   insert(__u.begin(), __u.end());
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map(unordered_map&& __u)
@@ -1723,7 +1725,7 @@ unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator=(initializer_list<value
   return *this;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 template <class _InputIterator>
@@ -1732,7 +1734,7 @@ inline void unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::insert(_InputIterato
     __table_.__insert_unique(*__first);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 _Tp& unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](const key_type& __k) {
@@ -1750,7 +1752,7 @@ _Tp& unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](key_type&& __k) 
       .first->__get_value()
       .second;
 }
-#else // _LIBCPP_CXX03_LANG
+#  else // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 typename unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::__node_holder
@@ -1775,7 +1777,7 @@ _Tp& unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::operator[](const key_type& 
   return __r.first->second;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 _Tp& unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::at(const key_type& __k) {
@@ -1800,13 +1802,13 @@ swap(unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x, unordered_map<_Key, _T
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type
 erase_if(unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
@@ -1822,7 +1824,7 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_map<_Key, _Tp, _Hash, _Pre
   return true;
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
@@ -1830,7 +1832,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_map<_Key, _Tp, _Has
   return !(__x == __y);
 }
 
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 struct __container_traits<unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc> > {
@@ -1893,9 +1895,9 @@ public:
   typedef __hash_map_iterator<typename __table::local_iterator> local_iterator;
   typedef __hash_map_const_iterator<typename __table::const_local_iterator> const_local_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __map_node_handle<__node, allocator_type> node_type;
-#endif
+#  endif
 
   template <class _Key2, class _Tp2, class _Hash2, class _Pred2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS unordered_map;
@@ -1925,7 +1927,7 @@ public:
       const key_equal& __eql,
       const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(
       from_range_t,
@@ -1940,12 +1942,12 @@ public:
     }
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI explicit unordered_multimap(const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(const unordered_multimap& __u);
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(const unordered_multimap& __u, const allocator_type& __a);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(unordered_multimap&& __u)
       _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(unordered_multimap&& __u, const allocator_type& __a);
@@ -1961,8 +1963,8 @@ public:
       const hasher& __hf,
       const key_equal& __eql,
       const allocator_type& __a);
-#endif // _LIBCPP_CXX03_LANG
-#if _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_CXX03_LANG
+#  if _LIBCPP_STD_VER >= 14
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(size_type __n, const allocator_type& __a)
       : unordered_multimap(__n, hasher(), key_equal(), __a) {}
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(size_type __n, const hasher& __hf, const allocator_type& __a)
@@ -1976,7 +1978,7 @@ public:
       _InputIterator __first, _InputIterator __last, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multimap(__first, __last, __n, __hf, key_equal(), __a) {}
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(from_range_t, _Range&& __range, size_type __n, const allocator_type& __a)
       : unordered_multimap(from_range, std::forward<_Range>(__range), __n, hasher(), key_equal(), __a) {}
@@ -1985,22 +1987,22 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   unordered_multimap(from_range_t, _Range&& __range, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multimap(from_range, std::forward<_Range>(__range), __n, __hf, key_equal(), __a) {}
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI unordered_multimap(initializer_list<value_type> __il, size_type __n, const allocator_type& __a)
       : unordered_multimap(__il, __n, hasher(), key_equal(), __a) {}
   _LIBCPP_HIDE_FROM_ABI
   unordered_multimap(initializer_list<value_type> __il, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multimap(__il, __n, __hf, key_equal(), __a) {}
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI ~unordered_multimap() {
     static_assert(sizeof(std::__diagnose_unordered_container_requirements<_Key, _Hash, _Pred>(0)), "");
   }
 
   _LIBCPP_HIDE_FROM_ABI unordered_multimap& operator=(const unordered_multimap& __u) {
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
     __table_ = __u.__table_;
-#else
+#  else
     if (this != std::addressof(__u)) {
       __table_.clear();
       __table_.hash_function()   = __u.__table_.hash_function();
@@ -2009,14 +2011,14 @@ public:
       __table_.__copy_assign_alloc(__u.__table_);
       insert(__u.begin(), __u.end());
     }
-#endif
+#  endif
     return *this;
   }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_multimap& operator=(unordered_multimap&& __u)
       _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_multimap& operator=(initializer_list<value_type> __il);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT {
     return allocator_type(__table_.__node_alloc());
@@ -2042,16 +2044,16 @@ public:
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI void insert(_InputIterator __first, _InputIterator __last);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     for (auto&& __element : __range) {
       __table_.__insert_multi(std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
   _LIBCPP_HIDE_FROM_ABI iterator insert(value_type&& __x) { return __table_.__insert_multi(std::move(__x)); }
 
@@ -2078,7 +2080,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator emplace_hint(const_iterator __p, _Args&&... __args) {
     return __table_.__emplace_hint_multi(__p.__i_, std::forward<_Args>(__args)...);
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __table_.erase(__p.__i_); }
   _LIBCPP_HIDE_FROM_ABI iterator erase(iterator __p) { return __table_.erase(__p.__i_); }
@@ -2088,7 +2090,7 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __table_.clear(); }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI iterator insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to unordered_multimap::insert()");
@@ -2130,7 +2132,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     return __table_.__node_handle_merge_multi(__source.__table_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(unordered_multimap& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
@@ -2141,7 +2143,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
@@ -2150,24 +2152,24 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __table_.__count_multi(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_multi(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __table_.__equal_range_multi(__k);
@@ -2175,7 +2177,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __table_.__equal_range_multi(__k);
   }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
@@ -2184,7 +2186,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type bucket_count() const _NOEXCEPT { return __table_.bucket_count(); }
   _LIBCPP_HIDE_FROM_ABI size_type max_bucket_count() const _NOEXCEPT { return __table_.max_bucket_count(); }
@@ -2206,7 +2208,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reserve(size_type __n) { __table_.__reserve_multi(__n); }
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Hash      = hash<__iter_key_type<_InputIterator>>,
           class _Pred      = equal_to<__iter_key_type<_InputIterator>>,
@@ -2228,7 +2230,7 @@ unordered_multimap(_InputIterator,
                           _Pred,
                           _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Hash      = hash<__range_key_type<_Range>>,
           class _Pred      = equal_to<__range_key_type<_Range>>,
@@ -2244,7 +2246,7 @@ unordered_multimap(from_range_t,
                    _Pred                                            = _Pred(),
                    _Allocator                                       = _Allocator())
     -> unordered_multimap<__range_key_type<_Range>, __range_mapped_type<_Range>, _Hash, _Pred, _Allocator>;
-#  endif
+#    endif
 
 template <class _Key,
           class _Tp,
@@ -2298,7 +2300,7 @@ unordered_multimap(_InputIterator, _InputIterator, typename allocator_traits<_Al
                           equal_to<__iter_key_type<_InputIterator>>,
                           _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -2329,7 +2331,7 @@ unordered_multimap(from_range_t, _Range&&, typename allocator_traits<_Allocator>
                           equal_to<__range_key_type<_Range>>,
                           _Allocator>;
 
-#  endif
+#    endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_multimap(initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -2357,7 +2359,7 @@ template <class _Key,
 unordered_multimap(
     initializer_list<pair<_Key, _Tp>>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, equal_to<remove_const_t<_Key>>, _Allocator>;
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_multimap(
@@ -2421,7 +2423,7 @@ unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_multimap(
   insert(__u.begin(), __u.end());
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_multimap(unordered_multimap&& __u)
@@ -2480,7 +2482,7 @@ unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::operator=(initializer_list<
   return *this;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 template <class _InputIterator>
@@ -2496,13 +2498,13 @@ swap(unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x, unordered_multima
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>::size_type
 erase_if(unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
@@ -2522,7 +2524,7 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_multimap<_Key, _Tp, _Hash,
   return true;
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
@@ -2530,7 +2532,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_multimap<_Key, _Tp,
   return !(__x == __y);
 }
 
-#endif
+#  endif
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
 struct __container_traits<unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc> > {
@@ -2544,7 +2546,7 @@ struct __container_traits<unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc> > 
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _KeyT, class _ValueT, class _HashT = std::hash<_KeyT>, class _PredT = std::equal_to<_KeyT>>
@@ -2556,18 +2558,19 @@ using unordered_multimap _LIBCPP_AVAILABILITY_PMR =
     std::unordered_multimap<_KeyT, _ValueT, _HashT, _PredT, polymorphic_allocator<std::pair<const _KeyT, _ValueT>>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <bit>
-#  include <cmath>
-#  include <concepts>
-#  include <cstdlib>
-#  include <iterator>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <bit>
+#    include <cmath>
+#    include <concepts>
+#    include <cstdlib>
+#    include <iterator>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_UNORDERED_MAP

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -531,59 +531,61 @@ template <class Value, class Hash, class Pred, class Alloc>
 
 // clang-format on
 
-#include <__algorithm/is_permutation.h>
-#include <__assert>
-#include <__config>
-#include <__functional/hash.h>
-#include <__functional/is_transparent.h>
-#include <__functional/operations.h>
-#include <__hash_table>
-#include <__iterator/distance.h>
-#include <__iterator/erase_if_container.h>
-#include <__iterator/iterator_traits.h>
-#include <__iterator/ranges_iterator_traits.h>
-#include <__memory/addressof.h>
-#include <__memory/allocator.h>
-#include <__memory/allocator_traits.h>
-#include <__memory_resource/polymorphic_allocator.h>
-#include <__node_handle>
-#include <__ranges/concepts.h>
-#include <__ranges/container_compatible_range.h>
-#include <__ranges/from_range.h>
-#include <__type_traits/container_traits.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/invoke.h>
-#include <__type_traits/is_allocator.h>
-#include <__type_traits/is_integral.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/type_identity.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/pair.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/is_permutation.h>
+#  include <__assert>
+#  include <__config>
+#  include <__functional/hash.h>
+#  include <__functional/is_transparent.h>
+#  include <__functional/operations.h>
+#  include <__hash_table>
+#  include <__iterator/distance.h>
+#  include <__iterator/erase_if_container.h>
+#  include <__iterator/iterator_traits.h>
+#  include <__iterator/ranges_iterator_traits.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocator.h>
+#  include <__memory/allocator_traits.h>
+#  include <__memory_resource/polymorphic_allocator.h>
+#  include <__node_handle>
+#  include <__ranges/concepts.h>
+#  include <__ranges/container_compatible_range.h>
+#  include <__ranges/from_range.h>
+#  include <__type_traits/container_traits.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/invoke.h>
+#  include <__type_traits/is_allocator.h>
+#  include <__type_traits/is_integral.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/type_identity.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/pair.h>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [unord.set.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -621,10 +623,10 @@ public:
   typedef typename __table::const_local_iterator local_iterator;
   typedef typename __table::const_local_iterator const_local_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __set_node_handle<typename __table::__node, allocator_type> node_type;
   typedef __insert_return_type<iterator, node_type> insert_return_type;
-#endif
+#  endif
 
   template <class _Value2, class _Hash2, class _Pred2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS unordered_set;
@@ -634,12 +636,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI unordered_set() _NOEXCEPT_(is_nothrow_default_constructible<__table>::value) {}
   explicit _LIBCPP_HIDE_FROM_ABI
   unordered_set(size_type __n, const hasher& __hf = hasher(), const key_equal& __eql = key_equal());
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   inline _LIBCPP_HIDE_FROM_ABI unordered_set(size_type __n, const allocator_type& __a)
       : unordered_set(__n, hasher(), key_equal(), __a) {}
   inline _LIBCPP_HIDE_FROM_ABI unordered_set(size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_set(__n, __hf, key_equal(), __a) {}
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI
   unordered_set(size_type __n, const hasher& __hf, const key_equal& __eql, const allocator_type& __a);
   template <class _InputIterator>
@@ -660,7 +662,7 @@ public:
       const key_equal& __eql,
       const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_set(
       from_range_t,
@@ -675,9 +677,9 @@ public:
     }
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <class _InputIterator>
   inline _LIBCPP_HIDE_FROM_ABI
   unordered_set(_InputIterator __first, _InputIterator __last, size_type __n, const allocator_type& __a)
@@ -686,9 +688,9 @@ public:
   _LIBCPP_HIDE_FROM_ABI unordered_set(
       _InputIterator __first, _InputIterator __last, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_set(__first, __last, __n, __hf, key_equal(), __a) {}
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_set(from_range_t, _Range&& __range, size_type __n, const allocator_type& __a)
       : unordered_set(from_range, std::forward<_Range>(__range), __n, hasher(), key_equal(), __a) {}
@@ -697,12 +699,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   unordered_set(from_range_t, _Range&& __range, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_set(from_range, std::forward<_Range>(__range), __n, __hf, key_equal(), __a) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI explicit unordered_set(const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI unordered_set(const unordered_set& __u);
   _LIBCPP_HIDE_FROM_ABI unordered_set(const unordered_set& __u, const allocator_type& __a);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_set(unordered_set&& __u) _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_set(unordered_set&& __u, const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI unordered_set(initializer_list<value_type> __il);
@@ -717,15 +719,15 @@ public:
       const hasher& __hf,
       const key_equal& __eql,
       const allocator_type& __a);
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   inline _LIBCPP_HIDE_FROM_ABI
   unordered_set(initializer_list<value_type> __il, size_type __n, const allocator_type& __a)
       : unordered_set(__il, __n, hasher(), key_equal(), __a) {}
   inline _LIBCPP_HIDE_FROM_ABI
   unordered_set(initializer_list<value_type> __il, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_set(__il, __n, __hf, key_equal(), __a) {}
-#  endif
-#endif // _LIBCPP_CXX03_LANG
+#    endif
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI ~unordered_set() {
     static_assert(sizeof(std::__diagnose_unordered_container_requirements<_Value, _Hash, _Pred>(0)), "");
   }
@@ -734,11 +736,11 @@ public:
     __table_ = __u.__table_;
     return *this;
   }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_set& operator=(unordered_set&& __u)
       _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_set& operator=(initializer_list<value_type> __il);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT {
     return allocator_type(__table_.__node_alloc());
@@ -755,7 +757,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT { return __table_.begin(); }
   _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return __table_.end(); }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> emplace(_Args&&... __args) {
     return __table_.__emplace_unique(std::forward<_Args>(__args)...);
@@ -771,21 +773,21 @@ public:
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator, value_type&& __x) { return insert(std::move(__x)).first; }
 
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI pair<iterator, bool> insert(const value_type& __x) { return __table_.__insert_unique(__x); }
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const_iterator, const value_type& __x) { return insert(__x).first; }
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI void insert(_InputIterator __first, _InputIterator __last);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     for (auto&& __element : __range) {
       __table_.__insert_unique(std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __table_.erase(__p); }
   _LIBCPP_HIDE_FROM_ABI size_type erase(const key_type& __k) { return __table_.__erase_unique(__k); }
@@ -794,7 +796,7 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI void clear() _NOEXCEPT { __table_.clear(); }
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI insert_return_type insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to unordered_set::insert()");
@@ -836,7 +838,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     __table_.__node_handle_merge_unique(__source.__table_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI void swap(unordered_set& __u) _NOEXCEPT_(__is_nothrow_swappable_v<__table>) {
     __table_.swap(__u.__table_);
@@ -847,7 +849,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
@@ -856,24 +858,24 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __table_.__count_unique(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_unique(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __table_.__equal_range_unique(__k);
@@ -881,7 +883,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __table_.__equal_range_unique(__k);
   }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_unique(__k);
@@ -890,7 +892,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_unique(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type bucket_count() const _NOEXCEPT { return __table_.bucket_count(); }
   _LIBCPP_HIDE_FROM_ABI size_type max_bucket_count() const _NOEXCEPT { return __table_.max_bucket_count(); }
@@ -912,7 +914,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reserve(size_type __n) { __table_.__reserve_unique(__n); }
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Hash      = hash<__iter_value_type<_InputIterator>>,
           class _Pred      = equal_to<__iter_value_type<_InputIterator>>,
@@ -929,7 +931,7 @@ unordered_set(_InputIterator,
               _Pred                                            = _Pred(),
               _Allocator = _Allocator()) -> unordered_set<__iter_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Hash      = hash<ranges::range_value_t<_Range>>,
           class _Pred      = equal_to<ranges::range_value_t<_Range>>,
@@ -945,7 +947,7 @@ unordered_set(
     _Hash                                            = _Hash(),
     _Pred                                            = _Pred(),
     _Allocator = _Allocator()) -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
-#  endif
+#    endif
 
 template <class _Tp,
           class _Hash      = hash<_Tp>,
@@ -981,7 +983,7 @@ template <class _InputIterator,
 unordered_set(_InputIterator, _InputIterator, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_set<__iter_value_type<_InputIterator>, _Hash, equal_to<__iter_value_type<_InputIterator>>, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_set(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -1006,7 +1008,7 @@ template <ranges::input_range _Range,
 unordered_set(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_set<ranges::range_value_t<_Range>, _Hash, equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
-#  endif
+#    endif
 
 template <class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_set(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -1020,7 +1022,7 @@ template <class _Tp,
           class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_set(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_set<_Tp, _Hash, equal_to<_Tp>, _Allocator>;
-#endif
+#  endif
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(size_type __n, const hasher& __hf, const key_equal& __eql)
@@ -1080,7 +1082,7 @@ unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(const unordered_set& 
   insert(__u.begin(), __u.end());
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline unordered_set<_Value, _Hash, _Pred, _Alloc>::unordered_set(unordered_set&& __u)
@@ -1137,7 +1139,7 @@ unordered_set<_Value, _Hash, _Pred, _Alloc>::operator=(initializer_list<value_ty
   return *this;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 template <class _InputIterator>
@@ -1153,13 +1155,13 @@ swap(unordered_set<_Value, _Hash, _Pred, _Alloc>& __x, unordered_set<_Value, _Ha
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Value, class _Hash, class _Pred, class _Alloc, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename unordered_set<_Value, _Hash, _Pred, _Alloc>::size_type
 erase_if(unordered_set<_Value, _Hash, _Pred, _Alloc>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_set<_Value, _Hash, _Pred, _Alloc>& __x,
@@ -1175,7 +1177,7 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_set<_Value, _Hash, _Pred, 
   return true;
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_set<_Value, _Hash, _Pred, _Alloc>& __x,
@@ -1183,7 +1185,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_set<_Value, _Hash, 
   return !(__x == __y);
 }
 
-#endif
+#  endif
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 struct __container_traits<unordered_set<_Value, _Hash, _Pred, _Alloc> > {
@@ -1225,9 +1227,9 @@ public:
   typedef typename __table::const_local_iterator local_iterator;
   typedef typename __table::const_local_iterator const_local_iterator;
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   typedef __set_node_handle<typename __table::__node, allocator_type> node_type;
-#endif
+#  endif
 
   template <class _Value2, class _Hash2, class _Pred2, class _Alloc2>
   friend class _LIBCPP_TEMPLATE_VIS unordered_set;
@@ -1239,12 +1241,12 @@ public:
   unordered_multiset(size_type __n, const hasher& __hf = hasher(), const key_equal& __eql = key_equal());
   _LIBCPP_HIDE_FROM_ABI
   unordered_multiset(size_type __n, const hasher& __hf, const key_equal& __eql, const allocator_type& __a);
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   inline _LIBCPP_HIDE_FROM_ABI unordered_multiset(size_type __n, const allocator_type& __a)
       : unordered_multiset(__n, hasher(), key_equal(), __a) {}
   inline _LIBCPP_HIDE_FROM_ABI unordered_multiset(size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multiset(__n, __hf, key_equal(), __a) {}
-#endif
+#  endif
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(_InputIterator __first, _InputIterator __last);
   template <class _InputIterator>
@@ -1263,7 +1265,7 @@ public:
       const key_equal& __eql,
       const allocator_type& __a);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(
       from_range_t,
@@ -1278,9 +1280,9 @@ public:
     }
     insert_range(std::forward<_Range>(__range));
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
   template <class _InputIterator>
   inline _LIBCPP_HIDE_FROM_ABI
   unordered_multiset(_InputIterator __first, _InputIterator __last, size_type __n, const allocator_type& __a)
@@ -1289,9 +1291,9 @@ public:
   inline _LIBCPP_HIDE_FROM_ABI unordered_multiset(
       _InputIterator __first, _InputIterator __last, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multiset(__first, __last, __n, __hf, key_equal(), __a) {}
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(from_range_t, _Range&& __range, size_type __n, const allocator_type& __a)
       : unordered_multiset(from_range, std::forward<_Range>(__range), __n, hasher(), key_equal(), __a) {}
@@ -1300,12 +1302,12 @@ public:
   _LIBCPP_HIDE_FROM_ABI
   unordered_multiset(from_range_t, _Range&& __range, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multiset(from_range, std::forward<_Range>(__range), __n, __hf, key_equal(), __a) {}
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI explicit unordered_multiset(const allocator_type& __a);
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(const unordered_multiset& __u);
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(const unordered_multiset& __u, const allocator_type& __a);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(unordered_multiset&& __u)
       _NOEXCEPT_(is_nothrow_move_constructible<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_multiset(unordered_multiset&& __u, const allocator_type& __a);
@@ -1321,15 +1323,15 @@ public:
       const hasher& __hf,
       const key_equal& __eql,
       const allocator_type& __a);
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   inline _LIBCPP_HIDE_FROM_ABI
   unordered_multiset(initializer_list<value_type> __il, size_type __n, const allocator_type& __a)
       : unordered_multiset(__il, __n, hasher(), key_equal(), __a) {}
   inline _LIBCPP_HIDE_FROM_ABI
   unordered_multiset(initializer_list<value_type> __il, size_type __n, const hasher& __hf, const allocator_type& __a)
       : unordered_multiset(__il, __n, __hf, key_equal(), __a) {}
-#  endif
-#endif // _LIBCPP_CXX03_LANG
+#    endif
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI ~unordered_multiset() {
     static_assert(sizeof(std::__diagnose_unordered_container_requirements<_Value, _Hash, _Pred>(0)), "");
   }
@@ -1338,11 +1340,11 @@ public:
     __table_ = __u.__table_;
     return *this;
   }
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI unordered_multiset& operator=(unordered_multiset&& __u)
       _NOEXCEPT_(is_nothrow_move_assignable<__table>::value);
   _LIBCPP_HIDE_FROM_ABI unordered_multiset& operator=(initializer_list<value_type> __il);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI allocator_type get_allocator() const _NOEXCEPT {
     return allocator_type(__table_.__node_alloc());
@@ -1359,7 +1361,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator cbegin() const _NOEXCEPT { return __table_.begin(); }
   _LIBCPP_HIDE_FROM_ABI const_iterator cend() const _NOEXCEPT { return __table_.end(); }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI iterator emplace(_Args&&... __args) {
     return __table_.__emplace_multi(std::forward<_Args>(__args)...);
@@ -1374,7 +1376,7 @@ public:
     return __table_.__insert_multi(__p, std::move(__x));
   }
   _LIBCPP_HIDE_FROM_ABI void insert(initializer_list<value_type> __il) { insert(__il.begin(), __il.end()); }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI iterator insert(const value_type& __x) { return __table_.__insert_multi(__x); }
 
@@ -1385,16 +1387,16 @@ public:
   template <class _InputIterator>
   _LIBCPP_HIDE_FROM_ABI void insert(_InputIterator __first, _InputIterator __last);
 
-#if _LIBCPP_STD_VER >= 23
+#  if _LIBCPP_STD_VER >= 23
   template <_ContainerCompatibleRange<value_type> _Range>
   _LIBCPP_HIDE_FROM_ABI void insert_range(_Range&& __range) {
     for (auto&& __element : __range) {
       __table_.__insert_multi(std::forward<decltype(__element)>(__element));
     }
   }
-#endif
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
   _LIBCPP_HIDE_FROM_ABI iterator insert(node_type&& __nh) {
     _LIBCPP_ASSERT_COMPATIBLE_ALLOCATOR(__nh.empty() || __nh.get_allocator() == get_allocator(),
                                         "node_type with incompatible allocator passed to unordered_multiset::insert()");
@@ -1436,7 +1438,7 @@ public:
         __source.get_allocator() == get_allocator(), "merging container with incompatible allocator");
     return __table_.__node_handle_merge_multi(__source.__table_);
   }
-#endif
+#  endif
 
   _LIBCPP_HIDE_FROM_ABI iterator erase(const_iterator __p) { return __table_.erase(__p); }
   _LIBCPP_HIDE_FROM_ABI size_type erase(const key_type& __k) { return __table_.__erase_multi(__k); }
@@ -1454,7 +1456,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI iterator find(const key_type& __k) { return __table_.find(__k); }
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const key_type& __k) const { return __table_.find(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI iterator find(const _K2& __k) {
     return __table_.find(__k);
@@ -1463,24 +1465,24 @@ public:
   _LIBCPP_HIDE_FROM_ABI const_iterator find(const _K2& __k) const {
     return __table_.find(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type count(const key_type& __k) const { return __table_.__count_multi(__k); }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI size_type count(const _K2& __k) const {
     return __table_.__count_multi(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool contains(const key_type& __k) const { return find(__k) != end(); }
 
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI bool contains(const _K2& __k) const {
     return find(__k) != end();
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const key_type& __k) {
     return __table_.__equal_range_multi(__k);
@@ -1488,7 +1490,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const key_type& __k) const {
     return __table_.__equal_range_multi(__k);
   }
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
   template <class _K2, enable_if_t<__is_transparent_v<hasher, _K2> && __is_transparent_v<key_equal, _K2>>* = nullptr>
   _LIBCPP_HIDE_FROM_ABI pair<iterator, iterator> equal_range(const _K2& __k) {
     return __table_.__equal_range_multi(__k);
@@ -1497,7 +1499,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> equal_range(const _K2& __k) const {
     return __table_.__equal_range_multi(__k);
   }
-#endif // _LIBCPP_STD_VER >= 20
+#  endif // _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI size_type bucket_count() const _NOEXCEPT { return __table_.bucket_count(); }
   _LIBCPP_HIDE_FROM_ABI size_type max_bucket_count() const _NOEXCEPT { return __table_.max_bucket_count(); }
@@ -1519,7 +1521,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI void reserve(size_type __n) { __table_.__reserve_multi(__n); }
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,
           class _Hash      = hash<__iter_value_type<_InputIterator>>,
           class _Pred      = equal_to<__iter_value_type<_InputIterator>>,
@@ -1537,7 +1539,7 @@ unordered_multiset(
     _Pred                                            = _Pred(),
     _Allocator = _Allocator()) -> unordered_multiset<__iter_value_type<_InputIterator>, _Hash, _Pred, _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range,
           class _Hash      = hash<ranges::range_value_t<_Range>>,
           class _Pred      = equal_to<ranges::range_value_t<_Range>>,
@@ -1553,7 +1555,7 @@ unordered_multiset(
     _Hash                                            = _Hash(),
     _Pred                                            = _Pred(),
     _Allocator = _Allocator()) -> unordered_multiset<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
-#  endif
+#    endif
 
 template <class _Tp,
           class _Hash      = hash<_Tp>,
@@ -1592,7 +1594,7 @@ unordered_multiset(_InputIterator, _InputIterator, typename allocator_traits<_Al
                           equal_to<__iter_value_type<_InputIterator>>,
                           _Allocator>;
 
-#  if _LIBCPP_STD_VER >= 23
+#    if _LIBCPP_STD_VER >= 23
 
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_multiset(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -1617,7 +1619,7 @@ template <ranges::input_range _Range,
 unordered_multiset(from_range_t, _Range&&, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_multiset<ranges::range_value_t<_Range>, _Hash, equal_to<ranges::range_value_t<_Range>>, _Allocator>;
 
-#  endif
+#    endif
 
 template <class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_multiset(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Allocator)
@@ -1631,7 +1633,7 @@ template <class _Tp,
           class = enable_if_t<__is_allocator<_Allocator>::value>>
 unordered_multiset(initializer_list<_Tp>, typename allocator_traits<_Allocator>::size_type, _Hash, _Allocator)
     -> unordered_multiset<_Tp, _Hash, equal_to<_Tp>, _Allocator>;
-#endif
+#  endif
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 unordered_multiset<_Value, _Hash, _Pred, _Alloc>::unordered_multiset(
@@ -1695,7 +1697,7 @@ unordered_multiset<_Value, _Hash, _Pred, _Alloc>::unordered_multiset(
   insert(__u.begin(), __u.end());
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline unordered_multiset<_Value, _Hash, _Pred, _Alloc>::unordered_multiset(unordered_multiset&& __u)
@@ -1753,7 +1755,7 @@ unordered_multiset<_Value, _Hash, _Pred, _Alloc>::operator=(initializer_list<val
   return *this;
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 template <class _InputIterator>
@@ -1769,13 +1771,13 @@ swap(unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __x, unordered_multiset<_
   __x.swap(__y);
 }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 template <class _Value, class _Hash, class _Pred, class _Alloc, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI typename unordered_multiset<_Value, _Hash, _Pred, _Alloc>::size_type
 erase_if(unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __c, _Predicate __pred) {
   return std::__libcpp_erase_if_container(__c, __pred);
 }
-#endif
+#  endif
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __x,
@@ -1795,7 +1797,7 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const unordered_multiset<_Value, _Hash, _P
   return true;
 }
 
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_multiset<_Value, _Hash, _Pred, _Alloc>& __x,
@@ -1803,7 +1805,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const unordered_multiset<_Value, _H
   return !(__x == __y);
 }
 
-#endif
+#  endif
 
 template <class _Value, class _Hash, class _Pred, class _Alloc>
 struct __container_traits<unordered_multiset<_Value, _Hash, _Pred, _Alloc> > {
@@ -1817,7 +1819,7 @@ struct __container_traits<unordered_multiset<_Value, _Hash, _Pred, _Alloc> > {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _KeyT, class _HashT = std::hash<_KeyT>, class _PredT = std::equal_to<_KeyT>>
@@ -1828,18 +1830,19 @@ using unordered_multiset _LIBCPP_AVAILABILITY_PMR =
     std::unordered_multiset<_KeyT, _HashT, _PredT, polymorphic_allocator<_KeyT>>;
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#endif
+#  endif
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cmath>
-#  include <concepts>
-#  include <cstdlib>
-#  include <functional>
-#  include <iterator>
-#  include <stdexcept>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cmath>
+#    include <concepts>
+#    include <cstdlib>
+#    include <functional>
+#    include <iterator>
+#    include <stdexcept>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_UNORDERED_SET

--- a/libcxx/include/utility
+++ b/libcxx/include/utility
@@ -246,65 +246,68 @@ template <class T>
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/pair.h>
-#include <__utility/piecewise_construct.h>
-#include <__utility/rel_ops.h>
-#include <__utility/swap.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/pair.h>
+#  include <__utility/piecewise_construct.h>
+#  include <__utility/rel_ops.h>
+#  include <__utility/swap.h>
 
-#if _LIBCPP_STD_VER >= 14
-#  include <__utility/exchange.h>
-#  include <__utility/integer_sequence.h>
-#endif
+#  if _LIBCPP_STD_VER >= 14
+#    include <__utility/exchange.h>
+#    include <__utility/integer_sequence.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__utility/as_const.h>
-#  include <__utility/in_place.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__utility/as_const.h>
+#    include <__utility/in_place.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__utility/cmp.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__utility/cmp.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__utility/forward_like.h>
-#  include <__utility/to_underlying.h>
-#  include <__utility/unreachable.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__utility/forward_like.h>
+#    include <__utility/to_underlying.h>
+#    include <__utility/unreachable.h>
+#  endif
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [utility.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
 // [tuple.creation]
 
-#include <__tuple/ignore.h>
+#  include <__tuple/ignore.h>
 
 // [tuple.helper]
-#include <__tuple/tuple_element.h>
-#include <__tuple/tuple_size.h>
+#  include <__tuple/tuple_element.h>
+#  include <__tuple/tuple_size.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <limits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <limits>
+#  endif
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <cstdlib>
-#  include <iosfwd>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <cstdlib>
+#    include <iosfwd>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_UTILITY

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -343,39 +343,41 @@ template <class T> unspecified2 end(const valarray<T>& v);
 
 */
 
-#include <__algorithm/copy.h>
-#include <__algorithm/count.h>
-#include <__algorithm/fill.h>
-#include <__algorithm/max_element.h>
-#include <__algorithm/min.h>
-#include <__algorithm/min_element.h>
-#include <__algorithm/unwrap_iter.h>
-#include <__assert>
-#include <__config>
-#include <__cstddef/ptrdiff_t.h>
-#include <__functional/operations.h>
-#include <__memory/addressof.h>
-#include <__memory/allocator.h>
-#include <__memory/uninitialized_algorithms.h>
-#include <__type_traits/decay.h>
-#include <__type_traits/remove_reference.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <cmath>
-#include <new>
-#include <version>
+#if 0
+#else // 0
+#  include <__algorithm/copy.h>
+#  include <__algorithm/count.h>
+#  include <__algorithm/fill.h>
+#  include <__algorithm/max_element.h>
+#  include <__algorithm/min.h>
+#  include <__algorithm/min_element.h>
+#  include <__algorithm/unwrap_iter.h>
+#  include <__assert>
+#  include <__config>
+#  include <__cstddef/ptrdiff_t.h>
+#  include <__functional/operations.h>
+#  include <__memory/addressof.h>
+#  include <__memory/allocator.h>
+#  include <__memory/uninitialized_algorithms.h>
+#  include <__type_traits/decay.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <cmath>
+#  include <new>
+#  include <version>
 
 // standard-mandated includes
 
 // [valarray.syn]
-#include <initializer_list>
+#  include <initializer_list>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -397,13 +399,13 @@ public:
   _LIBCPP_HIDE_FROM_ABI size_t size() const { return __size_; }
   _LIBCPP_HIDE_FROM_ABI size_t stride() const { return __stride_; }
 
-#if _LIBCPP_STD_VER >= 20
+#  if _LIBCPP_STD_VER >= 20
 
   _LIBCPP_HIDE_FROM_ABI friend bool operator==(const slice& __x, const slice& __y) {
     return __x.start() == __y.start() && __x.size() == __y.size() && __x.stride() == __y.stride();
   }
 
-#endif
+#  endif
 };
 
 template <class _Tp>
@@ -794,10 +796,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI valarray(const value_type& __x, size_t __n);
   valarray(const value_type* __p, size_t __n);
   valarray(const valarray& __v);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI valarray(valarray&& __v) _NOEXCEPT;
   valarray(initializer_list<value_type> __il);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   valarray(const slice_array<value_type>& __sa);
   valarray(const gslice_array<value_type>& __ga);
   valarray(const mask_array<value_type>& __ma);
@@ -806,10 +808,10 @@ public:
 
   // assignment:
   valarray& operator=(const valarray& __v);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI valarray& operator=(valarray&& __v) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI valarray& operator=(initializer_list<value_type>);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI valarray& operator=(const value_type& __x);
   _LIBCPP_HIDE_FROM_ABI valarray& operator=(const slice_array<value_type>& __sa);
   _LIBCPP_HIDE_FROM_ABI valarray& operator=(const gslice_array<value_type>& __ga);
@@ -828,22 +830,22 @@ public:
   _LIBCPP_HIDE_FROM_ABI slice_array<value_type> operator[](slice __s);
   _LIBCPP_HIDE_FROM_ABI __val_expr<__indirect_expr<const valarray&> > operator[](const gslice& __gs) const;
   _LIBCPP_HIDE_FROM_ABI gslice_array<value_type> operator[](const gslice& __gs);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __val_expr<__indirect_expr<const valarray&> > operator[](gslice&& __gs) const;
   _LIBCPP_HIDE_FROM_ABI gslice_array<value_type> operator[](gslice&& __gs);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __val_expr<__mask_expr<const valarray&> > operator[](const valarray<bool>& __vb) const;
   _LIBCPP_HIDE_FROM_ABI mask_array<value_type> operator[](const valarray<bool>& __vb);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __val_expr<__mask_expr<const valarray&> > operator[](valarray<bool>&& __vb) const;
   _LIBCPP_HIDE_FROM_ABI mask_array<value_type> operator[](valarray<bool>&& __vb);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __val_expr<__indirect_expr<const valarray&> > operator[](const valarray<size_t>& __vs) const;
   _LIBCPP_HIDE_FROM_ABI indirect_array<value_type> operator[](const valarray<size_t>& __vs);
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __val_expr<__indirect_expr<const valarray&> > operator[](valarray<size_t>&& __vs) const;
   _LIBCPP_HIDE_FROM_ABI indirect_array<value_type> operator[](valarray<size_t>&& __vs);
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   // unary operators:
   _LIBCPP_HIDE_FROM_ABI __val_expr<_UnaryOp<__unary_plus<_Tp>, const valarray&> > operator+() const;
@@ -942,10 +944,10 @@ private:
   valarray& __assign_range(const value_type* __f, const value_type* __l);
 };
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 template <class _Tp, size_t _Size>
 valarray(const _Tp (&)[_Size], size_t) -> valarray<_Tp>;
-#endif
+#  endif
 
 template <class _Expr,
           __enable_if_t<__is_val_expr<_Expr>::value && __val_expr_use_member_functions<_Expr>::value, int> = 0>
@@ -1221,7 +1223,7 @@ public:
     __init(__start);
   }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI gslice(size_t __start, const valarray<size_t>& __size, valarray<size_t>&& __stride)
       : __size_(__size), __stride_(std::move(__stride)) {
@@ -1238,7 +1240,7 @@ public:
     __init(__start);
   }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI size_t start() const { return __1d_.size() ? __1d_[0] : 0; }
 
@@ -1318,10 +1320,10 @@ private:
   gslice_array(const gslice& __gs, const valarray<value_type>& __v)
       : __vp_(const_cast<value_type*>(__v.__begin_)), __1d_(__gs.__1d_) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   gslice_array(gslice&& __gs, const valarray<value_type>& __v)
       : __vp_(const_cast<value_type*>(__v.__begin_)), __1d_(std::move(__gs.__1d_)) {}
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <class>
   friend class valarray;
@@ -1708,12 +1710,12 @@ private:
   _LIBCPP_HIDE_FROM_ABI indirect_array(const valarray<size_t>& __ia, const valarray<value_type>& __v)
       : __vp_(const_cast<value_type*>(__v.__begin_)), __1d_(__ia) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI indirect_array(valarray<size_t>&& __ia, const valarray<value_type>& __v)
       : __vp_(const_cast<value_type*>(__v.__begin_)), __1d_(std::move(__ia)) {}
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   template <class>
   friend class valarray;
@@ -1837,12 +1839,12 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI __indirect_expr(const valarray<size_t>& __ia, const _RmExpr& __e) : __expr_(__e), __1d_(__ia) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI __indirect_expr(valarray<size_t>&& __ia, const _RmExpr& __e)
       : __expr_(__e), __1d_(std::move(__ia)) {}
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 public:
   _LIBCPP_HIDE_FROM_ABI __result_type operator[](size_t __i) const { return __expr_[__1d_[__i]]; }
@@ -1984,17 +1986,17 @@ template <class _Tp>
 inline valarray<_Tp>::valarray(size_t __n) : __begin_(nullptr), __end_(nullptr) {
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (size_t __n_left = __n; __n_left; --__n_left, ++__end_)
         ::new ((void*)__end_) value_type();
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2007,17 +2009,17 @@ template <class _Tp>
 valarray<_Tp>::valarray(const value_type* __p, size_t __n) : __begin_(nullptr), __end_(nullptr) {
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (size_t __n_left = __n; __n_left; ++__end_, ++__p, --__n_left)
         ::new ((void*)__end_) value_type(*__p);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2025,21 +2027,21 @@ template <class _Tp>
 valarray<_Tp>::valarray(const valarray& __v) : __begin_(nullptr), __end_(nullptr) {
   if (__v.size()) {
     __begin_ = __end_ = allocator<value_type>().allocate(__v.size());
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (value_type* __p = __v.__begin_; __p != __v.__end_; ++__end_, ++__p)
         ::new ((void*)__end_) value_type(*__p);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__v.size());
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline valarray<_Tp>::valarray(valarray&& __v) _NOEXCEPT : __begin_(__v.__begin_), __end_(__v.__end_) {
@@ -2051,40 +2053,40 @@ valarray<_Tp>::valarray(initializer_list<value_type> __il) : __begin_(nullptr), 
   const size_t __n = __il.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     try {
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
       size_t __n_left = __n;
       for (const value_type* __p = __il.begin(); __n_left; ++__end_, ++__p, --__n_left)
         ::new ((void*)__end_) value_type(*__p);
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#  endif // _LIBCPP_HAS_EXCEPTIONS
+#    endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 valarray<_Tp>::valarray(const slice_array<value_type>& __sa) : __begin_(nullptr), __end_(nullptr) {
   const size_t __n = __sa.__size_;
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       size_t __n_left = __n;
       for (const value_type* __p = __sa.__vp_; __n_left; ++__end_, __p += __sa.__stride_, --__n_left)
         ::new ((void*)__end_) value_type(*__p);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2093,19 +2095,19 @@ valarray<_Tp>::valarray(const gslice_array<value_type>& __ga) : __begin_(nullptr
   const size_t __n = __ga.__1d_.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       typedef const size_t* _Ip;
       const value_type* __s = __ga.__vp_;
       for (_Ip __i = __ga.__1d_.__begin_, __e = __ga.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2114,19 +2116,19 @@ valarray<_Tp>::valarray(const mask_array<value_type>& __ma) : __begin_(nullptr),
   const size_t __n = __ma.__1d_.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       typedef const size_t* _Ip;
       const value_type* __s = __ma.__vp_;
       for (_Ip __i = __ma.__1d_.__begin_, __e = __ma.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2135,19 +2137,19 @@ valarray<_Tp>::valarray(const indirect_array<value_type>& __ia) : __begin_(nullp
   const size_t __n = __ia.__1d_.size();
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       typedef const size_t* _Ip;
       const value_type* __s = __ia.__vp_;
       for (_Ip __i = __ia.__1d_.__begin_, __e = __ia.__1d_.__end_; __i != __e; ++__i, ++__end_)
         ::new ((void*)__end_) value_type(__s[*__i]);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -2177,7 +2179,7 @@ valarray<_Tp>& valarray<_Tp>::operator=(const valarray& __v) {
   return *this;
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline valarray<_Tp>& valarray<_Tp>::operator=(valarray&& __v) _NOEXCEPT {
@@ -2194,7 +2196,7 @@ inline valarray<_Tp>& valarray<_Tp>::operator=(initializer_list<value_type> __il
   return __assign_range(__il.begin(), __il.end());
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline valarray<_Tp>& valarray<_Tp>::operator=(const value_type& __x) {
@@ -2273,7 +2275,7 @@ inline gslice_array<_Tp> valarray<_Tp>::operator[](const gslice& __gs) {
   return gslice_array<value_type>(__gs, *this);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline __val_expr<__indirect_expr<const valarray<_Tp>&> > valarray<_Tp>::operator[](gslice&& __gs) const {
@@ -2285,7 +2287,7 @@ inline gslice_array<_Tp> valarray<_Tp>::operator[](gslice&& __gs) {
   return gslice_array<value_type>(std::move(__gs), *this);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline __val_expr<__mask_expr<const valarray<_Tp>&> > valarray<_Tp>::operator[](const valarray<bool>& __vb) const {
@@ -2297,7 +2299,7 @@ inline mask_array<_Tp> valarray<_Tp>::operator[](const valarray<bool>& __vb) {
   return mask_array<value_type>(__vb, *this);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline __val_expr<__mask_expr<const valarray<_Tp>&> > valarray<_Tp>::operator[](valarray<bool>&& __vb) const {
@@ -2309,7 +2311,7 @@ inline mask_array<_Tp> valarray<_Tp>::operator[](valarray<bool>&& __vb) {
   return mask_array<value_type>(std::move(__vb), *this);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline __val_expr<__indirect_expr<const valarray<_Tp>&> >
@@ -2322,7 +2324,7 @@ inline indirect_array<_Tp> valarray<_Tp>::operator[](const valarray<size_t>& __v
   return indirect_array<value_type>(__vs, *this);
 }
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline __val_expr<__indirect_expr<const valarray<_Tp>&> > valarray<_Tp>::operator[](valarray<size_t>&& __vs) const {
@@ -2334,7 +2336,7 @@ inline indirect_array<_Tp> valarray<_Tp>::operator[](valarray<size_t>&& __vs) {
   return indirect_array<value_type>(std::move(__vs), *this);
 }
 
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
 template <class _Tp>
 inline __val_expr<_UnaryOp<__unary_plus<_Tp>, const valarray<_Tp>&> > valarray<_Tp>::operator+() const {
@@ -2636,17 +2638,17 @@ void valarray<_Tp>::resize(size_t __n, value_type __x) {
   __clear(size());
   if (__n) {
     __begin_ = __end_ = allocator<value_type>().allocate(__n);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     try {
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
       for (size_t __n_left = __n; __n_left; --__n_left, ++__end_)
         ::new ((void*)__end_) value_type(__x);
-#if _LIBCPP_HAS_EXCEPTIONS
+#  if _LIBCPP_HAS_EXCEPTIONS
     } catch (...) {
       __clear(__n);
       throw;
     }
-#endif // _LIBCPP_HAS_EXCEPTIONS
+#  endif // _LIBCPP_HAS_EXCEPTIONS
   }
 }
 
@@ -3351,14 +3353,15 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <concepts>
-#  include <cstdlib>
-#  include <cstring>
-#  include <functional>
-#  include <stdexcept>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <concepts>
+#    include <cstdlib>
+#    include <cstring>
+#    include <functional>
+#    include <stdexcept>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_VALARRAY

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -212,74 +212,76 @@ namespace std {
 
 */
 
-#include <__compare/common_comparison_category.h>
-#include <__compare/compare_three_way_result.h>
-#include <__compare/ordering.h>
-#include <__compare/three_way_comparable.h>
-#include <__config>
-#include <__exception/exception.h>
-#include <__functional/hash.h>
-#include <__functional/operations.h>
-#include <__functional/unary_function.h>
-#include <__fwd/variant.h>
-#include <__memory/addressof.h>
-#include <__memory/construct_at.h>
-#include <__tuple/find_index.h>
-#include <__tuple/sfinae_helpers.h>
-#include <__type_traits/add_cv_quals.h>
-#include <__type_traits/add_pointer.h>
-#include <__type_traits/common_type.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/conjunction.h>
-#include <__type_traits/decay.h>
-#include <__type_traits/dependent_type.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/invoke.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_assignable.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_destructible.h>
-#include <__type_traits/is_nothrow_assignable.h>
-#include <__type_traits/is_nothrow_constructible.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/is_trivially_assignable.h>
-#include <__type_traits/is_trivially_constructible.h>
-#include <__type_traits/is_trivially_destructible.h>
-#include <__type_traits/is_trivially_relocatable.h>
-#include <__type_traits/is_void.h>
-#include <__type_traits/remove_const.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
-#include <__type_traits/type_identity.h>
-#include <__type_traits/void_t.h>
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/forward_like.h>
-#include <__utility/in_place.h>
-#include <__utility/integer_sequence.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <__variant/monostate.h>
-#include <__verbose_abort>
-#include <initializer_list>
-#include <limits>
-#include <new>
-#include <version>
+#if 0
+#else // 0
+#  include <__compare/common_comparison_category.h>
+#  include <__compare/compare_three_way_result.h>
+#  include <__compare/ordering.h>
+#  include <__compare/three_way_comparable.h>
+#  include <__config>
+#  include <__exception/exception.h>
+#  include <__functional/hash.h>
+#  include <__functional/operations.h>
+#  include <__functional/unary_function.h>
+#  include <__fwd/variant.h>
+#  include <__memory/addressof.h>
+#  include <__memory/construct_at.h>
+#  include <__tuple/find_index.h>
+#  include <__tuple/sfinae_helpers.h>
+#  include <__type_traits/add_cv_quals.h>
+#  include <__type_traits/add_pointer.h>
+#  include <__type_traits/common_type.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/conjunction.h>
+#  include <__type_traits/decay.h>
+#  include <__type_traits/dependent_type.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/invoke.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_assignable.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_destructible.h>
+#  include <__type_traits/is_nothrow_assignable.h>
+#  include <__type_traits/is_nothrow_constructible.h>
+#  include <__type_traits/is_reference.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/is_trivially_assignable.h>
+#  include <__type_traits/is_trivially_constructible.h>
+#  include <__type_traits/is_trivially_destructible.h>
+#  include <__type_traits/is_trivially_relocatable.h>
+#  include <__type_traits/is_void.h>
+#  include <__type_traits/remove_const.h>
+#  include <__type_traits/remove_cvref.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__type_traits/type_identity.h>
+#  include <__type_traits/void_t.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/forward_like.h>
+#  include <__utility/in_place.h>
+#  include <__utility/integer_sequence.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <__variant/monostate.h>
+#  include <__verbose_abort>
+#  include <initializer_list>
+#  include <limits>
+#  include <new>
+#  include <version>
 
 // standard-mandated includes
 
 // [variant.syn]
-#include <compare>
+#  include <compare>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
 namespace std { // explicitly not using versioning namespace
 
@@ -292,7 +294,7 @@ public:
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if _LIBCPP_STD_VER >= 17
+#  if _LIBCPP_STD_VER >= 17
 
 // Light N-dimensional array of function pointers. Used in place of std::array to avoid
 // adding a dependency.
@@ -306,11 +308,11 @@ struct __farray {
 
 [[noreturn]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS void
 __throw_bad_variant_access() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   throw bad_variant_access();
-#  else
+#    else
   _LIBCPP_VERBOSE_ABORT("bad_variant_access was thrown in -fno-exceptions mode");
-#  endif
+#    endif
 }
 
 // variant_size
@@ -344,13 +346,13 @@ struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, variant<_Types...>> {
 
 template <size_t _NumAlternatives>
 _LIBCPP_HIDE_FROM_ABI constexpr auto __choose_index_type() {
-#  ifdef _LIBCPP_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
+#    ifdef _LIBCPP_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
   if constexpr (_NumAlternatives < numeric_limits<unsigned char>::max())
     return static_cast<unsigned char>(0);
   else if constexpr (_NumAlternatives < numeric_limits<unsigned short>::max())
     return static_cast<unsigned short>(0);
   else
-#  endif // _LIBCPP_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
+#    endif // _LIBCPP_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
     return static_cast<unsigned int>(0);
 }
 
@@ -595,12 +597,12 @@ struct __variant {
     return __visit_alt(__make_value_visitor(std::forward<_Visitor>(__visitor)), std::forward<_Vs>(__vs)...);
   }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _Rp, class _Visitor, class... _Vs>
   _LIBCPP_HIDE_FROM_ABI static constexpr _Rp __visit_value(_Visitor&& __visitor, _Vs&&... __vs) {
     return __visit_alt(__make_value_visitor<_Rp>(std::forward<_Visitor>(__visitor)), std::forward<_Vs>(__vs)...);
   }
-#  endif
+#    endif
 
 private:
   template <class _Visitor, class... _Values>
@@ -618,7 +620,7 @@ private:
     _Visitor&& __visitor;
   };
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _Rp, class _Visitor>
   struct __value_visitor_return_type {
     template <class... _Alts>
@@ -633,26 +635,26 @@ private:
 
     _Visitor&& __visitor;
   };
-#  endif
+#    endif
 
   template <class _Visitor>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_value_visitor(_Visitor&& __visitor) {
     return __value_visitor<_Visitor>{std::forward<_Visitor>(__visitor)};
   }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   template <class _Rp, class _Visitor>
   _LIBCPP_HIDE_FROM_ABI static constexpr auto __make_value_visitor(_Visitor&& __visitor) {
     return __value_visitor_return_type<_Rp, _Visitor>{std::forward<_Visitor>(__visitor)};
   }
-#  endif
+#    endif
 };
 
 } // namespace __visitation
 
 // Adding semi-colons in macro expansions helps clang-format to do a better job.
 // This macro is used to avoid compilation errors due to "stray" semi-colons.
-#  define _LIBCPP_EAT_SEMICOLON static_assert(true, "")
+#    define _LIBCPP_EAT_SEMICOLON static_assert(true, "")
 
 template <size_t _Index, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS __alt {
@@ -672,33 +674,33 @@ union _LIBCPP_TEMPLATE_VIS __union;
 template <_Trait _DestructibleTrait, size_t _Index>
 union _LIBCPP_TEMPLATE_VIS __union<_DestructibleTrait, _Index> {};
 
-#  define _LIBCPP_VARIANT_UNION(destructible_trait, destructor_definition)                                             \
-    template <size_t _Index, class _Tp, class... _Types>                                                               \
-    union _LIBCPP_TEMPLATE_VIS __union<destructible_trait, _Index, _Tp, _Types...> {                                   \
-    public:                                                                                                            \
-      _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(__valueless_t) noexcept : __dummy{} {}                          \
+#    define _LIBCPP_VARIANT_UNION(destructible_trait, destructor_definition)                                           \
+      template <size_t _Index, class _Tp, class... _Types>                                                             \
+      union _LIBCPP_TEMPLATE_VIS __union<destructible_trait, _Index, _Tp, _Types...> {                                 \
+      public:                                                                                                          \
+        _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(__valueless_t) noexcept : __dummy{} {}                        \
                                                                                                                        \
-      template <class... _Args>                                                                                        \
-      _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(in_place_index_t<0>, _Args&&... __args)                         \
-          : __head(in_place, std::forward<_Args>(__args)...) {}                                                        \
+        template <class... _Args>                                                                                      \
+        _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(in_place_index_t<0>, _Args&&... __args)                       \
+            : __head(in_place, std::forward<_Args>(__args)...) {}                                                      \
                                                                                                                        \
-      template <size_t _Ip, class... _Args>                                                                            \
-      _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(in_place_index_t<_Ip>, _Args&&... __args)                       \
-          : __tail(in_place_index<_Ip - 1>, std::forward<_Args>(__args)...) {}                                         \
+        template <size_t _Ip, class... _Args>                                                                          \
+        _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(in_place_index_t<_Ip>, _Args&&... __args)                     \
+            : __tail(in_place_index<_Ip - 1>, std::forward<_Args>(__args)...) {}                                       \
                                                                                                                        \
-      _LIBCPP_HIDE_FROM_ABI __union(const __union&)            = default;                                              \
-      _LIBCPP_HIDE_FROM_ABI __union(__union&&)                 = default;                                              \
-      _LIBCPP_HIDE_FROM_ABI __union& operator=(const __union&) = default;                                              \
-      _LIBCPP_HIDE_FROM_ABI __union& operator=(__union&&)      = default;                                              \
-      destructor_definition;                                                                                           \
+        _LIBCPP_HIDE_FROM_ABI __union(const __union&)            = default;                                            \
+        _LIBCPP_HIDE_FROM_ABI __union(__union&&)                 = default;                                            \
+        _LIBCPP_HIDE_FROM_ABI __union& operator=(const __union&) = default;                                            \
+        _LIBCPP_HIDE_FROM_ABI __union& operator=(__union&&)      = default;                                            \
+        destructor_definition;                                                                                         \
                                                                                                                        \
-    private:                                                                                                           \
-      char __dummy;                                                                                                    \
-      __alt<_Index, _Tp> __head;                                                                                       \
-      __union<destructible_trait, _Index + 1, _Types...> __tail;                                                       \
+      private:                                                                                                         \
+        char __dummy;                                                                                                  \
+        __alt<_Index, _Tp> __head;                                                                                     \
+        __union<destructible_trait, _Index + 1, _Types...> __tail;                                                     \
                                                                                                                        \
-      friend struct __access::__union;                                                                                 \
-    }
+        friend struct __access::__union;                                                                               \
+      }
 
 _LIBCPP_VARIANT_UNION(_Trait::_TriviallyAvailable,
                       _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 ~__union() = default);
@@ -706,7 +708,7 @@ _LIBCPP_VARIANT_UNION(
     _Trait::_Available, _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 ~__union() {} _LIBCPP_EAT_SEMICOLON);
 _LIBCPP_VARIANT_UNION(_Trait::_Unavailable, _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 ~__union() = delete);
 
-#  undef _LIBCPP_VARIANT_UNION
+#    undef _LIBCPP_VARIANT_UNION
 
 template <_Trait _DestructibleTrait, class... _Types>
 class _LIBCPP_TEMPLATE_VIS __base {
@@ -747,25 +749,25 @@ protected:
 template <class _Traits, _Trait = _Traits::__destructible_trait>
 class _LIBCPP_TEMPLATE_VIS __dtor;
 
-#  define _LIBCPP_VARIANT_DESTRUCTOR(destructible_trait, destructor_definition, destroy)                               \
-    template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __dtor<__traits<_Types...>, destructible_trait>                                         \
-        : public __base<destructible_trait, _Types...> {                                                               \
-      using __base_type = __base<destructible_trait, _Types...>;                                                       \
-      using __index_t   = typename __base_type::__index_t;                                                             \
+#    define _LIBCPP_VARIANT_DESTRUCTOR(destructible_trait, destructor_definition, destroy)                             \
+      template <class... _Types>                                                                                       \
+      class _LIBCPP_TEMPLATE_VIS __dtor<__traits<_Types...>, destructible_trait>                                       \
+          : public __base<destructible_trait, _Types...> {                                                             \
+        using __base_type = __base<destructible_trait, _Types...>;                                                     \
+        using __index_t   = typename __base_type::__index_t;                                                           \
                                                                                                                        \
-    public:                                                                                                            \
-      using __base_type::__base_type;                                                                                  \
-      using __base_type::operator=;                                                                                    \
-      _LIBCPP_HIDE_FROM_ABI __dtor(const __dtor&)            = default;                                                \
-      _LIBCPP_HIDE_FROM_ABI __dtor(__dtor&&)                 = default;                                                \
-      _LIBCPP_HIDE_FROM_ABI __dtor& operator=(const __dtor&) = default;                                                \
-      _LIBCPP_HIDE_FROM_ABI __dtor& operator=(__dtor&&)      = default;                                                \
-      destructor_definition;                                                                                           \
+      public:                                                                                                          \
+        using __base_type::__base_type;                                                                                \
+        using __base_type::operator=;                                                                                  \
+        _LIBCPP_HIDE_FROM_ABI __dtor(const __dtor&)            = default;                                              \
+        _LIBCPP_HIDE_FROM_ABI __dtor(__dtor&&)                 = default;                                              \
+        _LIBCPP_HIDE_FROM_ABI __dtor& operator=(const __dtor&) = default;                                              \
+        _LIBCPP_HIDE_FROM_ABI __dtor& operator=(__dtor&&)      = default;                                              \
+        destructor_definition;                                                                                         \
                                                                                                                        \
-    protected:                                                                                                         \
-      destroy;                                                                                                         \
-    }
+      protected:                                                                                                       \
+        destroy;                                                                                                       \
+      }
 
 _LIBCPP_VARIANT_DESTRUCTOR(
     _Trait::_TriviallyAvailable,
@@ -793,7 +795,7 @@ _LIBCPP_VARIANT_DESTRUCTOR(_Trait::_Unavailable,
                            _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 ~__dtor()                 = delete,
                            _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __destroy() noexcept = delete);
 
-#  undef _LIBCPP_VARIANT_DESTRUCTOR
+#    undef _LIBCPP_VARIANT_DESTRUCTOR
 
 template <class _Traits>
 class _LIBCPP_TEMPLATE_VIS __ctor : public __dtor<_Traits> {
@@ -825,22 +827,22 @@ protected:
 template <class _Traits, _Trait = _Traits::__move_constructible_trait>
 class _LIBCPP_TEMPLATE_VIS __move_constructor;
 
-#  define _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor_definition)                      \
-    template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __move_constructor<__traits<_Types...>, move_constructible_trait>                       \
-        : public __ctor<__traits<_Types...>> {                                                                         \
-      using __base_type = __ctor<__traits<_Types...>>;                                                                 \
+#    define _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor_definition)                    \
+      template <class... _Types>                                                                                       \
+      class _LIBCPP_TEMPLATE_VIS __move_constructor<__traits<_Types...>, move_constructible_trait>                     \
+          : public __ctor<__traits<_Types...>> {                                                                       \
+        using __base_type = __ctor<__traits<_Types...>>;                                                               \
                                                                                                                        \
-    public:                                                                                                            \
-      using __base_type::__base_type;                                                                                  \
-      using __base_type::operator=;                                                                                    \
+      public:                                                                                                          \
+        using __base_type::__base_type;                                                                                \
+        using __base_type::operator=;                                                                                  \
                                                                                                                        \
-      _LIBCPP_HIDE_FROM_ABI __move_constructor(const __move_constructor&)            = default;                        \
-      _LIBCPP_HIDE_FROM_ABI ~__move_constructor()                                    = default;                        \
-      _LIBCPP_HIDE_FROM_ABI __move_constructor& operator=(const __move_constructor&) = default;                        \
-      _LIBCPP_HIDE_FROM_ABI __move_constructor& operator=(__move_constructor&&)      = default;                        \
-      move_constructor_definition;                                                                                     \
-    }
+        _LIBCPP_HIDE_FROM_ABI __move_constructor(const __move_constructor&)            = default;                      \
+        _LIBCPP_HIDE_FROM_ABI ~__move_constructor()                                    = default;                      \
+        _LIBCPP_HIDE_FROM_ABI __move_constructor& operator=(const __move_constructor&) = default;                      \
+        _LIBCPP_HIDE_FROM_ABI __move_constructor& operator=(__move_constructor&&)      = default;                      \
+        move_constructor_definition;                                                                                   \
+      }
 
 _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
     _Trait::_TriviallyAvailable,
@@ -858,27 +860,27 @@ _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
     _Trait::_Unavailable,
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __move_constructor(__move_constructor&&) = delete);
 
-#  undef _LIBCPP_VARIANT_MOVE_CONSTRUCTOR
+#    undef _LIBCPP_VARIANT_MOVE_CONSTRUCTOR
 
 template <class _Traits, _Trait = _Traits::__copy_constructible_trait>
 class _LIBCPP_TEMPLATE_VIS __copy_constructor;
 
-#  define _LIBCPP_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, copy_constructor_definition)                      \
-    template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __copy_constructor<__traits<_Types...>, copy_constructible_trait>                       \
-        : public __move_constructor<__traits<_Types...>> {                                                             \
-      using __base_type = __move_constructor<__traits<_Types...>>;                                                     \
+#    define _LIBCPP_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, copy_constructor_definition)                    \
+      template <class... _Types>                                                                                       \
+      class _LIBCPP_TEMPLATE_VIS __copy_constructor<__traits<_Types...>, copy_constructible_trait>                     \
+          : public __move_constructor<__traits<_Types...>> {                                                           \
+        using __base_type = __move_constructor<__traits<_Types...>>;                                                   \
                                                                                                                        \
-    public:                                                                                                            \
-      using __base_type::__base_type;                                                                                  \
-      using __base_type::operator=;                                                                                    \
+      public:                                                                                                          \
+        using __base_type::__base_type;                                                                                \
+        using __base_type::operator=;                                                                                  \
                                                                                                                        \
-      _LIBCPP_HIDE_FROM_ABI __copy_constructor(__copy_constructor&&)                 = default;                        \
-      _LIBCPP_HIDE_FROM_ABI ~__copy_constructor()                                    = default;                        \
-      _LIBCPP_HIDE_FROM_ABI __copy_constructor& operator=(const __copy_constructor&) = default;                        \
-      _LIBCPP_HIDE_FROM_ABI __copy_constructor& operator=(__copy_constructor&&)      = default;                        \
-      copy_constructor_definition;                                                                                     \
-    }
+        _LIBCPP_HIDE_FROM_ABI __copy_constructor(__copy_constructor&&)                 = default;                      \
+        _LIBCPP_HIDE_FROM_ABI ~__copy_constructor()                                    = default;                      \
+        _LIBCPP_HIDE_FROM_ABI __copy_constructor& operator=(const __copy_constructor&) = default;                      \
+        _LIBCPP_HIDE_FROM_ABI __copy_constructor& operator=(__copy_constructor&&)      = default;                      \
+        copy_constructor_definition;                                                                                   \
+      }
 
 _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
     _Trait::_TriviallyAvailable,
@@ -893,7 +895,7 @@ _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
     _Trait::_Unavailable,
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_constructor(const __copy_constructor&) = delete);
 
-#  undef _LIBCPP_VARIANT_COPY_CONSTRUCTOR
+#    undef _LIBCPP_VARIANT_COPY_CONSTRUCTOR
 
 template <class _Traits>
 class _LIBCPP_TEMPLATE_VIS __assignment : public __copy_constructor<_Traits> {
@@ -952,22 +954,22 @@ protected:
 template <class _Traits, _Trait = _Traits::__move_assignable_trait>
 class _LIBCPP_TEMPLATE_VIS __move_assignment;
 
-#  define _LIBCPP_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment_definition)                           \
-    template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __move_assignment<__traits<_Types...>, move_assignable_trait>                           \
-        : public __assignment<__traits<_Types...>> {                                                                   \
-      using __base_type = __assignment<__traits<_Types...>>;                                                           \
+#    define _LIBCPP_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment_definition)                         \
+      template <class... _Types>                                                                                       \
+      class _LIBCPP_TEMPLATE_VIS __move_assignment<__traits<_Types...>, move_assignable_trait>                         \
+          : public __assignment<__traits<_Types...>> {                                                                 \
+        using __base_type = __assignment<__traits<_Types...>>;                                                         \
                                                                                                                        \
-    public:                                                                                                            \
-      using __base_type::__base_type;                                                                                  \
-      using __base_type::operator=;                                                                                    \
+      public:                                                                                                          \
+        using __base_type::__base_type;                                                                                \
+        using __base_type::operator=;                                                                                  \
                                                                                                                        \
-      _LIBCPP_HIDE_FROM_ABI __move_assignment(const __move_assignment&)            = default;                          \
-      _LIBCPP_HIDE_FROM_ABI __move_assignment(__move_assignment&&)                 = default;                          \
-      _LIBCPP_HIDE_FROM_ABI ~__move_assignment()                                   = default;                          \
-      _LIBCPP_HIDE_FROM_ABI __move_assignment& operator=(const __move_assignment&) = default;                          \
-      move_assignment_definition;                                                                                      \
-    }
+        _LIBCPP_HIDE_FROM_ABI __move_assignment(const __move_assignment&)            = default;                        \
+        _LIBCPP_HIDE_FROM_ABI __move_assignment(__move_assignment&&)                 = default;                        \
+        _LIBCPP_HIDE_FROM_ABI ~__move_assignment()                                   = default;                        \
+        _LIBCPP_HIDE_FROM_ABI __move_assignment& operator=(const __move_assignment&) = default;                        \
+        move_assignment_definition;                                                                                    \
+      }
 
 _LIBCPP_VARIANT_MOVE_ASSIGNMENT(_Trait::_TriviallyAvailable,
                                 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __move_assignment& operator=(
@@ -986,27 +988,27 @@ _LIBCPP_VARIANT_MOVE_ASSIGNMENT(
     _Trait::_Unavailable,
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __move_assignment& operator=(__move_assignment&&) = delete);
 
-#  undef _LIBCPP_VARIANT_MOVE_ASSIGNMENT
+#    undef _LIBCPP_VARIANT_MOVE_ASSIGNMENT
 
 template <class _Traits, _Trait = _Traits::__copy_assignable_trait>
 class _LIBCPP_TEMPLATE_VIS __copy_assignment;
 
-#  define _LIBCPP_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment_definition)                           \
-    template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __copy_assignment<__traits<_Types...>, copy_assignable_trait>                           \
-        : public __move_assignment<__traits<_Types...>> {                                                              \
-      using __base_type = __move_assignment<__traits<_Types...>>;                                                      \
+#    define _LIBCPP_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment_definition)                         \
+      template <class... _Types>                                                                                       \
+      class _LIBCPP_TEMPLATE_VIS __copy_assignment<__traits<_Types...>, copy_assignable_trait>                         \
+          : public __move_assignment<__traits<_Types...>> {                                                            \
+        using __base_type = __move_assignment<__traits<_Types...>>;                                                    \
                                                                                                                        \
-    public:                                                                                                            \
-      using __base_type::__base_type;                                                                                  \
-      using __base_type::operator=;                                                                                    \
+      public:                                                                                                          \
+        using __base_type::__base_type;                                                                                \
+        using __base_type::operator=;                                                                                  \
                                                                                                                        \
-      _LIBCPP_HIDE_FROM_ABI __copy_assignment(const __copy_assignment&)       = default;                               \
-      _LIBCPP_HIDE_FROM_ABI __copy_assignment(__copy_assignment&&)            = default;                               \
-      _LIBCPP_HIDE_FROM_ABI ~__copy_assignment()                              = default;                               \
-      _LIBCPP_HIDE_FROM_ABI __copy_assignment& operator=(__copy_assignment&&) = default;                               \
-      copy_assignment_definition;                                                                                      \
-    }
+        _LIBCPP_HIDE_FROM_ABI __copy_assignment(const __copy_assignment&)       = default;                             \
+        _LIBCPP_HIDE_FROM_ABI __copy_assignment(__copy_assignment&&)            = default;                             \
+        _LIBCPP_HIDE_FROM_ABI ~__copy_assignment()                              = default;                             \
+        _LIBCPP_HIDE_FROM_ABI __copy_assignment& operator=(__copy_assignment&&) = default;                             \
+        copy_assignment_definition;                                                                                    \
+      }
 
 _LIBCPP_VARIANT_COPY_ASSIGNMENT(_Trait::_TriviallyAvailable,
                                 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_assignment& operator=(
@@ -1024,7 +1026,7 @@ _LIBCPP_VARIANT_COPY_ASSIGNMENT(_Trait::_Unavailable,
                                 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_assignment& operator=(
                                     const __copy_assignment&) = delete);
 
-#  undef _LIBCPP_VARIANT_COPY_ASSIGNMENT
+#    undef _LIBCPP_VARIANT_COPY_ASSIGNMENT
 
 template <class... _Types>
 class _LIBCPP_TEMPLATE_VIS __impl : public __copy_assignment<__traits<_Types...>> {
@@ -1061,7 +1063,7 @@ public:
         std::swap(__lhs, __rhs);
       }
       __impl __tmp(std::move(*__rhs));
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
       if constexpr (__all<is_nothrow_move_constructible_v<_Types>...>::value) {
         this->__generic_construct(*__rhs, std::move(*__lhs));
       } else {
@@ -1077,11 +1079,11 @@ public:
           throw;
         }
       }
-#  else
+#    else
       // this isn't consolidated with the `if constexpr` branch above due to
       // `throw` being ill-formed with exceptions disabled even when discarded.
       this->__generic_construct(*__rhs, std::move(*__lhs));
-#  endif
+#    endif
       this->__generic_construct(*__lhs, std::move(__tmp));
     }
   }
@@ -1144,14 +1146,14 @@ template <class _Visitor, class... _Vs, typename = void_t<decltype(std::__as_var
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr decltype(auto)
 visit(_Visitor&& __visitor, _Vs&&... __vs);
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <class _Rp,
           class _Visitor,
           class... _Vs,
           typename = void_t<decltype(std::__as_variant(std::declval<_Vs>()))...>>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr _Rp
 visit(_Visitor&& __visitor, _Vs&&... __vs);
-#  endif
+#    endif
 
 template <class... _Types>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_DECLSPEC_EMPTY_BASES variant
@@ -1299,7 +1301,7 @@ public:
     __impl_.__swap(__that.__impl_);
   }
 
-#  if _LIBCPP_STD_VER >= 26 && _LIBCPP_HAS_EXPLICIT_THIS_PARAMETER
+#    if _LIBCPP_STD_VER >= 26 && _LIBCPP_HAS_EXPLICIT_THIS_PARAMETER
   // Helper class to implement [variant.visit]/10
   //   Constraints: The call to visit does not use an explicit template-argument-list
   //   that begins with a type template-argument.
@@ -1318,7 +1320,7 @@ public:
     using _VariantT = _OverrideRef<_Self&&, _CopyConst<remove_reference_t<_Self>, variant>>;
     return std::visit<_Rp>(std::forward<_Visitor>(__visitor), (_VariantT)__self);
   }
-#  endif
+#    endif
 
 private:
   __variant_detail::__impl<_Types...> __impl_;
@@ -1462,7 +1464,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool operator==(const variant<_Types...>& __lhs,
   return __variant::__visit_value_at(__lhs.index(), __convert_to_bool<equal_to<>>{}, __lhs, __rhs);
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 
 template <class... _Types>
   requires(three_way_comparable<_Types> && ...)
@@ -1482,7 +1484,7 @@ operator<=>(const variant<_Types...>& __lhs, const variant<_Types...>& __rhs) {
   return __variant::__visit_value_at(__lhs.index(), __three_way, __lhs, __rhs);
 }
 
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI constexpr bool operator!=(const variant<_Types...>& __lhs, const variant<_Types...>& __rhs) {
@@ -1566,7 +1568,7 @@ visit(_Visitor&& __visitor, _Vs&&... __vs) {
   return __variant::__visit_value(std::forward<_Visitor>(__visitor), std::forward<_Vs>(__vs)...);
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template < class _Rp, class _Visitor, class... _Vs, typename>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_AVAILABILITY_THROW_BAD_VARIANT_ACCESS constexpr _Rp
 visit(_Visitor&& __visitor, _Vs&&... __vs) {
@@ -1574,7 +1576,7 @@ visit(_Visitor&& __visitor, _Vs&&... __vs) {
   std::__throw_if_valueless(std::forward<_Vs>(__vs)...);
   return __variant::__visit_value<_Rp>(std::forward<_Visitor>(__visitor), std::forward<_Vs>(__vs)...);
 }
-#  endif
+#    endif
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 auto
@@ -1623,19 +1625,20 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto&& __unchecked_get(variant<_Types...>& __v) 
   return std::__unchecked_get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
-#endif // _LIBCPP_STD_VER >= 17
+#  endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <exception>
-#  include <tuple>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <exception>
+#    include <tuple>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_VARIANT

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -304,67 +304,70 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 
 // clang-format on
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#include <__vector/comparison.h>
-#include <__vector/swap.h>
-#include <__vector/vector.h>
-#include <__vector/vector_bool.h>
+#  include <__vector/comparison.h>
+#  include <__vector/swap.h>
+#  include <__vector/vector.h>
+#  include <__vector/vector_bool.h>
 
-#if _LIBCPP_STD_VER >= 17
-#  include <__vector/pmr.h>
-#endif
+#  if _LIBCPP_STD_VER >= 17
+#    include <__vector/pmr.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 20
-#  include <__vector/erase.h>
-#endif
+#  if _LIBCPP_STD_VER >= 20
+#    include <__vector/erase.h>
+#  endif
 
-#if _LIBCPP_STD_VER >= 23
-#  include <__vector/vector_bool_formatter.h>
-#endif
+#  if _LIBCPP_STD_VER >= 23
+#    include <__vector/vector_bool_formatter.h>
+#  endif
 
-#include <version>
+#  include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#include <__iterator/access.h>
-#include <__iterator/data.h>
-#include <__iterator/empty.h>
-#include <__iterator/reverse_access.h>
-#include <__iterator/size.h>
+#  include <__iterator/access.h>
+#  include <__iterator/data.h>
+#  include <__iterator/empty.h>
+#  include <__iterator/reverse_access.h>
+#  include <__iterator/size.h>
 
 // [vector.syn]
-#include <compare>
-#include <initializer_list>
+#  include <compare>
+#  include <initializer_list>
 
 // [vector.syn], [unord.hash]
-#include <__functional/hash.h>
+#  include <__functional/hash.h>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
-
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <algorithm>
-#  include <array>
-#  include <atomic>
-#  include <cctype>
-#  include <cerrno>
-#  include <clocale>
-#  include <concepts>
-#  include <cstdint>
-#  include <cstdlib>
-#  include <iosfwd>
-#  if _LIBCPP_HAS_LOCALIZATION
-#    include <locale>
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
 #  endif
-#  include <string>
-#  include <string_view>
-#  include <tuple>
-#  include <type_traits>
-#  include <typeinfo>
-#  include <utility>
-#endif
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <algorithm>
+#    include <array>
+#    include <atomic>
+#    include <cctype>
+#    include <cerrno>
+#    include <clocale>
+#    include <concepts>
+#    include <cstdint>
+#    include <cstdlib>
+#    include <iosfwd>
+#    if _LIBCPP_HAS_LOCALIZATION
+#      include <locale>
+#    endif
+#    include <string>
+#    include <string_view>
+#    include <tuple>
+#    include <type_traits>
+#    include <typeinfo>
+#    include <utility>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_VECTOR

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -105,40 +105,42 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 
 */
 
-#  include <__config>
-#  include <stddef.h>
+#  if 0
+#  else // 0
+#    include <__config>
+#    include <stddef.h>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 // We define this here to support older versions of glibc <wchar.h> that do
 // not define this for clang.
-#  ifdef __cplusplus
-#    define __CORRECT_ISO_CPP_WCHAR_H_PROTO
-#  endif
+#    ifdef __cplusplus
+#      define __CORRECT_ISO_CPP_WCHAR_H_PROTO
+#    endif
 
-#  if __has_include_next(<wchar.h>)
-#    include_next <wchar.h>
-#  else
-#    include <__mbstate_t.h> // make sure we have mbstate_t regardless of the existence of <wchar.h>
-#  endif
+#    if __has_include_next(<wchar.h>)
+#      include_next <wchar.h>
+#    else
+#      include <__mbstate_t.h> // make sure we have mbstate_t regardless of the existence of <wchar.h>
+#    endif
 
 // Determine whether we have const-correct overloads for wcschr and friends.
-#  if defined(_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_)
-#    define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
-#  elif defined(__GLIBC_PREREQ)
-#    if __GLIBC_PREREQ(2, 10)
+#    if defined(_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_)
 #      define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
+#    elif defined(__GLIBC_PREREQ)
+#      if __GLIBC_PREREQ(2, 10)
+#        define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
+#      endif
+#    elif defined(_LIBCPP_MSVCRT)
+#      if defined(_CRT_CONST_CORRECT_OVERLOADS)
+#        define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
+#      endif
 #    endif
-#  elif defined(_LIBCPP_MSVCRT)
-#    if defined(_CRT_CONST_CORRECT_OVERLOADS)
-#      define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1
-#    endif
-#  endif
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
-#    if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if defined(__cplusplus) && !defined(_LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS) && defined(_LIBCPP_PREFERRED_OVERLOAD)
 extern "C++" {
 inline _LIBCPP_HIDE_FROM_ABI wchar_t* __libcpp_wcschr(const wchar_t* __s, wchar_t __c) {
   return (wchar_t*)wcschr(__s, __c);
@@ -193,16 +195,17 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_PREFERRED_OVERLOAD wchar_t* wmemchr(wchar_t
   return __libcpp_wmemchr(__s, __c, __n);
 }
 }
-#    endif
+#      endif
 
-#    if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
+#      if defined(__cplusplus) && (defined(_LIBCPP_MSVCRT_LIKE) || defined(__MVS__))
 extern "C" {
 size_t mbsnrtowcs(
     wchar_t* __restrict __dst, const char** __restrict __src, size_t __nmc, size_t __len, mbstate_t* __restrict __ps);
 size_t wcsnrtombs(
     char* __restrict __dst, const wchar_t** __restrict __src, size_t __nwc, size_t __len, mbstate_t* __restrict __ps);
 } // extern "C"
-#    endif // __cplusplus && (_LIBCPP_MSVCRT || __MVS__)
-#  endif   // _LIBCPP_HAS_WIDE_CHARACTERS
+#      endif // __cplusplus && (_LIBCPP_MSVCRT || __MVS__)
+#    endif   // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif     // 0
 
 #endif // _LIBCPP_WCHAR_H

--- a/libcxx/include/wctype.h
+++ b/libcxx/include/wctype.h
@@ -44,11 +44,13 @@ wctrans_t wctrans(const char* property);
 
 */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 // TODO:
 // In the future, we should unconditionally include_next <wctype.h> here and instead
@@ -59,32 +61,33 @@ wctrans_t wctrans(const char* property);
 // nothing (with using_if_exists), and if we include another header that defines one
 // of these declarations (e.g. <wchar.h>), the second `using ::wint_t` with using_if_exists
 // will fail because it does not refer to the same declaration.
-#if __has_include_next(<wctype.h>)
-#  include_next <wctype.h>
-#  define _LIBCPP_INCLUDED_C_LIBRARY_WCTYPE_H
-#endif
+#  if __has_include_next(<wctype.h>)
+#    include_next <wctype.h>
+#    define _LIBCPP_INCLUDED_C_LIBRARY_WCTYPE_H
+#  endif
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 
-#  undef iswalnum
-#  undef iswalpha
-#  undef iswblank
-#  undef iswcntrl
-#  undef iswdigit
-#  undef iswgraph
-#  undef iswlower
-#  undef iswprint
-#  undef iswpunct
-#  undef iswspace
-#  undef iswupper
-#  undef iswxdigit
-#  undef iswctype
-#  undef wctype
-#  undef towlower
-#  undef towupper
-#  undef towctrans
-#  undef wctrans
+#    undef iswalnum
+#    undef iswalpha
+#    undef iswblank
+#    undef iswcntrl
+#    undef iswdigit
+#    undef iswgraph
+#    undef iswlower
+#    undef iswprint
+#    undef iswpunct
+#    undef iswspace
+#    undef iswupper
+#    undef iswxdigit
+#    undef iswctype
+#    undef wctype
+#    undef towlower
+#    undef towupper
+#    undef towctrans
+#    undef wctrans
 
-#endif // __cplusplus
+#  endif // __cplusplus
+#endif   // 0
 
 #endif // _LIBCPP_WCTYPE_H


### PR DESCRIPTION
Including The frozen C++03 headers results in a lot of formatting changes in the main headers, so this splits these changes into a separate commit instead.

This is part of https://discourse.llvm.org/t/rfc-freezing-c-03-headers-in-libc.
