### PR TITLE
[libc++] Optimize ranges::move{,_backward} for vector<bool>::iterator

### DIFF
--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -43,8 +43,8 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
-- The ``std::ranges::{copy, copy_n, copy_backward}`` algorithms have been optimized for ``std::vector<bool>::iterator``\s,
-  resulting in a performance improvement of up to 2000x.
+- The ``std::ranges::{copy, copy_n, copy_backward, move, move_backward}`` algorithms have been optimized for
+  ``std::vector<bool>::iterator``, resulting in a performance improvement of up to 2000x.
 
 - Updated formatting library to Unicode 16.0.0.
 

--- a/libcxx/include/__algorithm/move.h
+++ b/libcxx/include/__algorithm/move.h
@@ -9,11 +9,13 @@
 #ifndef _LIBCPP___ALGORITHM_MOVE_H
 #define _LIBCPP___ALGORITHM_MOVE_H
 
+#include <__algorithm/copy.h>
 #include <__algorithm/copy_move_common.h>
 #include <__algorithm/for_each_segment.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/min.h>
 #include <__config>
+#include <__fwd/bit_reference.h>
 #include <__iterator/iterator_traits.h>
 #include <__iterator/segmented_iterator.h>
 #include <__type_traits/common_type.h>
@@ -96,6 +98,14 @@ struct __move_impl {
 
       __local_first = _Traits::__begin(++__segment_iterator);
     }
+  }
+
+  template <class _Cp, bool _IsConst>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
+  operator()(__bit_iterator<_Cp, _IsConst> __first,
+             __bit_iterator<_Cp, _IsConst> __last,
+             __bit_iterator<_Cp, false> __result) {
+    return std::__copy(__first, __last, __result);
   }
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.

--- a/libcxx/include/__algorithm/move_backward.h
+++ b/libcxx/include/__algorithm/move_backward.h
@@ -9,10 +9,12 @@
 #ifndef _LIBCPP___ALGORITHM_MOVE_BACKWARD_H
 #define _LIBCPP___ALGORITHM_MOVE_BACKWARD_H
 
+#include <__algorithm/copy_backward.h>
 #include <__algorithm/copy_move_common.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/min.h>
 #include <__config>
+#include <__fwd/bit_reference.h>
 #include <__iterator/iterator_traits.h>
 #include <__iterator/segmented_iterator.h>
 #include <__type_traits/common_type.h>
@@ -105,6 +107,14 @@ struct __move_backward_impl {
 
       __local_last = _Traits::__end(--__segment_iterator);
     }
+  }
+
+  template <class _Cp, bool _IsConst>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
+  operator()(__bit_iterator<_Cp, _IsConst> __first,
+             __bit_iterator<_Cp, _IsConst> __last,
+             __bit_iterator<_Cp, false> __result) {
+    return std::__copy_backward<_ClassicAlgPolicy>(__first, __last, __result);
   }
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -210,22 +210,6 @@ private:
         __mask_(__m) {}
 };
 
-// move
-
-template <class _Cp, bool _IsConst>
-inline _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false>
-move(__bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, __bit_iterator<_Cp, false> __result) {
-  return std::copy(__first, __last, __result);
-}
-
-// move_backward
-
-template <class _Cp, bool _IsConst>
-inline _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false> move_backward(
-    __bit_iterator<_Cp, _IsConst> __first, __bit_iterator<_Cp, _IsConst> __last, __bit_iterator<_Cp, false> __result) {
-  return std::copy_backward(__first, __last, __result);
-}
-
 // swap_ranges
 
 template <class _Cl, class _Cr>

--- a/libcxx/test/benchmarks/algorithms/move.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/move.bench.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+
+#include <algorithm>
+#include <benchmark/benchmark.h>
+#include <vector>
+
+static void bm_ranges_move_vb(benchmark::State& state, bool aligned) {
+  auto n = state.range();
+  std::vector<bool> in(n, true);
+  std::vector<bool> out(aligned ? n : n + 8);
+  benchmark::DoNotOptimize(&in);
+  auto dst = aligned ? out.begin() : out.begin() + 4;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(std::ranges::move(in, dst));
+    benchmark::DoNotOptimize(&out);
+  }
+}
+
+static void bm_move_vb(benchmark::State& state, bool aligned) {
+  auto n = state.range();
+  std::vector<bool> in(n, true);
+  std::vector<bool> out(aligned ? n : n + 8);
+  benchmark::DoNotOptimize(&in);
+  auto beg = in.begin();
+  auto end = in.end();
+  auto dst = aligned ? out.begin() : out.begin() + 4;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(std::move(beg, end, dst));
+    benchmark::DoNotOptimize(&out);
+  }
+}
+
+static void bm_ranges_move_vb_aligned(benchmark::State& state) { bm_ranges_move_vb(state, true); }
+static void bm_ranges_move_vb_unaligned(benchmark::State& state) { bm_ranges_move_vb(state, false); }
+
+static void bm_move_vb_aligned(benchmark::State& state) { bm_move_vb(state, true); }
+static void bm_move_vb_unaligned(benchmark::State& state) { bm_move_vb(state, false); }
+
+// Test std::ranges::move for vector<bool>::iterator
+BENCHMARK(bm_ranges_move_vb_aligned)->Range(8, 1 << 16)->DenseRange(102400, 204800, 4096);
+BENCHMARK(bm_ranges_move_vb_unaligned)->Range(8, 1 << 20);
+
+// Test std::move for vector<bool>::iterator
+BENCHMARK(bm_move_vb_aligned)->Range(8, 1 << 20);
+BENCHMARK(bm_move_vb_unaligned)->Range(8, 1 << 20);
+
+BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/algorithms/move.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/move.bench.cpp
@@ -10,46 +10,61 @@
 
 #include <algorithm>
 #include <benchmark/benchmark.h>
