### PR TITLE
[SYCL] Basic diagnostics for the sycl_kernel_entry_point attribute.

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -3360,6 +3360,16 @@ public:
   /// this function.
   void registerSYCLEntryPointFunction(FunctionDecl *FD);
 
+  /// Given a type used as a SYCL kernel name, returns a reference to the
+  /// metadata generated from the corresponding SYCL kernel entry point.
+  /// Aborts if the provided type is not a registered SYCL kernel name.
+  const SYCLKernelInfo &getSYCLKernelInfo(QualType T) const;
+
+  /// Returns a pointer to the metadata generated from the corresponding
+  /// SYCLkernel entry point if the provided type corresponds to a registered
+  /// SYCL kernel name. Returns a null pointer otherwise.
+  const SYCLKernelInfo *findSYCLKernelInfo(QualType T) const;
+
   //===--------------------------------------------------------------------===//
   //                    Statistics
   //===--------------------------------------------------------------------===//

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1516,11 +1516,22 @@ def SYCLKernel : InheritableAttr {
 
 def SYCLKernelEntryPoint : InheritableAttr {
   let Spellings = [Clang<"sycl_kernel_entry_point">];
-  let Args = [TypeArgument<"KernelName">];
+  let Args = [
+    // KernelName is required and specifies the kernel name type.
+    TypeArgument<"KernelName">,
+    // InvalidAttr is a fake argument used to track whether the
+    // semantic requirements of the attribute have been satisified.
+    // A fake argument is used to enable serialization support.
+    DefaultBoolArgument<"Invalid", /*default=*/0, /*fake=*/1>
+  ];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let TemplateDependent = 1;
   let LangOpts = [SYCLHost, SYCLDevice];
   let Documentation = [SYCLKernelEntryPointDocs];
+  let AdditionalMembers = [{
+    void setInvalidAttr() { invalid = true; }
+    bool isInvalidAttr() const { return invalid; }
+  }];
 }
 
 def SYCLSpecialClass: InheritableAttr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -475,7 +475,7 @@ not first appear on a declaration that follows a definition of the function.
 The attribute only appertains to functions and only those that meet the
 following requirements.
 
-* Has a ``void`` return type.
+* Has a non-deduced ``void`` return type.
 * Is not a non-static member function, constructor, or destructor.
 * Is not a C variadic function.
 * Is not a coroutine.

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -648,6 +648,7 @@ def PoundPragmaMessage : DiagGroup<"#pragma-messages">,
 def : DiagGroup<"redundant-decls">;
 def RedeclaredClassMember : DiagGroup<"redeclared-class-member">;
 def GNURedeclaredEnum : DiagGroup<"gnu-redeclared-enum">;
+def RedundantAttribute : DiagGroup<"redundant-attribute">;
 def RedundantMove : DiagGroup<"redundant-move">;
 def Register : DiagGroup<"register", [DeprecatedRegister]>;
 def ReturnTypeCLinkage : DiagGroup<"return-type-c-linkage">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12431,6 +12431,9 @@ def err_sycl_entry_point_after_definition : Error<
 def err_sycl_entry_point_return_type : Error<
   "'sycl_kernel_entry_point' attribute only applies to functions with a"
   " 'void' return type">;
+def err_sycl_entry_point_deduced_return_type : Error<
+  "'sycl_kernel_entry_point' attribute only applies to functions with a"
+  " non-deduced 'void' return type">;
 
 def warn_cuda_maxclusterrank_sm_90 : Warning<
   "maxclusterrank requires sm_90 or higher, CUDA arch provided: %0, ignoring "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12411,8 +12411,9 @@ def err_sycl_special_type_num_init_method : Error<
 // SYCL kernel entry point diagnostics
 def err_sycl_entry_point_invalid : Error<
   "'sycl_kernel_entry_point' attribute cannot be applied to a"
-  " %select{non-static member|variadic|deleted|defaulted|constexpr|consteval|"
-           "noreturn|coroutine}0 function">;
+  " %select{non-static member function|variadic function|deleted function|"
+           "defaulted function|constexpr function|consteval function|"
+           "function declared with the 'noreturn' attribute|coroutine}0">;
 def err_sycl_entry_point_invalid_redeclaration : Error<
   "'sycl_kernel_entry_point' kernel name argument does not match prior"
   " declaration%diff{: $ vs $|}0,1">;
@@ -12420,7 +12421,7 @@ def err_sycl_kernel_name_conflict : Error<
   "'sycl_kernel_entry_point' kernel name argument conflicts with a previous"
   " declaration">;
 def warn_sycl_kernel_name_not_a_class_type : Warning<
-  "%0 is not a valid SYCL kernel name type; a class type is required">,
+  "%0 is not a valid SYCL kernel name type; a non-union class type is required">,
   InGroup<DiagGroup<"nonportable-sycl">>, DefaultError;
 def warn_sycl_entry_point_redundant_declaration : Warning<
   "redundant 'sycl_kernel_entry_point' attribute">, InGroup<RedundantAttribute>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12408,6 +12408,29 @@ def err_sycl_special_type_num_init_method : Error<
   "types with 'sycl_special_class' attribute must have one and only one '__init' "
   "method defined">;
 
+// SYCL kernel entry point diagnostics
+def err_sycl_entry_point_invalid : Error<
+  "'sycl_kernel_entry_point' attribute cannot be applied to a"
+  " %select{non-static member|variadic|deleted|defaulted|constexpr|consteval|"
+           "noreturn|coroutine}0 function">;
+def err_sycl_entry_point_invalid_redeclaration : Error<
+  "'sycl_kernel_entry_point' kernel name argument does not match prior"
+  " declaration%diff{: $ vs $|}0,1">;
+def err_sycl_kernel_name_conflict : Error<
+  "'sycl_kernel_entry_point' kernel name argument conflicts with a previous"
+  " declaration">;
+def warn_sycl_kernel_name_not_a_class_type : Warning<
+  "%0 is not a valid SYCL kernel name type; a class type is required">,
+  InGroup<DiagGroup<"nonportable-sycl">>, DefaultError;
+def warn_sycl_entry_point_redundant_declaration : Warning<
+  "redundant 'sycl_kernel_entry_point' attribute">, InGroup<RedundantAttribute>;
+def err_sycl_entry_point_after_definition : Error<
+  "'sycl_kernel_entry_point' attribute cannot be added to a function after the"
+  " function is defined">;
+def err_sycl_entry_point_return_type : Error<
+  "'sycl_kernel_entry_point' attribute only applies to functions with a"
+  " 'void' return type">;
+
 def warn_cuda_maxclusterrank_sm_90 : Warning<
   "maxclusterrank requires sm_90 or higher, CUDA arch provided: %0, ignoring "
   "%1 attribute">, InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -63,6 +63,8 @@ public:
 
   void handleKernelAttr(Decl *D, const ParsedAttr &AL);
   void handleKernelEntryPointAttr(Decl *D, const ParsedAttr &AL);
+
+  void CheckSYCLEntryPointFunctionDecl(FunctionDecl *FD);
 };
 
 } // namespace clang

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -14463,6 +14463,19 @@ void ASTContext::registerSYCLEntryPointFunction(FunctionDecl *FD) {
       std::make_pair(KernelNameType, BuildSYCLKernelInfo(KernelNameType, FD)));
 }
 
