### PR TITLE
[DirectX] Create symbols for resource handles

### DIFF
--- a/llvm/lib/Analysis/DXILResource.cpp
+++ b/llvm/lib/Analysis/DXILResource.cpp
@@ -216,6 +216,81 @@ ResourceTypeInfo::ResourceTypeInfo(TargetExtType *HandleTy,
     llvm_unreachable("Unknown handle type");
 }
 
+static void formatTypeName(SmallString<64> &Dest, StringRef Name,
+                           bool isWriteable, bool isROV) {
+  Dest = isWriteable ? (isROV ? "RasterizerOrdered" : "RW") : "";
+  Dest += Name;
+}
+
+StructType *ResourceTypeInfo::createElementStruct() {
+  SmallString<64> TypeName;
+
+  switch (Kind) {
+  case ResourceKind::Texture1D:
+  case ResourceKind::Texture2D:
+  case ResourceKind::Texture3D:
+  case ResourceKind::TextureCube:
+  case ResourceKind::Texture1DArray:
+  case ResourceKind::Texture2DArray:
+  case ResourceKind::TextureCubeArray: {
+    auto *RTy = cast<TextureExtType>(HandleTy);
+    formatTypeName(TypeName, getResourceKindName(Kind), RTy->isWriteable(),
+                   RTy->isROV());
+    return StructType::create(RTy->getResourceType(), TypeName);
+  }
+  case ResourceKind::Texture2DMS:
+  case ResourceKind::Texture2DMSArray: {
+    auto *RTy = cast<MSTextureExtType>(HandleTy);
+    formatTypeName(TypeName, getResourceKindName(Kind), RTy->isWriteable(),
+                   /*IsROV=*/false);
+    return StructType::create(RTy->getResourceType(), TypeName);
+  }
+  case ResourceKind::TypedBuffer: {
+    auto *RTy = cast<TypedBufferExtType>(HandleTy);
+    formatTypeName(TypeName, getResourceKindName(Kind), RTy->isWriteable(),
+                   RTy->isROV());
+    return StructType::create(RTy->getResourceType(), TypeName);
+  }
+  case ResourceKind::RawBuffer: {
+    auto *RTy = cast<RawBufferExtType>(HandleTy);
+    formatTypeName(TypeName, "ByteAddressBuffer", RTy->isWriteable(),
+                   RTy->isROV());
+    return StructType::create(Type::getInt32Ty(HandleTy->getContext()),
+                              TypeName);
+  }
+  case ResourceKind::StructuredBuffer: {
+    auto *RTy = cast<RawBufferExtType>(HandleTy);
+    formatTypeName(TypeName, "StructuredBuffer", RTy->isWriteable(),
+                   RTy->isROV());
+    return StructType::create(RTy->getResourceType(), TypeName);
+  }
+  case ResourceKind::FeedbackTexture2D:
+  case ResourceKind::FeedbackTexture2DArray: {
+    auto *RTy = cast<FeedbackTextureExtType>(HandleTy);
+    TypeName = formatv("{0}<{1}>", getResourceKindName(Kind),
+                       llvm::to_underlying(RTy->getFeedbackType()));
+    return StructType::create(Type::getInt32Ty(HandleTy->getContext()),
+                              TypeName);
+  }
+  case ResourceKind::CBuffer:
+    return StructType::create(HandleTy->getContext(), "cbuffer");
+  case ResourceKind::Sampler: {
+    auto *RTy = cast<SamplerExtType>(HandleTy);
+    TypeName = formatv("SamplerState<{0}>",
+                       llvm::to_underlying(RTy->getSamplerType()));
+    return StructType::create(Type::getInt32Ty(HandleTy->getContext()),
+                              TypeName);
+  }
+  case ResourceKind::TBuffer:
+  case ResourceKind::RTAccelerationStructure:
+    llvm_unreachable("Unhandled resource kind");
+  case ResourceKind::Invalid:
+  case ResourceKind::NumEntries:
+    llvm_unreachable("Invalid resource kind");
+  }
+  llvm_unreachable("Unhandled ResourceKind enum");
+}
+
 bool ResourceTypeInfo::isUAV() const { return RC == ResourceClass::UAV; }
 
 bool ResourceTypeInfo::isCBuffer() const {
@@ -449,6 +524,15 @@ void ResourceTypeInfo::print(raw_ostream &OS, const DataLayout &DL) const {
   }
 }
 
