### PR TITLE
[RISCV] Add ISAInfoTest tests for a few XQCI extensions

### DIFF
--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -653,29 +653,12 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
               "'xwchc' and 'zcb' extensions are incompatible");
   }
 
-  for (StringRef Input : {"rv64i_xqcisls0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcisls' is only supported for 'rv32'");
-  }
-
-  for (StringRef Input : {"rv64i_xqcia0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcia' is only supported for 'rv32'");
-  }
-
-  for (StringRef Input : {"rv64i_xqcicsr0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcicsr' is only supported for 'rv32'");
-  }
-
-  for (StringRef Input : {"rv64i_xqcilsm0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcilsm' is only supported for 'rv32'");
-  }
-
-  for (StringRef Input : {"rv64i_xqcics0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcics' is only supported for 'rv32'");
+  for (StringRef Input :
+       {"rv64i_xqcisls0p2", "rv64i_xqcia0p2", "rv64i_xqcicsr0p2",
+        "rv64i_xqcilsm0p2", "rv64i_xqcics0p2"}) {
+    EXPECT_THAT(
+        toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+        ::testing::EndsWith(" is only supported for 'rv32'"));
   }
 }
 

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -662,6 +662,21 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
     EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
               "'xqcia' is only supported for 'rv32'");
   }
+
+  for (StringRef Input : {"rv64i_xqcicsr0p2"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqcicsr' is only supported for 'rv32'");
+  }
+
+  for (StringRef Input : {"rv64i_xqcilsm0p2"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqcilsm' is only supported for 'rv32'");
+  }
+
+  for (StringRef Input : {"rv64i_xqcics0p2"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqcics' is only supported for 'rv32'");
+  }
 }
 
 TEST(ParseArchString, MissingDepency) {


### PR DESCRIPTION
Missed out adding rv32 only support test checks for a few of the extensions.