+const SYCLKernelInfo &ASTContext::getSYCLKernelInfo(QualType T) const {
+  CanQualType KernelNameType = getCanonicalType(T);
+  return SYCLKernels.at(KernelNameType);
+}
+
+const SYCLKernelInfo *ASTContext::findSYCLKernelInfo(QualType T) const {
+  CanQualType KernelNameType = getCanonicalType(T);
+  auto IT = SYCLKernels.find(KernelNameType);
+  if (IT != SYCLKernels.end())
+    return &IT->second;
+  return nullptr;
+}
+
 OMPTraitInfo &ASTContext::getNewOMPTraitInfo() {
   OMPTraitInfoVector.emplace_back(new OMPTraitInfo());
   return *OMPTraitInfoVector.back();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -12156,7 +12156,7 @@ bool Sema::CheckFunctionDeclaration(Scope *S, FunctionDecl *NewFD,
   if (LangOpts.OpenMP)
     OpenMP().ActOnFinishedFunctionDefinitionInOpenMPAssumeScope(NewFD);
 
-  if (LangOpts.isSYCL() && NewFD->hasAttr<SYCLKernelEntryPointAttr>())
+  if (NewFD->hasAttr<SYCLKernelEntryPointAttr>())
     SYCL().CheckSYCLEntryPointFunctionDecl(NewFD);
 
   // Semantic checking for this function declaration (in isolation).
@@ -15990,17 +15990,16 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
   }
 
   // Diagnose invalid SYCL kernel entry point function declarations.
-  if (FD && !FD->isInvalidDecl() && !FD->isTemplated() &&
-      FD->hasAttr<SYCLKernelEntryPointAttr>()) {
+  if (FD && !FD->isInvalidDecl() && FD->hasAttr<SYCLKernelEntryPointAttr>()) {
     SYCLKernelEntryPointAttr *SKEPAttr =
         FD->getAttr<SYCLKernelEntryPointAttr>();
-    if (FD->isDeleted()) {
-      Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
-          << /*deleted function*/ 2;
-      SKEPAttr->setInvalidAttr();
-    } else if (FD->isDefaulted()) {
+    if (FD->isDefaulted()) {
       Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
           << /*defaulted function*/ 3;
+      SKEPAttr->setInvalidAttr();
+    } else if (FD->isDeleted()) {
+      Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
+          << /*deleted function*/ 2;
       SKEPAttr->setInvalidAttr();
     } else if (FSI->isCoroutine()) {
       Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -52,8 +52,8 @@
 #include "clang/Sema/SemaOpenMP.h"
 #include "clang/Sema/SemaPPC.h"
 #include "clang/Sema/SemaRISCV.h"
-#include "clang/Sema/SemaSwift.h"
 #include "clang/Sema/SemaSYCL.h"
+#include "clang/Sema/SemaSwift.h"
 #include "clang/Sema/SemaWasm.h"
 #include "clang/Sema/Template.h"
 #include "llvm/ADT/STLForwardCompat.h"
@@ -15994,15 +15994,15 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
     if (FD->isDeleted()) {
       Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
            diag::err_sycl_entry_point_invalid)
-          << /*deleted function*/2;
+          << /*deleted function*/ 2;
     } else if (FD->isDefaulted()) {
       Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
            diag::err_sycl_entry_point_invalid)
-          << /*defaulted function*/3;
+          << /*defaulted function*/ 3;
     } else if (FSI->isCoroutine()) {
       Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
            diag::err_sycl_entry_point_invalid)
-          << /*coroutine*/7;
+          << /*coroutine*/ 7;
     }
   }
 

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -24,6 +24,7 @@
 #include "clang/Sema/SemaCUDA.h"
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/SemaOpenMP.h"
+#include "clang/Sema/SemaSYCL.h"
 #include "clang/Sema/Template.h"
 #include "llvm/ADT/STLExtras.h"
 #include <optional>
@@ -1948,6 +1949,10 @@ ExprResult Sema::BuildCaptureInit(const Capture &Cap,
 
 ExprResult Sema::ActOnLambdaExpr(SourceLocation StartLoc, Stmt *Body) {
   LambdaScopeInfo LSI = *cast<LambdaScopeInfo>(FunctionScopes.back());
+
+  if (LSI.CallOperator->hasAttr<SYCLKernelEntryPointAttr>())
+    SYCL().CheckSYCLEntryPointFunctionDecl(LSI.CallOperator);
+
   ActOnFinishFunctionBody(LSI.CallOperator, Body);
 
   return BuildLambdaExpr(StartLoc, Body->getEndLoc(), &LSI);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -252,7 +252,7 @@ void SemaSYCL::CheckSYCLEntryPointFunctionDecl(FunctionDecl *FD) {
   // Ensure that all attributes present on the declaration are consistent
   // and warn about any redundant ones.
   SYCLKernelEntryPointAttr *SKEPAttr = nullptr;
-  for (auto* SAI : FD->specific_attrs<SYCLKernelEntryPointAttr>()) {
+  for (auto *SAI : FD->specific_attrs<SYCLKernelEntryPointAttr>()) {
     if (!SKEPAttr) {
       SKEPAttr = SAI;
       continue;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -339,7 +339,7 @@ void SemaSYCL::CheckSYCLEntryPointFunctionDecl(FunctionDecl *FD) {
          diag::err_sycl_entry_point_deduced_return_type);
     SKEPAttr->setInvalidAttr();
   } else if (!FD->getReturnType()->isDependentType() &&
-      !FD->getReturnType()->isVoidType()) {
+             !FD->getReturnType()->isVoidType()) {
     Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_return_type);
     SKEPAttr->setInvalidAttr();
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -235,8 +235,7 @@ static bool CheckSYCLKernelName(Sema &S, SourceLocation Loc,
     S.Diag(Loc, diag::warn_sycl_kernel_name_not_a_class_type) << KernelName;
     SourceLocation DeclTypeLoc = SourceLocationForType(KernelName);
     if (DeclTypeLoc.isValid())
-      S.Diag(DeclTypeLoc, diag::note_entity_declared_at)
-          << KernelName;
+      S.Diag(DeclTypeLoc, diag::note_entity_declared_at) << KernelName;
     return true;
   }
 
@@ -248,8 +247,7 @@ void SemaSYCL::CheckSYCLEntryPointFunctionDecl(FunctionDecl *FD) {
   // and warn about any redundant ones.
   const SYCLKernelEntryPointAttr *SKEPAttr = nullptr;
   for (auto SAI = FD->specific_attr_begin<SYCLKernelEntryPointAttr>();
-       SAI != FD->specific_attr_end<SYCLKernelEntryPointAttr>();
-       ++SAI) {
+       SAI != FD->specific_attr_end<SYCLKernelEntryPointAttr>(); ++SAI) {
     if (!SKEPAttr) {
       SKEPAttr = *SAI;
       continue;
@@ -284,8 +282,7 @@ void SemaSYCL::CheckSYCLEntryPointFunctionDecl(FunctionDecl *FD) {
         Diag(SKEPAttr->getLocation(),
              diag::err_sycl_entry_point_invalid_redeclaration)
             << SKEPAttr->getKernelName() << PrevSKEPAttr->getKernelName();
-        Diag(PrevSKEPAttr->getLocation(), diag::note_previous_decl)
-            << PrevFD;;
+        Diag(PrevSKEPAttr->getLocation(), diag::note_previous_decl) << PrevFD;
       }
     }
   }
@@ -293,23 +290,23 @@ void SemaSYCL::CheckSYCLEntryPointFunctionDecl(FunctionDecl *FD) {
   if (auto *MD = dyn_cast<CXXMethodDecl>(FD)) {
     if (!MD->isStatic()) {
       Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
-          << /*non-static member function*/0;
+          << /*non-static member function*/ 0;
     }
   }
   if (FD->isVariadic()) {
     Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
-        << /*variadic function*/1;
+        << /*variadic function*/ 1;
   }
   if (FD->isConsteval()) {
     Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
-        << /*consteval function*/5;
+        << /*consteval function*/ 5;
   } else if (FD->isConstexpr()) {
     Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
-        << /*constexpr function*/4;
+        << /*constexpr function*/ 4;
   }
   if (FD->isNoReturn()) {
     Diag(SKEPAttr->getLocation(), diag::err_sycl_entry_point_invalid)
-        << /*noreturn function*/6;
+        << /*noreturn function*/ 6;
   }
 
   if (!FD->getReturnType()->isVoidType()) {

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1550,8 +1550,6 @@ NamedDecl *Sema::ActOnNonTypeTemplateParameter(Scope *S, Declarator &D,
     IdResolver.AddDecl(Param);
   }
 
-  ProcessDeclAttributes(S, Param, D);
-
   // C++0x [temp.param]p9:
   //   A default template-argument may be specified for any kind of
   //   template-parameter that is not a template parameter pack.

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1550,6 +1550,8 @@ NamedDecl *Sema::ActOnNonTypeTemplateParameter(Scope *S, Declarator &D,
     IdResolver.AddDecl(Param);
   }
 
+  ProcessDeclAttributes(S, Param, D);
+
   // C++0x [temp.param]p9:
   //   A default template-argument may be specified for any kind of
   //   template-parameter that is not a template parameter pack.

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1134,7 +1134,7 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
   // the presence of a sycl_kernel_entry_point attribute, register it so that
   // associated metadata is recreated.
   if (FD->hasAttr<SYCLKernelEntryPointAttr>()) {
-    const auto *SKEPAttr = FD->getAttr<SYCLKernelEntryPointAttr>();
+    auto *SKEPAttr = FD->getAttr<SYCLKernelEntryPointAttr>();
     ASTContext &C = Reader.getContext();
     const SYCLKernelInfo *SKI = C.findSYCLKernelInfo(SKEPAttr->getKernelName());
     if (SKI) {
@@ -1142,6 +1142,7 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
         Reader.Diag(FD->getLocation(), diag::err_sycl_kernel_name_conflict);
         Reader.Diag(SKI->getKernelEntryPointDecl()->getLocation(),
                     diag::note_previous_declaration);
+        SKEPAttr->setInvalidAttr();
       }
     } else {
       C.registerSYCLEntryPointFunction(FD);

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1136,13 +1136,12 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
   if (FD->hasAttr<SYCLKernelEntryPointAttr>()) {
     const auto *SKEPAttr = FD->getAttr<SYCLKernelEntryPointAttr>();
     ASTContext &C = Reader.getContext();
-    const SYCLKernelInfo *SKI =
-        C.findSYCLKernelInfo(SKEPAttr->getKernelName());
+    const SYCLKernelInfo *SKI = C.findSYCLKernelInfo(SKEPAttr->getKernelName());
     if (SKI) {
       if (!declaresSameEntity(FD, SKI->getKernelEntryPointDecl())) {
         Reader.Diag(FD->getLocation(), diag::err_sycl_kernel_name_conflict);
         Reader.Diag(SKI->getKernelEntryPointDecl()->getLocation(),
-             diag::note_previous_declaration);
+                    diag::note_previous_declaration);
       }
     } else {
       C.registerSYCLEntryPointFunction(FD);

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -1134,8 +1134,19 @@ void ASTDeclReader::VisitFunctionDecl(FunctionDecl *FD) {
   // the presence of a sycl_kernel_entry_point attribute, register it so that
   // associated metadata is recreated.
   if (FD->hasAttr<SYCLKernelEntryPointAttr>()) {
+    const auto *SKEPAttr = FD->getAttr<SYCLKernelEntryPointAttr>();
     ASTContext &C = Reader.getContext();
-    C.registerSYCLEntryPointFunction(FD);
+    const SYCLKernelInfo *SKI =
+        C.findSYCLKernelInfo(SKEPAttr->getKernelName());
+    if (SKI) {
+      if (!declaresSameEntity(FD, SKI->getKernelEntryPointDecl())) {
+        Reader.Diag(FD->getLocation(), diag::err_sycl_kernel_name_conflict);
+        Reader.Diag(SKI->getKernelEntryPointDecl()->getLocation(),
+             diag::note_previous_declaration);
+      }
+    } else {
+      C.registerSYCLEntryPointFunction(FD);
+    }
   }
 }
 

--- a/clang/test/ASTSYCL/ast-dump-sycl-kernel-entry-point.cpp
+++ b/clang/test/ASTSYCL/ast-dump-sycl-kernel-entry-point.cpp
@@ -107,14 +107,29 @@ void skep5<KN<5,2>>(long) {
 // CHECK:      | |-TemplateArgument type 'long'
 // CHECK:      | `-SYCLKernelEntryPointAttr {{.*}} KN<5, 2>
 
+// FIXME: C++23 [temp.expl.spec]p12 states:
+// FIXME:   ... Similarly, attributes appearing in the declaration of a template
+// FIXME:   have no effect on an explicit specialization of that template.
+// FIXME: Clang currently instantiates a function template specialization from
+// FIXME: the function template declaration and links it as a previous
+// FIXME: declaration of an explicit specialization. The instantiated
+// FIXME: declaration includes attributes instantiated from the function
+// FIXME: template declaration. When the instantiated declaration and the
+// FIXME: explicit specialization both specify a sycl_kernel_entry_point
+// FIXME: attribute with different kernel name types, a spurious diagnostic
+// FIXME: is issued. The following test case is incorrectly diagnosed as
+// FIXME: having conflicting kernel name types (KN<5,3> vs the incorrectly
+// FIXME: inherited KN<5,-1>).
+#if 0
 template<>
 [[clang::sycl_kernel_entry_point(KN<5,3>)]]
 void skep5<KN<5,-1>>(long long) {
 }
-// CHECK:      |-FunctionDecl {{.*}} prev {{.*}} skep5 'void (long long)' explicit_specialization
-// CHECK-NEXT: | |-TemplateArgument type 'KN<5, -1>'
-// CHECK:      | |-TemplateArgument type 'long long'
-// CHECK:      | `-SYCLKernelEntryPointAttr {{.*}} KN<5, 3>
+// FIXME-CHECK:      |-FunctionDecl {{.*}} prev {{.*}} skep5 'void (long long)' explicit_specialization
+// FIXME-CHECK-NEXT: | |-TemplateArgument type 'KN<5, -1>'
+// FIXME-CHECK:      | |-TemplateArgument type 'long long'
+// FIXME-CHECK:      | `-SYCLKernelEntryPointAttr {{.*}} KN<5, 3>
+#endif
 
 template void skep5<KN<5,4>>(int);
 // Checks are located with the primary template declaration above.

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
@@ -208,7 +208,7 @@ template<void (fp [[clang::sycl_kernel_entry_point(BADKN<18>)]])()>
 void bad18();
 
 #if __cplusplus >= 202002L
-// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a coroutine function}}
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a coroutine}}
 [[clang::sycl_kernel_entry_point(BADKN<19>)]]
 void bad19() {
   co_return;
@@ -245,7 +245,7 @@ constexpr void bad24() {}
 consteval void bad25() {}
 #endif
 
-// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a noreturn function}}
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a function declared with the 'noreturn' attribute}}
 [[clang::sycl_kernel_entry_point(BADKN<26>)]]
 [[noreturn]] void bad26();
 

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
@@ -78,7 +78,7 @@ struct S6 {
   static void ok6();
 };
 
-// Dependent friend function.
+// Dependent hidden friend definition.
 template<typename KNT>
 struct S7 {
   [[clang::sycl_kernel_entry_point(KNT)]]
@@ -88,24 +88,35 @@ void test_ok7() {
   ok7(S7<KN<7>>{});
 }
 
+// Non-dependent hidden friend definition.
+struct S8Base {};
+template<typename>
+struct S8 : S8Base {
+  [[clang::sycl_kernel_entry_point(KN<8>)]]
+  friend void ok8(const S8Base&) {}
+};
+void test_ok8() {
+  ok8(S8<int>{});
+}
+
 // The sycl_kernel_entry_point attribute must match across declarations and
 // cannot be added for the first time after a definition.
-[[clang::sycl_kernel_entry_point(KN<8>)]]
-void ok8();
-[[clang::sycl_kernel_entry_point(KN<8>)]]
-void ok8();
 [[clang::sycl_kernel_entry_point(KN<9>)]]
 void ok9();
-void ok9() {}
-void ok10();
+[[clang::sycl_kernel_entry_point(KN<9>)]]
+void ok9();
 [[clang::sycl_kernel_entry_point(KN<10>)]]
+void ok10();
 void ok10() {}
+void ok11();
+[[clang::sycl_kernel_entry_point(KN<11>)]]
+void ok11() {}
 
 using VOID = void;
-[[clang::sycl_kernel_entry_point(KN<11>)]]
-VOID ok11();
 [[clang::sycl_kernel_entry_point(KN<12>)]]
-const void ok12();
+VOID ok12();
+[[clang::sycl_kernel_entry_point(KN<13>)]]
+const void ok13();
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
@@ -226,7 +226,11 @@ int bad16();
 void bad17(void (fp [[clang::sycl_kernel_entry_point(BADKN<17>)]])());
 
 // Function template parameters.
-// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+// FIXME: Clang currently ignores attributes that appear in template parameters
+// FIXME: and the C++ standard is unclear regarding whether such attributes are
+// FIXME: permitted. P3324 (Attributes for namespace aliases, template
+// FIXME: parameters, and lambda captures) seeks to clarify the situation.
+// FIXME-expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
 template<void (fp [[clang::sycl_kernel_entry_point(BADKN<18>)]])()>
 void bad18();
 

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
@@ -1,0 +1,255 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -std=c++17 -fsyntax-only -fsycl-is-device -verify %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -std=c++20 -fsyntax-only -fsycl-is-device -verify %s
+
+// These tests validate appertainment for the sycl_kernel_entry_point attribute.
+
+#if __cplusplus >= 202002L
+// Mock coroutine support.
+namespace std {
+
+template<typename Promise = void>
+struct coroutine_handle {
+  template<typename T>
+  coroutine_handle(const coroutine_handle<T>&);
+  static coroutine_handle from_address(void *addr);
+};
+
+template<typename R, typename... Args>
+struct coroutine_traits {
+  struct suspend_never {
+    bool await_ready() const noexcept;
+    void await_suspend(std::coroutine_handle<>) const noexcept;
+    void await_resume() const noexcept;
+  };
+  struct promise_type {
+    void get_return_object() noexcept;
+    suspend_never initial_suspend() const noexcept;
+    suspend_never final_suspend() const noexcept;
+    void return_void() noexcept;
+    void unhandled_exception() noexcept;
+  };
+};
+
+}
+#endif
+
+// A unique kernel name type is required for each declared kernel entry point.
+template<int, int = 0> struct KN;
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Valid declarations.
+////////////////////////////////////////////////////////////////////////////////
+
+// Function declaration with GNU attribute spelling
+__attribute__((sycl_kernel_entry_point(KN<1>)))
+void ok1();
+
+// Function declaration with Clang attribute spelling.
+[[clang::sycl_kernel_entry_point(KN<2>)]]
+void ok2();
+
+// Function definition.
+[[clang::sycl_kernel_entry_point(KN<3>)]]
+void ok3() {}
+
+// Function template definition.
+template<typename KNT, typename T>
+[[clang::sycl_kernel_entry_point(KNT)]]
+void ok4(T) {}
+
+// Function template explicit specialization.
+template<>
+[[clang::sycl_kernel_entry_point(KN<4,1>)]]
+void ok4<KN<4,1>>(int) {}
+
+// Function template explicit instantiation.
+template void ok4<KN<4,2>, long>(long);
+
+namespace NS {
+// Function declaration at namespace scope.
+[[clang::sycl_kernel_entry_point(KN<5>)]]
+void ok5();
+}
+
+struct S6 {
+  // Static member function declaration.
+  [[clang::sycl_kernel_entry_point(KN<6>)]]
+  static void ok6();
+};
+
+// Dependent friend function.
+template<typename KNT>
+struct S7 {
+  [[clang::sycl_kernel_entry_point(KNT)]]
+  friend void ok7(S7) {}
+};
+void test_ok7() {
+  ok7(S7<KN<7>>{});
+}
+
+// The sycl_kernel_entry_point attribute must match across declarations and
+// cannot be added for the first time after a definition.
+[[clang::sycl_kernel_entry_point(KN<8>)]]
+void ok8();
+[[clang::sycl_kernel_entry_point(KN<8>)]]
+void ok8();
+[[clang::sycl_kernel_entry_point(KN<9>)]]
+void ok9();
+void ok9() {}
+void ok10();
+[[clang::sycl_kernel_entry_point(KN<10>)]]
+void ok10() {}
+
+using VOID = void;
+[[clang::sycl_kernel_entry_point(KN<11>)]]
+VOID ok11();
+[[clang::sycl_kernel_entry_point(KN<12>)]]
+const void ok12();
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Invalid declarations.
+////////////////////////////////////////////////////////////////////////////////
+
+// The sycl_kernel_entry_point attribute cannot appertain to main() because
+// main() has a non-void return type. However, if the requirement for a void
+// return type were to be relaxed or if an allowance was made for main() to
+// return void (as gcc allows in some modes and as has been proposed to WG21
+// on occassion), main() still can't function as a SYCL kernel entry point,
+// so this test ensures such attempted uses of the attribute are rejected.
+struct Smain;
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions with a 'void' return type}}
+[[clang::sycl_kernel_entry_point(Smain)]]
+int main();
+
+template<int> struct BADKN;
+
+struct B1 {
+  // Non-static data member declaration.
+  // expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+  [[clang::sycl_kernel_entry_point(BADKN<1>)]]
+  int bad1;
+};
+
+struct B2 {
+  // Static data member declaration.
+  // expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+  [[clang::sycl_kernel_entry_point(BADKN<2>)]]
+  static int bad2;
+};
+
+struct B3 {
+  // Non-static member function declaration.
+  // expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a non-static member function}}
+  [[clang::sycl_kernel_entry_point(BADKN<3>)]]
+  void bad3();
+};
+
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+namespace bad4 [[clang::sycl_kernel_entry_point(BADKN<4>)]] {}
+
+#if __cplusplus >= 202002L
+// expected-error@+2 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+template<typename>
+concept bad5 [[clang::sycl_kernel_entry_point(BADKN<5>)]] = true;
+#endif
+
+// Type alias declarations.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+typedef void bad6 [[clang::sycl_kernel_entry_point(BADKN<6>)]] ();
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+using bad7 [[clang::sycl_kernel_entry_point(BADKN<7>)]] = void();
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+using bad8 [[clang::sycl_kernel_entry_point(BADKN<8>)]] = int;
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to types}}
+using bad9 = int [[clang::sycl_kernel_entry_point(BADKN<9>)]];
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to types}}
+using bad10 = int() [[clang::sycl_kernel_entry_point(BADKN<10>)]];
+
+// Variable declaration.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+[[clang::sycl_kernel_entry_point(BADKN<11>)]]
+int bad11;
+
+// Class declaration.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+struct [[clang::sycl_kernel_entry_point(BADKN<12>)]] bad12;
+
+// Enumeration declaration.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+enum [[clang::sycl_kernel_entry_point(BADKN<13>)]] bad13 {};
+
+// Enumerator.
+// expected-error@+2 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+enum {
+  bad14 [[clang::sycl_kernel_entry_point(BADKN<14>)]]
+};
+
+// Attribute added after the definition.
+// expected-error@+3 {{'sycl_kernel_entry_point' attribute cannot be added to a function after the function is defined}}
+// expected-note@+1 {{previous definition is here}}
+void bad15() {}
+[[clang::sycl_kernel_entry_point(BADKN<15>)]]
+void bad15();
+
+// The function must return void.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions with a 'void' return type}}
+[[clang::sycl_kernel_entry_point(BADKN<16>)]]
+int bad16();
+
+// Function parameters.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+void bad17(void (fp [[clang::sycl_kernel_entry_point(BADKN<17>)]])());
+
+// Function template parameters.
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
+template<void (fp [[clang::sycl_kernel_entry_point(BADKN<18>)]])()>
+void bad18();
+
+#if __cplusplus >= 202002L
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a coroutine function}}
+[[clang::sycl_kernel_entry_point(BADKN<19>)]]
+void bad19() {
+  co_return;
+}
+#endif
+
+struct B20 {
+  // expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a non-static member function}}
+  [[clang::sycl_kernel_entry_point(BADKN<20>)]]
+  B20();
+};
+
+struct B21 {
+  // expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a non-static member function}}
+  [[clang::sycl_kernel_entry_point(BADKN<21>)]]
+  ~B21();
+};
+
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a variadic function}}
+[[clang::sycl_kernel_entry_point(BADKN<22>)]]
+void bad22(...);
+
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a deleted function}}
+[[clang::sycl_kernel_entry_point(BADKN<23>)]]
+void bad23() = delete;
+
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a constexpr function}}
+[[clang::sycl_kernel_entry_point(BADKN<24>)]]
+constexpr void bad24() {}
+
+#if __cplusplus >= 202002L
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a consteval function}}
+[[clang::sycl_kernel_entry_point(BADKN<25>)]]
+consteval void bad25() {}
+#endif
+
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute cannot be applied to a noreturn function}}
+[[clang::sycl_kernel_entry_point(BADKN<26>)]]
+[[noreturn]] void bad26();
+
+// expected-error@+3 {{attribute 'target' multiversioning cannot be combined with attribute 'sycl_kernel_entry_point'}}
+__attribute__((target("avx"))) void bad27();
+[[clang::sycl_kernel_entry_point(BADKN<27>)]]
+__attribute__((target("sse4.2"))) void bad27();

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-grammar.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-grammar.cpp
@@ -120,18 +120,3 @@ template<typename> concept C = true;
 // expected-error@+1 {{expected a type}}
 [[clang::sycl_kernel_entry_point(C<int>)]] void bad11();
 #endif
