### PR TITLE
[ASan][Win][compiler-rt] Fixes stack overflow when ntdll has mem* calls during exception handling

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp
@@ -53,9 +53,9 @@ bool ShouldReplaceIntrinsic(bool isNtdllCallee, void *addr, uptr size,
 using namespace __asan;
 
 #if SANITIZER_WINDOWS64
-#define IS_NTDLL_CALLEE __sanitizer::IsNtdllCallee(_ReturnAddress())
+#  define IS_NTDLL_CALLEE __sanitizer::IsNtdllCallee(_ReturnAddress())
 #else
-#define IS_NTDLL_CALLEE false
+#  define IS_NTDLL_CALLEE false
 #endif
 
 // memcpy is called during __asan_init() from the internals of printf(...).

--- a/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp
@@ -71,7 +71,8 @@ using namespace __asan;
 // See http://llvm.org/bugs/show_bug.cgi?id=11763.
 #define ASAN_MEMCPY_IMPL(ctx, to, from, size)                       \
   do {                                                              \
-    if (!ShouldReplaceIntrinsic(IS_NTDLL_CALLEE, to, size, from)) { \
+    if (SANITIZER_WINDOWS64 &&                                      \
+        !ShouldReplaceIntrinsic(IS_NTDLL_CALLEE, to, size, from)) { \
       return REAL(memcpy)(to, from, size);                          \
     }                                                               \
     if (LIKELY(replace_intrin_cached)) {                            \
@@ -89,7 +90,8 @@ using namespace __asan;
 // memset is called inside Printf.
 #define ASAN_MEMSET_IMPL(ctx, block, c, size)                    \
   do {                                                           \
-    if (!ShouldReplaceIntrinsic(IS_NTDLL_CALLEE, block, size)) { \
+    if (SANITIZER_WINDOWS64 &&                                   \
+        !ShouldReplaceIntrinsic(IS_NTDLL_CALLEE, block, size)) { \
       return REAL(memset)(block, c, size);                       \
     }                                                            \
     if (LIKELY(replace_intrin_cached)) {                         \
@@ -102,7 +104,8 @@ using namespace __asan;
 
 #define ASAN_MEMMOVE_IMPL(ctx, to, from, size)                      \
   do {                                                              \
-    if (!ShouldReplaceIntrinsic(IS_NTDLL_CALLEE, to, size, from)) { \
+    if (SANITIZER_WINDOWS64 &&                                      \
+        !ShouldReplaceIntrinsic(IS_NTDLL_CALLEE, to, size, from)) { \
       return internal_memmove(to, from, size);                      \
     }                                                               \
     if (LIKELY(replace_intrin_cached)) {                            \

--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -463,6 +463,10 @@ static bool AsanInitInternal() {
   if (SANITIZER_START_BACKGROUND_THREAD_IN_ASAN_INTERNAL)
     MaybeStartBackgroudThread();
 
+#if SANITIZER_WINDOWS64
+  __sanitizer::InitializeNtdllInfo();
+#endif
+
   // On Linux AsanThread::ThreadStart() calls malloc() that's why asan_inited
   // should be set to 1 prior to initializing the threads.
   replace_intrin_cached = flags()->replace_intrin;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1264,6 +1264,18 @@ void LogFullErrorReport(const char *buffer) {
 
 void InitializePlatformCommonFlags(CommonFlags *cf) {}
 
+static MODULEINFO ntdllInfo;
+void InitializeNtdllInfo() {
+  GetModuleInformation(GetCurrentProcess(), GetModuleHandle(L"ntdll.dll"),
+                       &ntdllInfo, sizeof(ntdllInfo));
+}
+
+bool IsNtdllCallee(void *calleeAddr) {
+  return (uptr)ntdllInfo.lpBaseOfDll <= (uptr)calleeAddr &&
+         ((uptr)ntdllInfo.lpBaseOfDll + (uptr)ntdllInfo.SizeOfImage) >=
+             (uptr)calleeAddr;
+}
+
 }  // namespace __sanitizer
 
 #endif  // _WIN32

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.h
@@ -19,6 +19,12 @@
 namespace __sanitizer {
 // Check based on flags if we should handle the exception.
 bool IsHandledDeadlyException(DWORD exceptionCode);
+
+// Initializes module information of ntdll for referencing callee addresses
+void InitializeNtdllInfo();
+
+// Returns whether or not the callee address lies within ntdll
+bool IsNtdllCallee(void* calleeAddr);
 }  // namespace __sanitizer
 
 #endif  // SANITIZER_WINDOWS

--- a/compiler-rt/test/asan/TestCases/Windows/ntdll_regression_tests.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/ntdll_regression_tests.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cl_asan /Od %s -Fe%t
+// RUN: not %run %t 2>&1 | FileCheck %s
+
+#include <Windows.h>
+#include <iostream>
+
+// Small sanity test to make sure ASAN does not stomp on
+// GetLastError values. This is motivated by __asan::ShouldReplaceIntrinsic,
+// which remedied infinite recursion due to ntdll exception handling paths calling
+// instrumented functions on startup before shadow memory can be committed.
+int TestNTStatusMaintained() {
+  ::SetLastError(ERROR_SUCCESS);
+  constexpr unsigned long c_initialSizeGuess = 1;
+  wchar_t szBuffer[c_initialSizeGuess];
+  unsigned long size = ::GetDllDirectoryW(c_initialSizeGuess, szBuffer);
+  auto le = ::GetLastError();
+  if (size == 0 && le != ERROR_SUCCESS) {
+    std::cerr << "Last error is different.\n";
+    return -1;
+  }
+  std::cerr << "Success.\n";
+  return 0;
+  // CHECK: Success.
+}
+
+int main() { return TestNTStatusMaintained(); }


### PR DESCRIPTION
This modifies intrinsic interception behavior in x64 Windows environments to defer back to the `REAL(mem*)` functions during exception handling machinery or if shadow memory needs to be committed. 

The current behavior on newer versions of Windows will be a stack overflow by virtue of `ntdll!memset` being called during exception handling. This should fix [this chromium](https://issues.chromium.org/issues/382310334) issue.