### PR TITLE
[RISCV] Move GIComplexOperandMatcher and GICustomOperandRenderer next to their SelectionDAG equivalents. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVGISel.td
+++ b/llvm/lib/Target/RISCV/RISCVGISel.td
@@ -33,69 +33,9 @@ def simm12Minus1NonzeroNonNeg1 : ImmLeaf<XLenVT, [{
 def ImmPlus1 : SDNodeXForm<imm, [{
   return CurDAG->getTargetConstant(N->getSExtValue() + 1, SDLoc(N),
                                    N->getValuePtrVTpe(0));}]>;
-
-def GINegImm : GICustomOperandRenderer<"renderNegImm">,
-  GISDNodeXFormEquiv<NegImm>;
-
-def GIImmSubFromXLen : GICustomOperandRenderer<"renderImmSubFromXLen">,
-  GISDNodeXFormEquiv<ImmSubFromXLen>;
-def GIImmSubFrom32 : GICustomOperandRenderer<"renderImmSubFrom32">,
-  GISDNodeXFormEquiv<ImmSubFrom32>;
-
 def GIImmPlus1 :
   GICustomOperandRenderer<"renderImmPlus1">,
   GISDNodeXFormEquiv<ImmPlus1>;
-
-def GIAddrRegImm :
-  GIComplexOperandMatcher<s32, "selectAddrRegImm">,
-  GIComplexPatternEquiv<AddrRegImm>;
-
-// FIXME: This is labelled as handling 's32', however the ComplexPattern it
-// refers to handles both i32 and i64 based on the HwMode. Currently this LLT
-// parameter appears to be ignored so this pattern works for both, however we
-// should add a LowLevelTypeByHwMode, and use that to define our XLenLLT instead
-// here.
-def GIVLOp : GIComplexOperandMatcher<s32, "renderVLOp">,
-             GIComplexPatternEquiv<VLOp>;
-
-def gi_trailing_zero : GICustomOperandRenderer<"renderTrailingZeros">,
-  GISDNodeXFormEquiv<TrailingZeros>;
-
-// FIXME: This is labelled as handling 's32', however the ComplexPattern it
-// refers to handles both i32 and i64 based on the HwMode. Currently this LLT
-// parameter appears to be ignored so this pattern works for both, however we
-// should add a LowLevelTypeByHwMode, and use that to define our XLenLLT instead
-// here.
-def GIShiftMaskXLen :
-    GIComplexOperandMatcher<s32, "selectShiftMaskXLen">,
-    GIComplexPatternEquiv<shiftMaskXLen>;
-def GIShiftMask32 :
-    GIComplexOperandMatcher<s64, "selectShiftMask32">,
-    GIComplexPatternEquiv<shiftMask32>;
-
-def gi_sh1add_op : GIComplexOperandMatcher<s32, "selectSHXADDOp<1>">,
-                   GIComplexPatternEquiv<sh1add_op>;
-def gi_sh2add_op : GIComplexOperandMatcher<s32, "selectSHXADDOp<2>">,
-                   GIComplexPatternEquiv<sh2add_op>;
-def gi_sh3add_op : GIComplexOperandMatcher<s32, "selectSHXADDOp<3>">,
-                   GIComplexPatternEquiv<sh3add_op>;
-
-def gi_sh1add_uw_op : GIComplexOperandMatcher<s32, "selectSHXADD_UWOp<1>">,
-                      GIComplexPatternEquiv<sh1add_uw_op>;
-def gi_sh2add_uw_op : GIComplexOperandMatcher<s32, "selectSHXADD_UWOp<2>">,
-                      GIComplexPatternEquiv<sh2add_uw_op>;
-def gi_sh3add_uw_op : GIComplexOperandMatcher<s32, "selectSHXADD_UWOp<3>">,
-                      GIComplexPatternEquiv<sh3add_uw_op>;
-
-def gi_sexti32 : GIComplexOperandMatcher<s64, "selectSExtBits<32>">,
-                 GIComplexPatternEquiv<sexti32>;
-
-def gi_zexti32 : GIComplexOperandMatcher<s64, "selectZExtBits<32>">,
-                 GIComplexPatternEquiv<zexti32>;
-def gi_zexti16 : GIComplexOperandMatcher<s32, "selectZExtBits<16>">,
-                 GIComplexPatternEquiv<zexti16>;
-def gi_zexti8  : GIComplexOperandMatcher<s32, "selectZExtBits<8>">,
-                 GIComplexPatternEquiv<zexti8>;
 
 // Ptr type used in patterns with GlobalISelEmitter
 def PtrVT : PtrValueTypeByHwMode<XLenVT, 0>;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -418,6 +418,8 @@ def NegImm : SDNodeXForm<imm, [{
   return CurDAG->getSignedTargetConstant(-N->getSExtValue(), SDLoc(N),
                                          N->getValueType(0));
 }]>;
+def GINegImm : GICustomOperandRenderer<"renderNegImm">,
+  GISDNodeXFormEquiv<NegImm>;
 
 // Return an immediate value minus 32.
 def ImmSub32 : SDNodeXForm<imm, [{
@@ -431,12 +433,16 @@ def ImmSubFromXLen : SDNodeXForm<imm, [{
   return CurDAG->getTargetConstant(XLen - N->getZExtValue(), SDLoc(N),
                                    N->getValueType(0));
 }]>;
+def GIImmSubFromXLen : GICustomOperandRenderer<"renderImmSubFromXLen">,
+  GISDNodeXFormEquiv<ImmSubFromXLen>;
 
 // Return an immediate subtracted from 32.
 def ImmSubFrom32 : SDNodeXForm<imm, [{
   return CurDAG->getTargetConstant(32 - N->getZExtValue(), SDLoc(N),
                                    N->getValueType(0));
 }]>;
+def GIImmSubFrom32 : GICustomOperandRenderer<"renderImmSubFrom32">,
+  GISDNodeXFormEquiv<ImmSubFrom32>;
 
 // Check if (add r, imm) can be optimized to (ADDI (ADDI r, imm0), imm1),
 // in which imm = imm0 + imm1 and both imm0 and imm1 are simm12. We make imm0
@@ -469,6 +475,8 @@ def TrailingZeros : SDNodeXForm<imm, [{
   return CurDAG->getTargetConstant(llvm::countr_zero(N->getZExtValue()),
                                    SDLoc(N), N->getValueType(0));
 }]>;
+def GITrailingZeros : GICustomOperandRenderer<"renderTrailingZeros">,
+  GISDNodeXFormEquiv<TrailingZeros>;
 
 def XLenSubTrailingOnes : SDNodeXForm<imm, [{
   uint64_t XLen = Subtarget->getXLen();
@@ -1267,13 +1275,26 @@ def assertsexti32 : PatFrag<(ops node:$src), (assertsext node:$src), [{
   return cast<VTSDNode>(N->getOperand(1))->getVT().bitsLE(MVT::i32);
 }]>;
 def sexti16 : ComplexPattern<XLenVT, 1, "selectSExtBits<16>">;
+
 def sexti32 : ComplexPattern<i64, 1, "selectSExtBits<32>">;
+def gi_sexti32 : GIComplexOperandMatcher<s64, "selectSExtBits<32>">,
+                 GIComplexPatternEquiv<sexti32>;
+
 def assertzexti32 : PatFrag<(ops node:$src), (assertzext node:$src), [{
   return cast<VTSDNode>(N->getOperand(1))->getVT().bitsLE(MVT::i32);
 }]>;
+
 def zexti32 : ComplexPattern<i64, 1, "selectZExtBits<32>">;
+def gi_zexti32 : GIComplexOperandMatcher<s64, "selectZExtBits<32>">,
+                 GIComplexPatternEquiv<zexti32>;
+
 def zexti16 : ComplexPattern<XLenVT, 1, "selectZExtBits<16>">;
+def gi_zexti16 : GIComplexOperandMatcher<s32, "selectZExtBits<16>">,
+                 GIComplexPatternEquiv<zexti16>;
+
 def zexti8 : ComplexPattern<XLenVT, 1, "selectZExtBits<8>">;
+def gi_zexti8  : GIComplexOperandMatcher<s32, "selectZExtBits<8>">,
+                 GIComplexPatternEquiv<zexti8>;
 
 def ext : PatFrags<(ops node:$A), [(sext node:$A), (zext node:$A)]>;
 
@@ -1357,6 +1378,17 @@ def : Pat<(XLenVT (and GPR:$rs, TrailingOnesMask:$mask)),
 // ISA only read the least significant 5 bits (RV32I) or 6 bits (RV64I).
 def shiftMaskXLen : ComplexPattern<XLenVT, 1, "selectShiftMaskXLen", [], [], 0>;
 def shiftMask32   : ComplexPattern<i64, 1, "selectShiftMask32", [], [], 0>;
+// FIXME: This is labelled as handling 's32', however the ComplexPattern it
+// refers to handles both i32 and i64 based on the HwMode. Currently this LLT
+// parameter appears to be ignored so this pattern works for both, however we
+// should add a LowLevelTypeByHwMode, and use that to define our XLenLLT instead
+// here.
+def GIShiftMaskXLen :
+    GIComplexOperandMatcher<s32, "selectShiftMaskXLen">,
+    GIComplexPatternEquiv<shiftMaskXLen>;
+def GIShiftMask32 :
+    GIComplexOperandMatcher<s64, "selectShiftMask32">,
+    GIComplexPatternEquiv<shiftMask32>;
 
 class shiftop<SDPatternOperator operator>
     : PatFrag<(ops node:$val, node:$count),
@@ -1382,6 +1414,9 @@ def PseudoAddTPRel : Pseudo<(outs GPR:$rd),
 
 def : Pat<(FrameAddrRegImm (iPTR GPR:$rs1), simm12:$imm12),
           (ADDI GPR:$rs1, simm12:$imm12)>;
+def GIAddrRegImm :
+  GIComplexOperandMatcher<s32, "selectAddrRegImm">,
+  GIComplexPatternEquiv<AddrRegImm>;
 
 /// Stack probing
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -102,6 +102,13 @@ def vec_rm : RISCVOp {
 // !X0 |  X0 |       VLMAX | Set vl to VLMAX
 //  X0 |  X0 | Value in vl | Keep current vl, just change vtype.
 def VLOp : ComplexPattern<XLenVT, 1, "selectVLOp">;
+// FIXME: This is labelled as handling 's32', however the ComplexPattern it
+// refers to handles both i32 and i64 based on the HwMode. Currently this LLT
+// parameter appears to be ignored so this pattern works for both, however we
+// should add a LowLevelTypeByHwMode, and use that to define our XLenLLT instead
+// here.
+def GIVLOp : GIComplexOperandMatcher<s32, "renderVLOp">,
+             GIComplexPatternEquiv<VLOp>;
 
 def DecImm : SDNodeXForm<imm, [{
   return CurDAG->getSignedTargetConstant(N->getSExtValue() - 1, SDLoc(N),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -213,10 +213,23 @@ def Shifted32OnesMask : IntImmLeaf<XLenVT, [{
 def sh1add_op : ComplexPattern<XLenVT, 1, "selectSHXADDOp<1>", [], [], 6>;
 def sh2add_op : ComplexPattern<XLenVT, 1, "selectSHXADDOp<2>", [], [], 6>;
 def sh3add_op : ComplexPattern<XLenVT, 1, "selectSHXADDOp<3>", [], [], 6>;
+def gi_sh1add_op : GIComplexOperandMatcher<s32, "selectSHXADDOp<1>">,
+                   GIComplexPatternEquiv<sh1add_op>;
+def gi_sh2add_op : GIComplexOperandMatcher<s32, "selectSHXADDOp<2>">,
+                   GIComplexPatternEquiv<sh2add_op>;
+def gi_sh3add_op : GIComplexOperandMatcher<s32, "selectSHXADDOp<3>">,
+                   GIComplexPatternEquiv<sh3add_op>;
+
 
 def sh1add_uw_op : ComplexPattern<XLenVT, 1, "selectSHXADD_UWOp<1>", [], [], 6>;
 def sh2add_uw_op : ComplexPattern<XLenVT, 1, "selectSHXADD_UWOp<2>", [], [], 6>;
 def sh3add_uw_op : ComplexPattern<XLenVT, 1, "selectSHXADD_UWOp<3>", [], [], 6>;
+def gi_sh1add_uw_op : GIComplexOperandMatcher<s32, "selectSHXADD_UWOp<1>">,
+                      GIComplexPatternEquiv<sh1add_uw_op>;
+def gi_sh2add_uw_op : GIComplexOperandMatcher<s32, "selectSHXADD_UWOp<2>">,
+                      GIComplexPatternEquiv<sh2add_uw_op>;
+def gi_sh3add_uw_op : GIComplexOperandMatcher<s32, "selectSHXADD_UWOp<3>">,
+                      GIComplexPatternEquiv<sh3add_uw_op>;
 
 //===----------------------------------------------------------------------===//
 // Instruction class templates


### PR DESCRIPTION
This makes it easier to see if the SelectionDAG node has an equivalent without needing to check another file. Putting them in the same file helps associate them with the relevant ISA and any additional context that may be provided by comments.

Naming is a little messy because we inconsistently use camel case and snake case in the SelectionDAG node names. Thus the GISel node names are named the same as the SelectionDAG node name with either GI or gi_ as a prefix.