### PR TITLE
[flang][cuda] Do not apply implicit data attribute on dummy arg with VALUE

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8976,7 +8976,7 @@ void ResolveNamesVisitor::FinishSpecificationPart(
     if (inDeviceSubprogram && IsDummy(symbol) &&
         symbol.has<ObjectEntityDetails>()) {
       auto *dummy{symbol.detailsIf<ObjectEntityDetails>()};
-      if (!dummy->cudaDataAttr()) {
+      if (!dummy->cudaDataAttr() && !IsValue(symbol)) {
         // Implicitly set device attribute if none is set in device context.
         dummy->set_cudaDataAttr(common::CUDADataAttr::Device);
       }

--- a/flang/test/Semantics/modfile55.cuf
+++ b/flang/test/Semantics/modfile55.cuf
@@ -29,7 +29,6 @@ end
 !contains
 !attributes(global) subroutine globsub(x,y,z)
 !real(4),value::x
-!attributes(device) x
 !real(4)::y
 !attributes(device) y
 !real(4)::z


### PR DESCRIPTION
Dummy arguments with the VALUE attribute do not need the implicit data attribute. 