### PR TITLE
[flang] Support linking to MLIR dylib

### DIFF
--- a/flang/cmake/modules/AddFlang.cmake
+++ b/flang/cmake/modules/AddFlang.cmake
@@ -18,7 +18,7 @@ endmacro()
 
 function(add_flang_library name)
   set(options SHARED STATIC INSTALL_WITH_TOOLCHAIN)
-  set(multiValueArgs ADDITIONAL_HEADERS CLANG_LIBS)
+  set(multiValueArgs ADDITIONAL_HEADERS CLANG_LIBS MLIR_LIBS)
   cmake_parse_arguments(ARG
     "${options}"
     ""
@@ -66,6 +66,7 @@ function(add_flang_library name)
   llvm_add_library(${name} ${LIBTYPE} ${ARG_UNPARSED_ARGUMENTS} ${srcs})
 
   clang_target_link_libraries(${name} PRIVATE ${ARG_CLANG_LIBS})
+  mlir_target_link_libraries(${name} PRIVATE ${ARG_MLIR_LIBS})
 
   if (TARGET ${name})
 

--- a/flang/lib/Common/CMakeLists.txt
+++ b/flang/lib/Common/CMakeLists.txt
@@ -47,6 +47,6 @@ add_flang_library(FortranCommon
   LINK_COMPONENTS
   Support
 
-  LINK_LIBS
+  MLIR_LIBS
   MLIRIR
 )

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -41,13 +41,6 @@ add_flang_library(flangFrontend
   flangPasses
   FIROpenACCSupport
   FlangOpenMPTransforms
-  MLIRTransforms
-  MLIRBuiltinToLLVMIRTranslation
-  MLIRLLVMToLLVMIRTranslation
-  MLIRSCFToControlFlow
-  MLIRTargetLLVMIRImport
-  ${dialect_libs}
-  ${extension_libs}
 
   LINK_COMPONENTS
   Passes
@@ -62,6 +55,15 @@ add_flang_library(flangFrontend
   FrontendDriver
   FrontendOpenACC
   FrontendOpenMP
+
+  MLIR_LIBS
+  MLIRTransforms
+  MLIRBuiltinToLLVMIRTranslation
+  MLIRLLVMToLLVMIRTranslation
+  MLIRSCFToControlFlow
+  MLIRTargetLLVMIRImport
+  ${dialect_libs}
+  ${extension_libs}
 
   CLANG_LIBS
   clangBasic

--- a/flang/lib/FrontendTool/CMakeLists.txt
+++ b/flang/lib/FrontendTool/CMakeLists.txt
@@ -8,11 +8,13 @@ add_flang_library(flangFrontendTool
 
   LINK_LIBS
   flangFrontend
-  MLIRPass
 
   LINK_COMPONENTS
   Option
   Support
+
+  MLIR_LIBS
+  MLIRPass
 
   CLANG_LIBS
   clangBasic

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -55,17 +55,19 @@ add_flang_library(FortranLower
   FIRSupport
   FIRTransforms
   HLFIRDialect
-  ${dialect_libs}
-  ${extension_libs}
   FortranCommon
   FortranParser
   FortranEvaluate
   FortranSemantics
+
+  LINK_COMPONENTS
+  Support
+
+  MLIR_LIBS
+  ${dialect_libs}
+  ${extension_libs}
   MLIRAffineToStandard
   MLIRFuncDialect
   MLIRLLVMDialect
   MLIRSCFToControlFlow
-
-  LINK_COMPONENTS
-  Support
 )

--- a/flang/lib/Optimizer/Analysis/CMakeLists.txt
+++ b/flang/lib/Optimizer/Analysis/CMakeLists.txt
@@ -13,6 +13,8 @@ add_flang_library(FIRAnalysis
   FIRBuilder
   FIRDialect
   HLFIRDialect
+
+  MLIR_LIBS
   MLIRFuncDialect
   MLIRLLVMDialect
   MLIRMathTransforms

--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -51,6 +51,8 @@ add_flang_library(FIRBuilder
   FIRSupport
   FortranEvaluate
   HLFIRDialect
+
+  MLIR_LIBS
   ${dialect_libs}
   ${extension_libs}
 )

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -21,6 +21,14 @@ add_flang_library(FIRCodeGen
   FIRDialect
   FIRDialectSupport
   FIRSupport
+
+  LINK_COMPONENTS
+  AsmParser
+  AsmPrinter
+  Remarks
+  TargetParser
+
+  MLIR_LIBS
   MLIRComplexToLLVM
   MLIRComplexToStandard
   MLIRGPUDialect
@@ -34,10 +42,4 @@ add_flang_library(FIRCodeGen
   MLIRLLVMToLLVMIRTranslation
   MLIRTargetLLVMIRExport
   MLIRVectorToLLVM
-
-  LINK_COMPONENTS
-  AsmParser
-  AsmPrinter
-  Remarks
-  TargetParser
 )

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -20,14 +20,16 @@ add_flang_library(FIRDialect
   LINK_LIBS
   CUFAttrs
   FIRDialectSupport
-  MLIRArithDialect
-  MLIRBuiltinToLLVMIRTranslation
-  MLIROpenMPToLLVM
-  MLIRLLVMToLLVMIRTranslation
-  MLIRTargetLLVMIRExport
 
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_LIBS
+  MLIRArithDialect
+  MLIRBuiltinToLLVMIRTranslation
+  MLIROpenMPToLLVM
+  MLIRLLVMToLLVMIRTranslation
+  MLIRTargetLLVMIRExport
 )

--- a/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
@@ -7,11 +7,11 @@ add_flang_library(CUFAttrs
   CUFAttrsIncGen
   CUFOpsIncGen
 
-  LINK_LIBS
-  MLIRTargetLLVMIRExport
-
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_LIBS
+  MLIRTargetLLVMIRExport
 )

--- a/flang/lib/Optimizer/Dialect/CUF/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CUF/CMakeLists.txt
@@ -14,12 +14,14 @@ add_flang_library(CUFDialect
   CUFAttrs
   FIRDialect
   FIRDialectSupport
-  MLIRIR
-  MLIRGPUDialect
-  MLIRTargetLLVMIRExport
 
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_LIBS
+  MLIRIR
+  MLIRGPUDialect
+  MLIRTargetLLVMIRExport
 )

--- a/flang/lib/Optimizer/Dialect/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/Support/CMakeLists.txt
@@ -8,6 +8,6 @@ add_flang_library(FIRDialectSupport
   MLIRIR
   intrinsics_gen
 
-  LINK_LIBS
+  MLIR_LIBS
   ${dialect_libs}
 )

--- a/flang/lib/Optimizer/HLFIR/IR/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/IR/CMakeLists.txt
@@ -13,11 +13,13 @@ add_flang_library(HLFIRDialect
   LINK_LIBS
   CUFAttrs
   FIRDialect
-  MLIRIR
-  ${dialect_libs}
 
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_LIBS
+  MLIRIR
+  ${dialect_libs}
 )

--- a/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
@@ -27,11 +27,13 @@ add_flang_library(HLFIRTransforms
   FIRTransforms
   FlangOpenMPTransforms
   HLFIRDialect
-  MLIRIR
-  ${dialect_libs}
 
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_LIBS
+  MLIRIR
+  ${dialect_libs}
 )

--- a/flang/lib/Optimizer/OpenACC/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/CMakeLists.txt
@@ -18,5 +18,7 @@ add_flang_library(FIROpenACCSupport
   FIRDialectSupport
   FIRSupport
   HLFIRDialect
+
+  MLIR_LIBS
   MLIROpenACCDialect
 )

--- a/flang/lib/Optimizer/OpenMP/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenMP/CMakeLists.txt
@@ -23,9 +23,11 @@ add_flang_library(FlangOpenMPTransforms
   FIRSupport
   FortranCommon
   FortranEvaluate
+  HLFIRDialect
+
+  MLIR_LIBS
   MLIRFuncDialect
   MLIROpenMPDialect
-  HLFIRDialect
   MLIRIR
   MLIRPass
   MLIRTransformUtils

--- a/flang/lib/Optimizer/Passes/CMakeLists.txt
+++ b/flang/lib/Optimizer/Passes/CMakeLists.txt
@@ -12,16 +12,18 @@ add_flang_library(flangPasses
   FIRCodeGen
   FIRTransforms
   FlangOpenMPTransforms
-  ${dialect_libs}
-  ${extension_libs}
   FortranCommon
   HLFIRTransforms
+
+  LINK_COMPONENTS
+  Passes
+
+  MLIR_LIBS
+  ${dialect_libs}
+  ${extension_libs}
   MLIRPass
   MLIRReconcileUnrealizedCasts
   MLIRSCFToControlFlow
   MLIRSupport
   MLIRTransforms
-
-  LINK_COMPONENTS
-  Passes
 )

--- a/flang/lib/Optimizer/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Support/CMakeLists.txt
@@ -16,6 +16,11 @@ add_flang_library(FIRSupport
 
   LINK_LIBS
   FIRDialect
+
+  LINK_COMPONENTS
+  TargetParser
+
+  MLIR_LIBS
   ${dialect_libs}
   ${extension_libs}
   MLIRBuiltinToLLVMIRTranslation
@@ -24,7 +29,4 @@ add_flang_library(FIRSupport
   MLIRLLVMToLLVMIRTranslation
   MLIRTargetLLVMIRExport
   MLIRTargetLLVMIRImport
-
-  LINK_COMPONENTS
-  TargetParser
 )

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -48,6 +48,8 @@ add_flang_library(FIRTransforms
   FIRSupport
   FortranCommon
   HLFIRDialect
+
+  MLIR_LIBS
   MLIRAffineUtils
   MLIRFuncDialect
   MLIRGPUDialect

--- a/flang/lib/Support/CMakeLists.txt
+++ b/flang/lib/Support/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_flang_library(FortranSupport
   Timing.cpp
 
-  LINK_LIBS
-  MLIRSupport
-
   LINK_COMPONENTS
   Support
+
+  MLIR_LIBS
+  MLIRSupport
 )

--- a/flang/test/lib/Analysis/AliasAnalysis/CMakeLists.txt
+++ b/flang/test/lib/Analysis/AliasAnalysis/CMakeLists.txt
@@ -16,11 +16,13 @@ add_flang_library(FIRTestAnalysis
   FIRSupport
   FIRTransforms
   FIRAnalysis
+  MLIRTestAnalysis
+
+  MLIR_LIBS
   ${dialect_libs}
   MLIRFuncDialect
   MLIRLLVMDialect
   MLIRAnalysis
-  MLIRTestAnalysis
   )
 
 target_include_directories(FIRTestAnalysis

--- a/flang/test/lib/OpenACC/CMakeLists.txt
+++ b/flang/test/lib/OpenACC/CMakeLists.txt
@@ -14,6 +14,8 @@ add_flang_library(FIRTestOpenACCInterfaces
   FIRDialect
   FIROpenACCSupport
   FIRSupport
+
+  MLIR_LIBS
   MLIRIR
   MLIROpenACCDialect
   MLIRPass

--- a/flang/tools/bbc/CMakeLists.txt
+++ b/flang/tools/bbc/CMakeLists.txt
@@ -29,6 +29,9 @@ target_link_libraries(bbc PRIVATE
   flangFrontend
   flangPasses
   FlangOpenMPTransforms
+)
+
+mlir_target_link_libraries(bbc PRIVATE
   ${dialect_libs}
   ${extension_libs}
   MLIRAffineToStandard

--- a/flang/tools/fir-lsp-server/CMakeLists.txt
+++ b/flang/tools/fir-lsp-server/CMakeLists.txt
@@ -12,7 +12,9 @@ target_link_libraries(fir-lsp-server PRIVATE
   CUFDialect
   FIRDialect
   FIROpenACCSupport
-  HLFIRDialect
+  HLFIRDialect)
+
+mlir_target_link_libraries(fir-lsp-server PRIVATE
   MLIRLspServerLib
   ${dialect_libs}
   ${extension_libs})

--- a/flang/tools/fir-opt/CMakeLists.txt
+++ b/flang/tools/fir-opt/CMakeLists.txt
@@ -24,6 +24,9 @@ target_link_libraries(fir-opt PRIVATE
   FlangOpenMPTransforms
   FIRAnalysis
   ${test_libs}
+)
+
+mlir_target_link_libraries(fir-opt PRIVATE
   ${dialect_libs}
   ${extension_libs}
 

--- a/flang/tools/tco/CMakeLists.txt
+++ b/flang/tools/tco/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(tco PRIVATE
   FIROpenACCSupport
   FlangOpenMPTransforms
   FortranCommon
+)
+
+mlir_target_link_libraries(tco PRIVATE
   ${dialect_libs}
   ${extension_libs}
   MLIRIR

--- a/flang/unittests/Frontend/CMakeLists.txt
+++ b/flang/unittests/Frontend/CMakeLists.txt
@@ -20,5 +20,9 @@ target_link_libraries(FlangFrontendTests
   FortranSemantics
   FortranCommon
   FortranEvaluate
+)
+
+mlir_target_link_libraries(FlangFrontendTests
+  PRIVATE
   MLIRIR
 )


### PR DESCRIPTION
Introduce a new `MLIR_LIBS` argument to `add_flang_library`, that uses `mlir_target_link_libraries` to link the MLIR dylib alterantively to the component libraries.  Use it, along with a few inline `mlir_target_link_libraries` in tools, to support linking Flang to MLIR dylib rather than the static libraries.

With these changes, the vast majority of Flang can be linked dynamically.  The only parts still using static libraries are these requiring MLIR test libraries, that are not included in the dylib.