+GlobalVariable *ResourceBindingInfo::createSymbol(Module &M, StructType *Ty,
+                                                  StringRef Name) {
+  assert(!Symbol && "Symbol has already been created");
+  Symbol = new GlobalVariable(M, Ty, /*isConstant=*/true,
+                              GlobalValue::ExternalLinkage,
+                              /*Initializer=*/nullptr, Name);
+  return Symbol;
+}
+
 MDTuple *ResourceBindingInfo::getAsMetadata(Module &M,
                                             dxil::ResourceTypeInfo &RTI) const {
   LLVMContext &Ctx = M.getContext();
@@ -468,13 +552,9 @@ MDTuple *ResourceBindingInfo::getAsMetadata(Module &M,
   };
 
   MDVals.push_back(getIntMD(Binding.RecordID));
-
-  // TODO: We need API to create a symbol of the appropriate type to emit here.
-  // See https://github.com/llvm/llvm-project/issues/116849
-  MDVals.push_back(
-      ValueAsMetadata::get(UndefValue::get(PointerType::getUnqual(Ctx))));
-  MDVals.push_back(MDString::get(Ctx, ""));
-
+  assert(Symbol && "Cannot yet create useful resource metadata without symbol");
+  MDVals.push_back(ValueAsMetadata::get(Symbol));
+  MDVals.push_back(MDString::get(Ctx, Symbol->getName()));
   MDVals.push_back(getIntMD(Binding.Space));
   MDVals.push_back(getIntMD(Binding.LowerBound));
   MDVals.push_back(getIntMD(Binding.Size));
@@ -573,6 +653,12 @@ ResourceBindingInfo::getAnnotateProps(Module &M,
 
 void ResourceBindingInfo::print(raw_ostream &OS, dxil::ResourceTypeInfo &RTI,
                                 const DataLayout &DL) const {
+  if (Symbol) {
+    OS << "  Symbol: ";
+    Symbol->printAsOperand(OS);
+    OS << "\n";
+  }
+
   OS << "  Binding:\n"
      << "    Record ID: " << Binding.RecordID << "\n"
      << "    Space: " << Binding.Space << "\n"

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -77,6 +77,10 @@ static NamedMDNode *emitResourceMetadata(Module &M, DXILBindingMap &DBM,
                                          const dxil::Resources &MDResources) {
   LLVMContext &Context = M.getContext();
 
+  for (ResourceBindingInfo &RI : DBM)
+    if (!RI.hasSymbol())
+      RI.createSymbol(M, DRTM[RI.getHandleTy()].createElementStruct());
+
   SmallVector<Metadata *> SRVs, UAVs, CBufs, Smps;
   for (const ResourceBindingInfo &RI : DBM.srvs())
     SRVs.push_back(RI.getAsMetadata(M, DRTM[RI.getHandleTy()]));

--- a/llvm/test/CodeGen/DirectX/Metadata/resource-symbols.ll
+++ b/llvm/test/CodeGen/DirectX/Metadata/resource-symbols.ll
@@ -1,0 +1,48 @@
+; RUN: opt -S -passes=dxil-translate-metadata %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-compute"
+
+%struct.S = type { <4 x float>, <4 x i32> }
+
+define void @test() {
+  ; Buffer<float4>
+  %float4 = call target("dx.TypedBuffer", <4 x float>, 0, 0, 0)
+      @llvm.dx.handle.fromBinding(i32 0, i32 0, i32 1, i32 0, i1 false)
+  ; CHECK: %TypedBuffer = type { <4 x float> }
+
+  ; Buffer<int>
+  %int = call target("dx.TypedBuffer", i32, 0, 0, 1)
+      @llvm.dx.handle.fromBinding(i32 0, i32 1, i32 1, i32 0, i1 false)
+  ; CHECK: %TypedBuffer.0 = type { i32 }
+
+  ; Buffer<uint3>
+  %uint3 = call target("dx.TypedBuffer", <3 x i32>, 0, 0, 0)
+      @llvm.dx.handle.fromBinding(i32 0, i32 2, i32 1, i32 0, i1 false)
+  ; CHECK: %TypedBuffer.1 = type { <3 x i32> }
+
+  ; StructuredBuffer<S>
+  %struct0 = call target("dx.RawBuffer", %struct.S, 0, 0)
+      @llvm.dx.handle.fromBinding(i32 0, i32 10, i32 1, i32 0, i1 true)
+  ; CHECK: %StructuredBuffer = type { %struct.S }
+
+  ; ByteAddressBuffer
+  %byteaddr = call target("dx.RawBuffer", i8, 0, 0)
+      @llvm.dx.handle.fromBinding(i32 0, i32 20, i32 1, i32 0, i1 false)
+  ; CHECK: %ByteAddressBuffer = type { i32 }
+
+  ret void
+}
+
+; CHECK:      @[[T0:.*]] = external constant %TypedBuffer
+; CHECK-NEXT: @[[T1:.*]] = external constant %TypedBuffer.0
+; CHECK-NEXT: @[[T2:.*]] = external constant %TypedBuffer.1
+; CHECK-NEXT: @[[S0:.*]] = external constant %StructuredBuffer
+; CHECK-NEXT: @[[B0:.*]] = external constant %ByteAddressBuffer
+
+; CHECK: !{i32 0, ptr @[[T0]], !""
+; CHECK: !{i32 1, ptr @[[T1]], !""
+; CHECK: !{i32 2, ptr @[[T2]], !""
+; CHECK: !{i32 3, ptr @[[S0]], !""
+; CHECK: !{i32 4, ptr @[[B0]], !""
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(none) }

--- a/llvm/unittests/Analysis/DXILResourceTest.cpp
+++ b/llvm/unittests/Analysis/DXILResourceTest.cpp
@@ -86,7 +86,6 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   Type *Int32x2Ty = FixedVectorType::get(Int32Ty, 2);
 
   MDBuilder TestMD(Context, Int32Ty, Int1Ty);
-  Value *DummyGV = UndefValue::get(PointerType::getUnqual(Context));
 
   // ByteAddressBuffer Buffer;
   ResourceTypeInfo RTI(llvm::TargetExtType::get(
@@ -97,11 +96,12 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   ResourceBindingInfo RBI(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GlobalVariable *GV = RBI.createSymbol(M, RTI.createElementStruct(), "Buffer");
   std::pair<uint32_t, uint32_t> Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000000bU);
   EXPECT_EQ(Props.second, 0U);
   MDTuple *MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 11, 0, nullptr));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "Buffer", 0, 0, 1, 11, 0, nullptr));
 
   // RWByteAddressBuffer BufferOut : register(u3, space2);
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -115,12 +115,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/1, /*Space=*/2, /*LowerBound=*/3, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "BufferOut");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000100bU);
   EXPECT_EQ(Props.second, 0U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(1, DummyGV, "", 2, 3, 1, 11, false, false, false,
-                             nullptr));
+  EXPECT_MDEQ(MD, TestMD.get(1, GV, "BufferOut", 2, 3, 1, 11, false, false,
+                             false, nullptr));
 
   // struct BufType0 { int i; float f; double d; };
   // StructuredBuffer<BufType0> Buffer0 : register(t0);
@@ -137,12 +138,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "Buffer0");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000030cU);
   EXPECT_EQ(Props.second, 0x00000010U);
   MD = RBI.getAsMetadata(M, RTI);
   EXPECT_MDEQ(MD,
-              TestMD.get(0, DummyGV, "", 0, 0, 1, 12, 0, TestMD.get(1, 16)));
+              TestMD.get(0, GV, "Buffer0", 0, 0, 1, 12, 0, TestMD.get(1, 16)));
 
   // StructuredBuffer<float3> Buffer1 : register(t1);
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -156,12 +158,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/1, /*Space=*/0, /*LowerBound=*/1, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "Buffer1");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000000cU);
   EXPECT_EQ(Props.second, 0x0000000cU);
   MD = RBI.getAsMetadata(M, RTI);
   EXPECT_MDEQ(MD,
-              TestMD.get(1, DummyGV, "", 0, 1, 1, 12, 0, TestMD.get(1, 12)));
+              TestMD.get(1, GV, "Buffer1", 0, 1, 1, 12, 0, TestMD.get(1, 12)));
 
   // Texture2D<float4> ColorMapTexture : register(t2);
   RTI = ResourceTypeInfo(
@@ -177,11 +180,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/2, /*Space=*/0, /*LowerBound=*/2, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "ColorMapTexture");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x00000002U);
   EXPECT_EQ(Props.second, 0x00000409U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(2, DummyGV, "", 0, 2, 1, 2, 0, TestMD.get(0, 9)));
