### PR TITLE
[MachineScheduler] Check whether the SUnit must end a dispatch group

### DIFF
--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -2450,8 +2450,6 @@ SchedBoundary::getNextResourceCycle(const MCSchedClassDesc *SC, unsigned PIdx,
 /// simple counters that the scheduler itself maintains. It explicitly checks
 /// for instruction dispatch limitations, including the number of micro-ops that
 /// can dispatch per cycle.
-///
-/// TODO: Also check whether the SU must start a new group.
 bool SchedBoundary::checkHazard(SUnit *SU) {
   if (HazardRec->isEnabled()
       && HazardRec->getHazardType(SU) != ScheduleHazardRecognizer::NoHazard) {
@@ -2460,8 +2458,7 @@ bool SchedBoundary::checkHazard(SUnit *SU) {
 
   unsigned uops = SchedModel->getNumMicroOps(SU->getInstr());
   if ((CurrMOps > 0) && (CurrMOps + uops > SchedModel->getIssueWidth())) {
-    LLVM_DEBUG(dbgs() << "  SU(" << SU->NodeNum << ") uops="
-                      << SchedModel->getNumMicroOps(SU->getInstr()) << '\n');
+    LLVM_DEBUG(dbgs() << "  SU(" << SU->NodeNum << ") uops=" << uops << '\n');
     return true;
   }
 

--- a/llvm/lib/CodeGen/VLIWMachineScheduler.cpp
+++ b/llvm/lib/CodeGen/VLIWMachineScheduler.cpp
@@ -428,7 +428,9 @@ void ConvergingVLIWScheduler::VLIWSchedBoundary::bumpNode(SUnit *SU) {
   startNewCycle = ResourceModel->reserveResources(SU, isTop());
 
   // Check the instruction group dispatch limit.
-  // TODO: Check if this SU must end a dispatch group.
+  assert(IssueCount == 0 ||
+         (!(isTop() && SchedModel->mustBeginGroup(SU->getInstr())) &&
+          !(!isTop() && SchedModel->mustEndGroup(SU->getInstr()))));
   IssueCount += SchedModel->getNumMicroOps(SU->getInstr());
   if (startNewCycle) {
     LLVM_DEBUG(dbgs() << "*** Max instrs at cycle " << CurrCycle << '\n');


### PR DESCRIPTION
3d594370933b515234c208a85a1c091d3e38d7f7 checks whether the SU must be issued alone, i.e., instruction that must be start/end a group. For example, in Cortex-R52 processor, vector load/stores can issue only in slot-0 and dual-issue with another instruction in slot-1, but only in the last issue. This provides finer control over instruction scheduling based on the design of each microarchitecture. 

The behavior of single issue and begin/end groups is actually the same., so the TODO check could be removed now.