### PR TITLE
[mlir][llvmir] implement missing attrs `getChecked`

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -311,12 +311,7 @@ TargetFeaturesAttr TargetFeaturesAttr::getChecked(
   SmallVector<StringRef> features;
   targetFeatures.split(features, ',', /*MaxSplit=*/-1,
                        /*KeepEmpty=*/false);
-  SmallVector<StringAttr> featuresAttrs;
-  featuresAttrs.reserve(features.size());
-  for (StringRef feature : features) {
-    featuresAttrs.push_back(StringAttr::get(context, feature));
-  }
-  return getChecked(emitError, context, featuresAttrs);
+  return getChecked(emitError, context, features);
 }
 
 LogicalResult

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -289,7 +289,7 @@ TargetFeaturesAttr TargetFeaturesAttr::get(MLIRContext *context,
 }
 
 TargetFeaturesAttr TargetFeaturesAttr::getChecked(
-    llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    function_ref<InFlightDiagnostic()> emitError,
     MLIRContext *context, llvm::ArrayRef<StringRef> features) {
   return Base::getChecked(emitError, context,
                           llvm::map_to_vector(features, [&](StringRef feature) {

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -48,6 +48,7 @@ void LLVMDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "mlir/Dialect/LLVMIR/LLVMOpsAttrDefs.cpp.inc"
+
       >();
 }
 
@@ -288,9 +289,10 @@ TargetFeaturesAttr TargetFeaturesAttr::get(MLIRContext *context,
                    }));
 }
 
-TargetFeaturesAttr TargetFeaturesAttr::getChecked(
-    function_ref<InFlightDiagnostic()> emitError,
-    MLIRContext *context, llvm::ArrayRef<StringRef> features) {
+TargetFeaturesAttr
+TargetFeaturesAttr::getChecked(function_ref<InFlightDiagnostic()> emitError,
+                               MLIRContext *context,
+                               llvm::ArrayRef<StringRef> features) {
   return Base::getChecked(emitError, context,
                           llvm::map_to_vector(features, [&](StringRef feature) {
                             return StringAttr::get(context, feature);
@@ -305,13 +307,14 @@ TargetFeaturesAttr TargetFeaturesAttr::get(MLIRContext *context,
   return get(context, features);
 }
 
-TargetFeaturesAttr TargetFeaturesAttr::getChecked(
-    function_ref<InFlightDiagnostic()> emitError,
-    MLIRContext *context, StringRef targetFeatures) {
+TargetFeaturesAttr
+TargetFeaturesAttr::getChecked(function_ref<InFlightDiagnostic()> emitError,
+                               MLIRContext *context, StringRef targetFeatures) {
   SmallVector<StringRef> features;
   targetFeatures.split(features, ',', /*MaxSplit=*/-1,
                        /*KeepEmpty=*/false);
-  return getChecked(emitError, context, features);
+  ArrayRef featuresRef(features);
+  return getChecked(emitError, context, featuresRef);
 }
 
 LogicalResult

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -288,12 +288,35 @@ TargetFeaturesAttr TargetFeaturesAttr::get(MLIRContext *context,
                    }));
 }
 
+TargetFeaturesAttr TargetFeaturesAttr::getChecked(
+    llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    MLIRContext *context, llvm::ArrayRef<StringRef> features) {
+  return Base::getChecked(emitError, context,
+                          llvm::map_to_vector(features, [&](StringRef feature) {
+                            return StringAttr::get(context, feature);
+                          }));
+}
+
 TargetFeaturesAttr TargetFeaturesAttr::get(MLIRContext *context,
                                            StringRef targetFeatures) {
   SmallVector<StringRef> features;
   targetFeatures.split(features, ',', /*MaxSplit=*/-1,
                        /*KeepEmpty=*/false);
   return get(context, features);
+}
+
+TargetFeaturesAttr TargetFeaturesAttr::getChecked(
+    llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    MLIRContext *context, StringRef targetFeatures) {
+  SmallVector<StringRef> features;
+  targetFeatures.split(features, ',', /*MaxSplit=*/-1,
+                       /*KeepEmpty=*/false);
+  SmallVector<StringAttr> featuresAttrs;
+  featuresAttrs.reserve(features.size());
+  for (StringRef feature : features) {
+    featuresAttrs.push_back(StringAttr::get(context, feature));
+  }
+  return getChecked(emitError, context, featuresAttrs);
 }
 
 LogicalResult

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMAttrs.cpp
@@ -306,7 +306,7 @@ TargetFeaturesAttr TargetFeaturesAttr::get(MLIRContext *context,
 }
 
 TargetFeaturesAttr TargetFeaturesAttr::getChecked(
-    llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    function_ref<InFlightDiagnostic()> emitError,
     MLIRContext *context, StringRef targetFeatures) {
   SmallVector<StringRef> features;
   targetFeatures.split(features, ',', /*MaxSplit=*/-1,


### PR DESCRIPTION
These are declared but not implemented in [LLVMAttrDefs.td](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td#L1164-L1167). This has gone unnoticed because the linker DCEs the decl _unless someone accidentally tries to actually call those functions..._