### PR TITLE
[RISCV] Use inheritance to simplify usage of the UnsupportedSched* multiclasses. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedRocket.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedRocket.td
@@ -259,7 +259,7 @@ defm : UnsupportedSchedZbs;
 defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedZfa;
-defm : UnsupportedSchedZfh;
+defm : UnsupportedSchedZfhmin;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedXsfvcp;
 defm : UnsupportedSchedZvk;

--- a/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR345.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR345.td
@@ -179,27 +179,27 @@ multiclass SCR_Other {
 }
 
 // Unsupported scheduling classes for SCR3-5.
-multiclass SCR_Unsupported {
-  defm : UnsupportedSchedSFB;
-  defm : UnsupportedSchedV;
-  defm : UnsupportedSchedXsfvcp;
-  defm : UnsupportedSchedZabha;
-  defm : UnsupportedSchedZba;
-  defm : UnsupportedSchedZbb;
-  defm : UnsupportedSchedZbc;
-  defm : UnsupportedSchedZbs;
-  defm : UnsupportedSchedZbkb;
-  defm : UnsupportedSchedZbkx;
-  defm : UnsupportedSchedZfa;
-  defm : UnsupportedSchedZfh;
-  defm : UnsupportedSchedZvk;
-}
+multiclass SCR_Unsupported :
+  UnsupportedSchedSFB,
+  UnsupportedSchedV,
+  UnsupportedSchedXsfvcp,
+  UnsupportedSchedZabha,
+  UnsupportedSchedZba,
+  UnsupportedSchedZbb,
+  UnsupportedSchedZbc,
+  UnsupportedSchedZbs,
+  UnsupportedSchedZbkb,
+  UnsupportedSchedZbkx,
+  UnsupportedSchedZfa,
+  UnsupportedSchedZvk;
 
