### PR TITLE
[AsmParser] Convert empty arrays to `poison`

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6185,7 +6185,7 @@ bool LLParser::convertValIDToValue(Type *Ty, ValID &ID, Value *&V,
   case ValID::t_EmptyArray:
     if (!Ty->isArrayTy() || cast<ArrayType>(Ty)->getNumElements() != 0)
       return error(ID.Loc, "invalid empty array initializer");
-    V = UndefValue::get(Ty);
+    V = PoisonValue::get(Ty);
     return false;
   case ValID::t_Zero:
     // FIXME: LabelTy should not be a first-class type.

--- a/llvm/test/Assembler/aggregate-constant-values.ll
+++ b/llvm/test/Assembler/aggregate-constant-values.ll
@@ -26,7 +26,7 @@ define void @bar(ptr %x) nounwind {
 }
 
 ; CHECK: @bar_empty
-; CHECK: store [0 x i32] undef, ptr %x
+; CHECK: store [0 x i32] poison, ptr %x
 ; CHECK: ret
 define void @bar_empty(ptr %x) nounwind {
   store [0 x i32][], ptr %x

--- a/llvm/test/CodeGen/AMDGPU/amdgpu.private-memory.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu.private-memory.ll
@@ -504,7 +504,7 @@ define amdgpu_kernel void @v2float_stack(ptr addrspace(1) %out, i32 %a) {
 }
 
 ; OPT-LABEL: @direct_alloca_read_0xi32(
-; OPT: store [0 x i32] undef, ptr addrspace(3)
+; OPT: store [0 x i32] poison, ptr addrspace(3)
 ; OPT: load [0 x i32], ptr addrspace(3)
 define amdgpu_kernel void @direct_alloca_read_0xi32(ptr addrspace(1) %out, i32 %index) {
 entry:


### PR DESCRIPTION
Empty arrays can be converted to `poison` instead of `undef`.