### PR TITLE
[libc++] Fix erroneous internal capacity evaluation in vector<bool>

### DIFF
--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -115,7 +115,7 @@ private:
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static size_type
   __external_cap_to_internal(size_type __n) _NOEXCEPT {
-    return (__n - 1) / __bits_per_word + 1;
+    return (__n + __bits_per_word - 1) / __bits_per_word;
   }
 
 public:

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -115,7 +115,7 @@ private:
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 static size_type
   __external_cap_to_internal(size_type __n) _NOEXCEPT {
-    return (__n + __bits_per_word - 1) / __bits_per_word;
+    return __n > 0 ? (__n - 1) / __bits_per_word + 1 : size_type(0);
   }
 
 public:

--- a/libcxx/test/std/containers/sequences/vector.bool/flip.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/flip.pass.cpp
@@ -32,6 +32,11 @@ TEST_CONSTEXPR_CXX20 void test_vector_flip(std::size_t n, Allocator a) {
 }
 
 TEST_CONSTEXPR_CXX20 bool tests() {
+  // Test empty vectors
+  test_vector_flip(0, std::allocator<bool>());
+  test_vector_flip(0, min_allocator<bool>());
+  test_vector_flip(0, test_allocator<bool>(5));
+
   // Test small vectors with different allocators
   test_vector_flip(3, std::allocator<bool>());
   test_vector_flip(3, min_allocator<bool>());


### PR DESCRIPTION
This PR fixes the erroneous internal capacity evaluation in `vector<bool>`, which caused a subsequent SIGSEGV error when calling `flip()` on `vector<bool>`. By fixing the internal capacity evaluation, the SIGSEGV is automatically resolved. 

Closes #121726.

