### PR TITLE
[libc] Make a couple of math smoke tests more robust.

### DIFF
--- a/libc/test/src/math/smoke/CanonicalizeTest.h
+++ b/libc/test/src/math/smoke/CanonicalizeTest.h
@@ -19,6 +19,7 @@
 #include "hdr/math_macros.h"
 
 #define TEST_SPECIAL(x, y, expected, expected_exception)                       \
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                         \
   EXPECT_EQ(expected, f(&x, &y));                                              \
   EXPECT_FP_EXCEPTION(expected_exception);                                     \
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT)

--- a/libc/test/src/math/smoke/FModTest.h
+++ b/libc/test/src/math/smoke/FModTest.h
@@ -18,7 +18,7 @@
 #include "hdr/fenv_macros.h"
 
 #define TEST_SPECIAL(x, y, expected, dom_err, expected_exception)              \
-  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);			       \
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                         \
   EXPECT_FP_EQ(expected, f(x, y));                                             \
   EXPECT_MATH_ERRNO((dom_err) ? EDOM : 0);                                     \
   EXPECT_FP_EXCEPTION(expected_exception);                                     \

--- a/libc/test/src/math/smoke/FModTest.h
+++ b/libc/test/src/math/smoke/FModTest.h
@@ -18,6 +18,7 @@
 #include "hdr/fenv_macros.h"
 
 #define TEST_SPECIAL(x, y, expected, dom_err, expected_exception)              \
+  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);			       \
   EXPECT_FP_EQ(expected, f(x, y));                                             \
   EXPECT_MATH_ERRNO((dom_err) ? EDOM : 0);                                     \
   EXPECT_FP_EXCEPTION(expected_exception);                                     \


### PR DESCRIPTION
Make sure to clear out all FE_ALL_EXCEPT bits both before and after invoking function under test -- otherwise the very first check for the exception bits in the unit test may fail due to bits set prior to test invocation.