### PR TITLE
[libc][docs] add redirect for math/index.html

### DIFF
--- a/libc/docs/conf.py
+++ b/libc/docs/conf.py
@@ -25,11 +25,7 @@ from datetime import date
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = [
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.todo",
-    "sphinx_reredirects"
-]
+extensions = ["sphinx.ext.intersphinx", "sphinx.ext.todo", "sphinx_reredirects"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -266,6 +262,4 @@ intersphinx_mapping = {}
 # Enable this if you want TODOs to show up in the generated documentation.
 todo_include_todos = True
 
-redirects = {
-  "math/index": "../headers/math/index.html"
-}
+redirects = {"math/index": "../headers/math/index.html"}

--- a/libc/docs/conf.py
+++ b/libc/docs/conf.py
@@ -25,7 +25,11 @@ from datetime import date
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.intersphinx", "sphinx.ext.todo"]
+extensions = [
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx_reredirects"
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -261,3 +265,7 @@ intersphinx_mapping = {}
 
 # Enable this if you want TODOs to show up in the generated documentation.
 todo_include_todos = True
+
+redirects = {
+  "math/index": "../headers/math/index.html"
+}

--- a/llvm/docs/requirements.txt
+++ b/llvm/docs/requirements.txt
@@ -5,6 +5,6 @@ recommonmark==0.7.1
 sphinx-automodapi==0.17.0
 sphinx-bootstrap-theme==0.8.1
 sphinxcontrib-applehelp==1.0.8
-sphinx-redirects==0.1.2
+sphinx-reredirects==0.1.2
 furo==2024.1.29
 myst-parser==2.0.0

--- a/llvm/docs/requirements.txt
+++ b/llvm/docs/requirements.txt
@@ -5,5 +5,6 @@ recommonmark==0.7.1
 sphinx-automodapi==0.17.0
 sphinx-bootstrap-theme==0.8.1
 sphinxcontrib-applehelp==1.0.8
+sphinx-redirects==0.1.2
 furo==2024.1.29
 myst-parser==2.0.0


### PR DESCRIPTION
commit a9aff440d9dd ("[libc][docs] reorganize documentation (#118836)")

moved https://libc.llvm.org/math/index.html to
https://libc.llvm.org/headers/math/index.html which makes links from various
slide decks stale.

There's an extension for sphinx that can generate redirects.  Add a dependency
on that, then use it to create a redirect so that those older links still work.

I was able to install this sphinx extension via:

    $ sudo apt install python3-sphinx-reredirects

We may need to install this on whatever server generates the llvm
documentation.
