### PR TITLE
[Clang][Sema] Process warnings conditionally

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6592,35 +6592,32 @@ void CheckFormatHandler::HandleNonStandardConversionSpecifier(
 void CheckFormatHandler::HandlePosition(const char *startPos,
                                         unsigned posLen) {
   if (!S.getDiagnostics().isIgnored(
-          diag::warn_format_non_standard_positional_arg, SourceLocation())) {
+          diag::warn_format_non_standard_positional_arg, SourceLocation()))
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard_positional_arg),
                          getLocationOfByte(startPos),
                          /*IsStringLocation*/ true,
                          getSpecifierRange(startPos, posLen));
-  }
 }
 
 void CheckFormatHandler::HandleInvalidPosition(
     const char *startSpecifier, unsigned specifierLen,
     analyze_format_string::PositionContext p) {
   if (!S.getDiagnostics().isIgnored(
-          diag::warn_format_invalid_positional_specifier, SourceLocation())) {
+          diag::warn_format_invalid_positional_specifier, SourceLocation()))
     EmitFormatDiagnostic(
         S.PDiag(diag::warn_format_invalid_positional_specifier) << (unsigned)p,
         getLocationOfByte(startSpecifier), /*IsStringLocation*/ true,
         getSpecifierRange(startSpecifier, specifierLen));
-  }
 }
 
 void CheckFormatHandler::HandleZeroPosition(const char *startPos,
                                             unsigned posLen) {
   if (!S.getDiagnostics().isIgnored(diag::warn_format_zero_positional_specifier,
-                                    SourceLocation())) {
+                                    SourceLocation()))
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_zero_positional_specifier),
                          getLocationOfByte(startPos),
                          /*IsStringLocation*/ true,
                          getSpecifierRange(startPos, posLen));
-  }
 }
 
 void CheckFormatHandler::HandleNullChar(const char *nullCharacter) {

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6591,27 +6591,33 @@ void CheckFormatHandler::HandleNonStandardConversionSpecifier(
 
 void CheckFormatHandler::HandlePosition(const char *startPos,
                                         unsigned posLen) {
-  EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard_positional_arg),
-                               getLocationOfByte(startPos),
-                               /*IsStringLocation*/true,
-                               getSpecifierRange(startPos, posLen));
+  if (!S.getDiagnostics().isIgnored(diag::warn_format_non_standard_positional_arg, SourceLocation())) {
+    EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard_positional_arg),
+                                getLocationOfByte(startPos),
+                                /*IsStringLocation*/true,
+                                getSpecifierRange(startPos, posLen));
+  }
 }
 
 void CheckFormatHandler::HandleInvalidPosition(
     const char *startSpecifier, unsigned specifierLen,
     analyze_format_string::PositionContext p) {
-  EmitFormatDiagnostic(
-      S.PDiag(diag::warn_format_invalid_positional_specifier) << (unsigned)p,
-      getLocationOfByte(startSpecifier), /*IsStringLocation*/ true,
-      getSpecifierRange(startSpecifier, specifierLen));
+  if (!S.getDiagnostics().isIgnored(diag::warn_format_invalid_positional_specifier, SourceLocation())) {
+    EmitFormatDiagnostic(
+        S.PDiag(diag::warn_format_invalid_positional_specifier) << (unsigned)p,
+        getLocationOfByte(startSpecifier), /*IsStringLocation*/ true,
+        getSpecifierRange(startSpecifier, specifierLen));
+  }
 }
 
 void CheckFormatHandler::HandleZeroPosition(const char *startPos,
                                             unsigned posLen) {
-  EmitFormatDiagnostic(S.PDiag(diag::warn_format_zero_positional_specifier),
-                               getLocationOfByte(startPos),
-                               /*IsStringLocation*/true,
-                               getSpecifierRange(startPos, posLen));
+  if (!S.getDiagnostics().isIgnored(diag::warn_format_zero_positional_specifier, SourceLocation())) {
+    EmitFormatDiagnostic(S.PDiag(diag::warn_format_zero_positional_specifier),
+                                getLocationOfByte(startPos),
+                                /*IsStringLocation*/true,
+                                getSpecifierRange(startPos, posLen));
+  }
 }
 
 void CheckFormatHandler::HandleNullChar(const char *nullCharacter) {

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6591,18 +6591,20 @@ void CheckFormatHandler::HandleNonStandardConversionSpecifier(
 
 void CheckFormatHandler::HandlePosition(const char *startPos,
                                         unsigned posLen) {
-  if (!S.getDiagnostics().isIgnored(diag::warn_format_non_standard_positional_arg, SourceLocation())) {
+  if (!S.getDiagnostics().isIgnored(
+          diag::warn_format_non_standard_positional_arg, SourceLocation())) {
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_non_standard_positional_arg),
-                                getLocationOfByte(startPos),
-                                /*IsStringLocation*/true,
-                                getSpecifierRange(startPos, posLen));
+                         getLocationOfByte(startPos),
+                         /*IsStringLocation*/ true,
+                         getSpecifierRange(startPos, posLen));
   }
 }
 
 void CheckFormatHandler::HandleInvalidPosition(
     const char *startSpecifier, unsigned specifierLen,
     analyze_format_string::PositionContext p) {
-  if (!S.getDiagnostics().isIgnored(diag::warn_format_invalid_positional_specifier, SourceLocation())) {
+  if (!S.getDiagnostics().isIgnored(
+          diag::warn_format_invalid_positional_specifier, SourceLocation())) {
     EmitFormatDiagnostic(
         S.PDiag(diag::warn_format_invalid_positional_specifier) << (unsigned)p,
         getLocationOfByte(startSpecifier), /*IsStringLocation*/ true,
@@ -6612,11 +6614,12 @@ void CheckFormatHandler::HandleInvalidPosition(
 
 void CheckFormatHandler::HandleZeroPosition(const char *startPos,
                                             unsigned posLen) {
-  if (!S.getDiagnostics().isIgnored(diag::warn_format_zero_positional_specifier, SourceLocation())) {
+  if (!S.getDiagnostics().isIgnored(diag::warn_format_zero_positional_specifier,
+                                    SourceLocation())) {
     EmitFormatDiagnostic(S.PDiag(diag::warn_format_zero_positional_specifier),
-                                getLocationOfByte(startPos),
-                                /*IsStringLocation*/true,
-                                getSpecifierRange(startPos, posLen));
+                         getLocationOfByte(startPos),
+                         /*IsStringLocation*/ true,
+                         getSpecifierRange(startPos, posLen));
   }
 }
 


### PR DESCRIPTION
There are a few functions that emit warnings related to positional arguments in format strings. These functions use `getLocationOfByte()` which has O(n) complexity and may lead to silent hang of compilation in some cases. But such warnings is not widely used and actually don't emit if user didn't pass the appropriate `-W...` flag, so if the flag is not passed dont make the call to `EmitFormatDiagnostic` for such diags.

Fix #120462