### PR TITLE
[mlir][tblgen] Fix bug around parsing optional prop-dict keys

### DIFF
--- a/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
+++ b/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
@@ -431,6 +431,13 @@ def FormatOptionalWithElse : TEST_Op<"format_optional_else"> {
   let assemblyFormat = "(`then` $isFirstBranchPresent^):(`else`)? attr-dict";
 }
 
+def FormatOptionalPropDict : TEST_Op<"format_optional_prop_dict"> {
+  let arguments = (ins
+    OptionalProperty<StringProperty>:$a,
+    DefaultValuedProperty<I32Property, "1">:$b);
+  let assemblyFormat = "prop-dict attr-dict";
+}
+
 def FormatCompoundAttr : TEST_Op<"format_compound_attr"> {
   let arguments = (ins CompoundAttrA:$compound);
   let assemblyFormat = "$compound attr-dict-with-keyword";

--- a/mlir/test/mlir-tblgen/op-format.mlir
+++ b/mlir/test/mlir-tblgen/op-format.mlir
@@ -277,6 +277,29 @@ test.format_optional_else then
 test.format_optional_else else
 
 //===----------------------------------------------------------------------===//
+// Default-valued properties (ex. optional) elided in property dictionary
+// TODO: elisions generate extra spaces
+//===----------------------------------------------------------------------===//
+
+// CHECK: test.format_optional_prop_dict {{$}}
+test.format_optional_prop_dict
+
+// CHECK: test.format_optional_prop_dict {{$}}
+test.format_optional_prop_dict <{a = [], b = 1 : i32}>
+
+// CHECK: test.format_optional_prop_dict {{$}}
+test.format_optional_prop_dict <{}>
+
+// CHECK: test.format_optional_prop_dict < {a = ["foo"]}>
+test.format_optional_prop_dict <{a = ["foo"]}>
+
+// CHECK: test.format_optional_prop_dict < {b = 2 : i32}>
+test.format_optional_prop_dict <{b = 2 : i32}>
+
+// CHECK: test.format_optional_prop_dict <{a = ["foo"], b = 2 : i32}>
+test.format_optional_prop_dict <{a = ["foo"], b = 2 : i32}>
+
+//===----------------------------------------------------------------------===//
 // Format a custom attribute
 //===----------------------------------------------------------------------===//
 

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -1309,7 +1309,7 @@ if (!attr && {2}) {{
              "Properties.";
   return ::mlir::failure();
 }
-if (::mlir::failed(setFromAttr(prop.{1}, attr, emitError)))
+if (attr && ::mlir::failed(setFromAttr(prop.{1}, attr, emitError)))
   return ::mlir::failure();
 )decl";
 


### PR DESCRIPTION
The printer for prop-dict would elide properties that had their default value, such as optional properties that were not present. The parser would similarly not raise an error if such a key was missing. However, after not raising an error, the parser would attempt to convert the null attribute to a property anyway, causing failures.

This commit fixes the issue and adds tests.