### PR TITLE
[clang-format] Detect nesting in template strings

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -826,8 +826,10 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
     for (const auto *Prev = &Tok; Prev; Prev = Prev->Previous) {
       if (Prev->is(TT_TemplateString) && Prev->opensScope())
         return true;
-      if (Prev->is(TT_TemplateString) && Prev->closesScope())
+      if (Prev->opensScope() ||
+          (Prev->is(TT_TemplateString) && Prev->closesScope())) {
         break;
+      }
     }
     return false;
   };

--- a/clang/unittests/Format/FormatTestJS.cpp
+++ b/clang/unittests/Format/FormatTestJS.cpp
@@ -2163,7 +2163,7 @@ TEST_F(FormatTestJS, TemplateStringMultiLineExpression) {
                "        FOOFOOFOOFOO____FOO_FOO_FO_FOO_FOOO -\n"
                "            (barbarbarbar____bar_bar_bar_bar_bar_bar +\n"
                "             bar_bar_bar_barbarbar___bar_bar_bar + 1),\n"
-               "        )}`;\n");
+               "        )}`;");
 }
 
 TEST_F(FormatTestJS, TemplateStringASI) {

--- a/clang/unittests/Format/FormatTestJS.cpp
+++ b/clang/unittests/Format/FormatTestJS.cpp
@@ -2157,6 +2157,13 @@ TEST_F(FormatTestJS, TemplateStringMultiLineExpression) {
                "                          aaaa:  aaaaa,\n"
                "                          bbbb:  bbbbb,\n"
                "                        })}`;");
+
+  verifyFormat("`${\n"
+               "    (\n"
+               "        FOOFOOFOOFOO____FOO_FOO_FO_FOO_FOOO -\n"
+               "            (barbarbarbar____bar_bar_bar_bar_bar_bar +\n"
+               "             bar_bar_bar_barbarbar___bar_bar_bar + 1),\n"
+               "        )}`;\n");
 }
 
 TEST_F(FormatTestJS, TemplateStringASI) {


### PR DESCRIPTION
The helper to check if a token is in a template string scans too far backward. It should stop if a different scope is found.

Fixes #107571