### PR TITLE
[llvm][docs] MemTagSanitizer is only supported on AArch64 Android

### DIFF
--- a/llvm/docs/MemTagSanitizer.rst
+++ b/llvm/docs/MemTagSanitizer.rst
@@ -30,8 +30,8 @@ Usage
 
 Compile and link your program with the ``-fsanitize=memtag`` flag. This
 will only work when targeting AArch64 Android with the memory tagging extension.
-One possible way to achieve that is to add ``-target
-aarch64-linux-android -march=armv8+memtag`` to your compilation flags.
+One possible way to achieve that is to add ``--target=aarch64-linux-android -march=armv8+memtag``
+to your compilation flags.
 
 Note that doing this will override existing flags of the same type. Assuming that
 you are already targeting AArch64 Android, an alternative is to add

--- a/llvm/docs/MemTagSanitizer.rst
+++ b/llvm/docs/MemTagSanitizer.rst
@@ -29,9 +29,9 @@ Usage
 =====
 
 Compile and link your program with ``-fsanitize=memtag`` flag. This
-will only work when targeting AArch64 with MemTag extension. One
+will only work when targeting AArch64 Android with MemTag extension. One
 possible way to achieve that is to add ``-target
-aarch64-linux -march=armv8+memtag`` to compilation flags.
+aarch64-linux-android -march=armv8+memtag`` to compilation flags.
 
 Implementation
 ==============

--- a/llvm/docs/MemTagSanitizer.rst
+++ b/llvm/docs/MemTagSanitizer.rst
@@ -28,10 +28,15 @@ memory bugs.
 Usage
 =====
 
-Compile and link your program with ``-fsanitize=memtag`` flag. This
-will only work when targeting AArch64 Android with MemTag extension. One
-possible way to achieve that is to add ``-target
-aarch64-linux-android -march=armv8+memtag`` to compilation flags.
+Compile and link your program with the ``-fsanitize=memtag`` flag. This
+will only work when targeting AArch64 Android with the memory tagging extension.
+One possible way to achieve that is to add ``-target
+aarch64-linux-android -march=armv8+memtag`` to your compilation flags.
+
+Note that doing this will override existing flags of the same type. Assuming that
+you are already targeting AArch64 Android, an alternative is to add
+``-Xclang -target-feature -Xclang +mte`` to your compilation flags. This
+adds the memory tagging feature, without changing anything else.
 
 Implementation
 ==============


### PR DESCRIPTION
```
$ ./bin/clang /tmp/test.c -o /tmp/test.o -target aarch64-linux -march=armv8+memtag -fsanitize=memtag-stack
clang: error: unsupported option '-fsanitize=memtag*' for target 'aarch64-unknown-linux'
```
But this works:
```
$ ./bin/clang /tmp/test.c -o /tmp/test.o --target=aarch64-linux-android -march=armv8+memtag -fsanitize=memtag-stack
```

Due to this check in Clang:
https://github.com/llvm/llvm-project/blob/2210da3b823ccf21fc634c858827c9f12c864b51/clang/lib/Driver/ToolChains/CommonArgs.cpp#L1651

Likely because the required notes and dynamic loader support only exist for Android.

You can get around this, sort of, by not linking the file. However this means you have to provide your own way of loading it, so it doesn't change the statement that this feature is Android only.

https://github.com/llvm/llvm-project/issues/64692 also confirms that the intent is to only support Android at this time.

And while I'm here, suggest an additive set of flags that can also be used.