### PR TITLE
Introducing LLVM Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/llvm/llvm-project/badge)](https://securityscorecards.dev/viewer/?uri=github.com/llvm/llvm-project)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8273/badge)](https://www.bestpractices.dev/projects/8273)
 [![libc++](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml/badge.svg?branch=main&event=schedule)](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml?query=event%3Aschedule)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20LLVM%20Guru-006BFF)](https://gurubase.io/g/llvm)
 
 Welcome to the LLVM project!
 


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [LLVM Guru](https://gurubase.io/g/llvm) has been added to Gurubase. The LLVM Guru uses data from this repository and the [documentation](https://llvm.org/docs/) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that LLVM users can now ask questions to LLVM Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable LLVM Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR.

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