+  EXPECT_MDEQ(MD, TestMD.get(2, GV, "ColorMapTexture", 0, 2, 1, 2, 0,
+                             TestMD.get(0, 9)));
 
   // Texture2DMS<float, 8> DepthBuffer : register(t0);
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -199,11 +204,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "DepthBuffer");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x00000003U);
   EXPECT_EQ(Props.second, 0x00080109U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 3, 8, TestMD.get(0, 9)));
+  EXPECT_MDEQ(
+      MD, TestMD.get(0, GV, "DepthBuffer", 0, 0, 1, 3, 8, TestMD.get(0, 9)));
 
   // FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> feedbackMinMip;
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -218,12 +225,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "feedbackMinMip");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x00001011U);
   EXPECT_EQ(Props.second, 0U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 17, false, false, false,
-                             TestMD.get(2, 0)));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "feedbackMinMip", 0, 0, 1, 17, false, false,
+                             false, TestMD.get(2, 0)));
 
   // FeedbackTexture2DArray<SAMPLER_FEEDBACK_MIP_REGION_USED> feedbackMipRegion;
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -238,12 +246,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "feedbackMipRegion");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x00001012U);
   EXPECT_EQ(Props.second, 0x00000001U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 18, false, false, false,
-                             TestMD.get(2, 1)));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "feedbackMipRegion", 0, 0, 1, 18, false,
+                             false, false, TestMD.get(2, 1)));
 
   // globallycoherent RWTexture2D<int2> OutputTexture : register(u0, space2);
   RTI = ResourceTypeInfo(
@@ -262,12 +271,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/2, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "OutputTexture");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x00005002U);
   EXPECT_EQ(Props.second, 0x00000204U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 2, 0, 1, 2, true, false, false,
-                             TestMD.get(0, 4)));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "OutputTexture", 2, 0, 1, 2, true, false,
+                             false, TestMD.get(0, 4)));
 
   // RasterizerOrderedBuffer<float4> ROB;
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -285,11 +295,12 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "ROB");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000300aU);
   EXPECT_EQ(Props.second, 0x00000409U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 10, false, false, true,
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "ROB", 0, 0, 1, 10, false, false, true,
                              TestMD.get(0, 9)));
 
   // RWStructuredBuffer<ParticleMotion> g_OutputBuffer : register(u2);
