### PR TITLE
[flang][cuda] Check for use of host array in device context

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -340,7 +340,7 @@ private:
   void ErrorIfHostSymbol(const A &expr, parser::CharBlock source) {
     if (const Symbol * hostArray{FindHostArray{}(expr)}) {
       context_.Say(source,
-          "Host array '%s' cannot be present in CUF kernel"_err_en_US,
+          "Host array '%s' cannot be present in device context"_err_en_US,
           hostArray->name());
     }
   }
@@ -387,13 +387,11 @@ private:
               Check(x.value());
             },
             [&](const common::Indirection<parser::AssignmentStmt> &x) {
-              if (IsCUFKernelDo) {
-                const evaluate::Assignment *assign{
-                    semantics::GetAssignment(x.value())};
-                if (assign) {
-                  ErrorIfHostSymbol(assign->lhs, source);
-                  ErrorIfHostSymbol(assign->rhs, source);
-                }
+              const evaluate::Assignment *assign{
+                  semantics::GetAssignment(x.value())};
+              if (assign) {
+                ErrorIfHostSymbol(assign->lhs, source);
+                ErrorIfHostSymbol(assign->rhs, source);
               }
               if (auto msg{ActionStmtChecker<IsCUFKernelDo>::WhyNotOk(x)}) {
                 context_.Say(source, std::move(*msg));

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -387,9 +387,8 @@ private:
               Check(x.value());
             },
             [&](const common::Indirection<parser::AssignmentStmt> &x) {
-              const evaluate::Assignment *assign{
-                  semantics::GetAssignment(x.value())};
-              if (assign) {
+              if (const evaluate::Assignment *
+                  assign{semantics::GetAssignment(x.value())}) {
                 ErrorIfHostSymbol(assign->lhs, source);
                 ErrorIfHostSymbol(assign->rhs, source);
               }

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -1,5 +1,6 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 module m
+ integer :: m(100)
  contains
   attributes(device) subroutine devsub
     !ERROR: Statement may not appear in device code
@@ -15,6 +16,12 @@ module m
     !WARNING: I/O statement might not be supported on device
     write(12,'(10F4.1)'), x
   end
+  attributes(global) subroutine hostglobal(a)
+    integer :: a(*)
+    i = threadIdx%x
+    !ERROR: Host array 'm' cannot be present in device context
+    if (i .le. N) a(i) = m(i)
+  end subroutine
 end
 
 program main
@@ -96,7 +103,7 @@ program main
   !$cuf kernel do (2) <<<*, *>>>
   do j = 1, 10
      do i = 1, 10
-        !ERROR: Host array 'b' cannot be present in CUF kernel
+        !ERROR: Host array 'b' cannot be present in device context
         a_d(i,j) = b(i,j)
      enddo
   enddo


### PR DESCRIPTION
Now that variables have implicit attribute, we can check for illegal use of module host variable in device context. 