### PR TITLE
[clang-tidy] support parameters file in command line

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -38,6 +38,11 @@ static cl::desc desc(StringRef description) { return {description.ltrim()}; }
 static cl::OptionCategory ClangTidyCategory("clang-tidy options");
 
 static cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
+static cl::extrahelp ClangTidyParameterFileHelp(R"(
+Parameters files:
+  A large number of options or source files can be passed as parameter files
+  by use '@parameter-file' in the command line.
+)");
 static cl::extrahelp ClangTidyHelp(R"(
 Configuration files:
   clang-tidy attempts to read configuration for each source file from a

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -557,6 +557,7 @@ int clangTidyMain(int argc, const char **argv) {
   llvm::InitLLVM X(argc, argv);
   SmallVector<const char *> Args{argv, argv + argc};
 
+  // expand parameters file to argc and argv.
   llvm::BumpPtrAllocator Alloc;
   llvm::cl::TokenizerCallback Tokenizer =
       llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -564,7 +564,7 @@ int clangTidyMain(int argc, const char **argv) {
           : llvm::cl::TokenizeGNUCommandLine;
   llvm::cl::ExpansionContext ECtx(Alloc, Tokenizer);
   if (llvm::Error Err = ECtx.expandResponseFiles(Args)) {
-    llvm::WithColor::error() << Err << "\n";
+    llvm::WithColor::error() << llvm::toString(std::move(Err)) << "\n";
     return 1;
   }
   argc = static_cast<int>(Args.size());

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -115,6 +115,8 @@ Improvements to clang-tidy
 - Improved :program:`run-clang-tidy.py` script. Fixed minor shutdown noise
   happening on certain platforms when interrupting the script.
 
+- Improved :program:`clang-tidy` by accepting parameters file in command line.
+
 - Removed :program:`clang-tidy`'s global options for most of checks. All options
   are changed to local options except `IncludeStyle`, `StrictMode` and
   `IgnoreMacros`.

--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -33,8 +33,9 @@ compilation options on the command line after ``--``:
 
   $ clang-tidy test.cpp -- -Imy_project/include -DMY_DEFINES ...
 
-If there are too many options to specify on the command line, you can store them
-in a parameter file, and use :program:`clang-tidy` with parameters file:
+If there are too many options or source files to specify on the command line,
+you can store them in a parameter file, and use :program:`clang-tidy` with that
+parameters file:
 
 .. code-block:: console
 
@@ -271,6 +272,9 @@ An overview of all the command-line options:
     automatically removed, but the rest of a relative path must be a
     suffix of a path in the compile command database.
 
+  Parameters files:
+    A large number of options or source files can be passed as parameter files
+    by use '@parameter-file' in the command line.
 
   Configuration files:
     clang-tidy attempts to read configuration for each source file from a

--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -33,6 +33,13 @@ compilation options on the command line after ``--``:
 
   $ clang-tidy test.cpp -- -Imy_project/include -DMY_DEFINES ...
 
+If there are too many options to specify on the command line, you can store them
+in a parameter file, and use :program:`clang-tidy` with parameters file:
+
+.. code-block:: console
+
+  $ clang-tidy @parameters_file
+
 :program:`clang-tidy` has its own checks and can also run Clang Static Analyzer
 checks. Each check has a name and the checks to run can be chosen using the
 ``-checks=`` option, which specifies a comma-separated list of positive and

--- a/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/param/parameters.txt
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/param/parameters.txt
@@ -1,0 +1,2 @@
+-checks='-*,llvm-namespace-comment'
+--warnings-as-errors=llvm-namespace-comment

--- a/clang-tools-extra/test/clang-tidy/infrastructure/read-parameters-from-file-error.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/read-parameters-from-file-error.cpp
@@ -1,0 +1,3 @@
+// RUN: echo @%t.param > %t.param && not clang-tidy %s @%t.param -- 2>&1 | FileCheck %s
+
+// CHECK: recursive expansion of

--- a/clang-tools-extra/test/clang-tidy/infrastructure/read-parameters-from-file.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/read-parameters-from-file.cpp
@@ -1,0 +1,5 @@
+// RUN: not clang-tidy %s @%S/Inputs/param/parameters.txt -- | FileCheck %s
+
+namespace i {
+}
+// CHECK: error: namespace 'i' not terminated with a closing comment [llvm-namespace-comment,-warnings-as-errors]


### PR DESCRIPTION
Fixes: #103499
