### PR TITLE
libc: Prefix RPC Status code to avoid conflict in windows build

### DIFF
--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -44,9 +44,9 @@ namespace rpc {
 
 /// Generic codes that can be used whem implementing the server.
 enum Status {
-  SUCCESS = 0x0,
+  RPC_SUCCESS = 0x0,
   RPC_ERROR = 0x1000,
-  UNHANDLED_OPCODE = 0x1001,
+  RPC_UNHANDLED_OPCODE = 0x1001,
 };
 
 /// A fixed size channel used to communicate between the RPC client and server.

--- a/libc/shared/rpc.h
+++ b/libc/shared/rpc.h
@@ -45,7 +45,7 @@ namespace rpc {
 /// Generic codes that can be used whem implementing the server.
 enum Status {
   SUCCESS = 0x0,
-  ERROR = 0x1000,
+  RPC_ERROR = 0x1000,
   UNHANDLED_OPCODE = 0x1001,
 };
 

--- a/libc/utils/gpu/loader/Loader.h
+++ b/libc/utils/gpu/loader/Loader.h
@@ -113,7 +113,7 @@ inline uint32_t handle_server(rpc::Server &server, uint32_t index,
     return 0;
   index = port->get_index() + 1;
 
-  int status = rpc::SUCCESS;
+  int status = rpc::RPC_SUCCESS;
   switch (port->get_opcode()) {
   case RPC_TEST_INCREMENT: {
     port->recv_and_send([](rpc::Buffer *buffer, uint32_t) {
@@ -186,7 +186,7 @@ inline uint32_t handle_server(rpc::Server &server, uint32_t index,
   }
 
   // Handle all of the `libc` specific opcodes.
-  if (status != rpc::SUCCESS)
+  if (status != rpc::RPC_SUCCESS)
     handle_error("Error handling RPC server");
 
   port->close();

--- a/libc/utils/gpu/server/rpc_server.cpp
+++ b/libc/utils/gpu/server/rpc_server.cpp
@@ -455,7 +455,7 @@ rpc::Status handle_libc_opcodes(rpc::Server::Port &port, uint32_t num_lanes) {
   case 64:
     return handle_port_impl<64>(port);
   default:
-    return rpc::ERROR;
+    return rpc::RPC_ERROR;
   }
 }
 } // namespace rpc

--- a/libc/utils/gpu/server/rpc_server.cpp
+++ b/libc/utils/gpu/server/rpc_server.cpp
@@ -437,10 +437,10 @@ rpc::Status handle_port_impl(rpc::Server::Port &port) {
     break;
   }
   default:
-    return rpc::UNHANDLED_OPCODE;
+    return rpc::RPC_UNHANDLED_OPCODE;
   }
 
-  return rpc::SUCCESS;
+  return rpc::RPC_SUCCESS;
 }
 
 namespace rpc {

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -56,10 +56,10 @@ rpc::Status handle_offload_opcodes(plugin::GenericDeviceTy &Device,
     break;
   }
   default:
-    return rpc::UNHANDLED_OPCODE;
+    return rpc::RPC_UNHANDLED_OPCODE;
     break;
   }
-  return rpc::SUCCESS;
+  return rpc::RPC_SUCCESS;
 }
 
 static rpc::Status handle_offload_opcodes(plugin::GenericDeviceTy &Device,
@@ -125,12 +125,12 @@ Error RPCServerTy::runServer(plugin::GenericDeviceTy &Device) {
 
   // Let the `libc` library handle any other unhandled opcodes.
 #ifdef LIBOMPTARGET_RPC_SUPPORT
-  if (Status == rpc::UNHANDLED_OPCODE)
+  if (Status == rpc::RPC_UNHANDLED_OPCODE)
     Status = handle_libc_opcodes(*Port, Device.getWarpSize());
 #endif
 
   Port->close();
-  if (Status != rpc::SUCCESS)
+  if (Status != rpc::RPC_SUCCESS)
     return createStringError("RPC server given invalid opcode!");
 
   return Error::success();

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -72,7 +72,7 @@ static rpc::Status handle_offload_opcodes(plugin::GenericDeviceTy &Device,
   else if (NumLanes == 64)
     return handle_offload_opcodes<64>(Device, Port);
   else
-    return rpc::ERROR;
+    return rpc::RPC_ERROR;
 }
 
 RPCServerTy::RPCServerTy(plugin::GenericPluginTy &Plugin)


### PR DESCRIPTION
Somehow conflict with define in wingdi.h.

Fix build failures:

[ 52%] Building CXX object projects/offload/plugins-nextgen/common/CMakeFiles/PluginCommon.dir/src/RPC.cpp.obj
In file included from ...llvm\offload\plugins-nextgen\common\src\RPC.cpp:16:
...\llvm\libc\shared\rpc.h(48,3): error: expected identifier
   48 |   ERROR = 0x1000,
      |   ^
c:\Program files (x86)\Windows Kits\10\include\10.0.22000.0\um\wingdi.h(118,29): note: expanded from macro 'ERROR'
  118 | #define ERROR               0
      |                             ^
...\llvm\offload\plugins-nextgen\common\src\RPC.cpp(75,17): error: expected unqualified-id
   75 |     return rpc::ERROR;
      |                 ^
c:\Program files (x86)\Windows Kits\10\include\10.0.22000.0\um\wingdi.h(118,29): note: expanded from macro 'ERROR'
  118 | #define ERROR               0
      |                             ^
2 errors generated.