-
-struct B12; // #B12-decl
-// FIXME: C++23 [temp.expl.spec]p12 states:
-// FIXME:   ... Similarly, attributes appearing in the declaration of a template
-// FIXME:   have no effect on an explicit specialization of that template.
-// FIXME: Clang currently instantiates and propagates attributes from a function
-// FIXME: template to its explicit specializations resulting in the following
-// FIXME: spurious error.
-// expected-error@+4 {{incomplete type 'B12' named in nested name specifier}}
-// expected-note@+5 {{in instantiation of function template specialization 'bad12<B12>' requested here}}
-// expected-note@#B12-decl {{forward declaration of 'B12'}}
-template<typename T>
-[[clang::sycl_kernel_entry_point(typename T::not_found)]] void bad12() {}
-template<>
-void bad12<B12>() {}

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name-module.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name-module.cpp
@@ -1,0 +1,104 @@
+// Test that SYCL kernel name conflicts that occur across module boundaries are
+// properly diagnosed and that declarations are properly merged so that spurious
+// conflicts are not reported.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t \
+// RUN:   -std=c++17 -fsycl-is-host %t/test.cpp -verify
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t \
+// RUN:   -std=c++17 -fsycl-is-device %t/test.cpp -verify
+
+#--- module.modulemap
+module M1 { header "m1.h" }
+module M2 { header "m2.h" }
+
+
+#--- common.h
+template<int> struct KN;
+
+[[clang::sycl_kernel_entry_point(KN<1>)]]
+void common_test1() {}
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]]
+void common_test2() {}
+template void common_test2<KN<2>>();
+
+
+#--- m1.h
+#include "common.h"
+
+[[clang::sycl_kernel_entry_point(KN<3>)]]
+void m1_test3() {} // << expected previous declaration note here.
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]]
+void m1_test4() {} // << expected previous declaration note here.
+template void m1_test4<KN<4>>();
+
+[[clang::sycl_kernel_entry_point(KN<5>)]]
+void m1_test5() {} // << expected previous declaration note here.
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]]
+void m1_test6() {} // << expected previous declaration note here.
+template void m1_test6<KN<6>>();
+
+
+#--- m2.h
+#include "common.h"
+
+[[clang::sycl_kernel_entry_point(KN<3>)]]
+void m2_test3() {} // << expected kernel name conflict here.
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]]
+void m2_test4() {} // << expected kernel name conflict here.
+template void m2_test4<KN<4>>();
+
+[[clang::sycl_kernel_entry_point(KN<7>)]]
+void m2_test7() {} // << expected previous declaration note here.
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]]
+void m2_test8() {} // << expected previous declaration note here.
+template void m2_test8<KN<8>>();
+
+
+#--- test.cpp
+#include "m1.h"
+#include "m2.h"
+
+// Expected diagnostics for m1_test3() and m2_test3():
+// expected-error@m2.h:4 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@m1.h:12 {{previous declaration is here}}
+
+// Expected diagnostics for m1_test4<KN<4>>() and m2_test4<KN<4>>():
+// expected-error@m2.h:8 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@m1.h:16 {{previous declaration is here}}
+
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@m1.h:4 {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(KN<5>)]]
+void test5() {}
+
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@m1.h:8 {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(KN<6>)]]
+void test6() {}
+
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@m2.h:12 {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(KN<7>)]]
+void test7() {}
+
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@m2.h:16 {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(KN<8>)]]
+void test8() {}
+
+void f() {
+  common_test1();
+  common_test2<KN<2>>();
+}

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name-pch.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name-pch.cpp
@@ -1,0 +1,36 @@
+// Test that SYCL kernel name conflicts that occur across PCH boundaries are
+// properly diagnosed.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -std=c++17 -fsycl-is-host -emit-pch -x c++-header \
+// RUN:   %t/pch.h -o %t/pch.h.host.pch
+// RUN: %clang_cc1 -std=c++17 -fsycl-is-host -verify \
+// RUN:   -include-pch %t/pch.h.host.pch %t/test.cpp
+// RUN: %clang_cc1 -std=c++17 -fsycl-is-device -emit-pch -x c++-header \
+// RUN:   %t/pch.h -o %t/pch.h.device.pch
+// RUN: %clang_cc1 -std=c++17 -fsycl-is-device -verify \
+// RUN:   -include-pch %t/pch.h.device.pch %t/test.cpp
+
+#--- pch.h
+template<int> struct KN;
+
+[[clang::sycl_kernel_entry_point(KN<1>)]]
+void pch_test1() {} // << expected previous declaration note here.
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]]
+void pch_test2() {} // << expected previous declaration note here.
+template void pch_test2<KN<2>>();
+
+
+#--- test.cpp
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@pch.h:4 {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(KN<1>)]]
+void test1() {}
+
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@pch.h:8 {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(KN<2>)]]
+void test2() {}

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
@@ -1,0 +1,87 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -std=c++17 -fsyntax-only -fsycl-is-device -verify %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -std=c++20 -fsyntax-only -fsycl-is-device -verify %s
+
+// These tests validate that the kernel name type argument provided to the
+// sycl_kernel_entry_point attribute meets the requirements of a SYCL kernel
+// name as described in section 5.2, "Naming of kernels", of the SYCL 2020
+// specification.
+
+struct S1;
+// expected-warning@+3 {{redundant 'sycl_kernel_entry_point' attribute}}
+// expected-note@+1  {{previous attribute is here}}
+[[clang::sycl_kernel_entry_point(S1),
+  clang::sycl_kernel_entry_point(S1)]]
+void ok1();
+
+// expected-error@+1 {{'int' is not a valid SYCL kernel name type; a class type is required}}
+[[clang::sycl_kernel_entry_point(int)]] void bad2();
+
+// expected-error@+1 {{'int ()' is not a valid SYCL kernel name type; a class type is required}}
+[[clang::sycl_kernel_entry_point(int())]] void bad3();
+
+// expected-error@+1 {{'int (*)()' is not a valid SYCL kernel name type; a class type is required}}
+[[clang::sycl_kernel_entry_point(int(*)())]] void bad4();
+
+// expected-error@+1 {{'int (&)()' is not a valid SYCL kernel name type; a class type is required}}
+[[clang::sycl_kernel_entry_point(int(&)())]] void bad5();
+
+// expected-error@+1 {{'decltype(nullptr)' (aka 'std::nullptr_t') is not a valid SYCL kernel name type; a class type is required}}
+[[clang::sycl_kernel_entry_point(decltype(nullptr))]] void bad6();
+
+union U7; // #U7-decl
+// expected-error@+2 {{'U7' is not a valid SYCL kernel name type; a class type is required}}
+// expected-note@#U7-decl {{'U7' declared here}}
+[[clang::sycl_kernel_entry_point(U7)]] void bad7();
+
+enum E8 {}; // #E8-decl
+// expected-error@+2 {{'E8' is not a valid SYCL kernel name type; a class type is required}}
+// expected-note@#E8-decl {{'E8' declared here}}
+[[clang::sycl_kernel_entry_point(E8)]] void bad8();
+
+enum E9 : int; // #E9-decl
+// expected-error@+2 {{'E9' is not a valid SYCL kernel name type; a class type is required}}
+// expected-note@#E9-decl {{'E9' declared here}}
+[[clang::sycl_kernel_entry_point(E9)]] void bad9();
+
+struct B10 {
+  struct MS;
+};
+// FIXME-expected-error@+1 {{'sycl_kernel_entry_point' attribute argument must be a forward declarable class type}}
+[[clang::sycl_kernel_entry_point(B10::MS)]] void bad10();
+
+struct B11 {
+  struct MS;
+};
+// FIXME-expected-error@+3 {{'sycl_kernel_entry_point' attribute argument must be a forward declarable class type}}
+template<typename T>
+[[clang::sycl_kernel_entry_point(typename T::MS)]] void bad11() {}
+template void bad11<B11>();
+
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]] void bad12();
+void f12() {
+  // FIXME-expected-error@+2 {{'sycl_kernel_entry_point' attribute argument must be a forward declarable class type}}
+  struct LS;
+  bad12<LS>();
+}
+
+struct B13_1;
+struct B13_2;
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument does not match prior declaration: 'B13_2' vs 'B13_1'}}
+// expected-note@+1  {{'bad13' declared here}}
+[[clang::sycl_kernel_entry_point(B13_1)]] void bad13();
+[[clang::sycl_kernel_entry_point(B13_2)]] void bad13() {}
+
+struct B14_1;
+struct B14_2;
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument does not match prior declaration: 'B14_2' vs 'B14_1'}}
+// expected-note@+1  {{previous attribute is here}}
+[[clang::sycl_kernel_entry_point(B14_1),
+  clang::sycl_kernel_entry_point(B14_2)]]
+void bad14();
+
+struct B15;
+// expected-error@+3 {{'sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@+1  {{previous declaration is here}}
+[[clang::sycl_kernel_entry_point(B15)]] void bad15_1();
+[[clang::sycl_kernel_entry_point(B15)]] void bad15_2();

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
@@ -98,5 +98,21 @@ template<int>
 struct B17 {
   // expected-error@+1 {{'int' is not a valid SYCL kernel name type; a non-union class type is required}}
   [[clang::sycl_kernel_entry_point(int)]]
-  static void bad_17();
+  static void bad17();
 };
