### PR TITLE
[BOLT][DWARF] Add support for transitive DW_AT_name/DW_AT_linkage_name resolution for DW_AT_name/DW_AT_linkage_name.

### DIFF
--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -162,7 +162,7 @@ private:
 
   /// Clone an attribute in reference format.
   void cloneDieOffsetReferenceAttribute(
-      DIE &Die, const DWARFUnit &U, const DWARFDie &InputDIE,
+      DIE &Die, DWARFUnit &U, const DWARFDie &InputDIE,
       const DWARFAbbreviationDeclaration::AttributeSpec AttrSpec, uint64_t Ref);
 
   /// Clone an attribute in block format.

--- a/bolt/include/bolt/Core/DebugNames.h
+++ b/bolt/include/bolt/Core/DebugNames.h
@@ -72,8 +72,8 @@ public:
     return std::move(FullTableBuffer);
   }
   /// Adds a DIE that is referenced across CUs.
-  void addCrossCUDie(const DIE *Die) {
-    CrossCUDies.insert({Die->getOffset(), Die});
+  void addCrossCUDie(DWARFUnit *Unit, const DIE *Die) {
+    CrossCUDies.insert({Die->getOffset(), {Unit, Die}});
   }
   /// Returns true if the DIE can generate an entry for a cross cu reference.
   /// This only checks TAGs of a DIE because when this is invoked DIE might not
@@ -145,7 +145,7 @@ private:
   llvm::DenseMap<uint64_t, uint32_t> CUOffsetsToPatch;
   // Contains a map of Entry ID to Entry relative offset.
   llvm::DenseMap<uint64_t, uint32_t> EntryRelativeOffsets;
-  llvm::DenseMap<uint64_t, const DIE *> CrossCUDies;
+  llvm::DenseMap<uint64_t, std::pair<DWARFUnit *, const DIE *>> CrossCUDies;
   /// Adds Unit to either CUList, LocalTUList or ForeignTUList.
   /// Input Unit being processed, and DWO ID if Unit is being processed comes
   /// from a DWO section.
@@ -191,6 +191,29 @@ private:
   void emitData();
   /// Emit augmentation string.
   void emitAugmentationString() const;
+  /// Creates a new entry for a given DIE.
+  std::optional<BOLTDWARF5AccelTableData *>
+  addEntry(DWARFUnit &DU, const DIE &CurrDie,
+           const std::optional<uint64_t> &DWOID,
+           const std::optional<BOLTDWARF5AccelTableData *> &Parent,
+           const std::optional<std::string> &Name,
+           const uint32_t NumberParentsInChain);
+  /// Returns UnitID for a given DWARFUnit.
+  uint32_t getUnitID(const DWARFUnit &Unit,
+                     const std::optional<uint64_t> &DWOID, bool &IsTU);
+  std::optional<std::string> getName(DWARFUnit &DU,
+                                     const std::optional<uint64_t> &DWOID,
+                                     const std::string &NameToUse,
+                                     DIEValue ValName);
+  /// Processes a DIE with references to other DIEs for DW_AT_name and
+  /// DW_AT_linkage_name resolution.
+  /// If DW_AT_name exists method creates a new entry for this DIE and returns
+  /// it.
+  std::optional<BOLTDWARF5AccelTableData *> processReferencedDie(
+      DWARFUnit &Unit, const DIE &Die, const std::optional<uint64_t> &DWOID,
+      const std::optional<BOLTDWARF5AccelTableData *> &Parent,
+      const std::string &NameToUse, const uint32_t NumberParentsInChain,
+      const dwarf::Attribute &Attr);
 };
 } // namespace bolt
 } // namespace llvm

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -622,7 +622,7 @@ DWARFDie DIEBuilder::resolveDIEReference(
 }
 
 void DIEBuilder::cloneDieOffsetReferenceAttribute(
-    DIE &Die, const DWARFUnit &U, const DWARFDie &InputDIE,
+    DIE &Die, DWARFUnit &U, const DWARFDie &InputDIE,
     const DWARFAbbreviationDeclaration::AttributeSpec AttrSpec, uint64_t Ref) {
   DIE *NewRefDie = nullptr;
   DWARFUnit *RefUnit = nullptr;
@@ -654,7 +654,7 @@ void DIEBuilder::cloneDieOffsetReferenceAttribute(
     // Adding referenced DIE to DebugNames to be used when entries are created
     // that contain cross cu references.
     if (DebugNamesTable.canGenerateEntryWithCrossCUReference(U, Die, AttrSpec))
-      DebugNamesTable.addCrossCUDie(DieInfo.Die);
+      DebugNamesTable.addCrossCUDie(&U, DieInfo.Die);
     // no matter forward reference or backward reference, we are supposed
     // to calculate them in `finish` due to the possible modification of
     // the DIE.

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -270,7 +270,7 @@ std::optional<std::string> DWARF5AcceleratorTable::getName(
     if (!NameToUse.empty())
       NameIndexOffset = MainBinaryStrWriter.addString(Name);
     It.StrOffset = NameIndexOffset;
-    // This the same hash function used in DWARF5AccelTableData.
+    // This is the same hash function used in DWARF5AccelTableData.
     It.HashValue = caseFoldingDjbHash(Name);
   }
   return Name;
@@ -301,9 +301,8 @@ std::optional<BOLTDWARF5AccelTableData *> DWARF5AcceleratorTable::addEntry(
   }
   std::optional<uint64_t> ParentOffset =
       (Parent ? std::optional<uint64_t>(getEntryID(**Parent)) : std::nullopt);
-  // This will be populated later in writeEntry.
-  // This way only parent entries get tracked.
-  // Keeping memory footprint down.
+  // This will be only populated in writeEntry, in order to keep only the parent
+  // entries, and keep the footprint down.
   if (ParentOffset)
     EntryRelativeOffsets.insert({*ParentOffset, 0});
   bool IsParentRoot = false;
@@ -387,7 +386,7 @@ DWARF5AcceleratorTable::addAccelTableEntry(
   if (!canProcess(Unit, Die, NameToUse, false))
     return std::nullopt;
 
-  // Addes a Unit to either CU, LocalTU or ForeignTU list the first time we
+  // Adds a Unit to either CU, LocalTU or ForeignTU list the first time we
   // encounter it.
   // Invoking it here so that we don't add Units that don't have any entries.
   if (&Unit != CurrentUnit) {
@@ -414,10 +413,10 @@ DWARF5AcceleratorTable::addAccelTableEntry(
 
   // The DIE doesn't have DW_AT_name or DW_AT_linkage_name, so we need to see if
   // we can follow other attributes to find them. For the purposes of
-  // determining whether a debugging information entry has a particular
-  // attribute (such as DW_AT_name), if debugging information entry A has a
+  // determining whether a debug information entry has a particular
+  // attribute (such as DW_AT_name), if debug information entry A has a
   // DW_AT_specification or DW_AT_abstract_origin attribute pointing to another
-  // debugging information entry B, any attributes of B are considered to be
+  // debug information entry B, any attributes of B are considered to be
   // part of A.
   if (std::optional<BOLTDWARF5AccelTableData *> Entry = processReferencedDie(
           Unit, Die, DWOID, Parent, NameToUse, NumberParentsInChain,

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -222,6 +222,159 @@ static uint64_t getEntryID(const BOLTDWARF5AccelTableData &Entry) {
   return reinterpret_cast<uint64_t>(&Entry);
 }
 
+uint32_t DWARF5AcceleratorTable::getUnitID(const DWARFUnit &Unit,
+                                           const std::optional<uint64_t> &DWOID,
+                                           bool &IsTU) {
+  IsTU = Unit.isTypeUnit();
+  if (IsTU) {
+    if (DWOID) {
+      const uint64_t TUHash = cast<DWARFTypeUnit>(&Unit)->getTypeHash();
+      auto Iter = TUHashToIndexMap.find(TUHash);
+      assert(Iter != TUHashToIndexMap.end() && "Could not find TU hash in map");
+      return Iter->second;
+    }
+    return LocalTUList.size() - 1;
+  }
+  return CUList.size() - 1;
+}
+
+std::optional<std::string> DWARF5AcceleratorTable::getName(
+    DWARFUnit &Unit, const std::optional<uint64_t> &DWOID,
+    const std::string &NameToUse, DIEValue ValName) {
+  if ((!ValName || ValName.getForm() == dwarf::DW_FORM_string) &&
+      NameToUse.empty())
+    return std::nullopt;
+  std::string Name = "";
+  uint64_t NameIndexOffset = 0;
+  if (NameToUse.empty()) {
+    NameIndexOffset = ValName.getDIEInteger().getValue();
+    if (ValName.getForm() != dwarf::DW_FORM_strp)
+      NameIndexOffset = getNameOffset(BC, Unit, NameIndexOffset);
+    // Counts on strings end with '\0'.
+    Name = std::string(&StrSection.data()[NameIndexOffset]);
+  } else {
+    Name = NameToUse;
+  }
+  auto &It = Entries[Name];
+  if (It.Values.empty()) {
+    if (DWOID && NameToUse.empty()) {
+      // For DWO Unit the offset is in the .debug_str.dwo section.
+      // Need to find offset for the name in the .debug_str section.
+      llvm::hash_code Hash = llvm::hash_value(llvm::StringRef(Name));
+      auto ItCache = StrCacheToOffsetMap.find(Hash);
+      if (ItCache == StrCacheToOffsetMap.end())
+        NameIndexOffset = MainBinaryStrWriter.addString(Name);
+      else
+        NameIndexOffset = ItCache->second;
+    }
+    if (!NameToUse.empty())
+      NameIndexOffset = MainBinaryStrWriter.addString(Name);
+    It.StrOffset = NameIndexOffset;
+    // This the same hash function used in DWARF5AccelTableData.
+    It.HashValue = caseFoldingDjbHash(Name);
+  }
+  return Name;
+}
+
+std::optional<BOLTDWARF5AccelTableData *> DWARF5AcceleratorTable::addEntry(
+    DWARFUnit &DU, const DIE &CurrDie, const std::optional<uint64_t> &DWOID,
+    const std::optional<BOLTDWARF5AccelTableData *> &Parent,
+    const std::optional<std::string> &Name,
+    const uint32_t NumberParentsInChain) {
+  if (!Name)
+    return std::nullopt;
+
+  auto &It = Entries[*Name];
+  bool IsTU = false;
+  uint32_t DieTag = CurrDie.getTag();
+  uint32_t UnitID = getUnitID(DU, DWOID, IsTU);
+  std::optional<unsigned> SecondIndex = std::nullopt;
+  if (IsTU && DWOID) {
+    auto Iter = CUOffsetsToPatch.find(*DWOID);
+    if (Iter == CUOffsetsToPatch.end())
+      BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
+                   "DWO ID in CU offsets for second Unit Index "
+                << *Name << ". For DIE at offset: "
+                << Twine::utohexstr(CurrentUnitOffset + CurrDie.getOffset())
+                << ".\n";
+    SecondIndex = Iter->second;
+  }
+  std::optional<uint64_t> ParentOffset =
+      (Parent ? std::optional<uint64_t>(getEntryID(**Parent)) : std::nullopt);
+  // This will be populated later in writeEntry.
+  // This way only parent entries get tracked.
+  // Keeping memory footprint down.
+  if (ParentOffset)
+    EntryRelativeOffsets.insert({*ParentOffset, 0});
+  bool IsParentRoot = false;
+  // If there is no parent and no valid Entries in parent chain this is a root
+  // to be marked with a flag.
+  if (!Parent && !NumberParentsInChain)
+    IsParentRoot = true;
+  It.Values.push_back(new (Allocator) BOLTDWARF5AccelTableData(
+      CurrDie.getOffset(), ParentOffset, DieTag, UnitID, IsParentRoot, IsTU,
+      SecondIndex));
+  return It.Values.back();
+}
+
+std::optional<BOLTDWARF5AccelTableData *>
+DWARF5AcceleratorTable::processReferencedDie(
+    DWARFUnit &Unit, const DIE &Die, const std::optional<uint64_t> &DWOID,
+    const std::optional<BOLTDWARF5AccelTableData *> &Parent,
+    const std::string &NameToUse, const uint32_t NumberParentsInChain,
+    const dwarf::Attribute &Attr) {
+  DIEValue Value = Die.findAttribute(Attr);
+  if (!Value)
+    return std::nullopt;
+  auto getReferenceDie = [&](const DIEValue &Value, const DIE *RefDieUsed)
+      -> std::optional<std::pair<DWARFUnit *, const DIE *>> {
+    if (!Value)
+      return std::nullopt;
+    if (Value.getForm() == dwarf::DW_FORM_ref_addr) {
+      auto Iter = CrossCUDies.find(Value.getDIEInteger().getValue());
+      if (Iter == CrossCUDies.end()) {
+        BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
+                     "referenced DIE in CrossCUDies for "
+                  << Twine::utohexstr(Value.getDIEInteger().getValue())
+                  << ".\n";
+        return std::nullopt;
+      }
+      return Iter->second;
+    }
+    const DIEEntry &DIEENtry = Value.getDIEEntry();
+    return {{&Unit, &DIEENtry.getEntry()}};
+  };
+
+  DIEValue AttrValLinkageName;
+  DIEValue AttrValName = Die.findAttribute(dwarf::Attribute::DW_AT_name);
+  DWARFUnit *RefUnit = &Unit;
+  const DIE *RefDieUsed = &Die;
+  // It is possible to have DW_TAG_subprogram only with  DW_AT_linkage_name that
+  // DW_AT_abstract_origin/DW_AT_specification point to.
+  while (!AttrValName) {
+    std::optional<std::pair<DWARFUnit *, const DIE *>> RefDUDie =
+        getReferenceDie(Value, RefDieUsed);
+    if (!RefDUDie)
+      break;
+    RefUnit = RefDUDie->first;
+    const DIE &RefDie = *RefDUDie->second;
+    RefDieUsed = &RefDie;
+    if (!AttrValLinkageName)
+      AttrValLinkageName =
+          RefDie.findAttribute(dwarf::Attribute::DW_AT_linkage_name);
+    AttrValName = RefDie.findAttribute(dwarf::Attribute::DW_AT_name);
+    Value = RefDie.findAttribute(dwarf::Attribute::DW_AT_abstract_origin);
+    if (!Value)
+      Value = RefDie.findAttribute(dwarf::Attribute::DW_AT_specification);
+  }
+  addEntry(Unit, Die, DWOID, Parent,
+           getName(*RefUnit, DWOID, NameToUse, AttrValLinkageName),
+           NumberParentsInChain);
+  return addEntry(Unit, Die, DWOID, Parent,
+                  getName(*RefUnit, DWOID, NameToUse, AttrValName),
+                  NumberParentsInChain);
+}
+
 std::optional<BOLTDWARF5AccelTableData *>
 DWARF5AcceleratorTable::addAccelTableEntry(
     DWARFUnit &Unit, const DIE &Die, const std::optional<uint64_t> &DWOID,
@@ -230,23 +383,6 @@ DWARF5AcceleratorTable::addAccelTableEntry(
   if (Unit.getVersion() < 5 || !NeedToCreate)
     return std::nullopt;
   std::string NameToUse = "";
-
-  auto getUnitID = [&](const DWARFUnit &Unit, bool &IsTU,
-                       uint32_t &DieTag) -> uint32_t {
-    IsTU = Unit.isTypeUnit();
-    DieTag = Die.getTag();
-    if (IsTU) {
-      if (DWOID) {
-        const uint64_t TUHash = cast<DWARFTypeUnit>(&Unit)->getTypeHash();
-        auto Iter = TUHashToIndexMap.find(TUHash);
-        assert(Iter != TUHashToIndexMap.end() &&
-               "Could not find TU hash in map");
-        return Iter->second;
-      }
-      return LocalTUList.size() - 1;
-    }
-    return CUList.size() - 1;
-  };
 
   if (!canProcess(Unit, Die, NameToUse, false))
     return std::nullopt;
@@ -259,124 +395,41 @@ DWARF5AcceleratorTable::addAccelTableEntry(
     addUnit(Unit, DWOID);
   }
 
-  auto getName = [&](DIEValue ValName) -> std::optional<std::string> {
-    if ((!ValName || ValName.getForm() == dwarf::DW_FORM_string) &&
-        NameToUse.empty())
-      return std::nullopt;
-    std::string Name = "";
-    uint64_t NameIndexOffset = 0;
-    if (NameToUse.empty()) {
-      NameIndexOffset = ValName.getDIEInteger().getValue();
-      if (ValName.getForm() != dwarf::DW_FORM_strp)
-        NameIndexOffset = getNameOffset(BC, Unit, NameIndexOffset);
-      // Counts on strings end with '\0'.
-      Name = std::string(&StrSection.data()[NameIndexOffset]);
-    } else {
-      Name = NameToUse;
-    }
-    auto &It = Entries[Name];
-    if (It.Values.empty()) {
-      if (DWOID && NameToUse.empty()) {
-        // For DWO Unit the offset is in the .debug_str.dwo section.
-        // Need to find offset for the name in the .debug_str section.
-        llvm::hash_code Hash = llvm::hash_value(llvm::StringRef(Name));
-        auto ItCache = StrCacheToOffsetMap.find(Hash);
-        if (ItCache == StrCacheToOffsetMap.end())
-          NameIndexOffset = MainBinaryStrWriter.addString(Name);
-        else
-          NameIndexOffset = ItCache->second;
-      }
-      if (!NameToUse.empty())
-        NameIndexOffset = MainBinaryStrWriter.addString(Name);
-      It.StrOffset = NameIndexOffset;
-      // This the same hash function used in DWARF5AccelTableData.
-      It.HashValue = caseFoldingDjbHash(Name);
-    }
-    return Name;
-  };
-
-  auto addEntry =
-      [&](DIEValue ValName) -> std::optional<BOLTDWARF5AccelTableData *> {
-    std::optional<std::string> Name = getName(ValName);
-    if (!Name)
-      return std::nullopt;
-
-    auto &It = Entries[*Name];
-    bool IsTU = false;
-    uint32_t DieTag = 0;
-    uint32_t UnitID = getUnitID(Unit, IsTU, DieTag);
-    std::optional<unsigned> SecondIndex = std::nullopt;
-    if (IsTU && DWOID) {
-      auto Iter = CUOffsetsToPatch.find(*DWOID);
-      if (Iter == CUOffsetsToPatch.end())
-        BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
-                     "DWO ID in CU offsets for second Unit Index "
-                  << *Name << ". For DIE at offset: "
-                  << Twine::utohexstr(CurrentUnitOffset + Die.getOffset())
-                  << ".\n";
-      SecondIndex = Iter->second;
-    }
-    std::optional<uint64_t> ParentOffset =
-        (Parent ? std::optional<uint64_t>(getEntryID(**Parent)) : std::nullopt);
-    // This will be populated later in writeEntry.
-    // This way only parent entries get tracked.
-    // Keeping memory footprint down.
-    if (ParentOffset)
-      EntryRelativeOffsets.insert({*ParentOffset, 0});
-    bool IsParentRoot = false;
-    // If there is no parent and no valid Entries in parent chain this is a root
-    // to be marked with a flag.
-    if (!Parent && !NumberParentsInChain)
-      IsParentRoot = true;
-    It.Values.push_back(new (Allocator) BOLTDWARF5AccelTableData(
-        Die.getOffset(), ParentOffset, DieTag, UnitID, IsParentRoot, IsTU,
-        SecondIndex));
-    return It.Values.back();
-  };
-
   // Minor optimization not to add entry twice for DW_TAG_namespace if it has no
   // DW_AT_name.
-  if (!(Die.getTag() == dwarf::DW_TAG_namespace &&
-        !Die.findAttribute(dwarf::Attribute::DW_AT_name)))
-    addEntry(Die.findAttribute(dwarf::Attribute::DW_AT_linkage_name));
-  // For the purposes of determining whether a debugging information entry has a
-  // particular attribute (such as DW_AT_name), if debugging information entry A
-  // has a DW_AT_specification or DW_AT_abstract_origin attribute pointing to
-  // another debugging information entry B, any attributes of B are considered
-  // to be part of A.
-  auto processReferencedDie = [&](const dwarf::Attribute &Attr)
-      -> std::optional<BOLTDWARF5AccelTableData *> {
-    const DIEValue Value = Die.findAttribute(Attr);
-    if (!Value)
-      return std::nullopt;
-    const DIE *EntryDie = nullptr;
-    if (Value.getForm() == dwarf::DW_FORM_ref_addr) {
-      auto Iter = CrossCUDies.find(Value.getDIEInteger().getValue());
-      if (Iter == CrossCUDies.end()) {
-        BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
-                     "referenced DIE in CrossCUDies for "
-                  << Twine::utohexstr(Value.getDIEInteger().getValue())
-                  << ".\n";
-        return std::nullopt;
-      }
-      EntryDie = Iter->second;
-    } else {
-      const DIEEntry &DIEENtry = Value.getDIEEntry();
-      EntryDie = &DIEENtry.getEntry();
-    }
+  std::optional<BOLTDWARF5AccelTableData *> LinkageEntry = std::nullopt;
+  DIEValue NameVal = Die.findAttribute(dwarf::Attribute::DW_AT_name);
+  DIEValue LinkageNameVal =
+      Die.findAttribute(dwarf::Attribute::DW_AT_linkage_name);
+  if (!(Die.getTag() == dwarf::DW_TAG_namespace && !NameVal))
+    LinkageEntry = addEntry(Unit, Die, DWOID, Parent,
+                            getName(Unit, DWOID, NameToUse, LinkageNameVal),
+                            NumberParentsInChain);
 
-    addEntry(EntryDie->findAttribute(dwarf::Attribute::DW_AT_linkage_name));
-    return addEntry(EntryDie->findAttribute(dwarf::Attribute::DW_AT_name));
-  };
+  std::optional<BOLTDWARF5AccelTableData *> NameEntry =
+      addEntry(Unit, Die, DWOID, Parent,
+               getName(Unit, DWOID, NameToUse, NameVal), NumberParentsInChain);
+  if (NameEntry)
+    return NameEntry;
 
-  if (std::optional<BOLTDWARF5AccelTableData *> Entry =
-          processReferencedDie(dwarf::Attribute::DW_AT_abstract_origin))
+  // The DIE doesn't have DW_AT_name or DW_AT_linkage_name, so we need to see if
+  // we can follow other attributes to find them. For the purposes of
+  // determining whether a debugging information entry has a particular
+  // attribute (such as DW_AT_name), if debugging information entry A has a
+  // DW_AT_specification or DW_AT_abstract_origin attribute pointing to another
+  // debugging information entry B, any attributes of B are considered to be
+  // part of A.
+  if (std::optional<BOLTDWARF5AccelTableData *> Entry = processReferencedDie(
+          Unit, Die, DWOID, Parent, NameToUse, NumberParentsInChain,
+          dwarf::Attribute::DW_AT_abstract_origin))
     return *Entry;
-  if (std::optional<BOLTDWARF5AccelTableData *> Entry =
-          processReferencedDie(dwarf::Attribute::DW_AT_specification))
+  if (std::optional<BOLTDWARF5AccelTableData *> Entry = processReferencedDie(
+          Unit, Die, DWOID, Parent, NameToUse, NumberParentsInChain,
+          dwarf::Attribute::DW_AT_specification))
     return *Entry;
 
-  return addEntry(Die.findAttribute(dwarf::Attribute::DW_AT_name));
+  // This point can be hit by DW_TAG_varialbe that has no DW_AT_name.
+  return std::nullopt;
 }
 
 /// Algorithm from llvm implementation.

--- a/bolt/test/X86/dwarf5-debug-names-abstract-origin-linkage-name-only.s
+++ b/bolt/test/X86/dwarf5-debug-names-abstract-origin-linkage-name-only.s
@@ -1,0 +1,568 @@
+# RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %s   -o %tmain.o
+# RUN: %clang %cflags -gdwarf-5 %tmain.o -o %tmain.exe
+# RUN: llvm-bolt %tmain.exe -o %tmain.exe.bolt --update-debug-sections
+# RUN: llvm-dwarfdump --debug-names %tmain.exe.bolt > %tlog.txt
+# RUN: cat %tlog.txt | FileCheck -check-prefix=BOLT %s
+
+## Tests that bolt can correctly generate debug_names when there is an DW_TAG_inlined_subroutine
+## with DW_AT_abstract_origin that points to DW_TAG_subprogram that only has DW_AT_linkage_name.
+
+# BOLT:      Name Index @ 0x0 {
+# BOLT-NEXT:  Header {
+# BOLT-NEXT:    Length: 0xA2
+# BOLT-NEXT:    Format: DWARF32
+# BOLT-NEXT:    Version: 5
+# BOLT-NEXT:    CU count: 1
+# BOLT-NEXT:    Local TU count: 0
+# BOLT-NEXT:    Foreign TU count: 0
+# BOLT-NEXT:    Bucket count: 4
+# BOLT-NEXT:    Name count: 4
+# BOLT-NEXT:    Abbreviations table size: 0x19
+# BOLT-NEXT:    Augmentation: 'BOLT'
+# BOLT-NEXT:  }
+# BOLT-NEXT:  Compilation Unit offsets [
+# BOLT-NEXT:    CU[0]: 0x00000000
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Abbreviations [
+# BOLT-NEXT:    Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_base_type
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_subprogram
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_inlined_subroutine
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_ref4
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 0 [
+# BOLT-NEXT:    Name 1 {
+# BOLT-NEXT:      Hash: 0xB888030
+# BOLT-NEXT:      String: {{.+}} "int"
+# BOLT-NEXT:      Entry @ {{.+}} {
+# BOLT-NEXT:        Abbrev: 0x1
+# BOLT-NEXT:        Tag: DW_TAG_base_type
+# BOLT-NEXT:        DW_IDX_die_offset: 0x0000004a
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 1 [
+# BOLT-NEXT:    EMPTY
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 2 [
+# BOLT-NEXT:    Name 2 {
+# BOLT-NEXT:      Hash: 0x7C9A7F6A
+# BOLT-NEXT:      String: {{.+}} "main"
+# BOLT-NEXT:      Entry @ [[REF1:0x[0-9a-f]*]] {
+# BOLT-NEXT:        Abbrev: [[ABBREV2]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x0000004e
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Name 3 {
+# BOLT-NEXT:      Hash: 0xB5063CFE
+# BOLT-NEXT:      String: {{.+}} "_Z3fooi"
+# BOLT-NEXT:      Entry @ {{.+}} {
+# BOLT-NEXT:        Abbrev: [[ABBREV2]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x00000024
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:      Entry @ 0x96 {
+# BOLT-NEXT:        Abbrev: [[ABBREV3]]
+# BOLT-NEXT:        Tag: DW_TAG_inlined_subroutine
+# BOLT-NEXT:        DW_IDX_die_offset: 0x0000007e
+# BOLT-NEXT:        DW_IDX_parent: Entry @ [[REF1]]
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 3 [
+# BOLT-NEXT:    Name 4 {
+# BOLT-NEXT:      Hash: 0x7C952063
+# BOLT-NEXT:      String: {{.+}} "char"
+# BOLT-NEXT:      Entry @ {{.+}} {
+# BOLT-NEXT:        Abbrev: [[ABBREV1]]
+# BOLT-NEXT:        Tag: DW_TAG_base_type
+# BOLT-NEXT:        DW_IDX_die_offset: 0x0000009f
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+
+## int foo(int i) {
+##   return i ++;
+## }
+## int main(int argc, char* argv[]) {
+##   int i = 0;
+##   [[clang::always_inline]] i = foo(argc);
+##   return i;
+## }
+## Test was manually modified so that DW_TAG_subprogram only had DW_AT_linkage_name.
+
+	.text
+	.file	"main.cpp"
+	.globl	_Z3fooi
+	.p2align	4, 0x90
+	.type	_Z3fooi,@function
+_Z3fooi:
+.Lfunc_begin0:
+	.file	0 "/abstractChain" "main.cpp" md5 0x2e29d55fc1320801a8057a4c50643ea1
+	.loc	0 1 0
+	.loc	0 2 12 prologue_end
+	.loc	0 2 3 epilogue_begin is_stmt 0
+	retq
+.Lfunc_end0:
+	.size	_Z3fooi, .Lfunc_end0-_Z3fooi
+
+	.globl	main
+	.p2align	4, 0x90
+	.type	main,@function
+main:
+.Lfunc_begin1:
+	.loc	0 4 0 is_stmt 1
+.Ltmp2:
+	.loc	0 5 7 prologue_end
+	.loc	0 6 36
+	movl	-12(%rbp), %eax
+.Ltmp3:
+	.loc	0 2 12
+.Ltmp4:
+	.loc	0 6 30
+	.loc	0 7 10
+	.loc	0 7 3 epilogue_begin is_stmt 0
+	retq
+.Ltmp5:
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+                                        # -- End function
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               # Abbreviation Code
+	.byte	17                              # DW_TAG_compile_unit
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	37                              # DW_AT_producer
+	.byte	37                              # DW_FORM_strx1
+	.byte	19                              # DW_AT_language
+	.byte	5                               # DW_FORM_data2
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	114                             # DW_AT_str_offsets_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	16                              # DW_AT_stmt_list
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	27                              # DW_AT_comp_dir
+	.byte	37                              # DW_FORM_strx1
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	115                             # DW_AT_addr_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	2                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	49                              # DW_AT_abstract_origin
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	3                               # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	49                              # DW_AT_abstract_origin
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	4                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	110                             # DW_AT_linkage_name
+	.byte	37                              # DW_FORM_strx1
+	#.byte	3                               # DW_AT_name
+	#.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	32                              # DW_AT_inline
+	.byte	33                              # DW_FORM_implicit_const
+	.byte	1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	5                               # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	6                               # Abbreviation Code
+	.byte	36                              # DW_TAG_base_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	62                              # DW_AT_encoding
+	.byte	11                              # DW_FORM_data1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	7                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	8                               # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	9                               # Abbreviation Code
+	.byte	52                              # DW_TAG_variable
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	10                              # Abbreviation Code
+	.byte	29                              # DW_TAG_inlined_subroutine
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	49                              # DW_AT_abstract_origin
+	.byte	19                              # DW_FORM_ref4
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	88                              # DW_AT_call_file
+	.byte	11                              # DW_FORM_data1
+	.byte	89                              # DW_AT_call_line
+	.byte	11                              # DW_FORM_data1
+	.byte	87                              # DW_AT_call_column
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	11                              # Abbreviation Code
+	.byte	15                              # DW_TAG_pointer_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	0                               # EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
+.Ldebug_info_start0:
+	.short	5                               # DWARF version number
+	.byte	1                               # DWARF Unit Type
+	.byte	8                               # Address Size (in bytes)
+	.long	.debug_abbrev                   # Offset Into Abbrev. Section
+	.byte	1                               # Abbrev [1] 0xc:0x98 DW_TAG_compile_unit
+	.byte	0                               # DW_AT_producer
+	.short	33                              # DW_AT_language
+	.byte	1                               # DW_AT_name
+	.long	.Lstr_offsets_base0             # DW_AT_str_offsets_base
+	.long	.Lline_table_start0             # DW_AT_stmt_list
+	.byte	2                               # DW_AT_comp_dir
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end1-.Lfunc_begin0       # DW_AT_high_pc
+	.long	.Laddr_table_base0              # DW_AT_addr_base
+	.byte	2                               # Abbrev [2] 0x23:0x15 DW_TAG_subprogram
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	86
+	.long	56                              # DW_AT_abstract_origin
+	.byte	3                               # Abbrev [3] 0x2f:0x8 DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	124
+	.long	64                              # DW_AT_abstract_origin Manually Modified
+	.byte	0                               # End Of Children Mark
+	.byte	4                               # Abbrev [4] 0x38:0x12 DW_TAG_subprogram
+	.byte	3                               # DW_AT_linkage_name
+	#.byte	4                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+	.long	74                              # DW_AT_type
+                                        # DW_AT_external
+                                        # DW_AT_inline
+	.byte	5                               # Abbrev [5] 0x41:0x8 DW_TAG_formal_parameter
+	.byte	6                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+	.long	74                              # DW_AT_type
+	.byte	0                               # End Of Children Mark
+	.byte	6                               # Abbrev [6] 0x4a:0x4 DW_TAG_base_type
+	.byte	5                               # DW_AT_name
+	.byte	5                               # DW_AT_encoding
+	.byte	4                               # DW_AT_byte_size
+	.byte	7                               # Abbrev [7] 0x4e:0x47 DW_TAG_subprogram
+	.byte	1                               # DW_AT_low_pc
+	.long	.Lfunc_end1-.Lfunc_begin1       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	86
+	.byte	7                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	4                               # DW_AT_decl_line
+	.long	73                              # DW_AT_type Manually Modified
+                                        # DW_AT_external
+	.byte	8                               # Abbrev [8] 0x5d:0xb DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	116
+	.byte	8                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	4                               # DW_AT_decl_line
+	.long	73                              # DW_AT_type Manually Modified
+	.byte	8                               # Abbrev [8] 0x68:0xb DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	104
+	.byte	9                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	4                               # DW_AT_decl_line
+	.long	148                             # DW_AT_type  Manually Modified
+	.byte	9                               # Abbrev [9] 0x73:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	100
+	.byte	6                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	5                               # DW_AT_decl_line
+	.long	73                              # DW_AT_type Manually Modified
+	.byte	10                              # Abbrev [10] 0x7e:0x16 DW_TAG_inlined_subroutine
+	.long	56                              # DW_AT_abstract_origin
+	.byte	2                               # DW_AT_low_pc
+	.long	.Ltmp4-.Ltmp3                   # DW_AT_high_pc
+	.byte	0                               # DW_AT_call_file
+	.byte	6                               # DW_AT_call_line
+	.byte	32                              # DW_AT_call_column
+	.byte	3                               # Abbrev [3] 0x8b:0x8 DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	124
+	.long	64                              # DW_AT_abstract_origin Manually Modified
+	.byte	0                               # End Of Children Mark
+	.byte	0                               # End Of Children Mark
+	.byte	11                              # Abbrev [11] 0x95:0x5 DW_TAG_pointer_type
+	.long	153                             # DW_AT_type  Manually Modified
+	.byte	11                              # Abbrev [11] 0x9a:0x5 DW_TAG_pointer_type
+	.long	158                             # DW_AT_type  Manually Modified
+	.byte	6                               # Abbrev [6] 0x9f:0x4 DW_TAG_base_type
+	.byte	10                              # DW_AT_name
+	.byte	6                               # DW_AT_encoding
+	.byte	1                               # DW_AT_byte_size
+	.byte	0                               # End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_str_offsets,"",@progbits
+	.long	48                              # Length of String Offsets Set
+	.short	5
+	.short	0
+.Lstr_offsets_base0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"clang version 20.0.0git"       # string offset=0
+.Linfo_string1:
+	.asciz	"main.cpp"                      # string offset=24
+.Linfo_string2:
+	.asciz	"/abstractChain" # string offset=33
+.Linfo_string3:
+	.asciz	"foo"                           # string offset=85
+.Linfo_string4:
+	.asciz	"_Z3fooi"                       # string offset=89
+.Linfo_string5:
+	.asciz	"int"                           # string offset=97
+.Linfo_string6:
+	.asciz	"i"                             # string offset=101
+.Linfo_string7:
+	.asciz	"main"                          # string offset=103
+.Linfo_string8:
+	.asciz	"argc"                          # string offset=108
+.Linfo_string9:
+	.asciz	"argv"                          # string offset=113
+.Linfo_string10:
+	.asciz	"char"                          # string offset=118
+	.section	.debug_str_offsets,"",@progbits
+	.long	.Linfo_string0
+	.long	.Linfo_string1
+	.long	.Linfo_string2
+	.long	.Linfo_string4
+	.long	.Linfo_string3
+	.long	.Linfo_string5
+	.long	.Linfo_string6
+	.long	.Linfo_string7
+	.long	.Linfo_string8
+	.long	.Linfo_string9
+	.long	.Linfo_string10
+	.section	.debug_addr,"",@progbits
+	.long	.Ldebug_addr_end0-.Ldebug_addr_start0 # Length of contribution
+.Ldebug_addr_start0:
+	.short	5                               # DWARF version number
+	.byte	8                               # Address size
+	.byte	0                               # Segment selector size
+.Laddr_table_base0:
+	.quad	.Lfunc_begin0
+	.quad	.Lfunc_begin1
+	.quad	.Ltmp3
+.Ldebug_addr_end0:
+	.section	.debug_names,"",@progbits
+	.long	.Lnames_end0-.Lnames_start0     # Header: unit length
+.Lnames_start0:
+	.short	5                               # Header: version
+	.short	0                               # Header: padding
+	.long	1                               # Header: compilation unit count
+	.long	0                               # Header: local type unit count
+	.long	0                               # Header: foreign type unit count
+	.long	5                               # Header: bucket count
+	.long	5                               # Header: name count
+	.long	.Lnames_abbrev_end0-.Lnames_abbrev_start0 # Header: abbreviation table size
+	.long	8                               # Header: augmentation string size
+	.ascii	"LLVM0700"                      # Header: augmentation string
+	.long	.Lcu_begin0                     # Compilation unit 0
+	.long	0                               # Bucket 0
+	.long	1                               # Bucket 1
+	.long	0                               # Bucket 2
+	.long	3                               # Bucket 3
+	.long	4                               # Bucket 4
+	.long	2090499946                      # Hash in Bucket 1
+	.long	-1257882370                     # Hash in Bucket 1
+	.long	193495088                       # Hash in Bucket 3
+	.long	193491849                       # Hash in Bucket 4
+	.long	2090147939                      # Hash in Bucket 4
+	.long	.Linfo_string7                  # String in Bucket 1: main
+	.long	.Linfo_string4                  # String in Bucket 1: _Z3fooi
+	.long	.Linfo_string5                  # String in Bucket 3: int
+	.long	.Linfo_string3                  # String in Bucket 4: foo
+	.long	.Linfo_string10                 # String in Bucket 4: char
+	.long	.Lnames3-.Lnames_entries0       # Offset in Bucket 1
+	.long	.Lnames1-.Lnames_entries0       # Offset in Bucket 1
+	.long	.Lnames2-.Lnames_entries0       # Offset in Bucket 3
+	.long	.Lnames0-.Lnames_entries0       # Offset in Bucket 4
+	.long	.Lnames4-.Lnames_entries0       # Offset in Bucket 4
+.Lnames_abbrev_start0:
+	.byte	1                               # Abbrev code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	2                               # Abbrev code
+	.byte	29                              # DW_TAG_inlined_subroutine
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	3                               # Abbrev code
+	.byte	36                              # DW_TAG_base_type
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev list
+.Lnames_abbrev_end0:
+.Lnames_entries0:
+.Lnames3:
+.L2:
+	.byte	1                               # Abbreviation code
+	.long	78                              # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: main
+.Lnames1:
+.L0:
+	.byte	1                               # Abbreviation code
+	.long	35                              # DW_IDX_die_offset
+.L3:                                    # DW_IDX_parent
+	.byte	2                               # Abbreviation code
+	.long	126                             # DW_IDX_die_offset
+	.long	.L2-.Lnames_entries0            # DW_IDX_parent
+	.byte	0                               # End of list: _Z3fooi
+.Lnames2:
+.L1:
+	.byte	3                               # Abbreviation code
+	.long	74                              # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: int
+.Lnames0:
+	.byte	1                               # Abbreviation code
+	.long	35                              # DW_IDX_die_offset
+	.byte	2                               # DW_IDX_parent
+                                        # Abbreviation code
+	.long	126                             # DW_IDX_die_offset
+	.long	.L2-.Lnames_entries0            # DW_IDX_parent
+	.byte	0                               # End of list: foo
+.Lnames4:
+.L4:
+	.byte	3                               # Abbreviation code
+	.long	159                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: char
+	.p2align	2, 0x0
+.Lnames_end0:
+	.ident	"clang version 20.0.0git"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/bolt/test/X86/dwarf5-debug-names-abstract-origin-specification.s
+++ b/bolt/test/X86/dwarf5-debug-names-abstract-origin-specification.s
@@ -1,0 +1,829 @@
+# RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %s   -o %tmain.o
+# RUN: %clang %cflags -gdwarf-5 %tmain.o -o %tmain.exe
+# RUN: llvm-bolt %tmain.exe -o %tmain.exe.bolt --update-debug-sections
+# RUN: llvm-dwarfdump --debug-names %tmain.exe.bolt > %tlog.txt
+# RUN: cat %tlog.txt | FileCheck -check-prefix=BOLT %s
+
+## This test checks that BOLT correctly generates .debug_names section when there is transative
+## DW_AT_name/DW_AT_linkage_name resolution.
+
+# BOLT:       Abbreviations [
+# BOLT-NEXT:   Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_subprogram
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_class_type
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Abbreviation [[ABBREV3:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_inlined_subroutine
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_ref4
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Abbreviation [[ABBREV4:0x[0-9a-f]*]] {
+# BOLT-NEXT:      Tag: DW_TAG_base_type
+# BOLT-NEXT:      DW_IDX_die_offset: DW_FORM_ref4
+# BOLT-NEXT:      DW_IDX_parent: DW_FORM_flag_present
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 0 [
+# BOLT-NEXT:    Name 1 {
+# BOLT-NEXT:      Hash: 0xD72418AA
+# BOLT-NEXT:      String: {{.+}} "_ZL3fooi"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV1]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x000000ba
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 1 [
+# BOLT-NEXT:    Name 2 {
+# BOLT-NEXT:      Hash: 0x10614A06
+# BOLT-NEXT:      String: {{.+}} "State"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV2]]
+# BOLT-NEXT:        Tag: DW_TAG_class_type
+# BOLT-NEXT:        DW_IDX_die_offset: 0x0000002b
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:      Entry @ [[REF1:0x[0-9a-f]*]] {
+# BOLT-NEXT:        Abbrev: [[ABBREV1]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x00000089
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV3]]
+# BOLT-NEXT:        Tag: DW_TAG_inlined_subroutine
+# BOLT-NEXT:        DW_IDX_die_offset: 0x000000a3
+# BOLT-NEXT:        DW_IDX_parent: Entry @ [[REF1]]
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 2 [
+# BOLT-NEXT:    EMPTY
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 3 [
+# BOLT-NEXT:    Name 3 {
+# BOLT-NEXT:      Hash: 0xB888030
+# BOLT-NEXT:      String: {{.+}} "int"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV4]]
+# BOLT-NEXT:        Tag: DW_TAG_base_type
+# BOLT-NEXT:        DW_IDX_die_offset: 0x00000085
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Name 4 {
+# BOLT-NEXT:      Hash: 0x7C9A7F6A
+# BOLT-NEXT:      String: {{.+}} "main"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV1]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x00000042
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 4 [
+# BOLT-NEXT:    EMPTY
+# BOLT-NEXT:  ]
+# BOLT-NEXT:  Bucket 5 [
+# BOLT-NEXT:    Name 5 {
+# BOLT-NEXT:      Hash: 0xB887389
+# BOLT-NEXT:      String: {{.+}} "foo"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV1]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x000000ba
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Name 6 {
+# BOLT-NEXT:      Hash: 0x7C952063
+# BOLT-NEXT:      String: {{.+}} "char"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV4]]
+# BOLT-NEXT:        Tag: DW_TAG_base_type
+# BOLT-NEXT:        DW_IDX_die_offset: 0x000000d9
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:    }
+# BOLT-NEXT:    Name 7 {
+# BOLT-NEXT:      Hash: 0xFBBDC812
+# BOLT-NEXT:      String: {{.+}} "_ZN5StateC2Ev"
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV1]]
+# BOLT-NEXT:        Tag: DW_TAG_subprogram
+# BOLT-NEXT:        DW_IDX_die_offset: 0x00000089
+# BOLT-NEXT:        DW_IDX_parent: <parent not indexed>
+# BOLT-NEXT:      }
+# BOLT-NEXT:      Entry @ {{.+}}  {
+# BOLT-NEXT:        Abbrev: [[ABBREV3]]
+# BOLT-NEXT:        Tag: DW_TAG_inlined_subroutine
+# BOLT-NEXT:        DW_IDX_die_offset: 0x000000a3
+# BOLT-NEXT:        DW_IDX_parent: Entry @ [[REF1]]
+
+## static int foo(int i) {
+##   return i ++;
+## }
+## class State {
+## public:
+##   State() {[[clang::always_inline]] foo(3);}
+## };
+##
+## int main(int argc, char* argv[]) {
+##   State S;
+##   return 0;
+## }
+
+## Test manually modified to redirect DW_TAG_inlined_subroutine to DW_TAG_subprogram with DW_AT_specification.
+
+	.text
+	.file	"main.cpp"
+	.file	0 "abstractChainTwo" "main.cpp" md5 0x17ad726b6a1fd49ee59559a1302da539
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+.Lfunc_begin0:
+	.loc	0 9 0                           # main.cpp:9:0
+.Ltmp0:
+	.loc	0 10 9 prologue_end             # main.cpp:10:9
+	callq	_ZN5StateC2Ev
+	.loc	0 11 3                          # main.cpp:11:3
+	.loc	0 11 3 epilogue_begin is_stmt 0 # main.cpp:11:3
+	retq
+.Ltmp1:
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+                                        # -- End function
+	.section	.text._ZN5StateC2Ev,"axG",@progbits,_ZN5StateC2Ev,comdat
+	.weak	_ZN5StateC2Ev                   # -- Begin function _ZN5StateC2Ev
+	.p2align	4, 0x90
+	.type	_ZN5StateC2Ev,@function
+_ZN5StateC2Ev:                          # @_ZN5StateC2Ev
+.Lfunc_begin1:
+	.loc	0 6 0 is_stmt 1                 # main.cpp:6:0
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movq	%rdi, -16(%rbp)
+	movl	$3, -4(%rbp)
+.Ltmp2:
+	.loc	0 2 12 prologue_end             # main.cpp:2:12
+	movl	-4(%rbp), %eax
+	addl	$1, %eax
+	movl	%eax, -4(%rbp)
+.Ltmp3:
+	.loc	0 6 44 epilogue_begin           # main.cpp:6:44
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Ltmp4:
+.Lfunc_end1:
+	.size	_ZN5StateC2Ev, .Lfunc_end1-_ZN5StateC2Ev
+	.cfi_endproc
+                                        # -- End function
+	.text
+	.p2align	4, 0x90                         # -- Begin function _ZL3fooi
+	.type	_ZL3fooi,@function
+_ZL3fooi:                               # @_ZL3fooi
+.Lfunc_begin2:
+	.loc	0 1 0                           # main.cpp:1:0
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+.Ltmp5:
+	.loc	0 2 12 prologue_end             # main.cpp:2:12
+	movl	-4(%rbp), %eax
+	movl	%eax, %ecx
+	addl	$1, %ecx
+	movl	%ecx, -4(%rbp)
+	.loc	0 2 3 epilogue_begin is_stmt 0  # main.cpp:2:3
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Ltmp6:
+.Lfunc_end2:
+	.size	_ZL3fooi, .Lfunc_end2-_ZL3fooi
+	.cfi_endproc
+                                        # -- End function
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               # Abbreviation Code
+	.byte	17                              # DW_TAG_compile_unit
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	37                              # DW_AT_producer
+	.byte	37                              # DW_FORM_strx1
+	.byte	19                              # DW_AT_language
+	.byte	5                               # DW_FORM_data2
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	114                             # DW_AT_str_offsets_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	16                              # DW_AT_stmt_list
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	27                              # DW_AT_comp_dir
+	.byte	37                              # DW_FORM_strx1
+	.byte	17                              # DW_AT_low_pc
+	.byte	1                               # DW_FORM_addr
+	.byte	85                              # DW_AT_ranges
+	.byte	35                              # DW_FORM_rnglistx
+	.byte	115                             # DW_AT_addr_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	116                             # DW_AT_rnglists_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	2                               # Abbreviation Code
+	.byte	2                               # DW_TAG_class_type
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	54                              # DW_AT_calling_convention
+	.byte	11                              # DW_FORM_data1
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	3                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	60                              # DW_AT_declaration
+	.byte	25                              # DW_FORM_flag_present
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	50                              # DW_AT_accessibility
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	4                               # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	52                              # DW_AT_artificial
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	5                               # Abbreviation Code
+	.byte	15                              # DW_TAG_pointer_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	6                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	7                               # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	8                               # Abbreviation Code
+	.byte	52                              # DW_TAG_variable
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	9                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	110                             # DW_AT_linkage_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	32                              # DW_AT_inline
+	.byte	33                              # DW_FORM_implicit_const
+	.byte	1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	10                              # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	11                              # Abbreviation Code
+	.byte	36                              # DW_TAG_base_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	62                              # DW_AT_encoding
+	.byte	11                              # DW_FORM_data1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	12                              # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	100                             # DW_AT_object_pointer
+	.byte	19                              # DW_FORM_ref4
+	.byte	110                             # DW_AT_linkage_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	71                              # DW_AT_specification
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	13                              # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	52                              # DW_AT_artificial
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	14                              # Abbreviation Code
+	.byte	29                              # DW_TAG_inlined_subroutine
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	49                              # DW_AT_abstract_origin
+	.byte	19                              # DW_FORM_ref4
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	88                              # DW_AT_call_file
+	.byte	11                              # DW_FORM_data1
+	.byte	89                              # DW_AT_call_line
+	.byte	11                              # DW_FORM_data1
+	.byte	87                              # DW_AT_call_column
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	15                              # Abbreviation Code
+	.byte	5                               # DW_TAG_formal_parameter
+	.byte	0                               # DW_CHILDREN_no
+	.byte	2                               # DW_AT_location
+	.byte	24                              # DW_FORM_exprloc
+	.byte	49                              # DW_AT_abstract_origin
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	16                              # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	49                              # DW_AT_abstract_origin
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	0                               # EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
+.Ldebug_info_start0:
+	.short	5                               # DWARF version number
+	.byte	1                               # DWARF Unit Type
+	.byte	8                               # Address Size (in bytes)
+	.long	.debug_abbrev                   # Offset Into Abbrev. Section
+	.byte	1                               # Abbrev [1] 0xc:0xd7 DW_TAG_compile_unit
+	.byte	0                               # DW_AT_producer
+	.short	33                              # DW_AT_language
+	.byte	1                               # DW_AT_name
+	.long	.Lstr_offsets_base0             # DW_AT_str_offsets_base
+	.long	.Lline_table_start0             # DW_AT_stmt_list
+	.byte	2                               # DW_AT_comp_dir
+	.quad	0                               # DW_AT_low_pc
+	.byte	0                               # DW_AT_ranges
+	.long	.Laddr_table_base0              # DW_AT_addr_base
+	.long	.Lrnglists_table_base0          # DW_AT_rnglists_base
+	.byte	2                               # Abbrev [2] 0x2b:0x12 DW_TAG_class_type
+	.byte	5                               # DW_AT_calling_convention
+	.byte	3                               # DW_AT_name
+	.byte	1                               # DW_AT_byte_size
+	.byte	0                               # DW_AT_decl_file
+	.byte	4                               # DW_AT_decl_line
+	.byte	3                               # Abbrev [3] 0x31:0xb DW_TAG_subprogram
+	.byte	3                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	6                               # DW_AT_decl_line
+                                        # DW_AT_declaration
+                                        # DW_AT_external
+	.byte	1                               # DW_AT_accessibility
+                                        # DW_ACCESS_public
+	.byte	4                               # Abbrev [4] 0x36:0x5 DW_TAG_formal_parameter
+	.long	61                              # DW_AT_type
+                                        # DW_AT_artificial
+	.byte	0                               # End Of Children Mark
+	.byte	0                               # End Of Children Mark
+	.byte	5                               # Abbrev [5] 0x3d:0x5 DW_TAG_pointer_type
+	.long	43                              # DW_AT_type
+	.byte	6                               # Abbrev [6] 0x42:0x31 DW_TAG_subprogram
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	86
+	.byte	8                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	9                               # DW_AT_decl_line
+	.long	133                             # DW_AT_type
+                                        # DW_AT_external
+	.byte	7                               # Abbrev [7] 0x51:0xb DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	120
+	.byte	10                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	9                               # DW_AT_decl_line
+	.long	133                             # DW_AT_type
+	.byte	7                               # Abbrev [7] 0x5c:0xb DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	112
+	.byte	11                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	9                               # DW_AT_decl_line
+	.long	207                             # DW_AT_type
+	.byte	8                               # Abbrev [8] 0x67:0xb DW_TAG_variable
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	111
+	.byte	13                              # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	10                              # DW_AT_decl_line
+	.long	43                              # DW_AT_type
+	.byte	0                               # End Of Children Mark
+	.byte	9                               # Abbrev [9] 0x73:0x12 DW_TAG_subprogram
+	.byte	4                               # DW_AT_linkage_name
+	.byte	5                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+	.long	133                             # DW_AT_type
+                                        # DW_AT_inline
+	.byte	10                              # Abbrev [10] 0x7c:0x8 DW_TAG_formal_parameter
+	.byte	7                               # DW_AT_name
+	.byte	0                               # DW_AT_decl_file
+	.byte	1                               # DW_AT_decl_line
+	.long	133                             # DW_AT_type
+	.byte	0                               # End Of Children Mark
+	.byte	11                              # Abbrev [11] 0x85:0x4 DW_TAG_base_type
+	.byte	6                               # DW_AT_name
+	.byte	5                               # DW_AT_encoding
+	.byte	4                               # DW_AT_byte_size
+	.byte	12                              # Abbrev [12] 0x89:0x31 DW_TAG_subprogram
+	.byte	1                               # DW_AT_low_pc
+	.long	.Lfunc_end1-.Lfunc_begin1       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	86
+	.long	154                             # DW_AT_object_pointer
+	.byte	9                               # DW_AT_linkage_name
+	.long	49                              # DW_AT_specification
+	.byte	13                              # Abbrev [13] 0x9a:0x9 DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	112
+	.byte	14                              # DW_AT_name
+	.long	221                             # DW_AT_type
+                                        # DW_AT_artificial
+	.byte	14                              # Abbrev [14] 0xa3:0x16 DW_TAG_inlined_subroutine
+	.long	137                             # DW_AT_abstract_origin Manually Modified
+	.byte	2                               # DW_AT_low_pc
+	.long	.Ltmp3-.Ltmp2                   # DW_AT_high_pc
+	.byte	0                               # DW_AT_call_file
+	.byte	6                               # DW_AT_call_line
+	.byte	37                              # DW_AT_call_column
+	.byte	15                              # Abbrev [15] 0xb0:0x8 DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	124
+	.long	124                             # DW_AT_abstract_origin
+	.byte	0                               # End Of Children Mark
+	.byte	0                               # End Of Children Mark
+	.byte	16                              # Abbrev [16] 0xba:0x15 DW_TAG_subprogram
+	.byte	3                               # DW_AT_low_pc
+	.long	.Lfunc_end2-.Lfunc_begin2       # DW_AT_high_pc
+	.byte	1                               # DW_AT_frame_base
+	.byte	86
+	.long	115                             # DW_AT_abstract_origin
+	.byte	15                              # Abbrev [15] 0xc6:0x8 DW_TAG_formal_parameter
+	.byte	2                               # DW_AT_location
+	.byte	145
+	.byte	124
+	.long	124                             # DW_AT_abstract_origin
+	.byte	0                               # End Of Children Mark
+	.byte	5                               # Abbrev [5] 0xcf:0x5 DW_TAG_pointer_type
+	.long	212                             # DW_AT_type
+	.byte	5                               # Abbrev [5] 0xd4:0x5 DW_TAG_pointer_type
+	.long	217                             # DW_AT_type
+	.byte	11                              # Abbrev [11] 0xd9:0x4 DW_TAG_base_type
+	.byte	12                              # DW_AT_name
+	.byte	6                               # DW_AT_encoding
+	.byte	1                               # DW_AT_byte_size
+	.byte	5                               # Abbrev [5] 0xdd:0x5 DW_TAG_pointer_type
+	.long	43                              # DW_AT_type
+	.byte	0                               # End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_rnglists,"",@progbits
+	.long	.Ldebug_list_header_end0-.Ldebug_list_header_start0 # Length
+.Ldebug_list_header_start0:
+	.short	5                               # Version
+	.byte	8                               # Address size
+	.byte	0                               # Segment selector size
+	.long	1                               # Offset entry count
+.Lrnglists_table_base0:
+	.long	.Ldebug_ranges0-.Lrnglists_table_base0
+.Ldebug_ranges0:
+	.byte	1                               # DW_RLE_base_addressx
+	.byte	0                               #   base address index
+	.byte	4                               # DW_RLE_offset_pair
+	.uleb128 .Lfunc_begin0-.Lfunc_begin0    #   starting offset
+	.uleb128 .Lfunc_end0-.Lfunc_begin0      #   ending offset
+	.byte	4                               # DW_RLE_offset_pair
+	.uleb128 .Lfunc_begin2-.Lfunc_begin0    #   starting offset
+	.uleb128 .Lfunc_end2-.Lfunc_begin0      #   ending offset
+	.byte	3                               # DW_RLE_startx_length
+	.byte	1                               #   start index
+	.uleb128 .Lfunc_end1-.Lfunc_begin1      #   length
+	.byte	0                               # DW_RLE_end_of_list
+.Ldebug_list_header_end0:
+	.section	.debug_str_offsets,"",@progbits
+	.long	64                              # Length of String Offsets Set
+	.short	5
+	.short	0
+.Lstr_offsets_base0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"clang version 20.0.0git"       # string offset=0
+.Linfo_string1:
+	.asciz	"main.cpp"                      # string offset=24
+.Linfo_string2:
+	.asciz	"abstractChainTwo" # string offset=33
+.Linfo_string3:
+	.asciz	"State"                         # string offset=88
+.Linfo_string4:
+	.asciz	"main"                          # string offset=94
+.Linfo_string5:
+	.asciz	"_ZL3fooi"                      # string offset=99
+.Linfo_string6:
+	.asciz	"foo"                           # string offset=108
+.Linfo_string7:
+	.asciz	"int"                           # string offset=112
+.Linfo_string8:
+	.asciz	"i"                             # string offset=116
+.Linfo_string9:
+	.asciz	"_ZN5StateC2Ev"                 # string offset=118
+.Linfo_string10:
+	.asciz	"argc"                          # string offset=132
+.Linfo_string11:
+	.asciz	"argv"                          # string offset=137
+.Linfo_string12:
+	.asciz	"char"                          # string offset=142
+.Linfo_string13:
+	.asciz	"S"                             # string offset=147
+.Linfo_string14:
+	.asciz	"this"                          # string offset=149
+	.section	.debug_str_offsets,"",@progbits
+	.long	.Linfo_string0
+	.long	.Linfo_string1
+	.long	.Linfo_string2
+	.long	.Linfo_string3
+	.long	.Linfo_string5
+	.long	.Linfo_string6
+	.long	.Linfo_string7
+	.long	.Linfo_string8
+	.long	.Linfo_string4
+	.long	.Linfo_string9
+	.long	.Linfo_string10
+	.long	.Linfo_string11
+	.long	.Linfo_string12
+	.long	.Linfo_string13
+	.long	.Linfo_string14
+	.section	.debug_addr,"",@progbits
+	.long	.Ldebug_addr_end0-.Ldebug_addr_start0 # Length of contribution
+.Ldebug_addr_start0:
+	.short	5                               # DWARF version number
+	.byte	8                               # Address size
+	.byte	0                               # Segment selector size
+.Laddr_table_base0:
+	.quad	.Lfunc_begin0
+	.quad	.Lfunc_begin1
+	.quad	.Ltmp2
+	.quad	.Lfunc_begin2
+.Ldebug_addr_end0:
+	.section	.debug_names,"",@progbits
+	.long	.Lnames_end0-.Lnames_start0     # Header: unit length
+.Lnames_start0:
+	.short	5                               # Header: version
+	.short	0                               # Header: padding
+	.long	1                               # Header: compilation unit count
+	.long	0                               # Header: local type unit count
+	.long	0                               # Header: foreign type unit count
+	.long	7                               # Header: bucket count
+	.long	7                               # Header: name count
+	.long	.Lnames_abbrev_end0-.Lnames_abbrev_start0 # Header: abbreviation table size
+	.long	8                               # Header: augmentation string size
+	.ascii	"LLVM0700"                      # Header: augmentation string
+	.long	.Lcu_begin0                     # Compilation unit 0
+	.long	1                               # Bucket 0
+	.long	2                               # Bucket 1
+	.long	0                               # Bucket 2
+	.long	3                               # Bucket 3
+	.long	0                               # Bucket 4
+	.long	5                               # Bucket 5
+	.long	0                               # Bucket 6
+	.long	-685500246                      # Hash in Bucket 0
+	.long	274811398                       # Hash in Bucket 1
+	.long	193495088                       # Hash in Bucket 3
+	.long	2090499946                      # Hash in Bucket 3
+	.long	193491849                       # Hash in Bucket 5
+	.long	2090147939                      # Hash in Bucket 5
+	.long	-71448558                       # Hash in Bucket 5
+	.long	.Linfo_string5                  # String in Bucket 0: _ZL3fooi
+	.long	.Linfo_string3                  # String in Bucket 1: State
+	.long	.Linfo_string7                  # String in Bucket 3: int
+	.long	.Linfo_string4                  # String in Bucket 3: main
+	.long	.Linfo_string6                  # String in Bucket 5: foo
+	.long	.Linfo_string12                 # String in Bucket 5: char
+	.long	.Linfo_string9                  # String in Bucket 5: _ZN5StateC2Ev
+	.long	.Lnames5-.Lnames_entries0       # Offset in Bucket 0
+	.long	.Lnames0-.Lnames_entries0       # Offset in Bucket 1
+	.long	.Lnames2-.Lnames_entries0       # Offset in Bucket 3
+	.long	.Lnames1-.Lnames_entries0       # Offset in Bucket 3
+	.long	.Lnames4-.Lnames_entries0       # Offset in Bucket 5
+	.long	.Lnames6-.Lnames_entries0       # Offset in Bucket 5
+	.long	.Lnames3-.Lnames_entries0       # Offset in Bucket 5
+.Lnames_abbrev_start0:
+	.byte	1                               # Abbrev code
+	.byte	29                              # DW_TAG_inlined_subroutine
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	19                              # DW_FORM_ref4
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	2                               # Abbrev code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	3                               # Abbrev code
+	.byte	2                               # DW_TAG_class_type
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	4                               # Abbrev code
+	.byte	36                              # DW_TAG_base_type
+	.byte	3                               # DW_IDX_die_offset
+	.byte	19                              # DW_FORM_ref4
+	.byte	4                               # DW_IDX_parent
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev
+	.byte	0                               # End of abbrev list
+.Lnames_abbrev_end0:
+.Lnames_entries0:
+.Lnames5:
+.L1:
+	.byte	1                               # Abbreviation code
+	.long	163                             # DW_IDX_die_offset
+	.long	.L2-.Lnames_entries0            # DW_IDX_parent
+.L0:
+	.byte	2                               # Abbreviation code
+	.long	186                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: _ZL3fooi
+.Lnames0:
+.L5:
+	.byte	3                               # Abbreviation code
+	.long	43                              # DW_IDX_die_offset
+.L2:                                    # DW_IDX_parent
+	.byte	2                               # Abbreviation code
+	.long	137                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: State
+.Lnames2:
+.L4:
+	.byte	4                               # Abbreviation code
+	.long	133                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: int
+.Lnames1:
+.L6:
+	.byte	2                               # Abbreviation code
+	.long	66                              # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: main
+.Lnames4:
+	.byte	1                               # Abbreviation code
+	.long	163                             # DW_IDX_die_offset
+	.long	.L2-.Lnames_entries0            # DW_IDX_parent
+	.byte	2                               # Abbreviation code
+	.long	186                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: foo
+.Lnames6:
+.L3:
+	.byte	4                               # Abbreviation code
+	.long	217                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: char
+.Lnames3:
+	.byte	2                               # Abbreviation code
+	.long	137                             # DW_IDX_die_offset
+	.byte	0                               # DW_IDX_parent
+                                        # End of list: _ZN5StateC2Ev
+	.p2align	2, 0x0
+.Lnames_end0:
+	.ident	"clang version 20.0.0git"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:


### PR DESCRIPTION
This fix handles a case where a DIE that does not have DW_AT_name/DW_AT_linkage_name, but has a reference to another DIE using  DW_AT_abstract_origin/DW_AT_specification. It also fixes a bug where there are cross CU references for those attributes. Previously it would use a DWARF Unit of a DIE which was being processed The warf5-debug-names-cross-cu.s test just happened to work because how it was constructed where string section was shared by both DWARF Units.

To resolve DW_AT_name/DW_AT_linkage_name this patch iterates over references until it either reaches the final DIE or finds both of those names.