### PR TITLE
[MLIR] Add a BlobAttr interface for attribute to wrap arbitrary content and use it as linkLibs for ModuleToObject

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/IR/CompilationInterfaces.h
+++ b/mlir/include/mlir/Dialect/GPU/IR/CompilationInterfaces.h
@@ -51,7 +51,7 @@ public:
   /// obtaining the parent symbol table. The default compilation target is
   /// `Fatbin`.
   TargetOptions(
-      StringRef toolkitPath = {}, ArrayRef<std::string> linkFiles = {},
+      StringRef toolkitPath = {}, ArrayRef<Attribute> librariesToLink = {},
       StringRef cmdOptions = {}, StringRef elfSection = {},
       CompilationTarget compilationTarget = getDefaultCompilationTarget(),
       function_ref<SymbolTable *()> getSymbolTableCallback = {},
@@ -66,8 +66,8 @@ public:
   /// Returns the toolkit path.
   StringRef getToolkitPath() const;
 
-  /// Returns the files to link to.
-  ArrayRef<std::string> getLinkFiles() const;
+  /// Returns the LLVM libraries to link to.
+  ArrayRef<Attribute> getLibrariesToLink() const;
 
   /// Returns the command line options.
   StringRef getCmdOptions() const;
@@ -113,7 +113,7 @@ protected:
   /// appropiate value: ie. `TargetOptions(TypeID::get<DerivedClass>())`.
   TargetOptions(
       TypeID typeID, StringRef toolkitPath = {},
-      ArrayRef<std::string> linkFiles = {}, StringRef cmdOptions = {},
+      ArrayRef<Attribute> librariesToLink = {}, StringRef cmdOptions = {},
       StringRef elfSection = {},
       CompilationTarget compilationTarget = getDefaultCompilationTarget(),
       function_ref<SymbolTable *()> getSymbolTableCallback = {},
@@ -126,7 +126,7 @@ protected:
   std::string toolkitPath;
 
   /// List of files to link with the LLVM module.
-  SmallVector<std::string> linkFiles;
+  SmallVector<Attribute> librariesToLink;
 
   /// An optional set of command line options to be used by the compilation
   /// process.

--- a/mlir/include/mlir/IR/BuiltinAttributeInterfaces.td
+++ b/mlir/include/mlir/IR/BuiltinAttributeInterfaces.td
@@ -35,6 +35,24 @@ def TypedAttrInterface : AttrInterface<"TypedAttr"> {
 }
 
 //===----------------------------------------------------------------------===//
+// BlobAttrInterface
+//===----------------------------------------------------------------------===//
+
+def BlobAttrInterface : AttrInterface<"BlobAttr"> {
+  let cppNamespace = "::mlir";
+  let description = [{
+    This interface allows an attribute to expose a blob of data without more
+    information. The data must be stored so that it can be accessed as a
+    contiguous ArrayRef.
+  }];
+
+  let methods = [InterfaceMethod<
+    "Get the attribute's data",
+    "::llvm::ArrayRef<char>", "getData"
+  >];
+}
+
+//===----------------------------------------------------------------------===//
 // ElementsAttrInterface
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/IR/BuiltinAttributes.td
+++ b/mlir/include/mlir/IR/BuiltinAttributes.td
@@ -153,7 +153,8 @@ def Builtin_DenseArrayRawDataParameter : ArrayRefParameter<
   }];
 }
 
