### PR TITLE
[compiler-rt][emutls] Fix race condition when allocating object

### DIFF
--- a/compiler-rt/lib/builtins/emutls.c
+++ b/compiler-rt/lib/builtins/emutls.c
@@ -392,8 +392,12 @@ __attribute__((visibility("default"), weak))
 void *__emutls_get_address(__emutls_control *control) {
   uintptr_t index = emutls_get_index(control);
   emutls_address_array *array = emutls_get_address_array(index--);
-  if (array->data[index] == NULL)
-    array->data[index] = emutls_allocate_object(control);
+  if (array->data[index] == NULL) {
+    emutls_lock();
+    if (array->data[index] == NULL)
+      array->data[index] = emutls_allocate_object(control);
+    emutls_unlock();
+  }
   return array->data[index];
 }
 


### PR DESCRIPTION
For following program compiled with `clang++ tls.cc -femulated-tls   -O3  -rtlib=compiler-rt -unwindlib=libunwind` on X86_64, there is chance the first allocated object is different from other allocation.
```
#include <atomic>
#include <iostream>
#include <mutex>
#include <thread>
#include <vector>

thread_local int id = 0;
std::mutex print_mutex;

int main() {
  // std::cout << "thread " << 0 << ": " << &id << std::endl;
  std::vector<std::thread> group;
  for (int i = 1; i < 8; ++i) {
    group.emplace_back([i] {
      std::unique_lock<std::mutex> _(print_mutex);
      std::cout << "thread " << i << ": " << &id << std::endl;
    });
  }
  for (auto &t : group) t.join();
  return 0;
}

Output:
thread 1: 0x7f57040010a8
thread 2: 0x7f56fc000c98
thread 3: 0x7f56fc000c98
thread 5: 0x7f56fc000c98
thread 4: 0x7f56fc000c98
thread 6: 0x7f56fc000c98
thread 7: 0x7f56fc000c98
```
Also I have a question, is this implementation broken since it's returning the same address for the same thread_local variable in different threads.