### PR TITLE
[libc][docs] add missing c99 docs

### DIFF
--- a/libc/docs/headers/float.rst
+++ b/libc/docs/headers/float.rst
@@ -1,0 +1,227 @@
+.. include:: ../check.rst
+
+=======
+float.h
+=======
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Macro
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - DBL_DECIMAL_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_EPSILON
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_HAS_SUBNORM
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_IS_IEC_60559
+    -
+    - 5.3.5.3.3
+    -
+  * - DBL_MANT_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_MAX
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_MAX_10_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_MAX_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_MIN
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_MIN_10_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_MIN_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DBL_NORM_MAX
+    -
+    - 5.3.5.3.3
+    -
+  * - DBL_SNAN
+    -
+    - 5.3.5.3.3
+    -
+  * - DBL_TRUE_MIN
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - DECIMAL_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_DECIMAL_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_EPSILON
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_EVAL_METHOD
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_HAS_SUBNORM
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_IS_IEC_60559
+    -
+    - 5.3.5.3.3
+    -
+  * - FLT_MANT_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_MAX
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_MAX_10_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_MAX_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_MIN
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_MIN_10_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_MIN_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_NORM_MAX
+    -
+    - 5.3.5.3.3
+    -
+  * - FLT_RADIX
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_ROUNDS
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - FLT_SNAN
+    -
+    - 5.3.5.3.3
+    -
+  * - FLT_TRUE_MIN
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - INFINITY
+    -
+    - 5.3.5.3.3
+    -
+  * - LDBL_DECIMAL_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_EPSILON
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_HAS_SUBNORM
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_IS_IEC_60559
+    -
+    - 5.3.5.3.3
+    -
+  * - LDBL_MANT_DIG
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_MAX
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_MAX_10_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_MAX_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_MIN
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_MIN_10_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_MIN_EXP
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - LDBL_NORM_MAX
+    -
+    - 5.3.5.3.3
+    -
+  * - LDBL_SNAN
+    -
+    - 5.3.5.3.3
+    -
+  * - LDBL_TRUE_MIN
+    - |check|
+    - 5.3.5.3.3
+    -
+  * - NAN
+    -
+    - 5.3.5.3.3
+    -
+  * - __STDC_VERSION_FLOAT_H__
+    -
+    - 7.7
+    -
+

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -9,6 +9,7 @@ Implementation Status
    ctype
    errno
    fenv
+   float
    locale
    math/index.rst
    search
@@ -20,3 +21,5 @@ Implementation Status
    threads
    time
    uchar
+   wchar
+   wctype

