### PR TITLE
[mlir][capi] make MLIR Pass C-API type safe

### DIFF
--- a/mlir/include/mlir-c/Pass.h
+++ b/mlir/include/mlir-c/Pass.h
@@ -174,11 +174,14 @@ typedef struct MlirExternalPassCallbacks MlirExternalPassCallbacks;
 /// Creates an external `MlirPass` that calls the supplied `callbacks` using the
 /// supplied `userData`. If `opName` is empty, the pass is a generic operation
 /// pass. Otherwise it is an operation pass specific to the specified pass name.
-MLIR_CAPI_EXPORTED MlirPass mlirCreateExternalPass(
+MLIR_CAPI_EXPORTED MlirExternalPass mlirExternalPassCreate(
     MlirTypeID passID, MlirStringRef name, MlirStringRef argument,
     MlirStringRef description, MlirStringRef opName,
     intptr_t nDependentDialects, MlirDialectHandle *dependentDialects,
     MlirExternalPassCallbacks callbacks, void *userData);
+
+// Static cast ExternalPass to Pass.
+MLIR_CAPI_EXPORTED MlirPass mlirExternalPassGetPass(MlirExternalPass pass);
 
 /// This signals that the pass has failed. This is only valid to call during
 /// the `run` callback of `MlirExternalPassCallbacks`.

--- a/mlir/lib/CAPI/IR/Pass.cpp
+++ b/mlir/lib/CAPI/IR/Pass.cpp
@@ -193,19 +193,23 @@ private:
 };
 } // namespace mlir
 
