### PR TITLE
[libc][docs] split up platform and arch support

### DIFF
--- a/libc/docs/arch_support.rst
+++ b/libc/docs/arch_support.rst
@@ -1,20 +1,17 @@
 Architecture Support
 ====================
 
-The currently continuously tested CPU architures are:
+The currently continuously tested architectures are:
 
-* x86_64
 * aarch64
+* amdgpu
 * arm
+* nvptx
 * riscv32
 * riscv64
+* x86_64
 
-i386 support is in the works.
-
-The currently continuously tested GPU architures are:
-
-* amdgcn-amd-amdhsa
-* nvptx64-nvidia-cuda
+i386 support is [in the works](https://github.com/llvm/llvm-project/issues/93709).
 
 See "`Bringup on a New OS or Architecture <porting.html>`__" for more
 information. Please do first file a bug in

--- a/libc/docs/arch_support.rst
+++ b/libc/docs/arch_support.rst
@@ -1,0 +1,22 @@
+Architecture Support
+====================
+
+The currently continuously tested CPU architures are:
+
+* x86_64
+* aarch64
+* arm
+* riscv32
+* riscv64
+
+i386 support is in the works.
+
+The currently continuously tested GPU architures are:
+
+* amdgcn-amd-amdhsa
+* nvptx64-nvidia-cuda
+
+See "`Bringup on a New OS or Architecture <porting.html>`__" for more
+information. Please do first file a bug in
+`our issue tracker <https://github.com/llvm/llvm-project/labels/libc>`__ before
+starting a port that you plan to upstream.

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -35,24 +35,6 @@ LLVM-libc aspires to a unique place in the software ecosystem.  The goals are:
   algorithms.
 - `Fuzzing <https://github.com/llvm/llvm-project/tree/main/libc/fuzzing>`__
 
-Platform Support
-================
-
-Most development is currently targeting Linux on x86_64, aarch64, arm, and
-RISC-V. Embedded/baremetal targets are supported on arm and RISC-V, and Windows
-and MacOS have limited support (may be broken).  The Fuchsia platform is
-slowly replacing functions from its bundled libc with functions from this
-project.
-
-LLVM-libc does not guarantee backward compatibility with operating systems that have reached their EOL.
-Compatibility patches for obsolete operating systems will not be accepted.
-
-For Linux, we support kernel versions as listed on `kernel.org <https://kernel.org/>`_, including
-``longterm`` (not past EOL date), ``stable``, and ``mainline`` versions. We actively adopt new features
-from ``linux-next``.
-
-For Windows, we plan to support products within their lifecycle. Please refer to 
-`Search Product and Services Lifecycle Information <https://learn.microsoft.com/en-us/lifecycle/products/?products=windows>`_ for more information.
 
 .. toctree::
    :hidden:
@@ -70,9 +52,17 @@ For Windows, we plan to support products within their lifecycle. Please refer to
    :maxdepth: 1
    :caption: Status
 
-   compiler_support
    headers/index.rst
    c23
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Support
+
+   arch_support
+   platform_support
+   compiler_support
 
 .. toctree::
    :hidden:

--- a/libc/docs/platform_support.rst
+++ b/libc/docs/platform_support.rst
@@ -1,0 +1,20 @@
+Platform Support
+================
+
+Development is currently mostly focused on Linux.  MacOS and Windows has
+partial support, but has bitrot and isn't being tested continuously.
+
+LLVM-libc is currently being integrated into Android and Fuchsia operating
+systems via `overlay move <overlay_mode.html>`__.
+
+For Linux, we support kernel versions as listed on
+`kernel.org <https://kernel.org/>`_, including ``longterm`` (not past EOL
+date), ``stable``, and ``mainline`` versions. We actively adopt new features
+from ``linux-next``.
+
+For Windows, we plan to support products within their lifecycle. Please refer to 
+`Search Product and Services Lifecycle Information <https://learn.microsoft.com/en-us/lifecycle/products/?products=windows>`_ for more information.
+
+LLVM-libc does not guarantee backward compatibility with operating systems that
+have reached their EOL. Compatibility patches for obsolete operating systems
+will not be accepted.

--- a/libc/docs/platform_support.rst
+++ b/libc/docs/platform_support.rst
@@ -18,3 +18,5 @@ For Windows, we plan to support products within their lifecycle. Please refer to
 LLVM-libc does not guarantee backward compatibility with operating systems that
 have reached their EOL. Compatibility patches for obsolete operating systems
 will not be accepted.
+
+For GPU, reference `our GPU docs <gpu/index.html>`__.

--- a/libc/docs/platform_support.rst
+++ b/libc/docs/platform_support.rst
@@ -5,7 +5,7 @@ Development is currently mostly focused on Linux.  MacOS and Windows has
 partial support, but has bitrot and isn't being tested continuously.
 
 LLVM-libc is currently being integrated into Android and Fuchsia operating
-systems via `overlay move <overlay_mode.html>`__.
+systems via `overlay mode <overlay_mode.html>`__.
 
 For Linux, we support kernel versions as listed on
 `kernel.org <https://kernel.org/>`_, including ``longterm`` (not past EOL


### PR DESCRIPTION
Creates a new toctree "Support" under which we have distinct links to arch,
platform, and compiler support.

* Moved "Platform Support" from index landing page to new doc.
* Created explicit "Architecture Support". Requested in
  https://github.com/llvm/llvm-project/issues/118964#issuecomment-2531503046.
* Moved "Compiler Support" from Status toctree to new Support toctree.
