### PR TITLE
[DiagnosticInfo] Fix the default DiagnosticSeverity

### DIFF
--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -150,7 +150,7 @@ public:
       : DiagnosticInfo(DK_Generic, Severity), MsgStr(MsgStr) {}
 
   DiagnosticInfoGeneric(const Instruction *I, const Twine &ErrMsg,
-                        DiagnosticSeverity Severity = DS_Warning)
+                        DiagnosticSeverity Severity = DS_Error)
       : DiagnosticInfo(DK_Generic, Severity), MsgStr(ErrMsg), Inst(I) {}
 
   const Twine &getMsgStr() const { return MsgStr; }


### PR DESCRIPTION
After
https://github.com/llvm/llvm-project/commit/ea632e1b34e1

the API call to LLVMContext->emitError(I, Errorstr) default to warning
instead of error.

This cause problems as the API mentioned it is "prefixed with error:".
