### PR TITLE
[libc++] Remove unnecessary division and modulo operations in bitset

### DIFF
--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -329,6 +329,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference operator*() const _NOEXCEPT {
+    _LIBCPP_ASSERT_INTERNAL(__ctz_ < __bits_per_word, "Dereferencing an invalid __bit_iterator.");
     return __conditional_t<_IsConst, __bit_const_reference<_Cp>, __bit_reference<_Cp> >(
         __seg_, __storage_type(1) << __ctz_);
   }
@@ -453,7 +454,10 @@ private:
   _LIBCPP_HIDE_FROM_ABI
   _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __bit_iterator(__storage_pointer __s, unsigned __ctz) _NOEXCEPT
       : __seg_(__s),
-        __ctz_(__ctz) {}
+        __ctz_(__ctz) {
+    _LIBCPP_ASSERT_VALID_INPUT_RANGE(
+        __ctz_ < __bits_per_word, "__bit_iterator initialized with an invalid number of trailing zeros.");
+  }
 
   friend typename _Cp::__self;
 

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -455,7 +455,7 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 explicit __bit_iterator(__storage_pointer __s, unsigned __ctz) _NOEXCEPT
       : __seg_(__s),
         __ctz_(__ctz) {
-    _LIBCPP_ASSERT_VALID_INPUT_RANGE(
+    _LIBCPP_ASSERT_INTERNAL(
         __ctz_ < __bits_per_word, "__bit_iterator initialized with an invalid number of trailing zeros.");
   }
 

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -464,10 +464,14 @@ protected:
     return __const_reference(&__first_, __storage_type(1) << __pos);
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 __iterator __make_iter(size_t __pos) _NOEXCEPT {
-    return __iterator(&__first_, __pos);
+    // Allow the == case to accommodate the past-the-end iterator.
+    _LIBCPP_ASSERT_INTERNAL(__pos <= __bits_per_word, "Out of bounds access in the single-word bitset implementation.");
+    return __pos != __bits_per_word ? __iterator(&__first_, __pos) : __iterator(&__first_ + 1, 0);
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 __const_iterator __make_iter(size_t __pos) const _NOEXCEPT {
-    return __const_iterator(&__first_, __pos);
+    // Allow the == case to accommodate the past-the-end iterator.
+    _LIBCPP_ASSERT_INTERNAL(__pos <= __bits_per_word, "Out of bounds access in the single-word bitset implementation.");
+    return __pos != __bits_per_word ? __const_iterator(&__first_, __pos) : __const_iterator(&__first_ + 1, 0);
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 void operator&=(const __bitset& __v) _NOEXCEPT;

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -464,10 +464,10 @@ protected:
     return __const_reference(&__first_, __storage_type(1) << __pos);
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 __iterator __make_iter(size_t __pos) _NOEXCEPT {
-    return __iterator(&__first_ + __pos / __bits_per_word, __pos % __bits_per_word);
+    return __iterator(&__first_, __pos);
   }
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 __const_iterator __make_iter(size_t __pos) const _NOEXCEPT {
-    return __const_iterator(&__first_ + __pos / __bits_per_word, __pos % __bits_per_word);
+    return __const_iterator(&__first_, __pos);
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 void operator&=(const __bitset& __v) _NOEXCEPT;


### PR DESCRIPTION
The PR removes the unnecessary division and modulo operations in the one-word specialization `__bitset<1, _Size>`. The reason is that for the one-word specialization, we have `__pos < __bits_per_word` (as `__bitset<1, _Size>` is an implementation detail only used by the public `bitset`). So `__pos / __bits_per_word == 0` and `__pos / __pos % __bits_per_word == __pos`. 