### PR TITLE
[libc] add __stack_chk_guard to generic

### DIFF
--- a/libc/src/compiler/generic/__stack_chk_fail.cpp
+++ b/libc/src/compiler/generic/__stack_chk_fail.cpp
@@ -12,6 +12,8 @@
 
 extern "C" {
 
+uintptr_t __stack_chk_guard = static_cast<uintptr_t>(0xa9fff01234);
+
 void __stack_chk_fail(void) {
   LIBC_NAMESPACE::write_to_stderr("stack smashing detected\n");
   LIBC_NAMESPACE::abort();


### PR DESCRIPTION
`__stack_chk_guard` is needed for many things and it's undefined so let's define it. If we need a more complex definition, we can do it per target or expand it. This is meant as a simple definition.