### PR TITLE
Fix typeinfo for undefined sanitizer

### DIFF
--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -315,7 +315,8 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI size_t hash_code() const _NOEXCEPT { return __impl::__hash(__type_name); }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool operator==(const type_info& __arg) const _NOEXCEPT {
+  // We need to inline this code because otherwise we will get a stack overflow with undefined sanitizer.
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_ALWAYS_INLINE _LIBCPP_CONSTEXPR_SINCE_CXX23 bool operator==(const type_info& __arg) const _NOEXCEPT {
     // When evaluated in a constant expression, both type infos simply can't come
     // from different translation units, so it is sufficient to compare their addresses.
     if (__libcpp_is_constant_evaluated()) {

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -316,7 +316,8 @@ public:
   _LIBCPP_HIDE_FROM_ABI size_t hash_code() const _NOEXCEPT { return __impl::__hash(__type_name); }
 
   // We need to inline this code because otherwise we will get a stack overflow with undefined sanitizer.
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_ALWAYS_INLINE _LIBCPP_CONSTEXPR_SINCE_CXX23 bool operator==(const type_info& __arg) const _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_ALWAYS_INLINE _LIBCPP_CONSTEXPR_SINCE_CXX23 bool
+  operator==(const type_info& __arg) const _NOEXCEPT {
     // When evaluated in a constant expression, both type infos simply can't come
     // from different translation units, so it is sufficient to compare their addresses.
     if (__libcpp_is_constant_evaluated()) {


### PR DESCRIPTION
This happened to me when I compiled my code on x86_64 linux (ubuntu 24.04) with clang-18 and everything except clang, compiler_rt, glibc built from source (llvm 19, llvm source) in debug (`-O1`)

I found this solution and luckily it works!
https://github.com/emscripten-core/emscripten/pull/13367 https://github.com/emscripten-core/emscripten/issues/13330

I saw that issue is abandoned, so I decided to try to push it in upstream