### PR TITLE
[llvm-dwp] turn duplicate dwo id into warning, continue to gen dwp

### DIFF
--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -786,8 +786,11 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
               return createFileError(Input, EID.takeError());
             const auto &ID = *EID;
             auto P = IndexEntries.insert(std::make_pair(ID.Signature, Entry));
-            if (!P.second)
-              return buildDuplicateError(*P.first, ID, "");
+            if (!P.second) {
+              WithColor::defaultWarningHandler(buildDuplicateError(*P.first, ID, ""));
+              FoundCUUnit = true;
+              continue;
+            }
             P.first->second.Name = ID.Name;
             P.first->second.DWOName = ID.DWOName;
 
@@ -858,8 +861,10 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
       if (!EID)
         return createFileError(Input, EID.takeError());
       const auto &ID = *EID;
-      if (!P.second)
-        return buildDuplicateError(*P.first, ID, Input);
+      if (!P.second) {
+        WithColor::defaultWarningHandler(buildDuplicateError(*P.first, ID, Input));
+        continue;
+      }
       auto &NewEntry = P.first->second;
       NewEntry.Name = ID.Name;
       NewEntry.DWOName = ID.DWOName;

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -787,7 +787,8 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
             const auto &ID = *EID;
             auto P = IndexEntries.insert(std::make_pair(ID.Signature, Entry));
             if (!P.second) {
-              WithColor::defaultWarningHandler(buildDuplicateError(*P.first, ID, ""));
+              WithColor::defaultWarningHandler(
+                  buildDuplicateError(*P.first, ID, ""));
               FoundCUUnit = true;
               continue;
             }
