### PR TITLE
[SPIRV][OPT] Adding flag to run spirv structurizer

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -37,6 +37,7 @@ void initializeSPIRVModuleAnalysisPass(PassRegistry &);
 void initializeSPIRVConvergenceRegionAnalysisWrapperPassPass(PassRegistry &);
 void initializeSPIRVPreLegalizerPass(PassRegistry &);
 void initializeSPIRVPostLegalizerPass(PassRegistry &);
+void initializeSPIRVStructurizerPass(PassRegistry &);
 void initializeSPIRVEmitIntrinsicsPass(PassRegistry &);
 void initializeSPIRVEmitNonSemanticDIPass(PassRegistry &);
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVPassRegistry.def
+++ b/llvm/lib/Target/SPIRV/SPIRVPassRegistry.def
@@ -1,0 +1,21 @@
+//===- SPIRVPassRegistry.def - Registry of SPIRV passes -----*- C++--*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is used as the registry of passes that are part of the
+// SPIRV backend.
+//
+//===----------------------------------------------------------------------===//
+
+// NOTE: NO INCLUDE GUARD DESIRED!
+
+
+#ifndef FUNCTION_PASS
+#define FUNCTION_PASS(NAME, CREATE_PASS)
+#endif
+FUNCTION_PASS("spirv-structurizer", SPIRVStructurizerWrapper())
+#undef FUNCTION_PASS

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -10,6 +10,7 @@
 
 #include "Analysis/SPIRVConvergenceRegionAnalysis.h"
 #include "SPIRV.h"
+#include "SPIRVStructurizerWrapper.h"
 #include "SPIRVSubtarget.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
