### PR TITLE
[libc] Install RPC server to `shared/rpc.h`

### DIFF
--- a/libc/utils/gpu/server/CMakeLists.txt
+++ b/libc/utils/gpu/server/CMakeLists.txt
@@ -23,6 +23,11 @@ target_compile_definitions(llvmlibc_rpc_server PUBLIC
                            LIBC_NAMESPACE=${LIBC_NAMESPACE})
 
 # Install the server and associated header.
+install(FILES ${LIBC_SOURCE_DIR}/shared/rpc.h
+              ${LIBC_SOURCE_DIR}/shared/rpc_util.h
+              ${LIBC_SOURCE_DIR}/shared/rpc_opcodes.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/shared
+        COMPONENT libc-headers)
 install(TARGETS llvmlibc_rpc_server
         ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
         COMPONENT libc)


### PR DESCRIPTION
Summary:
This installs the shared header to the users installation. I couldn't
decide if this should be a standalone thing or use the existing support
in `include/` mostly because this is completely separate from hdrgen
stuff and it's C++.
