### PR TITLE
[libc++abi] Don't leak in test

### DIFF
--- a/libcxxabi/test/forced_unwind2.pass.cpp
+++ b/libcxxabi/test/forced_unwind2.pass.cpp
@@ -43,15 +43,9 @@ struct Stop<R (*)(Args...)> {
   }
 };
 
-static void cleanup(_Unwind_Reason_Code, struct _Unwind_Exception* exc) {
-  delete exc;
-}
-
 static void forced_unwind() {
-  _Unwind_Exception* exc = new _Unwind_Exception;
-  memset(&exc->exception_class, 0, sizeof(exc->exception_class));
-  exc->exception_cleanup = cleanup;
-  _Unwind_ForcedUnwind(exc, Stop<_Unwind_Stop_Fn>::stop, 0);
+  static _Unwind_Exception exc = {};
+  _Unwind_ForcedUnwind(&exc, Stop<_Unwind_Stop_Fn>::stop, 0);
   abort();
 }
 

--- a/libcxxabi/test/forced_unwind2.pass.cpp
+++ b/libcxxabi/test/forced_unwind2.pass.cpp
@@ -43,10 +43,14 @@ struct Stop<R (*)(Args...)> {
   }
 };
 
+static void cleanup(_Unwind_Reason_Code, struct _Unwind_Exception* exc) {
+  delete exc;
+}
+
 static void forced_unwind() {
   _Unwind_Exception* exc = new _Unwind_Exception;
   memset(&exc->exception_class, 0, sizeof(exc->exception_class));
-  exc->exception_cleanup = 0;
+  exc->exception_cleanup = cleanup;
   _Unwind_ForcedUnwind(exc, Stop<_Unwind_Stop_Fn>::stop, 0);
   abort();
 }

--- a/libcxxabi/test/forced_unwind3.pass.cpp
+++ b/libcxxabi/test/forced_unwind3.pass.cpp
@@ -60,10 +60,14 @@ struct Stop<R (*)(Args...)> {
   }
 };
 
+static void cleanup(_Unwind_Reason_Code, struct _Unwind_Exception* exc) {
+  delete exc;
+}
+
 static void forced_unwind() {
   _Unwind_Exception* exc = new _Unwind_Exception;
   memset(&exc->exception_class, 0, sizeof(exc->exception_class));
-  exc->exception_cleanup = 0;
+  exc->exception_cleanup = cleanup;
   _Unwind_ForcedUnwind(exc, Stop<_Unwind_Stop_Fn>::stop, 0);
   abort();
 }

--- a/libcxxabi/test/forced_unwind3.pass.cpp
+++ b/libcxxabi/test/forced_unwind3.pass.cpp
@@ -60,14 +60,10 @@ struct Stop<R (*)(Args...)> {
   }
 };
 
-static void cleanup(_Unwind_Reason_Code, struct _Unwind_Exception* exc) {
-  delete exc;
-}
-
 static void forced_unwind() {
   _Unwind_Exception* exc = new _Unwind_Exception;
   memset(&exc->exception_class, 0, sizeof(exc->exception_class));
-  exc->exception_cleanup = cleanup;
+  exc->exception_cleanup = 0;
   _Unwind_ForcedUnwind(exc, Stop<_Unwind_Stop_Fn>::stop, 0);
   abort();
 }


### PR DESCRIPTION
Trying to re-enable a test on bots
https://github.com/llvm/llvm-zorg/blob/bb695735dba75e1a5dced13e836f4f46de464bac/zorg/buildbot/builders/sanitizers/buildbot_functions.sh#L443

When we reach `terminate()` `exc` pointer is not
on the stack, so lsan correctly report a leak.