@@ -17,6 +18,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/CodeGen/IntrinsicLowering.h"
+#include "llvm/IR/Analysis.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
@@ -1223,4 +1225,13 @@ INITIALIZE_PASS_END(SPIRVStructurizer, "spirv-structurizer",
 
 FunctionPass *llvm::createSPIRVStructurizerPass() {
   return new SPIRVStructurizer();
+}
+
+PreservedAnalyses SPIRVStructurizerWrapper::run(Function &F, FunctionAnalysisManager &AF){
+  FunctionPass *StructurizerPass = createSPIRVStructurizerPass();
+  if (!StructurizerPass->runOnFunction(F))
+    return PreservedAnalyses::all();
+  PreservedAnalyses PA;
+  PA.preserveSet<CFGAnalyses>();
+  return PA;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -1211,15 +1211,15 @@ public:
 
 char SPIRVStructurizer::ID = 0;
 
-INITIALIZE_PASS_BEGIN(SPIRVStructurizer, "structurizer", "structurize SPIRV",
-                      false, false)
+INITIALIZE_PASS_BEGIN(SPIRVStructurizer, "spirv-structurizer",
+                      "structurize SPIRV", false, false)
 INITIALIZE_PASS_DEPENDENCY(LoopSimplify)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(SPIRVConvergenceRegionAnalysisWrapperPass)
 
-INITIALIZE_PASS_END(SPIRVStructurizer, "structurizer", "structurize SPIRV",
-                    false, false)
+INITIALIZE_PASS_END(SPIRVStructurizer, "spirv-structurizer",
+                    "structurize SPIRV", false, false)
 
 FunctionPass *llvm::createSPIRVStructurizerPass() {
   return new SPIRVStructurizer();

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -1227,7 +1227,8 @@ FunctionPass *llvm::createSPIRVStructurizerPass() {
   return new SPIRVStructurizer();
 }
 
-PreservedAnalyses SPIRVStructurizerWrapper::run(Function &F, FunctionAnalysisManager &AF){
+PreservedAnalyses SPIRVStructurizerWrapper::run(Function &F,
+                                                FunctionAnalysisManager &AF) {
   FunctionPass *StructurizerPass = createSPIRVStructurizerPass();
   if (!StructurizerPass->runOnFunction(F))
     return PreservedAnalyses::all();

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -1218,7 +1218,7 @@ INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(SPIRVConvergenceRegionAnalysisWrapperPass)
 
-INITIALIZE_PASS_END(SPIRVStructurizer, "structurize", "structurize SPIRV",
+INITIALIZE_PASS_END(SPIRVStructurizer, "structurizer", "structurize SPIRV",
                     false, false)
 
 FunctionPass *llvm::createSPIRVStructurizerPass() {

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizerWrapper.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizerWrapper.h
@@ -1,0 +1,27 @@
+//===- SPIRVStructurizerWrapper.h - New pass manager wrapper from SPIRV Structurizer -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// \file New pass manager wrapper from SPIRV Structurizer.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_DIRECTX_SPIRVSTRUCTURIZER_H
+#define LLVM_LIB_TARGET_DIRECTX_SPIRVSTRUCTURIZER_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class SPIRVStructurizerWrapper : public PassInfoMixin<SPIRVStructurizerWrapper> {
+public:
+  PreservedAnalyses run(Function &M, FunctionAnalysisManager &AM);
+};
+
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_DIRECTX_SPIRVSTRUCTURIZER_H

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizerWrapper.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizerWrapper.h
@@ -1,4 +1,5 @@
-//===- SPIRVStructurizerWrapper.h - New pass manager wrapper from SPIRV Structurizer -----------*- C++ -*-===//
+//===- SPIRVStructurizerWrapper.h - New pass manager wrapper from SPIRV
+// Structurizer -----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -17,7 +18,8 @@
 
 namespace llvm {
 
-class SPIRVStructurizerWrapper : public PassInfoMixin<SPIRVStructurizerWrapper> {
+class SPIRVStructurizerWrapper
+    : public PassInfoMixin<SPIRVStructurizerWrapper> {
 public:
   PreservedAnalyses run(Function &M, FunctionAnalysisManager &AM);
 };

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -12,10 +12,10 @@
 
 #include "SPIRVTargetMachine.h"
 #include "SPIRV.h"
-#include "SPIRVStructurizerWrapper.h"
 #include "SPIRVCallLowering.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVLegalizerInfo.h"
+#include "SPIRVStructurizerWrapper.h"
 #include "SPIRVTargetObjectFile.h"
 #include "SPIRVTargetTransformInfo.h"
 #include "TargetInfo/SPIRVTargetInfo.h"

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -12,6 +12,7 @@
 
 #include "SPIRVTargetMachine.h"
 #include "SPIRV.h"
+#include "SPIRVStructurizerWrapper.h"
 #include "SPIRVCallLowering.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVLegalizerInfo.h"
@@ -28,6 +29,7 @@
 #include "llvm/InitializePasses.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Pass.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/Scalar/Reg2Mem.h"
 #include "llvm/Transforms/Utils.h"
@@ -91,6 +93,11 @@ SPIRVTargetMachine::SPIRVTargetMachine(const Target &T, const Triple &TT,
   setFastISel(false);
   setO0WantsFastISel(false);
   setRequiresStructuredCFG(false);
+}
+
+void SPIRVTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
+#define GET_PASS_REGISTRY "SPIRVPassRegistry.def"
+#include "llvm/Passes/TargetPassRegistry.inc"
 }
 
 namespace {

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -45,6 +45,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTarget() {
   initializeGlobalISel(PR);
   initializeSPIRVModuleAnalysisPass(PR);
   initializeSPIRVConvergenceRegionAnalysisWrapperPassPass(PR);
+  initializeSPIRVStructurizerPass(PR);
 }
 
 static std::string computeDataLayout(const Triple &TT) {

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.h
@@ -43,7 +43,7 @@ public:
   TargetLoweringObjectFile *getObjFileLowering() const override {
     return TLOF.get();
   }
-  
+
   void registerPassBuilderCallbacks(PassBuilder &PB) override;
 };
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.h
@@ -43,6 +43,8 @@ public:
   TargetLoweringObjectFile *getObjFileLowering() const override {
     return TLOF.get();
   }
+  
+  void registerPassBuilderCallbacks(PassBuilder &PB) override;
 };
 } // namespace llvm
 

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -376,7 +376,7 @@ static bool shouldPinPassToLegacyPM(StringRef Pass) {
       "expand-large-fp-convert",
       "callbrprepare",
       "scalarizer",
-      "structurizer"};
+      "spirv-structurizer"};
   for (const auto &P : PassNamePrefix)
     if (Pass.starts_with(P))
       return true;

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -376,7 +376,7 @@ static bool shouldPinPassToLegacyPM(StringRef Pass) {
       "expand-large-fp-convert",
       "callbrprepare",
       "scalarizer",
-      };
+  };
   for (const auto &P : PassNamePrefix)
     if (Pass.starts_with(P))
       return true;

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -376,7 +376,7 @@ static bool shouldPinPassToLegacyPM(StringRef Pass) {
       "expand-large-fp-convert",
       "callbrprepare",
       "scalarizer",
-  };
+      "structurizer"};
   for (const auto &P : PassNamePrefix)
     if (Pass.starts_with(P))
       return true;

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -376,7 +376,7 @@ static bool shouldPinPassToLegacyPM(StringRef Pass) {
       "expand-large-fp-convert",
       "callbrprepare",
       "scalarizer",
-      "spirv-structurizer"};
+      };
   for (const auto &P : PassNamePrefix)
     if (Pass.starts_with(P))
       return true;


### PR DESCRIPTION
This PR adds a new flag into OPT to run SPIRV structurizer, this is being added improving testing of such pass.

This change is required to implement a test request that come https://github.com/llvm/llvm-project/pull/116331.