### PR TITLE
[flang][cuda] Apply implict data attribute to local arrays

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -8973,12 +8973,12 @@ void ResolveNamesVisitor::FinishSpecificationPart(
     if (NeedsExplicitType(symbol)) {
       ApplyImplicitRules(symbol);
     }
-    if (inDeviceSubprogram && IsDummy(symbol) &&
-        symbol.has<ObjectEntityDetails>()) {
-      auto *dummy{symbol.detailsIf<ObjectEntityDetails>()};
-      if (!dummy->cudaDataAttr() && !IsValue(symbol)) {
+    if (inDeviceSubprogram && symbol.has<ObjectEntityDetails>()) {
+      auto *object{symbol.detailsIf<ObjectEntityDetails>()};
+      if (!object->cudaDataAttr() && !IsValue(symbol) &&
+          (IsDummy(symbol) || object->IsArray())) {
         // Implicitly set device attribute if none is set in device context.
-        dummy->set_cudaDataAttr(common::CUDADataAttr::Device);
+        object->set_cudaDataAttr(common::CUDADataAttr::Device);
       }
     }
     if (IsDummy(symbol) && isImplicitNoneType() &&

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -22,6 +22,12 @@ module m
     !ERROR: Host array 'm' cannot be present in device context
     if (i .le. N) a(i) = m(i)
   end subroutine
+
+  attributes(global) subroutine localarray()
+    integer :: a(10)
+    i = threadIdx%x
+    a(i) = i
+  end subroutine
 end
 
 program main


### PR DESCRIPTION
Add the implicit data attribute to local arrays that don't have one. This simplifies the host array detection in semantic. 