### PR TITLE
[libc][fenv] Use trivial place-holder implementation for i386 in FEnvImpl.h until it's fully supported.

### DIFF
--- a/libc/src/__support/FPUtil/FEnvImpl.h
+++ b/libc/src/__support/FPUtil/FEnvImpl.h
@@ -27,7 +27,7 @@
 // The extra !defined(APPLE) condition is to cause x86_64 MacOS builds to use
 // the dummy implementations below. Once a proper x86_64 darwin fenv is set up,
 // the apple condition here should be removed.
-#elif defined(LIBC_TARGET_ARCH_IS_X86) && !defined(__APPLE__)
+#elif defined(LIBC_TARGET_ARCH_IS_X86_64) && !defined(__APPLE__)
 #include "x86_64/FEnvImpl.h"
 #elif defined(LIBC_TARGET_ARCH_IS_ARM) && defined(__ARM_FP)
 #include "arm/FEnvImpl.h"

--- a/libc/test/UnitTest/FEnvSafeTest.cpp
+++ b/libc/test/UnitTest/FEnvSafeTest.cpp
@@ -45,7 +45,7 @@ void FEnvSafeTest::expect_fenv_eq(const fenv_t &before_fenv,
   EXPECT_EQ(before_state.ControlWord, after_state.ControlWord);
   EXPECT_EQ(before_state.StatusWord, after_state.StatusWord);
 
-#elif defined(LIBC_TARGET_ARCH_IS_X86) && !defined(__APPLE__)
+#elif defined(LIBC_TARGET_ARCH_IS_X86_64) && !defined(__APPLE__)
   using LIBC_NAMESPACE::fputil::internal::FPState;
   const FPState &before_state = reinterpret_cast<const FPState &>(before_fenv);
   const FPState &after_state = reinterpret_cast<const FPState &>(after_fenv);


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/118964
