### PR TITLE
[clang][bytecode] Allow checking builtin functions...

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1360,7 +1360,10 @@ bool CallVirt(InterpState &S, CodePtr OpPC, const Function *Func,
 
 bool CallBI(InterpState &S, CodePtr OpPC, const Function *Func,
             const CallExpr *CE, uint32_t BuiltinID) {
-  if (S.checkingPotentialConstantExpression())
+  // A little arbitrary, but the current interpreter allows evaluation
+  // of builtin functions in this mode, with some exceptions.
+  if (BuiltinID == Builtin::BI__builtin_operator_new &&
+      S.checkingPotentialConstantExpression())
     return false;
   auto NewFrame = std::make_unique<InterpFrame>(S, Func, OpPC);
 

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1198,11 +1198,11 @@ namespace BuiltinMemcpy {
   }
   static_assert(simpleMove() == 12);
 
-  constexpr int memcpyTypeRem() { // ref-error {{never produces a constant expression}}
+  constexpr int memcpyTypeRem() { // both-error {{never produces a constant expression}}
     int a = 12;
     int b = 0;
     __builtin_memmove(&b, &a, 1); // both-note {{'memmove' not supported: size to copy (1) is not a multiple of size of element type 'int'}} \
-                                  // ref-note {{not supported}}
+                                  // both-note {{not supported}}
     return b;
   }
   static_assert(memcpyTypeRem() == 12); // both-error {{not an integral constant expression}} \


### PR DESCRIPTION
... in checkingPotentialConstantExpression mode. This is what the current interpreter does, yet it doesn't do so for `__builtin_operator_new`.