### PR TITLE
[LLDB] Add external progress bit category

### DIFF
--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -127,7 +127,7 @@ public:
     std::optional<lldb::user_id_t> debugger_id;
 
     /// The origin of the progress event, wheter it is internal or external.
-    Progress::Origin origin;
+    Origin origin;
   };
 
 private:
@@ -145,7 +145,7 @@ private:
   const ProgressData m_progress_data;
 
   /// The origin of this progress event.
-  const Progress::Origin m_origin;
+  const Origin m_origin;
 
   /// How much work ([0...m_total]) that has been completed.
   std::atomic<uint64_t> m_completed = 0;

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -144,9 +144,6 @@ private:
   /// Data needed by the debugger to broadcast a progress event.
   const ProgressData m_progress_data;
 
-  /// The origin of this progress event.
-  const Origin m_origin;
-
   /// How much work ([0...m_total]) that has been completed.
   std::atomic<uint64_t> m_completed = 0;
 

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -60,7 +60,7 @@ namespace lldb_private {
 class Progress {
 public:
   /// Enum to indicate the origin of a progress event, internal or external.
-  enum class ProgressOrigin : uint8_t {
+  enum class Origin : uint8_t {
     eInternal = 0,
     eExternal = 1,
   };
@@ -90,7 +90,7 @@ public:
            std::optional<uint64_t> total = std::nullopt,
            lldb_private::Debugger *debugger = nullptr,
            Timeout<std::nano> minimum_report_time = std::nullopt,
-           ProgressOrigin origin = ProgressOrigin::eInternal);
+           Origin origin = Origin::eInternal);
 
   /// Destroy the progress object.
   ///
@@ -127,7 +127,7 @@ public:
     std::optional<lldb::user_id_t> debugger_id;
 
     /// The origin of the progress event, wheter it is internal or external.
-    Progress::ProgressOrigin origin;
+    Progress::Origin origin;
   };
 
 private:
@@ -145,7 +145,7 @@ private:
   const ProgressData m_progress_data;
 
   /// The origin of this progress event.
-  const ProgressOrigin m_origin;
+  const Progress::Origin m_origin;
 
   /// How much work ([0...m_total]) that has been completed.
   std::atomic<uint64_t> m_completed = 0;

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -21,12 +21,6 @@
 
 namespace lldb_private {
 
-/// Enum to indicate the origin of a progress event, internal or external.
-enum class ProgressOrigin : uint8_t {
-  eLLDBInternal = 0,
-  eExternal = 1,
-};
-
 /// A Progress indicator helper class.
 ///
 /// Any potentially long running sections of code in LLDB should report
@@ -65,6 +59,12 @@ enum class ProgressOrigin : uint8_t {
 
 class Progress {
 public:
+  /// Enum to indicate the origin of a progress event, internal or external.
+  enum class ProgressOrigin : uint8_t {
+    eInternal = 0,
+    eExternal = 1,
+  };
+
   /// Construct a progress object that will report information.
   ///
   /// The constructor will create a unique progress reporting object and
@@ -90,7 +90,7 @@ public:
            std::optional<uint64_t> total = std::nullopt,
            lldb_private::Debugger *debugger = nullptr,
            Timeout<std::nano> minimum_report_time = std::nullopt,
-           ProgressOrigin origin = ProgressOrigin::eLLDBInternal);
+           ProgressOrigin origin = ProgressOrigin::eInternal);
 
   /// Destroy the progress object.
   ///
@@ -125,6 +125,9 @@ public:
     /// The optional debugger ID to report progress to. If this has no value
     /// then all debuggers will receive this event.
     std::optional<lldb::user_id_t> debugger_id;
+
+    /// The origin of the progress event, wheter it is internal or external.
+    Progress::ProgressOrigin origin;
   };
 
 private:
@@ -141,6 +144,9 @@ private:
   /// Data needed by the debugger to broadcast a progress event.
   const ProgressData m_progress_data;
 
+  /// The origin of this progress event.
+  const ProgressOrigin m_origin;
+
   /// How much work ([0...m_total]) that has been completed.
   std::atomic<uint64_t> m_completed = 0;
 
@@ -156,9 +162,6 @@ private:
 
   /// The "completed" value of the last reported event.
   std::optional<uint64_t> m_prev_completed;
