### PR TITLE
flang: fix backtrace build on FreeBSD

### DIFF
--- a/flang/runtime/stop.cpp
+++ b/flang/runtime/stop.cpp
@@ -162,7 +162,7 @@ static void PrintBacktrace() {
   // TODO: Need to parse DWARF information to print function line numbers
   constexpr int MAX_CALL_STACK{999};
   void *buffer[MAX_CALL_STACK];
-  int nptrs{backtrace(buffer, MAX_CALL_STACK)};
+  int nptrs{(int)backtrace(buffer, MAX_CALL_STACK)};
 
   if (char **symbols{backtrace_symbols(buffer, nptrs)}) {
     for (int i = 0; i < nptrs; i++) {


### PR DESCRIPTION
FreeBSD's libexecinfo defines backtrace with a size_t for the size argument and return type.  This almost certainly doesn't make sense, but what's done is done so cast the output to allow compilation. Otherwise we get:

.../flang/runtime/stop.cpp:165:13: error: non-constant-expression cannot be narrowed from type 'size_t' (aka 'unsigned long') to 'int' in initializer list [-Wc++11-narrowing]
  165 |   int nptrs{backtrace(buffer, MAX_CALL_STACK)};
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~