### PR TITLE
[WinEH] Take musttail calls into account when unlinking eh records

### DIFF
--- a/llvm/lib/Target/X86/X86WinEHState.cpp
+++ b/llvm/lib/Target/X86/X86WinEHState.cpp
@@ -364,14 +364,9 @@ void WinEHStatePass::emitExceptionRegistrationRecord(Function *F) {
     if (!isa<ReturnInst>(T))
       continue;
 
-    // Back up to any preceding musttail call, the de-facto terminator.
-    Instruction *Prev = T->getPrevNonDebugInstruction();
-    if (isa_and_present<BitCastInst>(Prev))
-      Prev = T->getPrevNonDebugInstruction();
-    if (CallInst *CI = dyn_cast_or_null<CallInst>(Prev)) {
-      if (CI->isMustTailCall())
-        T = CI;
-    }
+    // If there is a musttail call, that's the de-facto terminator.
+    if (CallInst *CI = BB.getTerminatingMustTailCall())
+      T = CI;
 
     Builder.SetInsertPoint(T);
     unlinkExceptionRegistration(Builder);

--- a/llvm/test/CodeGen/WinEH/wineh-musttail-call.ll
+++ b/llvm/test/CodeGen/WinEH/wineh-musttail-call.ll
@@ -1,0 +1,32 @@
+; RUN: llc < %s | FileCheck %s
+
+target triple = "i386-pc-windows-msvc"
+
+; Check that codegen doesn't fail due to wineh inserting instructions between
+; the musttail call and return instruction.
+
+
+define void @test() personality ptr @__CxxFrameHandler3 {
+; CHECK-LABEL: test:
+
+entry:
+  invoke void @foo() to label %try.cont unwind label %catch.dispatch
+
+catch.dispatch:
+  %0 = catchswitch within none [label %catch] unwind to caller
+
+catch:
+  %1 = catchpad within %0 [ptr null, i32 64, ptr null]
+  catchret from %1 to label %try.cont
+
+try.cont:
+; CHECK: movl %{{[a-z0-9]+}}, %fs:0
+; CHECK: jmp _bar
+
+  musttail call void @bar()
+  ret void
+}
+
+declare i32 @__CxxFrameHandler3(...)
+declare void @foo()
+declare void @bar()


### PR DESCRIPTION
Exception handling records are unlinked on function return. However, if there is a musttail call before the return, that's the de-facto point of termination and the unlinking instructions must be inserted *before* that.

Fixes #119255