### PR TITLE
[libc] Use __attribute__((__noreturn__)) for _Noreturn in C < 11

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -52,6 +52,16 @@
 #undef __restrict
 #define __restrict restrict // C99 and above support the restrict keyword.
 
+#undef _Noreturn
+#if __STDC_VERSION__ >= 201112L
+// In C11 and later, _Noreturn is a keyword.
+#elif defined(__GNUC__)
+// GNU-compatible compilers have an equivalent attribute.
+#define _Noreturn __attribute__((__noreturn__))
+#else
+#define _Noreturn
+#endif
+
 #undef __NOEXCEPT
 #ifdef __GNUC__
 #define __NOEXCEPT __attribute__((__nothrow__))


### PR DESCRIPTION
When in modes like C99, the _Noreturn keyword is not available in
C.  But GNU-compatible compilers have a `noreturn` attribute with
the same effect on function declarations.
