### PR TITLE
Add OneTypedResult::getResultAs to simplify the result type casting logic

### DIFF
--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -694,9 +694,14 @@ public:
   class Impl
       : public TraitBase<ConcreteType, OneTypedResult<ResultType>::Impl> {
   public:
-    mlir::TypedValue<ResultType> getResult() {
-      return cast<mlir::TypedValue<ResultType>>(
+    template <typename ValTy>
+    mlir::TypedValue<ValTy> getResultOfType() {
+      return mlir::cast<mlir::TypedValue<ValTy>>(
           this->getOperation()->getResult(0));
+    }
+
+    mlir::TypedValue<ResultType> getResult() {
+      return getResultOfType<ResultType>();
     }
 
     /// If the operation returns a single value, then the Op can be implicitly

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -695,13 +695,13 @@ public:
       : public TraitBase<ConcreteType, OneTypedResult<ResultType>::Impl> {
   public:
     template <typename ValTy>
-    mlir::TypedValue<ValTy> getResultOfType() {
+    mlir::TypedValue<ValTy> getResultAs() {
       return mlir::cast<mlir::TypedValue<ValTy>>(
           this->getOperation()->getResult(0));
     }
 
     mlir::TypedValue<ResultType> getResult() {
-      return getResultOfType<ResultType>();
+      return getResultAs<ResultType>();
     }
 
     /// If the operation returns a single value, then the Op can be implicitly

--- a/mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp
@@ -213,7 +213,7 @@ struct ReinterpretCastOpInterface
     auto reinterpretCast = cast<ReinterpretCastOp>(op);
     auto baseMemref = reinterpretCast.getSource();
     auto resultMemref =
-        cast<TypedValue<BaseMemRefType>>(reinterpretCast.getResult());
+        reinterpretCast.getResultOfType<BaseMemRefType>();
 
     builder.setInsertionPointAfter(op);
 

--- a/mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp
@@ -212,7 +212,7 @@ struct ReinterpretCastOpInterface
                                    Location loc) const {
     auto reinterpretCast = cast<ReinterpretCastOp>(op);
     auto baseMemref = reinterpretCast.getSource();
-    auto resultMemref = reinterpretCast.getResultOfType<BaseMemRefType>();
+    auto resultMemref = reinterpretCast.getResultAs<BaseMemRefType>();
 
     builder.setInsertionPointAfter(op);
 

--- a/mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/RuntimeOpVerification.cpp
@@ -212,8 +212,7 @@ struct ReinterpretCastOpInterface
                                    Location loc) const {
     auto reinterpretCast = cast<ReinterpretCastOp>(op);
     auto baseMemref = reinterpretCast.getSource();
-    auto resultMemref =
-        reinterpretCast.getResultOfType<BaseMemRefType>();
+    auto resultMemref = reinterpretCast.getResultOfType<BaseMemRefType>();
 
     builder.setInsertionPointAfter(op);
 

--- a/mlir/lib/Dialect/Mesh/Transforms/Spmdization.cpp
+++ b/mlir/lib/Dialect/Mesh/Transforms/Spmdization.cpp
@@ -91,7 +91,7 @@ handlePartialAxesDuringResharding(OpBuilder &builder,
                                sourceSharding.getMeshAttr().getLeafReference(),
                                allReduceMeshAxes, sourceShard,
                                sourceSharding.getPartialType())
-          .getResultOfType<ShapedType>();
+          .getResultAs<ShapedType>();
 
   llvm::SmallVector<MeshAxis> remainingPartialAxes;
   llvm::copy_if(sourceShardingPartialAxesSet,
@@ -138,7 +138,7 @@ splitLastAxisInResharding(ImplicitLocOpBuilder &builder,
           .create<AllSliceOp>(sourceShard, mesh,
                               ArrayRef<MeshAxis>(splitMeshAxis),
                               splitTensorAxis)
-          .getResultOfType<ShapedType>();
+          .getResultAs<ShapedType>();
   MeshSharding targetSharding = targetShardingInSplitLastAxis(
       builder.getContext(), sourceSharding, splitTensorAxis, splitMeshAxis);
   return {targetShard, targetSharding};
@@ -276,7 +276,7 @@ unsplitLastAxisInResharding(ImplicitLocOpBuilder &builder,
       shardShapedType(sourceUnshardedShape, mesh, targetSharding);
   TypedValue<ShapedType> targetShard =
       builder.create<tensor::CastOp>(targetShape, allGatherResult)
-          .getResultOfType<ShapedType>();
+          .getResultAs<ShapedType>();
   return {targetShard, targetSharding};
 }
 
@@ -410,7 +410,7 @@ moveLastSplitAxisInResharding(ImplicitLocOpBuilder &builder, MeshOp mesh,
       shardShapedType(sourceUnshardedShape, mesh, targetSharding);
   TypedValue<ShapedType> targetShard =
       builder.create<tensor::CastOp>(targetShape, allToAllResult)
-          .getResultOfType<ShapedType>();
+          .getResultAs<ShapedType>();
   return {targetShard, targetSharding};
 }
 

--- a/mlir/lib/Dialect/Mesh/Transforms/Spmdization.cpp
+++ b/mlir/lib/Dialect/Mesh/Transforms/Spmdization.cpp
@@ -85,13 +85,13 @@ handlePartialAxesDuringResharding(OpBuilder &builder,
   }
 
   builder.setInsertionPointAfterValue(sourceShard);
-  TypedValue<ShapedType> resultValue = cast<TypedValue<ShapedType>>(
+  TypedValue<ShapedType> resultValue =
       builder
           .create<AllReduceOp>(sourceShard.getLoc(), sourceShard.getType(),
                                sourceSharding.getMeshAttr().getLeafReference(),
                                allReduceMeshAxes, sourceShard,
                                sourceSharding.getPartialType())
-          .getResult());
+          .getResultOfType<ShapedType>();
 
   llvm::SmallVector<MeshAxis> remainingPartialAxes;
   llvm::copy_if(sourceShardingPartialAxesSet,
@@ -133,12 +133,12 @@ splitLastAxisInResharding(ImplicitLocOpBuilder &builder,
                           MeshSharding sourceSharding,
                           TypedValue<ShapedType> sourceShard, MeshOp mesh,
                           int64_t splitTensorAxis, MeshAxis splitMeshAxis) {
-  TypedValue<ShapedType> targetShard = cast<TypedValue<ShapedType>>(
+  TypedValue<ShapedType> targetShard =
       builder
           .create<AllSliceOp>(sourceShard, mesh,
                               ArrayRef<MeshAxis>(splitMeshAxis),
                               splitTensorAxis)
-          .getResult());
+          .getResultOfType<ShapedType>();
   MeshSharding targetSharding = targetShardingInSplitLastAxis(
       builder.getContext(), sourceSharding, splitTensorAxis, splitMeshAxis);
   return {targetShard, targetSharding};
@@ -274,8 +274,10 @@ unsplitLastAxisInResharding(ImplicitLocOpBuilder &builder,
       APInt(64, splitTensorAxis));
   ShapedType targetShape =
       shardShapedType(sourceUnshardedShape, mesh, targetSharding);
-  TypedValue<ShapedType> targetShard = cast<TypedValue<ShapedType>>(
-      builder.create<tensor::CastOp>(targetShape, allGatherResult).getResult());
+  TypedValue<ShapedType> targetShard =
+      builder
+          .create<tensor::CastOp>(targetShape, allGatherResult)
+          .getResultOfType<ShapedType>();
   return {targetShard, targetSharding};
 }
 
@@ -407,8 +409,10 @@ moveLastSplitAxisInResharding(ImplicitLocOpBuilder &builder, MeshOp mesh,
       APInt(64, targetTensorAxis), APInt(64, sourceTensorAxis));
   ShapedType targetShape =
       shardShapedType(sourceUnshardedShape, mesh, targetSharding);
-  TypedValue<ShapedType> targetShard = cast<TypedValue<ShapedType>>(
-      builder.create<tensor::CastOp>(targetShape, allToAllResult).getResult());
+  TypedValue<ShapedType> targetShard =
+      builder
+          .create<tensor::CastOp>(targetShape, allToAllResult)
+          .getResultOfType<ShapedType>();
   return {targetShard, targetSharding};
 }
 

--- a/mlir/lib/Dialect/Mesh/Transforms/Spmdization.cpp
+++ b/mlir/lib/Dialect/Mesh/Transforms/Spmdization.cpp
@@ -275,8 +275,7 @@ unsplitLastAxisInResharding(ImplicitLocOpBuilder &builder,
   ShapedType targetShape =
       shardShapedType(sourceUnshardedShape, mesh, targetSharding);
   TypedValue<ShapedType> targetShard =
-      builder
-          .create<tensor::CastOp>(targetShape, allGatherResult)
+      builder.create<tensor::CastOp>(targetShape, allGatherResult)
           .getResultOfType<ShapedType>();
   return {targetShard, targetSharding};
 }
@@ -410,8 +409,7 @@ moveLastSplitAxisInResharding(ImplicitLocOpBuilder &builder, MeshOp mesh,
   ShapedType targetShape =
       shardShapedType(sourceUnshardedShape, mesh, targetSharding);
   TypedValue<ShapedType> targetShard =
-      builder
-          .create<tensor::CastOp>(targetShape, allToAllResult)
+      builder.create<tensor::CastOp>(targetShape, allToAllResult)
           .getResultOfType<ShapedType>();
   return {targetShard, targetSharding};
 }


### PR DESCRIPTION
## Description
This PR adds a `getResultAs` member to the `OneTypedResult` class to simplify the result type casting logic.
Casting the result type is necessary when converting between its concrete type and interface type.
Without this member, one typically needs to call the `getResult` method followed by an explicit cast, which makes the code tedious. Introducing the `getResultAs` member simplifies this process.

## Examples
Before this PR:
```cpp
auto targetShard = cast<TypedValue<ShapedType>>(
    builder.create<AllSliceOp>(sourceShard, mesh,
                               ArrayRef<MeshAxis>(splitMeshAxis),
                               splitTensorAxis)
        .getResult());
```
With this PR:
```cpp
auto targetShard = builder.create<AllSliceOp>(sourceShard, mesh,
                                             ArrayRef<MeshAxis>(splitMeshAxis),
                                             splitTensorAxis)
                       .getResultAs<ShapedType>();
```