### PR TITLE
[NFC] [RISCV] Refactor class RISCVExtension

### DIFF
--- a/clang/test/Driver/print-enabled-extensions/riscv-rocket-rv64.c
+++ b/clang/test/Driver/print-enabled-extensions/riscv-rocket-rv64.c
@@ -4,10 +4,10 @@
 // Simple litmus test to check the frontend handling of this option is
 // enabled.
 
-// CHECK: Extensions enabled for the given RISC-V target 
+// CHECK: Extensions enabled for the given RISC-V target
 // CHECK-EMPTY:
-// CHECK-NEXT: Name                 Version   Description 
-// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set) 
-// CHECK-NEXT:     zicsr                2.0       'zicsr' (CSRs) 
-// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i) 
+// CHECK-NEXT: Name                 Version   Description
+// CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
+// CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
 // CHECK-EMPTY:

--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -5,7 +5,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT:     Name                 Version   Description
 // CHECK-NEXT:     i                    2.1       'I' (Base Integer Instruction Set)
-// CHECK-NEXT:     e                    2.0       Implements RV{32,64}E (provides 16 rather than 32 GPRs)
+// CHECK-NEXT:     e                    2.0       'E' (Embedded Instruction Set with 16 GPRs)
 // CHECK-NEXT:     m                    2.0       'M' (Integer Multiplication and Division)
 // CHECK-NEXT:     a                    2.1       'A' (Atomic Instructions)
 // CHECK-NEXT:     f                    2.2       'F' (Single-Precision Floating-Point)
@@ -24,7 +24,7 @@
 // CHECK-NEXT:     ziccrse              1.0       'Ziccrse' (Main Memory Supports Forward Progress on LR/SC Sequences)
 // CHECK-NEXT:     zicntr               2.0       'Zicntr' (Base Counters and Timers)
 // CHECK-NEXT:     zicond               1.0       'Zicond' (Integer Conditional Operations)
-// CHECK-NEXT:     zicsr                2.0       'zicsr' (CSRs)
+// CHECK-NEXT:     zicsr                2.0       'Zicsr' (CSRs)
 // CHECK-NEXT:     zifencei             2.0       'Zifencei' (fence.i)
 // CHECK-NEXT:     zihintntl            1.0       'Zihintntl' (Non-Temporal Locality Hints)
 // CHECK-NEXT:     zihintpause          2.0       'Zihintpause' (Pause Hint)
@@ -78,7 +78,7 @@
 // CHECK-NEXT:     zve64d               1.0       'Zve64d' (Vector Extensions for Embedded Processors with maximal 64 EEW, F and D extension)
 // CHECK-NEXT:     zve64f               1.0       'Zve64f' (Vector Extensions for Embedded Processors with maximal 64 EEW and F extension)
 // CHECK-NEXT:     zve64x               1.0       'Zve64x' (Vector Extensions for Embedded Processors with maximal 64 EEW)
-// CHECK-NEXT:     zvfbfmin             1.0       'Zvbfmin' (Vector BF16 Converts)
+// CHECK-NEXT:     zvfbfmin             1.0       'Zvfbfmin' (Vector BF16 Converts)
 // CHECK-NEXT:     zvfbfwma             1.0       'Zvfbfwma' (Vector BF16 widening mul-add)
 // CHECK-NEXT:     zvfh                 1.0       'Zvfh' (Vector Half-Precision Floating-Point)
 // CHECK-NEXT:     zvfhmin              1.0       'Zvfhmin' (Vector Half-Precision Floating-Point Minimal)
@@ -87,7 +87,7 @@
 // CHECK-NEXT:     zvkn                 1.0       'Zvkn' (shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and 'Zvkt')
 // CHECK-NEXT:     zvknc                1.0       'Zvknc' (shorthand for 'Zvknc' and 'Zvbc')
 // CHECK-NEXT:     zvkned               1.0       'Zvkned' (Vector AES Encryption & Decryption (Single Round))
-// CHECK-NEXT:     zvkng                1.0       'zvkng' (shorthand for 'Zvkn' and 'Zvkg')
+// CHECK-NEXT:     zvkng                1.0       'Zvkng' (shorthand for 'Zvkn' and 'Zvkg')
 // CHECK-NEXT:     zvknha               1.0       'Zvknha' (Vector SHA-2 (SHA-256 only))
 // CHECK-NEXT:     zvknhb               1.0       'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))
 // CHECK-NEXT:     zvks                 1.0       'Zvks' (shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and 'Zvkt')
@@ -96,25 +96,25 @@
 // CHECK-NEXT:     zvksg                1.0       'Zvksg' (shorthand for 'Zvks' and 'Zvkg')
 // CHECK-NEXT:     zvksh                1.0       'Zvksh' (SM3 Hash Function Instructions)
 // CHECK-NEXT:     zvkt                 1.0       'Zvkt' (Vector Data-Independent Execution Latency)
-// CHECK-NEXT:     zvl1024b             1.0       'Zvl' (Minimum Vector Length) 1024
-// CHECK-NEXT:     zvl128b              1.0       'Zvl' (Minimum Vector Length) 128
-// CHECK-NEXT:     zvl16384b            1.0       'Zvl' (Minimum Vector Length) 16384
-// CHECK-NEXT:     zvl2048b             1.0       'Zvl' (Minimum Vector Length) 2048
-// CHECK-NEXT:     zvl256b              1.0       'Zvl' (Minimum Vector Length) 256
-// CHECK-NEXT:     zvl32768b            1.0       'Zvl' (Minimum Vector Length) 32768
-// CHECK-NEXT:     zvl32b               1.0       'Zvl' (Minimum Vector Length) 32
-// CHECK-NEXT:     zvl4096b             1.0       'Zvl' (Minimum Vector Length) 4096
-// CHECK-NEXT:     zvl512b              1.0       'Zvl' (Minimum Vector Length) 512
-// CHECK-NEXT:     zvl64b               1.0       'Zvl' (Minimum Vector Length) 64
-// CHECK-NEXT:     zvl65536b            1.0       'Zvl' (Minimum Vector Length) 65536
-// CHECK-NEXT:     zvl8192b             1.0       'Zvl' (Minimum Vector Length) 8192
+// CHECK-NEXT:     zvl1024b             1.0       'Zvl1024b' (Minimum Vector Length 1024)
+// CHECK-NEXT:     zvl128b              1.0       'Zvl128b' (Minimum Vector Length 128)
+// CHECK-NEXT:     zvl16384b            1.0       'Zvl16384b' (Minimum Vector Length 16384)
+// CHECK-NEXT:     zvl2048b             1.0       'Zvl2048b' (Minimum Vector Length 2048)
+// CHECK-NEXT:     zvl256b              1.0       'Zvl256b' (Minimum Vector Length 256)
+// CHECK-NEXT:     zvl32768b            1.0       'Zvl32768b' (Minimum Vector Length 32768)
+// CHECK-NEXT:     zvl32b               1.0       'Zvl32b' (Minimum Vector Length 32)
+// CHECK-NEXT:     zvl4096b             1.0       'Zvl4096b' (Minimum Vector Length 4096)
+// CHECK-NEXT:     zvl512b              1.0       'Zvl512b' (Minimum Vector Length 512)
+// CHECK-NEXT:     zvl64b               1.0       'Zvl64b' (Minimum Vector Length 64)
+// CHECK-NEXT:     zvl65536b            1.0       'Zvl65536b' (Minimum Vector Length 65536)
+// CHECK-NEXT:     zvl8192b             1.0       'Zvl8192b' (Minimum Vector Length 8192)
 // CHECK-NEXT:     zhinx                1.0       'Zhinx' (Half Float in Integer)
 // CHECK-NEXT:     zhinxmin             1.0       'Zhinxmin' (Half Float in Integer Minimal)
 // CHECK-NEXT:     sha                  1.0       'Sha' (Augmented Hypervisor)
 // CHECK-NEXT:     shcounterenw         1.0       'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero)
-// CHECK-NEXT:     shgatpa              1.0       'Sgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare)
+// CHECK-NEXT:     shgatpa              1.0       'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare)
 // CHECK-NEXT:     shtvala              1.0       'Shtvala' (htval provides all needed values)
-// CHECK-NEXT:     shvsatpa             1.0       'Svsatpa' (vsatp supports all modes supported by satp)
+// CHECK-NEXT:     shvsatpa             1.0       'Shvsatpa' (vsatp supports all modes supported by satp)
 // CHECK-NEXT:     shvstvala            1.0       'Shvstvala' (vstval provides all needed values)
 // CHECK-NEXT:     shvstvecd            1.0       'Shvstvecd' (vstvec supports Direct mode)
 // CHECK-NEXT:     smaia                1.0       'Smaia' (Advanced Interrupt Architecture Machine Level)
@@ -145,11 +145,11 @@
 // CHECK-NEXT:     supm                 1.0       'Supm' (Indicates User-mode Pointer Masking)
 // CHECK-NEXT:     svade                1.0       'Svade' (Raise exceptions on improper A/D bits)
 // CHECK-NEXT:     svadu                1.0       'Svadu' (Hardware A/D updates)
-// CHECK-NEXT:     svbare               1.0       'Svbare' $(satp mode Bare supported)
+// CHECK-NEXT:     svbare               1.0       'Svbare' (satp mode Bare supported)
 // CHECK-NEXT:     svinval              1.0       'Svinval' (Fine-Grained Address-Translation Cache Invalidation)
 // CHECK-NEXT:     svnapot              1.0       'Svnapot' (NAPOT Translation Contiguity)
 // CHECK-NEXT:     svpbmt               1.0       'Svpbmt' (Page-Based Memory Types)
-// CHECK-NEXT:     svvptc               1.0       'svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid)
+// CHECK-NEXT:     svvptc               1.0       'Svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid)
 // CHECK-NEXT:     xcvalu               1.0       'XCValu' (CORE-V ALU Operations)
 // CHECK-NEXT:     xcvbi                1.0       'XCVbi' (CORE-V Immediate Branching)
 // CHECK-NEXT:     xcvbitmanip          1.0       'XCVbitmanip' (CORE-V Bit Manipulation)

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -12,6 +12,9 @@
 
 // Subclass of SubtargetFeature to be used when the feature is also a RISC-V
 // extension. Extensions have a version and may be experimental.
+// NOTE: The extension name must start with
+//       - "FeatureStdExt" for standard extensions
+//       - "FeatureVendor" for vendor-specific extensions
 //
 // major     - Major version of extension.
 // minor     - Minor version of extension.

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -22,11 +22,17 @@
 //             uses the record name by replacing Feature with Has.
 // value     - Value to assign to the field in RISCVSubtarget when this
 //             extension is enabled. Usually "true", but can be changed.
-class RISCVExtension<string name, int major, int minor, string desc,
+class RISCVExtension<int major, int minor, string desc,
                      list<SubtargetFeature> implies = [],
                      string fieldname = !subst("Feature", "Has", NAME),
-                     string value = "true">
-    : SubtargetFeature<name, fieldname, value, desc, implies> {
+                     string value = "true", string prefix = "">
+    : SubtargetFeature<
+        prefix # !tolower(!subst("FeatureVendor", "",
+                                 !subst("FeatureStdExt", "", NAME))),
+        fieldname, value,
+        "'" # !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME))
+            # "' (" # desc # ")",
+        implies> {
   // MajorVersion - The major version for this extension.
   int MajorVersion = major;
 
@@ -37,7 +43,7 @@ class RISCVExtension<string name, int major, int minor, string desc,
   bit Experimental = false;
 }
 
-// The groupID/bitmask of RISCVExtension is used to retrieve a specific bit value 
+// The groupID/bitmask of RISCVExtension is used to retrieve a specific bit value
 // from __riscv_feature_bits based on the groupID and bitmask.
 // groupID - groupID of extension
 // bitPos  - bit position of extension bitmask
