### PR TITLE
[clang][Driver] Add -fuse-lipo option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6654,6 +6654,7 @@ def fbinutils_version_EQ : Joined<["-"], "fbinutils-version=">,
 def fuse_ld_EQ : Joined<["-"], "fuse-ld=">, Group<f_Group>,
   Flags<[LinkOption]>, Visibility<[ClangOption, FlangOption, CLOption]>;
 def ld_path_EQ : Joined<["--"], "ld-path=">, Group<Link_Group>;
+def fuse_lipo_EQ : Joined<["-"], "fuse-lipo=">, Group<f_clang_Group>, Flags<[LinkOption]>;
 
 defm align_labels : BooleanFFlag<"align-labels">, Group<clang_ignored_gcc_optimization_f_Group>;
 def falign_labels_EQ : Joined<["-"], "falign-labels=">, Group<clang_ignored_gcc_optimization_f_Group>;

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -910,7 +910,10 @@ void darwin::Lipo::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(II.getFilename());
   }
 
-  const char *Exec = Args.MakeArgString(getToolChain().GetProgramPath("lipo"));
+  std::string LipoName =
+      std::string(Args.getLastArgValue(options::OPT_fuse_lipo_EQ, "lipo"));
+  const char *Exec =
+      Args.MakeArgString(getToolChain().GetProgramPath(LipoName.c_str()));
   C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
                                          Exec, CmdArgs, Inputs, Output));
 }

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -910,10 +910,9 @@ void darwin::Lipo::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(II.getFilename());
   }
 
-  std::string LipoName =
-      std::string(Args.getLastArgValue(options::OPT_fuse_lipo_EQ, "lipo"));
+  StringRef LipoName = Args.getLastArgValue(options::OPT_fuse_lipo_EQ, "lipo");
   const char *Exec =
-      Args.MakeArgString(getToolChain().GetProgramPath(LipoName.c_str()));
+      Args.MakeArgString(getToolChain().GetProgramPath(LipoName.data()));
   C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
                                          Exec, CmdArgs, Inputs, Output));
 }

--- a/clang/test/Driver/fuse-lipo.c
+++ b/clang/test/Driver/fuse-lipo.c
@@ -9,3 +9,7 @@
 
 // RUN: %clang %s -### --target=arm64-apple-darwin -Wno-unused-command-line-argument -fuse-lipo=llvm-lipo 2>&1 | FileCheck -check-prefix=TEST4 %s
 // TEST4-NOT: llvm-lipo
+
+// RUN: %clang %s -### --target=arm64-apple-darwin -arch x86_64 -arch arm64 2>&1 | FileCheck -check-prefix=TEST5 %s
+// TEST5: lipo
+// TEST5-NOT: llvm-lipo

--- a/clang/test/Driver/fuse-lipo.c
+++ b/clang/test/Driver/fuse-lipo.c
@@ -1,0 +1,11 @@
+// RUN: %clang %s -### --target=arm64-apple-darwin -arch x86_64 -arch arm64 -fuse-lipo=llvm-lipo 2>&1 | FileCheck -check-prefix=TEST1 %s
+// TEST1: llvm-lipo
+
+// RUN: %clang %s -### --target=arm64-apple-darwin -arch x86_64 -arch arm64 -fuse-lipo=nonexistant-lipo 2>&1 | FileCheck -check-prefix=TEST2 %s
+// TEST2: nonexistant-lipo
+
+// RUN: %clang %s -### --target=arm64-apple-darwin -fuse-lipo=llvm-lipo 2>&1 | FileCheck -check-prefix=TEST3 %s
+// TEST3: clang: warning: argument unused during compilation: '-fuse-lipo=llvm-lipo'
+
+// RUN: %clang %s -### --target=arm64-apple-darwin -Wno-unused-command-line-argument -fuse-lipo=llvm-lipo 2>&1 | FileCheck -check-prefix=TEST4 %s
+// TEST4-NOT: llvm-lipo


### PR DESCRIPTION
Partially fixes https://github.com/llvm/llvm-project/issues/59552 by adding a new option `-fuse-lipo` that can specify the tool name to be used by clang-driver for the lipo action. For example, pass `-fuse-lipo=llvm-lipo` to use `llvm-lipo` instead of the default `lipo`.
