### PR TITLE
[MemRef] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/ComposeSubView.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ComposeSubView.cpp
@@ -82,7 +82,7 @@ struct ComposeSubViewOpPattern : public OpRewritePattern<memref::SubViewOp> {
          llvm::zip(op.getMixedOffsets(), sourceOp.getMixedOffsets(),
                    sourceOp.getMixedStrides(), op.getMixedSizes())) {
       // We only support static sizes.
-      if (opSize.is<Value>()) {
+      if (isa<Value>(opSize)) {
         return failure();
       }
       sizes.push_back(opSize);
@@ -109,7 +109,7 @@ struct ComposeSubViewOpPattern : public OpRewritePattern<memref::SubViewOp> {
               rewriter.getAffineConstantExpr(cast<IntegerAttr>(attr).getInt());
         } else {
           expr = rewriter.getAffineSymbolExpr(affineApplyOperands.size());
-          affineApplyOperands.push_back(sourceOffset.get<Value>());
+          affineApplyOperands.push_back(cast<Value>(sourceOffset));
         }
 
         // Multiply 'opOffset' by 'sourceStride' and make the 'expr' add the
@@ -121,7 +121,7 @@ struct ComposeSubViewOpPattern : public OpRewritePattern<memref::SubViewOp> {
           expr =
               expr + rewriter.getAffineSymbolExpr(affineApplyOperands.size()) *
                          cast<IntegerAttr>(sourceStrideAttr).getInt();
-          affineApplyOperands.push_back(opOffset.get<Value>());
+          affineApplyOperands.push_back(cast<Value>(opOffset));
         }
 
         AffineMap map = AffineMap::get(0, affineApplyOperands.size(), expr);

--- a/mlir/lib/Dialect/MemRef/Transforms/ExpandStridedMetadata.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExpandStridedMetadata.cpp
@@ -383,7 +383,7 @@ SmallVector<OpFoldResult> getExpandedStrides(memref::ExpandShapeOp expandShape,
     AffineExpr s1 = builder.getAffineSymbolExpr(1);
     for (; doneStrideIdx < *dynSizeIdx; ++doneStrideIdx) {
       int64_t baseExpandedStride =
-          cast<IntegerAttr>(expandedStrides[doneStrideIdx].get<Attribute>())
+          cast<IntegerAttr>(cast<Attribute>(expandedStrides[doneStrideIdx]))
               .getInt();
       expandedStrides[doneStrideIdx] = makeComposedFoldedAffineApply(
           builder, expandShape.getLoc(),
@@ -396,7 +396,7 @@ SmallVector<OpFoldResult> getExpandedStrides(memref::ExpandShapeOp expandShape,
   AffineExpr s0 = builder.getAffineSymbolExpr(0);
   for (; doneStrideIdx < groupSize; ++doneStrideIdx) {
     int64_t baseExpandedStride =
-        cast<IntegerAttr>(expandedStrides[doneStrideIdx].get<Attribute>())
+        cast<IntegerAttr>(cast<Attribute>(expandedStrides[doneStrideIdx]))
             .getInt();
     expandedStrides[doneStrideIdx] = makeComposedFoldedAffineApply(
         builder, expandShape.getLoc(), s0 * baseExpandedStride, {origStride});

--- a/mlir/lib/Dialect/MemRef/Transforms/IndependenceTransforms.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/IndependenceTransforms.cpp
@@ -21,7 +21,7 @@ using namespace mlir::memref;
 static FailureOr<OpFoldResult> makeIndependent(OpBuilder &b, Location loc,
                                                OpFoldResult ofr,
                                                ValueRange independencies) {
-  if (ofr.is<Attribute>())
+  if (isa<Attribute>(ofr))
     return ofr;
   AffineMap boundMap;
   ValueDimList mapOperands;


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
