### PR TITLE
[llvm-lib] Add /llvmlibindex:no to disable writing an index

### DIFF
--- a/lld/test/COFF/thin-archive.s
+++ b/lld/test/COFF/thin-archive.s
@@ -5,7 +5,20 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %t.lib.obj \
 # RUN:     %S/Inputs/mangled-symbol.s
 # RUN: lld-link /lib /out:%t.lib %t.lib.obj
-# RUN: lld-link /lib /llvmlibthin /out:%t_thin.lib %t.lib.obj
+# RUN: lld-link /lib /llvmlibindex:no /out:%t_noindex.lib %t.lib.obj
+# RUN: lld-link /lib /llvmlibthin /llvmlibindex /out:%t_thin.lib %t.lib.obj
+# RUN: lld-link /lib /llvmlibthin /llvmlibindex:no \
+# RUN:     /out:%t_thin_noindex.lib %t.lib.obj
+
+# RUN: llvm-nm --print-armap %t.lib \
+# RUN:   | FileCheck %s --check-prefix=SYMTAB
+# RUN: llvm-nm --print-armap %t_noindex.lib \
+# RUN:   | FileCheck %s --check-prefix=NO-SYMTAB
+# RUN: llvm-nm --print-armap %t_thin_noindex.lib \
+# RUN:   | FileCheck %s --check-prefix=NO-SYMTAB
+
+# SYMTAB:        ?f@@YAHXZ in
+# NO-SYMTAB-NOT: ?f@@YAHXZ in
 
 # RUN: lld-link /entry:main %t.main.obj %t.lib /out:%t.exe 2>&1 | \
 # RUN:     FileCheck --allow-empty %s

--- a/lld/test/COFF/thin-archive.s
+++ b/lld/test/COFF/thin-archive.s
@@ -14,6 +14,8 @@
 # RUN:   | FileCheck %s --check-prefix=SYMTAB
 # RUN: llvm-nm --print-armap %t_noindex.lib \
 # RUN:   | FileCheck %s --check-prefix=NO-SYMTAB
+# RUN: llvm-nm --print-armap %t_thin.lib \
+# RUN:   | FileCheck %s --check-prefix=SYMTAB
 # RUN: llvm-nm --print-armap %t_thin_noindex.lib \
 # RUN:   | FileCheck %s --check-prefix=NO-SYMTAB
 

--- a/llvm/lib/ToolDrivers/llvm-lib/LibDriver.cpp
+++ b/llvm/lib/ToolDrivers/llvm-lib/LibDriver.cpp
@@ -516,8 +516,14 @@ int llvm::libDriverMain(ArrayRef<const char *> ArgsArr) {
   std::reverse(Members.begin(), Members.end());
 
   bool Thin = Args.hasArg(OPT_llvmlibthin);
+
+  auto Symtab = Args.hasFlag(OPT_llvmlibindex, OPT_llvmlibindex_no,
+                             /*default=*/true)
+                    ? SymtabWritingMode::NormalSymtab
+                    : SymtabWritingMode::NoSymtab;
+
   if (Error E = writeArchive(
-          OutputPath, Members, SymtabWritingMode::NormalSymtab,
+          OutputPath, Members, Symtab,
           Thin ? object::Archive::K_GNU : object::Archive::K_COFF,
           /*Deterministic=*/true, Thin, nullptr, COFF::isArm64EC(LibMachine))) {
     handleAllErrors(std::move(E), [&](const ErrorInfoBase &EI) {

--- a/llvm/lib/ToolDrivers/llvm-lib/Options.td
+++ b/llvm/lib/ToolDrivers/llvm-lib/Options.td
@@ -28,10 +28,8 @@ def nativedeffile : P<"defArm64Native", "def file to use to generate native ARM6
 def llvmlibthin : F<"llvmlibthin">,
     HelpText<"Make .lib point to .obj files instead of copying their contents">;
 
-def llvmlibindex : F<"llvmlibindex">,
-    HelpText<"Write an index to the output (default)">;
-def llvmlibindex_no : F<"llvmlibindex:no">,
-    HelpText<"Do not write an index to the output">;
+defm llvmlibindex : B<"llvmlibindex", "Write an index to the output (default)",
+                      "Do not write an index to the output">;
 
 def llvmlibempty : F<"llvmlibempty">,
     HelpText<"When given no contents, produce an empty .lib file">;

--- a/llvm/lib/ToolDrivers/llvm-lib/Options.td
+++ b/llvm/lib/ToolDrivers/llvm-lib/Options.td
@@ -28,6 +28,11 @@ def nativedeffile : P<"defArm64Native", "def file to use to generate native ARM6
 def llvmlibthin : F<"llvmlibthin">,
     HelpText<"Make .lib point to .obj files instead of copying their contents">;
 
+def llvmlibindex : F<"llvmlibindex">,
+    HelpText<"Write an index to the output (default)">;
+def llvmlibindex_no : F<"llvmlibindex:no">,
+    HelpText<"Do not write an index to the output">;
+
 def llvmlibempty : F<"llvmlibempty">,
     HelpText<"When given no contents, produce an empty .lib file">;
 


### PR DESCRIPTION
This can be used with /llvmlibthin to create thin archives without an index, which is a prerequisite for porting
https://reviews.llvm.org/D117284 to lld-link.

---

Creating files like this is already possible with `llvm-ar rcS`, so this doesn't add additional problems.

lld-link currently doesn't behave super great when handed such a file: it just says "no such symbol" for symbols in static libs without index. But that'll improve in other PRs soon. And one has to try pretty hard to create such a file, and it was already possible to create such files with llvm-ar.