### PR TITLE
[lldb][Linux] Moving generic APIs from HostInfoLinux to HostInfoPosix

### DIFF
--- a/lldb/include/lldb/Host/linux/HostInfoLinux.h
+++ b/lldb/include/lldb/Host/linux/HostInfoLinux.h
@@ -15,7 +15,6 @@
 #include "llvm/Support/VersionTuple.h"
 
 #include <optional>
-#include <string>
 
 namespace lldb_private {
 
@@ -26,18 +25,12 @@ public:
   static void Initialize(SharedLibraryDirectoryHelper *helper = nullptr);
   static void Terminate();
 
-  static llvm::VersionTuple GetOSVersion();
-  static std::optional<std::string> GetOSBuildString();
   static llvm::StringRef GetDistributionId();
-  static FileSpec GetProgramFileSpec();
 
 protected:
-  static bool ComputeSupportExeDirectory(FileSpec &file_spec);
-  static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);
-  static bool ComputeUserPluginsDirectory(FileSpec &file_spec);
   static void ComputeHostArchitectureSupport(ArchSpec &arch_32,
                                              ArchSpec &arch_64);
 };
-}
+} // namespace lldb_private
 
 #endif

--- a/lldb/include/lldb/Host/linux/HostInfoLinux.h
+++ b/lldb/include/lldb/Host/linux/HostInfoLinux.h
@@ -26,6 +26,7 @@ public:
   static void Terminate();
 
   static llvm::StringRef GetDistributionId();
+  static FileSpec GetProgramFileSpec();
 
 protected:
   static void ComputeHostArchitectureSupport(ArchSpec &arch_32,

--- a/lldb/include/lldb/Host/posix/HostInfoPosix.h
+++ b/lldb/include/lldb/Host/posix/HostInfoPosix.h
@@ -12,6 +12,7 @@
 #include "lldb/Host/HostInfoBase.h"
 #include "lldb/Utility/FileSpec.h"
 #include <optional>
+#include <string>
 
 namespace lldb_private {
 
@@ -31,15 +32,20 @@ public:
   static uint32_t GetEffectiveGroupID();
 
   static FileSpec GetDefaultShell();
+  static FileSpec GetProgramFileSpec();
 
   static bool GetEnvironmentVar(const std::string &var_name, std::string &var);
 
   static UserIDResolver &GetUserIDResolver();
+  static llvm::VersionTuple GetOSVersion();
+  static std::optional<std::string> GetOSBuildString();
 
 protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);
   static bool ComputeHeaderDirectory(FileSpec &file_spec);
+  static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);
+  static bool ComputeUserPluginsDirectory(FileSpec &file_spec);
 };
-}
+} // namespace lldb_private
 
 #endif

--- a/lldb/include/lldb/Host/posix/HostInfoPosix.h
+++ b/lldb/include/lldb/Host/posix/HostInfoPosix.h
@@ -32,7 +32,6 @@ public:
   static uint32_t GetEffectiveGroupID();
 
   static FileSpec GetDefaultShell();
-  static FileSpec GetProgramFileSpec();
 
   static bool GetEnvironmentVar(const std::string &var_name, std::string &var);
 

--- a/lldb/source/Host/posix/HostInfoPosix.cpp
+++ b/lldb/source/Host/posix/HostInfoPosix.cpp
@@ -7,16 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/posix/HostInfoPosix.h"
+#include "lldb/Host/Config.h"
+#include "lldb/Host/FileSystem.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/UserIDResolver.h"
-
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <climits>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <grp.h>
 #include <mutex>
 #include <optional>
@@ -26,6 +29,31 @@
 #include <unistd.h>
 
 using namespace lldb_private;
+
+namespace {
+struct HostInfoPosixFields {
+  llvm::once_flag m_os_version_once_flag;
+  llvm::VersionTuple m_os_version;
+};
+} // namespace
+
+llvm::VersionTuple HostInfoPosix::GetOSVersion() {
+  static HostInfoPosixFields *g_fields = new HostInfoPosixFields();
+  assert(g_fields && "Missing call to Initialize?");
+  llvm::call_once(g_fields->m_os_version_once_flag, []() {
+    struct utsname un;
+    if (uname(&un) != 0)
+      return;
+
+    llvm::StringRef release = un.release;
+    // The kernel release string can include a lot of stuff (e.g.
+    // 4.9.0-6-amd64). We're only interested in the numbered prefix.
+    release = release.substr(0, release.find_first_not_of("0123456789."));
+    g_fields->m_os_version.tryParse(release);
+  });
+
+  return g_fields->m_os_version;
+}
 
 size_t HostInfoPosix::GetPageSize() { return ::getpagesize(); }
 
