### PR TITLE
[Clang] Interpreter test should not depend on system header

### DIFF
--- a/clang/test/Interpreter/Inputs/vector
+++ b/clang/test/Interpreter/Inputs/vector
@@ -1,0 +1,10 @@
+#ifndef VECTOR
+#define VECTOR
+namespace std {
+template <typename>
+class vector {
+public:
+  vector();
+};
+} // namespace std
+#endif // VECTOR

--- a/clang/test/Interpreter/crash.cpp
+++ b/clang/test/Interpreter/crash.cpp
@@ -5,7 +5,7 @@
 //
 // RUN: split-file %s %t
 //
-// RUN: %clang++ -std=c++20 -fPIC -c %t/vec.cpp -o %t/vec.o
+// RUN: %clang++ -Xclang -nostdsysteminc -I%S/Inputs/ -std=c++20 -fPIC -c %t/vec.cpp -o %t/vec.o
 // RUN: %clang++ -shared %t/vec.o -o %t/vec.so
 //
 // RUN: cat %t/Test.cpp | LD_LIBRARY_PATH=%t:$LD_LIBRARY_PATH clang-repl


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/30ad53b92cec0cff9679d559edcc5b933312ba0c introduced a new test that includes `<vector>` from the system include path without honoring environment variables that may provide the path to C++ standard library. This is not supported in some CI systems because we don't always have the C++ library in the standard location. 

The conventional way of doing includes in the test is through `Inputs` directory and pass it as an include path. 

The `vector` file included in this patch has been shortened, but I have verified that it works with this test. i.e. the clang repl crashes on this test in the same way if the fix in https://github.com/llvm/llvm-project/pull/117475 is reverted.