### PR TITLE
Add llvm-profgen to the list of toolchain tools

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1446,6 +1446,7 @@ if(NOT LLVM_TOOLCHAIN_TOOLS)
     llvm-strings
     llvm-strip
     llvm-profdata
+    llvm-profgen
     llvm-symbolizer
     # symlink version of some of above tools that are enabled by
     # LLVM_INSTALL_BINUTILS_SYMLINKS.


### PR DESCRIPTION
This tool is used for SPGO and is invoked directly by users as described in the Clang User's Manual[^1].

This change will include llvm-profgen in installations configured with LLVM_INSTALL_TOOLCHAIN_ONLY, such as those provided by LLVM's executable Windows installers. This is useful now that LLVM can perform SPGO on Windows.

[^1]: https://clang.llvm.org/docs/UsersManual.html#using-sampling-profilers