--- a/libc/docs/headers/wchar.rst
+++ b/libc/docs/headers/wchar.rst
@@ -1,0 +1,287 @@
+.. include:: ../check.rst
+
+=======
+wchar.h
+=======
+
+Macros
+======
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Macro
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - WEOF
+    - |check|
+    - 7.31.1
+    -
+  * - __STDC_VERSION_WCHAR_H__
+    -
+    - 7.31.1
+    -
+
+Functions
+=========
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - btowc
+    - |check|
+    - 7.31.6.2.1
+    -
+  * - fgetwc
+    -
+    - 7.31.3.1
+    -
+  * - fgetws
+    -
+    - 7.31.3.2
+    -
+  * - fputwc
+    -
+    - 7.31.3.3
+    -
+  * - fputws
+    -
+    - 7.31.3.4
+    -
+  * - fwide
+    -
+    - 7.31.3.5
+    -
+  * - fwprintf
+    -
+    - 7.31.2.2
+    -
+  * - fwscanf
+    -
+    - 7.31.2.3
+    -
+  * - getwc
+    -
+    - 7.31.3.6
+    -
+  * - getwchar
+    -
+    - 7.31.3.7
+    -
+  * - mbrlen
+    -
+    - 7.31.6.4.2
+    -
+  * - mbrtowc
+    -
+    - 7.31.6.4.3
+    -
+  * - mbsinit
+    -
+    - 7.31.6.3.1
+    -
+  * - mbsrtowcs
+    -
+    - 7.31.6.5.2
+    -
+  * - putwc
+    -
+    - 7.31.3.8
+    -
+  * - putwchar
+    -
+    - 7.31.3.9
+    -
+  * - swprintf
+    -
+    - 7.31.2.4
+    -
+  * - swscanf
+    -
+    - 7.31.2.5
+    -
+  * - ungetwc
+    -
+    - 7.31.3.10
+    -
+  * - vfwprintf
+    -
+    - 7.31.2.6
+    -
+  * - vfwscanf
+    -
+    - 7.31.2.7
+    -
+  * - vswprintf
+    -
+    - 7.31.2.8
+    -
+  * - vswscanf
+    -
+    - 7.31.2.9
+    -
+  * - vwprintf
+    -
+    - 7.31.2.10
+    -
+  * - vwscanf
+    -
+    - 7.31.2.11
+    -
+  * - wcrtomb
+    -
+    - 7.31.6.4.4
+    -
+  * - wcscat
+    -
+    - 7.31.4.4.1
+    -
+  * - wcschr
+    -
+    - 7.31.4.6.2
+    -
+  * - wcscmp
+    -
+    - 7.31.4.5.2
+    -
+  * - wcscoll
+    -
+    - 7.31.4.5.3
+    -
+  * - wcscpy
+    -
+    - 7.31.4.3.1
+    -
+  * - wcscspn
+    -
+    - 7.31.4.6.3
+    -
+  * - wcsftime
+    -
+    - 7.31.5.1
+    -
+  * - wcslen
+    -
+    - 7.31.4.7.1
+    -
+  * - wcsncat
+    -
+    - 7.31.4.4.2
+    -
+  * - wcsncmp
+    -
+    - 7.31.4.5.4
+    -
+  * - wcsncpy
+    -
+    - 7.31.4.3.2
+    -
+  * - wcspbrk
+    -
+    - 7.31.4.6.4
+    -
+  * - wcsrchr
+    -
+    - 7.31.4.6.5
+    -
+  * - wcsrtombs
+    -
+    - 7.31.6.5.3
+    -
+  * - wcsspn
+    -
+    - 7.31.4.6.6
+    -
+  * - wcsstr
+    -
+    - 7.31.4.6.7
+    -
+  * - wcstod
+    -
+    - 7.31.4.2.2
+    -
+  * - wcstod128
+    -
+    - 7.31.4.2.3
+    -
+  * - wcstod32
+    -
+    - 7.31.4.2.3
+    -
+  * - wcstod64
+    -
+    - 7.31.4.2.3
+    -
+  * - wcstof
+    -
+    - 7.31.4.2.2
+    -
+  * - wcstok
+    -
+    - 7.31.4.6.8
+    -
+  * - wcstol
+    -
+    - 7.31.4.2.4
+    -
+  * - wcstold
+    -
+    - 7.31.4.2.2
+    -
+  * - wcstoll
+    -
+    - 7.31.4.2.4
+    -
+  * - wcstoul
+    -
+    - 7.31.4.2.4
+    -
+  * - wcstoull
+    -
+    - 7.31.4.2.4
+    -
+  * - wcsxfrm
+    -
+    - 7.31.4.5.5
+    -
+  * - wctob
+    - |check|
+    - 7.31.6.2.2
+    -
+  * - wmemchr
+    -
+    - 7.31.4.6.9
+    -
+  * - wmemcmp
+    -
+    - 7.31.4.5.6
+    -
+  * - wmemcpy
+    -
+    - 7.31.4.3.3
+    -
+  * - wmemmove
+    -
+    - 7.31.4.3.4
+    -
+  * - wmemset
+    -
+    - 7.31.4.7.2
+    -
+  * - wprintf
+    -
+    - 7.31.2.12
+    -
+  * - wscanf
+    -
+    - 7.31.2.13
+    -

--- a/libc/docs/headers/wctype.rst
+++ b/libc/docs/headers/wctype.rst
@@ -1,0 +1,86 @@
+.. include:: ../check.rst
+
+========
+wctype.h
+========
+
+Functions
+=========
+
+.. list-table::
+  :widths: auto
+  :align: center
+  :header-rows: 1
+
+  * - Function
+    - Implemented
+    - C23 Standard Section
+    - POSIX.1-2024 Standard Section
+  * - iswalnum
+    -
+    - 7.32.2.1.1
+    -
+  * - iswalpha
+    -
+    - 7.32.2.1.2
+    -
+  * - iswblank
+    -
+    - 7.32.2.1.4
+    -
+  * - iswctype
+    -
+    - 7.32.2.2.1
+    -
+  * - iswdigit
+    -
+    - 7.32.2.1.5
+    -
+  * - iswgraph
+    -
+    - 7.32.2.1.6
+    -
+  * - iswlower
+    -
+    - 7.32.2.1.7
+    -
+  * - iswprint
+    -
+    - 7.32.2.1.8
+    -
+  * - iswpunct
+    -
+    - 7.32.2.1.9
+    -
+  * - iswspace
+    -
+    - 7.32.2.1.10
+    -
+  * - iswupper
+    -
+    - 7.32.2.1.11
+    -
+  * - iswxdigit
+    -
+    - 7.32.2.1.12
+    -
+  * - towctrans
+    -
+    - 7.32.3.2.1
+    -
+  * - towlower
+    -
+    - 7.32.3.1.1
+    -
+  * - towupper
+    -
+    - 7.32.3.1.2
+    -
+  * - wctrans
+    -
+    - 7.32.3.2.2
+    -
+  * - wctype
+    -
+    - 7.32.2.2.2
+    -

