### PR TITLE
[ExtractAPI] merge anon declarators even if they're array types

### DIFF
--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -252,6 +252,11 @@ protected:
     if (!NewRecordContext)
       return;
     auto *Tag = D.getType()->getAsTagDecl();
+    if (!Tag) {
+      if (const auto *AT = D.getASTContext().getAsArrayType(D.getType())) {
+        Tag = AT->getElementType()->getAsTagDecl();
+      }
+    }
     SmallString<128> TagUSR;
     clang::index::generateUSRForDecl(Tag, TagUSR);
     if (auto *Record = llvm::dyn_cast_if_present<TagRecord>(

--- a/clang/test/ExtractAPI/anonymous_record_no_typedef.c
+++ b/clang/test/ExtractAPI/anonymous_record_no_typedef.c
@@ -191,4 +191,44 @@ union Vector {
 // VEC-DAG: "!testRelLabel": "memberOf $ c:@U@Vector@Sa@FI@X $ c:@U@Vector"
 // VEC-DAG: "!testRelLabel": "memberOf $ c:@U@Vector@Sa@FI@Y $ c:@U@Vector"
 
+// RUN: FileCheck %s --input-file %t/output-c.symbols.json --check-prefix MYSTRUCT
+// RUN: FileCheck %s --input-file %t/output-cxx.symbols.json --check-prefix MYSTRUCT
+// RUN: FileCheck %s --input-file %t/output-c.symbols.json --check-prefix COUNTS
+// RUN: FileCheck %s --input-file %t/output-cxx.symbols.json --check-prefix COUNTS
+struct MyStruct {
+    struct {
+        int count;
+    } counts[1];
+};
+// MYSTRUCT-NOT: "spelling": ""
+// MYSTRUCT-NOT: "title": ""
+
+// COUNTS-LABEL: "!testLabel": "c:@S@MyStruct@FI@counts"
+// COUNTS:      "declarationFragments": [
+// COUNTS-NEXT:   {
+// COUNTS-NEXT:     "kind": "keyword",
+// COUNTS-NEXT:     "spelling": "struct"
+// COUNTS-NEXT:   },
+// COUNTS-NEXT:   {
+// COUNTS-NEXT:     "kind": "text",
+// COUNTS-NEXT:     "spelling": " { ... } "
+// COUNTS-NEXT:   },
+// COUNTS-NEXT:   {
+// COUNTS-NEXT:     "kind": "identifier",
+// COUNTS-NEXT:     "spelling": "counts"
+// COUNTS-NEXT:   },
+// COUNTS-NEXT:   {
+// COUNTS-NEXT:     "kind": "text",
+// COUNTS-NEXT:     "spelling": "["
+// COUNTS-NEXT:   },
+// COUNTS-NEXT:   {
+// COUNTS-NEXT:     "kind": "number",
+// COUNTS-NEXT:     "spelling": "1"
+// COUNTS-NEXT:   },
+// COUNTS-NEXT:   {
+// COUNTS-NEXT:     "kind": "text",
+// COUNTS-NEXT:     "spelling": "];"
+// COUNTS-NEXT:   }
+// COUNTS-NEXT: ],
+
 // expected-no-diagnostics


### PR DESCRIPTION
Resolves rdar://140210765

ExtractAPI currently checks declarator decls for embedded tag decls so that it can fold in anonymous tag decls as necessary. However, this check appears to be tricked when the field decl specifies an array of this embedded anonymous tag decl. This PR adds an extra check to `ExtractAPIVisitorBase::maybeMergeWithAnonymousTag()` to poke inside array types for a potential anonymous tag decl to merge, so that it doesn't erroneously create symbols with empty names.