### PR TITLE
[cmake] Serialize native builds for Make generator

### DIFF
--- a/llvm/cmake/modules/CrossCompile.cmake
+++ b/llvm/cmake/modules/CrossCompile.cmake
@@ -12,6 +12,14 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
     message(STATUS "Setting native build dir to " ${${project_name}_${target_name}_BUILD})
   endif(NOT DEFINED ${project_name}_${target_name}_BUILD)
 
+  if(NOT DEFINED ${project_name}_${target_name}_STAMP)
+    set(${project_name}_${target_name}_STAMP
+      "${CMAKE_CURRENT_BINARY_DIR}/${target_name}-stamps")
+    set(${project_name}_${target_name}_STAMP
+      ${${project_name}_${target_name}_STAMP} PARENT_SCOPE)
+    message(STATUS "Setting native stamp dir to " ${${project_name}_${target_name}_STAMP})
+  endif(NOT DEFINED ${project_name}_${target_name}_STAMP)
+
   if (EXISTS ${LLVM_MAIN_SRC_DIR}/cmake/platforms/${toolchain}.cmake)
     set(CROSS_TOOLCHAIN_FLAGS_INIT
       -DCMAKE_TOOLCHAIN_FILE=\"${LLVM_MAIN_SRC_DIR}/cmake/platforms/${toolchain}.cmake\")
@@ -130,13 +138,16 @@ function(build_native_tool target output_path_var)
     set_property(GLOBAL APPEND PROPERTY ${PROJECT_NAME}_HOST_TARGETS ${output_path})
   endif()
 
-  llvm_ExternalProject_BuildCmd(build_cmd ${target} ${${PROJECT_NAME}_NATIVE_BUILD}
+  llvm_ExternalProject_BuildCmd(build_cmd ${target}
+                                ${${PROJECT_NAME}_NATIVE_BUILD}
+                                ${${PROJECT_NAME}_NATIVE_STAMP}
                                 CONFIGURATION Release)
   add_custom_command(OUTPUT "${output_path}"
                      COMMAND ${build_cmd}
                      DEPENDS CONFIGURE_${PROJECT_NAME}_NATIVE ${ARG_DEPENDS} ${host_targets}
                      WORKING_DIRECTORY "${${PROJECT_NAME}_NATIVE_BUILD}"
                      COMMENT "Building native ${target}..."
-                     USES_TERMINAL)
+                     USES_TERMINAL
+                     VERBATIM)
   set(${output_path_var} "${output_path}" PARENT_SCOPE)
 endfunction()

--- a/llvm/cmake/modules/FileLock.cmake
+++ b/llvm/cmake/modules/FileLock.cmake
@@ -1,0 +1,9 @@
+# CMake script that synchronizes process execution on a given file lock.
+#
+# Input variables:
+#   LOCK_FILE_PATH    - The file to be locked for the scope of the process of this cmake script.
+#   COMMAND           - The command to be executed.
+
+file(LOCK ${LOCK_FILE_PATH})
+string(REPLACE "@" ";" command_args ${COMMAND})
+execute_process(COMMAND ${command_args} COMMAND_ERROR_IS_FATAL ANY)


### PR DESCRIPTION
The build system is fragile by allowing multiple invocation of subprocess builds in the native folder for Make generator.

For example, during sub-invocation of the native llvm-config, llvm-min-tblgen is also built. If there is another sub-invocation of the native llvm-min-tblgen build running in parallel, they may overwrite each other's build results, and may lead to errors like "Text file busy".

This patch adds a cmake script that uses file lock to serialize all native builds for Make generator.