@@ -48,125 +54,108 @@ class RISCVExtensionBitmask<bits<3> groupID, int bitPos> {
 
 // Version of RISCVExtension to be used for Experimental extensions. This
 // sets the Experimental flag and prepends experimental- to the -mattr name.
-class RISCVExperimentalExtension<string name, int major, int minor, string desc,
+class RISCVExperimentalExtension<int major, int minor, string desc,
                                  list<RISCVExtension> implies = [],
                                  string fieldname = !subst("Feature", "Has", NAME),
                                  string value = "true">
-    : RISCVExtension<"experimental-"#name, major, minor, desc, implies,
-                     fieldname, value> {
+    : RISCVExtension<major, minor, desc, implies, fieldname, value,
+                     "experimental-"> {
   let Experimental = true;
 }
 
 // Integer Extensions
 
 def FeatureStdExtI
-    : RISCVExtension<"i", 2, 1,
-                     "'I' (Base Integer Instruction Set)">,
+    : RISCVExtension<2, 1, "Base Integer Instruction Set">,
       RISCVExtensionBitmask<0, 8>;
 
 def FeatureStdExtE
-    : RISCVExtension<"e", 2, 0,
-                     "Implements RV{32,64}E (provides 16 rather than 32 GPRs)">;
+    : RISCVExtension<2, 0, "Embedded Instruction Set with 16 GPRs">;
 
 def FeatureStdExtZic64b
-    : RISCVExtension<"zic64b", 1, 0,
-                     "'Zic64b' (Cache Block Size Is 64 Bytes)">;
+    : RISCVExtension<1, 0, "Cache Block Size Is 64 Bytes">;
 
 def FeatureStdExtZicbom
-    : RISCVExtension<"zicbom", 1, 0,
-                     "'Zicbom' (Cache-Block Management Instructions)">;
+    : RISCVExtension<1, 0, "Cache-Block Management Instructions">;
 def HasStdExtZicbom : Predicate<"Subtarget->hasStdExtZicbom()">,
                       AssemblerPredicate<(all_of FeatureStdExtZicbom),
                           "'Zicbom' (Cache-Block Management Instructions)">;
 
 def FeatureStdExtZicbop
-    : RISCVExtension<"zicbop", 1, 0,
-                     "'Zicbop' (Cache-Block Prefetch Instructions)">;
+    : RISCVExtension<1, 0, "Cache-Block Prefetch Instructions">;
 def HasStdExtZicbop : Predicate<"Subtarget->hasStdExtZicbop()">,
                       AssemblerPredicate<(all_of FeatureStdExtZicbop),
                           "'Zicbop' (Cache-Block Prefetch Instructions)">;
 
 def FeatureStdExtZicboz
-    : RISCVExtension<"zicboz", 1, 0,
-                     "'Zicboz' (Cache-Block Zero Instructions)">,
+    : RISCVExtension<1, 0, "Cache-Block Zero Instructions">,
       RISCVExtensionBitmask<0, 37>;
 def HasStdExtZicboz : Predicate<"Subtarget->hasStdExtZicboz()">,
                       AssemblerPredicate<(all_of FeatureStdExtZicboz),
                           "'Zicboz' (Cache-Block Zero Instructions)">;
 
 def FeatureStdExtZiccamoa
-    : RISCVExtension<"ziccamoa", 1, 0,
-                     "'Ziccamoa' (Main Memory Supports All Atomics in A)">;
+    : RISCVExtension<1, 0, "Main Memory Supports All Atomics in A">;
 
 def FeatureStdExtZiccif
-    : RISCVExtension<"ziccif", 1, 0,
-                     "'Ziccif' (Main Memory Supports Instruction Fetch with Atomicity Requirement)">;
+    : RISCVExtension<1, 0,
+                     "Main Memory Supports Instruction Fetch with Atomicity Requirement">;
 
 def FeatureStdExtZicclsm
-    : RISCVExtension<"zicclsm", 1, 0,
-                     "'Zicclsm' (Main Memory Supports Misaligned Loads/Stores)">;
+    : RISCVExtension<1, 0, "Main Memory Supports Misaligned Loads/Stores">;
 
 def FeatureStdExtZiccrse
-    : RISCVExtension<"ziccrse", 1, 0,
-                     "'Ziccrse' (Main Memory Supports Forward Progress on LR/SC Sequences)">;
+    : RISCVExtension<1, 0,
+                     "Main Memory Supports Forward Progress on LR/SC Sequences">;
 
 def FeatureStdExtZicsr
-    : RISCVExtension<"zicsr", 2, 0,
-                     "'zicsr' (CSRs)">;
+    : RISCVExtension<2, 0, "CSRs">;
 def HasStdExtZicsr : Predicate<"Subtarget->hasStdExtZicsr()">,
                      AssemblerPredicate<(all_of FeatureStdExtZicsr),
                                         "'Zicsr' (CSRs)">;
 
 def FeatureStdExtZicntr
-    : RISCVExtension<"zicntr", 2, 0,
-                     "'Zicntr' (Base Counters and Timers)",
-                       [FeatureStdExtZicsr]>;
+    : RISCVExtension<2, 0, "Base Counters and Timers",
+                     [FeatureStdExtZicsr]>;
 
 def FeatureStdExtZicond
-    : RISCVExtension<"zicond", 1, 0,
-                     "'Zicond' (Integer Conditional Operations)">,
+    : RISCVExtension<1, 0, "Integer Conditional Operations">,
       RISCVExtensionBitmask<0, 38>;
 def HasStdExtZicond : Predicate<"Subtarget->hasStdExtZicond()">,
                       AssemblerPredicate<(all_of FeatureStdExtZicond),
-                          "'Zicond' (Integer Conditional Operations)">;
+                          "(Integer Conditional Operations)">;
 
 def FeatureStdExtZifencei
-    : RISCVExtension<"zifencei", 2, 0,
-                     "'Zifencei' (fence.i)">;
+    : RISCVExtension<2, 0, "fence.i">;
 def HasStdExtZifencei : Predicate<"Subtarget->hasStdExtZifencei()">,
                         AssemblerPredicate<(all_of FeatureStdExtZifencei),
                                            "'Zifencei' (fence.i)">;
 
 def FeatureStdExtZihintpause
-    : RISCVExtension<"zihintpause", 2, 0,
-                     "'Zihintpause' (Pause Hint)">,
+    : RISCVExtension<2, 0, "Pause Hint">,
       RISCVExtensionBitmask<0, 40>;
 def HasStdExtZihintpause : Predicate<"Subtarget->hasStdExtZihintpause()">,
                            AssemblerPredicate<(all_of FeatureStdExtZihintpause),
                                               "'Zihintpause' (Pause Hint)">;
 
 def FeatureStdExtZihintntl
-    : RISCVExtension<"zihintntl", 1, 0,
-                     "'Zihintntl' (Non-Temporal Locality Hints)">,
+    : RISCVExtension<1, 0, "Non-Temporal Locality Hints">,
       RISCVExtensionBitmask<0, 39>;
 def HasStdExtZihintntl : Predicate<"Subtarget->hasStdExtZihintntl()">,
                          AssemblerPredicate<(all_of FeatureStdExtZihintntl),
                              "'Zihintntl' (Non-Temporal Locality Hints)">;
 
 def FeatureStdExtZihpm
-    : RISCVExtension<"zihpm", 2, 0,
-                     "'Zihpm' (Hardware Performance Counters)",
+    : RISCVExtension<2, 0, "Hardware Performance Counters",
                      [FeatureStdExtZicsr]>;
 
-def FeatureStdExtZimop : RISCVExtension<"zimop", 1, 0,
-                                        "'Zimop' (May-Be-Operations)">;
+def FeatureStdExtZimop : RISCVExtension<1, 0, "May-Be-Operations">;
 def HasStdExtZimop : Predicate<"Subtarget->hasStdExtZimop()">,
                      AssemblerPredicate<(all_of FeatureStdExtZimop),
                                         "'Zimop' (May-Be-Operations)">;
 
 def FeatureStdExtZicfilp
-    : RISCVExperimentalExtension<"zicfilp", 1, 0,
-                                 "'Zicfilp' (Landing pad)",
+    : RISCVExperimentalExtension<1, 0, "Landing pad",
                                  [FeatureStdExtZicsr]>;
 def HasStdExtZicfilp : Predicate<"Subtarget->hasStdExtZicfilp()">,
                        AssemblerPredicate<(all_of FeatureStdExtZicfilp),
@@ -175,8 +164,7 @@ def NoStdExtZicfilp : Predicate<"!Subtarget->hasStdExtZicfilp()">,
                       AssemblerPredicate<(all_of (not FeatureStdExtZicfilp))>;
 
 def FeatureStdExtZicfiss
-    : RISCVExperimentalExtension<"zicfiss", 1, 0,
-                                 "'Zicfiss' (Shadow stack)",
+    : RISCVExperimentalExtension<1, 0, "Shadow stack",
                                  [FeatureStdExtZicsr, FeatureStdExtZimop]>;
 def HasStdExtZicfiss : Predicate<"Subtarget->hasStdExtZicfiss()">,
                        AssemblerPredicate<(all_of FeatureStdExtZicfiss),
@@ -186,15 +174,13 @@ def NoHasStdExtZicfiss : Predicate<"!Subtarget->hasStdExtZicfiss()">;
 // Multiply Extensions
 
 def FeatureStdExtZmmul
-    : RISCVExtension<"zmmul", 1, 0,
-                     "'Zmmul' (Integer Multiplication)">;
+    : RISCVExtension<1, 0, "Integer Multiplication">;
 def HasStdExtZmmul : Predicate<"Subtarget->hasStdExtZmmul()">,
                      AssemblerPredicate<(all_of FeatureStdExtZmmul),
                      "'Zmmul' (Integer Multiplication)">;
 
 def FeatureStdExtM
-    : RISCVExtension<"m", 2, 0,
-                     "'M' (Integer Multiplication and Division)",
+    : RISCVExtension<2, 0, "Integer Multiplication and Division",
                      [FeatureStdExtZmmul]>,
       RISCVExtensionBitmask<0, 12>;
 def HasStdExtM : Predicate<"Subtarget->hasStdExtM()">,
@@ -204,24 +190,21 @@ def HasStdExtM : Predicate<"Subtarget->hasStdExtM()">,
 // Atomic Extensions
 
 def FeatureStdExtZaamo
-    : RISCVExtension<"zaamo", 1, 0,
-                     "'Zaamo' (Atomic Memory Operations)">;
+    : RISCVExtension<1, 0, "Atomic Memory Operations">;
 def HasStdExtZaamo
     : Predicate<"Subtarget->hasStdExtZaamo()">,
       AssemblerPredicate<(any_of FeatureStdExtZaamo),
                          "'Zaamo' (Atomic Memory Operations)">;
 
 def FeatureStdExtZalrsc
-    : RISCVExtension<"zalrsc", 1, 0,
-                     "'Zalrsc' (Load-Reserved/Store-Conditional)">;
+    : RISCVExtension<1, 0, "Load-Reserved/Store-Conditional">;
 def HasStdExtZalrsc
     : Predicate<"Subtarget->hasStdExtZalrsc()">,
       AssemblerPredicate<(any_of FeatureStdExtZalrsc),
                          "'Zalrsc' (Load-Reserved/Store-Conditional)">;
 
 def FeatureStdExtA
-    : RISCVExtension<"a", 2, 1,
-                     "'A' (Atomic Instructions)",
+    : RISCVExtension<2, 1, "Atomic Instructions",
                      [FeatureStdExtZaamo, FeatureStdExtZalrsc]>,
       RISCVExtensionBitmask<0, 0>;
 def HasStdExtA : Predicate<"Subtarget->hasStdExtA()">,
@@ -229,31 +212,28 @@ def HasStdExtA : Predicate<"Subtarget->hasStdExtA()">,
                                     "'A' (Atomic Instructions)">;
 
 def FeatureStdExtZtso
-    : RISCVExtension<"ztso", 1, 0,
-                     "'Ztso' (Memory Model - Total Store Order)">,
+    : RISCVExtension<1, 0, "Memory Model - Total Store Order">,
       RISCVExtensionBitmask<0, 47>;
 def HasStdExtZtso : Predicate<"Subtarget->hasStdExtZtso()">,
                     AssemblerPredicate<(all_of FeatureStdExtZtso),
                         "'Ztso' (Memory Model - Total Store Order)">;
 def NotHasStdExtZtso : Predicate<"!Subtarget->hasStdExtZtso()">;
 
-def FeatureStdExtZa64rs : RISCVExtension<"za64rs", 1, 0,
-                                         "'Za64rs' (Reservation Set Size of at Most 64 Bytes)">;
+def FeatureStdExtZa64rs
+    : RISCVExtension<1, 0, "Reservation Set Size of at Most 64 Bytes">;
 
-def FeatureStdExtZa128rs : RISCVExtension<"za128rs", 1, 0,
-                                          "'Za128rs' (Reservation Set Size of at Most 128 Bytes)">;
+def FeatureStdExtZa128rs
+    : RISCVExtension<1, 0, "Reservation Set Size of at Most 128 Bytes">;
 
 def FeatureStdExtZabha
-    : RISCVExtension<"zabha", 1, 0,
-                     "'Zabha' (Byte and Halfword Atomic Memory Operations)",
+    : RISCVExtension<1, 0, "Byte and Halfword Atomic Memory Operations",
                      [FeatureStdExtZaamo]>;
 def HasStdExtZabha : Predicate<"Subtarget->hasStdExtZabha()">,
                      AssemblerPredicate<(all_of FeatureStdExtZabha),
                          "'Zabha' (Byte and Halfword Atomic Memory Operations)">;
 
 def FeatureStdExtZacas
-    : RISCVExtension<"zacas", 1, 0,
-                     "'Zacas' (Atomic Compare-And-Swap Instructions)",
+    : RISCVExtension<1, 0, "Atomic Compare-And-Swap Instructions",
                      [FeatureStdExtZaamo]>,
       RISCVExtensionBitmask<0, 26>;
 def HasStdExtZacas : Predicate<"Subtarget->hasStdExtZacas()">,
@@ -262,18 +242,15 @@ def HasStdExtZacas : Predicate<"Subtarget->hasStdExtZacas()">,
 def NoStdExtZacas : Predicate<"!Subtarget->hasStdExtZacas()">;
 
 def FeatureStdExtZalasr
-    : RISCVExperimentalExtension<"zalasr", 0, 1,
-                                 "'Zalasr' (Load-Acquire and Store-Release Instructions)">;
+    : RISCVExperimentalExtension<0, 1, "Load-Acquire and Store-Release Instructions">;
 def HasStdExtZalasr : Predicate<"Subtarget->hasStdExtZalasr()">,
                       AssemblerPredicate<(all_of FeatureStdExtZalasr),
                           "'Zalasr' (Load-Acquire and Store-Release Instructions)">;
 
 def FeatureStdExtZama16b
-    : RISCVExtension<"zama16b", 1, 0,
-                     "'Zama16b' (Atomic 16-byte misaligned loads, stores and AMOs)">;
+    : RISCVExtension<1, 0, "Atomic 16-byte misaligned loads, stores and AMOs">;
 
-def FeatureStdExtZawrs : RISCVExtension<"zawrs", 1, 0,
-                                        "'Zawrs' (Wait on Reservation Set)">;
+def FeatureStdExtZawrs : RISCVExtension<1, 0, "Wait on Reservation Set">;
 def HasStdExtZawrs : Predicate<"Subtarget->hasStdExtZawrs()">,
                      AssemblerPredicate<(all_of FeatureStdExtZawrs),
                                         "'Zawrs' (Wait on Reservation Set)">;
@@ -281,8 +258,7 @@ def HasStdExtZawrs : Predicate<"Subtarget->hasStdExtZawrs()">,
 // Floating Point Extensions
 
 def FeatureStdExtF
-    : RISCVExtension<"f", 2, 2,
-                     "'F' (Single-Precision Floating-Point)",
+    : RISCVExtension<2, 2, "Single-Precision Floating-Point",
                      [FeatureStdExtZicsr]>,
       RISCVExtensionBitmask<0, 5>;
 def HasStdExtF : Predicate<"Subtarget->hasStdExtF()">,
@@ -290,8 +266,7 @@ def HasStdExtF : Predicate<"Subtarget->hasStdExtF()">,
                                     "'F' (Single-Precision Floating-Point)">;
 
 def FeatureStdExtD
-    : RISCVExtension<"d", 2, 2,
-                     "'D' (Double-Precision Floating-Point)",
+    : RISCVExtension<2, 2, "Double-Precision Floating-Point",
                      [FeatureStdExtF]>,
       RISCVExtensionBitmask<0, 3>;
 def HasStdExtD : Predicate<"Subtarget->hasStdExtD()">,
@@ -299,8 +274,7 @@ def HasStdExtD : Predicate<"Subtarget->hasStdExtD()">,
                                     "'D' (Double-Precision Floating-Point)">;
 
 def FeatureStdExtZfhmin
-    : RISCVExtension<"zfhmin", 1, 0,
-                     "'Zfhmin' (Half-Precision Floating-Point Minimal)",
+    : RISCVExtension<1, 0, "Half-Precision Floating-Point Minimal",
                      [FeatureStdExtF]>,
       RISCVExtensionBitmask<0, 36>;
 def HasStdExtZfhmin : Predicate<"Subtarget->hasStdExtZfhmin()">,
@@ -309,8 +283,7 @@ def HasStdExtZfhmin : Predicate<"Subtarget->hasStdExtZfhmin()">,
                           "'Zfhmin' (Half-Precision Floating-Point Minimal)">;
 
 def FeatureStdExtZfh
-    : RISCVExtension<"zfh", 1, 0,
-                     "'Zfh' (Half-Precision Floating-Point)",
+    : RISCVExtension<1, 0, "Half-Precision Floating-Point",
                      [FeatureStdExtZfhmin]>,
       RISCVExtensionBitmask<0, 35>;
 def HasStdExtZfh : Predicate<"Subtarget->hasStdExtZfh()">,
@@ -319,8 +292,7 @@ def HasStdExtZfh : Predicate<"Subtarget->hasStdExtZfh()">,
 def NoStdExtZfh : Predicate<"!Subtarget->hasStdExtZfh()">;
 
 def FeatureStdExtZfbfmin
-    : RISCVExtension<"zfbfmin", 1, 0, "'Zfbfmin' (Scalar BF16 Converts)",
-                     [FeatureStdExtF]>;
+    : RISCVExtension<1, 0, "Scalar BF16 Converts", [FeatureStdExtF]>;
 def HasStdExtZfbfmin : Predicate<"Subtarget->hasStdExtZfbfmin()">,
                        AssemblerPredicate<(all_of FeatureStdExtZfbfmin),
                                           "'Zfbfmin' (Scalar BF16 Converts)">;
@@ -334,18 +306,14 @@ def HasHalfFPLoadStoreMove
                                     "'Zfbfmin' (Scalar BF16 Converts)">;
 
 def FeatureStdExtZfa
-    : RISCVExtension<"zfa", 1, 0,
-                     "'Zfa' (Additional Floating-Point)",
-                     [FeatureStdExtF]>,
+    : RISCVExtension<1, 0, "Additional Floating-Point", [FeatureStdExtF]>,
       RISCVExtensionBitmask<0, 34>;
 def HasStdExtZfa : Predicate<"Subtarget->hasStdExtZfa()">,
                    AssemblerPredicate<(all_of FeatureStdExtZfa),
                                       "'Zfa' (Additional Floating-Point)">;
 
 def FeatureStdExtZfinx
-    : RISCVExtension<"zfinx", 1, 0,
-                     "'Zfinx' (Float in Integer)",
-                     [FeatureStdExtZicsr]>;
+    : RISCVExtension<1, 0, "Float in Integer", [FeatureStdExtZicsr]>;
 def HasStdExtZfinx : Predicate<"Subtarget->hasStdExtZfinx()">,
                      AssemblerPredicate<(all_of FeatureStdExtZfinx),
                                         "'Zfinx' (Float in Integer)">;
@@ -356,16 +324,13 @@ def HasStdExtFOrZfinx : Predicate<"Subtarget->hasStdExtFOrZfinx()">,
                             "'Zfinx' (Float in Integer)">;
 
 def FeatureStdExtZdinx
-    : RISCVExtension<"zdinx", 1, 0,
-                     "'Zdinx' (Double in Integer)",
-                     [FeatureStdExtZfinx]>;
+    : RISCVExtension<1, 0, "Double in Integer", [FeatureStdExtZfinx]>;
 def HasStdExtZdinx : Predicate<"Subtarget->hasStdExtZdinx()">,
                      AssemblerPredicate<(all_of FeatureStdExtZdinx),
                                         "'Zdinx' (Double in Integer)">;
 
 def FeatureStdExtZhinxmin
-    : RISCVExtension<"zhinxmin", 1, 0,
-                     "'Zhinxmin' (Half Float in Integer Minimal)",
+    : RISCVExtension<1, 0, "Half Float in Integer Minimal",
                      [FeatureStdExtZfinx]>;
 def HasStdExtZhinxmin : Predicate<"Subtarget->hasStdExtZhinxmin()">,
                         AssemblerPredicate<(all_of FeatureStdExtZhinxmin),
@@ -373,9 +338,7 @@ def HasStdExtZhinxmin : Predicate<"Subtarget->hasStdExtZhinxmin()">,
                             "'Zhinxmin' (Half Float in Integer Minimal)">;
 
 def FeatureStdExtZhinx
-    : RISCVExtension<"zhinx", 1, 0,
-                     "'Zhinx' (Half Float in Integer)",
-                     [FeatureStdExtZhinxmin]>;
+    : RISCVExtension<1, 0, "Half Float in Integer", [FeatureStdExtZhinxmin]>;
 def HasStdExtZhinx : Predicate<"Subtarget->hasStdExtZhinx()">,
                      AssemblerPredicate<(all_of FeatureStdExtZhinx),
                                         "'Zhinx' (Half Float in Integer)">;
@@ -384,8 +347,7 @@ def NoStdExtZhinx : Predicate<"!Subtarget->hasStdExtZhinx()">;
 // Compressed Extensions
 
 def FeatureStdExtC
-    : RISCVExtension<"c", 2, 0,
-                     "'C' (Compressed Instructions)">,
+    : RISCVExtension<2, 0, "Compressed Instructions">,
       RISCVExtensionBitmask<0, 2>;
 def HasStdExtC : Predicate<"Subtarget->hasStdExtC()">,
                  AssemblerPredicate<(all_of FeatureStdExtC),
@@ -399,9 +361,9 @@ def HasRVCHints : Predicate<"Subtarget->enableRVCHintInstrs()">,
                                      "RVC Hint Instructions">;
 
 def FeatureStdExtZca
-    : RISCVExtension<"zca", 1, 0,
-                     "'Zca' (part of the C extension, excluding compressed "
-                     "floating point loads/stores)">;
+    : RISCVExtension<1, 0,
+                     "part of the C extension, excluding compressed "
+                     "floating point loads/stores">;
 
 def HasStdExtCOrZca
     : Predicate<"Subtarget->hasStdExtCOrZca()">,
@@ -411,16 +373,15 @@ def HasStdExtCOrZca
                          "compressed floating point loads/stores)">;
 
 def FeatureStdExtZcb
-    : RISCVExtension<"zcb", 1, 0,
-                     "'Zcb' (Compressed basic bit manipulation instructions)",
+    : RISCVExtension<1, 0, "Compressed basic bit manipulation instructions",
                      [FeatureStdExtZca]>;
 def HasStdExtZcb : Predicate<"Subtarget->hasStdExtZcb()">,
                    AssemblerPredicate<(all_of FeatureStdExtZcb),
                        "'Zcb' (Compressed basic bit manipulation instructions)">;
 
 def FeatureStdExtZcd
-    : RISCVExtension<"zcd", 1, 0,
-                     "'Zcd' (Compressed Double-Precision Floating-Point Instructions)",
+    : RISCVExtension<1, 0,
+                     "Compressed Double-Precision Floating-Point Instructions",
                      [FeatureStdExtD, FeatureStdExtZca]>;
 
 def HasStdExtCOrZcd
@@ -430,29 +391,29 @@ def HasStdExtCOrZcd
                          "'Zcd' (Compressed Double-Precision Floating-Point Instructions)">;
 
 def FeatureStdExtZcf
-    : RISCVExtension<"zcf", 1, 0,
-                     "'Zcf' (Compressed Single-Precision Floating-Point Instructions)",
+    : RISCVExtension<1, 0,
+                     "Compressed Single-Precision Floating-Point Instructions",
                      [FeatureStdExtF, FeatureStdExtZca]>;
 
 def FeatureStdExtZcmp
-    : RISCVExtension<"zcmp", 1, 0,
-                     "'Zcmp' (sequenced instructions for code-size reduction)",
+    : RISCVExtension<1, 0,
+                     "sequenced instructions for code-size reduction",
                      [FeatureStdExtZca]>;
 def HasStdExtZcmp : Predicate<"Subtarget->hasStdExtZcmp() && !Subtarget->hasStdExtC()">,
                     AssemblerPredicate<(all_of FeatureStdExtZcmp),
                         "'Zcmp' (sequenced instructions for code-size reduction)">;
 
 def FeatureStdExtZcmt
-    : RISCVExtension<"zcmt", 1, 0,
-                     "'Zcmt' (table jump instructions for code-size reduction)",
+    : RISCVExtension<1, 0,
+                     "table jump instructions for code-size reduction",
                      [FeatureStdExtZca, FeatureStdExtZicsr]>;
 def HasStdExtZcmt : Predicate<"Subtarget->hasStdExtZcmt()">,
                            AssemblerPredicate<(all_of FeatureStdExtZcmt),
                            "'Zcmt' (table jump instructions for code-size reduction)">;
 
 def FeatureStdExtZce
-    : RISCVExtension<"zce", 1, 0,
-                     "'Zce' (Compressed extensions for microcontrollers)",
+    : RISCVExtension<1, 0,
+                     "Compressed extensions for microcontrollers",
                      [FeatureStdExtZcb, FeatureStdExtZcmp, FeatureStdExtZcmt]>;
 
 def HasStdExtCOrZcfOrZce
@@ -464,8 +425,7 @@ def HasStdExtCOrZcfOrZce
                          "'Zcf' (Compressed Single-Precision Floating-Point Instructions)">;
 
 def FeatureStdExtZcmop
-    : RISCVExtension<"zcmop", 1, 0,
-                     "'Zcmop' (Compressed May-Be-Operations)",
+    : RISCVExtension<1, 0, "Compressed May-Be-Operations",
                      [FeatureStdExtZca]>;
 def HasStdExtZcmop : Predicate<"Subtarget->hasStdExtZcmop()">,
                      AssemblerPredicate<(all_of FeatureStdExtZcmop),
@@ -474,8 +434,7 @@ def HasStdExtZcmop : Predicate<"Subtarget->hasStdExtZcmop()">,
 // Bitmanip Extensions
 
 def FeatureStdExtZba
-    : RISCVExtension<"zba", 1, 0,
-                     "'Zba' (Address Generation Instructions)">,
+    : RISCVExtension<1, 0, "Address Generation Instructions">,
       RISCVExtensionBitmask<0, 27>;
 def HasStdExtZba : Predicate<"Subtarget->hasStdExtZba()">,
                    AssemblerPredicate<(all_of FeatureStdExtZba),
@@ -483,8 +442,7 @@ def HasStdExtZba : Predicate<"Subtarget->hasStdExtZba()">,
 def NotHasStdExtZba : Predicate<"!Subtarget->hasStdExtZba()">;
 
 def FeatureStdExtZbb
-    : RISCVExtension<"zbb", 1, 0,
-                     "'Zbb' (Basic Bit-Manipulation)">,
+    : RISCVExtension<1, 0, "Basic Bit-Manipulation">,
       RISCVExtensionBitmask<0, 28>;
 def HasStdExtZbb : Predicate<"Subtarget->hasStdExtZbb()">,
                    AssemblerPredicate<(all_of FeatureStdExtZbb),
@@ -493,16 +451,14 @@ def NoStdExtZbb : Predicate<"!Subtarget->hasStdExtZbb()">,
                   AssemblerPredicate<(all_of (not FeatureStdExtZbb))>;
 
 def FeatureStdExtZbc
-    : RISCVExtension<"zbc", 1, 0,
-                     "'Zbc' (Carry-Less Multiplication)">,
+    : RISCVExtension<1, 0, "Carry-Less Multiplication">,
       RISCVExtensionBitmask<0, 29>;
 def HasStdExtZbc : Predicate<"Subtarget->hasStdExtZbc()">,
                    AssemblerPredicate<(all_of FeatureStdExtZbc),
                                       "'Zbc' (Carry-Less Multiplication)">;
 
 def FeatureStdExtZbs
-    : RISCVExtension<"zbs", 1, 0,
-                     "'Zbs' (Single-Bit Instructions)">,
+    : RISCVExtension<1, 0, "Single-Bit Instructions">,
       RISCVExtensionBitmask<0, 33>;
 def HasStdExtZbs : Predicate<"Subtarget->hasStdExtZbs()">,
                    AssemblerPredicate<(all_of FeatureStdExtZbs),
@@ -511,13 +467,11 @@ def HasStdExtZbs : Predicate<"Subtarget->hasStdExtZbs()">,
 // Bitmanip Extensions for Cryptography Extensions
 
 def FeatureStdExtB
-    : RISCVExtension<"b", 1, 0,
-                     "'B' (the collection of the Zba, Zbb, Zbs extensions)",
+    : RISCVExtension<1, 0, "the collection of the Zba, Zbb, Zbs extensions",
                      [FeatureStdExtZba, FeatureStdExtZbb, FeatureStdExtZbs]>;
 
 def FeatureStdExtZbkb
-    : RISCVExtension<"zbkb", 1, 0,
-                     "'Zbkb' (Bitmanip instructions for Cryptography)">,
+    : RISCVExtension<1, 0, "Bitmanip instructions for Cryptography">,
       RISCVExtensionBitmask<0, 30>;
 def HasStdExtZbkb : Predicate<"Subtarget->hasStdExtZbkb()">,
                     AssemblerPredicate<(all_of FeatureStdExtZbkb),
@@ -526,8 +480,7 @@ def NoStdExtZbkb : Predicate<"!Subtarget->hasStdExtZbkb()">,
                    AssemblerPredicate<(all_of (not FeatureStdExtZbkb))>;
 
 def FeatureStdExtZbkx
-    : RISCVExtension<"zbkx", 1, 0,
-                     "'Zbkx' (Crossbar permutation instructions)">,
+    : RISCVExtension<1, 0, "Crossbar permutation instructions">,
       RISCVExtensionBitmask<0, 32>;
 def HasStdExtZbkx : Predicate<"Subtarget->hasStdExtZbkx()">,
                     AssemblerPredicate<(all_of FeatureStdExtZbkx),
@@ -543,9 +496,8 @@ def HasStdExtZbbOrZbkb
 // carry-less multiply subextension. The former should be enabled if the latter
 // is enabled.
 def FeatureStdExtZbkc
-    : RISCVExtension<"zbkc", 1, 0,
-                     "'Zbkc' (Carry-less multiply instructions for "
-                     "Cryptography)">,
+    : RISCVExtension<1, 0,
+                     "Carry-less multiply instructions for Cryptography">,
       RISCVExtensionBitmask<0, 31>;
 def HasStdExtZbkc
     : Predicate<"Subtarget->hasStdExtZbkc()">,
@@ -562,16 +514,14 @@ def HasStdExtZbcOrZbkc
 // Cryptography Extensions
 
 def FeatureStdExtZknd
-    : RISCVExtension<"zknd", 1, 0,
-                     "'Zknd' (NIST Suite: AES Decryption)">,
+    : RISCVExtension<1, 0, "NIST Suite: AES Decryption">,
       RISCVExtensionBitmask<0, 41>;
 def HasStdExtZknd : Predicate<"Subtarget->hasStdExtZknd()">,
                     AssemblerPredicate<(all_of FeatureStdExtZknd),
                                        "'Zknd' (NIST Suite: AES Decryption)">;
 
 def FeatureStdExtZkne
-    : RISCVExtension<"zkne", 1, 0,
-                     "'Zkne' (NIST Suite: AES Encryption)">,
+    : RISCVExtension<1, 0, "NIST Suite: AES Encryption">,
       RISCVExtensionBitmask<0, 42>;
 def HasStdExtZkne : Predicate<"Subtarget->hasStdExtZkne()">,
                     AssemblerPredicate<(all_of FeatureStdExtZkne),
@@ -586,39 +536,34 @@ def HasStdExtZkndOrZkne
                          "'Zkne' (NIST Suite: AES Encryption)">;
 
 def FeatureStdExtZknh
-    : RISCVExtension<"zknh", 1, 0,
-                     "'Zknh' (NIST Suite: Hash Function Instructions)">,
+    : RISCVExtension<1, 0, "NIST Suite: Hash Function Instructions">,
       RISCVExtensionBitmask<0, 43>;
 def HasStdExtZknh : Predicate<"Subtarget->hasStdExtZknh()">,
                     AssemblerPredicate<(all_of FeatureStdExtZknh),
                         "'Zknh' (NIST Suite: Hash Function Instructions)">;
 
 def FeatureStdExtZksed
-    : RISCVExtension<"zksed", 1, 0,
-                     "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)">,
+    : RISCVExtension<1, 0, "ShangMi Suite: SM4 Block Cipher Instructions">,
       RISCVExtensionBitmask<0, 44>;
 def HasStdExtZksed : Predicate<"Subtarget->hasStdExtZksed()">,
                      AssemblerPredicate<(all_of FeatureStdExtZksed),
                          "'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions)">;
 
 def FeatureStdExtZksh
-    : RISCVExtension<"zksh", 1, 0,
-                     "'Zksh' (ShangMi Suite: SM3 Hash Function Instructions)">,
+    : RISCVExtension<1, 0, "ShangMi Suite: SM3 Hash Function Instructions">,
       RISCVExtensionBitmask<0, 45>;
 def HasStdExtZksh : Predicate<"Subtarget->hasStdExtZksh()">,
                     AssemblerPredicate<(all_of FeatureStdExtZksh),
                         "'Zksh' (ShangMi Suite: SM3 Hash Function Instructions)">;
 
 def FeatureStdExtZkr
-    : RISCVExtension<"zkr", 1, 0,
-                     "'Zkr' (Entropy Source Extension)">;
+    : RISCVExtension<1, 0, "Entropy Source Extension">;
 def HasStdExtZkr : Predicate<"Subtarget->hasStdExtZkr()">,
                    AssemblerPredicate<(all_of FeatureStdExtZkr),
                                       "'Zkr' (Entropy Source Extension)">;
 
 def FeatureStdExtZkn
-    : RISCVExtension<"zkn", 1, 0,
-                     "'Zkn' (NIST Algorithm Suite)",
+    : RISCVExtension<1, 0, "NIST Algorithm Suite",
                      [FeatureStdExtZbkb,
                       FeatureStdExtZbkc,
                       FeatureStdExtZbkx,
@@ -627,8 +572,7 @@ def FeatureStdExtZkn
                       FeatureStdExtZknh]>;
 
 def FeatureStdExtZks
-    : RISCVExtension<"zks", 1, 0,
-                     "'Zks' (ShangMi Algorithm Suite)",
+    : RISCVExtension<1, 0, "ShangMi Algorithm Suite",
                      [FeatureStdExtZbkb,
                       FeatureStdExtZbkc,
                       FeatureStdExtZbkx,
@@ -636,93 +580,87 @@ def FeatureStdExtZks
                       FeatureStdExtZksh]>;
 
 def FeatureStdExtZkt
-    : RISCVExtension<"zkt", 1, 0,
-                     "'Zkt' (Data Independent Execution Latency)">,
+    : RISCVExtension<1, 0, "Data Independent Execution Latency">,
       RISCVExtensionBitmask<0, 46>;
 
 def FeatureStdExtZk
-    : RISCVExtension<"zk", 1, 0,
-                     "'Zk' (Standard scalar cryptography extension)",
+    : RISCVExtension<1, 0, "Standard scalar cryptography extension",
                      [FeatureStdExtZkn,
                       FeatureStdExtZkr,
                       FeatureStdExtZkt]>;
 
 // Vector Extensions
 
-def FeatureStdExtZvl32b : RISCVExtension<"zvl32b", 1, 0,
-                                         "'Zvl' (Minimum Vector Length) 32", [],
+def FeatureStdExtZvl32b : RISCVExtension<1, 0,
+                                         "Minimum Vector Length 32", [],
                                          "ZvlLen", "32">;
 
 foreach i = { 6-16 } in {
   defvar I = !shl(1, i);
   def FeatureStdExtZvl#I#b :
-      RISCVExtension<"zvl"#I#"b", 1, 0,
-                     "'Zvl' (Minimum Vector Length) "#I,
+      RISCVExtension<1, 0, "Minimum Vector Length "#I,
                      [!cast<RISCVExtension>("FeatureStdExtZvl"#!srl(I, 1)#"b")],
                      "ZvlLen", !cast<string>(I)>;
 }
 
 def FeatureStdExtZve32x
-    : RISCVExtension<"zve32x", 1, 0,
-                     "'Zve32x' (Vector Extensions for Embedded Processors "
-                     "with maximal 32 EEW)",
+    : RISCVExtension<1, 0,
+                     "Vector Extensions for Embedded Processors "
+                     "with maximal 32 EEW",
                      [FeatureStdExtZicsr, FeatureStdExtZvl32b]>;
 
 
 def FeatureStdExtZve32f
-    : RISCVExtension<"zve32f", 1, 0,
-                     "'Zve32f' (Vector Extensions for Embedded Processors "
-                     "with maximal 32 EEW and F extension)",
+    : RISCVExtension<1, 0,
+                     "Vector Extensions for Embedded Processors "
+                     "with maximal 32 EEW and F extension",
                      [FeatureStdExtZve32x, FeatureStdExtF]>;
 
 def FeatureStdExtZve64x
-    : RISCVExtension<"zve64x", 1, 0,
-                     "'Zve64x' (Vector Extensions for Embedded Processors "
-                     "with maximal 64 EEW)",
+    : RISCVExtension<1, 0,
+                     "Vector Extensions for Embedded Processors "
+                     "with maximal 64 EEW",
                      [FeatureStdExtZve32x, FeatureStdExtZvl64b]>;
 
 def FeatureStdExtZve64f
-    : RISCVExtension<"zve64f", 1, 0,
-                     "'Zve64f' (Vector Extensions for Embedded Processors "
-                     "with maximal 64 EEW and F extension)",
+    : RISCVExtension<1, 0,
+                     "Vector Extensions for Embedded Processors "
+                     "with maximal 64 EEW and F extension",
                      [FeatureStdExtZve32f, FeatureStdExtZve64x]>;
 
 def FeatureStdExtZve64d
-    : RISCVExtension<"zve64d", 1, 0,
-                     "'Zve64d' (Vector Extensions for Embedded Processors "
-                     "with maximal 64 EEW, F and D extension)",
+    : RISCVExtension<1, 0,
+                     "Vector Extensions for Embedded Processors "
+                     "with maximal 64 EEW, F and D extension",
                      [FeatureStdExtZve64f, FeatureStdExtD]>;
 
 def FeatureStdExtV
-    : RISCVExtension<"v", 1, 0,
-                     "'V' (Vector Extension for Application Processors)",
+    : RISCVExtension<1, 0,
+                     "Vector Extension for Application Processors",
                      [FeatureStdExtZvl128b, FeatureStdExtZve64d]>,
       RISCVExtensionBitmask<0, 21>;
 
 def FeatureStdExtZvfbfmin
-    : RISCVExtension<"zvfbfmin", 1, 0, "'Zvbfmin' (Vector BF16 Converts)",
-                     [FeatureStdExtZve32f]>;
+    : RISCVExtension<1, 0, "Vector BF16 Converts", [FeatureStdExtZve32f]>;
 def HasStdExtZvfbfmin : Predicate<"Subtarget->hasStdExtZvfbfmin()">,
                         AssemblerPredicate<(all_of FeatureStdExtZvfbfmin),
                             "'Zvfbfmin' (Vector BF16 Converts)">;
 
 def FeatureStdExtZvfbfwma
-    : RISCVExtension<"zvfbfwma", 1, 0,
-                     "'Zvfbfwma' (Vector BF16 widening mul-add)",
+    : RISCVExtension<1, 0, "Vector BF16 widening mul-add",
                      [FeatureStdExtZvfbfmin, FeatureStdExtZfbfmin]>;
 def HasStdExtZvfbfwma : Predicate<"Subtarget->hasStdExtZvfbfwma()">,
                         AssemblerPredicate<(all_of FeatureStdExtZvfbfwma),
                             "'Zvfbfwma' (Vector BF16 widening mul-add)">;
 
 def FeatureStdExtZvfhmin
-    : RISCVExtension<"zvfhmin", 1, 0,
-                     "'Zvfhmin' (Vector Half-Precision Floating-Point Minimal)",
+    : RISCVExtension<1, 0,
+                     "Vector Half-Precision Floating-Point Minimal",
                      [FeatureStdExtZve32f]>,
       RISCVExtensionBitmask<0, 51>;
 
 def FeatureStdExtZvfh
-    : RISCVExtension<"zvfh", 1, 0,
-                     "'Zvfh' (Vector Half-Precision Floating-Point)",
+    : RISCVExtension<1, 0, "Vector Half-Precision Floating-Point",
                      [FeatureStdExtZvfhmin, FeatureStdExtZfhmin]>,
       RISCVExtensionBitmask<0, 50>;
 
@@ -735,8 +673,7 @@ def HasStdExtZfhOrZvfh
 // Vector Cryptography and Bitmanip Extensions
 
 def FeatureStdExtZvkb
-    : RISCVExtension<"zvkb", 1, 0,
-                     "'Zvkb' (Vector Bit-manipulation used in Cryptography)",
+    : RISCVExtension<1, 0, "Vector Bit-manipulation used in Cryptography",
                      [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 52>;
 def HasStdExtZvkb : Predicate<"Subtarget->hasStdExtZvkb()">,
@@ -744,8 +681,7 @@ def HasStdExtZvkb : Predicate<"Subtarget->hasStdExtZvkb()">,
                         "'Zvkb' (Vector Bit-manipulation used in Cryptography)">;
 
 def FeatureStdExtZvbb
-    : RISCVExtension<"zvbb", 1, 0,
-                     "'Zvbb' (Vector basic bit-manipulation instructions)",
+    : RISCVExtension<1, 0, "Vector basic bit-manipulation instructions",
                      [FeatureStdExtZvkb]>,
       RISCVExtensionBitmask<0, 48>;
 def HasStdExtZvbb : Predicate<"Subtarget->hasStdExtZvbb()">,
@@ -753,8 +689,7 @@ def HasStdExtZvbb : Predicate<"Subtarget->hasStdExtZvbb()">,
                         "'Zvbb' (Vector basic bit-manipulation instructions)">;
 
 def FeatureStdExtZvbc
-    : RISCVExtension<"zvbc", 1, 0,
-                     "'Zvbc' (Vector Carryless Multiplication)",
+    : RISCVExtension<1, 0, "Vector Carryless Multiplication",
                      [FeatureStdExtZve64x]>,
       RISCVExtensionBitmask<0, 49>;
 def HasStdExtZvbc : Predicate<"Subtarget->hasStdExtZvbc()">,
@@ -762,8 +697,8 @@ def HasStdExtZvbc : Predicate<"Subtarget->hasStdExtZvbc()">,
                         "'Zvbc' (Vector Carryless Multiplication)">;
 
 def FeatureStdExtZvbc32e
-    : RISCVExperimentalExtension<"zvbc32e", 0, 7,
-                                 "'Zvbc32e' (Vector Carryless Multiplication with 32-bits elements)",
+    : RISCVExperimentalExtension<0, 7,
+                                 "Vector Carryless Multiplication with 32-bits elements",
                                  [FeatureStdExtZve32x]>;
 
 def HasStdExtZvbcOrZvbc32e : Predicate<"Subtarget->hasStdExtZvbc() || Subtarget->hasStdExtZvbc32e()">,
@@ -771,8 +706,7 @@ def HasStdExtZvbcOrZvbc32e : Predicate<"Subtarget->hasStdExtZvbc() || Subtarget-
                              "'Zvbc' or 'Zvbc32e' (Vector Carryless Multiplication)">;
 
 def FeatureStdExtZvkg
-    : RISCVExtension<"zvkg", 1, 0,
-                     "'Zvkg' (Vector GCM instructions for Cryptography)",
+    : RISCVExtension<1, 0, "Vector GCM instructions for Cryptography",
                      [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 53>;
 def HasStdExtZvkg : Predicate<"Subtarget->hasStdExtZvkg()">,
@@ -780,16 +714,16 @@ def HasStdExtZvkg : Predicate<"Subtarget->hasStdExtZvkg()">,
                         "'Zvkg' (Vector GCM instructions for Cryptography)">;
 
 def FeatureStdExtZvkgs
-    : RISCVExperimentalExtension<"zvkgs", 0, 7,
-                                 "'Zvkgs' (Vector-Scalar GCM instructions for Cryptography)",
+    : RISCVExperimentalExtension<0, 7,
+                                 "Vector-Scalar GCM instructions for Cryptography",
                                  [FeatureStdExtZvkg]>;
 def HasStdExtZvkgs : Predicate<"Subtarget->hasStdExtZvkgs()">,
                      AssemblerPredicate<(all_of FeatureStdExtZvkgs),
                         "'Zvkgs' (Vector-Scalar GCM instructions for Cryptography)">;
 
 def FeatureStdExtZvkned
-    : RISCVExtension<"zvkned", 1, 0,
-                     "'Zvkned' (Vector AES Encryption & Decryption (Single Round))",
+    : RISCVExtension<1, 0,
+                     "Vector AES Encryption & Decryption (Single Round)",
                      [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 54>;
 def HasStdExtZvkned : Predicate<"Subtarget->hasStdExtZvkned()">,
@@ -797,8 +731,7 @@ def HasStdExtZvkned : Predicate<"Subtarget->hasStdExtZvkned()">,
                           "'Zvkned' (Vector AES Encryption & Decryption (Single Round))">;
 
 def FeatureStdExtZvknha
-    : RISCVExtension<"zvknha", 1, 0,
-                     "'Zvknha' (Vector SHA-2 (SHA-256 only))",
+    : RISCVExtension<1, 0, "Vector SHA-2 (SHA-256 only)",
                      [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 55>;
 def HasStdExtZvknha : Predicate<"Subtarget->hasStdExtZvknha()">,
@@ -806,8 +739,7 @@ def HasStdExtZvknha : Predicate<"Subtarget->hasStdExtZvknha()">,
                           "'Zvknha' (Vector SHA-2 (SHA-256 only))">;
 
 def FeatureStdExtZvknhb
-    : RISCVExtension<"zvknhb", 1, 0,
-                     "'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512))",
+    : RISCVExtension<1, 0, "Vector SHA-2 (SHA-256 and SHA-512)",
                      [FeatureStdExtZve64x]>,
       RISCVExtensionBitmask<0, 56>;
 def HasStdExtZvknhb : Predicate<"Subtarget->hasStdExtZvknhb()">,
@@ -819,8 +751,7 @@ def HasStdExtZvknhaOrZvknhb : Predicate<"Subtarget->hasStdExtZvknha() || Subtarg
                                   "'Zvknha' or 'Zvknhb' (Vector SHA-2)">;
 
 def FeatureStdExtZvksed
-    : RISCVExtension<"zvksed", 1, 0,
-                     "'Zvksed' (SM4 Block Cipher Instructions)",
+    : RISCVExtension<1, 0, "SM4 Block Cipher Instructions",
                      [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 57>;
 def HasStdExtZvksed : Predicate<"Subtarget->hasStdExtZvksed()">,
@@ -828,8 +759,7 @@ def HasStdExtZvksed : Predicate<"Subtarget->hasStdExtZvksed()">,
                           "'Zvksed' (SM4 Block Cipher Instructions)">;
 
 def FeatureStdExtZvksh
-    : RISCVExtension<"zvksh", 1, 0,
-                     "'Zvksh' (SM3 Hash Function Instructions)",
+    : RISCVExtension<1, 0, "SM3 Hash Function Instructions",
                      [FeatureStdExtZve32x]>,
       RISCVExtensionBitmask<0, 58>;
 def HasStdExtZvksh : Predicate<"Subtarget->hasStdExtZvksh()">,
@@ -837,44 +767,37 @@ def HasStdExtZvksh : Predicate<"Subtarget->hasStdExtZvksh()">,
                          "'Zvksh' (SM3 Hash Function Instructions)">;
 
 def FeatureStdExtZvkt
-    : RISCVExtension<"zvkt", 1, 0,
-                     "'Zvkt' (Vector Data-Independent Execution Latency)">,
+    : RISCVExtension<1, 0, "Vector Data-Independent Execution Latency">,
       RISCVExtensionBitmask<0, 59>;
 
 // Zvk short-hand extensions
 
 def FeatureStdExtZvkn
-    : RISCVExtension<"zvkn", 1, 0,
-                     "'Zvkn' (shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and "
-                     "'Zvkt')",
+    : RISCVExtension<1, 0,
+                     "shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and 'Zvkt'",
                      [FeatureStdExtZvkned, FeatureStdExtZvknhb,
                       FeatureStdExtZvkb, FeatureStdExtZvkt]>;
 
 def FeatureStdExtZvknc
-    : RISCVExtension<"zvknc", 1, 0,
-                     "'Zvknc' (shorthand for 'Zvknc' and 'Zvbc')",
+    : RISCVExtension<1, 0, "shorthand for 'Zvknc' and 'Zvbc'",
                      [FeatureStdExtZvkn, FeatureStdExtZvbc]>;
 
 def FeatureStdExtZvkng
-    : RISCVExtension<"zvkng", 1, 0,
-                     "'zvkng' (shorthand for 'Zvkn' and 'Zvkg')",
+    : RISCVExtension<1, 0, "shorthand for 'Zvkn' and 'Zvkg'",
                      [FeatureStdExtZvkn, FeatureStdExtZvkg]>;
 
 def FeatureStdExtZvks
-    : RISCVExtension<"zvks", 1, 0,
-                     "'Zvks' (shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and "
-                     "'Zvkt')",
+    : RISCVExtension<1, 0,
+                     "shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and 'Zvkt'",
                      [FeatureStdExtZvksed, FeatureStdExtZvksh,
                       FeatureStdExtZvkb, FeatureStdExtZvkt]>;
 
 def FeatureStdExtZvksc
-    : RISCVExtension<"zvksc", 1, 0,
-                     "'Zvksc' (shorthand for 'Zvks' and 'Zvbc')",
+    : RISCVExtension<1, 0, "shorthand for 'Zvks' and 'Zvbc'",
                      [FeatureStdExtZvks, FeatureStdExtZvbc]>;
 
 def FeatureStdExtZvksg
-    : RISCVExtension<"zvksg", 1, 0,
-                     "'Zvksg' (shorthand for 'Zvks' and 'Zvkg')",
+    : RISCVExtension<1, 0, "shorthand for 'Zvks' and 'Zvkg'",
                      [FeatureStdExtZvks, FeatureStdExtZvkg]>;
 // Vector instruction predicates
 
@@ -907,9 +830,7 @@ def HasVInstructionsFullMultiply : Predicate<"Subtarget->hasVInstructionsFullMul
 
 // Hypervisor Extensions
 
-def FeatureStdExtH
-    : RISCVExtension<"h", 1, 0,
-                     "'H' (Hypervisor)">;
+def FeatureStdExtH : RISCVExtension<1, 0, "Hypervisor">;
 
 def HasStdExtH : Predicate<"Subtarget->hasStdExtH()">,
                  AssemblerPredicate<(all_of FeatureStdExtH),
@@ -918,150 +839,125 @@ def HasStdExtH : Predicate<"Subtarget->hasStdExtH()">,
 // Supervisor extensions
 
 def FeatureStdExtShgatpa
-    : RISCVExtension<"shgatpa", 1, 0,
-                     "'Sgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare)">;
+    : RISCVExtension<1, 0,
+                     "SvNNx4 mode supported for all modes supported by satp, as well as Bare">;
 def FeatureStdExtShvsatpa
-    : RISCVExtension<"shvsatpa", 1, 0,
-                     "'Svsatpa' (vsatp supports all modes supported by satp)">;
+    : RISCVExtension<1, 0,
+                     "vsatp supports all modes supported by satp">;
 
 def FeatureStdExtSmaia
-    : RISCVExtension<"smaia", 1, 0,
-                     "'Smaia' (Advanced Interrupt Architecture Machine Level)">;
+    : RISCVExtension<1, 0,
+                     "Advanced Interrupt Architecture Machine Level">;
 def FeatureStdExtSsaia
-    : RISCVExtension<"ssaia", 1, 0,
-                     "'Ssaia' (Advanced Interrupt Architecture Supervisor "
-                     "Level)">;
+    : RISCVExtension<1, 0,
+                     "Advanced Interrupt Architecture Supervisor Level">;
 
 def FeatureStdExtSmcsrind
-    : RISCVExtension<"smcsrind", 1, 0,
-                     "'Smcsrind' (Indirect CSR Access Machine Level)">;
+    : RISCVExtension<1, 0, "Indirect CSR Access Machine Level">;
 def FeatureStdExtSscsrind
-    : RISCVExtension<"sscsrind", 1, 0,
-                     "'Sscsrind' (Indirect CSR Access Supervisor Level)">;
+    : RISCVExtension<1, 0, "Indirect CSR Access Supervisor Level">;
 
 def FeatureStdExtSmdbltrp
-    : RISCVExtension<"smdbltrp", 1, 0,
-                     "'Smdbltrp' (Double Trap Machine Level)">;
+    : RISCVExtension<1, 0, "Double Trap Machine Level">;
 def FeatureStdExtSsdbltrp
-    : RISCVExtension<"ssdbltrp", 1, 0,
-                     "'Ssdbltrp' (Double Trap Supervisor Level)">;
+    : RISCVExtension<1, 0, "Double Trap Supervisor Level">;
 
 def FeatureStdExtSmepmp
-    : RISCVExtension<"smepmp", 1, 0,
-                     "'Smepmp' (Enhanced Physical Memory Protection)">;
+    : RISCVExtension<1, 0, "Enhanced Physical Memory Protection">;
 
 def FeatureStdExtSmrnmi
-    : RISCVExtension<"smrnmi", 1, 0,
-                     "'Smrnmi' (Resumable Non-Maskable Interrupts)">;
+    : RISCVExtension<1, 0, "Resumable Non-Maskable Interrupts">;
 def HasStdExtSmrnmi : Predicate<"Subtarget->hasStdExtSmrnmi()">,
                        AssemblerPredicate<(all_of FeatureStdExtSmrnmi),
-                           "'Smrnmi' (Resumable Non-Maskable Interrupts)">; 
+                           "'Smrnmi' (Resumable Non-Maskable Interrupts)">;
 
 def FeatureStdExtSmcdeleg
-    : RISCVExtension<"smcdeleg", 1, 0,
-                     "'Smcdeleg' (Counter Delegation Machine Level)">;
+    : RISCVExtension<1, 0, "Counter Delegation Machine Level">;
 def FeatureStdExtSsccfg
-    : RISCVExtension<"ssccfg", 1, 0,
-                     "'Ssccfg' (Counter Configuration Supervisor Level)">;
+    : RISCVExtension<1, 0, "Counter Configuration Supervisor Level">;
 
 def FeatureStdExtSsccptr
-    : RISCVExtension<"ssccptr", 1, 0,
-                     "'Ssccptr' (Main memory supports page table reads)">;
+    : RISCVExtension<1, 0, "Main memory supports page table reads">;
 
 def FeatureStdExtSscofpmf
-    : RISCVExtension<"sscofpmf", 1, 0,
-                     "'Sscofpmf' (Count Overflow and Mode-Based Filtering)">;
+    : RISCVExtension<1, 0, "Count Overflow and Mode-Based Filtering">;
 
 def FeatureStdExtShcounterenw
-    : RISCVExtension<"shcounterenw", 1, 0,
-                     "'Shcounterenw' (Support writeable hcounteren enable "
-                     "bit for any hpmcounter that is not read-only zero)">;
+    : RISCVExtension<1, 0,
+                     "Support writeable hcounteren enable "
+                     "bit for any hpmcounter that is not read-only zero">;
 def FeatureStdExtSscounterenw
-    : RISCVExtension<"sscounterenw", 1, 0,
-                     "'Sscounterenw' (Support writeable scounteren enable "
-                     "bit for any hpmcounter that is not read-only zero)">;
+    : RISCVExtension<1, 0,
+                     "Support writeable scounteren enable "
+                     "bit for any hpmcounter that is not read-only zero">;
 
 def FeatureStdExtSmstateen
-    : RISCVExtension<"smstateen", 1, 0,
-                     "'Smstateen' (Machine-mode view of the state-enable extension)">;
+    : RISCVExtension<1, 0,
+                     "Machine-mode view of the state-enable extension">;
 def FeatureStdExtSsstateen
-    : RISCVExtension<"ssstateen", 1, 0,
-                     "'Ssstateen' (Supervisor-mode view of the state-enable extension)">;
+    : RISCVExtension<1, 0,
+                     "Supervisor-mode view of the state-enable extension">;
 
 def FeatureStdExtSsstrict
-    : RISCVExtension<"ssstrict", 1, 0,
-                     "'Ssstrict' (No non-conforming extensions are present)">;
+    : RISCVExtension<1, 0,
+                     "No non-conforming extensions are present">;
 
 def FeatureStdExtSstc
-    : RISCVExtension<"sstc", 1, 0,
-                     "'Sstc' (Supervisor-mode timer interrupts)">;
+    : RISCVExtension<1, 0, "Supervisor-mode timer interrupts">;
 
 def FeatureStdExtSsqosid
-    : RISCVExtension<"ssqosid", 1, 0,
-                     "'Ssqosid' (Quality-of-Service (QoS) Identifiers)">;
+    : RISCVExtension<1, 0, "Quality-of-Service (QoS) Identifiers">;
 
 def FeatureStdExtShtvala
-    : RISCVExtension<"shtvala", 1, 0,
-                     "'Shtvala' (htval provides all needed values)">;
+    : RISCVExtension<1, 0, "htval provides all needed values">;
 def FeatureStdExtShvstvala
-    : RISCVExtension<"shvstvala", 1, 0,
-                     "'Shvstvala' (vstval provides all needed values)">;
+    : RISCVExtension<1, 0, "vstval provides all needed values">;
 def FeatureStdExtSstvala
-    : RISCVExtension<"sstvala", 1, 0,
-                     "'Sstvala' (stval provides all needed values)">;
+    : RISCVExtension<1, 0, "stval provides all needed values">;
 
 def FeatureStdExtShvstvecd
-    : RISCVExtension<"shvstvecd", 1, 0,
-                     "'Shvstvecd' (vstvec supports Direct mode)">;
+    : RISCVExtension<1, 0, "vstvec supports Direct mode">;
 def FeatureStdExtSstvecd
-    : RISCVExtension<"sstvecd", 1, 0,
-                     "'Sstvecd' (stvec supports Direct mode)">;
+    : RISCVExtension<1, 0, "stvec supports Direct mode">;
 
 def FeatureStdExtSsu64xl
-    : RISCVExtension<"ssu64xl", 1, 0,
-                     "'Ssu64xl' (UXLEN=64 supported)">;
+    : RISCVExtension<1, 0, "UXLEN=64 supported">;
 
 def FeatureStdExtSvade
-    : RISCVExtension<"svade", 1, 0,
-                     "'Svade' (Raise exceptions on improper A/D bits)">;
+    : RISCVExtension<1, 0, "Raise exceptions on improper A/D bits">;
 
 def FeatureStdExtSvadu
-    : RISCVExtension<"svadu", 1, 0,
-                     "'Svadu' (Hardware A/D updates)">;
+    : RISCVExtension<1, 0, "Hardware A/D updates">;
 
 def FeatureStdExtSvbare
-    : RISCVExtension<"svbare", 1, 0,
-                     "'Svbare' $(satp mode Bare supported)">;
+    : RISCVExtension<1, 0, "satp mode Bare supported">;
 
 def FeatureStdExtSvinval
-    : RISCVExtension<"svinval", 1, 0,
-                     "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)">;
+    : RISCVExtension<1, 0,
+                     "Fine-Grained Address-Translation Cache Invalidation">;
 def HasStdExtSvinval : Predicate<"Subtarget->hasStdExtSvinval()">,
                        AssemblerPredicate<(all_of FeatureStdExtSvinval),
                            "'Svinval' (Fine-Grained Address-Translation Cache Invalidation)">;
 
 def FeatureStdExtSvnapot
-    : RISCVExtension<"svnapot", 1, 0,
-                     "'Svnapot' (NAPOT Translation Contiguity)">;
+    : RISCVExtension<1, 0, "NAPOT Translation Contiguity">;
 
 def FeatureStdExtSvpbmt
-    : RISCVExtension<"svpbmt", 1, 0,
-                     "'Svpbmt' (Page-Based Memory Types)">;
+    : RISCVExtension<1, 0, "Page-Based Memory Types">;
 
 def FeatureStdExtSvvptc
-    : RISCVExtension<"svvptc", 1, 0,
-                     "'svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid)">;
+    : RISCVExtension<1, 0,
+                     "Obviating Memory-Management Instructions after Marking PTEs Valid">;
 
 def FeatureStdExtSha
-    : RISCVExtension<"sha", 1, 0,
-                     "'Sha' (Augmented Hypervisor)",
+    : RISCVExtension<1, 0, "Augmented Hypervisor",
                      [FeatureStdExtH, FeatureStdExtSsstateen, FeatureStdExtShcounterenw,
                       FeatureStdExtShvstvala, FeatureStdExtShtvala, FeatureStdExtShvstvecd,
                       FeatureStdExtShvsatpa, FeatureStdExtShgatpa]>;
 
 def FeatureStdExtSvukte
-    : RISCVExperimentalExtension<"svukte", 0, 3,
-                                 "'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses)">;
+    : RISCVExperimentalExtension<0, 3,
+                                 "Address-Independent Latency of User-Mode Faults to Supervisor Addresses">;
 
 // Pointer Masking extensions
 
@@ -1069,41 +965,41 @@ def FeatureStdExtSvukte
 // privilege mode (U-mode), and for VS- and VU-modes if the H extension is
 // present.
 def FeatureStdExtSsnpm
-    : RISCVExtension<"ssnpm", 1, 0,
-                     "'Ssnpm' (Supervisor-level Pointer Masking for next lower privilege mode)">;
+    : RISCVExtension<1, 0,
+                     "Supervisor-level Pointer Masking for next lower privilege mode">;
 
 // A machine-level extension that provides pointer masking for the next lower
 // privilege mode (S/HS if S-mode is implemented, or U-mode otherwise).
 def FeatureStdExtSmnpm
-    : RISCVExtension<"smnpm", 1, 0,
-                     "'Smnpm' (Machine-level Pointer Masking for next lower privilege mode)">;
+    : RISCVExtension<1, 0,
+                     "Machine-level Pointer Masking for next lower privilege mode">;
 
 // A machine-level extension that provides pointer masking for M-mode.
 def FeatureStdExtSmmpm
-    : RISCVExtension<"smmpm", 1, 0,
-                     "'Smmpm' (Machine-level Pointer Masking for M-mode)">;
+    : RISCVExtension<1, 0,
+                     "Machine-level Pointer Masking for M-mode">;
 
 // An extension that indicates that there is pointer-masking support available
 // in supervisor mode, with some facility provided in the supervisor execution
 // environment to control pointer masking.
 def FeatureStdExtSspm
-    : RISCVExtension<"sspm", 1, 0,
-                     "'Sspm' (Indicates Supervisor-mode Pointer Masking)">;
+    : RISCVExtension<1, 0,
+                     "Indicates Supervisor-mode Pointer Masking">;
 
 // An extension that indicates that there is pointer-masking support available
 // in user mode, with some facility provided in the application execution
 // environment to control pointer masking.
 def FeatureStdExtSupm
-    : RISCVExtension<"supm", 1, 0,
-                     "'Supm' (Indicates User-mode Pointer Masking)">;
+    : RISCVExtension<1, 0,
+                     "Indicates User-mode Pointer Masking">;
 
 def FeatureStdExtSmctr
-    : RISCVExperimentalExtension<"smctr", 1, 0,
-                                 "'Smctr' (Control Transfer Records Machine Level)",
+    : RISCVExperimentalExtension<1, 0,
+                                 "Control Transfer Records Machine Level",
                                  [FeatureStdExtSscsrind]>;
 def FeatureStdExtSsctr
-    : RISCVExperimentalExtension<"ssctr" ,1, 0,
-                                 "'Ssctr' (Control Transfer Records Supervisor Level)",
+    : RISCVExperimentalExtension<1, 0,
+                                 "Control Transfer Records Supervisor Level",
                                  [FeatureStdExtSscsrind]>;
 def HasStdExtSmctrOrSsctr : Predicate<"Subtarget->hasStdExtSmctrOrSsctr()">,
                             AssemblerPredicate<(any_of FeatureStdExtSmctr, FeatureStdExtSsctr),
@@ -1117,8 +1013,7 @@ def HasStdExtSmctrOrSsctr : Predicate<"Subtarget->hasStdExtSmctrOrSsctr()">,
 // Ventana Extenions
 
 def FeatureVendorXVentanaCondOps
-    : RISCVExtension<"xventanacondops", 1, 0,
-                     "'XVentanaCondOps' (Ventana Conditional Ops)">;
+    : RISCVExtension<1, 0, "Ventana Conditional Ops">;
 def HasVendorXVentanaCondOps : Predicate<"Subtarget->hasVendorXVentanaCondOps()">,
                                AssemblerPredicate<(all_of FeatureVendorXVentanaCondOps),
                                    "'XVentanaCondOps' (Ventana Conditional Ops)">;
@@ -1126,78 +1021,78 @@ def HasVendorXVentanaCondOps : Predicate<"Subtarget->hasVendorXVentanaCondOps()"
 // T-Head Extensions
 
 def FeatureVendorXTHeadBa
-    : RISCVExtension<"xtheadba", 1, 0,
-                     "'XTHeadBa' (T-Head address calculation instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head address calculation instructions">;
 def HasVendorXTHeadBa : Predicate<"Subtarget->hasVendorXTHeadBa()">,
                         AssemblerPredicate<(all_of FeatureVendorXTHeadBa),
                             "'XTHeadBa' (T-Head address calculation instructions)">;
 
 def FeatureVendorXTHeadBb
-    : RISCVExtension<"xtheadbb", 1, 0,
-                     "'XTHeadBb' (T-Head basic bit-manipulation instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head basic bit-manipulation instructions">;
 def HasVendorXTHeadBb : Predicate<"Subtarget->hasVendorXTHeadBb()">,
                         AssemblerPredicate<(all_of FeatureVendorXTHeadBb),
                             "'XTHeadBb' (T-Head basic bit-manipulation instructions)">;
 
 def FeatureVendorXTHeadBs
-    : RISCVExtension<"xtheadbs", 1, 0,
-                     "'XTHeadBs' (T-Head single-bit instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head single-bit instructions">;
 def HasVendorXTHeadBs : Predicate<"Subtarget->hasVendorXTHeadBs()">,
                         AssemblerPredicate<(all_of FeatureVendorXTHeadBs),
                             "'XTHeadBs' (T-Head single-bit instructions)">;
 
 def FeatureVendorXTHeadCondMov
-    : RISCVExtension<"xtheadcondmov", 1, 0,
-                     "'XTHeadCondMov' (T-Head conditional move instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head conditional move instructions">;
 def HasVendorXTHeadCondMov : Predicate<"Subtarget->hasVendorXTHeadCondMov()">,
                              AssemblerPredicate<(all_of FeatureVendorXTHeadCondMov),
                                  "'XTHeadCondMov' (T-Head conditional move instructions)">;
 
 def FeatureVendorXTHeadCmo
-    : RISCVExtension<"xtheadcmo", 1, 0,
-                     "'XTHeadCmo' (T-Head cache management instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head cache management instructions">;
 def HasVendorXTHeadCmo : Predicate<"Subtarget->hasVendorXTHeadCmo()">,
                          AssemblerPredicate<(all_of FeatureVendorXTHeadCmo),
                              "'XTHeadCmo' (T-Head cache management instructions)">;
 
 def FeatureVendorXTHeadFMemIdx
-    : RISCVExtension<"xtheadfmemidx", 1, 0,
-                     "'XTHeadFMemIdx' (T-Head FP Indexed Memory Operations)">;
+    : RISCVExtension<1, 0,
+                     "T-Head FP Indexed Memory Operations">;
 def HasVendorXTHeadFMemIdx : Predicate<"Subtarget->hasVendorXTHeadFMemIdx()">,
                              AssemblerPredicate<(all_of FeatureVendorXTHeadFMemIdx),
                                  "'XTHeadFMemIdx' (T-Head FP Indexed Memory Operations)">;
 
 def FeatureVendorXTHeadMac
-    : RISCVExtension<"xtheadmac", 1, 0,
-                     "'XTHeadMac' (T-Head Multiply-Accumulate Instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head Multiply-Accumulate Instructions">;
 def HasVendorXTHeadMac : Predicate<"Subtarget->hasVendorXTHeadMac()">,
                          AssemblerPredicate<(all_of FeatureVendorXTHeadMac),
                              "'XTHeadMac' (T-Head Multiply-Accumulate Instructions)">;
 
 def FeatureVendorXTHeadMemIdx
-    : RISCVExtension<"xtheadmemidx", 1, 0,
-                     "'XTHeadMemIdx' (T-Head Indexed Memory Operations)">;
+    : RISCVExtension<1, 0,
+                     "T-Head Indexed Memory Operations">;
 def HasVendorXTHeadMemIdx : Predicate<"Subtarget->hasVendorXTHeadMemIdx()">,
                             AssemblerPredicate<(all_of FeatureVendorXTHeadMemIdx),
                                 "'XTHeadMemIdx' (T-Head Indexed Memory Operations)">;
 
 def FeatureVendorXTHeadMemPair
-    : RISCVExtension<"xtheadmempair", 1, 0,
-                     "'XTHeadMemPair' (T-Head two-GPR Memory Operations)">;
+    : RISCVExtension<1, 0,
+                     "T-Head two-GPR Memory Operations">;
 def HasVendorXTHeadMemPair : Predicate<"Subtarget->hasVendorXTHeadMemPair()">,
                              AssemblerPredicate<(all_of FeatureVendorXTHeadMemPair),
                                  "'XTHeadMemPair' (T-Head two-GPR Memory Operations)">;
 
 def FeatureVendorXTHeadSync
-    : RISCVExtension<"xtheadsync", 1, 0,
-                     "'XTHeadSync' (T-Head multicore synchronization instructions)">;
+    : RISCVExtension<1, 0,
+                     "T-Head multicore synchronization instructions">;
 def HasVendorXTHeadSync : Predicate<"Subtarget->hasVendorXTHeadSync()">,
                           AssemblerPredicate<(all_of FeatureVendorXTHeadSync),
                               "'XTHeadSync' (T-Head multicore synchronization instructions)">;
 
 def FeatureVendorXTHeadVdot
-    : RISCVExtension<"xtheadvdot", 1, 0,
-                     "'XTHeadVdot' (T-Head Vector Extensions for Dot)",
+    : RISCVExtension<1, 0,
+                     "T-Head Vector Extensions for Dot",
                      [FeatureStdExtV]>;
 def HasVendorXTHeadVdot : Predicate<"Subtarget->hasVendorXTHeadVdot()">,
                           AssemblerPredicate<(all_of FeatureVendorXTHeadVdot),
@@ -1206,16 +1101,16 @@ def HasVendorXTHeadVdot : Predicate<"Subtarget->hasVendorXTHeadVdot()">,
 // SiFive Extensions
 
 def FeatureVendorXSfvcp
-    : RISCVExtension<"xsfvcp", 1, 0,
-                     "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)",
+    : RISCVExtension<1, 0,
+                     "SiFive Custom Vector Coprocessor Interface Instructions",
                      [FeatureStdExtZve32x]>;
 def HasVendorXSfvcp : Predicate<"Subtarget->hasVendorXSfvcp()">,
                       AssemblerPredicate<(all_of FeatureVendorXSfvcp),
                           "'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions)">;
 
 def FeatureVendorXSfvqmaccdod
-    : RISCVExtension<"xsfvqmaccdod", 1, 0,
-                     "'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2))",
+    : RISCVExtension<1, 0,
+                     "SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2)",
                      [FeatureStdExtZve32x]>;
 def HasVendorXSfvqmaccdod
     : Predicate<"Subtarget->hasVendorXSfvqmaccdod()">,
@@ -1223,8 +1118,8 @@ def HasVendorXSfvqmaccdod
                          "'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2))">;
 
 def FeatureVendorXSfvqmaccqoq
-    : RISCVExtension<"xsfvqmaccqoq", 1, 0,
-                     "'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4))",
+    : RISCVExtension<1, 0,
+                     "SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4)",
                      [FeatureStdExtZve32x]>;
 def HasVendorXSfvqmaccqoq
     : Predicate<"Subtarget->hasVendorXSfvqmaccqoq()">,
@@ -1232,8 +1127,8 @@ def HasVendorXSfvqmaccqoq
                          "'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4))">;
 
 def FeatureVendorXSfvfwmaccqqq
-    : RISCVExtension<"xsfvfwmaccqqq", 1, 0,
-                     "'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4))",
+    : RISCVExtension<1, 0,
+                     "SiFive Matrix Multiply Accumulate Instruction and 4-by-4)",
                      [FeatureStdExtZvfbfmin]>;
 def HasVendorXSfvfwmaccqqq
     : Predicate<"Subtarget->hasVendorXSfvfwmaccqqq()">,
@@ -1241,8 +1136,8 @@ def HasVendorXSfvfwmaccqqq
                          "'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4))">;
 
 def FeatureVendorXSfvfnrclipxfqf
-    : RISCVExtension<"xsfvfnrclipxfqf", 1, 0,
-                     "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)",
+    : RISCVExtension<1, 0,
+                     "SiFive FP32-to-int8 Ranged Clip Instructions",
                      [FeatureStdExtZve32f]>;
 def HasVendorXSfvfnrclipxfqf
     : Predicate<"Subtarget->hasVendorXSfvfnrclipxfqf()">,
@@ -1250,24 +1145,24 @@ def HasVendorXSfvfnrclipxfqf
                          "'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions)">;
 
 def FeatureVendorXSiFivecdiscarddlone
-    : RISCVExtension<"xsifivecdiscarddlone", 1, 0,
-                     "'XSiFivecdiscarddlone' (SiFive sf.cdiscard.d.l1 Instruction)", []>;
+    : RISCVExtension<1, 0,
+                     "SiFive sf.cdiscard.d.l1 Instruction", []>;
 def HasVendorXSiFivecdiscarddlone
     : Predicate<"Subtarget->hasVendorXSiFivecdiscarddlone()">,
       AssemblerPredicate<(all_of FeatureVendorXSiFivecdiscarddlone),
                          "'XSiFivecdiscarddlone' (SiFive sf.cdiscard.d.l1 Instruction)">;
 
 def FeatureVendorXSiFivecflushdlone
-    : RISCVExtension<"xsifivecflushdlone", 1, 0,
-                     "'XSiFivecflushdlone' (SiFive sf.cflush.d.l1 Instruction)", []>;
+    : RISCVExtension<1, 0,
+                     "SiFive sf.cflush.d.l1 Instruction", []>;
 def HasVendorXSiFivecflushdlone
     : Predicate<"Subtarget->hasVendorXSiFivecflushdlone()">,
       AssemblerPredicate<(all_of FeatureVendorXSiFivecflushdlone),
                          "'XSiFivecflushdlone' (SiFive sf.cflush.d.l1 Instruction)">;
 
 def FeatureVendorXSfcease
-    : RISCVExtension<"xsfcease", 1, 0,
-                     "'XSfcease' (SiFive sf.cease Instruction)", []>;
+    : RISCVExtension<1, 0,
+                     "SiFive sf.cease Instruction", []>;
 def HasVendorXSfcease
     : Predicate<"Subtarget->hasVendorXSfcease()">,
       AssemblerPredicate<(all_of FeatureVendorXSfcease),
@@ -1276,56 +1171,49 @@ def HasVendorXSfcease
 // Core-V Extensions
 
 def FeatureVendorXCVelw
-   : RISCVExtension<"xcvelw", 1, 0,
-                    "'XCVelw' (CORE-V Event Load Word)">;
+   : RISCVExtension<1, 0, "CORE-V Event Load Word">;
 def HasVendorXCVelw
    : Predicate<"Subtarget->hasVendorXCVelw()">,
      AssemblerPredicate<(any_of FeatureVendorXCVelw),
                         "'XCVelw' (CORE-V Event Load Word)">;
 
 def FeatureVendorXCVbitmanip
-    : RISCVExtension<"xcvbitmanip", 1, 0,
-                     "'XCVbitmanip' (CORE-V Bit Manipulation)">;
+    : RISCVExtension<1, 0, "CORE-V Bit Manipulation">;
 def HasVendorXCVbitmanip
     : Predicate<"Subtarget->hasVendorXCVbitmanip()">,
       AssemblerPredicate<(all_of FeatureVendorXCVbitmanip),
                          "'XCVbitmanip' (CORE-V Bit Manipulation)">;
 
 def FeatureVendorXCVmac
-    : RISCVExtension<"xcvmac", 1, 0,
-                     "'XCVmac' (CORE-V Multiply-Accumulate)">;
+    : RISCVExtension<1, 0, "CORE-V Multiply-Accumulate">;
 def HasVendorXCVmac
     : Predicate<"Subtarget->hasVendorXCVmac()">,
       AssemblerPredicate<(all_of FeatureVendorXCVmac),
                          "'XCVmac' (CORE-V Multiply-Accumulate)">;
 
 def FeatureVendorXCVmem
-    : RISCVExtension<"xcvmem", 1, 0,
-                     "'XCVmem' (CORE-V Post-incrementing Load & Store)">;
+    : RISCVExtension<1, 0, "CORE-V Post-incrementing Load & Store">;
 def HasVendorXCVmem
     : Predicate<"Subtarget->hasVendorXCVmem()">,
       AssemblerPredicate<(any_of FeatureVendorXCVmem),
                          "'XCVmem' (CORE-V Post-incrementing Load & Store)">;
 
 def FeatureVendorXCValu
-    : RISCVExtension<"xcvalu", 1, 0,
-                     "'XCValu' (CORE-V ALU Operations)">;
+    : RISCVExtension<1, 0, "CORE-V ALU Operations">;
 def HasVendorXCValu
     : Predicate<"Subtarget->hasVendorXCValu()">,
       AssemblerPredicate<(all_of FeatureVendorXCValu),
                          "'XCValu' (CORE-V ALU Operations)">;
 
 def FeatureVendorXCVsimd
-    : RISCVExtension<"xcvsimd", 1, 0,
-                     "'XCVsimd' (CORE-V SIMD ALU)">;
+    : RISCVExtension<1, 0, "CORE-V SIMD ALU">;
 def HasVendorXCVsimd
     : Predicate<"Subtarget->hasVendorXCVsimd()">,
       AssemblerPredicate<(any_of FeatureVendorXCVsimd),
                          "'XCVsimd' (CORE-V SIMD ALU)">;
 
 def FeatureVendorXCVbi
-    : RISCVExtension<"xcvbi", 1, 0,
-                     "'XCVbi' (CORE-V Immediate Branching)">;
+    : RISCVExtension<1, 0, "CORE-V Immediate Branching">;
 def HasVendorXCVbi
     : Predicate<"Subtarget->hasVendorXCVbi()">,
       AssemblerPredicate<(all_of FeatureVendorXCVbi),
@@ -1334,8 +1222,8 @@ def HasVendorXCVbi
 // WCH / Nanjing Qinheng Microelectronics Extension(s)
 
 def FeatureVendorXwchc
-    : RISCVExtension<"xwchc", 2, 2,
-                     "'Xwchc' (WCH/QingKe additional compressed opcodes)">;
+    : RISCVExtension<2, 2,
+                     "WCH/QingKe additional compressed opcodes">;
 def HasVendorXwchc
     : Predicate<"Subtarget->hasVendorXwchc()">,
       AssemblerPredicate<(all_of FeatureVendorXwchc),
@@ -1344,40 +1232,37 @@ def HasVendorXwchc
 // Qualcomm Extension(s)
 
 def FeatureVendorXqcicsr
-    : RISCVExperimentalExtension<"xqcicsr", 0, 2,
-                                 "'Xqcicsr' (Qualcomm uC CSR Extension)">;
+    : RISCVExperimentalExtension<0, 2, "Qualcomm uC CSR Extension">;
 def HasVendorXqcicsr
     : Predicate<"Subtarget->hasVendorXqcicsr()">,
       AssemblerPredicate<(all_of FeatureVendorXqcicsr),
                          "'Xqcicsr' (Qualcomm uC CSR Extension)">;
 
 def FeatureVendorXqcisls
-    : RISCVExperimentalExtension<"xqcisls", 0, 2,
-                                 "'Xqcisls' (Qualcomm uC Scaled Load Store Extension)">;
+    : RISCVExperimentalExtension<0, 2,
+                                 "Qualcomm uC Scaled Load Store Extension">;
 def HasVendorXqcisls
     : Predicate<"Subtarget->hasVendorXqcisls()">,
       AssemblerPredicate<(all_of FeatureVendorXqcisls),
                          "'Xqcisls' (Qualcomm uC Scaled Load Store Extension)">;
 
 def FeatureVendorXqcia
-    : RISCVExperimentalExtension<"xqcia", 0, 2,
-                                 "'Xqcia' (Qualcomm uC Arithmetic Extension)">;
+    : RISCVExperimentalExtension<0, 2, "Qualcomm uC Arithmetic Extension">;
 def HasVendorXqcia
     : Predicate<"Subtarget->hasVendorXqcia()">,
       AssemblerPredicate<(all_of FeatureVendorXqcia),
                          "'Xqcia' (Qualcomm uC Arithmetic Extension)">;
 
 def FeatureVendorXqcics
-    : RISCVExperimentalExtension<"xqcics", 0, 2,
-                                 "'Xqcics' (Qualcomm uC Conditional Select Extension)">;
+    : RISCVExperimentalExtension<0, 2, "Qualcomm uC Conditional Select Extension">;
 def HasVendorXqcics
     : Predicate<"Subtarget->hasVendorXqcics()">,
       AssemblerPredicate<(all_of FeatureVendorXqcics),
                          "'Xqcics' (Qualcomm uC Conditional Select Extension)">;
 
 def FeatureVendorXqcilsm
-    : RISCVExperimentalExtension<"xqcilsm", 0, 2,
-                                 "'Xqcilsm' (Qualcomm uC Load Store Multiple Extension)">;
+    : RISCVExperimentalExtension<0, 2,
+                                 "Qualcomm uC Load Store Multiple Extension">;
 def HasVendorXqcilsm
     : Predicate<"Subtarget->hasVendorXqcilsm()">,
       AssemblerPredicate<(all_of FeatureVendorXqcilsm),

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -22,13 +22,16 @@
 //             uses the record name by replacing Feature with Has.
 // value     - Value to assign to the field in RISCVSubtarget when this
 //             extension is enabled. Usually "true", but can be changed.
+// IsExperimental
+//           - Indicates whether the extension is experimental
 class RISCVExtension<int major, int minor, string desc,
                      list<SubtargetFeature> implies = [],
                      string fieldname = !subst("Feature", "Has", NAME),
-                     string value = "true", string prefix = "">
+                     string value = "true", bit IsExperimental = false>
     : SubtargetFeature<
-        prefix # !tolower(!subst("FeatureVendor", "",
-                                 !subst("FeatureStdExt", "", NAME))),
+        !if(IsExperimental, "experimental-", "")
+            # !tolower(!subst("FeatureVendor", "",
+                              !subst("FeatureStdExt", "", NAME))),
         fieldname, value,
         "'" # !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME))
             # "' (" # desc # ")",
@@ -58,8 +61,7 @@ class RISCVExperimentalExtension<int major, int minor, string desc,
                                  list<RISCVExtension> implies = [],
                                  string fieldname = !subst("Feature", "Has", NAME),
                                  string value = "true">
-    : RISCVExtension<major, minor, desc, implies, fieldname, value,
-                     "experimental-"> {
+    : RISCVExtension<major, minor, desc, implies, fieldname, value, true> {
   let Experimental = true;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -18,6 +18,7 @@
 //
 // major     - Major version of extension.
 // minor     - Minor version of extension.
+// desc      - Description of extension.
 // implies   - Extensions or features implied by this extension.
 // fieldname - name of field to create in RISCVSubtarget. By default replaces
 //             uses the record name by replacing Feature with Has.
@@ -30,13 +31,13 @@ class RISCVExtension<int major, int minor, string desc,
                      string fieldname = !subst("Feature", "Has", NAME),
                      string value = "true", bit IsExperimental = false>
     : SubtargetFeature<"", fieldname, value, "", implies> {
-  defvar N = !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME));
+  defvar ExtName = !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME));
 
   // Name - Name of the extension in lower case.
-  let Name = !if(IsExperimental, "experimental-", "") # !tolower(N);
+  let Name = !if(IsExperimental, "experimental-", "") # !tolower(ExtName);
 
-  // Desc - Description of extension.
-  let Desc = "'" # N # "' (" # desc # ")";
+  // Desc - Description of extension with its name.
+  let Desc = "'" # ExtName # "' (" # desc # ")";
 
   // MajorVersion - The major version for this extension.
   int MajorVersion = major;

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -13,10 +13,8 @@
 // Subclass of SubtargetFeature to be used when the feature is also a RISC-V
 // extension. Extensions have a version and may be experimental.
 //
-// name      - Name of the extension in lower case.
 // major     - Major version of extension.
 // minor     - Minor version of extension.
-// desc      - Description of extension.
 // implies   - Extensions or features implied by this extension.
 // fieldname - name of field to create in RISCVSubtarget. By default replaces
 //             uses the record name by replacing Feature with Has.
@@ -28,14 +26,15 @@ class RISCVExtension<int major, int minor, string desc,
                      list<SubtargetFeature> implies = [],
                      string fieldname = !subst("Feature", "Has", NAME),
                      string value = "true", bit IsExperimental = false>
-    : SubtargetFeature<
-        !if(IsExperimental, "experimental-", "")
-            # !tolower(!subst("FeatureVendor", "",
-                              !subst("FeatureStdExt", "", NAME))),
-        fieldname, value,
-        "'" # !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME))
-            # "' (" # desc # ")",
-        implies> {
+    : SubtargetFeature<"", fieldname, value, "", implies> {
+  defvar N = !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME));
+
+  // Name - Name of the extension in lower case.
+  let Name = !if(IsExperimental, "experimental-", "") # !tolower(N);
+
+  // Desc - Description of extension.
+  let Desc = "'" # N # "' (" # desc # ")";
+
   // MajorVersion - The major version for this extension.
   int MajorVersion = major;
 

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -31,13 +31,13 @@ class RISCVExtension<int major, int minor, string desc,
                      string fieldname = !subst("Feature", "Has", NAME),
                      string value = "true", bit IsExperimental = false>
     : SubtargetFeature<"", fieldname, value, "", implies> {
-  defvar ExtName = !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME));
+  defvar extName = !subst("FeatureVendor", "", !subst("FeatureStdExt", "", NAME));
 
   // Name - Name of the extension in lower case.
-  let Name = !if(IsExperimental, "experimental-", "") # !tolower(ExtName);
+  let Name = !if(IsExperimental, "experimental-", "") # !tolower(extName);
 
   // Desc - Description of extension with its name.
-  let Desc = "'" # ExtName # "' (" # desc # ")";
+  let Desc = "'" # extName # "' (" # desc # ")";
 
   // MajorVersion - The major version for this extension.
   int MajorVersion = major;

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -1,0 +1,271 @@
+; RUN: llc -mtriple=riscv32 -mattr=help 2>&1 | FileCheck %s
+; RUN: llc -mtriple=riscv64 -mattr=help 2>&1 | FileCheck %s
+
+; CHECK: Available features for this target:
+; CHECK:   32bit                            - Implements RV32.
+; CHECK:   64bit                            - Implements RV64.
+; CHECK:   a                                - 'A' (Atomic Instructions).
+; CHECK:   auipc-addi-fusion                - Enable AUIPC+ADDI macrofusion.
+; CHECK:   b                                - 'B' (the collection of the Zba, Zbb, Zbs extensions).
+; CHECK:   c                                - 'C' (Compressed Instructions).
+; CHECK:   conditional-cmv-fusion           - Enable branch+c.mv fusion.
+; CHECK:   d                                - 'D' (Double-Precision Floating-Point).
+; CHECK:   disable-latency-sched-heuristic  - Disable latency scheduling heuristic.
+; CHECK:   dlen-factor-2                    - Vector unit DLEN(data path width) is half of VLEN.
+; CHECK:   e                                - Implements RV{32,64}E (provides 16 rather than 32 GPRs).
+; CHECK:   experimental                     - Experimental intrinsics.
+; CHECK:   experimental-rvm23u32            - RISC-V experimental-rvm23u32 profile.
+; CHECK:   experimental-smctr               - 'Smctr' (Control Transfer Records Machine Level).
+; CHECK:   experimental-ssctr               - 'Ssctr' (Control Transfer Records Supervisor Level).
+; CHECK:   experimental-svukte              - 'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses).
+; CHECK:   experimental-xqcia               - 'Xqcia' (Qualcomm uC Arithmetic Extension).
+; CHECK:   experimental-xqcics              - 'Xqcics' (Qualcomm uC Conditional Select Extension).
+; CHECK:   experimental-xqcicsr             - 'Xqcicsr' (Qualcomm uC CSR Extension).
+; CHECK:   experimental-xqcilsm             - 'Xqcilsm' (Qualcomm uC Load Store Multiple Extension).
+; CHECK:   experimental-xqcisls             - 'Xqcisls' (Qualcomm uC Scaled Load Store Extension).
+; CHECK:   experimental-zalasr              - 'Zalasr' (Load-Acquire and Store-Release Instructions).
+; CHECK:   experimental-zicfilp             - 'Zicfilp' (Landing pad).
+; CHECK:   experimental-zicfiss             - 'Zicfiss' (Shadow stack).
+; CHECK:   experimental-zvbc32e             - 'Zvbc32e' (Vector Carryless Multiplication with 32-bits elements).
+; CHECK:   experimental-zvkgs               - 'Zvkgs' (Vector-Scalar GCM instructions for Cryptography).
+; CHECK:   f                                - 'F' (Single-Precision Floating-Point).
+; CHECK:   forced-atomics                   - Assume that lock-free native-width atomics are available.
+; CHECK:   h                                - 'H' (Hypervisor).
+; CHECK:   i                                - 'I' (Base Integer Instruction Set).
+; CHECK:   ld-add-fusion                    - Enable LD+ADD macrofusion.
+; CHECK:   lui-addi-fusion                  - Enable LUI+ADDI macro fusion.
+; CHECK:   m                                - 'M' (Integer Multiplication and Division).
+; CHECK:   mips-p8700                       - MIPS p8700 processor.
+; CHECK:   no-default-unroll                - Disable default unroll preference..
+; CHECK:   no-rvc-hints                     - Disable RVC Hint Instructions..
+; CHECK:   no-sink-splat-operands           - Disable sink splat operands to enable .vx, .vf,.wx, and .wf instructions.
+; CHECK:   no-trailing-seq-cst-fence        - Disable trailing fence for seq-cst store..
+; CHECK:   optimized-nf2-segment-load-store - vlseg2eN.v and vsseg2eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-nf3-segment-load-store - vlseg3eN.v and vsseg3eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-nf4-segment-load-store - vlseg4eN.v and vsseg4eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-nf5-segment-load-store - vlseg5eN.v and vsseg5eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-nf6-segment-load-store - vlseg6eN.v and vsseg6eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-nf7-segment-load-store - vlseg7eN.v and vsseg7eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-nf8-segment-load-store - vlseg8eN.v and vsseg8eN.v areimplemented as a wide memory op and shuffle.
+; CHECK:   optimized-zero-stride-load       - Optimized (perform fewer memory operations)zero-stride vector load.
+; CHECK:   predictable-select-expensive     - Prefer likely predicted branches over selects.
+; CHECK:   prefer-w-inst                    - Prefer instructions with W suffix.
+; CHECK:   relax                            - Enable Linker relaxation..
+; CHECK:   reserve-x1                       - Reserve X1.
+; CHECK:   reserve-x10                      - Reserve X10.
+; CHECK:   reserve-x11                      - Reserve X11.
+; CHECK:   reserve-x12                      - Reserve X12.
+; CHECK:   reserve-x13                      - Reserve X13.
+; CHECK:   reserve-x14                      - Reserve X14.
+; CHECK:   reserve-x15                      - Reserve X15.
+; CHECK:   reserve-x16                      - Reserve X16.
+; CHECK:   reserve-x17                      - Reserve X17.
+; CHECK:   reserve-x18                      - Reserve X18.
+; CHECK:   reserve-x19                      - Reserve X19.
+; CHECK:   reserve-x2                       - Reserve X2.
+; CHECK:   reserve-x20                      - Reserve X20.
+; CHECK:   reserve-x21                      - Reserve X21.
+; CHECK:   reserve-x22                      - Reserve X22.
+; CHECK:   reserve-x23                      - Reserve X23.
+; CHECK:   reserve-x24                      - Reserve X24.
+; CHECK:   reserve-x25                      - Reserve X25.
+; CHECK:   reserve-x26                      - Reserve X26.
+; CHECK:   reserve-x27                      - Reserve X27.
+; CHECK:   reserve-x28                      - Reserve X28.
+; CHECK:   reserve-x29                      - Reserve X29.
+; CHECK:   reserve-x3                       - Reserve X3.
+; CHECK:   reserve-x30                      - Reserve X30.
+; CHECK:   reserve-x31                      - Reserve X31.
+; CHECK:   reserve-x4                       - Reserve X4.
+; CHECK:   reserve-x5                       - Reserve X5.
+; CHECK:   reserve-x6                       - Reserve X6.
+; CHECK:   reserve-x7                       - Reserve X7.
+; CHECK:   reserve-x8                       - Reserve X8.
+; CHECK:   reserve-x9                       - Reserve X9.
+; CHECK:   rva20s64                         - RISC-V rva20s64 profile.
+; CHECK:   rva20u64                         - RISC-V rva20u64 profile.
+; CHECK:   rva22s64                         - RISC-V rva22s64 profile.
+; CHECK:   rva22u64                         - RISC-V rva22u64 profile.
+; CHECK:   rva23s64                         - RISC-V rva23s64 profile.
+; CHECK:   rva23u64                         - RISC-V rva23u64 profile.
+; CHECK:   rvb23s64                         - RISC-V rvb23s64 profile.
+; CHECK:   rvb23u64                         - RISC-V rvb23u64 profile.
+; CHECK:   rvi20u32                         - RISC-V rvi20u32 profile.
+; CHECK:   rvi20u64                         - RISC-V rvi20u64 profile.
+; CHECK:   save-restore                     - Enable save/restore..
+; CHECK:   sha                              - 'Sha' (Augmented Hypervisor).
+; CHECK:   shcounterenw                     - 'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero).
+; CHECK:   shgatpa                          - 'Sgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare).
+; CHECK:   shifted-zextw-fusion             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
+; CHECK:   short-forward-branch-opt         - Enable short forward branch optimization.
+; CHECK:   shtvala                          - 'Shtvala' (htval provides all needed values).
+; CHECK:   shvsatpa                         - 'Svsatpa' (vsatp supports all modes supported by satp).
+; CHECK:   shvstvala                        - 'Shvstvala' (vstval provides all needed values).
+; CHECK:   shvstvecd                        - 'Shvstvecd' (vstvec supports Direct mode).
+; CHECK:   sifive7                          - SiFive 7-Series processors.
+; CHECK:   smaia                            - 'Smaia' (Advanced Interrupt Architecture Machine Level).
+; CHECK:   smcdeleg                         - 'Smcdeleg' (Counter Delegation Machine Level).
+; CHECK:   smcsrind                         - 'Smcsrind' (Indirect CSR Access Machine Level).
+; CHECK:   smdbltrp                         - 'Smdbltrp' (Double Trap Machine Level).
+; CHECK:   smepmp                           - 'Smepmp' (Enhanced Physical Memory Protection).
+; CHECK:   smmpm                            - 'Smmpm' (Machine-level Pointer Masking for M-mode).
+; CHECK:   smnpm                            - 'Smnpm' (Machine-level Pointer Masking for next lower privilege mode).
+; CHECK:   smrnmi                           - 'Smrnmi' (Resumable Non-Maskable Interrupts).
+; CHECK:   smstateen                        - 'Smstateen' (Machine-mode view of the state-enable extension).
+; CHECK:   ssaia                            - 'Ssaia' (Advanced Interrupt Architecture Supervisor Level).
+; CHECK:   ssccfg                           - 'Ssccfg' (Counter Configuration Supervisor Level).
+; CHECK:   ssccptr                          - 'Ssccptr' (Main memory supports page table reads).
+; CHECK:   sscofpmf                         - 'Sscofpmf' (Count Overflow and Mode-Based Filtering).
+; CHECK:   sscounterenw                     - 'Sscounterenw' (Support writeable scounteren enable bit for any hpmcounter that is not read-only zero).
+; CHECK:   sscsrind                         - 'Sscsrind' (Indirect CSR Access Supervisor Level).
+; CHECK:   ssdbltrp                         - 'Ssdbltrp' (Double Trap Supervisor Level).
+; CHECK:   ssnpm                            - 'Ssnpm' (Supervisor-level Pointer Masking for next lower privilege mode).
+; CHECK:   sspm                             - 'Sspm' (Indicates Supervisor-mode Pointer Masking).
+; CHECK:   ssqosid                          - 'Ssqosid' (Quality-of-Service (QoS) Identifiers).
+; CHECK:   ssstateen                        - 'Ssstateen' (Supervisor-mode view of the state-enable extension).
+; CHECK:   ssstrict                         - 'Ssstrict' (No non-conforming extensions are present).
+; CHECK:   sstc                             - 'Sstc' (Supervisor-mode timer interrupts).
+; CHECK:   sstvala                          - 'Sstvala' (stval provides all needed values).
+; CHECK:   sstvecd                          - 'Sstvecd' (stvec supports Direct mode).
+; CHECK:   ssu64xl                          - 'Ssu64xl' (UXLEN=64 supported).
+; CHECK:   supm                             - 'Supm' (Indicates User-mode Pointer Masking).
+; CHECK:   svade                            - 'Svade' (Raise exceptions on improper A/D bits).
+; CHECK:   svadu                            - 'Svadu' (Hardware A/D updates).
+; CHECK:   svbare                           - 'Svbare' $(satp mode Bare supported).
+; CHECK:   svinval                          - 'Svinval' (Fine-Grained Address-Translation Cache Invalidation).
+; CHECK:   svnapot                          - 'Svnapot' (NAPOT Translation Contiguity).
+; CHECK:   svpbmt                           - 'Svpbmt' (Page-Based Memory Types).
+; CHECK:   svvptc                           - 'svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid).
+; CHECK:   tagged-globals                   - Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits.
+; CHECK:   unaligned-scalar-mem             - Has reasonably performant unaligned scalar loads and stores.
+; CHECK:   unaligned-vector-mem             - Has reasonably performant unaligned vector loads and stores.
+; CHECK:   use-postra-scheduler             - Schedule again after register allocation.
+; CHECK:   v                                - 'V' (Vector Extension for Application Processors).
+; CHECK:   ventana-veyron                   - Ventana Veyron-Series processors.
+; CHECK:   vxrm-pipeline-flush              - VXRM writes causes pipeline flush.
+; CHECK:   xcvalu                           - 'XCValu' (CORE-V ALU Operations).
+; CHECK:   xcvbi                            - 'XCVbi' (CORE-V Immediate Branching).
+; CHECK:   xcvbitmanip                      - 'XCVbitmanip' (CORE-V Bit Manipulation).
+; CHECK:   xcvelw                           - 'XCVelw' (CORE-V Event Load Word).
+; CHECK:   xcvmac                           - 'XCVmac' (CORE-V Multiply-Accumulate).
+; CHECK:   xcvmem                           - 'XCVmem' (CORE-V Post-incrementing Load & Store).
+; CHECK:   xcvsimd                          - 'XCVsimd' (CORE-V SIMD ALU).
+; CHECK:   xsfcease                         - 'XSfcease' (SiFive sf.cease Instruction).
+; CHECK:   xsfvcp                           - 'XSfvcp' (SiFive Custom Vector Coprocessor Interface Instructions).
+; CHECK:   xsfvfnrclipxfqf                  - 'XSfvfnrclipxfqf' (SiFive FP32-to-int8 Ranged Clip Instructions).
+; CHECK:   xsfvfwmaccqqq                    - 'XSfvfwmaccqqq' (SiFive Matrix Multiply Accumulate Instruction and 4-by-4)).
+; CHECK:   xsfvqmaccdod                     - 'XSfvqmaccdod' (SiFive Int8 Matrix Multiplication Instructions (2-by-8 and 8-by-2)).
+; CHECK:   xsfvqmaccqoq                     - 'XSfvqmaccqoq' (SiFive Int8 Matrix Multiplication Instructions (4-by-8 and 8-by-4)).
+; CHECK:   xsifivecdiscarddlone             - 'XSiFivecdiscarddlone' (SiFive sf.cdiscard.d.l1 Instruction).
+; CHECK:   xsifivecflushdlone               - 'XSiFivecflushdlone' (SiFive sf.cflush.d.l1 Instruction).
+; CHECK:   xtheadba                         - 'XTHeadBa' (T-Head address calculation instructions).
+; CHECK:   xtheadbb                         - 'XTHeadBb' (T-Head basic bit-manipulation instructions).
+; CHECK:   xtheadbs                         - 'XTHeadBs' (T-Head single-bit instructions).
+; CHECK:   xtheadcmo                        - 'XTHeadCmo' (T-Head cache management instructions).
+; CHECK:   xtheadcondmov                    - 'XTHeadCondMov' (T-Head conditional move instructions).
+; CHECK:   xtheadfmemidx                    - 'XTHeadFMemIdx' (T-Head FP Indexed Memory Operations).
+; CHECK:   xtheadmac                        - 'XTHeadMac' (T-Head Multiply-Accumulate Instructions).
+; CHECK:   xtheadmemidx                     - 'XTHeadMemIdx' (T-Head Indexed Memory Operations).
+; CHECK:   xtheadmempair                    - 'XTHeadMemPair' (T-Head two-GPR Memory Operations).
+; CHECK:   xtheadsync                       - 'XTHeadSync' (T-Head multicore synchronization instructions).
+; CHECK:   xtheadvdot                       - 'XTHeadVdot' (T-Head Vector Extensions for Dot).
+; CHECK:   xventanacondops                  - 'XVentanaCondOps' (Ventana Conditional Ops).
+; CHECK:   xwchc                            - 'Xwchc' (WCH/QingKe additional compressed opcodes).
+; CHECK:   za128rs                          - 'Za128rs' (Reservation Set Size of at Most 128 Bytes).
+; CHECK:   za64rs                           - 'Za64rs' (Reservation Set Size of at Most 64 Bytes).
+; CHECK:   zaamo                            - 'Zaamo' (Atomic Memory Operations).
+; CHECK:   zabha                            - 'Zabha' (Byte and Halfword Atomic Memory Operations).
+; CHECK:   zacas                            - 'Zacas' (Atomic Compare-And-Swap Instructions).
+; CHECK:   zalrsc                           - 'Zalrsc' (Load-Reserved/Store-Conditional).
+; CHECK:   zama16b                          - 'Zama16b' (Atomic 16-byte misaligned loads, stores and AMOs).
+; CHECK:   zawrs                            - 'Zawrs' (Wait on Reservation Set).
+; CHECK:   zba                              - 'Zba' (Address Generation Instructions).
+; CHECK:   zbb                              - 'Zbb' (Basic Bit-Manipulation).
+; CHECK:   zbc                              - 'Zbc' (Carry-Less Multiplication).
+; CHECK:   zbkb                             - 'Zbkb' (Bitmanip instructions for Cryptography).
+; CHECK:   zbkc                             - 'Zbkc' (Carry-less multiply instructions for Cryptography).
+; CHECK:   zbkx                             - 'Zbkx' (Crossbar permutation instructions).
+; CHECK:   zbs                              - 'Zbs' (Single-Bit Instructions).
+; CHECK:   zca                              - 'Zca' (part of the C extension, excluding compressed floating point loads/stores).
+; CHECK:   zcb                              - 'Zcb' (Compressed basic bit manipulation instructions).
+; CHECK:   zcd                              - 'Zcd' (Compressed Double-Precision Floating-Point Instructions).
+; CHECK:   zce                              - 'Zce' (Compressed extensions for microcontrollers).
+; CHECK:   zcf                              - 'Zcf' (Compressed Single-Precision Floating-Point Instructions).
+; CHECK:   zcmop                            - 'Zcmop' (Compressed May-Be-Operations).
+; CHECK:   zcmp                             - 'Zcmp' (sequenced instructions for code-size reduction).
+; CHECK:   zcmt                             - 'Zcmt' (table jump instructions for code-size reduction).
+; CHECK:   zdinx                            - 'Zdinx' (Double in Integer).
+; CHECK:   zexth-fusion                     - Enable SLLI+SRLI to be fused to zero extension of halfword.
+; CHECK:   zextw-fusion                     - Enable SLLI+SRLI to be fused to zero extension of word.
+; CHECK:   zfa                              - 'Zfa' (Additional Floating-Point).
+; CHECK:   zfbfmin                          - 'Zfbfmin' (Scalar BF16 Converts).
+; CHECK:   zfh                              - 'Zfh' (Half-Precision Floating-Point).
+; CHECK:   zfhmin                           - 'Zfhmin' (Half-Precision Floating-Point Minimal).
+; CHECK:   zfinx                            - 'Zfinx' (Float in Integer).
+; CHECK:   zhinx                            - 'Zhinx' (Half Float in Integer).
+; CHECK:   zhinxmin                         - 'Zhinxmin' (Half Float in Integer Minimal).
+; CHECK:   zic64b                           - 'Zic64b' (Cache Block Size Is 64 Bytes).
+; CHECK:   zicbom                           - 'Zicbom' (Cache-Block Management Instructions).
+; CHECK:   zicbop                           - 'Zicbop' (Cache-Block Prefetch Instructions).
+; CHECK:   zicboz                           - 'Zicboz' (Cache-Block Zero Instructions).
+; CHECK:   ziccamoa                         - 'Ziccamoa' (Main Memory Supports All Atomics in A).
+; CHECK:   ziccif                           - 'Ziccif' (Main Memory Supports Instruction Fetch with Atomicity Requirement).
+; CHECK:   zicclsm                          - 'Zicclsm' (Main Memory Supports Misaligned Loads/Stores).
+; CHECK:   ziccrse                          - 'Ziccrse' (Main Memory Supports Forward Progress on LR/SC Sequences).
+; CHECK:   zicntr                           - 'Zicntr' (Base Counters and Timers).
+; CHECK:   zicond                           - 'Zicond' (Integer Conditional Operations).
+; CHECK:   zicsr                            - 'zicsr' (CSRs).
+; CHECK:   zifencei                         - 'Zifencei' (fence.i).
+; CHECK:   zihintntl                        - 'Zihintntl' (Non-Temporal Locality Hints).
+; CHECK:   zihintpause                      - 'Zihintpause' (Pause Hint).
+; CHECK:   zihpm                            - 'Zihpm' (Hardware Performance Counters).
+; CHECK:   zimop                            - 'Zimop' (May-Be-Operations).
+; CHECK:   zk                               - 'Zk' (Standard scalar cryptography extension).
+; CHECK:   zkn                              - 'Zkn' (NIST Algorithm Suite).
+; CHECK:   zknd                             - 'Zknd' (NIST Suite: AES Decryption).
+; CHECK:   zkne                             - 'Zkne' (NIST Suite: AES Encryption).
+; CHECK:   zknh                             - 'Zknh' (NIST Suite: Hash Function Instructions).
+; CHECK:   zkr                              - 'Zkr' (Entropy Source Extension).
+; CHECK:   zks                              - 'Zks' (ShangMi Algorithm Suite).
+; CHECK:   zksed                            - 'Zksed' (ShangMi Suite: SM4 Block Cipher Instructions).
+; CHECK:   zksh                             - 'Zksh' (ShangMi Suite: SM3 Hash Function Instructions).
+; CHECK:   zkt                              - 'Zkt' (Data Independent Execution Latency).
+; CHECK:   zmmul                            - 'Zmmul' (Integer Multiplication).
+; CHECK:   ztso                             - 'Ztso' (Memory Model - Total Store Order).
+; CHECK:   zvbb                             - 'Zvbb' (Vector basic bit-manipulation instructions).
+; CHECK:   zvbc                             - 'Zvbc' (Vector Carryless Multiplication).
+; CHECK:   zve32f                           - 'Zve32f' (Vector Extensions for Embedded Processors with maximal 32 EEW and F extension).
+; CHECK:   zve32x                           - 'Zve32x' (Vector Extensions for Embedded Processors with maximal 32 EEW).
+; CHECK:   zve64d                           - 'Zve64d' (Vector Extensions for Embedded Processors with maximal 64 EEW, F and D extension).
+; CHECK:   zve64f                           - 'Zve64f' (Vector Extensions for Embedded Processors with maximal 64 EEW and F extension).
+; CHECK:   zve64x                           - 'Zve64x' (Vector Extensions for Embedded Processors with maximal 64 EEW).
+; CHECK:   zvfbfmin                         - 'Zvbfmin' (Vector BF16 Converts).
+; CHECK:   zvfbfwma                         - 'Zvfbfwma' (Vector BF16 widening mul-add).
+; CHECK:   zvfh                             - 'Zvfh' (Vector Half-Precision Floating-Point).
+; CHECK:   zvfhmin                          - 'Zvfhmin' (Vector Half-Precision Floating-Point Minimal).
+; CHECK:   zvkb                             - 'Zvkb' (Vector Bit-manipulation used in Cryptography).
+; CHECK:   zvkg                             - 'Zvkg' (Vector GCM instructions for Cryptography).
+; CHECK:   zvkn                             - 'Zvkn' (shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and 'Zvkt').
+; CHECK:   zvknc                            - 'Zvknc' (shorthand for 'Zvknc' and 'Zvbc').
+; CHECK:   zvkned                           - 'Zvkned' (Vector AES Encryption & Decryption (Single Round)).
+; CHECK:   zvkng                            - 'zvkng' (shorthand for 'Zvkn' and 'Zvkg').
+; CHECK:   zvknha                           - 'Zvknha' (Vector SHA-2 (SHA-256 only)).
+; CHECK:   zvknhb                           - 'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512)).
+; CHECK:   zvks                             - 'Zvks' (shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and 'Zvkt').
+; CHECK:   zvksc                            - 'Zvksc' (shorthand for 'Zvks' and 'Zvbc').
+; CHECK:   zvksed                           - 'Zvksed' (SM4 Block Cipher Instructions).
+; CHECK:   zvksg                            - 'Zvksg' (shorthand for 'Zvks' and 'Zvkg').
+; CHECK:   zvksh                            - 'Zvksh' (SM3 Hash Function Instructions).
+; CHECK:   zvkt                             - 'Zvkt' (Vector Data-Independent Execution Latency).
+; CHECK:   zvl1024b                         - 'Zvl' (Minimum Vector Length) 1024.
+; CHECK:   zvl128b                          - 'Zvl' (Minimum Vector Length) 128.
+; CHECK:   zvl16384b                        - 'Zvl' (Minimum Vector Length) 16384.
+; CHECK:   zvl2048b                         - 'Zvl' (Minimum Vector Length) 2048.
+; CHECK:   zvl256b                          - 'Zvl' (Minimum Vector Length) 256.
+; CHECK:   zvl32768b                        - 'Zvl' (Minimum Vector Length) 32768.
+; CHECK:   zvl32b                           - 'Zvl' (Minimum Vector Length) 32.
+; CHECK:   zvl4096b                         - 'Zvl' (Minimum Vector Length) 4096.
+; CHECK:   zvl512b                          - 'Zvl' (Minimum Vector Length) 512.
+; CHECK:   zvl64b                           - 'Zvl' (Minimum Vector Length) 64.
+; CHECK:   zvl65536b                        - 'Zvl' (Minimum Vector Length) 65536.
+; CHECK:   zvl8192b                         - 'Zvl' (Minimum Vector Length) 8192.

