### PR TITLE
[AMDGPU][True16][MC] added fake16 for gfx12 alias MC test

### DIFF
--- a/llvm/test/MC/AMDGPU/gfx12_asm_vop3_aliases-fake16.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vop3_aliases-fake16.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,+real-true16 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
+// RUN: llvm-mc -triple=amdgcn -mcpu=gfx1200 -mattr=+wavefrontsize32,-real-true16 -show-encoding %s | FileCheck --check-prefixes=GFX12 %s
 
 v_min3_f32 v5, v1, v2, v3
 // GFX12: v_min3_num_f32 v5, v1, v2, v3           ; encoding: [0x05,0x00,0x29,0xd6,0x01,0x05,0x0e,0x04]


### PR DESCRIPTION
This is a NFC.

Duplicate gfx12_asm_vop3_alias.s file to true16/fake16 version and update `real-true16` flag on it.

This is preparing the upcoming changes for true16