### PR TITLE
[clang][Driver] Allow `-fstack-clash-protection`  for Fuchsia targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3773,7 +3773,8 @@ static void RenderSCPOptions(const ToolChain &TC, const ArgList &Args,
                              ArgStringList &CmdArgs) {
   const llvm::Triple &EffectiveTriple = TC.getEffectiveTriple();
 
-  if (!EffectiveTriple.isOSFreeBSD() && !EffectiveTriple.isOSLinux())
+  if (!EffectiveTriple.isOSFreeBSD() && !EffectiveTriple.isOSLinux() &&
+      !EffectiveTriple.isOSFuchsia())
     return;
 
   if (!EffectiveTriple.isX86() && !EffectiveTriple.isSystemZ() &&

--- a/clang/test/Driver/stack-clash-protection.c
+++ b/clang/test/Driver/stack-clash-protection.c
@@ -22,6 +22,11 @@
 // SCP-ll-win64-NOT: attributes {{.*}} "probe-stack"="inline-asm"
 // SCP-ll-win64: argument unused during compilation: '-fstack-clash-protection'
 
+// RUN: %clang -target x86_64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-FUCHSIA
+// RUN: %clang -target aarch64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-FUCHSIA
+// RUN: %clang -target riscv64-unknown-fuchsia -fstack-clash-protection -### %s 2>&1 | FileCheck %s -check-prefix=SCP-FUCHSIA
+// SCP-FUCHSIA: "-fstack-clash-protection"
+
 int foo(int c) {
   int r;
   __asm__("sub %0, %%rsp"


### PR DESCRIPTION
Fuchsia uses guard pages for the stack, similar to Linux 
and other targets, which are required for stack-clash-protection.

This patch adds Fuchsia to the list of allowed targets.