### PR TITLE
[clang][NFC] Fix the static assertion in 4797437

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -114,10 +114,9 @@ protected:
 #define STMT(CLASS, PARENT)
 #define STMT_RANGE(BASE, FIRST, LAST)
 #define LAST_STMT_RANGE(BASE, FIRST, LAST)                                     \
-  static_assert(                                                               \
-      llvm::isInt<NumStmtBits>(StmtClass::LAST##Class),                        \
-      "The number of 'StmtClass'es is strictly bounded under two to "          \
-      "the power of 'NumStmtBits'");
+  static_assert(llvm::isUInt<NumStmtBits>(StmtClass::LAST##Class),             \
+                "The number of 'StmtClass'es is strictly bound "               \
+                "by a bitfield of width NumStmtBits");
 #define ABSTRACT_STMT(STMT)
 #include "clang/AST/StmtNodes.inc"
 


### PR DESCRIPTION
In the previous commit 4797437463e63ee289a1ff1904cfb7b2fe6cb4c2, I used `llvm::isInt<NumStmtBits>(StmtClass::LAST##Class)` to test if `StmtClass` is strictly bounded by the an unsigned integer of 'NumStmtBits'.  That is incorrect as `llvm::isInt` tests for signed integers. This commit fixes it.