### PR TITLE
[clang analyzer]consume `llvm::Error`

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/TextDiagnostics.cpp
+++ b/clang/lib/StaticAnalyzer/Core/TextDiagnostics.cpp
@@ -81,7 +81,7 @@ public:
 
         if (llvm::Error Err = Repls.add(Repl)) {
           llvm::errs() << "Error applying replacement " << Repl.toString()
-                       << ": " << Err << "\n";
+                       << ": " << llvm::toString(std::move(Err)) << "\n";
         }
       }
     };


### PR DESCRIPTION
`llvm::Error` must be consumed, otherwise it will cause trap during destructor
