### PR TITLE
[clangd] Index reserved symbols from `*intrin.h` system headers

### DIFF
--- a/clang-tools-extra/clangd/index/SymbolCollector.cpp
+++ b/clang-tools-extra/clangd/index/SymbolCollector.cpp
@@ -550,9 +550,14 @@ bool SymbolCollector::shouldCollectSymbol(const NamedDecl &ND,
   // Avoid indexing internal symbols in protobuf generated headers.
   if (isPrivateProtoDecl(ND))
     return false;
+
+  // System headers that end with `intrin.h` likely contain useful symbols.
   if (!Opts.CollectReserved &&
       (hasReservedName(ND) || hasReservedScope(*ND.getDeclContext())) &&
-      ASTCtx.getSourceManager().isInSystemHeader(ND.getLocation()))
+      ASTCtx.getSourceManager().isInSystemHeader(ND.getLocation()) &&
+      !ASTCtx.getSourceManager()
+           .getFilename(ND.getLocation())
+           .ends_with("intrin.h"))
     return false;
 
   return true;

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -2111,7 +2111,7 @@ TEST_F(SymbolCollectorTest, Reserved) {
   EXPECT_THAT(Symbols, IsEmpty());
 }
 
-TEST_F(SymbolCollectorTest, UnreservedIntrin) {
+TEST_F(SymbolCollectorTest, ReservedSymbolInIntrinsicHeader) {
   const char *Header = R"cpp(
     #pragma once
     void __foo();

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -2111,6 +2111,20 @@ TEST_F(SymbolCollectorTest, Reserved) {
   EXPECT_THAT(Symbols, IsEmpty());
 }
 
+TEST_F(SymbolCollectorTest, UnreservedIntrin) {
+  const char *Header = R"cpp(
+    #pragma once
+    void __foo();
+  )cpp";
+
+  TestHeaderName = "xintrin.h";
+  TestHeaderURI = URI::create(testPath(TestHeaderName)).toString();
+  InMemoryFileSystem = new llvm::vfs::InMemoryFileSystem;
+  CollectorOpts.FallbackDir = testRoot();
+  runSymbolCollector("#pragma GCC system_header\n" + std::string(Header), "");
+  EXPECT_THAT(Symbols, UnorderedElementsAre(qName("__foo")));
+}
+
 TEST_F(SymbolCollectorTest, Concepts) {
   const char *Header = R"cpp(
     template <class T>


### PR DESCRIPTION
Summary:
`clangd` intentionally suppresses indexing symbols from system headers
as these are likely implementation details the user does not want.
Howver, there are plenty of system headers that provide extensions that
we want to index, such as vector intrinsic headers. This patch adds an
extra check for these commonly-named '*intrin.h' headers. This is not
fully inclusive for all symbols the user might want, but it's a good
start.

Fixes: https://github.com/llvm/llvm-project/issues/118684
