### PR TITLE
[MLIR] Fix triple mismatch warning for embedded libdevice

### DIFF
--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -1562,8 +1562,7 @@ Error IRLinker::run() {
   bool EnableDLWarning = true;
   bool EnableTripleWarning = true;
   if (SrcTriple.isNVPTX() && DstTriple.isNVPTX()) {
-    std::string ModuleId = SrcM->getModuleIdentifier();
-    StringRef FileName = llvm::sys::path::filename(ModuleId);
+    StringRef FileName = SrcM->getSourceFileName();
     bool SrcIsLibDevice =
         FileName.starts_with("libdevice") && FileName.ends_with(".10.bc");
     bool SrcHasLibDeviceDL =


### PR DESCRIPTION
IRLinker emits warning when linking two modules of different target triples. The warning is disabled if the source module is libdevice. When using libdevice embedded in LLVM library via `MLIR_NVVM_EMBED_LIBDEVICE`, IRLinker can no longer tell whether the source module is libdevice via module identifier. This patch uses source filename for that purpose instead.

Note that `source_filename` is recorded as below in libdevice.10.bc:
```
; ModuleID = 'libdevice.10.bc'
source_filename = "libdevice.10.bc"
target datalayout = "e-i64:64-v16:16-v32:32-n16:32:64"
target triple = "nvptx64-nvidia-gpulibs"
```