### PR TITLE
[AIX] fix unsupported diff flag on AIX (-strip-trailing-cr)

### DIFF
--- a/clang/test/Format/lit.local.cfg
+++ b/clang/test/Format/lit.local.cfg
@@ -1,3 +1,6 @@
+import platform
+import lit.formats
+
 # Suffixes supported by clang-format.
 config.suffixes = [
     ".c",
@@ -19,3 +22,8 @@ config.suffixes = [
     ".td",
     ".test"
 ]
+
+# AIX 'diff' command doesn't support --strip-trailing-cr, but the internal
+# python implementation does, so use that for cross platform compatibility
+if platform.system() == "AIX":
+    config.test_format = lit.formats.ShTest()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/119666 adds the `-strip-trailing-cr` flag to diff which is not supported on AIX switch to use the python implementation of diff instead