### PR TITLE
[test][clang][driver] Fix test that assumes libomp default

### DIFF
--- a/clang/test/Driver/config-file.c
+++ b/clang/test/Driver/config-file.c
@@ -85,9 +85,9 @@
 
 //--- The linker input flags should be moved to the end of input list and appear only when linking.
 // RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-l.cfg %s -lmylib -Wl,foo.a -### 2>&1 | FileCheck %s -check-prefix CHECK-LINKING
-// RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-l.cfg -fopenmp %s -lmylib -Wl,foo.a -### 2>&1 | FileCheck %s -check-prefix CHECK-LINKING-LIBOMP-GOES-AFTER
+// RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-l.cfg -fopenmp=libomp %s -lmylib -Wl,foo.a -### 2>&1 | FileCheck %s -check-prefix CHECK-LINKING-LIBOMP-GOES-AFTER
 // RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-l.cfg -S %s -### 2>&1 | FileCheck %s -check-prefix CHECK-NOLINKING
-// RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-l.cfg -fopenmp -S %s -### 2>&1 | FileCheck %s -check-prefix CHECK-NOLINKING-OPENMP
+// RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-l.cfg -fopenmp=libomp -S %s -### 2>&1 | FileCheck %s -check-prefix CHECK-NOLINKING-OPENMP
 // RUN: %clang --target=x86_64-pc-windows-msvc    --config %S/Inputs/config-l.cfg %s -lmylib -Wl,foo.lib -### 2>&1 | FileCheck %s -check-prefix CHECK-LINKING-MSVC
 // RUN: %clang --target=x86_64-pc-windows-msvc    --config %S/Inputs/config-l.cfg -S %s -### 2>&1 | FileCheck %s -check-prefix CHECK-NOLINKING-MSVC
 // CHECK-LINKING: Configuration file: {{.*}}Inputs{{.}}config-l.cfg


### PR DESCRIPTION
755519f7f661375be05750001ff11e106e6b7f87 added a test that uses `-fopenmp`. The default configuration of CLANG_DEFAULT_OPENMP_RUNTIME is libomp, which causes `-fopenmp` to act as `-fopenmp=libomp`. In turn, this passes `-fopenmp` to downstream compilations. However, for other values, e.g. `libgomp`, Clang does not know how to generate useful openmp code, so it avoids passing the `-fopenmp` along. Fix the test to explicitly pass `-fopenmp=libomp` to pass regardless of the configured CLANG_DEFAULT_OPENMP_RUNTIME value.