### PR TITLE
[libc++] Fix the batch size used in the std::gcd benchmark

### DIFF
--- a/libcxx/test/benchmarks/numeric/gcd.bench.cpp
+++ b/libcxx/test/benchmarks/numeric/gcd.bench.cpp
@@ -25,7 +25,7 @@ static std::array<T, 1000> generate(std::uniform_int_distribution<T> distributio
 
 static void bm_gcd_random(benchmark::State& state) {
   std::array data = generate<int>();
-  while (state.KeepRunningBatch(data.size()))
+  while (state.KeepRunningBatch(data.size() * data.size()))
     for (auto v0 : data)
       for (auto v1 : data)
         benchmark::DoNotOptimize(std::gcd(v0, v1));


### PR DESCRIPTION
Since that benchmark is testing n*n inputs, the batch size reported to GoogleBenchmark should be that amount. Otherwise, GoogleBenchmark reports the timing for calling std::gcd on the whole sequence, which is misleading.