### PR TITLE
[DAG] SDPatternMatch - add matchers for reassociatable binops

### DIFF
--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1163,7 +1163,7 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
           Patterns);
     }
 
-    SmallBitVector Used(std::tuple_size_v<std::tuple<PatternTs...>>, false);
+    SmallBitVector Used(std::tuple_size_v<std::tuple<PatternTs...>>);
     return reassociatableMatchHelper(Matches, Used);
   }
 

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -14,8 +14,8 @@
 #define LLVM_CODEGEN_SDPATTERNMATCH_H
 
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallBitVector.h"
 #include "llvm/CodeGen/SelectionDAG.h"
 #include "llvm/CodeGen/SelectionDAGNodes.h"
 #include "llvm/CodeGen/TargetLowering.h"
@@ -1150,9 +1150,10 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
       return false;
     }
 
-    // J in Matches[I] iff sd_context_match(Leaves[I], Ctx,
+    // Matches[I][J] == true iff sd_context_match(Leaves[I], Ctx,
     // std::get<J>(Patterns)) == true
-    std::array<SmallBitVector, std::tuple_size_v<std::tuple<PatternTs...>>> Matches;
+    std::array<SmallBitVector, std::tuple_size_v<std::tuple<PatternTs...>>>
+        Matches;
     for (size_t I = 0; I < Leaves.size(); I += 1) {
       SmallVector<bool> MatchResults;
       std::apply(

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1183,7 +1183,7 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
                             SmallBitVector &Used, size_t Curr = 0) {
     if (Curr == Matches.size())
       return true;
-    for (size_t Match = 0; Match < Matches[Curr].size(); Match += 1) {
+    for (size_t Match = 0, N = Matches[Curr].size(); Match < N; Match++) {
       if (!Matches[Curr][Match] || Used[Match])
         continue;
       Used[Match] = true;

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1184,17 +1184,14 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
   [[nodiscard]] inline bool
   reassociatableMatchHelper(const SmallVector<SmallVector<size_t>> &Matches,
                             SmallVector<bool> &Used, size_t Curr = 0) {
-    if (Curr == Matches.size()) {
+    if (Curr == Matches.size())
       return true;
-    }
     for (auto Match : Matches[Curr]) {
-      if (Used[Match]) {
+      if (Used[Match])
         continue;
-      }
       Used[Match] = true;
-      if (reassociatableMatchHelper(Matches, Used, Curr + 1)) {
+      if (reassociatableMatchHelper(Matches, Used, Curr + 1))
         return true;
-      }
       Used[Match] = false;
     }
     return false;

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1154,7 +1154,7 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
     // std::get<J>(Patterns)) == true
     std::array<SmallBitVector, std::tuple_size_v<std::tuple<PatternTs...>>>
         Matches;
-    for (size_t I = 0; I < Leaves.size(); I += 1) {
+    for (size_t I = 0, N = Leaves.size(); I < N; I++) {
       SmallVector<bool> MatchResults;
       std::apply(
           [&](auto &...P) {

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -14,6 +14,7 @@
 #define LLVM_CODEGEN_SDPATTERNMATCH_H
 
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/CodeGen/SelectionDAG.h"
@@ -1175,9 +1176,8 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
     }
   }
 
-  template <size_t N>
   [[nodiscard]] inline bool
-  reassociatableMatchHelper(const std::array<SmallBitVector, N> &Matches,
+  reassociatableMatchHelper(const ArrayRef<SmallBitVector> Matches,
                             SmallBitVector &Used, size_t Curr = 0) {
     if (Curr == Matches.size())
       return true;

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1169,7 +1169,7 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
 
   void collectLeaves(SDValue V, SmallVector<SDValue> &Leaves) {
     if (V->getOpcode() == Opcode) {
-      for (size_t I = 0; I < V->getNumOperands(); I += 1) {
+      for (size_t I = 0, N = V->getNumOperands(); I < N; I++) {
         collectLeaves(V->getOperand(I), Leaves);
       }
     } else {

--- a/llvm/include/llvm/CodeGen/SDPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/SDPatternMatch.h
@@ -1146,9 +1146,8 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
   bool match(const MatchContext &Ctx, SDValue N) {
     SmallVector<SDValue> Leaves;
     collectLeaves(N, Leaves);
-    if (Leaves.size() != std::tuple_size_v<std::tuple<PatternTs...>>) {
+    if (Leaves.size() != std::tuple_size_v<std::tuple<PatternTs...>>)
       return false;
-    }
 
     // Matches[I][J] == true iff sd_context_match(Leaves[I], Ctx,
     // std::get<J>(Patterns)) == true
@@ -1169,9 +1168,8 @@ template <typename... PatternTs> struct ReassociatableOpc_match {
 
   void collectLeaves(SDValue V, SmallVector<SDValue> &Leaves) {
     if (V->getOpcode() == Opcode) {
-      for (size_t I = 0, N = V->getNumOperands(); I < N; I++) {
+      for (size_t I = 0, N = V->getNumOperands(); I < N; I++)
         collectLeaves(V->getOperand(I), Leaves);
-      }
     } else {
       Leaves.emplace_back(V);
     }

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -657,11 +657,10 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
 
   SDLoc DL;
   auto Int32VT = EVT::getIntegerVT(Context, 32);
-  auto Float32VT = EVT::getFloatingPointVT(32);
 
   SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
   SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
-  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Float32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Int32VT);
   SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 8, Int32VT);
 
   // (Op0 + Op1) + (Op2 + Op3)
@@ -675,7 +674,7 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
       ADD, m_ReassociatableAdd(m_Value(), m_Value(), m_Value(), m_Value())));
 
   // Op0 + (Op1 + (Op2 + Op3))
-  SDValue ADD123 = DAG->getNode(ISD::ADD, DL, Int32VT, Op2, ADD23);
+  SDValue ADD123 = DAG->getNode(ISD::ADD, DL, Int32VT, Op1, ADD23);
   SDValue ADD0123 = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, ADD123);
   EXPECT_TRUE(
       sd_match(ADD123, m_ReassociatableAdd(m_Value(), m_Value(), m_Value())));
@@ -693,7 +692,7 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
       MUL, m_ReassociatableMul(m_Value(), m_Value(), m_Value(), m_Value())));
 
   // Op0 * (Op1 * (Op2 * Op3))
-  SDValue MUL123 = DAG->getNode(ISD::MUL, DL, Int32VT, Op2, MUL23);
+  SDValue MUL123 = DAG->getNode(ISD::MUL, DL, Int32VT, Op1, MUL23);
   SDValue MUL0123 = DAG->getNode(ISD::MUL, DL, Int32VT, Op0, MUL123);
   EXPECT_TRUE(
       sd_match(MUL123, m_ReassociatableMul(m_Value(), m_Value(), m_Value())));
@@ -711,7 +710,7 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
       AND, m_ReassociatableAnd(m_Value(), m_Value(), m_Value(), m_Value())));
 
   // Op0 && (Op1 && (Op2 && Op3))
-  SDValue AND123 = DAG->getNode(ISD::AND, DL, Int32VT, Op2, AND23);
+  SDValue AND123 = DAG->getNode(ISD::AND, DL, Int32VT, Op1, AND23);
   SDValue AND0123 = DAG->getNode(ISD::AND, DL, Int32VT, Op0, AND123);
   EXPECT_TRUE(
       sd_match(AND123, m_ReassociatableAnd(m_Value(), m_Value(), m_Value())));
@@ -729,7 +728,7 @@ TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
       OR, m_ReassociatableOr(m_Value(), m_Value(), m_Value(), m_Value())));
 
   // Op0 || (Op1 || (Op2 || Op3))
-  SDValue OR123 = DAG->getNode(ISD::OR, DL, Int32VT, Op2, OR23);
+  SDValue OR123 = DAG->getNode(ISD::OR, DL, Int32VT, Op1, OR23);
   SDValue OR0123 = DAG->getNode(ISD::OR, DL, Int32VT, Op0, OR123);
   EXPECT_TRUE(
       sd_match(OR123, m_ReassociatableOr(m_Value(), m_Value(), m_Value())));

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -651,3 +651,88 @@ TEST_F(SelectionDAGPatternMatchTest, matchAdvancedProperties) {
   EXPECT_TRUE(sd_match(Add, DAG.get(),
                        m_LegalOp(m_IntegerVT(m_Add(m_Value(), m_Value())))));
 }
+
+TEST_F(SelectionDAGPatternMatchTest, matchReassociatableOp) {
+  using namespace SDPatternMatch;
+
+  SDLoc DL;
+  auto Int32VT = EVT::getIntegerVT(Context, 32);
+  auto Float32VT = EVT::getFloatingPointVT(32);
+
+  SDValue Op0 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 1, Int32VT);
+  SDValue Op1 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 2, Int32VT);
+  SDValue Op2 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 3, Float32VT);
+  SDValue Op3 = DAG->getCopyFromReg(DAG->getEntryNode(), DL, 8, Int32VT);
+
+  // (Op0 + Op1) + (Op2 + Op3)
+  SDValue ADD01 = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, Op1);
+  SDValue ADD23 = DAG->getNode(ISD::ADD, DL, Int32VT, Op2, Op3);
+  SDValue ADD = DAG->getNode(ISD::ADD, DL, Int32VT, ADD01, ADD23);
+
+  EXPECT_TRUE(sd_match(ADD01, m_ReassociatableAdd(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(ADD23, m_ReassociatableAdd(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(
+      ADD, m_ReassociatableAdd(m_Value(), m_Value(), m_Value(), m_Value())));
+
+  // Op0 + (Op1 + (Op2 + Op3))
+  SDValue ADD123 = DAG->getNode(ISD::ADD, DL, Int32VT, Op2, ADD23);
+  SDValue ADD0123 = DAG->getNode(ISD::ADD, DL, Int32VT, Op0, ADD123);
+  EXPECT_TRUE(
+      sd_match(ADD123, m_ReassociatableAdd(m_Value(), m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(ADD0123, m_ReassociatableAdd(m_Value(), m_Value(),
+                                                    m_Value(), m_Value())));
+
+  // (Op0 * Op1) * (Op2 * Op3)
+  SDValue MUL01 = DAG->getNode(ISD::MUL, DL, Int32VT, Op0, Op1);
+  SDValue MUL23 = DAG->getNode(ISD::MUL, DL, Int32VT, Op2, Op3);
+  SDValue MUL = DAG->getNode(ISD::MUL, DL, Int32VT, MUL01, MUL23);
+
+  EXPECT_TRUE(sd_match(MUL01, m_ReassociatableMul(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(MUL23, m_ReassociatableMul(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(
+      MUL, m_ReassociatableMul(m_Value(), m_Value(), m_Value(), m_Value())));
+
+  // Op0 * (Op1 * (Op2 * Op3))
+  SDValue MUL123 = DAG->getNode(ISD::MUL, DL, Int32VT, Op2, MUL23);
+  SDValue MUL0123 = DAG->getNode(ISD::MUL, DL, Int32VT, Op0, MUL123);
+  EXPECT_TRUE(
+      sd_match(MUL123, m_ReassociatableMul(m_Value(), m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(MUL0123, m_ReassociatableMul(m_Value(), m_Value(),
+                                                    m_Value(), m_Value())));
+
+  // (Op0 && Op1) && (Op2 && Op3)
+  SDValue AND01 = DAG->getNode(ISD::AND, DL, Int32VT, Op0, Op1);
+  SDValue AND23 = DAG->getNode(ISD::AND, DL, Int32VT, Op2, Op3);
+  SDValue AND = DAG->getNode(ISD::AND, DL, Int32VT, AND01, AND23);
+
+  EXPECT_TRUE(sd_match(AND01, m_ReassociatableAnd(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(AND23, m_ReassociatableAnd(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(
+      AND, m_ReassociatableAnd(m_Value(), m_Value(), m_Value(), m_Value())));
+
+  // Op0 && (Op1 && (Op2 && Op3))
+  SDValue AND123 = DAG->getNode(ISD::AND, DL, Int32VT, Op2, AND23);
+  SDValue AND0123 = DAG->getNode(ISD::AND, DL, Int32VT, Op0, AND123);
+  EXPECT_TRUE(
+      sd_match(AND123, m_ReassociatableAnd(m_Value(), m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(AND0123, m_ReassociatableAnd(m_Value(), m_Value(),
+                                                    m_Value(), m_Value())));
+
+  // (Op0 || Op1) || (Op2 || Op3)
+  SDValue OR01 = DAG->getNode(ISD::OR, DL, Int32VT, Op0, Op1);
+  SDValue OR23 = DAG->getNode(ISD::OR, DL, Int32VT, Op2, Op3);
+  SDValue OR = DAG->getNode(ISD::OR, DL, Int32VT, OR01, OR23);
+
+  EXPECT_TRUE(sd_match(OR01, m_ReassociatableOr(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(OR23, m_ReassociatableOr(m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(
+      OR, m_ReassociatableOr(m_Value(), m_Value(), m_Value(), m_Value())));
+
+  // Op0 || (Op1 || (Op2 || Op3))
+  SDValue OR123 = DAG->getNode(ISD::OR, DL, Int32VT, Op2, OR23);
+  SDValue OR0123 = DAG->getNode(ISD::OR, DL, Int32VT, Op0, OR123);
+  EXPECT_TRUE(
+      sd_match(OR123, m_ReassociatableOr(m_Value(), m_Value(), m_Value())));
+  EXPECT_TRUE(sd_match(
+      OR0123, m_ReassociatableOr(m_Value(), m_Value(), m_Value(), m_Value())));
+}


### PR DESCRIPTION
fixes https://github.com/llvm/llvm-project/issues/118847

implements matchers for reassociatable opcodes as well as helpers for commonly used reassociatable binary matchers.