### PR TITLE
Nominating Sven van Haastregt as OpenCL maintainer in Clang

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -320,8 +320,8 @@ OpenMP conformance
 
 OpenCL conformance
 ~~~~~~~~~~~~~~~~~~
-| Anastasia Stulova
-| anastasia\@compiler-experts.com (email), Anastasia (Phabricator), AnastasiaStulova (GitHub)
+| Sven van Haastregt
+| sven.vanhaastregt@arm.com (email), svenvh (GitHub)
 
 
 OpenACC
@@ -365,6 +365,7 @@ Emeritus Lead Maintainers
 
 Inactive component maintainers
 ------------------------------
+| Anastasia Stulova (stulovaa\@gmail.com) -- OpenCL, C++ for OpenCL
 | Chandler Carruth (chandlerc\@gmail.com, chandlerc\@google.com) -- CMake, library layering
 | Devin Coughlin (dcoughlin\@apple.com) -- Clang static analyzer
 | Manuel Klimek (klimek\@google.com (email), klimek (Phabricator), r4nt (GitHub)) -- Tooling, AST matchers


### PR DESCRIPTION
Sven has been a long-standing contributor to OpenCL support in Clang and LLVM, consistently delivering high-quality commits and thorough code reviews. His deep expertise and proven track record demonstrate his commitment to advancing the project and maintaining its standards. I strongly believe Sven would excel as an OpenCL maintainer for Clang, ensuring the continued growth and reliability of OpenCL within the LLVM ecosystem.

Unfortunately, due to other commitments I am stepping down from my duty as an OpenCL maintainer.