### PR TITLE
[flang][cuda] Do not consider SHARED array as host array

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -114,6 +114,7 @@ struct FindHostArray
               (details->cudaDataAttr() &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Device &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Managed &&
+                  *details->cudaDataAttr() != common::CUDADataAttr::Shared &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Unified))) {
         return &symbol;
       }

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -28,6 +28,13 @@ module m
     i = threadIdx%x
     a(i) = i
   end subroutine
+
+  attributes(global) subroutine sharedarray(a)
+    integer, device :: a(10)
+    integer, shared :: s(10)
+    i = threadIdx%x
+    a(i) = s(10) ! ok, a is device and s is shared
+  end subroutine
 end
 
 program main


### PR DESCRIPTION
Update the current `FindHostArray` to not return shared array as host array. 