### PR TITLE
[AST] Migrate away from PointerUnion::get (NFC)

### DIFF
--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -9657,7 +9657,7 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportConflictTypeAliasTemplate) {
 AST_MATCHER(ClassTemplateSpecializationDecl, hasInstantiatedFromMember) {
   if (auto Instantiate = Node.getInstantiatedFrom()) {
     if (auto *FromPartialSpecialization =
-            Instantiate.get<ClassTemplatePartialSpecializationDecl *>()) {
+            cast<ClassTemplatePartialSpecializationDecl *>(Instantiate)) {
       return nullptr != FromPartialSpecialization->getInstantiatedFromMember();
     }
   }


### PR DESCRIPTION
Note that PointerUnion::get has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>
