### PR TITLE
[clang-format] Fix crashes when the macro expansion is empty

### DIFF
--- a/clang/lib/Format/MacroExpander.cpp
+++ b/clang/lib/Format/MacroExpander.cpp
@@ -234,7 +234,7 @@ MacroExpander::expand(FormatToken *ID,
     ++Result[0]->MacroCtx->StartOfExpansion;
     ++Result[Result.size() - 2]->MacroCtx->EndOfExpansion;
   } else {
-    // If the macro expansion is empty, mark the start and end
+    // If the macro expansion is empty, mark the start and end.
     Result[0]->MacroCtx->StartOfExpansion = 1;
     Result[0]->MacroCtx->EndOfExpansion = 1;
   }

--- a/clang/lib/Format/MacroExpander.cpp
+++ b/clang/lib/Format/MacroExpander.cpp
@@ -233,6 +233,10 @@ MacroExpander::expand(FormatToken *ID,
   if (Result.size() > 1) {
     ++Result[0]->MacroCtx->StartOfExpansion;
     ++Result[Result.size() - 2]->MacroCtx->EndOfExpansion;
+  } else {
+    // If the macro expansion is empty, mark the start and end
+    Result[0]->MacroCtx->StartOfExpansion = 1;
+    Result[0]->MacroCtx->EndOfExpansion = 1;
   }
   return Result;
 }

--- a/clang/test/Format/empty-macro.cpp
+++ b/clang/test/Format/empty-macro.cpp
@@ -1,0 +1,5 @@
+// RUN: grep -Ev "// *[A-Z-]+:" %s | clang-format -style="{Macros: [A(x)=x]}" \
+// RUN:   | FileCheck -strict-whitespace %s
+
+// CHECK: A()
+A()

--- a/clang/test/Format/empty-macro.cpp
+++ b/clang/test/Format/empty-macro.cpp
@@ -1,5 +1,0 @@
-// RUN: grep -Ev "// *[A-Z-]+:" %s | clang-format -style="{Macros: [A(x)=x]}" \
-// RUN:   | FileCheck -strict-whitespace %s
-
-// CHECK: A()
-A()

--- a/clang/unittests/Format/MacroCallReconstructorTest.cpp
+++ b/clang/unittests/Format/MacroCallReconstructorTest.cpp
@@ -219,7 +219,7 @@ TEST_F(MacroCallReconstructorTest, Identifier) {
   EXPECT_THAT(std::move(Unexp).takeResult(), matchesLine(line(U.consume("X"))));
 }
 
-TEST_F(MacroCallReconstructorTest, IdentifierObject) {
+TEST_F(MacroCallReconstructorTest, EmptyDefinition) {
   auto Macros = createExpander({"X"});
   Expansion Exp(Lex, *Macros);
   TokenList Call = Exp.expand("X");

--- a/clang/unittests/Format/MacroCallReconstructorTest.cpp
+++ b/clang/unittests/Format/MacroCallReconstructorTest.cpp
@@ -219,6 +219,18 @@ TEST_F(MacroCallReconstructorTest, Identifier) {
   EXPECT_THAT(std::move(Unexp).takeResult(), matchesLine(line(U.consume("X"))));
 }
 
+TEST_F(MacroCallReconstructorTest, IdentifierObject) {
+  auto Macros = createExpander({"X"});
+  Expansion Exp(Lex, *Macros);
+  TokenList Call = Exp.expand("X");
+
+  MacroCallReconstructor Unexp(0, Exp.getUnexpanded());
+  Unexp.addLine(line(Exp.getTokens()));
+  EXPECT_TRUE(Unexp.finished());
+  Matcher U(Call, Lex);
+  EXPECT_THAT(std::move(Unexp).takeResult(), matchesLine(line(U.consume("X"))));
+}
+
 TEST_F(MacroCallReconstructorTest, EmptyExpansion) {
   auto Macros = createExpander({"A(x)=x"});
   Expansion Exp(Lex, *Macros);

--- a/clang/unittests/Format/MacroCallReconstructorTest.cpp
+++ b/clang/unittests/Format/MacroCallReconstructorTest.cpp
@@ -65,7 +65,9 @@ private:
     }
     Unexpanded[ID] = std::move(UnexpandedLine);
 
-    auto Expanded = uneof(Macros.expand(ID, Args));
+    auto Expanded = Macros.expand(ID, Args);
+    if (Expanded.size() > 1)
+      Expanded = uneof(Expanded);
     Tokens.append(Expanded.begin(), Expanded.end());
 
     TokenList UnexpandedTokens;
@@ -218,7 +220,7 @@ TEST_F(MacroCallReconstructorTest, Identifier) {
 }
 
 TEST_F(MacroCallReconstructorTest, EmptyExpansion) {
-  auto Macros = createExpander({"A(x)=y"});
+  auto Macros = createExpander({"A(x)=x"});
   Expansion Exp(Lex, *Macros);
   TokenList Call = Exp.expand("A", {""});
 

--- a/clang/unittests/Format/MacroCallReconstructorTest.cpp
+++ b/clang/unittests/Format/MacroCallReconstructorTest.cpp
@@ -217,6 +217,19 @@ TEST_F(MacroCallReconstructorTest, Identifier) {
   EXPECT_THAT(std::move(Unexp).takeResult(), matchesLine(line(U.consume("X"))));
 }
 
+TEST_F(MacroCallReconstructorTest, EmptyExpansion) {
+  auto Macros = createExpander({"A(x)=y"});
+  Expansion Exp(Lex, *Macros);
+  TokenList Call = Exp.expand("A", {""});
+
+  MacroCallReconstructor Unexp(0, Exp.getUnexpanded());
+  Unexp.addLine(line(Exp.getTokens()));
+  EXPECT_TRUE(Unexp.finished());
+  Matcher U(Call, Lex);
+  EXPECT_THAT(std::move(Unexp).takeResult(),
+              matchesLine(line(U.consume("A()"))));
+}
+
 TEST_F(MacroCallReconstructorTest, NestedLineWithinCall) {
   auto Macros = createExpander({"C(a)=class X { a; };"});
   Expansion Exp(Lex, *Macros);


### PR DESCRIPTION
An empty expansion should be valid, like `echo 'A()' | clang-format --style='{Macros: [A(x)=x]}'`.

Fixes #119258.