### PR TITLE
[cmake] Drop `AddFileDependencies` and `CMakeParseArguments`

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -362,7 +362,6 @@ if (APPLE AND NOT CMAKE_LINKER MATCHES ".*lld.*")
   message(STATUS "Host linker version: ${HOST_LINK_VERSION}")
 endif()
 
-include(CMakeParseArguments)
 include(AddClang)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/compiler-rt/cmake/Modules/CompilerRTAIXUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTAIXUtils.cmake
@@ -1,4 +1,3 @@
-include(CMakeParseArguments)
 include(CompilerRTUtils)
 
 function(get_aix_libatomic_default_link_flags link_flags export_list)

--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -1,4 +1,3 @@
-include(CMakeParseArguments)
 include(CompilerRTUtils)
 include(BuiltinTests)
 

--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -117,7 +117,6 @@ if (FLANG_STANDALONE_BUILD)
     set(USE_NO_MAYBE_UNINITIALIZED 1)
   endif()
 
-  include(CMakeParseArguments)
   include(AddLLVM)
   include(HandleLLVMOptions)
   include(VersionFromVCS)
@@ -445,7 +444,6 @@ if (APPLE)
   endif()
 endif()
 
-include(CMakeParseArguments)
 include(AddFlang)
 
 if (FLANG_INCLUDE_TESTS)

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -329,7 +329,6 @@ endif()
 
 option(LIBC_INCLUDE_DOCS "Build the libc documentation." ${LLVM_INCLUDE_DOCS})
 
-include(CMakeParseArguments)
 include(LLVMLibCCheckCpuFeatures)
 include(CheckCompilerFeatures)
 include(LLVMLibCRules)

--- a/llvm/cmake/modules/LLVMProcessSources.cmake
+++ b/llvm/cmake/modules/LLVMProcessSources.cmake
@@ -1,6 +1,3 @@
-include(AddFileDependencies)
-include(CMakeParseArguments)
-
 function(llvm_replace_compiler_option var old new)
   # Replaces a compiler option or switch `old' in `var' by `new'.
   # If `old' is not in `var', appends `new' to `var'.

--- a/llvm/tools/llvm-config/CMakeLists.txt
+++ b/llvm/tools/llvm-config/CMakeLists.txt
@@ -89,7 +89,9 @@ if(LLVM_ENABLE_MODULES)
 endif()
 
 # Add the dependency on the generation step.
-add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/llvm-config.cpp ${BUILDVARIABLES_OBJPATH})
+set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/llvm-config.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${BUILDVARIABLES_OBJPATH}
+)
 
 if(CMAKE_CROSSCOMPILING)
   if (LLVM_NATIVE_TOOL_DIR AND NOT LLVM_CONFIG_PATH)

--- a/polly/cmake/polly_macros.cmake
+++ b/polly/cmake/polly_macros.cmake
@@ -1,6 +1,3 @@
-
-include(CMakeParseArguments)
-
 macro(add_polly_library name)
   cmake_parse_arguments(ARG "" "" "" ${ARGN})
   set(srcs ${ARG_UNPARSED_ARGUMENTS})


### PR DESCRIPTION
Theses modules are deprecated and have trivial implementations in modern cmake.