### PR TITLE
[VPlan] Fix classof() in VPWiden{Load|Store}Recipe NFC.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -2966,7 +2966,15 @@ struct VPWidenLoadRecipe final : public VPWidenMemoryRecipe, public VPValue {
                                  getDebugLoc());
   }
 
-  VP_CLASSOF_IMPL(VPDef::VPWidenLoadSC);
+  static inline bool classof(const VPRecipeBase *R) {
+    return R->getVPDefID() == VPRecipeBase::VPWidenLoadSC ||
+           R->getVPDefID() == VPRecipeBase::VPWidenLoadEVLSC;
+  }
+
+  static inline bool classof(const VPUser *U) {
+    auto *R = dyn_cast<VPRecipeBase>(U);
+    return R && classof(R);
+  }
 
   /// Generate a wide load or gather.
   void execute(VPTransformState &State) override;
@@ -3043,7 +3051,15 @@ struct VPWidenStoreRecipe final : public VPWidenMemoryRecipe {
                                   Reverse, getDebugLoc());
   }
 
-  VP_CLASSOF_IMPL(VPDef::VPWidenStoreSC);
+  static inline bool classof(const VPRecipeBase *R) {
+    return R->getVPDefID() == VPRecipeBase::VPWidenStoreSC ||
+           R->getVPDefID() == VPRecipeBase::VPWidenStoreEVLSC;
+  }
+
+  static inline bool classof(const VPUser *U) {
+    auto *R = dyn_cast<VPRecipeBase>(U);
+    return R && classof(R);
+  }
 
   /// Return the value stored by this recipe.
   VPValue *getStoredValue() const { return getOperand(1); }


### PR DESCRIPTION
We should add VPWidenLoadEVLSC into `classof` in VPWidenLoadRecipe and VPWidenStoreSC into VPWidenStoreRecipe.