+
+template<int>
+struct B18 {
+  // expected-error@+1 {{'int' is not a valid SYCL kernel name type; a non-union class type is required}}
+  [[clang::sycl_kernel_entry_point(int)]]
+  friend void bad18() {}
+};
+
+template<typename KNT>
+struct B19 {
+  // expected-error@+1 {{'int' is not a valid SYCL kernel name type; a non-union class type is required}}
+  [[clang::sycl_kernel_entry_point(KNT)]]
+  friend void bad19() {}
+};
+// expected-note@+1 {{in instantiation of template class 'B19<int>' requested here}}
+B19<int> b19;

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
@@ -85,3 +85,18 @@ struct B15;
 // expected-note@+1  {{previous declaration is here}}
 [[clang::sycl_kernel_entry_point(B15)]] void bad15_1();
 [[clang::sycl_kernel_entry_point(B15)]] void bad15_2();
+
+struct B16_1;
+struct B16_2;
+// expected-error@+4 {{'sycl_kernel_entry_point' kernel name argument does not match prior declaration: 'B16_2' vs 'B16_1'}}
+// expected-note@+1  {{'bad16' declared here}}
+[[clang::sycl_kernel_entry_point(B16_1)]] void bad16();
+void bad16(); // The attribute from the previous declaration is inherited.
+[[clang::sycl_kernel_entry_point(B16_2)]] void bad16();
+
+template<int>
+struct B17 {
+  // expected-error@+1 {{'int' is not a valid SYCL kernel name type; a class type is required}}
+  [[clang::sycl_kernel_entry_point(int)]]
+  static void bad_17();
+};

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
@@ -13,33 +13,33 @@ struct S1;
   clang::sycl_kernel_entry_point(S1)]]
 void ok1();
 
