### PR TITLE
[LLVM][tools] Remove unnecessary newline from error message

### DIFF
--- a/llvm/lib/MC/TargetRegistry.cpp
+++ b/llvm/lib/MC/TargetRegistry.cpp
@@ -126,7 +126,7 @@ const Target *TargetRegistry::lookupTarget(StringRef ArchName,
                      [&](const Target &T) { return ArchName == T.getName(); });
 
     if (I == targets().end()) {
-      Error = ("invalid target '" + ArchName + "'.\n").str();
+      Error = ("invalid target '" + ArchName + "'.").str();
       return nullptr;
     }
 

--- a/llvm/test/tools/llc/invalid-target.ll
+++ b/llvm/test/tools/llc/invalid-target.ll
@@ -3,8 +3,11 @@
 
 ; Check the error message doesn't say error twice.
 
-; MARCH: {{.*}}llc{{.*}}: error: invalid target 'arst'.{{$}}
-; MTRIPLE: {{.*}}llc{{.*}}: error: unable to get target for 'arst-unknown-unknown', see --version and --triple.{{$}}
+; MARCH: {{.*}}llc{{.*}}: error: invalid target 'arst'.
+; MARCH-EMPTY:
+;
+; MTRIPLE: {{.*}}llc{{.*}}: error: unable to get target for 'arst-unknown-unknown', see --version and --triple.
+; MTRIPLE-EMPTY:
 
 define void @func() {
   ret void

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -549,7 +549,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
       TheTarget =
           TargetRegistry::lookupTarget(codegen::getMArch(), TheTriple, Error);
       if (!TheTarget) {
-        WithColor::error(errs(), argv[0]) << Error;
+        WithColor::error(errs(), argv[0]) << Error << "\n";
         exit(1);
       }
 
@@ -592,7 +592,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
     TheTarget =
         TargetRegistry::lookupTarget(codegen::getMArch(), TheTriple, Error);
     if (!TheTarget) {
-      WithColor::error(errs(), argv[0]) << Error;
+      WithColor::error(errs(), argv[0]) << Error << "\n";
       return 1;
     }
 


### PR DESCRIPTION
The previous missing a newline:
```shell
$ llc --mattr=help
llc: error: unable to get target for 'unknown', see --version and --triple.$
```