### PR TITLE
[lldb][ResolveSourceFileCallback] Call resolve source file callback

### DIFF
--- a/lldb/include/lldb/Symbol/LineEntry.h
+++ b/lldb/include/lldb/Symbol/LineEntry.h
@@ -128,7 +128,10 @@ struct LineEntry {
   ///
   /// \param[in] target_sp
   ///     Shared pointer to the target this LineEntry belongs to.
-  void ApplyFileMappings(lldb::TargetSP target_sp);
+  ///
+  /// \param[in] module_sp
+  ///     Shared pointer to the module this LineEntry belongs to.
+  void ApplyFileMappings(lldb::TargetSP target_sp, lldb::ModuleSP module_sp);
 
   /// Helper to access the file.
   const FileSpec &GetFile() const { return file_sp->GetSpecOnly(); }

--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -316,6 +316,12 @@ public:
   virtual bool GetModuleSpec(const FileSpec &module_file_spec,
                              const ArchSpec &arch, ModuleSpec &module_spec);
 
+  void
+  CallResolveSourceFileCallbackIfSet(const lldb::ModuleSP &module_sp,
+                                     const FileSpec &original_source_file_spec,
+                                     FileSpec &resolved_source_file_spec,
+                                     bool *did_create_ptr);
+
   virtual Status ConnectRemote(Args &args);
 
   virtual Status DisconnectRemote();
@@ -967,6 +973,11 @@ public:
                                FileSpec &symbol_file_spec)>
       LocateModuleCallback;
 
+  typedef std::function<Status(const lldb::ModuleSP &module_sp,
+                               const FileSpec &original_file_spec,
+                               FileSpec &resolved_file_spec)>
+      ResolveSourceFileCallback;
+
   /// Set locate module callback. This allows users to implement their own
   /// module cache system. For example, to leverage artifacts of build system,
   /// to bypass pulling files from remote platform, or to search symbol files
@@ -974,6 +985,13 @@ public:
   void SetLocateModuleCallback(LocateModuleCallback callback);
 
   LocateModuleCallback GetLocateModuleCallback() const;
+
+  /// Set resolve source file callback. This allows users to implement their own
+  /// source file cache system. For example, to search source files from source
+  /// servers.
+  void SetResolveSourceFileCallback(ResolveSourceFileCallback callback);
+
+  ResolveSourceFileCallback GetResolveSourceFileCallback() const;
 
 protected:
   /// Create a list of ArchSpecs with the given OS and a architectures. The
@@ -1022,6 +1040,7 @@ protected:
   bool m_calculated_trap_handlers;
   const std::unique_ptr<ModuleCache> m_module_cache;
   LocateModuleCallback m_locate_module_callback;
