### PR TITLE
[clang] fix uefi target for aarch64 & x86_64

### DIFF
--- a/clang/include/clang/Basic/TargetOSMacros.def
+++ b/clang/include/clang/Basic/TargetOSMacros.def
@@ -53,4 +53,7 @@ TARGET_OS(TARGET_OS_NANO, Triple.isWatchOS())
 TARGET_OS(TARGET_IPHONE_SIMULATOR, Triple.isSimulatorEnvironment())
 TARGET_OS(TARGET_OS_UIKITFORMAC, Triple.isMacCatalystEnvironment())
 
+// UEFI target.
+TARGET_OS(TARGET_OS_UEFI, Triple.isUEFI())
+
 #undef TARGET_OS

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -170,6 +170,10 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::OpenBSD:
       return std::make_unique<OpenBSDTargetInfo<AArch64leTargetInfo>>(Triple,
                                                                       Opts);
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<AArch64leTargetInfo>>(Triple,
+                                                                   Opts);
+
     case llvm::Triple::Win32:
       switch (Triple.getEnvironment()) {
       case llvm::Triple::GNU:
@@ -631,7 +635,7 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       return std::make_unique<SolarisTargetInfo<X86_64TargetInfo>>(Triple,
                                                                    Opts);
     case llvm::Triple::UEFI:
-      return std::make_unique<UEFIX86_64TargetInfo>(Triple, Opts);
+      return std::make_unique<UEFITargetInfo<X86_64TargetInfo>>(Triple, Opts);
 
     case llvm::Triple::Win32: {
       switch (Triple.getEnvironment()) {

--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -1626,6 +1626,9 @@ void AArch64leTargetInfo::setDataLayout() {
       resetDataLayout("e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-"
                       "n32:64-S128-Fn32",
                       "_");
+  } else if (getTriple().isUEFI() && getTriple().isOSBinFormatCOFF()) {
+    resetDataLayout("e-m:w-p270:32:32-p271:32:32-p272:64:64-p:64:64-i32:32-"
+                    "i64:64-i128:128-n32:64-S128-Fn32");
   } else
     resetDataLayout("e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-"
                     "i64:64-i128:128-n32:64-S128-Fn32");

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -13,6 +13,7 @@
 #define LLVM_CLANG_LIB_BASIC_TARGETS_OSTARGETS_H
 
 #include "Targets.h"
+#include "clang/Basic/TargetInfo.h"
 
 namespace clang {
 namespace targets {
@@ -806,6 +807,8 @@ public:
 // UEFI target
 template <typename Target>
 class LLVM_LIBRARY_VISIBILITY UEFITargetInfo : public OSTargetInfo<Target> {
+  llvm::Triple Triple;
+
 protected:
   void getOSDefines(const LangOptions &Opts, const llvm::Triple &Triple,
                     MacroBuilder &Builder) const override {
@@ -814,10 +817,18 @@ protected:
 
 public:
   UEFITargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
-      : OSTargetInfo<Target>(Triple, Opts) {
+      : OSTargetInfo<Target>(Triple, Opts), Triple(Triple) {
     this->WCharType = TargetInfo::UnsignedShort;
     this->WIntType = TargetInfo::UnsignedShort;
     this->UseMicrosoftManglingForC = true;
+  }
+
+  TargetInfo::CallingConvKind
+  getCallingConvKind(bool ClangABICompat4) const override {
+    if (Triple.getArch() == llvm::Triple::x86_64)
+      return TargetInfo::CallingConvKind::CCK_MicrosoftWin64;
+
+    return Target::getCallingConvKind(ClangABICompat4);
   }
 };
 

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -829,38 +829,6 @@ public:
   }
 };
 
-// x86-64 UEFI target
-class LLVM_LIBRARY_VISIBILITY UEFIX86_64TargetInfo
-    : public UEFITargetInfo<X86_64TargetInfo> {
-public:
-  UEFIX86_64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
-      : UEFITargetInfo<X86_64TargetInfo>(Triple, Opts) {
-    this->TheCXXABI.set(TargetCXXABI::Microsoft);
-    this->MaxTLSAlign = 8192u * this->getCharWidth();
-    this->resetDataLayout("e-m:w-p270:32:32-p271:32:32-p272:64:64-"
-                          "i64:64-i128:128-f80:128-n8:16:32:64-S128");
-  }
-
-  BuiltinVaListKind getBuiltinVaListKind() const override {
-    return TargetInfo::CharPtrBuiltinVaList;
-  }
-
-  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
-    switch (CC) {
-    case CC_C:
-    case CC_Win64:
-      return CCCR_OK;
-    default:
-      return CCCR_Warning;
-    }
-  }
-
-  TargetInfo::CallingConvKind
-  getCallingConvKind(bool ClangABICompat4) const override {
-    return CCK_MicrosoftWin64;
-  }
-};
-
 // x86-64 Windows target
 class LLVM_LIBRARY_VISIBILITY WindowsX86_64TargetInfo
     : public WindowsTargetInfo<X86_64TargetInfo> {

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -722,8 +722,8 @@ public:
   X86_64TargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
       : X86TargetInfo(Triple, Opts) {
     const bool IsX32 = getTriple().isX32();
-    bool IsWinCOFF =
-        getTriple().isOSWindows() && getTriple().isOSBinFormatCOFF();
+    bool IsWinCOFF = (getTriple().isOSWindows() || getTriple().isUEFI()) &&
+                     getTriple().isOSBinFormatCOFF();
     LongWidth = LongAlign = PointerWidth = PointerAlign = IsX32 ? 32 : 64;
     LongDoubleWidth = 128;
     LongDoubleAlign = 128;

--- a/clang/test/Preprocessor/init.c
+++ b/clang/test/Preprocessor/init.c
@@ -2835,6 +2835,8 @@
 // RISCV64-LINUX: #define unix 1
 
 // RUN: %clang_cc1 -dM -triple=x86_64-uefi -E /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=aarch64-unknown-uefi -E < /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
+// RUN: %clang_cc1 -dM -triple=x86_64-unknown-uefi -E /dev/null | FileCheck -match-full-lines -check-prefix UEFI %s
 
 // UEFI: #define __UEFI__ 1
 


### PR DESCRIPTION
This PR introduces some fixes where the data layout wasn't propagated correctly. To test this, feed clang any C file (I used an empty main for testing) and pass `-target aarch64-uefi` or `-target x86_64-uefi`.

Before this PR, you would get an error similar to this:
```
error: backend data layout 'e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128' does not match expected target description 'e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128'
1 error generated.
```

This PR also adds a new `__uefi__` macro which will hopefully let us work towards getting compiler-rt and libc working with UEFI.