### PR TITLE
Revert "[NFC] Don't recompute type name"

### DIFF
--- a/llvm/include/llvm/Support/TypeName.h
+++ b/llvm/include/llvm/Support/TypeName.h
@@ -13,8 +13,18 @@
 
 namespace llvm {
 
-namespace detail {
-template <typename DesiredTypeName> inline StringRef getTypeNameImpl() {
+/// We provide a function which tries to compute the (demangled) name of a type
+/// statically.
+///
+/// This routine may fail on some platforms or for particularly unusual types.
+/// Do not use it for anything other than logging and debugging aids. It isn't
+/// portable or dependendable in any real sense.
+///
+/// The returned StringRef will point into a static storage duration string.
+/// However, it may not be null terminated and may be some strangely aligned
+/// inner substring of a larger string.
+template <typename DesiredTypeName>
+inline StringRef getTypeName() {
 #if defined(__clang__) || defined(__GNUC__)
   StringRef Name = __PRETTY_FUNCTION__;
 
@@ -47,22 +57,6 @@ template <typename DesiredTypeName> inline StringRef getTypeNameImpl() {
   // We return a string that is unlikely to look like any type in LLVM.
   return "UNKNOWN_TYPE";
 #endif
-}
-} // namespace detail
-
-/// We provide a function which tries to compute the (demangled) name of a type
-/// statically.
-///
-/// This routine may fail on some platforms or for particularly unusual types.
-/// Do not use it for anything other than logging and debugging aids. It isn't
-/// portable or dependendable in any real sense.
-///
-/// The returned StringRef will point into a static storage duration string.
-/// However, it may not be null terminated and may be some strangely aligned
-/// inner substring of a larger string.
-template <typename DesiredTypeName> inline StringRef getTypeName() {
-  static StringRef Name = detail::getTypeNameImpl<DesiredTypeName>();
-  return Name;
 }
 
 } // namespace llvm

--- a/llvm/include/llvm/Support/TypeName.h
+++ b/llvm/include/llvm/Support/TypeName.h
@@ -23,8 +23,7 @@ namespace llvm {
 /// The returned StringRef will point into a static storage duration string.
 /// However, it may not be null terminated and may be some strangely aligned
 /// inner substring of a larger string.
-template <typename DesiredTypeName>
-inline StringRef getTypeName() {
+template <typename DesiredTypeName> inline StringRef getTypeName() {
 #if defined(__clang__) || defined(__GNUC__)
   StringRef Name = __PRETTY_FUNCTION__;
 


### PR DESCRIPTION
The change breaks windows builds because `StringRef Key = "getTypeName<";` wasn't updated to `getTypeNameImpl` https://github.com/llvm/llvm-project/blob/003a721c1c9e3a99d6d0c1a6755443b260235537/llvm/include/llvm/Support/TypeName.h#L31



Reverts llvm/llvm-project#119631