### PR TITLE
[libc][docgen] simplify posix links

### DIFF
--- a/libc/docs/headers/assert.rst
+++ b/libc/docs/headers/assert.rst
@@ -15,7 +15,7 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - __STDC_VERSION_ASSERT_H__
     - |check|
     - 7.2.1
@@ -23,5 +23,5 @@ Macros
   * - assert
     -
     - 7.2.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/assert.h.html>`__
 

--- a/libc/docs/headers/ctype.rst
+++ b/libc/docs/headers/ctype.rst
@@ -15,60 +15,116 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - isalnum
     - |check|
     - 7.4.1.1
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isalnum.html>`__
+  * - isalnum_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isalnum_l.html>`__
   * - isalpha
     - |check|
     - 7.4.1.2
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isalpha.html>`__
+  * - isalpha_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isalpha_l.html>`__
   * - isblank
     - |check|
     - 7.4.1.3
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isblank.html>`__
+  * - isblank_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isblank_l.html>`__
   * - iscntrl
     - |check|
     - 7.4.1.4
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/iscntrl.html>`__
+  * - iscntrl_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/iscntrl_l.html>`__
   * - isdigit
     - |check|
     - 7.4.1.5
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isdigit.html>`__
+  * - isdigit_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isdigit_l.html>`__
   * - isgraph
     - |check|
     - 7.4.1.6
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isgraph.html>`__
+  * - isgraph_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isgraph_l.html>`__
   * - islower
     - |check|
     - 7.4.1.7
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/islower.html>`__
+  * - islower_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/islower_l.html>`__
   * - isprint
     - |check|
     - 7.4.1.8
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isprint.html>`__
+  * - isprint_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isprint_l.html>`__
   * - ispunct
     - |check|
     - 7.4.1.9
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ispunct.html>`__
+  * - ispunct_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ispunct_l.html>`__
   * - isspace
     - |check|
     - 7.4.1.10
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isspace.html>`__
+  * - isspace_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isspace_l.html>`__
   * - isupper
     - |check|
     - 7.4.1.11
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isupper.html>`__
+  * - isupper_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isupper_l.html>`__
   * - isxdigit
     - |check|
     - 7.4.1.12
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isxdigit.html>`__
+  * - isxdigit_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/isxdigit_l.html>`__
   * - tolower
     - |check|
     - 7.4.2.1
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tolower.html>`__
+  * - tolower_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tolower_l.html>`__
   * - toupper
     - |check|
     - 7.4.2.2
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/toupper.html>`__
+  * - toupper_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/toupper_l.html>`__

--- a/libc/docs/headers/errno.rst
+++ b/libc/docs/headers/errno.rst
@@ -15,21 +15,21 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - EDOM
     -
     - 7.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/errno.h.html>`__
   * - EILSEQ
     -
     - 7.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/errno.h.html>`__
   * - ERANGE
     -
     - 7.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/errno.h.html>`__
   * - errno
     -
     - 7.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/errno.h.html>`__
 

--- a/libc/docs/headers/fenv.rst
+++ b/libc/docs/headers/fenv.rst
@@ -15,11 +15,11 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - FE_ALL_EXCEPT
     - |check|
     - 7.6.12
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_DEC_DOWNWARD
     -
     - 7.6.14
@@ -43,7 +43,7 @@ Macros
   * - FE_DFL_ENV
     - |check|
     - 7.6.17
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_DFL_MODE
     -
     - 7.6.11
@@ -51,27 +51,27 @@ Macros
   * - FE_DIVBYZERO
     - |check|
     - 7.6.9
-    -
-  * - FE_DOWNARD
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
+  * - FE_DOWNWARD
+    - |check|
     - 7.6.13
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_INEXACT
     - |check|
     - 7.6.9
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_INVALID
     - |check|
     - 7.6.9
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_OVERFLOW
     - |check|
     - 7.6.9
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_TONEAREST
     - |check|
     - 7.6.13
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_TONEARESTFROMZERO
     -
     - 7.6.13
@@ -79,15 +79,15 @@ Macros
   * - FE_TOWARDZERO
     - |check|
     - 7.6.13
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_UNDERFLOW
     - |check|
     - 7.6.9
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - FE_UPWARD
     - |check|
     - 7.6.13
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/fenv.h.html>`__
   * - __STDC_VERSION_FENV_H__
     -
     - 7.6.5
@@ -104,7 +104,7 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - fe_dec_getround
     -
     - 7.6.5.3
@@ -116,15 +116,15 @@ Functions
   * - feclearexcept
     - |check|
     - 7.6.4.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/feclearexcept.html>`__
   * - fegetenv
     - |check|
     - 7.6.6.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fegetenv.html>`__
   * - fegetexceptflag
     - |check|
     - 7.6.4.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fegetexceptflag.html>`__
   * - fegetmode
     -
     - 7.6.5.1
@@ -132,19 +132,19 @@ Functions
   * - fegetround
     - |check|
     - 7.6.5.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fegetround.html>`__
   * - feholdexcept
     - |check|
     - 7.6.6.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/feholdexcept.html>`__
   * - feraiseexcept
     - |check|
     - 7.6.4.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/feraiseexcept.html>`__
   * - fesetenv
     - |check|
     - 7.6.6.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fesetenv.html>`__
   * - fesetexcept
     - |check|
     - 7.6.4.4
@@ -152,7 +152,7 @@ Functions
   * - fesetexceptflag
     - |check|
     - 7.6.4.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fesetexceptflag.html>`__
   * - fesetmode
     -
     - 7.6.5.4
@@ -160,11 +160,11 @@ Functions
   * - fesetround
     - |check|
     - 7.6.5.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fesetround.html>`__
   * - fetestexcept
     - |check|
     - 7.6.4.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/fetestexcept.html>`__
   * - fetestexceptflag
     - |check|
     - 7.6.4.6
@@ -172,4 +172,4 @@ Functions
   * - feupdateenv
     - |check|
     - 7.6.6.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/feupdateenv.html>`__

--- a/libc/docs/headers/float.rst
+++ b/libc/docs/headers/float.rst
@@ -15,23 +15,23 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - DBL_DECIMAL_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_EPSILON
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_HAS_SUBNORM
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_IS_IEC_60559
     -
     - 5.3.5.3.3
@@ -43,27 +43,27 @@ Macros
   * - DBL_MAX
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_MAX_10_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_MAX_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_MIN
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_MIN_10_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_MIN_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DBL_NORM_MAX
     -
     - 5.3.5.3.3
@@ -75,31 +75,31 @@ Macros
   * - DBL_TRUE_MIN
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - DECIMAL_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_DECIMAL_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_EPSILON
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_EVAL_METHOD
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_HAS_SUBNORM
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_IS_IEC_60559
     -
     - 5.3.5.3.3
@@ -111,27 +111,27 @@ Macros
   * - FLT_MAX
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_MAX_10_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_MAX_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_MIN
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_MIN_10_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_MIN_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_NORM_MAX
     -
     - 5.3.5.3.3
@@ -139,11 +139,11 @@ Macros
   * - FLT_RADIX
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_ROUNDS
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - FLT_SNAN
     -
     - 5.3.5.3.3
@@ -151,7 +151,7 @@ Macros
   * - FLT_TRUE_MIN
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - INFINITY
     -
     - 5.3.5.3.3
@@ -159,19 +159,19 @@ Macros
   * - LDBL_DECIMAL_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_DIG
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_EPSILON
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_HAS_SUBNORM
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_IS_IEC_60559
     -
     - 5.3.5.3.3
@@ -183,27 +183,27 @@ Macros
   * - LDBL_MAX
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_MAX_10_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_MAX_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_MIN
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_MIN_10_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_MIN_EXP
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - LDBL_NORM_MAX
     -
     - 5.3.5.3.3
@@ -215,7 +215,7 @@ Macros
   * - LDBL_TRUE_MIN
     - |check|
     - 5.3.5.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/float.h.html>`__
   * - NAN
     -
     - 5.3.5.3.3

