### PR TITLE
[BOLT][Linux] Remove long-jump-labels option

### DIFF
--- a/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
+++ b/bolt/lib/Rewrite/LinuxKernelRewriter.cpp
@@ -79,11 +79,6 @@ static cl::opt<bool>
                    cl::desc("dump Linux kernel static keys jump table"),
                    cl::init(false), cl::Hidden, cl::cat(BoltCategory));
 
-static cl::opt<bool> LongJumpLabels(
-    "long-jump-labels",
-    cl::desc("always use long jumps/nops for Linux kernel static keys"),
-    cl::init(false), cl::Hidden, cl::cat(BoltCategory));
-
 static cl::opt<bool>
     PrintORC("print-orc",
              cl::desc("print ORC unwind information for instructions"),
@@ -237,6 +232,9 @@ class LinuxKernelRewriter final : public MetadataRewriter {
   /// Static key entries that need nop conversion.
   DenseSet<uint32_t> NopIDs;
 
+  /// Use long jumps/nops for Linux kernel static keys.
+  bool LongJumpLabels{false};
+
   /// Section containing static call table.
   ErrorOr<BinarySection &> StaticCallSection = std::errc::bad_address;
   uint64_t StaticCallTableAddress = 0;
@@ -350,6 +348,8 @@ public:
   Error preCFGInitializer() override {
     if (Error E = detectLinuxKernelVersion())
       return E;
+
+    LongJumpLabels = LinuxKernelVersion < LKVersion(5, 14, 0);
 
     processLKSections();
 
@@ -1799,13 +1799,13 @@ Error LinuxKernelRewriter::readStaticKeysJumpTable() {
     // the code, it will be converted to a different instruction in
     // rewriteStaticKeysJumpTable().
     //
-    // NB: for older kernels, under LongJumpLabels option, we create long
+    // NB: for older kernels (for which LongJumpLabels is true), we create long
     //     conditional branch to guarantee that code size estimation takes
     //     into account the extra bytes needed for long branch that will be used
     //     by the kernel patching code. Newer kernels can work with both short
     //     and long branches. The code for long conditional branch is larger
     //     than unconditional one, so we are pessimistic in our estimations.
-    if (opts::LongJumpLabels)
+    if (LongJumpLabels)
       BC.MIB->createLongCondBranch(StaticKeyBranch, Target, 0, BC.Ctx.get());
     else
       BC.MIB->createCondBranch(StaticKeyBranch, Target, 0, BC.Ctx.get());
@@ -1832,7 +1832,7 @@ Error LinuxKernelRewriter::readStaticKeysJumpTable() {
     if (!BC.MIB->getOffset(*Inst))
       BC.MIB->setOffset(*Inst, JumpAddress - BF->getAddress());
 
-    if (opts::LongJumpLabels)
+    if (LongJumpLabels)
       BC.MIB->setSize(*Inst, 5);
   }
 
@@ -1879,7 +1879,7 @@ Error LinuxKernelRewriter::rewriteStaticKeysJumpTable() {
         MCInst NewInst;
         // Replace the instruction with unconditional jump even if it needs to
         // be nop in the binary.
-        if (opts::LongJumpLabels) {
+        if (LongJumpLabels) {
           BC.MIB->createLongUncondBranch(NewInst, Target, BC.Ctx.get());
         } else {
           // Newer kernels can handle short and long jumps for static keys.


### PR DESCRIPTION
It is not easy for users to figure out `long-jump-labels` is required for Linux kernel < `5.14`. Remove this user-unfriendly option and use `LinuxKernelVersion` instead.

References:

* https://elixir.bootlin.com/linux/v5.13.19/source/arch/x86/include/asm/jump_label.h
* https://elixir.bootlin.com/linux/v5.14-rc1/source/arch/x86/include/asm/jump_label.h