### PR TITLE
[Github] Use hashed dependencies in docs job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -106,9 +106,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: 'llvm/docs/requirements.txt'
+          cache-dependency-path: 'llvm/docs/requirements-hashed.txt'
       - name: Install python dependencies
-        run: pip install -r llvm/docs/requirements.txt
+        run: pip install -r llvm/docs/requirements-hashed.txt
       - name: Install system dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
This patch forces the docs test build job to use the hashed dpendencies file rather than the normal requirements.txt. This ensures that we get the exact transitive closure specified rather than whatever the dependency solver feels like it should use in the CI job.