### PR TITLE
[lld-macho] Fix branch extension thunk estimation logic

### DIFF
--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -194,8 +194,6 @@ uint64_t TextOutputSection::estimateStubsInRangeVA(size_t callIdx) const {
       });
   uint64_t existingForwardThunks = thunks.end() - itPostcallIdxThunks;
 
-  // Estimate the address after which call sites can safely call stubs
-  // directly rather than through intermediary thunks.
   uint64_t forwardBranchRange = target->forwardBranchRange;
   assert(isecEnd > forwardBranchRange &&
          "should not run thunk insertion if all code fits in jump range");
@@ -219,8 +217,8 @@ uint64_t TextOutputSection::estimateStubsInRangeVA(size_t callIdx) const {
   // Estimated maximum VA of last stub.
   uint64_t maxVAOfLastStub = maxTextSize + in.stubs->getSize();
 
-  // Calculaate the first address that is gueranteed to not need a thunk to
-  // reach any stub.
+  // Estimate the address after which call sites can safely call stubs
+  // directly rather than through intermediary thunks.
   uint64_t stubsInRangeVA = maxVAOfLastStub - forwardBranchRange;
 
   log("thunks = " + std::to_string(thunkMap.size()) +

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -221,10 +221,11 @@ uint64_t TextOutputSection::estimateStubsInRangeVA(size_t callIdx) const {
   uint64_t stubsInRangeVA = maxVAOfLastStub - forwardBranchRange;
 
   log("thunks = " + std::to_string(thunkMap.size()) +
-      ", potential = " + std::to_string(maxPotentialThunks) + ", stubs = " +
-      std::to_string(in.stubs->getSize()) + ", isecVA = " + utohexstr(isecVA) +
-      ", threshold = " + utohexstr(stubsInRangeVA) + ", isecEnd = " +
-      utohexstr(isecEnd) + ", tail = " + utohexstr(isecEnd - isecVA) +
+      ", potential = " + std::to_string(maxPotentialThunks) +
+      ", stubs = " + std::to_string(in.stubs->getSize()) + ", isecVA = " +
+      utohexstr(isecVA) + ", threshold = " + utohexstr(stubsInRangeVA) +
+      ", isecEnd = " + utohexstr(isecEnd) +
+      ", tail = " + utohexstr(isecEnd - isecVA) +
       ", slop = " + utohexstr(forwardBranchRange - (isecEnd - isecVA)));
   return stubsInRangeVA;
 }

--- a/lld/MachO/ConcatOutputSection.cpp
+++ b/lld/MachO/ConcatOutputSection.cpp
@@ -188,9 +188,10 @@ uint64_t TextOutputSection::estimateStubsInRangeVA(size_t callIdx) const {
   // Tally up any thunks that have already been placed that have VA higher than
   // inputs[callIdx]. First, find the index of the first thunk that is beyond
   // the current inputs[callIdx].
-  auto itPostcallIdxThunks = std::partition_point(
-      thunks.begin(), thunks.end(),
-      [isecVA](const ConcatInputSection *t) { return t->getVA() <= isecVA; });
+  auto itPostcallIdxThunks =
+      llvm::partition_point(thunks, [isecVA](const ConcatInputSection *t) {
+        return t->getVA() <= isecVA;
+      });
   uint64_t existingForwardThunks = thunks.end() - itPostcallIdxThunks;
 
   // Estimate the address after which call sites can safely call stubs


### PR DESCRIPTION
This patch improves the linker’s ability to estimate stub reachability in the `TextOutputSection::estimateStubsInRangeVA` function. It does so by including thunks that have already been placed ahead of the current call site address when calculating the threshold for direct stub calls.

Before this fix, the estimation process overlooked existing forward thunks. This could result in some thunks not being inserted where needed. In rare situations, particularly with large and specially arranged codebases, this might lead to branch instructions being out of range, causing linking errors.

Although this patch successfully addresses the problem, it is not feasible to create a test for this issue. The specific layout and order of thunk creation required to reproduce the corner case are too complex, making test creation impractical.

Example error messages the issue could generate:
```
ld64.lld: error: banana.o:(symbol OUTLINED_FUNCTION_24949_3875): relocation BRANCH26 is out of range: 134547892 is not in [-134217728, 134217727]; references objc_autoreleaseReturnValue
ld64.lld: error: main.o:(symbol _main+0xc): relocation BRANCH26 is out of range: 134544132 is not in [-134217728, 134217727]; references objc_release
```