### PR TITLE
[libc++] Bump the version of CMake built in the CI Docker image

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -160,7 +160,7 @@ EOF
 RUN <<EOF
     # Install a recent CMake
     set -e
-    wget https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1-linux-x86_64.sh -O /tmp/install-cmake.sh
+    wget https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3.24.4-linux-x86_64.sh -O /tmp/install-cmake.sh
     sudo bash /tmp/install-cmake.sh --prefix=/usr --exclude-subdir --skip-license
     rm /tmp/install-cmake.sh
 EOF


### PR DESCRIPTION
This will allow using the $<LINK_LIBRARY> generator expression in some of our configurations. We should separately pursue officially bumping the minimum CMake version across all LLVM so we can use this feature more widely.