### PR TITLE
[flang][cuda] Relax host array check for cuda constant

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -114,6 +114,7 @@ struct FindHostArray
           (!details->cudaDataAttr() ||
               (details->cudaDataAttr() &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Device &&
+                  *details->cudaDataAttr() != common::CUDADataAttr::Constant &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Managed &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Shared &&
                   *details->cudaDataAttr() != common::CUDADataAttr::Unified))) {

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -1,6 +1,7 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 module m
  integer :: m(100)
+ integer, constant :: c(10)
  integer, parameter :: p(5) = [1,2,3,4,5]
  contains
   attributes(device) subroutine devsub
@@ -41,6 +42,12 @@ module m
     integer, shared :: s(10)
     i = threadIdx%x
     a(i) = s(10) ! ok, a is device and s is shared
+  end subroutine
+
+  attributes(global) subroutine cstarray(a)
+    integer, device :: a(10)
+    i = threadIdx%x
+    a(i) = c(10) ! ok, a is device and c is constant
   end subroutine
 end
 


### PR DESCRIPTION
Array with CONSTANT attribute declared in module spec part are device arrays and should not trigger the host array check. 