### PR TITLE
[X86] Correct the cdisp8 encoding for VGF2P8AFFINEINVQB and VGF2P8AFFINEQB.

### DIFF
--- a/llvm/lib/Target/X86/X86InstrAVX512.td
+++ b/llvm/lib/Target/X86/X86InstrAVX512.td
@@ -12569,10 +12569,10 @@ multiclass GF2P8AFFINE_avx512_common<bits<8> Op, string OpStr, SDNode OpNode,
 
 defm VGF2P8AFFINEINVQB : GF2P8AFFINE_avx512_common<0xCF, "vgf2p8affineinvqb",
                          X86GF2P8affineinvqb, SchedWriteVecIMul>,
-                         EVEX, VVVV, EVEX_CD8<8, CD8VF>, REX_W, AVX512AIi8Base;
+                         EVEX, VVVV, EVEX_CD8<64, CD8VF>, REX_W, AVX512AIi8Base;
 defm VGF2P8AFFINEQB    : GF2P8AFFINE_avx512_common<0xCE, "vgf2p8affineqb",
                          X86GF2P8affineqb, SchedWriteVecIMul>,
-                         EVEX, VVVV, EVEX_CD8<8, CD8VF>, REX_W, AVX512AIi8Base;
+                         EVEX, VVVV, EVEX_CD8<64, CD8VF>, REX_W, AVX512AIi8Base;
 
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/MC/X86/avx512gfni-att.s
+++ b/llvm/test/MC/X86/avx512gfni-att.s
@@ -176,3 +176,10 @@
 // CHECK: encoding: [0x62,0xf3,0xdd,0x50,0xce,0x09,0x07]
           vgf2p8affineqb  $7, (%rcx){1to8}, %zmm20, %zmm1
 
+// CHECK: vgf2p8affineinvqb $7, 8(%rcx){1to8}, %zmm20, %zmm1
+// CHECK: encoding: [0x62,0xf3,0xdd,0x50,0xcf,0x49,0x01,0x07]
+          vgf2p8affineinvqb $7, 8(%rcx){1to8}, %zmm20, %zmm1
+
+// CHECK: vgf2p8affineqb  $7, 8(%rcx){1to8}, %zmm20, %zmm1
+// CHECK: encoding: [0x62,0xf3,0xdd,0x50,0xce,0x49,0x01,0x07]
+          vgf2p8affineqb  $7, 8(%rcx){1to8}, %zmm20, %zmm1

--- a/llvm/test/MC/X86/avx512vl_gfni-att.s
+++ b/llvm/test/MC/X86/avx512vl_gfni-att.s
@@ -352,3 +352,18 @@
 // CHECK: encoding: [0x62,0xf3,0xdd,0x30,0xce,0x09,0x07]
           vgf2p8affineqb  $7, (%rcx){1to4}, %ymm20, %ymm1
 
+// CHECK: vgf2p8affineinvqb $7, 8(%rcx){1to2}, %xmm20, %xmm1
+// CHECK: encoding: [0x62,0xf3,0xdd,0x10,0xcf,0x49,0x01,0x07]
+          vgf2p8affineinvqb $7, 8(%rcx){1to2}, %xmm20, %xmm1
+
+// CHECK: vgf2p8affineinvqb $7, 8(%rcx){1to4}, %ymm20, %ymm1
+// CHECK: encoding: [0x62,0xf3,0xdd,0x30,0xcf,0x49,0x01,0x07]
+          vgf2p8affineinvqb $7, 8(%rcx){1to4}, %ymm20, %ymm1
+
+// CHECK: vgf2p8affineqb  $7, 8(%rcx){1to2}, %xmm20, %xmm1
+// CHECK: encoding: [0x62,0xf3,0xdd,0x10,0xce,0x49,0x01,0x07]
+          vgf2p8affineqb  $7, 8(%rcx){1to2}, %xmm20, %xmm1
+
+// CHECK: vgf2p8affineqb  $7, 8(%rcx){1to4}, %ymm20, %ymm1
+// CHECK: encoding: [0x62,0xf3,0xdd,0x30,0xce,0x49,0x01,0x07]
+          vgf2p8affineqb  $7, 8(%rcx){1to4}, %ymm20, %ymm1


### PR DESCRIPTION
These instructions use a 64-bit broadcast size so the element size for CD8 should be 64.

Pointed out by larkmjc on discord.