### PR TITLE
RegAlloc: Use DiagnosticInfo to report register allocation failures

### DIFF
--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -61,6 +61,7 @@ enum DiagnosticKind {
   DK_Generic,
   DK_GenericWithLoc,
   DK_InlineAsm,
+  DK_RegAllocFailure,
   DK_ResourceLimit,
   DK_StackSize,
   DK_Linker,
@@ -396,6 +397,32 @@ public:
 
   static bool classof(const DiagnosticInfo *DI) {
     return DI->getKind() == DK_GenericWithLoc;
+  }
+};
+
+class DiagnosticInfoRegAllocFailure : public DiagnosticInfoWithLocationBase {
+private:
+  /// Message to be reported.
+  const Twine &MsgStr;
+
+public:
+  /// \p MsgStr is the message to be reported to the frontend.
+  /// This class does not copy \p MsgStr, therefore the reference must be valid
+  /// for the whole life time of the Diagnostic.
+  DiagnosticInfoRegAllocFailure(const Twine &MsgStr, const Function &Fn,
+                                const DiagnosticLocation &DL,
+                                DiagnosticSeverity Severity = DS_Error);
+
+  DiagnosticInfoRegAllocFailure(const Twine &MsgStr, const Function &Fn,
+                                DiagnosticSeverity Severity = DS_Error);
+
+  const Twine &getMsgStr() const { return MsgStr; }
+
+  /// \see DiagnosticInfo::print.
+  void print(DiagnosticPrinter &DP) const override;
+
+  static bool classof(const DiagnosticInfo *DI) {
+    return DI->getKind() == DK_RegAllocFailure;
   }
 };
 

--- a/llvm/lib/IR/DiagnosticInfo.cpp
+++ b/llvm/lib/IR/DiagnosticInfo.cpp
@@ -80,6 +80,24 @@ void DiagnosticInfoInlineAsm::print(DiagnosticPrinter &DP) const {
     DP << " at line " << getLocCookie();
 }
 
+DiagnosticInfoRegAllocFailure::DiagnosticInfoRegAllocFailure(
+    const Twine &MsgStr, const Function &Fn, const DiagnosticLocation &DL,
+    DiagnosticSeverity Severity)
+    : DiagnosticInfoWithLocationBase(DK_RegAllocFailure, Severity, Fn,
+                                     DL.isValid() ? DL : Fn.getSubprogram()),
+      MsgStr(MsgStr) {}
+
+DiagnosticInfoRegAllocFailure::DiagnosticInfoRegAllocFailure(
+    const Twine &MsgStr, const Function &Fn, DiagnosticSeverity Severity)
+    : DiagnosticInfoWithLocationBase(DK_RegAllocFailure, Severity, Fn,
+                                     Fn.getSubprogram()),
+      MsgStr(MsgStr) {}
+
+void DiagnosticInfoRegAllocFailure::print(DiagnosticPrinter &DP) const {
+  DP << getLocationStr() << ": " << MsgStr << " in function '" << getFunction()
+     << '\'';
+}
+
 DiagnosticInfoResourceLimit::DiagnosticInfoResourceLimit(
     const Function &Fn, const char *ResourceName, uint64_t ResourceSize,
     uint64_t ResourceLimit, DiagnosticSeverity Severity, DiagnosticKind Kind)

--- a/llvm/test/CodeGen/AArch64/arm64-anyregcc-crash.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-anyregcc-crash.ll
@@ -2,7 +2,7 @@
 ;
 ; Check that misuse of anyregcc results in a compile time error.
 
