### PR TITLE
workflows/build-ci-container: Fix typos in variables

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Push Container
         run: |
           podman load -i ${{ needs.build-ci-container.outputs.container-filename }}
-          podman tag ${{ steps.vars.outputs.container-name-tag }} ${{ steps.vars.outputs.container-name }}:latest
+          podman tag ${{ needs.build-ci-container.outputs.container-name-tag }} ${{ needs.build-ci-container.outputs.container-name }}:latest
           podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
           podman push ${{ needs.build-ci-container.outputs.container-name-tag }}
           podman push ${{ needs.build-ci-container.outputs.container-name }}:latest

--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Push Container
         run: |
-          podman load -i ${{ needs.build-ci-container.outptus.container-filename }}
+          podman load -i ${{ needs.build-ci-container.outputs.container-filename }}
           podman tag ${{ steps.vars.outputs.container-name-tag }} ${{ steps.vars.outputs.container-name }}:latest
           podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
           podman push ${{ needs.build-ci-container.outputs.container-name-tag }}


### PR DESCRIPTION
This was preventing the containers from being pushed to the registry.