### PR TITLE
[libcxx] Remove the second inclusion of the system header

### DIFF
--- a/libcxx/include/stdio.h
+++ b/libcxx/include/stdio.h
@@ -106,10 +106,6 @@ void perror(const char* s);
 #  ifndef _LIBCPP_STDIO_H
 #    define _LIBCPP_STDIO_H
 
-#    if __has_include_next(<stdio.h>)
-#      include_next <stdio.h>
-#    endif
-
 #    ifdef __cplusplus
 
 #      undef getc

--- a/libcxx/include/stdlib.h
+++ b/libcxx/include/stdlib.h
@@ -92,10 +92,6 @@ void *aligned_alloc(size_t alignment, size_t size);                       // C11
 #  if !defined(_LIBCPP_STDLIB_H)
 #    define _LIBCPP_STDLIB_H
 
-#    if __has_include_next(<stdlib.h>)
-#      include_next <stdlib.h>
-#    endif
-
 #    ifdef __cplusplus
 extern "C++" {
 // abs

--- a/libcxx/include/wchar.h
+++ b/libcxx/include/wchar.h
@@ -122,10 +122,6 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #    include <__mbstate_t.h> // provide mbstate_t
 #    include <stddef.h>      // provide size_t
 
-#    if __has_include_next(<wchar.h>)
-#      include_next <wchar.h>
-#    endif
-
 // Determine whether we have const-correct overloads for wcschr and friends.
 #    if defined(_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_)
 #      define _LIBCPP_WCHAR_H_HAS_CONST_OVERLOADS 1


### PR DESCRIPTION
This was introduced in #119025 and not only seems unnecessary, it broke the build with older versions of glibc.