### PR TITLE
[MLGO] Only configure tests with `LLVM_INCLUDE_TESTS`

### DIFF
--- a/llvm/utils/mlgo-utils/CMakeLists.txt
+++ b/llvm/utils/mlgo-utils/CMakeLists.txt
@@ -1,9 +1,11 @@
-configure_lit_site_cfg(
-  "${CMAKE_CURRENT_SOURCE_DIR}/tests/lit.site.cfg.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg"
-)
+if(LLVM_INCLUDE_TESTS)
+  configure_lit_site_cfg(
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/lit.site.cfg.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg"
+  )
 
-add_lit_testsuite(check-mlgo-utils "Running mlgo-utils tests"
-  ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS "FileCheck" "not" "count" "split-file" "yaml2obj" "llvm-objcopy"
-)
+  add_lit_testsuite(check-mlgo-utils "Running mlgo-utils tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS "FileCheck" "not" "count" "split-file" "yaml2obj" "llvm-objcopy"
+  )
+endif()


### PR DESCRIPTION
This allows downstream customers to remove all test directories and save quite some space when only building with `LLVM_INCLUDE_TESTS=OFF`.