### PR TITLE
Add check for SYS_gettid support

### DIFF
--- a/llvm/lib/Support/Unix/Threading.inc
+++ b/llvm/lib/Support/Unix/Threading.inc
@@ -140,7 +140,7 @@ uint64_t llvm::get_threadid() {
   return uint64_t(getthrid());
 #elif defined(__ANDROID__)
   return uint64_t(gettid());
-#elif defined(__linux__)
+#elif defined(__linux__) && defined(SYS_gettid)
   return uint64_t(syscall(SYS_gettid));
 #else
   return uint64_t(pthread_self());


### PR DESCRIPTION
To improve compatibility with old glibc version which lack `syscall(SYS_gettid)` will use `pthread_self()` as a fallback.