### PR TITLE
[lldb] Disallow left shifts of negative values in the interpreter

### DIFF
--- a/lldb/source/DataFormatters/FormatterBytecode.cpp
+++ b/lldb/source/DataFormatters/FormatterBytecode.cpp
@@ -379,7 +379,7 @@ llvm::Error Interpret(std::vector<ControlStackElement> &control,
       BINOP_CHECKZERO(%);
       continue;
     case op_shl:
-#define SHIFTOP(OP)                                                            \
+#define SHIFTOP(OP, LEFT)                                                      \
   {                                                                            \
     TYPE_CHECK(Any, UInt);                                                     \
     uint64_t y = data.Pop<uint64_t>();                                         \
@@ -390,16 +390,18 @@ llvm::Error Interpret(std::vector<ControlStackElement> &control,
       data.Push(x OP y);                                                       \
     } else if (std::holds_alternative<int64_t>(data.back())) {                 \
       int64_t x = data.Pop<int64_t>();                                         \
+      if (x < 0 && LEFT)                                                       \
+        return error("left shift of negative value");                          \
       if (y > 64)                                                              \
         return error("shift out of bounds");                                   \
       data.Push(x OP y);                                                       \
     } else                                                                     \
       return error("unsupported data types");                                  \
   }
-      SHIFTOP(<<);
+      SHIFTOP(<<, true);
       continue;
     case op_shr:
-      SHIFTOP(<<);
+      SHIFTOP(>>, false);
       continue;
     case op_and:
       BINOP(&);

--- a/lldb/unittests/DataFormatter/FormatterBytecodeTest.cpp
+++ b/lldb/unittests/DataFormatter/FormatterBytecodeTest.cpp
@@ -147,9 +147,12 @@ TEST_F(FormatterBytecodeTest, ArithOps) {
   {
     DataStack data;
     unsigned char minus_one = 127;
-    ASSERT_TRUE(
+    ASSERT_FALSE(
         Interpret({op_lit_int, minus_one, op_lit_uint, 2, op_shl}, data));
-    ASSERT_EQ(data.Pop<int64_t>(), -4);
+    unsigned char minus_two = 126;
+    ASSERT_TRUE(
+        Interpret({op_lit_int, minus_two, op_lit_uint, 1, op_shr}, data));
+    ASSERT_EQ(data.Pop<int64_t>(), -1);
   }
   {
     DataStack data;


### PR DESCRIPTION
This trips UBSAN and probably isn't partiuclarly useful either.