--- a/llvm/test/CodeGen/RISCV/features-info.ll
+++ b/llvm/test/CodeGen/RISCV/features-info.ll
@@ -12,7 +12,7 @@
 ; CHECK:   d                                - 'D' (Double-Precision Floating-Point).
 ; CHECK:   disable-latency-sched-heuristic  - Disable latency scheduling heuristic.
 ; CHECK:   dlen-factor-2                    - Vector unit DLEN(data path width) is half of VLEN.
-; CHECK:   e                                - Implements RV{32,64}E (provides 16 rather than 32 GPRs).
+; CHECK:   e                                - 'E' (Embedded Instruction Set with 16 GPRs).
 ; CHECK:   experimental                     - Experimental intrinsics.
 ; CHECK:   experimental-rvm23u32            - RISC-V experimental-rvm23u32 profile.
 ; CHECK:   experimental-smctr               - 'Smctr' (Control Transfer Records Machine Level).
@@ -95,11 +95,11 @@
 ; CHECK:   save-restore                     - Enable save/restore..
 ; CHECK:   sha                              - 'Sha' (Augmented Hypervisor).
 ; CHECK:   shcounterenw                     - 'Shcounterenw' (Support writeable hcounteren enable bit for any hpmcounter that is not read-only zero).
-; CHECK:   shgatpa                          - 'Sgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare).
+; CHECK:   shgatpa                          - 'Shgatpa' (SvNNx4 mode supported for all modes supported by satp, as well as Bare).
 ; CHECK:   shifted-zextw-fusion             - Enable SLLI+SRLI to be fused when computing (shifted) word zero extension.
 ; CHECK:   short-forward-branch-opt         - Enable short forward branch optimization.
 ; CHECK:   shtvala                          - 'Shtvala' (htval provides all needed values).
