### PR TITLE
[AArch64][docs] Add release notes for FUJITSU-MONAKA support

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -979,6 +979,8 @@ Arm and AArch64 Support
 
 - Support has been added for the following processors (-mcpu identifiers in parenthesis):
 
+  For AArch64:
+
   * FUJITSU-MONAKA (fujitsu-monaka)
 
 Android Support

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -977,6 +977,10 @@ Arm and AArch64 Support
   in leaf functions after enabling ``-fno-omit-frame-pointer``, you can do so by adding
   the ``-momit-leaf-frame-pointer`` option.
 
+- Support has been added for the following processors (-mcpu identifiers in parenthesis):
+
+  * FUJITSU-MONAKA (fujitsu-monaka)
+
 Android Support
 ^^^^^^^^^^^^^^^
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -131,6 +131,8 @@ Changes to the AArch64 Backend
 * Assembler/disassembler support has been added for Armv9.6-A (2024)
   architecture extensions.
 
+* Added support for the FUJITSU-MONAKA CPU.
+
 Changes to the AMDGPU Backend
 -----------------------------
 


### PR DESCRIPTION
Adds release notes for the FUJITSU-MONAKA support introduced in PR #118432. These notes were missing from the original PR.