### PR TITLE
[libc++][C++03] Add #if 0 to the experimental/ and ext/ headers as well

### DIFF
--- a/libcxx/include/experimental/iterator
+++ b/libcxx/include/experimental/iterator
@@ -52,23 +52,25 @@ namespace std {
 
 */
 
-#include <__config>
-#include <__memory/addressof.h>
-#include <__ostream/basic_ostream.h>
-#include <__string/char_traits.h>
-#include <__type_traits/decay.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <iterator>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__memory/addressof.h>
+#  include <__ostream/basic_ostream.h>
+#  include <__string/char_traits.h>
+#  include <__type_traits/decay.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <iterator>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
 _LIBCPP_BEGIN_NAMESPACE_LFTS
 
@@ -117,14 +119,15 @@ make_ostream_joiner(basic_ostream<_CharT, _Traits>& __os, _Delim&& __d) {
 
 _LIBCPP_END_NAMESPACE_LFTS
 
-#endif // _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <iosfwd>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <iosfwd>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_EXPERIMENTAL_ITERATOR

--- a/libcxx/include/experimental/memory
+++ b/libcxx/include/experimental/memory
@@ -49,27 +49,29 @@ public:
 }
 */
 
-#include <__config>
-#include <__cstddef/nullptr_t.h>
-#include <__cstddef/size_t.h>
-#include <__functional/hash.h>
-#include <__functional/operations.h>
-#include <__type_traits/add_lvalue_reference.h>
-#include <__type_traits/add_pointer.h>
-#include <__type_traits/common_type.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_convertible.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/nullptr_t.h>
+#  include <__cstddef/size_t.h>
+#  include <__functional/hash.h>
+#  include <__functional/operations.h>
+#  include <__type_traits/add_lvalue_reference.h>
+#  include <__type_traits/add_pointer.h>
+#  include <__type_traits/common_type.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_convertible.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
-#ifdef _LIBCPP_ENABLE_EXPERIMENTAL
+#  ifdef _LIBCPP_ENABLE_EXPERIMENTAL
 
 _LIBCPP_BEGIN_NAMESPACE_LFTS_V2
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 
 template <class _Wp>
 class observer_ptr {
@@ -172,7 +174,7 @@ _LIBCPP_HIDE_FROM_ABI bool operator>=(observer_ptr<_W1> __a, observer_ptr<_W2> _
   return !(__a < __b);
 }
 
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_END_NAMESPACE_LFTS_V2
 
@@ -180,22 +182,23 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // hash
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 template <class _Tp>
 struct hash<experimental::observer_ptr<_Tp>> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const experimental::observer_ptr<_Tp>& __ptr) const noexcept {
     return hash<_Tp*>()(__ptr.get());
   }
 };
-#  endif // _LIBCPP_STD_VER >= 17
+#    endif // _LIBCPP_STD_VER >= 17
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_ENABLE_EXPERIMENTAL
+#  endif // _LIBCPP_ENABLE_EXPERIMENTAL
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <limits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <limits>
+#  endif
+#endif // 0
 
 #endif /* _LIBCPP_EXPERIMENTAL_MEMORY */

--- a/libcxx/include/experimental/propagate_const
+++ b/libcxx/include/experimental/propagate_const
@@ -107,39 +107,41 @@
 
 */
 
