### PR TITLE
[APINotes] Avoid assertion failure with expensive checks

### DIFF
--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -2045,7 +2045,12 @@ APINotesReader::VersionedInfo<T>::VersionedInfo(
       Results.begin(), Results.end(),
       [](const std::pair<llvm::VersionTuple, T> &left,
          const std::pair<llvm::VersionTuple, T> &right) -> bool {
-        assert(left.first != right.first && "two entries for the same version");
+        // The comparison function should be reflective, and with expensive
+        // checks we can get callbacks basically checking that lambda(a,a) is
+        // false. We could still check that we do not find equal elements when
+        // left!=right.
+        assert((&left == &right || left.first != right.first) &&
+               "two entries for the same version");
         return left.first < right.first;
       }));
 


### PR DESCRIPTION
Found assertion failures when using EXPENSIVE_CHECKS and running lit tests for APINotes:
   Assertion `left.first != right.first && "two entries for the same version"' failed.

It seems like std::is_sorted is verifying that the comparison function is reflective (comp(a,a)=false) when using expensive checks. So we would get callbacks to the lambda used for comparison, even for vectors with a single element in APINotesReader::VersionedInfo<T>::VersionedInfo, with "left" and "right" being the same object. Therefore the assert checking that we never found equal values would fail.

Fix makes sure that we skip the check for equal values when "left" and "right" is the same object.