### PR TITLE
[mlir][dataflow] Allow re-run all analyses in DataFlowSolver

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlowFramework.h
+++ b/mlir/include/mlir/Analysis/DataFlowFramework.h
@@ -308,6 +308,10 @@ private:
 ///    according to their dependency relations until a fixed point is reached.
 /// 3. Query analysis state results from the solver.
 ///
+/// Steps to re-run a data-flow analysis when IR changes:
+/// 1. Erase all analysis states as they are no longer valid.
+/// 2. Re-run the analysis using `initializeAndRun`.
+///
 /// TODO: Optimize the internal implementation of the solver.
 class DataFlowSolver {
 public:
@@ -345,6 +349,9 @@ public:
         analysisStates.erase(it);
     }
   }
+
+  // Erase all analysis states
+  void eraseAllStates() { analysisStates.clear(); }
 
   /// Get a uniqued lattice anchor instance. If one is not present, it is
   /// created with the provided arguments.


### PR DESCRIPTION
In downstream (check https://github.com/google/heir/pull/1228, especially [this commit](https://github.com/ZenithalHourlyRate/heir/commit/fbf0b2733f1f60e852c757602afac65a4364e30c); also check https://github.com/google/heir/pull/1154) we often need to re-run the analysis during the transformation pass as IR get changed based on the analysis result and analysis continuously get invalidated.

There are solutions to it like `getOrCreateState` for newly created `Value` (`AnchorT`), but warning is that the new state does not propagate! This is quite unexpected as user of analysis would expect it to propagate. We downstream used to use `solver->propagateIfChanged` but that turned out to be not working, see detailed writeup in https://github.com/google/heir/issues/1153. 

Just call `initializeAndRun` repeatedly also does not solve the problem as `analysisStates` is not cleared and the monotonicity of `AnalysisState` will make the analysis invalid as `join` will not work as expected (the first join is no longer `join(uninitialized, init value)`, instead it becomes `join(higher value, init value)`.

To correctly re-run the analysis, either a new `DataFlowSolver` is created, or we can just clear the `analysisState`.

Cc @j2kun for downstream. Cc @Mogball for review.

