### PR TITLE
[libc] Enable 'timespec_get' for the GPU build

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -257,6 +257,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # time.h entrypoints
     libc.src.time.clock
     libc.src.time.clock_gettime
+    libc.src.time.timespec_get
     libc.src.time.nanosleep
 
     # wchar.h entrypoints

--- a/libc/src/__support/time/gpu/time_utils.h
+++ b/libc/src/__support/time/gpu/time_utils.h
@@ -38,6 +38,8 @@ extern gpu::Constant<uint64_t> __llvm_libc_clock_freq;
 #error "Unsupported target"
 #endif
 
+constexpr uint64_t TICKS_PER_SEC = 1000000000UL;
+
 } // namespace LIBC_NAMESPACE_DECL
 
 #endif // LLVM_LIBC_SRC_TIME_GPU_TIME_UTILS_H

--- a/libc/src/time/gpu/nanosleep.cpp
+++ b/libc/src/time/gpu/nanosleep.cpp
@@ -13,8 +13,6 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-constexpr uint64_t TICKS_PER_SEC = 1000000000UL;
-
 LLVM_LIBC_FUNCTION(int, nanosleep,
                    (const struct timespec *req, struct timespec *rem)) {
   if (!GPU_CLOCKS_PER_SEC || !req)

--- a/libc/src/time/gpu/timespec_get.cpp
+++ b/libc/src/time/gpu/timespec_get.cpp
@@ -10,6 +10,7 @@
 #include "hdr/time_macros.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
+#include "src/__support/time/gpu/time_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 


### PR DESCRIPTION
Summary:
Currently fails to build libc++ because this is missing.
