### PR TITLE
[GitHub] Add Xtensa backend labeler.

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -747,6 +747,12 @@ backend:RISC-V:
   - llvm/**/*riscv*
   - llvm/**/*RISCV*
 
+backend:Xtensa:
+  - clang/**/*xtensa*
+  - clang/**/*Xtensa*
+  - llvm/**/*xtensa*
+  - llvm/**/*Xtensa*
+
 lld:coff:
   - lld/**/COFF/**
   - lld/Common/**


### PR DESCRIPTION
Add patterns to label Xtensa backend related changes automatically.