-; CHECK:   shvsatpa                         - 'Svsatpa' (vsatp supports all modes supported by satp).
+; CHECK:   shvsatpa                         - 'Shvsatpa' (vsatp supports all modes supported by satp).
 ; CHECK:   shvstvala                        - 'Shvstvala' (vstval provides all needed values).
 ; CHECK:   shvstvecd                        - 'Shvstvecd' (vstvec supports Direct mode).
 ; CHECK:   sifive7                          - SiFive 7-Series processors.
@@ -131,11 +131,11 @@
 ; CHECK:   supm                             - 'Supm' (Indicates User-mode Pointer Masking).
 ; CHECK:   svade                            - 'Svade' (Raise exceptions on improper A/D bits).
 ; CHECK:   svadu                            - 'Svadu' (Hardware A/D updates).
-; CHECK:   svbare                           - 'Svbare' $(satp mode Bare supported).
+; CHECK:   svbare                           - 'Svbare' (satp mode Bare supported).
 ; CHECK:   svinval                          - 'Svinval' (Fine-Grained Address-Translation Cache Invalidation).
 ; CHECK:   svnapot                          - 'Svnapot' (NAPOT Translation Contiguity).
 ; CHECK:   svpbmt                           - 'Svpbmt' (Page-Based Memory Types).
