### PR TITLE
[BOLT] Require non root user for unreadable-profile.test

### DIFF
--- a/bolt/test/unreadable-profile.test
+++ b/bolt/test/unreadable-profile.test
@@ -1,4 +1,4 @@
-REQUIRES: system-linux
+REQUIRES: system-linux, non-root-user
 
 RUN: touch %t.profile && chmod 000 %t.profile
 RUN: %clang %S/Inputs/hello.c -o %t


### PR DESCRIPTION
This patch adds a requirement for a non root user in unreadable-profile.test. This test fails if run as a root user (like in a container without explicitly changing the user), which can lead to some CI test failures.