### PR TITLE
[flang][OpenMP][NFC] Turn symTable into a reference

### DIFF
--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.cpp
@@ -38,7 +38,7 @@ DataSharingProcessor::DataSharingProcessor(
     lower::AbstractConverter &converter, semantics::SemanticsContext &semaCtx,
     const List<Clause> &clauses, lower::pft::Evaluation &eval,
     bool shouldCollectPreDeterminedSymbols, bool useDelayedPrivatization,
-    lower::SymMap *symTable)
+    lower::SymMap &symTable)
     : converter(converter), semaCtx(semaCtx),
       firOpBuilder(converter.getFirOpBuilder()), clauses(clauses), eval(eval),
       shouldCollectPreDeterminedSymbols(shouldCollectPreDeterminedSymbols),
@@ -93,7 +93,7 @@ void DataSharingProcessor::insertDeallocs() {
       fir::ExtendedValue symExV = converter.getSymbolExtendedValue(*sym);
       mlir::omp::PrivateClauseOp privatizer = symToPrivatizer.at(sym);
 
-      lower::SymMapScope scope(*symTable);
+      lower::SymMapScope scope(symTable);
       mlir::OpBuilder::InsertionGuard guard(firOpBuilder);
 
       mlir::Region &deallocRegion = privatizer.getDeallocRegion();
@@ -102,8 +102,8 @@ void DataSharingProcessor::insertDeallocs() {
           &deallocRegion, /*insertPt=*/{}, symType, symLoc);
 
       firOpBuilder.setInsertionPointToEnd(deallocEntryBlock);
-      symTable->addSymbol(*sym,
-                          fir::substBase(symExV, deallocRegion.getArgument(0)));
+      symTable.addSymbol(*sym,
+                         fir::substBase(symExV, deallocRegion.getArgument(0)));
 
       converter.createHostAssociateVarCloneDealloc(*sym);
       firOpBuilder.create<mlir::omp::YieldOp>(hsb.getAddr().getLoc());
@@ -474,7 +474,7 @@ void DataSharingProcessor::doPrivatize(const semantics::Symbol *sym,
         isFirstPrivate ? mlir::omp::DataSharingClauseType::FirstPrivate
                        : mlir::omp::DataSharingClauseType::Private);
     fir::ExtendedValue symExV = converter.getSymbolExtendedValue(*sym);
-    lower::SymMapScope outerScope(*symTable);
+    lower::SymMapScope outerScope(symTable);
 
     // Populate the `alloc` region.
     {
@@ -491,10 +491,10 @@ void DataSharingProcessor::doPrivatize(const semantics::Symbol *sym,
               evaluate::IsSimplyContiguous(*sym, converter.getFoldingContext()))
               .first;
 
-      symTable->addSymbol(*sym, localExV);
-      lower::SymMapScope innerScope(*symTable);
+      symTable.addSymbol(*sym, localExV);
+      lower::SymMapScope innerScope(symTable);
       cloneSymbol(sym);
-      mlir::Value cloneAddr = symTable->shallowLookupSymbol(*sym).getAddr();
+      mlir::Value cloneAddr = symTable.shallowLookupSymbol(*sym).getAddr();
       mlir::Type cloneType = cloneAddr.getType();
 
       // A `convert` op is required for variables that are storage associated
@@ -522,25 +522,24 @@ void DataSharingProcessor::doPrivatize(const semantics::Symbol *sym,
       auto addSymbol = [&](unsigned argIdx, bool force = false) {
         symExV.match(
             [&](const fir::MutableBoxValue &box) {
-              symTable->addSymbol(
+              symTable.addSymbol(
                   *sym, fir::substBase(box, copyRegion.getArgument(argIdx)),
                   force);
             },
             [&](const auto &box) {
-              symTable->addSymbol(*sym, copyRegion.getArgument(argIdx), force);
+              symTable.addSymbol(*sym, copyRegion.getArgument(argIdx), force);
             });
       };
 
       addSymbol(0, true);
-      lower::SymMapScope innerScope(*symTable);
+      lower::SymMapScope innerScope(symTable);
       addSymbol(1);
 
       auto ip = firOpBuilder.saveInsertionPoint();
       copyFirstPrivateSymbol(sym, &ip);
 
       firOpBuilder.create<mlir::omp::YieldOp>(
-          hsb.getAddr().getLoc(),
-          symTable->shallowLookupSymbol(*sym).getAddr());
+          hsb.getAddr().getLoc(), symTable.shallowLookupSymbol(*sym).getAddr());
     }
 
     return result;

--- a/flang/lib/Lower/OpenMP/DataSharingProcessor.h
+++ b/flang/lib/Lower/OpenMP/DataSharingProcessor.h
@@ -86,7 +86,7 @@ private:
   lower::pft::Evaluation &eval;
   bool shouldCollectPreDeterminedSymbols;
   bool useDelayedPrivatization;
-  lower::SymMap *symTable;
+  lower::SymMap &symTable;
   OMPConstructSymbolVisitor visitor;
 
   bool needBarrier();
@@ -122,8 +122,7 @@ public:
                        const List<Clause> &clauses,
                        lower::pft::Evaluation &eval,
                        bool shouldCollectPreDeterminedSymbols,
-                       bool useDelayedPrivatization = false,
-                       lower::SymMap *symTable = nullptr);
+                       bool useDelayedPrivatization, lower::SymMap &symTable);
 
   // Privatisation is split into two steps.
   // Step1 performs cloning of all privatisation clauses and copying for


### PR DESCRIPTION
Convert `DataSharingProcessor::symTable` from pointer to reference.
This avoids accidental null pointer dereferences and makes it
possible to use `symTable` when delayed privatization is disabled.
