### PR TITLE
[clang-cl] Don't add implicit NoBuiltinAttr to deleted or defaulted functions

### DIFF
--- a/clang/lib/Sema/SemaAttr.cpp
+++ b/clang/lib/Sema/SemaAttr.cpp
@@ -1310,6 +1310,8 @@ void Sema::AddOptnoneAttributeIfNoConflicts(FunctionDecl *FD,
 }
 
 void Sema::AddImplicitMSFunctionNoBuiltinAttr(FunctionDecl *FD) {
+  if (FD->isDeleted() || FD->isDefaulted())
+    return;
   SmallVector<StringRef> V(MSFunctionNoBuiltins.begin(),
                            MSFunctionNoBuiltins.end());
   if (!MSFunctionNoBuiltins.empty())

--- a/clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp
+++ b/clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cl -fms-compatibility -Xclang -ast-dump -fsyntax-only %s | FileCheck %s
+
+extern "C" __inline float __cdecl fabsf(  float _X);
+// CHECK: FunctionDecl {{.*}} fabsf
+#pragma function(fabsf)
+  __inline float __cdecl fabsf(  float _X)
+{
+    return 0;
+}
+// CHECK: FunctionDecl {{.*}} fabsf
+// CHECK: NoBuiltinAttr {{.*}} <<invalid sloc>> Implicit fabsf
+
+int bar() {
+  return 0;
+}
+// CHECK: FunctionDecl {{.*}} bar
+// CHECK: NoBuiltinAttr {{.*}} <<invalid sloc>> Implicit fabsf
+
+struct A {
+    int foo() = delete;
+    // CHECK: CXXMethodDecl {{.*}} foo 'int ()' delete
+    // CHECK-NOT: NoBuiltinAttr
+    A() = default;
+    // CHECK: CXXConstructorDecl {{.*}} A 'void ()' default
+    // CHECK-NOT: NoBuiltinAttr
+};
+
+int main() {
+    return 0;
+}
+// CHECK: FunctionDecl {{.*}} main
+// CHECK: NoBuiltinAttr {{.*}} <<invalid sloc>> Implicit fabsf


### PR DESCRIPTION
In Clang `#pragma function` is implemented by adding an implicit NoBuiltin Attribute to all function definitions after the pragma. This (wrongly) includes also defaulted or deleted functions, which results in the error, shown in #116256.

As this attribute has no effect on the deleted or defaulted functions, this commit fixes the previously mentioned issue by simply not adding the attribute in such cases.

Fixes #116256