@@ -45,6 +73,16 @@ std::optional<std::string> HostInfoPosix::GetOSKernelDescription() {
     return std::nullopt;
 
   return std::string(un.version);
+}
+
+std::optional<std::string> HostInfoPosix::GetOSBuildString() {
+  struct utsname un;
+  ::memset(&un, 0, sizeof(utsname));
+
+  if (uname(&un) < 0)
+    return std::nullopt;
+
+  return std::string(un.release);
 }
 
 #ifdef __ANDROID__
@@ -139,8 +177,53 @@ FileSpec HostInfoPosix::GetDefaultShell() {
   return FileSpec("/bin/sh");
 }
 
+FileSpec HostInfoPosix::GetProgramFileSpec() {
+  static FileSpec g_program_filespec;
+
+  if (!g_program_filespec) {
+    char exe_path[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len > 0) {
+      exe_path[len] = 0;
+      g_program_filespec.SetFile(exe_path, FileSpec::Style::native);
+    }
+  }
+
+  return g_program_filespec;
+}
+
+// Keeping the original one for reference
+// bool HostInfoPosix::ComputeSupportExeDirectory(FileSpec &file_spec) {
+//  return ComputePathRelativeToLibrary(file_spec, "/bin");
+// }
+
 bool HostInfoPosix::ComputeSupportExeDirectory(FileSpec &file_spec) {
-  return ComputePathRelativeToLibrary(file_spec, "/bin");
+  if (ComputePathRelativeToLibrary(file_spec, "/bin") &&
+      file_spec.IsAbsolute() && FileSystem::Instance().Exists(file_spec))
+    return true;
+  file_spec.SetDirectory(GetProgramFileSpec().GetDirectory());
+  return !file_spec.GetDirectory().IsEmpty();
+}
+
+bool HostInfoPosix::ComputeSystemPluginsDirectory(FileSpec &file_spec) {
+  FileSpec temp_file("/usr/" LLDB_INSTALL_LIBDIR_BASENAME "/lldb/plugins");
+  FileSystem::Instance().Resolve(temp_file);
+  file_spec.SetDirectory(temp_file.GetPath());
+  return true;
+}
+
+bool HostInfoPosix::ComputeUserPluginsDirectory(FileSpec &file_spec) {
+  // XDG Base Directory Specification
+  // http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html If
+  // XDG_DATA_HOME exists, use that, otherwise use ~/.local/share/lldb.
+  const char *xdg_data_home = getenv("XDG_DATA_HOME");
+  if (xdg_data_home && xdg_data_home[0]) {
+    std::string user_plugin_dir(xdg_data_home);
+    user_plugin_dir += "/lldb";
+    file_spec.SetDirectory(user_plugin_dir.c_str());
+  } else
+    file_spec.SetDirectory("~/.local/share/lldb");
+  return true;
 }
 
 bool HostInfoPosix::ComputeHeaderDirectory(FileSpec &file_spec) {

--- a/lldb/source/Host/posix/HostInfoPosix.cpp
+++ b/lldb/source/Host/posix/HostInfoPosix.cpp
@@ -178,11 +178,6 @@ FileSpec HostInfoPosix::GetDefaultShell() {
   return FileSpec("/bin/sh");
 }
 
-// Keeping the original one for reference
-// bool HostInfoPosix::ComputeSupportExeDirectory(FileSpec &file_spec) {
-//  return ComputePathRelativeToLibrary(file_spec, "/bin");
-// }
-
 bool HostInfoPosix::ComputeSupportExeDirectory(FileSpec &file_spec) {
   if (ComputePathRelativeToLibrary(file_spec, "/bin") &&
       file_spec.IsAbsolute() && FileSystem::Instance().Exists(file_spec))


### PR DESCRIPTION
This change is related merging some of the APIs in HostInfoLinux into HostInfoPosix. 

Here is the reference PR comment:
https://github.com/llvm/llvm-project/pull/117906#discussion_r1865427495, https://github.com/llvm/llvm-project/pull/117906#discussion_r1861616945