### PR TITLE
[lldb][AIX] Introducing _ALL_SOURCE macro into driver CMakeLists

### DIFF
--- a/lldb/tools/driver/CMakeLists.txt
+++ b/lldb/tools/driver/CMakeLists.txt
@@ -11,6 +11,11 @@ if(APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-sectcreate,__TEXT,__info_plist,${CMAKE_CURRENT_BINARY_DIR}/lldb-Info.plist")
 endif()
 
+if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")                               
+  remove_definitions("-D_XOPEN_SOURCE=700")                                    
+  add_definitions("-D_ALL_SOURCE")                                             
+endif()
+
 add_lldb_tool(lldb
   Driver.cpp
   Platform.cpp


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX.

Link to discussions on llvm discourse and github:
1. https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640
2. https://github.com/llvm/llvm-project/issues/101657
The complete changes for porting are present in this draft PR:
https://github.com/llvm/llvm-project/pull/102601

Adding changes for minimal build for lldb binary on AIX: 
The `struct winsize` needed by `lldb/tools/driver/Driver.cpp` is only recognised in AIX under the AIX specific `_ALL_SOURCE` macro, hence its enablement is required here.

Review Request: @labath @DavidSpickett