### PR TITLE
Introduce virtual interface for lattices and remove dependency on `llvm::Any`.

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/DataflowLattice.h
+++ b/clang/include/clang/Analysis/FlowSensitive/DataflowLattice.h
@@ -14,6 +14,10 @@
 #ifndef LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_DATAFLOWLATTICE_H
 #define LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_DATAFLOWLATTICE_H
 
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/ExtensibleRTTI.h"
+#include <memory>
+
 namespace clang {
 namespace dataflow {
 
@@ -24,6 +28,48 @@ enum class LatticeEffect {
 };
 // DEPRECATED. Use `LatticeEffect`.
 using LatticeJoinEffect = LatticeEffect;
+
+class DataflowLattice
+    : public llvm::RTTIExtends<DataflowLattice, llvm::RTTIRoot> {
+public:
+  /// For RTTI.
+  inline static char ID = 0;
+
+  DataflowLattice() = default;
+
+  /// Joins the object with `Other` by computing their least upper bound,
+  /// modifies the object if necessary, and returns an effect indicating whether
+  /// any changes were made to it.
+  virtual LatticeEffect join(const DataflowLattice &Other) = 0;
+
+  virtual std::unique_ptr<DataflowLattice> clone() = 0;
+
+  /// Replaces this lattice element with one that approximates it, given the
+  /// previous element at the current program point.  The approximation should
+  /// be chosen so that the analysis can reach a fixed point more quickly than
+  /// iterated application of the transfer function alone. The previous value is
+  /// provided to inform the choice of widened value. The function must also
+  /// serve as a comparison operation, by indicating whether the widened value
+  /// is equivalent to the previous value with the returned `LatticeJoinEffect`.
+  ///
+  /// Overriding `widen` is optional -- it is only needed to either accelerate
+  /// convergence (for lattices with non-trivial height) or guarantee
+  /// convergence (for lattices with infinite height). The default
+  /// implementation simply checks for equality.
+  ///
+  /// Returns an indication of whether any changes were made to the object. This
+  /// saves a separate call to `isEqual` after the widening.
+  virtual LatticeEffect widen(const DataflowLattice &Previous) {
+    return isEqual(Previous) ? LatticeEffect::Unchanged
+                             : LatticeEffect::Changed;
+  }
+
+  /// Returns true if and only if the two given type-erased lattice elements are
+  /// equal.
+  virtual bool isEqual(const DataflowLattice &) const = 0;
+};
+
+using DataflowLatticePtr = std::unique_ptr<DataflowLattice>;
 
 } // namespace dataflow
 } // namespace clang

