### PR TITLE
Fix clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp for x86

### DIFF
--- a/clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp
+++ b/clang/test/SemaCXX/msvc-pragma-function-no-builtin-attr.cpp
@@ -18,10 +18,10 @@ int bar() {
 
 struct A {
     int foo() = delete;
-    // CHECK: CXXMethodDecl {{.*}} foo 'int ()' delete
+    // CHECK: CXXMethodDecl {{.*}} foo {{.*}} delete
     // CHECK-NOT: NoBuiltinAttr
     A() = default;
-    // CHECK: CXXConstructorDecl {{.*}} A 'void ()' default
+    // CHECK: CXXConstructorDecl {{.*}} A {{.*}} default
     // CHECK-NOT: NoBuiltinAttr
 };
 


### PR DESCRIPTION
Fix test failure from #119719
84b0f0145887bbfe49fd4dc85490b14108a72cee

Closes #119979