### PR TITLE
[LLVM] Move Bigcheese to inactive maintainer for Windows object tools

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -386,11 +386,6 @@ tstellar@redhat.com (email), [tstellar](https://github.com/tstellar) (GitHub)
 Martin Storsjö \
 martin@martin.st (email), [mstorsjo](https://github.com/mstorsjo) (GitHub)
 
-#### Windows support in object tools
-
-Michael Spencer \
-bigcheesegs@gmail.com (email), [Bigcheese](https://github.com/Bigcheese) (GitHub)
-
 #### Sony PlayStation support
 
 Jeremy Morse \
@@ -463,6 +458,7 @@ Anton Korobeynikov (anton@korobeynikov.info, [asl](https://github.com/asl)) -- A
 Chad Rosier (mcrosier@codeaurora.org) -- FastISel \
 Hans Wennborg (hans@chromium.org, [zmodem](https://github.com/zmodem)) -- Release management \
 Kostya Serebryany ([kcc](https://github.com/kcc)) -- Sanitizers \
+Michael Spencer (bigcheesegs@gmail.com), [Bigcheese](https://github.com/Bigcheese)) -- Windows support in object tools \
 Alexei Starovoitov (alexei.starovoitov@gmail.com, [4ast](https://github.com/4ast)) -- BPF backend \
 Evgeniy Stepanov ([eugenis](https://github.com/eugenis)) -- Sanitizers
 


### PR DESCRIPTION
> See [developer policy](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for context on the maintainers terminology.

Hey @Bigcheese! You're currently listed as the maintainer for "Windows support in object tools". I know you're still active in LLVM in general, but I don't think you're involved in this particular area anymore? Please let me know if I'm wrong on that.

I'm also not aware of anyone else who is actively involved in this area currently, so I'm dropping the category entirely for now.