### PR TITLE
[mlir][Target] Make nvptxcompiler passed options high priority to keep consistent with ptxas behavior

### DIFF
--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -587,7 +587,8 @@ NVPTXSerializer::compileToBinaryNVPTX(StringRef ptxCode) {
   std::string optLevel = std::to_string(this->optLevel);
   std::pair<llvm::BumpPtrAllocator, SmallVector<const char *>> cmdOpts =
       targetOptions.tokenizeCmdOptions();
-  cmdOpts.second.append(
+  cmdOpts.second.insert(
+      cmdOpts.second.begin(),
       {"-arch", getTarget().getChip().data(), "--opt-level", optLevel.c_str()});
 
   // Set optional command line arguments

--- a/mlir/test/Integration/GPU/CUDA/command-line-arg.mlir
+++ b/mlir/test/Integration/GPU/CUDA/command-line-arg.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s \
-// RUN:  | mlir-opt -gpu-lower-to-nvvm-pipeline="cubin-chip=sm_80 ptxas-cmd-options='-v --register-usage-level=8' allow-pattern-rollback=0" -debug-only=serialize-to-binary \
+// RUN:  | mlir-opt -gpu-lower-to-nvvm-pipeline="cubin-chip=sm_80 opt-level=3 ptxas-cmd-options='-v --opt-level=2 --register-usage-level=8' allow-pattern-rollback=0" -debug-only=serialize-to-binary \
 // RUN:  2>&1 | FileCheck %s
 
 func.func @host_function(%arg0 : f32, %arg1 : memref<?xf32>) {
@@ -16,6 +16,8 @@ func.func @host_function(%arg0 : f32, %arg1 : memref<?xf32>) {
     return
 }
 
-// CHECK: ptxas -arch sm_80
-// CHECK-SAME: -v 
+// CHECK: {{ptxas args: ptxas|Arguments:}} -arch sm_80
+// CHECK-SAME: --opt-level 3
+// CHECK-SAME: -v
+// CHECK-SAME: --opt-level=2
 // CHECK-SAME: --register-usage-level=8


### PR DESCRIPTION
When using `ptxas` to do ptx->cubin, the options passed (via `cmd`) have higher priority than the gpuModule target (such as `opt-level`). When using `nvptxcompiler`, it is the opposite and we need to be consistent.