### PR TITLE
[compiler-rt][test] Apply CFLAGS from sanitizer_common to all tests

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -309,6 +309,14 @@ macro(get_test_cc_for_arch arch cc_out cflags_out)
     endif()
     string(REPLACE ";" " " ${cflags_out} "${${cflags_out}}")
   endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT ANDROID)
+    # ARM on Linux might use the slow unwinder as default and the unwind table
+    # is required to get a complete stacktrace.
+    string(APPEND ${cflags_out} " -funwind-tables")
+    if(CMAKE_SYSROOT)
+      string(APPEND ${cflags_out} " --sysroot=${CMAKE_SYSROOT}")
+    endif()
+  endif()
 endmacro()
 
 # Returns CFLAGS that should be used to run tests for the

--- a/compiler-rt/test/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/test/sanitizer_common/CMakeLists.txt
@@ -73,17 +73,6 @@ foreach(tool ${SUPPORTED_TOOLS})
     get_test_cc_for_arch(${arch} SANITIZER_COMMON_TEST_TARGET_CC SANITIZER_COMMON_TEST_TARGET_CFLAGS)
     set(CONFIG_NAME ${tool}-${arch}-${OS_NAME})
 
-    # ARM on Linux might use the slow unwinder as default and the unwind table is
-    # required to get a complete stacktrace.
-    if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" AND NOT ANDROID)
-      list(APPEND SANITIZER_COMMON_TEST_TARGET_CFLAGS -funwind-tables)
-      if(CMAKE_SYSROOT)
-        list(APPEND SANITIZER_COMMON_TEST_TARGET_CFLAGS "--sysroot=${CMAKE_SYSROOT}")
-      endif()
-      string(REPLACE ";" " " SANITIZER_COMMON_TEST_TARGET_CFLAGS
-                             "${SANITIZER_COMMON_TEST_TARGET_CFLAGS}")
-    endif()
-
     configure_lit_site_cfg(
       ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
       ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg.py)


### PR DESCRIPTION
Sanitizer-specific tests don't use the sanitizer_common flags, but the issues they address probably also apply to the individual sanitizers.

This was observed in #119071: moving a test from sanitizer_common to msan broke it in builds with CMAKE_SYSROOT set, because the --sysroot argument was no longer applied to the test.