### PR TITLE
[rtsan][llvm] Remove function pass, only support module pass

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1023,14 +1023,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
             FPM.addPass(BoundsCheckingPass());
           });
 
-    if (LangOpts.Sanitize.has(SanitizerKind::Realtime)) {
-      PB.registerScalarOptimizerLateEPCallback(
-          [](FunctionPassManager &FPM, OptimizationLevel Level) {
-            RealtimeSanitizerOptions Opts;
-            FPM.addPass(RealtimeSanitizerPass(Opts));
-          });
-      MPM.addPass(ModuleRealtimeSanitizerPass());
-    }
+    if (LangOpts.Sanitize.has(SanitizerKind::Realtime))
+      MPM.addPass(RealtimeSanitizerPass());
 
     // Don't add sanitizers if we are here from ThinLTO PostLink. That already
     // done on PreLink stage.

--- a/llvm/include/llvm/Transforms/Instrumentation/RealtimeSanitizer.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/RealtimeSanitizer.h
@@ -23,19 +23,8 @@
 
 namespace llvm {
 
-struct RealtimeSanitizerOptions {};
-
-class RealtimeSanitizerPass : public PassInfoMixin<RealtimeSanitizerPass> {
-public:
-  RealtimeSanitizerPass(const RealtimeSanitizerOptions &Options);
-  PreservedAnalyses run(Function &F, AnalysisManager<Function> &AM);
-
-  static bool isRequired() { return true; }
-};
-
 /// Create ctor and init functions.
-struct ModuleRealtimeSanitizerPass
-    : public PassInfoMixin<ModuleRealtimeSanitizerPass> {
+struct RealtimeSanitizerPass : public PassInfoMixin<RealtimeSanitizerPass> {
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
   static bool isRequired() { return true; }
 };

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1281,11 +1281,6 @@ parseRegAllocFastPassOptions(PassBuilder &PB, StringRef Params) {
   return Opts;
 }
 
-Expected<RealtimeSanitizerOptions> parseRtSanPassOptions(StringRef Params) {
-  RealtimeSanitizerOptions Result;
-  return Result;
-}
-
 } // namespace
 
 /// Tests whether a pass name starts with a valid prefix for a default pipeline

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -138,7 +138,7 @@ MODULE_PASS("rel-lookup-table-converter", RelLookupTableConverterPass())
 MODULE_PASS("rewrite-statepoints-for-gc", RewriteStatepointsForGC())
 MODULE_PASS("rewrite-symbols", RewriteSymbolPass())
 MODULE_PASS("rpo-function-attrs", ReversePostOrderFunctionAttrsPass())
-MODULE_PASS("rtsan-module", ModuleRealtimeSanitizerPass())
+MODULE_PASS("rtsan", RealtimeSanitizerPass())
 MODULE_PASS("sample-profile", SampleProfileLoaderPass())
 MODULE_PASS("sancov-module", SanitizerCoveragePass())
 MODULE_PASS("sanmd-module", SanitizerBinaryMetadataPass())
@@ -618,10 +618,6 @@ FUNCTION_PASS_WITH_PARAMS(
       return WinEHPreparePass(DemoteCatchSwitchPHIOnly);
     },
     parseWinEHPrepareOptions, "demote-catchswitch-only")
-FUNCTION_PASS_WITH_PARAMS(
-    "rtsan", "RealtimeSanitizerPass",
-    [](RealtimeSanitizerOptions Opts) { return RealtimeSanitizerPass(Opts); },
-    parseRtSanPassOptions, "")
 #undef FUNCTION_PASS_WITH_PARAMS
 
 #ifndef LOOPNEST_PASS

--- a/llvm/test/Instrumentation/RealtimeSanitizer/rtsan.ll
+++ b/llvm/test/Instrumentation/RealtimeSanitizer/rtsan.ll
@@ -1,4 +1,4 @@
-; RUN: opt < %s -passes='function(rtsan),module(rtsan-module)' -S | FileCheck %s
+; RUN: opt < %s -passes='rtsan' -S | FileCheck %s
 
 define void @violation() #0 {
   %1 = alloca ptr, align 8


### PR DESCRIPTION
As suggested by @vitalybuka on #118989 

Most of the other sanitizers are now only module level passes. This moves all functionality into the module pass, and removes the function pass.