### PR TITLE
UncountedLocalVarsChecker and UncheckedLocalVarsChecker should recognize signletons.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -263,7 +263,7 @@ public:
       if (tryToFindPtrOrigin(
               Value, /*StopAtFirstRefCountedObj=*/false,
               [&](const clang::Expr *InitArgOrigin, bool IsSafe) {
-                if (!InitArgOrigin)
+                if (!InitArgOrigin || IsSafe)
                   return true;
 
                 if (isa<CXXThisExpr>(InitArgOrigin))

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -456,3 +456,12 @@ int TreeNode::recursiveWeight() {
 }
 
 } // namespace local_var_in_recursive_function
+
+namespace local_var_for_singleton {
+  RefCountable *singleton();
+  RefCountable *otherSingleton();
+  void foo() {
+    RefCountable* bar = singleton();
+    RefCountable* baz = otherSingleton();
+  }
+}


### PR DESCRIPTION
It's safe to have a raw pointer or a raw reference to a singleton object. Explicitly allow this in UncountedLocalVarsChecker and UncheckedLocalVarsChecker.