### PR TITLE
[flang] Add cmake error if building with clang-cl and MSVC 17.12

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -66,6 +66,13 @@ if (MSVC AND CMAKE_CXX_COMPILER_ID MATCHES Clang)
   if (IS_DIRECTORY "${LIBDIR}")
     link_libraries(${CLANG_RT_BUILTINS_LIBRARY})
   endif()
+
+  if (MSVC_VERSION EQUAL 1942)
+    message(FATAL_ERROR "Flang cannot be built with clang and the MSVC 17.12 "
+            "toolchain version. Please upgrade to 17.13 or later, or switch "
+            "to the 17.10 LTSC release. "
+            "See https://github.com/microsoft/STL/issues/4959 for more details.")
+  endif()
 endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)


### PR DESCRIPTION
A bug in the C++ library in MSVC 17.12 prevents clang-cl from being able to build flang with that library version. This bug is not present in 17.11 or earlier, nor in 17.13. This patch adds a cmake error telling the user to either upgrade or downgrade to avoid the bug.