### PR TITLE
[mlir][Properties] Shorten "Property" to "Prop" in most places

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -334,13 +334,13 @@ TODO: Design and implement more primitive constraints
 
 #### Optional and default-valued properties
 
-To declare a property with a default value, use `DefaultValuedProperty<..., "...">`.
+To declare a property with a default value, use `DefaultValuedProp<..., "...">`.
 If the property's storage data type is different from its interface type,
 for example, in the case of array properties (which are stored as `SmallVector`s
 but use `ArrayRef` as an interface type), add the storage-type equivalent
 of the default value as the third argument.
 
-To declare an optional property, use `OptionalProperty<...>`.
+To declare an optional property, use `OptionalProp<...>`.
 This wraps the underlying property in an `std::optional` and gives it a
 default value of `std::nullopt`.
 
@@ -449,7 +449,7 @@ def MyOp : ... {
     I32Attr:$i32_attr,
     F32Attr:$f32_attr,
     ...
-    I32Property:$i32_prop,
+    I32Prop:$i32_prop,
     ...
   );
 
@@ -1011,7 +1011,7 @@ foo.op is_read_only
 foo.op
 ```
 
-The same logic applies to a `UnitProperty`.
+The same logic applies to a `UnitProp`.
 
 ##### Optional "else" Group
 

--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.td
@@ -1193,7 +1193,7 @@ def AffineLinearizeIndexOp : Affine_Op<"linearize_index",
   let arguments = (ins Variadic<Index>:$multi_index,
     Variadic<Index>:$dynamic_basis,
     DenseI64ArrayAttr:$static_basis,
-    UnitProperty:$disjoint);
+    UnitProp:$disjoint);
   let results = (outs Index:$linear_index);
 
   let assemblyFormat = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -60,7 +60,7 @@ class LLVM_IntArithmeticOpWithOverflowFlag<string mnemonic, string instName,
                                    list<Trait> traits = []> :
     LLVM_ArithmeticOpBase<AnySignlessInteger, mnemonic, instName,
     !listconcat([DeclareOpInterfaceMethods<IntegerOverflowFlagsInterface>], traits)> {
-  dag iofArg = (ins EnumProperty<"IntegerOverflowFlags", "", "IntegerOverflowFlags::none">:$overflowFlags);
+  dag iofArg = (ins EnumProp<"IntegerOverflowFlags", "", "IntegerOverflowFlags::none">:$overflowFlags);
   let arguments = !con(commonArgs, iofArg);
 
   string mlirBuilder = [{
@@ -558,7 +558,7 @@ class LLVM_CastOpWithOverflowFlag<string mnemonic, string instName, Type type,
                   Type resultType, list<Trait> traits = []> :
     LLVM_Op<mnemonic, !listconcat([Pure], [DeclareOpInterfaceMethods<IntegerOverflowFlagsInterface>], traits)>,
     LLVM_Builder<"$res = builder.Create" # instName # "($arg, $_resultType, /*Name=*/\"\", op.hasNoUnsignedWrap(), op.hasNoSignedWrap());"> {
-  let arguments = (ins type:$arg, EnumProperty<"IntegerOverflowFlags", "", "IntegerOverflowFlags::none">:$overflowFlags);
+  let arguments = (ins type:$arg, EnumProp<"IntegerOverflowFlags", "", "IntegerOverflowFlags::none">:$overflowFlags);
   let results = (outs resultType:$res);
   let builders = [LLVM_OneResultOpBuilder];
   let assemblyFormat = "$arg `` custom<OverflowFlags>($overflowFlags) attr-dict `:` type($arg) `to` type($res)";

--- a/mlir/include/mlir/IR/Properties.td
+++ b/mlir/include/mlir/IR/Properties.td
@@ -14,6 +14,7 @@
 #define PROPERTIES
 
 include "mlir/IR/Constraints.td"
+include "mlir/IR/Utils.td"
 
 // Base class for defining properties.
 class Property<string storageTypeParam = "", string desc = ""> {
@@ -211,7 +212,7 @@ defvar writeMlirBytecodeWithConvertToAttribute = [{
 // Primitive property kinds
 
 // Any kind of integer stored as properties.
-class IntProperty<string storageTypeParam, string desc = ""> :
+class IntProp<string storageTypeParam, string desc = ""> :
     Property<storageTypeParam, desc> {
   let summary = !if(!empty(desc), storageTypeParam, desc);
   let optionalParser = [{
@@ -228,10 +229,16 @@ class IntProperty<string storageTypeParam, string desc = ""> :
   }];
 }
 
-def I32Property : IntProperty<"int32_t">;
-def I64Property : IntProperty<"int64_t">;
+class IntProperty<string storageTypeParam, string desc = "">
+  : IntProp<storageTypeParam, desc>, Deprecated<"moved to the shorter name IntProp">;
 
-class EnumProperty<string storageTypeParam, string desc = "", string default = ""> :
+def I32Prop : IntProp<"int32_t">;
+def I64Prop : IntProp<"int64_t">;
+
+def I32Property : IntProp<"int32_t">, Deprecated<"moved to shorter name I32Prop">;
+def I64Property : IntProp<"int64_t">, Deprecated<"moved to shorter name I64Prop">;
+
+class EnumProp<string storageTypeParam, string desc = "", string default = ""> :
     Property<storageTypeParam, desc> {
   // TODO:  implement predicate for enum validity.
   let writeToMlirBytecode = [{
@@ -246,7 +253,12 @@ class EnumProperty<string storageTypeParam, string desc = "", string default = "
   let defaultValue = default;
 }
 
-def StringProperty : Property<"std::string", "string"> {
+class EnumProperty<string storageTypeParam, string desc = "", string default = ""> :
+  EnumProp<storageTypeParam, desc, default>,
+  Deprecated<"moved to shorter name EnumProp">;
+
+// Note: only a class so we can deprecate the old name
+class _cls_StringProp : Property<"std::string", "string"> {
   let interfaceType = "::llvm::StringRef";
   let convertFromStorage = "::llvm::StringRef{$_storage}";
   let assignToStorage = "$_storage = $_value.str()";
@@ -265,8 +277,11 @@ def StringProperty : Property<"std::string", "string"> {
     $_writer.writeOwnedString($_storage);
   }];
 }
+def StringProp : _cls_StringProp;
+def StringProperty : _cls_StringProp, Deprecated<"moved to shorter name StringProp">;
 
-def BoolProperty : IntProperty<"bool", "boolean"> {
+// Note: only a class so we can deprecate the old name
+class _cls_BoolProp : IntProp<"bool", "boolean"> {
   let printer = [{ $_printer << ($_storage ? "true" : "false") }];
   let readFromMlirBytecode = [{
     return $_reader.readBool($_storage);
@@ -275,8 +290,11 @@ def BoolProperty : IntProperty<"bool", "boolean"> {
     $_writer.writeOwnedBool($_storage);
   }];
 }
+def BoolProp : _cls_BoolProp;
+def BoolProperty : _cls_BoolProp, Deprecated<"moved to shorter name BoolProp">;
 
-def UnitProperty : Property<"bool", "unit property"> {
+// Note: only a class so we can deprecate the old name
+class _cls_UnitProp : Property<"bool", "unit property"> {
   let summary = "unit property";
   let description = [{
     A property whose presence or abscence is used as a flag.
@@ -337,6 +355,8 @@ def UnitProperty : Property<"bool", "unit property"> {
       return ::mlir::failure();
   }];
 }
+def UnitProp : _cls_UnitProp;
+def UnitProperty : _cls_UnitProp, Deprecated<"moved to shorter name UnitProp">;
 
 //===----------------------------------------------------------------------===//
 // Property field overwrites
@@ -344,7 +364,7 @@ def UnitProperty : Property<"bool", "unit property"> {
 /// Class for giving a property a default value.
 /// This doesn't change anything about the property other than giving it a default
 /// which can be used by ODS to elide printing.
-class DefaultValuedProperty<Property p, string default = "", string storageDefault = ""> : Property<p.storageType, p.summary> {
+class DefaultValuedProp<Property p, string default = "", string storageDefault = ""> : Property<p.storageType, p.summary> {
   let defaultValue = default;
   let storageTypeValueOverride = storageDefault;
   let baseProperty = p;
@@ -365,11 +385,13 @@ class DefaultValuedProperty<Property p, string default = "", string storageDefau
   let readFromMlirBytecode = p.readFromMlirBytecode;
   let writeToMlirBytecode = p.writeToMlirBytecode;
 }
+class DefaultValuedProperty<Property p, string default = "", string storageDefault = "">
+  : DefaultValuedProp<p, default, storageDefault>, Deprecated<"moved to shorter name DefaultValuedProp">;
 
 /// Apply the predicate `pred` to the property `p`, ANDing it with any
 /// predicates it may already have. If `newSummary` is provided, replace the
 /// summary of `p` with `newSummary`.
-class ConfinedProperty<Property p, Pred pred, string newSummary = "">
+class ConfinedProp<Property p, Pred pred, string newSummary = "">
     : Property<p.storageType, !if(!empty(newSummary), p.summary, newSummary)> {
   let predicate = !if(!ne(p.predicate, TruePred), And<[p.predicate, pred]>, pred);
   let baseProperty = p;
@@ -390,6 +412,10 @@ class ConfinedProperty<Property p, Pred pred, string newSummary = "">
   let defaultValue = p.defaultValue;
   let storageTypeValueOverride = p.storageTypeValueOverride;
 }
+
+class ConfinedProperty<Property p, Pred pred, string newSummary = "">
+  : ConfinedProp<p, pred, newSummary>,
+    Deprecated<"moved to shorter name ConfinedProp">;
 
 //===----------------------------------------------------------------------===//
 // Primitive property combinators
@@ -428,8 +454,8 @@ class _makeStorageWrapperPred<Property wrappedProp> {
 /// `SmallVector` of that property. This uses an `ArrayAttr` as its attribute form
 /// though subclasses can override this, as is the case with IntArrayAttr below.
 /// Those wishing to use a non-default number of SmallVector elements should
-/// subclass `ArrayProperty`.
-class ArrayProperty<Property elem = Property<>, string newSummary = ""> :
+/// subclass `ArrayProp`.
+class ArrayProp<Property elem = Property<>, string newSummary = ""> :
   Property<"::llvm::SmallVector<" # elem.storageType # ">",
     !if(!empty(newSummary), "array of " # elem.summary, newSummary)> {
   let interfaceType = "::llvm::ArrayRef<" # elem.storageType # ">";
@@ -548,9 +574,11 @@ class ArrayProperty<Property elem = Property<>, string newSummary = ""> :
       }()
     }]);
 }
+class ArrayProperty<Property elem = Property<>, string newSummary = "">
+  : ArrayProp<elem, newSummary>, Deprecated<"moved to shorter name ArrayProp">;
 
-class IntArrayProperty<Property elem, string newSummary=""> :
-    ArrayProperty<elem, newSummary> {
+class IntArrayProp<Property elem, string newSummary=""> :
+    ArrayProp<elem, newSummary> {
   // Bring back the trivial conversions we don't get in the general case.
   let convertFromAttribute = [{
     return convertFromAttribute($_storage, $_attr, $_diag);
@@ -559,6 +587,8 @@ class IntArrayProperty<Property elem, string newSummary=""> :
     return convertToAttribute($_ctxt, $_storage);
   }];
 }
+class IntArrayProperty<Property elem, string newSummary="">
+  : IntArrayProp<elem, newSummary>, Deprecated<"moved to shorter name IntArrayProp">;
 
 /// An optional property, stored as an std::optional<p.storageType>
 /// interfaced with as an std::optional<p.interfaceType>..
@@ -570,7 +600,7 @@ class IntArrayProperty<Property elem, string newSummary=""> :
 /// bracketing and delegate to the optional parser. In that case, the syntax is the
 /// syntax of the underlying property, or the keyword `none` in the rare cases that
 /// it is needed. This behavior can be disabled by setting `canDelegateParsing` to 0.
-class OptionalProperty<Property p, bit canDelegateParsing = 1>
+class OptionalProp<Property p, bit canDelegateParsing = 1>
     : Property<"std::optional<" # p.storageType # ">", "optional " # p.summary> {
 
   // In the cases where the underlying attribute is plain old data that's passed by
@@ -754,4 +784,7 @@ class OptionalProperty<Property p, bit canDelegateParsing = 1>
     "For delegated parsing to be used, the default value must be nullopt. " #
     "To use a non-trivial default, set the canDelegateParsing argument to 0";
 }
+class OptionalProperty<Property p, bit canDelegateParsing = 1>
+  : OptionalProp<p, canDelegateParsing>,
+    Deprecated<"moved to shorter name OptionalProp">;
 #endif // PROPERTIES

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -2994,11 +2994,11 @@ def TestOpWithProperties : TEST_Op<"with_properties"> {
     `flag` `=` $flag `,`
     `array` `=` $array attr-dict}];
   let arguments = (ins
-    I64Property:$a,
+    I64Prop:$a,
     StrAttr:$b, // Attributes can directly be used here.
-    StringProperty:$c,
-    BoolProperty:$flag,
-    IntArrayProperty<I64Property>:$array // example of an array
+    StringProp:$c,
+    BoolProp:$flag,
+    IntArrayProp<I64Prop>:$array // example of an array
   );
 }
 
@@ -3006,7 +3006,7 @@ def TestOpWithPropertiesAndAttr
   : TEST_Op<"with_properties_and_attr"> {
   let assemblyFormat = "$lhs prop-dict attr-dict";
 
-  let arguments = (ins I32Attr:$lhs, IntProperty<"int64_t">:$rhs);
+  let arguments = (ins I32Attr:$lhs, IntProp<"int64_t">:$rhs);
 }
 
 def TestOpWithPropertiesAndInferredType
@@ -3015,7 +3015,7 @@ def TestOpWithPropertiesAndInferredType
   ]> {
   let assemblyFormat = "$lhs prop-dict attr-dict";
 
-  let arguments = (ins I32Attr:$lhs, IntProperty<"int64_t">:$rhs);
+  let arguments = (ins I32Attr:$lhs, IntProp<"int64_t">:$rhs);
   let results = (outs AnyType:$result);
 }
 
@@ -3040,15 +3040,15 @@ def TestOpWithEmptyProperties : TEST_Op<"empty_properties"> {
 
 def TestOpUsingPropertyInCustom : TEST_Op<"using_property_in_custom"> {
   let assemblyFormat = "custom<UsingPropertyInCustom>($prop) attr-dict";
-  let arguments = (ins IntArrayProperty<I64Property>:$prop);
+  let arguments = (ins IntArrayProp<I64Prop>:$prop);
 }
 
 def TestOpUsingPropertyInCustomAndOther
   : TEST_Op<"using_property_in_custom_and_other"> {
   let assemblyFormat = "custom<UsingPropertyInCustom>($prop) prop-dict attr-dict";
   let arguments = (ins
-    IntArrayProperty<I64Property>:$prop,
-    I64Property:$other
+    IntArrayProp<I64Prop>:$prop,
+    I64Prop:$other
   );
 }
 
@@ -3063,7 +3063,7 @@ def TestOpWithVariadicSegmentProperties : TEST_Op<"variadic_segment_prop",
 
 def TestOpUsingPropertyRefInCustom : TEST_Op<"using_property_ref_in_custom"> {
   let assemblyFormat = "custom<IntProperty>($first) `+` custom<SumProperty>($second, ref($first)) attr-dict";
-  let arguments = (ins IntProperty<"int64_t">:$first, IntProperty<"int64_t">:$second);
+  let arguments = (ins IntProp<"int64_t">:$first, IntProp<"int64_t">:$second);
 }
 
 def IntPropertyWithWorseBytecode : Property<"int64_t"> {
@@ -3200,9 +3200,9 @@ def TestOpWithDefaultValuedProperties : TEST_Op<"with_default_valued_properties"
     attr-dict
   }];
   let arguments = (ins DefaultValuedAttr<I32Attr, "0">:$a,
-    DefaultValuedProperty<StringProperty, "\"\"">:$b,
-    DefaultValuedProperty<IntProperty<"int32_t">, "-1">:$c,
-    UnitProperty:$unit);
+    DefaultValuedProp<StringProp, "\"\"">:$b,
+    DefaultValuedProp<IntProp<"int32_t">, "-1">:$c,
+    UnitProp:$unit);
 }
 
 def TestOpWithOptionalProperties : TEST_Op<"with_optional_properties"> {
@@ -3219,15 +3219,15 @@ def TestOpWithOptionalProperties : TEST_Op<"with_optional_properties"> {
   }];
   let arguments = (ins
     OptionalAttr<I32Attr>:$anAttr,
-    OptionalProperty<I64Property>:$simple,
-    OptionalProperty<StringProperty>:$nonTrivialStorage,
+    OptionalProp<I64Prop>:$simple,
+    OptionalProp<StringProp>:$nonTrivialStorage,
     // Confirm that properties with default values now default to nullopt and have
     // the long syntax.
-    OptionalProperty<DefaultValuedProperty<I64Property, "0">>:$hasDefault,
-    OptionalProperty<OptionalProperty<I64Property>>:$nested,
-    OptionalProperty<StringProperty, 0>:$longSyntax,
-    UnitProperty:$hasUnit,
-    OptionalProperty<UnitProperty>:$maybeUnit);
+    OptionalProp<DefaultValuedProp<I64Prop, "0">>:$hasDefault,
+    OptionalProp<OptionalProp<I64Prop>>:$nested,
+    OptionalProp<StringProp, 0>:$longSyntax,
+    UnitProp:$hasUnit,
+    OptionalProp<UnitProp>:$maybeUnit);
 }
 
 def TestOpWithArrayProperties : TEST_Op<"with_array_properties"> {
@@ -3242,37 +3242,37 @@ def TestOpWithArrayProperties : TEST_Op<"with_array_properties"> {
     attr-dict
   }];
   let arguments = (ins
-    ArrayProperty<I64Property>:$ints,
-    ArrayProperty<StringProperty>:$strings,
-    ArrayProperty<ArrayProperty<I32Property>>:$nested,
-    OptionalProperty<ArrayProperty<I32Property>>:$opt,
-    ArrayProperty<OptionalProperty<I64Property>>:$explicitOptions,
-    ArrayProperty<UnitProperty>:$explicitUnits,
-    DefaultValuedProperty<ArrayProperty<I64Property>,
+    ArrayProp<I64Prop>:$ints,
+    ArrayProp<StringProp>:$strings,
+    ArrayProp<ArrayProp<I32Prop>>:$nested,
+    OptionalProp<ArrayProp<I32Prop>>:$opt,
+    ArrayProp<OptionalProp<I64Prop>>:$explicitOptions,
+    ArrayProp<UnitProp>:$explicitUnits,
+    DefaultValuedProp<ArrayProp<I64Prop>,
       "::llvm::ArrayRef<int64_t>{}", "::llvm::SmallVector<int64_t>{}">:$hasDefault
   );
 }
 
-def NonNegativeI64Property : ConfinedProperty<I64Property,
+def NonNegativeI64Prop : ConfinedProp<I64Prop,
   CPred<"$_self >= 0">, "non-negative int64_t">;
 
-class NonEmptyArray<Property p> : ConfinedProperty
-    <ArrayProperty<p>, Neg<CPred<"$_self.empty()">>,
+class NonEmptyArray<Property p> : ConfinedProp
+    <ArrayProp<p>, Neg<CPred<"$_self.empty()">>,
     "non-empty array of " # p.summary>;
 
 def OpWithPropertyPredicates : TEST_Op<"op_with_property_predicates"> {
   let arguments = (ins
-    NonNegativeI64Property:$scalar,
-    OptionalProperty<NonNegativeI64Property>:$optional,
-    DefaultValuedProperty<NonNegativeI64Property, "0">:$defaulted,
-    ConfinedProperty<NonNegativeI64Property,
+    NonNegativeI64Prop:$scalar,
+    OptionalProp<NonNegativeI64Prop>:$optional,
+    DefaultValuedProp<NonNegativeI64Prop, "0">:$defaulted,
+    ConfinedProp<NonNegativeI64Prop,
       CPred<"$_self <= 5">, "between 0 and 5">:$more_constrained,
-    ArrayProperty<NonNegativeI64Property>:$array,
-    NonEmptyArray<I64Property>:$non_empty_unconstrained,
-    NonEmptyArray<NonNegativeI64Property>:$non_empty_constrained,
+    ArrayProp<NonNegativeI64Prop>:$array,
+    NonEmptyArray<I64Prop>:$non_empty_unconstrained,
+    NonEmptyArray<NonNegativeI64Prop>:$non_empty_constrained,
     // Test applying predicates when the fromStorage() on the optional<> isn't trivial.
-    OptionalProperty<NonEmptyArray<NonNegativeI64Property>>:$non_empty_optional,
-    I64Property:$unconstrained
+    OptionalProp<NonEmptyArray<NonNegativeI64Prop>>:$non_empty_optional,
+    I64Prop:$unconstrained
   );
   let assemblyFormat = "attr-dict prop-dict";
 }

--- a/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
+++ b/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
@@ -88,12 +88,12 @@ def OIListTrivial : TEST_Op<"oilist_with_keywords_only"> {
 
 // Ops related to OIList primitive
 def OIListTrivialProperties : TEST_Op<"oilist_with_keywords_only_properties"> {
-  let arguments = (ins UnitProperty:$keyword, UnitProperty:$otherKeyword,
-                       UnitProperty:$diffNameUnitPropertyKeyword);
+  let arguments = (ins UnitProp:$keyword, UnitProp:$otherKeyword,
+                       UnitProp:$diffNameUnitPropKeyword);
   let assemblyFormat = [{
     oilist( `keyword` $keyword
           | `otherKeyword` $otherKeyword
-          | `thirdKeyword` $diffNameUnitPropertyKeyword) attr-dict
+          | `thirdKeyword` $diffNameUnitPropKeyword) attr-dict
   }];
 }
 
@@ -404,13 +404,13 @@ def FormatOptionalUnitAttrNoElide
 }
 
 def FormatOptionalUnitProperty : TEST_Op<"format_optional_unit_property"> {
-  let arguments = (ins UnitProperty:$is_optional);
+  let arguments = (ins UnitProp:$is_optional);
   let assemblyFormat = "(`is_optional` $is_optional^)? attr-dict";
 }
 
 def FormatOptionalUnitPropertyNoElide
     : TEST_Op<"format_optional_unit_property_no_elide"> {
-  let arguments = (ins UnitProperty:$is_optional);
+  let arguments = (ins UnitProp:$is_optional);
   let assemblyFormat = "($is_optional^)? attr-dict";
 }
 
@@ -433,8 +433,8 @@ def FormatOptionalWithElse : TEST_Op<"format_optional_else"> {
 
 def FormatOptionalPropDict : TEST_Op<"format_optional_prop_dict"> {
   let arguments = (ins
-    OptionalProperty<StringProperty>:$a,
-    DefaultValuedProperty<I32Property, "1">:$b);
+    OptionalProp<StringProp>:$a,
+    DefaultValuedProp<I32Prop, "1">:$b);
   let assemblyFormat = "prop-dict attr-dict";
 }
 

--- a/mlir/test/mlir-tblgen/op-format-invalid.td
+++ b/mlir/test/mlir-tblgen/op-format-invalid.td
@@ -481,12 +481,12 @@ def VariableInvalidN : TestFormat_Op<[{
 // CHECK: error: property 'prop' is already bound
 def VariableInvalidO : TestFormat_Op<[{
   custom<Test>($prop, $prop) attr-dict
-}]>, Arguments<(ins IntProperty<"int64_t">:$prop)>;
+}]>, Arguments<(ins IntProp<"int64_t">:$prop)>;
 
 // CHECK: error: property 'prop' must be bound before it is referenced
 def VariableInvalidP : TestFormat_Op<[{
   custom<Test>(ref($prop)) attr-dict
-}]>, Arguments<(ins IntProperty<"int64_t">:$prop)>;
+}]>, Arguments<(ins IntProp<"int64_t">:$prop)>;
 
 //===----------------------------------------------------------------------===//
 // Coverage Checks

--- a/mlir/test/mlir-tblgen/op-properties-predicates.td
+++ b/mlir/test/mlir-tblgen/op-properties-predicates.td
@@ -12,26 +12,26 @@ def Test_Dialect : Dialect {
 class NS_Op<string mnemonic, list<Trait> traits = []> :
     Op<Test_Dialect, mnemonic, traits>;
 
-def NonNegativeI64Property : ConfinedProperty<I64Property,
+def NonNegativeI64Prop : ConfinedProp<I64Prop,
   CPred<"$_self >= 0">, "non-negative int64_t">;
 
-class NonEmptyArray<Property p> : ConfinedProperty
-    <ArrayProperty<p>, Neg<CPred<"$_self.empty()">>,
+class NonEmptyArray<Property p> : ConfinedProp
+    <ArrayProp<p>, Neg<CPred<"$_self.empty()">>,
     "non-empty array of " # p.summary>;
 
 def OpWithPredicates : NS_Op<"op_with_predicates"> {
   let arguments = (ins
-    NonNegativeI64Property:$scalar,
-    OptionalProperty<NonNegativeI64Property>:$optional,
-    DefaultValuedProperty<NonNegativeI64Property, "0">:$defaulted,
-    ConfinedProperty<NonNegativeI64Property,
+    NonNegativeI64Prop:$scalar,
+    OptionalProp<NonNegativeI64Prop>:$optional,
+    DefaultValuedProp<NonNegativeI64Prop, "0">:$defaulted,
+    ConfinedProp<NonNegativeI64Prop,
       CPred<"$_self <= 5">, "between 0 and 5">:$moreConstrained,
-    ArrayProperty<NonNegativeI64Property>:$array,
-    NonEmptyArray<I64Property>:$non_empty_unconstrained,
-    NonEmptyArray<NonNegativeI64Property>:$non_empty_constrained,
+    ArrayProp<NonNegativeI64Prop>:$array,
+    NonEmptyArray<I64Prop>:$non_empty_unconstrained,
+    NonEmptyArray<NonNegativeI64Prop>:$non_empty_constrained,
     // Test applying predicates when the fromStorage() on the optional<> isn't trivial.
-    OptionalProperty<NonEmptyArray<NonNegativeI64Property>>:$non_empty_optional,
-    I64Property:$unconstrained
+    OptionalProp<NonEmptyArray<NonNegativeI64Prop>>:$non_empty_optional,
+    I64Prop:$unconstrained
   );
 }
 

--- a/mlir/test/mlir-tblgen/op-properties.td
+++ b/mlir/test/mlir-tblgen/op-properties.td
@@ -20,18 +20,18 @@ def OpWithAttr : NS_Op<"op_with_attr">{
 // Test required and optional properties
 // ---
 
-def DefaultI64Array : IntArrayProperty<I64Property> {
+def DefaultI64Array : IntArrayProp<I64Prop> {
   let defaultValue = "::llvm::ArrayRef<int64_t>{}";
   let storageTypeValueOverride = "::llvm::SmallVector<int64_t>{}";
 }
 
 def OpWithProps : NS_Op<"op_with_props"> {
   let arguments = (ins
-    BoolProperty:$flag,
-    StringProperty:$string,
-    ArrayProperty<StringProperty>:$strings,
-    DefaultValuedProperty<I32Property, "0">:$default_int,
-    OptionalProperty<I64Property>:$optional,
+    BoolProp:$flag,
+    StringProp:$string,
+    ArrayProp<StringProp>:$strings,
+    DefaultValuedProp<I32Prop, "0">:$default_int,
+    OptionalProp<I64Prop>:$optional,
     DefaultI64Array:$intArray
   );
 }
@@ -39,10 +39,10 @@ def OpWithProps : NS_Op<"op_with_props"> {
 /// Check that optional arguments to builders only go at the end.
 def OpWithSomeOptionalProperties : NS_Op<"op_with_some_optional_props"> {
   let arguments = (ins
-    OptionalProperty<I64Property>:$mustSpecify,
-    I64Property:$required,
-    OptionalProperty<StringProperty>:$canOmit,
-    DefaultValuedProperty<I64Property, "-1">:$canOmit2
+    OptionalProp<I64Prop>:$mustSpecify,
+    I64Prop:$required,
+    OptionalProp<StringProp>:$canOmit,
+    DefaultValuedProp<I64Prop, "-1">:$canOmit2
   );
 }
 
@@ -51,10 +51,10 @@ def OpWithSomeOptionalProperties : NS_Op<"op_with_some_optional_props"> {
 def OpWithOptionalPropsAndAttrs :
     NS_Op<"with_some_optional_props_and_atts"> {
   let arguments = (ins
-    OptionalProperty<BoolProperty>:$mustSpecify,
+    OptionalProp<BoolProp>:$mustSpecify,
     OptionalAttr<BoolAttr>:$ambiguous,
     OptionalAttr<I32Attr>:$canOmit,
-    OptionalProperty<I32Property>:$canOmitProp
+    OptionalProp<I32Prop>:$canOmitProp
   );
 }
 

--- a/mlir/tools/mlir-tblgen/OpFormatGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpFormatGen.cpp
@@ -113,13 +113,16 @@ struct AttributeLikeVariable : public VariableElement {
     return isa<VariableElement>(fe) && classof(cast<VariableElement>(fe));
   }
 
-  /// Returns true if the variable is a UnitAttr or a UnitProperty.
+  /// Returns true if the variable is a UnitAttr or a UnitProp.
   bool isUnit() const {
     if (const auto *attr = dyn_cast<AttributeVariable>(this))
       return attr->getVar()->attr.getBaseAttr().getAttrDefName() == "UnitAttr";
     if (const auto *prop = dyn_cast<PropertyVariable>(this)) {
-      return prop->getVar()->prop.getBaseProperty().getPropertyDefName() ==
-             "UnitProperty";
+      StringRef baseDefName =
+          prop->getVar()->prop.getBaseProperty().getPropertyDefName();
+      // Note: remove the `UnitProperty` case once the deprecation period is
+      // over.
+      return baseDefName == "UnitProp" || baseDefName == "UnitProperty";
     }
     llvm_unreachable("Type that wasn't listed in classof()");
   }


### PR DESCRIPTION
Since the property system isn't currently in heavy use, it's probably the right time to fix a choice I made when expanding ODS property support.

Specifically, most of the property subclasses, like OptionalProperty or IntProperty, wrote out the word "Property" in full. The corresponding classes in the Attribute hierarchy uses the short-form "Attr" in those cases, as in OptionalAttr or DefaultValuedAttr.

This commit changes all those uses of "Property" to "Prop" in order to prevent excessively verbose tablegen files that needlessly repeat the full name of a core concept that can be abbreviated.

So, this commit renames all the FooProperty classes to FooProp, and keeps the existing names as alias with a Deprecated<> on them to warn people.

In addition, this commit updates the documentation around properties to mention the constraint support.