### PR TITLE
[mlir][arith] DCE `getPredicateByName`

### DIFF
--- a/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
+++ b/mlir/include/mlir/Dialect/Arith/IR/ArithOps.td
@@ -1499,10 +1499,6 @@ def Arith_CmpIOp
                        SignlessIntegerLikeOfAnyRank:$lhs,
                        SignlessIntegerLikeOfAnyRank:$rhs);
 
-  let extraClassDeclaration = [{
-    static arith::CmpIPredicate getPredicateByName(StringRef name);
-  }];
-
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
@@ -1545,10 +1541,6 @@ def Arith_CmpFOp : Arith_CompareOp<"cmpf",
                        FloatLike:$rhs,
                        DefaultValuedAttr<
                          Arith_FastMathAttr, "::mlir::arith::FastMathFlags::none">:$fastmath);
-
-  let extraClassDeclaration = [{
-    static arith::CmpFPredicate getPredicateByName(StringRef name);
-  }];
 
   let hasFolder = 1;
   let hasCanonicalizer = 1;


### PR DESCRIPTION
This is dead code (no impls or uses anywhere in the code base) that causes linker errors in some build configurations.