### PR TITLE
[Github] Add LLVM Premerge Checks to the watchlist

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -12,7 +12,10 @@ GRAFANA_URL = (
     "https://influx-prod-13-prod-us-east-0.grafana.net/api/v1/push/influx/write"
 )
 GITHUB_PROJECT = "llvm/llvm-project"
-WORKFLOWS_TO_TRACK = ["Check code formatting"]
+WORKFLOWS_TO_TRACK = [
+    "Check code formatting",
+    "LLVM Premerge Checks"
+]
 SCRAPE_INTERVAL_SECONDS = 5 * 60
 
 

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -12,10 +12,7 @@ GRAFANA_URL = (
     "https://influx-prod-13-prod-us-east-0.grafana.net/api/v1/push/influx/write"
 )
 GITHUB_PROJECT = "llvm/llvm-project"
-WORKFLOWS_TO_TRACK = [
-    "Check code formatting",
-    "LLVM Premerge Checks"
-]
+WORKFLOWS_TO_TRACK = ["Check code formatting", "LLVM Premerge Checks"]
 SCRAPE_INTERVAL_SECONDS = 5 * 60
 
 


### PR DESCRIPTION
LLVM Premerge Checks is running on the new GCP cluster. Tracking its metrics will allow us to determine the stability of the presubmit and make sure the new infra is working as intended.