### PR TITLE
[Sema] Fix tautological bounds check warning with -fwrapv

### DIFF
--- a/clang/test/Sema/tautological-pointer-comparison.c
+++ b/clang/test/Sema/tautological-pointer-comparison.c
@@ -1,40 +1,72 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -DFWRAPV -fwrapv -verify %s
+
+#ifdef FWRAPV
+// expected-no-diagnostics
+#endif
 
 int add_ptr_idx_ult_ptr(const char *ptr, unsigned index) {
-  return ptr + index < ptr; // expected-warning {{pointer comparison always evaluates to false}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to false}}
+#endif
+  return ptr + index < ptr;
 }
 
 int add_idx_ptr_ult_ptr(const char *ptr, unsigned index) {
-  return index + ptr < ptr; // expected-warning {{pointer comparison always evaluates to false}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to false}}
+#endif
+  return index + ptr < ptr;
 }
 
 int ptr_ugt_add_ptr_idx(const char *ptr, unsigned index) {
-  return ptr > ptr + index; // expected-warning {{pointer comparison always evaluates to false}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to false}}
+#endif
+  return ptr > ptr + index;
 }
 
 int ptr_ugt_add_idx_ptr(const char *ptr, unsigned index) {
-  return ptr > index + ptr; // expected-warning {{pointer comparison always evaluates to false}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to false}}
+#endif
+  return ptr > index + ptr;
 }
 
 int add_ptr_idx_uge_ptr(const char *ptr, unsigned index) {
-  return ptr + index >= ptr; // expected-warning {{pointer comparison always evaluates to true}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to true}}
+#endif
+  return ptr + index >= ptr;
 }
 
 int add_idx_ptr_uge_ptr(const char *ptr, unsigned index) {
-  return index + ptr >= ptr; // expected-warning {{pointer comparison always evaluates to true}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to true}}
+#endif
+  return index + ptr >= ptr;
 }
 
 int ptr_ule_add_ptr_idx(const char *ptr, unsigned index) {
-  return ptr <= ptr + index; // expected-warning {{pointer comparison always evaluates to true}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to true}}
+#endif
+  return ptr <= ptr + index;
 }
 
 int ptr_ule_add_idx_ptr(const char *ptr, unsigned index) {
-  return ptr <= index + ptr; // expected-warning {{pointer comparison always evaluates to true}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to true}}
+#endif
+  return ptr <= index + ptr;
 }
 
 int add_ptr_idx_ult_ptr_array(unsigned index) {
   char ptr[10];
-  return ptr + index < ptr; // expected-warning {{pointer comparison always evaluates to false}}
+#ifndef FWRAPV
+  // expected-warning@+2 {{pointer comparison always evaluates to false}}
+#endif
+  return ptr + index < ptr;
 }
 
 // Negative tests with wrong predicate.

--- a/clang/test/Sema/tautological-pointer-comparison.c
+++ b/clang/test/Sema/tautological-pointer-comparison.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify=expected %s
+// RUN: %clang_cc1 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fwrapv -verify=fwrapv %s
 
 // fwrapv-no-diagnostics

--- a/clang/test/Sema/tautological-pointer-comparison.c
+++ b/clang/test/Sema/tautological-pointer-comparison.c
@@ -1,72 +1,43 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -fsyntax-only -DFWRAPV -fwrapv -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected %s
+// RUN: %clang_cc1 -fsyntax-only -fwrapv -verify=fwrapv %s
 
-#ifdef FWRAPV
-// expected-no-diagnostics
-#endif
+// fwrapv-no-diagnostics
 
 int add_ptr_idx_ult_ptr(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to false}}
-#endif
-  return ptr + index < ptr;
+  return ptr + index < ptr; // expected-warning {{pointer comparison always evaluates to false}}
 }
 
 int add_idx_ptr_ult_ptr(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to false}}
-#endif
-  return index + ptr < ptr;
+  return index + ptr < ptr; // expected-warning {{pointer comparison always evaluates to false}}
 }
 
 int ptr_ugt_add_ptr_idx(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to false}}
-#endif
-  return ptr > ptr + index;
+  return ptr > ptr + index; // expected-warning {{pointer comparison always evaluates to false}}
 }
 
 int ptr_ugt_add_idx_ptr(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to false}}
-#endif
-  return ptr > index + ptr;
+  return ptr > index + ptr; // expected-warning {{pointer comparison always evaluates to false}}
 }
 
 int add_ptr_idx_uge_ptr(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to true}}
-#endif
-  return ptr + index >= ptr;
+  return ptr + index >= ptr; // expected-warning {{pointer comparison always evaluates to true}}
 }
 
 int add_idx_ptr_uge_ptr(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to true}}
-#endif
-  return index + ptr >= ptr;
+  return index + ptr >= ptr; // expected-warning {{pointer comparison always evaluates to true}}
 }
 
 int ptr_ule_add_ptr_idx(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to true}}
-#endif
-  return ptr <= ptr + index;
+  return ptr <= ptr + index; // expected-warning {{pointer comparison always evaluates to true}}
 }
 
 int ptr_ule_add_idx_ptr(const char *ptr, unsigned index) {
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to true}}
-#endif
-  return ptr <= index + ptr;
+  return ptr <= index + ptr; // expected-warning {{pointer comparison always evaluates to true}}
 }
 
 int add_ptr_idx_ult_ptr_array(unsigned index) {
   char ptr[10];
-#ifndef FWRAPV
-  // expected-warning@+2 {{pointer comparison always evaluates to false}}
-#endif
-  return ptr + index < ptr;
+  return ptr + index < ptr; // expected-warning {{pointer comparison always evaluates to false}}
 }
 
 // Negative tests with wrong predicate.


### PR DESCRIPTION
The tautological bounds check warning added in #120222 does not take into account whether signed integer overflow is well defined or not, which could result in a developer removing a bounds check that may not actually be always false because of different overflow semantics.

```c
int check(const int* foo, unsigned int idx)
{
    return foo + idx < foo;
}
```

```
$ clang -O2 -c test.c
test.c:3:19: warning: pointer comparison always evaluates to false [-Wtautological-compare]
    3 |         return foo + idx < foo;
      |                          ^
1 warning generated.

# Bounds check is eliminated without -fwrapv, warning was correct
$ llvm-objdump -dr test.o
...
0000000000000000 <check>:
       0: 31 c0                         xorl    %eax, %eax
       2: c3                            retq
```

```
$ clang -O2 -fwrapv -c test.c
test.c:3:19: warning: pointer comparison always evaluates to false [-Wtautological-compare]
    3 |         return foo + idx < foo;
      |                          ^
1 warning generated.

# Bounds check remains, warning was wrong
$ llvm-objdump -dr test.o
0000000000000000 <check>:
       0: 89 f0                         movl    %esi, %eax
       2: 48 8d 0c 87                   leaq    (%rdi,%rax,4), %rcx
       6: 31 c0                         xorl    %eax, %eax
       8: 48 39 f9                      cmpq    %rdi, %rcx
       b: 0f 92 c0                      setb    %al
       e: c3                            retq
```

Prevent the warning from firing when `-fwrapv` is enabled.
