### PR TITLE
[clang][docs] fix rendering of `$`-prefixed options

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1066,6 +1066,7 @@ is being invoked, and added after all of the command-line specified linker
 inputs. Here is some example of ``$``-prefixed options:
 
 ::
+
     $-Wl,-Bstatic $-lm
     $-Wl,-Bshared
 


### PR DESCRIPTION
This was added in #117573 but the options were not being rendered
correctly due to the missing newline after `::`.
