### PR TITLE
[CIR] Cleanup: mlirContext and astContext

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -37,14 +37,14 @@ namespace cir {
 class CIRGenerator : public clang::ASTConsumer {
   virtual void anchor();
   clang::DiagnosticsEngine &diags;
-  clang::ASTContext *astCtx;
+  clang::ASTContext *astContext;
   // Only used for debug info.
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs;
 
   const clang::CodeGenOptions &codeGenOpts;
 
 protected:
-  std::unique_ptr<mlir::MLIRContext> mlirCtx;
+  std::unique_ptr<mlir::MLIRContext> mlirContext;
   std::unique_ptr<clang::CIRGen::CIRGenModule> cgm;
 
 public:
@@ -52,7 +52,7 @@ public:
                llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fs,
                const clang::CodeGenOptions &cgo);
   ~CIRGenerator() override;
-  void Initialize(clang::ASTContext &astCtx) override;
+  void Initialize(clang::ASTContext &astContext) override;
   bool HandleTopLevelDecl(clang::DeclGroupRef group) override;
   mlir::ModuleOp getModule() const;
 };

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -25,13 +25,14 @@
 using namespace clang;
 using namespace clang::CIRGen;
 
-CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
-                           clang::ASTContext &astctx,
+CIRGenModule::CIRGenModule(mlir::MLIRContext &mlirContext,
+                           clang::ASTContext &astContext,
                            const clang::CodeGenOptions &cgo,
                            DiagnosticsEngine &diags)
