### PR TITLE
[DataFlow] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -87,7 +87,7 @@ public:
   using AbstractSparseLattice::AbstractSparseLattice;
 
   /// Return the value this lattice is located at.
-  Value getAnchor() const { return anchor.get<Value>(); }
+  Value getAnchor() const { return cast<Value>(anchor); }
 
   /// Return the value held by this lattice. This requires that the value is
   /// initialized.

--- a/mlir/lib/Analysis/DataFlow/ConstantPropagationAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/ConstantPropagationAnalysis.cpp
@@ -103,9 +103,9 @@ LogicalResult SparseConstantPropagation::visitOperation(
                          lattice->join(ConstantValue(attr, op->getDialect())));
     } else {
       LLVM_DEBUG(llvm::dbgs()
-                 << "Folded to value: " << foldResult.get<Value>() << "\n");
+                 << "Folded to value: " << cast<Value>(foldResult) << "\n");
       AbstractSparseForwardDataFlowAnalysis::join(
-          lattice, *getLatticeElement(foldResult.get<Value>()));
+          lattice, *getLatticeElement(cast<Value>(foldResult)));
     }
   }
   return success();

--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -43,7 +43,7 @@ void IntegerValueRangeLattice::onUpdate(DataFlowSolver *solver) const {
   // If the integer range can be narrowed to a constant, update the constant
   // value of the SSA value.
   std::optional<APInt> constant = getValue().getValue().getConstantValue();
-  auto value = anchor.get<Value>();
+  auto value = cast<Value>(anchor);
   auto *cv = solver->getOrCreateState<Lattice<ConstantValue>>(value);
   if (!constant)
     return solver->propagateIfChanged(
@@ -155,9 +155,9 @@ void IntegerRangeAnalysis::visitNonControlFlowArguments(
                                   Type boundType, bool getUpper) {
     unsigned int width = ConstantIntRanges::getStorageBitwidth(boundType);
     if (loopBound.has_value()) {
-      if (loopBound->is<Attribute>()) {
+      if (isa<Attribute>(*loopBound)) {
         if (auto bound =
-                dyn_cast_or_null<IntegerAttr>(loopBound->get<Attribute>()))
+                dyn_cast_or_null<IntegerAttr>(cast<Attribute>(*loopBound)))
           return bound.getValue();
       } else if (auto value = llvm::dyn_cast_if_present<Value>(*loopBound)) {
         const IntegerValueRangeLattice *lattice =

--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -155,9 +155,8 @@ void IntegerRangeAnalysis::visitNonControlFlowArguments(
                                   Type boundType, bool getUpper) {
     unsigned int width = ConstantIntRanges::getStorageBitwidth(boundType);
     if (loopBound.has_value()) {
-      if (isa<Attribute>(*loopBound)) {
-        if (auto bound =
-                dyn_cast_or_null<IntegerAttr>(cast<Attribute>(*loopBound)))
+      if (auto attr = dyn_cast<Attribute>(*loopBound)) {
+        if (auto bound = dyn_cast_or_null<IntegerAttr>(attr))
           return bound.getValue();
       } else if (auto value = llvm::dyn_cast_if_present<Value>(*loopBound)) {
         const IntegerValueRangeLattice *lattice =

--- a/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/SparseAnalysis.cpp
@@ -34,7 +34,7 @@ void AbstractSparseLattice::onUpdate(DataFlowSolver *solver) const {
   AnalysisState::onUpdate(solver);
 
   // Push all users of the value to the queue.
-  for (Operation *user : anchor.get<Value>().getUsers())
+  for (Operation *user : cast<Value>(anchor).getUsers())
     for (DataFlowAnalysis *analysis : useDefSubscribers)
       solver->enqueue({solver->getProgramPointAfter(user), analysis});
 }


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
