### PR TITLE
[Statepoint] Treat undef operands less specially

### DIFF
--- a/llvm/lib/CodeGen/FixupStatepointCallerSaved.cpp
+++ b/llvm/lib/CodeGen/FixupStatepointCallerSaved.cpp
@@ -381,8 +381,6 @@ public:
                   EndIdx = MI.getNumOperands();
          Idx < EndIdx; ++Idx) {
       MachineOperand &MO = MI.getOperand(Idx);
-      // Leave `undef` operands as is, StackMaps will rewrite them
-      // into a constant.
       if (!MO.isReg() || MO.isImplicit() || MO.isUndef())
         continue;
       Register Reg = MO.getReg();

--- a/llvm/lib/CodeGen/StackMaps.cpp
+++ b/llvm/lib/CodeGen/StackMaps.cpp
@@ -268,12 +268,6 @@ StackMaps::parseOperand(MachineInstr::const_mop_iterator MOI,
     if (MOI->isImplicit())
       return ++MOI;
 
-    if (MOI->isUndef()) {
-      // Record `undef` register as constant. Use same value as ISel uses.
-      Locs.emplace_back(Location::Constant, sizeof(int64_t), 0, 0xFEFEFEFE);
-      return ++MOI;
-    }
-
     assert(MOI->getReg().isPhysical() &&
            "Virtreg operands should have been rewritten before now.");
     const TargetRegisterClass *RC = TRI->getMinimalPhysRegClass(MOI->getReg());

--- a/llvm/test/CodeGen/X86/stackmap-undef-operand-anyregcc.mir
+++ b/llvm/test/CodeGen/X86/stackmap-undef-operand-anyregcc.mir
@@ -1,0 +1,77 @@
+# RUN: llc -mtriple=x86_64-apple-darwin -start-after=virtregrewriter -o - %s | FileCheck %s
+
+# Check there's no assertion for anyregcc with an undef operand to a stackmap.
+
+# CHECK: __LLVM_StackMaps:
+# CHECK-NEXT: .byte	3
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .long	1
+# CHECK-NEXT: .long	0
+# CHECK-NEXT: .long	1
+# CHECK-NEXT: .quad	_undef_anyregcc_patchpoint
+# CHECK-NEXT: .quad	8
+# CHECK-NEXT: .quad	1
+# CHECK-NEXT: .quad	12
+# CHECK-NEXT: .long	Ltmp0-_undef_anyregcc_patchpoint
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .short	2
+# CHECK-NEXT: .byte	1
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .short	8
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .long	0
+# CHECK-NEXT: .byte	1
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .short	8
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .long	0
+# CHECK-NEXT: .p2align	3, 0x0
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .short	7
+# CHECK-NEXT: .short	0
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .short	3
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .short	7
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .short	12
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .short	13
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .short	14
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .short	15
+# CHECK-NEXT: .byte	0
+# CHECK-NEXT: .byte	8
+# CHECK-NEXT: .p2align	3
+---
+name:  undef_anyregcc_patchpoint
+tracksRegLiveness: true
+frameInfo:
+  hasPatchPoint:   true
+  hasCalls:        true
+  adjustsStack:    true
+fixedStack:
+  - { id: 0, type: default, offset: 72, size: 8, alignment: 8, stack-id: default,
+      isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+body:             |
+  bb.0:
+    liveins: $rcx, $rdi, $rdx, $rsi, $r8, $r9
+
+    ADJCALLSTACKDOWN64 0, 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    dead renamable $rax = MOV64rm %fixed-stack.0, 1, $noreg, 0, $noreg :: (load (s64) from %fixed-stack.0)
+    renamable $rax = PATCHPOINT 12, 15, 0, 1, 13, undef renamable $rax, csr_64_allregs, implicit-def dead early-clobber $r11, implicit-def $rsp, implicit-def $ssp
+    ADJCALLSTACKUP64 0, 0, implicit-def dead $rsp, implicit-def dead $eflags, implicit-def dead $ssp, implicit $rsp, implicit $ssp
+    RET 0, $rax
+
+...

--- a/llvm/test/CodeGen/X86/statepoint-fixup-undef.mir
+++ b/llvm/test/CodeGen/X86/statepoint-fixup-undef.mir
@@ -181,13 +181,13 @@ body:             |
   ; STACKMAP-NEXT:	.short	3
   ; STACKMAP-NEXT:	.short	0
   ; STACKMAP-NEXT:	.long	0
-  ;      This is a constant 0xFEFEFEFE we are looking for
-  ; STACKMAP-NEXT:	.byte	4
+  ;      This is entry we're looking for
+  ; STACKMAP-NEXT:	.byte	1
   ; STACKMAP-NEXT:	.byte	0
-  ; STACKMAP-NEXT:	.short	8
+  ; STACKMAP-NEXT:	.short	4
   ; STACKMAP-NEXT:	.short	0
   ; STACKMAP-NEXT:	.short	0
-  ; STACKMAP-NEXT:	.long	-16843010
+  ; STACKMAP-NEXT:	.long	0
   ; STACKMAP-NEXT:	.byte	4
   ; STACKMAP-NEXT:	.byte	0
   ; STACKMAP-NEXT:	.short	8


### PR DESCRIPTION
This reverts commit f7443905af1e06eaacda1e437fff8d54dc89c487.

This is to avoid an assertion if an undef operand appears in a
stackmap. This is important to avoid hitting verifier errors
when register allocation starts adding undefs in error scenarios.

Rather than trying to treat undef operands as special, leave them
alone and avoid producing an invalid spill. It would a bit more
precise to produce a spill of an undef register here, but that's not
exposed through the storeRegToStackSlot API.

https://reviews.llvm.org/D122605

This was an alternative to https://reviews.llvm.org/D122582