### PR TITLE
[NFC] Don't recompute type name

### DIFF
--- a/llvm/include/llvm/Support/TypeName.h
+++ b/llvm/include/llvm/Support/TypeName.h
@@ -13,18 +13,8 @@
 
 namespace llvm {
 
-/// We provide a function which tries to compute the (demangled) name of a type
-/// statically.
-///
-/// This routine may fail on some platforms or for particularly unusual types.
-/// Do not use it for anything other than logging and debugging aids. It isn't
-/// portable or dependendable in any real sense.
-///
-/// The returned StringRef will point into a static storage duration string.
-/// However, it may not be null terminated and may be some strangely aligned
-/// inner substring of a larger string.
-template <typename DesiredTypeName>
-inline StringRef getTypeName() {
+namespace detail {
+template <typename DesiredTypeName> inline StringRef getTypeNameImpl() {
 #if defined(__clang__) || defined(__GNUC__)
   StringRef Name = __PRETTY_FUNCTION__;
 
@@ -57,6 +47,22 @@ inline StringRef getTypeName() {
   // We return a string that is unlikely to look like any type in LLVM.
   return "UNKNOWN_TYPE";
 #endif
+}
+} // namespace detail
+
+/// We provide a function which tries to compute the (demangled) name of a type
+/// statically.
+///
+/// This routine may fail on some platforms or for particularly unusual types.
+/// Do not use it for anything other than logging and debugging aids. It isn't
+/// portable or dependendable in any real sense.
+///
+/// The returned StringRef will point into a static storage duration string.
+/// However, it may not be null terminated and may be some strangely aligned
+/// inner substring of a larger string.
+template <typename DesiredTypeName> inline StringRef getTypeName() {
+  static StringRef Name = detail::getTypeNameImpl<DesiredTypeName>();
+  return Name;
 }
 
 } // namespace llvm


### PR DESCRIPTION
This change uses a local static variable to cache the computed `StringRef` containing the type's name.


I found that `RelWithDebInfo` builds of MLIR were spending a relatively large amount of time in `StringRef::find` and I tracked it down to `getTypeName` which utilizes `StringRef` methods that are defined in a separate translation unit. This is especially impactful on perf because `getTypeName` is supposed to be used for debug logging. See an example here: https://github.com/llvm/llvm-project/blob/4b825c7417f72ee88ee3e4316d0c01ed463f1241/mlir/include/mlir/IR/Types.h#L294-L300