### PR TITLE
[IR] Correct Value::use_iterator::value_type.

### DIFF
--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -131,7 +131,7 @@ private:
 
   public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type = UseT *;
+    using value_type = UseT;
     using difference_type = std::ptrdiff_t;
     using pointer = value_type *;
     using reference = value_type &;


### PR DESCRIPTION
operator* for this iterator returns Use& so I think the value_type should be Use not Use*.

Noticed while comparing with SDNode::use_iterator.