### PR TITLE
[IR] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/mlir/lib/IR/AffineMap.cpp
+++ b/mlir/lib/IR/AffineMap.cpp
@@ -753,7 +753,7 @@ AffineMap mlir::foldAttributesIntoMap(Builder &b, AffineMap map,
           b.getAffineConstantExpr(cast<IntegerAttr>(attr).getInt()));
     } else {
       dimReplacements.push_back(b.getAffineDimExpr(numDims++));
-      remainingValues.push_back(operands[i].get<Value>());
+      remainingValues.push_back(cast<Value>(operands[i]));
     }
   }
   int64_t numSymbols = 0;
@@ -763,7 +763,7 @@ AffineMap mlir::foldAttributesIntoMap(Builder &b, AffineMap map,
           b.getAffineConstantExpr(cast<IntegerAttr>(attr).getInt()));
     } else {
       symReplacements.push_back(b.getAffineSymbolExpr(numSymbols++));
-      remainingValues.push_back(operands[i + map.getNumDims()].get<Value>());
+      remainingValues.push_back(cast<Value>(operands[i + map.getNumDims()]));
     }
   }
   return map.replaceDimsAndSymbols(dimReplacements, symReplacements, numDims,

--- a/mlir/lib/IR/Builders.cpp
+++ b/mlir/lib/IR/Builders.cpp
@@ -553,7 +553,7 @@ LogicalResult OpBuilder::tryFold(Operation *op,
       return cleanupFailure();
 
     // Ask the dialect to materialize a constant operation for this value.
-    Attribute attr = foldResult.get<Attribute>();
+    Attribute attr = cast<Attribute>(foldResult);
     auto *constOp = dialect->materializeConstant(cstBuilder, attr, expectedType,
                                                  op->getLoc());
     if (!constOp) {

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -657,7 +657,7 @@ ValueRange::OwnerT ValueRange::offset_base(const OwnerT &owner,
     return {value + index};
   if (auto *operand = llvm::dyn_cast_if_present<OpOperand *>(owner))
     return {operand + index};
-  return owner.get<detail::OpResultImpl *>()->getNextResultAtOffset(index);
+  return cast<detail::OpResultImpl *>(owner)->getNextResultAtOffset(index);
 }
 /// See `llvm::detail::indexed_accessor_range_base` for details.
 Value ValueRange::dereference_iterator(const OwnerT &owner, ptrdiff_t index) {
@@ -665,7 +665,7 @@ Value ValueRange::dereference_iterator(const OwnerT &owner, ptrdiff_t index) {
     return value[index];
   if (auto *operand = llvm::dyn_cast_if_present<OpOperand *>(owner))
     return operand[index].get();
-  return owner.get<detail::OpResultImpl *>()->getNextResultAtOffset(index);
+  return cast<detail::OpResultImpl *>(owner)->getNextResultAtOffset(index);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/IR/Region.cpp
+++ b/mlir/lib/IR/Region.cpp
@@ -271,7 +271,7 @@ RegionRange::OwnerT RegionRange::offset_base(const OwnerT &owner,
     return region + index;
   if (auto **region = llvm::dyn_cast_if_present<Region **>(owner))
     return region + index;
-  return &owner.get<Region *>()[index];
+  return &cast<Region *>(owner)[index];
 }
 /// See `llvm::detail::indexed_accessor_range_base` for details.
 Region *RegionRange::dereference_iterator(const OwnerT &owner,
@@ -280,5 +280,5 @@ Region *RegionRange::dereference_iterator(const OwnerT &owner,
     return region[index].get();
   if (auto **region = llvm::dyn_cast_if_present<Region **>(owner))
     return region[index];
-  return &owner.get<Region *>()[index];
+  return &cast<Region *>(owner)[index];
 }

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -623,7 +623,7 @@ struct SymbolScope {
   std::optional<WalkResult> walk(CallbackT cback) {
     if (Region *region = llvm::dyn_cast_if_present<Region *>(limit))
       return walkSymbolUses(*region, cback);
-    return walkSymbolUses(limit.get<Operation *>(), cback);
+    return walkSymbolUses(cast<Operation *>(limit), cback);
   }
   /// This variant is used when the callback type matches a stripped down type:
   /// void(SymbolTable::SymbolUse use)
@@ -643,7 +643,7 @@ struct SymbolScope {
   std::optional<WalkResult> walkSymbolTable(CallbackT &&cback) {
     if (Region *region = llvm::dyn_cast_if_present<Region *>(limit))
       return ::walkSymbolTable(*region, cback);
-    return ::walkSymbolTable(limit.get<Operation *>(), cback);
+    return ::walkSymbolTable(cast<Operation *>(limit), cback);
   }
 
   /// The representation of the symbol within this scope.

--- a/mlir/lib/IR/TypeRange.cpp
+++ b/mlir/lib/IR/TypeRange.cpp
@@ -32,7 +32,7 @@ TypeRange::TypeRange(ValueRange values) : TypeRange(OwnerT(), values.size()) {
   else if (auto *operand = llvm::dyn_cast_if_present<OpOperand *>(owner))
     this->base = operand;
   else
-    this->base = owner.get<const Value *>();
+    this->base = cast<const Value *>(owner);
 }
 
 /// See `llvm::detail::indexed_accessor_range_base` for details.


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