-
-  /// The origin of this progress event.
-  ProgressOrigin m_origin;
 };
 
 /// A class used to group progress reports by category. This is done by using a

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -21,6 +21,12 @@
 
 namespace lldb_private {
 
+/// Enum to indicate the origin of a progress event, internal or external.
+enum class ProgressOrigin : uint8_t {
+  eLLDBInternal = 0,
+  eExternal = 1,
+};
+
 /// A Progress indicator helper class.
 ///
 /// Any potentially long running sections of code in LLDB should report
@@ -83,7 +89,8 @@ public:
   Progress(std::string title, std::string details = {},
            std::optional<uint64_t> total = std::nullopt,
            lldb_private::Debugger *debugger = nullptr,
-           Timeout<std::nano> minimum_report_time = std::nullopt);
+           Timeout<std::nano> minimum_report_time = std::nullopt,
+           ProgressOrigin origin = ProgressOrigin::eLLDBInternal);
 
   /// Destroy the progress object.
   ///
@@ -149,6 +156,9 @@ private:
 
   /// The "completed" value of the last reported event.
   std::optional<uint64_t> m_prev_completed;
+
+  /// The origin of this progress event.
+  ProgressOrigin m_origin;
 };
 
 /// A class used to group progress reports by category. This is done by using a

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -195,10 +195,10 @@ enum Format {
                          ///< character arrays that can contain non printable
                          ///< characters
   eFormatAddressInfo,    ///< Describe what an address points to (func + offset
-                      ///< with file/line, symbol + offset, data, etc)
-  eFormatHexFloat,    ///< ISO C99 hex float string
-  eFormatInstruction, ///< Disassemble an opcode
-  eFormatVoid,        ///< Do not print this
+                         ///< with file/line, symbol + offset, data, etc)
+  eFormatHexFloat,       ///< ISO C99 hex float string
+  eFormatInstruction,    ///< Disassemble an opcode
+  eFormatVoid,           ///< Do not print this
   eFormatUnicode8,
   kNumFormats
 };
