### PR TITLE
[flang] Fix finding system install of LLVM/Clang/MLIR in standalone builds

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -89,13 +89,16 @@ if (FLANG_STANDALONE_BUILD)
     mark_as_advanced(LLVM_ENABLE_ASSERTIONS)
   endif()
 
+  # We need a pre-built/installed version of LLVM.
+  find_package(LLVM REQUIRED HINTS "${LLVM_DIR}")
   # If the user specifies a relative path to LLVM_DIR, the calls to include
   # LLVM modules fail. Append the absolute path to LLVM_DIR instead.
   get_filename_component(LLVM_DIR_ABSOLUTE ${LLVM_DIR}
     REALPATH BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
   list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR_ABSOLUTE})
-  # We need a pre-built/installed version of LLVM.
-  find_package(LLVM REQUIRED HINTS "${LLVM_DIR_ABSOLUTE}")
+
+  # TODO: Remove when libclangDriver is lifted out of Clang
+  find_package(Clang REQUIRED PATHS "${CLANG_DIR}")
 
   # Users might specify a path to CLANG_DIR that's:
   #   * a full path, or
@@ -104,16 +107,10 @@ if (FLANG_STANDALONE_BUILD)
   # cases.
   get_filename_component(
     CLANG_DIR_ABSOLUTE
-    ${CLANG_DIR}
+    ${Clang_DIR}
     REALPATH
     BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
   list(APPEND CMAKE_MODULE_PATH ${CLANG_DIR_ABSOLUTE})
-
-  # TODO: Remove when libclangDriver is lifted out of Clang
-  find_package(Clang REQUIRED PATHS "${CLANG_DIR_ABSOLUTE}" NO_DEFAULT_PATH)
-  if (NOT Clang_FOUND)
-    message(FATAL_ERROR "Failed to find Clang")
-  endif()
 
   # If LLVM links to zlib we need the imported targets so we can too.
   if(LLVM_ENABLE_ZLIB)
@@ -132,12 +129,12 @@ if (FLANG_STANDALONE_BUILD)
   include(AddClang)
 
   include(TableGen)
+  find_package(MLIR REQUIRED CONFIG HINTS ${MLIR_DIR})
   # If the user specifies a relative path to MLIR_DIR, the calls to include
   # MLIR modules fail. Append the absolute path to MLIR_DIR instead.
   get_filename_component(MLIR_DIR_ABSOLUTE ${MLIR_DIR}
     REALPATH BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
   list(APPEND CMAKE_MODULE_PATH ${MLIR_DIR_ABSOLUTE})
-  find_package(MLIR REQUIRED CONFIG HINTS ${MLIR_DIR_ABSOLUTE})
   # Use SYSTEM for the same reasons as for LLVM includes
   include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
   include(AddMLIR)


### PR DESCRIPTION
The changes in #87822 introduced a regression where Flang could no longer be built standalone without explicitly specifying all of LLVM_DIR, CLANG_DIR and MLIR_DIR.  Restore the earlier logic that used these paths as hints, and supported finding system-wide LLVM install via default paths.  Instead, make paths absolute after locating the packages, using the paths CMake determined.

-----

@vzakhari, could you confirm that this doesn't break your use case?