### PR TITLE
[AArch64] Move SME_ZA_LDR and SME_ZA_STR into FIRST_TARGET_MEMORY_OPCODE. NFCI

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -480,10 +480,6 @@ enum NodeType : unsigned {
   STRICT_FCMP = ISD::FIRST_TARGET_STRICTFP_OPCODE,
   STRICT_FCMPE,
 
-  // SME ZA loads and stores
-  SME_ZA_LDR,
-  SME_ZA_STR,
-
   // NEON Load/Store with post-increment base updates
   LD2post = ISD::FIRST_TARGET_MEMORY_OPCODE,
   LD3post,
@@ -520,6 +516,10 @@ enum NodeType : unsigned {
   STP,
   STILP,
   STNP,
+
+  // SME ZA loads and stores
+  SME_ZA_LDR,
+  SME_ZA_STR,
 };
 
 } // end namespace AArch64ISD


### PR DESCRIPTION
These opcodes are currently in the "strictfp" section. They should either be in "memory", or moved into the generic ocodes.

Note that isTargetMemoryOpcode/FIRST_TARGET_MEMORY_OPCODE doesn't seem to be used for anything at the moment.