@@ -862,7 +863,8 @@ Error write(MCStreamer &Out, ArrayRef<std::string> Inputs,
         return createFileError(Input, EID.takeError());
       const auto &ID = *EID;
       if (!P.second) {
-        WithColor::defaultWarningHandler(buildDuplicateError(*P.first, ID, Input));
+        WithColor::defaultWarningHandler(
+            buildDuplicateError(*P.first, ID, Input));
         continue;
       }
       auto &NewEntry = P.first->second;

--- a/llvm/test/tools/llvm-dwp/X86/duplicate.test
+++ b/llvm/test/tools/llvm-dwp/X86/duplicate.test
@@ -1,27 +1,27 @@
-RUN: not llvm-dwp %p/../Inputs/duplicate/c.dwo %p/../Inputs/duplicate/c.dwo -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/duplicate/c.dwo %p/../Inputs/duplicate/c.dwo -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=DWOS %s
 
-RUN: not llvm-dwp %p/../Inputs/duplicate/c.dwo %p/../Inputs/duplicate/bc.dwp -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/duplicate/c.dwo %p/../Inputs/duplicate/bc.dwp -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=2DWP %s
 
-RUN: not llvm-dwp %p/../Inputs/duplicate/ac.dwp %p/../Inputs/duplicate/c.dwo -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/duplicate/ac.dwp %p/../Inputs/duplicate/c.dwo -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=1DWP %s
 
-RUN: not llvm-dwp %p/../Inputs/duplicate_dwo_name/c.dwo %p/../Inputs/duplicate_dwo_name/c.dwo -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/duplicate_dwo_name/c.dwo %p/../Inputs/duplicate_dwo_name/c.dwo -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=DWODWOS %s
 
-RUN: not llvm-dwp %p/../Inputs/duplicate_dwo_name/c.dwo %p/../Inputs/duplicate_dwo_name/bc.dwp -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/duplicate_dwo_name/c.dwo %p/../Inputs/duplicate_dwo_name/bc.dwp -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=DWO2DWP %s
 
-RUN: not llvm-dwp %p/../Inputs/duplicate_dwo_name/ac.dwp %p/../Inputs/duplicate_dwo_name/c.dwo -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/duplicate_dwo_name/ac.dwp %p/../Inputs/duplicate_dwo_name/c.dwo -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=DWO1DWP %s
 
 Build from a, b, and c.c all containing a single void() func by the name of the file.
 
-DWOS: error: duplicate DWO ID ({{.*}}) in 'c.c' and 'c.c'{{$}}
-1DWP: error: duplicate DWO ID ({{.*}}) in 'c.c' (from '{{.*}}ac.dwp') and 'c.c'{{$}}
-2DWP: error: duplicate DWO ID ({{.*}}) in 'c.c' and 'c.c' (from '{{.*}}bc.dwp'){{$}}
+DWOS: warning: duplicate DWO ID ({{.*}}) in 'c.c' and 'c.c'{{$}}
+1DWP: warning: duplicate DWO ID ({{.*}}) in 'c.c' (from '{{.*}}ac.dwp') and 'c.c'{{$}}
+2DWP: warning: duplicate DWO ID ({{.*}}) in 'c.c' and 'c.c' (from '{{.*}}bc.dwp'){{$}}
 
-DWODWOS: error: duplicate DWO ID ({{.*}}) in 'c.c' (from 'c.dwo') and 'c.c' (from 'c.dwo'){{$}}
-DWO1DWP: error: duplicate DWO ID ({{.*}}) in 'c.c' (from 'c.dwo' in '{{.*}}ac.dwp') and 'c.c' (from 'c.dwo'){{$}}
-DWO2DWP: error: duplicate DWO ID ({{.*}}) in 'c.c' (from 'c.dwo') and 'c.c' (from 'c.dwo' in '{{.*}}bc.dwp'){{$}}
+DWODWOS: warning: duplicate DWO ID ({{.*}}) in 'c.c' (from 'c.dwo') and 'c.c' (from 'c.dwo'){{$}}
+DWO1DWP: warning: duplicate DWO ID ({{.*}}) in 'c.c' (from 'c.dwo' in '{{.*}}ac.dwp') and 'c.c' (from 'c.dwo'){{$}}
+DWO2DWP: warning: duplicate DWO ID ({{.*}}) in 'c.c' (from 'c.dwo') and 'c.c' (from 'c.dwo' in '{{.*}}bc.dwp'){{$}}

--- a/llvm/test/tools/llvm-dwp/X86/gcc_type.test
+++ b/llvm/test/tools/llvm-dwp/X86/gcc_type.test
@@ -1,5 +1,5 @@
 RUN: llvm-dwp %p/../Inputs/gcc_type/a.dwo -o - | llvm-dwarfdump -v - | FileCheck %s
-RUN: not llvm-dwp %p/../Inputs/gcc_type/a.dwo %p/../Inputs/gcc_type/a.dwo -o %t 2>&1 | FileCheck --check-prefix=DUP %s
+RUN: llvm-dwp %p/../Inputs/gcc_type/a.dwo %p/../Inputs/gcc_type/a.dwo -o %t 2>&1 | FileCheck --check-prefix=DUP %s
 
 CHECK: Type Unit
 CHECK: Type Unit

--- a/llvm/test/tools/llvm-dwp/X86/handle_strx.test
+++ b/llvm/test/tools/llvm-dwp/X86/handle_strx.test
@@ -1,7 +1,7 @@
 RUN: llvm-dwp %p/../Inputs/handle_strx/dw5.dwo -o %t 2>/dev/null
 RUN: llvm-dwarfdump --verbose %t 2>/dev/null | FileCheck --check-prefix=READ_STRX %s
 
-RUN: not llvm-dwp %p/../Inputs/handle_strx/dw5.dwo %p/../Inputs/handle_strx/dw5.dwo -o %t 2>&1 \
+RUN: llvm-dwp %p/../Inputs/handle_strx/dw5.dwo %p/../Inputs/handle_strx/dw5.dwo -o %t 2>&1 \
 RUN:   | FileCheck --check-prefix=PARSE_STRX %s
 
 
@@ -10,5 +10,5 @@ with options -gdwarf-5 and -gsplit-dwarf.
 
 READ_STRX: DW_AT_name [DW_FORM_strx1]{{.*}}dw5.cc
 
-PARSE_STRX: error: duplicate DWO ID ({{.*}}) in 'dw5.cc' (from 'dw5.dwo') and 'dw5.cc' (from 'dw5.dwo')
+PARSE_STRX: warning: duplicate DWO ID ({{.*}}) in 'dw5.cc' (from 'dw5.dwo') and 'dw5.cc' (from 'dw5.dwo')
 


### PR DESCRIPTION
The current behavior of binutils dwp when encountering duplicate DWO inputs is to issue a warning and continue generating the DWP.  like this：
```
dwp a.dwo a.dwo -o x.dwp
dwp: warning: xx.dwp: duplicate entry for CU (dwo_id xxx)
```
However, llvm-dwp uses a map structure, which cannot store duplicate entries, so it throws an error and exits when faced with such scenarios.
```
llvm-dwp a.dwo a.dwo -o x.dwp
error: duplicate DWO ID (xx) in 'a.c' and 'a.c'
```
Therefore, this PR attempts to skip the duplicate DWO inputs in such case, and generate the dwp.

