### PR TITLE
[lldb] Fix bad method call in `TestExprDiagnostics.py`

### DIFF
--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -252,7 +252,7 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         value = frame.EvaluateExpression("a+b")
         error = value.GetError()
         self.assertTrue(error.Fail())
-        self.assertEquals(error.GetType(), lldb.eErrorTypeExpression)
+        self.assertEqual(error.GetType(), lldb.eErrorTypeExpression)
         data = error.GetErrorData()
         version = data.GetValueForKey("version")
         self.assertEqual(version.GetIntegerValue(), 1)


### PR DESCRIPTION
Fixes

    Traceback (most recent call last):
      File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1770, in test_method
        return attrvalue(self)
               ^^^^^^^^^^^^^^^
      File "/home/buildbot/worker/as-builder-9/lldb-remote-linux-ubuntu/llvm-project/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py", line 255, in test_command_expr_sbdata
        self.assertEquals(error.GetType(), lldb.eErrorTypeExpression)
        ^^^^^^^^^^^^^^^^^
    AttributeError: 'ExprDiagnosticsTestCase' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?

`assertEqual` is a method inherited from `unittest.TestCase`.

See #120784 and https://github.com/llvm/llvm-project/pull/120784#issuecomment-2557871308
