### PR TITLE
[HLSL][NFC] Fix static analyzer concerns

### DIFF
--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -546,6 +546,9 @@ private:
 public:
   ~BuiltinTypeMethodBuilder() { finalizeMethod(); }
 
+  BuiltinTypeMethodBuilder(BuiltinTypeMethodBuilder &Other) = delete;
+  BuiltinTypeMethodBuilder &operator=(BuiltinTypeMethodBuilder &Other) = delete;
+
   Expr *getResourceHandleExpr() {
     // The first statement added to a method or access to 'this' creates the
     // declaration.

--- a/clang/lib/Sema/HLSLExternalSemaSource.cpp
+++ b/clang/lib/Sema/HLSLExternalSemaSource.cpp
@@ -546,8 +546,9 @@ private:
 public:
   ~BuiltinTypeMethodBuilder() { finalizeMethod(); }
 
-  BuiltinTypeMethodBuilder(BuiltinTypeMethodBuilder &Other) = delete;
-  BuiltinTypeMethodBuilder &operator=(BuiltinTypeMethodBuilder &Other) = delete;
+  BuiltinTypeMethodBuilder(const BuiltinTypeMethodBuilder &Other) = delete;
+  BuiltinTypeMethodBuilder &
+  operator=(const BuiltinTypeMethodBuilder &Other) = delete;
 
   Expr *getResourceHandleExpr() {
     // The first statement added to a method or access to 'this' creates the


### PR DESCRIPTION
Class BuiltinTypeMethodBuilder has a user-defined destructor so likely compiler generated special functions may behave incorrectly. Delete explicitly copy constructor and copy assignment operator to avoid potential errors.