### PR TITLE
[mlir] [nfc] add assert for function 'getReturnOps'

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
@@ -21,11 +21,12 @@
 namespace mlir {
 /// Return all func.return ops in the given function.
 SmallVector<func::ReturnOp> bufferization::getReturnOps(func::FuncOp funcOp) {
-  SmallVector<func::ReturnOp> result;
+  SmallVector<func::ReturnOp> results;
   for (Block &b : funcOp.getBody())
     if (auto returnOp = dyn_cast<func::ReturnOp>(b.getTerminator()))
-      result.push_back(returnOp);
-  return result;
+      results.push_back(returnOp);
+  assert(!results.empty() && "expected at least one ReturnOp");
+  return results;
 }
 
 namespace bufferization {


### PR DESCRIPTION
This patch fixes bug where func.return could not be found by using return-like trait to locate the function's return operation in 'getReturnOps'.

Fixed https://github.com/llvm/llvm-project/issues/120535