### PR TITLE
[BOLT][DRAFT] Enable binary stripping

### DIFF
--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -62,6 +62,7 @@ extern llvm::cl::opt<bool> SplitEH;
 extern llvm::cl::opt<bool> StrictMode;
 extern llvm::cl::opt<bool> TimeOpts;
 extern llvm::cl::opt<bool> UseOldText;
+extern llvm::cl::opt<bool> StripBinary;
 extern llvm::cl::opt<bool> UpdateDebugSections;
 
 // The default verbosity level (0) is pretty terse, level 1 is fairly

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -208,6 +208,9 @@ cl::opt<bool> UpdateDebugSections(
     cl::desc("update DWARF debug sections of the executable"),
     cl::cat(BoltCategory));
 
+cl::opt<bool> StripBinary("strip-binary", cl::desc("perform binary stripping"),
+                          cl::cat(BoltCategory));
+
 cl::opt<unsigned>
     Verbosity("v", cl::desc("set verbosity level for diagnostic output"),
               cl::init(0), cl::ZeroOrMore, cl::cat(BoltCategory),

--- a/bolt/test/AArch64/strip-binary.test
+++ b/bolt/test/AArch64/strip-binary.test
@@ -1,0 +1,26 @@
+## Verify that bolt correctly strips the binary of symbols and sections.
+
+REQUIRES: system-linux
+
+RUN: %clang %cflags -g %p/../Inputs/asm_foo.s %p/../Inputs/asm_main.c -o %t.exe -Wl,-q
+RUN: llvm-bolt %t.exe -o %t.stripped -strip-binary
+
+RUN: nm %t.stripped  2>&1 | FileCheck %s --check-prefix=CHECK-NM
+RUN: llvm-readelf --sections %t.stripped 2>&1 | FileCheck %s --check-prefix=CHECK-READELF
+
+CHECK-NM: nm: {{.*}}: no symbols
+CHECK-READELF-NOT: .debug
+CHECK-READELF-NOT: .comment
+CHECK-READELF-NOT: .note{{.*}}
+
+RUN: not llvm-bolt %t.exe -o %t -strip-binary -update-debug-sections 2>&1 | FileCheck %s --check-prefix CHECK-UPDATE-DEBUG
+CHECK-UPDATE-DEBUG: BOLT-ERROR: -strip-binary and -update-debug-sections cannot be used at the same time
+
+RUN: not llvm-bolt %t.exe -o %t -strip-binary -enable-bat 2>&1 | FileCheck %s --check-prefix CHECK-BAT
+CHECK-BAT: BOLT-ERROR: -strip-binary and -enable-bat cannot be used at the same time
+
+RUN: not llvm-bolt %t.exe -o %t -strip-binary -instrument 2>&1 | FileCheck %s --check-prefix CHECK-INSTRUMENT
+CHECK-INSTRUMENT: BOLT-ERROR: -strip-binary and -instrument cannot be used at the same time
+
+RUN: not llvm-bolt %t.exe -o %t -strip-binary -hugify 2>&1 | FileCheck %s --check-prefix CHECK-HUGIFY
+CHECK-HUGIFY: BOLT-ERROR: -strip-binary and -hugify cannot be used at the same time


### PR DESCRIPTION
The patch toggles on `-remove-symtab`, checks compatibility with other flags, and omits sections that are removed by tools like `llvm-strip`.
