### PR TITLE
[RISCV] Fix typo in CV_SH_rr_inc pattern

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -698,7 +698,7 @@ let Predicates = [HasVendorXCVmem, IsRV32], AddedComplexity = 1 in {
   def : CVStriPat<post_store, CV_SW_ri_inc>;
 
   def : CVStrriPat<post_truncsti8, CV_SB_rr_inc>;
-  def : CVStrriPat<post_truncsti16, CV_SH_ri_inc>;
+  def : CVStrriPat<post_truncsti16, CV_SH_rr_inc>;
   def : CVStrriPat<post_store, CV_SW_rr_inc>;
 
   def : CVStrrPat<truncstorei8, CV_SB_rr>;


### PR DESCRIPTION
This typo in https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td#L701:L701 caused a compiler crash in 'RISC-V Assembly Printer' because CV_SH_ri_inc was selected, leading to `getImmOpValue` being called for a register operand.

This bug did not affect the Assembler output and therefore does not trigger any existing unit tests, but is visible by examining the final MIR function.

I came up with a minimal test, but I am unsure how to integrate this into [llvm/test/CodeGen/RISCV/xcvmem.ll](https://github.com/llvm/llvm-project/blob/main/llvm/test/CodeGen/RISCV/xcvmem.ll) while still using `utils/update_llc_test_checks.py`. I would be happy I you could provide a hint on how both `CHECK_ASM` as well as `CHECK_MIR` lines could be generated automatically in the same test.
```ll
; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
; RUN: llc -O3 -mtriple=riscv32 -mattr=+xcvmem -verify-machineinstrs -stop-after=instruction-select < %s \
; RUN:   | FileCheck %s --check-prefixes=CHECK_MIR

define i16* @sh_ri_inc(i16* %a, i16 %b) {
; CHECK_MIR: CV_SH_ri_inc
  store i16 %b, i16* %a
  %1 = getelementptr i16, i16* %a, i32 42
  ret i16* %1
}

define i16* @sh_rr_inc(i16* %a, i16 %b, i32 %c) {
; CHECK_MIR: CV_SH_rr_inc
  store i16 %b, i16* %a
  %1 = getelementptr i16, i16* %a, i32 %c
  ret i16* %1
}
```