-; CHECK: error: ran out of registers during register allocation
+; CHECK: error: <unknown>:0:0: ran out of registers during register allocation
 define i64 @anyreglimit(i64 %v1, i64 %v2, i64 %v3, i64 %v4, i64 %v5, i64 %v6, i64 %v7, i64 %v8,
                         i64 %v9, i64 %v10, i64 %v11, i64 %v12, i64 %v13, i64 %v14, i64 %v15, i64 %v16,
                         i64 %v17, i64 %v18, i64 %v19, i64 %v20, i64 %v21, i64 %v22, i64 %v23, i64 %v24,

--- a/llvm/test/CodeGen/AMDGPU/illegal-eviction-assert.mir
+++ b/llvm/test/CodeGen/AMDGPU/illegal-eviction-assert.mir
@@ -6,7 +6,7 @@
 # check was inconsistent with a later assertion when the eviction was
 # performed.
 
-# ERR: error: ran out of registers during register allocation
+# ERR: error: <unknown>:0:0: ran out of registers during register allocation
 
 --- |
   define void @foo() #0 {

--- a/llvm/test/CodeGen/AMDGPU/issue48473.mir
+++ b/llvm/test/CodeGen/AMDGPU/issue48473.mir
@@ -2,7 +2,7 @@
 # RUN: FileCheck -check-prefix=ERR %s < %t.err
 
 # ERR: error: register allocation failed: maximum depth for recoloring reached. Use -fexhaustive-register-search to skip cutoffs
-# ERR-NEXT: error: ran out of registers during register allocation
+# ERR-NEXT: error: <unknown>:0:0: ran out of registers during register allocation
 
 # This testcase used to fail with an "overlapping insert" assertion
 # when trying to roll back an unsucessful recoloring of %25. One of

--- a/llvm/test/CodeGen/AMDGPU/ran-out-of-registers-error-all-regs-reserved.ll
+++ b/llvm/test/CodeGen/AMDGPU/ran-out-of-registers-error-all-regs-reserved.ll
@@ -1,0 +1,21 @@
+; RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -vgpr-regalloc=greedy -filetype=null %s 2>&1 | FileCheck %s
+; RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -vgpr-regalloc=basic -filetype=null %s 2>&1 | FileCheck %s
+
+; TODO: Check regalloc fast when it doesn't assert after failing.
+
+; CHECK: LLVM ERROR: no registers from class available to allocate
+
+declare <32 x i32> @llvm.amdgcn.mfma.i32.32x32x4i8(i32, i32, <32 x i32>, i32 immarg, i32 immarg, i32 immarg)
+
+define <32 x i32> @no_registers_from_class_available_to_allocate(<32 x i32> %arg) #0 {
+  %ret = call <32 x i32> @llvm.amdgcn.mfma.i32.32x32x4i8(i32 1, i32 2, <32 x i32> %arg, i32 1, i32 2, i32 3)
+  ret <32 x i32> %ret
+}
+
+; FIXME: Special case in fast RA, asserts. Also asserts in greedy
+; define void @no_registers_from_class_available_to_allocate_undef_asm() #0 {
+;   call void asm sideeffect "; use $0", "v"(<32 x i32> poison)
+;   ret void
+; }
+
+attributes #0 = { "amdgpu-waves-per-eu"="10,10" }

--- a/llvm/test/CodeGen/AMDGPU/ran-out-of-registers-errors.ll
+++ b/llvm/test/CodeGen/AMDGPU/ran-out-of-registers-errors.ll
@@ -1,0 +1,70 @@
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 -vgpr-regalloc=greedy -filetype=null %s 2>&1 | FileCheck -check-prefixes=CHECK,GREEDY -implicit-check-not=error %s
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 -vgpr-regalloc=basic -filetype=null %s 2>&1 | FileCheck -implicit-check-not=error -check-prefixes=CHECK,BASIC %s
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 -vgpr-regalloc=fast -filetype=null %s 2>&1 | FileCheck -implicit-check-not=error -check-prefixes=CHECK,FAST %s
+; RUN: opt -passes=debugify -o %t.bc %s
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 -vgpr-regalloc=greedy -filetype=null %t.bc 2>&1 | FileCheck -implicit-check-not=error -check-prefixes=DBGINFO-CHECK,DBGINFO-GREEDY %s
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 -vgpr-regalloc=basic -filetype=null %t.bc 2>&1 | FileCheck -implicit-check-not=error -check-prefixes=DBGINFO-CHECK,DBGINFO-BASIC %s
+
+; FIXME: Asserts when using -O2 + -vgpr-regalloc=fast
+; RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -stress-regalloc=1 -O0 -filetype=null %t.bc 2>&1 | FileCheck -implicit-check-not=error -check-prefixes=DBGINFO-CHECK,DBGINFO-FAST %s
+
+; TODO: Should we fix emitting multiple errors sometimes in basic and fast?
+
+
+; CHECK: error: <unknown>:0:0: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+; BASIC: error: <unknown>:0:0: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+; FAST: error: <unknown>:0:0: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+
+; DBGINFO-GREEDY: error: {{.*}}:3:1: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+
+; DBGINFO-BASIC: error: {{.*}}:1:1: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+; DBGINFO-BASIC: error: {{.*}}:3:1: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+
+; DBGINFO-FAST: error: {{.*}}:3:1: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+; DBGINFO-FAST: error: {{.*}}:1:0: ran out of registers during register allocation in function 'ran_out_of_registers_general'
+define i32 @ran_out_of_registers_general(ptr addrspace(1) %ptr) #0 {
+  %ld0 = load volatile i32, ptr addrspace(1) %ptr
+  %ld1 = load volatile i32, ptr addrspace(1) %ptr
+  %add = add i32 %ld0, %ld1
+  ret i32 %add
+}
+
+; CHECK: error: inline assembly requires more registers than available at line 23
+; DBGINFO-CHECK: error: inline assembly requires more registers than available at line 23
+define void @ran_out_of_registers_asm_def() #0 {
+  %asm = call { i32, i32 } asm sideeffect "; def $0 $1", "=v,=v"(), !srcloc !0
+  ret void
+}
+
+; CHECK: error: inline assembly requires more registers than available at line 23
+; DBGINFO-CHECK: error: inline assembly requires more registers than available at line 23
+define void @ran_out_of_registers_asm_use() #0 {
+  call void asm sideeffect "; def $0 $1", "v,v"(i32 0, i32 1), !srcloc !0
+  ret void
+}
+
+; Test error in anonymous function.
+
+; GREEDY: error: inline assembly requires more registers than available at line 23
+; BASIC: error: inline assembly requires more registers than available at line 23
+
+; FAST: error: <unknown>:0:0: ran out of registers during register allocation in function '@0'
+; FAST: error: <unknown>:0:0: ran out of registers during register allocation in function '@0'
+
+
+; DBGINFO-GREEDY: error: inline assembly requires more registers than available at line 23
+; DBGINFO-BASIC: error: inline assembly requires more registers than available at line 23
+
+; DBGINFO-FAST: error: {{.*}}:12:1: ran out of registers during register allocation in function '@0'
+; DBGINFO-FAST: error: {{.*}}:9:0: ran out of registers during register allocation in function '@0'
+define i32 @0(ptr addrspace(1) %ptr) #0 {
+  %asm = call { i32, i32 } asm sideeffect "; def $0 $1 use $2", "=v,=v,v"(ptr addrspace(1) %ptr), !srcloc !0
+  %elt0 = extractvalue { i32, i32 } %asm, 0
+  %elt1 = extractvalue { i32, i32 } %asm, 1
+  %add = add i32 %elt0, %elt1
+  ret i32 %add
+}
+
+attributes #0 = { "target-cpu"="gfx908" }
+
+!0 = !{i32 23}

