### PR TITLE
Fix-forward 'RegAllocFast: Avoid using temporary DiagnosticInfo #120184'

### DIFF
--- a/llvm/lib/CodeGen/RegAllocFast.cpp
+++ b/llvm/lib/CodeGen/RegAllocFast.cpp
@@ -1187,10 +1187,9 @@ MCPhysReg RegAllocFastImpl::getErrorAssignment(const LiveReg &LR,
   if (AllocationOrder.empty()) {
     const Function &Fn = MF.getFunction();
     if (EmitError) {
-      DiagnosticInfoRegAllocFailure DI(
+      Fn.getContext().diagnose(DiagnosticInfoRegAllocFailure(
           "no registers from class available to allocate", Fn,
-          MI.getDebugLoc());
-      Fn.getContext().diagnose(DI);
+          MI.getDebugLoc()));
     }
 
     ArrayRef<MCPhysReg> RawRegs = RC.getRegisters();


### PR DESCRIPTION
There was a buildbot breakage
(https://lab.llvm.org/buildbot/#/builders/24/builds/3329/steps/11/logs/stdio):

/home/b/sanitizer-aarch64-linux-bootstrap-asan/build/llvm-project/llvm/test/CodeGen/AMDGPU/ran-out-of-registers-error-all-regs-reserved.ll:9:10: error: CHECK: expected string not found in input
; CHECK: error: <unknown>:0:0: no registers from class available to allocate in function 'no_registers_from_class_available_to_allocate'

2: ==75198==ERROR: AddressSanitizer: stack-use-after-scope on address 0xfa23f9f1c270 at pc 0xb2660dda9340 bp 0xfffffe8ab340 sp 0xfffffe8ab338

caused by https://github.com/llvm/llvm-project/pull/120184, which made a partial fix but also renabled the tests. This patch attempts to fix forward by applying the same fix to the error message highlighted in the buildbot.