### PR TITLE
Temporarily disable test `clang/Interpreter/crash.cpp`

### DIFF
--- a/clang/test/Interpreter/crash.cpp
+++ b/clang/test/Interpreter/crash.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: host-supports-jit, x86_64-linux
+// UNSUPPORTED: target={{.*}}
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t


### PR DESCRIPTION
See discussion on https://github.com/llvm/llvm-project/pull/117475#issuecomment-2543223954

This test currently invokes the system ld, which can cause issues on some CI systems where system ld only works with $LDFLAGS and $LIBS. @vgvassilev has suggested to use the `yaml2obj` tool to avoid invoking ld.

Before that happens, proposing to disable this test until we find a solution to unblock downstream CI. 