-// expected-error@+1 {{'int' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+1 {{'int' is not a valid SYCL kernel name type; a non-union class type is required}}
 [[clang::sycl_kernel_entry_point(int)]] void bad2();
 
-// expected-error@+1 {{'int ()' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+1 {{'int ()' is not a valid SYCL kernel name type; a non-union class type is required}}
 [[clang::sycl_kernel_entry_point(int())]] void bad3();
 
-// expected-error@+1 {{'int (*)()' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+1 {{'int (*)()' is not a valid SYCL kernel name type; a non-union class type is required}}
 [[clang::sycl_kernel_entry_point(int(*)())]] void bad4();
 
-// expected-error@+1 {{'int (&)()' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+1 {{'int (&)()' is not a valid SYCL kernel name type; a non-union class type is required}}
 [[clang::sycl_kernel_entry_point(int(&)())]] void bad5();
 
-// expected-error@+1 {{'decltype(nullptr)' (aka 'std::nullptr_t') is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+1 {{'decltype(nullptr)' (aka 'std::nullptr_t') is not a valid SYCL kernel name type; a non-union class type is required}}
 [[clang::sycl_kernel_entry_point(decltype(nullptr))]] void bad6();
 
 union U7; // #U7-decl
-// expected-error@+2 {{'U7' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+2 {{'U7' is not a valid SYCL kernel name type; a non-union class type is required}}
 // expected-note@#U7-decl {{'U7' declared here}}
 [[clang::sycl_kernel_entry_point(U7)]] void bad7();
 
 enum E8 {}; // #E8-decl
