### PR TITLE
[lldb][test] Add test-coverage for DW_AT_APPLE_objc_complete_type parsing

### DIFF
--- a/lldb/test/Shell/Expr/TestObjCHiddenIvars.test
+++ b/lldb/test/Shell/Expr/TestObjCHiddenIvars.test
@@ -1,3 +1,5 @@
+# REQUIRES: system-darwin
+#
 # Tests that LLDB correctly finds the implementation
 # DIE (with a `DW_AT_APPLE_objc_complete_type`)
 # given an interface DIE (without said attribute).

--- a/lldb/test/Shell/Expr/TestObjCHiddenIvars.test
+++ b/lldb/test/Shell/Expr/TestObjCHiddenIvars.test
@@ -1,0 +1,63 @@
+# Tests that LLDB correctly finds the implementation
+# DIE (with a `DW_AT_APPLE_objc_complete_type`)
+# given an interface DIE (without said attribute).
+#
+# RUN: split-file %s %t
+# RUN: %clangxx_host %t/lib.m  -c -g -o %t/lib.o
+# RUN: %clangxx_host %t/main.m -c -g -o %t/main.o
+# RUN: %clangxx_host %t/main.o %t/lib.o -o %t/a.out -framework Foundation
+#
+# RUN: %lldb %t/a.out \
+# RUN:       -o "breakpoint set -p 'return' -X main" \
+# RUN:       -o run \
+# RUN:       -o "expression *f" \
+# RUN:       -o exit | FileCheck %s
+
+# CHECK:      (lldb) expression *f
+# CHECK:      (Foo) ${{[0-9]+}} = {
+# CHECK:         y = 2 
+# CHECK-NEXT:    i = 1 
+
+#--- main.m
+#import <Foundation/Foundation.h>
+#import "lib.h"
+
+extern Foo * func();
+
+int main() {
+    Foo * f = func();
+    return 0;
+}
+
+#--- lib.m
+#import <Foundation/Foundation.h>
+#import "lib.h"
+
+@implementation Foo {
+int i;
+}
+
+- (id)init {
+  self->i = 1;
+  self->y = 2;
+
+  return self;
+}
+@end
+
+Foo * func() {
+  return [[Foo alloc] init];
+}
+
+#--- lib.h
+#ifndef LIB_H_IN
+#define LIB_H_IN
+
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject {
+int y;
+}
+@end
+
+#endif  // _H_IN


### PR DESCRIPTION
When given a DIE for an Objective-C interface (which doesn't have a `DW_AT_APPLE_objc_complete_type`), the `DWARFASTParserClang` will try to find the DIE which corresponds to the implementation to complete the interface DIE. The code is here:
https://github.com/llvm/llvm-project/blob/d2e7ee77d33e8b3be3b1d4e9bc5bc4c60b62b554/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp#L1718-L1738

However, this was currently not exercised in our test-suite (removing the code above didn't fail any LLDB test).

This patch adds a test which exercises this codepath (it will fail if we don't fetch the implementation DIE in the `DWARFASTParserClang`).

Something that's not currently clear to me is why `frame var *f` succeeds even without the `DW_AT_APPLE_objc_complete_type` infrastructure. If it's using the ObjC runtime, we should make `expr` do the same, in which case we can remove this code from `DWARFASTParserClang`.