### PR TITLE
[lldb][Docs] Add equivalents of GDB's "skip" to command map

### DIFF
--- a/lldb/docs/use/map.rst
+++ b/lldb/docs/use/map.rst
@@ -247,10 +247,7 @@ Ignore a function when doing a source level single step in
 
   (lldb) settings show target.process.thread.step-avoid-regexp
   target.process.thread.step-avoid-regexp (regex) = ^std::
-  (lldb) settings set target.process.thread.step-avoid-regexp (^std::)|(^abc)
-
-Get the default value, make it into a capture group, then add another capture
-group for the new function name.
+  (lldb) settings set target.process.thread.step-avoid-regexp ^std::|^abc
 
 You can ignore a function once using:
 
@@ -258,10 +255,11 @@ You can ignore a function once using:
 
   (lldb) thread step-in -r ^abc
 
-Or you can do the opposite, only step into functions with a certain name:
+Or you can do the opposite, only step into functions matching a certain name:
 
 .. code-block:: shell
 
+  # Step in if abc is a substring of the function name.
   (lldb) sif abc
   # Which is equivalent to:
   (lldb) thread step-in -t abc

--- a/lldb/docs/use/map.rst
+++ b/lldb/docs/use/map.rst
@@ -235,6 +235,23 @@ Do a source level single step in the currently selected thread
   (lldb) step
   (lldb) s
 
+Ignore a function when doing a source level single step in
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+
+  (gdb) skip abc
+  Function abc will be skipped when stepping.
+
+.. code-block:: shell
+
+  (lldb) settings show target.process.thread.step-avoid-regexp
+  target.process.thread.step-avoid-regexp (regex) = ^std::
+  (lldb) settings set target.process.thread.step-avoid-regexp (^std::)|(^abc)
+
+Get the default value, make it into a capture group, then add another capture
+group for the new function name.
+
 Do a source level single step over in the currently selected thread
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lldb/docs/use/map.rst
+++ b/lldb/docs/use/map.rst
@@ -252,6 +252,23 @@ Ignore a function when doing a source level single step in
 Get the default value, make it into a capture group, then add another capture
 group for the new function name.
 
+You can ignore a function once using:
+
+.. code-block:: shell
+
+  (lldb) thread step-in -r ^abc
+
+Or you can do the opposite, only step into functions with a certain name:
+
+.. code-block:: shell
+
+  (lldb) sif abc
+  # Which is equivalent to:
+  (lldb) thread step-in -t abc
+
+``thread step-in`` has more options which cover some of ``skip``'s other
+features. See ``help thread step-in`` for details.
+
 Do a source level single step over in the currently selected thread
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
https://sourceware.org/gdb/current/onlinedocs/gdb.html/Skipping-Over-Functions-and-Files.html

We can't emulate all the features of that command but we can skip a function by name with some extra steps.

As far as I know this only matches function name unlike GDB that can filter on file and line and so on:
```
target.process.thread.step-avoid-regexp -- A regular expression defining functions step-in won't stop in.
```
It's likely it's got some corner cases that don't work, maybe inlining, but it doesn't seem worth going into it here.

I don't think we can chain lldb interpreter commands, so I have shown the steps separately.

I have also mentioned `thread step-in` and its alias `sif`. Which were new to me too.