### PR TITLE
[lld] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/lld/MachO/Arch/ARM64.cpp
+++ b/lld/MachO/Arch/ARM64.cpp
@@ -202,7 +202,7 @@ InputSection *ARM64::getThunkBranchTarget(InputSection *thunk) const {
   assert(thunk->relocs.size() == 1 &&
          "expected a single reloc on ARM64 ICF thunk");
   auto &reloc = thunk->relocs[0];
-  assert(reloc.referent.is<InputSection *>() &&
+  assert(isa<InputSection *>(reloc.referent) &&
          "ARM64 thunk reloc is expected to point to an InputSection");
 
   return reloc.referent.dyn_cast<InputSection *>();

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -145,7 +145,7 @@ bool TextOutputSection::needsThunks() const {
     for (Reloc &r : isec->relocs) {
       if (!target->hasAttr(r.type, RelocAttrBits::BRANCH))
         continue;
-      auto *sym = r.referent.get<Symbol *>();
+      auto *sym = cast<Symbol *>(r.referent);
       // Pre-populate the thunkMap and memoize call site counts for every
       // InputSection and ThunkInfo. We do this for the benefit of
       // estimateStubsInRangeVA().
@@ -297,7 +297,7 @@ void TextOutputSection::finalize() {
           backwardBranchRange < callVA ? callVA - backwardBranchRange : 0;
       uint64_t highVA = callVA + forwardBranchRange;
       // Calculate our call referent address
-      auto *funcSym = r.referent.get<Symbol *>();
+      auto *funcSym = cast<Symbol *>(r.referent);
       ThunkInfo &thunkInfo = thunkMap[funcSym];
       // The referent is not reachable, so we need to use a thunk ...
       if (funcSym->isInStubs() && callVA >= stubsInRangeVA) {

--- a/lld/MachO/EhFrame.cpp
+++ b/lld/MachO/EhFrame.cpp
@@ -114,7 +114,7 @@ static void createSubtraction(PointerUnion<Symbol *, InputSection *> a,
   auto minuend = b;
   if (Invert)
     std::swap(subtrahend, minuend);
-  assert(subtrahend.is<Symbol *>());
+  assert(isa<Symbol *>(subtrahend));
   Reloc subtrahendReloc(target->subtractorRelocType, /*pcrel=*/false, length,
                         off, /*addend=*/0, subtrahend);
   Reloc minuendReloc(target->unsignedRelocType, /*pcrel=*/false, length, off,

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -115,16 +115,16 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
       return false;
     if (ra.offset != rb.offset)
       return false;
-    if (ra.referent.is<Symbol *>() != rb.referent.is<Symbol *>())
+    if (isa<Symbol *>(ra.referent) != isa<Symbol *>(rb.referent))
       return false;
 
     InputSection *isecA, *isecB;
 
     uint64_t valueA = 0;
     uint64_t valueB = 0;
-    if (ra.referent.is<Symbol *>()) {
-      const auto *sa = ra.referent.get<Symbol *>();
-      const auto *sb = rb.referent.get<Symbol *>();
+    if (isa<Symbol *>(ra.referent)) {
+      const auto *sa = cast<Symbol *>(ra.referent);
+      const auto *sb = cast<Symbol *>(rb.referent);
       if (sa->kind() != sb->kind())
         return false;
       // ICF runs before Undefineds are treated (and potentially converted into
@@ -143,8 +143,8 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
       isecB = db->isec();
       valueB = db->value;
     } else {
-      isecA = ra.referent.get<InputSection *>();
-      isecB = rb.referent.get<InputSection *>();
+      isecA = cast<InputSection *>(ra.referent);
+      isecB = cast<InputSection *>(rb.referent);
     }
 
     // Typically, we should not encounter sections marked with `keepUnique` at
@@ -167,7 +167,7 @@ bool ICF::equalsConstant(const ConcatInputSection *ia,
       return ra.addend == rb.addend;
     // Else we have two literal sections. References to them are equal iff their
     // offsets in the output section are equal.
-    if (ra.referent.is<Symbol *>())
+    if (isa<Symbol *>(ra.referent))
       // For symbol relocs, we compare the contents at the symbol address. We
       // don't do `getOffset(value + addend)` because value + addend may not be
       // a valid offset in the literal section.
@@ -195,12 +195,12 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
     if (ra.referent == rb.referent)
       return true;
     const ConcatInputSection *isecA, *isecB;
-    if (ra.referent.is<Symbol *>()) {
+    if (isa<Symbol *>(ra.referent)) {
       // Matching DylibSymbols are already filtered out by the
       // identical-referent check above. Non-matching DylibSymbols were filtered
       // out in equalsConstant(). So we can safely cast to Defined here.
-      const auto *da = cast<Defined>(ra.referent.get<Symbol *>());
-      const auto *db = cast<Defined>(rb.referent.get<Symbol *>());
+      const auto *da = cast<Defined>(cast<Symbol *>(ra.referent));
+      const auto *db = cast<Defined>(cast<Symbol *>(rb.referent));
       if (da->isAbsolute())
         return true;
       isecA = dyn_cast<ConcatInputSection>(da->isec());
@@ -208,8 +208,8 @@ bool ICF::equalsVariable(const ConcatInputSection *ia,
         return true; // literal sections were checked in equalsConstant.
       isecB = cast<ConcatInputSection>(db->isec());
     } else {
-      const auto *sa = ra.referent.get<InputSection *>();
-      const auto *sb = rb.referent.get<InputSection *>();
+      const auto *sa = cast<InputSection *>(ra.referent);
+      const auto *sb = cast<InputSection *>(rb.referent);
       isecA = dyn_cast<ConcatInputSection>(sa);
       if (!isecA)
         return true;

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -1291,7 +1291,7 @@ static CIE parseCIE(const InputSection *isec, const EhReader &reader,
     const auto *personalityReloc = isec->getRelocAt(personalityAddrOff);
     if (!personalityReloc)
       reader.failOn(off, "Failed to locate relocation for personality symbol");
-    cie.personalitySymbol = personalityReloc->referent.get<macho::Symbol *>();
+    cie.personalitySymbol = cast<macho::Symbol *>(personalityReloc->referent);
   }
   return cie;
 }
@@ -1338,12 +1338,12 @@ targetSymFromCanonicalSubtractor(const InputSection *isec,
   assert(target->hasAttr(minuend.type, RelocAttrBits::UNSIGNED));
   // Note: pcSym may *not* be exactly at the PC; there's usually a non-zero
   // addend.
-  auto *pcSym = cast<Defined>(subtrahend.referent.get<macho::Symbol *>());
+  auto *pcSym = cast<Defined>(cast<macho::Symbol *>(subtrahend.referent));
   Defined *target =
       cast_or_null<Defined>(minuend.referent.dyn_cast<macho::Symbol *>());
   if (!pcSym) {
     auto *targetIsec =
-        cast<ConcatInputSection>(minuend.referent.get<InputSection *>());
+        cast<ConcatInputSection>(cast<InputSection *>(minuend.referent));
     target = findSymbolAtOffset(targetIsec, minuend.addend);
   }
   if (Invert)

--- a/lld/MachO/InputSection.cpp
+++ b/lld/MachO/InputSection.cpp
@@ -226,13 +226,13 @@ void ConcatInputSection::writeTo(uint8_t *buf) {
     const bool needsFixup = config->emitChainedFixups &&
                             target->hasAttr(r.type, RelocAttrBits::UNSIGNED);
     if (target->hasAttr(r.type, RelocAttrBits::SUBTRAHEND)) {
-      const Symbol *fromSym = r.referent.get<Symbol *>();
+      const Symbol *fromSym = cast<Symbol *>(r.referent);
       const Reloc &minuend = relocs[++i];
       uint64_t minuendVA;
       if (const Symbol *toSym = minuend.referent.dyn_cast<Symbol *>())
         minuendVA = toSym->getVA() + minuend.addend;
       else {
-        auto *referentIsec = minuend.referent.get<InputSection *>();
+        auto *referentIsec = cast<InputSection *>(minuend.referent);
         assert(!::shouldOmitFromOutput(referentIsec));
         minuendVA = referentIsec->getVA(minuend.addend);
       }

--- a/lld/MachO/MarkLive.cpp
+++ b/lld/MachO/MarkLive.cpp
@@ -160,7 +160,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
         if (auto *s = r.referent.dyn_cast<Symbol *>())
           addSym(s, entry);
         else
-          enqueue(r.referent.get<InputSection *>(), r.addend, entry);
+          enqueue(cast<InputSection *>(r.referent), r.addend, entry);
       }
       for (Defined *d : getInputSection(entry)->symbols)
         addSym(d, entry);
@@ -183,7 +183,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
             enqueue(isec, 0, makeEntry(referentIsec, nullptr));
           }
         } else {
-          auto *referentIsec = r.referent.get<InputSection *>();
+          auto *referentIsec = cast<InputSection *>(r.referent);
           if (referentIsec->isLive(r.addend))
             enqueue(isec, 0, makeEntry(referentIsec, nullptr));
         }

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -263,7 +263,7 @@ void ObjcCategoryChecker::parseCategory(const ConcatInputSection *catIsec) {
   if (!classReloc)
     return;
 
-  auto *classSym = classReloc->referent.get<Symbol *>();
+  auto *classSym = cast<Symbol *>(classReloc->referent);
   if (auto *d = dyn_cast<Defined>(classSym))
     if (!classMap.count(d))
       parseClass(d);
@@ -603,7 +603,7 @@ void ObjcCategoryMerger::tryEraseDefinedAtIsecOffset(
   if (!reloc)
     return;
 
-  Defined *sym = dyn_cast_or_null<Defined>(reloc->referent.get<Symbol *>());
+  Defined *sym = dyn_cast_or_null<Defined>(cast<Symbol *>(reloc->referent));
   if (!sym)
     return;
 
@@ -675,7 +675,7 @@ void ObjcCategoryMerger::parseProtocolListInfo(
   if (!reloc)
     return;
 
-  auto *ptrListSym = dyn_cast_or_null<Defined>(reloc->referent.get<Symbol *>());
+  auto *ptrListSym = dyn_cast_or_null<Defined>(cast<Symbol *>(reloc->referent));
   assert(ptrListSym && "Protocol list reloc does not have a valid Defined");
 
   // Theoretically protocol count can be either 32b or 64b, depending on
@@ -707,7 +707,7 @@ void ObjcCategoryMerger::parseProtocolListInfo(
     const Reloc *reloc = ptrListSym->isec()->getRelocAt(off);
     assert(reloc && "No reloc found at protocol list offset");
 
-    auto *listSym = dyn_cast_or_null<Defined>(reloc->referent.get<Symbol *>());
+    auto *listSym = dyn_cast_or_null<Defined>(cast<Symbol *>(reloc->referent));
     assert(listSym && "Protocol list reloc does not have a valid Defined");
 
     ptrList.allPtrs.push_back(listSym);
@@ -745,7 +745,7 @@ bool ObjcCategoryMerger::parsePointerListInfo(const ConcatInputSection *isec,
   if (!reloc)
     return true;
 
-  auto *ptrListSym = dyn_cast_or_null<Defined>(reloc->referent.get<Symbol *>());
+  auto *ptrListSym = dyn_cast_or_null<Defined>(cast<Symbol *>(reloc->referent));
   assert(ptrListSym && "Reloc does not have a valid Defined");
 
   uint32_t thisStructSize = *reinterpret_cast<const uint32_t *>(

--- a/lld/MachO/Relocations.cpp
+++ b/lld/MachO/Relocations.cpp
@@ -27,7 +27,7 @@ InputSection *Reloc::getReferentInputSection() const {
       return d->isec();
     return nullptr;
   } else {
-    return referent.get<InputSection *>();
+    return cast<InputSection *>(referent);
   }
 }
 
@@ -38,7 +38,7 @@ StringRef Reloc::getReferentString() const {
     return cisec->getStringRefAtOffset(addend);
   }
 
-  auto *sym = dyn_cast<Defined>(referent.get<Symbol *>());
+  auto *sym = dyn_cast<Defined>(cast<Symbol *>(referent));
   assert(sym && "referent must be a Defined symbol");
 
   auto *symIsec = sym->isec();

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -1990,7 +1990,7 @@ void InitOffsetsSection::setUp() {
       if (rel.addend != 0)
         error(isec->getLocation(rel.offset) +
               ": relocation addend is not representable in __init_offsets");
-      if (rel.referent.is<InputSection *>())
+      if (isa<InputSection *>(rel.referent))
         error(isec->getLocation(rel.offset) +
               ": unexpected section relocation");
 
@@ -2136,12 +2136,12 @@ void ObjCMethListSection::writeRelativeOffsetForIsec(
     symVA = selRef->getVA();
     assert(selRef->data.size() == target->wordSize &&
            "Expected one selref per ConcatInputSection");
-  } else if (reloc->referent.is<Symbol *>()) {
-    auto *def = dyn_cast_or_null<Defined>(reloc->referent.get<Symbol *>());
+  } else if (auto *sym = dyn_cast<Symbol *>(reloc->referent)) {
+    auto *def = dyn_cast_or_null<Defined>(sym);
     assert(def && "Expected all syms in __objc_methlist to be defined");
     symVA = def->getVA();
   } else {
-    auto *isec = reloc->referent.get<InputSection *>();
+    auto *isec = cast<InputSection *>(reloc->referent);
     symVA = isec->getVA(reloc->addend);
   }
 

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -390,7 +390,7 @@ void UnwindInfoSectionImpl::relocateCompactUnwind(
     cu.encoding = support::endian::read32le(buf + cuLayout.encodingOffset);
     for (const Reloc &r : d->unwindEntry()->relocs) {
       if (r.offset == cuLayout.personalityOffset)
-        cu.personality = r.referent.get<Symbol *>();
+        cu.personality = cast<Symbol *>(r.referent);
       else if (r.offset == cuLayout.lsdaOffset)
         cu.lsda = r.getReferentInputSection();
     }


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
