### PR TITLE
[SandboxIR] Make some instruction constructors private

### DIFF
--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -1744,11 +1744,12 @@ public:
 
 class CatchSwitchInst
     : public SingleLLVMInstructionImpl<llvm::CatchSwitchInst> {
-public:
   CatchSwitchInst(llvm::CatchSwitchInst *CSI, Context &Ctx)
       : SingleLLVMInstructionImpl(ClassID::CatchSwitch, Opcode::CatchSwitch,
                                   CSI, Ctx) {}
+  friend class Context; // For accessing the constructor in create*()
 
+public:
   static CatchSwitchInst *create(Value *ParentPad, BasicBlock *UnwindBB,
                                  unsigned NumHandlers, InsertPosition Pos,
                                  Context &Ctx, const Twine &Name = "");
@@ -1833,10 +1834,11 @@ public:
 };
 
 class ResumeInst : public SingleLLVMInstructionImpl<llvm::ResumeInst> {
-public:
   ResumeInst(llvm::ResumeInst *CSI, Context &Ctx)
       : SingleLLVMInstructionImpl(ClassID::Resume, Opcode::Resume, CSI, Ctx) {}
+  friend class Context; // For accessing the constructor in create*()
 
+public:
   static ResumeInst *create(Value *Exn, InsertPosition Pos, Context &Ctx);
   Value *getValue() const;
   unsigned getNumSuccessors() const {
@@ -1848,10 +1850,11 @@ public:
 };
 
 class SwitchInst : public SingleLLVMInstructionImpl<llvm::SwitchInst> {
-public:
   SwitchInst(llvm::SwitchInst *SI, Context &Ctx)
       : SingleLLVMInstructionImpl(ClassID::Switch, Opcode::Switch, SI, Ctx) {}
+  friend class Context; // For accessing the constructor in create*()
 
+public:
   static constexpr const unsigned DefaultPseudoIndex =
       llvm::SwitchInst::DefaultPseudoIndex;
 


### PR DESCRIPTION
This patch changes the visibility of the constructors of CatchSwitchInst ResumeInst and SwitchInst to private instead of public. This is similar to all other Sandbox IR instructions. The constructor is private to force the user go through the Context create* API.

The issue was exposed by: https://github.com/llvm/llvm-project/pull/119824