### PR TITLE
[LLD][ELF] Add --why-live flag to report GC liveness reason

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -223,6 +223,7 @@ struct Config {
   llvm::StringRef thinLTOCacheDir;
   llvm::StringRef thinLTOIndexOnlyArg;
   llvm::StringRef whyExtract;
+  llvm::SmallVector<llvm::GlobPattern, 0> whyLive;
   llvm::StringRef cmseInputLib;
   llvm::StringRef cmseOutputLib;
   StringRef zBtiReport = "none";

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1472,6 +1472,15 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.warnSymbolOrdering =
       args.hasFlag(OPT_warn_symbol_ordering, OPT_no_warn_symbol_ordering, true);
   ctx.arg.whyExtract = args.getLastArgValue(OPT_why_extract);
+  for (opt::Arg *arg : args.filtered(OPT_why_live)) {
+    StringRef value(arg->getValue());
+    if (Expected<GlobPattern> pat = GlobPattern::create(arg->getValue())) {
+      ctx.arg.whyLive.emplace_back(std::move(*pat));
+    } else {
+      ErrAlways(ctx) << arg->getSpelling() << ": " << pat.takeError();
+      continue;
+    }
+  }
   ctx.arg.zCombreloc = getZFlag(args, "combreloc", "nocombreloc", true);
   ctx.arg.zCopyreloc = getZFlag(args, "copyreloc", "nocopyreloc", true);
   ctx.arg.zForceBti = hasZOption(args, "force-bti");

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -56,6 +56,7 @@ public:
 private:
   void enqueue(InputSectionBase *sec, std::optional<uint64_t> offset,
                std::optional<LiveObject> parent);
+  void printWhyLive(const Symbol *s) const;
   void markSymbol(Symbol *sym);
   void mark();
 
@@ -230,6 +231,10 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec,
     queue.push_back(s);
 }
 
+template <class ELFT>
+void MarkLive<ELFT>::printWhyLive(const Symbol *s) const {
+}
+
 template <class ELFT> void MarkLive<ELFT>::markSymbol(Symbol *sym) {
   if (auto *d = dyn_cast_or_null<Defined>(sym))
     if (auto *isec = dyn_cast_or_null<InputSectionBase>(d->section))
@@ -353,6 +358,8 @@ template <class ELFT> void MarkLive<ELFT>::mark() {
     if (sec.nextInSectionGroup)
       enqueue(sec.nextInSectionGroup, std::nullopt, &sec);
   }
+
+  printWhyLive(ctx.symtab->find("foo"));
 }
 
 // Move the sections for some symbols to the main partition, specifically ifuncs

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -382,7 +382,7 @@ template <class ELFT> void MarkLive<ELFT>::mark() {
       enqueue(sec.nextInSectionGroup, std::nullopt, &sec);
   }
 
-  printWhyLive(ctx.symtab->find("foo"));
+  printWhyLive(ctx.symtab->find("bar"));
 }
 
 // Move the sections for some symbols to the main partition, specifically ifuncs

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -239,7 +239,8 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
     auto it = whyLive.find(cur);
     if (it == whyLive.end())
       if (auto *d = dyn_cast<Defined>(s))
-        it = whyLive.find(LiveObject{d->section});
+        if (auto *s = dyn_cast<InputSectionBase>(d->section))
+          it = whyLive.find(LiveObject{s});
     if (it == whyLive.end())
       break;
     cur = it->second;

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -246,11 +246,11 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
       out += "\n" + std::string(indent, ' ');
     if (std::holds_alternative<Symbol *>(*cur)) {
       auto *s = std::get<Symbol *>(*cur);
-      out += toString(*s) + " from " + toString(s->file);
+      out += toStr(ctx, *s) + " from " + toStr(ctx, s->file);
     } else {
       auto *s = std::get<InputSectionBase *>(*cur);
       // TODO: Fancy formatting
-      out += toString(s);
+      out += toStr(ctx, s);
     }
 
     auto it = whyLive.find(*cur);

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -75,6 +75,8 @@ private:
   // There are normally few input sections whose names are valid C
   // identifiers, so we just store a SmallVector instead of a multimap.
   DenseMap<StringRef, SmallVector<InputSectionBase *, 0>> cNamedSections;
