### PR TITLE
[libc][test] Adjust header paths in tests

### DIFF
--- a/libc/test/src/strings/CMakeLists.txt
+++ b/libc/test/src/strings/CMakeLists.txt
@@ -20,7 +20,7 @@ add_libc_test(
     index_test.cpp
   DEPENDS
     libc.src.strings.index
-    libc.test.src.strchr_test_support
+    libc.test.src.string.strchr_test_support
 )
 
 add_libc_test(
@@ -31,7 +31,7 @@ add_libc_test(
     rindex_test.cpp
   DEPENDS
     libc.src.strings.rindex
-    libc.test.src.strchr_test_support
+    libc.test.src.string.strchr_test_support
 )
 
 add_libc_test(

--- a/libc/test/src/strings/index_test.cpp
+++ b/libc/test/src/strings/index_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "StrchrTest.h"
+#include "test/src/string/StrchrTest.h"
 
-#include "src/string/index.h"
+#include "src/strings/index.h"
 #include "test/UnitTest/Test.h"
 
 STRCHR_TEST(Index, LIBC_NAMESPACE::index)

--- a/libc/test/src/strings/rindex_test.cpp
+++ b/libc/test/src/strings/rindex_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "StrchrTest.h"
+#include "test/src/string/StrchrTest.h"
 
-#include "src/string/rindex.h"
+#include "src/strings/rindex.h"
 #include "test/UnitTest/Test.h"
 
 STRRCHR_TEST(Rindex, LIBC_NAMESPACE::rindex)


### PR DESCRIPTION
Since `index_test.cpp` and `rindex_test.cpp` now reside in /strings, adjust some header paths accordingly.

Link: #118899