### PR TITLE
[clang-doc] Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -696,13 +696,11 @@ emitInfo(const RecordDecl *D, const FullComment *FC, int LineNumber,
 
     // What this is a specialization of.
     auto SpecOf = CTSD->getSpecializedTemplateOrPartial();
-    if (SpecOf.is<ClassTemplateDecl *>()) {
-      Specialization.SpecializationOf =
-          getUSRForDecl(SpecOf.get<ClassTemplateDecl *>());
-    } else if (SpecOf.is<ClassTemplatePartialSpecializationDecl *>()) {
-      Specialization.SpecializationOf =
-          getUSRForDecl(SpecOf.get<ClassTemplatePartialSpecializationDecl *>());
-    }
+    if (auto *CTD = dyn_cast<ClassTemplateDecl *>(SpecOf))
+      Specialization.SpecializationOf = getUSRForDecl(CTD);
+    else if (auto *CTPSD =
+                 dyn_cast<ClassTemplatePartialSpecializationDecl *>(SpecOf))
+      Specialization.SpecializationOf = getUSRForDecl(CTPSD);
 
     // Parameters to the specilization. For partial specializations, get the
     // parameters "as written" from the ClassTemplatePartialSpecializationDecl


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>
