### PR TITLE
[AArch64] Enable FEAT_SVE2p1 by default for Armv9.4-A and later

### DIFF
--- a/clang/test/Driver/print-enabled-extensions/aarch64-armv9.4-a.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-armv9.4-a.c
@@ -58,6 +58,7 @@
 // CHECK-NEXT:     FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
 // CHECK-NEXT:     FEAT_SVE                                               Enable Scalable Vector Extension (SVE) instructions
 // CHECK-NEXT:     FEAT_SVE2                                              Enable Scalable Vector Extension 2 (SVE2) instructions
+// CHECK-NEXT:     FEAT_SVE2p1                                            Enable Scalable Vector Extension 2.1 instructions
 // CHECK-NEXT:     FEAT_TLBIOS, FEAT_TLBIRANGE                            Enable Armv8.4-A TLB Range and Maintenance instructions
 // CHECK-NEXT:     FEAT_TRBE                                              Enable Trace Buffer Extension
 // CHECK-NEXT:     FEAT_TRF                                               Enable Armv8.4-A Trace extension

--- a/clang/test/Driver/print-enabled-extensions/aarch64-armv9.5-a.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-armv9.5-a.c
@@ -61,6 +61,7 @@
 // CHECK-NEXT:     FEAT_SSBS, FEAT_SSBS2                                  Enable Speculative Store Bypass Safe bit
 // CHECK-NEXT:     FEAT_SVE                                               Enable Scalable Vector Extension (SVE) instructions
 // CHECK-NEXT:     FEAT_SVE2                                              Enable Scalable Vector Extension 2 (SVE2) instructions
+// CHECK-NEXT:     FEAT_SVE2p1                                            Enable Scalable Vector Extension 2.1 instructions
 // CHECK-NEXT:     FEAT_TLBIOS, FEAT_TLBIRANGE                            Enable Armv8.4-A TLB Range and Maintenance instructions
 // CHECK-NEXT:     FEAT_TRBE                                              Enable Trace Buffer Extension
 // CHECK-NEXT:     FEAT_TRF                                               Enable Armv8.4-A Trace extension

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -872,9 +872,9 @@ def HasV9_3aOps : Architecture64<9, 3, "a", "v9.3a",
   [HasV8_8aOps, HasV9_2aOps],
   !listconcat(HasV9_2aOps.DefaultExts, [FeatureMOPS, FeatureHBC])>;
 def HasV9_4aOps : Architecture64<9, 4, "a", "v9.4a",
-  [HasV8_9aOps, HasV9_3aOps, FeatureSVE2p1],
+  [HasV8_9aOps, HasV9_3aOps],
   !listconcat(HasV9_3aOps.DefaultExts, [FeatureSPECRES2, FeatureCSSC,
-    FeatureRASv2])>;
+    FeatureRASv2, FeatureSVE2p1])>;
 def HasV9_5aOps : Architecture64<9, 5, "a", "v9.5a",
   [HasV9_4aOps, FeatureCPA],
   !listconcat(HasV9_4aOps.DefaultExts, [FeatureCPA,  FeatureLUT, FeatureFAMINMAX])>;

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -872,7 +872,7 @@ def HasV9_3aOps : Architecture64<9, 3, "a", "v9.3a",
   [HasV8_8aOps, HasV9_2aOps],
   !listconcat(HasV9_2aOps.DefaultExts, [FeatureMOPS, FeatureHBC])>;
 def HasV9_4aOps : Architecture64<9, 4, "a", "v9.4a",
-  [HasV8_9aOps, HasV9_3aOps],
+  [HasV8_9aOps, HasV9_3aOps, FeatureSVE2p1],
   !listconcat(HasV9_3aOps.DefaultExts, [FeatureSPECRES2, FeatureCSSC,
     FeatureRASv2])>;
 def HasV9_5aOps : Architecture64<9, 5, "a", "v9.5a",


### PR DESCRIPTION
The ArmARM says:
```
    "In an Armv9.4 implementation, if FEAT_SVE2 is implemented,
     FEAT_SVE2p1 is implemented."
```
Since FEAT_SVE2 is already enabled for Armv9.0-A and later, then FEAT_SVE2p1 should also be enabled by default.