### PR TITLE
[libc++] Rename `__` prefix to `__libcpp_` for locale related functions

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -381,6 +381,7 @@ set(llvm_libc_wrapper_files
 
 set(zos_wrapper_files
   zos_wrappers/builtins.h
+  zos_wrappers/locale.h
 )
 
 include(GetClangResourceDir)

--- a/clang/lib/Headers/zos_wrappers/locale.h
+++ b/clang/lib/Headers/zos_wrappers/locale.h
@@ -1,4 +1,5 @@
-/*===----------------------------- locale.h ----------------------------------===
+/*===----------------------------- locale.h
+ *----------------------------------===
  *
  * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
  * See https://llvm.org/LICENSE.txt for license information.
@@ -9,11 +10,11 @@
 
 #ifndef __ZOS_WRAPPERS_LOCALE_H
 #define __ZOS_WRAPPERS_LOCALE_H
-  #if defined(__MVS__)
-    #include_next <locale.h>
-    #ifdef __locale
-      #undef __locale
-      #define __locale __locale
-    #endif
-  #endif /* defined(__MVS__) */
+#if defined(__MVS__)
+#include_next <locale.h>
+#ifdef __locale
+#undef __locale
+#define __locale __locale
+#endif
+#endif /* defined(__MVS__) */
 #endif /* __ZOS_WRAPPERS_LOCALE_H */

--- a/clang/lib/Headers/zos_wrappers/locale.h
+++ b/clang/lib/Headers/zos_wrappers/locale.h
@@ -1,0 +1,19 @@
+/*===----------------------------- locale.h ----------------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-------------------------------------------------------------------------===
+ */
+
+#ifndef __ZOS_WRAPPERS_LOCALE_H
+#define __ZOS_WRAPPERS_LOCALE_H
+  #if defined(__MVS__)
+    #include_next <locale.h>
+    #ifdef __locale
+      #undef __locale
+      #define __locale __locale
+    #endif
+  #endif /* defined(__MVS__) */
+#endif /* __ZOS_WRAPPERS_LOCALE_H */

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -39,41 +39,41 @@
 // Strtonum functions
 // ------------------
 // namespace __locale {
-//  float               __strtof(const char*, char**, __locale_t);
-//  double              __strtod(const char*, char**, __locale_t);
-//  long double         __strtold(const char*, char**, __locale_t);
-//  long long           __strtoll(const char*, char**, __locale_t);
-//  unsigned long long  __strtoull(const char*, char**, __locale_t);
+//  float               __libcpp_strtof(const char*, char**, __locale_t);
+//  double              __libcpp_strtod(const char*, char**, __locale_t);
+//  long double         __libcpp_strtold(const char*, char**, __locale_t);
+//  long long           __libcpp_strtoll(const char*, char**, __locale_t);
+//  unsigned long long  __libcpp_strtoull(const char*, char**, __locale_t);
 // }
 //
 // Character manipulation functions
 // --------------------------------
 // namespace __locale {
-//  int     __islower(int, __locale_t);
-//  int     __isupper(int, __locale_t);
-//  int     __isdigit(int, __locale_t);
-//  int     __isxdigit(int, __locale_t);
-//  int     __toupper(int, __locale_t);
-//  int     __tolower(int, __locale_t);
-//  int     __strcoll(const char*, const char*, __locale_t);
-//  size_t  __strxfrm(char*, const char*, size_t, __locale_t);
+//  int     __libcpp_islower(int, __locale_t);
+//  int     __libcpp_isupper(int, __locale_t);
+//  int     __libcpp_isdigit(int, __locale_t);
+//  int     __libcpp_isxdigit(int, __locale_t);
+//  int     __libcpp_toupper(int, __locale_t);
+//  int     __libcpp_tolower(int, __locale_t);
+//  int     __libcpp_strcoll(const char*, const char*, __locale_t);
+//  size_t  __libcpp_strxfrm(char*, const char*, size_t, __locale_t);
 //
-//  int     __iswspace(wint_t, __locale_t);
-//  int     __iswprint(wint_t, __locale_t);
-//  int     __iswcntrl(wint_t, __locale_t);
-//  int     __iswupper(wint_t, __locale_t);
-//  int     __iswlower(wint_t, __locale_t);
-//  int     __iswalpha(wint_t, __locale_t);
-//  int     __iswblank(wint_t, __locale_t);
-//  int     __iswdigit(wint_t, __locale_t);
-//  int     __iswpunct(wint_t, __locale_t);
-//  int     __iswxdigit(wint_t, __locale_t);
-//  wint_t  __towupper(wint_t, __locale_t);
-//  wint_t  __towlower(wint_t, __locale_t);
-//  int     __wcscoll(const wchar_t*, const wchar_t*, __locale_t);
-//  size_t  __wcsxfrm(wchar_t*, const wchar_t*, size_t, __locale_t);
+//  int     __libcpp_iswspace(wint_t, __locale_t);
+//  int     __libcpp_iswprint(wint_t, __locale_t);
+//  int     __libcpp_iswcntrl(wint_t, __locale_t);
+//  int     __libcpp_iswupper(wint_t, __locale_t);
+//  int     __libcpp_iswlower(wint_t, __locale_t);
+//  int     __libcpp_iswalpha(wint_t, __locale_t);
+//  int     __libcpp_iswblank(wint_t, __locale_t);
+//  int     __libcpp_iswdigit(wint_t, __locale_t);
+//  int     __libcpp_iswpunct(wint_t, __locale_t);
+//  int     __libcpp_iswxdigit(wint_t, __locale_t);
+//  wint_t  __libcpp_towupper(wint_t, __locale_t);
+//  wint_t  __libcpp_towlower(wint_t, __locale_t);
+//  int     __libcpp_wcscoll(const wchar_t*, const wchar_t*, __locale_t);
+//  size_t  __libcpp_wcsxfrm(wchar_t*, const wchar_t*, size_t, __locale_t);
 //
-//  size_t  __strftime(char*, size_t, const char*, const tm*, __locale_t);
+//  size_t  __libcpp_strftime(char*, size_t, const char*, const tm*, __locale_t);
 // }
 //
 // Other functions
@@ -154,68 +154,71 @@ inline _LIBCPP_HIDE_FROM_ABI lconv* __localeconv(__locale_t& __loc) { return __l
 //
 // Strtonum functions
 //
-inline _LIBCPP_HIDE_FROM_ABI float __strtof(const char* __nptr, char** __endptr, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI float __libcpp_strtof(const char* __nptr, char** __endptr, __locale_t __loc) {
   return strtof_l(__nptr, __endptr, __loc);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI double __strtod(const char* __nptr, char** __endptr, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI double __libcpp_strtod(const char* __nptr, char** __endptr, __locale_t __loc) {
   return strtod_l(__nptr, __endptr, __loc);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long double __strtold(const char* __nptr, char** __endptr, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI long double __libcpp_strtold(const char* __nptr, char** __endptr, __locale_t __loc) {
   return strtold_l(__nptr, __endptr, __loc);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long long __strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI long long __libcpp_strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
   return strtoll_l(__nptr, __endptr, __base, __loc);
 }
 
 inline _LIBCPP_HIDE_FROM_ABI unsigned long long
-__strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
+__libcpp_strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
   return strtoull_l(__nptr, __endptr, __base, __loc);
 }
+
+#    if defined(__MVS__)
+using namespace __ibm;
+#    endif
 
 //
 // Character manipulation functions
 //
-inline _LIBCPP_HIDE_FROM_ABI int __islower(int __ch, __locale_t __loc) { return islower_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __isupper(int __ch, __locale_t __loc) { return isupper_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __isdigit(int __ch, __locale_t __loc) { return isdigit_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __isxdigit(int __ch, __locale_t __loc) { return isxdigit_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __strcoll(const char* __s1, const char* __s2, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_islower(int __ch, __locale_t __loc) { return islower_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_isupper(int __ch, __locale_t __loc) { return isupper_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_isdigit(int __ch, __locale_t __loc) { return isdigit_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_isxdigit(int __ch, __locale_t __loc) { return isxdigit_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_strcoll(const char* __s1, const char* __s2, __locale_t __loc) {
   return strcoll_l(__s1, __s2, __loc);
 }
-inline _LIBCPP_HIDE_FROM_ABI size_t __strxfrm(char* __dest, const char* __src, size_t __n, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_strxfrm(char* __dest, const char* __src, size_t __n, __locale_t __loc) {
   return strxfrm_l(__dest, __src, __n, __loc);
 }
-inline _LIBCPP_HIDE_FROM_ABI int __toupper(int __ch, __locale_t __loc) { return toupper_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __tolower(int __ch, __locale_t __loc) { return tolower_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_toupper(int __ch, __locale_t __loc) { return toupper_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_tolower(int __ch, __locale_t __loc) { return tolower_l(__ch, __loc); }
 
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-inline _LIBCPP_HIDE_FROM_ABI int __wcscoll(const wchar_t* __s1, const wchar_t* __s2, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_wcscoll(const wchar_t* __s1, const wchar_t* __s2, __locale_t __loc) {
   return wcscoll_l(__s1, __s2, __loc);
 }
-inline _LIBCPP_HIDE_FROM_ABI size_t __wcsxfrm(wchar_t* __dest, const wchar_t* __src, size_t __n, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcsxfrm(wchar_t* __dest, const wchar_t* __src, size_t __n, __locale_t __loc) {
   return wcsxfrm_l(__dest, __src, __n, __loc);
 }
-inline _LIBCPP_HIDE_FROM_ABI int __iswspace(wint_t __ch, __locale_t __loc) { return iswspace_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswprint(wint_t __ch, __locale_t __loc) { return iswprint_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswcntrl(wint_t __ch, __locale_t __loc) { return iswcntrl_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswupper(wint_t __ch, __locale_t __loc) { return iswupper_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswlower(wint_t __ch, __locale_t __loc) { return iswlower_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswalpha(wint_t __ch, __locale_t __loc) { return iswalpha_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswblank(wint_t __ch, __locale_t __loc) { return iswblank_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswdigit(wint_t __ch, __locale_t __loc) { return iswdigit_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswpunct(wint_t __ch, __locale_t __loc) { return iswpunct_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI int __iswxdigit(wint_t __ch, __locale_t __loc) { return iswxdigit_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI wint_t __towupper(wint_t __ch, __locale_t __loc) { return towupper_l(__ch, __loc); }
-inline _LIBCPP_HIDE_FROM_ABI wint_t __towlower(wint_t __ch, __locale_t __loc) { return towlower_l(__ch, __loc); }
-#  endif
-
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswspace(wint_t __ch, __locale_t __loc) { return iswspace_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswprint(wint_t __ch, __locale_t __loc) { return iswprint_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswcntrl(wint_t __ch, __locale_t __loc) { return iswcntrl_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswupper(wint_t __ch, __locale_t __loc) { return iswupper_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswlower(wint_t __ch, __locale_t __loc) { return iswlower_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswalpha(wint_t __ch, __locale_t __loc) { return iswalpha_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswblank(wint_t __ch, __locale_t __loc) { return iswblank_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswdigit(wint_t __ch, __locale_t __loc) { return iswdigit_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswpunct(wint_t __ch, __locale_t __loc) { return iswpunct_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswxdigit(wint_t __ch, __locale_t __loc) { return iswxdigit_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI wint_t __libcpp_towupper(wint_t __ch, __locale_t __loc) { return towupper_l(__ch, __loc); }
+inline _LIBCPP_HIDE_FROM_ABI wint_t __libcpp_towlower(wint_t __ch, __locale_t __loc) { return towlower_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI size_t
-__strftime(char* __s, size_t __max, const char* __format, const tm* __tm, __locale_t __loc) {
+__libcpp_strftime(char* __s, size_t __max, const char* __format, const tm* __tm, __locale_t __loc) {
   return strftime_l(__s, __max, __format, __tm, __loc);
 }
+#  endif
 
 //
 // Other functions

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -166,7 +166,8 @@ inline _LIBCPP_HIDE_FROM_ABI long double __libcpp_strtold(const char* __nptr, ch
   return strtold_l(__nptr, __endptr, __loc);
 }
 
-inline _LIBCPP_HIDE_FROM_ABI long long __libcpp_strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI long long
+__libcpp_strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
   return strtoll_l(__nptr, __endptr, __base, __loc);
 }
 
@@ -175,9 +176,9 @@ __libcpp_strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __
   return strtoull_l(__nptr, __endptr, __base, __loc);
 }
 
-#    if defined(__MVS__)
+#  if defined(__MVS__)
 using namespace __ibm;
-#    endif
+#  endif
 
 //
 // Character manipulation functions
@@ -199,7 +200,8 @@ inline _LIBCPP_HIDE_FROM_ABI int __libcpp_tolower(int __ch, __locale_t __loc) { 
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_wcscoll(const wchar_t* __s1, const wchar_t* __s2, __locale_t __loc) {
   return wcscoll_l(__s1, __s2, __loc);
 }
-inline _LIBCPP_HIDE_FROM_ABI size_t __libcpp_wcsxfrm(wchar_t* __dest, const wchar_t* __src, size_t __n, __locale_t __loc) {
+inline _LIBCPP_HIDE_FROM_ABI size_t
+__libcpp_wcsxfrm(wchar_t* __dest, const wchar_t* __src, size_t __n, __locale_t __loc) {
   return wcsxfrm_l(__dest, __src, __n, __loc);
 }
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_iswspace(wint_t __ch, __locale_t __loc) { return iswspace_l(__ch, __loc); }

--- a/libcxx/include/__locale_dir/locale_base_api/ibm.h
+++ b/libcxx/include/__locale_dir/locale_base_api/ibm.h
@@ -105,4 +105,37 @@ _LIBCPP_ATTRIBUTE_FORMAT(__printf__, 2, 0) int vasprintf(char** strp, const char
   return str_size;
 }
 
+namespace __ibm {
+_LIBCPP_EXPORTED_FROM_ABI int isalnum_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int isalpha_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int isblank_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iscntrl_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int isgraph_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int islower_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int isprint_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int ispunct_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int isspace_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int isupper_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswalnum_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswalpha_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswblank_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswcntrl_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswdigit_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswgraph_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswlower_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswprint_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswpunct_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswspace_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswupper_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int iswxdigit_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int toupper_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int tolower_l(int, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI wint_t towupper_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI wint_t towlower_l(wint_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int strcoll_l(const char *, const char *, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI size_t strxfrm_l(char *, const char *, size_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI size_t strftime_l(char *, size_t , const char *, const struct tm *, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int wcscoll_l(const wchar_t *, const wchar_t *, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI size_t wcsxfrm_l(wchar_t *, const wchar_t *, size_t , locale_t);
+}
 #endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_IBM_H

--- a/libcxx/include/__locale_dir/locale_base_api/ibm.h
+++ b/libcxx/include/__locale_dir/locale_base_api/ibm.h
@@ -132,10 +132,10 @@ _LIBCPP_EXPORTED_FROM_ABI int toupper_l(int, locale_t);
 _LIBCPP_EXPORTED_FROM_ABI int tolower_l(int, locale_t);
 _LIBCPP_EXPORTED_FROM_ABI wint_t towupper_l(wint_t, locale_t);
 _LIBCPP_EXPORTED_FROM_ABI wint_t towlower_l(wint_t, locale_t);
-_LIBCPP_EXPORTED_FROM_ABI int strcoll_l(const char *, const char *, locale_t);
-_LIBCPP_EXPORTED_FROM_ABI size_t strxfrm_l(char *, const char *, size_t, locale_t);
-_LIBCPP_EXPORTED_FROM_ABI size_t strftime_l(char *, size_t , const char *, const struct tm *, locale_t);
-_LIBCPP_EXPORTED_FROM_ABI int wcscoll_l(const wchar_t *, const wchar_t *, locale_t);
-_LIBCPP_EXPORTED_FROM_ABI size_t wcsxfrm_l(wchar_t *, const wchar_t *, size_t , locale_t);
-}
+_LIBCPP_EXPORTED_FROM_ABI int strcoll_l(const char*, const char*, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI size_t strxfrm_l(char*, const char*, size_t, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI size_t strftime_l(char*, size_t, const char*, const struct tm*, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI int wcscoll_l(const wchar_t*, const wchar_t*, locale_t);
+_LIBCPP_EXPORTED_FROM_ABI size_t wcsxfrm_l(wchar_t*, const wchar_t*, size_t, locale_t);
+} // namespace __ibm
 #endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_IBM_H

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -722,7 +722,7 @@ __num_get_signed_integral(const char* __a, const char* __a_end, ios_base::iostat
     __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
     errno                                                     = 0;
     char* __p2;
-    long long __ll = __locale::__strtoll(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
+    long long __ll = __locale::__libcpp_strtoll(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
     __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
     if (__current_errno == 0)
       errno = __save_errno;
@@ -754,7 +754,7 @@ __num_get_unsigned_integral(const char* __a, const char* __a_end, ios_base::iost
     __libcpp_remove_reference_t<decltype(errno)> __save_errno = errno;
     errno                                                     = 0;
     char* __p2;
-    unsigned long long __ll = __locale::__strtoull(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
+    unsigned long long __ll = __locale::__libcpp_strtoull(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
     __libcpp_remove_reference_t<decltype(errno)> __current_errno = errno;
     if (__current_errno == 0)
       errno = __save_errno;
@@ -779,17 +779,17 @@ _LIBCPP_HIDE_FROM_ABI _Tp __do_strtod(const char* __a, char** __p2);
 
 template <>
 inline _LIBCPP_HIDE_FROM_ABI float __do_strtod<float>(const char* __a, char** __p2) {
-  return __locale::__strtof(__a, __p2, _LIBCPP_GET_C_LOCALE);
+  return __locale::__libcpp_strtof(__a, __p2, _LIBCPP_GET_C_LOCALE);
 }
 
 template <>
 inline _LIBCPP_HIDE_FROM_ABI double __do_strtod<double>(const char* __a, char** __p2) {
-  return __locale::__strtod(__a, __p2, _LIBCPP_GET_C_LOCALE);
+  return __locale::__libcpp_strtod(__a, __p2, _LIBCPP_GET_C_LOCALE);
 }
 
 template <>
 inline _LIBCPP_HIDE_FROM_ABI long double __do_strtod<long double>(const char* __a, char** __p2) {
-  return __locale::__strtold(__a, __p2, _LIBCPP_GET_C_LOCALE);
+  return __locale::__libcpp_strtold(__a, __p2, _LIBCPP_GET_C_LOCALE);
 }
 
 template <class _Tp>

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -1126,11 +1126,11 @@ void __num_put<_CharT>::__widen_and_group_float(
     *__oe++ = __ct.widen(*__nf++);
     *__oe++ = __ct.widen(*__nf++);
     for (__ns = __nf; __ns < __ne; ++__ns)
-      if (!__locale::__isxdigit(*__ns, _LIBCPP_GET_C_LOCALE))
+      if (!__locale::__libcpp_isxdigit(*__ns, _LIBCPP_GET_C_LOCALE))
         break;
   } else {
     for (__ns = __nf; __ns < __ne; ++__ns)
-      if (!__locale::__isdigit(*__ns, _LIBCPP_GET_C_LOCALE))
+      if (!__locale::__libcpp_isdigit(*__ns, _LIBCPP_GET_C_LOCALE))
         break;
   }
   if (__grouping.empty()) {

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -1115,7 +1115,7 @@ bool ctype_byname<wchar_t>::do_is(mask m, char_type c) const {
   bool result = false;
   wint_t ch   = static_cast<wint_t>(c);
   if ((m & space) == space)
-    result |= (__locale__libcpp_iswspace(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswspace(ch, __l_) != 0);
   if ((m & print) == print)
     result |= (__locale::__libcpp_iswprint(ch, __l_) != 0);
   if ((m & cntrl) == cntrl)
@@ -1145,7 +1145,7 @@ const wchar_t* ctype_byname<wchar_t>::do_is(const char_type* low, const char_typ
     else {
       *vec      = 0;
       wint_t ch = static_cast<wint_t>(*low);
-      if (__locale__libcpp_iswspace(ch, __l_))
+      if (__locale::__libcpp_iswspace(ch, __l_))
         *vec |= space;
 #  ifndef _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
       if (__locale::__libcpp_iswprint(ch, __l_))
@@ -1183,7 +1183,7 @@ const wchar_t* ctype_byname<wchar_t>::do_scan_is(mask m, const char_type* low, c
       break;
 #  else
     wint_t ch = static_cast<wint_t>(*low);
-    if ((m & space) == space && __locale__libcpp_iswspace(ch, __l_))
+    if ((m & space) == space && __locale::__libcpp_iswspace(ch, __l_))
       break;
     if ((m & print) == print && __locale::__libcpp_iswprint(ch, __l_))
       break;
@@ -1215,7 +1215,7 @@ const wchar_t* ctype_byname<wchar_t>::do_scan_not(mask m, const char_type* low, 
       break;
 #  else
     wint_t ch = static_cast<wint_t>(*low);
-    if ((m & space) == space && __locale__libcpp_iswspace(ch, __l_))
+    if ((m & space) == space && __locale::__libcpp_iswspace(ch, __l_))
       continue;
     if ((m & print) == print && __locale::__libcpp_iswprint(ch, __l_))
       continue;

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -625,7 +625,7 @@ int collate_byname<char>::do_compare(
     const char_type* __lo1, const char_type* __hi1, const char_type* __lo2, const char_type* __hi2) const {
   string_type lhs(__lo1, __hi1);
   string_type rhs(__lo2, __hi2);
-  int r = __locale::__strcoll(lhs.c_str(), rhs.c_str(), __l_);
+  int r = __locale::__libcpp_strcoll(lhs.c_str(), rhs.c_str(), __l_);
   if (r < 0)
     return -1;
   if (r > 0)
@@ -635,8 +635,8 @@ int collate_byname<char>::do_compare(
 
 collate_byname<char>::string_type collate_byname<char>::do_transform(const char_type* lo, const char_type* hi) const {
   const string_type in(lo, hi);
-  string_type out(__locale::__strxfrm(0, in.c_str(), 0, __l_), char());
-  __locale::__strxfrm(const_cast<char*>(out.c_str()), in.c_str(), out.size() + 1, __l_);
+  string_type out(__locale::__libcpp_strxfrm(0, in.c_str(), 0, __l_), char());
+  __locale::__libcpp_strxfrm(const_cast<char*>(out.c_str()), in.c_str(), out.size() + 1, __l_);
   return out;
 }
 
@@ -669,7 +669,7 @@ int collate_byname<wchar_t>::do_compare(
     const char_type* __lo1, const char_type* __hi1, const char_type* __lo2, const char_type* __hi2) const {
   string_type lhs(__lo1, __hi1);
   string_type rhs(__lo2, __hi2);
-  int r = __locale::__wcscoll(lhs.c_str(), rhs.c_str(), __l_);
+  int r = __locale::__libcpp_wcscoll(lhs.c_str(), rhs.c_str(), __l_);
   if (r < 0)
     return -1;
   if (r > 0)
@@ -680,8 +680,8 @@ int collate_byname<wchar_t>::do_compare(
 collate_byname<wchar_t>::string_type
 collate_byname<wchar_t>::do_transform(const char_type* lo, const char_type* hi) const {
   const string_type in(lo, hi);
-  string_type out(__locale::__wcsxfrm(0, in.c_str(), 0, __l_), wchar_t());
-  __locale::__wcsxfrm(const_cast<wchar_t*>(out.c_str()), in.c_str(), out.size() + 1, __l_);
+  string_type out(__locale::__libcpp_wcsxfrm(0, in.c_str(), 0, __l_), wchar_t());
+  __locale::__libcpp_wcsxfrm(const_cast<wchar_t*>(out.c_str()), in.c_str(), out.size() + 1, __l_);
   return out;
 }
 #endif // _LIBCPP_HAS_WIDE_CHARACTERS
@@ -736,7 +736,7 @@ wchar_t ctype<wchar_t>::do_toupper(char_type c) const {
 #  elif defined(__GLIBC__) || defined(__EMSCRIPTEN__) || defined(__NetBSD__) || defined(__MVS__)
   return isascii(c) ? ctype<char>::__classic_upper_table()[c] : c;
 #  else
-  return (isascii(c) && __locale::__iswlower(c, _LIBCPP_GET_C_LOCALE)) ? c - L'a' + L'A' : c;
+  return (isascii(c) && __locale::__libcpp_iswlower(c, _LIBCPP_GET_C_LOCALE)) ? c - L'a' + L'A' : c;
 #  endif
 }
 
@@ -1064,22 +1064,22 @@ ctype_byname<char>::ctype_byname(const string& name, size_t refs)
 ctype_byname<char>::~ctype_byname() { __locale::__freelocale(__l_); }
 
 char ctype_byname<char>::do_toupper(char_type c) const {
-  return static_cast<char>(__locale::__toupper(static_cast<unsigned char>(c), __l_));
+  return static_cast<char>(__locale::__libcpp_toupper(static_cast<unsigned char>(c), __l_));
 }
 
 const char* ctype_byname<char>::do_toupper(char_type* low, const char_type* high) const {
   for (; low != high; ++low)
-    *low = static_cast<char>(__locale::__toupper(static_cast<unsigned char>(*low), __l_));
+    *low = static_cast<char>(__locale::__libcpp_toupper(static_cast<unsigned char>(*low), __l_));
   return low;
 }
 
 char ctype_byname<char>::do_tolower(char_type c) const {
-  return static_cast<char>(__locale::__tolower(static_cast<unsigned char>(c), __l_));
+  return static_cast<char>(__locale::__libcpp_tolower(static_cast<unsigned char>(c), __l_));
 }
 
 const char* ctype_byname<char>::do_tolower(char_type* low, const char_type* high) const {
   for (; low != high; ++low)
-    *low = static_cast<char>(__locale::__tolower(static_cast<unsigned char>(*low), __l_));
+    *low = static_cast<char>(__locale::__libcpp_tolower(static_cast<unsigned char>(*low), __l_));
   return low;
 }
 
@@ -1115,25 +1115,25 @@ bool ctype_byname<wchar_t>::do_is(mask m, char_type c) const {
   bool result = false;
   wint_t ch   = static_cast<wint_t>(c);
   if ((m & space) == space)
-    result |= (__locale::__iswspace(ch, __l_) != 0);
+    result |= (__locale__libcpp_iswspace(ch, __l_) != 0);
   if ((m & print) == print)
-    result |= (__locale::__iswprint(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswprint(ch, __l_) != 0);
   if ((m & cntrl) == cntrl)
-    result |= (__locale::__iswcntrl(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswcntrl(ch, __l_) != 0);
   if ((m & upper) == upper)
-    result |= (__locale::__iswupper(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswupper(ch, __l_) != 0);
   if ((m & lower) == lower)
-    result |= (__locale::__iswlower(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswlower(ch, __l_) != 0);
   if ((m & alpha) == alpha)
-    result |= (__locale::__iswalpha(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswalpha(ch, __l_) != 0);
   if ((m & digit) == digit)
-    result |= (__locale::__iswdigit(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswdigit(ch, __l_) != 0);
   if ((m & punct) == punct)
-    result |= (__locale::__iswpunct(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswpunct(ch, __l_) != 0);
   if ((m & xdigit) == xdigit)
-    result |= (__locale::__iswxdigit(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswxdigit(ch, __l_) != 0);
   if ((m & blank) == blank)
-    result |= (__locale::__iswblank(ch, __l_) != 0);
+    result |= (__locale::__libcpp_iswblank(ch, __l_) != 0);
   return result;
 #  endif
 }
@@ -1145,31 +1145,31 @@ const wchar_t* ctype_byname<wchar_t>::do_is(const char_type* low, const char_typ
     else {
       *vec      = 0;
       wint_t ch = static_cast<wint_t>(*low);
-      if (__locale::__iswspace(ch, __l_))
+      if (__locale__libcpp_iswspace(ch, __l_))
         *vec |= space;
 #  ifndef _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
-      if (__locale::__iswprint(ch, __l_))
+      if (__locale::__libcpp_iswprint(ch, __l_))
         *vec |= print;
 #  endif
-      if (__locale::__iswcntrl(ch, __l_))
+      if (__locale::__libcpp_iswcntrl(ch, __l_))
         *vec |= cntrl;
-      if (__locale::__iswupper(ch, __l_))
+      if (__locale::__libcpp_iswupper(ch, __l_))
         *vec |= upper;
-      if (__locale::__iswlower(ch, __l_))
+      if (__locale::__libcpp_iswlower(ch, __l_))
         *vec |= lower;
 #  ifndef _LIBCPP_CTYPE_MASK_IS_COMPOSITE_ALPHA
-      if (__locale::__iswalpha(ch, __l_))
+      if (__locale::__libcpp_iswalpha(ch, __l_))
         *vec |= alpha;
 #  endif
-      if (__locale::__iswdigit(ch, __l_))
+      if (__locale::__libcpp_iswdigit(ch, __l_))
         *vec |= digit;
-      if (__locale::__iswpunct(ch, __l_))
+      if (__locale::__libcpp_iswpunct(ch, __l_))
         *vec |= punct;
 #  ifndef _LIBCPP_CTYPE_MASK_IS_COMPOSITE_XDIGIT
-      if (__locale::__iswxdigit(ch, __l_))
+      if (__locale::__libcpp_iswxdigit(ch, __l_))
         *vec |= xdigit;
 #  endif
-      if (__locale::__iswblank(ch, __l_))
+      if (__locale::__libcpp_iswblank(ch, __l_))
         *vec |= blank;
     }
   }
@@ -1183,25 +1183,25 @@ const wchar_t* ctype_byname<wchar_t>::do_scan_is(mask m, const char_type* low, c
       break;
 #  else
     wint_t ch = static_cast<wint_t>(*low);
-    if ((m & space) == space && __locale::__iswspace(ch, __l_))
+    if ((m & space) == space && __locale__libcpp_iswspace(ch, __l_))
       break;
-    if ((m & print) == print && __locale::__iswprint(ch, __l_))
+    if ((m & print) == print && __locale::__libcpp_iswprint(ch, __l_))
       break;
-    if ((m & cntrl) == cntrl && __locale::__iswcntrl(ch, __l_))
+    if ((m & cntrl) == cntrl && __locale::__libcpp_iswcntrl(ch, __l_))
       break;
-    if ((m & upper) == upper && __locale::__iswupper(ch, __l_))
+    if ((m & upper) == upper && __locale::__libcpp_iswupper(ch, __l_))
       break;
-    if ((m & lower) == lower && __locale::__iswlower(ch, __l_))
+    if ((m & lower) == lower && __locale::__libcpp_iswlower(ch, __l_))
       break;
-    if ((m & alpha) == alpha && __locale::__iswalpha(ch, __l_))
+    if ((m & alpha) == alpha && __locale::__libcpp_iswalpha(ch, __l_))
       break;
-    if ((m & digit) == digit && __locale::__iswdigit(ch, __l_))
+    if ((m & digit) == digit && __locale::__libcpp_iswdigit(ch, __l_))
       break;
-    if ((m & punct) == punct && __locale::__iswpunct(ch, __l_))
+    if ((m & punct) == punct && __locale::__libcpp_iswpunct(ch, __l_))
       break;
-    if ((m & xdigit) == xdigit && __locale::__iswxdigit(ch, __l_))
+    if ((m & xdigit) == xdigit && __locale::__libcpp_iswxdigit(ch, __l_))
       break;
-    if ((m & blank) == blank && __locale::__iswblank(ch, __l_))
+    if ((m & blank) == blank && __locale::__libcpp_iswblank(ch, __l_))
       break;
 #  endif
   }
@@ -1215,25 +1215,25 @@ const wchar_t* ctype_byname<wchar_t>::do_scan_not(mask m, const char_type* low, 
       break;
 #  else
     wint_t ch = static_cast<wint_t>(*low);
-    if ((m & space) == space && __locale::__iswspace(ch, __l_))
+    if ((m & space) == space && __locale__libcpp_iswspace(ch, __l_))
       continue;
-    if ((m & print) == print && __locale::__iswprint(ch, __l_))
+    if ((m & print) == print && __locale::__libcpp_iswprint(ch, __l_))
       continue;
-    if ((m & cntrl) == cntrl && __locale::__iswcntrl(ch, __l_))
+    if ((m & cntrl) == cntrl && __locale::__libcpp_iswcntrl(ch, __l_))
       continue;
-    if ((m & upper) == upper && __locale::__iswupper(ch, __l_))
+    if ((m & upper) == upper && __locale::__libcpp_iswupper(ch, __l_))
       continue;
-    if ((m & lower) == lower && __locale::__iswlower(ch, __l_))
+    if ((m & lower) == lower && __locale::__libcpp_iswlower(ch, __l_))
       continue;
-    if ((m & alpha) == alpha && __locale::__iswalpha(ch, __l_))
+    if ((m & alpha) == alpha && __locale::__libcpp_iswalpha(ch, __l_))
       continue;
-    if ((m & digit) == digit && __locale::__iswdigit(ch, __l_))
+    if ((m & digit) == digit && __locale::__libcpp_iswdigit(ch, __l_))
       continue;
-    if ((m & punct) == punct && __locale::__iswpunct(ch, __l_))
+    if ((m & punct) == punct && __locale::__libcpp_iswpunct(ch, __l_))
       continue;
-    if ((m & xdigit) == xdigit && __locale::__iswxdigit(ch, __l_))
+    if ((m & xdigit) == xdigit && __locale::__libcpp_iswxdigit(ch, __l_))
       continue;
-    if ((m & blank) == blank && __locale::__iswblank(ch, __l_))
+    if ((m & blank) == blank && __locale::__libcpp_iswblank(ch, __l_))
       continue;
     break;
 #  endif
@@ -1241,19 +1241,19 @@ const wchar_t* ctype_byname<wchar_t>::do_scan_not(mask m, const char_type* low, 
   return low;
 }
 
-wchar_t ctype_byname<wchar_t>::do_toupper(char_type c) const { return __locale::__towupper(c, __l_); }
+wchar_t ctype_byname<wchar_t>::do_toupper(char_type c) const { return __locale::__libcpp_towupper(c, __l_); }
 
 const wchar_t* ctype_byname<wchar_t>::do_toupper(char_type* low, const char_type* high) const {
   for (; low != high; ++low)
-    *low = __locale::__towupper(*low, __l_);
+    *low = __locale::__libcpp_towupper(*low, __l_);
   return low;
 }
 
-wchar_t ctype_byname<wchar_t>::do_tolower(char_type c) const { return __locale::__towlower(c, __l_); }
+wchar_t ctype_byname<wchar_t>::do_tolower(char_type c) const { return __locale::__libcpp_towlower(c, __l_); }
 
 const wchar_t* ctype_byname<wchar_t>::do_tolower(char_type* low, const char_type* high) const {
   for (; low != high; ++low)
-    *low = __locale::__towlower(*low, __l_);
+    *low = __locale::__libcpp_towlower(*low, __l_);
   return low;
 }
 
@@ -4467,7 +4467,7 @@ string __time_get_storage<char>::__analyze(char fmt, const ctype<char>& ct) {
   char f[3] = {0};
   f[0]      = '%';
   f[1]      = fmt;
-  size_t n  = __locale::__strftime(buf, countof(buf), f, &t, __loc_);
+  size_t n  = __locale::__libcpp_strftime(buf, countof(buf), f, &t, __loc_);
   char* bb  = buf;
   char* be  = buf + n;
   string result;
@@ -4598,7 +4598,7 @@ wstring __time_get_storage<wchar_t>::__analyze(char fmt, const ctype<wchar_t>& c
   char f[3] = {0};
   f[0]      = '%';
   f[1]      = fmt;
-  __locale::__strftime(buf, countof(buf), f, &t, __loc_);
+  __locale::__libcpp_strftime(buf, countof(buf), f, &t, __loc_);
   wchar_t wbuf[100];
   wchar_t* wbb   = wbuf;
   mbstate_t mb   = {0};
@@ -4724,25 +4724,25 @@ void __time_get_storage<char>::init(const ctype<char>& ct) {
   // __weeks_
   for (int i = 0; i < 7; ++i) {
     t.tm_wday = i;
-    __locale::__strftime(buf, countof(buf), "%A", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%A", &t, __loc_);
     __weeks_[i] = buf;
-    __locale::__strftime(buf, countof(buf), "%a", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%a", &t, __loc_);
     __weeks_[i + 7] = buf;
   }
   // __months_
   for (int i = 0; i < 12; ++i) {
     t.tm_mon = i;
-    __locale::__strftime(buf, countof(buf), "%B", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%B", &t, __loc_);
     __months_[i] = buf;
-    __locale::__strftime(buf, countof(buf), "%b", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%b", &t, __loc_);
     __months_[i + 12] = buf;
   }
   // __am_pm_
   t.tm_hour = 1;
-  __locale::__strftime(buf, countof(buf), "%p", &t, __loc_);
+  __locale::__libcpp_strftime(buf, countof(buf), "%p", &t, __loc_);
   __am_pm_[0] = buf;
   t.tm_hour   = 13;
-  __locale::__strftime(buf, countof(buf), "%p", &t, __loc_);
+  __locale::__libcpp_strftime(buf, countof(buf), "%p", &t, __loc_);
   __am_pm_[1] = buf;
   __c_        = __analyze('c', ct);
   __r_        = __analyze('r', ct);
@@ -4761,7 +4761,7 @@ void __time_get_storage<wchar_t>::init(const ctype<wchar_t>& ct) {
   // __weeks_
   for (int i = 0; i < 7; ++i) {
     t.tm_wday = i;
-    __locale::__strftime(buf, countof(buf), "%A", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%A", &t, __loc_);
     mb             = mbstate_t();
     const char* bb = buf;
     size_t j       = __locale::__mbsrtowcs(wbuf, &bb, countof(wbuf), &mb, __loc_);
@@ -4769,7 +4769,7 @@ void __time_get_storage<wchar_t>::init(const ctype<wchar_t>& ct) {
       __throw_runtime_error("locale not supported");
     wbe = wbuf + j;
     __weeks_[i].assign(wbuf, wbe);
-    __locale::__strftime(buf, countof(buf), "%a", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%a", &t, __loc_);
     mb = mbstate_t();
     bb = buf;
     j  = __locale::__mbsrtowcs(wbuf, &bb, countof(wbuf), &mb, __loc_);
@@ -4781,7 +4781,7 @@ void __time_get_storage<wchar_t>::init(const ctype<wchar_t>& ct) {
   // __months_
   for (int i = 0; i < 12; ++i) {
     t.tm_mon = i;
-    __locale::__strftime(buf, countof(buf), "%B", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%B", &t, __loc_);
     mb             = mbstate_t();
     const char* bb = buf;
     size_t j       = __locale::__mbsrtowcs(wbuf, &bb, countof(wbuf), &mb, __loc_);
@@ -4789,7 +4789,7 @@ void __time_get_storage<wchar_t>::init(const ctype<wchar_t>& ct) {
       __throw_runtime_error("locale not supported");
     wbe = wbuf + j;
     __months_[i].assign(wbuf, wbe);
-    __locale::__strftime(buf, countof(buf), "%b", &t, __loc_);
+    __locale::__libcpp_strftime(buf, countof(buf), "%b", &t, __loc_);
     mb = mbstate_t();
     bb = buf;
     j  = __locale::__mbsrtowcs(wbuf, &bb, countof(wbuf), &mb, __loc_);
@@ -4800,7 +4800,7 @@ void __time_get_storage<wchar_t>::init(const ctype<wchar_t>& ct) {
   }
   // __am_pm_
   t.tm_hour = 1;
-  __locale::__strftime(buf, countof(buf), "%p", &t, __loc_);
+  __locale::__libcpp_strftime(buf, countof(buf), "%p", &t, __loc_);
   mb             = mbstate_t();
   const char* bb = buf;
   size_t j       = __locale::__mbsrtowcs(wbuf, &bb, countof(wbuf), &mb, __loc_);
@@ -4809,7 +4809,7 @@ void __time_get_storage<wchar_t>::init(const ctype<wchar_t>& ct) {
   wbe = wbuf + j;
   __am_pm_[0].assign(wbuf, wbe);
   t.tm_hour = 13;
-  __locale::__strftime(buf, countof(buf), "%p", &t, __loc_);
+  __locale::__libcpp_strftime(buf, countof(buf), "%p", &t, __loc_);
   mb = mbstate_t();
   bb = buf;
   j  = __locale::__mbsrtowcs(wbuf, &bb, countof(wbuf), &mb, __loc_);
@@ -5041,7 +5041,7 @@ void __time_put::__do_put(char* __nb, char*& __ne, const tm* __tm, char __fmt, c
   char fmt[] = {'%', __fmt, __mod, 0};
   if (__mod != 0)
     swap(fmt[1], fmt[2]);
-  size_t n = __locale::__strftime(__nb, countof(__nb, __ne), fmt, __tm, __loc_);
+  size_t n = __locale::__libcpp_strftime(__nb, countof(__nb, __ne), fmt, __tm, __loc_);
   __ne     = __nb + n;
 }
 


### PR DESCRIPTION
This PR is necessary to resolve name collisions between locale functions defined within libc++ and macros used in z/OS system   header, `locale.h`. Those macros cannot be changed since they are visible and out in the field for many releases. 

In addition, the zos wrapper locale.h header is created to remove conflict between `__locale` namespace and guard macro used by z/OS system header. This change is temporary until system header is altered to do the same.

The PR is to address build issues on z/OS caused by PR [114596](https://github.com/llvm/llvm-project/pull/114596).
The following is a sample of errors:
```
.../include/c++/v1/__locale_dir/locale_base_api.h:181:54: error: too many arguments provided to function-like macro invocation
  181 | inline _LIBCPP_HIDE_FROM_ABI int __islower(int __ch, __locale_t __loc) { return islower_l(__ch, __loc); }
      |                                                      ^
...util/usr/include/ctype.h:387:11: note: macro '__islower' defined here
  387 |   #define __islower(c) (_TYPCHK((c),__ISLOWER))
      |           ^
```