+#include <ranges>
 #include <vector>
 
-static void bm_ranges_move_vb(benchmark::State& state, bool aligned) {
+template <bool aligned>
+void bm_ranges_move_vb(benchmark::State& state) {
   auto n = state.range();
-  std::vector<bool> in(n, true);
-  std::vector<bool> out(aligned ? n : n + 8);
-  benchmark::DoNotOptimize(&in);
-  auto dst = aligned ? out.begin() : out.begin() + 4;
+  std::vector<bool> v1(n, true);
+  std::vector<bool> v2(n, false);
+  benchmark::DoNotOptimize(v1);
+  benchmark::DoNotOptimize(v2);
+  std::vector<bool>* in  = &v1;
+  std::vector<bool>* out = &v2;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(std::ranges::move(in, dst));
-    benchmark::DoNotOptimize(&out);
+    if constexpr (aligned) {
+      benchmark::DoNotOptimize(std::ranges::move(*in, std::ranges::begin(*out)));
+    } else {
+      benchmark::DoNotOptimize(std::ranges::move(*in | std::views::drop(4), std::ranges::begin(*out)));
+    }
+    std::swap(in, out);
+    benchmark::DoNotOptimize(in);
+    benchmark::DoNotOptimize(out);
   }
 }
 
-static void bm_move_vb(benchmark::State& state, bool aligned) {
+template <bool aligned>
+void bm_move_vb(benchmark::State& state) {
   auto n = state.range();
-  std::vector<bool> in(n, true);
-  std::vector<bool> out(aligned ? n : n + 8);
-  benchmark::DoNotOptimize(&in);
-  auto beg = in.begin();
-  auto end = in.end();
-  auto dst = aligned ? out.begin() : out.begin() + 4;
+  std::vector<bool> v1(n, true);
+  std::vector<bool> v2(n, false);
+  benchmark::DoNotOptimize(v1);
+  benchmark::DoNotOptimize(v2);
+  std::vector<bool>* in  = &v1;
+  std::vector<bool>* out = &v2;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(std::move(beg, end, dst));
-    benchmark::DoNotOptimize(&out);
+    auto first1 = in->begin();
+    auto last1  = in->end();
+    auto first2 = out->begin();
+    if constexpr (aligned) {
+      benchmark::DoNotOptimize(std::move(first1, last1, first2));
+    } else {
+      benchmark::DoNotOptimize(std::move(first1 + 4, last1, first2));
+    }
+    std::swap(in, out);
+    benchmark::DoNotOptimize(in);
+    benchmark::DoNotOptimize(out);
   }
 }
 
-static void bm_ranges_move_vb_aligned(benchmark::State& state) { bm_ranges_move_vb(state, true); }
-static void bm_ranges_move_vb_unaligned(benchmark::State& state) { bm_ranges_move_vb(state, false); }
+BENCHMARK(bm_ranges_move_vb<true>)
+    ->Name("bm_ranges_move_vb_aligned")
+    ->Range(8, 1 << 16)
+    ->DenseRange(102400, 204800, 4096);
+BENCHMARK(bm_ranges_move_vb<false>)->Name("bm_ranges_move_vb_unaligned")->Range(8, 1 << 20);
 
