### PR TITLE
[Support] Fix getTypeNameImpl on msvc

### DIFF
--- a/llvm/include/llvm/Support/TypeName.h
+++ b/llvm/include/llvm/Support/TypeName.h
@@ -28,7 +28,7 @@ template <typename DesiredTypeName> inline StringRef getTypeNameImpl() {
 #elif defined(_MSC_VER)
   StringRef Name = __FUNCSIG__;
 
-  StringRef Key = "getTypeName<";
+  StringRef Key = "getTypeNameImpl<";
   Name = Name.substr(Name.find(Key));
   assert(!Name.empty() && "Unable to find the function name!");
   Name = Name.drop_front(Key.size());


### PR DESCRIPTION
Updates `Key` to reflect the new name of the function enclosing `__FUNCSIG__`. Fixes CI failures https://github.com/llvm/llvm-project/pull/119631#issuecomment-2541927804