### PR TITLE
[LoongArch] Emit R_LARCH_RELAX when expanding some macros

### DIFF
--- a/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
+++ b/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
@@ -1176,7 +1176,7 @@ void LoongArchAsmParser::emitLoadAddressTLSIE(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       LD, LoongArchMCExpr::VK_LoongArch_TLS_IE_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSIELarge(MCInst &Inst, SMLoc IDLoc,
@@ -1248,7 +1248,7 @@ void LoongArchAsmParser::emitLoadAddressTLSLD(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       ADDI, LoongArchMCExpr::VK_LoongArch_GOT_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSLDLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1320,7 +1320,7 @@ void LoongArchAsmParser::emitLoadAddressTLSGD(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       ADDI, LoongArchMCExpr::VK_LoongArch_GOT_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSGDLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1409,7 +1409,7 @@ void LoongArchAsmParser::emitLoadAddressTLSDesc(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::JIRL, LoongArchMCExpr::VK_LoongArch_TLS_DESC_CALL));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSDescLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1500,8 +1500,9 @@ void LoongArchAsmParser::emitFuncCall36(MCInst &Inst, SMLoc IDLoc,
       IsTailCall ? Inst.getOperand(0).getReg() : MCRegister(LoongArch::R1);
   const MCExpr *Sym =
       IsTailCall ? Inst.getOperand(1).getExpr() : Inst.getOperand(0).getExpr();
-  const LoongArchMCExpr *LE = LoongArchMCExpr::create(
-      Sym, llvm::LoongArchMCExpr::VK_LoongArch_CALL36, getContext());
+  const LoongArchMCExpr *LE =
+      LoongArchMCExpr::create(Sym, llvm::LoongArchMCExpr::VK_LoongArch_CALL36,
+                              getContext(), /*RelaxHint=*/true);
 
   Out.emitInstruction(
       MCInstBuilder(LoongArch::PCADDU18I).addReg(ScratchReg).addExpr(LE),

--- a/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
+++ b/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
@@ -1009,7 +1009,8 @@ void LoongArchAsmParser::emitLoadAddressPcrel(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(
       LoongArchAsmParser::Inst(ADDI, LoongArchMCExpr::VK_LoongArch_PCALA_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out,
+                /*RelaxHint=*/true);
 }
 
 void LoongArchAsmParser::emitLoadAddressPcrelLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1083,7 +1084,8 @@ void LoongArchAsmParser::emitLoadAddressGot(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(
       LoongArchAsmParser::Inst(LD, LoongArchMCExpr::VK_LoongArch_GOT_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out,
+                /*RelaxHint=*/true);
 }
 
 void LoongArchAsmParser::emitLoadAddressGotLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1176,7 +1178,8 @@ void LoongArchAsmParser::emitLoadAddressTLSIE(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       LD, LoongArchMCExpr::VK_LoongArch_TLS_IE_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out,
+                /*RelaxHint=*/true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSIELarge(MCInst &Inst, SMLoc IDLoc,
@@ -1248,7 +1251,8 @@ void LoongArchAsmParser::emitLoadAddressTLSLD(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       ADDI, LoongArchMCExpr::VK_LoongArch_GOT_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out,
+                /*RelaxHint=*/true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSLDLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1320,7 +1324,8 @@ void LoongArchAsmParser::emitLoadAddressTLSGD(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       ADDI, LoongArchMCExpr::VK_LoongArch_GOT_PC_LO12));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out,
+                /*RelaxHint=*/true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSGDLarge(MCInst &Inst, SMLoc IDLoc,
@@ -1409,7 +1414,8 @@ void LoongArchAsmParser::emitLoadAddressTLSDesc(MCInst &Inst, SMLoc IDLoc,
   Insts.push_back(LoongArchAsmParser::Inst(
       LoongArch::JIRL, LoongArchMCExpr::VK_LoongArch_TLS_DESC_CALL));
 
-  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out, true);
+  emitLAInstSeq(DestReg, DestReg, Symbol, Insts, IDLoc, Out,
+                /*RelaxHint=*/true);
 }
 
 void LoongArchAsmParser::emitLoadAddressTLSDescLarge(MCInst &Inst, SMLoc IDLoc,

--- a/llvm/test/MC/LoongArch/Macros/aliases-la.s
+++ b/llvm/test/MC/LoongArch/Macros/aliases-la.s
@@ -3,12 +3,25 @@
 
 # RUN: llvm-mc --triple=loongarch64 %s \
 # RUN:     | FileCheck %s --check-prefix=NORMAL
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=-relax %s -o %t
+# RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=RELOC
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+relax %s -o %t.relax
+# RUN: llvm-readobj -r %t.relax | FileCheck %s --check-prefixes=RELOC,RELAX
 # RUN: llvm-mc --triple=loongarch64 --mattr=+la-global-with-pcrel < %s \
 # RUN:     | FileCheck %s --check-prefix=GTOPCR
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+la-global-with-pcrel \
+# RUN:     --mattr=-relax %s -o %t
+# RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=GTOPCR-RELOC
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+la-global-with-pcrel \
+# RUN:     --mattr=+relax %s -o %t.relax
+# RUN: llvm-readobj -r %t.relax | FileCheck %s --check-prefixes=GTOPCR-RELOC,GTOPCR-RELAX
 # RUN: llvm-mc --triple=loongarch64 --mattr=+la-global-with-abs < %s \
 # RUN:     | FileCheck %s --check-prefix=GTOABS
 # RUN: llvm-mc --triple=loongarch64 --mattr=+la-local-with-abs < %s \
 # RUN:     | FileCheck %s --check-prefix=LTOABS
+
+# RELOC:      Relocations [
+# RELOC-NEXT:   Section ({{.*}}) .rela.text {
 
 la $a0, sym
 # NORMAL:      pcalau12i $a0, %got_pc_hi20(sym)
@@ -22,6 +35,16 @@ la $a0, sym
 # GTOABS-NEXT: lu32i.d $a0, %abs64_lo20(sym)
 # GTOABS-NEXT: lu52i.d $a0, $a0, %abs64_hi12(sym)
 
+# RELOC-NEXT: R_LARCH_GOT_PC_HI20 sym 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+
+# GTOPCR-RELOC: R_LARCH_PCALA_HI20 sym 0x0
+# GTOPCR-RELAX: R_LARCH_RELAX - 0x0
+# GTOPCR-RELOC-NEXT: R_LARCH_PCALA_LO12 sym 0x0
+# GTOPCR-RELAX-NEXT: R_LARCH_RELAX - 0x0
+
 la.global $a0, sym_global
 # NORMAL:      pcalau12i $a0, %got_pc_hi20(sym_global)
 # NORMAL-NEXT: ld.d $a0, $a0, %got_pc_lo12(sym_global)
@@ -33,6 +56,16 @@ la.global $a0, sym_global
 # GTOABS-NEXT: ori $a0, $a0, %abs_lo12(sym_global)
 # GTOABS-NEXT: lu32i.d $a0, %abs64_lo20(sym_global)
 # GTOABS-NEXT: lu52i.d $a0, $a0, %abs64_hi12(sym_global)
+
+# RELOC-NEXT: R_LARCH_GOT_PC_HI20 sym_global 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_global 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+
+# GTOPCR-RELOC-NEXT: R_LARCH_PCALA_HI20 sym_global 0x0
+# GTOPCR-RELAX-NEXT: R_LARCH_RELAX - 0x0
+# GTOPCR-RELOC-NEXT: R_LARCH_PCALA_LO12 sym_global 0x0
+# GTOPCR-RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.global $a0, $a1, sym_global_large
 # NORMAL:      pcalau12i $a0, %got_pc_hi20(sym_global_large)
@@ -52,6 +85,11 @@ la.global $a0, $a1, sym_global_large
 # GTOABS-NEXT: lu32i.d $a0, %abs64_lo20(sym_global_large)
 # GTOABS-NEXT: lu52i.d $a0, $a0, %abs64_hi12(sym_global_large)
 
+# RELOC-NEXT: R_LARCH_GOT_PC_HI20 sym_global_large 0x0
+# RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_global_large 0x0
+# RELOC-NEXT: R_LARCH_GOT64_PC_LO20 sym_global_large 0x0
+# RELOC-NEXT: R_LARCH_GOT64_PC_HI12 sym_global_large 0x0
+
 la.local $a0, sym_local
 # NORMAL:      pcalau12i $a0, %pc_hi20(sym_local)
 # NORMAL-NEXT: addi.d $a0, $a0, %pc_lo12(sym_local)
@@ -60,6 +98,11 @@ la.local $a0, sym_local
 # LTOABS-NEXT: ori $a0, $a0, %abs_lo12(sym_local)
 # LTOABS-NEXT: lu32i.d $a0, %abs64_lo20(sym_local)
 # LTOABS-NEXT: lu52i.d $a0, $a0, %abs64_hi12(sym_local)
+
+# RELOC-NEXT: R_LARCH_PCALA_HI20 sym_local 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+# RELOC-NEXT: R_LARCH_PCALA_LO12 sym_local 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.local $a0, $a1, sym_local_large
 # NORMAL:      pcalau12i $a0, %pc_hi20(sym_local_large)
@@ -72,3 +115,12 @@ la.local $a0, $a1, sym_local_large
 # LTOABS-NEXT: ori $a0, $a0, %abs_lo12(sym_local_large)
 # LTOABS-NEXT: lu32i.d $a0, %abs64_lo20(sym_local_large)
 # LTOABS-NEXT: lu52i.d $a0, $a0, %abs64_hi12(sym_local_large)
+
+# RELOC-NEXT: R_LARCH_PCALA_HI20 sym_local_large 0x0
+# RELOC-NEXT: R_LARCH_PCALA_LO12 sym_local_large 0x0
+# RELOC-NEXT: R_LARCH_PCALA64_LO20 sym_local_large 0x0
+# RELOC-NEXT: R_LARCH_PCALA64_HI12 sym_local_large 0x0
+
+
+# RELOC-NEXT:   }
+# RELOC-NEXT: ]

--- a/llvm/test/MC/LoongArch/Macros/macros-call.s
+++ b/llvm/test/MC/LoongArch/Macros/macros-call.s
@@ -1,9 +1,26 @@
 # RUN: llvm-mc --triple=loongarch64 %s | FileCheck %s
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=-relax %s -o %t
+# RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=RELOC
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+relax %s -o %t.relax
+# RUN: llvm-readobj -r %t.relax | FileCheck %s --check-prefixes=RELOC,RELAX
+
+# RELOC:      Relocations [
+# RELOC-NEXT:   Section ({{.*}}) .rela.text {
 
 call36 sym_call
 # CHECK:      pcaddu18i $ra, %call36(sym_call)
 # CHECK-NEXT: jirl $ra, $ra, 0
 
+# RELOC-NEXT: R_LARCH_CALL36 sym_call 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+
 tail36 $t0, sym_tail
 # CHECK:      pcaddu18i $t0, %call36(sym_tail)
 # CHECK-NEXT: jr $t0
+
+# RELOC-NEXT: R_LARCH_CALL36 sym_tail 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
+
+
+# RELOC-NEXT:   }
+# RELOC-NEXT: ]

--- a/llvm/test/MC/LoongArch/Macros/macros-la.s
+++ b/llvm/test/MC/LoongArch/Macros/macros-la.s
@@ -5,6 +5,12 @@
 # RUN: llvm-readobj -r %t.relax | FileCheck %s --check-prefixes=RELOC,RELAX
 # RUN: llvm-mc --triple=loongarch64 --mattr=+la-global-with-abs \
 # RUN:     %s | FileCheck %s --check-prefix=ABS
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+la-global-with-abs \
+# RUN:     --mattr=-relax %s -o %t
+# RUN: llvm-readobj -r %t | FileCheck %s --check-prefix=GTOABS-RELOC
+# RUN: llvm-mc --filetype=obj --triple=loongarch64 --mattr=+la-global-with-abs \
+# RUN:     --mattr=+relax %s -o %t.relax
+# RUN: llvm-readobj -r %t.relax | FileCheck %s --check-prefixes=GTOABS-RELOC,GTOABS-RELAX
 
 # RELOC:      Relocations [
 # RELOC-NEXT:   Section ({{.*}}) .rela.text {
@@ -36,6 +42,10 @@ la.pcrel $a0, sym_pcrel
 # RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_PCALA_LO12 sym_pcrel 0x0
 # RELAX-NEXT: R_LARCH_RELAX - 0x0
+# GTOABS-RELOC: R_LARCH_PCALA_HI20 sym_pcrel 0x0
+# GTOABS-RELAX-NEXT: R_LARCH_RELAX - 0x0
+# GTOABS-RELOC-NEXT: R_LARCH_PCALA_LO12 sym_pcrel 0x0
+# GTOABS-RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.got $a0, sym_got
 # CHECK-NEXT: pcalau12i $a0, %got_pc_hi20(sym_got)
@@ -73,7 +83,9 @@ la.tls.ie $a0, sym_ie
 # ABS-NEXT:   ld.d $a0, $a0, 0
 # ABS-EMPTY:
 # RELOC-NEXT: R_LARCH_TLS_IE_PC_HI20 sym_ie 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_TLS_IE_PC_LO12 sym_ie 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.tls.ld $a0, sym_ld
 # CHECK-NEXT: pcalau12i $a0, %ld_pc_hi20(sym_ld)
@@ -85,7 +97,9 @@ la.tls.ld $a0, sym_ld
 # ABS-NEXT:   lu52i.d $a0, $a0, %got64_hi12(sym_ld)
 # ABS-EMPTY:
 # RELOC-NEXT: R_LARCH_TLS_LD_PC_HI20 sym_ld 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_ld 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.tls.gd $a0, sym_gd
 # CHECK-NEXT: pcalau12i $a0, %gd_pc_hi20(sym_gd)
@@ -97,7 +111,9 @@ la.tls.gd $a0, sym_gd
 # ABS-NEXT:   lu52i.d $a0, $a0, %got64_hi12(sym_gd)
 # ABS-EMPTY:
 # RELOC-NEXT: R_LARCH_TLS_GD_PC_HI20 sym_gd 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_GOT_PC_LO12 sym_gd 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 la.tls.desc $a0, sym_desc
 # CHECK-NEXT: pcalau12i $a0, %desc_pc_hi20(sym_desc)
@@ -113,9 +129,13 @@ la.tls.desc $a0, sym_desc
 # ABS-NEXT:   jirl $ra, $ra, %desc_call(sym_desc)
 # ABS-EMPTY:
 # RELOC-NEXT: R_LARCH_TLS_DESC_PC_HI20 sym_desc 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_TLS_DESC_PC_LO12 sym_desc 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_TLS_DESC_LD sym_desc 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 # RELOC-NEXT: R_LARCH_TLS_DESC_CALL sym_desc 0x0
+# RELAX-NEXT: R_LARCH_RELAX - 0x0
 
 #############################################################
 ## with a temporary register.


### PR DESCRIPTION
Emit `R_LARCH_RELAX` relocations when expanding some macros, including:

- `la.tls.ie`, `la.tls.ld`, `la.tls.gd`, `la.tls.desc`,
- `call36`, `tail36`.

Other macros that need to emit `R_LARCH_RELAX` relocations was implemented in https://github.com/llvm/llvm-project/pull/72961, including:

- `la.local`, `la.pcrel`, `la.pcrel` expanded as `la.abs`, `la`, `la.global`, `la/la.global` expanded as `la.pcrel`, `la.got`.

Note: `la.tls.le` macro can be relaxed when expanded with `R_LARCH_TLS_LE_{HI20/ADD/LO12}_R` relocations. But if we do so, previously handwritten assembly code will occur error due to the redundant `add.{w/d}` followed by `la.tls.le`. So `la.tls.le` keeps to expands with `R_LARCH_TLS_LE_{HI20/LO12}`.