### PR TITLE
[clang][NFC] Increase NumStmtBits by 2 as we are approaching the limit

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -109,6 +109,18 @@ protected:
 
   //===--- Statement bitfields classes ---===//
 
+  enum { NumStmtBits = 9 };
+
+#define STMT(CLASS, PARENT)
+#define STMT_RANGE(BASE, FIRST, LAST)
+#define LAST_STMT_RANGE(BASE, FIRST, LAST)                                     \
+  static_assert(                                                               \
+      llvm::isInt<NumStmtBits>(StmtClass::LAST##Class),                        \
+      "The number of 'StmtClass'es is strictly bounded under two to "          \
+      "the power of 'NumStmtBits'");
+#define ABSTRACT_STMT(STMT)
+#include "clang/AST/StmtNodes.inc"
+
   class StmtBitfields {
     friend class ASTStmtReader;
     friend class ASTStmtWriter;
@@ -116,9 +128,8 @@ protected:
 
     /// The statement class.
     LLVM_PREFERRED_TYPE(StmtClass)
-    unsigned sClass : 8;
+    unsigned sClass : NumStmtBits;
   };
-  enum { NumStmtBits = 8 };
 
   class NullStmtBitfields {
     friend class ASTStmtReader;


### PR DESCRIPTION
We have already hit the limit of NumStmtBits downstream after 010d0115fc8e3834fc6f747f0841f3b1e467c4da, which adds 4 new StmtNodes.