### PR TITLE
[lld-macho] Include branch extension thunks in linker map

### DIFF
--- a/lld/MachO/ConcatOutputSection.h
+++ b/lld/MachO/ConcatOutputSection.h
@@ -72,7 +72,7 @@ public:
   void finalizeContents() override {}
   void finalize() override;
   bool needsThunks() const;
-  const std::vector<ConcatInputSection *> &getThunks() const { return thunks; }
+  ArrayRef<ConcatInputSection *> getThunks() const { return thunks; }
   void writeTo(uint8_t *buf) const override;
 
   static bool classof(const OutputSection *sec) {

--- a/lld/MachO/ConcatOutputSection.h
+++ b/lld/MachO/ConcatOutputSection.h
@@ -25,8 +25,9 @@ class Defined;
 // in the final binary.
 class ConcatOutputSection : public OutputSection {
 public:
-  explicit ConcatOutputSection(StringRef name)
-      : OutputSection(ConcatKind, name) {}
+  explicit ConcatOutputSection(StringRef name,
+                               OutputSection::Kind kind = ConcatKind)
+      : OutputSection(kind, name) {}
 
   const ConcatInputSection *firstSection() const { return inputs.front(); }
   const ConcatInputSection *lastSection() const { return inputs.back(); }
@@ -46,7 +47,7 @@ public:
   void writeTo(uint8_t *buf) const override;
 
   static bool classof(const OutputSection *sec) {
-    return sec->kind() == ConcatKind;
+    return sec->kind() == ConcatKind || sec->kind() == TextKind;
   }
 
   static ConcatOutputSection *getOrCreateForInput(const InputSection *);
@@ -66,11 +67,17 @@ private:
 // support thunk insertion.
 class TextOutputSection : public ConcatOutputSection {
 public:
-  explicit TextOutputSection(StringRef name) : ConcatOutputSection(name) {}
+  explicit TextOutputSection(StringRef name)
+      : ConcatOutputSection(name, TextKind) {}
   void finalizeContents() override {}
   void finalize() override;
   bool needsThunks() const;
+  const std::vector<ConcatInputSection *> &getThunks() const { return thunks; }
   void writeTo(uint8_t *buf) const override;
+
+  static bool classof(const OutputSection *sec) {
+    return sec->kind() == TextKind;
+  }
 
 private:
   uint64_t estimateStubsInRangeVA(size_t callIdx) const;

--- a/lld/MachO/MapFile.cpp
+++ b/lld/MachO/MapFile.cpp
@@ -165,21 +165,13 @@ static uint64_t getSymSizeForMap(Defined *sym) {
 // This approach creates a new (temporary) vector which is not ideal but the
 // ideal approach leads to a lot of code duplication.
 static std::vector<ConcatInputSection *>
-mergeOrderedInputs(const std::vector<ConcatInputSection *> &inputs1,
-                   const std::vector<ConcatInputSection *> &inputs2) {
-  std::vector<ConcatInputSection *> vec;
-  size_t i = 0, ie = inputs1.size();
-  size_t t = 0, te = inputs2.size();
-  while (i < ie || t < te) {
-    while (i < ie &&
-           (t == te || inputs1[i]->outSecOff <= inputs2[t]->outSecOff)) {
-      vec.push_back(inputs1[i++]);
-    }
-    while (t < te &&
-           (i == ie || inputs2[t]->outSecOff < inputs1[i]->outSecOff)) {
-      vec.push_back(inputs2[t++]);
-    }
-  }
+mergeOrderedInputs(ArrayRef<ConcatInputSection *> inputs1,
+                   ArrayRef<ConcatInputSection *> inputs2) {
+  std::vector<ConcatInputSection *> vec(inputs1.size() + inputs2.size());
+  std::merge(inputs1.begin(), inputs1.end(), inputs2.begin(), inputs2.end(),
+             vec.begin(), [](ConcatInputSection *a, ConcatInputSection *b) {
+               return a->outSecOff < b->outSecOff;
+             });
   return vec;
 }
 

--- a/lld/MachO/MapFile.cpp
+++ b/lld/MachO/MapFile.cpp
@@ -234,8 +234,7 @@ void macho::writeMapFile() {
   os << "# Address\tSize    \tFile  Name\n";
   for (const OutputSegment *seg : outputSegments) {
     for (const OutputSection *osec : seg->getSections()) {
-      const TextOutputSection *textOsec = dyn_cast<TextOutputSection>(osec);
-      if (textOsec && textOsec->getThunks().size()) {
+      if (auto *textOsec = dyn_cast<TextOutputSection>(osec)) {
         auto inputsAndThunks =
             mergeOrderedInputs(textOsec->inputs, textOsec->getThunks());
         printIsecArrSyms(inputsAndThunks);

--- a/lld/MachO/OutputSection.h
+++ b/lld/MachO/OutputSection.h
@@ -37,6 +37,7 @@ public:
   enum Kind {
     ConcatKind,
     SyntheticKind,
+    TextKind,
   };
 
   OutputSection(Kind kind, StringRef name) : name(name), sectionKind(kind) {}

--- a/lld/test/MachO/arm64-thunks.s
+++ b/lld/test/MachO/arm64-thunks.s
@@ -18,27 +18,34 @@
 # RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/thunk | FileCheck %s
 
 ## Check that the thunks appear in the map file and that everything is sorted by address
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] ___nan.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _a.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _main
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c.thunk.0
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.1
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.1
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.1
-# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _z
+# Because of the `.space` instructions, there will end up being a lot of dead symbols in the linker map
+# so generate a version of the linker map without dead symbols.
+# RUN: awk '/# Dead Stripped Symbols:/ {exit} {print}' %t/thunk.map > %t/thunk_no_dead_syms.map
+
+# RUN: FileCheck %s --input-file %t/thunk_no_dead_syms.map --check-prefix=MAP
+ 
+# MAP:      [[ADDR1:0x[0-9A-Fa-f]+]] {{.*}} _b
+# MAP-NEXT: [[ADDR2:0x[0-9A-Fa-f]+]] {{.*}} _c
+# MAP-NEXT: [[ADDR3:0x[0-9A-Fa-f]+]] {{.*}} _d.thunk.0
+# MAP-NEXT: [[ADDR4:0x[0-9A-Fa-f]+]] {{.*}} _e.thunk.0
+# MAP-NEXT: [[ADDR5:0x[0-9A-Fa-f]+]] {{.*}} _f.thunk.0
+# MAP-NEXT: [[ADDR6:0x[0-9A-Fa-f]+]] {{.*}} _g.thunk.0
+# MAP-NEXT: [[ADDR7:0x[0-9A-Fa-f]+]] {{.*}} _h.thunk.0
+# MAP-NEXT: [[ADDR8:0x[0-9A-Fa-f]+]] {{.*}} ___nan.thunk.0
+# MAP-NEXT: [[ADDR9:0x[0-9A-Fa-f]+]] {{.*}} _d
+# MAP-NEXT: [[ADDR10:0x[0-9A-Fa-f]+]] {{.*}} _e
+# MAP-NEXT: [[ADDR11:0x[0-9A-Fa-f]+]] {{.*}} _f
+# MAP-NEXT: [[ADDR12:0x[0-9A-Fa-f]+]] {{.*}} _g
+# MAP-NEXT: [[ADDR13:0x[0-9A-Fa-f]+]] {{.*}} _a.thunk.0
+# MAP-NEXT: [[ADDR14:0x[0-9A-Fa-f]+]] {{.*}} _b.thunk.0
+# MAP-NEXT: [[ADDR15:0x[0-9A-Fa-f]+]] {{.*}} _h
+# MAP-NEXT: [[ADDR16:0x[0-9A-Fa-f]+]] {{.*}} _main
+# MAP-NEXT: [[ADDR17:0x[0-9A-Fa-f]+]] {{.*}} _c.thunk.0
+# MAP-NEXT: [[ADDR18:0x[0-9A-Fa-f]+]] {{.*}} _d.thunk.1
+# MAP-NEXT: [[ADDR19:0x[0-9A-Fa-f]+]] {{.*}} _e.thunk.1
+# MAP-NEXT: [[ADDR20:0x[0-9A-Fa-f]+]] {{.*}} _f.thunk.1
+# MAP-NEXT: [[ADDR21:0x[0-9A-Fa-f]+]] {{.*}} _z
+
 
 # CHECK: Disassembly of section __TEXT,__text:
 

--- a/lld/test/MachO/arm64-thunks.s
+++ b/lld/test/MachO/arm64-thunks.s
@@ -18,27 +18,27 @@
 # RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/thunk | FileCheck %s
 
 ## Check that the thunks appear in the map file and that everything is sorted by address
-# MAP: [[ADDR2:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b [[#ADDR2 > #ADDR1]]
-# MAP: [[ADDR3:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c [[#ADDR3 > #ADDR2]]
-# MAP: [[ADDR4:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.0 [[#ADDR4 > #ADDR3]]
-# MAP: [[ADDR5:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.0 [[#ADDR5 > #ADDR4]]
-# MAP: [[ADDR6:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.0 [[#ADDR6 > #ADDR5]]
-# MAP: [[ADDR7:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g.thunk.0 [[#ADDR7 > #ADDR6]]
-# MAP: [[ADDR8:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h.thunk.0 [[#ADDR8 > #ADDR7]]
-# MAP: [[ADDR9:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] ___nan.thunk.0 [[#ADDR9 > #ADDR8]]
-# MAP: [[ADDR10:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d [[#ADDR10 > #ADDR9]]
-# MAP: [[ADDR11:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e [[#ADDR11 > #ADDR10]]
-# MAP: [[ADDR12:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f [[#ADDR12 > #ADDR11]]
-# MAP: [[ADDR13:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g [[#ADDR13 > #ADDR12]]
-# MAP: [[ADDR14:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _a.thunk.0 [[#ADDR14 > #ADDR13]]
-# MAP: [[ADDR15:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b.thunk.0 [[#ADDR15 > #ADDR14]]
-# MAP: [[ADDR16:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h [[#ADDR16 > #ADDR15]]
-# MAP: [[ADDR17:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _main [[#ADDR17 > #ADDR16]]
-# MAP: [[ADDR18:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c.thunk.0 [[#ADDR18 > #ADDR17]]
-# MAP: [[ADDR19:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.1 [[#ADDR19 > #ADDR18]]
-# MAP: [[ADDR20:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.1 [[#ADDR20 > #ADDR19]]
-# MAP: [[ADDR21:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.1 [[#ADDR21 > #ADDR20]]
-# MAP: [[ADDR22:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _z [[#ADDR22 > #ADDR21]]
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] ___nan.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _a.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _main
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c.thunk.0
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.1
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.1
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.1
+# MAP: [[0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _z
 
 # CHECK: Disassembly of section __TEXT,__text:
 

--- a/lld/test/MachO/arm64-thunks.s
+++ b/lld/test/MachO/arm64-thunks.s
@@ -18,33 +18,34 @@
 # RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/thunk | FileCheck %s
 
 ## Check that the thunks appear in the map file and that everything is sorted by address
-# Because of the `.space` instructions, there will end up being a lot of dead symbols in the linker map
-# so generate a version of the linker map without dead symbols.
+# Because of the `.space` instructions, there will end up being a lot of dead symbols in the 
+# linker map (linker map will be ~2.7GB). So to avoid the test trying to (slowly) match regex
+# across all the ~2.7GB of the linker map - generate a version of the linker map without dead symbols.
 # RUN: awk '/# Dead Stripped Symbols:/ {exit} {print}' %t/thunk.map > %t/thunk_no_dead_syms.map
 
 # RUN: FileCheck %s --input-file %t/thunk_no_dead_syms.map --check-prefix=MAP
  
-# MAP:      [[ADDR1:0x[0-9A-Fa-f]+]] {{.*}} _b
-# MAP-NEXT: [[ADDR2:0x[0-9A-Fa-f]+]] {{.*}} _c
-# MAP-NEXT: [[ADDR3:0x[0-9A-Fa-f]+]] {{.*}} _d.thunk.0
-# MAP-NEXT: [[ADDR4:0x[0-9A-Fa-f]+]] {{.*}} _e.thunk.0
-# MAP-NEXT: [[ADDR5:0x[0-9A-Fa-f]+]] {{.*}} _f.thunk.0
-# MAP-NEXT: [[ADDR6:0x[0-9A-Fa-f]+]] {{.*}} _g.thunk.0
-# MAP-NEXT: [[ADDR7:0x[0-9A-Fa-f]+]] {{.*}} _h.thunk.0
-# MAP-NEXT: [[ADDR8:0x[0-9A-Fa-f]+]] {{.*}} ___nan.thunk.0
-# MAP-NEXT: [[ADDR9:0x[0-9A-Fa-f]+]] {{.*}} _d
-# MAP-NEXT: [[ADDR10:0x[0-9A-Fa-f]+]] {{.*}} _e
-# MAP-NEXT: [[ADDR11:0x[0-9A-Fa-f]+]] {{.*}} _f
-# MAP-NEXT: [[ADDR12:0x[0-9A-Fa-f]+]] {{.*}} _g
-# MAP-NEXT: [[ADDR13:0x[0-9A-Fa-f]+]] {{.*}} _a.thunk.0
-# MAP-NEXT: [[ADDR14:0x[0-9A-Fa-f]+]] {{.*}} _b.thunk.0
-# MAP-NEXT: [[ADDR15:0x[0-9A-Fa-f]+]] {{.*}} _h
-# MAP-NEXT: [[ADDR16:0x[0-9A-Fa-f]+]] {{.*}} _main
-# MAP-NEXT: [[ADDR17:0x[0-9A-Fa-f]+]] {{.*}} _c.thunk.0
-# MAP-NEXT: [[ADDR18:0x[0-9A-Fa-f]+]] {{.*}} _d.thunk.1
-# MAP-NEXT: [[ADDR19:0x[0-9A-Fa-f]+]] {{.*}} _e.thunk.1
-# MAP-NEXT: [[ADDR20:0x[0-9A-Fa-f]+]] {{.*}} _f.thunk.1
-# MAP-NEXT: [[ADDR21:0x[0-9A-Fa-f]+]] {{.*}} _z
+# MAP:      0x{{[[:xdigit:]]+}} {{.*}} _b
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _c
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _d.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _e.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _f.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _g.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _h.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} ___nan.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _d
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _e
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _f
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _g
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _a.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _b.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _h
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _main
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _c.thunk.0
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _d.thunk.1
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _e.thunk.1
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _f.thunk.1
+# MAP-NEXT: 0x{{[[:xdigit:]]+}} {{.*}} _z
 
 
 # CHECK: Disassembly of section __TEXT,__text:

--- a/lld/test/MachO/arm64-thunks.s
+++ b/lld/test/MachO/arm64-thunks.s
@@ -8,13 +8,37 @@
 ## (4) early calls to a dylib stub use a thunk, and later calls the stub
 ##     directly
 ## (5) Thunks are created for all sections in the text segment with branches.
+## (6) Thunks are in the linker map file.
 ## Notes:
 ## 0x4000000 = 64 Mi = half the magnitude of the forward-branch range
 
 # RUN: rm -rf %t; mkdir %t
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %s -o %t/input.o
-# RUN: %lld -arch arm64 -dead_strip -lSystem -U _extern_sym -o %t/thunk %t/input.o
+# RUN: %lld -arch arm64 -dead_strip -lSystem -U _extern_sym -map %t/thunk.map -o %t/thunk %t/input.o
 # RUN: llvm-objdump --no-print-imm-hex -d --no-show-raw-insn %t/thunk | FileCheck %s
+
+## Check that the thunks appear in the map file and that everything is sorted by address
+# MAP: [[ADDR2:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b [[#ADDR2 > #ADDR1]]
+# MAP: [[ADDR3:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c [[#ADDR3 > #ADDR2]]
+# MAP: [[ADDR4:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.0 [[#ADDR4 > #ADDR3]]
+# MAP: [[ADDR5:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.0 [[#ADDR5 > #ADDR4]]
+# MAP: [[ADDR6:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.0 [[#ADDR6 > #ADDR5]]
+# MAP: [[ADDR7:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g.thunk.0 [[#ADDR7 > #ADDR6]]
+# MAP: [[ADDR8:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h.thunk.0 [[#ADDR8 > #ADDR7]]
+# MAP: [[ADDR9:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] ___nan.thunk.0 [[#ADDR9 > #ADDR8]]
+# MAP: [[ADDR10:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d [[#ADDR10 > #ADDR9]]
+# MAP: [[ADDR11:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e [[#ADDR11 > #ADDR10]]
+# MAP: [[ADDR12:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f [[#ADDR12 > #ADDR11]]
+# MAP: [[ADDR13:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _g [[#ADDR13 > #ADDR12]]
+# MAP: [[ADDR14:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _a.thunk.0 [[#ADDR14 > #ADDR13]]
+# MAP: [[ADDR15:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _b.thunk.0 [[#ADDR15 > #ADDR14]]
+# MAP: [[ADDR16:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _h [[#ADDR16 > #ADDR15]]
+# MAP: [[ADDR17:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _main [[#ADDR17 > #ADDR16]]
+# MAP: [[ADDR18:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _c.thunk.0 [[#ADDR18 > #ADDR17]]
+# MAP: [[ADDR19:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _d.thunk.1 [[#ADDR19 > #ADDR18]]
+# MAP: [[ADDR20:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _e.thunk.1 [[#ADDR20 > #ADDR19]]
+# MAP: [[ADDR21:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _f.thunk.1 [[#ADDR21 > #ADDR20]]
+# MAP: [[ADDR22:0x[0-9A-Fa-f]+]] 0x[0-9A-Fa-f]+ \[[0-9]+\] _z [[#ADDR22 > #ADDR21]]
 
 # CHECK: Disassembly of section __TEXT,__text:
 


### PR DESCRIPTION
This patch extends the MachO linker's map file generation to include branch extension thunk symbols. Previously, thunks were omitted from the map file, making it difficult to understand the final layout of the binary, especially when debugging issues related to long branch thunks. This change ensures thunks are included and correctly interleaved with other symbols based on their address, providing an accurate representation of the linked output.