### PR TITLE
[compiler-rt] Don't build SME routines if __arm_cpu_features is not initialised.

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -572,8 +572,10 @@ set(aarch64_SOURCES
   aarch64/fp_mode.c
 )
 
+set(COMPILER_RT_AARCH64_FMV_USES_GLOBAL_CONSTRUCTOR NOT(FUCHSIA OR APPLE))
+
 if (COMPILER_RT_HAS_AARCH64_SME)
-  if (NOT COMPILER_RT_DISABLE_AARCH64_FMV AND COMPILER_RT_HAS_FNO_BUILTIN_FLAG)
+  if (NOT COMPILER_RT_DISABLE_AARCH64_FMV AND COMPILER_RT_HAS_FNO_BUILTIN_FLAG AND COMPILER_RT_AARCH64_FMV_USES_GLOBAL_CONSTRUCTOR)
     list(APPEND aarch64_SOURCES aarch64/sme-abi.S aarch64/sme-libc-mem-routines.S aarch64/sme-abi-assert.c aarch64/sme-libc-routines.c)
     message(STATUS "AArch64 SME ABI routines enabled")
     set_source_files_properties(aarch64/sme-libc-routines.c PROPERTIES COMPILE_FLAGS "-fno-builtin")


### PR DESCRIPTION
According to the conversation
[here](https://github.com/llvm/llvm-project/pull/119414#issuecomment-2536495859), some platforms don't enable `__arm_cpu_features` with a global constructor, but rather do so lazily when called from the FMV resolver.

PR #119414 removed the CMake guard to check to see if the targetted platform is baremetal or supports sys/auxv. Without this check, the routines rely on `__arm_cpu_features` being initialised when they may not be, depending on the platform.

This PR simply avoids building the SME routines for those platforms for now.