### PR TITLE
[mlir][emitc] Fix invalid syntax in example of emitc.return

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -727,7 +727,7 @@ def EmitC_ReturnOp : EmitC_Op<"return", [Pure, HasParent<"FuncOp">,
     Example:
 
     ```mlir
-    emitc.func @foo() : (i32) {
+    emitc.func @foo() -> (i32) {
       ...
       emitc.return %0 : i32
     }


### PR DESCRIPTION
A return type of `emitc.func` must be specified with `->` instead of `:`.
I've verified the syntax using `mlir-translate --mlir-to-cpp`.