### PR TITLE
[BOLT] Fix Linux kernel static keys handling

### DIFF
--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -1660,12 +1660,13 @@ Error LinuxKernelRewriter::readStaticKeysJumpTable() {
   DataExtractor::Cursor Cursor(StaticKeysJumpTableAddress - SectionAddress);
   uint32_t EntryID = 0;
   while (Cursor && Cursor.tell() < Stop->getAddress() - SectionAddress) {
+    uint64_t _;
     const uint64_t JumpAddress =
-        SectionAddress + Cursor.tell() + (int32_t)DE.getU32(Cursor);
+        (_ = SectionAddress + Cursor.tell(), _ + (int32_t)DE.getU32(Cursor));
     const uint64_t TargetAddress =
-        SectionAddress + Cursor.tell() + (int32_t)DE.getU32(Cursor);
+        (_ = SectionAddress + Cursor.tell(), _ + (int32_t)DE.getU32(Cursor));
     const uint64_t KeyAddress =
-        SectionAddress + Cursor.tell() + (int64_t)DE.getU64(Cursor);
+        (_ = SectionAddress + Cursor.tell(), _ + (int64_t)DE.getU64(Cursor));
 
     // Consume the status of the cursor.
     if (!Cursor)

--- a/bolt/test/X86/linux-static-keys.s
+++ b/bolt/test/X86/linux-static-keys.s
@@ -35,13 +35,13 @@ _start:
 .L0:
   jmp L1
 # CHECK:      jit
-# CHECK-SAME: # ID: 1 {{.*}} # Likely: 0 # InitValue: 1
+# CHECK-SAME: # ID: 1 {{.*}} # Likely: 1 # InitValue: 0
   nop
 L1:
   .nops 5
   jmp .L0
 # CHECK:      jit
-# CHECK-SAME: # ID: 2 {{.*}} # Likely: 1 # InitValue: 1
+# CHECK-SAME: # ID: 2 {{.*}} # Likely: 0 # InitValue: 0
 
 ## Check that a branch profile associated with a NOP is handled properly when
 ## dynamic branch is created.
@@ -65,6 +65,7 @@ foo:
   .rodata
   .globl __start___jump_table
   .type __start___jump_table, %object
+  .align 8
 __start___jump_table:
 
   .long .L0 - . # Jump address


### PR DESCRIPTION
Fix the following issues:

* `Cursor.tell() + (int32_t)DE.getU32(Cursor)` is undefined

* In `bolt/test/X86/linux-static-keys.s`, `__start___jump_table`
  is unaligned:

  ```
  ffffffff800001fd g     O .rodata        0000000000000000 __start___jump_table
  ```

  This makes the test case undeterministic.