### PR TITLE
[mlir][LLVM] Fix missing MLIRNVGPUDialect dependency for MLIRGPUToNVVMTransforms

### DIFF
--- a/mlir/lib/Conversion/GPUToNVVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/GPUToNVVM/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_conversion_library(MLIRGPUToNVVMTransforms
   MLIRLLVMCommonConversion
   MLIRLLVMDialect
   MLIRMemRefToLLVM
+  MLIRNVGPUDialect
   MLIRNVVMDialect
   MLIRPass
   MLIRTransformUtils


### PR DESCRIPTION
This patch adds the missing MLIRNVGPUDialect dependency for MLIRGPUToNVVMTransforms, which comes from [LowerGpuOpsToNVVMOps.cpp](https://github.com/llvm/llvm-project/blob/7498eaa9abf2e4ac0c10fa9a02576d708cc1b624/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp#L34)