### PR TITLE
[libc] Fix gnu::naked and return-type errors with gcc on aarch64

### DIFF
--- a/libc/src/setjmp/aarch64/longjmp.cpp
+++ b/libc/src/setjmp/aarch64/longjmp.cpp
@@ -22,9 +22,11 @@ namespace LIBC_NAMESPACE_DECL {
 // supports the MTE instructions, not whether the compiler is configured to use
 // them.)
 
-[[gnu::naked]] LLVM_LIBC_FUNCTION(void, longjmp,
-                                  ([[maybe_unused]] jmp_buf buf,
-                                   [[maybe_unused]] int val)) {
+#ifndef __GNUC__
+[[gnu::naked]]
+#endif
+LLVM_LIBC_FUNCTION(void, longjmp,
+                   ([[maybe_unused]] jmp_buf buf, [[maybe_unused]] int val)) {
   // If BTI branch protection is in use, the compiler will automatically insert
   // a BTI here, so we don't need to make any extra effort to do so.
 
@@ -87,6 +89,11 @@ namespace LIBC_NAMESPACE_DECL {
       R"(
         ret
       )");
+
+#ifdef __GNUC__
+  // GCC fails here because it doesn't recognize a value is returned.
+  __builtin_unreachable();
+#endif
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/setjmp/aarch64/setjmp.cpp
+++ b/libc/src/setjmp/aarch64/setjmp.cpp
@@ -12,7 +12,10 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-[[gnu::naked]] LLVM_LIBC_FUNCTION(int, setjmp, ([[maybe_unused]] jmp_buf buf)) {
+#ifndef __GNUC__
+[[gnu::naked]]
+#endif
+LLVM_LIBC_FUNCTION(int, setjmp, ([[maybe_unused]] jmp_buf buf)) {
   // If BTI branch protection is in use, the compiler will automatically insert
   // a BTI here, so we don't need to make any extra effort to do so.
 
@@ -88,6 +91,11 @@ namespace LIBC_NAMESPACE_DECL {
       R"(
         ret
       )");
+
+#ifdef __GNUC__
+  // GCC fails here because it doesn't recognize a value is returned.
+  __builtin_unreachable();
+#endif
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This fixes `gnu::naked` from being used on aarch64 which GCC does not support. It also uses the unreachable builtin so GCC stops failing with `-Werror=return-type`.