### PR TITLE
[lldb][test] Prefer gmake to make and warn for potentially non-GNU make

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -52,13 +52,24 @@ set(LLDB_DEFAULT_TEST_DSYMUTIL "${LLVM_TOOLS_BINARY_DIR}/dsymutil${CMAKE_EXECUTA
 if(LLDB_TEST_MAKE)
   set(LLDB_DEFAULT_TEST_MAKE ${LLDB_TEST_MAKE})
 else()
-  find_program(LLDB_DEFAULT_TEST_MAKE make gmake)
+  # Prefer gmake as it will be a version of GNU make. 'make' could be GNU compatible or not.
+  set(MAKE_NAMES "gmake" "make")
+  find_program(LLDB_DEFAULT_TEST_MAKE NAMES ${MAKE_NAMES})
   if(LLDB_DEFAULT_TEST_MAKE)
     message(STATUS "Found make: ${LLDB_DEFAULT_TEST_MAKE}")
+    execute_process(COMMAND ${LLDB_DEFAULT_TEST_MAKE} --version OUTPUT_VARIABLE MAKE_VERSION
+           ERROR_QUIET)
+    if(NOT MAKE_VERSION MATCHES "^GNU Make")
+      message(WARNING "'make' tool ${LLDB_DEFAULT_TEST_MAKE} may not be GNU make compatible. "
+             "Some tests may fail to build. Provide a GNU compatible 'make' tool by setting "
+             "LLDB_TEST_MAKE.")
+    endif()
   else()
-    message(STATUS "Not found: make")
+    list(JOIN "${MAKE_NAMES}" " " MAKE_NAMES_SPACES)
+    string(REPLACE ";" " " MAKE_NAMES_SPACES "${MAKE_NAMES}")
+    message(STATUS "Did not find one of: ${MAKE_NAMES_SPACES}")
     message(WARNING
-          "Many LLDB API tests require 'make' tool. Please provide it in Path "
+          "Many LLDB API tests require a 'make' tool. Please provide it in Path "
           "or pass via LLDB_TEST_MAKE.")
   endif()
 endif()


### PR DESCRIPTION
System make on FreeBSD is missing some GNU make features so out of the box you get a lot of: 
```
make: "<...>/Makefile.rules" line 569: Invalid line type
```

To solve this, you can install gmake which is a port of GNU make. However because we prefer 'make', gmake won't be used unless you set LLDB_TEST_MAKE.

To fix that, prefer 'gmake'. Also check (as best we can) that the make we found is GNU make. This won't be perfect but it's better than the cryptic error shown above.
```
-- Found make: /usr/bin/make
CMake Warning at /home/ec2-user/llvm-project/lldb/test/API/CMakeLists.txt:63 (message):
  'make' tool /usr/bin/make may not be GNU make compatible.  Some tests may
  fail to build.  Provide a GNU compatible 'make' tool by setting
  LLDB_TEST_MAKE.
```
When a make isn't found at all, the warning message will show the names we tried:
```
-- Did not find one of: gmake make
CMake Warning at /home/ec2-user/llvm-project/lldb/test/API/CMakeLists.txt:69 (message):
  Many LLDB API tests require a 'make' tool.  Please provide it in Path or
  pass via LLDB_TEST_MAKE.
```