-; CHECK:   svvptc                           - 'svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid).
+; CHECK:   svvptc                           - 'Svvptc' (Obviating Memory-Management Instructions after Marking PTEs Valid).
 ; CHECK:   tagged-globals                   - Use an instruction sequence for taking the address of a global that allows a memory tag in the upper address bits.
 ; CHECK:   unaligned-scalar-mem             - Has reasonably performant unaligned scalar loads and stores.
 ; CHECK:   unaligned-vector-mem             - Has reasonably performant unaligned vector loads and stores.
@@ -214,7 +214,7 @@
 ; CHECK:   ziccrse                          - 'Ziccrse' (Main Memory Supports Forward Progress on LR/SC Sequences).
 ; CHECK:   zicntr                           - 'Zicntr' (Base Counters and Timers).
 ; CHECK:   zicond                           - 'Zicond' (Integer Conditional Operations).
-; CHECK:   zicsr                            - 'zicsr' (CSRs).
+; CHECK:   zicsr                            - 'Zicsr' (CSRs).
 ; CHECK:   zifencei                         - 'Zifencei' (fence.i).
 ; CHECK:   zihintntl                        - 'Zihintntl' (Non-Temporal Locality Hints).
 ; CHECK:   zihintpause                      - 'Zihintpause' (Pause Hint).
