### PR TITLE
[mlir] fix copypaste typos in asserts

### DIFF
--- a/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
+++ b/mlir/lib/Interfaces/ValueBoundsOpInterface.cpp
@@ -777,11 +777,11 @@ FailureOr<bool>
 ValueBoundsConstraintSet::areOverlappingSlices(MLIRContext *ctx,
                                                HyperrectangularSlice slice1,
                                                HyperrectangularSlice slice2) {
-  assert(slice1.getMixedOffsets().size() == slice1.getMixedOffsets().size() &&
+  assert(slice1.getMixedOffsets().size() == slice2.getMixedOffsets().size() &&
          "expected slices of same rank");
-  assert(slice1.getMixedSizes().size() == slice1.getMixedSizes().size() &&
+  assert(slice1.getMixedSizes().size() == slice2.getMixedSizes().size() &&
          "expected slices of same rank");
-  assert(slice1.getMixedStrides().size() == slice1.getMixedStrides().size() &&
+  assert(slice1.getMixedStrides().size() == slice2.getMixedStrides().size() &&
          "expected slices of same rank");
 
   Builder b(ctx);
@@ -842,11 +842,11 @@ FailureOr<bool>
 ValueBoundsConstraintSet::areEquivalentSlices(MLIRContext *ctx,
                                               HyperrectangularSlice slice1,
                                               HyperrectangularSlice slice2) {
-  assert(slice1.getMixedOffsets().size() == slice1.getMixedOffsets().size() &&
+  assert(slice1.getMixedOffsets().size() == slice2.getMixedOffsets().size() &&
          "expected slices of same rank");
-  assert(slice1.getMixedSizes().size() == slice1.getMixedSizes().size() &&
+  assert(slice1.getMixedSizes().size() == slice2.getMixedSizes().size() &&
          "expected slices of same rank");
-  assert(slice1.getMixedStrides().size() == slice1.getMixedStrides().size() &&
+  assert(slice1.getMixedStrides().size() == slice2.getMixedStrides().size() &&
          "expected slices of same rank");
 
   // The two slices are equivalent if all of their offsets, sizes and strides


### PR DESCRIPTION
This fixes few copypaste typos

I've also spotted weird `getNumRows() == getNumRows()`: looks like leftover after refactoring

https://github.com/llvm/llvm-project/blob/ea8e328ae2bea9d9a7d556ef4d791fa116f7de18/mlir/lib/Analysis/Presburger/Simplex.cpp#L107-L111