### PR TITLE
[libc] add wmemchr, wcslen, wcschr, wcsrchr, wcspbrk, wcsstr

### DIFF
--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
 
     # wchar.h entrypoints
+    libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob
 

--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
 
     # wchar.h entrypoints
+    libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob

--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr

--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
 
     # wchar.h entrypoints
+    libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen

--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsstr
     libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr

--- a/libc/config/gpu/entrypoints.txt
+++ b/libc/config/gpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
 
     # wchar.h entrypoints
+    libc.src.wchar.wmemchr
     libc.src.wchar.wctob
 
     # locale.h entrypoints

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -349,6 +349,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob
 )

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -349,6 +349,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -349,6 +349,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -349,6 +349,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -349,6 +349,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsstr
     libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -349,6 +349,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wmemchr
     libc.src.wchar.wctob
 )
 

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob
 )

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wmemchr
     libc.src.wchar.wctob
 )
 

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsstr
     libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -346,6 +346,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wmemchr
     libc.src.wchar.wctob
     libc.src.wchar.btowc
 )

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsstr
     libc.src.wchar.wcspbrk
     libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcsrchr
     libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcschr
     libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -348,6 +348,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.write
 
     # wchar.h entrypoints
+    libc.src.wchar.wcslen
     libc.src.wchar.wmemchr
     libc.src.wchar.wctob
     libc.src.wchar.btowc

--- a/libc/hdrgen/yaml/wchar.yaml
+++ b/libc/hdrgen/yaml/wchar.yaml
@@ -49,3 +49,10 @@ functions:
     arguments:
       - type: const wchar_t *
       - type: const wchar_t *
+  - name: wcsstr
+    standards:
+      - stdc
+    return_type: const wchar_t *
+    arguments:
+      - type: const wchar_t *
+      - type: const wchar_t *

--- a/libc/hdrgen/yaml/wchar.yaml
+++ b/libc/hdrgen/yaml/wchar.yaml
@@ -14,3 +14,11 @@ functions:
     return_type: int
     arguments:
       - type: wint_t
+  - name: wmemchr
+    standards:
+      - stdc
+    return_type: const wchar_t *
+    arguments:
+      - type: const wchar_t *
+      - type: wchar_t
+      - type: size_t

--- a/libc/hdrgen/yaml/wchar.yaml
+++ b/libc/hdrgen/yaml/wchar.yaml
@@ -35,3 +35,10 @@ functions:
     arguments:
       - type: const wchar_t *
       - type: wchar_t
+  - name: wcsrchr
+    standards:
+      - stdc
+    return_type: const wchar_t *
+    arguments:
+      - type: const wchar_t *
+      - type: wchar_t

--- a/libc/hdrgen/yaml/wchar.yaml
+++ b/libc/hdrgen/yaml/wchar.yaml
@@ -42,3 +42,10 @@ functions:
     arguments:
       - type: const wchar_t *
       - type: wchar_t
+  - name: wcspbrk
+    standards:
+      - stdc
+    return_type: const wchar_t *
+    arguments:
+      - type: const wchar_t *
+      - type: const wchar_t *

--- a/libc/hdrgen/yaml/wchar.yaml
+++ b/libc/hdrgen/yaml/wchar.yaml
@@ -22,3 +22,9 @@ functions:
       - type: const wchar_t *
       - type: wchar_t
       - type: size_t
+  - name: wcslen
+    standards:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: const wchar_t *

--- a/libc/hdrgen/yaml/wchar.yaml
+++ b/libc/hdrgen/yaml/wchar.yaml
@@ -28,3 +28,10 @@ functions:
     return_type: size_t
     arguments:
       - type: const wchar_t *
+  - name: wcschr
+    standards:
+      - stdc
+    return_type: const wchar_t *
+    arguments:
+      - type: const wchar_t *
+      - type: wchar_t

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -58,3 +58,14 @@ add_entrypoint_object(
     .wmemchr
     libc.hdr.types.wchar_t
 )
+
+add_entrypoint_object(
+  wcsrchr
+  SRCS
+    wcsrchr.cpp
+  HDRS
+    wcsrchr.h
+  DEPENDS
+    .wcslen
+    libc.hdr.types.wchar_t
+)

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -22,3 +22,15 @@ add_entrypoint_object(
     libc.hdr.wchar_macros
     libc.src.__support.wctype_utils
 )
+
+add_entrypoint_object(
+  wmemchr
+  SRCS
+    wmemchr.cpp
+  HDRS
+    wmemchr.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.wctype_utils
+)

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -80,3 +80,14 @@ add_entrypoint_object(
     .wcslen
     libc.hdr.types.wchar_t
 )
+
+add_entrypoint_object(
+  wcsstr
+  SRCS
+    wcsstr.cpp
+  HDRS
+    wcsstr.h
+  DEPENDS
+    .wcslen
+    libc.hdr.types.wchar_t
+)

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -34,3 +34,27 @@ add_entrypoint_object(
     libc.hdr.types.wchar_t
     libc.src.__support.wctype_utils
 )
+
+add_entrypoint_object(
+  wcslen
+  SRCS
+    wcslen.cpp
+  HDRS
+    wcslen.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.hdr.types.wchar_t
+    libc.src.__support.wctype_utils
+)
+
+add_entrypoint_object(
+  wcschr
+  SRCS
+    wcschr.cpp
+  HDRS
+    wcschr.h
+  DEPENDS
+    .wcslen
+    .wmemchr
+    libc.hdr.types.wchar_t
+)

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -69,3 +69,14 @@ add_entrypoint_object(
     .wcslen
     libc.hdr.types.wchar_t
 )
