### PR TITLE
[Assignment Tracking] Change placeholder from `undef` to `poison`

### DIFF
--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -223,12 +223,12 @@ void DbgAssignIntrinsic::setAddress(Value *V) {
 void DbgAssignIntrinsic::setKillAddress() {
   if (isKillAddress())
     return;
-  setAddress(UndefValue::get(getAddress()->getType()));
+  setAddress(PoisonValue::get(getAddress()->getType()));
 }
 
 bool DbgAssignIntrinsic::isKillAddress() const {
   Value *Addr = getAddress();
-  return !Addr || isa<UndefValue>(Addr);
+  return !Addr || isa<PoisonValue>(Addr);
 }
 
 void DbgAssignIntrinsic::setValue(Value *V) {

--- a/llvm/lib/IR/IntrinsicInst.cpp
+++ b/llvm/lib/IR/IntrinsicInst.cpp
@@ -228,7 +228,7 @@ void DbgAssignIntrinsic::setKillAddress() {
 
 bool DbgAssignIntrinsic::isKillAddress() const {
   Value *Addr = getAddress();
-  return !Addr || isa<PoisonValue>(Addr);
+  return !Addr || isa<UndefValue>(Addr);
 }
 
 void DbgAssignIntrinsic::setValue(Value *V) {


### PR DESCRIPTION
Empty metadata address components of `dbg.assign` can be represented as `poison` values instead of `undef` values.