### PR TITLE
Fix dangling IPOAmendableCB function_ref.

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -1478,7 +1478,7 @@ struct AttributorConfig {
   /// The name of the pass running the attributor, used to emit remarks.
   const char *PassName = nullptr;
 
-  using IPOAmendableCBTy = function_ref<bool(const Function &F)>;
+  using IPOAmendableCBTy = std::function<bool(const Function &F)>;
   IPOAmendableCBTy IPOAmendableCB;
 };
 


### PR DESCRIPTION
The `IPOAmendableCB`'s type is `llvm::function_ref`, it is error-prone to write code (e.g. https://github.com/llvm/llvm-project/blob/5656cbca52545e608f6fb8b7c9a778c7c9b4b468/llvm/lib/Transforms/IPO/OpenMPOpt.cpp#L5812) that assign a temporary lambda to an `IPOAmendableCB` object, which is a use-after-free issue.

This patch changes the `IPOAmendableCB` to `std::function`, to avoid the dangling issue.
   