### PR TITLE
DiagnosticPrinter: Use printAsOperand to handle anonymous values

### DIFF
--- a/llvm/lib/IR/DiagnosticPrinter.cpp
+++ b/llvm/lib/IR/DiagnosticPrinter.cpp
@@ -97,7 +97,12 @@ DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(const Twine &Str) {
 
 // IR related types.
 DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(const Value &V) {
-  Stream << V.getName();
+  // Avoid printing '@' prefix for named functions.
+  if (V.hasName())
+    Stream << V.getName();
+  else
+    V.printAsOperand(Stream, /*PrintType=*/false);
+
   return *this;
 }
 


### PR DESCRIPTION
To avoid changing the behavior in the general case, only do this
for anonymous functions. Otherwise, we'll end up with a leading
'@' on the name, which may not be meaningful to end users.