### PR TITLE
[flang] Disabled hlfir.sum inlining by default.

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/SimplifyHLFIRIntrinsics.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/SimplifyHLFIRIntrinsics.cpp
@@ -29,6 +29,10 @@ namespace hlfir {
 #include "flang/Optimizer/HLFIR/Passes.h.inc"
 } // namespace hlfir
 
+static llvm::cl::opt<bool>
+    simplifySum("flang-simplify-hlfir-sum",
+                llvm::cl::desc("Expand hlfir.sum into an inline sequence"),
+                llvm::cl::init(false));
 namespace {
 
 class TransposeAsElementalConversion
@@ -349,6 +353,8 @@ public:
     // expanding the SUM into a total reduction loop nest
     // would avoid creating a temporary for the elemental array expression.
     target.addDynamicallyLegalOp<hlfir::SumOp>([](hlfir::SumOp sum) {
+      if (!simplifySum)
+        return true;
       if (mlir::Value dim = sum.getDim()) {
         if (auto dimVal = fir::getIntIfConstant(dim)) {
           if (!fir::isa_trivial(sum.getType())) {

--- a/flang/test/HLFIR/simplify-hlfir-intrinsics-sum.fir
+++ b/flang/test/HLFIR/simplify-hlfir-intrinsics-sum.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt --simplify-hlfir-intrinsics %s | FileCheck %s
+// RUN: fir-opt --simplify-hlfir-intrinsics -flang-simplify-hlfir-sum %s | FileCheck %s
 
 // box with known extents
 func.func @sum_box_known_extents(%arg0: !fir.box<!fir.array<2x3xi32>>) {


### PR DESCRIPTION
To temporarily address exchange2 perf regression reported in #118556
I disabled the inlining by default, and put it under engineering
option `-flang-simplify-hlfir-sum`.
