### PR TITLE
Skip negative length while inferring initializes attr

### DIFF
--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -633,13 +633,10 @@ ArgumentAccessInfo getArgmentAccessInfo(const Instruction *I,
       [](Value *Length,
          std::optional<int64_t> Offset) -> std::optional<ConstantRange> {
     auto *ConstantLength = dyn_cast<ConstantInt>(Length);
-    if (ConstantLength && Offset) {
-      if (ConstantLength->getSExtValue() < 0)
-        return std::nullopt;
+    if (ConstantLength && Offset && !ConstantLength->isNegative())
       return ConstantRange(
           APInt(64, *Offset, true),
           APInt(64, *Offset + ConstantLength->getSExtValue(), true));
-    }
     return std::nullopt;
   };
   if (auto *SI = dyn_cast<StoreInst>(I)) {

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -633,10 +633,13 @@ ArgumentAccessInfo getArgmentAccessInfo(const Instruction *I,
       [](Value *Length,
          std::optional<int64_t> Offset) -> std::optional<ConstantRange> {
     auto *ConstantLength = dyn_cast<ConstantInt>(Length);
-    if (ConstantLength && Offset)
+    if (ConstantLength && Offset) {
+      if (ConstantLength->getSExtValue() < 0)
+        return std::nullopt;
       return ConstantRange(
           APInt(64, *Offset, true),
           APInt(64, *Offset + ConstantLength->getSExtValue(), true));
+    }
     return std::nullopt;
   };
   if (auto *SI = dyn_cast<StoreInst>(I)) {

--- a/llvm/test/Transforms/FunctionAttrs/initializes.ll
+++ b/llvm/test/Transforms/FunctionAttrs/initializes.ll
@@ -423,6 +423,17 @@ define void @memset_offset(ptr %p) {
   ret void
 }
 
+define void @memset_neg(ptr %p) {
+; CHECK: Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write)
+; CHECK-LABEL: define void @memset_neg(
+; CHECK-SAME: ptr nocapture writeonly [[P:%.*]]) #[[ATTR0]] {
+; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr [[P]], i8 2, i64 -1, i1 false)
+; CHECK-NEXT:    ret void
+;
+  call void @llvm.memset(ptr %p, i8 2, i64 -1, i1 false)
+  ret void
+}
+
 define void @memset_volatile(ptr %p) {
 ; CHECK: Function Attrs: mustprogress nofree norecurse nounwind willreturn memory(argmem: write)
 ; CHECK-LABEL: define void @memset_volatile(


### PR DESCRIPTION
Bail out negative length while inferring initializes attr. Otherwise it causes an assertion error:
`Attribute 'initializes' does not support unordered ranges`