### PR TITLE
[libc++] Simplify vector<bool>::__construct_at_end (Reopend)

### DIFF
--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -558,30 +558,20 @@ vector<bool, _Allocator>::__recommend(size_type __new_size) const {
 template <class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<bool, _Allocator>::__construct_at_end(size_type __n, bool __x) {
-  size_type __old_size = this->__size_;
+  iterator __old_end = end();
   this->__size_ += __n;
-  if (__old_size == 0 || ((__old_size - 1) / __bits_per_word) != ((this->__size_ - 1) / __bits_per_word)) {
-    if (this->__size_ <= __bits_per_word)
-      this->__begin_[0] = __storage_type(0);
-    else
-      this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
-  }
-  std::fill_n(__make_iter(__old_size), __n, __x);
+  this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
+  std::fill_n(__old_end, __n, __x);
 }
 
 template <class _Allocator>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<bool, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel __last, size_type __n) {
-  size_type __old_size = this->__size_;
+  iterator __old_end = end();
   this->__size_ += __n;
-  if (__old_size == 0 || ((__old_size - 1) / __bits_per_word) != ((this->__size_ - 1) / __bits_per_word)) {
-    if (this->__size_ <= __bits_per_word)
-      this->__begin_[0] = __storage_type(0);
-    else
-      this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
-  }
-  std::__copy(std::move(__first), std::move(__last), __make_iter(__old_size));
+  this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
+  std::__copy(std::move(__first), std::move(__last), __old_end);
 }
 
 template <class _Allocator>
@@ -855,7 +845,9 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::reserve(size_type _
       this->__throw_length_error();
     vector __v(this->get_allocator());
     __v.__vallocate(__n);
-    __v.__construct_at_end(this->begin(), this->end(), this->size());
+    // Ensure that the call to __construct_at_end(first, last, n) meets the precondition of n > 0
+    if (this->size() > 0)
+      __v.__construct_at_end(this->begin(), this->end(), this->size());
     swap(__v);
   }
 }

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -558,6 +558,7 @@ vector<bool, _Allocator>::__recommend(size_type __new_size) const {
 template <class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<bool, _Allocator>::__construct_at_end(size_type __n, bool __x) {
+  _LIBCPP_ASSERT_INTERNAL(__n > 0, "This function expects __n > 0");
   iterator __old_end = end();
   this->__size_ += __n;
   this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
@@ -568,6 +569,7 @@ template <class _Allocator>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<bool, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel __last, size_type __n) {
+  _LIBCPP_ASSERT_INTERNAL(__n > 0, "This function expects __n > 0");
   iterator __old_end = end();
   this->__size_ += __n;
   this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -561,7 +561,7 @@ vector<bool, _Allocator>::__construct_at_end(size_type __n, bool __x) {
       capacity() >= size() + __n, "vector<bool>::__construct_at_end called with insufficient capacity");
   std::fill_n(end(), __n, __x);
   this->__size_ += __n;
-  if (end().__ctz_ != 0) // has uninitialized trailing bits in the last word
+  if (end().__ctz_ != 0) // Ensure uninitialized leading bits in the last word are set to zero
     std::fill_n(end(), __bits_per_word - end().__ctz_, 0);
 }
 
@@ -573,7 +573,7 @@ vector<bool, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel _
       capacity() >= size() + __n, "vector<bool>::__construct_at_end called with insufficient capacity");
   std::__copy(std::move(__first), std::move(__last), end());
   this->__size_ += __n;
-  if (end().__ctz_ != 0) // has uninitialized trailing bits in the last word
+  if (end().__ctz_ != 0) // Ensure uninitialized leading bits in the last word are set to zero
     std::fill_n(end(), __bits_per_word - end().__ctz_, 0);
 }
 
@@ -848,9 +848,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void vector<bool, _Allocator>::reserve(size_type _
       this->__throw_length_error();
     vector __v(this->get_allocator());
     __v.__vallocate(__n);
-    // Ensure that the call to __construct_at_end(first, last, n) meets the precondition of n > 0
-    if (this->size() > 0)
-      __v.__construct_at_end(this->begin(), this->end(), this->size());
+    __v.__construct_at_end(this->begin(), this->end(), this->size());
     swap(__v);
   }
 }

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -552,28 +552,29 @@ vector<bool, _Allocator>::__recommend(size_type __new_size) const {
 }
 
 //  Default constructs __n objects starting at __end_
-//  Precondition:  __n > 0
 //  Precondition:  size() + __n <= capacity()
 //  Postcondition:  size() == size() + __n
 template <class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<bool, _Allocator>::__construct_at_end(size_type __n, bool __x) {
-  _LIBCPP_ASSERT_INTERNAL(__n > 0, "This function expects __n > 0");
-  iterator __old_end = end();
+  _LIBCPP_ASSERT_INTERNAL(
+      capacity() >= size() + __n, "vector<bool>::__construct_at_end called with insufficient capacity");
+  std::fill_n(end(), __n, __x);
   this->__size_ += __n;
-  this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
-  std::fill_n(__old_end, __n, __x);
+  if (end().__ctz_ != 0) // has uninitialized trailing bits in the last word
+    std::fill_n(end(), __bits_per_word - end().__ctz_, 0);
 }
 
 template <class _Allocator>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 vector<bool, _Allocator>::__construct_at_end(_InputIterator __first, _Sentinel __last, size_type __n) {
-  _LIBCPP_ASSERT_INTERNAL(__n > 0, "This function expects __n > 0");
-  iterator __old_end = end();
+  _LIBCPP_ASSERT_INTERNAL(
+      capacity() >= size() + __n, "vector<bool>::__construct_at_end called with insufficient capacity");
+  std::__copy(std::move(__first), std::move(__last), end());
   this->__size_ += __n;
-  this->__begin_[(this->__size_ - 1) / __bits_per_word] = __storage_type(0);
-  std::__copy(std::move(__first), std::move(__last), __old_end);
+  if (end().__ctz_ != 0) // has uninitialized trailing bits in the last word
+    std::fill_n(end(), __bits_per_word - end().__ctz_, 0);
 }
 
 template <class _Allocator>


### PR DESCRIPTION
This PR aims to simplify the implementation of `__construct_at_end` in `vector<bool>`, which currently contains duplicate initialization logic across its two overloads.

https://github.com/llvm/llvm-project/blob/743c84bb9b79ed70d9bed926c2a173db3b30f587/libcxx/include/__vector/vector_bool.h#L539-L546

https://github.com/llvm/llvm-project/blob/743c84bb9b79ed70d9bed926c2a173db3b30f587/libcxx/include/__vector/vector_bool.h#L554-L561

In my initial attempt, I sought to simplify the code by completely removing the duplicate initialization logic. However, thanks to @philnik777's review, it was pointed out that this approach introduced uninitialized loads and undefined behavior, resulting in the closure of the PR.

I am now reopening this PR with a refined approach. I have simplified the initialization logic into a more compact and readable form, while maintaining equivalent functionality. This not only simplifies the implementation but also eliminates code duplication. Additionally, this refactoring addresses a call to `__construct_at_end` in `reserve`, ensuring it meets the precondition of `__n > 0`, as required by `__construct_at_end(, , __n)`. 