### PR TITLE
[clang][dataflow] Fix a missing break from a switch case -Wimplicit-fallthrough

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -71,7 +71,8 @@ bool hasSmartPointerClassShape(const CXXRecordDecl &RD, bool &HasGet,
                                 ->getCanonicalTypeUnqualified();
         }
       }
-    }
+   }
+       break;
     default:
       break;
     }

--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -71,8 +71,7 @@ bool hasSmartPointerClassShape(const CXXRecordDecl &RD, bool &HasGet,
                                 ->getCanonicalTypeUnqualified();
         }
       }
-   }
-       break;
+    } break;
     default:
       break;
     }


### PR DESCRIPTION
Missed when changing code in https://github.com/llvm/llvm-project/pull/120102