### PR TITLE
[flang] Ignore -f[no-]realloc-lhs.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3465,7 +3465,7 @@ defm diagnostics_show_line_numbers : BoolFOption<"diagnostics-show-line-numbers"
   PosFlag<SetTrue>>;
 def fno_realloc_lhs : Flag<["-"], "fno-realloc-lhs">, Group<f_Group>,
   HelpText<"An allocatable left-hand side of an intrinsic assignment is assumed to be allocated and match the shape/type of the right-hand side">,
-  Visibility<[FlangOption, FC1Option]>;
+  Visibility<[ClangOption, CLOption, FlangOption, FC1Option]>;
 def fno_stack_protector : Flag<["-"], "fno-stack-protector">, Group<f_Group>,
   HelpText<"Disable the use of stack protectors">;
 def fno_strict_aliasing : Flag<["-"], "fno-strict-aliasing">, Group<f_Group>,
@@ -4300,7 +4300,7 @@ defm stack_size_section : BoolFOption<"stack-size-section",
           "Emit section containing metadata on function stack sizes">,
   NegFlag<SetFalse>>;
 def frealloc_lhs : Flag<["-"], "frealloc-lhs">, Group<f_Group>,
-  Visibility<[FlangOption, FC1Option]>,
+  Visibility<[ClangOption, CLOption, FlangOption, FC1Option]>,
   HelpText<"If an allocatable left-hand side of an intrinsic assignment is unallocated or its shape/type does not match the right-hand side, then it is automatically (re)allocated">;
 def fstack_usage : Flag<["-"], "fstack-usage">, Group<f_Group>,
   HelpText<"Emit .su file containing information on function stack sizes">;

--- a/clang/test/Driver/frealloc-lhs.cpp
+++ b/clang/test/Driver/frealloc-lhs.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang -Wunused-command-line-argument -frealloc-lhs -### %s 2> %t
+// RUN: FileCheck < %t %s --check-prefix=REALLOCLHS
+// RUN: %clang -Wunused-command-line-argument -fno-realloc-lhs -### %s 2> %t
+// RUN: FileCheck < %t %s --check-prefix=NOREALLOCLHS
+
+// CHECK: argument unused during compilation: '-frealloc-lhs'
+// CHECK: argument unused during compilation: '-fno-realloc-lhs'


### PR DESCRIPTION
After #120165 clang started complaining about unknown
option -f[no-]realloc-lhs. This change fixes it to ignore
the option like it used to be.
