### PR TITLE
Fix a bug that CXXConstructExpr wasn't recognized by tryToFindPtrOrigin

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -33,7 +33,7 @@ bool tryToFindPtrOrigin(
       E = tempExpr->getSubExpr();
       continue;
     }
-    if (auto *tempExpr = dyn_cast<CXXTemporaryObjectExpr>(E)) {
+    if (auto *tempExpr = dyn_cast<CXXConstructExpr>(E)) {
       if (auto *C = tempExpr->getConstructor()) {
         if (auto *Class = C->getParent(); Class && isSafePtr(Class))
           return callback(E, true);

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -364,4 +364,15 @@ namespace call_with_explicit_temporary_obj {
     Ref { *provide() }->method();
     RefPtr { provide() }->method();
   }
+  template <typename T>
+  void bar() {
+    Ref { *provide() }->method();
+    RefPtr { provide() }->method();
+  }
+  void baz() {
+    bar<int>();
+  }
+}
+
+namespace call_with_explicit_construct {
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -366,8 +366,8 @@ namespace call_with_explicit_temporary_obj {
   }
   template <typename T>
   void bar() {
-    Ref { *provide() }->method();
-    RefPtr { provide() }->method();
+    Ref(*provide())->method();
+    RefPtr(provide())->method();
   }
   void baz() {
     bar<int>();


### PR DESCRIPTION
Prior to this PR, only CXXTemporaryObjectExpr, not CXXConstructExpr was recognized in tryToFindPtrOrigin.