### PR TITLE
[MTE] [NFC] use vector to collect globals to tag

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2444,11 +2444,14 @@ bool AsmPrinter::doFinalization(Module &M) {
   // we can conditionalize accesses based on whether or not it is nullptr.
   MF = nullptr;
 
-  for (GlobalVariable &G : make_early_inc_range(M.globals())) {
+  std::vector<GlobalVariable*> GlobalsToTag;
+  for (GlobalVariable &G : M.globals()) {
     if (G.isDeclaration() || !G.isTagged())
       continue;
-    tagGlobalDefinition(M, &G);
+    GlobalsToTag.push_back(&G);
   }
+  for (GlobalVariable* G : GlobalsToTag)
+    tagGlobalDefinition(M, G);
 
   // Gather all GOT equivalent globals in the module. We really need two
   // passes over the globals: one to compute and another to avoid its emission

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2444,13 +2444,13 @@ bool AsmPrinter::doFinalization(Module &M) {
   // we can conditionalize accesses based on whether or not it is nullptr.
   MF = nullptr;
 
-  std::vector<GlobalVariable*> GlobalsToTag;
+  std::vector<GlobalVariable *> GlobalsToTag;
   for (GlobalVariable &G : M.globals()) {
     if (G.isDeclaration() || !G.isTagged())
       continue;
     GlobalsToTag.push_back(&G);
   }
-  for (GlobalVariable* G : GlobalsToTag)
+  for (GlobalVariable *G : GlobalsToTag)
     tagGlobalDefinition(M, G);
 
   // Gather all GOT equivalent globals in the module. We really need two


### PR DESCRIPTION
The same pattern caused test failures in the HWASan pass, so is brittle.
Let's go for the easier approach.
