### PR TITLE
[lldb][AIX] XCOFF clang-format and other minor changes

### DIFF
--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -191,6 +191,7 @@ bool ObjectFileXCOFF::ParseHeader() {
 bool ObjectFileXCOFF::ParseXCOFFHeader(lldb_private::DataExtractor &data,
                                        lldb::offset_t *offset_ptr,
                                        xcoff_header_t &xcoff_header) {
+
   // FIXME: data.ValidOffsetForDataOfSize
   xcoff_header.magic = data.GetU16(offset_ptr);
   xcoff_header.nsects = data.GetU16(offset_ptr);
@@ -199,12 +200,14 @@ bool ObjectFileXCOFF::ParseXCOFFHeader(lldb_private::DataExtractor &data,
   xcoff_header.auxhdrsize = data.GetU16(offset_ptr);
   xcoff_header.flags = data.GetU16(offset_ptr);
   xcoff_header.nsyms = data.GetU32(offset_ptr);
+  
   return true;
 }
 
 bool ObjectFileXCOFF::ParseXCOFFOptionalHeader(
     lldb_private::DataExtractor &data, lldb::offset_t *offset_ptr) {
   lldb::offset_t init_offset = *offset_ptr;
+
   // FIXME: data.ValidOffsetForDataOfSize
   m_xcoff_aux_header.AuxMagic = data.GetU16(offset_ptr);
   m_xcoff_aux_header.Version = data.GetU16(offset_ptr);
@@ -236,9 +239,11 @@ bool ObjectFileXCOFF::ParseXCOFFOptionalHeader(
   m_xcoff_aux_header.SecNumOfTData = data.GetU16(offset_ptr);
   m_xcoff_aux_header.SecNumOfTBSS = data.GetU16(offset_ptr);
   m_xcoff_aux_header.XCOFF64Flag = data.GetU16(offset_ptr);
+  
   lldb::offset_t last_offset = *offset_ptr;
   if ((last_offset - init_offset) < m_xcoff_header.auxhdrsize)
     *offset_ptr += (m_xcoff_header.auxhdrsize - (last_offset - init_offset));
+  
   return true;
 }
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -200,7 +200,6 @@ bool ObjectFileXCOFF::ParseXCOFFHeader(lldb_private::DataExtractor &data,
   xcoff_header.auxhdrsize = data.GetU16(offset_ptr);
   xcoff_header.flags = data.GetU16(offset_ptr);
   xcoff_header.nsyms = data.GetU32(offset_ptr);
-  
   return true;
 }
 
@@ -239,11 +238,9 @@ bool ObjectFileXCOFF::ParseXCOFFOptionalHeader(
   m_xcoff_aux_header.SecNumOfTData = data.GetU16(offset_ptr);
   m_xcoff_aux_header.SecNumOfTBSS = data.GetU16(offset_ptr);
   m_xcoff_aux_header.XCOFF64Flag = data.GetU16(offset_ptr);
-  
   lldb::offset_t last_offset = *offset_ptr;
   if ((last_offset - init_offset) < m_xcoff_header.auxhdrsize)
     *offset_ptr += (m_xcoff_header.auxhdrsize - (last_offset - init_offset));
-  
   return true;
 }
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -143,12 +143,8 @@ bool ObjectFileXCOFF::IsExecutable() const { return true; }
 
 uint32_t ObjectFileXCOFF::GetAddressByteSize() const {
 
-  // 32-bit not supprted. return 8 for 64-bit XCOFF::XCOFF64
+  // 32-bit not supported. return 8 for 64-bit XCOFF::XCOFF64
   return 8;
-}
-
-AddressClass ObjectFileXCOFF::GetAddressClass(addr_t file_addr) {
-  return AddressClass::eUnknown;
 }
 
 void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {}

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -127,7 +127,6 @@ bool ObjectFileXCOFF::MagicBytesMatch(DataBufferSP &data_sp,
                                       lldb::addr_t data_length) {
   lldb_private::DataExtractor data;
   data.SetData(data_sp, data_offset, data_length);
-
   // Need to set this as XCOFF is only compatible with Big Endian
   data.SetByteOrder(eByteOrderBig);
   lldb::offset_t offset = 0;
@@ -142,7 +141,6 @@ ByteOrder ObjectFileXCOFF::GetByteOrder() const { return eByteOrderBig; }
 bool ObjectFileXCOFF::IsExecutable() const { return true; }
 
 uint32_t ObjectFileXCOFF::GetAddressByteSize() const {
-
   // 32-bit not supported. return 8 for 64-bit XCOFF::XCOFF64
   return 8;
 }

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -127,7 +127,6 @@ bool ObjectFileXCOFF::MagicBytesMatch(DataBufferSP &data_sp,
                                       lldb::addr_t data_length) {
   lldb_private::DataExtractor data;
   data.SetData(data_sp, data_offset, data_length);
-  // Need to set this as XCOFF is only compatible with Big Endian
   data.SetByteOrder(eByteOrderBig);
   lldb::offset_t offset = 0;
   uint16_t magic = data.GetU16(&offset);
@@ -140,10 +139,7 @@ ByteOrder ObjectFileXCOFF::GetByteOrder() const { return eByteOrderBig; }
 
 bool ObjectFileXCOFF::IsExecutable() const { return true; }
 
-uint32_t ObjectFileXCOFF::GetAddressByteSize() const {
-  // 32-bit not supported. return 8 for 64-bit XCOFF::XCOFF64
-  return 8;
-}
+uint32_t ObjectFileXCOFF::GetAddressByteSize() const { return 8; }
 
 void ObjectFileXCOFF::ParseSymtab(Symtab &lldb_symtab) {}
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -164,6 +164,8 @@ bool ObjectFileXCOFF::MagicBytesMatch(DataBufferSP &data_sp,
                                       lldb::addr_t data_length) {
   lldb_private::DataExtractor data;
   data.SetData(data_sp, data_offset, data_length);
+
+  // Need to set this as XCOFF is only compatible with Big Endian
   data.SetByteOrder(eByteOrderBig);
   lldb::offset_t offset = 0;
   uint16_t magic = data.GetU16(&offset);
@@ -175,6 +177,7 @@ bool ObjectFileXCOFF::ParseHeader() {
   bool retVal = false;
   ModuleSP module_sp(GetModule());
   if (module_sp) {
+    // Only 64-bit is supported for now
     if (m_binary->fileHeader64()->Magic == XCOFF::XCOFF64)
       retVal = true;
   }

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -179,7 +179,7 @@ bool ObjectFileXCOFF::ParseHeader() {
 
     if (ParseXCOFFHeader(m_data, &offset, m_xcoff_header)) {
       m_data.SetAddressByteSize(GetAddressByteSize());
-      if (m_xcoff_header.auxhdrsize > 0)
+      if (m_xcoff_header.AuxHeaderSize > 0)
         ParseXCOFFOptionalHeader(m_data, &offset);
     }
     return true;
@@ -193,13 +193,13 @@ bool ObjectFileXCOFF::ParseXCOFFHeader(lldb_private::DataExtractor &data,
                                        xcoff_header_t &xcoff_header) {
 
   // FIXME: data.ValidOffsetForDataOfSize
-  xcoff_header.magic = data.GetU16(offset_ptr);
-  xcoff_header.nsects = data.GetU16(offset_ptr);
-  xcoff_header.modtime = data.GetU32(offset_ptr);
-  xcoff_header.symoff = data.GetU64(offset_ptr);
-  xcoff_header.auxhdrsize = data.GetU16(offset_ptr);
-  xcoff_header.flags = data.GetU16(offset_ptr);
-  xcoff_header.nsyms = data.GetU32(offset_ptr);
+  xcoff_header.Magic = data.GetU16(offset_ptr);
+  xcoff_header.NumberOfSections = data.GetU16(offset_ptr);
+  xcoff_header.TimeStamp = data.GetU32(offset_ptr);
+  xcoff_header.SymbolTableOffset = data.GetU64(offset_ptr);
+  xcoff_header.AuxHeaderSize = data.GetU16(offset_ptr);
+  xcoff_header.Flags = data.GetU16(offset_ptr);
+  xcoff_header.NumberOfSymTableEntries = data.GetU32(offset_ptr);
   return true;
 }
 
@@ -239,8 +239,8 @@ bool ObjectFileXCOFF::ParseXCOFFOptionalHeader(
   m_xcoff_aux_header.SecNumOfTBSS = data.GetU16(offset_ptr);
   m_xcoff_aux_header.XCOFF64Flag = data.GetU16(offset_ptr);
   lldb::offset_t last_offset = *offset_ptr;
-  if ((last_offset - init_offset) < m_xcoff_header.auxhdrsize)
-    *offset_ptr += (m_xcoff_header.auxhdrsize - (last_offset - init_offset));
+  if ((last_offset - init_offset) < m_xcoff_header.AuxHeaderSize)
+    *offset_ptr += (m_xcoff_header.AuxHeaderSize - (last_offset - init_offset));
   return true;
 }
 
@@ -249,9 +249,9 @@ ByteOrder ObjectFileXCOFF::GetByteOrder() const { return eByteOrderBig; }
 bool ObjectFileXCOFF::IsExecutable() const { return true; }
 
 uint32_t ObjectFileXCOFF::GetAddressByteSize() const {
-  if (m_xcoff_header.magic == XCOFF::XCOFF64)
+  if (m_xcoff_header.Magic == XCOFF::XCOFF64)
     return 8;
-  else if (m_xcoff_header.magic == XCOFF::XCOFF32)
+  else if (m_xcoff_header.Magic == XCOFF::XCOFF32)
     return 4;
   return 4;
 }
@@ -279,9 +279,9 @@ UUID ObjectFileXCOFF::GetUUID() { return UUID(); }
 uint32_t ObjectFileXCOFF::GetDependentModules(FileSpecList &files) { return 0; }
 
 ObjectFile::Type ObjectFileXCOFF::CalculateType() {
-  if (m_xcoff_header.flags & XCOFF::F_EXEC)
+  if (m_xcoff_header.Flags & XCOFF::F_EXEC)
     return eTypeExecutable;
-  else if (m_xcoff_header.flags & XCOFF::F_SHROBJ)
+  else if (m_xcoff_header.Flags & XCOFF::F_SHROBJ)
     return eTypeSharedLibrary;
   return eTypeUnknown;
 }

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -177,6 +177,7 @@ bool ObjectFileXCOFF::ParseHeader() {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     lldb::offset_t offset = 0;
 
+    m_data.SetByteOrder(eByteOrderBig);
     if (ParseXCOFFHeader(m_data, &offset, m_xcoff_header)) {
       m_data.SetAddressByteSize(GetAddressByteSize());
       if (m_xcoff_header.AuxHeaderSize > 0)

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -98,10 +98,6 @@ public:
                   const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
 protected:
-  typedef struct llvm::object::XCOFFFileHeader64 xcoff_header_t;
-
-  typedef struct llvm::object::XCOFFAuxiliaryHeader64 xcoff_aux_header_t;
-
   static lldb::WritableDataBufferSP
   MapFileDataWritable(const lldb_private::FileSpec &file, uint64_t Size,
                       uint64_t Offset);
@@ -109,8 +105,6 @@ protected:
 private:
   bool CreateBinary();
 
-  xcoff_header_t m_xcoff_header = {};
-  xcoff_aux_header_t m_xcoff_aux_header = {};
   std::unique_ptr<llvm::object::XCOFFObjectFile> m_binary;
 };
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -10,16 +10,14 @@
 #ifndef LLDB_SOURCE_PLUGINS_OBJECTFILE_XCOFF_OBJECTFILEXCOFF_H
 #define LLDB_SOURCE_PLUGINS_OBJECTFILE_XCOFF_OBJECTFILEXCOFF_H
 
-#include <cstdint>
-
-#include <vector>
-
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-private.h"
 #include "llvm/Object/XCOFFObjectFile.h"
+#include <cstdint>
+#include <vector>
 
 /// \class ObjectFileXCOFF
 /// Generic XCOFF object file reader.
@@ -103,12 +101,6 @@ protected:
   typedef struct llvm::object::XCOFFFileHeader64 xcoff_header_t;
 
   typedef struct llvm::object::XCOFFAuxiliaryHeader64 xcoff_aux_header_t;
-
-  static bool ParseXCOFFHeader(lldb_private::DataExtractor &data,
-                               lldb::offset_t *offset_ptr,
-                               xcoff_header_t &xcoff_header);
-  bool ParseXCOFFOptionalHeader(lldb_private::DataExtractor &data,
-                                lldb::offset_t *offset_ptr);
 
   static lldb::WritableDataBufferSP
   MapFileDataWritable(const lldb_private::FileSpec &file, uint64_t Size,

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -70,6 +70,8 @@ public:
 
   uint32_t GetAddressByteSize() const override;
 
+  lldb_private::AddressClass GetAddressClass(lldb::addr_t file_addr) override;
+
   void ParseSymtab(lldb_private::Symtab &symtab) override;
 
   bool IsStripped() override;
@@ -98,9 +100,65 @@ public:
                   const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
 protected:
+  typedef struct xcoff_header {
+    uint16_t magic;
+    uint16_t nsects;
+    uint32_t modtime;
+    uint64_t symoff;
+    uint32_t nsyms;
+    uint16_t auxhdrsize;
+    uint16_t flags;
+  } xcoff_header_t;
+
+  typedef struct xcoff_aux_header {
+    uint16_t AuxMagic;
+    uint16_t Version;
+    uint32_t ReservedForDebugger;
+    uint64_t TextStartAddr;
+    uint64_t DataStartAddr;
+    uint64_t TOCAnchorAddr;
+    uint16_t SecNumOfEntryPoint;
+    uint16_t SecNumOfText;
+    uint16_t SecNumOfData;
+    uint16_t SecNumOfTOC;
+    uint16_t SecNumOfLoader;
+    uint16_t SecNumOfBSS;
+    uint16_t MaxAlignOfText;
+    uint16_t MaxAlignOfData;
+    uint16_t ModuleType;
+    uint8_t CpuFlag;
+    uint8_t CpuType;
+    uint8_t TextPageSize;
+    uint8_t DataPageSize;
+    uint8_t StackPageSize;
+    uint8_t FlagAndTDataAlignment;
+    uint64_t TextSize;
+    uint64_t InitDataSize;
+    uint64_t BssDataSize;
+    uint64_t EntryPointAddr;
+    uint64_t MaxStackSize;
+    uint64_t MaxDataSize;
+    uint16_t SecNumOfTData;
+    uint16_t SecNumOfTBSS;
+    uint16_t XCOFF64Flag;
+  } xcoff_aux_header_t;
+
+  static bool ParseXCOFFHeader(lldb_private::DataExtractor &data,
+                               lldb::offset_t *offset_ptr,
+                               xcoff_header_t &xcoff_header);
+  bool ParseXCOFFOptionalHeader(lldb_private::DataExtractor &data,
+                                lldb::offset_t *offset_ptr);
+
   static lldb::WritableDataBufferSP
   MapFileDataWritable(const lldb_private::FileSpec &file, uint64_t Size,
                       uint64_t Offset);
+
+private:
+  bool CreateBinary();
+
+  xcoff_header_t m_xcoff_header;
+  xcoff_aux_header_t m_xcoff_aux_header;
+  std::unique_ptr<llvm::object::XCOFFObjectFile> m_binary;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_XCOFF_OBJECTFILE_H

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -68,8 +68,6 @@ public:
 
   uint32_t GetAddressByteSize() const override;
 
-  lldb_private::AddressClass GetAddressClass(lldb::addr_t file_addr) override;
-
   void ParseSymtab(lldb_private::Symtab &symtab) override;
 
   bool IsStripped() override;
@@ -101,11 +99,6 @@ protected:
   static lldb::WritableDataBufferSP
   MapFileDataWritable(const lldb_private::FileSpec &file, uint64_t Size,
                       uint64_t Offset);
-
-private:
-  bool CreateBinary();
-
-  std::unique_ptr<llvm::object::XCOFFObjectFile> m_binary;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_XCOFF_OBJECTFILE_H

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -100,9 +100,9 @@ public:
                   const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
 protected:
-  typedef struct XCOFFFileHeader64 xcoff_header_t;
+  typedef struct llvm::object::XCOFFFileHeader64 xcoff_header_t;
 
-  typedef struct XCOFFAuxiliaryHeader64 xcoff_aux_header_t;
+  typedef struct llvm::object::XCOFFAuxiliaryHeader64 xcoff_aux_header_t;
 
   static bool ParseXCOFFHeader(lldb_private::DataExtractor &data,
                                lldb::offset_t *offset_ptr,
@@ -117,8 +117,8 @@ protected:
 private:
   bool CreateBinary();
 
-  xcoff_header_t m_xcoff_header;
-  xcoff_aux_header_t m_xcoff_aux_header;
+  xcoff_header_t m_xcoff_header = {};
+  xcoff_aux_header_t m_xcoff_aux_header = {};
   std::unique_ptr<llvm::object::XCOFFObjectFile> m_binary;
 };
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -100,48 +100,9 @@ public:
                   const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);
 
 protected:
-  typedef struct xcoff_header {
-    uint16_t magic;
-    uint16_t nsects;
-    uint32_t modtime;
-    uint64_t symoff;
-    uint32_t nsyms;
-    uint16_t auxhdrsize;
-    uint16_t flags;
-  } xcoff_header_t;
+  typedef struct XCOFFFileHeader64 xcoff_header_t;
 
-  typedef struct xcoff_aux_header {
-    uint16_t AuxMagic;
-    uint16_t Version;
-    uint32_t ReservedForDebugger;
-    uint64_t TextStartAddr;
-    uint64_t DataStartAddr;
-    uint64_t TOCAnchorAddr;
-    uint16_t SecNumOfEntryPoint;
-    uint16_t SecNumOfText;
-    uint16_t SecNumOfData;
-    uint16_t SecNumOfTOC;
-    uint16_t SecNumOfLoader;
-    uint16_t SecNumOfBSS;
-    uint16_t MaxAlignOfText;
-    uint16_t MaxAlignOfData;
-    uint16_t ModuleType;
-    uint8_t CpuFlag;
-    uint8_t CpuType;
-    uint8_t TextPageSize;
-    uint8_t DataPageSize;
-    uint8_t StackPageSize;
-    uint8_t FlagAndTDataAlignment;
-    uint64_t TextSize;
-    uint64_t InitDataSize;
-    uint64_t BssDataSize;
-    uint64_t EntryPointAddr;
-    uint64_t MaxStackSize;
-    uint64_t MaxDataSize;
-    uint16_t SecNumOfTData;
-    uint16_t SecNumOfTBSS;
-    uint16_t XCOFF64Flag;
-  } xcoff_aux_header_t;
+  typedef struct XCOFFAuxiliaryHeader64 xcoff_aux_header_t;
 
   static bool ParseXCOFFHeader(lldb_private::DataExtractor &data,
                                lldb::offset_t *offset_ptr,

--- a/lldb/test/Shell/ObjectFile/XCOFF/basic-info.yaml
+++ b/lldb/test/Shell/ObjectFile/XCOFF/basic-info.yaml
@@ -13,7 +13,7 @@ FileHeader:
   MagicNumber:     0x1F7
   NumberOfSections: 1 
   CreationTime:    000000000
-  Flags:           0x0000
+  Flags:           0x0002
 Sections:
   - Name:            .text
     Address:         0x100000438

--- a/lldb/test/Shell/ObjectFile/XCOFF/basic-info.yaml
+++ b/lldb/test/Shell/ObjectFile/XCOFF/basic-info.yaml
@@ -13,7 +13,7 @@ FileHeader:
   MagicNumber:     0x1F7
   NumberOfSections: 1 
   CreationTime:    000000000
-  Flags:           0x0002
+  Flags:           0x0000
 Sections:
   - Name:            .text
     Address:         0x100000438


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX.

Link to discussions on llvm discourse and github:

1. https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640
2. https://github.com/llvm/llvm-project/issues/101657
3. The complete changes for porting are present in this draft PR:
4. https://github.com/llvm/llvm-project/pull/102601

Added XCOFF Object File Header Parsing for AIX.
This PR is an incremental PR to the base:
https://github.com/llvm/llvm-project/pull/111814
Details about XCOFF file format on AIX: [XCOFF](https://www.ibm.com/docs/en/aix/7.3?topic=formats-xcoff-object-file-format)

Added some clang-format and other minor changes, Ref: https://github.com/llvm/llvm-project/pull/116338#discussion_r1884069848

Review Request: @DavidSpickett