### PR TITLE
[Serialization] Migrate away from PointerUnion::get (NFC)

### DIFF
--- a/clang/lib/Serialization/MultiOnDiskHashTable.h
+++ b/clang/lib/Serialization/MultiOnDiskHashTable.h
@@ -93,7 +93,7 @@ private:
     using result_type = OnDiskTable *;
 
     result_type operator()(void *P) const {
-      return Table::getFromOpaqueValue(P).template get<OnDiskTable *>();
+      return llvm::cast<OnDiskTable *>(Table::getFromOpaqueValue(P));
     }
   };
 
@@ -130,7 +130,7 @@ private:
     Files.insert(PendingOverrides.begin(), PendingOverrides.end());
     // Explicitly capture Files to work around an MSVC 2015 rejects-valid bug.
     auto ShouldRemove = [&Files](void *T) -> bool {
-      auto *ODT = Table::getFromOpaqueValue(T).template get<OnDiskTable *>();
+      auto *ODT = llvm::cast<OnDiskTable *>(Table::getFromOpaqueValue(T));
       bool Remove = Files.count(ODT->File);
       if (Remove)
         delete ODT;


### PR DESCRIPTION
Note that PointerUnion::get has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
