### PR TITLE
[DirectX] Lower ops after translating metadata

### DIFF
--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -10,8 +10,11 @@
 #include "DXILConstants.h"
 #include "DXILIntrinsicExpansion.h"
 #include "DXILOpBuilder.h"
+#include "DXILResourceAnalysis.h"
+#include "DXILShaderFlags.h"
 #include "DirectX.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/DXILMetadataAnalysis.h"
 #include "llvm/Analysis/DXILResource.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm/IR/DiagnosticInfo.h"
@@ -763,6 +766,8 @@ PreservedAnalyses DXILOpLowering::run(Module &M, ModuleAnalysisManager &MAM) {
     return PreservedAnalyses::all();
   PreservedAnalyses PA;
   PA.preserve<DXILResourceBindingAnalysis>();
+  PA.preserve<DXILMetadataAnalysis>();
+  PA.preserve<ShaderFlagsAnalysis>();
   return PA;
 }
 
@@ -785,6 +790,9 @@ public:
     AU.addRequired<DXILResourceTypeWrapperPass>();
     AU.addRequired<DXILResourceBindingWrapperPass>();
     AU.addPreserved<DXILResourceBindingWrapperPass>();
+    AU.addPreserved<DXILResourceMDWrapper>();
+    AU.addPreserved<DXILMetadataAnalysisWrapperPass>();
+    AU.addPreserved<ShaderFlagsAnalysisWrapper>();
   }
 };
 char DXILOpLoweringLegacy::ID = 0;

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -49,8 +49,11 @@ static void updateFunctionFlags(ComputedShaderFlags &CSF,
 void ModuleShaderFlags::initialize(const Module &M) {
   // Collect shader flags for each of the functions
   for (const auto &F : M.getFunctionList()) {
-    if (F.isDeclaration())
+    if (F.isDeclaration()) {
+      assert(!F.getName().starts_with("dx.op.") &&
+             "DXIL Shader Flag analysis should not be run post-lowering.");
       continue;
+    }
     ComputedShaderFlags CSF;
     for (const auto &BB : F)
       for (const auto &I : BB)

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -393,6 +393,7 @@ public:
     AU.addPreserved<DXILResourceBindingWrapperPass>();
     AU.addPreserved<DXILResourceMDWrapper>();
     AU.addPreserved<DXILMetadataAnalysisWrapperPass>();
+    AU.addPreserved<ShaderFlagsAnalysisWrapper>();
   }
 
   bool runOnModule(Module &M) override {

--- a/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetMachine.cpp
@@ -99,8 +99,8 @@ public:
     ScalarizerPassOptions DxilScalarOptions;
     DxilScalarOptions.ScalarizeLoadStore = true;
     addPass(createScalarizerPass(DxilScalarOptions));
-    addPass(createDXILOpLoweringLegacyPass());
     addPass(createDXILTranslateMetadataLegacyPass());
+    addPass(createDXILOpLoweringLegacyPass());
     addPass(createDXILPrepareModulePass());
   }
 };

--- a/llvm/test/CodeGen/DirectX/CreateHandle.ll
+++ b/llvm/test/CodeGen/DirectX/CreateHandle.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -passes=dxil-op-lower,dxil-translate-metadata %s | FileCheck %s
+; RUN: opt -S -passes=dxil-translate-metadata,dxil-op-lower %s | FileCheck %s
 ; RUN: opt -S -passes=dxil-pretty-printer %s 2>&1 >/dev/null | FileCheck --check-prefix=CHECK-PRETTY %s
 
 ; CHECK-PRETTY:       Type  Format         Dim      ID      HLSL Bind     Count

--- a/llvm/test/CodeGen/DirectX/CreateHandleFromBinding.ll
+++ b/llvm/test/CodeGen/DirectX/CreateHandleFromBinding.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -passes=dxil-op-lower,dxil-translate-metadata %s | FileCheck %s
+; RUN: opt -S -passes=dxil-translate-metadata,dxil-op-lower %s | FileCheck %s
 ; RUN: opt -S -passes=dxil-pretty-printer %s 2>&1 >/dev/null | FileCheck --check-prefix=CHECK-PRETTY %s
 
 ; CHECK-PRETTY:       Type  Format         Dim      ID      HLSL Bind     Count

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=dxil-pc-shadermodel6.3-library -debug-pass=Structure < %s -o /dev/null 2>&1 | \
-; RUN:     grep -v "Verify generated machine code" | FileCheck %s
+; RUN: llc -filetype=asm -mtriple=dxil-pc-shadermodel6.3-library -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-ASM
+; RUN: llc -filetype=obj -mtriple=dxil-pc-shadermodel6.3-library -debug-pass=Structure < %s -o /dev/null 2>&1 | grep -v "Verify generated machine code" | FileCheck %s --check-prefixes=CHECK,CHECK-OBJ
 
 ; REQUIRES: asserts
 
@@ -7,6 +7,11 @@
 ; CHECK-NEXT: Target Library Information
 ; CHECK-NEXT: DXIL Resource Type Analysis
 ; CHECK-NEXT: Target Transform Information
+
+; CHECK-OBJ-NEXT: Machine Module Information
+; CHECK-OBJ-NEXT: Machine Branch Probability Analysis
+; CHECK-OBJ-NEXT: Create Garbage Collector Module Metadata
+
 ; CHECK-NEXT: ModulePass Manager
 ; CHECK-NEXT:   DXIL Finalize Linkage
 ; CHECK-NEXT:   DXIL Intrinsic Expansion
@@ -17,11 +22,19 @@
 ; CHECK-NEXT:     Dominator Tree Construction
 ; CHECK-NEXT:     Scalarize vector operations
 ; CHECK-NEXT:   DXIL Resource Binding Analysis
-; CHECK-NEXT:   DXIL Op Lowering
 ; CHECK-NEXT:   DXIL resource Information
 ; CHECK-NEXT:   DXIL Shader Flag Analysis
 ; CHECK-NEXT:   DXIL Module Metadata analysis
 ; CHECK-NEXT:   DXIL Translate Metadata
+; CHECK-NEXT:   DXIL Op Lowering
 ; CHECK-NEXT:   DXIL Prepare Module
-; CHECK-NEXT:   DXIL Metadata Pretty Printer
-; CHECK-NEXT:   Print Module IR
+
+; CHECK-ASM-NEXT: DXIL Metadata Pretty Printer
+; CHECK-ASM-NEXT: Print Module IR
+
+; CHECK-OBJ-NEXT: DXIL Embedder
+; CHECK-OBJ-NEXT: DXContainer Global Emitter
+; CHECK-OBJ-NEXT: FunctionPass Manager
+; CHECK-OBJ-NEXT:   Lazy Machine Block Frequency Analysis
+; CHECK-OBJ-NEXT:   Machine Optimization Remark Emitter
+; CHECK-OBJ-NEXT:   DXIL Assembly Printer


### PR DESCRIPTION
Move the DXILOpLoweringPass after DXILTranslateMetadata, and add asserts in DXILShaderFlags to ensure it isn't scheduled after op lowering. This will allow us to rely on DirectX intrinsics in the shader flags analysis rather than having to recover information from lowered operations.

Fixes #120119.