### PR TITLE
Remove an assertion on this pointer.

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2843,7 +2843,6 @@ void TypeConverter::SignatureConversion::remapInput(unsigned origInputNo,
 
 LogicalResult TypeConverter::convertType(Type t,
                                          SmallVectorImpl<Type> &results) const {
-  assert(this && "expected non-null type converter");
   assert(t && "expected non-null type");
 
   {


### PR DESCRIPTION
Remove an assertion on this pointer, as it triggers this error: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true.