### PR TITLE
[clang] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/clang/include/clang/Basic/FileEntry.h
+++ b/clang/include/clang/Basic/FileEntry.h
@@ -68,7 +68,7 @@ public:
   StringRef getNameAsRequested() const { return ME->first(); }
 
   const FileEntry &getFileEntry() const {
-    return *getBaseMapEntry().second->V.get<FileEntry *>();
+    return *cast<FileEntry *>(getBaseMapEntry().second->V);
   }
 
   // This function is used if the buffer size needs to be increased
@@ -361,7 +361,7 @@ bool FileEntryRef::isNamedPipe() const { return getFileEntry().isNamedPipe(); }
 void FileEntryRef::closeFile() const { getFileEntry().closeFile(); }
 
 void FileEntryRef::updateFileEntryBufferSize(unsigned BufferSize) {
-  getBaseMapEntry().second->V.get<FileEntry *>()->setSize(BufferSize);
+  cast<FileEntry *>(getBaseMapEntry().second->V)->setSize(BufferSize);
 }
 
 } // end namespace clang

--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -1012,7 +1012,7 @@ class Selector {
   }
 
   MultiKeywordSelector *getMultiKeywordSelector() const {
-    return InfoPtr.getPointer().get<MultiKeywordSelector *>();
+    return cast<MultiKeywordSelector *>(InfoPtr.getPointer());
   }
 
   unsigned getIdentifierInfoFlag() const {
@@ -1020,7 +1020,7 @@ class Selector {
     // IMPORTANT NOTE: We have to reconstitute this data rather than use the
     // value directly from the PointerIntPair. See the comments in `InfoPtr`
     // for more details.
-    if (InfoPtr.getPointer().is<MultiKeywordSelector *>())
+    if (isa<MultiKeywordSelector *>(InfoPtr.getPointer()))
       new_flags |= MultiArg;
     return new_flags;
   }

--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -392,19 +392,17 @@ public:
   }
 
   bool isArgExpr(unsigned Arg) const {
-    return Arg < NumArgs && getArg(Arg).is<Expr*>();
+    return Arg < NumArgs && isa<Expr *>(getArg(Arg));
   }
 