+
+add_entrypoint_object(
+  wcspbrk
+  SRCS
+    wcspbrk.cpp
+  HDRS
+    wcspbrk.h
+  DEPENDS
+    .wcslen
+    libc.hdr.types.wchar_t
+)

--- a/libc/src/wchar/wcschr.cpp
+++ b/libc/src/wchar/wcschr.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of wcschr ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcschr.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "wcslen.h"
+#include "wmemchr.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(const wchar_t *, wcschr, (const wchar_t *s, wchar_t c)) {
+  return wmemchr(s, c, wcslen(s));
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcschr.h
+++ b/libc/src/wchar/wcschr.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for wmemchr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSCHR_H
+#define LLVM_LIBC_SRC_WCHAR_WCSCHR_H
+
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+const wchar_t *wcschr(const wchar_t *s, wchar_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSCHR_H

--- a/libc/src/wchar/wcslen.cpp
+++ b/libc/src/wchar/wcslen.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of wcslen ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcslen.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(size_t, wcslen, (const wchar_t *s)) {
+  size_t length = 0;
+  while (s[length++])
+    ;
+  return length;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcslen.h
+++ b/libc/src/wchar/wcslen.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for wcslen ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSLEN_H
+#define LLVM_LIBC_SRC_WCHAR_WCSLEN_H
+
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t wcslen(const wchar_t *s);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSLEN_H

--- a/libc/src/wchar/wcspbrk.cpp
+++ b/libc/src/wchar/wcspbrk.cpp
@@ -1,0 +1,37 @@
+//===-- Implementation of wcspbrk -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcspbrk.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "wcslen.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(const wchar_t *, wcspbrk,
+                   (const wchar_t *wcs, const wchar_t *accept)) {
+  size_t n_accept = wcslen(accept);
+
+  for (size_t i = 0; i < wcslen(wcs); i++) {
+    bool accepted = true;
+
+    for (size_t x = 0; x < n_accept; i++) {
+      if (wcs[i] != accept[x]) {
+        accepted = false;
+        break;
+      }
+    }
+
+    if (!accepted)
+      continue;
+    return &wcs[i];
+  }
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcspbrk.h
+++ b/libc/src/wchar/wcspbrk.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for wcspbrk -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSPBRK_H
+#define LLVM_LIBC_SRC_WCHAR_WCSPBRK_H
+
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+const wchar_t *wcspbrk(const wchar_t *wcs, const wchar_t *accept);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSPBRK_H

--- a/libc/src/wchar/wcsrchr.cpp
+++ b/libc/src/wchar/wcsrchr.cpp
@@ -1,0 +1,26 @@
+//===-- Implementation of wcsrchr
+//------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcsrchr.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "wcslen.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(const wchar_t *, wcsrchr, (const wchar_t *s, wchar_t c)) {
+  size_t length = wcslen(s);
+  for (size_t i = 0; i < length; i++) {
+    if (s[length - i] == c)
+      return &s[length - i];
+  }
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcsrchr.h
+++ b/libc/src/wchar/wcsrchr.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for wcsrchr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSRCHR_H
+#define LLVM_LIBC_SRC_WCHAR_WCSRCHR_H
+
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+const wchar_t *wcsrchr(const wchar_t *s, wchar_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSRCHR_H

--- a/libc/src/wchar/wcsstr.cpp
+++ b/libc/src/wchar/wcsstr.cpp
@@ -1,0 +1,44 @@
+//===-- Implementation of wcsstr ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wcsstr.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "wcslen.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(const wchar_t *, wcsstr,
+                   (const wchar_t *s, const wchar_t *needle)) {
+  size_t s_len = wcslen(s);
+  size_t needle_len = wcslen(needle);
+
+  if (needle_len > s_len)
+    return nullptr;
+
+  for (size_t i = 0; i < s_len; i++) {
+    size_t end = needle_len + i;
+    if (end > s_len)
+      break;
+
+    bool found = true;
+    for (size_t x = 0; x < needle_len; x++) {
+      if (s[i + x] != needle[x]) {
+        found = false;
+        break;
+      }
+    }
+
+    if (!found)
+      continue;
+    return &s[i];
+  }
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcsstr.h
+++ b/libc/src/wchar/wcsstr.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for wcsstr ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCSSTR_H
+#define LLVM_LIBC_SRC_WCHAR_WCSSTR_H
+
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+const wchar_t *wcsstr(const wchar_t *s, const wchar_t *needle);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCSSTR_H

--- a/libc/src/wchar/wmemchr.cpp
+++ b/libc/src/wchar/wmemchr.cpp
@@ -1,0 +1,26 @@
+//===-- Implementation of wmemchr -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wchar/wmemchr.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(const wchar_t *, wmemchr,
+                   (const wchar_t *s, wchar_t c, size_t n)) {
+  for (size_t i = 0; i < n; i++) {
+    if (s[i] == c) {
+      return &s[i];
+    }
+  }
+
+  return nullptr;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wmemchr.h
+++ b/libc/src/wchar/wmemchr.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for wmemchr -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WMEMCHR_H
+#define LLVM_LIBC_SRC_WCHAR_WMEMCHR_H
+
+#include "hdr/types/size_t.h"
+#include "hdr/types/wchar_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+const wchar_t *wmemchr(const wchar_t *s, wchar_t c, size_t n);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WMEMCHR_H


### PR DESCRIPTION
Adds a few wchar functions which are missing. More functions to come in follow up PR's or may be tacked onto this one. Goal is to start getting LLVM libc to work with libcxx.