-#include <__config>
-#include <__cstddef/nullptr_t.h>
-#include <__cstddef/size_t.h>
-#include <__functional/operations.h>
-#include <__fwd/functional.h>
-#include <__type_traits/conditional.h>
-#include <__type_traits/decay.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_array.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_convertible.h>
-#include <__type_traits/is_function.h>
-#include <__type_traits/is_pointer.h>
-#include <__type_traits/is_reference.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/is_swappable.h>
-#include <__type_traits/remove_cv.h>
-#include <__type_traits/remove_pointer.h>
-#include <__type_traits/remove_reference.h>
-#include <__utility/declval.h>
-#include <__utility/forward.h>
-#include <__utility/move.h>
-#include <__utility/swap.h>
-#include <version>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__cstddef/nullptr_t.h>
+#  include <__cstddef/size_t.h>
+#  include <__functional/operations.h>
+#  include <__fwd/functional.h>
+#  include <__type_traits/conditional.h>
+#  include <__type_traits/decay.h>
+#  include <__type_traits/enable_if.h>
+#  include <__type_traits/is_array.h>
+#  include <__type_traits/is_constructible.h>
+#  include <__type_traits/is_convertible.h>
+#  include <__type_traits/is_function.h>
+#  include <__type_traits/is_pointer.h>
+#  include <__type_traits/is_reference.h>
+#  include <__type_traits/is_same.h>
+#  include <__type_traits/is_swappable.h>
+#  include <__type_traits/remove_cv.h>
+#  include <__type_traits/remove_pointer.h>
+#  include <__type_traits/remove_reference.h>
+#  include <__utility/declval.h>
+#  include <__utility/forward.h>
+#  include <__utility/move.h>
+#  include <__utility/swap.h>
+#  include <version>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_PUSH_MACROS
-#include <__undef_macros>
+#  include <__undef_macros>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
 _LIBCPP_BEGIN_NAMESPACE_LFTS_V2
 
