### PR TITLE
[LLD][COFF] Store machine type in SymbolTable (NFC)

### DIFF
--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -167,7 +167,7 @@ public:
 
   void getBaserels(std::vector<Baserel> *res) override {
     if (file->impchkThunk)
-      res->emplace_back(rva, file->symtab.ctx.config.machine);
+      res->emplace_back(rva, file->symtab.machine);
   }
 
 private:

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -596,6 +596,7 @@ void LinkerDriver::setMachine(MachineTypes machine) {
   assert(machine != IMAGE_FILE_MACHINE_UNKNOWN);
 
   ctx.config.machine = machine;
+  ctx.symtab.machine = machine;
   addWinSysRootLibSearchPaths();
 }
 

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -551,7 +551,7 @@ Symbol *ObjFile::createUndefined(COFFSymbolRef sym, bool overrideLazy) {
 
   // Add an anti-dependency alias for undefined AMD64 symbols on the ARM64EC
   // target.
-  if (isArm64EC(symtab.ctx.config.machine) && getMachineType() == AMD64) {
+  if (symtab.isEC() && getMachineType() == AMD64) {
     auto u = dyn_cast<Undefined>(s);
     if (u && !u->weakAlias) {
       if (std::optional<std::string> mangledName =
@@ -1035,7 +1035,7 @@ ObjFile::getVariableLocation(StringRef var) {
     if (!dwarf)
       return std::nullopt;
   }
-  if (symtab.ctx.config.machine == I386)
+  if (symtab.machine == I386)
     var.consume_front("_");
   std::optional<std::pair<std::string, unsigned>> ret =
       dwarf->getVariableLoc(var);
@@ -1139,7 +1139,7 @@ void ImportFile::parse() {
 
   bool isCode = hdr->getType() == llvm::COFF::IMPORT_CODE;
 
-  if (symtab.ctx.config.machine != ARM64EC) {
+  if (!symtab.isEC()) {
     impSym = symtab.addImportData(impName, this, location);
   } else {
     // In addition to the regular IAT, ARM64EC also contains an auxiliary IAT,
@@ -1175,7 +1175,7 @@ void ImportFile::parse() {
   // address pointed by the __imp_ symbol. (This allows you to call
   // DLL functions just like regular non-DLL functions.)
   if (isCode) {
-    if (symtab.ctx.config.machine != ARM64EC) {
+    if (!symtab.isEC()) {
       thunkSym = symtab.addImportThunk(name, impSym, makeImportThunk());
     } else {
       thunkSym = symtab.addImportThunk(

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -300,7 +300,7 @@ void SymbolTable::loadMinGWSymbols() {
 
     StringRef name = undef->getName();
 
-    if (ctx.config.machine == I386 && ctx.config.stdcallFixup) {
+    if (machine == I386 && ctx.config.stdcallFixup) {
       // Check if we can resolve an undefined decorated symbol by finding
       // the intended target as an undecorated symbol (only with a leading
       // underscore).
@@ -524,7 +524,7 @@ bool SymbolTable::resolveRemainingUndefines() {
 
       StringRef impName = name.substr(strlen("__imp_"));
       Symbol *imp = findLocalSym(impName);
-      if (!imp && isArm64EC(ctx.config.machine)) {
+      if (!imp && isEC()) {
         // Try to use the mangled symbol on ARM64EC.
         std::optional<std::string> mangledName =
             getArm64ECMangledFunctionName(impName);
@@ -582,7 +582,7 @@ std::pair<Symbol *, bool> SymbolTable::insert(StringRef name) {
     sym->canInline = true;
     inserted = true;
 
-    if (isArm64EC(ctx.config.machine) && name.starts_with("EXP+"))
+    if (isEC() && name.starts_with("EXP+"))
       expSymbols.push_back(sym);
   }
   return {sym, inserted};
@@ -700,8 +700,7 @@ bool checkLazyECPair(SymbolTable *symtab, StringRef name, InputFile *f) {
 
 void SymbolTable::addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym) {
   StringRef name = sym.getName();
-  if (isArm64EC(ctx.config.machine) &&
-      !checkLazyECPair<LazyArchive>(this, name, f))
+  if (isEC() && !checkLazyECPair<LazyArchive>(this, name, f))
     return;
   auto [s, wasInserted] = insert(name);
   if (wasInserted) {
@@ -709,8 +708,7 @@ void SymbolTable::addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym) {
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
-  if (!u || (u->weakAlias && !u->isECAlias(ctx.config.machine)) ||
-      s->pendingArchiveLoad)
+  if (!u || (u->weakAlias && !u->isECAlias(machine)) || s->pendingArchiveLoad)
     return;
   s->pendingArchiveLoad = true;
   f->addMember(sym);
@@ -718,7 +716,7 @@ void SymbolTable::addLazyArchive(ArchiveFile *f, const Archive::Symbol &sym) {
 
 void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
   assert(f->lazy);
-  if (isArm64EC(ctx.config.machine) && !checkLazyECPair<LazyObject>(this, n, f))
+  if (isEC() && !checkLazyECPair<LazyObject>(this, n, f))
     return;
   auto [s, wasInserted] = insert(n, f);
   if (wasInserted) {
@@ -726,8 +724,7 @@ void SymbolTable::addLazyObject(InputFile *f, StringRef n) {
     return;
   }
   auto *u = dyn_cast<Undefined>(s);
-  if (!u || (u->weakAlias && !u->isECAlias(ctx.config.machine)) ||
-      s->pendingArchiveLoad)
+  if (!u || (u->weakAlias && !u->isECAlias(machine)) || s->pendingArchiveLoad)
     return;
   s->pendingArchiveLoad = true;
   f->lazy = false;
@@ -939,7 +936,7 @@ Symbol *SymbolTable::find(StringRef name) const {
 }
 
 Symbol *SymbolTable::findUnderscore(StringRef name) const {
-  if (ctx.config.machine == I386)
+  if (machine == I386)
     return find(("_" + name).str());
   return find(name);
 }
@@ -986,7 +983,7 @@ Symbol *SymbolTable::findMangle(StringRef name) {
   };
 
   // For non-x86, just look for C++ functions.
-  if (ctx.config.machine != I386)
+  if (machine != I386)
     return findByPrefix("?" + name + "@@Y");
 
   if (!name.starts_with("_"))

--- a/lld/COFF/SymbolTable.h
+++ b/lld/COFF/SymbolTable.h
@@ -120,6 +120,9 @@ public:
                        uint32_t newSectionOffset = 0);
 
   COFFLinkerContext &ctx;
+  llvm::COFF::MachineTypes machine = IMAGE_FILE_MACHINE_UNKNOWN;
+
+  bool isEC() const { return machine == ARM64EC; }
 
   // A list of chunks which to be added to .rdata.
   std::vector<Chunk *> localImportChunks;


### PR DESCRIPTION
This change prepares for hybrid ARM64X support, which requires two `SymbolTable` instances: one for native symbols and one for EC symbols. In such cases, `config.machine` will remain ARM64X, while the `SymbolTable` instances will store ARM64 and ARM64EC machine types.

