### PR TITLE
clang/limits.h: Avoid including limits.h twice

### DIFF
--- a/clang/lib/Headers/limits.h
+++ b/clang/lib/Headers/limits.h
@@ -20,8 +20,10 @@
 #endif
 
 /* System headers include a number of constants from POSIX in <limits.h>.
-   Include it if we're hosted. */
-#if __STDC_HOSTED__ && __has_include_next(<limits.h>)
+   Include it if we're hosted. If we are included by libc with include_next,
+   we shouldn't include it again. */
+#if __STDC_HOSTED__ &&                                                         \
+    __has_include_next(<limits.h>) && !defined(_LIBC_LIMITS_H_) && !defined(_LIMITS_H)
 #include_next <limits.h>
 #endif
 


### PR DESCRIPTION
The limits.h of glibc, aka /usr/include/limits.h file of *-linux-gnu systems, has `#include_next <limits.h>`, so the limits.h from clang is included.

And in the limits.h for clang, `#include_next <limits.h>` is also used.

Normally it won't be a problem as the headers is protected by something like `_LIBC_LIMITS_H_`, while it may be a problem when we cross-build glibc on a none glibc platform. For example if we build glibc for x86_64-linux-gnu on a x86_64-linux-musl platform.

To test it, we can do
```
echo "#include </usr/include/limits.h>" | clang-19 -E -O2 -xc - -MM -H
```
We can see there is
```
. /usr/include/limits.h
.. /usr/lib/llvm-19/lib/clang/19/include/limits.h
... /usr/include/limits.h
```

It seems that other libc implementations other than glibc don't have this problem.