### PR TITLE
[CI] Only upload test results if buildkite-agent is present

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -34,8 +34,11 @@ function at-exit {
 
   # If building fails there will be no results files.
   shopt -s nullglob
-  python3 "${MONOREPO_ROOT}"/.ci/generate_test_report.py ":linux: Linux x64 Test Results" \
-    "linux-x64-test-results" "${BUILD_DIR}"/test-results.*.xml
+  if command -v buildkite-agent 2>&1 >/dev/null
+  then
+    python3 "${MONOREPO_ROOT}"/.ci/generate_test_report.py ":linux: Linux x64 Test Results" \
+      "linux-x64-test-results" "${BUILD_DIR}"/test-results.*.xml
+  fi
 }
 trap at-exit EXIT
 

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -33,8 +33,11 @@ function at-exit {
 
   # If building fails there will be no results files.
   shopt -s nullglob
-  python "${MONOREPO_ROOT}"/.ci/generate_test_report.py ":windows: Windows x64 Test Results" \
-    "windows-x64-test-results" "${BUILD_DIR}"/test-results.*.xml
+  if command -v buildkite-agent 2>&1 >/dev/null
+  then
+    python "${MONOREPO_ROOT}"/.ci/generate_test_report.py ":windows: Windows x64 Test Results" \
+      "windows-x64-test-results" "${BUILD_DIR}"/test-results.*.xml
+  fi
 }
 trap at-exit EXIT
 


### PR DESCRIPTION
This patch modifies the monolithic shell scrips to only run if the buildkite-agent application is present. This allows for running the scripts to completion outside of buildkite (eg inside of a GHA pipeline).