### PR TITLE
[lldb] Disable TestIOHandlerResizeNoEditline.py for Windows hosts

### DIFF
--- a/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
+++ b/lldb/test/API/iohandler/resize/TestIOHandlerResizeNoEditline.py
@@ -6,7 +6,10 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @no_debug_info_test
-    @skipIfWindows
+    @skipIf(
+        hostoslist=["windows"],
+        bugnumber="https://github.com/llvm/llvm-project/issues/120021",
+    )
     def test_resize_no_editline(self):
         """Tests terminal resizing if the editline isn't used."""
         dbg = lldb.SBDebugger.Create(False)


### PR DESCRIPTION
See #120021 for details.