### PR TITLE
[MemProf] Remove dead code (NFC)

### DIFF
--- a/llvm/lib/Analysis/MemoryProfileInfo.cpp
+++ b/llvm/lib/Analysis/MemoryProfileInfo.cpp
@@ -164,8 +164,6 @@ void CallStackTrie::addCallStack(
   assert(Curr);
   Curr->ContextSizeInfo.insert(Curr->ContextSizeInfo.end(),
                                ContextSizeInfo.begin(), ContextSizeInfo.end());
-  std::vector<ContextTotalSize> AllContextSizeInfo;
-  collectContextSizeInfo(Curr, AllContextSizeInfo);
 }
 
 void CallStackTrie::addCallStack(MDNode *MIB) {


### PR DESCRIPTION
Remove unused collection of context size information that was likely
leftover from debugging / testing.
