### PR TITLE
[llvm-gsymutil] Ensure stable ordering of merged functions

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -200,8 +200,8 @@ void GsymCreator::prepareMergedFunctions(OutputAggregator &Out) {
   if (Funcs.size() < 2)
     return;
 
-  // Sort the function infos by address range first
-  llvm::sort(Funcs);
+  // Sort the function infos by address range first, preserving input order
+  llvm::stable_sort(Funcs);
   std::vector<FunctionInfo> TopLevelFuncs;
 
   // Add the first function info to the top level functions

--- a/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
+++ b/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
@@ -1,7 +1,3 @@
-# FIXME: Currently disabled as it fails on some Linux hosts
-# UNSUPPORTED: true
-
-
 ## Test that reconstructs a dSYM file from YAML and generates a gsym from it. The gsym has callsite info and merged functions.
 
 # RUN: split-file %s %t


### PR DESCRIPTION
Previously, the test `llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml` [was disabled](https://github.com/llvm/llvm-project/pull/119957/files) due to failing on Linux. 

The issue is that the merged functions appear in a different order in the final produced `gSYM`.
To ensure deterministic ordering of merged functions, we change the sorting of functions to use the `stable_sort` algorithm. Before merged functions, this was not an issue as the address is used as a comparator in the sorting algorithm so there was no chance of two functions testing as identical according to the comparator.

Confirmed that test now passes locally with `-DLLVM_ENABLE_EXPENSIVE_CHECKS=ON`.