### PR TITLE
[flang][cuda] Apply implicit data attribute only in device context

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8958,9 +8958,9 @@ void ResolveNamesVisitor::FinishSpecificationPart(
               ? currScope().symbol()->detailsIf<SubprogramDetails>()
               : nullptr}) {
     if (auto attrs{subp->cudaSubprogramAttrs()}) {
-      if (*attrs != common::CUDASubprogramAttrs::Device ||
-          *attrs != common::CUDASubprogramAttrs::Global ||
-          *attrs != common::CUDASubprogramAttrs::Grid_Global) {
+      if (*attrs == common::CUDASubprogramAttrs::Device ||
+          *attrs == common::CUDASubprogramAttrs::Global ||
+          *attrs == common::CUDASubprogramAttrs::Grid_Global) {
         inDeviceSubprogram = true;
       }
     }

--- a/flang/test/Semantics/modfile55.cuf
+++ b/flang/test/Semantics/modfile55.cuf
@@ -14,6 +14,10 @@ module m
   attributes(host,device) real function foo(x)
     foo = x + 1.
   end function
+  attributes(host) subroutine hostsub(a)
+    integer, intent(out) :: a(14)
+    a = 99
+  end subroutine
 end
 
 !Expect: m.mod
@@ -39,4 +43,7 @@ end
 !real(4)::x
 !real(4)::foo
 !end
+attributes(host)subroutinehostsub(a)
+integer(4),intent(out)::a(1_8:14_8)
+end
 !end


### PR DESCRIPTION
Fix the condition so the implicit device data attribute is not applied when the routine has `attribute(host)`