### PR TITLE
[InstCombine] foldFPSignBitOps - fabs(X) * fabs(X) -> freeze(X) * freeze(X)

### DIFF
--- a/llvm/test/Transforms/InstCombine/fdiv.ll
+++ b/llvm/test/Transforms/InstCombine/fdiv.ll
@@ -593,7 +593,8 @@ define float @fdiv_fneg1_extra_use(float %x, float %y) {
 
 define float @fabs_same_op(float %x) {
 ; CHECK-LABEL: @fabs_same_op(
-; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[X:%.*]] = freeze float [[X1:%.*]]
+; CHECK-NEXT:    [[R:%.*]] = fdiv float [[X]], [[X]]
 ; CHECK-NEXT:    ret float [[R]]
 ;
   %a = call float @llvm.fabs.f32(float %x)
@@ -603,7 +604,8 @@ define float @fabs_same_op(float %x) {
 
 define float @fabs_same_op_extra_use(float %x) {
 ; CHECK-LABEL: @fabs_same_op_extra_use(
-; CHECK-NEXT:    [[A:%.*]] = call float @llvm.fabs.f32(float [[X:%.*]])
+; CHECK-NEXT:    [[X:%.*]] = freeze float [[X1:%.*]]
+; CHECK-NEXT:    [[A:%.*]] = call float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    call void @use_f32(float [[A]])
 ; CHECK-NEXT:    [[R:%.*]] = fdiv reassoc ninf float [[X]], [[X]]
 ; CHECK-NEXT:    ret float [[R]]

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -463,7 +463,8 @@ declare float @llvm.fabs.f32(float) nounwind readnone
 
 define float @fabs_squared(float %x) {
 ; CHECK-LABEL: @fabs_squared(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[X:%.*]] = freeze float [[X1:%.*]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[X]], [[X]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.fabs = call float @llvm.fabs.f32(float %x)
@@ -473,7 +474,8 @@ define float @fabs_squared(float %x) {
 
 define float @fabs_squared_fast(float %x) {
 ; CHECK-LABEL: @fabs_squared_fast(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul fast float [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[X:%.*]] = freeze float [[X1:%.*]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul fast float [[X]], [[X]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %x.fabs = call float @llvm.fabs.f32(float %x)


### PR DESCRIPTION
Ensure we freeze the repeated X operand as we are increasing its number of uses.

Reported on Project Zero: https://web.ist.utl.pt/nuno.lopes/alive2/index.php?hash=de3d864b2cd8f709&test=Transforms%2FInstCombine%2Ffmul.ll