### PR TITLE
[RISCV] Set RegState for the stack-clash prologue registers

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -2043,7 +2043,7 @@ static void emitStackProbeInline(MachineFunction &MF, MachineBasicBlock &MBB,
   //   SUB SP, SP, ProbeSize
   BuildMI(*LoopTestMBB, LoopTestMBB->end(), DL, TII->get(RISCV::SUB), SPReg)
       .addReg(SPReg)
-      .addReg(ScratchReg)
+      .addReg(ScratchReg, RegState::InternalRead)
       .setMIFlags(Flags);
 
   //   s[d|w] zero, 0(sp)
@@ -2057,7 +2057,7 @@ static void emitStackProbeInline(MachineFunction &MF, MachineBasicBlock &MBB,
   //   BNE SP, TargetReg, LoopTest
   BuildMI(*LoopTestMBB, LoopTestMBB->end(), DL, TII->get(RISCV::BNE))
       .addReg(SPReg)
-      .addReg(TargetReg)
+      .addReg(TargetReg, RegState::InternalRead)
       .addMBB(LoopTestMBB)
       .setMIFlags(Flags);
 


### PR DESCRIPTION
Set both prologue scratch registers as InternalRead for stack-clash protection to fix the tests with LLVM_ENABLE_EXPENSIVE_CHECKS.

See buildbot failure: https://lab.llvm.org/buildbot/#/builders/16/builds/10433