### PR TITLE
[test][AArch64] Fix test in non-writeable dir

### DIFF
--- a/clang/test/Sema/aarch64-sve2-intrinsics/acle_sve2_fp8.c
+++ b/clang/test/Sema/aarch64-sve2-intrinsics/acle_sve2_fp8.c
@@ -1,6 +1,6 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sve -verify -emit-llvm %s
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sve -verify -emit-llvm -o - %s
 
 #include <arm_sve.h>
 


### PR DESCRIPTION
cc1a2ea61e3f8e790125b10d9ec4e7d179156ddf adds a test which can fail if the output directory is not writeable. Following the pattern of other tests in this package, use `-o -` to print the IR to stdout instead of to a file.