### PR TITLE
[PseudoProbe] Fix cleanup for pseudo probe after annotation

### DIFF
--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-profile.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-profile.ll
@@ -4,6 +4,8 @@
 ; RUN: opt < %t -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-profile.prof -sample-profile-remove-probe -S | FileCheck %s -check-prefix=REMOVE-PROBE
 
 ; REMOVE-PROBE-NOT: call void @llvm.pseudoprobe
+; REMOVE-PROBE-NOT: !llvm.pseudo_probe_desc
+; REMOVE-PROBE:     !DILexicalBlockFile({{.*}}, discriminator: 0)
 
 define dso_local i32 @foo(i32 %x, ptr %f) #0 !dbg !4 {
 entry:


### PR DESCRIPTION
When using -sample-profile-remove-probe, pseudo probe desc should
also be removed and dwarf discriminator for call instruction should
be restored.