-  Expr *getArgAsExpr(unsigned Arg) const {
-    return getArg(Arg).get<Expr*>();
-  }
+  Expr *getArgAsExpr(unsigned Arg) const { return cast<Expr *>(getArg(Arg)); }
 
   bool isArgIdent(unsigned Arg) const {
-    return Arg < NumArgs && getArg(Arg).is<IdentifierLoc*>();
+    return Arg < NumArgs && isa<IdentifierLoc *>(getArg(Arg));
   }
 
   IdentifierLoc *getArgAsIdent(unsigned Arg) const {
-    return getArg(Arg).get<IdentifierLoc*>();
+    return cast<IdentifierLoc *>(getArg(Arg));
   }
 
   const AvailabilityChange &getAvailabilityIntroduced() const {

--- a/clang/include/clang/Sema/SemaConcept.h
+++ b/clang/include/clang/Sema/SemaConcept.h
@@ -210,17 +210,17 @@ bool subsumes(const NormalForm &PDNF, const NormalForm &QCNF,
       bool Found = false;
       for (NormalFormConstraint Pia : Pi) {
         for (NormalFormConstraint Qjb : Qj) {
-          if (Pia.is<FoldExpandedConstraint *>() &&
-              Qjb.is<FoldExpandedConstraint *>()) {
-            if (Pia.get<FoldExpandedConstraint *>()->subsumes(
-                    *Qjb.get<FoldExpandedConstraint *>(), E)) {
+          if (isa<FoldExpandedConstraint *>(Pia) &&
+              isa<FoldExpandedConstraint *>(Qjb)) {
+            if (cast<FoldExpandedConstraint *>(Pia)->subsumes(
+                    *cast<FoldExpandedConstraint *>(Qjb), E)) {
               Found = true;
               break;
             }
-          } else if (Pia.is<AtomicConstraint *>() &&
-                     Qjb.is<AtomicConstraint *>()) {
-            if (E(*Pia.get<AtomicConstraint *>(),
-                  *Qjb.get<AtomicConstraint *>())) {
+          } else if (isa<AtomicConstraint *>(Pia) &&
+                     isa<AtomicConstraint *>(Qjb)) {
+            if (E(*cast<AtomicConstraint *>(Pia),
+                  *cast<AtomicConstraint *>(Qjb))) {
               Found = true;
               break;
             }

--- a/clang/include/clang/Sema/SemaInternal.h
+++ b/clang/include/clang/Sema/SemaInternal.h
@@ -75,7 +75,7 @@ getDepthAndIndex(UnexpandedParameterPack UPP) {
   if (const auto *TTP = UPP.first.dyn_cast<const TemplateTypeParmType *>())
     return std::make_pair(TTP->getDepth(), TTP->getIndex());
 
-  return getDepthAndIndex(UPP.first.get<NamedDecl *>());
+  return getDepthAndIndex(cast<NamedDecl *>(UPP.first));
 }
 
 class TypoCorrectionConsumer : public VisibleDeclConsumer {

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -486,10 +486,10 @@ enum class TemplateSubstitutionKind : char {
         const Decl *D = I->first;
         llvm::PointerUnion<Decl *, DeclArgumentPack *> &Stored =
           newScope->LocalDecls[D];
-        if (I->second.is<Decl *>()) {
-          Stored = I->second.get<Decl *>();
+        if (isa<Decl *>(I->second)) {
+          Stored = cast<Decl *>(I->second);
         } else {
-          DeclArgumentPack *OldPack = I->second.get<DeclArgumentPack *>();
+          DeclArgumentPack *OldPack = cast<DeclArgumentPack *>(I->second);
           DeclArgumentPack *NewPack = new DeclArgumentPack(*OldPack);
           Stored = NewPack;
           newScope->ArgumentPacks.push_back(NewPack);

--- a/clang/include/clang/Sema/Template.h
+++ b/clang/include/clang/Sema/Template.h
@@ -486,8 +486,8 @@ enum class TemplateSubstitutionKind : char {
         const Decl *D = I->first;
         llvm::PointerUnion<Decl *, DeclArgumentPack *> &Stored =
           newScope->LocalDecls[D];
-        if (isa<Decl *>(I->second)) {
-          Stored = cast<Decl *>(I->second);
+        if (auto *D2 = dyn_cast<Decl *>(I->second)) {
+          Stored = D2;
         } else {
           DeclArgumentPack *OldPack = cast<DeclArgumentPack *>(I->second);
           DeclArgumentPack *NewPack = new DeclArgumentPack(*OldPack);

--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -374,9 +374,9 @@ APINotesManager::findAPINotes(SourceLocation Loc) {
       ++NumDirectoryCacheHits;
 
       // We've been redirected to another directory for answers. Follow it.
-      if (Known->second && Known->second.is<DirectoryEntryRef>()) {
+      if (Known->second && isa<DirectoryEntryRef>(Known->second)) {
         DirsVisited.insert(*Dir);
-        Dir = Known->second.get<DirectoryEntryRef>();
+        Dir = cast<DirectoryEntryRef>(Known->second);
         continue;
       }
 

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -326,7 +326,7 @@ til::SExpr *SExprBuilder::translateDeclRefExpr(const DeclRefExpr *DRE,
         }
 
         assert(I == 0);
-        return Ctx->FunArgs.get<til::SExpr *>();
+        return cast<til::SExpr *>(Ctx->FunArgs);
       }
     }
     // Map the param back to the param of the original function declaration

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -324,9 +324,9 @@ llvm::Expected<FileEntryRef> FileManager::getFileRef(StringRef Filename,
         *SeenFileEntries
              .insert({Status.getName(), FileEntryRef::MapValue(*UFE, DirInfo)})
              .first;
-    assert(Redirection.second->V.is<FileEntry *>() &&
+    assert(isa<FileEntry *>(Redirection.second->V) &&
            "filename redirected to a non-canonical filename?");
-    assert(Redirection.second->V.get<FileEntry *>() == UFE &&
+    assert(cast<FileEntry *>(Redirection.second->V) == UFE &&
            "filename from getStatValue() refers to wrong file");
 
     // Cache the redirection in the previously-inserted entry, still available
@@ -400,7 +400,7 @@ FileEntryRef FileManager::getVirtualFileRef(StringRef Filename, off_t Size,
     FileEntryRef::MapValue Value = *NamedFileEnt.second;
     if (LLVM_LIKELY(isa<FileEntry *>(Value.V)))
       return FileEntryRef(NamedFileEnt);
-    return FileEntryRef(*Value.V.get<const FileEntryRef::MapEntry *>());
+    return FileEntryRef(*cast<const FileEntryRef::MapEntry *>(Value.V));
   }
 
   // We've not seen this before, or the file is cached as non-existent.
@@ -620,7 +620,7 @@ void FileManager::GetUniqueIDMapping(
 
   for (const auto &Entry : SeenFileEntries) {
     // Only return files that exist and are not redirected.
-    if (!Entry.getValue() || !Entry.getValue()->V.is<FileEntry *>())
+    if (!Entry.getValue() || !isa<FileEntry *>(Entry.getValue()->V))
       continue;
     FileEntryRef FE(Entry);
     // Add this file if it's the first one with the UID, or if its name is

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -4085,7 +4085,7 @@ static void emitDependData(CodeGenFunction &CGF, QualType &KmpDependInfoTy,
           CGF.Builder.CreateConstGEP(DependenciesArray, *P), KmpDependInfoTy);
     } else {
       assert(E && "Expected a non-null expression");
-      LValue &PosLVal = *Pos.get<LValue *>();
+      LValue &PosLVal = *cast<LValue *>(Pos);
       llvm::Value *Idx = CGF.EmitLoadOfScalar(PosLVal, E->getExprLoc());
       Base = CGF.MakeAddrLValue(
           CGF.Builder.CreateGEP(CGF, DependenciesArray, Idx), KmpDependInfoTy);
@@ -4113,7 +4113,7 @@ static void emitDependData(CodeGenFunction &CGF, QualType &KmpDependInfoTy,
     if (unsigned *P = Pos.dyn_cast<unsigned *>()) {
       ++(*P);
     } else {
-      LValue &PosLVal = *Pos.get<LValue *>();
+      LValue &PosLVal = *cast<LValue *>(Pos);
       llvm::Value *Idx = CGF.EmitLoadOfScalar(PosLVal, E->getExprLoc());
       Idx = CGF.Builder.CreateNUWAdd(Idx,
                                      llvm::ConstantInt::get(Idx->getType(), 1));

--- a/clang/lib/Index/IndexDecl.cpp
+++ b/clang/lib/Index/IndexDecl.cpp
@@ -666,7 +666,7 @@ public:
         Template = D->getSpecializedTemplateOrPartial();
     const Decl *SpecializationOf =
         isa<ClassTemplateDecl *>(Template)
-            ? (Decl *)Template.get<ClassTemplateDecl *>()
+            ? (Decl *)cast<ClassTemplateDecl *>(Template)
             : cast<ClassTemplatePartialSpecializationDecl *>(Template);
     if (!D->isThisDeclarationADefinition())
       IndexCtx.indexNestedNameSpecifierLoc(D->getQualifierLoc(), D);


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
