### PR TITLE
[compiler-rt] Work around a warning from -Wgnu-anonymous-struct

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -601,11 +601,7 @@ struct __sanitizer_siginfo_pad {
 #if SANITIZER_LINUX
 # define SANITIZER_HAS_SIGINFO 1
 union __sanitizer_siginfo {
-# ifdef __clang__
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
-# endif
-  struct {
+  __extension__ struct {
     int si_signo;
 # if SANITIZER_MIPS
     int si_code;
@@ -615,9 +611,6 @@ union __sanitizer_siginfo {
     int si_code;
 # endif
   };
-# ifdef __clang__
-#  pragma clang diagnostic pop
-# endif
   __sanitizer_siginfo_pad pad;
 };
 #else

--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
@@ -601,6 +601,10 @@ struct __sanitizer_siginfo_pad {
 #if SANITIZER_LINUX
 # define SANITIZER_HAS_SIGINFO 1
 union __sanitizer_siginfo {
+# ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+# endif
   struct {
     int si_signo;
 # if SANITIZER_MIPS
@@ -611,6 +615,9 @@ union __sanitizer_siginfo {
     int si_code;
 # endif
   };
+# ifdef __clang__
+#  pragma clang diagnostic pop
+# endif
   __sanitizer_siginfo_pad pad;
 };
 #else


### PR DESCRIPTION
This patch works around:

  compiler-rt/lib/tysan/../sanitizer_common/sanitizer_platform_limits_posix.h:604:3:
  error: anonymous structs are a GNU extension
  [-Werror,-Wgnu-anonymous-struct]
