### PR TITLE
MIPS: Adding a check for JAL argument in PIC mode to prevent crashing on getExpr

### DIFF
--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -2109,7 +2109,7 @@ bool MipsAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
     warnIfNoMacro(IDLoc);
 
     if (!Inst.getOperand(0).isExpr()) {
-      return Error(IDLoc, "jal needs a symbolic expression in PIC mode");
+      return Error(IDLoc, "unsupported constant in relocation");
     }
 
     const MCExpr *JalExpr = Inst.getOperand(0).getExpr();

--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -2108,6 +2108,10 @@ bool MipsAsmParser::processInstruction(MCInst &Inst, SMLoc IDLoc,
   if ((Opcode == Mips::JAL || Opcode == Mips::JAL_MM) && inPicMode()) {
     warnIfNoMacro(IDLoc);
 
+    if (!Inst.getOperand(0).isExpr()) {
+      return Error(IDLoc, "jal needs a symbolic expression in PIC mode");
+    }
+
     const MCExpr *JalExpr = Inst.getOperand(0).getExpr();
 
     // We can do this expansion if there's only 1 symbol in the argument


### PR DESCRIPTION
Only an Expr is supported by JAL.
Let's check it before getExpr.
https://github.com/llvm/llvm-project/issues/80535