+
+  DenseMap<InputSectionBase*, LiveParent> parents;
 };
 } // namespace
 
@@ -208,6 +210,9 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
   if (sec->partition == 1 || sec->partition == partition)
     return;
   sec->partition = sec->partition ? 1 : partition;
+
+  if (parent)
+    parents.try_emplace(sec, *parent);
 
   // Add input section to the queue.
   if (InputSection *s = dyn_cast<InputSection>(sec))

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -209,8 +209,13 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
     return;
   sec->partition = sec->partition ? 1 : partition;
 
-  if (parent)
+  if (parent) {
     whyLive.try_emplace(LiveOffset{sec, offset}, *parent);
+    // Offset zero is treated as a stand-in for the section itself. The parent
+    // is both a specific reason that an offset within this section is alive and
+    // a generic reason the section itself is alive.
+    whyLive.try_emplace(LiveOffset{sec, 0}, *parent);
+  }
 
   // Add input section to the queue.
   if (InputSection *s = dyn_cast<InputSection>(sec))

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -42,14 +42,7 @@ using namespace lld;
 using namespace lld::elf;
 
 namespace {
-struct LiveOffset {
-  InputSectionBase *sec;
-  std::optional<uint64_t> offset;
-
-  LiveOffset(InputSectionBase *sec,
-             std::optional<uint64_t> offset = std::nullopt)
-      : sec(sec), offset(offset) {}
-};
+typedef std::pair<InputSectionBase *, uint64_t> LiveOffset;
 
 template <class ELFT> class MarkLive {
 public:
@@ -341,11 +334,11 @@ template <class ELFT> void MarkLive<ELFT>::mark() {
       resolveReloc(sec, rel, false);
 
     for (InputSectionBase *isec : sec.dependentSections)
-      enqueue(isec, 0, &sec);
+      enqueue(isec, 0, {{&sec, 0}});
 
     // Mark the next group member.
     if (sec.nextInSectionGroup)
-      enqueue(sec.nextInSectionGroup, 0, &sec);
+      enqueue(sec.nextInSectionGroup, 0, {{&sec, 0}});
   }
 }
 

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -397,8 +397,13 @@ template <class ELFT> void MarkLive<ELFT>::mark() {
       enqueue(sec.nextInSectionGroup, 0, nullptr, &sec);
   }
 
-  printWhyLive(ctx.symtab->find("bar"));
-}
+  for (Symbol *sym : ctx.symtab->getSymbols()) {
+    if (llvm::any_of(ctx.arg.whyLive, [sym](const llvm::GlobPattern &pat) {
+          return pat.match(sym->getName());
+        }))
+      printWhyLive(sym);
+  }
+  }
 
 // Move the sections for some symbols to the main partition, specifically ifuncs
 // (because they can result in an IRELATIVE being added to the main partition's

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -151,7 +151,7 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
   }
 
   for (InputSectionBase *sec : cNamedSections.lookup(sym.getName()))
-    enqueue(sec);
+    enqueue(sec, 0, nullptr, parent);
 }
 
 // The .eh_frame section is an unfortunate special case.

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -136,6 +136,8 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
       if (offset >= d->value + d->size)
         if (Symbol *s = relSec->getEnclosingSymbol(offset))
           canonicalSym = s;
+      if (canonicalSym->isSection())
+        canonicalSym = nullptr;
       enqueue(relSec, offset, canonicalSym, parent);
     }
     return;

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -132,10 +132,13 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
     // discarded, marking the LSDA will unnecessarily retain the text section.
     if (!(fromFDE && ((relSec->flags & (SHF_EXECINSTR | SHF_LINK_ORDER)) ||
                       relSec->nextInSectionGroup))) {
+// TODO: Test
       Symbol *canonicalSym = d;
+#if 0
       if (d->isSection())
         if (Symbol *s = relSec->getEnclosingSymbol(offset))
           canonicalSym = s;
+#endif
       enqueue(relSec, offset, canonicalSym, parent);
     }
     return;

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -253,7 +253,6 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
       if (!it->second)
         break;
       cur = *it->second;
-      msg << "\n>>> referenced by ";
     } else {
       // This object is live merely by being a member of its parent section, so
       // report the parent.
@@ -263,16 +262,15 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
       assert(parent &&
              "all live objects should have a tracked reason for being live");
       cur = LiveObject{parent};
-      msg << "\n>>> included in ";
     }
 
