### PR TITLE
[libc++] Optimize rotate

### DIFF
--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -73,6 +73,9 @@ Improvements and New Features
   optimized, resulting in a performance improvement of up to 2x for trivial element types (e.g., `std::vector<int>`),
   and up to 3.4x for non-trivial element types (e.g., `std::vector<std::vector<int>>`).
 
+- ``rotate`` has been optimized, resulting in a performance improvement of up to 2.2x for trivially move assignable
+  types.
+
 Deprecations and Removals
 -------------------------
 

--- a/libcxx/test/benchmarks/algorithms/rotate.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/rotate.bench.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <algorithm>
+#include <cassert>
+
+#include <benchmark/benchmark.h>
+
+void run_sizes(auto benchmark) {
+  benchmark->Arg(1)->Arg(2)->Arg(3)->Arg(4)->Arg(32)->Arg(64)->Arg(512)->Arg(4096)->Arg(65536);
+}
+
+template <class T>
+static void BM_std_rotate(benchmark::State& state) {
+  std::vector<T> vec(state.range(), T());
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(vec);
+    benchmark::DoNotOptimize(std::rotate(vec.begin(), vec.begin() + vec.size() / 3, vec.end()));
+  }
+}
+BENCHMARK(BM_std_rotate<int>)->Apply(run_sizes);
+#ifndef TEST_HAS_NO_INT128
+BENCHMARK(BM_std_rotate<__int128>)->Apply(run_sizes);
+#endif
+BENCHMARK(BM_std_rotate<std::string>)->Apply(run_sizes);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
```
----------------------------------------------------------
Benchmark                                 old          new
----------------------------------------------------------
BM_std_rotate<int>/1                 0.707 ns      2.83 ns
BM_std_rotate<int>/2                 0.706 ns      2.83 ns
BM_std_rotate<int>/3                  4.93 ns      5.04 ns
BM_std_rotate<int>/4                  5.12 ns      5.14 ns
BM_std_rotate<int>/32                 41.3 ns      16.5 ns
BM_std_rotate<int>/64                 94.1 ns      42.8 ns
BM_std_rotate<int>/512                 764 ns       194 ns
BM_std_rotate<int>/4096               5899 ns      2687 ns
BM_std_rotate<int>/65536             94248 ns     43003 ns
BM_std_rotate<__int128>/1            0.713 ns      2.16 ns
BM_std_rotate<__int128>/2            0.711 ns      2.16 ns
BM_std_rotate<__int128>/3             5.63 ns      5.70 ns
BM_std_rotate<__int128>/4             5.64 ns      5.62 ns
BM_std_rotate<__int128>/32            46.1 ns      29.8 ns
BM_std_rotate<__int128>/64            98.6 ns      75.6 ns
BM_std_rotate<__int128>/512            752 ns       486 ns
BM_std_rotate<__int128>/4096          5849 ns      4913 ns
BM_std_rotate<__int128>/65536        97091 ns     78037 ns
BM_std_rotate<std::string>/1         0.722 ns     0.717 ns
BM_std_rotate<std::string>/2         0.722 ns     0.718 ns
BM_std_rotate<std::string>/3          4.35 ns      4.42 ns
BM_std_rotate<std::string>/4          6.12 ns      6.08 ns
BM_std_rotate<std::string>/32         46.7 ns      46.4 ns
BM_std_rotate<std::string>/64         95.7 ns      94.9 ns
BM_std_rotate<std::string>/512         795 ns       792 ns
BM_std_rotate<std::string>/4096       6500 ns      6442 ns
BM_std_rotate<std::string>/65536    106532 ns    103567 ns
```

Fixes #54949
Fixes #39644