-def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array"> {
+def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array", 
+    [BlobAttrInterface]> {
   let summary = "A dense array of integer or floating point elements.";
   let description = [{
     A dense array attribute is an attribute that represents a dense array of
@@ -211,6 +212,10 @@ def Builtin_DenseArray : Builtin_Attr<"DenseArray", "dense_array"> {
     int64_t size() const { return getSize(); }
     /// Return true if there are no elements in the dense array.
     bool empty() const { return !size(); }
+    /// BlobAttrInterface method.
+    ArrayRef<char> getData() {
+      return getRawData();
+    }
   }];
 }
 
@@ -431,7 +436,7 @@ def Builtin_DenseStringElementsAttr : Builtin_Attr<
 //===----------------------------------------------------------------------===//
 
 def Builtin_DenseResourceElementsAttr : Builtin_Attr<"DenseResourceElements",
-    "dense_resource_elements", [ElementsAttrInterface]> {
+    "dense_resource_elements", [ElementsAttrInterface, BlobAttrInterface]> {
   let summary = "An Attribute containing a dense multi-dimensional array "
                 "backed by a resource";
   let description = [{
@@ -485,6 +490,10 @@ def Builtin_DenseResourceElementsAttr : Builtin_Attr<"DenseResourceElements",
       "ShapedType":$type, "StringRef":$blobName, "AsmResourceBlob":$blob
     )>
   ];
+  let extraClassDeclaration = [{
+    /// BlobAttrInterface method.
+    ArrayRef<char> getData();
+  }];
 
   let skipDefaultBuilders = 1;
 }

--- a/mlir/include/mlir/Target/LLVM/ModuleToObject.h
+++ b/mlir/include/mlir/Target/LLVM/ModuleToObject.h
@@ -83,7 +83,7 @@ protected:
 
   /// Loads multiple bitcode files.
   LogicalResult loadBitcodeFilesFromList(
-      llvm::LLVMContext &context, ArrayRef<std::string> fileList,
+      llvm::LLVMContext &context, ArrayRef<Attribute> librariesToLink,
       SmallVector<std::unique_ptr<llvm::Module>> &llvmModules,
       bool failureOnError = true);
 

--- a/mlir/include/mlir/Target/LLVM/NVVM/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/NVVM/Utils.h
@@ -46,14 +46,15 @@ public:
   /// Returns the CUDA toolkit path.
   StringRef getToolkitPath() const;
 
-  /// Returns the bitcode files to be loaded.
-  ArrayRef<std::string> getFileList() const;
+  /// Returns the bitcode libraries to be linked into the gpu module after
+  /// translation to LLVM IR.
+  ArrayRef<Attribute> getLibrariesToLink() const;
 
-  /// Appends `nvvm/libdevice.bc` into `fileList`. Returns failure if the
+  /// Appends `nvvm/libdevice.bc` into `librariesToLink`. Returns failure if the
   /// library couldn't be found.
   LogicalResult appendStandardLibs();
 
-  /// Loads the bitcode files in `fileList`.
+  /// Loads the bitcode files in `librariesToLink`.
   virtual std::optional<SmallVector<std::unique_ptr<llvm::Module>>>
   loadBitcodeFiles(llvm::Module &module) override;
 
@@ -64,8 +65,10 @@ protected:
   /// CUDA toolkit path.
   std::string toolkitPath;
 
-  /// List of LLVM bitcode files to link to.
-  SmallVector<std::string> fileList;
+  /// List of LLVM bitcode to link into after translation to LLVM IR.
+  /// The attributes can be StringAttr pointing to a file path, or
+  /// a Resource blob pointing to the LLVM bitcode in-memory.
+  SmallVector<Attribute> librariesToLink;
 };
 } // namespace NVVM
 } // namespace mlir

--- a/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/ROCDL/Utils.h
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Target/LLVM/ModuleToObject.h"
 
@@ -61,8 +62,8 @@ public:
   /// Returns the ROCM toolkit path.
   StringRef getToolkitPath() const;
 
-  /// Returns the bitcode files to be loaded.
-  ArrayRef<std::string> getFileList() const;
+  /// Returns the LLVM bitcode libraries to be linked.
+  ArrayRef<Attribute> getLibrariesToLink() const;
 
   /// Appends standard ROCm device libraries to `fileList`.
   LogicalResult appendStandardLibs(AMDGCNLibraries libs);
@@ -107,7 +108,7 @@ protected:
   std::string toolkitPath;
 
   /// List of LLVM bitcode files to link to.
