### PR TITLE
Fix a cmake error when using the Xcode generator.

### DIFF
--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -109,13 +109,14 @@ macro(add_clang_library name)
   llvm_add_library(${name} ${LIBTYPE} ${ARG_UNPARSED_ARGUMENTS} ${srcs})
 
   if(MSVC AND NOT CLANG_LINK_CLANG_DYLIB)
-    # Make sure all consumers also turn off visibility macros so there not trying to dllimport symbols.
+    # Make sure all consumers also turn off visibility macros so they're not
+    # trying to dllimport symbols.
     target_compile_definitions(${name} PUBLIC CLANG_BUILD_STATIC)
     if(TARGET "obj.${name}")
       target_compile_definitions("obj.${name}" PUBLIC CLANG_BUILD_STATIC)
     endif()
-  elseif(NOT ARG_SHARED AND NOT ARG_STATIC)
-    # Clang component libraries linked in to clang-cpp are declared without SHARED or STATIC
+  elseif(TARGET "obj.${name}" AND NOT ARG_SHARED AND NOT ARG_STATIC)
+    # Clang component libraries linked to clang-cpp are declared without SHARED or STATIC
     target_compile_definitions("obj.${name}" PUBLIC CLANG_EXPORTS)
   endif()
 


### PR DESCRIPTION
I’m seeing a series of errors when trying to run the cmake configure step on macOS when the cmake generator is set to Xcode. All is well if I use the Ninja or Unix Makefile generators. Messages are all of the form:
~~~
CMake Error at …llvm-project/clang/cmake/modules/AddClang.cmake:120 (target_compile_definitions):
  Cannot specify compile definitions for target "obj.clangBasic" which
  is not built by this project.
Call Stack (most recent call first):
  …llvm-project/clang/lib/Basic/CMakeLists.txt:57 (add_clang_library)
~~~
The remaining errors are similar but mention targets obj.clangAPINotes, obj.clangLex, obj.clangParse, and so on.

The regression appears to have been introduced by commit 09fa2f012fcc (Oct 14 2024) which added the code in this area.

My proposed solution is simply to add a test to ensure that the obj.x target exists before setting its compile definitions. There is precedent doing just this in both clang/cmake/modules/AddClang.cmake and clang/lib/support/CMakeLists.txt as well as in the “MSVC AND NOT CLANG_LINK_CLANG_DYLIB” path immediately above the offending line.

I’ve also made a couple of grammatical tweaks in the comments surrounding this code.

In case it's relevant, the cmake settings and definitions I've used to trigger these errors is:
~~~bash
GENERATOR="Xcode"                                                                                                                                                                                                     
OUTDIR=build_macos                                                                                                                                                                                                    
cmake                                 \                                                                                                                                                                               
  -S "$SCRIPT_DIR/llvm"               \                                                                                                                                                                               
  -B "$SCRIPT_DIR/$OUTDIR"            \                                                                                                                                                                               
  -G "$GENERATOR"                     \                                                                                                                                                                               
  -D CMAKE_BUILD_TYPE=Release         \                                                                                                                                                                               
  -D CMAKE_OSX_ARCHITECTURES=arm64    \                                                                                                                                                                               
  -D LLVM_PARALLEL_LINK_JOBS=1        \                                                                                                                                                                               
  -D LLVM_ENABLE_PROJECTS="clang;lld" \                                                                                                                                                                               
  -D LLVM_TARGETS_TO_BUILD=RISCV      \                                                                                                                                                                               
  -D LLVM_DEFAULT_TARGET_TRIPLE=riscv32-unknown-elf \                                                                                                                                                                 
  -D LLVM_OPTIMIZED_TABLEGEN=Yes                                                                                                                                                                                      
~~~
(cmake v3.31.1, Xcode 16.1. I know that not all of these variables are useful for the Xcode generator!)