### PR TITLE
[DSE] Consider the aliasing through global variable while checking clobber

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -2287,8 +2287,8 @@ DSEState::getInitializesArgMemLoc(const Instruction *I) {
     // Check whether "CurArg" could alias with global variables. We require
     // either it's function local and isn't captured before or the "CB" only
     // accesses arg or inaccessible mem.
-    if (!Inits.empty() && !isFuncLocalAndNotCaptured(CurArg, CB, EA) &&
-        !CB->onlyAccessesInaccessibleMemOrArgMem())
+    if (!Inits.empty() && !CB->onlyAccessesInaccessibleMemOrArgMem() &&
+        !isFuncLocalAndNotCaptured(CurArg, CB, EA))
       Inits = ConstantRangeList();
 
     // We don't perform incorrect DSE on unwind edges in the current function,

--- a/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
@@ -329,14 +329,12 @@ declare void @read_global(ptr nocapture noundef initializes((0, 2))) nounwind
 define i16 @global_var_alias() {
 ; CHECK-LABEL: @global_var_alias(
 ; CHECK-NEXT:    store i16 0, ptr @g, align 4
-; CHECK-NEXT:    [[G_ADDR:%.*]] = getelementptr i8, ptr @g, i64 1
-; CHECK-NEXT:    call void @read_global(ptr [[G_ADDR]])
+; CHECK-NEXT:    call void @read_global(ptr @g)
 ; CHECK-NEXT:    [[L:%.*]] = load i16, ptr @g, align 2
 ; CHECK-NEXT:    ret i16 [[L]]
 ;
   store i16 0, ptr @g, align 4
-  %g_addr = getelementptr i8, ptr @g, i64 1
-  call void @read_global(ptr %g_addr)
+  call void @read_global(ptr @g)
   %l = load i16, ptr @g
   ret i16 %l
 }

--- a/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
@@ -307,14 +307,14 @@ declare void @read_global(ptr nocapture noundef initializes((0, 2))) nounwind
 
 define i16 @global_var_alias() {
 ; CHECK-LABEL: @global_var_alias(
-; CHECK-NEXT:    store i32 0, ptr @g, align 4
-; CHECK-NEXT:    [[G_ADDR:%.*]] = getelementptr i32, ptr @g, i64 1
+; CHECK-NEXT:    store i16 0, ptr @g, align 4
+; CHECK-NEXT:    [[G_ADDR:%.*]] = getelementptr i8, ptr @g, i64 1
 ; CHECK-NEXT:    call void @read_global(ptr [[G_ADDR]])
 ; CHECK-NEXT:    [[L:%.*]] = load i16, ptr @g, align 2
 ; CHECK-NEXT:    ret i16 [[L]]
 ;
-  store i32 0, ptr @g, align 4
-  %g_addr = getelementptr i32, ptr @g, i64 1
+  store i16 0, ptr @g, align 4
+  %g_addr = getelementptr i8, ptr @g, i64 1
   call void @read_global(ptr %g_addr)
   %l = load i16, ptr @g
   ret i16 %l

--- a/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
@@ -39,6 +39,26 @@ define i16 @p1_write_then_read_caller() {
   ret i16 %l
 }
 
+declare void @fn_capture(ptr noundef)
+; Function Attrs: mustprogress nounwind uwtable
+define i16 @p1_write_then_read_caller_escape() {
+; CHECK-LABEL: @p1_write_then_read_caller_escape(
+; CHECK-NEXT:    [[PTR:%.*]] = alloca i16, align 2
+; CHECK-NEXT:    store i16 0, ptr [[PTR]], align 2
+; CHECK-NEXT:    call void @fn_capture(ptr [[PTR]])
+; CHECK-NEXT:    call void @p1_write_then_read(ptr [[PTR]])
+; CHECK-NEXT:    [[L:%.*]] = load i16, ptr [[PTR]], align 2
+; CHECK-NEXT:    ret i16 [[L]]
+;
+  %ptr = alloca i16
+  store i16 0, ptr %ptr
+  call void @fn_capture(ptr %ptr)
+  call void @p1_write_then_read(ptr %ptr)
+  %l = load i16, ptr %ptr
+  ret i16 %l
+}
+
+
 ; Function Attrs: mustprogress nounwind uwtable
 define i16 @p1_write_then_read_caller_with_clobber() {
 ; CHECK-LABEL: @p1_write_then_read_caller_with_clobber(
@@ -304,6 +324,7 @@ define i16 @large_p2_may_or_partial_alias_caller2(ptr %base1, ptr %base2) {
 @g = global i16 123, align 2
 
 declare void @read_global(ptr nocapture noundef initializes((0, 2))) nounwind
+  memory(read, argmem: write, inaccessiblemem: none) nounwind
 
 define i16 @global_var_alias() {
 ; CHECK-LABEL: @global_var_alias(

--- a/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/inter-procedural.ll
@@ -39,8 +39,7 @@ define i16 @p1_write_then_read_caller() {
   ret i16 %l
 }
 
-declare void @fn_capture(ptr noundef)
-; Function Attrs: mustprogress nounwind uwtable
+declare void @fn_capture(ptr)
 define i16 @p1_write_then_read_caller_escape() {
 ; CHECK-LABEL: @p1_write_then_read_caller_escape(
 ; CHECK-NEXT:    [[PTR:%.*]] = alloca i16, align 2


### PR DESCRIPTION
While update the read clobber check for the "initializes" attr, we checked the aliasing among arguments, but didn't consider the aliasing through global variable. It causes problems in this example:

```
int g_var = 123;

void update(int* ptr) {
  *ptr = g_var;

void foo() {
  g_var = 0;
  bar(&g_var);
}
```
We mistakenly removed `g_var = 0;` as a dead store.

Fix the issue by requiring the CallBase only access argmem or inaccessiblemem.
