### PR TITLE
[test][clang][AArch64] Don't assume current dir is writeable

### DIFF
--- a/clang/test/CodeGen/AArch64/fixed-register-global.c
+++ b/clang/test/CodeGen/AArch64/fixed-register-global.c
@@ -2,13 +2,13 @@
 /// Regression test for #76426, #109778
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang -c --target=aarch64-none-gnu -ffixed-x15 %s 2>&1 | count 0
+// RUN: %clang -c --target=aarch64-none-gnu -ffixed-x15 %s -o /dev/null 2>&1 | count 0
 
-// RUN: not %clang -c --target=aarch64-none-gnu %s 2>&1 | \
+// RUN: not %clang -c --target=aarch64-none-gnu %s -o /dev/null 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=ERR_INVREG
 // ERR_INVREG: error: register 'x15' unsuitable for global register variables on this target
 
-// RUN: not %clang -c --target=aarch64-none-gnu -ffixed-x15 -DTYPE=short %s 2>&1 | \
+// RUN: not %clang -c --target=aarch64-none-gnu -ffixed-x15 -DTYPE=short %s -o /dev/null 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=ERR_SIZE
 // ERR_SIZE: error: size of register 'x15' does not match variable size
 


### PR DESCRIPTION
afa2fbf87a8e3fff609fd325c938929c48e94280 adds a test which can fail with `error: unable to open output file 'fixed-register-global.o': 'Permission denied'`. We don't check the output file at all, so just use /dev/null.