-static void bm_move_vb_aligned(benchmark::State& state) { bm_move_vb(state, true); }
-static void bm_move_vb_unaligned(benchmark::State& state) { bm_move_vb(state, false); }
-
-// Test std::ranges::move for vector<bool>::iterator
-BENCHMARK(bm_ranges_move_vb_aligned)->Range(8, 1 << 16)->DenseRange(102400, 204800, 4096);
-BENCHMARK(bm_ranges_move_vb_unaligned)->Range(8, 1 << 20);
-
-// Test std::move for vector<bool>::iterator
-BENCHMARK(bm_move_vb_aligned)->Range(8, 1 << 20);
-BENCHMARK(bm_move_vb_unaligned)->Range(8, 1 << 20);
+BENCHMARK(bm_move_vb<true>)->Name("bm_move_vb_aligned")->Range(8, 1 << 20);
+BENCHMARK(bm_move_vb<false>)->Name("bm_move_vb_unaligned")->Range(8, 1 << 20);
 
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/algorithms/move.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/move.bench.cpp
@@ -26,7 +26,8 @@ void bm_ranges_move_vb(benchmark::State& state) {
     if constexpr (aligned) {
       benchmark::DoNotOptimize(std::ranges::move(*in, std::ranges::begin(*out)));
     } else {
-      benchmark::DoNotOptimize(std::ranges::move(*in | std::views::drop(4), std::ranges::begin(*out)));
+      benchmark::DoNotOptimize(
+          std::ranges::move(std::views::counted(in->begin() + 4, n - 4), std::ranges::begin(*out)));
     }
     std::swap(in, out);
     benchmark::DoNotOptimize(in);

--- a/libcxx/test/benchmarks/algorithms/move_backward.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/move_backward.bench.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+
+#include <algorithm>
+#include <benchmark/benchmark.h>
+#include <vector>
+
+static void bm_ranges_move_backward_vb(benchmark::State& state, bool aligned) {
+  auto n = state.range();
+  std::vector<bool> in(n, true);
+  std::vector<bool> out(aligned ? n : n + 8);
+  benchmark::DoNotOptimize(&in);
+  auto dst = aligned ? out.end() : out.end() - 4;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(std::ranges::move_backward(in, dst));
+    benchmark::DoNotOptimize(&out);
+  }
+}
+
+static void bm_move_backward(benchmark::State& state, bool aligned) {
+  auto n = state.range();
+  std::vector<bool> in(n, true);
+  std::vector<bool> out(aligned ? n : n + 8);
+  benchmark::DoNotOptimize(&in);
+  auto beg = in.begin();
+  auto end = in.end();
+  auto dst = aligned ? out.end() : out.end() - 4;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(std::move_backward(beg, end, dst));
+    benchmark::DoNotOptimize(&out);
+  }
+}
+
+static void bm_ranges_move_backward_vb_aligned(benchmark::State& state) { bm_ranges_move_backward_vb(state, true); }
+static void bm_ranges_move_backward_vb_unaligned(benchmark::State& state) { bm_ranges_move_backward_vb(state, false); }
+
+static void bm_move_backward_vb_aligned(benchmark::State& state) { bm_move_backward(state, true); }
+static void bm_move_backward_vb_unaligned(benchmark::State& state) { bm_move_backward(state, false); }
+
+// Test std::ranges::move_backward for vector<bool>::iterator
+BENCHMARK(bm_ranges_move_backward_vb_aligned)->Range(8, 1 << 16)->DenseRange(102400, 204800, 4096);
+BENCHMARK(bm_ranges_move_backward_vb_unaligned)->Range(8, 1 << 20);
+
+// Test std::move_backward for vector<bool>::iterator
+BENCHMARK(bm_move_backward_vb_aligned)->Range(8, 1 << 20);
+BENCHMARK(bm_move_backward_vb_unaligned)->Range(8, 1 << 20);
+
+BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/algorithms/move_backward.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/move_backward.bench.cpp
@@ -26,7 +26,8 @@ void bm_ranges_move_backward_vb(benchmark::State& state) {
     if constexpr (aligned) {
       benchmark::DoNotOptimize(std::ranges::move_backward(*in, std::ranges::end(*out)));
     } else {
-      benchmark::DoNotOptimize(std::ranges::move_backward(*in | std::views::take(n - 4), std::ranges::end(*out)));
+      benchmark::DoNotOptimize(
+          std::ranges::move_backward(std::views::counted(in->begin(), n - 4), std::ranges::end(*out)));
     }
     std::swap(in, out);
     benchmark::DoNotOptimize(in);

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <iterator>
 #include <memory>
+#include <vector>
 
 #include "MoveOnly.h"
 #include "test_iterators.h"
@@ -45,15 +46,15 @@ struct Test {
   template <class OutIter>
   TEST_CONSTEXPR_CXX20 void operator()() {
     const unsigned N = 1000;
-    int ia[N] = {};
+    int ia[N]        = {};
     for (unsigned i = 0; i < N; ++i)
-        ia[i] = i;
+      ia[i] = i;
     int ib[N] = {0};
 
-    OutIter r = std::move(InIter(ia), InIter(ia+N), OutIter(ib));
-    assert(base(r) == ib+N);
+    OutIter r = std::move(InIter(ia), InIter(ia + N), OutIter(ib));
+    assert(base(r) == ib + N);
     for (unsigned i = 0; i < N; ++i)
-        assert(ia[i] == ib[i]);
+      assert(ia[i] == ib[i]);
   }
 };
 
@@ -73,13 +74,13 @@ struct Test1 {
     const unsigned N = 100;
     std::unique_ptr<int> ia[N];
     for (unsigned i = 0; i < N; ++i)
-        ia[i].reset(new int(i));
+      ia[i].reset(new int(i));
     std::unique_ptr<int> ib[N];
 
-    OutIter r = std::move(InIter(ia), InIter(ia+N), OutIter(ib));
-    assert(base(r) == ib+N);
+    OutIter r = std::move(InIter(ia), InIter(ia + N), OutIter(ib));
+    assert(base(r) == ib + N);
     for (unsigned i = 0; i < N; ++i)
-        assert(*ib[i] == static_cast<int>(i));
+      assert(*ib[i] == static_cast<int>(i));
   }
 };
 
@@ -91,6 +92,26 @@ struct Test1OutIters {
                     Test1<InIter>());
   }
 };
