### PR TITLE
[flang] Ensure directive sentinels are in cols 1-5 in pp output

### DIFF
--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -159,8 +159,9 @@ void Parsing::EmitPreprocessedSource(
         // which signifies a comment (directive) in both source forms.
         inDirective = true;
       }
-      if (inDirective && directive.size() < directiveNameLength &&
-          IsLetter(ch)) {
+      bool inDirectiveSentinel{
+          inDirective && directive.size() < directiveNameLength};
+      if (inDirectiveSentinel && IsLetter(ch)) {
         directive += getOriginalChar(ch);
       }
 
@@ -211,7 +212,8 @@ void Parsing::EmitPreprocessedSource(
           out << ' ';
         }
       }
-      if (!inContinuation && position && position->column <= 72 && ch != ' ') {
+      if (!inContinuation && !inDirectiveSentinel && position &&
+          position->column <= 72 && ch != ' ') {
         // Preserve original indentation
         for (; column < position->column; ++column) {
           out << ' ';

--- a/flang/test/Preprocessing/pp132.f90
+++ b/flang/test/Preprocessing/pp132.f90
@@ -1,9 +1,10 @@
-! RUN: %flang -E -fopenmp -fopenacc %s 2>&1 | FileCheck %s
-! CHECK:  !$OMP parallel default(shared) private(super_very_long_name_for_the_va&
-! CHECK:  !$OMP&riable)
-! CHECK:  !$acc data copyin(super_very_long_name_for_the_variable, another_super&
-! CHECK:  !$acc&_wordy_variable_to_test)
-! Test correct continuations in compiler directives
+! RUN: %flang -E -fopenmp -fopenacc %s 2>&1 | FileCheck --strict-whitespace %s
+! CHECK:       {{^}}!$OMP   parallel default(shared) private(super_very_long_name_for_the_va&
+! CHECK-NEXT:  {{^}}!$OMP&riable)
+! CHECK:       {{^}}!$acc   data copyin(super_very_long_name_for_the_variable, another_super&
+! CHECK-NEXT:  {{^}}!$acc&_wordy_variable_to_test)
+! CHECK:       {{^}}!$OMP          something something
+! Test correct continuations in compiler directives and left-alignment of sentinels
 subroutine foo
   integer :: super_very_long_name_for_the_variable
   integer :: another_super_wordy_variable_to_test
@@ -15,4 +16,6 @@ subroutine foo
 
   !$acc data copyin(super_very_long_name_for_the_variable, another_super_wordy_variable_to_test)
   !$acc end data
+  
+         !$OMP something something
 end subroutine foo


### PR DESCRIPTION
Preprocessor output is intended to be valid fixed form.