--- a/libc/utils/docgen/float.json
+++ b/libc/utils/docgen/float.json
@@ -1,0 +1,163 @@
+{
+  "macros": {
+    "__STDC_VERSION_FLOAT_H__": {
+      "c-definition": "7.7"
+    },
+    "FLT_EVAL_METHOD" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_ROUNDS" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_EVAL_METHOD" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_HAS_SUBNORM" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_HAS_SUBNORM" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_HAS_SUBNORM" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_RADIX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MANT_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MANT_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MANT_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_DECIMAL_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_DECIMAL_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_DECIMAL_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DECIMAL_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_IS_IEC_60559" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_IS_IEC_60559" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_IS_IEC_60559" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_DIG" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MIN_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MIN_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MIN_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MIN_10_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MIN_10_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MIN_10_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MAX_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MAX_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MAX_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MAX_10_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MAX_10_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MAX_10_EXP" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MAX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MAX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MAX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_NORM_MAX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_NORM_MAX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_NORM_MAX" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_EPSILON" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_EPSILON" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_EPSILON" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_MIN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_MIN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_MIN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_SNAN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_SNAN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_SNAN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "FLT_TRUE_MIN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "DBL_TRUE_MIN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "LDBL_TRUE_MIN" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "INFINITY" : {
+      "c-definition": "5.3.5.3.3"
+    },
+    "NAN" : {
+      "c-definition": "5.3.5.3.3"
+    }
+  }
+}

--- a/libc/utils/docgen/wchar.json
+++ b/libc/utils/docgen/wchar.json
@@ -1,0 +1,198 @@
+{
+  "macros": {
+    "__STDC_VERSION_WCHAR_H__": {
+      "c-definition": "7.31.1"
+    },
+    "WEOF": {
+      "c-definition": "7.31.1"
+    }
+  },
+  "functions": {
+    "fwprintf": {
+      "c-definition": "7.31.2.2"
+    },
+    "fwscanf": {
+      "c-definition": "7.31.2.3"
+    },
+    "swprintf": {
+      "c-definition": "7.31.2.4"
+    },
+    "swscanf": {
+      "c-definition": "7.31.2.5"
+    },
+    "vfwprintf": {
+      "c-definition": "7.31.2.6"
+    },
+    "vfwscanf": {
+      "c-definition": "7.31.2.7"
+    },
+    "vswprintf": {
+      "c-definition": "7.31.2.8"
+    },
+    "vswscanf": {
+      "c-definition": "7.31.2.9"
+    },
+    "vwprintf": {
+      "c-definition": "7.31.2.10"
+    },
+    "vwscanf": {
+      "c-definition": "7.31.2.11"
+    },
+    "wprintf": {
+      "c-definition": "7.31.2.12"
+    },
+    "wscanf": {
+      "c-definition": "7.31.2.13"
+    },
+    "fgetwc": {
+      "c-definition": "7.31.3.1"
+    },
+    "fgetws": {
+      "c-definition": "7.31.3.2"
+    },
+    "fputwc": {
+      "c-definition": "7.31.3.3"
+    },
+    "fputws": {
+      "c-definition": "7.31.3.4"
+    },
+    "fwide": {
+      "c-definition": "7.31.3.5"
+    },
+    "getwc": {
+      "c-definition": "7.31.3.6"
+    },
+    "getwchar": {
+      "c-definition": "7.31.3.7"
+    },
+    "putwc": {
+      "c-definition": "7.31.3.8"
+    },
+    "putwchar": {
+      "c-definition": "7.31.3.9"
+    },
+    "ungetwc": {
+      "c-definition": "7.31.3.10"
+    },
+    "wcstod": {
+      "c-definition": "7.31.4.2.2"
+    },
+    "wcstof": {
+      "c-definition": "7.31.4.2.2"
+    },
+    "wcstold": {
+      "c-definition": "7.31.4.2.2"
+    },
+    "wcstod32": {
+      "c-definition": "7.31.4.2.3"
+    },
+    "wcstod64": {
+      "c-definition": "7.31.4.2.3"
+    },
+    "wcstod128": {
+      "c-definition": "7.31.4.2.3"
+    },
+    "wcstol": {
+      "c-definition": "7.31.4.2.4"
+    },
+    "wcstoll": {
+      "c-definition": "7.31.4.2.4"
+    },
+    "wcstoul": {
+      "c-definition": "7.31.4.2.4"
+    },
+    "wcstoull": {
+      "c-definition": "7.31.4.2.4"
+    },
+    "wcscpy": {
+      "c-definition": "7.31.4.3.1"
+    },
+    "wcsncpy": {
+      "c-definition": "7.31.4.3.2"
+    },
+    "wmemcpy": {
+      "c-definition": "7.31.4.3.3"
+    },
+    "wmemmove": {
+      "c-definition": "7.31.4.3.4"
+    },
+    "wcscat": {
+      "c-definition": "7.31.4.4.1"
+    },
+    "wcsncat": {
+      "c-definition": "7.31.4.4.2"
+    },
+    "wcscmp": {
+      "c-definition": "7.31.4.5.2"
+    },
+    "wcscoll": {
+      "c-definition": "7.31.4.5.3"
+    },
+    "wcsncmp": {
+      "c-definition": "7.31.4.5.4"
+    },
+    "wcsxfrm": {
+      "c-definition": "7.31.4.5.5"
+    },
+    "wmemcmp": {
+      "c-definition": "7.31.4.5.6"
+    },
+    "wcschr": {
+      "c-definition": "7.31.4.6.2"
+    },
+    "wcscspn": {
+      "c-definition": "7.31.4.6.3"
+    },
+    "wcspbrk": {
+      "c-definition": "7.31.4.6.4"
+    },
+    "wcsrchr": {
+      "c-definition": "7.31.4.6.5"
+    },
+    "wcsspn": {
+      "c-definition": "7.31.4.6.6"
+    },
+    "wcsstr": {
+      "c-definition": "7.31.4.6.7"
+    },
+    "wcstok": {
+      "c-definition": "7.31.4.6.8"
+    },
+    "wmemchr": {
+      "c-definition": "7.31.4.6.9"
+    },
+    "wcslen": {
+      "c-definition": "7.31.4.7.1"
+    },
+    "wmemset": {
+      "c-definition": "7.31.4.7.2"
+    },
+    "wcsftime": {
+      "c-definition": "7.31.5.1"
+    },
+    "btowc": {
+      "c-definition": "7.31.6.2.1"
+    },
+    "wctob": {
+      "c-definition": "7.31.6.2.2"
+    },
+    "mbsinit": {
+      "c-definition": "7.31.6.3.1"
+    },
+    "mbrlen": {
+      "c-definition": "7.31.6.4.2"
+    },
+    "mbrtowc": {
+      "c-definition": "7.31.6.4.3"
+    },
+    "wcrtomb": {
+      "c-definition": "7.31.6.4.4"
+    },
+    "mbsrtowcs": {
+      "c-definition": "7.31.6.5.2"
+    },
+    "wcsrtombs": {
+      "c-definition": "7.31.6.5.3"
+    }
+  }
+}