-  SmallVector<std::string> fileList;
+  SmallVector<Attribute> librariesToLink;
 
   /// AMD GCN libraries to use when linking, the default is using none.
   AMDGCNLibraries deviceLibs = AMDGCNLibraries::None;

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2483,7 +2483,7 @@ KernelMetadataAttr KernelTableAttr::lookup(StringAttr key) const {
 //===----------------------------------------------------------------------===//
 
 TargetOptions::TargetOptions(
-    StringRef toolkitPath, ArrayRef<std::string> linkFiles,
+    StringRef toolkitPath, ArrayRef<Attribute> librariesToLink,
     StringRef cmdOptions, StringRef elfSection,
     CompilationTarget compilationTarget,
     function_ref<SymbolTable *()> getSymbolTableCallback,
@@ -2491,14 +2491,14 @@ TargetOptions::TargetOptions(
     function_ref<void(llvm::Module &)> linkedLlvmIRCallback,
     function_ref<void(llvm::Module &)> optimizedLlvmIRCallback,
     function_ref<void(StringRef)> isaCallback)
-    : TargetOptions(TypeID::get<TargetOptions>(), toolkitPath, linkFiles,
+    : TargetOptions(TypeID::get<TargetOptions>(), toolkitPath, librariesToLink,
                     cmdOptions, elfSection, compilationTarget,
                     getSymbolTableCallback, initialLlvmIRCallback,
                     linkedLlvmIRCallback, optimizedLlvmIRCallback,
                     isaCallback) {}
 
 TargetOptions::TargetOptions(
-    TypeID typeID, StringRef toolkitPath, ArrayRef<std::string> linkFiles,
+    TypeID typeID, StringRef toolkitPath, ArrayRef<Attribute> librariesToLink,
     StringRef cmdOptions, StringRef elfSection,
     CompilationTarget compilationTarget,
     function_ref<SymbolTable *()> getSymbolTableCallback,
@@ -2506,7 +2506,7 @@ TargetOptions::TargetOptions(
     function_ref<void(llvm::Module &)> linkedLlvmIRCallback,
     function_ref<void(llvm::Module &)> optimizedLlvmIRCallback,
     function_ref<void(StringRef)> isaCallback)
-    : toolkitPath(toolkitPath.str()), linkFiles(linkFiles),
+    : toolkitPath(toolkitPath.str()), librariesToLink(librariesToLink),
       cmdOptions(cmdOptions.str()), elfSection(elfSection.str()),
       compilationTarget(compilationTarget),
       getSymbolTableCallback(getSymbolTableCallback),
@@ -2519,7 +2519,9 @@ TypeID TargetOptions::getTypeID() const { return typeID; }
 
 StringRef TargetOptions::getToolkitPath() const { return toolkitPath; }
 
-ArrayRef<std::string> TargetOptions::getLinkFiles() const { return linkFiles; }
+ArrayRef<Attribute> TargetOptions::getLibrariesToLink() const {
+  return librariesToLink;
+}
 
 StringRef TargetOptions::getCmdOptions() const { return cmdOptions; }
 

--- a/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
@@ -71,8 +71,8 @@ void GpuModuleToBinaryPass::runOnOperation() {
   SmallVector<Attribute> librariesToLink;
   for (const std::string &path : linkFiles)
     librariesToLink.push_back(StringAttr::get(&getContext(), path));
-  TargetOptions targetOptions(toolkitPath, librariesToLink, cmdOptions, elfSection,
-                              *targetFormat, lazyTableBuilder);
+  TargetOptions targetOptions(toolkitPath, librariesToLink, cmdOptions,
+                              elfSection, *targetFormat, lazyTableBuilder);
   if (failed(transformGpuModulesToBinaries(
           getOperation(), OffloadingLLVMTranslationAttrInterface(nullptr),
           targetOptions)))

--- a/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/ModuleToBinary.cpp
@@ -68,8 +68,10 @@ void GpuModuleToBinaryPass::runOnOperation() {
     }
     return &parentTable.value();
   };
-
-  TargetOptions targetOptions(toolkitPath, linkFiles, cmdOptions, elfSection,
+  SmallVector<Attribute> librariesToLink;
+  for (const std::string &path : linkFiles)
+    librariesToLink.push_back(StringAttr::get(&getContext(), path));
+  TargetOptions targetOptions(toolkitPath, librariesToLink, cmdOptions, elfSection,
                               *targetFormat, lazyTableBuilder);
   if (failed(transformGpuModulesToBinaries(
           getOperation(), OffloadingLLVMTranslationAttrInterface(nullptr),

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -1544,6 +1544,12 @@ DenseResourceElementsAttr DenseResourceElementsAttr::get(ShapedType type,
   return get(type, manager.insert(blobName, std::move(blob)));
 }
 
+ArrayRef<char> DenseResourceElementsAttr::getData() {
+  if (AsmResourceBlob *blob = this->getRawHandle().getBlob())
+    return blob->getDataAs<char>();
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // DenseResourceElementsAttrBase
 

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -100,7 +100,8 @@ SerializeGPUModuleBase::SerializeGPUModuleBase(
     toolkitPath = getCUDAToolkitPath();
 
   // Append the files in the target attribute.
-  librariesToLink.append(target.getLink().begin(), target.getLink().end());
+  if (target.getLink())
+    librariesToLink.append(target.getLink().begin(), target.getLink().end());
 
   // Append libdevice to the files to be loaded.
   (void)appendStandardLibs();

--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -93,17 +93,14 @@ SerializeGPUModuleBase::SerializeGPUModuleBase(
                      targetOptions.getOptimizedLlvmIRCallback(),
                      targetOptions.getISACallback()),
       target(target), toolkitPath(targetOptions.getToolkitPath()),
-      fileList(targetOptions.getLinkFiles()) {
+      librariesToLink(targetOptions.getLibrariesToLink()) {
 
   // If `targetOptions` have an empty toolkitPath use `getCUDAToolkitPath`
   if (toolkitPath.empty())
     toolkitPath = getCUDAToolkitPath();
 
   // Append the files in the target attribute.
-  if (ArrayAttr files = target.getLink())
-    for (Attribute attr : files.getValue())
-      if (auto file = dyn_cast<StringAttr>(attr))
-        fileList.push_back(file.str());
+  librariesToLink.append(target.getLink().begin(), target.getLink().end());
 
   // Append libdevice to the files to be loaded.
   (void)appendStandardLibs();
@@ -126,8 +123,8 @@ NVVMTargetAttr SerializeGPUModuleBase::getTarget() const { return target; }
 
 StringRef SerializeGPUModuleBase::getToolkitPath() const { return toolkitPath; }
 
-ArrayRef<std::string> SerializeGPUModuleBase::getFileList() const {
-  return fileList;
+ArrayRef<Attribute> SerializeGPUModuleBase::getLibrariesToLink() const {
+  return librariesToLink;
 }
 
 // Try to append `libdevice` from a CUDA toolkit installation.
@@ -149,7 +146,7 @@ LogicalResult SerializeGPUModuleBase::appendStandardLibs() {
                                  << " does not exist or is not a file.\n";
       return failure();
     }
-    fileList.push_back(pathRef.str());
+    librariesToLink.push_back(StringAttr::get(target.getContext(), pathRef));
   }
   return success();
 }
@@ -157,8 +154,8 @@ LogicalResult SerializeGPUModuleBase::appendStandardLibs() {
 std::optional<SmallVector<std::unique_ptr<llvm::Module>>>
 SerializeGPUModuleBase::loadBitcodeFiles(llvm::Module &module) {
   SmallVector<std::unique_ptr<llvm::Module>> bcFiles;
-  if (failed(loadBitcodeFilesFromList(module.getContext(), fileList, bcFiles,
-                                      true)))
+  if (failed(loadBitcodeFilesFromList(module.getContext(), librariesToLink,
+                                      bcFiles, true)))
     return std::nullopt;
   return std::move(bcFiles);
 }

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -97,17 +97,14 @@ SerializeGPUModuleBase::SerializeGPUModuleBase(
     : ModuleToObject(module, target.getTriple(), target.getChip(),
                      target.getFeatures(), target.getO()),
       target(target), toolkitPath(targetOptions.getToolkitPath()),
-      fileList(targetOptions.getLinkFiles()) {
+      librariesToLink(targetOptions.getLibrariesToLink()) {
 
   // If `targetOptions` has an empty toolkitPath use `getROCMPath`
   if (toolkitPath.empty())
     toolkitPath = getROCMPath();
 
   // Append the files in the target attribute.
-  if (ArrayAttr files = target.getLink())
-    for (Attribute attr : files.getValue())
-      if (auto file = dyn_cast<StringAttr>(attr))
-        fileList.push_back(file.str());
+  librariesToLink.append(target.getLink().begin(), target.getLink().end());
 }
 
 void SerializeGPUModuleBase::init() {
@@ -128,8 +125,8 @@ ROCDLTargetAttr SerializeGPUModuleBase::getTarget() const { return target; }
 
 StringRef SerializeGPUModuleBase::getToolkitPath() const { return toolkitPath; }
 
-ArrayRef<std::string> SerializeGPUModuleBase::getFileList() const {
-  return fileList;
+ArrayRef<Attribute> SerializeGPUModuleBase::getLibrariesToLink() const {
+  return librariesToLink;
 }
 
 LogicalResult SerializeGPUModuleBase::appendStandardLibs(AMDGCNLibraries libs) {
@@ -160,7 +157,7 @@ LogicalResult SerializeGPUModuleBase::appendStandardLibs(AMDGCNLibraries libs) {
                                   << " does not exist or is not a file";
       return true;
     }
-    fileList.push_back(pathRef.str());
+    librariesToLink.push_back(StringAttr::get(target.getContext(), pathRef));
     path.truncate(baseSize);
     return false;
   };
@@ -178,13 +175,13 @@ LogicalResult SerializeGPUModuleBase::appendStandardLibs(AMDGCNLibraries libs) {
 std::optional<SmallVector<std::unique_ptr<llvm::Module>>>
 SerializeGPUModuleBase::loadBitcodeFiles(llvm::Module &module) {
   // Return if there are no libs to load.
-  if (deviceLibs == AMDGCNLibraries::None && fileList.empty())
+  if (deviceLibs == AMDGCNLibraries::None && librariesToLink.empty())
     return SmallVector<std::unique_ptr<llvm::Module>>();
   if (failed(appendStandardLibs(deviceLibs)))
     return std::nullopt;
   SmallVector<std::unique_ptr<llvm::Module>> bcFiles;
-  if (failed(loadBitcodeFilesFromList(module.getContext(), fileList, bcFiles,
-                                      true)))
+  if (failed(loadBitcodeFilesFromList(module.getContext(), librariesToLink,
+                                      bcFiles, true)))
     return std::nullopt;
   return std::move(bcFiles);
 }

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -104,7 +104,8 @@ SerializeGPUModuleBase::SerializeGPUModuleBase(
     toolkitPath = getROCMPath();
 
   // Append the files in the target attribute.
-  librariesToLink.append(target.getLink().begin(), target.getLink().end());
+  if (target.getLink())
+    librariesToLink.append(target.getLink().begin(), target.getLink().end());
 }
 
 void SerializeGPUModuleBase::init() {

--- a/mlir/unittests/Target/LLVM/CMakeLists.txt
+++ b/mlir/unittests/Target/LLVM/CMakeLists.txt
@@ -1,9 +1,13 @@
 set(LLVM_LINK_COMPONENTS nativecodegen)
 
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
 add_mlir_unittest(MLIRTargetLLVMTests
   SerializeNVVMTarget.cpp
   SerializeROCDLTarget.cpp
   SerializeToLLVMBitcode.cpp
+DEPENDS
+  ${dialect_libs}
 )
 
 mlir_target_link_libraries(MLIRTargetLLVMTests

--- a/mlir/unittests/Target/LLVM/SerializeNVVMTarget.cpp
+++ b/mlir/unittests/Target/LLVM/SerializeNVVMTarget.cpp
@@ -18,15 +18,18 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
 
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_HAS_NVPTX_TARGET
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
 
 #include "gmock/gmock.h"
+#include <cstdint>
 
 using namespace mlir;
 
@@ -213,5 +216,83 @@ TEST_F(MLIRTargetLLVMNVVM,
     linkedLLVMIR.clear();
     optimizedLLVMIR.clear();
     isaResult.clear();
+  }
+}
+
+// Test linking LLVM IR from a resource attribute.
+TEST_F(MLIRTargetLLVMNVVM, SKIP_WITHOUT_NVPTX(LinkedLLVMIRResource)) {
+  MLIRContext context(registry);
+  std::string moduleStr = R"mlir(
+    gpu.module @nvvm_test {
+      llvm.func @bar()
+      llvm.func @nvvm_kernel(%arg0: f32) attributes {gpu.kernel, nvvm.kernel} {
+        llvm.call @bar() : () -> ()
+        llvm.return
+      }
+    }
+  )mlir";
+  // Provide the library to link as a serialized bitcode blob.
+  SmallVector<char> bitcodeToLink;
+  {
+    std::string linkedLib = R"llvm(
+  define void @bar() {
+    ret void
+  }
+  )llvm";
+    llvm::SMDiagnostic err;
+    llvm::MemoryBufferRef buffer(linkedLib, "linkedLib");
+    llvm::LLVMContext llvmCtx;
+    std::unique_ptr<llvm::Module> module = llvm::parseIR(buffer, err, llvmCtx);
+    ASSERT_TRUE(module) << " Can't parse IR: " << err.getMessage();
+    {
+      llvm::raw_svector_ostream os(bitcodeToLink);
+      WriteBitcodeToFile(*module, os);
+    }
+  }
+
+  OwningOpRef<ModuleOp> module =
+      parseSourceString<ModuleOp>(moduleStr, &context);
+  ASSERT_TRUE(!!module);
+  Builder builder(&context);
+
+  NVVM::NVVMTargetAttr target = NVVM::NVVMTargetAttr::get(&context);
+  auto serializer = dyn_cast<gpu::TargetAttrInterface>(target);
+
+  // Hook to intercept the LLVM IR after linking external libs.
+  std::string linkedLLVMIR;
+  auto linkedCallback = [&linkedLLVMIR](llvm::Module &module) {
+    llvm::raw_string_ostream ros(linkedLLVMIR);
+    module.print(ros, nullptr);
+  };
+
+  // Store the bitcode as a DenseI8ArrayAttr.
+  SmallVector<Attribute> librariesToLink;
+  librariesToLink.push_back(DenseI8ArrayAttr::get(
+      &context,
+      ArrayRef<int8_t>((int8_t *)bitcodeToLink.data(), bitcodeToLink.size())));
+  gpu::TargetOptions options({}, librariesToLink, {}, {},
+                             gpu::CompilationTarget::Assembly, {}, {},
+                             linkedCallback);
+  for (auto gpuModule : (*module).getBody()->getOps<gpu::GPUModuleOp>()) {
+    std::optional<SmallVector<char, 0>> object =
+        serializer.serializeToObject(gpuModule, options);
+
+    // Verify that we correctly linked in the library: the external call is
+    // replaced by the definition.
+    ASSERT_TRUE(!linkedLLVMIR.empty());
+    {
+      llvm::SMDiagnostic err;
+      llvm::MemoryBufferRef buffer(linkedLLVMIR, "linkedLLVMIR");
+      llvm::LLVMContext llvmCtx;
+      std::unique_ptr<llvm::Module> module =
+          llvm::parseIR(buffer, err, llvmCtx);
+      ASSERT_TRUE(module) << " Can't parse linkedLLVMIR: " << err.getMessage()
+                          << " IR: \n\b" << linkedLLVMIR;
+      llvm::Function *bar = module->getFunction("bar");
+      ASSERT_TRUE(bar);
+      ASSERT_FALSE(bar->empty());
+    }
+    ASSERT_TRUE(object != std::nullopt);
+    ASSERT_TRUE(!object->empty());
   }
 }


### PR DESCRIPTION
This change allows to expose through an interface attributes wrapping content as external
resources, and the usage inside the ModuleToObject show how we will be able to provide
runtime libraries without relying on the filesystem.