### PR TITLE
[lldb] Add a progress event for executing an expression

### DIFF
--- a/lldb/source/Expression/FunctionCaller.cpp
+++ b/lldb/source/Expression/FunctionCaller.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Expression/FunctionCaller.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Expression/IRExecutionUnit.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
@@ -337,6 +338,10 @@ lldb::ExpressionResults FunctionCaller::ExecuteFunction(
     const EvaluateExpressionOptions &options,
     DiagnosticManager &diagnostic_manager, Value &results) {
   lldb::ExpressionResults return_value = lldb::eExpressionSetupError;
+
+  Debugger *debugger =
+      exe_ctx.GetTargetPtr() ? &exe_ctx.GetTargetPtr()->GetDebugger() : nullptr;
+  Progress progress("Calling function", FunctionName(), {}, debugger);
 
   // FunctionCaller::ExecuteFunction execution is always just to get the
   // result. Unless explicitly asked for, ignore breakpoints and unwind on

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -14,6 +14,7 @@
 #include <string>
 
 #include "lldb/Core/Module.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Expression/ExpressionVariable.h"
 #include "lldb/Expression/IRExecutionUnit.h"
@@ -424,6 +425,18 @@ UserExpression::Execute(DiagnosticManager &diagnostic_manager,
                         const EvaluateExpressionOptions &options,
                         lldb::UserExpressionSP &shared_ptr_to_me,
                         lldb::ExpressionVariableSP &result_var) {
+  Debugger *debugger =
+      exe_ctx.GetTargetPtr() ? &exe_ctx.GetTargetPtr()->GetDebugger() : nullptr;
+  std::string details;
+  if (m_options.IsForUtilityExpr())
+    details = "LLDB utility";
+  else if (m_expr_text.size() > 15)
+    details = m_expr_text.substr(0, 14) + "…";
+  else
+    details = m_expr_text;
+
+  Progress progress("Running expression", details, {}, debugger);
+
   lldb::ExpressionResults expr_result = DoExecute(
       diagnostic_manager, exe_ctx, options, shared_ptr_to_me, result_var);
   Target *target = exe_ctx.GetTargetPtr();

--- a/lldb/test/Shell/Expr/TestExecProgress.test
+++ b/lldb/test/Shell/Expr/TestExecProgress.test
@@ -1,0 +1,8 @@
+# RUN: %lldb -s %s  | FileCheck %s
+log enable lldb event
+expr 1
+expr 1 // And a very long comment.
+quit
+
+# CHECK: {{title = "Running expression", details = "1"}}
+# CHECK: {{title = "Running expression", details = "1 // And a ver…"}}


### PR DESCRIPTION
Expressions can take arbitrary amounts of time to run, so IDEs might want to be informed about the fact that an expression is currently being executed.

rdar://141253078