### PR TITLE
[ci] Bump the version of clang-format used in the CI

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install clang-format
         uses: aminya/setup-cpp@v1
         with:
-          clangformat: 19.1.5
+          clangformat: 19.1.6
 
       - name: Setup Python env
         uses: actions/setup-python@v5

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install clang-format
         uses: aminya/setup-cpp@v1
         with:
-          clangformat: 18.1.7
+          clangformat: 19.1.5
 
       - name: Setup Python env
         uses: actions/setup-python@v5


### PR DESCRIPTION
The version of clang-format we use in the CI to format all PRs is a bit outdated, leading to some confusion when the CI job produces different output from what people have locally.

We should decide on a policy for updating this version since it impacts the whole monorepo, and we should document the version currently in use somewhere (in the Contributing docs?). We should also decide on a policy for whether to re-apply clang-format to the whole codebase whenever we change this version.