### PR TITLE
[mlir] Prepend include directories before LLVM includes

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -196,8 +196,10 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-include_directories( "include")
-include_directories( ${MLIR_INCLUDE_DIR})
+include_directories(BEFORE
+  "include"
+  ${MLIR_INCLUDE_DIR}
+  )
 
 # Adding tools/mlir-tblgen here as calling add_tablegen sets some variables like
 # MLIR_TABLEGEN_EXE in PARENT_SCOPE which gets lost if that folder is included


### PR DESCRIPTION
Prepend mlir's include directories before system LLVM include directories.  This is particularly important for standalone builds, where system include directory may contain the previous version of mlir, and therefore various mlir targets (particularly tablegen) end up using the headers from the previous version over the fresh ones.  The new logic is copied from clang.