### PR TITLE
Allow `CoverageMapping::getCoverageForFile()` to show Branches also outside functions

### DIFF
--- a/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp
@@ -1412,7 +1412,7 @@ CoverageData CoverageMapping::getCoverageForFile(StringRef Filename) const {
       }
     // Capture branch regions specific to the function (excluding expansions).
     for (const auto &CR : Function.CountedBranchRegions)
-      if (FileIDs.test(CR.FileID) && (CR.FileID == CR.ExpandedFileID))
+      if (FileIDs.test(CR.FileID))
         FileCoverage.BranchRegions.push_back(CR);
     // Capture MCDC records specific to the function.
     for (const auto &MR : Function.MCDCRecords)

--- a/llvm/test/tools/llvm-cov/branch-macros.cpp
+++ b/llvm/test/tools/llvm-cov/branch-macros.cpp
@@ -5,7 +5,7 @@
 #define COND1 (a == b)
 #define COND2 (a != b)
 #define COND3 (COND1 && COND2)
-#define COND4 (COND3 ? COND2 : COND1)
+#define COND4 (COND3 ? COND2 : COND1) // CHECK: | Branch ([[@LINE]]:15): [True: 1, False: 2]
 #define MACRO1 COND3
 #define MACRO2 MACRO1
 #define MACRO3 MACRO2


### PR DESCRIPTION
Fixes #119952