### PR TITLE
[clang][Sema] Move computing best enum types to a separate function

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1726,6 +1726,12 @@ public:
 
   QualType getEnumType(const EnumDecl *Decl) const;
 
+  /// Compute BestType and BestPromotionType for an enum based on the highest
+  /// number of negative and positive bits of its elements.
+  bool computeBestEnumTypes(bool isPacked, unsigned NumNegativeBits,
+                            unsigned NumPositiveBits, QualType &BestType,
+                            QualType &BestPromotionType);
+
   QualType
   getUnresolvedUsingType(const UnresolvedUsingTypenameDecl *Decl) const;
 

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1728,7 +1728,8 @@ public:
 
   /// Compute BestType and BestPromotionType for an enum based on the highest
   /// number of negative and positive bits of its elements.
-  bool computeBestEnumTypes(bool isPacked, unsigned NumNegativeBits,
+  /// Returns true if enum width is too large.
+  bool computeBestEnumTypes(bool IsPacked, unsigned NumNegativeBits,
                             unsigned NumPositiveBits, QualType &BestType,
                             QualType &BestPromotionType);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3988,10 +3988,9 @@ public:
                           const ParsedAttributesView &Attrs,
                           SourceLocation EqualLoc, Expr *Val);
 
-  bool ComputeBestEnumProperties(ASTContext &Context, bool isPacked,
-                                 unsigned NumNegativeBits,
-                                 unsigned NumPositiveBits, QualType &BestType,
-                                 QualType &BestPromotionType);
+  bool ComputeBestEnumTypes(ASTContext &Context, bool isPacked,
+                            unsigned NumNegativeBits, unsigned NumPositiveBits,
+                            QualType &BestType, QualType &BestPromotionType);
   void ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
                      Decl *EnumDecl, ArrayRef<Decl *> Elements, Scope *S,
                      const ParsedAttributesView &Attr);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3988,11 +3988,9 @@ public:
                           const ParsedAttributesView &Attrs,
                           SourceLocation EqualLoc, Expr *Val);
 
-  bool ComputeBestEnumProperties(ASTContext &Context, EnumDecl *Enum,
-                                 bool isCpp, bool isPacked,
+  bool ComputeBestEnumProperties(ASTContext &Context, bool isPacked,
                                  unsigned NumNegativeBits,
-                                 unsigned NumPositiveBits, unsigned &BestWidth,
-                                 QualType &BestType,
+                                 unsigned NumPositiveBits, QualType &BestType,
                                  QualType &BestPromotionType);
   void ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
                      Decl *EnumDecl, ArrayRef<Decl *> Elements, Scope *S,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3987,6 +3987,13 @@ public:
                           SourceLocation IdLoc, IdentifierInfo *Id,
                           const ParsedAttributesView &Attrs,
                           SourceLocation EqualLoc, Expr *Val);
+
+  bool ComputeBestEnumProperties(ASTContext &Context, EnumDecl *Enum,
+                                 bool isCpp, bool isPacked,
+                                 unsigned NumNegativeBits,
+                                 unsigned NumPositiveBits, unsigned &BestWidth,
+                                 QualType &BestType,
+                                 QualType &BestPromotionType);
   void ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
                      Decl *EnumDecl, ArrayRef<Decl *> Elements, Scope *S,
                      const ParsedAttributesView &Attr);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3988,9 +3988,6 @@ public:
                           const ParsedAttributesView &Attrs,
                           SourceLocation EqualLoc, Expr *Val);
 
-  bool ComputeBestEnumTypes(ASTContext &Context, bool isPacked,
-                            unsigned NumNegativeBits, unsigned NumPositiveBits,
-                            QualType &BestType, QualType &BestPromotionType);
   void ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
                      Decl *EnumDecl, ArrayRef<Decl *> Elements, Scope *S,
                      const ParsedAttributesView &Attr);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3987,7 +3987,6 @@ public:
                           SourceLocation IdLoc, IdentifierInfo *Id,
                           const ParsedAttributesView &Attrs,
                           SourceLocation EqualLoc, Expr *Val);
