### PR TITLE
[libc++] Switch _LIBCPP_NODEBUG to [[gnu::nodebug]]

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1170,11 +1170,7 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_NOESCAPE
 #  endif
 
-#  if __has_attribute(__nodebug__)
-#    define _LIBCPP_NODEBUG __attribute__((__nodebug__))
-#  else
-#    define _LIBCPP_NODEBUG
-#  endif
+#  define _LIBCPP_NODEBUG [[__gnu__::__nodebug__]]
 
 #  if __has_attribute(__standalone_debug__)
 #    define _LIBCPP_STANDALONE_DEBUG __attribute__((__standalone_debug__))

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -146,8 +146,8 @@ class __alloc_func<_Fp, _Ap, _Rp(_ArgTypes...)> {
   _LIBCPP_COMPRESSED_PAIR(_Fp, __func_, _Ap, __alloc_);
 
 public:
-  typedef _LIBCPP_NODEBUG _Fp _Target;
-  typedef _LIBCPP_NODEBUG _Ap _Alloc;
+  using _Target _LIBCPP_NODEBUG = _Fp;
+  using _Alloc _LIBCPP_NODEBUG  = _Ap;
 
   _LIBCPP_HIDE_FROM_ABI const _Target& __target() const { return __func_; }
 
@@ -198,7 +198,7 @@ class __default_alloc_func<_Fp, _Rp(_ArgTypes...)> {
   _Fp __f_;
 
 public:
-  typedef _LIBCPP_NODEBUG _Fp _Target;
+  using _Target _LIBCPP_NODEBUG = _Fp;
 
   _LIBCPP_HIDE_FROM_ABI const _Target& __target() const { return __f_; }
 

--- a/libcxx/include/__memory/allocator_arg_t.h
+++ b/libcxx/include/__memory/allocator_arg_t.h
@@ -39,10 +39,10 @@ constexpr allocator_arg_t allocator_arg = allocator_arg_t();
 
 template <class _Tp, class _Alloc, class... _Args>
 struct __uses_alloc_ctor_imp {
-  typedef _LIBCPP_NODEBUG __remove_cvref_t<_Alloc> _RawAlloc;
-  static const bool __ua = uses_allocator<_Tp, _RawAlloc>::value;
-  static const bool __ic = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
-  static const int value = __ua ? 2 - __ic : 0;
+  using _RawAlloc _LIBCPP_NODEBUG = __remove_cvref_t<_Alloc>;
+  static const bool __ua          = uses_allocator<_Tp, _RawAlloc>::value;
+  static const bool __ic          = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
+  static const int value          = __ua ? 2 - __ic : 0;
 };
 
 template <class _Tp, class _Alloc, class... _Args>

--- a/libcxx/include/__memory/allocator_destructor.h
+++ b/libcxx/include/__memory/allocator_destructor.h
@@ -20,11 +20,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Alloc>
 class __allocator_destructor {
-  typedef _LIBCPP_NODEBUG allocator_traits<_Alloc> __alloc_traits;
+  using __alloc_traits _LIBCPP_NODEBUG = allocator_traits<_Alloc>;
 
 public:
-  typedef _LIBCPP_NODEBUG typename __alloc_traits::pointer pointer;
-  typedef _LIBCPP_NODEBUG typename __alloc_traits::size_type size_type;
+  using pointer _LIBCPP_NODEBUG   = typename __alloc_traits::pointer;
+  using size_type _LIBCPP_NODEBUG = typename __alloc_traits::size_type;
 
 private:
   _Alloc& __alloc_;

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -50,17 +50,17 @@ struct __pointer_traits_element_type {};
 
 template <class _Ptr>
 struct __pointer_traits_element_type<_Ptr, true> {
-  typedef _LIBCPP_NODEBUG typename _Ptr::element_type type;
+  using type _LIBCPP_NODEBUG = typename _Ptr::element_type;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args>
 struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, true> {
-  typedef _LIBCPP_NODEBUG typename _Sp<_Tp, _Args...>::element_type type;
+  using type _LIBCPP_NODEBUG = typename _Sp<_Tp, _Args...>::element_type;
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args>
 struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, false> {
-  typedef _LIBCPP_NODEBUG _Tp type;
+  using type _LIBCPP_NODEBUG = _Tp;
 };
 
 template <class _Tp, class = void>
@@ -71,12 +71,12 @@ struct __has_difference_type<_Tp, __void_t<typename _Tp::difference_type> > : tr
 
 template <class _Ptr, bool = __has_difference_type<_Ptr>::value>
 struct __pointer_traits_difference_type {
-  typedef _LIBCPP_NODEBUG ptrdiff_t type;
+  using type _LIBCPP_NODEBUG = ptrdiff_t;
 };
 
 template <class _Ptr>
 struct __pointer_traits_difference_type<_Ptr, true> {
-  typedef _LIBCPP_NODEBUG typename _Ptr::difference_type type;
+  using type _LIBCPP_NODEBUG = typename _Ptr::difference_type;
 };
 
 template <class _Tp, class _Up>
@@ -96,18 +96,18 @@ public:
 template <class _Tp, class _Up, bool = __has_rebind<_Tp, _Up>::value>
 struct __pointer_traits_rebind {
 #ifndef _LIBCPP_CXX03_LANG
-  typedef _LIBCPP_NODEBUG typename _Tp::template rebind<_Up> type;
+  using type _LIBCPP_NODEBUG = typename _Tp::template rebind<_Up>;
 #else
-  typedef _LIBCPP_NODEBUG typename _Tp::template rebind<_Up>::other type;
+  using type _LIBCPP_NODEBUG = typename _Tp::template rebind<_Up>::other;
 #endif
 };
 
 template <template <class, class...> class _Sp, class _Tp, class... _Args, class _Up>
 struct __pointer_traits_rebind<_Sp<_Tp, _Args...>, _Up, true> {
 #ifndef _LIBCPP_CXX03_LANG
-  typedef _LIBCPP_NODEBUG typename _Sp<_Tp, _Args...>::template rebind<_Up> type;
+  using type _LIBCPP_NODEBUG = typename _Sp<_Tp, _Args...>::template rebind<_Up>;
 #else
-  typedef _LIBCPP_NODEBUG typename _Sp<_Tp, _Args...>::template rebind<_Up>::other type;
+  using type _LIBCPP_NODEBUG = typename _Sp<_Tp, _Args...>::template rebind<_Up>::other;
 #endif
 };
 

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -161,7 +161,7 @@ public:
 private:
   _LIBCPP_COMPRESSED_PAIR(pointer, __ptr_, deleter_type, __deleter_);
 
-  typedef _LIBCPP_NODEBUG __unique_ptr_deleter_sfinae<_Dp> _DeleterSFINAE;
+  using _DeleterSFINAE _LIBCPP_NODEBUG = __unique_ptr_deleter_sfinae<_Dp>;
 
   template <bool _Dummy>
   using _LValRefType _LIBCPP_NODEBUG = typename __dependent_type<_DeleterSFINAE, _Dummy>::__lval_ref_type;

--- a/libcxx/include/__ranges/join_view.h
+++ b/libcxx/include/__ranges/join_view.h
@@ -377,8 +377,8 @@ template <class _JoinViewIterator>
            __has_random_access_iterator_category<typename _JoinViewIterator::_Outer>::value &&
            __has_random_access_iterator_category<typename _JoinViewIterator::_Inner>::value)
 struct __segmented_iterator_traits<_JoinViewIterator> {
-  using __segment_iterator =
-      _LIBCPP_NODEBUG __iterator_with_data<typename _JoinViewIterator::_Outer, typename _JoinViewIterator::_Parent*>;
+  using __segment_iterator _LIBCPP_NODEBUG =
+      __iterator_with_data<typename _JoinViewIterator::_Outer, typename _JoinViewIterator::_Parent*>;
   using __local_iterator = typename _JoinViewIterator::_Inner;
 
   // TODO: Would it make sense to enable the optimization for other iterator types?

--- a/libcxx/include/__tuple/make_tuple_types.h
+++ b/libcxx/include/__tuple/make_tuple_types.h
@@ -65,12 +65,12 @@ struct __make_tuple_types {
 
 template <class... _Types, size_t _Ep>
 struct __make_tuple_types<tuple<_Types...>, _Ep, 0, true> {
-  typedef _LIBCPP_NODEBUG __tuple_types<_Types...> type;
+  using type _LIBCPP_NODEBUG = __tuple_types<_Types...>;
 };
 
 template <class... _Types, size_t _Ep>
 struct __make_tuple_types<__tuple_types<_Types...>, _Ep, 0, true> {
-  typedef _LIBCPP_NODEBUG __tuple_types<_Types...> type;
+  using type _LIBCPP_NODEBUG = __tuple_types<_Types...>;
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -59,7 +59,7 @@ struct __tuple_constructible<_Tp, _Up, true, true>
 
 template <size_t _Ip, class... _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, tuple<_Tp...> > {
-  typedef _LIBCPP_NODEBUG typename tuple_element<_Ip, __tuple_types<_Tp...> >::type type;
+  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, __tuple_types<_Tp...> >::type;
 };
 
 struct _LIBCPP_EXPORTED_FROM_ABI __check_tuple_constructor_fail {

--- a/libcxx/include/__tuple/tuple_element.h
+++ b/libcxx/include/__tuple/tuple_element.h
@@ -25,17 +25,17 @@ struct _LIBCPP_TEMPLATE_VIS tuple_element;
 
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const _Tp> {
-  typedef _LIBCPP_NODEBUG const typename tuple_element<_Ip, _Tp>::type type;
+  using type _LIBCPP_NODEBUG = const typename tuple_element<_Ip, _Tp>::type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, volatile _Tp> {
-  typedef _LIBCPP_NODEBUG volatile typename tuple_element<_Ip, _Tp>::type type;
+  using type _LIBCPP_NODEBUG = volatile typename tuple_element<_Ip, _Tp>::type;
 };
 
 template <size_t _Ip, class _Tp>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const volatile _Tp> {
-  typedef _LIBCPP_NODEBUG const volatile typename tuple_element<_Ip, _Tp>::type type;
+  using type _LIBCPP_NODEBUG = const volatile typename tuple_element<_Ip, _Tp>::type;
 };
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -43,7 +43,7 @@ struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const volatile _Tp> {
 template <size_t _Ip, class... _Types>
 struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, __tuple_types<_Types...> > {
   static_assert(_Ip < sizeof...(_Types), "tuple_element index out of range");
-  typedef _LIBCPP_NODEBUG __type_pack_element<_Ip, _Types...> type;
+  using type _LIBCPP_NODEBUG = __type_pack_element<_Ip, _Types...>;
 };
 
 #  if _LIBCPP_STD_VER >= 14

--- a/libcxx/include/__type_traits/add_cv_quals.h
+++ b/libcxx/include/__type_traits/add_cv_quals.h
@@ -19,7 +19,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS add_const {
-  typedef _LIBCPP_NODEBUG const _Tp type;
+  using type _LIBCPP_NODEBUG = const _Tp;
 };
 
 #if _LIBCPP_STD_VER >= 14
@@ -29,7 +29,7 @@ using add_const_t = typename add_const<_Tp>::type;
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS add_cv {
-  typedef _LIBCPP_NODEBUG const volatile _Tp type;
+  using type _LIBCPP_NODEBUG = const volatile _Tp;
 };
 
 #if _LIBCPP_STD_VER >= 14
@@ -39,7 +39,7 @@ using add_cv_t = typename add_cv<_Tp>::type;
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS add_volatile {
-  typedef _LIBCPP_NODEBUG volatile _Tp type;
+  using type _LIBCPP_NODEBUG = volatile _Tp;
 };
 
 #if _LIBCPP_STD_VER >= 14

--- a/libcxx/include/__type_traits/add_lvalue_reference.h
+++ b/libcxx/include/__type_traits/add_lvalue_reference.h
@@ -27,11 +27,11 @@ using __add_lvalue_reference_t = __add_lvalue_reference(_Tp);
 
 template <class _Tp, bool = __libcpp_is_referenceable<_Tp>::value>
 struct __add_lvalue_reference_impl {
-  typedef _LIBCPP_NODEBUG _Tp type;
+  using type _LIBCPP_NODEBUG = _Tp;
 };
 template <class _Tp >
 struct __add_lvalue_reference_impl<_Tp, true> {
-  typedef _LIBCPP_NODEBUG _Tp& type;
+  using type _LIBCPP_NODEBUG = _Tp&;
 };
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/add_pointer.h
+++ b/libcxx/include/__type_traits/add_pointer.h
@@ -28,11 +28,11 @@ using __add_pointer_t = __add_pointer(_Tp);
 #else
 template <class _Tp, bool = __libcpp_is_referenceable<_Tp>::value || is_void<_Tp>::value>
 struct __add_pointer_impl {
-  typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tp>* type;
+  using type _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tp>*;
 };
 template <class _Tp>
 struct __add_pointer_impl<_Tp, false> {
-  typedef _LIBCPP_NODEBUG _Tp type;
+  using type _LIBCPP_NODEBUG = _Tp;
 };
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/add_rvalue_reference.h
+++ b/libcxx/include/__type_traits/add_rvalue_reference.h
@@ -27,11 +27,11 @@ using __add_rvalue_reference_t = __add_rvalue_reference(_Tp);
 
 template <class _Tp, bool = __libcpp_is_referenceable<_Tp>::value>
 struct __add_rvalue_reference_impl {
-  typedef _LIBCPP_NODEBUG _Tp type;
+  using type _LIBCPP_NODEBUG = _Tp;
 };
 template <class _Tp >
 struct __add_rvalue_reference_impl<_Tp, true> {
-  typedef _LIBCPP_NODEBUG _Tp&& type;
+  using type _LIBCPP_NODEBUG = _Tp&&;
 };
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/common_type.h
+++ b/libcxx/include/__type_traits/common_type.h
@@ -61,7 +61,7 @@ struct __common_type2_imp {};
 // sub-bullet 3 - "if decay_t<decltype(false ? declval<D1>() : declval<D2>())> ..."
 template <class _Tp, class _Up>
 struct __common_type2_imp<_Tp, _Up, __void_t<decltype(true ? std::declval<_Tp>() : std::declval<_Up>())> > {
-  typedef _LIBCPP_NODEBUG __decay_t<decltype(true ? std::declval<_Tp>() : std::declval<_Up>())> type;
+  using type _LIBCPP_NODEBUG = __decay_t<decltype(true ? std::declval<_Tp>() : std::declval<_Up>())>;
 };
 
 template <class, class = void>

--- a/libcxx/include/__type_traits/decay.h
+++ b/libcxx/include/__type_traits/decay.h
@@ -37,26 +37,25 @@ struct decay {
 #else
 template <class _Up, bool>
 struct __decay {
-  typedef _LIBCPP_NODEBUG __remove_cv_t<_Up> type;
+  using type _LIBCPP_NODEBUG = __remove_cv_t<_Up>;
 };
 
 template <class _Up>
 struct __decay<_Up, true> {
 public:
-  typedef _LIBCPP_NODEBUG
+  using type _LIBCPP_NODEBUG =
       __conditional_t<is_array<_Up>::value,
                       __add_pointer_t<__remove_extent_t<_Up> >,
-                      __conditional_t<is_function<_Up>::value, typename add_pointer<_Up>::type, __remove_cv_t<_Up> > >
-          type;
+                      __conditional_t<is_function<_Up>::value, typename add_pointer<_Up>::type, __remove_cv_t<_Up> > >;
 };
 
 template <class _Tp>
 struct _LIBCPP_TEMPLATE_VIS decay {
 private:
-  typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tp> _Up;
+  using _Up _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tp>;
 
 public:
-  typedef _LIBCPP_NODEBUG typename __decay<_Up, __libcpp_is_referenceable<_Up>::value>::type type;
+  using type _LIBCPP_NODEBUG = typename __decay<_Up, __libcpp_is_referenceable<_Up>::value>::type;
 };
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/remove_pointer.h
+++ b/libcxx/include/__type_traits/remove_pointer.h
@@ -32,11 +32,11 @@ using __remove_pointer_t = __remove_pointer(_Tp);
 #  endif
 #else
 // clang-format off
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer                      {typedef _LIBCPP_NODEBUG _Tp type;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp*>                {typedef _LIBCPP_NODEBUG _Tp type;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const>          {typedef _LIBCPP_NODEBUG _Tp type;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* volatile>       {typedef _LIBCPP_NODEBUG _Tp type;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const volatile> {typedef _LIBCPP_NODEBUG _Tp type;};
+template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer                      {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp*>                {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const>          {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* volatile>       {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const volatile> {using type _LIBCPP_NODEBUG = _Tp;};
 // clang-format on
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/type_list.h
+++ b/libcxx/include/__type_traits/type_list.h
@@ -29,12 +29,12 @@ struct __find_first;
 
 template <class _Hp, class _Tp, size_t _Size>
 struct __find_first<__type_list<_Hp, _Tp>, _Size, true> {
-  typedef _LIBCPP_NODEBUG _Hp type;
+  using type _LIBCPP_NODEBUG = _Hp;
 };
 
 template <class _Hp, class _Tp, size_t _Size>
 struct __find_first<__type_list<_Hp, _Tp>, _Size, false> {
-  typedef _LIBCPP_NODEBUG typename __find_first<_Tp, _Size>::type type;
+  using type _LIBCPP_NODEBUG = typename __find_first<_Tp, _Size>::type;
 };
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__type_traits/unwrap_ref.h
+++ b/libcxx/include/__type_traits/unwrap_ref.h
@@ -21,12 +21,12 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct __unwrap_reference {
-  typedef _LIBCPP_NODEBUG _Tp type;
+  using type _LIBCPP_NODEBUG = _Tp;
 };
 
 template <class _Tp>
 struct __unwrap_reference<reference_wrapper<_Tp> > {
-  typedef _LIBCPP_NODEBUG _Tp& type;
+  using type _LIBCPP_NODEBUG = _Tp&;
 };
 
 #if _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__utility/exception_guard.h
+++ b/libcxx/include/__utility/exception_guard.h
@@ -96,10 +96,10 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(__exception_guard_exceptions);
 template <class _Rollback>
 struct __exception_guard_noexceptions {
   __exception_guard_noexceptions() = delete;
-  _LIBCPP_HIDE_FROM_ABI
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NODEBUG explicit __exception_guard_noexceptions(_Rollback) {}
+  _LIBCPP_NODEBUG _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __exception_guard_noexceptions(_Rollback) {}
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NODEBUG
+  _LIBCPP_NODEBUG _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
   __exception_guard_noexceptions(__exception_guard_noexceptions&& __other)
       _NOEXCEPT_(is_nothrow_move_constructible<_Rollback>::value)
       : __completed_(__other.__completed_) {
@@ -110,11 +110,11 @@ struct __exception_guard_noexceptions {
   __exception_guard_noexceptions& operator=(__exception_guard_noexceptions const&) = delete;
   __exception_guard_noexceptions& operator=(__exception_guard_noexceptions&&)      = delete;
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NODEBUG void __complete() _NOEXCEPT {
+  _LIBCPP_NODEBUG _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __complete() _NOEXCEPT {
     __completed_ = true;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NODEBUG ~__exception_guard_noexceptions() {
+  _LIBCPP_NODEBUG _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 ~__exception_guard_noexceptions() {
     _LIBCPP_ASSERT_INTERNAL(__completed_, "__exception_guard not completed with exceptions disabled");
   }
 

--- a/libcxx/include/__utility/move.h
+++ b/libcxx/include/__utility/move.h
@@ -28,7 +28,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp>
 [[__nodiscard__]] inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __libcpp_remove_reference_t<_Tp>&&
 move(_LIBCPP_LIFETIMEBOUND _Tp&& __t) _NOEXCEPT {
-  typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tp> _Up;
+  using _Up _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tp>;
   return static_cast<_Up&&>(__t);
 }
 

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -1067,28 +1067,28 @@ swap(const tuple<_Tp...>& __lhs,
 template <size_t _Ip, class... _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&
 get(tuple<_Tp...>& __t) _NOEXCEPT {
-  typedef _LIBCPP_NODEBUG typename tuple_element<_Ip, tuple<_Tp...> >::type type;
+  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
   return static_cast<__tuple_leaf<_Ip, type>&>(__t.__base_).get();
 }
 
 template <size_t _Ip, class... _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, tuple<_Tp...> >::type&
 get(const tuple<_Tp...>& __t) _NOEXCEPT {
-  typedef _LIBCPP_NODEBUG typename tuple_element<_Ip, tuple<_Tp...> >::type type;
+  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
   return static_cast<const __tuple_leaf<_Ip, type>&>(__t.__base_).get();
 }
 
 template <size_t _Ip, class... _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&&
 get(tuple<_Tp...>&& __t) _NOEXCEPT {
-  typedef _LIBCPP_NODEBUG typename tuple_element<_Ip, tuple<_Tp...> >::type type;
+  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
   return static_cast<type&&>(static_cast<__tuple_leaf<_Ip, type>&&>(__t.__base_).get());
 }
 
 template <size_t _Ip, class... _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, tuple<_Tp...> >::type&&
 get(const tuple<_Tp...>&& __t) _NOEXCEPT {
-  typedef _LIBCPP_NODEBUG typename tuple_element<_Ip, tuple<_Tp...> >::type type;
+  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
   return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__t.__base_).get());
 }
 
@@ -1240,7 +1240,7 @@ struct __tuple_cat_type;
 
 template <class... _Ttypes, class... _Utypes>
 struct __tuple_cat_type<tuple<_Ttypes...>, __tuple_types<_Utypes...> > {
-  typedef _LIBCPP_NODEBUG tuple<_Ttypes..., _Utypes...> type;
+  using type _LIBCPP_NODEBUG = tuple<_Ttypes..., _Utypes...>;
 };
 
 template <class _ResultTuple, bool _Is_Tuple0TupleLike, class... _Tuples>
@@ -1274,7 +1274,7 @@ struct __tuple_cat_return<_Tuple0, _Tuples...>
 
 template <>
 struct __tuple_cat_return<> {
-  typedef _LIBCPP_NODEBUG tuple<> type;
+  using type _LIBCPP_NODEBUG = tuple<>;
 };
 
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 tuple<> tuple_cat() { return tuple<>(); }
@@ -1284,7 +1284,7 @@ struct __tuple_cat_return_ref_imp;
 
 template <class... _Types, size_t... _I0, class _Tuple0>
 struct __tuple_cat_return_ref_imp<tuple<_Types...>, __tuple_indices<_I0...>, _Tuple0> {
-  typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple0> _T0;
+  using _T0 _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tuple0>;
   typedef tuple<_Types..., __copy_cvref_t<_Tuple0, typename tuple_element<_I0, _T0>::type>&&...> type;
 };
 
@@ -1324,8 +1324,8 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
   typename __tuple_cat_return_ref<tuple<_Types...>&&, _Tuple0&&, _Tuple1&&, _Tuples&&...>::type
   operator()(tuple<_Types...> __t, _Tuple0&& __t0, _Tuple1&& __t1, _Tuples&&... __tpls) {
     (void)__t; // avoid unused parameter warning on GCC when _I0 is empty
-    typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple0> _T0;
-    typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple1> _T1;
+    using _T0 _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tuple0>;
+    using _T1 _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tuple1>;
     return __tuple_cat<tuple<_Types..., __copy_cvref_t<_Tuple0, typename tuple_element<_J0, _T0>::type>&&...>,
                        typename __make_tuple_indices<sizeof...(_Types) + tuple_size<_T0>::value>::type,
                        typename __make_tuple_indices<tuple_size<_T1>::value>::type>()(
@@ -1339,7 +1339,7 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
 template <class _Tuple0, class... _Tuples>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename __tuple_cat_return<_Tuple0, _Tuples...>::type
 tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls) {
-  typedef _LIBCPP_NODEBUG __libcpp_remove_reference_t<_Tuple0> _T0;
+  using _T0 _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tuple0>;
   return __tuple_cat<tuple<>, __tuple_indices<>, typename __make_tuple_indices<tuple_size<_T0>::value>::type>()(
       tuple<>(), std::forward<_Tuple0>(__t0), std::forward<_Tuples>(__tpls)...);
 }


### PR DESCRIPTION
This makes the placement of the attribute more consistent. This also avoids clang dropping the attribute silently (see #120722).
