### PR TITLE
[BoundsSan] Update BoundsChecking.cpp to use no-merge attribute where applicable

### DIFF
--- a/clang/test/CodeGen/bounds-checking.c
+++ b/clang/test/CodeGen/bounds-checking.c
@@ -85,11 +85,11 @@ char B2[10];
 // NOOPTLOCAL-LABEL: @f8
 // NOOPTARRAY-LABEL: @f8
 void f8(int i, int k) {
-  // NOOPTLOCAL: call void @llvm.ubsantrap(i8 3)
+  // NOOPTLOCAL: call void @llvm.ubsantrap(i8 3) #[[ATTR1:[0-9]+]]
   // NOOPTARRAY: call void @llvm.ubsantrap(i8 18) #[[ATTR2:[0-9]+]]
   B[i] = '\0';
 
-  // NOOPTLOCAL: call void @llvm.ubsantrap(i8 5)
+  // NOOPTLOCAL: call void @llvm.ubsantrap(i8 5) #[[ATTR1:[0-9]+]]
   // NOOPTARRAY: call void @llvm.ubsantrap(i8 18) #[[ATTR2:[0-9]+]]
   B2[k] = '\0';
 }
@@ -102,4 +102,5 @@ struct S {
 struct S *f9(int i) {
   return &s[i];
 }
+// NOOPTLOCAL: attributes #[[ATTR1]] = { nomerge noreturn nounwind }
 // NOOPTARRAY: attributes #[[ATTR2]] = { nomerge noreturn nounwind }

--- a/llvm/lib/Transforms/Instrumentation/BoundsChecking.cpp
+++ b/llvm/lib/Transforms/Instrumentation/BoundsChecking.cpp
@@ -196,8 +196,10 @@ static bool addBoundsChecking(Function &F, TargetLibraryInfo &TLI,
 
     CallInst *TrapCall;
     if (DebugTrapBB) {
+      // Ideally we would use the SanitizerHandler::OutOfBounds constant
       TrapCall = IRB.CreateIntrinsic(
           IntrID, {}, ConstantInt::get(IRB.getInt8Ty(), Fn->size()));
+      TrapCall->addFnAttr(llvm::Attribute::NoMerge);
     } else {
       TrapCall = IRB.CreateIntrinsic(IntrID, {}, {});
     }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/65972 introduced -ubsan-unique-traps and -bounds-checking-unique-traps, which attach the function size to the ubsantrap intrinsic.

https://github.com/llvm/llvm-project/pull/117651 changed ubsan-unique-traps to use nomerge instead of the function size, but did not update -bounds-checking-unique-traps. This patch adds nomerge to bounds-checking-unique-traps.