### PR TITLE
[mlir] Use mlir_target_link_libraries for unit tests

### DIFF
--- a/mlir/unittests/Analysis/Presburger/CMakeLists.txt
+++ b/mlir/unittests/Analysis/Presburger/CMakeLists.txt
@@ -17,7 +17,7 @@ add_mlir_unittest(MLIRPresburgerTests
   UtilsTest.cpp
 )
 
-target_link_libraries(MLIRPresburgerTests
+mlir_target_link_libraries(MLIRPresburgerTests
   PRIVATE MLIRPresburger
   MLIRAffineAnalysis
   MLIRParser

--- a/mlir/unittests/Bytecode/CMakeLists.txt
+++ b/mlir/unittests/Bytecode/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRBytecodeTests
   BytecodeTest.cpp
 )
-target_link_libraries(MLIRBytecodeTests
+mlir_target_link_libraries(MLIRBytecodeTests
   PRIVATE
   MLIRBytecodeReader
   MLIRBytecodeWriter

--- a/mlir/unittests/Conversion/PDLToPDLInterp/CMakeLists.txt
+++ b/mlir/unittests/Conversion/PDLToPDLInterp/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRPDLToPDLInterpTests
   RootOrderingTest.cpp
 )
-target_link_libraries(MLIRPDLToPDLInterpTests
+mlir_target_link_libraries(MLIRPDLToPDLInterpTests
   PRIVATE
   MLIRArithDialect
   MLIRPDLToPDLInterp

--- a/mlir/unittests/Debug/CMakeLists.txt
+++ b/mlir/unittests/Debug/CMakeLists.txt
@@ -4,5 +4,5 @@ add_mlir_unittest(MLIRDebugTests
   FileLineColLocBreakpointManagerTest.cpp
 )
 
-target_link_libraries(MLIRDebugTests
+mlir_target_link_libraries(MLIRDebugTests
   PRIVATE MLIRDebug)

--- a/mlir/unittests/Dialect/AMDGPU/CMakeLists.txt
+++ b/mlir/unittests/Dialect/AMDGPU/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRAMDGPUTests
   AMDGPUUtilsTest.cpp
 )
-target_link_libraries(MLIRAMDGPUTests
+mlir_target_link_libraries(MLIRAMDGPUTests
   PRIVATE
   MLIRAMDGPUUtils
 )

--- a/mlir/unittests/Dialect/ArmSME/CMakeLists.txt
+++ b/mlir/unittests/Dialect/ArmSME/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_unittest(MLIRArmSMETests
   TileTypeConversionTest.cpp)
-target_link_libraries(MLIRArmSMETests
+mlir_target_link_libraries(MLIRArmSMETests
   PRIVATE
   MLIRArmSMEToLLVM)

--- a/mlir/unittests/Dialect/CMakeLists.txt
+++ b/mlir/unittests/Dialect/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRDialectTests
   BroadcastShapeTest.cpp
 )
-target_link_libraries(MLIRDialectTests
+mlir_target_link_libraries(MLIRDialectTests
   PRIVATE
   MLIRIR
   MLIRDialect)

--- a/mlir/unittests/Dialect/Index/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Index/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRIndexOpsTests
   IndexOpsFoldersTest.cpp
 )
-target_link_libraries(MLIRIndexOpsTests
+mlir_target_link_libraries(MLIRIndexOpsTests
   PRIVATE
   MLIRIndexDialect
 )

--- a/mlir/unittests/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/unittests/Dialect/LLVMIR/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRLLVMIRTests
   LLVMTypeTest.cpp
 )
-target_link_libraries(MLIRLLVMIRTests
+mlir_target_link_libraries(MLIRLLVMIRTests
   PRIVATE
   MLIRLLVMDialect
   )

--- a/mlir/unittests/Dialect/MemRef/CMakeLists.txt
+++ b/mlir/unittests/Dialect/MemRef/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRMemRefTests
   InferShapeTest.cpp
 )
-target_link_libraries(MLIRMemRefTests
+mlir_target_link_libraries(MLIRMemRefTests
   PRIVATE
   MLIRMemRefDialect
   )

--- a/mlir/unittests/Dialect/OpenACC/CMakeLists.txt
+++ b/mlir/unittests/Dialect/OpenACC/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIROpenACCTests
   OpenACCOpsTest.cpp
 )
-target_link_libraries(MLIROpenACCTests
+mlir_target_link_libraries(MLIROpenACCTests
   PRIVATE
   MLIRIR
   MLIROpenACCDialect

--- a/mlir/unittests/Dialect/Polynomial/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Polynomial/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRPolynomialTests
   PolynomialMathTest.cpp
 )
-target_link_libraries(MLIRPolynomialTests
+mlir_target_link_libraries(MLIRPolynomialTests
   PRIVATE
   MLIRIR
   MLIRPolynomialDialect

--- a/mlir/unittests/Dialect/SCF/CMakeLists.txt
+++ b/mlir/unittests/Dialect/SCF/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRSCFTests
   LoopLikeSCFOpsTest.cpp
 )
-target_link_libraries(MLIRSCFTests
+mlir_target_link_libraries(MLIRSCFTests
   PRIVATE
   MLIRIR
   MLIRSCFDialect

--- a/mlir/unittests/Dialect/SPIRV/CMakeLists.txt
+++ b/mlir/unittests/Dialect/SPIRV/CMakeLists.txt
@@ -2,7 +2,7 @@ add_mlir_unittest(MLIRSPIRVImportExportTests
   DeserializationTest.cpp
   SerializationTest.cpp
 )
-target_link_libraries(MLIRSPIRVImportExportTests
+mlir_target_link_libraries(MLIRSPIRVImportExportTests
   PRIVATE
   MLIRIR
   MLIRSPIRVDialect

--- a/mlir/unittests/Dialect/SparseTensor/CMakeLists.txt
+++ b/mlir/unittests/Dialect/SparseTensor/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRSparseTensorTests
   MergerTest.cpp
 )
-target_link_libraries(MLIRSparseTensorTests
+mlir_target_link_libraries(MLIRSparseTensorTests
   PRIVATE
   MLIRSparseTensorUtils
 )

--- a/mlir/unittests/Dialect/Transform/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Transform/CMakeLists.txt
@@ -2,7 +2,7 @@ add_mlir_unittest(MLIRTransformDialectTests
   BuildOnlyExtensionTest.cpp
   Preload.cpp
 )
-target_link_libraries(MLIRTransformDialectTests
+mlir_target_link_libraries(MLIRTransformDialectTests
   PRIVATE
   MLIRFuncDialect
   MLIRTestTransformDialect

--- a/mlir/unittests/Dialect/Utils/CMakeLists.txt
+++ b/mlir/unittests/Dialect/Utils/CMakeLists.txt
@@ -2,6 +2,6 @@ add_mlir_unittest(MLIRDialectUtilsTests
   StructuredOpsUtilsTest.cpp
   IndexingUtilsTest.cpp
 )
-target_link_libraries(MLIRDialectUtilsTests
+mlir_target_link_libraries(MLIRDialectUtilsTests
   PRIVATE
   MLIRDialectUtils)

--- a/mlir/unittests/ExecutionEngine/CMakeLists.txt
+++ b/mlir/unittests/ExecutionEngine/CMakeLists.txt
@@ -5,12 +5,14 @@ add_mlir_unittest(MLIRExecutionEngineTests
 )
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
-target_link_libraries(MLIRExecutionEngineTests
+mlir_target_link_libraries(MLIRExecutionEngineTests
   PRIVATE
   MLIRArithToLLVM
-  MLIRExecutionEngine
   MLIRMemRefToLLVM
   MLIRReconcileUnrealizedCasts
   ${dialect_libs}
-
+)
+target_link_libraries(MLIRExecutionEngineTests
+  PRIVATE
+  MLIRExecutionEngine
 )

--- a/mlir/unittests/IR/CMakeLists.txt
+++ b/mlir/unittests/IR/CMakeLists.txt
@@ -22,7 +22,5 @@ add_mlir_unittest(MLIRIRTests
   MLIRTestInterfaceIncGen
 )
 target_include_directories(MLIRIRTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
-target_link_libraries(MLIRIRTests
-  PRIVATE
-  MLIRIR
-  MLIRTestDialect)
+mlir_target_link_libraries(MLIRIRTests PRIVATE MLIRIR)
+target_link_libraries(MLIRIRTests PRIVATE MLIRTestDialect)

--- a/mlir/unittests/Interfaces/CMakeLists.txt
+++ b/mlir/unittests/Interfaces/CMakeLists.txt
@@ -5,7 +5,7 @@ add_mlir_unittest(MLIRInterfacesTests
   InferTypeOpInterfaceTest.cpp
 )
 
-target_link_libraries(MLIRInterfacesTests
+mlir_target_link_libraries(MLIRInterfacesTests
   PRIVATE
   MLIRArithDialect
   MLIRControlFlowInterfaces

--- a/mlir/unittests/Parser/CMakeLists.txt
+++ b/mlir/unittests/Parser/CMakeLists.txt
@@ -7,10 +7,10 @@ add_mlir_unittest(MLIRParserTests
 )
 target_include_directories(MLIRParserTests PRIVATE "${MLIR_BINARY_DIR}/test/lib/Dialect/Test")
 
-target_link_libraries(MLIRParserTests PRIVATE
+mlir_target_link_libraries(MLIRParserTests PRIVATE
   MLIRFuncDialect
   MLIRLLVMDialect
   MLIRIR
   MLIRParser
-  MLIRTestDialect
 )
+target_link_libraries(MLIRParserTests PRIVATE MLIRTestDialect)

--- a/mlir/unittests/Pass/CMakeLists.txt
+++ b/mlir/unittests/Pass/CMakeLists.txt
@@ -3,7 +3,7 @@ add_mlir_unittest(MLIRPassTests
   PassManagerTest.cpp
   PassPipelineParserTest.cpp
 )
-target_link_libraries(MLIRPassTests
+mlir_target_link_libraries(MLIRPassTests
   PRIVATE
   MLIRDebug
   MLIRFuncDialect

--- a/mlir/unittests/Rewrite/CMakeLists.txt
+++ b/mlir/unittests/Rewrite/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_mlir_unittest(MLIRRewriteTests
   PatternBenefit.cpp
 )
-target_link_libraries(MLIRRewriteTests
+mlir_target_link_libraries(MLIRRewriteTests
   PRIVATE
   MLIRRewrite
   MLIRTransformUtils)

--- a/mlir/unittests/Support/CMakeLists.txt
+++ b/mlir/unittests/Support/CMakeLists.txt
@@ -4,5 +4,5 @@ add_mlir_unittest(MLIRSupportTests
   StorageUniquerTest.cpp
 )
 
-target_link_libraries(MLIRSupportTests
+mlir_target_link_libraries(MLIRSupportTests
   PRIVATE MLIRSupport)

--- a/mlir/unittests/Target/LLVM/CMakeLists.txt
+++ b/mlir/unittests/Target/LLVM/CMakeLists.txt
@@ -6,7 +6,7 @@ add_mlir_unittest(MLIRTargetLLVMTests
   SerializeToLLVMBitcode.cpp
 )
 
-target_link_libraries(MLIRTargetLLVMTests
+mlir_target_link_libraries(MLIRTargetLLVMTests
   PRIVATE
   MLIRTargetLLVM
   MLIRNVVMTarget

--- a/mlir/unittests/Tools/lsp-server-support/CMakeLists.txt
+++ b/mlir/unittests/Tools/lsp-server-support/CMakeLists.txt
@@ -2,6 +2,6 @@ add_mlir_unittest(MLIRLspServerSupportTests
   Protocol.cpp
   Transport.cpp
 )
-target_link_libraries(MLIRLspServerSupportTests
+mlir_target_link_libraries(MLIRLspServerSupportTests
   PRIVATE
   MLIRLspServerSupportLib)

--- a/mlir/unittests/Transforms/CMakeLists.txt
+++ b/mlir/unittests/Transforms/CMakeLists.txt
@@ -2,7 +2,7 @@ add_mlir_unittest(MLIRTransformsTests
   Canonicalizer.cpp
   DialectConversion.cpp
 )
-target_link_libraries(MLIRTransformsTests
+mlir_target_link_libraries(MLIRTransformsTests
   PRIVATE
   MLIRParser
   MLIRTransforms)


### PR DESCRIPTION
This is a followup to https://github.com/llvm/llvm-project/pull/119408, which switches unit test binaries to also use
mlir_target_link_libraries() where necessary. This allows them to link against against the MLIR dylib.