### PR TITLE
[lld][MachO] Fix warning while building for wasm

### DIFF
--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -2084,7 +2084,7 @@ void ObjCMethListSection::writeTo(uint8_t *bufStart) const {
     uint32_t writtenSize = writeRelativeMethodList(isec, buf);
     buf += writtenSize;
   }
-  assert(buf - bufStart == sectionSize &&
+  assert(buf - bufStart == long(sectionSize) &&
          "Written size does not match expected section size");
 }
 

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -2079,12 +2079,12 @@ void ObjCMethListSection::finalize() {
 void ObjCMethListSection::writeTo(uint8_t *bufStart) const {
   uint8_t *buf = bufStart;
   for (const ConcatInputSection *isec : inputs) {
-    assert(buf - bufStart == long(isec->outSecOff) &&
+    assert(buf - bufStart == std::ptrdiff_t(isec->outSecOff) &&
            "Writing at unexpected offset");
     uint32_t writtenSize = writeRelativeMethodList(isec, buf);
     buf += writtenSize;
   }
-  assert(buf - bufStart == long(sectionSize) &&
+  assert(buf - bufStart == std::ptrdiff_t(sectionSize) &&
          "Written size does not match expected section size");
 }
 


### PR DESCRIPTION
While building clang & lld against emscripten for wasm, I see the following 
```
 │ │ /home/runner/work/recipes/recipes/output/bld/rattler-build_llvm_1734801187/work/lld/MachO/SyntheticSections.cpp:2075:25: warning: comparison of integers of
 │ │  different signs: 'long' and 'const uint32_t' (aka 'const unsigned int') [-Wsign-compare]
 │ │  2075 |   assert(buf - bufStart == sectionSize &&
 │ │       |          ~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~
 │ │ $BUILD_PREFIX/opt/emsdk/upstream/emscripten/cache/sysroot/include/assert.h:8:28: note: expanded from macro 'assert'
 │ │     8 | #define assert(x) ((void)((x) || (__assert_fail(#x, __FILE__, __LINE__, __func__),0)))
 │ │       |                            ^
 ```
 
 Casting `sectionSize` using `long` should be enough I think