### PR TITLE
Revert "LLVMContext: Cleanup registration of known bundle IDs"

### DIFF
--- a/llvm/lib/IR/LLVMContext.cpp
+++ b/llvm/lib/IR/LLVMContext.cpp
@@ -31,35 +31,6 @@
 
 using namespace llvm;
 
-static constexpr StringRef knownBundleName(unsigned BundleTagID) {
-  switch (BundleTagID) {
-  case LLVMContext::OB_deopt:
-    return "deopt";
-  case LLVMContext::OB_funclet:
-    return "funclet";
-  case LLVMContext::OB_gc_transition:
-    return "gc-transition";
-  case LLVMContext::OB_cfguardtarget:
-    return "cfguardtarget";
-  case LLVMContext::OB_preallocated:
-    return "preallocated";
-  case LLVMContext::OB_gc_live:
-    return "gc-live";
-  case LLVMContext::OB_clang_arc_attachedcall:
-    return "clang.arc.attachedcall";
-  case LLVMContext::OB_ptrauth:
-    return "ptrauth";
-  case LLVMContext::OB_kcfi:
-    return "kcfi";
-  case LLVMContext::OB_convergencectrl:
-    return "convergencectrl";
-  default:
-    llvm_unreachable("unknown bundle id");
-  }
-
-  llvm_unreachable("covered switch");
-}
-
 LLVMContext::LLVMContext() : pImpl(new LLVMContextImpl(*this)) {
   // Create the fixed metadata kinds. This is done in the same order as the
   // MD_* enum values so that they correspond.
@@ -75,12 +46,56 @@ LLVMContext::LLVMContext() : pImpl(new LLVMContextImpl(*this)) {
     (void)ID;
   }
 
-  for (unsigned BundleTagID = LLVMContext::OB_deopt;
-       BundleTagID <= LLVMContext::OB_convergencectrl; ++BundleTagID) {
-    [[maybe_unused]] const auto *Entry =
-        pImpl->getOrInsertBundleTag(knownBundleName(BundleTagID));
-    assert(Entry->second == BundleTagID && "operand bundle id drifted!");
-  }
+  auto *DeoptEntry = pImpl->getOrInsertBundleTag("deopt");
+  assert(DeoptEntry->second == LLVMContext::OB_deopt &&
+         "deopt operand bundle id drifted!");
+  (void)DeoptEntry;
+
+  auto *FuncletEntry = pImpl->getOrInsertBundleTag("funclet");
+  assert(FuncletEntry->second == LLVMContext::OB_funclet &&
+         "funclet operand bundle id drifted!");
+  (void)FuncletEntry;
+
+  auto *GCTransitionEntry = pImpl->getOrInsertBundleTag("gc-transition");
+  assert(GCTransitionEntry->second == LLVMContext::OB_gc_transition &&
+         "gc-transition operand bundle id drifted!");
+  (void)GCTransitionEntry;
+
+  auto *CFGuardTargetEntry = pImpl->getOrInsertBundleTag("cfguardtarget");
+  assert(CFGuardTargetEntry->second == LLVMContext::OB_cfguardtarget &&
+         "cfguardtarget operand bundle id drifted!");
+  (void)CFGuardTargetEntry;
+
+  auto *PreallocatedEntry = pImpl->getOrInsertBundleTag("preallocated");
+  assert(PreallocatedEntry->second == LLVMContext::OB_preallocated &&
+         "preallocated operand bundle id drifted!");
+  (void)PreallocatedEntry;
+
+  auto *GCLiveEntry = pImpl->getOrInsertBundleTag("gc-live");
+  assert(GCLiveEntry->second == LLVMContext::OB_gc_live &&
+         "gc-transition operand bundle id drifted!");
+  (void)GCLiveEntry;
+
+  auto *ClangAttachedCall =
+      pImpl->getOrInsertBundleTag("clang.arc.attachedcall");
+  assert(ClangAttachedCall->second == LLVMContext::OB_clang_arc_attachedcall &&
+         "clang.arc.attachedcall operand bundle id drifted!");
+  (void)ClangAttachedCall;
+
+  auto *PtrauthEntry = pImpl->getOrInsertBundleTag("ptrauth");
+  assert(PtrauthEntry->second == LLVMContext::OB_ptrauth &&
+         "ptrauth operand bundle id drifted!");
+  (void)PtrauthEntry;
+
+  auto *KCFIEntry = pImpl->getOrInsertBundleTag("kcfi");
+  assert(KCFIEntry->second == LLVMContext::OB_kcfi &&
+         "kcfi operand bundle id drifted!");
+  (void)KCFIEntry;
+
+  auto *ConvergenceCtrlEntry = pImpl->getOrInsertBundleTag("convergencectrl");
+  assert(ConvergenceCtrlEntry->second == LLVMContext::OB_convergencectrl &&
+         "convergencectrl operand bundle id drifted!");
+  (void)ConvergenceCtrlEntry;
 
   SyncScope::ID SingleThreadSSID =
       pImpl->getOrInsertSyncScopeID("singlethread");


### PR DESCRIPTION
Reverts llvm/llvm-project#120359

This broke buildbots with older GCC versions: https://lab.llvm.org/buildbot/#/builders/140/builds/13302

Failure
```
7.815 [4326/32/2685] Building CXX object lib/IR/CMakeFiles/LLVMCore.dir/LLVMContext.cpp.o
FAILED: lib/IR/CMakeFiles/LLVMCore.dir/LLVMContext.cpp.o 
ccache /usr/bin/c++ -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Ilib/IR -I/home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR -Iinclude -I/home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -fno-lifetime-dse -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-uninitialized -Wno-nonnull -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -Wno-misleading-indentation -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -std=c++1z -MD -MT lib/IR/CMakeFiles/LLVMCore.dir/LLVMContext.cpp.o -MF lib/IR/CMakeFiles/LLVMCore.dir/LLVMContext.cpp.o.d -o lib/IR/CMakeFiles/LLVMCore.dir/LLVMContext.cpp.o -c /home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR/LLVMContext.cpp
In file included from /home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/include/llvm/ADT/Hashing.h:49:0,
                 from /home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/include/llvm/ADT/ArrayRef.h:12,
                 from /home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR/ConstantsContext.h:17,
                 from /home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR/LLVMContextImpl.h:17,
                 from /home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR/LLVMContext.cpp:15:
/home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR/LLVMContext.cpp: In function ‘constexpr llvm::StringRef knownBundleName(unsigned int)’:
/home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/include/llvm/Support/ErrorHandling.h:144:36: error: call to non-constexpr function ‘void llvm::llvm_unreachable_internal(const char*, const char*, unsigned int)’
   ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
/home/botworker/bbot/builds/openmp-offload-sles-build/llvm.src/llvm/lib/IR/LLVMContext.cpp:60:3: note: in expansion of macro ‘llvm_unreachable’
   llvm_unreachable("covered switch");
   ^~~~~~~~~~~~~~~~
```