-// expected-error@+2 {{'E8' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+2 {{'E8' is not a valid SYCL kernel name type; a non-union class type is required}}
 // expected-note@#E8-decl {{'E8' declared here}}
 [[clang::sycl_kernel_entry_point(E8)]] void bad8();
 
 enum E9 : int; // #E9-decl
-// expected-error@+2 {{'E9' is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+2 {{'E9' is not a valid SYCL kernel name type; a non-union class type is required}}
 // expected-note@#E9-decl {{'E9' declared here}}
 [[clang::sycl_kernel_entry_point(E9)]] void bad9();
 
@@ -96,7 +96,7 @@ void bad16(); // The attribute from the previous declaration is inherited.
 
 template<int>
 struct B17 {
-  // expected-error@+1 {{'int' is not a valid SYCL kernel name type; a class type is required}}
+  // expected-error@+1 {{'int' is not a valid SYCL kernel name type; a non-union class type is required}}
   [[clang::sycl_kernel_entry_point(int)]]
   static void bad_17();
 };

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-sfinae.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-sfinae.cpp
@@ -51,7 +51,7 @@ struct Select3 {
   using bad_type = int;
   using good_type = S3;
 };
-// expected-error@+5 {{'typename Select3::bad_type' (aka 'int') is not a valid SYCL kernel name type; a class type is required}}
+// expected-error@+5 {{'typename Select3::bad_type' (aka 'int') is not a valid SYCL kernel name type; a non-union class type is required}}
 // expected-note@+9 {{in instantiation of function template specialization 'ok3<Select3>' requested here}}
 template<typename T>
 [[clang::sycl_kernel_entry_point(typename T::good_type)]] void ok3(int) {}

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-sfinae.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-sfinae.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -std=c++17 -fsyntax-only -fsycl-is-device -verify %s
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -std=c++20 -fsyntax-only -fsycl-is-device -verify %s
+
+// These tests are intended to validate that a sycl_kernel_entry_point attribute
+// appearing in the declaration of a function template does not affect overload
+// resolution or cause spurious errors during overload resolution due to either
+// a substitution failure in the attribute argument or a semantic check of the
+// attribute during instantiation of a specialization unless that specialization
+// is selected by overload resolution.
+
+// FIXME: C++23 [temp.expl.spec]p12 states:
+// FIXME:   ... Similarly, attributes appearing in the declaration of a template
+// FIXME:   have no effect on an explicit specialization of that template.
+// FIXME: Clang currently instantiates and propagates attributes from a function
+// FIXME: template to its explicit specializations resulting in the following
+// FIXME: spurious error.
+struct S1; // #S1-decl
+// expected-error@+4 {{incomplete type 'S1' named in nested name specifier}}
+// expected-note@+5 {{in instantiation of function template specialization 'ok1<S1>' requested here}}
+// expected-note@#S1-decl {{forward declaration of 'S1'}}
+template<typename T>
+[[clang::sycl_kernel_entry_point(typename T::invalid)]] void ok1() {}
+template<>
+void ok1<S1>() {}
+void test_ok1() {
+  // ok1<S1>() is not a call to a SYCL kernel entry point function.
+  ok1<S1>();
+}
+
+// FIXME: The sycl_kernel_entry_point attribute should not be instantiated
+// FIXME: until after overload resolution has completed.
+struct S2; // #S2-decl
+// expected-error@+6 {{incomplete type 'S2' named in nested name specifier}}
+// expected-note@+10 {{in instantiation of function template specialization 'ok2<S2>' requested here}}
+// expected-note@#S2-decl {{forward declaration of 'S2'}}
+template<typename T>
+[[clang::sycl_kernel_entry_point(T)]] void ok2(int) {}
+template<typename T>
+[[clang::sycl_kernel_entry_point(typename T::invalid)]] void ok2(long) {}
+void test_ok2() {
+  // ok2(int) is a better match and is therefore selected by overload
+  // resolution; the attempted instantiation of ok2(long) should not produce
+  // an error for the substitution failure into the attribute argument.
+  ok2<S2>(2);
+}
+
+// FIXME: The sycl_kernel_entry_point attribute should not be instantiated
+// FIXME: until after overload resolution has completed.
+struct S3;
+struct Select3 {
+  using bad_type = int;
+  using good_type = S3;
+};
+// expected-error@+5 {{'typename Select3::bad_type' (aka 'int') is not a valid SYCL kernel name type; a class type is required}}
+// expected-note@+9 {{in instantiation of function template specialization 'ok3<Select3>' requested here}}
+template<typename T>
+[[clang::sycl_kernel_entry_point(typename T::good_type)]] void ok3(int) {}
+template<typename T>
+[[clang::sycl_kernel_entry_point(typename T::bad_type)]] void ok3(long) {}
+void test_ok3() {
+  // ok3(int) is a better match and is therefore selected by overload
+  // resolution; the attempted instantiation of ok3(long) should not produce
+  // an error for the invalid kernel name provided as the attribute argument.
+  ok3<Select3>(2);
+}