+  ResolveSourceFileCallback m_resolve_source_file_callback;
 
   /// Ask the Platform subclass to fill in the list of trap handler names
   ///

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -396,7 +396,7 @@ StackFrame::GetSymbolContext(SymbolContextItem resolve_scope) {
         if ((resolved & eSymbolContextLineEntry) &&
             !m_sc.line_entry.IsValid()) {
           m_sc.line_entry = sc.line_entry;
-          m_sc.line_entry.ApplyFileMappings(m_sc.target_sp);
+          m_sc.line_entry.ApplyFileMappings(m_sc.target_sp, m_sc.module_sp);
         }
       }
     } else {

--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -494,7 +494,8 @@ bool StackFrameList::FetchFramesUpTo(uint32_t end_idx,
 
       while (unwind_sc.GetParentOfInlinedScope(
           curr_frame_address, next_frame_sc, next_frame_address)) {
-        next_frame_sc.line_entry.ApplyFileMappings(target_sp);
+        next_frame_sc.line_entry.ApplyFileMappings(target_sp,
+                                                   unwind_sc.module_sp);
         behaves_like_zeroth_frame = false;
         StackFrameSP frame_sp(new StackFrame(
             m_thread.shared_from_this(), m_frames.size(), idx,

--- a/lldb/source/Target/ThreadPlanStepRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepRange.cpp
@@ -430,8 +430,11 @@ bool ThreadPlanStepRange::SetNextBranchBreakpoint() {
                 new SupportFile(call_site_file_spec));
             top_most_line_entry.range = range;
             top_most_line_entry.file_sp.reset();
-            top_most_line_entry.ApplyFileMappings(
-                GetThread().CalculateTarget());
+
+            lldb::ModuleSP module_sp =
+                run_to_address.CalculateSymbolContextModule();
+            top_most_line_entry.ApplyFileMappings(GetThread().CalculateTarget(),
+                                                  module_sp);
             if (!top_most_line_entry.file_sp)
               top_most_line_entry.file_sp =
                   top_most_line_entry.original_file_sp;

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -19,6 +19,7 @@ add_lldb_unittest(SymbolTests
     lldbUtilityHelpers
     lldbPluginObjectFileELF
     lldbPluginObjectFileMachO
+    lldbPluginPlatformLinux
     lldbPluginSymbolFileDWARF
     lldbPluginSymbolFileSymtab
     lldbPluginTypeSystemClang
@@ -26,6 +27,7 @@ add_lldb_unittest(SymbolTests
   )
 
 set(test_inputs
+  inlined-functions.cpp
   inlined-functions.yaml
   )
 add_unittest_inputs(SymbolTests "${test_inputs}")

--- a/lldb/unittests/Symbol/Inputs/inlined-functions.cpp
+++ b/lldb/unittests/Symbol/Inputs/inlined-functions.cpp
@@ -1,0 +1,22 @@
+inline __attribute__((always_inline)) int sum2(int a, int b) {
+  int result = a + b;
+  return result;
+}
+
+int sum3(int a, int b, int c) {
+  int result = a + b + c;
+  return result;
+}
+
+inline __attribute__((always_inline)) int sum4(int a, int b, int c, int d) {
+  int result = sum2(a, b) + sum2(c, d);
+  result += 0;
+  return result;
+}
+
+int main(int argc, char **argv) {
+  sum3(3, 4, 5) + sum2(1, 2);
+  int sum = sum4(1, 2, 3, 4);
+  sum2(5, 6);
+  return 0;
+}

--- a/lldb/unittests/Symbol/TestLineEntry.cpp
+++ b/lldb/unittests/Symbol/TestLineEntry.cpp
@@ -11,13 +11,16 @@
 #include <optional>
 
 #include "Plugins/ObjectFile/Mach-O/ObjectFileMachO.h"
+#include "Plugins/Platform/Linux/PlatformLinux.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
 #include "Plugins/SymbolFile/DWARF/SymbolFileDWARF.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "TestingSupport/SubsystemRAII.h"
 #include "TestingSupport/TestUtilities.h"
 
+#include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/PluginManager.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -29,21 +32,36 @@
 
 using namespace lldb;
 using namespace lldb_private;
+using namespace lldb_private::platform_linux;
 using namespace lldb_private::plugin::dwarf;
+using namespace testing;
+
+namespace {
+
+constexpr llvm::StringLiteral k_source_file("inlined-functions.cpp");
 
 class LineEntryTest : public testing::Test {
-  SubsystemRAII<FileSystem, HostInfo, ObjectFileMachO, SymbolFileDWARF,
-                TypeSystemClang>
+  SubsystemRAII<FileSystem, HostInfo, ObjectFileMachO, PlatformLinux,
+                SymbolFileDWARF, TypeSystemClang>
       subsystem;
 
 public:
   void SetUp() override;
+  void TearDown() override;
 
 protected:
   llvm::Expected<SymbolContextList>
   GetLineEntriesForLine(uint32_t line, std::optional<uint16_t> column);
+  void CheckNoCallback();
+  void CheckCallbackWithArgs(const ModuleSP &module_sp,
+                             const FileSpec &resolved_file_spec,
+                             const ModuleSP &expected_module_sp);
+  FileSpec GetTestSourceFile();
   std::optional<TestFile> m_file;
   ModuleSP m_module_sp;
+  DebuggerSP m_debugger_sp;
+  PlatformSP m_platform_sp;
+  TargetSP m_target_sp;
 };
 
 void LineEntryTest::SetUp() {
@@ -51,6 +69,59 @@ void LineEntryTest::SetUp() {
   ASSERT_THAT_EXPECTED(ExpectedFile, llvm::Succeeded());
   m_file.emplace(std::move(*ExpectedFile));
   m_module_sp = std::make_shared<Module>(m_file->moduleSpec());
+
+  // Create Debugger.
+  m_debugger_sp = Debugger::CreateInstance();
+  EXPECT_TRUE(m_debugger_sp);
+
+  // Create Platform.
+  ArchSpec host_arch("i386-pc-linux");
+  m_platform_sp =
+      platform_linux::PlatformLinux::CreateInstance(true, &host_arch);
+  Platform::SetHostPlatform(m_platform_sp);
+  EXPECT_TRUE(m_platform_sp);
+
+  // Create Target.
+  m_debugger_sp->GetTargetList().CreateTarget(*m_debugger_sp, "", host_arch,
+                                              eLoadDependentsNo, m_platform_sp,
+                                              m_target_sp);
+  EXPECT_TRUE(m_target_sp);
+
+  m_target_sp->SetExecutableModule(m_module_sp);
+}
+
+void LineEntryTest::TearDown() {
+  if (m_module_sp) {
+    ModuleList::RemoveSharedModule(m_module_sp);
+  }
+}
+
+void LineEntryTest::CheckNoCallback() {
+  EXPECT_FALSE(m_platform_sp->GetResolveSourceFileCallback());
+}
+
+void LineEntryTest::CheckCallbackWithArgs(const ModuleSP &module_sp,
+                                          const FileSpec &resolved_file_spec,
+                                          const ModuleSP &expected_module_sp) {
+  EXPECT_TRUE(module_sp == expected_module_sp);
+  EXPECT_FALSE(resolved_file_spec);
+}
+
+FileSpec LineEntryTest::GetTestSourceFile() {
+  const auto *info = UnitTest::GetInstance()->current_test_info();
+  FileSpec test_file = HostInfo::GetProcessTempDir();
+  test_file.AppendPathComponent(std::string(info->test_case_name()) + "-" +
+                                info->name());
+  test_file.AppendPathComponent(k_source_file);
+
+  std::error_code ec =
+      llvm::sys::fs::create_directory(test_file.GetDirectory().GetCString());
+  EXPECT_FALSE(ec);
+
+  ec = llvm::sys::fs::copy_file(GetInputFilePath(k_source_file),
+                                test_file.GetPath().c_str());
+  EXPECT_FALSE(ec);
+  return test_file;
 }
 
   // TODO: Handle SourceLocationSpec column information
@@ -77,6 +148,8 @@ llvm::Expected<SymbolContextList> LineEntryTest::GetLineEntriesForLine(
                                    "No line entry found on the test object.");
   return sc_line_entries;
 }
+
+} // end namespace
 
 // This tests if we can get all line entries that match the passed line, if
 // no column is specified.
@@ -123,6 +196,93 @@ TEST_F(LineEntryTest, GetSameLineContiguousAddressRangeNestedInline) {
   auto range =
       line_entry.GetSameLineContiguousAddressRange(include_inlined_functions);
   ASSERT_EQ(range.GetByteSize(), (uint64_t)0x33);
+}
+
+TEST_F(LineEntryTest, ResolveSourceFileCallbackNotSetTest) {
+  // Resolve source file callback is not set. ApplyFileMappings should succeed
+  // to return the original file spec from line entry
+  auto sc_line_entries = GetLineEntriesForLine(12);
+  ASSERT_THAT_EXPECTED(sc_line_entries, llvm::Succeeded());
+  auto line_entry = sc_line_entries.get()[0].line_entry;
+
+  const lldb::SupportFileSP original_file_sp = line_entry.file_sp;
+  CheckNoCallback();
+
+  line_entry.ApplyFileMappings(m_target_sp, m_module_sp);
+  ASSERT_EQ(line_entry.file_sp, original_file_sp);
+}
+
+TEST_F(LineEntryTest, ResolveSourceFileCallbackSetFailTest) {
+  // Resolve source file callback fails for some reason.
+  // CallResolveSourceFileCallbackIfSet should fail and ApplyFileMappings should
+  // return the original file spec.
+  auto sc_line_entries = GetLineEntriesForLine(12);
+  ASSERT_THAT_EXPECTED(sc_line_entries, llvm::Succeeded());
+  auto line_entry = sc_line_entries.get()[0].line_entry;
+
+  const lldb::SupportFileSP original_file_sp = line_entry.file_sp;
+  m_platform_sp->SetResolveSourceFileCallback(
+      [this](const lldb::ModuleSP &module_sp,
+             const FileSpec &original_file_spec, FileSpec &resolved_file_spec) {
+        CheckCallbackWithArgs(module_sp, resolved_file_spec, m_module_sp);
+        return Status::FromErrorString(
+            "The resolve source file callback failed");
+      });
+
+  line_entry.ApplyFileMappings(m_target_sp, m_module_sp);
+  ASSERT_EQ(line_entry.file_sp, original_file_sp);
+}
+
+TEST_F(LineEntryTest, ResolveSourceFileCallbackSetNonExistentPathTest) {
+  // Resolve source file callback succeeds but returns a non-existent path.
+  // CallResolveSourceFileCallbackIfSet should succeed and ApplyFileMappings
+  // should return the original file spec.
+  auto sc_line_entries = GetLineEntriesForLine(12);
+  ASSERT_THAT_EXPECTED(sc_line_entries, llvm::Succeeded());
+  auto line_entry = sc_line_entries.get()[0].line_entry;
+
+  const lldb::SupportFileSP original_file_sp = line_entry.file_sp;
+  FileSpec callback_file_spec;
+  const FileSpec expected_callback_file_spec =
+      FileSpec("/this path does not exist");
+
+  m_platform_sp->SetResolveSourceFileCallback(
+      [this, &expected_callback_file_spec, &callback_file_spec](
+          const lldb::ModuleSP &module_sp, const FileSpec &original_file_spec,
+          FileSpec &resolved_file_spec) {
+        CheckCallbackWithArgs(module_sp, resolved_file_spec, m_module_sp);
+        resolved_file_spec.SetPath(expected_callback_file_spec.GetPath());
+        callback_file_spec.SetPath(resolved_file_spec.GetPath());
+        return Status();
+      });
+
+  line_entry.ApplyFileMappings(m_target_sp, m_module_sp);
+
+  ASSERT_EQ(callback_file_spec, expected_callback_file_spec);
+  ASSERT_EQ(line_entry.file_sp, original_file_sp);
+}
+
+TEST_F(LineEntryTest, ResolveSourceFileCallbackSetSuccessTest) {
+  // Resolve source file callback is set. CallResolveSourceFileCallbackIfSet
+  // should succeed and ApplyFileMappings should return the new file spec from
+  // the callback.
+  auto sc_line_entries = GetLineEntriesForLine(12);
+  ASSERT_THAT_EXPECTED(sc_line_entries, llvm::Succeeded());
+  auto line_entry = sc_line_entries.get()[0].line_entry;
+
+  const FileSpec expected_callback_file_spec = GetTestSourceFile();
+
+  m_platform_sp->SetResolveSourceFileCallback(
+      [this, &expected_callback_file_spec](const lldb::ModuleSP &module_sp,
+                                           const FileSpec &original_file_spec,
+                                           FileSpec &resolved_file_spec) {
+        CheckCallbackWithArgs(module_sp, resolved_file_spec, m_module_sp);
+        resolved_file_spec.SetPath(expected_callback_file_spec.GetPath());
+        return Status();
+      });
+
+  line_entry.ApplyFileMappings(m_target_sp, m_module_sp);
+  ASSERT_EQ(line_entry.file_sp->GetSpecOnly(), expected_callback_file_spec);
 }
 
 /*


### PR DESCRIPTION
Summary:
RFC https://discourse.llvm.org/t/rfc-python-callback-for-source-file-resolution/83545

Updated LineEntry::ApplyFileMappings to call resolve source file callback if set.

include/lldb/Target/Platform.h, source/Target/Platform.cpp Implemented SetResolveSourceFileCallback and GetResolveSourceFileCallback

include/lldb/Symbol/LineEntry.h, Source/Symbol/LineEntry.cpp Implemented CallResolveSourceFileCallbackIfSet

Source/Target/StackFrame.cpp
Source/Target/StackFrameList.cpp
Source/Target/ThreadPlanStepRange.cpp
Updated the caller  to ApplyFileMappings


unittests/Symbol/TestLineEntry.cpp
Added comprehensive ResolveSourceFileCallback tests.

Test Plan:
Added unittests for LineEntry.

```
ninja check-lldb-unit
```