### PR TITLE
[Driver][SPIR-V] Use consistent tools to convert between text and binary form

### DIFF
--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -26,13 +26,10 @@ void SPIRV::constructTranslateCommand(Compilation &C, const Tool &T,
   llvm::opt::ArgStringList CmdArgs(Args);
   CmdArgs.push_back(Input.getFilename());
 
-  if (Input.getType() == types::TY_PP_Asm)
-    CmdArgs.push_back("-to-binary");
+  assert(Input.getType() != types::TY_PP_Asm && "Unexpected input type");
 
-  // The text output from spirv-dis is not in the format expected
-  // by llvm-spirv, so use the text output from llvm-spirv.
   if (Output.getType() == types::TY_PP_Asm)
-    CmdArgs.push_back("-to-text");
+    CmdArgs.push_back("--spirv-tools-dis");
 
   CmdArgs.append({"-o", Output.getFilename()});
 
@@ -43,6 +40,31 @@ void SPIRV::constructTranslateCommand(Compilation &C, const Tool &T,
   std::string ExeCand = T.getToolChain().GetProgramPath(VersionedTool.c_str());
   if (!llvm::sys::fs::can_execute(ExeCand))
     ExeCand = T.getToolChain().GetProgramPath("llvm-spirv");
+
+  const char *Exec = C.getArgs().MakeArgString(ExeCand);
+  C.addCommand(std::make_unique<Command>(JA, T, ResponseFileSupport::None(),
+                                         Exec, CmdArgs, Input, Output));
+}
+
+void SPIRV::constructAssembleCommand(Compilation &C, const Tool &T,
+                                     const JobAction &JA,
+                                     const InputInfo &Output,
+                                     const InputInfo &Input,
+                                     const llvm::opt::ArgStringList &Args) {
+  llvm::opt::ArgStringList CmdArgs(Args);
+  CmdArgs.push_back(Input.getFilename());
+
+  assert(Input.getType() == types::TY_PP_Asm && "Unexpected input type");
+
+  CmdArgs.append({"-o", Output.getFilename()});
+
+  // Try to find "spirv-as-<LLVM_VERSION_MAJOR>". Otherwise, fall back to
+  // plain "spirv-as".
+  using namespace std::string_literals;
+  auto VersionedTool = "spirv-as-"s + std::to_string(LLVM_VERSION_MAJOR);
+  std::string ExeCand = T.getToolChain().GetProgramPath(VersionedTool.c_str());
+  if (!llvm::sys::fs::can_execute(ExeCand))
+    ExeCand = T.getToolChain().GetProgramPath("spirv-as");
 
   const char *Exec = C.getArgs().MakeArgString(ExeCand);
   C.addCommand(std::make_unique<Command>(JA, T, ResponseFileSupport::None(),
@@ -60,10 +82,27 @@ void SPIRV::Translator::ConstructJob(Compilation &C, const JobAction &JA,
   constructTranslateCommand(C, *this, JA, Output, Inputs[0], {});
 }
 
+void SPIRV::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
+                                    const InputInfo &Output,
+                                    const InputInfoList &Inputs,
+                                    const ArgList &Args,
+                                    const char *AssembleOutput) const {
+  claimNoWarnArgs(Args);
+  if (Inputs.size() != 1)
+    llvm_unreachable("Invalid number of input files.");
+  constructAssembleCommand(C, *this, JA, Output, Inputs[0], {});
+}
+
 clang::driver::Tool *SPIRVToolChain::getTranslator() const {
   if (!Translator)
     Translator = std::make_unique<SPIRV::Translator>(*this);
   return Translator.get();
+}
+
+clang::driver::Tool *SPIRVToolChain::getAssembler() const {
+  if (!Assembler)
+    Assembler = std::make_unique<SPIRV::Assembler>(*this);
+  return Assembler.get();
 }
 
 clang::driver::Tool *SPIRVToolChain::SelectTool(const JobAction &JA) const {
@@ -76,8 +115,9 @@ clang::driver::Tool *SPIRVToolChain::getTool(Action::ActionClass AC) const {
   default:
     break;
   case Action::BackendJobClass:
-  case Action::AssembleJobClass:
     return SPIRVToolChain::getTranslator();
+  case Action::AssembleJobClass:
+    return SPIRVToolChain::getAssembler();
   }
   return ToolChain::getTool(AC);
 }

--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -28,8 +28,11 @@ void SPIRV::constructTranslateCommand(Compilation &C, const Tool &T,
 
   if (Input.getType() == types::TY_PP_Asm)
     CmdArgs.push_back("-to-binary");
+
+  // The text output from spirv-dis is not in the format expected
+  // by llvm-spirv, so use the text output from llvm-spirv.
   if (Output.getType() == types::TY_PP_Asm)
-    CmdArgs.push_back("--spirv-tools-dis");
+    CmdArgs.push_back("-to-text");
 
   CmdArgs.append({"-o", Output.getFilename()});
 

--- a/clang/lib/Driver/ToolChains/SPIRV.h
+++ b/clang/lib/Driver/ToolChains/SPIRV.h
@@ -22,6 +22,11 @@ void constructTranslateCommand(Compilation &C, const Tool &T,
                                const InputInfo &Input,
                                const llvm::opt::ArgStringList &Args);
 
+void constructAssembleCommand(Compilation &C, const Tool &T,
+                              const JobAction &JA, const InputInfo &Output,
+                              const InputInfo &Input,
+                              const llvm::opt::ArgStringList &Args);
+
 class LLVM_LIBRARY_VISIBILITY Translator : public Tool {
 public:
   Translator(const ToolChain &TC)
@@ -47,6 +52,17 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+class LLVM_LIBRARY_VISIBILITY Assembler final : public Tool {
+public:
+  Assembler(const ToolChain &TC) : Tool("SPIRV::Assembler", "spirv-as", TC) {}
+  bool hasIntegratedAssembler() const override { return false; }
+  bool hasIntegratedCPP() const override { return false; }
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *AssembleOutput) const override;
+};
+
 } // namespace SPIRV
 } // namespace tools
 
@@ -54,6 +70,7 @@ namespace toolchains {
 
 class LLVM_LIBRARY_VISIBILITY SPIRVToolChain final : public ToolChain {
   mutable std::unique_ptr<Tool> Translator;
+  mutable std::unique_ptr<Tool> Assembler;
 
 public:
   SPIRVToolChain(const Driver &D, const llvm::Triple &Triple,
@@ -81,6 +98,8 @@ protected:
 
 private:
   clang::driver::Tool *getTranslator() const;
+  clang::driver::Tool *getAssembler() const;
+
   bool NativeLLVMSupport;
 };
 

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -28,7 +28,7 @@
 
 // SPT64: "-cc1" "-triple" "spirv64"
 // SPT64-SAME: "-o" [[BC:".*bc"]]
-// SPT64: {{llvm-spirv.*"}} [[BC]] "-to-text" "-o" {{".*s"}}
+// SPT64: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" {{".*s"}}
 
 // RUN: %clang -### --target=spirv32 -x cl -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
 // RUN: %clang -### --target=spirv32 -x ir -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
@@ -37,13 +37,13 @@
 
 // SPT32: "-cc1" "-triple" "spirv32"
 // SPT32-SAME: "-o" [[BC:".*bc"]]
-// SPT32: {{llvm-spirv.*"}} [[BC]] "-to-text" "-o" {{".*s"}}
+// SPT32: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" {{".*s"}}
 
 //-----------------------------------------------------------------------------
 // Check assembly input -> object output
 // RUN: %clang -### --target=spirv64 -x assembler -c %s 2>&1 | FileCheck --check-prefix=ASM %s
 // RUN: %clang -### --target=spirv32 -x assembler -c %s 2>&1 | FileCheck --check-prefix=ASM %s
-// ASM: {{llvm-spirv.*"}} {{".*"}} "-to-binary" "-o" {{".*o"}}
+// ASM: {{spirv-as.*"}} {{".*"}} "-o" {{".*o"}}
 
 //-----------------------------------------------------------------------------
 // Check --save-temps.
@@ -55,8 +55,8 @@
 // TMP: "-cc1" "-triple" "spirv64"
 // TMP-SAME: "-o" [[BC:".*bc"]]
 // TMP-SAME: [[I]]
-// TMP: {{llvm-spirv.*"}} [[BC]] "-to-text" "-o" [[S:".*s"]]
-// TMP: {{llvm-spirv.*"}} [[S]] "-to-binary" "-o" {{".*o"}}
+// TMP: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" [[S:".*s"]]
+// TMP: {{spirv-as.*"}} [[S]] "-o" {{".*o"}}
 
 //-----------------------------------------------------------------------------
 // Check linking when multiple input files are passed.

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -28,7 +28,7 @@
 
 // SPT64: "-cc1" "-triple" "spirv64"
 // SPT64-SAME: "-o" [[BC:".*bc"]]
-// SPT64: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" {{".*s"}}
+// SPT64: {{llvm-spirv.*"}} [[BC]] "-to-text" "-o" {{".*s"}}
 
 // RUN: %clang -### --target=spirv32 -x cl -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
 // RUN: %clang -### --target=spirv32 -x ir -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
@@ -37,7 +37,7 @@
 
 // SPT32: "-cc1" "-triple" "spirv32"
 // SPT32-SAME: "-o" [[BC:".*bc"]]
-// SPT32: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" {{".*s"}}
+// SPT32: {{llvm-spirv.*"}} [[BC]] "-to-text" "-o" {{".*s"}}
 
 //-----------------------------------------------------------------------------
 // Check assembly input -> object output
@@ -55,7 +55,7 @@
 // TMP: "-cc1" "-triple" "spirv64"
 // TMP-SAME: "-o" [[BC:".*bc"]]
 // TMP-SAME: [[I]]
-// TMP: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" [[S:".*s"]]
+// TMP: {{llvm-spirv.*"}} [[BC]] "-to-text" "-o" [[S:".*s"]]
 // TMP: {{llvm-spirv.*"}} [[S]] "-to-binary" "-o" {{".*o"}}
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Currently we produce SPIR-V text with `spirv-dis` but assemble it with `llvm-spirv`. The SPIR-V text format is different between the tools so the assemble fails. Use `spirv-as` for assembly as it uses the same format.