+
+TEST_CONSTEXPR_CXX20 bool test_vector_bool(std::size_t N) {
+  std::vector<bool> in(N, false);
+  for (std::size_t i = 0; i < N; i += 2)
+    in[i] = true;
+
+  { // Test move with aligned bytes
+    std::vector<bool> out(N);
+    std::move(in.begin(), in.end(), out.begin());
+    assert(in == out);
+  }
+  { // Test move with unaligned bytes
+    std::vector<bool> out(N + 8);
+    std::move(in.begin(), in.end(), out.begin() + 4);
+    for (std::size_t i = 0; i < N; ++i)
+      assert(out[i + 4] == in[i]);
+  }
+
+  return true;
+}
 
 TEST_CONSTEXPR_CXX20 bool test() {
   types::for_each(types::cpp17_input_iterator_list<int*>(), TestOutIters());
@@ -118,7 +139,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
     // When non-trivial
     {
       MoveOnly from[3] = {1, 2, 3};
-      MoveOnly to[3] = {};
+      MoveOnly to[3]   = {};
       std::move(std::begin(from), std::end(from), std::begin(to));
       assert(to[0] == MoveOnly(1));
       assert(to[1] == MoveOnly(2));
@@ -127,12 +148,22 @@ TEST_CONSTEXPR_CXX20 bool test() {
     // When trivial
     {
       TrivialMoveOnly from[3] = {1, 2, 3};
-      TrivialMoveOnly to[3] = {};
+      TrivialMoveOnly to[3]   = {};
       std::move(std::begin(from), std::end(from), std::begin(to));
       assert(to[0] == TrivialMoveOnly(1));
       assert(to[1] == TrivialMoveOnly(2));
       assert(to[2] == TrivialMoveOnly(3));
     }
+  }
+
+  { // Test vector<bool>::iterator optimization
+    assert(test_vector_bool(8));
+    assert(test_vector_bool(19));
+    assert(test_vector_bool(32));
+    assert(test_vector_bool(49));
+    assert(test_vector_bool(64));
+    assert(test_vector_bool(199));
+    assert(test_vector_bool(256));
   }
 
   return true;

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/move.pass.cpp
@@ -94,20 +94,22 @@ struct Test1OutIters {
 };
 
 TEST_CONSTEXPR_CXX20 bool test_vector_bool(std::size_t N) {
-  std::vector<bool> in(N, false);
+  std::vector<bool> v(N, false);
   for (std::size_t i = 0; i < N; i += 2)
-    in[i] = true;
+    v[i] = true;
 
   { // Test move with aligned bytes
+    std::vector<bool> in(v);
     std::vector<bool> out(N);
     std::move(in.begin(), in.end(), out.begin());
-    assert(in == out);
+    assert(out == v);
   }
   { // Test move with unaligned bytes
-    std::vector<bool> out(N + 8);
-    std::move(in.begin(), in.end(), out.begin() + 4);
-    for (std::size_t i = 0; i < N; ++i)
-      assert(out[i + 4] == in[i]);
+    std::vector<bool> in(v);
+    std::vector<bool> out(N);
+    std::move(in.begin() + 4, in.end(), out.begin());
+    for (std::size_t i = 0; i < N - 4; ++i)
+      assert(v[i + 4] == out[i]);
   }
 
   return true;

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/move_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/move_backward.pass.cpp
@@ -90,20 +90,22 @@ struct Test1OutIters {
 };
 
 TEST_CONSTEXPR_CXX20 bool test_vector_bool(std::size_t N) {
-  std::vector<bool> in(N, false);
+  std::vector<bool> v(N, false);
   for (std::size_t i = 0; i < N; i += 2)
-    in[i] = true;
+    v[i] = true;
 
   { // Test move_backward with aligned bytes
+    std::vector<bool> in(v);
     std::vector<bool> out(N);
     std::move_backward(in.begin(), in.end(), out.end());
-    assert(in == out);
+    assert(out == v);
   }
   { // Test move_backward with unaligned bytes
-    std::vector<bool> out(N + 8);
-    std::move_backward(in.begin(), in.end(), out.end() - 4);
-    for (std::size_t i = 0; i < N; ++i)
-      assert(out[i + 4] == in[i]);
+    std::vector<bool> in(v);
+    std::vector<bool> out(N);
+    std::move_backward(in.begin(), in.end() - 4, out.end());
+    for (std::size_t i = 0; i < N - 4; ++i)
+      assert(out[i + 4] == v[i]);
   }
 
   return true;

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
@@ -190,20 +190,21 @@ struct IteratorWithMoveIter {
 
 #if TEST_STD_VER >= 23
 constexpr bool test_vector_bool(std::size_t N) {
-  std::vector<bool> in(N, false);
+  std::vector<bool> v(N, false);
   for (std::size_t i = 0; i < N; i += 2)
-    in[i] = true;
+    v[i] = true;
 
   { // Test move with aligned bytes
+    std::vector<bool> in{v};
     std::vector<bool> out(N);
     std::ranges::move(in, out.begin());
-    assert(in == out);
+    assert(out == v);
   }
   { // Test move with unaligned bytes
-    std::vector<bool> out(N + 8);
-    std::ranges::move(in, out.begin() + 4);
-    for (std::size_t i = 0; i < N; ++i)
-      assert(out[i + 4] == in[i]);
+    std::vector<bool> in{v};
+    std::vector<bool> out(N);
+    std::ranges::move(in | std::views::drop(4), out.begin());
+    assert(std::ranges::equal(v | std::views::drop(4), out | std::views::take(N - 4)));
   }
 
   return true;

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
@@ -31,6 +31,7 @@
 #include "almost_satisfies_types.h"
 #include "MoveOnly.h"
 #include "test_iterators.h"
+#include "test_macros.h"
 
 template <class In, class Out = In, class Sent = sentinel_wrapper<In>>
 concept HasMoveIt = requires(In in, Sent sent, Out out) { std::ranges::move(in, sent, out); };
@@ -65,7 +66,7 @@ constexpr void test(std::array<int, N> in) {
   {
     std::array<int, N> out;
     std::same_as<std::ranges::in_out_result<In, Out>> decltype(auto) ret =
-      std::ranges::move(In(in.data()), Sent(In(in.data() + in.size())), Out(out.data()));
+        std::ranges::move(In(in.data()), Sent(In(in.data() + in.size())), Out(out.data()));
     assert(in == out);
     assert(base(ret.in) == in.data() + in.size());
     assert(base(ret.out) == out.data() + out.size());
@@ -73,8 +74,7 @@ constexpr void test(std::array<int, N> in) {
   {
     std::array<int, N> out;
     auto range = std::ranges::subrange(In(in.data()), Sent(In(in.data() + in.size())));
-    std::same_as<std::ranges::in_out_result<In, Out>> decltype(auto) ret =
-        std::ranges::move(range, Out(out.data()));
+    std::same_as<std::ranges::in_out_result<In, Out>> decltype(auto) ret = std::ranges::move(range, Out(out.data()));
     assert(in == out);
     assert(base(ret.in) == in.data() + in.size());
     assert(base(ret.out) == out.data() + out.size());
@@ -84,16 +84,16 @@ constexpr void test(std::array<int, N> in) {
 template <class InContainer, class OutContainer, class In, class Out, class Sent = In>
 constexpr void test_containers() {
   {
-    InContainer in {1, 2, 3, 4};
+    InContainer in{1, 2, 3, 4};
     OutContainer out(4);
     std::same_as<std::ranges::in_out_result<In, Out>> auto ret =
-      std::ranges::move(In(in.begin()), Sent(In(in.end())), Out(out.begin()));
+        std::ranges::move(In(in.begin()), Sent(In(in.end())), Out(out.begin()));
     assert(std::ranges::equal(in, out));
     assert(base(ret.in) == in.end());
     assert(base(ret.out) == out.end());
   }
   {
-    InContainer in {1, 2, 3, 4};
+    InContainer in{1, 2, 3, 4};
     OutContainer out(4);
     auto range = std::ranges::subrange(In(in.begin()), Sent(In(in.end())));
     std::same_as<std::ranges::in_out_result<In, Out>> auto ret = std::ranges::move(range, Out(out.begin()));
@@ -165,21 +165,50 @@ constexpr void test_proxy_in_iterators() {
 }
 
 struct IteratorWithMoveIter {
-  using value_type = int;
-  using difference_type = int;
+  using value_type                = int;
+  using difference_type           = int;
   explicit IteratorWithMoveIter() = default;
   int* ptr;
   constexpr IteratorWithMoveIter(int* ptr_) : ptr(ptr_) {}
 
   constexpr int& operator*() const; // iterator with iter_move should not be dereferenced
 
-  constexpr IteratorWithMoveIter& operator++() { ++ptr; return *this; }
-  constexpr IteratorWithMoveIter operator++(int) { auto ret = *this; ++*this; return ret; }
+  constexpr IteratorWithMoveIter& operator++() {
+    ++ptr;
+    return *this;
+  }
+  constexpr IteratorWithMoveIter operator++(int) {
+    auto ret = *this;
+    ++*this;
+    return ret;
+  }
 
   friend constexpr int iter_move(const IteratorWithMoveIter&) { return 42; }
 
   constexpr bool operator==(const IteratorWithMoveIter& other) const = default;
 };
+
+#if TEST_STD_VER >= 23
+constexpr bool test_vector_bool(std::size_t N) {
+  std::vector<bool> in(N, false);
+  for (std::size_t i = 0; i < N; i += 2)
+    in[i] = true;
+
+  { // Test move with aligned bytes
+    std::vector<bool> out(N);
+    std::ranges::move(in, out.begin());
+    assert(in == out);
+  }
+  { // Test move with unaligned bytes
+    std::vector<bool> out(N + 8);
+    std::ranges::move(in, out.begin() + 4);
+    for (std::size_t i = 0; i < N; ++i)
+      assert(out[i + 4] == in[i]);
+  }
+
+  return true;
+}
+#endif
 
 // cpp17_intput_iterator has a defaulted template argument
 template <class Iter>
@@ -267,13 +296,13 @@ constexpr bool test() {
   { // check that ranges::dangling is returned
     std::array<int, 4> out;
     std::same_as<std::ranges::in_out_result<std::ranges::dangling, int*>> decltype(auto) ret =
-      std::ranges::move(std::array {1, 2, 3, 4}, out.data());
+        std::ranges::move(std::array{1, 2, 3, 4}, out.data());
     assert(ret.out == out.data() + 4);
     assert((out == std::array{1, 2, 3, 4}));
   }
 
   { // check that an iterator is returned with a borrowing range
-    std::array in {1, 2, 3, 4};
+    std::array in{1, 2, 3, 4};
     std::array<int, 4> out;
     std::same_as<std::ranges::in_out_result<std::array<int, 4>::iterator, int*>> decltype(auto) ret =
         std::ranges::move(std::views::all(in), out.data());
@@ -284,8 +313,8 @@ constexpr bool test() {
 
   { // check that every element is moved exactly once
     struct MoveOnce {
-      bool moved = false;
-      constexpr MoveOnce() = default;
+      bool moved                                = false;
+      constexpr MoveOnce()                      = default;
       constexpr MoveOnce(const MoveOnce& other) = delete;
       constexpr MoveOnce& operator=(MoveOnce&& other) {
         assert(!other.moved);
@@ -294,16 +323,16 @@ constexpr bool test() {
       }
     };
     {
-      std::array<MoveOnce, 4> in {};
-      std::array<MoveOnce, 4> out {};
+      std::array<MoveOnce, 4> in{};
+      std::array<MoveOnce, 4> out{};
       auto ret = std::ranges::move(in.begin(), in.end(), out.begin());
       assert(ret.in == in.end());
       assert(ret.out == out.end());
       assert(std::all_of(out.begin(), out.end(), [](const auto& e) { return e.moved; }));
     }
     {
-      std::array<MoveOnce, 4> in {};
-      std::array<MoveOnce, 4> out {};
+      std::array<MoveOnce, 4> in{};
+      std::array<MoveOnce, 4> out{};
       auto ret = std::ranges::move(in, out.begin());
       assert(ret.in == in.end());
       assert(ret.out == out.end());
@@ -314,8 +343,8 @@ constexpr bool test() {
   { // check that the range is moved forwards
     struct OnlyForwardsMovable {
       OnlyForwardsMovable* next = nullptr;
-      bool canMove = false;
-      OnlyForwardsMovable() = default;
+      bool canMove              = false;
+      OnlyForwardsMovable()     = default;
       constexpr OnlyForwardsMovable& operator=(OnlyForwardsMovable&&) {
         assert(canMove);
         if (next != nullptr)
@@ -324,12 +353,12 @@ constexpr bool test() {
       }
     };
     {
-      std::array<OnlyForwardsMovable, 3> in {};
-      std::array<OnlyForwardsMovable, 3> out {};
-      out[0].next = &out[1];
-      out[1].next = &out[2];
+      std::array<OnlyForwardsMovable, 3> in{};
+      std::array<OnlyForwardsMovable, 3> out{};
+      out[0].next    = &out[1];
+      out[1].next    = &out[2];
       out[0].canMove = true;
-      auto ret = std::ranges::move(in.begin(), in.end(), out.begin());
+      auto ret       = std::ranges::move(in.begin(), in.end(), out.begin());
       assert(ret.in == in.end());
       assert(ret.out == out.end());
       assert(out[0].canMove);
@@ -337,12 +366,12 @@ constexpr bool test() {
       assert(out[2].canMove);
     }
     {
-      std::array<OnlyForwardsMovable, 3> in {};
-      std::array<OnlyForwardsMovable, 3> out {};
-      out[0].next = &out[1];
-      out[1].next = &out[2];
+      std::array<OnlyForwardsMovable, 3> in{};
+      std::array<OnlyForwardsMovable, 3> out{};
+      out[0].next    = &out[1];
+      out[1].next    = &out[2];
       out[0].canMove = true;
-      auto ret = std::ranges::move(in, out.begin());
+      auto ret       = std::ranges::move(in, out.begin());
       assert(ret.in == in.end());
       assert(ret.out == out.end());
       assert(out[0].canMove);
@@ -358,18 +387,30 @@ constexpr bool test() {
       auto ret = std::ranges::move(IteratorWithMoveIter(a), IteratorWithMoveIter(a + 4), b.data());
       assert(ret.in == a + 4);
       assert(ret.out == b.data() + 4);
-      assert((b == std::array {42, 42, 42, 42}));
+      assert((b == std::array{42, 42, 42, 42}));
     }
     {
       int a[] = {1, 2, 3, 4};
       std::array<int, 4> b;
       auto range = std::ranges::subrange(IteratorWithMoveIter(a), IteratorWithMoveIter(a + 4));
-      auto ret = std::ranges::move(range, b.data());
+      auto ret   = std::ranges::move(range, b.data());
       assert(ret.in == a + 4);
       assert(ret.out == b.data() + 4);
-      assert((b == std::array {42, 42, 42, 42}));
+      assert((b == std::array{42, 42, 42, 42}));
     }
   }
+
+#if TEST_STD_VER >= 23
+  { // Test vector<bool>::iterator optimization
+    assert(test_vector_bool(8));
+    assert(test_vector_bool(19));
+    assert(test_vector_bool(32));
+    assert(test_vector_bool(49));
+    assert(test_vector_bool(64));
+    assert(test_vector_bool(199));
+    assert(test_vector_bool(256));
+  }
+#endif
 
   return true;
 }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move.pass.cpp
@@ -203,7 +203,7 @@ constexpr bool test_vector_bool(std::size_t N) {
   { // Test move with unaligned bytes
     std::vector<bool> in{v};
     std::vector<bool> out(N);
-    std::ranges::move(in | std::views::drop(4), out.begin());
+    std::ranges::move(std::views::counted(in.begin() + 4, N - 4), out.begin());
     assert(std::ranges::equal(v | std::views::drop(4), out | std::views::take(N - 4)));
   }
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.pass.cpp
@@ -195,20 +195,21 @@ struct IteratorWithMoveIter {
 
 #if TEST_STD_VER >= 23
 constexpr bool test_vector_bool(std::size_t N) {
-  std::vector<bool> in(N, false);
+  std::vector<bool> v(N, false);
   for (std::size_t i = 0; i < N; i += 2)
-    in[i] = true;
+    v[i] = true;
 
   { // Test move_backward with aligned bytes
+    std::vector<bool> in{v};
     std::vector<bool> out(N);
     std::ranges::move_backward(in, out.end());
-    assert(in == out);
+    assert(out == v);
   }
   { // Test move_backward with unaligned bytes
-    std::vector<bool> out(N + 8);
-    std::ranges::move_backward(in, out.end() - 4);
-    for (std::size_t i = 0; i < N; ++i)
-      assert(out[i + 4] == in[i]);
+    std::vector<bool> in{v};
+    std::vector<bool> out(N);
+    std::ranges::move_backward(in | std::views::take(N - 4), out.end());
+    assert(std::ranges::equal(v | std::views::take(N - 4), out | std::views::drop(4)));
   }
 
   return true;

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.move/ranges.move_backward.pass.cpp
@@ -208,7 +208,7 @@ constexpr bool test_vector_bool(std::size_t N) {
   { // Test move_backward with unaligned bytes
     std::vector<bool> in{v};
     std::vector<bool> out(N);
-    std::ranges::move_backward(in | std::views::take(N - 4), out.end());
+    std::ranges::move_backward(std::views::counted(in.begin(), N - 4), out.end());
     assert(std::ranges::equal(v | std::views::take(N - 4), out | std::views::drop(4)));
   }
 


### PR DESCRIPTION
As a follow-up to #121013 (which optimized `ranges::copy`) and #121026 (which optimized `ranges::copy_backward`), this PR enhances the performance of `std::ranges::{move, move_backward}` for `vector<bool>::iterator`, addressing a subtask outlined in issue #64038. 

The optimizations bring performance improvements analogous to those achieved for the `{copy, copy_backward}` algorithms: up to **2000x** for aligned moves and **60x** for unaligned moves. Moreover, comprehensive tests covering up to 4 storage words (256 bytes) with odd and even bit sizes are provided, which validate the proposed optimizations in this patch. 

### Benchmarks 

 #### Aligned move (up to 2111x)

```
---------------------------------------------------------------------------
Benchmark                                  Before        After  Improvement
---------------------------------------------------------------------------
bm_ranges_move_vb_aligned/8               11.4 ns      5.29 ns           2x
bm_ranges_move_vb_aligned/64              92.1 ns      5.73 ns          16x
bm_ranges_move_vb_aligned/512              729 ns      5.31 ns         137x
bm_ranges_move_vb_aligned/4096            5759 ns      10.4 ns        1168x
bm_ranges_move_vb_aligned/32768          45092 ns      38.6 ns        15424
bm_ranges_move_vb_aligned/65536          91119 ns      63.5 ns        1435x
bm_ranges_move_vb_aligned/102400        141736 ns       112 ns        1266x
bm_ranges_move_vb_aligned/106496        146472 ns       116 ns        1263x
bm_ranges_move_vb_aligned/110592        153312 ns       121 ns        1267x
bm_ranges_move_vb_aligned/114688        159366 ns       125 ns        1275x
bm_ranges_move_vb_aligned/118784        164790 ns       130 ns        1267x
bm_ranges_move_vb_aligned/122880        171524 ns       136 ns        1261x
bm_ranges_move_vb_aligned/126976        175769 ns       143 ns        1229x
bm_ranges_move_vb_aligned/131072        182248 ns       175 ns        1041x
bm_ranges_move_vb_aligned/135168        188863 ns       177 ns        1067x
bm_ranges_move_vb_aligned/139264        192792 ns       165 ns        1168x
bm_ranges_move_vb_aligned/143360        194506 ns       156 ns        1247x
bm_ranges_move_vb_aligned/147456        203244 ns       160 ns        1270x
bm_ranges_move_vb_aligned/151552        207067 ns      99.4 ns        2083x
bm_ranges_move_vb_aligned/155648        213459 ns       116 ns        1840x
bm_ranges_move_vb_aligned/159744        219885 ns       162 ns        1357x
bm_ranges_move_vb_aligned/163840        228873 ns       142 ns        1612x
bm_ranges_move_vb_aligned/167936        233786 ns       160 ns        1461x
bm_ranges_move_vb_aligned/172032        236231 ns       129 ns        1831x
bm_ranges_move_vb_aligned/176128        247542 ns       119 ns        2080x
bm_ranges_move_vb_aligned/180224        249135 ns       118 ns        2111x
bm_ranges_move_vb_aligned/184320        253485 ns       123 ns        2060x
bm_ranges_move_vb_aligned/188416        258189 ns       148 ns        1745x
bm_ranges_move_vb_aligned/192512        267000 ns       207 ns        1290x
bm_ranges_move_vb_aligned/196608        269285 ns       185 ns        1456x
bm_ranges_move_vb_aligned/200704        279332 ns       238 ns        1174x
bm_ranges_move_vb_aligned/204800        286305 ns       236 ns        1213x
```

#### Aligned move_backward (up to 2233x)

```
-----------------------------------------------------------------------------------
Benchmark                                           Before       After  Improvement
-----------------------------------------------------------------------------------
bm_ranges_move_backward_vb_aligned/8               11.3 ns     5.81 ns           2x
bm_ranges_move_backward_vb_aligned/64              82.2 ns     6.15 ns          13x
bm_ranges_move_backward_vb_aligned/512              651 ns     5.59 ns         116x
bm_ranges_move_backward_vb_aligned/4096            5234 ns     10.9 ns         480x
bm_ranges_move_backward_vb_aligned/32768          42212 ns     39.0 ns        1082x
bm_ranges_move_backward_vb_aligned/65536          84501 ns     63.0 ns        1341x
bm_ranges_move_backward_vb_aligned/102400        133306 ns     62.0 ns        2150x
bm_ranges_move_backward_vb_aligned/106496        140072 ns     63.6 ns        2202x
bm_ranges_move_backward_vb_aligned/110592        147510 ns     66.4 ns        2222x
bm_ranges_move_backward_vb_aligned/114688        147312 ns     68.0 ns        2166x
bm_ranges_move_backward_vb_aligned/118784        155653 ns     70.7 ns        2202x
bm_ranges_move_backward_vb_aligned/122880        161665 ns     72.4 ns        2233x
bm_ranges_move_backward_vb_aligned/126976        164021 ns     76.6 ns        2142x
bm_ranges_move_backward_vb_aligned/131072        171836 ns     76.9 ns        2235x
bm_ranges_move_backward_vb_aligned/135168        177469 ns      128 ns        1386x
bm_ranges_move_backward_vb_aligned/139264        180642 ns     99.6 ns        1814x
bm_ranges_move_backward_vb_aligned/143360        186952 ns     90.3 ns        2070x
bm_ranges_move_backward_vb_aligned/147456        192811 ns     90.7 ns        2126x
bm_ranges_move_backward_vb_aligned/151552        201549 ns     94.3 ns        2137x
bm_ranges_move_backward_vb_aligned/155648        205928 ns      111 ns        1855x
bm_ranges_move_backward_vb_aligned/159744        210829 ns      152 ns        1387x
bm_ranges_move_backward_vb_aligned/163840        213758 ns      137 ns        1560x
bm_ranges_move_backward_vb_aligned/167936        221136 ns      153 ns        1445x
bm_ranges_move_backward_vb_aligned/172032        225363 ns      124 ns        1817x
bm_ranges_move_backward_vb_aligned/176128        230920 ns      116 ns        1991x
bm_ranges_move_backward_vb_aligned/180224        237196 ns      117 ns        2027x
bm_ranges_move_backward_vb_aligned/184320        243265 ns      123 ns        1978x
bm_ranges_move_backward_vb_aligned/188416        244984 ns      143 ns        1713x
bm_ranges_move_backward_vb_aligned/192512        252805 ns      197 ns        1283x
bm_ranges_move_backward_vb_aligned/196608        259500 ns      185 ns        1403x
bm_ranges_move_backward_vb_aligned/200704        260624 ns      231 ns        1128x
bm_ranges_move_backward_vb_aligned/204800        268815 ns      239 ns        1125x
```


 #### Unaligned move (up to 67x)

```
---------------------------------------------------------------------------
Benchmark                                  Before        After  Improvement
---------------------------------------------------------------------------
bm_ranges_move_vb_unaligned/8             6.23 ns      10.4 ns         0.6x
bm_ranges_move_vb_unaligned/64            89.3 ns      10.3 ns           9x
bm_ranges_move_vb_unaligned/512            741 ns      18.9 ns          39x
bm_ranges_move_vb_unaligned/4096          6059 ns      96.7 ns          63x
bm_ranges_move_vb_unaligned/32768        49585 ns       747 ns          66x
bm_ranges_move_vb_unaligned/262144      395276 ns      5895 ns          67x
bm_ranges_move_vb_unaligned/1048576    1567811 ns     23451 ns          67x
```

 #### Unaligned move_backward (up to 60x)

```
-----------------------------------------------------------------------------------
Benchmark                                           Before       After  Improvement
-----------------------------------------------------------------------------------
bm_ranges_move_backward_vb_unaligned/8             5.63 ns     10.2 ns         0.5x
bm_ranges_move_backward_vb_unaligned/64            88.2 ns     9.43 ns           9x
bm_ranges_move_backward_vb_unaligned/512            727 ns     18.4 ns          40x
bm_ranges_move_backward_vb_unaligned/4096          5789 ns      103 ns          56x
bm_ranges_move_backward_vb_unaligned/32768        45744 ns      835 ns          55x
bm_ranges_move_backward_vb_unaligned/262144      377009 ns     6307 ns          60x
bm_ranges_move_backward_vb_unaligned/1048576    1507192 ns    25390 ns          59x
```

