### PR TITLE
[CMake] Use shm_open, not clock_gettime, to detect librt

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -124,7 +124,7 @@ if( NOT PURE_WINDOWS )
     endif()
   endif()
   check_library_exists(dl dlopen "" HAVE_LIBDL)
-  check_library_exists(rt clock_gettime "" HAVE_LIBRT)
+  check_library_exists(rt shm_open "" HAVE_LIBRT)
 endif()
 
 # Check for libpfm.


### PR DESCRIPTION
On systems with glibc, clock_gettime() was moved from librt to libc in version 2.17, in which case the current librt detection attempt would always fail.

Look for shm_open instead, like other parts of the tree also do when looking for librt.