### PR TITLE
[TableGen][GISel] Don't use std::optional with pointers (NFC)

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -163,7 +163,7 @@ CodeGenRegBank &CodeGenTarget::getRegBank() const {
   return *RegBank;
 }
 
-std::optional<CodeGenRegisterClass *> CodeGenTarget::getSuperRegForSubReg(
+const CodeGenRegisterClass *CodeGenTarget::getSuperRegForSubReg(
     const ValueTypeByHwMode &ValueTy, CodeGenRegBank &RegBank,
     const CodeGenSubRegIndex *SubIdx, bool MustBeAllocatable) const {
   std::vector<CodeGenRegisterClass *> Candidates;
@@ -192,7 +192,7 @@ std::optional<CodeGenRegisterClass *> CodeGenTarget::getSuperRegForSubReg(
 
   // If we didn't find anything, we're done.
   if (Candidates.empty())
-    return std::nullopt;
+    return nullptr;
 
   // Find and return the largest of our candidate classes.
   llvm::stable_sort(Candidates, [&](const CodeGenRegisterClass *A,

--- a/llvm/utils/TableGen/Common/CodeGenTarget.h
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.h
@@ -124,7 +124,7 @@ public:
 
   /// Return the largest register class on \p RegBank which supports \p Ty and
   /// covers \p SubIdx if it exists.
-  std::optional<CodeGenRegisterClass *>
+  const CodeGenRegisterClass *
   getSuperRegForSubReg(const ValueTypeByHwMode &Ty, CodeGenRegBank &RegBank,
                        const CodeGenSubRegIndex *SubIdx,
                        bool MustBeAllocatable = false) const;


### PR DESCRIPTION
Pointers already have a well-defined null value.