### PR TITLE
[GISel] Remove unnecessary MachineVerifier checks for G_ABDS/G_ABDU.

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1586,31 +1586,6 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
 
     break;
   }
-  case TargetOpcode::G_ABDS:
-  case TargetOpcode::G_ABDU: {
-    LLT DstTy = MRI->getType(MI->getOperand(0).getReg());
-    LLT SrcTy = MRI->getType(MI->getOperand(1).getReg());
-    LLT SrcTy2 = MRI->getType(MI->getOperand(2).getReg());
-
-    if ((DstTy.isVector() != SrcTy.isVector()) ||
-        (DstTy.isVector() &&
-         DstTy.getElementCount() != SrcTy.getElementCount())) {
-      report("Generic vector abds/abdu must preserve number of lanes", MI);
-      break;
-    }
-
-    if (SrcTy != SrcTy2) {
-      report("Generic abds/abdu must have same input types", MI);
-      break;
-    }
-
-    if (DstTy != SrcTy) {
-      report("Generic abds/abdu must have same input and output types", MI);
-      break;
-    }
-
-    break;
-  }
   case TargetOpcode::G_SCMP:
   case TargetOpcode::G_UCMP: {
     LLT DstTy = MRI->getType(MI->getOperand(0).getReg());

--- a/llvm/test/MachineVerifier/test_abd_su.mir
+++ b/llvm/test/MachineVerifier/test_abd_su.mir
@@ -8,25 +8,32 @@ body: |
 
     %2:_(p0) = G_IMPLICIT_DEF
     %3:_(p0) = G_IMPLICIT_DEF
+    ; CHECK: Type mismatch in generic instruction
+    ; CHECK: Type mismatch in generic instruction
     %4:_(s1) = G_ABDS %2, %3
 
     %12:_(s64) = G_IMPLICIT_DEF
     %13:_(s64) = G_IMPLICIT_DEF
+    ; CHECK: Type mismatch in generic instruction
+    ; CHECK: Type mismatch in generic instruction
     %14:_(p0) = G_ABDS %12, %13
 
     %23:_(<2 x s32>) = G_IMPLICIT_DEF
     %24:_(<2 x s32>) = G_IMPLICIT_DEF
-    ; CHECK: Generic vector abds/abdu must preserve number of lanes
+    ; CHECK: Type mismatch in generic instruction
+    ; CHECK: Type mismatch in generic instruction
     %5:_(s1) = G_ABDU  %23, %24
 
     %15:_(s32) = G_CONSTANT i32 0
     %16:_(s64) = G_CONSTANT i64 2
-    ; CHECK: Generic abds/abdu must have same input types
+    ; CHECK: Type mismatch in generic instruction
+    ; CHECK: Type mismatch in generic instruction
     %17:_(s1) = G_ABDU %15, %16
 
     %18:_(s64) = G_CONSTANT i64 0
     %19:_(s64) = G_CONSTANT i64 2
-    ; CHECK: Generic abds/abdu must have same input and output types
+    ; CHECK: Type mismatch in generic instruction
+    ; CHECK: Type mismatch in generic instruction
     %20:_(s1) = G_ABDU %18, %19
 
 ...


### PR DESCRIPTION
These are declared to use a single type index for all operands in GenericOpcodes.td and the verifier knows how to check that all operands with the same type index match.