### PR TITLE
[LLVM] Update contact info for VLIW instruction scheduling maintainer

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -171,7 +171,7 @@ matze@braunis.de (email), [MatzeB](https://github.com/MatzeB) (GitHub)
 #### VLIW Instruction Scheduling, Packetization
 
 Sergei Larin \
-slarin@codeaurora.org (email)
+slarin@qti.qualcomm.com (email), [SergeiYLarin](https://github.com/SergeiYLarin) (GitHub)
 
 #### Register allocation
 


### PR DESCRIPTION
> See [developer policy](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for context on the maintainers terminology.

We currently list Sergei Larin as the maintainer for VLIW instruction scheduling. However, he hasn't been active in about 8 years.

I believe that this functionality is only used by hexagon, so cc @llvm/pr-subscribers-backend-hexagon in case somebody would like to pick this up. Otherwise I'd just drop this component from the list.