### PR TITLE
[Hexagon] Only handle simple types memory accesses

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -3793,6 +3793,8 @@ EVT HexagonTargetLowering::getOptimalMemOpType(
 bool HexagonTargetLowering::allowsMemoryAccess(
     LLVMContext &Context, const DataLayout &DL, EVT VT, unsigned AddrSpace,
     Align Alignment, MachineMemOperand::Flags Flags, unsigned *Fast) const {
+  if (!VT.isSimple())
+    return false;
   MVT SVT = VT.getSimpleVT();
   if (Subtarget.isHVXVectorType(SVT, true))
     return allowsHvxMemoryAccess(SVT, Flags, Fast);
@@ -3803,6 +3805,8 @@ bool HexagonTargetLowering::allowsMemoryAccess(
 bool HexagonTargetLowering::allowsMisalignedMemoryAccesses(
     EVT VT, unsigned AddrSpace, Align Alignment, MachineMemOperand::Flags Flags,
     unsigned *Fast) const {
+  if (!VT.isSimple())
+    return false;
   MVT SVT = VT.getSimpleVT();
   if (Subtarget.isHVXVectorType(SVT, true))
     return allowsHvxMisalignedMemoryAccesses(SVT, Flags, Fast);

--- a/llvm/test/CodeGen/Hexagon/simple-types-mem.ll
+++ b/llvm/test/CodeGen/Hexagon/simple-types-mem.ll
@@ -1,0 +1,22 @@
+; RUN: llc -march=hexagon < %s
+; REQUIRES: asserts
+
+; Only simple types memory accesses are handled.
+
+target triple = "hexagon"
+
+%struct.hoge = type { i320 }
+
+define dso_local void @widget() {
+bb:
+  %tmp = alloca %struct.hoge, align 1
+  %tmp1 = bitcast %struct.hoge* %tmp to i320*
+  %tmp2 = load i320, i320* %tmp1, align 1
+  %tmp3 = and i320 %tmp2, -18446744073709551616
+  %tmp4 = or i320 %tmp3, 0
+  store i320 %tmp4, i320* %tmp1, align 1
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap()


### PR DESCRIPTION
The code was asserting because allowsMemoryAccess() was called with Extended Value Type INVALID_SIMPLE_VALUE_TYPE in HexagonISelLowering.cpp.
Fixes https://github.com/llvm/llvm-project/issues/118881