### PR TITLE
[ubsan] Don't merge non-trap handlers if -ubsan-unique-traps or not optimized

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -3581,9 +3581,10 @@ static void emitCheckHandlerCall(CodeGenFunction &CGF,
                                llvm::AttributeList::FunctionIndex, B),
       /*Local=*/true);
   llvm::CallInst *HandlerCall = CGF.EmitNounwindRuntimeCall(Fn, FnArgs);
-  bool NoMerge = ClSanitizeDebugDeoptimization ||
-                 !CGF.CGM.getCodeGenOpts().OptimizationLevel ||
-                 (CGF.CurCodeDecl && CGF.CurCodeDecl->hasAttr<OptimizeNoneAttr>());
+  bool NoMerge =
+      ClSanitizeDebugDeoptimization ||
+      !CGF.CGM.getCodeGenOpts().OptimizationLevel ||
+      (CGF.CurCodeDecl && CGF.CurCodeDecl->hasAttr<OptimizeNoneAttr>());
   // Regular runtime provides a backtrace, making NoMerge a waste of space
   if (NoMerge && MinimalRuntime)
     HandlerCall->addFnAttr(llvm::Attribute::NoMerge);

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -3585,8 +3585,7 @@ static void emitCheckHandlerCall(CodeGenFunction &CGF,
       ClSanitizeDebugDeoptimization ||
       !CGF.CGM.getCodeGenOpts().OptimizationLevel ||
       (CGF.CurCodeDecl && CGF.CurCodeDecl->hasAttr<OptimizeNoneAttr>());
-  // Regular runtime provides a backtrace, making NoMerge a waste of space
-  if (NoMerge && MinimalRuntime)
+  if (NoMerge)
     HandlerCall->addFnAttr(llvm::Attribute::NoMerge);
   if (!MayReturn) {
     HandlerCall->setDoesNotReturn();

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -3581,6 +3581,12 @@ static void emitCheckHandlerCall(CodeGenFunction &CGF,
                                llvm::AttributeList::FunctionIndex, B),
       /*Local=*/true);
   llvm::CallInst *HandlerCall = CGF.EmitNounwindRuntimeCall(Fn, FnArgs);
+  bool NoMerge = ClSanitizeDebugDeoptimization ||
+                 !CGF.CGM.getCodeGenOpts().OptimizationLevel ||
+                 (CGF.CurCodeDecl && CGF.CurCodeDecl->hasAttr<OptimizeNoneAttr>());
+  // Regular runtime provides a backtrace, making NoMerge a waste of space
+  if (NoMerge && MinimalRuntime)
+    HandlerCall->addFnAttr(llvm::Attribute::NoMerge);
   if (!MayReturn) {
     HandlerCall->setDoesNotReturn();
     CGF.Builder.CreateUnreachable();

--- a/clang/test/CodeGen/ubsan-trap-merge.c
+++ b/clang/test/CodeGen/ubsan-trap-merge.c
@@ -265,5 +265,5 @@ int m(int x, int y) {
   return f(x) + g(y);
 }
 // TRAP: attributes #[[ATTR4]] = { nomerge noreturn nounwind }
-// HANDLER: attributes #[[ATTR4]] = { noreturn nounwind }
+// HANDLER: attributes #[[ATTR4]] = { nomerge noreturn nounwind }
 // MINRT: attributes #[[ATTR4]] = { nomerge noreturn nounwind }

--- a/clang/test/CodeGen/ubsan-trap-merge.c
+++ b/clang/test/CodeGen/ubsan-trap-merge.c
@@ -266,4 +266,4 @@ int m(int x, int y) {
 }
 // TRAP: attributes #[[ATTR4]] = { nomerge noreturn nounwind }
 // HANDLER: attributes #[[ATTR4]] = { noreturn nounwind }
-// MINRT: attributes #[[ATTR4]] = { noreturn nounwind }
+// MINRT: attributes #[[ATTR4]] = { nomerge noreturn nounwind }

--- a/clang/test/CodeGenCXX/catch-undef-behavior.cpp
+++ b/clang/test/CodeGenCXX/catch-undef-behavior.cpp
@@ -734,6 +734,6 @@ void ThisAlign::this_align_lambda_2() {
   p();
 }
 
-// CHECK: attributes [[NR_NUW]] = { nomerge noreturn nounwind }
+// CHECK: attributes [[NR_NUW]] = { noreturn nounwind }
 
 // CHECK-FUNCSAN: ![[FUNCSAN]] = !{i32 -1056584962, i32 -1000226989}

--- a/clang/test/CodeGenCXX/catch-undef-behavior.cpp
+++ b/clang/test/CodeGenCXX/catch-undef-behavior.cpp
@@ -734,6 +734,6 @@ void ThisAlign::this_align_lambda_2() {
   p();
 }
 
-// CHECK: attributes [[NR_NUW]] = { noreturn nounwind }
+// CHECK: attributes [[NR_NUW]] = { nomerge noreturn nounwind }
 
 // CHECK-FUNCSAN: ![[FUNCSAN]] = !{i32 -1056584962, i32 -1000226989}


### PR DESCRIPTION
UBSan handler calls can sometimes be merged by the backend, which complicates debugging. Merging is currently disabled for UBSan traps if -ubsan-unique-traps is specified or if optimization is disabled. This patch applies the same policy to non-trap handler calls.

N.B. "-ubsan-unique-traps" becomes somewhat of a misnomer since it will now apply to non-trap handler calls as well as traps. We keep the naming for backwards compatibility.