@@ -239,7 +239,7 @@
 ; CHECK:   zve64d                           - 'Zve64d' (Vector Extensions for Embedded Processors with maximal 64 EEW, F and D extension).
 ; CHECK:   zve64f                           - 'Zve64f' (Vector Extensions for Embedded Processors with maximal 64 EEW and F extension).
 ; CHECK:   zve64x                           - 'Zve64x' (Vector Extensions for Embedded Processors with maximal 64 EEW).
-; CHECK:   zvfbfmin                         - 'Zvbfmin' (Vector BF16 Converts).
+; CHECK:   zvfbfmin                         - 'Zvfbfmin' (Vector BF16 Converts).
 ; CHECK:   zvfbfwma                         - 'Zvfbfwma' (Vector BF16 widening mul-add).
 ; CHECK:   zvfh                             - 'Zvfh' (Vector Half-Precision Floating-Point).
 ; CHECK:   zvfhmin                          - 'Zvfhmin' (Vector Half-Precision Floating-Point Minimal).
@@ -248,7 +248,7 @@
 ; CHECK:   zvkn                             - 'Zvkn' (shorthand for 'Zvkned', 'Zvknhb', 'Zvkb', and 'Zvkt').
 ; CHECK:   zvknc                            - 'Zvknc' (shorthand for 'Zvknc' and 'Zvbc').
 ; CHECK:   zvkned                           - 'Zvkned' (Vector AES Encryption & Decryption (Single Round)).
