### PR TITLE
[flang][Driver] Don't require -fno-integrated-as when using -save-temps

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -155,9 +155,16 @@ llvm::vfs::FileSystem &ToolChain::getVFS() const {
 }
 
 bool ToolChain::useIntegratedAs() const {
-  return Args.hasFlag(options::OPT_fintegrated_as,
-                      options::OPT_fno_integrated_as,
-                      IsIntegratedAssemblerDefault());
+  // When -save-temps is enabled in flang, it will attempt to use -cc1as which
+  // will not work. For now, we would like -save-temps to imply
+  // -fno-integrated-as. Eventually, we may want to consider having -fc1as - the
+  // flang analog of clang's cc1as.
+  if (D.IsFlangMode() && Args.hasArg(options::OPT_save_temps_EQ))
+    return false;
+  else
+    return Args.hasFlag(options::OPT_fintegrated_as,
+                        options::OPT_fno_integrated_as,
+                        IsIntegratedAssemblerDefault());
 }
 
 bool ToolChain::useIntegratedBackend() const {

--- a/flang/test/Driver/save-mlir-temps.f90
+++ b/flang/test/Driver/save-mlir-temps.f90
@@ -4,8 +4,8 @@
 ! the driver does not generate specific passes for MLIR. Instead, they are
 ! generated during code generation as additional outputs.
 
-! As `flang` does not implement `-fc1as` (i.e. a driver for the integrated
-! assembler), we need to use `-fno-integrated-as` here.
+! `flang` does not implement `-fc1as` (i.e. a driver for the integrated
+! assembler).
 ! However, calling an external assembler on arm64 Macs fails, because it's
 ! currently being invoked with the `-Q` flag, that is not supported on arm64.
 ! UNSUPPORTED: system-windows, system-darwin
@@ -20,13 +20,13 @@
 ! Save to cwd
 !--------------------------
 ! RUN: rm -rf %t && mkdir -p %t
-! RUN: pushd %t && %flang -c -fno-integrated-as -save-temps=cwd -o out.o %s 2>&1
+! RUN: pushd %t && %flang -c -save-temps=cwd -o out.o %s 2>&1
 ! RUN: FileCheck %s -input-file=save-mlir-temps-fir.mlir -check-prefix=MLIR-FIR
 ! RUN: FileCheck %s -input-file=save-mlir-temps-llvmir.mlir -check-prefix=MLIR-LLVMIR
 ! RUN: popd
 
 ! RUN: rm -rf %t && mkdir -p %t
-! RUN: pushd %t && %flang -c -fno-integrated-as -save-temps -o out.o %s 2>&1
+! RUN: pushd %t && %flang -c -save-temps -o out.o %s 2>&1
 ! RUN: FileCheck %s -input-file=save-mlir-temps-fir.mlir -check-prefix=MLIR-FIR
 ! RUN: FileCheck %s -input-file=save-mlir-temps-llvmir.mlir -check-prefix=MLIR-LLVMIR
 ! RUN: popd
@@ -35,7 +35,7 @@
 ! Save to output directory
 !--------------------------
 ! RUN: rm -rf %t && mkdir -p %t
-! RUN: %flang -c -fno-integrated-as -save-temps=obj -o %t/out.o %s 2>&1
+! RUN: %flang -c -save-temps=obj -o %t/out.o %s 2>&1
 ! RUN: FileCheck %s -input-file=%t/save-mlir-temps-fir.mlir -check-prefix=MLIR-FIR
 ! RUN: FileCheck %s -input-file=%t/save-mlir-temps-llvmir.mlir -check-prefix=MLIR-LLVMIR
 
@@ -43,7 +43,7 @@
 ! Save to specific directory
 !--------------------------
 ! RUN: rm -rf %t && mkdir -p %t
-! RUN: %flang -c -fno-integrated-as -save-temps=%t -o %t/out.o %s 2>&1
+! RUN: %flang -c -save-temps=%t -o %t/out.o %s 2>&1
 ! RUN: FileCheck %s -input-file=%t/save-mlir-temps-fir.mlir -check-prefix=MLIR-FIR
 ! RUN: FileCheck %s -input-file=%t/save-mlir-temps-llvmir.mlir -check-prefix=MLIR-LLVMIR
 

--- a/flang/test/Driver/save-temps-use-module.f90
+++ b/flang/test/Driver/save-temps-use-module.f90
@@ -4,7 +4,7 @@
 ! RUN: rm -rf %t && split-file %s %t
 ! RUN: mkdir %t/mod_inc_dir
 ! RUN: mv %t/somemodule.mod %t/mod_inc_dir
-! RUN: %flang -S -emit-llvm --save-temps=obj -I%t/mod_inc_dir -fno-integrated-as \
+! RUN: %flang -S -emit-llvm --save-temps=obj -I%t/mod_inc_dir \
 ! RUN:   %t/ModuleUser.f90 -o %t/ModuleUser
 ! RUN: ls %t | FileCheck %s
 

--- a/flang/test/Driver/save-temps.f90
+++ b/flang/test/Driver/save-temps.f90
@@ -1,24 +1,28 @@
-! Tests for the `-save-temps` flag. As `flang` does not implement `-fc1as` (i.e. a driver for the integrated assembler), we need to
-! use `-fno-integrated-as` here.
+! Tests for the `-save-temps` flag. As `flang` does not implement `-fc1as`
+! (i.e. a driver for the integrated assembler), we also need to check that
+! clang's integrated assembler does not get used.
 
 ! UNSUPPORTED: system-windows
 
 !--------------------------
 ! Basic case: `-save-temps`
 !--------------------------
-! RUN: %flang -save-temps -fno-integrated-as %s -### 2>&1 | FileCheck %s
+! RUN: %flang -save-temps %s -### 2>&1 | FileCheck %s
 ! CHECK: "-o" "save-temps.i"
 ! CHECK-NEXT: "-o" "save-temps.bc"
 ! CHECK-NEXT: "-o" "save-temps.s"
 ! CHECK-NEXT: "-o" "save-temps.o"
 ! CHECK-NEXT: "-o" "a.out"
 
+! RUN: %flang -save-temps %s -### 2>&1 | FileCheck %s --check-prefix=NOCC1AS
+! NOCC1AS-NOT: "-cc1as"
+
 !--------------------------
 ! `-save-temps=cwd`
 !--------------------------
 ! This should work the same as -save-temps above
 
-! RUN: %flang -save-temps=cwd -fno-integrated-as  %s -### 2>&1 | FileCheck %s -check-prefix=CWD
+! RUN: %flang -save-temps=cwd  %s -### 2>&1 | FileCheck %s -check-prefix=CWD
 ! CWD: "-o" "save-temps.i"
 ! CWD-NEXT: "-o" "save-temps.bc"
 ! CWD-NEXT: "-o" "save-temps.s"
@@ -31,14 +35,14 @@
 ! Check that temp files are saved in the same directory as the output file
 ! regardless of whether -o is specified.
 
-! RUN: %flang -save-temps=obj -fno-integrated-as -o obj/dir/a.out %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-OBJ
+! RUN: %flang -save-temps=obj -o obj/dir/a.out %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-OBJ
 ! CHECK-OBJ: "-o" "obj/dir/save-temps.i"
 ! CHECK-OBJ-NEXT: "-o" "obj/dir/save-temps.bc"
 ! CHECK-OBJ-NEXT: "-o" "obj/dir/save-temps.s"
 ! CHECK-OBJ-NEXT: "-o" "obj/dir/save-temps.o"
 ! CHECK-OBJ-NEXT: "-o" "obj/dir/a.out"
 
-! RUN: %flang -save-temps=obj -fno-integrated-as %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-OBJ-NOO
+! RUN: %flang -save-temps=obj %s -### 2>&1 | FileCheck %s -check-prefix=CHECK-OBJ-NOO
 ! CHECK-OBJ-NOO: "-o" "save-temps.i"
 ! CHECK-OBJ-NOO-NEXT: "-o" "save-temps.bc"
 ! CHECK-OBJ-NOO-NEXT: "-o" "save-temps.s"


### PR DESCRIPTION
Currently, --save-temps requires -fno-integrated-as since flang does not have `fc1as` i.e. a driver for an integrated assembler. This simply checks if the driver is in flang-mode and forces useIntegratedAs() to return true if -save-temps was found on the command line.

This will also allow us to enable some tests in the gfortran test suite within the LLVM test suite.

Fixes #58587