### PR TITLE
[CrossCompile] pass HOST_CC/CXX to CMAKE_<C/CXX>_COMPILER when CMAKE_CROSSCOMPILING=True

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -15,10 +15,10 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
   if (EXISTS ${LLVM_MAIN_SRC_DIR}/cmake/platforms/${toolchain}.cmake)
     set(CROSS_TOOLCHAIN_FLAGS_INIT
       -DCMAKE_TOOLCHAIN_FILE=\"${LLVM_MAIN_SRC_DIR}/cmake/platforms/${toolchain}.cmake\")
-  elseif (NOT CMAKE_CROSSCOMPILING)
+  elseif (CMAKE_CROSSCOMPILING)
     set(CROSS_TOOLCHAIN_FLAGS_INIT
-      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_C_COMPILER=${CMAKE_C_HOST_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_HOST_COMPILER}
       )
   endif()
   set(CROSS_TOOLCHAIN_FLAGS_${target_name} ${CROSS_TOOLCHAIN_FLAGS_INIT}


### PR DESCRIPTION
* Top CMake Command

```shell
CMAKE_EXTRA="-D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -D CMAKE_TOOLCHAIN_FILE=${CROSS_TOOLCHAIN}/linux310-gcc7/toolchain-cmake-template.aarch64-unknown-linux-gnu"
# ^^^^ Just a note on the variables `CMAKE_EXTRA` ^^^^

CMAKE_COMMAND=$(cat <<- EOF
cmake -G Ninja \
  -S "${SUBPROJ_SRC}/llvm" -B "${PKG_BULD_DIR}" \
  -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON  \
  -D CMAKE_INSTALL_PREFIX="${PKG_INST_DIR}" \
  -D CMAKE_INSTALL_LIBDIR:PATH=lib \
  ${PKG_BULD_TYPE} ${PKG_TYPE_FLAG} ${CMAKE_EXTRA} \
  -D LLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb" \
  -D CLANG_PLUGIN_SUPPORT:BOOL=0 \
  -D LLVM_APPEND_VC_REV:BOOL=0   \
  -D LLVM_ENABLE_BINDINGS:BOOL=0 \
  -D LLVM_INCLUDE_BENCHMARKS:BOOL=0 \
  -D LLVM_INCLUDE_EXAMPLES:BOOL=0   \
  -D LLVM_INCLUDE_TESTS:BOOL=0 \
  -D LLVM_INCLUDE_DOCS:BOOL=0  \
  -D LLVM_INCLUDE_UTILS:BOOL=0 \
  -D LLVM_TARGETS_TO_BUILD="AArch64;ARM;RISCV;WebAssembly;X86" \
  -D LLDB_USE_SYSTEM_DEBUGSERVER:BOOL=1
EOF
)
if [ "${CROSS_BUILD_ENABLED}" == "1" ]; then
  [ "${PKG_ARCH}" == "amd64" ] && { LLVM_ARCH="X86"; }
  [ "${PKG_ARCH}" == "arm64" ] && { LLVM_ARCH="AArch64"; }
  [ "${PKG_ARCH}" == "armv7" ] && { LLVM_ARCH="ARM"; }
  CMAKE_COMMAND="${CMAKE_COMMAND} -D LLVM_HOST_TRIPLE=${TARGET_TRIPLE} -D LLVM_TARGET_ARCH=${LLVM_ARCH} \
    -D CMAKE_C_HOST_COMPILER='${HOSTCC}' -D CMAKE_CXX_HOST_COMPILER='${HOSTCXX}'"
    # ^^^^ Pass HOST_CC/CXX to CMAKE_<C/CXX>_COMPILER ^^^^
fi
printf "\e[1m\e[36m%s\e[0m\n" "${CMAKE_COMMAND}"; eval ${CMAKE_COMMAND}
```

* File: `toolchain-cmake-template.aarch64-unknown-linux-gnu`

```cmake
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR "aarch64")
set(CMAKE_CROSSCOMPILING TRUE)

set(CROSS_TARGET_TRIPLE "aarch64-unknown-linux-gnu")
set(CROSS_ROOT "$ENV{CROSS_TOOLCHAIN_ROOT}")
set(CMAKE_SYSROOT "${CROSS_ROOT}/${CROSS_TARGET_TRIPLE}")

set(CMAKE_C_COMPILER   "clang"   "--target=${CROSS_TARGET_TRIPLE}" "--gcc-toolchain=${CMAKE_SYSROOT}/usr" "")
set(CMAKE_CXX_COMPILER "clang++" "--target=${CROSS_TARGET_TRIPLE}" "--gcc-toolchain=${CMAKE_SYSROOT}/usr" "")
set(CMAKE_LINKER_TYPE  "LLD")

set(CMAKE_FIND_ROOT_PATH "${CMAKE_SYSROOT}" )
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

set(PKG_CONFIG_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/pkgconf-wrapper.${CROSS_TARGET_TRIPLE}" CACHE FILEPATH "pkgconf executable")

```

* Error message shows when building with original code

<img width="1349" alt="Screenshot 2024-12-20 at 20 45 40" src="https://github.com/user-attachments/assets/cc970c03-5602-4cdd-894b-79fa3c824152" />

