### PR TITLE
Fix SemaCXX/msvc-pragma-function-no-builtin-attr.cpp test

### DIFF
--- a/clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp
+++ b/clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cl -fms-compatibility -Xclang -ast-dump -fsyntax-only %s | FileCheck %s
+// RUN: %clang_cl -fms-compatibility -Xclang -ast-dump -fsyntax-only -- %s | FileCheck %s
 
 extern "C" __inline float __cdecl fabsf(  float _X);
 // CHECK: FunctionDecl {{.*}} fabsf


### PR DESCRIPTION
Fix test failure from 84b0f0145887bbfe49fd4dc85490b14108a72cee