### PR TITLE
[flang] Enable hlfir.sum inlining by default.

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/SimplifyHLFIRIntrinsics.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/SimplifyHLFIRIntrinsics.cpp
@@ -33,7 +33,8 @@ namespace hlfir {
 static llvm::cl::opt<bool>
     simplifySum("flang-simplify-hlfir-sum",
                 llvm::cl::desc("Expand hlfir.sum into an inline sequence"),
-                llvm::cl::init(false));
+                llvm::cl::init(true));
+
 namespace {
 
 class TransposeAsElementalConversion


### PR DESCRIPTION
There is already a LIT test for hlfir.sum inlining that uses
the engineering option. I would like to keep the option
for short period of time to be able to revert
in case of performance regressions that I was not able to see.
