### PR TITLE
[libc] add basic arena allocator

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -54,7 +54,7 @@ jobs:
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
         echo "build-install-dir=${{ github.workspace }}/install" >> "$GITHUB_OUTPUT"
     
-    # Configure libc fullbuild with scudo.
+    # Configure libc fullbuild.
     # Use MinSizeRel to reduce the size of the build.
     - name: Configure CMake
       run: >
@@ -65,12 +65,8 @@ jobs:
         -DCMAKE_C_COMPILER_LAUNCHER=sccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         -DCMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.build-install-dir }}
-        -DLLVM_ENABLE_RUNTIMES="libc;compiler-rt"
+        -DLLVM_ENABLE_RUNTIMES="libc"
         -DLLVM_LIBC_FULL_BUILD=ON
-        -DLLVM_LIBC_INCLUDE_SCUDO=ON
-        -DCOMPILER_RT_BUILD_SCUDO_STANDALONE_WITH_LLVM_LIBC=ON
-        -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
-        -DCOMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED=OFF
         -G Ninja
         -S ${{ github.workspace }}/runtimes
 

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -87,6 +87,7 @@ jobs:
         -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
         -DLLVM_ENABLE_RUNTIMES=libc
+        -DLIBC_CONF_ALLOC_TYPE=LIBC_ALLOC_TYPE_EXTERN
         -G Ninja
         -S ${{ github.workspace }}/runtimes
 

--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -384,6 +384,12 @@ else()
   set(libc_opt_high_flag "-O3")
 endif()
 
+if(${LIBC_CONF_ALLOC_TYPE} MATCHES "LIBC_ALLOC_TYPE_SCUDO")
+  set(LLVM_LIBC_INCLUDE_SCUDO ON)
+elseif(LLVM_LIBC_INCLUDE_SCUDO)
+  message(FATAL_ERROR "Cannot include scudo and use a different allocator.")
+endif()
+
 add_subdirectory(include)
 add_subdirectory(config)
 add_subdirectory(hdr)

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -116,5 +116,11 @@
       "value": true,
       "doc": "Add nullptr checks in the library's implementations to some functions for which passing nullptr is undefined behavior."
     }
