### PR TITLE
Fix rtsan build with musl

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -46,6 +46,7 @@ void OSSpinLockLock(volatile OSSpinLock *__lock);
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <time.h>


### PR DESCRIPTION
fd_set is defined by `sys/select.h`. On musl, this header is not transitively included by the other headers.

Failure message:
```
compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp:761:37: error: unknown type name 'fd_set'; did you mean 'fd_t'?
  761 | INTERCEPTOR(int, pselect, int nfds, fd_set *readfds, fd_set *writefds,
      |                                     ^~~~~~
      |                                     fd_t
```