@@ -311,12 +322,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/2, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "g_OutputBuffer");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000920cU);
   EXPECT_EQ(Props.second, 0x00000014U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 2, 1, 12, false, true, false,
-                             TestMD.get(1, 20)));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "g_OutputBuffer", 0, 2, 1, 12, false, true,
+                             false, TestMD.get(1, 20)));
 
   // RWTexture2DMSArray<uint, 8> g_rw_t2dmsa;
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -337,12 +349,13 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "g_rw_t2dmsa");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x00001008U);
   EXPECT_EQ(Props.second, 0x00080105U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 8, false, false, false,
-                             TestMD.get(0, 5)));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "g_rw_t2dmsa", 0, 0, 1, 8, false, false,
+                             false, TestMD.get(0, 5)));
 
   // cbuffer cb0 { float4 g_X; float4 g_Y; }
   StructType *CBufType0 =
@@ -356,11 +369,12 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000000dU);
   EXPECT_EQ(Props.second, 0x00000020U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 32, nullptr));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "", 0, 0, 1, 32, nullptr));
 
   // SamplerState ColorMapSampler : register(s0);
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
@@ -373,11 +387,12 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "ColorMapSampler");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000000eU);
   EXPECT_EQ(Props.second, 0U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 0, nullptr));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "ColorMapSampler", 0, 0, 1, 0, nullptr));
 
   RTI = ResourceTypeInfo(llvm::TargetExtType::get(
       Context, "dx.Sampler", {},
@@ -389,9 +404,10 @@ TEST(DXILResource, AnnotationsAndMetadata) {
   RBI = ResourceBindingInfo(
       /*RecordID=*/0, /*Space=*/0, /*LowerBound=*/0, /*Size=*/1,
       RTI.getHandleTy());
+  GV = RBI.createSymbol(M, RTI.createElementStruct(), "CmpSampler");
   Props = RBI.getAnnotateProps(M, RTI);
   EXPECT_EQ(Props.first, 0x0000800eU);
   EXPECT_EQ(Props.second, 0U);
   MD = RBI.getAsMetadata(M, RTI);
-  EXPECT_MDEQ(MD, TestMD.get(0, DummyGV, "", 0, 0, 1, 1, nullptr));
+  EXPECT_MDEQ(MD, TestMD.get(0, GV, "CmpSampler", 0, 0, 1, 1, nullptr));
 }


### PR DESCRIPTION
We need to create symbols with "the original shape of resource and element type" to put in the resource metadata in order to generate valid DXIL.

Note that DXC generally doesn't emit an actual symbol outside of library shaders (it emits an undef of a pointer to the type), but since we have to deal with opaque pointers we would need a way to smuggle the type through to match that. Instead, we simply emit symbols for now.

Fixed #116849