### PR TITLE
[clang-cl] Accept `cl`-style output arguments (`/Fo`, `-Fo`) for `--precompile`

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6210,13 +6210,13 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     bool IsCLNonPCH =
         IsCLMode() && !C.getArgs().hasArg(options::OPT__SLASH_Yc) &&
         (isa<PreprocessJobAction>(JA) || isa<PrecompileJobAction>(JA));
-        bool HasAnyOutputArg =
-          C.getArgs().hasArg(options::OPT_o, options::OPT__SLASH_Fo);
+    bool HasAnyOutputArg =
+        C.getArgs().hasArg(options::OPT_o, options::OPT__SLASH_Fo);
 
     Arg *FinalOutput = nullptr;
     if (IsCLNonPCH && HasAnyOutputArg) {
       FinalOutput =
-        C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_Fo);
+          C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_Fo);
     } else if (IsCLNonPCH) {
       FinalOutput = C.getArgs().getLastArg(options::OPT__SLASH_Fo);
     } else {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6210,16 +6210,15 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
     bool IsCLNonPCH =
         IsCLMode() && !C.getArgs().hasArg(options::OPT__SLASH_Yc) &&
         (isa<PreprocessJobAction>(JA) || isa<PrecompileJobAction>(JA));
-    bool HasAnyOutputArg = C.getArgs().hasArg(
-        options::OPT_o, options::OPT__SLASH_Fo, options::OPT__SLASH_Fo_COLON);
+        bool HasAnyOutputArg =
+          C.getArgs().hasArg(options::OPT_o, options::OPT__SLASH_Fo);
 
     Arg *FinalOutput = nullptr;
     if (IsCLNonPCH && HasAnyOutputArg) {
-      FinalOutput = C.getArgs().getLastArg(
-          options::OPT_o, options::OPT__SLASH_Fo, options::OPT__SLASH_Fo_COLON);
+      FinalOutput =
+        C.getArgs().getLastArg(options::OPT_o, options::OPT__SLASH_Fo);
     } else if (IsCLNonPCH) {
-      FinalOutput = C.getArgs().getLastArg(options::OPT__SLASH_Fo,
-                                           options::OPT__SLASH_Fo_COLON);
+      FinalOutput = C.getArgs().getLastArg(options::OPT__SLASH_Fo);
     } else {
       FinalOutput = C.getArgs().getLastArg(options::OPT_o);
     }

--- a/clang/test/Driver/cl-cxx20-modules.cppm
+++ b/clang/test/Driver/cl-cxx20-modules.cppm
@@ -16,7 +16,7 @@
 // CPP20WARNING-NOT: clang-cl: warning: argument unused during compilation: '/std:c++20' [-Wunused-command-line-argument]
 
 // test whether the following outputs %Hello.bmi
-// RUN: %clang_cl /std:c++20 --precompile -x c++-module -Fo:"%t/Hello.bmi" -c %t/Hello.cppm -### 2>&1 | FileCheck %s
+// RUN: %clang_cl /std:c++20 --precompile -x c++-module -Fo:"%t/Hello.bmi" -c -- %t/Hello.cppm -### 2>&1 | FileCheck %s
 // CHECK: "-emit-module-interface"
 // CHECK: "-o" "{{.*}}Hello.bmi"
 

--- a/clang/test/Driver/cl-cxx20-modules.cppm
+++ b/clang/test/Driver/cl-cxx20-modules.cppm
@@ -16,7 +16,7 @@
 // CPP20WARNING-NOT: clang-cl: warning: argument unused during compilation: '/std:c++20' [-Wunused-command-line-argument]
 
 // test whether the following outputs %Hello.bmi
-// RUN: %clang_cl /std:c++20 --precompile -x c++-module -fmodule-output=%t/Hello.bmi -Fo"%t/Hello.bmi" -c %t/Hello.cppm -### 2>&1 | FileCheck %s
+// RUN: %clang_cl /std:c++20 --precompile -x c++-module -Fo:"%t/Hello.bmi" -c %t/Hello.cppm -### 2>&1 | FileCheck %s
 // CHECK: "-emit-module-interface"
 // CHECK: "-o" "{{.*}}Hello.bmi"
 

--- a/clang/test/Driver/cl-cxx20-modules.cppm
+++ b/clang/test/Driver/cl-cxx20-modules.cppm
@@ -14,3 +14,11 @@
 
 //--- test.pcm
 // CPP20WARNING-NOT: clang-cl: warning: argument unused during compilation: '/std:c++20' [-Wunused-command-line-argument]
+
+// test whether the following outputs %Hello.bmi
+// RUN: %clang_cl /std:c++20 --precompile -x c++-module -fmodule-output=%t/Hello.bmi -Fo"%t/Hello.bmi" -c %t/Hello.cppm -### 2>&1 | FileCheck %s
+// CHECK: "-emit-module-interface"
+// CHECK: "-o" "{{.*}}Hello.bmi"
+
+//--- Hello.cppm
+export module Hello;


### PR DESCRIPTION
This PR resolves [this issue](https://discourse.llvm.org/t/clang-cl-exe-support-for-c-modules/72257/50?u=sharadhr), which can be summarised as such. Given the following `foo.cxx`:

```cxx
export module foo;
export int from_foo()
{
  return 0;
}
```

Running the following outputs `foo.pcm`, but doesn’t output `foo.bmi` as requested by `-Fo`:

```
clang-cl.exe -std:c++20 --precompile -x c++-module -fmodule-output=foo.bmi -Fo"foo.bmi" -c foo.cxx
```

However, running the following outputs `foo.bmi` as requested:

```
clang++.exe -std=c++20 --precompile -x c++-module -fmodule-output=foo.bmi -o foo.bmi -c foo.cxx
```

This behaviour is then used by `clang-scan-deps` to output the dependency scanning JSON. In the former case since no `.bmi` is output, the corresponding value of the `primary-output` key [here](https://discourse.llvm.org/t/clang-cl-exe-support-for-c-modules/72257/47) is `"-"`.

This invocation is [used by CMake](https://gitlab.kitware.com/cmake/cmake/-/issues/25731) to run `clang-scan-deps` and build the dependency tree. 

