### PR TITLE
LLVMContext: rem constexpr to unblock build w/ gcc

### DIFF
--- a/llvm/lib/IR/LLVMContext.cpp
+++ b/llvm/lib/IR/LLVMContext.cpp
@@ -31,7 +31,7 @@
 
 using namespace llvm;
 
-static constexpr StringRef knownBundleName(unsigned BundleTagID) {
+static StringRef knownBundleName(unsigned BundleTagID) {
   switch (BundleTagID) {
   case LLVMContext::OB_deopt:
     return "deopt";


### PR DESCRIPTION
Address issues observed in buildbots with older GCC versions: https://lab.llvm.org/buildbot/#/builders/140/builds/13302