### PR TITLE
Add LLVM_GSL_POINTER to llvm::function_ref.

### DIFF
--- a/llvm/include/llvm/ADT/STLFunctionalExtras.h
+++ b/llvm/include/llvm/ADT/STLFunctionalExtras.h
@@ -36,7 +36,7 @@ namespace llvm {
 /// a function_ref.
 template<typename Fn> class function_ref;
 
-template<typename Ret, typename ...Params>
+template <typename Ret, typename... Params>
 class LLVM_GSL_POINTER function_ref<Ret(Params...)> {
   Ret (*callback)(intptr_t callable, Params ...params) = nullptr;
   intptr_t callable;

--- a/llvm/include/llvm/ADT/STLFunctionalExtras.h
+++ b/llvm/include/llvm/ADT/STLFunctionalExtras.h
@@ -37,7 +37,7 @@ namespace llvm {
 template<typename Fn> class function_ref;
 
 template<typename Ret, typename ...Params>
-class function_ref<Ret(Params...)> {
+class LLVM_GSL_POINTER function_ref<Ret(Params...)> {
   Ret (*callback)(intptr_t callable, Params ...params) = nullptr;
   intptr_t callable;
 


### PR DESCRIPTION
This can enable clang to detect dangling assignment issues, see #120698.