### PR TITLE
[Clang-CL][DXC] Expose -fdiagnostic-color= to clang-cl and clang-dxc

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -445,6 +445,9 @@ New Compiler Flags
 - The ``-Warray-compare-cxx26`` warning has been added to warn about array comparison
   starting from C++26, this warning is enabled as an error by default.
 
+- clang-cl and clang-dxc now support ``-fdiagnostics-color=[auto|never|always]``
+  in addition to ``-f[no-]color-diagnostics``.
+
 Deprecated Compiler Flags
 -------------------------
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1990,7 +1990,7 @@ def : Flag<["-"], "fno-diagnostics-color">, Group<f_Group>,
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   Alias<fno_color_diagnostics>;
 def fdiagnostics_color_EQ : Joined<["-"], "fdiagnostics-color=">, Group<f_Group>,
-  Visibility<[ClangOption, FlangOption]>,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   Values<"auto,always,never">,
   HelpText<"When to use colors in diagnostics">;
 def fansi_escape_codes : Flag<["-"], "fansi-escape-codes">, Group<f_Group>,

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -664,6 +664,15 @@
 // RUN: not %clang_cl /guard:foo -### -- %s 2>&1 | FileCheck -check-prefix=CFGUARDINVALID %s
 // CFGUARDINVALID: invalid value 'foo' in '/guard:'
 
+// The test doesn't run in a PTY, so "auto" defaults to off.
+// RUN: %clang_cl -fdiagnostics-color=auto -### -- %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
+
+// RUN: %clang_cl -fdiagnostics-color -### -- %s 2>&1 | FileCheck -check-prefix=COLOR %s
+// RUN: %clang_cl -fdiagnostics-color=always -### -- %s 2>&1 | FileCheck -check-prefix=COLOR %s
+// RUN: %clang_cl -fdiagnostics-color=never -### -- %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
+// COLOR: "-fcolor-diagnostics"
+// NO_COLOR-NOT: "-fcolor-diagnostics"
+
 // Accept "core" clang options.
 // (/Zs is for syntax-only, -Werror makes it fail hard on unknown options)
 // RUN: %clang_cl \

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -664,15 +664,6 @@
 // RUN: not %clang_cl /guard:foo -### -- %s 2>&1 | FileCheck -check-prefix=CFGUARDINVALID %s
 // CFGUARDINVALID: invalid value 'foo' in '/guard:'
 
-// The test doesn't run in a PTY, so "auto" defaults to off.
-// RUN: %clang_cl -fdiagnostics-color=auto -### -- %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
-
-// RUN: %clang_cl -fdiagnostics-color -### -- %s 2>&1 | FileCheck -check-prefix=COLOR %s
-// RUN: %clang_cl -fdiagnostics-color=always -### -- %s 2>&1 | FileCheck -check-prefix=COLOR %s
-// RUN: %clang_cl -fdiagnostics-color=never -### -- %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
-// COLOR: "-fcolor-diagnostics"
-// NO_COLOR-NOT: "-fcolor-diagnostics"
-
 // Accept "core" clang options.
 // (/Zs is for syntax-only, -Werror makes it fail hard on unknown options)
 // RUN: %clang_cl \
@@ -689,6 +680,7 @@
 // RUN:     -fcoverage-mapping \
 // RUN:     -fno-coverage-mapping \
 // RUN:     -fdiagnostics-color \
+// RUN:     -fdiagnostics-color=auto \
 // RUN:     -fno-diagnostics-color \
 // RUN:     -fdebug-compilation-dir . \
 // RUN:     -fdebug-compilation-dir=. \

--- a/clang/test/Driver/dxc_options.hlsl
+++ b/clang/test/Driver/dxc_options.hlsl
@@ -1,8 +1,8 @@
-// The test doesn't run in a PTY, so "auto" defaults to off.
-// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color=auto -### -- %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
+// RUN: %clang_dxc \
+// RUN: -fcolor-diagnostics \
+// RUN: -fno-color-diagnostics \
+// RUN: -fdiagnostics-color \
+// RUN: -fno-diagnostics-color \
+// RUN: -fdiagnostics-color=auto \
+// RUN: -Tlib_6_7 -Vd -fdriver-only -- %s 2>&1 |count 0
 
-// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color -### %s 2>&1 | FileCheck -check-prefix=COLOR %s
-// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color=always -### %s 2>&1 | FileCheck -check-prefix=COLOR %s
-// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color=never -### %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
-// COLOR: "-fcolor-diagnostics"
-// NO_COLOR-NOT: "-fcolor-diagnostics"

--- a/clang/test/Driver/dxc_options.hlsl
+++ b/clang/test/Driver/dxc_options.hlsl
@@ -1,0 +1,8 @@
+// The test doesn't run in a PTY, so "auto" defaults to off.
+// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color=auto -### -- %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
+
+// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color -### %s 2>&1 | FileCheck -check-prefix=COLOR %s
+// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color=always -### %s 2>&1 | FileCheck -check-prefix=COLOR %s
+// RUN: %clang_dxc -Tlib_6_7 -fdiagnostics-color=never -### %s 2>&1 | FileCheck -check-prefix=NO_COLOR %s
+// COLOR: "-fcolor-diagnostics"
+// NO_COLOR-NOT: "-fcolor-diagnostics"

--- a/clang/test/Driver/unknown-arg-drivermodes.test
+++ b/clang/test/Driver/unknown-arg-drivermodes.test
@@ -1,6 +1,5 @@
 // RUN: %clang_cl                  \
 // RUN: --config                   \
-// RUN: -fdiagnostics-color=auto   \
 // RUN: -fno-record-command-line   \
 // RUN: -frecord-command-line      \
 // RUN: -nodefaultlibs             \
@@ -15,7 +14,6 @@
 
 // RUN: not %clang_dxc             \
 // RUN: --config                   \
-// RUN: -fdiagnostics-color=auto   \
 // RUN: -fno-record-command-line   \
 // RUN: -frecord-command-line      \
 // RUN: -nodefaultlibs             \
@@ -30,7 +28,6 @@
 // RUN: | FileCheck %s --check-prefix=DXC --implicit-check-not="error:"
 
 // CL: warning: unknown argument ignored in clang-cl: '--config'
-// CL: warning: unknown argument ignored in clang-cl: '-fdiagnostics-color=auto'
 // CL: warning: unknown argument ignored in clang-cl: '-fno-record-command-line'
 // CL: warning: unknown argument ignored in clang-cl: '-frecord-command-line'
 // CL: warning: unknown argument ignored in clang-cl: '-nodefaultlibs'
@@ -42,7 +39,6 @@
 // CL: warning: unknown argument ignored in clang-cl: '-Xoffload-linker'
 
 // DXC: error: unknown argument: '--config'
-// DXC: error: unknown argument: '-fdiagnostics-color=auto'
 // DXC: error: unknown argument: '-fno-record-command-line'
 // DXC: error: unknown argument: '-frecord-command-line'
 // DXC: error: unknown argument: '-nodefaultlibs'


### PR DESCRIPTION
Exposing `-fdiagnostic-color=` to clang-cl and clang-dxc. `-fcolor-diagnostics` and `-fno-color-diagnostics` are already allowed in both of these and `-fdiagnostics-color=` allows one additional value, `auto`.

I've added the tests for clang-cl to `cl-options.c` as per the comments in the issue linked below. I couldn't finding a suitable existing file to add the clang-dxc tests to so I've created a new one.

Resolves #119184