### PR TITLE
[NFC][Clang] Fix static analyzer concerns

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -119,7 +119,6 @@ public:
              (isTargetAddressSpace(A) &&
               toTargetAddressSpace(A) == llvm::AMDGPUAS::FLAT_ADDRESS)) &&
             isTargetAddressSpace(B) &&
-            toTargetAddressSpace(B) >= llvm::AMDGPUAS::FLAT_ADDRESS &&
             toTargetAddressSpace(B) <= llvm::AMDGPUAS::PRIVATE_ADDRESS &&
             toTargetAddressSpace(B) != llvm::AMDGPUAS::REGION_ADDRESS);
   }

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -99,7 +99,6 @@ public:
               toTargetAddressSpace(A) ==
                   llvm::NVPTXAS::ADDRESS_SPACE_GENERIC)) &&
             isTargetAddressSpace(B) &&
-            toTargetAddressSpace(B) >= llvm::NVPTXAS::ADDRESS_SPACE_GENERIC &&
             toTargetAddressSpace(B) <= llvm::NVPTXAS::ADDRESS_SPACE_LOCAL &&
             toTargetAddressSpace(B) != 2);
   }


### PR DESCRIPTION
Remove unnecessary checks since they are checking that an unsigned number >= 0, which is always true.