### PR TITLE
[LV] Add VPWiden{Load|Store}EVLRecipe into emitInvalidCostRemarks().

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4496,9 +4496,9 @@ void LoopVectorizationPlanner::emitInvalidCostRemarks(
                 [](const auto *R) { return Instruction::PHI; })
             .Case<VPWidenSelectRecipe>(
                 [](const auto *R) { return Instruction::Select; })
-            .Case<VPWidenStoreRecipe>(
+            .Case<VPWidenStoreRecipe, VPWidenStoreEVLRecipe>(
                 [](const auto *R) { return Instruction::Store; })
-            .Case<VPWidenLoadRecipe>(
+            .Case<VPWidenLoadRecipe, VPWidenLoadEVLRecipe>(
                 [](const auto *R) { return Instruction::Load; })
             .Case<VPWidenCallRecipe, VPWidenIntrinsicRecipe>(
                 [](const auto *R) { return Instruction::Call; })


### PR DESCRIPTION
When the cost of `VPWiden{Load|Store}EVLRecipe` is invalid, it will fell out of the type switch.
