### PR TITLE
[M68k] update dissassmbly test to require atLeastM68020 for BSR32

### DIFF
--- a/llvm/test/MC/Disassembler/M68k/control.txt
+++ b/llvm/test/MC/Disassembler/M68k/control.txt
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -disassemble -triple m68k %s | FileCheck %s
+# RUN: llvm-mc -disassemble -triple m68k -mcpu=M68020 %s | FileCheck %s
 
 # CHECK: bra $0
 0x60 0x00 0x00 0x00


### PR DESCRIPTION
Fixes test failure reported in #117371. `BSR32` was previously (incorrectly) allowed for CPUs <M68020, this test was missed while updating the rest to fit the new model