--- a/libc/docs/headers/inttypes.rst
+++ b/libc/docs/headers/inttypes.rst
@@ -15,28 +15,28 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - imaxabs
     - |check|
     - 7.8.2.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/imaxabs.html>`__
   * - imaxdiv
     - |check|
     - 7.8.2.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/imaxdiv.html>`__
   * - strtoimax
     - |check|
     - 7.8.2.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoimax.html>`__
   * - strtoumax
     - |check|
     - 7.8.2.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoumax.html>`__
   * - wcstoimax
     -
     - 7.8.2.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wcstoimax.html>`__
   * - wcstoumax
     -
     - 7.8.2.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wcstoumax.html>`__

--- a/libc/docs/headers/locale.rst
+++ b/libc/docs/headers/locale.rst
@@ -15,31 +15,31 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - LC_ALL
     - |check|
     - 7.11
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/locale.h.html>`__
   * - LC_COLLATE
     - |check|
     - 7.11
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/locale.h.html>`__
   * - LC_CTYPE
     - |check|
     - 7.11
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/locale.h.html>`__
   * - LC_MONETARY
     - |check|
     - 7.11
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/locale.h.html>`__
   * - LC_NUMERIC
     - |check|
     - 7.11
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/locale.h.html>`__
   * - LC_TIME
     - |check|
     - 7.11
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/locale.h.html>`__
 
 Functions
 =========
@@ -52,12 +52,32 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
+  * - duplocale
+    - |check|
+    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/duplocale.html>`__
+  * - freelocale
+    - |check|
+    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/freelocale.html>`__
+  * - getlocalename_l
+    -
+    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getlocalename_l.html>`__
   * - localeconv
     - |check|
     - 7.11.2.1
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/localeconv.html>`__
+  * - newlocale
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/newlocale.html>`__
   * - setlocale
     - |check|
     - 7.11.1.1
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/setlocale.html>`__
+  * - uselocale
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/uselocale.html>`__

--- a/libc/docs/headers/signal.rst
+++ b/libc/docs/headers/signal.rst
@@ -15,143 +15,143 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - SIGABRT
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGALRM
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGBUS
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGCHLD
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGCONT
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGFPE
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGHUP
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGILL
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGINT
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGKILL
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGPIPE
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGPOLL
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGPROF
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGQUIT
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGRTMAX
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGRTMIN
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGSEGV
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGSTOP
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGSYS
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGTERM
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGTRAP
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGTSTP
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGTTIN
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGTTOU
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGURG
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGUSR1
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGUSR2
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGVTALRM
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGXCPU
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIGXFSZ
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIG_DFL
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIG_ERR
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIG_HOLD
     -
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
   * - SIG_IGN
     - |check|
     - 7.14.3
-    - https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html>`__
 
 Functions
 =========
@@ -164,44 +164,44 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - kill
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/kill.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/kill.html>`__
   * - raise
     - |check|
     - 7.14.2.1
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/raise.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/raise.html>`__
   * - sigaction
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaction.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaction.html>`__
   * - sigaddset
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaddset.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaddset.html>`__
   * - sigaltstack
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaltstack.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaltstack.html>`__
   * - sigdelset
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigdelset.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigdelset.html>`__
   * - sigemptyset
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigemptyset.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigemptyset.html>`__
   * - sigfillset
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigfillset.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigfillset.html>`__
   * - signal
     - |check|
     - 7.14.1.1
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/signal.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/signal.html>`__
   * - sigprocmask
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigprocmask.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigprocmask.html>`__

--- a/libc/docs/headers/stdlib.rst
+++ b/libc/docs/headers/stdlib.rst
@@ -15,23 +15,23 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - EXIT_FAILURE
     - |check|
     - 7.24
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/stdlib.h.html>`__
   * - EXIT_SUCCESS
     - |check|
     - 7.24
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/stdlib.h.html>`__
   * - MB_CUR_MAX
     - |check|
     - 7.24
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/stdlib.h.html>`__
   * - RAND_MAX
     - |check|
     - 7.24
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/stdlib.h.html>`__
   * - __STDC_VERSION_STDLIB_H__
     -
     - 7.24
@@ -48,67 +48,67 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - _Exit
     - |check|
     - 7.24.4.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/_Exit.html>`__
   * - abort
     - |check|
     - 7.24.4.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/abort.html>`__
   * - abs
     - |check|
     - 7.24.6.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/abs.html>`__
   * - aligned_alloc
     - |check|
     - 7.24.3.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/aligned_alloc.html>`__
   * - at_quick_exit
     - |check|
     - 7.24.4.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/at_quick_exit.html>`__
   * - atexit
     - |check|
     - 7.24.4.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/atexit.html>`__
   * - atof
     - |check|
     - 7.24.1.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/atof.html>`__
   * - atoi
     - |check|
     - 7.24.1.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/atoi.html>`__
   * - atol
     - |check|
     - 7.24.1.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/atol.html>`__
   * - atoll
     - |check|
     - 7.24.1.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/atoll.html>`__
   * - bsearch
     - |check|
     - 7.24.5.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/bsearch.html>`__
   * - calloc
     - |check|
     - 7.24.3.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/calloc.html>`__
   * - div
     - |check|
     - 7.24.6.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/div.html>`__
   * - exit
     - |check|
     - 7.24.4.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/exit.html>`__
   * - free
     - |check|
     - 7.24.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/free.html>`__
   * - free_aligned_sized
     -
     - 7.24.3.5
@@ -120,39 +120,39 @@ Functions
   * - getenv
     - |check|
     - 7.24.4.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getenv.html>`__
   * - labs
     - |check|
     - 7.24.6.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/labs.html>`__
   * - ldiv
     - |check|
     - 7.24.6.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ldiv.html>`__
   * - llabs
     - |check|
     - 7.24.6.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/llabs.html>`__
   * - lldiv
     - |check|
     - 7.24.6.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/lldiv.html>`__
   * - malloc
     - |check|
     - 7.24.3.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/malloc.html>`__
   * - mblen
     -
     - 7.24.7.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mblen.html>`__
   * - mbstowcs
     -
     - 7.24.8.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mbstowcs.html>`__
   * - mbtowc
     -
     - 7.24.7.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mbtowc.html>`__
   * - memalignment
     -
     - 7.24.9.1
@@ -160,23 +160,23 @@ Functions
   * - qsort
     - |check|
     - 7.24.5.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/qsort.html>`__
   * - quick_exit
     - |check|
     - 7.24.4.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/quick_exit.html>`__
   * - rand
     - |check|
     - 7.24.2.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/rand.html>`__
   * - realloc
     - |check|
     - 7.24.3.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/realloc.html>`__
   * - srand
     - |check|
     - 7.24.2.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/srand.html>`__
   * - strfromd
     - |check|
     - 7.24.1.3
@@ -204,7 +204,7 @@ Functions
   * - strtod
     - |check|
     - 7.24.1.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtod.html>`__
   * - strtod128
     -
     - 7.24.1.6
@@ -220,36 +220,36 @@ Functions
   * - strtof
     - |check|
     - 7.24.1.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtof.html>`__
   * - strtol
     - |check|
     - 7.24.1.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtol.html>`__
   * - strtold
     - |check|
     - 7.24.1.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtold.html>`__
   * - strtoll
     - |check|
     - 7.24.1.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoll.html>`__
   * - strtoul
     - |check|
     - 7.24.1.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoul.html>`__
   * - strtoull
     - |check|
     - 7.24.1.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtoull.html>`__
   * - system
     - |check|
     - 7.24.4.8
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/system.html>`__
   * - wcstombs
     -
     - 7.24.8.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wcstombs.html>`__
   * - wctomb
     -
     - 7.24.7.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/wctomb.html>`__

--- a/libc/docs/headers/string.rst
+++ b/libc/docs/headers/string.rst
@@ -15,7 +15,7 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - __STDC_VERSION_STRING_H__
     -
     - 7.26.1
@@ -32,27 +32,27 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - memccpy
     - |check|
     - 7.26.2.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/memccpy.html>`__
   * - memchr
     - |check|
     - 7.26.5.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/memchr.html>`__
   * - memcmp
     - |check|
     - 7.26.4.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/memcmp.html>`__
   * - memcpy
     - |check|
     - 7.26.2.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/memcpy.html>`__
   * - memmove
     - |check|
     - 7.26.2.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/memmove.html>`__
   * - mempcpy
     - |check|
     - TODO: glibc extension
