### PR TITLE
[Interfaces] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/mlir/lib/Interfaces/CallInterfaces.cpp
+++ b/mlir/lib/Interfaces/CallInterfaces.cpp
@@ -22,7 +22,7 @@ call_interface_impl::resolveCallable(CallOpInterface call,
     return symbolVal.getDefiningOp();
 
   // If the callable isn't a value, lookup the symbol reference.
-  auto symbolRef = callable.get<SymbolRefAttr>();
+  auto symbolRef = cast<SymbolRefAttr>(callable);
   if (symbolTable)
     return symbolTable->lookupNearestSymbolFrom(call.getOperation(), symbolRef);
   return SymbolTable::lookupNearestSymbolFrom(call.getOperation(), symbolRef);

--- a/mlir/lib/Interfaces/InferTypeOpInterface.cpp
+++ b/mlir/lib/Interfaces/InferTypeOpInterface.cpp
@@ -53,7 +53,7 @@ mlir::reifyResultShapes(OpBuilder &b, Operation *op,
       // * Attribute for static dimensions
       // * Value for dynamic dimensions
       assert(shapedType.isDynamicDim(dim) ==
-                 reifiedReturnShapes[resultIdx][dim].is<Value>() &&
+                 isa<Value>(reifiedReturnShapes[resultIdx][dim]) &&
              "incorrect implementation of ReifyRankedShapedTypeOpInterface");
     }
     ++resultIdx;
@@ -70,9 +70,9 @@ bool ShapeAdaptor::hasRank() const {
     return false;
   if (auto t = llvm::dyn_cast_if_present<Type>(val))
     return cast<ShapedType>(t).hasRank();
-  if (val.is<Attribute>())
+  if (isa<Attribute>(val))
     return true;
-  return val.get<ShapedTypeComponents *>()->hasRank();
+  return cast<ShapedTypeComponents *>(val)->hasRank();
 }
 
 Type ShapeAdaptor::getElementType() const {
@@ -80,9 +80,9 @@ Type ShapeAdaptor::getElementType() const {
     return nullptr;
   if (auto t = llvm::dyn_cast_if_present<Type>(val))
     return cast<ShapedType>(t).getElementType();
-  if (val.is<Attribute>())
+  if (isa<Attribute>(val))
     return nullptr;
-  return val.get<ShapedTypeComponents *>()->getElementType();
+  return cast<ShapedTypeComponents *>(val)->getElementType();
 }
 
 void ShapeAdaptor::getDims(SmallVectorImpl<int64_t> &res) const {
@@ -97,7 +97,7 @@ void ShapeAdaptor::getDims(SmallVectorImpl<int64_t> &res) const {
     for (auto it : dattr.getValues<APInt>())
       res.push_back(it.getSExtValue());
   } else {
-    auto vals = val.get<ShapedTypeComponents *>()->getDims();
+    auto vals = cast<ShapedTypeComponents *>(val)->getDims();
     res.assign(vals.begin(), vals.end());
   }
 }
@@ -116,7 +116,7 @@ int64_t ShapeAdaptor::getDimSize(int index) const {
     return cast<DenseIntElementsAttr>(attr)
         .getValues<APInt>()[index]
         .getSExtValue();
-  auto *stc = val.get<ShapedTypeComponents *>();
+  auto *stc = cast<ShapedTypeComponents *>(val);
   return stc->getDims()[index];
 }
 
@@ -126,7 +126,7 @@ int64_t ShapeAdaptor::getRank() const {
     return cast<ShapedType>(t).getRank();
   if (auto attr = llvm::dyn_cast_if_present<Attribute>(val))
     return cast<DenseIntElementsAttr>(attr).size();
-  return val.get<ShapedTypeComponents *>()->getDims().size();
+  return cast<ShapedTypeComponents *>(val)->getDims().size();
 }
 
 bool ShapeAdaptor::hasStaticShape() const {
@@ -142,7 +142,7 @@ bool ShapeAdaptor::hasStaticShape() const {
         return false;
     return true;
   }
-  auto *stc = val.get<ShapedTypeComponents *>();
+  auto *stc = cast<ShapedTypeComponents *>(val);
   return llvm::none_of(stc->getDims(), ShapedType::isDynamic);
 }
 
@@ -162,7 +162,7 @@ int64_t ShapeAdaptor::getNumElements() const {
     return num;
   }
 
-  auto *stc = val.get<ShapedTypeComponents *>();
+  auto *stc = cast<ShapedTypeComponents *>(val);
   int64_t num = 1;
   for (int64_t dim : stc->getDims()) {
     num *= dim;


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

I'm not touching PointerUnion::dyn_cast for now because it's a bit
complicated; we could blindly migrate it to dyn_cast_if_present, but
we should probably use dyn_cast when the operand is known to be
non-null.
