### PR TITLE
[mlir][python] Support `CLANG_CL`

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -584,7 +584,7 @@ function(add_mlir_aggregate name)
   # TODO: Should be transitive.
   set_target_properties(${name} PROPERTIES
     MLIR_AGGREGATE_EXCLUDE_LIBS "${_embed_libs}")
-  if(MSVC)
+  if(WIN32)
     set_property(TARGET ${name} PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
   endif()
 


### PR DESCRIPTION
Without passing `${eh_rtti_enable}` to `target_compile_options(nanobind-static ...` this fails to build under `clang-cl.exe` on [Windows](https://github.com/llvm/eudsl/actions/runs/12475469634/job/34818915629) because exceptions aren't enabled.

Tested by rebasing on top of this PR (i.e., my fork) [here](https://github.com/llvm/eudsl/actions/runs/12488184019/job/34850256655).