### PR TITLE
[flang] Silence inappropriate error message

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2536,6 +2536,15 @@ static bool CheckCompatibleArgument(bool isElemental,
             return false;
           },
           [&](const characteristics::DummyProcedure &dummy) {
+            if ((dummy.attrs.test(
+                     characteristics::DummyProcedure::Attr::Optional) ||
+                    dummy.attrs.test(
+                        characteristics::DummyProcedure::Attr::Pointer)) &&
+                IsBareNullPointer(expr)) {
+              // NULL() is compatible with any dummy pointer
+              // or optional dummy procedure.
+              return true;
+            }
             if (!expr || !IsProcedurePointerTarget(*expr)) {
               return false;
             }


### PR DESCRIPTION
A recent patch added better compatibility checking for actual procedure arguments, but it has led to a few failures in the Fujitsu Fortran test suite in cases of NULL() actual arguments being associated with dummy procedure pointers.  As is the case with dummy data pointers, these must always be accepted.

Fixes Fujitsu Fortran test cases 0249_0023 through 0028 and 0387_0047.