### PR TITLE
[clang-tidy][NFC][doc] clean out-dated clang-static-analyzer checks documents and update check list

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.PutenvStackArray.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - clang-analyzer-security.PutenvStackArray
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-putenvstackarray-c
 
 clang-analyzer-security.PutenvStackArray
 ========================================

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/security.SetgidSetuidOrder.rst
@@ -1,4 +1,6 @@
 .. title:: clang-tidy - clang-analyzer-security.SetgidSetuidOrder
+.. meta::
+   :http-equiv=refresh: 5;URL=https://clang.llvm.org/docs/analyzer/checkers.html#security-setgidsetuidorder-c
 
 clang-analyzer-security.SetgidSetuidOrder
 =========================================

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/valist.CopyToSelf.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/valist.CopyToSelf.rst
@@ -1,9 +1,0 @@
-.. title:: clang-tidy - clang-analyzer-valist.CopyToSelf
-
-clang-analyzer-valist.CopyToSelf
-================================
-
-Check for va_lists which are copied onto itself.
-
-The clang-analyzer-valist.CopyToSelf check is an alias of
-Clang Static Analyzer valist.CopyToSelf.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/valist.Uninitialized.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/valist.Uninitialized.rst
@@ -1,9 +1,0 @@
-.. title:: clang-tidy - clang-analyzer-valist.Uninitialized
-
-clang-analyzer-valist.Uninitialized
-===================================
-
-Check for usages of uninitialized (or already released) va_lists.
-
-The clang-analyzer-valist.Uninitialized check is an alias of
-Clang Static Analyzer valist.Uninitialized.

--- a/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/valist.Unterminated.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/clang-analyzer/valist.Unterminated.rst
@@ -1,9 +1,0 @@
-.. title:: clang-tidy - clang-analyzer-valist.Unterminated
-
-clang-analyzer-valist.Unterminated
-==================================
-
-Check for va_lists which are not released by a va_end call.
-
-The clang-analyzer-valist.Unterminated check is an alias of
-Clang Static Analyzer valist.Unterminated.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -115,8 +115,8 @@ Clang-Tidy Checks
    :doc:`bugprone-multiple-new-in-one-expression <bugprone/multiple-new-in-one-expression>`,
    :doc:`bugprone-multiple-statement-macro <bugprone/multiple-statement-macro>`,
    :doc:`bugprone-no-escape <bugprone/no-escape>`,
-   :doc:`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>`,
    :doc:`bugprone-non-zero-enum-to-bool-conversion <bugprone/non-zero-enum-to-bool-conversion>`,
+   :doc:`bugprone-nondeterministic-pointer-iteration-order <bugprone/nondeterministic-pointer-iteration-order>`,
    :doc:`bugprone-not-null-terminated-result <bugprone/not-null-terminated-result>`, "Yes"
    :doc:`bugprone-optional-value-conversion <bugprone/optional-value-conversion>`, "Yes"
    :doc:`bugprone-parent-virtual-call <bugprone/parent-virtual-call>`, "Yes"
@@ -514,6 +514,7 @@ Check aliases
    :doc:`clang-analyzer-security.insecureAPI.bcmp <clang-analyzer/security.insecureAPI.bcmp>`, `Clang Static Analyzer security.insecureAPI.bcmp <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcmp>`_,
    :doc:`clang-analyzer-security.insecureAPI.bcopy <clang-analyzer/security.insecureAPI.bcopy>`, `Clang Static Analyzer security.insecureAPI.bcopy <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bcopy>`_,
    :doc:`clang-analyzer-security.insecureAPI.bzero <clang-analyzer/security.insecureAPI.bzero>`, `Clang Static Analyzer security.insecureAPI.bzero <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-bzero>`_,
+   :doc:`clang-analyzer-security.insecureAPI.decodeValueOfObjCType <clang-analyzer/security.insecureAPI.decodeValueOfObjCType>`, Clang Static Analyzer security.insecureAPI.decodeValueOfObjCType,
    :doc:`clang-analyzer-security.insecureAPI.getpw <clang-analyzer/security.insecureAPI.getpw>`, `Clang Static Analyzer security.insecureAPI.getpw <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-getpw>`_,
    :doc:`clang-analyzer-security.insecureAPI.gets <clang-analyzer/security.insecureAPI.gets>`, `Clang Static Analyzer security.insecureAPI.gets <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-gets>`_,
    :doc:`clang-analyzer-security.insecureAPI.mkstemp <clang-analyzer/security.insecureAPI.mkstemp>`, `Clang Static Analyzer security.insecureAPI.mkstemp <https://clang.llvm.org/docs/analyzer/checkers.html#security-insecureapi-mkstemp>`_,


### PR DESCRIPTION
The missing part of #119580
