### PR TITLE
[RISCV][VLOPT] Add vl-opt-op-info tests for unit strided and strided stores

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -247,6 +247,24 @@ static OperandInfo getOperandInfo(const MachineInstr &MI,
     llvm_unreachable("Configuration setting instructions do not read or write "
                      "vector registers");
 
+  // Vector Loads and Stores
+  // Vector Unit-Stride Instructions
+  // Vector Strided Instructions
+  /// Dest EEW encoded in the instruction and EMUL=(EEW/SEW)*LMUL
+  case RISCV::VSE8_V:
+  case RISCV::VSM_V:
+  case RISCV::VSSE8_V:
+    return OperandInfo(RISCVVType::getEMULEqualsEEWDivSEWTimesLMUL(3, MI), 3);
+  case RISCV::VSE16_V:
+  case RISCV::VSSE16_V:
+    return OperandInfo(RISCVVType::getEMULEqualsEEWDivSEWTimesLMUL(4, MI), 4);
+  case RISCV::VSE32_V:
+  case RISCV::VSSE32_V:
+    return OperandInfo(RISCVVType::getEMULEqualsEEWDivSEWTimesLMUL(5, MI), 5);
+  case RISCV::VSE64_V:
+  case RISCV::VSSE64_V:
+    return OperandInfo(RISCVVType::getEMULEqualsEEWDivSEWTimesLMUL(6, MI), 6);
+
   // Vector Integer Arithmetic Instructions
   // Vector Single-Width Integer Add and Subtract
   case RISCV::VADD_VI:

--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -252,7 +252,6 @@ static OperandInfo getOperandInfo(const MachineInstr &MI,
   // Vector Strided Instructions
   /// Dest EEW encoded in the instruction and EMUL=(EEW/SEW)*LMUL
   case RISCV::VSE8_V:
-  case RISCV::VSM_V:
   case RISCV::VSSE8_V:
     return OperandInfo(RISCVVType::getEMULEqualsEEWDivSEWTimesLMUL(3, MI), 3);
   case RISCV::VSE16_V:

--- a/llvm/test/CodeGen/RISCV/rvv/vl-opt-op-info.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vl-opt-op-info.mir
@@ -483,3 +483,82 @@ body: |
     %x:vr = PseudoVADD_VV_MF4 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0
     %y:vr = PseudoVNSRL_WV_MF2 $noreg, $noreg, %x, 1, 3 /* e8 */, 0
 ...
+---
+name: vseN_v
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vseN_v
+    ; CHECK: %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, 1, 3 /* e8 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %y:gpr = ADDI $x0, 1
+    ; CHECK-NEXT: PseudoVSE8_V_M1 %x, %y, 1, 3 /* e8 */
+    %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0
+    %y:gpr = ADDI $x0, 1
+    PseudoVSE8_V_M1 %x, %y, 1, 3 /* e8 */
+...
+---
+name: vseN_v_incompatible_eew
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vseN_v_incompatible_eew
+    ; CHECK: %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 4 /* e16 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %y:gpr = ADDI $x0, 1
+    ; CHECK-NEXT: PseudoVSE8_V_M1 %x, %y, 1, 3 /* e8 */
+    %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 4 /* e16 */, 0
+    %y:gpr = ADDI $x0, 1
+    PseudoVSE8_V_M1 %x, %y, 1, 3 /* e8 */
+...
+---
+name: vseN_v_incompatible_emul
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vseN_v_incompatible_emul
+    ; CHECK: %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %y:gpr = ADDI $x0, 1
+    ; CHECK-NEXT: PseudoVSE8_V_MF2 %x, %y, 1, 3 /* e8 */
+    %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0
+    %y:gpr = ADDI $x0, 1
+    PseudoVSE8_V_MF2 %x, %y, 1, 3 /* e8 */
+...
+---
+name: vsseN_v
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vsseN_v
+    ; CHECK: %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, 1, 3 /* e8 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %y:gpr = ADDI $x0, 1
+    ; CHECK-NEXT: %z:gpr = ADDI $x0, 2
+    ; CHECK-NEXT: PseudoVSSE8_V_M1 %x, %y, %z, 1, 3 /* e8 */
+    %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0
+    %y:gpr = ADDI $x0, 1
+    %z:gpr = ADDI $x0, 2
+    PseudoVSSE8_V_M1 %x, %y, %z, 1, 3 /* e8 */
+...
+---
+name: vsseN_v_incompatible_eew
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vsseN_v_incompatible_eew
+    ; CHECK: %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 4 /* e16 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %y:gpr = ADDI $x0, 1
+    ; CHECK-NEXT: %z:gpr = ADDI $x0, 2
+    ; CHECK-NEXT: PseudoVSSE8_V_M1 %x, %y, %z, 1, 3 /* e8 */
+    %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 4 /* e16 */, 0
+    %y:gpr = ADDI $x0, 1
+    %z:gpr = ADDI $x0, 2
+    PseudoVSSE8_V_M1 %x, %y, %z, 1, 3 /* e8 */
+...
+---
+name: vsseN_v_incompatible_emul
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vsseN_v_incompatible_emul
+    ; CHECK: %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0 /* tu, mu */
+    ; CHECK-NEXT: %y:gpr = ADDI $x0, 1
+    ; CHECK-NEXT: %z:gpr = ADDI $x0, 2
+    ; CHECK-NEXT: PseudoVSSE8_V_MF2 %x, %y, %z, 1, 3 /* e8 */
+    %x:vr = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 3 /* e8 */, 0
+    %y:gpr = ADDI $x0, 1
+    %z:gpr = ADDI $x0, 2
+    PseudoVSSE8_V_MF2 %x, %y, %z, 1, 3 /* e8 */
+...
+


### PR DESCRIPTION
I don't include getOperandInfo for the loads, since they don't take a vector use operand, and we don't include the loads in isSupportedInstr so we will never call getOperandInfo on the vector destination of these instructions.