### PR TITLE
[libc++] Optimize ranges::rotate for vector<bool>::iterator

### DIFF
--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -46,7 +46,7 @@ Implemented Papers
 Improvements and New Features
 -----------------------------
 
-- The ``std::ranges::{copy, copy_n, copy_backward, move, move_backward}`` algorithms have been optimized for
+- The ``std::ranges::{copy, copy_n, copy_backward, move, move_backward, rotate}`` algorithms have been optimized for
   ``std::vector<bool>::iterator``, resulting in a performance improvement of up to 2000x.
 
 - The ``std::ranges::equal`` algorithm has been optimized for ``std::vector<bool>::iterator``, resulting in a performance

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -16,6 +16,7 @@
 #include <__algorithm/copy_n.h>
 #include <__algorithm/equal.h>
 #include <__algorithm/min.h>
+#include <__algorithm/rotate.h>
 #include <__algorithm/swap_ranges.h>
 #include <__assert>
 #include <__bit/countr.h>
@@ -216,8 +217,6 @@ private:
         __mask_(__m) {}
 };
 
-// rotate
-
 template <class _Cp>
 struct __bit_array {
   using difference_type _LIBCPP_NODEBUG   = typename __size_difference_type_traits<_Cp>::difference_type;
@@ -248,45 +247,6 @@ struct __bit_array {
                     static_cast<unsigned>(__size_ % __bits_per_word));
   }
 };
