### PR TITLE
[ARM][Thumb2] Allow 2-operand variants of `[us]div`

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -4765,6 +4765,7 @@ def : ARMV6Pat<(int_arm_smusdx GPRnopc:$Rn, GPRnopc:$Rm),
 //===----------------------------------------------------------------------===//
 //  Division Instructions (ARMv7-A with virtualization extension)
 //
+let TwoOperandAliasConstraint = "$Rn = $Rd" in {
 def SDIV : ADivA1I<0b001, (outs GPR:$Rd), (ins GPR:$Rn, GPR:$Rm), IIC_iDIV,
                    "sdiv", "\t$Rd, $Rn, $Rm",
                    [(set GPR:$Rd, (sdiv GPR:$Rn, GPR:$Rm))]>,
@@ -4776,6 +4777,7 @@ def UDIV : ADivA1I<0b011, (outs GPR:$Rd), (ins GPR:$Rn, GPR:$Rm), IIC_iDIV,
                    [(set GPR:$Rd, (udiv GPR:$Rn, GPR:$Rm))]>,
            Requires<[IsARM, HasDivideInARM]>,
            Sched<[WriteDIV]>;
+}
 
 //===----------------------------------------------------------------------===//
 //  Misc. Arithmetic Instructions.

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -3300,6 +3300,7 @@ def : Thumb2DSPPat<(ARMSmlsldx rGPR:$Rn, rGPR:$Rm, rGPR:$RLo, rGPR:$RHi),
 //  Division Instructions.
 //  Signed and unsigned division on v7-M
 //
+let TwoOperandAliasConstraint = "$Rn = $Rd" in {
 def t2SDIV : T2ThreeReg<(outs rGPR:$Rd), (ins rGPR:$Rn, rGPR:$Rm), IIC_iDIV,
                  "sdiv", "\t$Rd, $Rn, $Rm",
                  [(set rGPR:$Rd, (sdiv rGPR:$Rn, rGPR:$Rm))]>,
@@ -3322,6 +3323,7 @@ def t2UDIV : T2ThreeReg<(outs rGPR:$Rd), (ins rGPR:$Rn, rGPR:$Rm), IIC_iDIV,
   let Inst{20} = 0b1;
   let Inst{15-12} = 0b1111;
   let Inst{7-4} = 0b1111;
+}
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/MC/ARM/idiv-2op.s
+++ b/llvm/test/MC/ARM/idiv-2op.s
@@ -11,7 +11,7 @@
 @ RUN: llvm-mc -triple=thumbv8 -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8 %s
 
 @ RUN: llvm-mc -triple=armv8 -mattr=-hwdiv -show-encoding < %s 2>&1 | FileCheck -check-prefix ARMV8-NOTHUMBHWDIV %s
-@ RUN: llvm-mc -triple=thumbv8 -mattr=-hwdiv-arm -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8-NOTHUMBHWDIV %s
+@ RUN: llvm-mc -triple=thumbv8 -mattr=-hwdiv-arm -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8-NOARMHWDIV %s
 
         sdiv  r1, r2
         udiv  r3, r4
@@ -38,5 +38,5 @@
 
 @ ARMV8-NOTHUMBHWDIV:   sdiv    r1, r1, r2              @ encoding: [0x11,0xf2,0x11,0xe7] 
 @ ARMV8-NOTHUMBHWDIV:   udiv    r3, r3, r4              @ encoding: [0x13,0xf4,0x33,0xe7]
-@ THUMBV8-NOTHUMBHWDIV: sdiv    r1, r1, r2              @ encoding: [0x91,0xfb,0xf2,0xf1]
-@ THUMBV8-NOTHUMBHWDIV: udiv    r3, r3, r4              @ encoding: [0xb3,0xfb,0xf4,0xf3]
+@ THUMBV8-NOARMHWDIV:   sdiv    r1, r1, r2              @ encoding: [0x91,0xfb,0xf2,0xf1]
+@ THUMBV8-NOARMHWDIV:   udiv    r3, r3, r4              @ encoding: [0xb3,0xfb,0xf4,0xf3]

