### PR TITLE
[clang-format] Fix a crash in `QualifierAlignment: Right`

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -348,7 +348,7 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeRight(
       }
     }
 
-    if (Next->is(tok::kw_auto))
+    if (Next && Next->is(tok::kw_auto))
       TypeToken = Next;
 
     // Place the Qualifier at the end of the list of qualifiers.

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -531,6 +531,11 @@ TEST_F(QualifierFixerTest, RightQualifier) {
   verifyFormat("float (C::*const p)(int);", Style);
   verifyFormat("float (C::*p)(int) const;", Style);
   verifyFormat("float const (C::*p)(int);", "const float (C::*p)(int);", Style);
+
+  Style.BreakBeforeBraces = FormatStyle::BS_Custom;
+  Style.BraceWrapping.AfterFunction = true;
+  verifyFormat("auto foo() -> T const { return bar; }",
+               "auto foo() -> const T { return bar; }", Style);
 }
 
 TEST_F(QualifierFixerTest, LeftQualifier) {


### PR DESCRIPTION
Fixes #120793.