### PR TITLE
[llvm] add vt_gen target as a dependency of llvm/lib/Analysis

### DIFF
--- a/llvm/lib/Analysis/CMakeLists.txt
+++ b/llvm/lib/Analysis/CMakeLists.txt
@@ -150,6 +150,7 @@ add_llvm_component_library(LLVMAnalysis
 
   DEPENDS
   intrinsics_gen
+  vt_gen
   ${MLDeps}
 
   LINK_LIBS


### PR DESCRIPTION
`DroppedVariableStats.cpp` includes `llvm/include/llvm/Analysis/DroppedVariableStats.h` through its header, which transitively requires `llvm/CodeGen/GenVT.inc` (which is what `vt_gen` depends on) through `llvm/include/llvm/CodeGenTypes/MachineValueType.h`

Based on my testing, this should address #107687, at least for the case where only llvm is being built. There may be further places in clang, mlir etc. that need to add `DEPENDS vt_gen` for using `llvm/include/llvm/CodeGenTypes/MachineValueType.h`

CC @chapuni as author of https://github.com/llvm/llvm-project/commit/631bfdbee5b45eda9f99dff6a716d63c5698e4bd