--- a/clang/include/clang/Analysis/FlowSensitive/Logger.h
+++ b/clang/include/clang/Analysis/FlowSensitive/Logger.h
@@ -16,7 +16,7 @@
 namespace clang::dataflow {
 // Forward declarations so we can use Logger anywhere in the framework.
 class AdornedCFG;
-class TypeErasedDataflowAnalysis;
+class DataflowAnalysis;
 struct TypeErasedDataflowAnalysisState;
 
 /// A logger is notified as the analysis progresses.
@@ -40,8 +40,7 @@ public:
 
   /// Called by the framework as we start analyzing a new function or statement.
   /// Forms a pair with endAnalysis().
-  virtual void beginAnalysis(const AdornedCFG &, TypeErasedDataflowAnalysis &) {
-  }
+  virtual void beginAnalysis(const AdornedCFG &, DataflowAnalysis &) {}
   virtual void endAnalysis() {}
 
   // At any time during the analysis, we're computing the state for some target

--- a/clang/include/clang/Analysis/FlowSensitive/NoopAnalysis.h
+++ b/clang/include/clang/Analysis/FlowSensitive/NoopAnalysis.h
@@ -13,26 +13,26 @@
 #ifndef LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_NOOPANALYSIS_H
 #define LLVM_CLANG_ANALYSIS_FLOWSENSITIVE_NOOPANALYSIS_H
 
-#include "clang/AST/ASTContext.h"
 #include "clang/Analysis/CFG.h"
-#include "clang/Analysis/FlowSensitive/DataflowAnalysis.h"
 #include "clang/Analysis/FlowSensitive/DataflowEnvironment.h"
 #include "clang/Analysis/FlowSensitive/NoopLattice.h"
+#include "clang/Analysis/FlowSensitive/TypeErasedDataflowAnalysis.h"
+#include <memory>
 
 namespace clang {
 namespace dataflow {
 
-class NoopAnalysis : public DataflowAnalysis<NoopAnalysis, NoopLattice> {
+class NoopAnalysis : public DataflowAnalysis {
 public:
-  NoopAnalysis(ASTContext &Context)
-      : DataflowAnalysis<NoopAnalysis, NoopLattice>(Context) {}
+  using DataflowAnalysis::DataflowAnalysis;
+  using Lattice = NoopLattice;
 
-  NoopAnalysis(ASTContext &Context, DataflowAnalysisOptions Options)
-      : DataflowAnalysis<NoopAnalysis, NoopLattice>(Context, Options) {}
+  std::unique_ptr<DataflowLattice> initialElement() override {
+    return std::make_unique<NoopLattice>();
+  }
 
-  static NoopLattice initialElement() { return {}; }
-
-  void transfer(const CFGElement &E, NoopLattice &L, Environment &Env) {}
+  void transfer(const CFGElement &E, DataflowLattice &L,
+                Environment &Env) override {}
 };
 
 } // namespace dataflow

--- a/clang/lib/Analysis/FlowSensitive/Arena.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Arena.cpp
@@ -180,7 +180,7 @@ class FormulaParseError : public llvm::ErrorInfo<FormulaParseError> {
   unsigned Offset;
 
 public:
-  static char ID;
+  inline static char ID;
   FormulaParseError(llvm::StringRef Formula, unsigned Offset)
       : Formula(Formula), Offset(Offset) {}
 
@@ -194,8 +194,6 @@ public:
     return std::make_error_code(std::errc::invalid_argument);
   }
 };
-
-char FormulaParseError::ID = 0;
 
 } // namespace
 

--- a/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
+++ b/clang/lib/Analysis/FlowSensitive/HTMLLogger.cpp
@@ -175,8 +175,7 @@ class HTMLLogger : public Logger {
 
 public:
   explicit HTMLLogger(StreamFactory Streams) : Streams(std::move(Streams)) {}
-  void beginAnalysis(const AdornedCFG &ACFG,
-                     TypeErasedDataflowAnalysis &A) override {
+  void beginAnalysis(const AdornedCFG &ACFG, DataflowAnalysis &A) override {
     OS = Streams();
     this->ACFG = &ACFG;
     *OS << llvm::StringRef(HTMLLogger_html).split("<?INJECT?>").first;

--- a/clang/lib/Analysis/FlowSensitive/Logger.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Logger.cpp
@@ -28,13 +28,13 @@ struct TextualLogger final : Logger {
   unsigned CurrentElementIndex;
   bool ShowColors;
   llvm::DenseMap<const CFGBlock *, unsigned> VisitCount;
-  TypeErasedDataflowAnalysis *CurrentAnalysis;
+  DataflowAnalysis *CurrentAnalysis;
 
   TextualLogger(llvm::raw_ostream &OS)
       : OS(OS), ShowColors(llvm::WithColor::defaultAutoDetectFunction()(OS)) {}
 
   virtual void beginAnalysis(const AdornedCFG &ACFG,
-                             TypeErasedDataflowAnalysis &Analysis) override {
+                             DataflowAnalysis &Analysis) override {
     {
       llvm::WithColor Header(OS, llvm::raw_ostream::Colors::RED, /*Bold=*/true);
       OS << "=== Beginning data flow analysis ===\n";

--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -1102,9 +1102,7 @@ UncheckedOptionalAccessModel::optionalClassDecl() {
 
 UncheckedOptionalAccessModel::UncheckedOptionalAccessModel(ASTContext &Ctx,
                                                            Environment &Env)
-    : DataflowAnalysis<UncheckedOptionalAccessModel,
-                       UncheckedOptionalAccessLattice>(Ctx),
-      TransferMatchSwitch(buildTransferMatchSwitch()) {
+    : DataflowAnalysis(Ctx), TransferMatchSwitch(buildTransferMatchSwitch()) {
   Env.getDataflowAnalysisContext().setSyntheticFieldCallback(
       [&Ctx](QualType Ty) -> llvm::StringMap<QualType> {
         const CXXRecordDecl *Optional =
@@ -1117,9 +1115,10 @@ UncheckedOptionalAccessModel::UncheckedOptionalAccessModel(ASTContext &Ctx,
 }
 
 void UncheckedOptionalAccessModel::transfer(const CFGElement &Elt,
-                                            UncheckedOptionalAccessLattice &L,
+                                            DataflowLattice &L,
                                             Environment &Env) {
-  LatticeTransferState State(L, Env);
+  LatticeTransferState State(llvm::cast<UncheckedOptionalAccessLattice>(L),
+                             Env);
   TransferMatchSwitch(Elt, getASTContext(), State);
 }
 

--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -22,6 +22,7 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Analysis/FlowSensitive/ASTOps.h"
 #include "clang/Analysis/FlowSensitive/AdornedCFG.h"
+#include "clang/Analysis/FlowSensitive/DataflowAnalysis.h"
 #include "clang/Analysis/FlowSensitive/DataflowAnalysisContext.h"
 #include "clang/Analysis/FlowSensitive/DataflowEnvironment.h"
 #include "clang/Analysis/FlowSensitive/NoopAnalysis.h"

--- a/clang/unittests/Analysis/FlowSensitive/ChromiumCheckModelTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/ChromiumCheckModelTest.cpp
@@ -108,16 +108,19 @@ std::string ReplacePattern(std::string S, const std::string &Pattern,
   return S;
 }
 
-template <typename Model>
-class ModelAdaptorAnalysis
-    : public DataflowAnalysis<ModelAdaptorAnalysis<Model>, NoopLattice> {
+template <typename Model> class ModelAdaptorAnalysis : public DataflowAnalysis {
 public:
+  using Lattice = NoopLattice;
+
   explicit ModelAdaptorAnalysis(ASTContext &Context)
-      : DataflowAnalysis<ModelAdaptorAnalysis, NoopLattice>(Context) {}
+      : DataflowAnalysis(Context) {}
 
-  static NoopLattice initialElement() { return NoopLattice(); }
+  std::unique_ptr<DataflowLattice> initialElement() override {
+    return std::make_unique<Lattice>();
+  }
 
-  void transfer(const CFGElement &E, NoopLattice &, Environment &Env) {
+  void transfer(const CFGElement &E, DataflowLattice &,
+                Environment &Env) override {
     M.transfer(E, Env);
   }
 

--- a/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
+++ b/clang/unittests/Analysis/FlowSensitive/TestingSupport.h
@@ -102,7 +102,7 @@ struct AnalysisOutputs {
   /// function and is analyzed.
   const AdornedCFG &ACFG;
   /// The analysis to be run.
-  TypeErasedDataflowAnalysis &Analysis;
+  DataflowAnalysis &Analysis;
   /// Initial state to start the analysis.
   const Environment &InitEnv;
   // Stores the state of a CFG block if it has been evaluated by the analysis.
@@ -254,8 +254,8 @@ checkDataflow(AnalysisInputs<AnalysisT> AI,
           AI.Callbacks.Before(
               Context, Element,
               TransferStateForDiagnostics<typename AnalysisT::Lattice>(
-                  llvm::any_cast<const typename AnalysisT::Lattice &>(
-                      State.Lattice.Value),
+                  *llvm::cast<const typename AnalysisT::Lattice>(
+                      State.Lattice.get()),
                   State.Env));
         };
   }
@@ -266,8 +266,8 @@ checkDataflow(AnalysisInputs<AnalysisT> AI,
           AI.Callbacks.After(
               Context, Element,
               TransferStateForDiagnostics<typename AnalysisT::Lattice>(
-                  llvm::any_cast<const typename AnalysisT::Lattice &>(
-                      State.Lattice.Value),
+                  *llvm::cast<const typename AnalysisT::Lattice>(
+                      State.Lattice.get()),
                   State.Env));
         };
   }


### PR DESCRIPTION
This PR has 2 related goals:

*Remove dependency on `llvm::Any`*. For some platforms, use of `llvm::Any`
forces users to explicitly define internal details related to `Any`. Aside from
aesthetics, this places an obscure requirement on lattice implementers. We
prefer to use LLVM's (explicit) RTTI framework instead.

*Introduce virtual interface for lattices*. Currently, we implicitly define the
interface for lattices, because the interface to analyses is fully captured in
templates. This PR moves to an explicit, virtual interface.

We combine these two changes in a single PR because they are closely related: we
use the new lattice interface as the basis of an open type hierarchy that embeds
RTTI for safe interfacing with the dataflow engine.
