### PR TITLE
[Github] Skip MIR files for undef check

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -382,7 +382,7 @@ You can test this locally with the following command:
             # We skip checking in MIR files as undef is a valid token and not
             # going away.
             if file.endswith(".mir"):
-              continue
+                continue
             # search for additions of undef
             if re.search(r"^[+](?!\s*#\s*).*(\bundef\b|UndefValue::get)", file, re.MULTILINE):
                 files.append(re.match("a/([^ ]+)", file.splitlines()[0])[1])

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -379,6 +379,10 @@ You can test this locally with the following command:
         # Each file is prefixed like:
         # diff --git a/file b/file
         for file in re.split("^diff --git ", stdout, 0, re.MULTILINE):
+            # We skip checking in MIR files as undef is a valid token and not
+            # going away.
+            if file.endswith(".mir"):
+              continue
             # search for additions of undef
             if re.search(r"^[+](?!\s*#\s*).*(\bundef\b|UndefValue::get)", file, re.MULTILINE):
                 files.append(re.match("a/([^ ]+)", file.splitlines()[0])[1])


### PR DESCRIPTION
This patch skips checking files with a .mir extension for the presence of undef. This was creating false positives that got reported on discourse.