+    msg << "\n>>> alive because of ";
     if (std::holds_alternative<Symbol *>(*cur)) {
       auto *s = std::get<Symbol *>(*cur);
-      // Match the syntax for sections below.
-      msg << "symbol " << toStr(ctx, s->file) << ":(" << toStr(ctx, *s) << ')';
+      msg << toStr(ctx, *s);
     } else {
       auto *s = std::get<InputSectionBase *>(*cur);
-      msg << "section " << toStr(ctx, s);
+      msg << toStr(ctx, s);
     }
   }
 }

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -244,9 +244,8 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
 }
 
 template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
-  // TODO: Test
-  // if (!whyLive.contains(s))
-  // return;
+  if (!whyLive.contains(s))
+   return;
 
   auto msg = Msg(ctx);
 

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -245,10 +245,13 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
 }
 
 template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
+  // If the symbol isn't live, return.
   if (!whyLive.contains(s)) {
     auto *d = dyn_cast<Defined>(s);
+    // TODO: Test
     if (!d)
       return;
+    // TODO: Test both cases
     auto *parent = dyn_cast<InputSectionBase>(d->section);
     if (!parent || !parent->isLive())
       return;
@@ -260,15 +263,16 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
   LiveObject cur = s;
   while (true) {
     auto it = whyLive.find(cur);
+    // If there is a specific reason this object is live...
     if (it != whyLive.end()) {
-      // If there is a specific reason this object is live, report it.
+      // The object may be a liveness root.
       if (!it->second)
         break;
       cur = *it->second;
     } else {
       // This object made something else live, but it has no direct reason to be
-      // live. That means it a symbol made alive merely by being a member of its
-      // parent section, so report that section.
+      // live. That means it a symbol kept live only by being a member of its
+      // parent section. Report that section as the symbol's parent.
       auto *d = cast<Defined>(std::get<Symbol *>(cur));
       auto *parent = cast<InputSectionBase>(d->section);
       cur = LiveObject{parent};

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -240,20 +240,21 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
 template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
   if (!whyLive.contains(s))
     return;
-  auto diag = Msg(ctx);
+
+  auto msg = Msg(ctx);
   bool first = true;
   for (std::optional<LiveObject> cur = s; cur;) {
     if (std::holds_alternative<Symbol *>(*cur)) {
       auto *s = std::get<Symbol *>(*cur);
       // Match the syntax for sections below.
-      diag << toStr(ctx, s->file) << ":(" << toStr(ctx, *s) << ')';
+      msg << toStr(ctx, s->file) << ":(" << toStr(ctx, *s) << ')';
     } else {
       auto *s = std::get<InputSectionBase *>(*cur);
-      diag << toStr(ctx, s);
+      msg << toStr(ctx, s);
     }
 
     if (first) {
-      diag << " live because:";
+      msg << " live because:";
       first = false;
     }
 
@@ -275,8 +276,8 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
     }
 
     if (cur)
-      diag << "\n>>> referenced by "
-           << (std::holds_alternative<Symbol *>(*cur) ? "symbol " : "section ");
+      msg << "\n>>> referenced by "
+          << (std::holds_alternative<Symbol *>(*cur) ? "symbol " : "section ");
   }
 }
 

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -248,7 +248,6 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
   // If the symbol isn't live, return.
   if (!whyLive.contains(s)) {
     auto *d = dyn_cast<Defined>(s);
-    // TODO: Test
     if (!d)
       return;
     // TODO: Test both cases

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -141,12 +141,14 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
     return;
   }
 
+#if 0
   if (auto *ss = dyn_cast<SharedSymbol>(&sym)) {
     if (!ss->isWeak()) {
       cast<SharedFile>(ss->file)->isNeeded = true;
       whyLive.try_emplace(&sym, parent);
     }
   }
+#endif
 
   for (InputSectionBase *sec : cNamedSections.lookup(sym.getName()))
     enqueue(sec, 0, nullptr, parent);
@@ -229,7 +231,7 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
     whyLive.try_emplace(sec, sym);
   } else {
     // Otherwise, the parent generically makes the section itself live.
-    whyLive.try_emplace(sec, parent);
+    //whyLive.try_emplace(sec, parent);
   }
 
   // Add input section to the queue.
