### PR TITLE
[mlir] Allow specifying name for EnumAttr

### DIFF
--- a/mlir/include/mlir/IR/EnumAttr.td
+++ b/mlir/include/mlir/IR/EnumAttr.td
@@ -384,9 +384,9 @@ class EnumParameter<EnumAttrInfo enumInfo>
 // The op will appear in the IR as `my_dialect.my_op first`. However, the
 // generic format of the attribute will be `#my_dialect<"enum first">`. Override
 // the attribute's assembly format as required.
-class EnumAttr<Dialect dialect, EnumAttrInfo enumInfo, string name = "",
-               list <Trait> traits = []>
-    : AttrDef<dialect, enumInfo.className, traits> {
+class EnumAttr<Dialect dialect, EnumAttrInfo enumInfo, string mnemonicArg = "",
+               string name = "", list <Trait> traits = []>
+    : AttrDef<dialect, !if(!empty(name), enumInfo.className, name), traits> {
   let summary = enumInfo.summary;
   let description = enumInfo.description;
 
@@ -410,7 +410,7 @@ class EnumAttr<Dialect dialect, EnumAttrInfo enumInfo, string name = "",
   let parameters = (ins EnumParameter<enumInfo>:$value);
 
   // If a mnemonic was provided, use it to generate a custom assembly format.
-  let mnemonic = name;
+  let mnemonic = mnemonicArg;
 
   // The default assembly format for enum attributes. Selected to best work with
   // operation assembly formats.


### PR DESCRIPTION
The name of an EnumAttr is currently always based on the name of the
underlying enum, which is a good default, but users may wish to
customize it. Add a template argument to enable this, while preserving
the old default. This is changing the position of the existing `traits`
argument, but that has no in-tree uses (so nothing needs to be updated),
and any out-of-tree uses should see a type mismatch error instead of
silently getting an incorrect argument value.
