### PR TITLE
AMDGPU: Fix libcall recognition of image array types

### DIFF
--- a/clang/test/CodeGenOpenCL/opencl_types.cl
+++ b/clang/test/CodeGenOpenCL/opencl_types.cl
@@ -73,3 +73,81 @@ kernel void foo_wo_pipe(write_only pipe int p) {}
 void __attribute__((overloadable)) bad1(image1d_t b, image2d_t c, image2d_t d) {}
 // CHECK-SPIR-LABEL: @{{_Z4bad114ocl_image1d_ro14ocl_image2d_roS0_|"\\01\?bad1@@\$\$J0YAXPAUocl_image1d_ro@@PAUocl_image2d_ro@@1@Z"}}
 // CHECK-AMDGCN-LABEL: @{{_Z4bad114ocl_image1d_ro14ocl_image2d_roS0_|"\\01\?bad1@@\$\$J0YAXPAUocl_image1d_ro@@PAUocl_image2d_ro@@1@Z"}}(ptr addrspace(4){{.*}}ptr addrspace(4){{.*}}ptr addrspace(4){{.*}})
+
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test20ocl_image1d_array_ro(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_only image1d_array_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test20ocl_image1d_array_wo(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(write_only image1d_array_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test20ocl_image1d_array_rw(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_write image1d_array_t img) {}
+
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test21ocl_image1d_buffer_ro(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_only image1d_buffer_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test21ocl_image1d_buffer_wo(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(write_only image1d_buffer_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test21ocl_image1d_buffer_rw(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_write image1d_buffer_t img) {}
+
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test20ocl_image2d_array_ro(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_only image2d_array_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test20ocl_image2d_array_wo(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(write_only image2d_array_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test20ocl_image2d_array_rw(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_write image2d_array_t img) {}
+
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image1d_ro(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_only image1d_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image1d_wo(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(write_only image1d_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image1d_rw(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_write image1d_t img) {}
+
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image2d_ro(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_only image2d_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image2d_wo(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(write_only image2d_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image2d_rw(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_write image2d_t img) {}
+
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image3d_ro(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_only image3d_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image3d_wo(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(write_only image3d_t img) {}
+
+// CHECK-AMDGCN: define dso_local void @_Z20img_type_mangle_test14ocl_image3d_rw(ptr addrspace(4) %img)
+__attribute__((overloadable))
+void img_type_mangle_test(read_write image3d_t img) {}

--- a/llvm/lib/Target/AMDGPU/AMDGPULibFunc.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibFunc.cpp
@@ -622,9 +622,9 @@ bool ItaniumParamParser::parseItaniumParam(StringRef& param,
   if (isDigit(TC)) {
     res.ArgType =
         StringSwitch<AMDGPULibFunc::EType>(eatLengthPrefixedName(param))
-            .Case("ocl_image1darray", AMDGPULibFunc::IMG1DA)
-            .Case("ocl_image1dbuffer", AMDGPULibFunc::IMG1DB)
-            .Case("ocl_image2darray", AMDGPULibFunc::IMG2DA)
+            .StartsWith("ocl_image1d_array", AMDGPULibFunc::IMG1DA)
+            .StartsWith("ocl_image1d_buffer", AMDGPULibFunc::IMG1DB)
+            .StartsWith("ocl_image2d_array", AMDGPULibFunc::IMG2DA)
             .StartsWith("ocl_image1d", AMDGPULibFunc::IMG1D)
             .StartsWith("ocl_image2d", AMDGPULibFunc::IMG2D)
             .StartsWith("ocl_image3d", AMDGPULibFunc::IMG3D)

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-image-function-signatures.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-image-function-signatures.ll
@@ -4,62 +4,338 @@
 ; Make sure we can produce a valid FunctionType for the expected
 ; signature of image functions.
 
-declare i32 @_Z16get_image_height20ocl_image2d_depth_rw(ptr addrspace(4))
-
-define i32 @call_ocl_image2d_depth(ptr addrspace(4) %img) {
-; CHECK-LABEL: define i32 @call_ocl_image2d_depth(
-; CHECK-SAME: ptr addrspace(4) [[IMG:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @_Z16get_image_height20ocl_image2d_depth_rw(ptr addrspace(4) [[IMG]])
-; CHECK-NEXT:    ret i32 [[RESULT]]
+define i32 @test_get_image_width_ro_image1d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image1d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image1d_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
 ;
-  %result = call i32 @_Z16get_image_height20ocl_image2d_depth_rw(ptr addrspace(4) %img)
-  ret i32 %result
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image1d_ro(ptr addrspace(4) %img)
+  ret i32 %call
 }
 
-declare i32 @_Z15get_image_width14ocl_image3d_ro(ptr addrspace(4))
+declare i32 @_Z15get_image_width14ocl_image1d_ro(ptr addrspace(4)) #1
 
-define i32 @call_ocl_image3d_depth(ptr addrspace(4) %img) {
-; CHECK-LABEL: define i32 @call_ocl_image3d_depth(
-; CHECK-SAME: ptr addrspace(4) [[IMG:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @_Z15get_image_width14ocl_image3d_ro(ptr addrspace(4) [[IMG]])
-; CHECK-NEXT:    ret i32 [[RESULT]]
+define i32 @test_get_image_width_wo_image1d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image1d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image1d_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
 ;
-  %result = call i32 @_Z15get_image_width14ocl_image3d_ro(ptr addrspace(4) %img)
-  ret i32 %result
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image1d_wo(ptr addrspace(4) %img)
+  ret i32 %call
 }
 
-declare i32 @_Z15get_image_width14ocl_image1d_ro(ptr addrspace(4))
+declare i32 @_Z15get_image_width14ocl_image1d_wo(ptr addrspace(4)) #1
 
-define i32 @call_get_image_width14ocl_image1d_ro(ptr addrspace(4) %img) {
-; CHECK-LABEL: define i32 @call_get_image_width14ocl_image1d_ro(
-; CHECK-SAME: ptr addrspace(4) [[IMG:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @_Z15get_image_width14ocl_image1d_ro(ptr addrspace(4) [[IMG]])
-; CHECK-NEXT:    ret i32 [[RESULT]]
+define i32 @test_get_image_width_rw_image1d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image1d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image1d_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
 ;
-  %result = call i32 @_Z15get_image_width14ocl_image1d_ro(ptr addrspace(4) %img)
-  ret i32 %result
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image1d_rw(ptr addrspace(4) %img)
+  ret i32 %call
 }
 
-declare <2 x i32> @_Z13get_image_dim20ocl_image2d_array_ro(ptr addrspace(4))
+declare i32 @_Z15get_image_width14ocl_image1d_rw(ptr addrspace(4)) #1
 
-define <2 x i32> @call_Z13get_image_dim20ocl_image2d_array_ro(ptr addrspace(4) %img) {
-; CHECK-LABEL: define <2 x i32> @call_Z13get_image_dim20ocl_image2d_array_ro(
-; CHECK-SAME: ptr addrspace(4) [[IMG:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call <2 x i32> @_Z13get_image_dim20ocl_image2d_array_ro(ptr addrspace(4) [[IMG]])
-; CHECK-NEXT:    ret <2 x i32> [[RESULT]]
+define i32 @test_get_image_width_ro_image1d_buffer_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image1d_buffer_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width21ocl_image1d_buffer_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
 ;
-  %result = call <2 x i32> @_Z13get_image_dim20ocl_image2d_array_ro(ptr addrspace(4) %img)
-  ret <2 x i32> %result
+entry:
+  %call = tail call i32 @_Z15get_image_width21ocl_image1d_buffer_ro(ptr addrspace(4) %img)
+  ret i32 %call
 }
 
-declare i32 @_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4))
+declare i32 @_Z15get_image_width21ocl_image1d_buffer_ro(ptr addrspace(4)) #1
 
-define i32 @call_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4) %img) {
-; CHECK-LABEL: define i32 @call_Z15get_image_width20ocl_image1d_array_ro(
-; CHECK-SAME: ptr addrspace(4) [[IMG:%.*]]) {
-; CHECK-NEXT:    [[RESULT:%.*]] = call i32 @_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4) [[IMG]])
-; CHECK-NEXT:    ret i32 [[RESULT]]
+define i32 @test_get_image_width_wo_image1d_buffer_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image1d_buffer_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width21ocl_image1d_buffer_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
 ;
-  %result = call i32 @_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4) %img)
-  ret i32 %result
+entry:
+  %call = tail call i32 @_Z15get_image_width21ocl_image1d_buffer_wo(ptr addrspace(4) %img)
+  ret i32 %call
 }
+
+declare i32 @_Z15get_image_width21ocl_image1d_buffer_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image1d_buffer_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image1d_buffer_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width21ocl_image1d_buffer_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width21ocl_image1d_buffer_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width21ocl_image1d_buffer_rw(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_ro_image2d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image2d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image2d_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image2d_ro(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width14ocl_image2d_ro(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_wo_image2d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image2d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image2d_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image2d_wo(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width14ocl_image2d_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image2d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image2d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image2d_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image2d_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width14ocl_image2d_rw(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_ro_image3d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image3d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image3d_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image3d_ro(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width14ocl_image3d_ro(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_wo_image3d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image3d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image3d_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image3d_wo(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width14ocl_image3d_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image3d_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image3d_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width14ocl_image3d_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width14ocl_image3d_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width14ocl_image3d_rw(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_ro_image1d_array_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image1d_array_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image1d_array_ro(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_wo_image1d_array_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image1d_array_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image1d_array_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image1d_array_wo(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image1d_array_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image1d_array_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image1d_array_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image1d_array_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image1d_array_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image1d_array_rw(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_ro_image2d_array_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image2d_array_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image2d_array_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image2d_array_ro(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image2d_array_ro(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_wo_image2d_array_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image2d_array_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image2d_array_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image2d_array_wo(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image2d_array_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image2d_array_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image2d_array_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image2d_array_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image2d_array_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image2d_array_rw(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_ro_image2d_depth_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image2d_depth_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image2d_depth_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image2d_depth_ro(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image2d_depth_ro(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_wo_image2d_depth_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image2d_depth_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image2d_depth_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image2d_depth_wo(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image2d_depth_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image2d_depth_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image2d_depth_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width20ocl_image2d_depth_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width20ocl_image2d_depth_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width20ocl_image2d_depth_rw(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_ro_image2d_array_depth_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_ro_image2d_array_depth_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width26ocl_image2d_array_depth_ro(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width26ocl_image2d_array_depth_ro(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width26ocl_image2d_array_depth_ro(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_wo_image2d_array_depth_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_wo_image2d_array_depth_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width26ocl_image2d_array_depth_wo(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width26ocl_image2d_array_depth_wo(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width26ocl_image2d_array_depth_wo(ptr addrspace(4)) #1
+
+define i32 @test_get_image_width_rw_image2d_array_depth_t(ptr addrspace(4) readnone %img) {
+; CHECK-LABEL: define i32 @test_get_image_width_rw_image2d_array_depth_t(
+; CHECK-SAME: ptr addrspace(4) readnone [[IMG:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT:    [[CALL:%.*]] = tail call i32 @_Z15get_image_width26ocl_image2d_array_depth_rw(ptr addrspace(4) [[IMG]])
+; CHECK-NEXT:    ret i32 [[CALL]]
+;
+entry:
+  %call = tail call i32 @_Z15get_image_width26ocl_image2d_array_depth_rw(ptr addrspace(4) %img)
+  ret i32 %call
+}
+
+declare i32 @_Z15get_image_width26ocl_image2d_array_depth_rw(ptr addrspace(4)) #1


### PR DESCRIPTION
Add tests with get_image_width as a sample for all of the non-extension
image types. The transform doesn't do anything, but this runs through
all the mangled libfunc parsing and shows it does not crash. It would
probably be smarter to check for exact match of the types, rather than
checking the prefix.