### PR TITLE
[Clang] Don't check incomplete CXXRecordDecl's members when transforming sizeof...(expr)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -796,6 +796,7 @@ Bug Fixes to C++ Support
 - Fixed an assertion failure caused by using ``consteval`` in condition in consumed analyses. (#GH117385)
 - Fix a crash caused by incorrect argument position in merging deduced template arguments. (#GH113659)
 - Fixed a parser crash when using pack indexing as a nested name specifier. (#GH119072) 
+- Fixed a null pointer dereference issue when heuristically computing ``sizeof...(pack)`` expressions. (#GH81436)
 - Fixed an assertion failure caused by mangled names with invalid identifiers. (#GH112205)
 - Fixed an incorrect lambda scope of generic lambdas that caused Clang to crash when computing potential lambda
   captures at the end of a full expression. (#GH115931)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19297,7 +19297,7 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
       if (VD->getType()->isReferenceType())
         return true;
       if (auto *RD = VD->getType()->getAsCXXRecordDecl())
-        if (RD->hasMutableFields())
+        if (RD->hasDefinition() && RD->hasMutableFields())
           return true;
       if (!VD->isUsableInConstantExpressions(S.Context))
         return true;

--- a/clang/test/CXX/temp/temp.decls/temp.variadic/sizeofpack.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.variadic/sizeofpack.cpp
@@ -1,3 +1,4 @@
+// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
 // expected-no-diagnostics
 
@@ -202,6 +203,7 @@ void func()
 
 }
 
+#if __cplusplus >= 202002L
 namespace GH81436 {
 
 template <class E> struct Bar;
@@ -220,3 +222,4 @@ auto func() requires requires(Bar<Ts> ...init_lists) {
 void f() { func<int>(); }
 
 } // namespace GH81436
+#endif

--- a/clang/test/CXX/temp/temp.decls/temp.variadic/sizeofpack.cpp
+++ b/clang/test/CXX/temp/temp.decls/temp.variadic/sizeofpack.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 namespace pr12262 {
@@ -201,3 +201,22 @@ void func()
 }
 
 }
+
+namespace GH81436 {
+
+template <class E> struct Bar;
+
+template <class E>
+Bar(E) -> Bar<E>;
+
+template <int> struct Foo {};
+
+// Bar<Ts> doesn't have to be of a complete type.
+template <class... Ts>
+auto func() requires requires(Bar<Ts> ...init_lists) {
+  sizeof...(init_lists) > 0;
+} {}
+
+void f() { func<int>(); }
+
+} // namespace GH81436


### PR DESCRIPTION
For a FunctionParmPackExpr that is used as the argument of a sizeof...(pack) expression, we might exercise the logic that checks the CXXRecordDecl's members regardless of the type being incomplete, when rebuilding the DeclRefExpr into non-ODR-used forms.

Fixes https://github.com/llvm/llvm-project/issues/81436