### PR TITLE
[llvm-split][nfc] Harmonize help and error message

### DIFF
--- a/llvm/test/tools/llvm-split/target-specific-split.ll
+++ b/llvm/test/tools/llvm-split/target-specific-split.ll
@@ -4,7 +4,7 @@
 
 ; Basic test for a target that doesn't support target-specific module splitting.
 
-; CHECK: warning: -preserve-locals has no effect when using TargetMachine::splitModule
+; CHECK: warning: --preserve-locals has no effect when using TargetMachine::splitModule
 ; CHECK: warning: TargetMachine::splitModule failed, falling back to default splitModule implementation
 
 define void @bar() {

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -67,7 +67,7 @@ static cl::opt<std::string>
             cl::value_desc("triple"), cl::cat(SplitCategory));
 
 static cl::opt<std::string>
-    MCPU("mcpu", cl::desc("Target CPU, ignored if -mtriple is not used"),
+    MCPU("mcpu", cl::desc("Target CPU, ignored if --mtriple is not used"),
          cl::value_desc("cpu"), cl::cat(SplitCategory));
 
 int main(int argc, char **argv) {
@@ -125,11 +125,11 @@ int main(int argc, char **argv) {
 
   if (TM) {
     if (PreserveLocals) {
-      errs() << "warning: -preserve-locals has no effect when using "
+      errs() << "warning: --preserve-locals has no effect when using "
                 "TargetMachine::splitModule\n";
     }
     if (RoundRobin)
-      errs() << "warning: -round-robin has no effect when using "
+      errs() << "warning: --round-robin has no effect when using "
                 "TargetMachine::splitModule\n";
 
     if (TM->splitModule(*M, NumOutputs, HandleModulePart))


### PR DESCRIPTION
Somme error / help message refer to options with a single dash while help refer to options with a double dash.