@@ -302,7 +302,7 @@ enum ConnectionStatus {
   eConnectionStatusNoConnection,   ///< No connection
   eConnectionStatusLostConnection, ///< Lost connection while connected to a
                                    ///< valid connection
-  eConnectionStatusInterrupted ///< Interrupted read
+  eConnectionStatusInterrupted     ///< Interrupted read
 };
 
 enum ErrorType {
@@ -1094,7 +1094,7 @@ enum PathType {
   ePathTypeGlobalLLDBTempSystemDir, ///< The LLDB temp directory for this
                                     ///< system, NOT cleaned up on a process
                                     ///< exit.
-  ePathTypeClangDir ///< Find path to Clang builtin headers
+  ePathTypeClangDir                 ///< Find path to Clang builtin headers
 };
 
 /// Kind of member function.
@@ -1357,6 +1357,7 @@ enum DebuggerBroadcastBit {
   eBroadcastBitError = (1 << 2),
   eBroadcastSymbolChange = (1 << 3),
   eBroadcastBitProgressCategory = (1 << 4),
+  eBroadcastBitExternalProgressCategory = (1 << 5),
 };
 
 /// Used for expressing severity in logs and diagnostics.

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -195,10 +195,10 @@ enum Format {
                          ///< character arrays that can contain non printable
                          ///< characters
   eFormatAddressInfo,    ///< Describe what an address points to (func + offset
-                         ///< with file/line, symbol + offset, data, etc)
-  eFormatHexFloat,       ///< ISO C99 hex float string
-  eFormatInstruction,    ///< Disassemble an opcode
-  eFormatVoid,           ///< Do not print this
+                      ///< with file/line, symbol + offset, data, etc)
+  eFormatHexFloat,    ///< ISO C99 hex float string
+  eFormatInstruction, ///< Disassemble an opcode
+  eFormatVoid,        ///< Do not print this
   eFormatUnicode8,
   kNumFormats
 };
@@ -302,7 +302,7 @@ enum ConnectionStatus {
   eConnectionStatusNoConnection,   ///< No connection
   eConnectionStatusLostConnection, ///< Lost connection while connected to a
                                    ///< valid connection
-  eConnectionStatusInterrupted     ///< Interrupted read
+  eConnectionStatusInterrupted ///< Interrupted read
 };
 
 enum ErrorType {
@@ -1094,7 +1094,7 @@ enum PathType {
   ePathTypeGlobalLLDBTempSystemDir, ///< The LLDB temp directory for this
                                     ///< system, NOT cleaned up on a process
                                     ///< exit.
-  ePathTypeClangDir                 ///< Find path to Clang builtin headers
+  ePathTypeClangDir ///< Find path to Clang builtin headers
 };
 
 /// Kind of member function.
@@ -1357,7 +1357,8 @@ enum DebuggerBroadcastBit {
   eBroadcastBitError = (1 << 2),
   eBroadcastSymbolChange = (1 << 3),
   eBroadcastBitProgressCategory = (1 << 4),
-  eBroadcastBitExternalProgressCategory = (1 << 5),
+  eBroadcastBitExternalProgress = (1 << 5),
+  eBroadcastBitExternalProgressCategory = (1 << 6),
 };
 
 /// Used for expressing severity in logs and diagnostics.

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -36,7 +36,6 @@ Progress::Progress(std::string title, std::string details,
                       debugger ? std::optional<user_id_t>(debugger->GetID())
                                : std::nullopt,
                       origin},
-      m_origin(origin),
       m_last_report_time_ns(
           std::chrono::nanoseconds(
               std::chrono::steady_clock::now().time_since_epoch())
@@ -110,9 +109,10 @@ void Progress::ReportProgress() {
     return; // An overflow in the m_completed counter. Just ignore these events.
 
   // Change the category bit if we're an internal or external progress.
-  uint32_t progress_category_bit = m_origin == Progress::Origin::eExternal
-                                       ? lldb::eBroadcastBitExternalProgress
-                                       : lldb::eBroadcastBitProgress;
+  uint32_t progress_category_bit =
+      m_progress_data.origin == Progress::Origin::eExternal
+          ? lldb::eBroadcastBitExternalProgress
+          : lldb::eBroadcastBitProgress;
 
   Debugger::ReportProgress(m_progress_data.progress_id, m_progress_data.title,
                            m_details, completed, m_total,

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -29,7 +29,7 @@ Progress::Progress(std::string title, std::string details,
                    std::optional<uint64_t> total,
                    lldb_private::Debugger *debugger,
                    Timeout<std::nano> minimum_report_time,
-                   Progress::ProgressOrigin origin)
+                   Progress::Origin origin)
     : m_total(total.value_or(Progress::kNonDeterministicTotal)),
       m_minimum_report_time(minimum_report_time),
       m_progress_data{title, ++g_id,
@@ -110,7 +110,7 @@ void Progress::ReportProgress() {
     return; // An overflow in the m_completed counter. Just ignore these events.
 
   // Change the category bit if we're an internal or external progress.
-  uint32_t progress_category_bit = m_origin == ProgressOrigin::eExternal
+  uint32_t progress_category_bit = m_origin == Progress::Origin::eExternal
                                        ? lldb::eBroadcastBitExternalProgress
                                        : lldb::eBroadcastBitProgress;
 
@@ -210,7 +210,7 @@ void ProgressManager::ReportProgress(
   const uint64_t completed =
       (type == EventType::Begin) ? 0 : Progress::kNonDeterministicTotal;
   const uint32_t progress_category_bit =
-      progress_data.origin == Progress::ProgressOrigin::eExternal
+      progress_data.origin == Progress::Origin::eExternal
           ? lldb::eBroadcastBitExternalProgressCategory
           : lldb::eBroadcastBitProgressCategory;
   Debugger::ReportProgress(progress_data.progress_id, progress_data.title, "",

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -111,8 +111,8 @@ void Progress::ReportProgress() {
 
   // Change the category bit if we're an internal or external progress.
   uint32_t progress_category_bit = m_origin == ProgressOrigin::eExternal
-                                       ? lldb::eBroadcastBitProgress
-                                       : lldb::eBroadcastBitExternalProgress;
+                                       ? lldb::eBroadcastBitExternalProgress
+                                       : lldb::eBroadcastBitProgress;
 
   Debugger::ReportProgress(m_progress_data.progress_id, m_progress_data.title,
                            m_details, completed, m_total,

--- a/lldb/unittests/Core/ProgressReportTest.cpp
+++ b/lldb/unittests/Core/ProgressReportTest.cpp
@@ -508,3 +508,21 @@ TEST_F(ProgressReportTest, TestExternalReportCreation) {
   EXPECT_FALSE(data->IsFinite());
   EXPECT_EQ(data->GetMessage(), "Progress report 1: Starting report 1");
 }
+
+TEST_F(ProgressReportTest, TestExternalReportNotReceived) {
+  ListenerSP listener_sp = CreateListenerFor(lldb::eBroadcastBitProgress);
+  EventSP event_sp;
+
+  // Scope this for RAII on the progress objects.
+  // Create progress reports and check that their respective events for having
+  // started and ended are broadcasted.
+  {
+    Progress progress1("External Progress report 1",
+                       "Starting external report 1",
+                       /*total=*/std::nullopt, /*debugger=*/nullptr,
+                       /*minimum_report_time=*/std::chrono::seconds(0),
+                       Progress::Origin::eExternal);
+  }
+
+  ASSERT_FALSE(listener_sp->GetEvent(event_sp, TIMEOUT));
+}

--- a/lldb/unittests/Core/ProgressReportTest.cpp
+++ b/lldb/unittests/Core/ProgressReportTest.cpp
@@ -425,3 +425,86 @@ TEST_F(ProgressReportTest, TestProgressManagerDisjointReports) {
 
   ASSERT_FALSE(listener_sp->GetEvent(event_sp, TIMEOUT));
 }
+
+TEST_F(ProgressReportTest, TestExternalReportCreation) {
+  ListenerSP listener_sp =
+      CreateListenerFor(lldb::eBroadcastBitExternalProgress);
+  EventSP event_sp;
+  const ProgressEventData *data;
+
+  // Scope this for RAII on the progress objects.
+  // Create progress reports and check that their respective events for having
+  // started and ended are broadcasted.
+  {
+    Progress progress1("Progress report 1", "Starting report 1",
+                       /*total=*/std::nullopt, /*debugger=*/nullptr,
+                       /*minimum_report_time=*/std::chrono::seconds(0),
+                       Progress::Origin::eExternal);
+    Progress progress2("Progress report 2", "Starting report 2",
+                       /*total=*/std::nullopt, /*debugger=*/nullptr,
+                       /*minimum_report_time=*/std::chrono::seconds(0),
+                       Progress::Origin::eExternal);
+    Progress progress3("Progress report 3", "Starting report 3",
+                       /*total=*/std::nullopt, /*debugger=*/nullptr,
+                       /*minimum_report_time=*/std::chrono::seconds(0),
+                       Progress::Origin::eExternal);
+  }
+
+  // Start popping events from the queue, they should have been recevied
+  // in this order:
+  // Starting progress: 1, 2, 3
+  // Ending progress: 3, 2, 1
+  ASSERT_TRUE(listener_sp->GetEvent(event_sp, TIMEOUT));
+  data = ProgressEventData::GetEventDataFromEvent(event_sp.get());
+
+  EXPECT_EQ(data->GetDetails(), "Starting report 1");
+  EXPECT_FALSE(data->IsFinite());
+  EXPECT_FALSE(data->GetCompleted());
+  EXPECT_EQ(data->GetTotal(), Progress::kNonDeterministicTotal);
+  EXPECT_EQ(data->GetMessage(), "Progress report 1: Starting report 1");
+
+  ASSERT_TRUE(listener_sp->GetEvent(event_sp, TIMEOUT));
+  data = ProgressEventData::GetEventDataFromEvent(event_sp.get());
+
+  EXPECT_EQ(data->GetDetails(), "Starting report 2");
+  EXPECT_FALSE(data->IsFinite());
+  EXPECT_FALSE(data->GetCompleted());
+  EXPECT_EQ(data->GetTotal(), Progress::kNonDeterministicTotal);
+  EXPECT_EQ(data->GetMessage(), "Progress report 2: Starting report 2");
+
+  ASSERT_TRUE(listener_sp->GetEvent(event_sp, TIMEOUT));
+  data = ProgressEventData::GetEventDataFromEvent(event_sp.get());
+
+  EXPECT_EQ(data->GetDetails(), "Starting report 3");
+  EXPECT_FALSE(data->IsFinite());
+  EXPECT_FALSE(data->GetCompleted());
+  EXPECT_EQ(data->GetTotal(), Progress::kNonDeterministicTotal);
+  EXPECT_EQ(data->GetMessage(), "Progress report 3: Starting report 3");
+
+  // Progress report objects should be destroyed at this point so
+  // get each report from the queue and check that they've been
+  // destroyed in reverse order.
+  ASSERT_TRUE(listener_sp->GetEvent(event_sp, TIMEOUT));
+  data = ProgressEventData::GetEventDataFromEvent(event_sp.get());
+
+  EXPECT_EQ(data->GetTitle(), "Progress report 3");
+  EXPECT_TRUE(data->GetCompleted());
+  EXPECT_FALSE(data->IsFinite());
+  EXPECT_EQ(data->GetMessage(), "Progress report 3: Starting report 3");
+
+  ASSERT_TRUE(listener_sp->GetEvent(event_sp, TIMEOUT));
+  data = ProgressEventData::GetEventDataFromEvent(event_sp.get());
+
+  EXPECT_EQ(data->GetTitle(), "Progress report 2");
+  EXPECT_TRUE(data->GetCompleted());
+  EXPECT_FALSE(data->IsFinite());
+  EXPECT_EQ(data->GetMessage(), "Progress report 2: Starting report 2");
+
+  ASSERT_TRUE(listener_sp->GetEvent(event_sp, TIMEOUT));
+  data = ProgressEventData::GetEventDataFromEvent(event_sp.get());
+
+  EXPECT_EQ(data->GetTitle(), "Progress report 1");
+  EXPECT_TRUE(data->GetCompleted());
+  EXPECT_FALSE(data->IsFinite());
+  EXPECT_EQ(data->GetMessage(), "Progress report 1: Starting report 1");
+}


### PR DESCRIPTION
As feedback on #119052, it was recommended I add a new bit to delineate internal and external progress events. This patch adds this new category, and sets up Progress.h to support external events via SBProgress.