-multiclass SCR3_Unsupported {
-  defm : SCR_Unsupported;
-  defm : UnsupportedSchedD;
-  defm : UnsupportedSchedF;
-}
+multiclass SCR3_Unsupported :
+  SCR_Unsupported,
+  UnsupportedSchedF;
+
+multiclass SCR4_SCR5_Unsupported :
+  SCR_Unsupported,
+  UnsupportedSchedZfhmin;
 
 // Bypasses (none)
 multiclass SCR_NoReadAdvances {
@@ -231,8 +231,7 @@ multiclass SCR_NoReadAdvances {
 }
 
 // Floating-point bypasses (none)
-multiclass SCR4_SCR5_NoReadAdvances {
-  defm : SCR_NoReadAdvances;
+multiclass SCR4_SCR5_NoReadAdvances : SCR_NoReadAdvances {
   def : ReadAdvance<ReadFStoreData, 0>;
   def : ReadAdvance<ReadFMemBase, 0>;
   def : ReadAdvance<ReadFAdd32, 0>;
@@ -353,7 +352,7 @@ let SchedModel = SyntacoreSCR4RV32Model in {
   defm : SCR_FDU<SCR4RV32_FDU>;
   defm : SCR_Other;
 
-  defm : SCR_Unsupported;
+  defm : SCR4_SCR5_Unsupported;
   defm : SCR4_SCR5_NoReadAdvances;
 }
 
@@ -383,7 +382,7 @@ let SchedModel = SyntacoreSCR4RV64Model in {
   defm : SCR_FDU<SCR4RV64_FDU>;
   defm : SCR_Other;
 
-  defm : SCR_Unsupported;
+  defm : SCR4_SCR5_Unsupported;
   defm : SCR4_SCR5_NoReadAdvances;
 }
 
@@ -416,7 +415,7 @@ let SchedModel = SyntacoreSCR5RV32Model in {
   defm : SCR_FDU<SCR5RV32_FDU>;
   defm : SCR_Other;
 
-  defm : SCR_Unsupported;
+  defm : SCR4_SCR5_Unsupported;
   defm : SCR4_SCR5_NoReadAdvances;
 }
 
@@ -446,6 +445,6 @@ let SchedModel = SyntacoreSCR5RV64Model in {
   defm : SCR_FDU<SCR5RV64_FDU>;
   defm : SCR_Other;
 
-  defm : SCR_Unsupported;
+  defm : SCR4_SCR5_Unsupported;
   defm : SCR4_SCR5_NoReadAdvances;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR7.td
@@ -246,7 +246,7 @@ multiclass SCR7_Unsupported {
   defm : UnsupportedSchedXsfvcp;
   defm : UnsupportedSchedZabha;
   defm : UnsupportedSchedZfa;
-  defm : UnsupportedSchedZfh;
+  defm : UnsupportedSchedZfhmin;
   defm : UnsupportedSchedZvk;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVSchedXiangShanNanHu.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedXiangShanNanHu.td
@@ -308,7 +308,7 @@ def : ReadAdvance<ReadXPERM, 0>;
 // Unsupported extensions
 defm : UnsupportedSchedV;
 defm : UnsupportedSchedZfa;
-defm : UnsupportedSchedZfh;
+defm : UnsupportedSchedZfhmin;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZabha;
 defm : UnsupportedSchedXsfvcp;

--- a/llvm/lib/Target/RISCV/RISCVSchedule.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedule.td
@@ -211,90 +211,57 @@ def ReadFClass16         : SchedRead;
 def ReadFClass32         : SchedRead;
 def ReadFClass64         : SchedRead;
 
+// For CPUs that support Zfhmin, but not Zfh.
 multiclass UnsupportedSchedZfh {
 let Unsupported = true in {
 def : WriteRes<WriteFAdd16, []>;
 def : WriteRes<WriteFClass16, []>;
-def : WriteRes<WriteFCvtF16ToF64, []>;
-def : WriteRes<WriteFCvtF64ToF16, []>;
 def : WriteRes<WriteFCvtI64ToF16, []>;
-def : WriteRes<WriteFCvtF32ToF16, []>;
 def : WriteRes<WriteFCvtI32ToF16, []>;
 def : WriteRes<WriteFCvtF16ToI64, []>;
-def : WriteRes<WriteFCvtF16ToF32, []>;
 def : WriteRes<WriteFCvtF16ToI32, []>;
 def : WriteRes<WriteFDiv16, []>;
 def : WriteRes<WriteFCmp16, []>;
-def : WriteRes<WriteFLD16, []>;
 def : WriteRes<WriteFMA16, []>;
 def : WriteRes<WriteFMinMax16, []>;
 def : WriteRes<WriteFMul16, []>;
-def : WriteRes<WriteFMovI16ToF16, []>;
-def : WriteRes<WriteFMovF16ToI16, []>;
 def : WriteRes<WriteFSGNJ16, []>;
-def : WriteRes<WriteFST16, []>;
 def : WriteRes<WriteFSqrt16, []>;
 
 def : ReadAdvance<ReadFAdd16, 0>;
 def : ReadAdvance<ReadFClass16, 0>;
-def : ReadAdvance<ReadFCvtF16ToF64, 0>;
-def : ReadAdvance<ReadFCvtF64ToF16, 0>;
 def : ReadAdvance<ReadFCvtI64ToF16, 0>;
-def : ReadAdvance<ReadFCvtF32ToF16, 0>;
 def : ReadAdvance<ReadFCvtI32ToF16, 0>;
 def : ReadAdvance<ReadFCvtF16ToI64, 0>;
-def : ReadAdvance<ReadFCvtF16ToF32, 0>;
 def : ReadAdvance<ReadFCvtF16ToI32, 0>;
 def : ReadAdvance<ReadFDiv16, 0>;
 def : ReadAdvance<ReadFCmp16, 0>;
 def : ReadAdvance<ReadFMA16, 0>;
 def : ReadAdvance<ReadFMinMax16, 0>;
 def : ReadAdvance<ReadFMul16, 0>;
-def : ReadAdvance<ReadFMovI16ToF16, 0>;
-def : ReadAdvance<ReadFMovF16ToI16, 0>;
 def : ReadAdvance<ReadFSGNJ16, 0>;
 def : ReadAdvance<ReadFSqrt16, 0>;
 } // Unsupported = true
 }
 
-multiclass UnsupportedSchedF {
+// For CPUs that support neither Zfhmin or Zfh.
+multiclass UnsupportedSchedZfhmin : UnsupportedSchedZfh {
 let Unsupported = true in {
-def : WriteRes<WriteFST32, []>;
-def : WriteRes<WriteFLD32, []>;
-def : WriteRes<WriteFAdd32, []>;
-def : WriteRes<WriteFSGNJ32, []>;
-def : WriteRes<WriteFMinMax32, []>;
-def : WriteRes<WriteFCvtI32ToF32, []>;
-def : WriteRes<WriteFCvtI64ToF32, []>;
-def : WriteRes<WriteFCvtF32ToI32, []>;
-def : WriteRes<WriteFCvtF32ToI64, []>;
-def : WriteRes<WriteFClass32, []>;
-def : WriteRes<WriteFCmp32, []>;
-def : WriteRes<WriteFMovF32ToI32, []>;
-def : WriteRes<WriteFMovI32ToF32, []>;
-def : WriteRes<WriteFMul32, []>;
-def : WriteRes<WriteFMA32, []>;
-def : WriteRes<WriteFDiv32, []>;
-def : WriteRes<WriteFSqrt32, []>;
+def : WriteRes<WriteFCvtF16ToF64, []>;
+def : WriteRes<WriteFCvtF64ToF16, []>;
+def : WriteRes<WriteFCvtF16ToF32, []>;
+def : WriteRes<WriteFCvtF32ToF16, []>;
+def : WriteRes<WriteFLD16, []>;
+def : WriteRes<WriteFMovI16ToF16, []>;
+def : WriteRes<WriteFMovF16ToI16, []>;
+def : WriteRes<WriteFST16, []>;
 
-def : ReadAdvance<ReadFAdd32, 0>;
-def : ReadAdvance<ReadFMul32, 0>;
-def : ReadAdvance<ReadFMA32, 0>;
-def : ReadAdvance<ReadFMA32Addend, 0>;
-def : ReadAdvance<ReadFDiv32, 0>;
-def : ReadAdvance<ReadFSqrt32, 0>;
-def : ReadAdvance<ReadFCmp32, 0>;
-def : ReadAdvance<ReadFSGNJ32, 0>;
-def : ReadAdvance<ReadFMinMax32, 0>;
-def : ReadAdvance<ReadFCvtF32ToI32, 0>;
-def : ReadAdvance<ReadFCvtF32ToI64, 0>;
-def : ReadAdvance<ReadFCvtI32ToF32, 0>;
-def : ReadAdvance<ReadFCvtI64ToF32, 0>;
-def : ReadAdvance<ReadFMovF32ToI32, 0>;
-def : ReadAdvance<ReadFMovI32ToF32, 0>;
-def : ReadAdvance<ReadFClass32, 0>;
-def : ReadAdvance<ReadFStoreData, 0>;
-def : ReadAdvance<ReadFMemBase, 0>;
+def : ReadAdvance<ReadFCvtF16ToF64, 0>;
+def : ReadAdvance<ReadFCvtF64ToF16, 0>;
+def : ReadAdvance<ReadFCvtF16ToF32, 0>;
+def : ReadAdvance<ReadFCvtF32ToF16, 0>;
+def : ReadAdvance<ReadFMovI16ToF16, 0>;
+def : ReadAdvance<ReadFMovF16ToI16, 0>;
 } // Unsupported = true
 }
 
@@ -338,6 +305,48 @@ def : ReadAdvance<ReadFCvtF64ToF32, 0>;
 def : ReadAdvance<ReadFMovF64ToI64, 0>;
 def : ReadAdvance<ReadFMovI64ToF64, 0>;
 def : ReadAdvance<ReadFClass64, 0>;
+} // Unsupported = true
+}
+
+// For CPUs with no floating point.
+multiclass UnsupportedSchedF : UnsupportedSchedD, UnsupportedSchedZfhmin {
+let Unsupported = true in {
+def : WriteRes<WriteFST32, []>;
+def : WriteRes<WriteFLD32, []>;
+def : WriteRes<WriteFAdd32, []>;
+def : WriteRes<WriteFSGNJ32, []>;
+def : WriteRes<WriteFMinMax32, []>;
+def : WriteRes<WriteFCvtI32ToF32, []>;
+def : WriteRes<WriteFCvtI64ToF32, []>;
+def : WriteRes<WriteFCvtF32ToI32, []>;
+def : WriteRes<WriteFCvtF32ToI64, []>;
+def : WriteRes<WriteFClass32, []>;
+def : WriteRes<WriteFCmp32, []>;
+def : WriteRes<WriteFMovF32ToI32, []>;
+def : WriteRes<WriteFMovI32ToF32, []>;
+def : WriteRes<WriteFMul32, []>;
+def : WriteRes<WriteFMA32, []>;
+def : WriteRes<WriteFDiv32, []>;
+def : WriteRes<WriteFSqrt32, []>;
+
+def : ReadAdvance<ReadFAdd32, 0>;
+def : ReadAdvance<ReadFMul32, 0>;
+def : ReadAdvance<ReadFMA32, 0>;
+def : ReadAdvance<ReadFMA32Addend, 0>;
+def : ReadAdvance<ReadFDiv32, 0>;
+def : ReadAdvance<ReadFSqrt32, 0>;
+def : ReadAdvance<ReadFCmp32, 0>;
+def : ReadAdvance<ReadFSGNJ32, 0>;
+def : ReadAdvance<ReadFMinMax32, 0>;
+def : ReadAdvance<ReadFCvtF32ToI32, 0>;
+def : ReadAdvance<ReadFCvtF32ToI64, 0>;
+def : ReadAdvance<ReadFCvtI32ToF32, 0>;
+def : ReadAdvance<ReadFCvtI64ToF32, 0>;
+def : ReadAdvance<ReadFMovF32ToI32, 0>;
+def : ReadAdvance<ReadFMovI32ToF32, 0>;
+def : ReadAdvance<ReadFClass32, 0>;
+def : ReadAdvance<ReadFStoreData, 0>;
+def : ReadAdvance<ReadFMemBase, 0>;
 } // Unsupported = true
 }
 


### PR DESCRIPTION
Split UnsupportedSchedZfhmin from UnsupportedSchedZfh. UnsupportedSchedZfhmin inherits from UnsupportedSchedZfh and should be used when no F16 is supported. UnsupportedSchedZfh can be used direclty for CPUs that support Zfhmin but not Zfh.

Make UnsupportedSchedF inherit from both UnsupportedSchedD and UnsupportedSchedZfhmin so that CPUs with no FP only need to include UnsupportedSchedF. This required some minor refactorings to RISCVSchedSyntacoreSCR345.td. I've also switch to inheritance instead of using defm.

Alternative to #120196.

CC: @BoyaoWang430