--- a/llvm/test/MC/ARM/idiv-2op.s
+++ b/llvm/test/MC/ARM/idiv-2op.s
@@ -1,0 +1,42 @@
+@ RUN: llvm-mc -triple=armv7 -mcpu=cortex-m3 -show-encoding < %s 2>&1 | FileCheck -check-prefix M3-ARM %s
+@ RUN: llvm-mc -triple=thumbv7 -mcpu=cortex-m3 -show-encoding < %s 2>&1 | FileCheck -check-prefix M3-THUMB %s
+
+@ RUN: llvm-mc -triple=thumbv7 -mcpu=cortex-a15 -show-encoding < %s 2>&1 | FileCheck -check-prefix A15-THUMB %s
+@ RUN: llvm-mc -triple=thumbv7 -mcpu=cortex-a15 -show-encoding < %s 2>&1 | FileCheck -check-prefix A15-THUMB %s
+
+@ RUN: llvm-mc -triple=armv7 -mcpu=cortex-a15 -mattr=-hwdiv -show-encoding < %s 2>&1 | FileCheck -check-prefix A15-ARM-NOTHUMBHWDIV %s
+@ RUN: llvm-mc -triple=thumbv7 -mcpu=cortex-a15 -mattr=-hwdiv-arm -show-encoding < %s 2>&1 | FileCheck -check-prefix A15-THUMB-NOARMHWDIV %s
+
+@ RUN: llvm-mc -triple=armv8 -show-encoding < %s 2>&1 | FileCheck -check-prefix ARMV8 %s
+@ RUN: llvm-mc -triple=thumbv8 -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8 %s
+
+@ RUN: llvm-mc -triple=armv8 -mattr=-hwdiv -show-encoding < %s 2>&1 | FileCheck -check-prefix ARMV8-NOTHUMBHWDIV %s
+@ RUN: llvm-mc -triple=thumbv8 -mattr=-hwdiv-arm -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8-NOTHUMBHWDIV %s
+
+        sdiv  r1, r2
+        udiv  r3, r4
+
+@ M3-ARM:               sdiv   r1, r1, r2               @ encoding: [0x91,0xfb,0xf2,0xf1]
+@ M3-ARM:               udiv   r3, r3, r4               @ encoding: [0xb3,0xfb,0xf4,0xf3]
+@ M3-THUMB:             sdiv   r1, r1, r2               @ encoding: [0x91,0xfb,0xf2,0xf1]
+@ M3-THUMB:             udiv   r3, r3, r4               @ encoding: [0xb3,0xfb,0xf4,0xf3]
+
+@ A15-ARM:              sdiv   r1, r1, r2               @ encoding: [0x11,0xf2,0x11,0xe7]
+@ A15-ARM:              udiv   r3, r3, r4               @ encoding: [0x13,0xf4,0x33,0xe7]
+@ A15-THUMB:            sdiv   r1, r1, r2               @ encoding: [0x91,0xfb,0xf2,0xf1]
+@ A15-THUMB:            udiv   r3, r3, r4               @ encoding: [0xb3,0xfb,0xf4,0xf3]
+
+@ A15-ARM-NOTHUMBHWDIV: sdiv    r1, r1, r2              @ encoding: [0x11,0xf2,0x11,0xe7]
+@ A15-ARM-NOTHUMBHWDIV: udiv    r3, r3, r4              @ encoding: [0x13,0xf4,0x33,0xe7] 
+@ A15-THUMB-NOARMHWDIV: sdiv    r1, r1, r2              @ encoding: [0x91,0xfb,0xf2,0xf1]
+@ A15-THUMB-NOARMHWDIV: udiv    r3, r3, r4              @ encoding: [0xb3,0xfb,0xf4,0xf3]
+
+@ ARMV8:                sdiv    r1, r1, r2              @ encoding: [0x11,0xf2,0x11,0xe7]
+@ ARMV8:                udiv    r3, r3, r4              @ encoding: [0x13,0xf4,0x33,0xe7]
+@ THUMBV8:              sdiv    r1, r1, r2              @ encoding: [0x91,0xfb,0xf2,0xf1] 
+@ THUMBV8:              udiv    r3, r3, r4              @ encoding: [0xb3,0xfb,0xf4,0xf3]
+
+@ ARMV8-NOTHUMBHWDIV:   sdiv    r1, r1, r2              @ encoding: [0x11,0xf2,0x11,0xe7] 
+@ ARMV8-NOTHUMBHWDIV:   udiv    r3, r3, r4              @ encoding: [0x13,0xf4,0x33,0xe7]
+@ THUMBV8-NOTHUMBHWDIV: sdiv    r1, r1, r2              @ encoding: [0x91,0xfb,0xf2,0xf1]
+@ THUMBV8-NOTHUMBHWDIV: udiv    r3, r3, r4              @ encoding: [0xb3,0xfb,0xf4,0xf3]

--- a/llvm/test/MC/ARM/idiv.s
+++ b/llvm/test/MC/ARM/idiv.s
@@ -8,7 +8,7 @@
 @ RUN: llvm-mc -triple=thumbv8 -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8 %s
 
 @ RUN: llvm-mc -triple=armv8 -mattr=-hwdiv -show-encoding < %s 2>&1 | FileCheck -check-prefix ARMV8-NOTHUMBHWDIV %s
-@ RUN: llvm-mc -triple=thumbv8 -mattr=-hwdiv-arm -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8-NOTHUMBHWDIV %s
+@ RUN: llvm-mc -triple=thumbv8 -mattr=-hwdiv-arm -show-encoding < %s 2>&1 | FileCheck -check-prefix THUMBV8-NOARMHWDIV %s
 
         sdiv  r1, r2, r3
         udiv  r3, r4, r5
@@ -29,5 +29,5 @@
 
 @ ARMV8-NOTHUMBHWDIV:   sdiv    r1, r2, r3              @ encoding: [0x12,0xf3,0x11,0xe7]
 @ ARMV8-NOTHUMBHWDIV:   udiv    r3, r4, r5              @ encoding: [0x14,0xf5,0x33,0xe7]
-@ THUMBV8-NOTHUMBHWDIV: sdiv    r1, r2, r3              @ encoding: [0x92,0xfb,0xf3,0xf1]
-@ THUMBV8-NOTHUMBHWDIV: udiv    r3, r4, r5              @ encoding: [0xb4,0xfb,0xf5,0xf3]
+@ THUMBV8-NOARMHWDIV:   sdiv    r1, r2, r3              @ encoding: [0x92,0xfb,0xf3,0xf1]
+@ THUMBV8-NOARMHWDIV:   udiv    r3, r4, r5              @ encoding: [0xb4,0xfb,0xf5,0xf3]


### PR DESCRIPTION
Fixes #119963