### PR TITLE
[GISel] Improve MachineVerifier for G_SCMP/UCMP.

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1615,9 +1615,8 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
   case TargetOpcode::G_UCMP: {
     LLT DstTy = MRI->getType(MI->getOperand(0).getReg());
     LLT SrcTy = MRI->getType(MI->getOperand(1).getReg());
-    LLT SrcTy2 = MRI->getType(MI->getOperand(2).getReg());
 
-    if (SrcTy.isPointerOrPointerVector() || SrcTy2.isPointerOrPointerVector()) {
+    if (SrcTy.isPointerOrPointerVector()) {
       report("Generic scmp/ucmp does not support pointers as operands", MI);
       break;
     }
@@ -1627,15 +1626,15 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
+    if (DstTy.getScalarSizeInBits() < 2) {
+      report("result type must be at least 2 bits wide", MI);
+      break;
+    }
+
     if ((DstTy.isVector() != SrcTy.isVector()) ||
         (DstTy.isVector() &&
          DstTy.getElementCount() != SrcTy.getElementCount())) {
       report("Generic vector scmp/ucmp must preserve number of lanes", MI);
-      break;
-    }
-
-    if (SrcTy != SrcTy2) {
-      report("Generic scmp/ucmp must have same input types", MI);
       break;
     }
 

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1627,7 +1627,7 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     if (DstTy.getScalarSizeInBits() < 2) {
-      report("result type must be at least 2 bits wide", MI);
+      report("Result type must be at least 2 bits wide", MI);
       break;
     }
 

--- a/llvm/test/MachineVerifier/test_uscmp.mir
+++ b/llvm/test/MachineVerifier/test_uscmp.mir
@@ -19,13 +19,17 @@ body:             |
     %23:_(<2 x s32>) = G_IMPLICIT_DEF
     %24:_(<2 x s32>) = G_IMPLICIT_DEF
     ; CHECK: Generic vector scmp/ucmp must preserve number of lanes
-    %5:_(s1) = G_UCMP  %23, %24
+    %5:_(s2) = G_UCMP  %23, %24
 
     %15:_(s32) = G_CONSTANT i32 0
     %16:_(s64) = G_CONSTANT i64 2
-    ; CHECK: Generic scmp/ucmp must have same input types
-    %17:_(s1) = G_SCMP %15, %16
+    ; CHECK: Type mismatch in generic instruction
+    %17:_(s2) = G_SCMP %15, %16
 
+    %18:_(s32) = G_CONSTANT i32 0
+    %19:_(s32) = G_CONSTANT i32 2
+    ; CHECK: result type must be at least 2 bits wide
+    %20:_(s1) = G_SCMP %18, %19
 
 
 ...

--- a/llvm/test/MachineVerifier/test_uscmp.mir
+++ b/llvm/test/MachineVerifier/test_uscmp.mir
@@ -28,7 +28,7 @@ body:             |
 
     %18:_(s32) = G_CONSTANT i32 0
     %19:_(s32) = G_CONSTANT i32 2
-    ; CHECK: result type must be at least 2 bits wide
+    ; CHECK: Result type must be at least 2 bits wide
     %20:_(s1) = G_SCMP %18, %19
 
 


### PR DESCRIPTION
Ensure destination type is at least 2 bits.
Remove unnecessary check that both sources are the same type. The verifier already handles this generically.