### PR TITLE
[libc] Exclude FreeListHeap test and fuzzer on GPU

### DIFF
--- a/libc/fuzzing/__support/CMakeLists.txt
+++ b/libc/fuzzing/__support/CMakeLists.txt
@@ -24,7 +24,9 @@ add_libc_fuzzer(
     -D__LIBC_EXPLICIT_SIMD_OPT
 ) 
 
-if(LLVM_LIBC_FULL_BUILD)
+# TODO: FreeListHeap uses the _end symbol which conflicts with the _end symbol
+# defined by GPU start.cpp files so for now we exclude this fuzzer on GPU.
+if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_OS_IS_GPU)
   add_libc_fuzzer(
     freelist_heap_fuzz
     SRCS

--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -55,7 +55,9 @@ if(NOT LIBC_TARGET_OS_IS_GPU)
   )
 endif()
 
-if(LLVM_LIBC_FULL_BUILD)
+# TODO: FreeListHeap uses the _end symbol which conflicts with the _end symbol
+# defined by GPU start.cpp files so for now we exclude this test on GPU.
+if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_OS_IS_GPU)
   add_libc_test(
     freelist_heap_test
     SUITE


### PR DESCRIPTION
FreeListHeap uses the _end symbol which conflicts with the _end symbol defined by GPU start.cpp files so for now we exclude the test and the fuzzer on GPU.