### PR TITLE
[Kaleidoscope] Add mem2reg pass to function pass manager

### DIFF
--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl07.rst
@@ -336,7 +336,7 @@ the function:
     /// CreateEntryBlockAlloca - Create an alloca instruction in the entry block of
     /// the function.  This is used for mutable variables etc.
     static AllocaInst *CreateEntryBlockAlloca(Function *TheFunction,
-                                              const std::string &VarName) {
+                                              StringRef VarName) {
       IRBuilder<> TmpB(&TheFunction->getEntryBlock(),
                      TheFunction->getEntryBlock().begin());
       return TmpB.CreateAlloca(Type::getDoubleTy(*TheContext), nullptr,
@@ -440,11 +440,11 @@ get good codegen once again:
 .. code-block:: c++
 
         // Promote allocas to registers.
-        TheFPM->add(createPromoteMemoryToRegisterPass());
+        TheFPM->addPass(PromotePass());
         // Do simple "peephole" optimizations and bit-twiddling optzns.
-        TheFPM->add(createInstructionCombiningPass());
+        TheFPM->addPass(InstCombinePass());
         // Reassociate expressions.
-        TheFPM->add(createReassociatePass());
+        TheFPM->addPass(ReassociatePass());
         ...
 
 It is interesting to see what the code looks like before and after the

--- a/llvm/examples/Kaleidoscope/Chapter7/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter7/toy.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Scalar/Reassociate.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
-#include "llvm/Transforms/Utils.h"
+#include "llvm/Transforms/Utils/Mem2Reg.h"
 #include <algorithm>
 #include <cassert>
 #include <cctype>
@@ -1142,6 +1142,8 @@ static void InitializeModuleAndManagers() {
   TheSI->registerCallbacks(*ThePIC, TheMAM.get());
 
   // Add transform passes.
+  // Promote allocas to registers.
+  TheFPM->addPass(PromotePass());
   // Do simple "peephole" optimizations and bit-twiddling optzns.
   TheFPM->addPass(InstCombinePass());
   // Reassociate expressions.


### PR DESCRIPTION
Kaleidoscope has switched to new pass manager before (#72324), but both code and tutorial document have some missing parts.

This pull request fixes the following problems:
1. Adds `PromotePass` to the function pass manager. This pass was removed during the switch from legacy pass manager to the new pass manager. 
2. Syncs the tutorial with the code.