### PR TITLE
[clang] Recover necessary AddrSpaceCast

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3302,6 +3302,9 @@ void ItaniumCXXABI::EmitThreadLocalInitFuncs(
       CharUnits Align = CGM.getContext().getDeclAlign(VD);
       Val = Builder.CreateAlignedLoad(Var->getValueType(), Val, Align);
     }
+    if (Val->getType() != Wrapper->getReturnType()) {
+      Val = Builder.CreateAddrSpaceCast(Val, Wrapper->getReturnType());
+    }
 
     Builder.CreateRet(Val);
   }

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3302,9 +3302,7 @@ void ItaniumCXXABI::EmitThreadLocalInitFuncs(
       CharUnits Align = CGM.getContext().getDeclAlign(VD);
       Val = Builder.CreateAlignedLoad(Var->getValueType(), Val, Align);
     }
-    if (Val->getType() != Wrapper->getReturnType()) {
-      Val = Builder.CreateAddrSpaceCast(Val, Wrapper->getReturnType());
-    }
+    Val = Builder.CreateAddrSpaceCast(Val, Wrapper->getReturnType());
 
     Builder.CreateRet(Val);
   }

--- a/clang/test/OpenMP/amdgpu_threadprivate.cpp
+++ b/clang/test/OpenMP/amdgpu_threadprivate.cpp
@@ -1,0 +1,11 @@
+// REQUIRES: asserts
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-cpu x86-64 -disable-llvm-passes -fopenmp-targets=amdgcn-amd-amdhsa -x c++ -emit-llvm-bc %s -o %t-x86-host.bc
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -target-cpu gfx906 -fopenmp -nogpulib -fopenmp-is-target-device -fopenmp-host-ir-file-path %t-x86-host.bc -x c++ %s
+
+// Don't crash with assertions build.
+int MyGlobVar;
+#pragma omp threadprivate(MyGlobVar)
+int main() {
+  MyGlobVar = 1;
+}

--- a/clang/test/OpenMP/amdgpu_threadprivate.cpp
+++ b/clang/test/OpenMP/amdgpu_threadprivate.cpp
@@ -1,5 +1,4 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-cpu x86-64 -disable-llvm-passes -fopenmp-targets=amdgcn-amd-amdhsa -x c++ -emit-llvm-bc %s -o %t-x86-host.bc
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -target-cpu gfx906 -fopenmp -nogpulib -fopenmp-is-target-device -fopenmp-host-ir-file-path %t-x86-host.bc -x c++ -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -target-cpu gfx906 -fopenmp -nogpulib -fopenmp-is-target-device -emit-llvm %s -o - | FileCheck %s
 
 // Don't crash with assertions build.
 

--- a/clang/test/OpenMP/amdgpu_threadprivate.cpp
+++ b/clang/test/OpenMP/amdgpu_threadprivate.cpp
@@ -1,11 +1,17 @@
-// REQUIRES: asserts
-
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -target-cpu x86-64 -disable-llvm-passes -fopenmp-targets=amdgcn-amd-amdhsa -x c++ -emit-llvm-bc %s -o %t-x86-host.bc
-// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -target-cpu gfx906 -fopenmp -nogpulib -fopenmp-is-target-device -fopenmp-host-ir-file-path %t-x86-host.bc -x c++ %s
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -target-cpu gfx906 -fopenmp -nogpulib -fopenmp-is-target-device -fopenmp-host-ir-file-path %t-x86-host.bc -x c++ -emit-llvm %s -o - | FileCheck %s
 
 // Don't crash with assertions build.
+
+// CHECK:       @MyGlobVar = external thread_local addrspace(1) global i32, align 4
+// CHECK:       define weak_odr hidden noundef ptr @_ZTW9MyGlobVar() #0 comdat {
+// CHECK-NEXT:    %1 = call align 4 ptr addrspace(1) @llvm.threadlocal.address.p1(ptr addrspace(1) align 4 @MyGlobVar)
+// CHECK-NEXT:    %2 = addrspacecast ptr addrspace(1) %1 to ptr
+// CHECK-NEXT:    ret ptr %2
+// CHECK-NEXT:  }
 int MyGlobVar;
 #pragma omp threadprivate(MyGlobVar)
 int main() {
   MyGlobVar = 1;
 }
+


### PR DESCRIPTION
A necessary AddrSpaceCast was wrongfully deleted in 5c91b2886f6bf400b60ca7839069839ac3980f8f . Recover the AddrSpaceCast.

This fixes #86791 .