### PR TITLE
[flang][cuda] Implicitly add DEVICE attribute in device/global functions

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8973,7 +8973,8 @@ void ResolveNamesVisitor::FinishSpecificationPart(
     if (NeedsExplicitType(symbol)) {
       ApplyImplicitRules(symbol);
     }
-    if (inDeviceSubprogram && IsDummy(symbol) && symbol.has<ObjectEntityDetails>()) {
+    if (inDeviceSubprogram && IsDummy(symbol) &&
+        symbol.has<ObjectEntityDetails>()) {
       auto *dummy{symbol.detailsIf<ObjectEntityDetails>()};
       if (!dummy->cudaDataAttr()) {
         // Implicitly set device attribute if none is set in device context.

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8953,6 +8953,18 @@ void ResolveNamesVisitor::FinishSpecificationPart(
   misparsedStmtFuncFound_ = false;
   funcResultStack().CompleteFunctionResultType();
   CheckImports();
+  bool inDeviceSubprogram = false;
+  if (auto *subp{currScope().symbol()
+              ? currScope().symbol()->detailsIf<SubprogramDetails>()
+              : nullptr}) {
+    if (auto attrs{subp->cudaSubprogramAttrs()}) {
+      if (*attrs != common::CUDASubprogramAttrs::Device ||
+          *attrs != common::CUDASubprogramAttrs::Global ||
+          *attrs != common::CUDASubprogramAttrs::Grid_Global) {
+        inDeviceSubprogram = true;
+      }
+    }
+  }
   for (auto &pair : currScope()) {
     auto &symbol{*pair.second};
     if (inInterfaceBlock()) {
@@ -8960,6 +8972,13 @@ void ResolveNamesVisitor::FinishSpecificationPart(
     }
     if (NeedsExplicitType(symbol)) {
       ApplyImplicitRules(symbol);
+    }
+    if (inDeviceSubprogram && IsDummy(symbol) && symbol.has<ObjectEntityDetails>()) {
+      auto *dummy{symbol.detailsIf<ObjectEntityDetails>()};
+      if (!dummy->cudaDataAttr()) {
+        // Implicitly set device attribute if none is set in device context.
+        dummy->set_cudaDataAttr(common::CUDADataAttr::Device);
+      }
     }
     if (IsDummy(symbol) && isImplicitNoneType() &&
         symbol.test(Symbol::Flag::Implicit) && !context().HasError(symbol)) {

--- a/flang/test/Semantics/modfile55.cuf
+++ b/flang/test/Semantics/modfile55.cuf
@@ -29,6 +29,7 @@ end
 !contains
 !attributes(global) subroutine globsub(x,y,z)
 !real(4),value::x
+!attributes(device) x
 !real(4)::y
 !attributes(device) y
 !real(4)::z


### PR DESCRIPTION
Variables in global and device function/subroutine that have no CUDA Fortran data attribute are implicitly DEVICE. 