### PR TITLE
[MLIR] Prevent invalid IR from being passed outside of RemoveDeadValues

### DIFF
--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -219,7 +219,7 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 ///   1. Adding the operation to a list for future removal, and
 ///   2. Marking all its results as non-live values
 ///
-/// The operation `op` is assumed to be simple. 
+/// The operation `op` is assumed to be simple.
 /// A simple operation is one that is NOT:
 ///   - Function-like
 ///   - Call-like
@@ -237,14 +237,15 @@ static void processSimpleOp(Operation *op, RunLivenessAnalysis &la,
                        BitVector(op->getNumResults(), true));
 }
 
-/// Process a function-like operation `funcOp` using the liveness analysis `la` 
+/// Process a function-like operation `funcOp` using the liveness analysis `la`
 /// and the IR in `module`. If it is not public or external:
 ///   1. Adding its non-live arguments to a list for future removal.
 ///   2. Marking their corresponding operands in its callers for removal.
-///   3. Identifying and enqueueing unnecessary terminator operands 
+///   3. Identifying and enqueueing unnecessary terminator operands
 ///      (return values that are non-live across all callers) for removal.
 ///   4. Enqueueing the non-live arguments themselves for removal.
-///   5. Collecting the uses of these return values in its callers for future removal.
+///   5. Collecting the uses of these return values in its callers for future
+///   removal.
 ///   6. Marking all its results as non-live values.
 static void processFuncOp(FunctionOpInterface funcOp, Operation *module,
                           RunLivenessAnalysis &la, DenseSet<Value> &deletionSet,
@@ -332,29 +333,34 @@ static void processFuncOp(FunctionOpInterface funcOp, Operation *module,
   }
 }
 
-/// Process a region branch operation `regionBranchOp` using the liveness information in `la`. 
-/// The processing involves two scenarios:
+/// Process a region branch operation `regionBranchOp` using the liveness
+/// information in `la`. The processing involves two scenarios:
 ///
-/// Scenario 1: If the operation has no memory effects and none of its results are live:
+/// Scenario 1: If the operation has no memory effects and none of its results
+/// are live:
 ///   1. Enqueue all its uses for deletion.
 ///   2. Enqueue the branch itself for deletion.
 ///
 /// Scenario 2: Otherwise:
-///   1. Collect its unnecessary operands (operands forwarded to unnecessary results or arguments).
+///   1. Collect its unnecessary operands (operands forwarded to unnecessary
+///   results or arguments).
 ///   2. Process each of its regions.
-///   3. Collect the uses of its unnecessary results (results forwarded from unnecessary operands 
+///   3. Collect the uses of its unnecessary results (results forwarded from
+///   unnecessary operands
 ///      or terminator operands).
 ///   4. Add these results to the deletion list.
 ///
 /// Processing a region includes:
-///   a. Collecting the uses of its unnecessary arguments (arguments forwarded from unnecessary operands 
+///   a. Collecting the uses of its unnecessary arguments (arguments forwarded
+///   from unnecessary operands
 ///      or terminator operands).
 ///   b. Collecting these unnecessary arguments.
-///   c. Collecting its unnecessary terminator operands (terminator operands forwarded to unnecessary results 
+///   c. Collecting its unnecessary terminator operands (terminator operands
+///   forwarded to unnecessary results
 ///      or arguments).
 ///
 /// Value Flow Note: In this operation, values flow as follows:
-/// - From operands and terminator operands (successor operands) 
+/// - From operands and terminator operands (successor operands)
 /// - To arguments and results (successor inputs).
 static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
                                   RunLivenessAnalysis &la,
@@ -627,9 +633,9 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 
 /// Steps to process a `BranchOpInterface` operation:
 /// 1. Iterate through each successor block of the operation.
-/// 2. For each successor block, gather all operands from all successors 
+/// 2. For each successor block, gather all operands from all successors
 ///    along with their associated liveness analysis data.
-/// 3. Identify and collect the dead operands from the branch operation 
+/// 3. Identify and collect the dead operands from the branch operation
 ///    as well as their corresponding arguments.
 
 static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -219,8 +219,7 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 ///   1. Add the operation to a list for future removal, and
 ///   2. Mark all its results as non-live values
 ///