@@ -256,12 +258,14 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
     } else {
       // This object is live merely by being a member of its parent section, so
       // report the parent.
+#if 0
       InputSectionBase *parent = nullptr;
       if (auto *d = dyn_cast<Defined>(s))
         parent = dyn_cast<InputSectionBase>(d->section);
       assert(parent &&
              "all live objects should have a tracked reason for being live");
       cur = LiveObject{parent};
+#endif
     }
 
     msg << "\n>>> alive because of ";

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -258,14 +258,12 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
     } else {
       // This object is live merely by being a member of its parent section, so
       // report the parent.
-#if 0
       InputSectionBase *parent = nullptr;
       if (auto *d = dyn_cast<Defined>(s))
         parent = dyn_cast<InputSectionBase>(d->section);
       assert(parent &&
              "all live objects should have a tracked reason for being live");
       cur = LiveObject{parent};
-#endif
     }
 
     msg << "\n>>> alive because of ";

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -132,8 +132,8 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
     // discarded, marking the LSDA will unnecessarily retain the text section.
     if (!(fromFDE && ((relSec->flags & (SHF_EXECINSTR | SHF_LINK_ORDER)) ||
                       relSec->nextInSectionGroup))) {
-// TODO: Test
       Symbol *canonicalSym = d;
+// TODO: Test
 #if 0
       if (d->isSection())
         if (Symbol *s = relSec->getEnclosingSymbol(offset))
@@ -144,6 +144,7 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
     return;
   }
 
+// TODO: Test
 #if 0
   if (auto *ss = dyn_cast<SharedSymbol>(&sym)) {
     if (!ss->isWeak()) {
@@ -234,7 +235,7 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
     whyLive.try_emplace(sec, sym);
   } else {
     // Otherwise, the parent generically makes the section itself live.
-    //whyLive.try_emplace(sec, parent);
+    // whyLive.try_emplace(sec, parent);
   }
 
   // Add input section to the queue.
@@ -243,8 +244,9 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
 }
 
 template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
-  //if (!whyLive.contains(s))
-    //return;
+  // TODO: Test
+  // if (!whyLive.contains(s))
+  // return;
 
   auto msg = Msg(ctx);
 
@@ -269,7 +271,7 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
       cur = LiveObject{parent};
     }
 
-    msg << "\n>>> alive because of ";
+    msg << "\n>>> kept alive by ";
     if (std::holds_alternative<Symbol *>(*cur)) {
       auto *s = std::get<Symbol *>(*cur);
       msg << toStr(ctx, *s);

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -240,8 +240,8 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
 }
 
 template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
-  if (!whyLive.contains(s))
-    return;
+  //if (!whyLive.contains(s))
+    //return;
 
   auto msg = Msg(ctx);
 

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -266,15 +266,13 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
       msg << "\n>>> included in ";
     }
 
-    msg << (std::holds_alternative<Symbol *>(*cur) ? "symbol " : "section ");
-
     if (std::holds_alternative<Symbol *>(*cur)) {
       auto *s = std::get<Symbol *>(*cur);
       // Match the syntax for sections below.
-      msg << toStr(ctx, s->file) << ":(" << toStr(ctx, *s) << ')';
+      msg << "symbol " << toStr(ctx, s->file) << ":(" << toStr(ctx, *s) << ')';
     } else {
       auto *s = std::get<InputSectionBase *>(*cur);
-      msg << toStr(ctx, s);
+      msg << "section " << toStr(ctx, s);
     }
   }
 }

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -241,6 +241,8 @@ void MarkLive<ELFT>::enqueue(InputSectionBase *sec, uint64_t offset,
 template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
   std::string out;
   int indent = 0;
+  if (!whyLive.contains(s))
+    return;
   for (std::optional<LiveObject> cur = s; cur; indent += 2) {
     if (indent)
       out += "\n" + std::string(indent, ' ');
@@ -403,7 +405,7 @@ template <class ELFT> void MarkLive<ELFT>::mark() {
         }))
       printWhyLive(sym);
   }