+  },
+  "unistd": {
+    "LIBC_CONF_PAGE_SIZE": {
+      "value": "LIBC_PAGE_SIZE_SYSTEM",
+      "doc": "The value to use for the system page size, acceptable values are LIBC_CONF_PAGE_SIZE_SYSTEM, LIBC_CONF_PAGE_SIZE_4K, LIBC_CONF_PAGE_SIZE_16K, LIBC_CONF_PAGE_SIZE_64K."
+    }
   }
 }

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -115,6 +115,10 @@
     "LIBC_ADD_NULL_CHECKS": {
       "value": true,
       "doc": "Add nullptr checks in the library's implementations to some functions for which passing nullptr is undefined behavior."
+    },
+    "LIBC_CONF_ALLOC_TYPE": {
+      "value": "LIBC_ALLOC_TYPE_ARENA",
+      "doc": "The implementation used for allocations, acceptable values are LIBC_ALLOC_TYPE_EXTERN, LIBC_ALLOC_TYPE_SCUDO, LIBC_ALLOC_TYPE_ARENA."
     }
   },
   "unistd": {

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -323,6 +323,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
     libc.src.unistd.geteuid
+    libc.src.unistd.getpagesize
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.gettid

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -320,6 +320,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
     libc.src.unistd.geteuid
+    libc.src.unistd.getpagesize
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.gettid

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -322,6 +322,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.ftruncate
     libc.src.unistd.getcwd
     libc.src.unistd.geteuid
+    libc.src.unistd.getpagesize
     libc.src.unistd.getpid
     libc.src.unistd.getppid
     libc.src.unistd.gettid

--- a/libc/docs/configure.rst
+++ b/libc/docs/configure.rst
@@ -32,6 +32,7 @@ to learn about the defaults for your platform and target.
     - ``LIBC_CONF_ERRNO_MODE``: The implementation used for errno, acceptable values are LIBC_ERRNO_MODE_DEFAULT, LIBC_ERRNO_MODE_UNDEFINED, LIBC_ERRNO_MODE_THREAD_LOCAL, LIBC_ERRNO_MODE_SHARED, LIBC_ERRNO_MODE_EXTERNAL, and LIBC_ERRNO_MODE_SYSTEM.
 * **"general" options**
     - ``LIBC_ADD_NULL_CHECKS``: Add nullptr checks in the library's implementations to some functions for which passing nullptr is undefined behavior.
+    - ``LIBC_CONF_ALLOC_TYPE``: The implementation used for allocations, acceptable values are LIBC_ALLOC_TYPE_EXTERN, LIBC_ALLOC_TYPE_SCUDO, LIBC_ALLOC_TYPE_ARENA.
 * **"math" options**
     - ``LIBC_CONF_FREXP_INF_NAN_EXPONENT``: The value written back to the second parameter when calling frexp/frexpf/frexpl` with `+/-Inf`/`NaN` is unspecified.  Configue an explicit exp value for Inf/NaN inputs.
     - ``LIBC_CONF_MATH_OPTIMIZATIONS``: Configures optimizations for math functions. Values accepted are LIBC_MATH_SKIP_ACCURATE_PASS, LIBC_MATH_SMALL_TABLES, LIBC_MATH_NO_ERRNO, LIBC_MATH_NO_EXCEPT, and LIBC_MATH_FAST.

--- a/libc/docs/configure.rst
+++ b/libc/docs/configure.rst
@@ -60,3 +60,5 @@ to learn about the defaults for your platform and target.
     - ``LIBC_CONF_STRING_UNSAFE_WIDE_READ``: Read more than a byte at a time to perform byte-string operations like strlen.
 * **"time" options**
     - ``LIBC_CONF_TIME_64BIT``: Force the size of time_t to 64 bits, even on platforms where compatibility considerations would otherwise make it 32-bit.
+* **"unistd" options**
+    - ``LIBC_CONF_PAGE_SIZE``: The value to use for the system page size, acceptable values are LIBC_CONF_PAGE_SIZE_SYSTEM, LIBC_CONF_PAGE_SIZE_4K, LIBC_CONF_PAGE_SIZE_16K, LIBC_CONF_PAGE_SIZE_64K.

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -141,6 +141,12 @@ functions:
       - type: int
       - type: __getoptargv_t
       - type: const char *
+  - name: getpagesize
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: void
   - name: getpid
     standards:
       - POSIX

--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -370,3 +370,5 @@ add_subdirectory(HashTable)
 add_subdirectory(fixed_point)
 
 add_subdirectory(time)
+
+add_subdirectory(alloc)

--- a/libc/src/__support/alloc/CMakeLists.txt
+++ b/libc/src/__support/alloc/CMakeLists.txt
@@ -1,0 +1,54 @@
+add_object_library(
+  base
+  SRCS
+    base.cpp
+  HDRS
+    base.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.src.__support.macros.config
+)
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
+  add_subdirectory(${LIBC_TARGET_OS})
+endif()
+
+if(TARGET libc.src.__support.alloc.${LIBC_TARGET_OS}.page)
+  add_object_library(
+    page
+    ALIAS
+    DEPENDS
+      .${LIBC_TARGET_OS}.page
+  )
+
+  add_object_library(
+    arena
+    SRCS
+      arena.cpp
+    HDRS
+      arena.h
+    COMPILE_OPTIONS
+      -DLIBC_PAGE_SIZE=${LIBC_CONF_PAGE_SIZE}
+    DEPENDS
+      .base
+      .page
+      libc.src.string.memmove
+      libc.src.unistd.getpagesize
+  )
+endif()
+
+if(NOT ${LIBC_CONF_ALLOC_TYPE} MATCHES "LIBC_ALLOC_TYPE_SCUDO" AND NOT ${LIBC_CONF_ALLOC_TYPE} MATCHES "LIBC_ALLOC_TYPE_EXTERN")
+  string(TOLOWER ${LIBC_CONF_ALLOC_TYPE} LIBC_CONF_ALLOC_TYPE_NAME)
+  string(REPLACE "libc_alloc_type_" "" LIBC_CONF_ALLOC_TYPE_NAME "${LIBC_CONF_ALLOC_TYPE_NAME}")
+  add_object_library(
+    alloc
+    SRCS
+      alloc.cpp
+    HDRS
+      alloc.h
+    COMPILE_OPTIONS
+      -DLIBC_CONF_ALLOC_TYPE=${LIBC_CONF_ALLOC_TYPE_NAME}
+    DEPENDS
+      .${LIBC_CONF_ALLOC_TYPE_NAME}
+  )
+endif()

--- a/libc/src/__support/alloc/alloc.cpp
+++ b/libc/src/__support/alloc/alloc.cpp
@@ -1,0 +1,13 @@
+#include <src/__support/alloc/alloc.h>
+#include <src/__support/alloc/arena.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+#define CONCAT(a, b) a##b
+#define EXPAND_AND_CONCAT(a, b) CONCAT(a, b)
+
+#define ALLOCATOR EXPAND_AND_CONCAT(LIBC_CONF_ALLOC_TYPE, _allocator)
+
+BaseAllocator *allocator = reinterpret_cast<BaseAllocator *>(&ALLOCATOR);
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/alloc/alloc.h
+++ b/libc/src/__support/alloc/alloc.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for sysconf -----------------------*- C++ -*-===//
+//===-- libc-wide allocator -------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,16 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_UNISTD_SYSCONF_H
-#define LLVM_LIBC_SRC_UNISTD_SYSCONF_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_ALLOC_ALLOC_H
+#define LLVM_LIBC_SRC___SUPPORT_ALLOC_ALLOC_H
 
-#include "hdr/unistd_macros.h"
+#include "src/__support/alloc/base.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-long int sysconf(int name);
+// The primary allocator to use
+extern BaseAllocator *allocator;
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_UNISTD_SYSCONF_H
+#endif

--- a/libc/src/__support/alloc/arena.cpp
+++ b/libc/src/__support/alloc/arena.cpp
@@ -1,0 +1,71 @@
+#include "src/__support/alloc/arena.h"
+#include "src/__support/alloc/page.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/page_size.h"
+#include "src/__support/memory_size.h"
+#include "src/string/memmove.h"
+#include "src/unistd/getpagesize.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *arena_allocate(BaseAllocator *base, size_t alignment, size_t size) {
+  ArenaAllocator *self = reinterpret_cast<ArenaAllocator *>(base);
+
+  if (self->buffer == nullptr) {
+    self->buffer = reinterpret_cast<uint8_t *>(page_allocate(1));
+    self->buffer_size = self->get_page_size();
+  }
+
+  uintptr_t curr_ptr = (uintptr_t)self->buffer + (uintptr_t)self->curr_offset;
+  uintptr_t offset = internal::align_forward<uintptr_t>(curr_ptr, alignment);
+  offset -= (uintptr_t)self->buffer;
+
+  if (offset + size > self->buffer_size) {
+    self->buffer = reinterpret_cast<uint8_t *>(
+        page_expand(self->buffer, self->buffer_size / self->get_page_size()));
+    self->buffer_size += self->get_page_size();
+  }
+
+  if (offset + size <= self->buffer_size) {
+    void *ptr = &self->buffer[offset];
+    self->prev_offset = offset;
+    self->curr_offset = offset + size;
+    return ptr;
+  }
+  return nullptr;
+}
+
+void *arena_expand(BaseAllocator *base, void *ptr, size_t alignment,
+                   size_t size) {
+  ArenaAllocator *self = reinterpret_cast<ArenaAllocator *>(base);
+
+  if (self->buffer + self->prev_offset == ptr) {
+    self->curr_offset = self->prev_offset + size;
+    return ptr;
+  } else {
+    void *new_mem = arena_allocate(base, alignment, size);
+    memmove(new_mem, ptr, size);
+    return new_mem;
+  }
+  return nullptr;
+}
+
+bool arena_free(BaseAllocator *base, void *ptr) {
+  (void)base;
+  (void)ptr;
+  return true;
+}
+
+size_t ArenaAllocator::get_page_size() {
+  if (page_size == LIBC_PAGE_SIZE_SYSTEM) {
+    page_size = getpagesize();
+  }
+  return page_size;
+}
+
+static ArenaAllocator default_arena_allocator(LIBC_PAGE_SIZE,
+                                              2 * sizeof(void *));
+BaseAllocator *arena_allocator = &default_arena_allocator;
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/alloc/arena.h
+++ b/libc/src/__support/alloc/arena.h
@@ -1,0 +1,47 @@
+//===-- An arena allocator using pages. -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_ALLOC_ARENA_H
+#define LLVM_LIBC_SRC___SUPPORT_ALLOC_ARENA_H
+
+#include "hdr/types/size_t.h"
+#include "src/__support/alloc/base.h"
+#include <stdint.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *arena_allocate(BaseAllocator *base, size_t alignment, size_t size);
+void *arena_expand(BaseAllocator *base, void *ptr, size_t alignment,
+                   size_t size);
+bool arena_free(BaseAllocator *base, void *ptr);
+
+class ArenaAllocator : public BaseAllocator {
+public:
+  uint8_t *buffer;
+  size_t buffer_size;
+  size_t prev_offset;
+  size_t curr_offset;
+
+private:
+  size_t page_size;
+
+public:
+  constexpr ArenaAllocator(size_t page_size, size_t default_alignment)
+      : BaseAllocator(arena_allocate, arena_expand, arena_free,
+                      default_alignment),
+        buffer(nullptr), buffer_size(0), prev_offset(0), curr_offset(0),
+        page_size(page_size) {}
+
+  size_t get_page_size();
+};
+
+extern BaseAllocator *arena_allocator;
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif

--- a/libc/src/__support/alloc/baremetal/CMakeLists.txt
+++ b/libc/src/__support/alloc/baremetal/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_object_library(
+  page
+  SRCS
+    page.cpp
+  HDRS
+    ../page.h
+  DEPENDS
+    libc.src.__support.alloc.base
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.mremap
+    libc.src.sys.mman.munmap
+    libc.src.unistd.getpagesize
+)

--- a/libc/src/__support/alloc/baremetal/page.cpp
+++ b/libc/src/__support/alloc/baremetal/page.cpp
@@ -1,0 +1,22 @@
+#include "src/__support/alloc/page.h"
+#include "src/__suport/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+extern "C" void *__llvm_libc_page_allocate(size_t n_pages);
+extern "C" void *__llvm_libc_page_expand(void *ptr, size_t n_pages);
+extern "C" bool __llvm_libc_page_free(void *ptr, size_t n_pages);
+
+void *page_allocate(size_t n_pages) {
+  return __llvm_libc_page_allocate(n_pages);
+}
+
+void *page_expand(void *ptr, size_t n_pages) {
+  return __llvm_libc_page_expand(ptr, n_pages);
+}
+
+bool page_free(void *ptr, size_t n_pages) {
+  return __llvm_libc_page_free(ptr, n_pages);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/alloc/base.cpp
+++ b/libc/src/__support/alloc/base.cpp
@@ -1,0 +1,16 @@
+#include "src/__support/alloc/base.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+void *BaseAllocator::alloc(size_t alignment, size_t size) {
+  return impl_alloc(this, alignment, size);
+}
+
+void *BaseAllocator::expand(void *ptr, size_t alignment, size_t size) {
+  return impl_expand(this, ptr, alignment, size);
+}
+
+bool BaseAllocator::free(void *ptr) { return impl_free(this, ptr); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/alloc/base.h
+++ b/libc/src/__support/alloc/base.h
@@ -1,0 +1,44 @@
+//===-- A generic base allocator. -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_ALLOC_BASE_H
+#define LLVM_LIBC_SRC___SUPPORT_ALLOC_BASE_H
+
+#include "hdr/types/size_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+class BaseAllocator {
+public:
+  using AllocFunc = void *(BaseAllocator *self, size_t, size_t);
+  using ExpandFunc = void *(BaseAllocator *self, void *, size_t, size_t);
+  using FreeFunc = bool(BaseAllocator *self, void *);
+
+private:
+  // Implementation specific functions
+  AllocFunc *impl_alloc;
+  ExpandFunc *impl_expand;
+  FreeFunc *impl_free;
+
+public:
+  constexpr BaseAllocator(AllocFunc *ia, ExpandFunc *ie, FreeFunc *ifr,
+                          size_t default_alignment)
+      : impl_alloc(ia), impl_expand(ie), impl_free(ifr),
+        default_alignment(default_alignment) {}
+
+  size_t default_alignment;
+
+  void *alloc(size_t alignment, size_t size);
+  void *expand(void *ptr, size_t alignment, size_t size);
+  bool free(void *ptr);
+};
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_ALLOC_BASE_H

--- a/libc/src/__support/alloc/linux/CMakeLists.txt
+++ b/libc/src/__support/alloc/linux/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_object_library(
+  page
+  SRCS
+    page.cpp
+  HDRS
+    ../page.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.include.llvm-libc-macros.stdlib_macros
+    libc.include.llvm-libc-macros.stdint_macros
+    libc.src.__support.alloc.base
+    libc.src.sys.mman.mmap
+    libc.src.sys.mman.mremap
+    libc.src.sys.mman.munmap
+    libc.src.unistd.getpagesize
+)

--- a/libc/src/__support/alloc/linux/page.cpp
+++ b/libc/src/__support/alloc/linux/page.cpp
@@ -1,0 +1,41 @@
+#include "src/__support/alloc/page.h"
+#include "include/llvm-libc-macros/stdlib-macros.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/memory_size.h"
+#include "src/sys/mman/mmap.h"
+#include "src/sys/mman/mremap.h"
+#include "src/sys/mman/munmap.h"
+#include "src/unistd/getpagesize.h"
+#include <stdint.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+static void *alloc_hint = NULL;
+
+void *page_allocate(size_t n_pages) {
+  size_t page_size = getpagesize();
+  size_t size = n_pages * page_size;
+  size_t aligned_size = internal::SafeMemSize(size).align_up(page_size);
+
+  void *ptr = mmap(&alloc_hint, aligned_size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (ptr == NULL)
+    return nullptr;
+
+  alloc_hint = (void *)(((uintptr_t)ptr) + aligned_size);
+  return ptr;
+}
+
+void *page_expand(void *ptr, size_t n_pages) {
+  (void)ptr;
+  (void)n_pages;
+  return nullptr;
+}
+
+bool page_free(void *ptr, size_t n_pages) {
+  (void)ptr;
+  (void)n_pages;
+  return false;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/alloc/page.h
+++ b/libc/src/__support/alloc/page.h
@@ -1,4 +1,4 @@
-//===-- Implementation header for sysconf -----------------------*- C++ -*-===//
+//===-- Page allocations ----------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,16 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_UNISTD_SYSCONF_H
-#define LLVM_LIBC_SRC_UNISTD_SYSCONF_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_ALLOC_PAGE_H
+#define LLVM_LIBC_SRC___SUPPORT_ALLOC_PAGE_H
 
-#include "hdr/unistd_macros.h"
+#include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-long int sysconf(int name);
+void *page_allocate(size_t n_pages);
+void *page_expand(void *ptr, size_t n_pages);
+bool page_free(void *ptr, size_t n_pages);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_UNISTD_SYSCONF_H
+#endif // LLVM_LIBC_SRC___SUPPORT_ALLOC_BASE_H

--- a/libc/src/__support/macros/CMakeLists.txt
+++ b/libc/src/__support/macros/CMakeLists.txt
@@ -21,6 +21,12 @@ add_header_library(
 )
 
 add_header_library(
+  page_size
+  HDRS
+    page_size.h
+)
+
+add_header_library(
   sanitizer
   HDRS
     sanitizer.h

--- a/libc/src/__support/macros/page_size.h
+++ b/libc/src/__support/macros/page_size.h
@@ -1,0 +1,17 @@
+//===-- Convenient page size macros -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MACROS_PAGE_SIZE_H
+#define LLVM_LIBC_SRC___SUPPORT_MACROS_PAGE_SIZE_H
+
+#define LIBC_PAGE_SIZE_SYSTEM 0
+#define LIBC_PAGE_SIZE_4K (4 * 1024)
+#define LIBC_PAGE_SIZE_16K (16 * 1024)
+#define LIBC_PAGE_SIZE_64K (64 * 1024)
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PAGE_SIZE_H

--- a/libc/src/__support/memory_size.h
+++ b/libc/src/__support/memory_size.h
@@ -12,6 +12,7 @@
 #include "src/__support/CPP/bit.h" // has_single_bit
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/type_traits.h"
+#include "src/__support/libc_assert.h"
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
@@ -32,6 +33,19 @@ template <class T> LIBC_INLINE bool mul_overflow(T a, T b, T *res) {
   return overflow;
 #endif
 }
+
+template <class T> LIBC_INLINE T align_forward(T ptr, size_t align) {
+  LIBC_ASSERT((align & (align - 1)) == 0);
+
+  T p = ptr;
+  T a = (T)align;
+
+  T modulo = p & (a - 1);
+  if (modulo != 0)
+    p += a - modulo;
+  return p;
+}
+
 // Limit memory size to the max of ssize_t
 class SafeMemSize {
 private:

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -324,7 +324,7 @@ add_entrypoint_object(
 )
 
 if(NOT LIBC_TARGET_OS_IS_BAREMETAL AND NOT LIBC_TARGET_OS_IS_GPU)
-  if(LLVM_LIBC_INCLUDE_SCUDO)
+  if(LLVM_LIBC_INCLUDE_SCUDO AND ${LIBC_CONF_ALLOC_TYPE} MATCHES "LIBC_ALLOC_TYPE_SCUDO")
     set(SCUDO_DEPS "")
 
     include(${LIBC_SOURCE_DIR}/../compiler-rt/cmake/Modules/AllSupportedArchDefs.cmake)
@@ -388,7 +388,7 @@ if(NOT LIBC_TARGET_OS_IS_BAREMETAL AND NOT LIBC_TARGET_OS_IS_GPU)
       DEPENDS
         ${SCUDO_DEPS}
     )
-  else()
+  elseif(${LIBC_CONF_ALLOC_TYPE} MATCHES "LIBC_ALLOC_TYPE_EXTERN")
     add_entrypoint_external(
       malloc
     )
@@ -406,6 +406,57 @@ if(NOT LIBC_TARGET_OS_IS_BAREMETAL AND NOT LIBC_TARGET_OS_IS_GPU)
     )
     add_entrypoint_external(
       mallopt
+    )
+  else()
+    add_entrypoint_object(
+      aligned_alloc
+      SRCS
+        aligned_alloc.cpp
+      HDRS
+        aligned_alloc.h
+      DEPENDS
+        libc.src.__support.alloc.alloc
+    )
+
+    add_entrypoint_object(
+      malloc
+      SRCS
+        malloc.cpp
+      HDRS
+        malloc.h
+      DEPENDS
+        .aligned_alloc
+    )
+
+    add_entrypoint_object(
+      calloc
+      SRCS
+        calloc.cpp
+      HDRS
+        calloc.h
+      DEPENDS
+        .malloc
+    )
+
+    add_entrypoint_object(
+      realloc
+      SRCS
+        realloc.cpp
+      HDRS
+        realloc.h
+      DEPENDS
+        libc.src.__support.alloc.alloc
+    )
+
+    add_entrypoint_object(
+      free
+      SRCS
+        free.cpp
+      HDRS
+        free.h
+      DEPENDS
+        libc.src.__support.libc_assert
+        libc.src.__support.alloc.alloc
     )
   endif()
 endif()
@@ -495,7 +546,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
 
-if(LIBC_TARGET_OS_IS_BAREMETAL OR LIBC_TARGET_OS_IS_GPU)
+if((LIBC_TARGET_OS_IS_BAREMETAL OR LIBC_TARGET_OS_IS_GPU) AND NOT TARGET libc.src.__support.alloc.alloc)
   add_entrypoint_object(
     malloc
     ALIAS

--- a/libc/src/stdlib/aligned_alloc.cpp
+++ b/libc/src/stdlib/aligned_alloc.cpp
@@ -1,0 +1,12 @@
+#include "src/stdlib/aligned_alloc.h"
+#include "src/__support/alloc/alloc.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, aligned_alloc, (size_t alignment, size_t size)) {
+  return allocator->alloc(alignment, size);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/calloc.cpp
+++ b/libc/src/stdlib/calloc.cpp
@@ -1,0 +1,12 @@
+#include "src/stdlib/calloc.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/stdlib/malloc.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, calloc, (size_t nmeb, size_t size)) {
+  return malloc(nmeb * size);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/free.cpp
+++ b/libc/src/stdlib/free.cpp
@@ -1,0 +1,15 @@
+#include "src/stdlib/free.h"
+#include "src/__support/alloc/alloc.h"
+#include "src/__support/common.h"
+#include "src/__support/libc_assert.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, free, (void *ptr)) {
+  bool r = allocator->free(ptr);
+  (void)r;
+  LIBC_ASSERT(r);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/malloc.cpp
+++ b/libc/src/stdlib/malloc.cpp
@@ -1,0 +1,13 @@
+#include "src/stdlib/malloc.h"
+#include "src/__support/alloc/alloc.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/stdlib/aligned_alloc.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, malloc, (size_t size)) {
+  return aligned_alloc(allocator->default_alignment, size);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/realloc.cpp
+++ b/libc/src/stdlib/realloc.cpp
@@ -1,0 +1,12 @@
+#include "src/stdlib/realloc.h"
+#include "src/__support/alloc/alloc.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void *, realloc, (void *ptr, size_t size)) {
+  return allocator->expand(ptr, allocator->default_alignment, size);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/CMakeLists.txt
+++ b/libc/src/unistd/CMakeLists.txt
@@ -1,5 +1,31 @@
+function(add_unistd_entrypoint_object name)
+  if(TARGET libc.src.unistd.${LIBC_TARGET_OS}.${name})
+    add_entrypoint_object(
+      ${name}
+      ALIAS
+      DEPENDS
+        .${LIBC_TARGET_OS}.${name}
+    )
+  elseif(TARGET libc.src.unistd.generic.${name})
+    add_entrypoint_object(
+      ${name}
+      ALIAS
+      DEPENDS
+        .generic.${name}
+    )
+  endif()
+endfunction(add_unistd_entrypoint_object)
+
+if(LIBC_CONF_PAGE_SIZE)
+  set(getpagesize_config_copts "-DLIBC_PAGE_SIZE=${LIBC_CONF_PAGE_SIZE}")
+endif()
+
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
+endif()
+
+if(NOT LIBC_TARGET_OS_IS_BAREMETAL AND NOT LIBC_TARGET_OS_IS_GPU)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/generic)
 endif()
 
 add_entrypoint_object(
@@ -350,3 +376,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.threads.identifier
 )
+
+# These entrypoints have multiple potential implementations.
+add_unistd_entrypoint_object(getpagesize)

--- a/libc/src/unistd/generic/CMakeLists.txt
+++ b/libc/src/unistd/generic/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_entrypoint_object(
+  getpagesize
+  SRCS
+    getpagesize.cpp
+  HDRS
+    ../getpagesize.h
+  COMPILE_OPTIONS
+    ${getpagesize_config_copts}
+  DEPENDS
+    libc.include.unistd
+    libc.src.__support.macros.page_size
+)

--- a/libc/src/unistd/generic/getpagesize.cpp
+++ b/libc/src/unistd/generic/getpagesize.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of getpagesize -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getpagesize.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/page_size.h"
+
+#if LIBC_PAGE_SIZE == LIBC_PAGE_SIZE_SYSTEM
+#error "System implementation for getpagesize is missing"
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, getpagesize, ()) { return LIBC_PAGE_SIZE; }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/getpagesize.h
+++ b/libc/src/unistd/getpagesize.h
@@ -1,0 +1,20 @@
+//===-- Implementation header for getpagesize -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_UNISTD_GETPAGESIZE_H
+#define LLVM_LIBC_SRC_UNISTD_GETPAGESIZE_H
+
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+int getpagesize();
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_UNISTD_GETPAGESIZE_H

--- a/libc/src/unistd/linux/CMakeLists.txt
+++ b/libc/src/unistd/linux/CMakeLists.txt
@@ -208,6 +208,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  getpagesize
+  SRCS
+    getpagesize.cpp
+  HDRS
+    ../getpagesize.h
+  DEPENDS
+    .sysconf
+    libc.include.unistd
+    libc.src.__support.macros.page_size
+    libc.src.sys.auxv.getauxval
+)
+
+add_entrypoint_object(
   getpid
   SRCS
     getpid.cpp

--- a/libc/src/unistd/linux/getpagesize.cpp
+++ b/libc/src/unistd/linux/getpagesize.cpp
@@ -1,0 +1,26 @@
+//===-- Implementation of getpagesize -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getpagesize.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/page_size.h"
+#include "src/sys/auxv/getauxval.h"
+#include "src/unistd/sysconf.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, getpagesize, ()) {
+#if LIBC_PAGE_SIZE == LIBC_PAGE_SIZE_SYSTEM
+  return static_cast<int>(LIBC_NAMESPACE::sysconf(_SC_PAGESIZE));
+#else
+  return LIBC_PAGE_SIZE;
+#endif
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/unistd/linux/sysconf.cpp
+++ b/libc/src/unistd/linux/sysconf.cpp
@@ -18,7 +18,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(long, sysconf, (int name)) {
+LLVM_LIBC_FUNCTION(long int, sysconf, (int name)) {
   long ret = 0;
   if (name == _SC_PAGESIZE)
     return static_cast<long>(getauxval(AT_PAGESZ));

--- a/libc/test/src/unistd/CMakeLists.txt
+++ b/libc/test/src/unistd/CMakeLists.txt
@@ -418,6 +418,16 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  getpagesize
+  SUITE
+    libc_unistd_unittests
+  SRCS
+    getpagesize_test.cpp
+  DEPENDS
+    libc.src.unistd.getpagesize
+)
+
+add_libc_unittest(
   syscall_test
   SUITE
     libc_unistd_unittests

--- a/libc/test/src/unistd/getpagesize_test.cpp
+++ b/libc/test/src/unistd/getpagesize_test.cpp
@@ -1,0 +1,16 @@
+//===-- Unittests for getpagesize -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/unistd/getpagesize.h"
+#include "test/UnitTest/Test.h"
+
+TEST(LlvmLibcGetPageSizeTest, SmokeTest) {
+  int r = LIBC_NAMESPACE::getpagesize();
+  ASSERT_GT(r, 0);
+  ASSERT_EQ(r % 1024, 0);
+}


### PR DESCRIPTION
This PR adds support for multiple allocator implementations. This will be beneficial for distros and embedded systems where different kinds of allocators can be better than others. To start out with, I just added a primitive arena allocator. This PR also adds `getpagesize` which supports dynamic and static page sizes.