### PR TITLE
[flang] Handle substring in data statement constant

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -1481,9 +1481,10 @@ struct DataStmtConstant {
   UNION_CLASS_BOILERPLATE(DataStmtConstant);
   CharBlock source;
   mutable TypedExpr typedExpr;
-  std::variant<LiteralConstant, SignedIntLiteralConstant,
-      SignedRealLiteralConstant, SignedComplexLiteralConstant, NullInit,
-      common::Indirection<Designator>, StructureConstructor>
+  std::variant<common::Indirection<CharLiteralConstantSubstring>,
+      LiteralConstant, SignedIntLiteralConstant, SignedRealLiteralConstant,
+      SignedComplexLiteralConstant, NullInit, common::Indirection<Designator>,
+      StructureConstructor>
       u;
 };
 

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -929,8 +929,11 @@ TYPE_PARSER(construct<DataStmtRepeat>(intLiteralConstant) ||
 // components can be ambiguous with a scalar-constant-subobject.
 // So we parse literal constants, designator, null-init, and
 // structure-constructor, so that semantics can figure things out later
-// with the symbol table.
-TYPE_PARSER(sourced(first(construct<DataStmtConstant>(literalConstant),
+// with the symbol table.  A literal constant substring must be attempted
+// first to avoid a partial match with a literal constant.
+TYPE_PARSER(sourced(first(
+    construct<DataStmtConstant>(indirect(charLiteralConstantSubstring)),
+    construct<DataStmtConstant>(literalConstant),
     construct<DataStmtConstant>(signedRealLiteralConstant),
     construct<DataStmtConstant>(signedIntLiteralConstant),
     extension<LanguageFeature::SignedComplexLiteral>(

--- a/flang/lib/Parser/expr-parsers.cpp
+++ b/flang/lib/Parser/expr-parsers.cpp
@@ -68,7 +68,7 @@ TYPE_PARSER(construct<AcImpliedDoControl>(
 // type-param-inquiry is parsed as a structure component, except for
 // substring%KIND/LEN
 constexpr auto primary{instrumented("primary"_en_US,
-    first(construct<Expr>(indirect(Parser<CharLiteralConstantSubstring>{})),
+    first(construct<Expr>(indirect(charLiteralConstantSubstring)),
         construct<Expr>(literalConstant),
         construct<Expr>(construct<Expr::Parentheses>("(" >>
             expr / !","_tok / recovery(")"_tok, SkipPastNested<'(', ')'>{}))),

--- a/flang/lib/Parser/type-parsers.h
+++ b/flang/lib/Parser/type-parsers.h
@@ -63,6 +63,7 @@ constexpr Parser<KindParam> kindParam; // R709
 constexpr Parser<RealLiteralConstant> realLiteralConstant; // R714
 constexpr Parser<CharLength> charLength; // R723
 constexpr Parser<CharLiteralConstant> charLiteralConstant; // R724
+constexpr Parser<CharLiteralConstantSubstring> charLiteralConstantSubstring;
 constexpr Parser<Initialization> initialization; // R743 & R805
 constexpr Parser<DerivedTypeSpec> derivedTypeSpec; // R754
 constexpr Parser<TypeDeclarationStmt> typeDeclarationStmt; // R801

--- a/flang/test/Parser/lit-substr-data.f90
+++ b/flang/test/Parser/lit-substr-data.f90
@@ -1,0 +1,7 @@
+!RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+!Regression test for bug #119005
+character*2 :: ary4
+!CHECK: DATA ary4/"cd"/
+data ary4/"abcdef"(3:4)/
+end
+


### PR DESCRIPTION
The case of a constant substring wasn't handled in the parser for data statement constants.

Fixes https://github.com/llvm/llvm-project/issues/119005.