### PR TITLE
[Github] Bump CI container to LLVM 19.1.5

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/ubuntu:22.04 as base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base as stage1-toolchain
-ENV LLVM_VERSION=19.1.2
+ENV LLVM_VERSION=19.1.5
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Bump the CI container version to the latest release.