### PR TITLE
[clang] Generate appropriate assume in presence of libc's memcpy

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4531,6 +4531,12 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Value *SizeVal = EmitScalarExpr(E->getArg(2));
     EmitArgCheck(TCK_Store, Dest, E->getArg(0), 0);
     EmitArgCheck(TCK_Load, Src, E->getArg(1), 1);
+    if (BuiltinID == Builtin::BImemcpy || BuiltinID == Builtin::BImempcpy) {
+      Builder.CreateAssumption(
+          Builder.CreateIsNotNull(Dest.emitRawPointer(*this)));
+      Builder.CreateAssumption(
+          Builder.CreateIsNotNull(Src.emitRawPointer(*this)));
+    }
     Builder.CreateMemCpy(Dest, Src, SizeVal, false);
     if (BuiltinID == Builtin::BImempcpy ||
         BuiltinID == Builtin::BI__builtin_mempcpy)

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4532,10 +4532,11 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     EmitArgCheck(TCK_Store, Dest, E->getArg(0), 0);
     EmitArgCheck(TCK_Load, Src, E->getArg(1), 1);
     if (BuiltinID == Builtin::BImemcpy || BuiltinID == Builtin::BImempcpy) {
-      Builder.CreateAssumption(
-          Builder.CreateIsNotNull(Dest.emitRawPointer(*this)));
-      Builder.CreateAssumption(
-          Builder.CreateIsNotNull(Src.emitRawPointer(*this)));
+      Value *NullSize = Builder.CreateIsNull(SizeVal);
+      Builder.CreateAssumption(Builder.CreateOr(
+          NullSize, Builder.CreateIsNotNull(Dest.emitRawPointer(*this))));
+      Builder.CreateAssumption(Builder.CreateOr(
+          NullSize, Builder.CreateIsNotNull(Src.emitRawPointer(*this))));
     }
     Builder.CreateMemCpy(Dest, Src, SizeVal, false);
     if (BuiltinID == Builtin::BImempcpy ||

--- a/clang/test/CodeGen/catch-undef-behavior.c
+++ b/clang/test/CodeGen/catch-undef-behavior.c
@@ -371,6 +371,10 @@ void call_memcpy_nonnull(void *p, void *q, int sz) {
   // CHECK-TRAP: call void @llvm.ubsantrap(i8 16)
   // CHECK-COMMON-NOT: call
 
+  // CHECK-COMMON: %5 = icmp ne ptr %0, null
+  // CHECK-COMMON: call void @llvm.assume(i1 %5)
+  // CHECK-COMMON: %6 = icmp ne ptr %0, null
+  // CHECK-COMMON: call void @llvm.assume(i1 %6)
   // CHECK-COMMON: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %0, ptr align 1 %1, i64 %conv, i1 false)
   memcpy(p, q, sz);
 }

--- a/clang/test/CodeGen/catch-undef-behavior.c
+++ b/clang/test/CodeGen/catch-undef-behavior.c
@@ -366,15 +366,17 @@ void call_memcpy_nonnull(void *p, void *q, int sz) {
   // CHECK-TRAP: call void @llvm.ubsantrap(i8 16)
   // CHECK-COMMON-NOT: call
 
-  // CHECK-COMMON: icmp ne ptr {{.*}}, null
+  // CHECK-COMMON: icmp ne ptr %[[#]], null
   // CHECK-UBSAN: call void @__ubsan_handle_nonnull_arg
   // CHECK-TRAP: call void @llvm.ubsantrap(i8 16)
-  // CHECK-COMMON-NOT: call
-
-  // CHECK-COMMON: %5 = icmp ne ptr %0, null
-  // CHECK-COMMON: call void @llvm.assume(i1 %5)
-  // CHECK-COMMON: %6 = icmp ne ptr %0, null
-  // CHECK-COMMON: call void @llvm.assume(i1 %6)
+  //
+  // CHECK-COMMON: icmp eq i64 %conv, 0
+  // CHECK-COMMON: icmp ne ptr %0, null
+  // CHECK-COMMON: or i1 %[[#]], %[[#]]
+  // CHECK-COMMON: call void @llvm.assume(i1 %[[#]])
+  // CHECK-COMMON: icmp ne ptr %1, null
+  // CHECK-COMMON: or i1 %[[#]], %[[#]]
+  // CHECK-COMMON: call void @llvm.assume(i1 %[[#]])
   // CHECK-COMMON: call void @llvm.memcpy.p0.p0.i64(ptr align 1 %0, ptr align 1 %1, i64 %conv, i1 false)
   memcpy(p, q, sz);
 }


### PR DESCRIPTION
It is an undefined behavior to pass null arguments as memcpy source or destination parameter, so generate the appropriate llvm.assume call to communicate this to the backend.

Don't do it for builtin memcpy as they don't suffer the same behavior in case of null size.