--- a/libc/utils/docgen/wctype.json
+++ b/libc/utils/docgen/wctype.json
@@ -1,0 +1,58 @@
+{
+  "functions": {
+    "iswalnum": {
+      "c-definition": "7.32.2.1.1"
+    },
+    "iswalpha": {
+      "c-definition": "7.32.2.1.2"
+    },
+    "iswblank": {
+      "c-definition": "7.32.2.1.3"
+    },
+    "iswblank": {
+      "c-definition": "7.32.2.1.4"
+    },
+    "iswdigit": {
+      "c-definition": "7.32.2.1.5"
+    },
+    "iswgraph": {
+      "c-definition": "7.32.2.1.6"
+    },
+    "iswlower": {
+      "c-definition": "7.32.2.1.7"
+    },
+    "iswprint": {
+      "c-definition": "7.32.2.1.8"
+    },
+    "iswpunct": {
+      "c-definition": "7.32.2.1.9"
+    },
+    "iswspace": {
+      "c-definition": "7.32.2.1.10"
+    },
+    "iswupper": {
+      "c-definition": "7.32.2.1.11"
+    },
+    "iswxdigit": {
+      "c-definition": "7.32.2.1.12"
+    },
+    "iswctype": {
+      "c-definition": "7.32.2.2.1"
+    },
+    "wctype": {
+      "c-definition": "7.32.2.2.2"
+    },
+    "towlower": {
+      "c-definition": "7.32.3.1.1"
+    },
+    "towupper": {
+      "c-definition": "7.32.3.1.2"
+    },
+    "towctrans": {
+      "c-definition": "7.32.3.2.1"
+    },
+    "wctrans": {
+      "c-definition": "7.32.3.2.2"
+    }
+  }
+}


### PR DESCRIPTION
Looks like we were missing docs for:
- float.h
- wchar.h
- wctype.h

Which AFAICT were added in ISO C99.
