### PR TITLE
[clang-tidy] add depercation warning for non-whitelisted global options

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyCheck.cpp
@@ -79,11 +79,11 @@ findPriorityOption(const ClangTidyOptions::OptionMap &Options,
   auto IterLocal = Options.find((NamePrefix + LocalName).str());
   auto IterGlobal = Options.find(LocalName);
   // FIXME: temporary solution for deprecation warnings, should be removed
-  // after 22.x.
-  if (IterGlobal != Options.end() &&
+  // after 22.x. Warn configuration deps on deprecation global options.
+  if (IterLocal == Options.end() && IterGlobal != Options.end() &&
       DeprecatedGlobalOptions.contains(LocalName))
     Context->configurationDiag(
-        "deprecation global option '%0', please use '%1%0'.")
+        "global option '%0' is deprecated, please use '%1%0' instead.")
         << LocalName << NamePrefix;
   if (IterLocal == Options.end())
     return IterGlobal;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -117,7 +117,8 @@ Improvements to clang-tidy
 
 - Removed :program:`clang-tidy`'s global options for most of checks. All options
   are changed to local options except `IncludeStyle`, `StrictMode` and
-  `IgnoreMacros`.
+  `IgnoreMacros`. Global scoped `StrictMode` and `IgnoreMacros` are deprecated
+  and will be removed in further releases.
 
 .. csv-table::
   :header: "Check", "Options removed from global option"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-fmt.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-fmt.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s modernize-use-std-format %t -- \
 // RUN:   -config="{CheckOptions: { \
-// RUN:              StrictMode: true, \
+// RUN:              modernize-use-std-format.StrictMode: true, \
 // RUN:              modernize-use-std-format.StrFormatLikeFunctions: 'fmt::sprintf', \
 // RUN:              modernize-use-std-format.ReplacementFormatFunction: 'fmt::format', \
 // RUN:              modernize-use-std-format.FormatHeader: '<fmt/core.h>' \

--- a/clang-tools-extra/test/clang-tidy/infrastructure/deprecation-global-option.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/deprecation-global-option.cpp
@@ -1,0 +1,3 @@
+// RUN: clang-tidy %s --config="{CheckOptions:{StrictMode: true}}" -checks="-*,modernize-use-std-format" | FileCheck %s 
+
+// CHECK: warning: deprecation global option 'StrictMode', please use 'modernize-use-std-format.StrictMode'. [clang-tidy-config]

--- a/clang-tools-extra/test/clang-tidy/infrastructure/deprecation-global-option.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/deprecation-global-option.cpp
@@ -1,3 +1,3 @@
 // RUN: clang-tidy %s --config="{CheckOptions:{StrictMode: true}}" -checks="-*,modernize-use-std-format" | FileCheck %s 
 
-// CHECK: warning: deprecation global option 'StrictMode', please use 'modernize-use-std-format.StrictMode'. [clang-tidy-config]
+// CHECK: warning: global option 'StrictMode' is deprecated, please use 'modernize-use-std-format.StrictMode' instead. [clang-tidy-config]


### PR DESCRIPTION
We plan to depercate `StrictMode` and `IgnoreMacros` global options after 2 major versions and support local options only for them.
This patch introduces the depercation warning.
