### PR TITLE
[libc++] Validate vector<bool> copy/move-assignment operators in realistic scenarios

### DIFF
--- a/libcxx/test/std/containers/sequences/vector.bool/assign_copy.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/assign_copy.pass.cpp
@@ -7,39 +7,69 @@
 //===----------------------------------------------------------------------===//
 
 // <vector>
+// vector<bool>
 
 // vector& operator=(const vector& c);
 
-#include <vector>
 #include <cassert>
-#include "test_macros.h"
-#include "test_allocator.h"
-#include "min_allocator.h"
+#include <vector>
 
-TEST_CONSTEXPR_CXX20 bool tests() {
-  {
-    std::vector<bool, test_allocator<bool> > l(3, true, test_allocator<bool>(5));
-    std::vector<bool, test_allocator<bool> > l2(l, test_allocator<bool>(3));
-    l2 = l;
-    assert(l2 == l);
-    assert(l2.get_allocator() == test_allocator<bool>(3));
-  }
-  {
-    std::vector<bool, other_allocator<bool> > l(3, true, other_allocator<bool>(5));
-    std::vector<bool, other_allocator<bool> > l2(l, other_allocator<bool>(3));
+#include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
+
+TEST_CONSTEXPR_CXX20 void test_copy_assignment(unsigned N) {
+  //
+  // Test with insufficient space where reallocation occurs during assignment
+  //
+  { // POCCA = true_type, thus copy-assign the allocator
+    std::vector<bool, other_allocator<bool> > l(N, true, other_allocator<bool>(5));
+    std::vector<bool, other_allocator<bool> > l2(other_allocator<bool>(3));
     l2 = l;
     assert(l2 == l);
     assert(l2.get_allocator() == other_allocator<bool>(5));
   }
-#if TEST_STD_VER >= 11
-  {
-    std::vector<bool, min_allocator<bool> > l(3, true, min_allocator<bool>());
-    std::vector<bool, min_allocator<bool> > l2(l, min_allocator<bool>());
+  { // POCCA = false_type, thus allocator is unchanged
+    std::vector<bool, test_allocator<bool> > l(N + 64, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > l2(10, false, test_allocator<bool>(3));
+    l2 = l;
+    assert(l2 == l);
+    assert(l2.get_allocator() == test_allocator<bool>(3));
+  }
+  { // Stateless allocator
+    std::vector<bool, min_allocator<bool> > l(N + 64, true, min_allocator<bool>());
+    std::vector<bool, min_allocator<bool> > l2(N / 2, false, min_allocator<bool>());
     l2 = l;
     assert(l2 == l);
     assert(l2.get_allocator() == min_allocator<bool>());
   }
-#endif
+
+  //
+  // Test with sufficient size where no reallocation occurs during assignment
+  //
+  { // POCCA = false_type, thus allocator is unchanged
+    std::vector<bool, test_allocator<bool> > l(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > l2(N + 64, false, test_allocator<bool>(3));
+    l2 = l;
+    assert(l2 == l);
+    assert(l2.get_allocator() == test_allocator<bool>(3));
+  }
+  { // POCCA = true_type, thus copy-assign the allocator
+    std::vector<bool, other_allocator<bool> > l(N, true, other_allocator<bool>(5));
+    std::vector<bool, other_allocator<bool> > l2(N * 2, false, other_allocator<bool>(3));
+    l2.reserve(5);
+    l2 = l;
+    assert(l2 == l);
+    assert(l2.get_allocator() == other_allocator<bool>(5));
+  }
+}
+
+TEST_CONSTEXPR_CXX20 bool tests() {
+  test_copy_assignment(3);
+  test_copy_assignment(18);
+  test_copy_assignment(33);
+  test_copy_assignment(65);
+  test_copy_assignment(299);
 
   return true;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/assign_move.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/assign_move.pass.cpp
@@ -9,68 +9,87 @@
 // UNSUPPORTED: c++03
 
 // <vector>
+// vector<bool>
 
 // vector& operator=(vector&& c);
 
-#include <vector>
 #include <cassert>
-#include "test_macros.h"
-#include "test_allocator.h"
-#include "min_allocator.h"
+#include <vector>
 
-TEST_CONSTEXPR_CXX20 bool tests() {
-  {
-    std::vector<bool, test_allocator<bool> > l(test_allocator<bool>(5));
-    std::vector<bool, test_allocator<bool> > lo(test_allocator<bool>(5));
-    for (int i = 1; i <= 3; ++i) {
-      l.push_back(i);
-      lo.push_back(i);
-    }
-    std::vector<bool, test_allocator<bool> > l2(test_allocator<bool>(5));
+#include "min_allocator.h"
+#include "test_allocator.h"
+#include "test_macros.h"
+
+TEST_CONSTEXPR_CXX20 void test_move_assignment(unsigned N) {
+  //
+  // Testing for container move where either POCMA = true_type or the allocators compare equal
+  //
+  { // Test with POCMA = true_type
+    std::vector<bool, other_allocator<bool> > l(N, true, other_allocator<bool>(5));
+    std::vector<bool, other_allocator<bool> > lo(N, true, other_allocator<bool>(5));
+    std::vector<bool, other_allocator<bool> > l2(N + 10, false, other_allocator<bool>(42));
+    l2 = std::move(l);
+    assert(l2 == lo);
+    LIBCPP_ASSERT(l.empty()); // After move, source vector is in a vliad but unspecified state. libc++ leaves it empty.
+    assert(l2.get_allocator() == lo.get_allocator());
+  }
+  { // Test with POCMA = false_type and allocators compare equal
+    std::vector<bool, test_allocator<bool> > l(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > lo(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > l2(N + 10, false, test_allocator<bool>(5));
     l2 = std::move(l);
     assert(l2 == lo);
     LIBCPP_ASSERT(l.empty());
     assert(l2.get_allocator() == lo.get_allocator());
   }
-  {
-    std::vector<bool, test_allocator<bool> > l(test_allocator<bool>(5));
-    std::vector<bool, test_allocator<bool> > lo(test_allocator<bool>(5));
-    for (int i = 1; i <= 3; ++i) {
-      l.push_back(i);
-      lo.push_back(i);
-    }
-    std::vector<bool, test_allocator<bool> > l2(test_allocator<bool>(6));
+  { // Test with POCMA = false_type and allocators compare equal
+    std::vector<bool, min_allocator<bool> > l(N, true, min_allocator<bool>{});
+    std::vector<bool, min_allocator<bool> > lo(N, true, min_allocator<bool>{});
+    std::vector<bool, min_allocator<bool> > l2(N + 10, false, min_allocator<bool>{});
     l2 = std::move(l);
     assert(l2 == lo);
-    assert(!l.empty());
-    assert(l2.get_allocator() == test_allocator<bool>(6));
-  }
-  {
-    std::vector<bool, other_allocator<bool> > l(other_allocator<bool>(5));
-    std::vector<bool, other_allocator<bool> > lo(other_allocator<bool>(5));
-    for (int i = 1; i <= 3; ++i) {
-      l.push_back(i);
-      lo.push_back(i);
-    }
-    std::vector<bool, other_allocator<bool> > l2(other_allocator<bool>(6));
-    l2 = std::move(l);
-    assert(l2 == lo);
-    assert(l.empty());
+    LIBCPP_ASSERT(l.empty());
     assert(l2.get_allocator() == lo.get_allocator());
   }
-  {
-    std::vector<bool, min_allocator<bool> > l(min_allocator<bool>{});
-    std::vector<bool, min_allocator<bool> > lo(min_allocator<bool>{});
-    for (int i = 1; i <= 3; ++i) {
-      l.push_back(i);
-      lo.push_back(i);
-    }
-    std::vector<bool, min_allocator<bool> > l2(min_allocator<bool>{});
+
+  //
+  // Testing for element-wise move where POCMA = false_type and allocators compare unequal
+  //
+  { // Test with reallocation during the element-wise move due to empty destination vector.
+    std::vector<bool, test_allocator<bool> > l(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > lo(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > l2(test_allocator<bool>(42));
     l2 = std::move(l);
     assert(l2 == lo);
-    assert(l.empty());
-    assert(l2.get_allocator() == lo.get_allocator());
+    LIBCPP_ASSERT(!l.empty());
+    assert(l2.get_allocator() == test_allocator<bool>(42));
   }
+  { // Test with reallocation occurs during the element-wise move due to insufficient destination space.
+    std::vector<bool, test_allocator<bool> > l(N + 64, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > lo(N + 64, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > l2(10, false, test_allocator<bool>(42));
+    l2 = std::move(l);
+    assert(l2 == lo);
+    LIBCPP_ASSERT(!l.empty());
+    assert(l2.get_allocator() == test_allocator<bool>(42));
+  }
+  { // Test without reallocation where source vector elements fit within destination size.
+    std::vector<bool, test_allocator<bool> > l(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > lo(N, true, test_allocator<bool>(5));
+    std::vector<bool, test_allocator<bool> > l2(N * 2, false, test_allocator<bool>(42));
+    l2 = std::move(l);
+    assert(l2 == lo);
+    LIBCPP_ASSERT(!l.empty());
+    assert(l2.get_allocator() == test_allocator<bool>(42));
+  }
+}
+
+TEST_CONSTEXPR_CXX20 bool tests() {
+  test_move_assignment(3);
+  test_move_assignment(18);
+  test_move_assignment(33);
+  test_move_assignment(65);
+  test_move_assignment(299);
 
   return true;
 }


### PR DESCRIPTION
The existing tests for `vector<bool>` copy- and move-assignment operators are limited to 3 bits only, which are inadequate to cover realistic scenarios. Most `vector<bool>` operations have code paths that are executed only when multiple storage words are involved, with each storage word typically comprising 64 bits on a 64-bit platform. Furthermore, the existing tests fail to cover all combinations `POCCA`/`POCMA`, along with different allocator equality and/or reallocation scenarios, leaving some critical code paths untested. 

This patch enhances the test coverage by introducing new tests covering up to 5 storage words, ensuring that partial words in the front or tail, and whole words in the middle are all properly tested. Moreover, these new tests ensure that the copy- and move-assignment operators are tested under all combinations of `POCCA`/`POCMA` and various allocator equality scenarios, both with or without reallocations. 
 
(Note: The performance improvements originally intended have been dropped from this patch, as they have been addressed in separate work. This patch now focuses exclusively on improving the test coverage.)


~~### General description~~
~~This PR is part of a series aimed at improving the performance of `vector<bool>`. Each PR focuses on enhancing a specific subset of operations, ensuring they are self-contained and easy to review. The main idea for performance improvements involves using word-wise implementation along with bit manipulation techniques, rather than solely using bit-wise operations in the previous implementation, resulting in substantial performance gains.~~



~~### Current PR~~
~~This PR significantly enhances the performance of the `vector<bool>` move-assignment operator by at least **500x** in the specific scenario where `pocma = false_type` and the allocators compare unequal, where the move-assignment effectively performs element-wise copy-assignment.~~

~~While the previous implementation copied individual bits in a bit-wise manner, the new implementation copies entire storage words, yielding substantial performance improvements. Since this word-wise copying is essentially the same operation currently performed in the copy-assignment operator, we have refactored the common copy-operation into a function called `__copy_by_words`, which is now called by both the copy- and move-assignment operators.~~

~~### Tests~~

~~The existing tests for `vector<bool>` are largely insufficient to cover realistic scenarios. Existing tests are limited to cases of up to 1~2 bytes. However, most `vector<bool>` operations have code paths that are only executed when multiple storage words, 8 bytes each, are involved. Furthermore, the tests for copy- and move-assignment operators do not cover different combinations of `pocca`/`pocma` values with reallocation scenarios, leaving some important code paths untested.~~

~~To improve the test coverage, this PR completely rewrites the tests for  the copy/move- assignment operators, ensuring that every possible code path is properly tested.~~

~~Furthermore, this PR conducts benchmark testing for the move-assignment operator, demonstrating at least 500x  performance improvement under different word sizes of 32 and 64.~~


~~#### Before:~~

~~------------------------------------------------------------------------------------------~~
~~Benchmark                                                Time             CPU   Iterations~~
~~------------------------------------------------------------------------------------------~~
~~BM_Move_Assignment/vector_bool_uint32_t/5140480    7530901 ns      7545633 ns           86~~
~~BM_Move_Assignment/vector_bool_uint64_t/5140480    7677517 ns      7696633 ns           89~~
~~BM_Move_Assignment/vector_bool_size_t/5140480      7806975 ns      7828858 ns           85~~

~~####  After:~~

~~------------------------------------------------------------------------------------------~~
~~Benchmark                                                Time             CPU   Iterations~~
~~------------------------------------------------------------------------------------------~~
~~BM_Move_Assignment/vector_bool_uint32_t/5140480      14651 ns        14496 ns        45996~~
~~BM_Move_Assignment/vector_bool_uint64_t/5140480      14516 ns        14389 ns        47239~~
~~BM_Move_Assignment/vector_bool_size_t/5140480        15150 ns        15045 ns        44761~~

