### PR TITLE
[flang] Fix generic resolution with actual/dummy procedure incompatib…

### DIFF
--- a/flang/test/Semantics/generic11.f90
+++ b/flang/test/Semantics/generic11.f90
@@ -1,0 +1,25 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Regression test for bug #119151
+interface sub
+  subroutine sub1(ifun)
+    interface
+      integer function ifun()
+      end
+     end interface
+   end
+   subroutine sub2(rfun)
+     real rfun
+     external rfun
+   end
+end interface
+integer ifun
+real rfun
+complex zfun
+external ifun, rfun, zfun, xfun
+call sub(ifun)
+call sub(rfun)
+!ERROR: No specific subroutine of generic 'sub' matches the actual arguments
+call sub(zfun)
+!ERROR: The actual arguments to the generic procedure 'sub' matched multiple specific procedures, perhaps due to use of NULL() without MOLD= or an actual procedure with an implicit interface
+call sub(xfun)
+end


### PR DESCRIPTION
…ility

We generally allow any legal procedure pointer target as an actual argument for association with a dummy procedure, since many actual procedures are underspecified EXTERNALs.  But for proper generic resolution, it is necessary to disallow incompatible functions with explicit result types.

Fixes https://github.com/llvm/llvm-project/issues/119151.