### PR TITLE
[clang] Fix dangling false positives for conditional operators.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -700,6 +700,8 @@ Improvements to Clang's diagnostics
       return ptr + index < ptr; // warning
     }
 
+- Fix -Wdangling false positives on conditional operators (#120206).
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
+++ b/clang/test/Sema/warn-lifetime-analysis-nocfg.cpp
@@ -777,3 +777,32 @@ void test4() {
 }
 
 } // namespace LifetimeboundInterleave
+
+namespace GH120206 {
+struct S {
+  std::string_view s;
+};
+
+struct [[gsl::Owner]] Q1 {
+  const S* get() const [[clang::lifetimebound]];
+};
+std::string_view test1(int c, std::string_view sv) {
+  std::string_view k = c > 1 ? Q1().get()->s : sv;
+  if (c == 1)
+    return  c > 1 ? Q1().get()->s : sv;
+  Q1 q;
+  return c > 1 ? q.get()->s : sv;
+}
+
+struct Q2 {
+  const S* get() const [[clang::lifetimebound]];
+};
+std::string_view test2(int c, std::string_view sv) {
+  std::string_view k = c > 1 ? Q2().get()->s : sv;
+  if (c == 1)
+    return c > 1 ? Q2().get()->s : sv;
+  Q2 q;
+  return c > 1 ? q.get()->s : sv;
+}
+
+} // namespace GH120206


### PR DESCRIPTION
When analyzing a dangling gsl pointer, we currently filter out all field access `MemberExpr` to avoid common false positives (`string_view sv = Temp().sv`), However, this filter only applies to direct MemberExpr instances, leaving the conditional operator as an escaping example (`GSLPointer pointer(Cond ? Owner().ptr : GSLPointer());`).

This patch extends the MemberExpr logic to handle the conditional operator. The heuristic is intentionally simple, which may result in some false negatives. However, it effectively covers common cases like `std::string_view sv = cond ? "123" : std::string();`, which is a reasonable trade-off.

Fixes https://github.com/llvm/llvm-project/issues/120206