### PR TITLE
[MLIR] correct return type of parse() functions

### DIFF
--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2114,7 +2114,7 @@ LogicalResult ObjectAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 }
 
 namespace {
-LogicalResult parseObject(AsmParser &odsParser, CompilationTarget &format,
+ParseResult parseObject(AsmParser &odsParser, CompilationTarget &format,
                           StringAttr &object) {
   std::optional<CompilationTarget> formatResult;
   StringRef enumKeyword;

--- a/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
+++ b/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp
@@ -2115,7 +2115,7 @@ LogicalResult ObjectAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 
 namespace {
 ParseResult parseObject(AsmParser &odsParser, CompilationTarget &format,
-                          StringAttr &object) {
+                        StringAttr &object) {
   std::optional<CompilationTarget> formatResult;
   StringRef enumKeyword;
   auto loc = odsParser.getCurrentLocation();

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -28,7 +28,7 @@ using namespace mlir::LLVM;
 /// opcode. Some DWARF expression operations have a specific number of operands
 /// and may appear in a textual form.
 static ParseResult parseExpressionArg(AsmParser &parser, uint64_t opcode,
-                                        SmallVector<uint64_t> &args);
+                                      SmallVector<uint64_t> &args);
 
 /// Prints DWARF expression arguments with respect to the specific DWARF
 /// operation. Some operands are printed in their textual form.
@@ -145,7 +145,7 @@ DIExpressionAttr DIExpressionAttr::get(MLIRContext *context) {
 }
 
 ParseResult parseExpressionArg(AsmParser &parser, uint64_t opcode,
-                                 SmallVector<uint64_t> &args) {
+                               SmallVector<uint64_t> &args) {
   auto operandParser = [&]() -> LogicalResult {
     uint64_t operand = 0;
     if (!args.empty() && opcode == llvm::dwarf::DW_OP_LLVM_convert) {

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -27,7 +27,7 @@ using namespace mlir::LLVM;
 /// Parses DWARF expression arguments with respect to the DWARF operation
 /// opcode. Some DWARF expression operations have a specific number of operands
 /// and may appear in a textual form.
-static LogicalResult parseExpressionArg(AsmParser &parser, uint64_t opcode,
+static ParseResult parseExpressionArg(AsmParser &parser, uint64_t opcode,
                                         SmallVector<uint64_t> &args);
 
 /// Prints DWARF expression arguments with respect to the specific DWARF
@@ -144,7 +144,7 @@ DIExpressionAttr DIExpressionAttr::get(MLIRContext *context) {
   return get(context, ArrayRef<DIExpressionElemAttr>({}));
 }
 
-LogicalResult parseExpressionArg(AsmParser &parser, uint64_t opcode,
+ParseResult parseExpressionArg(AsmParser &parser, uint64_t opcode,
                                  SmallVector<uint64_t> &args) {
   auto operandParser = [&]() -> LogicalResult {
     uint64_t operand = 0;

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -90,13 +90,13 @@ static llvm::hash_code test::hash_value(const FieldInfo &fi) { // NOLINT
 // TestCustomType
 //===----------------------------------------------------------------------===//
 
-static LogicalResult parseCustomTypeA(AsmParser &parser, int &aResult) {
+static ParseResult parseCustomTypeA(AsmParser &parser, int &aResult) {
   return parser.parseInteger(aResult);
 }
 
 static void printCustomTypeA(AsmPrinter &printer, int a) { printer << a; }
 
-static LogicalResult parseCustomTypeB(AsmParser &parser, int a,
+static ParseResult parseCustomTypeB(AsmParser &parser, int a,
                                       std::optional<int> &bResult) {
   if (a < 0)
     return success();
@@ -116,7 +116,7 @@ static void printCustomTypeB(AsmPrinter &printer, int a, std::optional<int> b) {
   printer << *b;
 }
 
-static LogicalResult parseFooString(AsmParser &parser, std::string &foo) {
+static ParseResult parseFooString(AsmParser &parser, std::string &foo) {
   std::string result;
   if (parser.parseString(&result))
     return failure();
@@ -128,7 +128,7 @@ static void printFooString(AsmPrinter &printer, StringRef foo) {
   printer << '"' << foo << '"';
 }
 
-static LogicalResult parseBarString(AsmParser &parser, StringRef foo) {
+static ParseResult parseBarString(AsmParser &parser, StringRef foo) {
   return parser.parseKeyword(foo);
 }
 

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -97,7 +97,7 @@ static ParseResult parseCustomTypeA(AsmParser &parser, int &aResult) {
 static void printCustomTypeA(AsmPrinter &printer, int a) { printer << a; }
 
 static ParseResult parseCustomTypeB(AsmParser &parser, int a,
-                                      std::optional<int> &bResult) {
+                                    std::optional<int> &bResult) {
   if (a < 0)
     return success();
   for (int i : llvm::seq(0, a))


### PR DESCRIPTION
The `parseX()` functions that are defined to support `custom<X>` in `assemblyFormat` should return `ParseResult` rather than `LogicalResult`. The `ParseResult` type is necessary due to tablegen generating code that expects this type within an Op `parseX()` function.