### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Detect protectedThis pattern.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -105,7 +105,7 @@ public:
         return true;
       }
 
-      LambdaExpr* findLambdaInArg(Expr* E) {
+      LambdaExpr *findLambdaInArg(Expr* E) {
         if (auto *Lambda = dyn_cast_or_null<LambdaExpr>(E))
           return Lambda;
         auto *TempExpr = dyn_cast_or_null<CXXBindTemporaryExpr>(E);
@@ -130,7 +130,7 @@ public:
         auto *VD = dyn_cast_or_null<VarDecl>(DRE->getDecl());
         if (!VD)
           return nullptr;
-        auto* Init = VD->getInit();
+        auto *Init = VD->getInit();
         if (!Init)
           return nullptr;
         TempExpr = dyn_cast<CXXBindTemporaryExpr>(Init->IgnoreParenCasts());
@@ -202,7 +202,7 @@ public:
   }
 
   bool protectThis(const ValueDecl *ValueDecl) const {
-    auto* VD = dyn_cast<VarDecl>(ValueDecl);
+    auto *VD = dyn_cast<VarDecl>(ValueDecl);
     if (!VD)
       return false;
     auto *Init = VD->getInit()->IgnoreParenCasts();
@@ -214,7 +214,7 @@ public:
     auto *CE = dyn_cast_or_null<CXXConstructExpr>(BTE->getSubExpr());
     if (!CE)
       return false;
-    auto* Ctor = CE->getConstructor();
+    auto *Ctor = CE->getConstructor();
     if (!Ctor)
       return false;
     auto clsName = safeGetName(Ctor->getParent());

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -96,14 +96,45 @@ public:
               return true;
             auto *Arg = CE->getArg(ArgIndex)->IgnoreParenCasts();
             if (!Param->hasAttr<NoEscapeAttr>() && !TreatAllArgsAsNoEscape) {
-              if (auto *L = dyn_cast_or_null<LambdaExpr>(Arg)) {
-                Checker->visitLambdaExpr(L, shouldCheckThis());
-              }
+              if (auto *Lambda = findLambdaInArg(Arg))
+                Checker->visitLambdaExpr(Lambda, shouldCheckThis());
             }
             ++ArgIndex;
           }
         }
         return true;
+      }
+
+      LambdaExpr* findLambdaInArg(Expr* E) {
+        if (auto *Lambda = dyn_cast_or_null<LambdaExpr>(E))
+          return Lambda;
+        auto *TempExpr = dyn_cast_or_null<CXXBindTemporaryExpr>(E);
+        if (!TempExpr)
+          return nullptr;
+        E = TempExpr->getSubExpr()->IgnoreParenCasts();
+        if (!E)
+          return nullptr;
+        if (auto *Lambda = dyn_cast<LambdaExpr>(E))
+          return Lambda;
+        auto *CE = dyn_cast_or_null<CXXConstructExpr>(E);
+        if (!CE || !CE->getNumArgs())
+          return nullptr;
+        auto *CtorArg = CE->getArg(0)->IgnoreParenCasts();
+        if (!CtorArg)
+          return nullptr;
+        if (auto *Lambda = dyn_cast<LambdaExpr>(CtorArg))
+          return Lambda;
+        auto *DRE = dyn_cast<DeclRefExpr>(CtorArg);
+        if (!DRE)
+          return nullptr;
+        auto *VD = dyn_cast_or_null<VarDecl>(DRE->getDecl());
+        if (!VD)
+          return nullptr;
+        auto* Init = VD->getInit();
+        if (!Init)
+          return nullptr;
+        TempExpr = dyn_cast<CXXBindTemporaryExpr>(Init->IgnoreParenCasts());
+        return dyn_cast_or_null<LambdaExpr>(TempExpr->getSubExpr());
       }
 
       void checkCalleeLambda(CallExpr *CE) {
@@ -155,9 +186,49 @@ public:
       } else if (C.capturesThis() && shouldCheckThis) {
         if (ignoreParamVarDecl) // this is always a parameter to this function.
           continue;
-        reportBugOnThisPtr(C);
+        bool hasProtectThis = false;
+        for (const LambdaCapture &OtherCapture : L->captures()) {
+          if (auto *ValueDecl = OtherCapture.getCapturedVar()) {
+            if (protectThis(ValueDecl)) {
+              hasProtectThis = true;
+              break;
+            }
+          }
+        }
+        if (!hasProtectThis)
+          reportBugOnThisPtr(C);
       }
     }
+  }
+
+  bool protectThis(const ValueDecl *ValueDecl) const {
+    auto* VD = dyn_cast<VarDecl>(ValueDecl);
+    if (!VD)
+      return false;
+    auto *Init = VD->getInit()->IgnoreParenCasts();
+    if (!Init)
+      return false;
+    auto *BTE = dyn_cast<CXXBindTemporaryExpr>(Init);
+    if (!BTE)
+      return false;
+    auto *CE = dyn_cast_or_null<CXXConstructExpr>(BTE->getSubExpr());
+    if (!CE)
+      return false;
+    auto* Ctor = CE->getConstructor();
+    if (!Ctor)
+      return false;
+    auto clsName = safeGetName(Ctor->getParent());
+    if (!isRefType(clsName) || !CE->getNumArgs())
+      return false;
+    auto *Arg = CE->getArg(0)->IgnoreParenCasts();
+    while (auto *UO = dyn_cast<UnaryOperator>(Arg)) {
+      auto OpCode = UO->getOpcode();
+      if (OpCode == UO_Deref || OpCode == UO_AddrOf)
+        Arg = UO->getSubExpr();
+      else
+        break;
+    }
+    return isa<CXXThisExpr>(Arg);
   }
 
   void reportBug(const LambdaCapture &Capture, ValueDecl *CapturedVar,

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -105,7 +105,7 @@ public:
         return true;
       }
 
-      LambdaExpr *findLambdaInArg(Expr* E) {
+      LambdaExpr *findLambdaInArg(Expr *E) {
         if (auto *Lambda = dyn_cast_or_null<LambdaExpr>(E))
           return Lambda;
         auto *TempExpr = dyn_cast_or_null<CXXBindTemporaryExpr>(E);


### PR DESCRIPTION
In WebKit, we often capture this as Ref or RefPtr in addition to this itself so that the object lives as long as a capturing lambda stays alive.

Detect this pattern and treat it as safe. This PR also makes the check for a lambda being passed as a function argument more robust by handling CXXBindTemporaryExpr, CXXConstructExpr, and DeclRefExpr referring to the lambda.