### PR DESCRIPTION
The `sycl_kernel_entry_point` attribute is used to declare a function that defines a pattern for an offload kernel entry point. The attribute requires a single type argument that specifies a class type that meets the requirements for a SYCL kernel name as described in section 5.2, "Naming of kernels", of the SYCL 2020 specification. A unique kernel name type is required for each function declared with the attribute. The attribute may not first appear on a declaration that follows a definition of the function. The function is required to have a `void` return type. The function must not be a non-static member function, be deleted or defaulted, be declared with the `constexpr` or `consteval` specifiers, be declared with the `[[noreturn]]` attribute, be a coroutine, or accept variadic arguments.

Diagnostics are not yet provided for the following:
- Use of a type as a kernel name that does not satisfy the forward declarability requirements specified in section 5.2, "Naming of kernels", of the SYCL 2020 specification.
- Use of a type as a parameter of the attributed function that does not satisfy the kernel parameter requirements specified in section 4.12.4, "Rules for parameter passing to kernels", of the SYCL 2020 specification (each such function parameter constitutes a kernel parameter).
- Use of language features that are not permitted in device functions as specified in section 5.4, "Language restrictions for device functions", of the SYCL 2020 specification.

There are several issues noted by various FIXME comments.
- The diagnostic generated for kernel name conflicts needs additional work to better detail the relevant source locations; such as the location of each declaration as well as the original source of each kernel name.
- A number of the tests illustrate spurious errors being produced due to attributes that appertain to function templates being instantiated too early (during overload resolution as opposed to after an overload is selected).