### PR TITLE
[clang] wasm cpu name is supposed to be lime1, not lime

### DIFF
--- a/clang/lib/Basic/Targets/WebAssembly.cpp
+++ b/clang/lib/Basic/Targets/WebAssembly.cpp
@@ -35,7 +35,7 @@ static constexpr auto BuiltinStorage = Builtin::Storage<NumBuiltins>::Make(
       });
 
 static constexpr llvm::StringLiteral ValidCPUNames[] = {
-    {"mvp"}, {"bleeding-edge"}, {"generic"}, {"lime"}};
+    {"mvp"}, {"bleeding-edge"}, {"generic"}, {"lime1"}};
 
 StringRef WebAssemblyTargetInfo::getABI() const { return ABI; }
 


### PR DESCRIPTION
Originally added in #112035
cc @sunfishcode