### PR TITLE
[Polly] Fix gtest logic for standalone builds

### DIFF
--- a/polly/CMakeLists.txt
+++ b/polly/CMakeLists.txt
@@ -29,11 +29,7 @@ if(POLLY_STANDALONE_BUILD)
 
   # Enable unit tests if available.
   set(POLLY_GTEST_AVAIL 0)
-  set(UNITTEST_DIR ${LLVM_THIRD_PARTY_DIR}/unittest)
-  if(EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h)
-    if (NOT TARGET gtest)
-      add_subdirectory(${UNITTEST_DIR} third-party/unittest)
-    endif()
+  if(TARGET llvm_gtest)
     set(POLLY_GTEST_AVAIL 1)
   endif()
 


### PR DESCRIPTION
Fix the gtest logic to account for llvm_gtest being installed as part of LLVM, as of 91b3ca39667b6341a8c1983a1467fae14b58318b.