-; CHECK:   zvkng                            - 'zvkng' (shorthand for 'Zvkn' and 'Zvkg').
+; CHECK:   zvkng                            - 'Zvkng' (shorthand for 'Zvkn' and 'Zvkg').
 ; CHECK:   zvknha                           - 'Zvknha' (Vector SHA-2 (SHA-256 only)).
 ; CHECK:   zvknhb                           - 'Zvknhb' (Vector SHA-2 (SHA-256 and SHA-512)).
 ; CHECK:   zvks                             - 'Zvks' (shorthand for 'Zvksed', 'Zvksh', 'Zvkb', and 'Zvkt').
@@ -257,15 +257,15 @@
 ; CHECK:   zvksg                            - 'Zvksg' (shorthand for 'Zvks' and 'Zvkg').
 ; CHECK:   zvksh                            - 'Zvksh' (SM3 Hash Function Instructions).
 ; CHECK:   zvkt                             - 'Zvkt' (Vector Data-Independent Execution Latency).
-; CHECK:   zvl1024b                         - 'Zvl' (Minimum Vector Length) 1024.
-; CHECK:   zvl128b                          - 'Zvl' (Minimum Vector Length) 128.
-; CHECK:   zvl16384b                        - 'Zvl' (Minimum Vector Length) 16384.
-; CHECK:   zvl2048b                         - 'Zvl' (Minimum Vector Length) 2048.
-; CHECK:   zvl256b                          - 'Zvl' (Minimum Vector Length) 256.
-; CHECK:   zvl32768b                        - 'Zvl' (Minimum Vector Length) 32768.
-; CHECK:   zvl32b                           - 'Zvl' (Minimum Vector Length) 32.
-; CHECK:   zvl4096b                         - 'Zvl' (Minimum Vector Length) 4096.
-; CHECK:   zvl512b                          - 'Zvl' (Minimum Vector Length) 512.
-; CHECK:   zvl64b                           - 'Zvl' (Minimum Vector Length) 64.
-; CHECK:   zvl65536b                        - 'Zvl' (Minimum Vector Length) 65536.
-; CHECK:   zvl8192b                         - 'Zvl' (Minimum Vector Length) 8192.
+; CHECK:   zvl1024b                         - 'Zvl1024b' (Minimum Vector Length 1024).
+; CHECK:   zvl128b                          - 'Zvl128b' (Minimum Vector Length 128).
+; CHECK:   zvl16384b                        - 'Zvl16384b' (Minimum Vector Length 16384).
+; CHECK:   zvl2048b                         - 'Zvl2048b' (Minimum Vector Length 2048).
+; CHECK:   zvl256b                          - 'Zvl256b' (Minimum Vector Length 256).
+; CHECK:   zvl32768b                        - 'Zvl32768b' (Minimum Vector Length 32768).
+; CHECK:   zvl32b                           - 'Zvl32b' (Minimum Vector Length 32).
+; CHECK:   zvl4096b                         - 'Zvl4096b' (Minimum Vector Length 4096).
+; CHECK:   zvl512b                          - 'Zvl512b' (Minimum Vector Length 512).
+; CHECK:   zvl64b                           - 'Zvl64b' (Minimum Vector Length 64).
+; CHECK:   zvl65536b                        - 'Zvl65536b' (Minimum Vector Length 65536).
+; CHECK:   zvl8192b                         - 'Zvl8192b' (Minimum Vector Length 8192).


### PR DESCRIPTION
I think typo can be avoided by reducing the number of times we re-enter the extension name.