@@ -60,7 +60,7 @@ Functions
   * - memset
     - |check|
     - 7.26.6.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/memset.html>`__
   * - memset_explicit
     - |check|
     - 7.26.6.2
@@ -68,88 +68,96 @@ Functions
   * - stpcpy
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/stpcpy.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/stpcpy.html>`__
   * - stpncpy
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/stpncpy.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/stpncpy.html>`__
   * - strcat
     - |check|
     - 7.26.3.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcat.html>`__
   * - strchr
     - |check|
     - 7.26.5.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strchr.html>`__
   * - strcmp
     - |check|
     - 7.26.4.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcmp.html>`__
   * - strcoll
     - |check|
     - 7.26.4.3
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcoll.html>`__
+  * - strcoll_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcoll_l.html>`__
   * - strcpy
     - |check|
     - 7.26.2.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcpy.html>`__
   * - strcspn
     - |check|
     - 7.26.5.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcspn.html>`__
   * - strdup
     - |check|
     - 7.26.2.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strdup.html>`__
   * - strerror
     - |check|
     - 7.26.6.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strerror.html>`__
   * - strlen
     - |check|
     - 7.26.6.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strlen.html>`__
   * - strncat
     - |check|
     - 7.26.3.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncat.html>`__
   * - strncmp
     - |check|
     - 7.26.4.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncmp.html>`__
   * - strncpy
     - |check|
     - 7.26.2.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncpy.html>`__
   * - strndup
     - |check|
     - 7.26.2.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strndup.html>`__
   * - strpbrk
     - |check|
     - 7.26.5.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strpbrk.html>`__
   * - strrchr
     - |check|
     - 7.26.5.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strrchr.html>`__
   * - strspn
     - |check|
     - 7.26.5.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strspn.html>`__
   * - strstr
     - |check|
     - 7.26.5.8
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strstr.html>`__
   * - strtok
     - |check|
     - 7.26.5.9
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtok.html>`__
   * - strtok_r
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtok_r.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtok_r.html>`__
   * - strxfrm
     - |check|
     - 7.26.4.5
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strxfrm.html>`__
+  * - strxfrm_l
+    - |check|
     -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strxfrm_l.html>`__

--- a/libc/docs/headers/strings.rst
+++ b/libc/docs/headers/strings.rst
@@ -15,52 +15,52 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - bcmp
     - |check|
     -
-    - removed in POSIX.1-2008
+    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/bcmp.html>`__
   * - bcopy
     - |check|
     -
-    - removed in POSIX.1-2008
+    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/bcopy.html>`__
   * - bzero
     - |check|
     -
-    - removed in POSIX.1-2008
+    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/bzero.html>`__
   * - ffs
     -
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffs.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffs.html>`__
   * - ffsl
     -
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffsl.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffsl.html>`__
   * - ffsll
     -
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffsll.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffsll.html>`__
   * - index
     - |check|
     -
-    - removed in POSIX.1-2008
+    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/index.html>`__
   * - rindex
     - |check|
     -
-    - removed in POSIX.1-2008
+    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/rindex.html>`__
   * - strcasecmp
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcasecmp.html>`__
   * - strcasecmp_l
     -
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strcasecmp_l.html>`__
   * - strncasecmp
     - |check|
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html>`__
   * - strncasecmp_l
     -
     -
-    - https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp_l.html>`__

--- a/libc/docs/headers/threads.rst
+++ b/libc/docs/headers/threads.rst
@@ -15,19 +15,23 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - ONCE_FLAG_INIT
     -
     - 7.28.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/threads.h.html>`__
   * - TSS_DTOR_ITERATIONS
     -
     - 7.28.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/threads.h.html>`__
   * - __STDC_NO_THREADS__
     -
     - 7.28.1
     -
+  * - thread_local
+    -
+    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/threads.h.html>`__
 
 Functions
 =========
@@ -40,104 +44,104 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - call_once
     - |check|
     - 7.28.2.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/call_once.html>`__
   * - cnd_broadcast
     - |check|
     - 7.28.3.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_broadcast.html>`__
   * - cnd_destroy
     - |check|
     - 7.28.3.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_destroy.html>`__
   * - cnd_init
     - |check|
     - 7.28.3.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_init.html>`__
   * - cnd_signal
     - |check|
     - 7.28.3.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_signal.html>`__
   * - cnd_timedwait
     -
     - 7.28.3.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_timedwait.html>`__
   * - cnd_wait
     - |check|
     - 7.28.3.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/cnd_wait.html>`__
   * - mtx_destroy
     - |check|
     - 7.28.4.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_destroy.html>`__
   * - mtx_init
     - |check|
     - 7.28.4.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_init.html>`__
   * - mtx_lock
     - |check|
     - 7.28.4.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_lock.html>`__
   * - mtx_timedlock
     -
     - 7.28.4.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_timedlock.html>`__
   * - mtx_trylock
     -
     - 7.28.4.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_trylock.html>`__
   * - mtx_unlock
     - |check|
     - 7.28.4.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mtx_unlock.html>`__
   * - thrd_create
     - |check|
     - 7.28.5.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_create.html>`__
   * - thrd_current
     - |check|
     - 7.28.5.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_current.html>`__
   * - thrd_detach
     - |check|
     - 7.28.5.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_detach.html>`__
   * - thrd_equal
     - |check|
     - 7.28.5.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_equal.html>`__
   * - thrd_exit
     - |check|
     - 7.28.5.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_exit.html>`__
   * - thrd_join
     - |check|
     - 7.28.5.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_join.html>`__
   * - thrd_sleep
     -
     - 7.28.5.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_sleep.html>`__
   * - thrd_yield
     -
     - 7.28.5.8
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/thrd_yield.html>`__
   * - tss_create
     - |check|
     - 7.28.6.1
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tss_create.html>`__
   * - tss_delete
     - |check|
     - 7.28.6.2
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tss_delete.html>`__
   * - tss_get
     - |check|
     - 7.28.6.3
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tss_get.html>`__
   * - tss_set
     - |check|
     - 7.28.6.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/tss_set.html>`__

--- a/libc/docs/headers/uchar.rst
+++ b/libc/docs/headers/uchar.rst
@@ -15,7 +15,7 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - __STDC_VERSION_UCHAR_H__
     -
     - 7.30.1
@@ -32,15 +32,15 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - c16rtomb
     -
     - 7.30.2.5
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/c16rtomb.html>`__
   * - c32rtomb
     -
     - 7.30.2.7
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/c32rtomb.html>`__
   * - c8rtomb
     -
     - 7.30.2.3
@@ -48,11 +48,11 @@ Functions
   * - mbrtoc16
     -
     - 7.30.2.4
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mbrtoc16.html>`__
   * - mbrtoc32
     -
     - 7.30.2.6
