### PR TITLE
[clang][bytecode] Check vector element types for eligibility

### DIFF
--- a/clang/test/AST/ByteCode/builtin-bit-cast.cpp
+++ b/clang/test/AST/ByteCode/builtin-bit-cast.cpp
@@ -502,3 +502,8 @@ namespace OversizedBitField {
                                                                                  // ref-note {{constexpr bit_cast involving bit-field is not yet supported}}
 #endif
 }
+
+typedef bool bool9 __attribute__((ext_vector_type(9)));
+// both-error@+2 {{constexpr variable 'bad_bool9_to_short' must be initialized by a constant expression}}
+// both-note@+1 {{bit_cast involving type 'bool __attribute__((ext_vector_type(9)))' (vector of 9 'bool' values) is not allowed in a constant expression; element size 1 * element count 9 is not a multiple of the byte size 8}}
+constexpr unsigned short bad_bool9_to_short = __builtin_bit_cast(unsigned short, bool9{1,1,0,1,0,1,0,1,0});


### PR DESCRIPTION
Like we do in ExprConstant.cpp.