### PR TITLE
[libc] Stop installing `sys/types.h` when not requested

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -137,7 +137,6 @@ add_proxy_header_library(
     clockid_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.clockid_t
-    libc.include.sys_types
 )
 
 add_proxy_header_library(
@@ -173,7 +172,6 @@ add_proxy_header_library(
     pid_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.pid_t
-    libc.include.sys_types
 )
 
 add_proxy_header_library(


### PR DESCRIPTION
Summary:
This is installed unconditionally because of the dependency in the
`hdr/` directory. Remove this so it's only used on the systems that need
it.
