### PR TITLE
[LLVM] Update InstCombine maintainers

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -46,10 +46,12 @@ Matthew.Arsenault@amd.com, arsenm2@gmail.com (email), [arsenm](https://github.co
 Chandler Carruth \
 chandlerc@gmail.com, chandlerc@google.com (email), [chandlerc](https://github.com/chandlerc) (GitHub)
 
-#### InstCombine, ConstantFold
+#### InstCombine, InstSimplify, ValueTracking, ConstantFold
 
-David Majnemer \
-david.majnemer@gmail.com (email), [majnemer](https://github.com/majnemer) (GitHub)
+Nikita Popov \
+llvm@npopov.com, npopov@redhat.com (email), [nikic](https://github.com/nikic) (GitHub), nikic (Discourse) \
+Yingwei Zheng \
+dtcxzyw2333@gmail.com (email), [dtcxzyw](https://github.com/dtcxzyw) (GitHub)
 
 #### InstrProfiling and related parts of ProfileData
 
@@ -458,6 +460,7 @@ Evan Cheng (evan.cheng@apple.com) -- Parts of code generator not covered by some
 Renato Golin (rengolin@systemcall.eu, [rengolin](https://github.com/rengolin)) -- ARM backend \
 James Grosbach (grosbach@apple.com) -- MC layer \
 Anton Korobeynikov (anton@korobeynikov.info, [asl](https://github.com/asl)) -- ARM EABI \
+David Majnemer (david.majnemer@gmail.com, [majnemer](https://github.com/majnemer)) -- InstCombine, ConstantFold \
 Chad Rosier (mcrosier@codeaurora.org) -- FastISel \
 Hans Wennborg (hans@chromium.org, [zmodem](https://github.com/zmodem)) -- Release management \
 Kostya Serebryany ([kcc](https://github.com/kcc)) -- Sanitizers \


### PR DESCRIPTION
> See [developer policy](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for context on the maintainers terminology.

We currently list @majnemer as the maintainer for InstCombine. While David does still occasionally contribute in this area, most of the contributions/reviews come from other people nowadays.

I'd like to propose @dtcxzyw and myself as the new maintainers for this area. I've also expanded it to include InstSimplify and ValueTracking, and these tend to all go together.