### PR TITLE
[analyzer] Fix zext assertion failure in loop unrolling

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/LoopUnrolling.cpp
+++ b/clang/lib/StaticAnalyzer/Core/LoopUnrolling.cpp
@@ -285,10 +285,8 @@ static bool shouldCompletelyUnroll(const Stmt *LoopStmt, ASTContext &ASTCtx,
   auto CondOp = Matches[0].getNodeAs<BinaryOperator>("conditionOperator");
   unsigned MaxWidth = std::max(InitNum.getBitWidth(), BoundNum.getBitWidth());
 
-  if (InitNum.getBitWidth() != MaxWidth)
-    InitNum = InitNum.zext(MaxWidth);
-  if (BoundNum.getBitWidth() != MaxWidth)
-    BoundNum = BoundNum.zext(MaxWidth);
+  InitNum = InitNum.zext(MaxWidth);
+  BoundNum = BoundNum.zext(MaxWidth);
 
   if (CondOp->getOpcode() == BO_GE || CondOp->getOpcode() == BO_LE)
     maxStep = (BoundNum - InitNum + 1).abs().getZExtValue();

--- a/clang/lib/StaticAnalyzer/Core/LoopUnrolling.cpp
+++ b/clang/lib/StaticAnalyzer/Core/LoopUnrolling.cpp
@@ -283,10 +283,12 @@ static bool shouldCompletelyUnroll(const Stmt *LoopStmt, ASTContext &ASTCtx,
   llvm::APInt InitNum =
       Matches[0].getNodeAs<IntegerLiteral>("initNum")->getValue();
   auto CondOp = Matches[0].getNodeAs<BinaryOperator>("conditionOperator");
-  if (InitNum.getBitWidth() != BoundNum.getBitWidth()) {
-    InitNum = InitNum.zext(BoundNum.getBitWidth());
-    BoundNum = BoundNum.zext(InitNum.getBitWidth());
-  }
+  unsigned MaxWidth = std::max(InitNum.getBitWidth(), BoundNum.getBitWidth());
+
+  if (InitNum.getBitWidth() != MaxWidth)
+    InitNum = InitNum.zext(MaxWidth);
+  if (BoundNum.getBitWidth() != MaxWidth)
+    BoundNum = BoundNum.zext(MaxWidth);
 
   if (CondOp->getOpcode() == BO_GE || CondOp->getOpcode() == BO_LE)
     maxStep = (BoundNum - InitNum + 1).abs().getZExtValue();

--- a/clang/test/Analysis/PR121201.cpp
+++ b/clang/test/Analysis/PR121201.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core -analyzer-config
-// unroll-loops=true -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s \
+// RUN:    -analyzer-config unroll-loops=true
 
 // expected-no-diagnostics
 
@@ -52,8 +52,8 @@ template <long N> struct formatter<bitset<N>> {
     bitset<N> bs;
 
     template <typename OutputIt> void operator()(OutputIt) {
-      for (auto pos = N; pos > 0; --pos) // no-crash
-        ;
+      for (auto pos = N; pos > 0; --pos)
+        ; // no-crash
     }
   };
 

--- a/clang/test/Analysis/PR121201.cpp
+++ b/clang/test/Analysis/PR121201.cpp
@@ -1,0 +1,50 @@
+
+template < bool, typename T, typename > using conditional_t = T;
+class basic_format_arg;
+template < typename > struct formatter;
+template < typename Context > struct value {
+  template < typename T > value(T) {
+    using value_type = T;
+    format_custom_arg<
+        value_type, typename Context::template formatter_type< value_type > >;
+  }
+  template < typename, typename Formatter > static void format_custom_arg() {
+    Context ctx;
+    auto f = Formatter();
+    f.format(0, ctx);
+  }
+};
+struct context {
+  template < typename T > using formatter_type = formatter< T >;
+};
+enum { max_packed_args };
+template < typename Context, long >
+using arg_t =
+    conditional_t< max_packed_args, value< Context >, basic_format_arg >;
+template < int NUM_ARGS > struct format_arg_store {
+  arg_t< context, NUM_ARGS > args;
+};
+template < typename... T, long NUM_ARGS = sizeof...(T) >
+auto make_format_args(T... args) -> format_arg_store< NUM_ARGS > {
+  return {args...};
+}
+template < typename F > void write_padded(F write) { write(0); }
+template < typename... T > void format(T... args) { make_format_args(args...); }
+template < int > struct bitset {
+  bitset(long);
+};
+template < long N > struct formatter< bitset< N > > {
+  struct writer {
+    bitset< N > bs;
+    template < typename OutputIt > void operator()(OutputIt) {
+      for (auto pos = N; pos > 0; --pos)
+        ;
+    }
+  };
+  template < typename FormatContext >
+  void format(bitset< N > bs, FormatContext) {
+    write_padded(writer{bs});
+  }
+};
+bitset< 6 > TestBody_bs(2);
+void TestBody() { format(TestBody_bs); }

--- a/clang/test/Analysis/PR121201.cpp
+++ b/clang/test/Analysis/PR121201.cpp
@@ -1,50 +1,67 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -analyzer-config
+// unroll-loops=true -verify %s
 
-template < bool, typename T, typename > using conditional_t = T;
+// expected-no-diagnostics
+
+template <bool, typename T, typename> using conditional_t = T;
 class basic_format_arg;
-template < typename > struct formatter;
-template < typename Context > struct value {
-  template < typename T > value(T) {
+template <typename> struct formatter;
+
+template <typename Context> struct value {
+  template <typename T> value(T) {
     using value_type = T;
-    format_custom_arg<
-        value_type, typename Context::template formatter_type< value_type > >;
+    format_custom_arg<value_type,
+                      typename Context::template formatter_type<value_type>>;
   }
-  template < typename, typename Formatter > static void format_custom_arg() {
+
+  template <typename, typename Formatter> static void format_custom_arg() {
     Context ctx;
     auto f = Formatter();
     f.format(0, ctx);
   }
 };
+
 struct context {
-  template < typename T > using formatter_type = formatter< T >;
+  template <typename T> using formatter_type = formatter<T>;
 };
+
 enum { max_packed_args };
-template < typename Context, long >
-using arg_t =
-    conditional_t< max_packed_args, value< Context >, basic_format_arg >;
-template < int NUM_ARGS > struct format_arg_store {
-  arg_t< context, NUM_ARGS > args;
+
+template <typename Context, long>
+using arg_t = conditional_t<max_packed_args, value<Context>, basic_format_arg>;
+
+template <int NUM_ARGS> struct format_arg_store {
+  arg_t<context, NUM_ARGS> args;
 };
-template < typename... T, long NUM_ARGS = sizeof...(T) >
-auto make_format_args(T... args) -> format_arg_store< NUM_ARGS > {
+
+template <typename... T, long NUM_ARGS = sizeof...(T)>
+auto make_format_args(T... args) -> format_arg_store<NUM_ARGS> {
   return {args...};
 }
-template < typename F > void write_padded(F write) { write(0); }
-template < typename... T > void format(T... args) { make_format_args(args...); }
-template < int > struct bitset {
+
+template <typename F> void write_padded(F write) { write(0); }
+
+template <typename... T> void format(T... args) { make_format_args(args...); }
+
+template <int> struct bitset {
   bitset(long);
 };
-template < long N > struct formatter< bitset< N > > {
+
+template <long N> struct formatter<bitset<N>> {
   struct writer {
-    bitset< N > bs;
-    template < typename OutputIt > void operator()(OutputIt) {
+    bitset<N> bs;
+
+    template <typename OutputIt> void operator()(OutputIt) {
       for (auto pos = N; pos > 0; --pos)
         ;
     }
   };
-  template < typename FormatContext >
-  void format(bitset< N > bs, FormatContext) {
+
+  template <typename FormatContext> void format(bitset<N> bs, FormatContext) {
     write_padded(writer{bs});
   }
 };
-bitset< 6 > TestBody_bs(2);
+
+bitset<6> TestBody_bs(2);
+
 void TestBody() { format(TestBody_bs); }

--- a/clang/test/Analysis/PR121201.cpp
+++ b/clang/test/Analysis/PR121201.cpp
@@ -52,7 +52,7 @@ template <long N> struct formatter<bitset<N>> {
     bitset<N> bs;
 
     template <typename OutputIt> void operator()(OutputIt) {
-      for (auto pos = N; pos > 0; --pos)
+      for (auto pos = N; pos > 0; --pos) // no-crash
         ;
     }
   };

--- a/clang/test/Analysis/PR121201.cpp
+++ b/clang/test/Analysis/PR121201.cpp
@@ -10,7 +10,7 @@ template <typename> struct formatter;
 template <typename Context> struct value {
   template <typename T> value(T) {
     using value_type = T;
-    format_custom_arg<value_type,
+    (void)format_custom_arg<value_type,
                       typename Context::template formatter_type<value_type>>;
   }
 
@@ -52,8 +52,8 @@ template <long N> struct formatter<bitset<N>> {
     bitset<N> bs;
 
     template <typename OutputIt> void operator()(OutputIt) {
-      for (auto pos = N; pos > 0; --pos)
-        ; // no-crash
+      for (auto pos = N; pos > 0; --pos) // no-crash
+        ;
     }
   };
 


### PR DESCRIPTION
The current implementation of APInt extension in the code can trigger an assertion failure when the `zext` function is called with a target width smaller than the current bit width. For example:
```cpp
if (InitNum.getBitWidth() != BoundNum.getBitWidth()) {
    InitNum = InitNum.zext(BoundNum.getBitWidth());
    BoundNum = BoundNum.zext(InitNum.getBitWidth());
}
```

This logic does not guarantee that the `zext` target width is always greater than or equal to the current bit width, leading to potential crashes.

Expected Behavior:
- Ensure InitNum and BoundNum are extended to the maximum of their respective widths.
- Prevent assertion failures by enforcing correct `zext` usage.

Fixes #121201