-    -
+    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/mbrtoc32.html>`__
   * - mbrtoc8
     -
     - 7.30.2.2

--- a/libc/docs/headers/wchar.rst
+++ b/libc/docs/headers/wchar.rst
@@ -15,7 +15,7 @@ Macros
   * - Macro
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - WEOF
     - |check|
     - 7.31.1
@@ -36,7 +36,7 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - btowc
     - |check|
     - 7.31.6.2.1

--- a/libc/docs/headers/wctype.rst
+++ b/libc/docs/headers/wctype.rst
@@ -15,7 +15,7 @@ Functions
   * - Function
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section
+    - POSIX Docs
   * - iswalnum
     -
     - 7.32.2.1.1

--- a/libc/utils/docgen/assert.json
+++ b/libc/utils/docgen/assert.json
@@ -4,7 +4,8 @@
       "c-definition": "7.2.1"
     },
     "assert": {
-      "c-definition": "7.2.1"
+      "c-definition": "7.2.1",
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/ctype.json
+++ b/libc/utils/docgen/ctype.json
@@ -1,47 +1,102 @@
 {
   "functions": {
     "isalnum": {
-      "c-definition": "7.4.1.1"
+      "c-definition": "7.4.1.1",
+      "in-latest-posix": ""
+    },
+    "isalnum_l": {
+      "in-latest-posix": ""
     },
     "isalpha": {
-      "c-definition": "7.4.1.2"
+      "c-definition": "7.4.1.2",
+      "in-latest-posix": ""
+    },
+    "isalpha_l": {
+      "in-latest-posix": ""
     },
     "isblank": {
-      "c-definition": "7.4.1.3"
+      "c-definition": "7.4.1.3",
+      "in-latest-posix": ""
+    },
+    "isblank_l": {
+      "in-latest-posix": ""
     },
     "iscntrl": {
-      "c-definition": "7.4.1.4"
+      "c-definition": "7.4.1.4",
+      "in-latest-posix": ""
+    },
+    "iscntrl_l": {
+      "in-latest-posix": ""
     },
     "isdigit": {
-      "c-definition": "7.4.1.5"
+      "c-definition": "7.4.1.5",
+      "in-latest-posix": ""
+    },
+    "isdigit_l": {
+      "in-latest-posix": ""
     },
     "isgraph": {
-      "c-definition": "7.4.1.6"
+      "c-definition": "7.4.1.6",
+      "in-latest-posix": ""
+    },
+    "isgraph_l": {
+      "in-latest-posix": ""
     },
     "islower": {
-      "c-definition": "7.4.1.7"
+      "c-definition": "7.4.1.7",
+      "in-latest-posix": ""
+    },
+    "islower_l": {
+      "in-latest-posix": ""
     },
     "isprint": {
-      "c-definition": "7.4.1.8"
+      "c-definition": "7.4.1.8",
+      "in-latest-posix": ""
+    },
+    "isprint_l": {
+      "in-latest-posix": ""
     },
     "ispunct": {
-      "c-definition": "7.4.1.9"
+      "c-definition": "7.4.1.9",
+      "in-latest-posix": ""
+    },
+    "ispunct_l": {
+      "in-latest-posix": ""
     },
     "isspace": {
-      "c-definition": "7.4.1.10"
+      "c-definition": "7.4.1.10",
+      "in-latest-posix": ""
+    },
+    "isspace_l": {
+      "in-latest-posix": ""
     },
     "isupper": {
-      "c-definition": "7.4.1.11"
+      "c-definition": "7.4.1.11",
+      "in-latest-posix": ""
+    },
+    "isupper_l": {
+      "in-latest-posix": ""
     },
     "isxdigit": {
-      "c-definition": "7.4.1.12"
+      "c-definition": "7.4.1.12",
+      "in-latest-posix": ""
+    },
+    "isxdigit_l": {
+      "in-latest-posix": ""
     },
     "tolower" : {
-      "c-definition": "7.4.2.1"
+      "c-definition": "7.4.2.1",
+      "in-latest-posix": ""
+    },
+    "tolower_l" : {
+      "in-latest-posix": ""
     },
     "toupper": {
-      "c-definition": "7.4.2.2"
+      "c-definition": "7.4.2.2",
+      "in-latest-posix": ""
+    },
+    "toupper_l": {
+      "in-latest-posix": ""
     }
   }
 }
-

--- a/libc/utils/docgen/docgen.py
+++ b/libc/utils/docgen/docgen.py
@@ -70,8 +70,8 @@ def check_api(header: Header, api: Dict):
         macros = api["macros"]
 
         for name, obj in macros.items():
-            if (not any(k in obj.keys() for k in possible_keys)):
-                err = f'error: Macro {name} does not contain at least one required property: {possible_keys}'
+            if not any(k in obj.keys() for k in possible_keys):
+                err = f"error: Macro {name} does not contain at least one required property: {possible_keys}"
                 errors.append(err)
 
     # Validate functions
@@ -84,8 +84,8 @@ def check_api(header: Header, api: Dict):
 
         fns = api["functions"]
         for name, obj in fns.items():
-          if (not any(k in obj.keys() for k in possible_keys)):
-                err = f'error: function {name} does not contain at least one required property: {possible_keys}'
+            if not any(k in obj.keys() for k in possible_keys):
+                err = f"error: function {name} does not contain at least one required property: {possible_keys}"
                 errors.append(err)
 
     if errors:
@@ -133,9 +133,13 @@ def print_functions_rst(header: Header, functions: Dict):
             print("    -")
 
         if "in-latest-posix" in functions[name]:
-            print(f'    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/{name}.html>`__')
+            print(
+                f"    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/{name}.html>`__"
+            )
         elif "removed-in-posix-2008" in functions[name]:
-            print(f'    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/{name}.html>`__')
+            print(
+                f"    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/{name}.html>`__"
+            )
         else:
             print("    -")
 
@@ -161,7 +165,9 @@ def print_macros_rst(header: Header, macros: Dict):
             print("    -")
 
         if "in-latest-posix" in macros[name]:
-            print(f'    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/{header.name}.html>`__')
+            print(
+                f"    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/{header.name}.html>`__"
+            )
         else:
             print("    -")
     print()