-  }
+}
 
 // Move the sections for some symbols to the main partition, specifically ifuncs
 // (because they can result in an IRELATIVE being added to the main partition's

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -132,13 +132,10 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
     // discarded, marking the LSDA will unnecessarily retain the text section.
     if (!(fromFDE && ((relSec->flags & (SHF_EXECINSTR | SHF_LINK_ORDER)) ||
                       relSec->nextInSectionGroup))) {
-      Symbol *canonicalSym = nullptr;
-      if (!d->isSection()) {
-        if (offset < d->value + d->size)
-          canonicalSym = d;
-        else if (Symbol *s = relSec->getEnclosingSymbol(offset))
+      Symbol *canonicalSym = d;
+      if (d->isSection())
+        if (Symbol *s = relSec->getEnclosingSymbol(offset))
           canonicalSym = s;
-      }
       enqueue(relSec, offset, canonicalSym, parent);
     }
     return;

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -132,12 +132,13 @@ void MarkLive<ELFT>::resolveReloc(InputSectionBase &sec, RelTy &rel,
     // discarded, marking the LSDA will unnecessarily retain the text section.
     if (!(fromFDE && ((relSec->flags & (SHF_EXECINSTR | SHF_LINK_ORDER)) ||
                       relSec->nextInSectionGroup))) {
-      Symbol *canonicalSym = d;
-      if (offset >= d->value + d->size)
-        if (Symbol *s = relSec->getEnclosingSymbol(offset))
+      Symbol *canonicalSym = nullptr;
+      if (!d->isSection()) {
+        if (offset < d->value + d->size)
+          canonicalSym = d;
+        else if (Symbol *s = relSec->getEnclosingSymbol(offset))
           canonicalSym = s;
-      if (canonicalSym->isSection())
-        canonicalSym = nullptr;
+      }
       enqueue(relSec, offset, canonicalSym, parent);
     }
     return;

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -54,8 +54,9 @@ public:
   void moveToMain();
 
 private:
-  void enqueue(InputSectionBase *sec, uint64_t offset, Symbol *sym,
-               std::optional<LiveObject> parent);
+  void enqueue(InputSectionBase *sec, uint64_t offset = 0,
+               Symbol *sym = nullptr,
+               std::optional<LiveObject> parent = std::nullopt);
   void printWhyLive(Symbol *s) const;
   void markSymbol(Symbol *sym);
   void mark();
@@ -278,7 +279,7 @@ template <class ELFT> void MarkLive<ELFT>::printWhyLive(Symbol *s) const {
 template <class ELFT> void MarkLive<ELFT>::markSymbol(Symbol *sym) {
   if (auto *d = dyn_cast_or_null<Defined>(sym))
     if (auto *isec = dyn_cast_or_null<InputSectionBase>(d->section))
-      enqueue(isec, d->value, sym, std::nullopt);
+      enqueue(isec, d->value, sym);
 }
 
 // This is the main function of the garbage collector.
@@ -364,7 +365,7 @@ template <class ELFT> void MarkLive<ELFT>::run() {
     // Preserve special sections and those which are specified in linker
     // script KEEP command.
     if (isReserved(sec) || ctx.script->shouldKeep(sec)) {
-      enqueue(sec, 0, nullptr, std::nullopt);
+      enqueue(sec);
     } else if ((!ctx.arg.zStartStopGC || sec->name.starts_with("__libc_")) &&
                isValidCIdentifier(sec->name)) {
       // As a workaround for glibc libc.a before 2.34
@@ -429,7 +430,7 @@ template <class ELFT> void MarkLive<ELFT>::moveToMain() {
       continue;
     if (ctx.symtab->find(("__start_" + sec->name).str()) ||
         ctx.symtab->find(("__stop_" + sec->name).str()))
-      enqueue(sec, 0, nullptr, std::nullopt);
+      enqueue(sec);
   }
 
   mark();

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -559,9 +559,11 @@ defm wrap : Eq<"wrap", "Redirect symbol references to __wrap_symbol and "
                        "__real_symbol references to symbol">,
             MetaVarName<"<symbol>">;
 
-defm why_live : EEq<"why-live", "Report a chain of references preventing garbage collection for "
-                                "each symbol matching <glob>">,
-                MetaVarName<"<glob>">;
+defm why_live
+    : EEq<"why-live",
+          "Report a chain of references preventing garbage collection for "
+          "each symbol matching <glob>">,
+      MetaVarName<"<glob>">;
 
 def z: JoinedOrSeparate<["-"], "z">, MetaVarName<"<option>">,
   HelpText<"Linker option extensions">;

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -559,6 +559,10 @@ defm wrap : Eq<"wrap", "Redirect symbol references to __wrap_symbol and "
                        "__real_symbol references to symbol">,
             MetaVarName<"<symbol>">;
 
+defm why_live : EEq<"why-live", "Report a chain of references to <symbol-glob> that keeps it from "
+                                "being garbage collected">,
+                MetaVarName<"<symbol-glob>">;
+
 def z: JoinedOrSeparate<["-"], "z">, MetaVarName<"<option>">,
   HelpText<"Linker option extensions">;
 

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -559,9 +559,9 @@ defm wrap : Eq<"wrap", "Redirect symbol references to __wrap_symbol and "
                        "__real_symbol references to symbol">,
             MetaVarName<"<symbol>">;
 
-defm why_live : EEq<"why-live", "Report a chain of references to <symbol-glob> that keeps it from "
-                                "being garbage collected">,
-                MetaVarName<"<symbol-glob>">;
+defm why_live : EEq<"why-live", "Report a chain of references preventing garbage collection for "
+                                "each symbol matching <glob>">,
+                MetaVarName<"<glob>">;
 
 def z: JoinedOrSeparate<["-"], "z">, MetaVarName<"<option>">,
   HelpText<"Linker option extensions">;

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -4,14 +4,14 @@
 # RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_* | FileCheck %s
 
 # CHECK:      live symbol: test_a
-# CHECK-NEXT: >>> alive because of {{.*}}.o:(._start)
-# CHECK-NEXT: >>> alive because of _start
+# CHECK-NEXT: >>> kept alive by {{.*}}.o:(._start)
+# CHECK-NEXT: >>> kept alive by _start
 
 # CHECK:      live symbol: test_b
-# CHECK-NEXT: >>> alive because of {{.*}}.o:(.test_a)
-# CHECK-NEXT: >>> alive because of test_a
-# CHECK-NEXT: >>> alive because of {{.*}}.o:(._start)
-# CHECK-NEXT: >>> alive because of _start
+# CHECK-NEXT: >>> kept alive by {{.*}}.o:(.test_a)
+# CHECK-NEXT: >>> kept alive by test_a
+# CHECK-NEXT: >>> kept alive by {{.*}}.o:(._start)
+# CHECK-NEXT: >>> kept alive by _start
 
 .globl _start
 .section ._start,"ax",@progbits

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -3,29 +3,26 @@
 # RUN: llvm-mc -n -filetype=obj -triple=x86_64 %s -o %t.o
 # RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_* | FileCheck %s
 
-# CHECK:      live symbol: test_a
-# CHECK-NEXT: >>> kept alive by {{.*}}.o:(._start)
-# CHECK-NEXT: >>> kept alive by _start
-
-# CHECK:      live symbol: test_b
-# CHECK-NEXT: >>> kept alive by {{.*}}.o:(.test_a)
-# CHECK-NEXT: >>> kept alive by test_a
-# CHECK-NEXT: >>> kept alive by {{.*}}.o:(._start)
-# CHECK-NEXT: >>> kept alive by _start
-
 .globl _start
 .section ._start,"ax",@progbits
 _start:
 # DO NOT SUBMIT: If this reads, "jmp a", then LLD hangs.
 jmp test_a
+.size _start, .-_start
 
+# CHECK:      live symbol: test_a
+# CHECK-NEXT: >>> kept alive by _start
 .globl test_a
 .section .test_a,"ax",@progbits
 test_a:
 jmp test_a
 
-# This is alive merely by virtue of being a member of test_a.
-.globl test_b
-test_b:
-jmp test_b
+## This is alive merely by virtue of being a member of test_a.
+# CHECK:      live symbol: test_incidental
+# CHECK-NEXT: >>> kept alive by {{.*}}.o:(.test_a)
+# CHECK-NEXT: >>> kept alive by test_a
+# CHECK-NEXT: >>> kept alive by _start
+.globl test_incidental
+test_incidental:
+jmp test_incidental
 

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -46,3 +46,9 @@ jmp test_dead
 ## Undefined symbols are not considered live.
 # RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_undef -u test_undef | count 0
 
+## Defined symbols without input section parents are considered directly live.
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_absolute | FileCheck %s --check-prefix=ABSOLUTE
+# ABSOLUTE: live symbol: test_absolute
+# ABSOLUTE-NOT: >>>
+.globl test_absolute
+test_absolute = 1234

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -5,7 +5,6 @@
 .globl _start
 .section ._start,"ax",@progbits
 _start:
-# DO NOT SUBMIT: If this reads, "jmp a", then LLD hangs.
 jmp test_simple
 .size _start, .-_start
 
@@ -28,14 +27,18 @@ jmp test_from_unsized
 test_incidental:
 jmp test_incidental
 
-## Since test_simple is unsized, the reference to test_from_unsized is accounted to its parent section.
-# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_from_unsized | FileCheck %s --check-prefix=FROM_UNSIZED
-# FROM_UNSIZED:          live symbol: test_from_unsized
-# FROM_UNSIZED-NEXT: >>> kept alive by /usr/local/google/home/dthorn/llvm-project/build/tools/lld/test/ELF/Output/why-live.s.tmp.o:(.test_simple)
-# FROM_UNSIZED-NEXT: >>> kept alive by test_simple
-# FROM_UNSIZED-NEXT: >>> kept alive by _start
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_from_unsized | FileCheck %s --check-prefix=FROM-UNSIZED
+# FROM-UNSIZED:          live symbol: test_from_unsized
+# FROM-UNSIZED-NEXT: >>> kept alive by /usr/local/google/home/dthorn/llvm-project/build/tools/lld/test/ELF/Output/why-live.s.tmp.o:(.test_simple)
+# FROM-UNSIZED-NEXT: >>> kept alive by test_simple
+# FROM-UNSIZED-NEXT: >>> kept alive by _start
 .globl test_from_unsized
 .section .test_from_unsized,"ax",@progbits
 test_from_unsized:
 jmp test_from_unsized
 
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_dead | count 0
+.globl test_dead
+.section .test_dead,"ax",@progbits
+test_dead:
+jmp test_dead

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -43,8 +43,10 @@ jmp test_from_unsized
 test_dead:
 jmp test_dead
 
-## Undefined symbols are not considered live.
-# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_undef -u test_undef | count 0
+## Undefined symbols are considered live, since they are not attached to dead sections.
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_undef -u test_undef | FileCheck %s --check-prefix=UNDEFINED
+# UNDEFINED: live symbol: test_undef
+# UNDEFINED-NOT: >>>
 
 ## Defined symbols without input section parents are considered directly live.
 # RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_absolute | FileCheck %s --check-prefix=ABSOLUTE

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -1,0 +1,17 @@
+# REQUIRES: x86
+
+# RUN: llvm-mc -n -filetype=obj -triple=x86_64 %s -o %t.o
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=a | FileCheck %s
+
+# CHECK: blah
+
+.globl _start
+.section ._start,"ax",@progbits
+_start:
+jmp a
+
+.globl a
+.section .a,"ax",@progbits
+a:
+jmp a
+

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -1,28 +1,41 @@
 # REQUIRES: x86
 
 # RUN: llvm-mc -n -filetype=obj -triple=x86_64 %s -o %t.o
-# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_* | FileCheck %s
 
 .globl _start
 .section ._start,"ax",@progbits
 _start:
 # DO NOT SUBMIT: If this reads, "jmp a", then LLD hangs.
-jmp test_a
+jmp test_simple
 .size _start, .-_start
 
-# CHECK:      live symbol: test_a
-# CHECK-NEXT: >>> kept alive by _start
-.globl test_a
-.section .test_a,"ax",@progbits
-test_a:
-jmp test_a
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_simple | FileCheck %s --check-prefix=SIMPLE
+# SIMPLE:      live symbol: test_simple
+# SIMPLE-NEXT: >>> kept alive by _start
+.globl test_simple
+.section .test_simple,"ax",@progbits
+test_simple:
+jmp test_simple
+jmp test_from_unsized
 
-## This is alive merely by virtue of being a member of test_a.
-# CHECK:      live symbol: test_incidental
-# CHECK-NEXT: >>> kept alive by {{.*}}.o:(.test_a)
-# CHECK-NEXT: >>> kept alive by test_a
-# CHECK-NEXT: >>> kept alive by _start
+## This is alive merely by virtue of being a member of test_simple.
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_incidental | FileCheck %s --check-prefix=INCIDENTAL
+# INCIDENTAL:          live symbol: test_incidental
+# INCIDENTAL-NEXT: >>> kept alive by {{.*}}.o:(.test_simple)
+# INCIDENTAL-NEXT: >>> kept alive by test_simple
+# INCIDENTAL-NEXT: >>> kept alive by _start
 .globl test_incidental
 test_incidental:
 jmp test_incidental
+
+## Since test_simple is unsized, the reference to test_from_unsized is accounted to its parent section.
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_from_unsized | FileCheck %s --check-prefix=FROM_UNSIZED
+# FROM_UNSIZED:          live symbol: test_from_unsized
+# FROM_UNSIZED-NEXT: >>> kept alive by /usr/local/google/home/dthorn/llvm-project/build/tools/lld/test/ELF/Output/why-live.s.tmp.o:(.test_simple)
+# FROM_UNSIZED-NEXT: >>> kept alive by test_simple
+# FROM_UNSIZED-NEXT: >>> kept alive by _start
+.globl test_from_unsized
+.section .test_from_unsized,"ax",@progbits
+test_from_unsized:
+jmp test_from_unsized
 

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -3,7 +3,9 @@
 # RUN: llvm-mc -n -filetype=obj -triple=x86_64 %s -o %t.o
 # RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=a | FileCheck %s
 
-# CHECK: blah
+# CHECK: live symbol: a
+# CHECK: >>> alive because of {{.*}}.o:(._start)
+# CHECK: >>> alive because of _start
 
 .globl _start
 .section ._start,"ax",@progbits

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -1,19 +1,31 @@
 # REQUIRES: x86
 
 # RUN: llvm-mc -n -filetype=obj -triple=x86_64 %s -o %t.o
-# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=a | FileCheck %s
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_* | FileCheck %s
 
-# CHECK: live symbol: a
-# CHECK: >>> alive because of {{.*}}.o:(._start)
-# CHECK: >>> alive because of _start
+# CHECK:      live symbol: test_a
+# CHECK-NEXT: >>> alive because of {{.*}}.o:(._start)
+# CHECK-NEXT: >>> alive because of _start
+
+# CHECK:      live symbol: test_b
+# CHECK-NEXT: >>> alive because of {{.*}}.o:(.test_a)
+# CHECK-NEXT: >>> alive because of test_a
+# CHECK-NEXT: >>> alive because of {{.*}}.o:(._start)
+# CHECK-NEXT: >>> alive because of _start
 
 .globl _start
 .section ._start,"ax",@progbits
 _start:
-jmp a
+# DO NOT SUBMIT: If this reads, "jmp a", then LLD hangs.
+jmp test_a
 
-.globl a
-.section .a,"ax",@progbits
-a:
-jmp a
+.globl test_a
+.section .test_a,"ax",@progbits
+test_a:
+jmp test_a
+
+# This is alive merely by virtue of being a member of test_a.
+.globl test_b
+test_b:
+jmp test_b
 

--- a/lld/test/ELF/why-live.s
+++ b/lld/test/ELF/why-live.s
@@ -42,3 +42,7 @@ jmp test_from_unsized
 .section .test_dead,"ax",@progbits
 test_dead:
 jmp test_dead
+
+## Undefined symbols are not considered live.
+# RUN: ld.lld %t.o -o /dev/null --gc-sections --why-live=test_undef -u test_undef | count 0
+


### PR DESCRIPTION
This adds a loose port of the MachO why-live flag to ELF LLD.

This flag takes a glob matching symbols for which to report liveness information. The flag can be specified multiple times. For each symbol, a chain of objects is reported from GC root to that symbol.

A reported object is either a symbol or a section. Sections might be alive by virtue of some symbol within them being alive. Symbols might be alive either by being directly referenced by another symbol or just by virtue of being within a live section. Both symbols and sections may intrinsically be alive for various internal or flag reasons; these are the GC roots.