### PR TITLE
[clang] Fix use of dangling ptr in CommandLineTest

### DIFF
--- a/clang/unittests/Frontend/CompilerInvocationTest.cpp
+++ b/clang/unittests/Frontend/CompilerInvocationTest.cpp
@@ -31,17 +31,19 @@ class CommandLineTest : public ::testing::Test {
 public:
   IntrusiveRefCntPtr<DiagnosticsEngine> Diags;
   SmallVector<const char *, 32> GeneratedArgs;
-  SmallVector<std::string, 32> GeneratedArgsStorage;
+  BumpPtrAllocator Alloc;
+  StringSaver StringPool;
   CompilerInvocation Invocation;
 
   const char *operator()(const Twine &Arg) {
-    return GeneratedArgsStorage.emplace_back(Arg.str()).c_str();
+    return StringPool.save(Arg).data();
   }
 
   CommandLineTest()
       : Diags(CompilerInstance::createDiagnostics(
             *llvm::vfs::getRealFileSystem(), new DiagnosticOptions(),
-            new TextDiagnosticBuffer())) {}
+            new TextDiagnosticBuffer())),
+        StringPool(Alloc) {}
 };
 
 template <typename M>


### PR DESCRIPTION
If 'GeneratedArgsStorage' ever grows, contained strings may get copied and data pointers stored in 'GeneratedArgs' may become invalid, pointing to deallocated memory.