### PR TITLE
[scudo] Clean the TODO in list.h

### DIFF
--- a/compiler-rt/lib/scudo/standalone/list.h
+++ b/compiler-rt/lib/scudo/standalone/list.h
@@ -48,10 +48,11 @@ public:
 
 template <class T> class LinkOp<T, /*LinkWithPtr=*/false> {
 public:
-  using LinkTy = decltype(T::Next);
+  using LinkTy = typename assertSameType<
+      typename removeConst<decltype(T::Next)>::type,
+      typename removeConst<decltype(T::EndOfListVal)>::type>::type;
 
   LinkOp() = default;
-  // TODO: Check if the `BaseSize` can fit in `Size`.
   LinkOp(T *BaseT, uptr BaseSize)
       : Base(BaseT), Size(static_cast<LinkTy>(BaseSize)) {}
   void init(T *LinkBase, uptr BaseSize) {
@@ -70,11 +71,12 @@ public:
   }
   // Set `X->Next` to `Next`.
   void setNext(T *X, T *Next) const {
-    // TODO: Check if the offset fits in the size of `LinkTy`.
-    if (Next == nullptr)
+    if (Next == nullptr) {
       X->Next = getEndOfListVal();
-    else
+    } else {
+      DCHECK_LE(static_cast<LinkTy>(Next - Base), Size);
       X->Next = static_cast<LinkTy>(Next - Base);
+    }
   }
 
   T *getPrev(T *X) const {
@@ -94,7 +96,6 @@ public:
       X->Prev = static_cast<LinkTy>(Prev - Base);
   }
 
-  // TODO: `LinkTy` should be the same as decltype(T::EndOfListVal).
   LinkTy getEndOfListVal() const { return T::EndOfListVal; }
 
 protected:


### PR DESCRIPTION
* Finished the type and size verification
* Remove the TODO for checking if array size can be fit into LinkTy because if there's a truncation happens, other DCHECK like offset checking will catch the failure. In addition, it's supposed to be a rare case.