### PR TITLE
[libc++] run clang-tidy on src/ in the CI

### DIFF
--- a/libcxx/src/.clang-tidy
+++ b/libcxx/src/.clang-tidy
@@ -1,4 +1,18 @@
 InheritParentConfig: true
 
 Checks: >
-  -readability-identifier-naming
+  -clang-analyzer-*,
+
+  -llvm-include-order,
+
+  -modernize-loop-convert,
+  -modernize-use-equals-delete,
+  -modernize-use-nullptr,
+  -modernize-use-override,
+
+  -readability-identifier-naming,
+  -readability-function-cognitive-complexity,
+  -readability-function-size,
+  -readability-simplify-boolean-expr,
+
+# TODO: Consider enabling clang-analyzer. Without the checks clang-tidy runs 18x faster on my system.

--- a/libcxx/test/configs/cmake-bridge.cfg.in
+++ b/libcxx/test/configs/cmake-bridge.cfg.in
@@ -23,6 +23,7 @@ config.recursiveExpansionLimit = 10
 config.test_exec_root = os.path.join('@LIBCXX_BINARY_DIR@', 'test')
 
 # Add substitutions for bootstrapping the test suite configuration
+config.substitutions.append(('%{bin-dir}', '@LIBCXX_BINARY_DIR@'))
 config.substitutions.append(('%{libcxx-dir}', '@LIBCXX_SOURCE_DIR@'))
 config.substitutions.append(('%{install-prefix}', '@LIBCXX_TESTING_INSTALL_PREFIX@'))
 config.substitutions.append(('%{include-dir}', '@LIBCXX_TESTING_INSTALL_PREFIX@/@LIBCXX_INSTALL_INCLUDE_DIR@'))

--- a/libcxx/test/libcxx/clang_tidy.sh.py
+++ b/libcxx/test/libcxx/clang_tidy.sh.py
@@ -1,0 +1,11 @@
+# ===----------------------------------------------------------------------===##
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===##
+
+# REQUIRES: has-clang-tidy
+
+# RUN: %{python} %{libcxx-dir}/../clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -clang-tidy-binary %{clang-tidy} -warnings-as-errors "*" -source-filter=".*libcxx/src.*" -quiet -p %{bin-dir}/..

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -147,7 +147,7 @@ function generate-cmake() {
     generate-cmake-base \
           -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
           -DLIBCXX_CXX_ABI=libcxxabi \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           "${@}"
 }
 

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -147,6 +147,7 @@ function generate-cmake() {
     generate-cmake-base \
           -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
           -DLIBCXX_CXX_ABI=libcxxabi \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
           "${@}"
 }
 


### PR DESCRIPTION
This adds a new test to run clang-tidy on the `src/` directory and temporarily disables and clang-tidy checks that currently fail. They will be enabled in follow-up patches.