### PR TITLE
[lldb] Remove references to llvm-gcc

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.cpp
@@ -736,15 +736,9 @@ bool DWARFUnit::LinkToSkeletonUnit(DWARFUnit &skeleton_unit) {
   return false; // Already linked to a different unit.
 }
 
-bool DWARFUnit::Supports_DW_AT_APPLE_objc_complete_type() {
-  return GetProducer() != eProducerLLVMGCC;
-}
+bool DWARFUnit::Supports_DW_AT_APPLE_objc_complete_type() { return true; }
 
-bool DWARFUnit::DW_AT_decl_file_attributes_are_invalid() {
-  // llvm-gcc makes completely invalid decl file attributes and won't ever be
-  // fixed, so we need to know to ignore these.
-  return GetProducer() == eProducerLLVMGCC;
-}
+bool DWARFUnit::DW_AT_decl_file_attributes_are_invalid() { return false; }
 
 bool DWARFUnit::Supports_unnamed_objc_bitfields() {
   if (GetProducer() == eProducerClang)
@@ -768,10 +762,6 @@ void DWARFUnit::ParseProducerInfo() {
       llvm::StringRef(R"(swiftlang-([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?))"));
   static const RegularExpression g_clang_version_regex(
       llvm::StringRef(R"(clang-([0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?))"));
-  static const RegularExpression g_llvm_gcc_regex(
-      llvm::StringRef(R"(4\.[012]\.[01] )"
-                      R"(\(Based on Apple Inc\. build [0-9]+\) )"
-                      R"(\(LLVM build [\.0-9]+\)$)"));
 
   llvm::SmallVector<llvm::StringRef, 3> matches;
   if (g_swiftlang_version_regex.Execute(producer, &matches)) {
@@ -783,8 +773,6 @@ void DWARFUnit::ParseProducerInfo() {
     m_producer = eProducerClang;
   } else if (producer.contains("GNU")) {
     m_producer = eProducerGCC;
-  } else if (g_llvm_gcc_regex.Execute(producer)) {
-    m_producer = eProducerLLVMGCC;
   }
 }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -34,7 +34,6 @@ enum DWARFProducer {
   eProducerInvalid = 0,
   eProducerClang,
   eProducerGCC,
-  eProducerLLVMGCC,
   eProducerSwift,
   eProducerOther
 };

--- a/lldb/test/API/functionalities/conditional_break/TestConditionalBreak.py
+++ b/lldb/test/API/functionalities/conditional_break/TestConditionalBreak.py
@@ -10,7 +10,7 @@ from lldbsuite.test import lldbutil
 # rdar://problem/8532131
 # lldb not able to digest the clang-generated debug info correctly with respect to function name
 #
-# This class currently fails for clang as well as llvm-gcc.
+# This class currently fails for clang.
 
 
 class ConditionalBreakTestCase(TestBase):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -67,7 +67,7 @@ class CppDataFormatterTestCase(TestBase):
         )
 
         # gcc4.2 on Mac OS X skips typedef chains in the DWARF output
-        if self.getCompiler() in ["clang"]
+        if self.getCompiler() in ["clang"]:
             self.expect(
                 "frame variable",
                 patterns=[

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-cpp/TestDataFormatterCpp.py
@@ -67,7 +67,7 @@ class CppDataFormatterTestCase(TestBase):
         )
 
         # gcc4.2 on Mac OS X skips typedef chains in the DWARF output
-        if self.getCompiler() in ["clang", "llvm-gcc"]:
+        if self.getCompiler() in ["clang"]
             self.expect(
                 "frame variable",
                 patterns=[

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-skip-summary/TestDataFormatterSkipSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-skip-summary/TestDataFormatterSkipSummary.py
@@ -157,27 +157,6 @@ class SkipSummaryDataFormatterTestCase(TestBase):
             ],
         )
 
-        # Bad debugging info on SnowLeopard gcc (Apple Inc. build 5666).
-        # Skip the following tests if the condition is met.
-        if self.getCompiler().endswith("gcc") and not self.getCompiler().endswith(
-            "llvm-gcc"
-        ):
-            import re
-
-            gcc_version_output = system([[lldbutil.which(self.getCompiler()), "-v"]])
-            self.trace("my output:", gcc_version_output)
-            for line in gcc_version_output.split(os.linesep):
-                m = re.search("\(Apple Inc\. build ([0-9]+)\)", line)
-                self.trace("line:", line)
-                if m:
-                    gcc_build = int(m.group(1))
-                    self.trace("gcc build:", gcc_build)
-                    if gcc_build >= 5666:
-                        # rdar://problem/9804600"
-                        self.skipTest(
-                            "rdar://problem/9804600 wrong namespace for std::string in debug info"
-                        )
-
         # Expand same expression, skipping 3 layers of summaries
         self.expect(
             "frame variable data1.m_child1->m_child2 --show-types --no-summary-depth=3",

--- a/lldb/test/API/lang/cpp/namespace/TestNamespace.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespace.py
@@ -161,7 +161,7 @@ class NamespaceTestCase(TestBase):
         # On Mac OS X, gcc 4.2 emits the wrong debug info with respect to
         # types.
         slist = ["(int) a = 12", "anon_uint", "a_uint", "b_uint", "y_uint"]
-        if self.platformIsDarwin() and self.getCompiler() in ["clang", "llvm-gcc"]:
+        if self.platformIsDarwin() and self.getCompiler() in ["clang"]:
             slist = [
                 "(int) a = 12",
                 "::my_uint_t",

--- a/lldb/unittests/SymbolFile/DWARF/DWARFUnitTest.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFUnitTest.cpp
@@ -122,41 +122,6 @@ DWARF:
   EXPECT_EQ(unit->GetProducerVersion(), llvm::VersionTuple(1300, 0, 29, 3));
 }
 
-TEST(DWARFUnitTest, LLVMGCCProducer) {
-  const char *yamldata = R"(
---- !ELF
-FileHeader:
-  Class:   ELFCLASS64
-  Data:    ELFDATA2LSB
-  Type:    ET_EXEC
-  Machine: EM_386
-DWARF:
-  debug_str:
-    - 'i686-apple-darwin11-llvm-gcc-4.2 (GCC) 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)'
-  debug_abbrev:
-    - Table:
-        - Code:            0x00000001
-          Tag:             DW_TAG_compile_unit
-          Children:        DW_CHILDREN_yes
-          Attributes:
-            - Attribute:       DW_AT_producer
-              Form:            DW_FORM_strp
-  debug_info:
-    - Version:         4
-      AddrSize:        8
-      Entries:
-        - AbbrCode:        0x1
-          Values:
-            - Value:           0x0
-        - AbbrCode:        0x0
-)";
-
-  YAMLModuleTester t(yamldata);
-  DWARFUnit *unit = t.GetDwarfUnit();
-  ASSERT_TRUE((bool)unit);
-  EXPECT_EQ(unit->GetProducer(), eProducerLLVMGCC);
-}
-
 TEST(DWARFUnitTest, SwiftProducer) {
   const char *yamldata = R"(
 --- !ELF


### PR DESCRIPTION
The `llvm-gcc` front-end has been EOL'd at least since 2011 (based on some `git` archeology). And Clang/LLVM has been removing references to it ever since.

This patch removes the remaining references to it from LLDB. One benefit of this is that it will allow us to remove the code checking for `DW_AT_decl_file_attributes_are_invalid` and `Supports_DW_AT_APPLE_objc_complete_type`.