### PR TITLE
ci: Fix `pr-code-format` permissions for private forks

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -2,6 +2,8 @@ name: "Check code formatting"
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
The action requires the ability to change the contents of a pull request (by adding the formatting-related comment) which is only possible through the `write` permission, but if this permission is missing, potential private forks with Actions enabled will break, and because the action triggers on `pull_request_target` even a PR initially fixing this issue downstream will not exhibit the fix until merged.