### PR TITLE
Reapply "[NFC][AMDGPU] Pre-commit clang and llvm tests for dynamic allocas"

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/dynamic-alloca-divergent.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/dynamic-alloca-divergent.ll
@@ -13,12 +13,56 @@ define amdgpu_kernel void @kernel_dynamic_stackalloc_vgpr_align4(ptr addrspace(1
   ret void
 }
 
+; ERR: remark: <unknown>:0:0: cannot select: %{{[0-9]+}}:sreg_32(p5) = G_DYN_STACKALLOC %{{[0-9]+}}:vgpr(s32), 1 (in function: kernel_dynamic_stackalloc_vgpr_default_align)
+; ERR-NEXT: warning: Instruction selection used fallback path for kernel_dynamic_stackalloc_vgpr_default_align
+; ERR-NEXT: error: <unknown>:0:0: in function kernel_dynamic_stackalloc_vgpr_default_align void (ptr addrspace(1)): unsupported dynamic alloca
+
+define amdgpu_kernel void @kernel_dynamic_stackalloc_vgpr_default_align(ptr addrspace(1) %ptr) {
+  %id = call i32 @llvm.amdgcn.workitem.id.x()
+  %gep = getelementptr i32, ptr addrspace(1) %ptr, i32 %id
+  %n = load i32, ptr addrspace(1) %gep
+  %alloca = alloca i32, i32 %n, addrspace(5)
+  store volatile i32 123, ptr addrspace(5) %alloca
+  ret void
+}
+; ERR: remark: <unknown>:0:0: cannot select: %{{[0-9]+}}:sreg_32(p5) = G_DYN_STACKALLOC %{{[0-9]+}}:vgpr(s32), 64 (in function: kernel_dynamic_stackalloc_vgpr_align64)
+; ERR-NEXT: warning: Instruction selection used fallback path for kernel_dynamic_stackalloc_vgpr_align64
+; ERR-NEXT: error: <unknown>:0:0: in function kernel_dynamic_stackalloc_vgpr_align64 void (ptr addrspace(1)): unsupported dynamic alloca
+
+define amdgpu_kernel void @kernel_dynamic_stackalloc_vgpr_align64(ptr addrspace(1) %ptr) {
+  %id = call i32 @llvm.amdgcn.workitem.id.x()
+  %gep = getelementptr i32, ptr addrspace(1) %ptr, i32 %id
+  %n = load i32, ptr addrspace(1) %gep
+  %alloca = alloca i32, i32 %n, align 64, addrspace(5)
+  store volatile i32 123, ptr addrspace(5) %alloca
+  ret void
+}
+
 ; ERR: remark: <unknown>:0:0: cannot select: %{{[0-9]+}}:sreg_32(p5) = G_DYN_STACKALLOC %{{[0-9]+}}:vgpr(s32), 1 (in function: func_dynamic_stackalloc_vgpr_align4)
 ; ERR-NEXT: warning: Instruction selection used fallback path for func_dynamic_stackalloc_vgpr_align4
 ; ERR-NEXT: error: <unknown>:0:0: in function func_dynamic_stackalloc_vgpr_align4 void (i32): unsupported dynamic alloca
 
 define void @func_dynamic_stackalloc_vgpr_align4(i32 %n) {
   %alloca = alloca i32, i32 %n, align 4, addrspace(5)
+  store volatile i32 456, ptr addrspace(5) %alloca
+  ret void
+}
+
+; ERR: remark: <unknown>:0:0: cannot select: %{{[0-9]+}}:sreg_32(p5) = G_DYN_STACKALLOC %{{[0-9]+}}:vgpr(s32), 1 (in function: func_dynamic_stackalloc_vgpr_default_align)
+; ERR-NEXT: warning: Instruction selection used fallback path for func_dynamic_stackalloc_vgpr_default_align
+; ERR-NEXT: error: <unknown>:0:0: in function func_dynamic_stackalloc_vgpr_default_align void (i32): unsupported dynamic alloca
+
+define void @func_dynamic_stackalloc_vgpr_default_align(i32 %n) {
+  %alloca = alloca i32, i32 %n, addrspace(5)
+  store volatile i32 456, ptr addrspace(5) %alloca
+  ret void
+}
+; ERR: remark: <unknown>:0:0: cannot select: %{{[0-9]+}}:sreg_32(p5) = G_DYN_STACKALLOC %{{[0-9]+}}:vgpr(s32), 64 (in function: func_dynamic_stackalloc_vgpr_align64)
+; ERR-NEXT: warning: Instruction selection used fallback path for func_dynamic_stackalloc_vgpr_align64
+; ERR-NEXT: error: <unknown>:0:0: in function func_dynamic_stackalloc_vgpr_align64 void (i32): unsupported dynamic alloca
+
+define void @func_dynamic_stackalloc_vgpr_align64(i32 %n) {
+  %alloca = alloca i32, i32 %n, align 64, addrspace(5)
   store volatile i32 456, ptr addrspace(5) %alloca
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/dynamic_stackalloc.ll
+++ b/llvm/test/CodeGen/AMDGPU/dynamic_stackalloc.ll
@@ -5,8 +5,188 @@ target datalayout = "A5"
 
 ; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
 
-define amdgpu_kernel void @test_dynamic_stackalloc(ptr addrspace(1) %out, i32 %n) {
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_uniform(i32 %n) {
   %alloca = alloca i32, i32 %n, addrspace(5)
-  store volatile i32 0, ptr addrspace(5) %alloca
+  store volatile i32 123, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_uniform_over_aligned(i32 %n) {
+  %alloca = alloca i32, i32 %n, align 128, addrspace(5)
+  store volatile i32 10, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_uniform_under_aligned(i32 %n) {
+  %alloca = alloca i32, i32 %n, align 2, addrspace(5)
+  store volatile i32 22, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_divergent() {
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca = alloca float, i32 %idx, addrspace(5)
+  store volatile i32 123, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_divergent_over_aligned() {
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca = alloca i32, i32 %idx, align 128, addrspace(5)
+  store volatile i32 444, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_divergent_under_aligned() {
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca = alloca i128, i32 %idx, align 2, addrspace(5)
+  store volatile i32 666, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_multiple_allocas(i32 %n, i32 %m) {
+entry:
+  %cond = icmp eq i32 %n, 0
+  %alloca1 = alloca i32, i32 8, addrspace(5)
+  %alloca2 = alloca i17, i32 %n, addrspace(5)
+  br i1 %cond, label %bb.0, label %bb.1
+bb.0:
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca3 = alloca i32, i32 %m, align 64, addrspace(5)
+  %alloca4 = alloca i32, i32 %idx, align 4, addrspace(5)
+  store volatile i32 3, ptr addrspace(5) %alloca3
+  store volatile i32 4, ptr addrspace(5) %alloca4
+  br label %bb.1
+bb.1:
+  store volatile i32 1, ptr addrspace(5) %alloca1
+  store volatile i32 2, ptr addrspace(5) %alloca2
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define amdgpu_kernel void @test_dynamic_stackalloc_kernel_control_flow(i32 %n, i32 %m) {
+entry:
+  %cond = icmp eq i32 %n, 0
+  br i1 %cond, label %bb.0, label %bb.1
+bb.0:
+  %alloca2 = alloca i32, i32 %m, align 64, addrspace(5)
+  store volatile i32 2, ptr addrspace(5) %alloca2
+  br label %bb.2
+bb.1:
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca1 = alloca i32, i32 %idx, align 4, addrspace(5)
+  store volatile i32 1, ptr addrspace(5) %alloca1
+  br label %bb.2
+bb.2:
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_uniform(i32 %n) {
+  %alloca = alloca i32, i32 %n, addrspace(5)
+  store volatile i32 123, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_uniform_over_aligned(i32 %n) {
+  %alloca = alloca i32, i32 %n, align 128, addrspace(5)
+  store volatile i32 10, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_uniform_under_aligned(i32 %n) {
+  %alloca = alloca i32, i32 %n, align 2, addrspace(5)
+  store volatile i32 22, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_divergent() {
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca = alloca i32, i32 %idx, addrspace(5)
+  store volatile i32 123, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_divergent_over_aligned() {
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca = alloca i32, i32 %idx, align 128, addrspace(5)
+  store volatile i32 444, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_divergent_under_aligned() {
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca = alloca i32, i32 %idx, align 2, addrspace(5)
+  store volatile i32 666, ptr addrspace(5) %alloca
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_multiple_allocas(i32 %n, i32 %m) {
+entry:
+  %cond = icmp eq i32 %n, 0
+  %alloca1 = alloca i32, i32 8, addrspace(5)
+  %alloca2 = alloca i32, i32 %n, addrspace(5)
+  br i1 %cond, label %bb.0, label %bb.1
+bb.0:
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca3 = alloca i32, i32 %m, align 64, addrspace(5)
+  %alloca4 = alloca i32, i32 %idx, align 4, addrspace(5)
+  store volatile i32 3, ptr addrspace(5) %alloca3
+  store volatile i32 4, ptr addrspace(5) %alloca4
+  br label %bb.1
+bb.1:
+  store volatile i32 1, ptr addrspace(5) %alloca1
+  store volatile i32 2, ptr addrspace(5) %alloca2
+  ret void
+}
+
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+; CHECK: in function test_dynamic_stackalloc{{.*}}: unsupported dynamic alloca
+
+define void @test_dynamic_stackalloc_device_control_flow(i32 %n, i32 %m) {
+entry:
+  %cond = icmp eq i32 %n, 0
+  br i1 %cond, label %bb.0, label %bb.1
+bb.0:
+  %idx = call i32 @llvm.amdgcn.workitem.id.x()
+  %alloca1 = alloca i32, i32 %idx, align 4, addrspace(5)
+  store volatile i32 1, ptr addrspace(5) %alloca1
+  br label %bb.2
+bb.1:
+  %alloca2 = alloca i32, i32 %m, align 64, addrspace(5)
+  store volatile i32 2, ptr addrspace(5) %alloca2
+  br label %bb.2
+bb.2:
   ret void
 }


### PR DESCRIPTION
This reapplies commit https://github.com/llvm/llvm-project/pull/120063.

A machine-verifier bug was causing a crash in the previous commit. 
This has been addressed in https://github.com/llvm/llvm-project/pull/120393.