@@ -481,13 +483,14 @@ struct greater_equal<experimental::propagate_const<_Tp>> {
 
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // _LIBCPP_STD_VER >= 14
+#  endif // _LIBCPP_STD_VER >= 14
 
 _LIBCPP_POP_MACROS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_EXPERIMENTAL_PROPAGATE_CONST

--- a/libcxx/include/experimental/simd
+++ b/libcxx/include/experimental/simd
@@ -75,18 +75,21 @@ inline namespace parallelism_v2 {
 #  pragma GCC system_header
 #endif
 
-#include <__config>
-#include <experimental/__simd/aligned_tag.h>
-#include <experimental/__simd/declaration.h>
-#include <experimental/__simd/reference.h>
-#include <experimental/__simd/scalar.h>
-#include <experimental/__simd/simd.h>
-#include <experimental/__simd/simd_mask.h>
-#include <experimental/__simd/traits.h>
-#include <experimental/__simd/vec_ext.h>
+#if 0
+#else // 0
+#  include <__config>
+#  include <experimental/__simd/aligned_tag.h>
+#  include <experimental/__simd/declaration.h>
+#  include <experimental/__simd/reference.h>
+#  include <experimental/__simd/scalar.h>
+#  include <experimental/__simd/simd.h>
+#  include <experimental/__simd/simd_mask.h>
+#  include <experimental/__simd/traits.h>
+#  include <experimental/__simd/vec_ext.h>
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif /* _LIBCPP_EXPERIMENTAL_SIMD */

--- a/libcxx/include/experimental/type_traits
+++ b/libcxx/include/experimental/type_traits
@@ -68,16 +68,18 @@ inline namespace fundamentals_v1 {
 
  */
 
-#include <__config>
+#if 0
+#else // 0
+#  include <__config>
 
-#if _LIBCPP_STD_VER >= 14
+#  if _LIBCPP_STD_VER >= 14
 
-#  include <initializer_list>
-#  include <type_traits>
+#    include <initializer_list>
+#    include <type_traits>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_BEGIN_NAMESPACE_LFTS
 
@@ -148,10 +150,11 @@ constexpr bool is_detected_convertible_v = is_detected_convertible<_To, _Op, _Ar
 
 _LIBCPP_END_NAMESPACE_LFTS
 
-#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#    include <cstddef>
-#  endif
+#    if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#      include <cstddef>
+#    endif
 
-#endif /* _LIBCPP_STD_VER >= 14 */
+#  endif /* _LIBCPP_STD_VER >= 14 */
+#endif   // 0
 
 #endif /* _LIBCPP_EXPERIMENTAL_TYPE_TRAITS */

--- a/libcxx/include/experimental/utility
+++ b/libcxx/include/experimental/utility
@@ -30,12 +30,14 @@ inline namespace fundamentals_v1 {
 
  */
 
-#include <__config>
-#include <utility>
+#if 0
+#else // 0
+#  include <__config>
+#  include <utility>
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_LFTS
 
@@ -43,8 +45,9 @@ struct _LIBCPP_TEMPLATE_VIS erased_type {};
 
 _LIBCPP_END_NAMESPACE_LFTS
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <cstddef>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <cstddef>
+#  endif
+#endif // 0
 
 #endif /* _LIBCPP_EXPERIMENTAL_UTILITY */

--- a/libcxx/include/ext/hash_map
+++ b/libcxx/include/ext/hash_map
@@ -201,23 +201,25 @@ template <class Key, class T, class Hash, class Pred, class Alloc>
 
 */
 
-#include <__config>
-#include <__hash_table>
-#include <algorithm>
-#include <ext/__hash>
-#include <functional>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__hash_table>
+#  include <algorithm>
+#  include <ext/__hash>
+#  include <functional>
 
-#if defined(__DEPRECATED) && __DEPRECATED
-#  if defined(_LIBCPP_WARNING)
+#  if defined(__DEPRECATED) && __DEPRECATED
+#    if defined(_LIBCPP_WARNING)
 _LIBCPP_WARNING("Use of the header <ext/hash_map> is deprecated.  Migrate to <unordered_map>")
-#  else
-#    warning Use of the header <ext/hash_map> is deprecated.  Migrate to <unordered_map>
+#    else
+#      warning Use of the header <ext/hash_map> is deprecated.  Migrate to <unordered_map>
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 namespace __gnu_cxx {
 
@@ -312,17 +314,17 @@ public:
   _LIBCPP_HIDE_FROM_ABI explicit __hash_map_node_destructor(allocator_type& __na)
       : __na_(__na), __first_constructed(false), __second_constructed(false) {}
 
-#ifndef _LIBCPP_CXX03_LANG
+#  ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __hash_map_node_destructor(std::__hash_node_destructor<allocator_type>&& __x)
       : __na_(__x.__na_), __first_constructed(__x.__value_constructed), __second_constructed(__x.__value_constructed) {
     __x.__value_constructed = false;
   }
-#else  // _LIBCPP_CXX03_LANG
+#  else  // _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI __hash_map_node_destructor(const std::__hash_node_destructor<allocator_type>& __x)
       : __na_(__x.__na_), __first_constructed(__x.__value_constructed), __second_constructed(__x.__value_constructed) {
     const_cast<bool&>(__x.__value_constructed) = false;
   }
-#endif // _LIBCPP_CXX03_LANG
+#  endif // _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI void operator()(pointer __p) {
     if (__second_constructed)
@@ -863,10 +865,11 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const hash_multimap<_Key, _Tp, _Has
 
 } // namespace __gnu_cxx
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <iterator>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <iterator>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_HASH_MAP

--- a/libcxx/include/ext/hash_set
+++ b/libcxx/include/ext/hash_set
@@ -192,23 +192,25 @@ template <class Value, class Hash, class Pred, class Alloc>
 
 */
 
-#include <__config>
-#include <__hash_table>
-#include <algorithm>
-#include <ext/__hash>
-#include <functional>
+#if 0
+#else // 0
+#  include <__config>
+#  include <__hash_table>
+#  include <algorithm>
+#  include <ext/__hash>
+#  include <functional>
 
-#if defined(__DEPRECATED) && __DEPRECATED
-#  if defined(_LIBCPP_WARNING)
+#  if defined(__DEPRECATED) && __DEPRECATED
+#    if defined(_LIBCPP_WARNING)
 _LIBCPP_WARNING("Use of the header <ext/hash_set> is deprecated.  Migrate to <unordered_set>")
-#  else
-#    warning Use of the header <ext/hash_set> is deprecated.  Migrate to <unordered_set>
+#    else
+#      warning Use of the header <ext/hash_set> is deprecated.  Migrate to <unordered_set>
+#    endif
 #  endif
-#endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 namespace __gnu_cxx {
 
@@ -575,10 +577,11 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const hash_multiset<_Value, _Hash, 
 
 } // namespace __gnu_cxx
 
-#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
-#  include <concepts>
-#  include <iterator>
-#  include <type_traits>
-#endif
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#    include <concepts>
+#    include <iterator>
+#    include <type_traits>
+#  endif
+#endif // 0
 
 #endif // _LIBCPP_HASH_SET


### PR DESCRIPTION
This has already been done for the most headers in https://github.com/llvm/llvm-project/pull/119234, but I forgot to also do it for the experimental/ and ext/ headers.

This is part of https://discourse.llvm.org/t/rfc-freezing-c-03-headers-in-libc.