--- a/llvm/test/CodeGen/AMDGPU/remaining-virtual-register-operands.ll
+++ b/llvm/test/CodeGen/AMDGPU/remaining-virtual-register-operands.ll
@@ -10,7 +10,7 @@
 ; This happens due to when register allocator is out of registers
 ; it takes the first avialable register.
 
-; CHECK: error: ran out of registers during register allocation
+; CHECK: error: <unknown>:0:0: ran out of registers during register allocation
 ; CHECK: Bad machine code: Using an undefined physical register
 define amdgpu_kernel void @alloc_failure_with_split_vregs(float %v0, float %v1) #0 {
   %agpr0 = call float asm sideeffect "; def $0", "=${a0}"()

--- a/llvm/test/CodeGen/PowerPC/ppc64-anyregcc-crash.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-anyregcc-crash.ll
@@ -2,7 +2,7 @@
 ;
 ; Check that misuse of anyregcc results in a compile time error.
 
-; CHECK: error: ran out of registers during register allocation
+; CHECK: error: <unknown>:0:0: ran out of registers during register allocation
 define i64 @anyreglimit(i64 %v1, i64 %v2, i64 %v3, i64 %v4, i64 %v5, i64 %v6, i64 %v7, i64 %v8,
                         i64 %v9, i64 %v10, i64 %v11, i64 %v12, i64 %v13, i64 %v14, i64 %v15, i64 %v16,
                         i64 %v17, i64 %v18, i64 %v19, i64 %v20, i64 %v21, i64 %v22, i64 %v23, i64 %v24,

--- a/llvm/test/CodeGen/X86/anyregcc-crash.ll
+++ b/llvm/test/CodeGen/X86/anyregcc-crash.ll
@@ -2,7 +2,7 @@
 ;
 ; Check that misuse of anyregcc results in a compile time error.
 
-; CHECK: error: ran out of registers during register allocation
+; CHECK: error: <unknown>:0:0: ran out of registers during register allocation
 define i64 @anyreglimit(i64 %v1, i64 %v2, i64 %v3, i64 %v4, i64 %v5, i64 %v6,
                         i64 %v7, i64 %v8, i64 %v9, i64 %v10, i64 %v11, i64 %v12,
                         i64 %v13, i64 %v14, i64 %v15, i64 %v16) {


### PR DESCRIPTION
Improve the non-fatal cases to use DiagnosticInfo, which will now
provide a location. The allocators attempt to report different errors
if it happens to see inline assembly is involved (this detection is
quite unreliable) using srcloc instead of dbgloc. For now, leave this
behavior unchanged. I think reporting the full location and context
function would be more useful.