### PR TITLE
[memprof] Don't use Frame::hash() (NFC)

### DIFF
--- a/llvm/unittests/ProfileData/MemProfTest.cpp
+++ b/llvm/unittests/ProfileData/MemProfTest.cpp
@@ -422,7 +422,7 @@ TEST(MemProf, BaseMemProfReader) {
   Block.AllocCount = 1U, Block.TotalAccessDensity = 4,
   Block.TotalLifetime = 200001;
   FakeRecord.AllocSites.emplace_back(/*CSId=*/CSId, /*MB=*/Block);
-  MemProfData.Records.insert({F1.hash(), FakeRecord});
+  MemProfData.Records.try_emplace(0x1234, std::move(FakeRecord));
 
   MemProfReader Reader(std::move(MemProfData));
 
@@ -454,7 +454,7 @@ TEST(MemProf, BaseMemProfReaderWithCSIdMap) {
   Block.AllocCount = 1U, Block.TotalAccessDensity = 4,
   Block.TotalLifetime = 200001;
   FakeRecord.AllocSites.emplace_back(/*CSId=*/CSId, /*MB=*/Block);
-  MemProfData.Records.insert({F1.hash(), FakeRecord});
+  MemProfData.Records.try_emplace(0x1234, std::move(FakeRecord));
 
   MemProfReader Reader(std::move(MemProfData));
 


### PR DESCRIPTION
In these tests, we just want to add one instance of
IndexedMemProfRecord to MemProfData.Records and retrieve it from
MemProfReader.  There is no particular reason to associate F1.hash()
with the IndexedMemProfRecord instance.  A fake value suffices.

While I am at it, I'm switching to try_emplace so that I can move
FakeRecord.
