### PR TITLE
[NFC] llvm-cgdata use StringRef in exitWithError to reduce construction

### DIFF
--- a/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
+++ b/llvm/tools/llvm-cgdata/llvm-cgdata.cpp
@@ -83,8 +83,8 @@ static CGDataAction Action;
 static std::optional<CGDataFormat> OutputFormat;
 static std::vector<std::string> InputFilenames;
 
-static void exitWithError(Twine Message, std::string Whence = "",
-                          std::string Hint = "") {
+static void exitWithError(Twine Message, StringRef Whence = "",
+                          StringRef Hint = "") {
   WithColor::error();
   if (!Whence.empty())
     errs() << Whence << ": ";
@@ -97,16 +97,16 @@ static void exitWithError(Twine Message, std::string Whence = "",
 static void exitWithError(Error E, StringRef Whence = "") {
   if (E.isA<CGDataError>()) {
     handleAllErrors(std::move(E), [&](const CGDataError &IPE) {
-      exitWithError(IPE.message(), std::string(Whence));
+      exitWithError(IPE.message(), Whence);
     });
     return;
   }
 
-  exitWithError(toString(std::move(E)), std::string(Whence));
+  exitWithError(toString(std::move(E)), Whence);
 }
 
 static void exitWithErrorCode(std::error_code EC, StringRef Whence = "") {
-  exitWithError(EC.message(), std::string(Whence));
+  exitWithError(EC.message(), Whence);
 }
 
 static int convert_main(int argc, const char *argv[]) {


### PR DESCRIPTION
Replace `static void exitWithError(Twine Message, std::string Whence = "", std::string Hint = "")` std::string with StringRef to remove constructing Strings on every call or passing by value

Fixes: #100065