-    : builder(context, *this), astCtx(astctx), langOpts(astctx.getLangOpts()),
-      theModule{mlir::ModuleOp::create(mlir::UnknownLoc::get(&context))},
-      diags(diags), target(astctx.getTargetInfo()), genTypes(*this) {
+    : builder(mlirContext, *this), astContext(astContext),
+      langOpts(astContext.getLangOpts()),
+      theModule{mlir::ModuleOp::create(mlir::UnknownLoc::get(&mlirContext))},
+      diags(diags), target(astContext.getTargetInfo()), genTypes(*this) {
 
   // Initialize cached types
   SInt8Ty = cir::IntType::get(&getMLIRContext(), 8, /*isSigned=*/true);
@@ -48,7 +49,7 @@ CIRGenModule::CIRGenModule(mlir::MLIRContext &context,
 
 mlir::Location CIRGenModule::getLoc(SourceLocation cLoc) {
   assert(cLoc.isValid() && "expected valid source location");
-  const SourceManager &sm = astCtx.getSourceManager();
+  const SourceManager &sm = astContext.getSourceManager();
   PresumedLoc pLoc = sm.getPresumedLoc(cLoc);
   StringRef filename = pLoc.getFilename();
   return mlir::FileLineColLoc::get(builder.getStringAttr(filename),

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -41,7 +41,7 @@ class CIRGenModule : public CIRGenTypeCache {
   CIRGenModule &operator=(CIRGenModule &) = delete;
 
 public:
-  CIRGenModule(mlir::MLIRContext &context, clang::ASTContext &astctx,
+  CIRGenModule(mlir::MLIRContext &mlirContext, clang::ASTContext &astContext,
                const clang::CodeGenOptions &cgo,
                clang::DiagnosticsEngine &diags);
 
@@ -51,7 +51,7 @@ private:
   CIRGenBuilderTy builder;
 
   /// Hold Clang AST information.
-  clang::ASTContext &astCtx;
+  clang::ASTContext &astContext;
 
   const clang::LangOptions &langOpts;
 
@@ -67,7 +67,7 @@ private:
 public:
   mlir::ModuleOp getModule() const { return theModule; }
   CIRGenBuilderTy &getBuilder() { return builder; }
-  clang::ASTContext &getASTContext() const { return astCtx; }
+  clang::ASTContext &getASTContext() const { return astContext; }
   CIRGenTypes &getTypes() { return genTypes; }
   mlir::MLIRContext &getMLIRContext() { return *builder.getContext(); }
 

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.cpp
@@ -9,7 +9,7 @@ using namespace clang;
 using namespace clang::CIRGen;
 
 CIRGenTypes::CIRGenTypes(CIRGenModule &genModule)
-    : cgm(genModule), context(genModule.getASTContext()),
+    : cgm(genModule), astContext(genModule.getASTContext()),
       builder(cgm.getBuilder()) {}
 
 CIRGenTypes::~CIRGenTypes() {}
@@ -19,7 +19,7 @@ mlir::MLIRContext &CIRGenTypes::getMLIRContext() const {
 }
 
 mlir::Type CIRGenTypes::convertType(QualType type) {
-  type = context.getCanonicalType(type);
+  type = astContext.getCanonicalType(type);
   const Type *ty = type.getTypePtr();
 
   // Has the type already been processed?
@@ -43,8 +43,9 @@ mlir::Type CIRGenTypes::convertType(QualType type) {
     case BuiltinType::SChar:
     case BuiltinType::Short:
     case BuiltinType::WChar_S:
-      resultType = cir::IntType::get(&getMLIRContext(), context.getTypeSize(ty),
-                                     /*isSigned=*/true);
+      resultType =
+          cir::IntType::get(&getMLIRContext(), astContext.getTypeSize(ty),
+                            /*isSigned=*/true);
       break;
     // Unsigned integral types.
     case BuiltinType::Char8:
@@ -58,8 +59,9 @@ mlir::Type CIRGenTypes::convertType(QualType type) {
     case BuiltinType::ULongLong:
     case BuiltinType::UShort:
     case BuiltinType::WChar_U:
-      resultType = cir::IntType::get(&getMLIRContext(), context.getTypeSize(ty),
-                                     /*isSigned=*/false);
+      resultType =
+          cir::IntType::get(&getMLIRContext(), astContext.getTypeSize(ty),
+                            /*isSigned=*/false);
       break;
     default:
       cgm.errorNYI(SourceLocation(), "processing of built-in type", type);

--- a/clang/lib/CIR/CodeGen/CIRGenTypes.h
+++ b/clang/lib/CIR/CodeGen/CIRGenTypes.h
@@ -36,7 +36,7 @@ class CIRGenModule;
 /// AST types to CIR types.
 class CIRGenTypes {
   CIRGenModule &cgm;
-  clang::ASTContext &context;
+  clang::ASTContext &astContext;
   CIRGenBuilderTy &builder;
 
 public:

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -29,15 +29,15 @@ CIRGenerator::CIRGenerator(clang::DiagnosticsEngine &diags,
     : diags(diags), fs(std::move(vfs)), codeGenOpts{cgo} {}
 CIRGenerator::~CIRGenerator() = default;
 
-void CIRGenerator::Initialize(ASTContext &astCtx) {
+void CIRGenerator::Initialize(ASTContext &astContext) {
   using namespace llvm;
 
-  this->astCtx = &astCtx;
+  this->astContext = &astContext;
 
-  mlirCtx = std::make_unique<mlir::MLIRContext>();
-  mlirCtx->loadDialect<cir::CIRDialect>();
-  cgm = std::make_unique<clang::CIRGen::CIRGenModule>(*mlirCtx.get(), astCtx,
-                                                      codeGenOpts, diags);
+  mlirContext = std::make_unique<mlir::MLIRContext>();
+  mlirContext->loadDialect<cir::CIRDialect>();
+  cgm = std::make_unique<clang::CIRGen::CIRGenModule>(
+      *mlirContext.get(), astContext, codeGenOpts, diags);
 }
 
 mlir::ModuleOp CIRGenerator::getModule() const { return cgm->getModule(); }


### PR DESCRIPTION
ClangIR CodeGen code uses both `mlir::MLIRContext` and `clang::ASTContext` objects extensively.  Refering to either of those as just "context" can be confusing.

Change the names of all variables, parameters, and fields in `clang/lib/CIR/CodeGen` that refer to `MLIRContext` or an `ASTContext` to be either `mlirContext` or `astContext`.

This change is only the renaming of variables/parameters/fields.  There are no behavior changes.  So there are no new tests or changes to existing tests.  This change mimics a recent change in the ClangIR incubator repository.