### PR TITLE
[clangd] Augment code completion results with documentation from the index.

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -1890,9 +1890,9 @@ private:
     // Look up documentation from the index.
     if (Opts.Index) {
       Opts.Index->lookup(Req, [&](const Symbol &S) {
-        auto &C = Output.Completions[SymbolToCompletion.at(S.ID)];
         if (S.Documentation.empty())
           return;
+        auto &C = Output.Completions[SymbolToCompletion.at(S.ID)];
         C.Documentation.emplace();
         parseDocumentation(S.Documentation, *C.Documentation);
       });

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -1863,14 +1863,41 @@ private:
     CodeCompleteResult Output;
 
     // Convert the results to final form, assembling the expensive strings.
+    // If necessary, search the index for documentation comments.
+    LookupRequest Req;
+    llvm::DenseMap<SymbolID, uint32_t> SymbolToCompletion;
     for (auto &C : Scored) {
       Output.Completions.push_back(toCodeCompletion(C.first));
       Output.Completions.back().Score = C.second;
       Output.Completions.back().CompletionTokenRange = ReplacedRange;
+      if (Opts.Index && !Output.Completions.back().Documentation) {
+        for (auto &Cand : C.first) {
+          if (Cand.SemaResult &&
+              Cand.SemaResult->Kind == CodeCompletionResult::RK_Declaration) {
+            auto ID = clangd::getSymbolID(Cand.SemaResult->getDeclaration());
+            if (!ID)
+              continue;
+            Req.IDs.insert(ID);
+            SymbolToCompletion[ID] = Output.Completions.size() - 1;
+          }
+        }
+      }
     }
     Output.HasMore = Incomplete;
     Output.Context = CCContextKind;
     Output.CompletionRange = ReplacedRange;
+
+    // Look up documentation from the index.
+    if (Opts.Index) {
+      Opts.Index->lookup(Req, [&](const Symbol &S) {
+        auto &C = Output.Completions[SymbolToCompletion.at(S.ID)];
+        if (S.Documentation.empty())
+          return;
+        C.Documentation.emplace();
+        parseDocumentation(S.Documentation, *C.Documentation);
+      });
+    }
+
     return Output;
   }
 

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -1177,9 +1177,9 @@ int x = a.^
   EXPECT_THAT(
       CompletionList.Completions,
       Contains(AllOf(named("epsilon"), doc("This one has a comment."))));
-  EXPECT_THAT(
-      CompletionList.Completions,
-      Contains(AllOf(named("delta"), AnyOf(doc("bool overload."), doc("int overload.")))));
+  EXPECT_THAT(CompletionList.Completions,
+              Contains(AllOf(named("delta"), AnyOf(doc("bool overload."),
+                                                   doc("int overload.")))));
 }
 
 TEST(CompletionTest, GlobalCompletionFiltering) {

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -1130,9 +1130,8 @@ int x = a.^
   auto CompletionList =
       llvm::cantFail(runCodeComplete(Server, File, Test.point(), {}));
 
-  EXPECT_THAT(
-      CompletionList.Completions,
-      Contains(AllOf(named("gamma"), doc("This is a member field."))));
+  EXPECT_THAT(CompletionList.Completions,
+              Contains(AllOf(named("gamma"), doc("This is a member field."))));
   EXPECT_THAT(
       CompletionList.Completions,
       Contains(AllOf(named("delta"), doc("This is a member function."))));


### PR DESCRIPTION
When looking up code completions from Sema, there is no associated
documentation. This is due to crash issues with stale preambles.
However, this also means that code completion results from other
than the main file do not have documentation in certain cases,
which is a bad user experience.

This patch performs a lookup into the index using the code
completion result declarations to find documentation, and
attaches it to the results.

This fixes clangd/clangd#2252 and clangd/clangd#564.
