### PR TITLE
[clang] add llvm abi support

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1531,7 +1531,7 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
 
   // Check if the environment version is valid except wasm case.
   llvm::Triple Triple = TC.getTriple();
-  if (!Triple.isWasm()) {
+  if (!Triple.isWasm() && Triple.getEnvironment() != llvm::Triple::LLVM) {
     StringRef TripleVersionName = Triple.getEnvironmentVersionString();
     StringRef TripleObjectFormat =
         Triple.getObjectFormatTypeName(Triple.getObjectFormat());

--- a/clang/test/Driver/invalid-version.cpp
+++ b/clang/test/Driver/invalid-version.cpp
@@ -29,3 +29,13 @@
 // RUN:   FileCheck --check-prefix=CHECK-WASM1 %s
 
 // CHECK-WASM1: "-triple" "wasm32-unknown-wasi-pthread"
+
+// RUN: %clang --target=aarch64-unknown-linux-llvm -c %s -### 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-AARCH64-LLVM %s
+
+// CHECK-AARCH64-LLVM: "-triple" "aarch64-unknown-linux-llvm"
+
+// RUN: %clang --target=x86_64-unknown-linux-llvm -c %s -### 2>&1 | \
+// RUN:   FileCheck --check-prefix=CHECK-X86-64-LLVM %s
+
+// CHECK-X86-64-LLVM: "-triple" "x86_64-unknown-linux-llvm"


### PR DESCRIPTION
This PR makes it possible to use the LLVM ABI which uses LLVM libc.