### PR TITLE
[llvm-exegesis] Fix warnings

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -135,9 +135,6 @@ ExegesisRISCVTarget::ExegesisRISCVTarget()
     : ExegesisTarget(ArrayRef<CpuAndPfmCounters>{},
                      RISCV_MC::isOpcodeAvailable) {}
 
-#define GET_REGISTER_MATCHER
-#include "RISCVGenAsmMatcher.inc"
-
 bool ExegesisRISCVTarget::matchesArch(Triple::ArchType Arch) const {
   return Arch == Triple::riscv32 || Arch == Triple::riscv64;
 }


### PR DESCRIPTION
This patch fixes:

  lib/Target/RISCV/RISCVGenAsmMatcher.inc:239:19: error: unused
  function 'MatchRegisterName' [-Werror,-Wunused-function]

  lib/Target/RISCV/RISCVGenAsmMatcher.inc:568:19: error: unused
  function 'MatchRegisterAltName' [-Werror,-Wunused-function]