-
   void ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
                      Decl *EnumDecl, ArrayRef<Decl *> Elements, Scope *S,
                      const ParsedAttributesView &Attr);

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5209,6 +5209,85 @@ QualType ASTContext::getEnumType(const EnumDecl *Decl) const {
   return QualType(newType, 0);
 }
 
+bool ASTContext::computeBestEnumTypes(bool isPacked, unsigned NumNegativeBits,
+                                      unsigned NumPositiveBits,
+                                      QualType &BestType,
+                                      QualType &BestPromotionType) {
+  unsigned IntWidth = Target->getIntWidth();
+  unsigned CharWidth = Target->getCharWidth();
+  unsigned ShortWidth = Target->getShortWidth();
+  bool EnumTooLarge = false;
+  unsigned BestWidth;
+  if (NumNegativeBits) {
+    // If there is a negative value, figure out the smallest integer type (of
+    // int/long/longlong) that fits.
+    // If it's packed, check also if it fits a char or a short.
+    if (isPacked && NumNegativeBits <= CharWidth &&
+        NumPositiveBits < CharWidth) {
+      BestType = SignedCharTy;
+      BestWidth = CharWidth;
+    } else if (isPacked && NumNegativeBits <= ShortWidth &&
+               NumPositiveBits < ShortWidth) {
+      BestType = ShortTy;
+      BestWidth = ShortWidth;
+    } else if (NumNegativeBits <= IntWidth && NumPositiveBits < IntWidth) {
+      BestType = IntTy;
+      BestWidth = IntWidth;
+    } else {
+      BestWidth = Target->getLongWidth();
+
+      if (NumNegativeBits <= BestWidth && NumPositiveBits < BestWidth) {
+        BestType = LongTy;
+      } else {
+        BestWidth = Target->getLongLongWidth();
+
+        if (NumNegativeBits > BestWidth || NumPositiveBits >= BestWidth)
+          EnumTooLarge = true;
+        BestType = LongLongTy;
+      }
+    }
+    BestPromotionType = (BestWidth <= IntWidth ? IntTy : BestType);
+  } else {
+    // If there is no negative value, figure out the smallest type that fits
+    // all of the enumerator values.
+    // If it's packed, check also if it fits a char or a short.
+    if (isPacked && NumPositiveBits <= CharWidth) {
+      BestType = UnsignedCharTy;
+      BestPromotionType = IntTy;
+      BestWidth = CharWidth;
+    } else if (isPacked && NumPositiveBits <= ShortWidth) {
+      BestType = UnsignedShortTy;
+      BestPromotionType = IntTy;
+      BestWidth = ShortWidth;
+    } else if (NumPositiveBits <= IntWidth) {
+      BestType = UnsignedIntTy;
+      BestWidth = IntWidth;
+      BestPromotionType = (NumPositiveBits == BestWidth || !LangOpts.CPlusPlus)
+                              ? UnsignedIntTy
+                              : IntTy;
+    } else if (NumPositiveBits <= (BestWidth = Target->getLongWidth())) {
+      BestType = UnsignedLongTy;
+      BestPromotionType = (NumPositiveBits == BestWidth || !LangOpts.CPlusPlus)
+                              ? UnsignedLongTy
+                              : LongTy;
+    } else {
+      BestWidth = Target->getLongLongWidth();
+      if (NumPositiveBits > BestWidth) {
+        // This can happen with bit-precise integer types, but those are not
+        // allowed as the type for an enumerator per C23 6.7.2.2p4 and p12.
+        // FIXME: GCC uses __int128_t and __uint128_t for cases that fit within
+        // a 128-bit integer, we should consider doing the same.
+        EnumTooLarge = true;
+      }
+      BestType = UnsignedLongLongTy;
+      BestPromotionType = (NumPositiveBits == BestWidth || !LangOpts.CPlusPlus)
+                              ? UnsignedLongLongTy
+                              : LongLongTy;
+    }
+  }
+  return EnumTooLarge;
+}
+
 QualType ASTContext::getUnresolvedUsingType(
     const UnresolvedUsingTypenameDecl *Decl) const {
   if (Decl->TypeForDecl)

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5209,7 +5209,7 @@ QualType ASTContext::getEnumType(const EnumDecl *Decl) const {
   return QualType(newType, 0);
 }
 
-bool ASTContext::computeBestEnumTypes(bool isPacked, unsigned NumNegativeBits,
+bool ASTContext::computeBestEnumTypes(bool IsPacked, unsigned NumNegativeBits,
                                       unsigned NumPositiveBits,
                                       QualType &BestType,
                                       QualType &BestPromotionType) {
@@ -5222,11 +5222,11 @@ bool ASTContext::computeBestEnumTypes(bool isPacked, unsigned NumNegativeBits,
     // If there is a negative value, figure out the smallest integer type (of
     // int/long/longlong) that fits.
     // If it's packed, check also if it fits a char or a short.
-    if (isPacked && NumNegativeBits <= CharWidth &&
+    if (IsPacked && NumNegativeBits <= CharWidth &&
         NumPositiveBits < CharWidth) {
       BestType = SignedCharTy;
       BestWidth = CharWidth;
-    } else if (isPacked && NumNegativeBits <= ShortWidth &&
+    } else if (IsPacked && NumNegativeBits <= ShortWidth &&
                NumPositiveBits < ShortWidth) {
       BestType = ShortTy;
       BestWidth = ShortWidth;
@@ -5251,11 +5251,11 @@ bool ASTContext::computeBestEnumTypes(bool isPacked, unsigned NumNegativeBits,
     // If there is no negative value, figure out the smallest type that fits
     // all of the enumerator values.
     // If it's packed, check also if it fits a char or a short.
-    if (isPacked && NumPositiveBits <= CharWidth) {
+    if (IsPacked && NumPositiveBits <= CharWidth) {
       BestType = UnsignedCharTy;
       BestPromotionType = IntTy;
       BestWidth = CharWidth;
-    } else if (isPacked && NumPositiveBits <= ShortWidth) {
+    } else if (IsPacked && NumPositiveBits <= ShortWidth) {
       BestType = UnsignedShortTy;
       BestPromotionType = IntTy;
       BestWidth = ShortWidth;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20008,11 +20008,10 @@ bool Sema::IsValueInFlagEnum(const EnumDecl *ED, const llvm::APInt &Val,
   return !(FlagMask & Val) || (AllowMask && !(FlagMask & ~Val));
 }
 
-bool Sema::ComputeBestEnumProperties(ASTContext &Context, bool isPacked,
-                                     unsigned NumNegativeBits,
-                                     unsigned NumPositiveBits,
-                                     QualType &BestType,
-                                     QualType &BestPromotionType) {
+bool Sema::ComputeBestEnumTypes(ASTContext &Context, bool isPacked,
+                                unsigned NumNegativeBits,
+                                unsigned NumPositiveBits, QualType &BestType,
+                                QualType &BestPromotionType) {
   unsigned IntWidth = Context.getTargetInfo().getIntWidth();
   unsigned CharWidth = Context.getTargetInfo().getCharWidth();
   unsigned ShortWidth = Context.getTargetInfo().getShortWidth();
@@ -20181,8 +20180,8 @@ void Sema::ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
     BestWidth = Context.getIntWidth(BestType);
   } else {
     bool EnumTooLarge =
-        ComputeBestEnumProperties(Context, Packed, NumNegativeBits,
-                                  NumPositiveBits, BestType, BestPromotionType);
+        ComputeBestEnumTypes(Context, Packed, NumNegativeBits, NumPositiveBits,
+                             BestType, BestPromotionType);
     BestWidth = Context.getIntWidth(BestType);
     if (EnumTooLarge)
       Diag(Enum->getLocation(), diag::ext_enum_too_large);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -20096,7 +20096,7 @@ void Sema::ActOnEnumBody(SourceLocation EnumLoc, SourceRange BraceRange,
 
     BestWidth = Context.getIntWidth(BestType);
   } else {
-    const bool EnumTooLarge = Context.computeBestEnumTypes(
+    bool EnumTooLarge = Context.computeBestEnumTypes(
         Packed, NumNegativeBits, NumPositiveBits, BestType, BestPromotionType);
     BestWidth = Context.getIntWidth(BestType);
     if (EnumTooLarge)


### PR DESCRIPTION
Move the code that computes BestType and BestPromotionType for an enum to a separate function which can be called from outside of Sema.
