### PR TITLE
[mlir] [test] Do not add dependencies on llvm tools in standalone builds

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -99,7 +99,6 @@ configure_lit_site_cfg(
   )
 
 set(MLIR_TEST_DEPENDS
-  FileCheck count not split-file
   mlir-capi-ir-test
   mlir-capi-irdl-test
   mlir-capi-llvm-test
@@ -121,6 +120,9 @@ set(MLIR_TEST_DEPENDS
   tblgen-lsp-server
   tblgen-to-irdl
   )
+if(NOT MLIR_STANDALONE_BUILD)
+  list(APPEND MLIR_TEST_DEPENDS FileCheck count not split-file)
+endif()
 
 set(MLIR_TEST_DEPENDS ${MLIR_TEST_DEPENDS}
   mlir-capi-pdl-test


### PR DESCRIPTION
Since LLVM tools are installed system-wide, adding dependencies on them is unnecessary.  Furthermore, it is problematic for multilib builds, where the tools are only built once, for the native ABI, and therefore are not listed in CMake files for non-native ABIs.