### PR TITLE
IR: fix getSwappedCmpPredicate() return type

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -1226,9 +1226,9 @@ public:
     return {getSwappedPredicate(Pred), Pred.hasSameSign()};
   }
 
-  /// @returns the swapped predicate.
-  Predicate getSwappedCmpPredicate() const {
-    return getSwappedPredicate(getCmpPredicate());
+  /// @returns the swapped predicate along with samesign information.
+  CmpPredicate getSwappedCmpPredicate() const {
+    return getSwappedCmpPredicate(getCmpPredicate());
   }
 
   /// For example, EQ->EQ, SLE->SLE, UGT->SGT, etc.


### PR DESCRIPTION
The change 51a895a (IR: introduce struct with CmpInst::Predicate and samesign) missed a change to ICmpInst::getSwappedCmpPredicate(), which intends to return a CmpPredicate, but returns a Predicate instead. Fix this.