### PR TITLE
[Passes] Manage extra passes using inner pass managers (NFC).

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/ExtraPassManager.h
+++ b/llvm/include/llvm/Transforms/Utils/ExtraPassManager.h
@@ -71,6 +71,8 @@ public:
     PA.abandon<MarkerTy>();
     return PA;
   }
+
+  static bool isRequired() { return true; }
 };
 
 /// A pass manager to run a set of extra loop passes if the MarkerTy analysis is
@@ -94,6 +96,8 @@ public:
     PA.abandon<MarkerTy>();
     return PA;
   }
+
+  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -366,6 +366,8 @@ FUNCTION_PASS("dwarf-eh-prepare", DwarfEHPreparePass(TM))
 FUNCTION_PASS("expand-large-div-rem", ExpandLargeDivRemPass(TM))
 FUNCTION_PASS("expand-large-fp-convert", ExpandLargeFpConvertPass(TM))
 FUNCTION_PASS("expand-memcmp", ExpandMemCmpPass(TM))
+FUNCTION_PASS("extra-vector-passes",
+                  ExtraFunctionPassManager<ShouldRunExtraVectorPasses>())
 FUNCTION_PASS("fix-irreducible", FixIrreduciblePass())
 FUNCTION_PASS("flatten-cfg", FlattenCFGPass())
 FUNCTION_PASS("float2int", Float2IntPass())
@@ -651,6 +653,8 @@ LOOP_ANALYSIS("should-run-extra-simple-loop-unswitch",
 LOOP_PASS("canon-freeze", CanonicalizeFreezeInLoopsPass())
 LOOP_PASS("dot-ddg", DDGDotPrinterPass())
 LOOP_PASS("guard-widening", GuardWideningPass())
+LOOP_PASS("extra-simple-loop-unswitch-passes",
+              ExtraLoopPassManager<ShouldRunExtraSimpleLoopUnswitch>())
 LOOP_PASS("indvars", IndVarSimplifyPass())
 LOOP_PASS("invalidate<all>", InvalidateAllAnalysesPass())
 LOOP_PASS("loop-bound-split", LoopBoundSplitPass())


### PR DESCRIPTION
As suggested post-commit for
https://github.com/llvm/llvm-project/pull/118323, adjust the extra pass managers to no inherit from Function/LoopPassManager, but manage the extra passes via member pass managers.