### PR TITLE
[llvm-gsymutil] Disable test macho-gsym-merged-callsites-dsym

### DIFF
--- a/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
+++ b/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
@@ -1,3 +1,7 @@
+# FIXME: Currently disabled as it fails on some Linux hosts
+# UNSUPPORTED: true
+
+
 ## Test that reconstructs a dSYM file from YAML and generates a gsym from it. The gsym has callsite info and merged functions.
 
 # RUN: split-file %s %t


### PR DESCRIPTION
The macho-gsym-merged-callsites-dsym is failing on some hosts.

Disabling for now while we come up with a fix. 