-
-template <class _Cp>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false>
-rotate(__bit_iterator<_Cp, false> __first, __bit_iterator<_Cp, false> __middle, __bit_iterator<_Cp, false> __last) {
-  using _I1             = __bit_iterator<_Cp, false>;
-  using difference_type = typename _I1::difference_type;
-
-  difference_type __d1 = __middle - __first;
-  difference_type __d2 = __last - __middle;
-  _I1 __r              = __first + __d2;
-  while (__d1 != 0 && __d2 != 0) {
-    if (__d1 <= __d2) {
-      if (__d1 <= __bit_array<_Cp>::capacity()) {
-        __bit_array<_Cp> __b(__d1);
-        std::copy(__first, __middle, __b.begin());
-        std::copy(__b.begin(), __b.end(), std::copy(__middle, __last, __first));
-        break;
-      } else {
-        __bit_iterator<_Cp, false> __mp = std::swap_ranges(__first, __middle, __middle);
-        __first                         = __middle;
-        __middle                        = __mp;
-        __d2 -= __d1;
-      }
-    } else {
-      if (__d2 <= __bit_array<_Cp>::capacity()) {
-        __bit_array<_Cp> __b(__d2);
-        std::copy(__middle, __last, __b.begin());
-        std::copy_backward(__b.begin(), __b.end(), std::copy_backward(__first, __middle, __last));
-        break;
-      } else {
-        __bit_iterator<_Cp, false> __mp = __first + __d2;
-        std::swap_ranges(__first, __mp, __middle);
-        __first = __mp;
-        __d1 -= __d2;
-      }
-    }
-  }
-  return __r;
-}
 
 template <class _Cp, bool _IsConst, typename _Cp::__storage_type>
 class __bit_iterator {
@@ -507,9 +467,9 @@ private:
   template <class, class _Cl, class _Cr>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 friend pair<__bit_iterator<_Cl, false>, __bit_iterator<_Cr, false> >
       __swap_ranges(__bit_iterator<_Cl, false>, __bit_iterator<_Cl, false>, __bit_iterator<_Cr, false>);
-  template <class _Dp>
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 friend __bit_iterator<_Dp, false>
-      rotate(__bit_iterator<_Dp, false>, __bit_iterator<_Dp, false>, __bit_iterator<_Dp, false>);
+  template <class, class _Dp>
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 friend pair<__bit_iterator<_Dp, false>, __bit_iterator<_Dp, false> >
+      __rotate(__bit_iterator<_Dp, false>, __bit_iterator<_Dp, false>, __bit_iterator<_Dp, false>);
   template <class _Dp, bool _IsConst1, bool _IsConst2>
   _LIBCPP_CONSTEXPR_SINCE_CXX20 friend bool
       __equal_aligned(__bit_iterator<_Dp, _IsConst1>, __bit_iterator<_Dp, _IsConst1>, __bit_iterator<_Dp, _IsConst2>);

--- a/libcxx/include/__fwd/bit_reference.h
+++ b/libcxx/include/__fwd/bit_reference.h
@@ -23,6 +23,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Cp, bool _IsConst, typename _Cp::__storage_type = 0>
 class __bit_iterator;
 
+template <class _Cp>
+struct __bit_array;
+
 template <class, class = void>
 struct __size_difference_type_traits;
 

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -14,6 +14,7 @@
 #include <__algorithm/fill_n.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/max.h>
+#include <__algorithm/rotate.h>
 #include <__assert>
 #include <__bit_reference>
 #include <__config>

--- a/libcxx/test/benchmarks/algorithms/modifying/rotate.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/rotate.bench.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <iterator>
+#include <list>
+#include <ranges>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "../../GenerateInput.h"
+#include "test_macros.h"
+
+int main(int argc, char** argv) {
+  auto std_rotate = [](auto first, auto middle, auto last) { return std::rotate(first, middle, last); };
+
+  // Benchmark {std,ranges}::rotate where we rotate various fractions of the range. It is possible to
+  // special-case some of these fractions to cleverly perform swap_ranges.
+  {
+    auto bm = []<class Container>(std::string name, auto rotate, double fraction) {
+      benchmark::RegisterBenchmark(
+          name,
+          [=](auto& st) {
+            std::size_t const size = st.range(0);
+            using ValueType        = typename Container::value_type;
+            Container c;
+            std::generate_n(std::back_inserter(c), size, [] { return Generate<ValueType>::random(); });
+
+            auto nth = std::next(c.begin(), static_cast<std::size_t>(size * fraction));
+            for ([[maybe_unused]] auto _ : st) {
+              benchmark::DoNotOptimize(c);
+              auto result = rotate(c.begin(), nth, c.end());
+              benchmark::DoNotOptimize(result);
+            }
+          })
+          ->Arg(32)
+          ->Arg(50) // non power-of-two
+          ->RangeMultiplier(2)
+          ->Range(64, 1 << 20);
+    };
+
+    bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (by 1/4)", std_rotate, 0.25);
+    bm.operator()<std::vector<bool>>("std::rotate(vector<bool>) (by 51%)", std_rotate, 0.51);
+#if TEST_STD_VER >= 23 // vector<bool>::iterator is not std::permutable before C++23
+    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (by 1/4)", std::ranges::rotate, 0.25);
+    bm.operator()<std::vector<bool>>("rng::rotate(vector<bool>) (by 51%)", std::ranges::rotate, 0.51);
+#endif
+  }
+
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+  return 0;
+}

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/ranges_rotate.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/ranges_rotate.pass.cpp
@@ -21,8 +21,10 @@
 #include <array>
 #include <cassert>
 #include <ranges>
+#include <vector>
 
 #include "almost_satisfies_types.h"
+#include "test_macros.h"
 #include "test_iterators.h"
 #include "type_algorithms.h"
 
@@ -131,6 +133,29 @@ constexpr void test_iter_sent() {
   test_one<Iter, Sent, 7>({1, 2, 3, 4, 5, 6, 7}, 7, {1, 2, 3, 4, 5, 6, 7});
 }
 
+#if TEST_STD_VER >= 23
+template <std::size_t N>
+TEST_CONSTEXPR_CXX20 bool test_vector_bool() {
+  for (int offset = -4; offset <= 4; ++offset) {
+    std::vector<bool> a(N, false);
+    std::size_t mid = N / 2 + offset;
+    for (std::size_t i = mid; i < N; ++i)
+      a[i] = true;
+
+    // (iterator, sentinel)-overload
+    std::ranges::rotate(std::ranges::begin(a), std::ranges::begin(a) + mid, std::ranges::end(a));
+    for (std::size_t i = 0; i < N; ++i)
+      assert(a[i] == (i < N - mid));
+
+    // range-overload
+    std::ranges::rotate(a, std::ranges::begin(a) + (N - mid));
+    for (std::size_t i = 0; i < N; ++i)
+      assert(a[i] == (i >= mid));
+  }
+  return true;
+};
+#endif
+
 constexpr bool test() {
   types::for_each(types::forward_iterator_list<int*>(), []<class Iter>() {
     test_iter_sent<Iter, Iter>();
@@ -166,6 +191,16 @@ constexpr bool test() {
       }
     }
   }
+
+#if TEST_STD_VER >= 23
+  test_vector_bool<8>();
+  test_vector_bool<19>();
+  test_vector_bool<32>();
+  test_vector_bool<49>();
+  test_vector_bool<64>();
+  test_vector_bool<199>();
+  test_vector_bool<256>();
+#endif
 
   return true;
 }

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/rotate.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/rotate.pass.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <memory>
 #include <type_traits>
+#include <vector>
 
 #include "test_macros.h"
 #include "test_iterators.h"
@@ -420,6 +421,20 @@ struct TestUniquePtr {
 
 #endif // TEST_STD_VER >= 11
 
+template <std::size_t N>
+TEST_CONSTEXPR_CXX20 bool test_vector_bool() {
+  for (int offset = -4; offset <= 4; ++offset) {
+    std::vector<bool> a(N, false);
+    std::size_t mid = N / 2 + offset;
+    for (std::size_t i = mid; i < N; ++i)
+      a[i] = true;
+    std::rotate(a.begin(), a.begin() + mid, a.end());
+    for (std::size_t i = 0; i < N; ++i)
+      assert(a[i] == (i < N - mid));
+  }
+  return true;
+};
+
 TEST_CONSTEXPR_CXX20 bool test() {
   types::for_each(types::forward_iterator_list<int*>(), TestIter());
 
@@ -427,6 +442,14 @@ TEST_CONSTEXPR_CXX20 bool test() {
   if (TEST_STD_VER >= 23 || !TEST_IS_CONSTANT_EVALUATED)
     types::for_each(types::forward_iterator_list<std::unique_ptr<int>*>(), TestUniquePtr());
 #endif
+
+  test_vector_bool<8>();
+  test_vector_bool<19>();
+  test_vector_bool<32>();
+  test_vector_bool<49>();
+  test_vector_bool<64>();
+  test_vector_bool<199>();
+  test_vector_bool<256>();
 
   return true;
 }


### PR DESCRIPTION
This PR optimizes the performance of `std::ranges::rotate` for `vector<bool>::iterator`. The optimization yields a performance improvement of up to **2096x**.

```
-----------------------------------------------------------------------------------
Benchmark                                         Before        After   Improvement
-----------------------------------------------------------------------------------
rng::rotate(vector<bool>) (by 1/4)/32            73.4 ns      25.9 ns         2.8x
rng::rotate(vector<bool>) (by 1/4)/50             107 ns      25.8 ns         4.1x
rng::rotate(vector<bool>) (by 1/4)/64             124 ns      25.5 ns         4.9x
rng::rotate(vector<bool>) (by 1/4)/128            227 ns      26.3 ns         8.6x
rng::rotate(vector<bool>) (by 1/4)/256            439 ns      18.5 ns          24x
rng::rotate(vector<bool>) (by 1/4)/512            866 ns      18.9 ns          46x
rng::rotate(vector<bool>) (by 1/4)/1024          1698 ns      19.1 ns          89x
rng::rotate(vector<bool>) (by 1/4)/2048          3908 ns      27.4 ns         143x
rng::rotate(vector<bool>) (by 1/4)/4096         14057 ns      26.6 ns         528x
rng::rotate(vector<bool>) (by 1/4)/8192         32199 ns      36.9 ns         873x
rng::rotate(vector<bool>) (by 1/4)/16384        66743 ns      54.9 ns        1216x
rng::rotate(vector<bool>) (by 1/4)/32768       133562 ns      93.4 ns        1430x
rng::rotate(vector<bool>) (by 1/4)/65536       305561 ns       166 ns        1841x
rng::rotate(vector<bool>) (by 1/4)/131072      621524 ns       323 ns        1924x
rng::rotate(vector<bool>) (by 1/4)/262144     1230311 ns       587 ns        2096x
rng::rotate(vector<bool>) (by 1/4)/524288     2475596 ns      1454 ns        1703x
rng::rotate(vector<bool>) (by 1/4)/1048576    5003340 ns      3177 ns        1575x
rng::rotate(vector<bool>) (by 51%)/32            15.0 ns      27.3 ns       -0.45x
rng::rotate(vector<bool>) (by 51%)/50            15.1 ns      27.6 ns       -0.45x
rng::rotate(vector<bool>) (by 51%)/64            15.2 ns      27.1 ns       -0.44x
rng::rotate(vector<bool>) (by 51%)/128            268 ns      29.2 ns           9x
rng::rotate(vector<bool>) (by 51%)/256            646 ns      34.5 ns          19x
rng::rotate(vector<bool>) (by 51%)/512           1604 ns      39.2 ns          41x
rng::rotate(vector<bool>) (by 51%)/1024          3397 ns      66.3 ns          51x
rng::rotate(vector<bool>) (by 51%)/2048          7965 ns      87.0 ns          92x
rng::rotate(vector<bool>) (by 51%)/4096         16475 ns       156 ns         106x
rng::rotate(vector<bool>) (by 51%)/8192         35793 ns       249 ns         144x
rng::rotate(vector<bool>) (by 51%)/16384        73247 ns       783 ns          94x
rng::rotate(vector<bool>) (by 51%)/32768       150151 ns      1223 ns         123x
rng::rotate(vector<bool>) (by 51%)/65536       296511 ns      2197 ns         135x
rng::rotate(vector<bool>) (by 51%)/131072      596007 ns      3951 ns         151x
rng::rotate(vector<bool>) (by 51%)/262144     1241285 ns      7553 ns         164x
rng::rotate(vector<bool>) (by 51%)/524288     2660962 ns     14659 ns         182x
rng::rotate(vector<bool>) (by 51%)/1048576    5295160 ns     28842 ns         184x
```

Closes #64038.

(Note: I've adopted the same benchmark code `modifying/rotate.bench.cpp` from #127354 for consistency. This ensures minimum conflicts when merging them.)