### PR TITLE
[memprof] Use addCallStack in a unit test (NFC)

### DIFF
--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -556,14 +556,12 @@ TEST(MemProf, MissingCallStackId) {
 }
 
 TEST(MemProf, MissingFrameId) {
-  IndexedAllocationInfo AI(0x222, makePartialMIB(), getHotColdSchema());
-
-  IndexedMemProfRecord IndexedMR;
-  IndexedMR.AllocSites.push_back(AI);
-
   // An empty Frame map to trigger a mapping error.
   IndexedMemProfData MemProfData;
-  MemProfData.CallStacks.insert({0x222, {2, 3}});
+  auto CSId = MemProfData.addCallStack(SmallVector<FrameId>{2, 3});
+
+  IndexedMemProfRecord IndexedMR;
+  IndexedMR.AllocSites.emplace_back(CSId, makePartialMIB(), getHotColdSchema());
 
   FrameIdConverter<decltype(MemProfData.Frames)> FrameIdConv(
       MemProfData.Frames);


### PR DESCRIPTION
Here IndexedMemProfRecord just needs to reference a CallStackID, so we
can use addCallStack for a real hash-based CallStackId instead of a
fake value like 0x222.