-MlirPass mlirCreateExternalPass(MlirTypeID passID, MlirStringRef name,
-                                MlirStringRef argument,
-                                MlirStringRef description, MlirStringRef opName,
-                                intptr_t nDependentDialects,
-                                MlirDialectHandle *dependentDialects,
-                                MlirExternalPassCallbacks callbacks,
-                                void *userData) {
-  return wrap(static_cast<mlir::Pass *>(new mlir::ExternalPass(
+MlirExternalPass mlirExternalPassCreate(MlirTypeID passID, MlirStringRef name,
+                                        MlirStringRef argument,
+                                        MlirStringRef description, MlirStringRef opName,
+                                        intptr_t nDependentDialects,
+                                        MlirDialectHandle *dependentDialects,
+                                        MlirExternalPassCallbacks callbacks,
+                                        void *userData) {
+  return wrap(new mlir::ExternalPass(
       unwrap(passID), unwrap(name), unwrap(argument), unwrap(description),
       opName.length > 0 ? std::optional<StringRef>(unwrap(opName))
                         : std::nullopt,
       {dependentDialects, static_cast<size_t>(nDependentDialects)}, callbacks,
-      userData)));
+      userData));
+}
+
+MlirPass mlirExternalPassGetPass(MlirExternalPass externalPass) {
+  return wrap(static_cast<mlir::Pass *>(&externalPass));
 }
 
 void mlirExternalPassSignalFailure(MlirExternalPass pass) {

--- a/mlir/test/CAPI/pass.c
+++ b/mlir/test/CAPI/pass.c
@@ -367,9 +367,11 @@ void testExternalPass(void) {
         mlirStringRefCreateFromCString("test-external-pass");
     TestExternalPassUserData userData = {0};
 
-    MlirPass externalPass = mlirCreateExternalPass(
+    MlirExternalPass externalPass = mlirExternalPassCreate(
         passID, name, argument, description, emptyOpName, 0, NULL,
         makeTestExternalPassCallbacks(NULL, testRunExternalPass), &userData);
+
+    MlirPass pass = mlirExternalPassGetPass(externalPass);
 
     if (userData.constructCallCount != 1) {
       fprintf(stderr, "Expected constructCallCount to be 1\n");
@@ -377,7 +379,7 @@ void testExternalPass(void) {
     }
 
     MlirPassManager pm = mlirPassManagerCreate(ctx);
-    mlirPassManagerAddOwnedPass(pm, externalPass);
+    mlirPassManagerAddOwnedPass(pm, pass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsFailure(success)) {
       fprintf(stderr, "Unexpected failure running external pass.\n");
@@ -408,10 +410,12 @@ void testExternalPass(void) {
     MlirDialectHandle funcHandle = mlirGetDialectHandle__func__();
     MlirStringRef funcOpName = mlirStringRefCreateFromCString("func.func");
 
-    MlirPass externalPass = mlirCreateExternalPass(
+    MlirExternalPass externalPass = mlirExternalPassCreate(
         passID, name, argument, description, funcOpName, 1, &funcHandle,
         makeTestExternalPassCallbacks(NULL, testRunExternalFuncPass),
         &userData);
+
+    MlirPass pass = mlirExternalPassGetPass(externalPass);
 
     if (userData.constructCallCount != 1) {
       fprintf(stderr, "Expected constructCallCount to be 1\n");
@@ -421,7 +425,7 @@ void testExternalPass(void) {
     MlirPassManager pm = mlirPassManagerCreate(ctx);
     MlirOpPassManager nestedFuncPm =
         mlirPassManagerGetNestedUnder(pm, funcOpName);
-    mlirOpPassManagerAddOwnedPass(nestedFuncPm, externalPass);
+    mlirOpPassManagerAddOwnedPass(nestedFuncPm, pass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsFailure(success)) {
       fprintf(stderr, "Unexpected failure running external operation pass.\n");
@@ -457,11 +461,13 @@ void testExternalPass(void) {
         mlirStringRefCreateFromCString("test-external-pass");
     TestExternalPassUserData userData = {0};
 
-    MlirPass externalPass = mlirCreateExternalPass(
+    MlirExternalPass externalPass = mlirExternalPassCreate(
         passID, name, argument, description, emptyOpName, 0, NULL,
         makeTestExternalPassCallbacks(testInitializeExternalPass,
                                       testRunExternalPass),
         &userData);
+
+    MlirPass pass = mlirExternalPassGetPass(externalPass);
 
     if (userData.constructCallCount != 1) {
       fprintf(stderr, "Expected constructCallCount to be 1\n");
@@ -469,7 +475,7 @@ void testExternalPass(void) {
     }
 
     MlirPassManager pm = mlirPassManagerCreate(ctx);
-    mlirPassManagerAddOwnedPass(pm, externalPass);
+    mlirPassManagerAddOwnedPass(pm, pass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsFailure(success)) {
       fprintf(stderr, "Unexpected failure running external pass.\n");
@@ -504,11 +510,13 @@ void testExternalPass(void) {
         mlirStringRefCreateFromCString("test-external-failing-pass");
     TestExternalPassUserData userData = {0};
 
-    MlirPass externalPass = mlirCreateExternalPass(
+    MlirExternalPass externalPass = mlirExternalPassCreate(
         passID, name, argument, description, emptyOpName, 0, NULL,
         makeTestExternalPassCallbacks(testInitializeFailingExternalPass,
                                       testRunExternalPass),
         &userData);
+
+    MlirPass pass = mlirExternalPassGetPass(externalPass);
 
     if (userData.constructCallCount != 1) {
       fprintf(stderr, "Expected constructCallCount to be 1\n");
@@ -516,7 +524,7 @@ void testExternalPass(void) {
     }
 
     MlirPassManager pm = mlirPassManagerCreate(ctx);
-    mlirPassManagerAddOwnedPass(pm, externalPass);
+    mlirPassManagerAddOwnedPass(pm, pass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsSuccess(success)) {
       fprintf(
@@ -553,10 +561,12 @@ void testExternalPass(void) {
         mlirStringRefCreateFromCString("test-external-failing-pass");
     TestExternalPassUserData userData = {0};
 
-    MlirPass externalPass = mlirCreateExternalPass(
+    MlirExternalPass externalPass = mlirExternalPassCreate(
         passID, name, argument, description, emptyOpName, 0, NULL,
         makeTestExternalPassCallbacks(NULL, testRunFailingExternalPass),
         &userData);
+
+    MlirPass pass = mlirExternalPassGetPass(externalPass);
 
     if (userData.constructCallCount != 1) {
       fprintf(stderr, "Expected constructCallCount to be 1\n");
@@ -564,7 +574,7 @@ void testExternalPass(void) {
     }
 
     MlirPassManager pm = mlirPassManagerCreate(ctx);
-    mlirPassManagerAddOwnedPass(pm, externalPass);
+    mlirPassManagerAddOwnedPass(pm, pass);
     MlirLogicalResult success = mlirPassManagerRunOnOp(pm, module);
     if (mlirLogicalResultIsSuccess(success)) {
       fprintf(


### PR DESCRIPTION
This PR changes C-API name `mlirCreateExternalPass` to `mlirExternalPassCreate` for aligning the naming convention in C-API, and now it returns `MlirExternalPass`.
I added a new C-API `MlirExternalPassGetPass` to cast `MlirExternalPass` to `MlirPass`;

The X Problem is in the MLIR C-API, there is no way to create a `MlirExternalPass`, related API `mlirCreateExternalPass` create a `MlirPass`.
While creation of `MlirExternalPassCallbacks` requires `MlirExternalPass`, see https://github.com/llvm/llvm-project/blob/1557eeda738d7dbe51d2f52fce28a1fd6f5844ce/mlir/include/mlir-c/Pass.h#L169-L171
Thus it's impossible to create `MlirExternalPassCallbacks` type safely externally.