### PR TITLE
[clang][WebAssembly] Support the `-m(no-)red-zone` flag.

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2404,6 +2404,9 @@ void Clang::AddWebAssemblyTargetArgs(const ArgList &Args,
   if (!Args.hasArg(options::OPT_fvisibility_EQ,
                    options::OPT_fvisibility_ms_compat))
     CmdArgs.push_back("-fvisibility=hidden");
+
+  if (!Args.hasFlag(options::OPT_mred_zone, options::OPT_mno_red_zone, true))
+    CmdArgs.push_back("-disable-red-zone");
 }
 
 void Clang::AddVETargetArgs(const ArgList &Args, ArgStringList &CmdArgs) const {


### PR DESCRIPTION
LLVM's WebAssembly backend supports the `noredzone` function attribute, but this support was not exposed in Clang. This just mirrors what is done for AArch64, PowerPC, and x86, minus the Apple-specific checks that are irrelevant here.