### PR TITLE
[libc++] Simplify vector<bool>::flip() and add new tests

### DIFF
--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -1049,14 +1049,11 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::resize(size_type __
 
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::flip() _NOEXCEPT {
-  // Process the whole words in the front
-  size_type __n         = __size_;
+  // Flip each storage word entirely, including the last potentially partial word.
+  // The unused bits in the last word are safe to flip as they won't be accessed.
   __storage_pointer __p = __begin_;
-  for (; __n >= __bits_per_word; ++__p, __n -= __bits_per_word)
+  for (size_type __n = __external_cap_to_internal(size()); __n; ++__p, --__n)
     *__p = ~*__p;
-  // Process the last partial word, if it exists
-  if (__n > 0)
-    *__p ^= ~__storage_type(0) >> (__bits_per_word - __n);
 }
 
 template <class _Allocator>

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -1052,7 +1052,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::flip() _NOEXCEPT {
   // Flip each storage word entirely, including the last potentially partial word.
   // The unused bits in the last word are safe to flip as they won't be accessed.
   __storage_pointer __p = __begin_;
-  for (size_type __n = __external_cap_to_internal(size()); __n; ++__p, --__n)
+  for (size_type __n = __external_cap_to_internal(size()); __n != 0; ++__p, --__n)
     *__p = ~*__p;
 }
 

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -1049,18 +1049,14 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::resize(size_type __
 
 template <class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::flip() _NOEXCEPT {
-  // do middle whole words
+  // Process the whole words in the front
   size_type __n         = __size_;
   __storage_pointer __p = __begin_;
   for (; __n >= __bits_per_word; ++__p, __n -= __bits_per_word)
     *__p = ~*__p;
-  // do last partial word
-  if (__n > 0) {
-    __storage_type __m = ~__storage_type(0) >> (__bits_per_word - __n);
-    __storage_type __b = *__p & __m;
-    *__p &= ~__m;
-    *__p |= ~__b & __m;
-  }
+  // Process the last partial word, if it exists
+  if (__n > 0)
+    *__p ^= ~__storage_type(0) >> (__bits_per_word - __n);
 }
 
 template <class _Allocator>

--- a/libcxx/test/std/containers/sequences/vector.bool/flip.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/flip.pass.cpp
@@ -8,7 +8,7 @@
 
 // <vector>
 
-// flip()
+// void flip();
 
 #include <cassert>
 #include <vector>

--- a/libcxx/test/std/containers/sequences/vector.bool/flip.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/flip.pass.cpp
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <vector>
+
+// flip()
+
+#include <cassert>
+#include <vector>
+
+#include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
+
+TEST_CONSTEXPR_CXX20 bool tests() {
+  //
+  // Testing flip() function with small vectors and various allocators
+  //
+  {
+    std::vector<bool> v;
+    v.push_back(true);
+    v.push_back(false);
+    v.push_back(true);
+    v.flip();
+    assert(!v[0]);
+    assert(v[1]);
+    assert(!v[2]);
+  }
+  {
+    std::vector<bool, min_allocator<bool> > v;
+    v.push_back(true);
+    v.push_back(false);
+    v.push_back(true);
+    v.flip();
+    assert(!v[0]);
+    assert(v[1]);
+    assert(!v[2]);
+  }
+  {
+    std::vector<bool, test_allocator<bool> > v(test_allocator<bool>(5));
+    v.push_back(true);
+    v.push_back(false);
+    v.push_back(true);
+    v.flip();
+    assert(!v[0]);
+    assert(v[1]);
+    assert(!v[2]);
+  }
+
+  //
+  // Testing flip() function with larger vectors
+  //
+  {
+    std::vector<bool> v(1000);
+    for (std::size_t i = 0; i < v.size(); ++i)
+      v[i] = i & 1;
+    std::vector<bool> original = v;
+    v.flip();
+    for (size_t i = 0; i < v.size(); ++i) {
+      assert(v[i] == !original[i]);
+    }
+  }
+  {
+    std::vector<bool, min_allocator<bool> > v(1000, false, min_allocator<bool>());
+    for (std::size_t i = 0; i < v.size(); ++i)
+      v[i] = i & 1;
+    std::vector<bool, min_allocator<bool> > original = v;
+    v.flip();
+    for (size_t i = 0; i < v.size(); ++i)
+      assert(v[i] == !original[i]);
+    v.flip();
+    assert(v == original);
+  }
+  {
+    std::vector<bool, test_allocator<bool> > v(1000, false, test_allocator<bool>(5));
+    for (std::size_t i = 0; i < v.size(); ++i)
+      v[i] = i & 1;
+    std::vector<bool, test_allocator<bool> > original = v;
+    v.flip();
+    for (size_t i = 0; i < v.size(); ++i)
+      assert(v[i] == !original[i]);
+    v.flip();
+    assert(v == original);
+  }
+
+  return true;
+}
+
+int main(int, char**) {
+  tests();
+#if TEST_STD_VER > 17
+  static_assert(tests());
+#endif
+  return 0;
+}


### PR DESCRIPTION
This PR simplifies the internal bitwise logic of the `flip()` function for `vector<bool>`, and creates new tests to validate the changes.