-/// The operation `op` is assumed to be simple.
-/// A simple operation is one that is NOT:
+/// The operation `op` is assumed to be simple. A simple operation is one that is NOT:
 ///   - Function-like
 ///   - Call-like
 ///   - A region branch operation

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -228,7 +228,8 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 ///   - A region branch terminator
 ///   - Return-like
 static void processSimpleOp(Operation *op, RunLivenessAnalysis &la,
-                            DenseSet<Value> &deletionSet, RDVFinalCleanupList &cl) {
+                            DenseSet<Value> &deletionSet,
+                            RDVFinalCleanupList &cl) {
   if (!isMemoryEffectFree(op) || hasLive(op->getResults(), deletionSet, la))
     return;
 
@@ -639,7 +640,8 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 ///    as well as their corresponding arguments.
 
 static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,
-                            DenseSet<Value> &deletionSet, RDVFinalCleanupList &cl) {
+                            DenseSet<Value> &deletionSet,
+                            RDVFinalCleanupList &cl) {
   unsigned numSuccessors = branchOp->getNumSuccessors();
 
   // Do (1)
@@ -742,7 +744,8 @@ void RemoveDeadValues::runOnOperation() {
     if (auto funcOp = dyn_cast<FunctionOpInterface>(op)) {
       processFuncOp(funcOp, module, la, deadVals, finalRDVFinalCleanupList);
     } else if (auto regionBranchOp = dyn_cast<RegionBranchOpInterface>(op)) {
-      processRegionBranchOp(regionBranchOp, la, deadVals, finalRDVFinalCleanupList);
+      processRegionBranchOp(regionBranchOp, la, deadVals,
+                            finalRDVFinalCleanupList);
     } else if (auto branchOp = dyn_cast<BranchOpInterface>(op)) {
       processBranchOp(branchOp, la, deadVals, finalRDVFinalCleanupList);
     } else if (op->hasTrait<::mlir::OpTrait::IsTerminator>()) {

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -127,8 +127,7 @@ static bool hasLive(ValueRange values, const DenseSet<Value> &nonLiveSet,
 
 /// Return a BitVector of size `values.size()` where its i-th bit is 1 iff the
 /// i-th value in `values` is live, given the liveness information in `la`.
-static BitVector markLives(ValueRange values,
-                           const DenseSet<Value> &nonLiveSet,
+static BitVector markLives(ValueRange values, const DenseSet<Value> &nonLiveSet,
                            RunLivenessAnalysis &la) {
   BitVector lives(values.size(), true);
 

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -216,8 +216,8 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 
 /// Process a simple operation `op` using the liveness analysis `la`.
 /// If the operation has no memory effects and none of its results are live:
-///   1. Adding the operation to a list for future removal, and
-///   2. Marking all its results as non-live values
+///   1. Add the operation to a list for future removal, and
+///   2. Mark all its results as non-live values
 ///
 /// The operation `op` is assumed to be simple.
 /// A simple operation is one that is NOT:

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -218,7 +218,8 @@ static SmallVector<OpOperand *> operandsToOpOperands(OperandRange operands) {
 ///   1. Add the operation to a list for future removal, and
 ///   2. Mark all its results as non-live values
 ///
-/// The operation `op` is assumed to be simple. A simple operation is one that is NOT:
+/// The operation `op` is assumed to be simple. A simple operation is one that
+/// is NOT:
 ///   - Function-like
 ///   - Call-like
 ///   - A region branch operation

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -636,8 +636,8 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 /// Steps to process a `BranchOpInterface` operation:
 /// Iterate through each successor block of the operation.
 /// (1) For each successor block, gather all operands from all successors.
-/// (2) Fetch their associated liveness analysis data and collect for future removal.
-/// (3) Identify and collect the dead operands from the successor block
+/// (2) Fetch their associated liveness analysis data and collect for future
+/// removal. (3) Identify and collect the dead operands from the successor block
 ///     as well as their corresponding arguments.
 
 static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -748,8 +748,7 @@ void RemoveDeadValues::runOnOperation() {
     if (auto funcOp = dyn_cast<FunctionOpInterface>(op)) {
       processFuncOp(funcOp, module, la, deadVals, finalCleanupList);
     } else if (auto regionBranchOp = dyn_cast<RegionBranchOpInterface>(op)) {
-      processRegionBranchOp(regionBranchOp, la, deadVals,
-                            finalCleanupList);
+      processRegionBranchOp(regionBranchOp, la, deadVals, finalCleanupList);
     } else if (auto branchOp = dyn_cast<BranchOpInterface>(op)) {
       processBranchOp(branchOp, la, deadVals, finalCleanupList);
     } else if (op->hasTrait<::mlir::OpTrait::IsTerminator>()) {

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -239,14 +239,17 @@ static void processSimpleOp(Operation *op, RunLivenessAnalysis &la,
 
 /// Process a function-like operation `funcOp` using the liveness analysis `la`
 /// and the IR in `module`. If it is not public or external:
-///   1. Adding its non-live arguments to a list for future removal.
-///   2. Marking their corresponding operands in its callers for removal.
-///   3. Identifying and enqueueing unnecessary terminator operands
+/// Process a function-like op `funcOp`, given the liveness information in `la`
+/// and the IR in `module`. Here, processing means:
+///   (1) Adding its non-live arguments to a list for future removal.
+///   (2) Marking their corresponding operands in its callers for removal.
+///   (3) Identifying and enqueueing unnecessary terminator operands
 ///      (return values that are non-live across all callers) for removal.
-///   4. Enqueueing the non-live arguments themselves for removal.
-///   5. Collecting the uses of these return values in its callers for future
+///   (4) Enqueueing the non-live arguments themselves for removal.
+///   (5) Collecting the uses of these return values in its callers for future
 ///   removal.
 ///   6. Marking all its results as non-live values.
+/// iff it is not public or external.
 static void processFuncOp(FunctionOpInterface funcOp, Operation *module,
                           RunLivenessAnalysis &la, DenseSet<Value> &deletionSet,
                           RDVFinalCleanupList &cl) {

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -636,9 +636,8 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 /// Steps to process a `BranchOpInterface` operation:
 /// Iterate through each successor block of the operation.
 /// (1) For each successor block, gather all operands from all successors.
-///     along with their associated liveness analysis data.
-/// (2) Fetch their associated liveness analysis data.
-/// (3) Identify and collect the dead operands from the branch operation
+/// (2) Fetch their associated liveness analysis data and collect for future removal.
+/// (3) Identify and collect the dead operands from the successor block
 ///     as well as their corresponding arguments.
 
 static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -634,7 +634,7 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 }
 
 /// Steps to process a `BranchOpInterface` operation:
-/// Iterate through each successor block of the operation.
+/// Iterate through each successor block of `branchOp`.
 /// (1) For each successor block, gather all operands from all successors.
 /// (2) Fetch their associated liveness analysis data and collect for future
 /// removal. 

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -242,10 +242,10 @@ static void processSimpleOp(Operation *op, RunLivenessAnalysis &la,
 ///   (1) Adding its non-live arguments to a list for future removal.
 ///   (2) Marking their corresponding operands in its callers for removal.
 ///   (3) Identifying and enqueueing unnecessary terminator operands
-///      (return values that are non-live across all callers) for removal.
+///       (return values that are non-live across all callers) for removal.
 ///   (4) Enqueueing the non-live arguments and return values for removal.
 ///   (5) Collecting the uses of these return values in its callers for future
-///   removal.
+///       removal.
 ///   (6) Marking all its results as non-live values.
 static void processFuncOp(FunctionOpInterface funcOp, Operation *module,
                           RunLivenessAnalysis &la, DenseSet<Value> &nonLiveSet,
@@ -344,21 +344,21 @@ static void processFuncOp(FunctionOpInterface funcOp, Operation *module,
 ///
 /// Scenario 2: Otherwise:
 ///   (1) Collect its unnecessary operands (operands forwarded to unnecessary
-///   results or arguments).
+///       results or arguments).
 ///   (2) Process each of its regions.
 ///   (3) Collect the uses of its unnecessary results (results forwarded from
-///   unnecessary operands
-///      or terminator operands).
+///       unnecessary operands
+///       or terminator operands).
 ///   (4) Add these results to the deletion list.
 ///
 /// Processing a region includes:
 ///   (a) Collecting the uses of its unnecessary arguments (arguments forwarded
-///   from unnecessary operands
-///      or terminator operands).
+///       from unnecessary operands
+///       or terminator operands).
 ///   (b) Collecting these unnecessary arguments.
 ///   (c) Collecting its unnecessary terminator operands (terminator operands
-///   forwarded to unnecessary results
-///      or arguments).
+///       forwarded to unnecessary results
+///       or arguments).
 ///
 /// Value Flow Note: In this operation, values flow as follows:
 /// - From operands and terminator operands (successor operands)
@@ -637,9 +637,9 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 /// Iterate through each successor block of `branchOp`.
 /// (1) For each successor block, gather all operands from all successors.
 /// (2) Fetch their associated liveness analysis data and collect for future
-/// removal.
+///     removal.
 /// (3) Identify and collect the dead operands from the successor block
-///      as well as their corresponding arguments.
+///     as well as their corresponding arguments.
 
 static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,
                             DenseSet<Value> &nonLiveSet,

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -705,6 +705,7 @@ static void cleanUpDeadVals(RDVFinalCleanupList &list) {
     // blocks that are accessed via multiple codepaths processed once
     if (b.b->getNumArguments() != b.nonLiveArgs.size())
       continue;
+    // it iterates backwards because erase invalidates all successor indexes
     for (int i = b.nonLiveArgs.size() - 1; i >= 0; --i) {
       if (!b.nonLiveArgs[i])
         continue;
@@ -720,6 +721,7 @@ static void cleanUpDeadVals(RDVFinalCleanupList &list) {
     // blocks that are accessed via multiple codepaths processed once
     if (successorOperands.size() != op.nonLiveOperands.size())
       continue;
+    // it iterates backwards because erase invalidates all successor indexes
     for (int i = successorOperands.size() - 1; i >= 0; --i) {
       if (!op.nonLiveOperands[i])
         continue;

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -637,8 +637,9 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 /// Iterate through each successor block of the operation.
 /// (1) For each successor block, gather all operands from all successors.
 /// (2) Fetch their associated liveness analysis data and collect for future
-/// removal. (3) Identify and collect the dead operands from the successor block
-///     as well as their corresponding arguments.
+/// removal. 
+/// (3) Identify and collect the dead operands from the successor block
+///      as well as their corresponding arguments.
 
 static void processBranchOp(BranchOpInterface branchOp, RunLivenessAnalysis &la,
                             DenseSet<Value> &nonLiveSet,

--- a/mlir/lib/Transforms/RemoveDeadValues.cpp
+++ b/mlir/lib/Transforms/RemoveDeadValues.cpp
@@ -637,7 +637,7 @@ static void processRegionBranchOp(RegionBranchOpInterface regionBranchOp,
 /// Iterate through each successor block of `branchOp`.
 /// (1) For each successor block, gather all operands from all successors.
 /// (2) Fetch their associated liveness analysis data and collect for future
-/// removal. 
+/// removal.
 /// (3) Identify and collect the dead operands from the successor block
 ///      as well as their corresponding arguments.
 

--- a/mlir/test/Transforms/remove-dead-values.mlir
+++ b/mlir/test/Transforms/remove-dead-values.mlir
@@ -73,6 +73,32 @@ func.func @cleanable_loop_iter_args_value(%arg0: index) -> index {
 
 // -----
 
+// Checking that the arguments of linalg.generic are properly handled
+// All code below is removed as a result of the pass
+//
+#map = affine_map<(d0, d1, d2) -> (0, d1, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+module {
+  func.func @main() {
+    %cst_3 = arith.constant dense<54> : tensor<1x25x13xi32>
+    %cst_7 = arith.constant dense<11> : tensor<1x25x13xi32>
+    // CHECK-NOT: arith.constant
+    %0 = tensor.empty() : tensor<1x25x13xi32>
+    // CHECK-NOT: tensor
+    %1 = linalg.generic {indexing_maps = [#map, #map, #map1], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst_3, %cst_7 : tensor<1x25x13xi32>, tensor<1x25x13xi32>) outs(%0 : tensor<1x25x13xi32>) {
+    // CHECK-NOT: linalg.generic
+    ^bb0(%in: i32, %in_15: i32, %out: i32):
+      %29 = arith.xori %in, %in_15 : i32
+      // CHECK-NOT: arith.xori
+      linalg.yield %29 : i32
+      // CHECK-NOT: linalg.yield
+    } -> tensor<1x25x13xi32>
+    return
+  }
+}
+
+// -----
+
 // Note that this cleanup cannot be done by the `canonicalize` pass.
 //
 // CHECK-LABEL: func.func private @clean_func_op_remove_argument_and_return_value() {


### PR DESCRIPTION
This is a follow-up for https://github.com/llvm/llvm-project/pull/119110 and a fix for https://github.com/llvm/llvm-project/issues/118450

RemoveDeadValues used to delete Values and analyzing the IR at the same time, because of that, `isMemoryEffectFree` got invalid IR with half-deleted linalg.generic operation. This PR separates analysis and cleanup to prevent such situation.

Thank you!