### PR TITLE
[flang][rt][device] Use enum-set.h as Fortran.h

### DIFF
--- a/flang/include/flang/Common/Fortran-consts.h
+++ b/flang/include/flang/Common/Fortran-consts.h
@@ -9,7 +9,7 @@
 #ifndef FORTRAN_COMMON_FORTRAN_CONSTS_H_
 #define FORTRAN_COMMON_FORTRAN_CONSTS_H_
 
-#include "flang/Common/enum-class.h"
+#include "enum-set.h"
 #include <cstdint>
 
 namespace Fortran::common {


### PR DESCRIPTION
The code in `flang/include/flang/Common/Fortran-consts.h` was taken from `flang/include/flang/Common/Fortran.h` where we use `enum-set.h` and not `enum-class.h`. This was making some of our downstream device build failing. 