### PR TITLE
[libc++abi] Don't do pointer arithmetic on nullptr

### DIFF
--- a/libcxxabi/src/private_typeinfo.cpp
+++ b/libcxxabi/src/private_typeinfo.cpp
@@ -591,10 +591,9 @@ __base_class_type_info::has_unambiguous_public_base(__dynamic_cast_info* info,
     // .. and reset the pointer.
     adjustedPtr = nullptr;
   }
-    __base_type->has_unambiguous_public_base(
-            info,
-            reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(adjustedPtr) + offset_to_base),
-            (__offset_flags & __public_mask) ? path_below : not_public_path);
+  __base_type->has_unambiguous_public_base(
+      info, reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(adjustedPtr) + offset_to_base),
+      (__offset_flags & __public_mask) ? path_below : not_public_path);
 }
 
 void

--- a/libcxxabi/src/private_typeinfo.cpp
+++ b/libcxxabi/src/private_typeinfo.cpp
@@ -593,7 +593,7 @@ __base_class_type_info::has_unambiguous_public_base(__dynamic_cast_info* info,
   }
     __base_type->has_unambiguous_public_base(
             info,
-            static_cast<char*>(adjustedPtr) + offset_to_base,
+            reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(adjustedPtr) + offset_to_base),
             (__offset_flags & __public_mask) ? path_below : not_public_path);
 }
 


### PR DESCRIPTION
`nullptr + offset` is possible after `!is_virtual` branch.

Detected with check-cxxabi on configured with:
```
cmake -DLLVM_APPEND_VC_REV=OFF -GNinja \
  -DCMAKE_BUILD_TYPE=Release \
  -DLLVM_CCACHE_BUILD=ON \
  -DLLVM_USE_LINKER=lld \
  -DLLVM_ENABLE_ASSERTIONS=ON \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DLIBCXXABI_USE_LLVM_UNWINDER=OFF \
  -DCMAKE_INSTALL_PREFIX=/home/b/sanitizer-aarch64-linux-bootstrap-ubsan/build/libcxx_install_ubsan \
  '-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi;libunwind' \
  -DLIBCXX_TEST_PARAMS=long_tests=False \
  -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
  -DLLVM_USE_SANITIZER=Undefined \
  '-DCMAKE_C_FLAGS=-fsanitize=undefined -fno-sanitize-recover=all   -fno-sanitize=vptr' \
  '-DCMAKE_CXX_FLAGS=-fsanitize=undefined -fno-sanitize-recover=all   -fno-sanitize=vptr' \
  /home/b/sanitizer-aarch64-linux-bootstrap-ubsan/build/llvm-project/llvm/../runtimes

********************
Failed Tests (2):
  llvm-libc++abi-shared.cfg.in :: catch_null_pointer_to_object_pr64953.pass.cpp
  llvm-libc++abi-shared.cfg.in :: catch_ptr_02.pass.cpp
```
