### PR TITLE
[Clang][TableGen] Add missing __bf16 type to the builtins parser

### DIFF
--- a/clang/test/TableGen/target-builtins-prototype-parser.td
+++ b/clang/test/TableGen/target-builtins-prototype-parser.td
@@ -57,6 +57,12 @@ def : Builtin {
   let Spellings = ["__builtin_08"];
 }
 
+def : Builtin {
+// CHECK: BUILTIN(__builtin_09, "V2yy", "")
+  let Prototype = "_Vector<2, __bf16>(__bf16)";
+  let Spellings = ["__builtin_09"];
+}
+
 #ifdef ERROR_EXPECTED_LANES
 def : Builtin {
 // ERROR_EXPECTED_LANES: :[[# @LINE + 1]]:7: error: Expected number of lanes after '_ExtVector<'
@@ -112,4 +118,3 @@ def : Builtin {
   let Spellings = ["__builtin_test_use_clang_extended_vectors"];
 }
 #endif
-

--- a/clang/utils/TableGen/ClangBuiltinsEmitter.cpp
+++ b/clang/utils/TableGen/ClangBuiltinsEmitter.cpp
@@ -155,6 +155,7 @@ private:
                                .Case("__fp16", "h")
                                .Case("__int128_t", "LLLi")
                                .Case("_Float16", "x")
+                               .Case("__bf16", "y")
                                .Case("bool", "b")
                                .Case("char", "c")
                                .Case("constant_CFString", "F")


### PR DESCRIPTION
The Clang tablegen built-in function prototype parser has the `__bf16`
type missing. This patch adds the missing type to the parser.