### PR TITLE
[RISCV][VLOPT] Get MachineInstr from MachineOperand in getOperandInfo. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -205,7 +205,7 @@ static bool isMaskOperand(const MachineInstr &MI, const MachineOperand &MO,
   return Desc.operands()[MO.getOperandNo()].RegClass == RISCV::VMV0RegClassID;
 }
 
-/// Return the OperandInfo for MO, which is an operand of MI.
+/// Return the OperandInfo for MO.
 static OperandInfo getOperandInfo(const MachineOperand &MO,
                                   const MachineRegisterInfo *MRI) {
   const MachineInstr &MI = *MO.getParent();

--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -206,9 +206,9 @@ static bool isMaskOperand(const MachineInstr &MI, const MachineOperand &MO,
 }
 
 /// Return the OperandInfo for MO, which is an operand of MI.
-static OperandInfo getOperandInfo(const MachineInstr &MI,
-                                  const MachineOperand &MO,
+static OperandInfo getOperandInfo(const MachineOperand &MO,
                                   const MachineRegisterInfo *MRI) {
+  const MachineInstr &MI = *MO.getParent();
   const RISCVVPseudosTable::PseudoInfo *RVV =
       RISCVVPseudosTable::getPseudoInfo(MI.getOpcode());
   assert(RVV && "Could not find MI in PseudoTable");
@@ -804,8 +804,8 @@ bool RISCVVLOptimizer::checkUsers(const MachineOperand *&CommonVL,
     assert(isVectorRegClass(UserMI.getOperand(0).getReg(), MRI) &&
            "Expected DEF and USE to be vector registers");
 
-    OperandInfo ConsumerInfo = getOperandInfo(UserMI, UserOp, MRI);
-    OperandInfo ProducerInfo = getOperandInfo(MI, MI.getOperand(0), MRI);
+    OperandInfo ConsumerInfo = getOperandInfo(UserOp, MRI);
+    OperandInfo ProducerInfo = getOperandInfo(MI.getOperand(0), MRI);
     if (ConsumerInfo.isUnknown() || ProducerInfo.isUnknown() ||
         !OperandInfo::EMULAndEEWAreEqual(ConsumerInfo, ProducerInfo)) {
       LLVM_DEBUG(dbgs() << "    Abort due to incompatible or unknown "


### PR DESCRIPTION
IICU MI should be MO's parent, so just use MachineOperand::getParent().