--- a/libc/utils/docgen/docgen.py
+++ b/libc/utils/docgen/docgen.py
@@ -52,8 +52,12 @@ def check_api(header: Header, api: Dict):
     :param api: docgen json file contents parsed into a dict
     """
     errors = []
-    cdef = "c-definition"
-    pdef = "posix-definition"
+    # We require entries to have at least one of these.
+    possible_keys = [
+        "c-definition",
+        "in-latest-posix",
+        "removed-in-posix-2008",
+    ]
 
     # Validate macros
     if "macros" in api:
@@ -66,8 +70,8 @@ def check_api(header: Header, api: Dict):
         macros = api["macros"]
 
         for name, obj in macros.items():
-            if not (cdef in obj or pdef in obj):
-                err = f'error: Macro {name} does not contain at least one required property: "{cdef}" or "{pdef}"'
+            if (not any(k in obj.keys() for k in possible_keys)):
+                err = f'error: Macro {name} does not contain at least one required property: {possible_keys}'
                 errors.append(err)
 
     # Validate functions
@@ -80,8 +84,8 @@ def check_api(header: Header, api: Dict):
 
         fns = api["functions"]
         for name, obj in fns.items():
-            if not (cdef in obj or pdef in obj):
-                err = f'error: function {name} does not contain at least one required property: "{cdef}" or "{pdef}"'
+          if (not any(k in obj.keys() for k in possible_keys)):
+                err = f'error: function {name} does not contain at least one required property: {possible_keys}'
                 errors.append(err)
 
     if errors:
@@ -104,7 +108,7 @@ def print_tbl_dir(name):
   * - {name}
     - Implemented
     - C23 Standard Section
-    - POSIX.1-2024 Standard Section"""
+    - POSIX Docs"""
     )
 
 
@@ -128,8 +132,10 @@ def print_functions_rst(header: Header, functions: Dict):
         else:
             print("    -")
 
-        if "posix-definition" in functions[name]:
-            print(f'    - {functions[name]["posix-definition"]}')
+        if "in-latest-posix" in functions[name]:
+            print(f'    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/{name}.html>`__')
+        elif "removed-in-posix-2008" in functions[name]:
+            print(f'    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/{name}.html>`__')
         else:
             print("    -")
 
@@ -154,8 +160,8 @@ def print_macros_rst(header: Header, macros: Dict):
         else:
             print("    -")
 
-        if "posix-definition" in macros[name]:
-            print(f'    - {macros[name]["posix-definition"]}')
+        if "in-latest-posix" in macros[name]:
+            print(f'    - `POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/{header.name}.html>`__')
         else:
             print("    -")
     print()

--- a/libc/utils/docgen/docgen.py
+++ b/libc/utils/docgen/docgen.py
@@ -70,7 +70,7 @@ def check_api(header: Header, api: Dict):
         macros = api["macros"]
 
         for name, obj in macros.items():
-            if not any(k in obj.keys() for k in possible_keys):
+            if not any(k in obj for k in possible_keys):
                 err = f"error: Macro {name} does not contain at least one required property: {possible_keys}"
                 errors.append(err)
 
@@ -84,7 +84,7 @@ def check_api(header: Header, api: Dict):
 
         fns = api["functions"]
         for name, obj in fns.items():
-            if not any(k in obj.keys() for k in possible_keys):
+            if not any(k in obj for k in possible_keys):
                 err = f"error: function {name} does not contain at least one required property: {possible_keys}"
                 errors.append(err)
 

--- a/libc/utils/docgen/errno.json
+++ b/libc/utils/docgen/errno.json
@@ -1,16 +1,20 @@
 {
   "macros": {
     "EDOM": {
-      "c-definition": "7.5"
+      "c-definition": "7.5",
+      "in-latest-posix": ""
     },
     "EILSEQ": {
-      "c-definition": "7.5"
+      "c-definition": "7.5",
+      "in-latest-posix": ""
     },
     "ERANGE": {
-      "c-definition": "7.5"
+      "c-definition": "7.5",
+      "in-latest-posix": ""
     },
     "errno": {
-      "c-definition": "7.5"
+      "c-definition": "7.5",
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/fenv.json
+++ b/libc/utils/docgen/fenv.json
@@ -4,40 +4,50 @@
       "c-definition": "7.6.5"
     },
     "FE_DIVBYZERO": {
-      "c-definition": "7.6.9"
+      "c-definition": "7.6.9",
+      "in-latest-posix": ""
     },
     "FE_INEXACT": {
-      "c-definition": "7.6.9"
+      "c-definition": "7.6.9",
+      "in-latest-posix": ""
     },
     "FE_INVALID": {
-      "c-definition": "7.6.9"
+      "c-definition": "7.6.9",
+      "in-latest-posix": ""
     },
     "FE_OVERFLOW": {
-      "c-definition": "7.6.9"
+      "c-definition": "7.6.9",
+      "in-latest-posix": ""
     },
     "FE_UNDERFLOW": {
-      "c-definition": "7.6.9"
+      "c-definition": "7.6.9",
+      "in-latest-posix": ""
     },
     "FE_ALL_EXCEPT": {
-      "c-definition": "7.6.12"
+      "c-definition": "7.6.12",
+      "in-latest-posix": ""
     },
     "FE_DFL_MODE": {
       "c-definition": "7.6.11"
     },
-    "FE_DOWNARD": {
-      "c-definition": "7.6.13"
+    "FE_DOWNWARD": {
+      "c-definition": "7.6.13",
+      "in-latest-posix": ""
     },
     "FE_TONEAREST": {
-      "c-definition": "7.6.13"
+      "c-definition": "7.6.13",
+      "in-latest-posix": ""
     },
     "FE_TONEARESTFROMZERO": {
       "c-definition": "7.6.13"
     },
     "FE_TOWARDZERO": {
-      "c-definition": "7.6.13"
+      "c-definition": "7.6.13",
+      "in-latest-posix": ""
     },
     "FE_UPWARD": {
-      "c-definition": "7.6.13"
+      "c-definition": "7.6.13",
+      "in-latest-posix": ""
     },
     "FE_DEC_DOWNWARD": {
       "c-definition": "7.6.14"
@@ -55,36 +65,43 @@
       "c-definition": "7.6.14"
     },
     "FE_DFL_ENV": {
-      "c-definition": "7.6.17"
+      "c-definition": "7.6.17",
+      "in-latest-posix": ""
     }
   },
   "functions": {
     "feclearexcept": {
-      "c-definition": "7.6.4.1"
+      "c-definition": "7.6.4.1",
+      "in-latest-posix": ""
     },
     "fegetexceptflag": {
-      "c-definition": "7.6.4.2"
+      "c-definition": "7.6.4.2",
+      "in-latest-posix": ""
     },
     "feraiseexcept": {
-      "c-definition": "7.6.4.3"
+      "c-definition": "7.6.4.3",
+      "in-latest-posix": ""
     },
     "fesetexcept": {
       "c-definition": "7.6.4.4"
     },
     "fesetexceptflag": {
-      "c-definition": "7.6.4.5"
+      "c-definition": "7.6.4.5",
+      "in-latest-posix": ""
     },
     "fetestexceptflag": {
       "c-definition": "7.6.4.6"
     },
     "fetestexcept": {
-      "c-definition": "7.6.4.7"
+      "c-definition": "7.6.4.7",
+      "in-latest-posix": ""
     },
     "fegetmode": {
       "c-definition": "7.6.5.1"
     },
     "fegetround": {
-      "c-definition": "7.6.5.2"
+      "c-definition": "7.6.5.2",
+      "in-latest-posix": ""
     },
     "fe_dec_getround": {
       "c-definition": "7.6.5.3"
@@ -93,22 +110,27 @@
       "c-definition": "7.6.5.4"
     },
     "fesetround": {
-      "c-definition": "7.6.5.5"
+      "c-definition": "7.6.5.5",
+      "in-latest-posix": ""
     },
     "fe_dec_setround": {
       "c-definition": "7.6.5.6"
     },
     "fegetenv": {
-      "c-definition": "7.6.6.1"
+      "c-definition": "7.6.6.1",
+      "in-latest-posix": ""
     },
     "feholdexcept": {
-      "c-definition": "7.6.6.2"
+      "c-definition": "7.6.6.2",
+      "in-latest-posix": ""
     },
     "fesetenv": {
-      "c-definition": "7.6.6.3"
+      "c-definition": "7.6.6.3",
+      "in-latest-posix": ""
     },
     "feupdateenv": {
-      "c-definition": "7.6.6.4"
+      "c-definition": "7.6.6.4",
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/float.json
+++ b/libc/utils/docgen/float.json
@@ -4,25 +4,32 @@
       "c-definition": "7.7"
     },
     "FLT_EVAL_METHOD" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_ROUNDS" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_EVAL_METHOD" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_HAS_SUBNORM" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_HAS_SUBNORM" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_HAS_SUBNORM" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_RADIX" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MANT_DIG" : {
       "c-definition": "5.3.5.3.3"
@@ -34,16 +41,20 @@
       "c-definition": "5.3.5.3.3"
     },
     "FLT_DECIMAL_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_DECIMAL_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_DECIMAL_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DECIMAL_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_IS_IEC_60559" : {
       "c-definition": "5.3.5.3.3"
@@ -55,58 +66,76 @@
       "c-definition": "5.3.5.3.3"
     },
     "FLT_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_DIG" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MIN_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_MIN_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_MIN_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MIN_10_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_MIN_10_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_MIN_10_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MAX_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_MAX_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_MAX_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MAX_10_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_MAX_10_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_MAX_10_EXP" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MAX" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_MAX" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_MAX" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_NORM_MAX" : {
       "c-definition": "5.3.5.3.3"
@@ -118,22 +147,28 @@
       "c-definition": "5.3.5.3.3"
     },
     "FLT_EPSILON" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_EPSILON" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_EPSILON" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_MIN" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_MIN" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_MIN" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "FLT_SNAN" : {
       "c-definition": "5.3.5.3.3"
@@ -145,13 +180,16 @@
       "c-definition": "5.3.5.3.3"
     },
     "FLT_TRUE_MIN" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "DBL_TRUE_MIN" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "LDBL_TRUE_MIN" : {
-      "c-definition": "5.3.5.3.3"
+      "c-definition": "5.3.5.3.3",
+      "in-latest-posix": ""
     },
     "INFINITY" : {
       "c-definition": "5.3.5.3.3"

--- a/libc/utils/docgen/inttypes.json
+++ b/libc/utils/docgen/inttypes.json
@@ -1,22 +1,28 @@
 {
   "functions": {
     "imaxabs": {
-      "c-definition": "7.8.2.1"
+      "c-definition": "7.8.2.1",
+      "in-latest-posix": ""
     },
     "imaxdiv": {
-      "c-definition": "7.8.2.2"
+      "c-definition": "7.8.2.2",
+      "in-latest-posix": ""
     },
     "strtoimax": {
-      "c-definition": "7.8.2.3"
+      "c-definition": "7.8.2.3",
+      "in-latest-posix": ""
     },
     "strtoumax": {
-      "c-definition": "7.8.2.3"
+      "c-definition": "7.8.2.3",
+      "in-latest-posix": ""
     },
     "wcstoimax": {
-      "c-definition": "7.8.2.4"
+      "c-definition": "7.8.2.4",
+      "in-latest-posix": ""
     },
     "wcstoumax": {
-      "c-definition": "7.8.2.4"
+      "c-definition": "7.8.2.4",
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/locale.json
+++ b/libc/utils/docgen/locale.json
@@ -1,30 +1,53 @@
 {
   "macros": {
     "LC_ALL": {
-      "c-definition": "7.11"
+      "c-definition": "7.11",
+      "in-latest-posix": ""
     },
     "LC_COLLATE": {
-      "c-definition": "7.11"
+      "c-definition": "7.11",
+      "in-latest-posix": ""
     },
     "LC_CTYPE": {
-      "c-definition": "7.11"
+      "c-definition": "7.11",
+      "in-latest-posix": ""
     },
     "LC_MONETARY": {
-      "c-definition": "7.11"
+      "c-definition": "7.11",
+      "in-latest-posix": ""
     },
     "LC_NUMERIC": {
-      "c-definition": "7.11"
+      "c-definition": "7.11",
+      "in-latest-posix": ""
     },
     "LC_TIME": {
-      "c-definition": "7.11"
+      "c-definition": "7.11",
+      "in-latest-posix": ""
     }
   },
   "functions": {
     "setlocale": {
-      "c-definition": "7.11.1.1"
+      "c-definition": "7.11.1.1",
+      "in-latest-posix": ""
     },
     "localeconv": {
-      "c-definition": "7.11.2.1"
+      "c-definition": "7.11.2.1",
+      "in-latest-posix": ""
+    },
+    "duplocale": {
+      "in-latest-posix": ""
+    },
+    "freelocale": {
+      "in-latest-posix": ""
+    },
+    "getlocalename_l": {
+      "in-latest-posix": ""
+    },
+    "newlocale": {
+      "in-latest-posix": ""
+    },
+    "uselocale": {
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/setjmp.json
+++ b/libc/utils/docgen/setjmp.json
@@ -6,10 +6,18 @@
   },
   "functions": {
     "setjmp": {
-      "c-definition": "7.13.1.1"
+      "c-definition": "7.13.1.1",
+      "in-latest-posix": ""
     },
     "longjmp": {
-      "c-definition": "7.13.2.1"
+      "c-definition": "7.13.2.1",
+      "in-latest-posix": ""
+    },
+    "sigsetjmp": {
+      "in-latest-posix": ""
+    },
+    "siglongjmp": {
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/signal.json
+++ b/libc/utils/docgen/signal.json
@@ -2,151 +2,151 @@
   "macros": {
     "SIG_DFL": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIG_ERR": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIG_HOLD": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIG_IGN": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGRTMIN": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGRTMAX": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGABRT": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGALRM": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGBUS": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGCHLD": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGCONT": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGFPE": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGHUP": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGILL": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGINT": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGKILL": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGPIPE": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGPIPE": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGQUIT": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGSEGV": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGSTOP": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGTERM": {
       "c-definition": "7.14.3",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGTSTP": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGTTIN": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGTTOU": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGUSR1": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGUSR2": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGPOLL": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGPROF": {
-    "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGSYS": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGTRAP": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGURG": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGVTALRM": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGXCPU": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     },
     "SIGXFSZ": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html"
+      "in-latest-posix": ""
     }
   },
   "functions": {
     "signal": {
       "c-definition": "7.14.1.1",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/signal.html"
+      "in-latest-posix": ""
     },
     "raise": {
       "c-definition": "7.14.2.1",
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/raise.html"
+      "in-latest-posix": ""
     },
     "kill": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/kill.html"
+      "in-latest-posix": ""
     },
     "sigaction": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaction.html"
+      "in-latest-posix": ""
     },
     "sigaddset": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaddset.html"
+      "in-latest-posix": ""
     },
     "sigaltstack": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigaltstack.html"
+      "in-latest-posix": ""
     },
     "sigdelset": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigdelset.html"
+      "in-latest-posix": ""
     },
     "sigemptyset": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigemptyset.html"
+      "in-latest-posix": ""
     },
     "sigfillset": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigfillset.html"
+      "in-latest-posix": ""
     },
     "sigprocmask": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/sigprocmask.html"
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/stdlib.json
+++ b/libc/utils/docgen/stdlib.json
@@ -4,30 +4,38 @@
       "c-definition": "7.24"
     },
     "EXIT_FAILURE": {
-      "c-definition": "7.24"
+      "c-definition": "7.24",
+      "in-latest-posix": ""
     },
     "EXIT_SUCCESS": {
-      "c-definition": "7.24"
+      "c-definition": "7.24",
+      "in-latest-posix": ""
     },
     "RAND_MAX": {
-      "c-definition": "7.24"
+      "c-definition": "7.24",
+      "in-latest-posix": ""
     },
     "MB_CUR_MAX": {
-      "c-definition": "7.24"
+      "c-definition": "7.24",
+      "in-latest-posix": ""
     }
   },
   "functions": {
     "atof": {
-      "c-definition": "7.24.1.1"
+      "c-definition": "7.24.1.1",
+      "in-latest-posix": ""
     },
     "atoi": {
-      "c-definition": "7.24.1.2"
+      "c-definition": "7.24.1.2",
+      "in-latest-posix": ""
     },
     "atol": {
-      "c-definition": "7.24.1.2"
+      "c-definition": "7.24.1.2",
+      "in-latest-posix": ""
     },
     "atoll": {
-      "c-definition": "7.24.1.2"
+      "c-definition": "7.24.1.2",
+      "in-latest-posix": ""
     },
     "strfromd": {
       "c-definition": "7.24.1.3"
@@ -48,13 +56,16 @@
       "c-definition": "7.24.1.4"
     },
     "strtod": {
-      "c-definition": "7.24.1.5"
+      "c-definition": "7.24.1.5",
+      "in-latest-posix": ""
     },
     "strtof": {
-      "c-definition": "7.24.1.5"
+      "c-definition": "7.24.1.5",
+      "in-latest-posix": ""
     },
     "strtold": {
-      "c-definition": "7.24.1.5"
+      "c-definition": "7.24.1.5",
+      "in-latest-posix": ""
     },
     "strtod32": {
       "c-definition": "7.24.1.6"
@@ -66,31 +77,40 @@
       "c-definition": "7.24.1.6"
     },
     "strtol": {
-      "c-definition": "7.24.1.7"
+      "c-definition": "7.24.1.7",
+      "in-latest-posix": ""
     },
     "strtoll": {
-      "c-definition": "7.24.1.7"
+      "c-definition": "7.24.1.7",
+      "in-latest-posix": ""
     },
     "strtoul": {
-      "c-definition": "7.24.1.7"
+      "c-definition": "7.24.1.7",
+      "in-latest-posix": ""
     },
     "strtoull": {
-      "c-definition": "7.24.1.7"
+      "c-definition": "7.24.1.7",
+      "in-latest-posix": ""
     },
     "rand": {
-      "c-definition": "7.24.2.1"
+      "c-definition": "7.24.2.1",
+      "in-latest-posix": ""
     },
     "srand": {
-      "c-definition": "7.24.2.2"
+      "c-definition": "7.24.2.2",
+      "in-latest-posix": ""
     },
     "aligned_alloc": {
-      "c-definition": "7.24.3.1"
+      "c-definition": "7.24.3.1",
+      "in-latest-posix": ""
     },
     "calloc": {
-      "c-definition": "7.24.3.2"
+      "c-definition": "7.24.3.2",
+      "in-latest-posix": ""
     },
     "free": {
-      "c-definition": "7.24.3.3"
+      "c-definition": "7.24.3.3",
+      "in-latest-posix": ""
     },
     "free_sized": {
       "c-definition": "7.24.3.4"
@@ -99,73 +119,96 @@
       "c-definition": "7.24.3.5"
     },
     "malloc": {
-      "c-definition": "7.24.3.6"
+      "c-definition": "7.24.3.6",
+      "in-latest-posix": ""
     },
     "realloc": {
-      "c-definition": "7.24.3.7"
+      "c-definition": "7.24.3.7",
+      "in-latest-posix": ""
     },
     "abort": {
-      "c-definition": "7.24.4.1"
+      "c-definition": "7.24.4.1",
+      "in-latest-posix": ""
     },
     "atexit": {
-      "c-definition": "7.24.4.2"
+      "c-definition": "7.24.4.2",
+      "in-latest-posix": ""
     },
     "at_quick_exit": {
-      "c-definition": "7.24.4.3"
+      "c-definition": "7.24.4.3",
+      "in-latest-posix": ""
     },
     "exit": {
-      "c-definition": "7.24.4.4"
+      "c-definition": "7.24.4.4",
+      "in-latest-posix": ""
     },
     "_Exit": {
-      "c-definition": "7.24.4.5"
+      "c-definition": "7.24.4.5",
+      "in-latest-posix": ""
     },
     "getenv": {
-      "c-definition": "7.24.4.6"
+      "c-definition": "7.24.4.6",
+      "in-latest-posix": ""
     },
     "quick_exit": {
-      "c-definition": "7.24.4.7"
+      "c-definition": "7.24.4.7",
+      "in-latest-posix": ""
     },
     "system": {
-      "c-definition": "7.24.4.8"
+      "c-definition": "7.24.4.8",
+      "in-latest-posix": ""
     },
     "bsearch": {
-      "c-definition": "7.24.5.1"
+      "c-definition": "7.24.5.1",
+      "in-latest-posix": ""
     },
     "qsort": {
-      "c-definition": "7.24.5.2"
+      "c-definition": "7.24.5.2",
+      "in-latest-posix": ""
     },
     "abs": {
-      "c-definition": "7.24.6.1"
+      "c-definition": "7.24.6.1",
+      "in-latest-posix": ""
     },
     "labs": {
-      "c-definition": "7.24.6.1"
+      "c-definition": "7.24.6.1",
+      "in-latest-posix": ""
     },
     "llabs": {
-      "c-definition": "7.24.6.1"
+      "c-definition": "7.24.6.1",
+      "in-latest-posix": ""
     },
     "div": {
-      "c-definition": "7.24.6.2"
+      "c-definition": "7.24.6.2",
+      "in-latest-posix": ""
     },
     "ldiv": {
-      "c-definition": "7.24.6.2"
+      "c-definition": "7.24.6.2",
+      "in-latest-posix": ""
     },
     "lldiv": {
-      "c-definition": "7.24.6.2"
+      "c-definition": "7.24.6.2",
+      "in-latest-posix": ""
     },
     "mblen": {
-      "c-definition": "7.24.7.1"
+      "c-definition": "7.24.7.1",
+      "in-latest-posix": ""
     },
     "mbtowc": {
-      "c-definition": "7.24.7.2"
+      "c-definition": "7.24.7.2",
+      "in-latest-posix": ""
     },
     "wctomb": {
-      "c-definition": "7.24.7.3"
+      "c-definition": "7.24.7.3",
+      "in-latest-posix": ""
     },
     "mbstowcs": {
-      "c-definition": "7.24.8.1"
+      "c-definition": "7.24.8.1",
+      "in-latest-posix": ""
     },
     "wcstombs": {
-      "c-definition": "7.24.8.2"
+      "c-definition": "7.24.8.2",
+      "in-latest-posix": ""
     },
     "memalignment": {
       "c-definition": "7.24.9.1"

--- a/libc/utils/docgen/string.json
+++ b/libc/utils/docgen/string.json
@@ -6,94 +6,125 @@
   },
   "functions": {
     "memcpy": {
-      "c-definition": "7.26.2.1"
+      "c-definition": "7.26.2.1",
+      "in-latest-posix": ""
     },
     "memccpy": {
-      "c-definition": "7.26.2.2"
+      "c-definition": "7.26.2.2",
+      "in-latest-posix": ""
     },
     "mempcpy": {
       "c-definition": "TODO: glibc extension"
     },
     "memmove": {
-      "c-definition": "7.26.2.3"
+      "c-definition": "7.26.2.3",
+      "in-latest-posix": ""
     },
     "strcpy": {
-      "c-definition": "7.26.2.4"
+      "c-definition": "7.26.2.4",
+      "in-latest-posix": ""
     },
     "strncpy": {
-      "c-definition": "7.26.2.5"
+      "c-definition": "7.26.2.5",
+      "in-latest-posix": ""
     },
     "stpcpy": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/stpcpy.html"
+      "in-latest-posix": ""
     },
     "stpncpy": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/stpncpy.html"
+      "in-latest-posix": ""
     },
     "strdup": {
-      "c-definition": "7.26.2.6"
+      "c-definition": "7.26.2.6",
+      "in-latest-posix": ""
     },
     "strndup": {
-      "c-definition": "7.26.2.7"
+      "c-definition": "7.26.2.7",
+      "in-latest-posix": ""
     },
     "strcat": {
-      "c-definition": "7.26.3.1"
+      "c-definition": "7.26.3.1",
+      "in-latest-posix": ""
     },
     "strncat": {
-      "c-definition": "7.26.3.2"
+      "c-definition": "7.26.3.2",
+      "in-latest-posix": ""
     },
     "memcmp": {
-      "c-definition": "7.26.4.1"
+      "c-definition": "7.26.4.1",
+      "in-latest-posix": ""
     },
     "strcmp": {
-      "c-definition": "7.26.4.2"
+      "c-definition": "7.26.4.2",
+      "in-latest-posix": ""
     },
     "strcoll": {
-      "c-definition": "7.26.4.3"
+      "c-definition": "7.26.4.3",
+      "in-latest-posix": ""
+    },
+    "strcoll_l": {
+      "in-latest-posix": ""
     },
     "strncmp": {
-      "c-definition": "7.26.4.4"
+      "c-definition": "7.26.4.4",
+      "in-latest-posix": ""
     },
     "strxfrm": {
-      "c-definition": "7.26.4.5"
+      "c-definition": "7.26.4.5",
+      "in-latest-posix": ""
+    },
+    "strxfrm_l": {
+      "in-latest-posix": ""
     },
     "memchr": {
-      "c-definition": "7.26.5.2"
+      "c-definition": "7.26.5.2",
+      "in-latest-posix": ""
     },
     "strchr": {
-      "c-definition": "7.26.5.3"
+      "c-definition": "7.26.5.3",
+      "in-latest-posix": ""
     },
     "strcspn": {
-      "c-definition": "7.26.5.4"
+      "c-definition": "7.26.5.4",
+      "in-latest-posix": ""
     },
     "strpbrk": {
-      "c-definition": "7.26.5.5"
+      "c-definition": "7.26.5.5",
+      "in-latest-posix": ""
     },
     "strrchr": {
-      "c-definition": "7.26.5.6"
+      "c-definition": "7.26.5.6",
+      "in-latest-posix": ""
     },
     "strspn": {
-      "c-definition": "7.26.5.7"
+      "c-definition": "7.26.5.7",
+      "in-latest-posix": ""
     },
     "strstr": {
-      "c-definition": "7.26.5.8"
+      "c-definition": "7.26.5.8",
+      "in-latest-posix": ""
     },
     "strtok": {
-      "c-definition": "7.26.5.9"
+      "c-definition": "7.26.5.9",
+      "in-latest-posix": ""
     },
     "strtok_r": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/strtok_r.html"
+      "in-latest-posix": ""
     },
     "memset": {
-      "c-definition": "7.26.6.1"
+      "c-definition": "7.26.6.1",
+      "in-latest-posix": ""
     },
     "memset_explicit": {
       "c-definition": "7.26.6.2"
     },
     "strerror": {
-      "c-definition": "7.26.6.3"
+      "c-definition": "7.26.6.3",
+      "in-latest-posix": ""
     },
     "strlen": {
-      "c-definition": "7.26.6.4"
+      "c-definition": "7.26.6.4",
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/strings.json
+++ b/libc/utils/docgen/strings.json
@@ -1,40 +1,40 @@
 {
   "functions": {
     "bzero": {
-      "posix-definition": "removed in POSIX.1-2008"
+      "removed-in-posix-2008": ""
     },
     "bcmp": {
-      "posix-definition": "removed in POSIX.1-2008"
+      "removed-in-posix-2008": ""
     },
     "bcopy": {
-      "posix-definition": "removed in POSIX.1-2008"
+      "removed-in-posix-2008": ""
     },
     "ffs": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffs.html"
+      "in-latest-posix": ""
     },
     "ffsl": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffsl.html"
+      "in-latest-posix": ""
     },
     "ffsll": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/ffsll.html"
+      "in-latest-posix": ""
     },
     "index": {
-      "posix-definition": "removed in POSIX.1-2008"
+      "removed-in-posix-2008": ""
     },
     "rindex": {
-      "posix-definition": "removed in POSIX.1-2008"
+      "removed-in-posix-2008": ""
     },
     "strcasecmp": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html"
+      "in-latest-posix": ""
     },
     "strcasecmp_l": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html"
+      "in-latest-posix": ""
     },
     "strncasecmp": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html"
+      "in-latest-posix": ""
     },
     "strncasecmp_l": {
-      "posix-definition": "https://pubs.opengroup.org/onlinepubs/9799919799/functions/strncasecmp.html"
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/threads.json
+++ b/libc/utils/docgen/threads.json
@@ -4,87 +4,117 @@
       "c-definition": "7.28.1"
     },
     "ONCE_FLAG_INIT": {
-      "c-definition": "7.28.1"
+      "c-definition": "7.28.1",
+      "in-latest-posix": ""
     },
     "TSS_DTOR_ITERATIONS": {
-      "c-definition": "7.28.1"
+      "c-definition": "7.28.1",
+      "in-latest-posix": ""
+    },
+    "thread_local": {
+      "in-latest-posix": ""
     }
   },
   "functions": {
     "call_once": {
-      "c-definition": "7.28.2.1"
+      "c-definition": "7.28.2.1",
+      "in-latest-posix": ""
     },
     "cnd_broadcast": {
-      "c-definition": "7.28.3.1"
+      "c-definition": "7.28.3.1",
+      "in-latest-posix": ""
     },
     "cnd_destroy": {
-      "c-definition": "7.28.3.2"
+      "c-definition": "7.28.3.2",
+      "in-latest-posix": ""
     },
     "cnd_init": {
-      "c-definition": "7.28.3.3"
+      "c-definition": "7.28.3.3",
+      "in-latest-posix": ""
     },
     "cnd_signal": {
-      "c-definition": "7.28.3.4"
+      "c-definition": "7.28.3.4",
+      "in-latest-posix": ""
     },
     "cnd_timedwait": {
-      "c-definition": "7.28.3.5"
+      "c-definition": "7.28.3.5",
+      "in-latest-posix": ""
     },
     "cnd_wait": {
-      "c-definition": "7.28.3.6"
+      "c-definition": "7.28.3.6",
+      "in-latest-posix": ""
     },
     "mtx_destroy": {
-      "c-definition": "7.28.4.2"
+      "c-definition": "7.28.4.2",
+      "in-latest-posix": ""
     },
     "mtx_init": {
-      "c-definition": "7.28.4.3"
+      "c-definition": "7.28.4.3",
+      "in-latest-posix": ""
     },
     "mtx_lock": {
-      "c-definition": "7.28.4.4"
+      "c-definition": "7.28.4.4",
+      "in-latest-posix": ""
     },
     "mtx_timedlock": {
-      "c-definition": "7.28.4.5"
+      "c-definition": "7.28.4.5",
+      "in-latest-posix": ""
     },
     "mtx_trylock": {
-      "c-definition": "7.28.4.6"
+      "c-definition": "7.28.4.6",
+      "in-latest-posix": ""
     },
     "mtx_unlock": {
-      "c-definition": "7.28.4.7"
+      "c-definition": "7.28.4.7",
+      "in-latest-posix": ""
     },
     "thrd_create": {
-      "c-definition": "7.28.5.1"
+      "c-definition": "7.28.5.1",
+      "in-latest-posix": ""
     },
     "thrd_current": {
-      "c-definition": "7.28.5.2"
+      "c-definition": "7.28.5.2",
+      "in-latest-posix": ""
     },
     "thrd_detach": {
-      "c-definition": "7.28.5.3"
+      "c-definition": "7.28.5.3",
+      "in-latest-posix": ""
     },
     "thrd_equal": {
-      "c-definition": "7.28.5.4"
+      "c-definition": "7.28.5.4",
+      "in-latest-posix": ""
     },
     "thrd_exit": {
-      "c-definition": "7.28.5.5"
+      "c-definition": "7.28.5.5",
+      "in-latest-posix": ""
     },
     "thrd_join": {
-      "c-definition": "7.28.5.6"
+      "c-definition": "7.28.5.6",
+      "in-latest-posix": ""
     },
     "thrd_sleep": {
-      "c-definition": "7.28.5.7"
+      "c-definition": "7.28.5.7",
+      "in-latest-posix": ""
     },
     "thrd_yield": {
-      "c-definition": "7.28.5.8"
+      "c-definition": "7.28.5.8",
+      "in-latest-posix": ""
     },
     "tss_create": {
-      "c-definition": "7.28.6.1"
+      "c-definition": "7.28.6.1",
+      "in-latest-posix": ""
     },
     "tss_delete": {
-      "c-definition": "7.28.6.2"
+      "c-definition": "7.28.6.2",
+      "in-latest-posix": ""
     },
     "tss_get": {
-      "c-definition": "7.28.6.3"
+      "c-definition": "7.28.6.3",
+      "in-latest-posix": ""
     },
     "tss_set": {
-      "c-definition": "7.28.6.4"
+      "c-definition": "7.28.6.4",
+      "in-latest-posix": ""
     }
   }
 }

--- a/libc/utils/docgen/uchar.json
+++ b/libc/utils/docgen/uchar.json
@@ -12,16 +12,20 @@
       "c-definition": "7.30.2.3"
     },
     "mbrtoc16": {
-      "c-definition": "7.30.2.4"
+      "c-definition": "7.30.2.4",
+      "in-latest-posix": ""
     },
     "c16rtomb": {
-      "c-definition": "7.30.2.5"
+      "c-definition": "7.30.2.5",
+      "in-latest-posix": ""
     },
     "mbrtoc32": {
-      "c-definition": "7.30.2.6"
+      "c-definition": "7.30.2.6",
+      "in-latest-posix": ""
     },
     "c32rtomb": {
-      "c-definition": "7.30.2.7"
+      "c-definition": "7.30.2.7",
+      "in-latest-posix": ""
     }
   }
 }


### PR DESCRIPTION
Usually posix functions have individual doc pages, and each header has its own
list of required macro definitions. Use a simpler key of "in-latest-posix" to
signal that the URL convention can be followed.

Add support for a "removed-in-posix-2008" key which will link to the 2004 docs
for functions like bcmp, bcopy, bzero, index, and rindex from strings.h.

I don't want to add all of these links for pthreads.h, so automating this will
make documenting these go much faster.
