### PR TITLE
[Clang] Add GCC's __builtin_stack_address() to Clang.

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -899,6 +899,12 @@ def FrameAddress : Builtin {
   let Prototype = "void*(_Constant unsigned int)";
 }
 
+def StackAddress : Builtin {
+  let Spellings = ["__builtin_stack_address"];
+  let Attributes = [NoThrow];
+  let Prototype = "void*()";
+}
+
 def ClearCache : Builtin {
   let Spellings = ["__builtin___clear_cache"];
   let Attributes = [NoThrow];

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4865,6 +4865,14 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Triple::x86_64:
       return RValue::get(EmitSpecialRegisterBuiltin(
           *this, E, Int64Ty, VoidPtrTy, NormalRead, "rsp"));
+    case Triple::riscv32:
+    case Triple::riscv64: {
+      llvm::IntegerType *SPRegIntTy =
+          getTarget().getTriple().getArchPointerBitWidth() == 64 ? Int64Ty
+                                                                 : Int32Ty;
+      return RValue::get(EmitSpecialRegisterBuiltin(
+          *this, E, SPRegIntTy, VoidPtrTy, NormalRead, "sp"));
+    }
     default:
       ErrorUnsupported(E, "__builtin_stack_address");
       return GetUndefRValue(E->getType());

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -4865,6 +4865,13 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Triple::x86_64:
       return RValue::get(EmitSpecialRegisterBuiltin(
           *this, E, Int64Ty, VoidPtrTy, NormalRead, "rsp"));
+    case Triple::arm:
+    case Triple::armeb:
+    case Triple::thumb:
+    case Triple::thumbeb:
+    case Triple::aarch64:
+    case Triple::aarch64_be:
+    case Triple::aarch64_32:
     case Triple::riscv32:
     case Triple::riscv64: {
       llvm::IntegerType *SPRegIntTy =

--- a/clang/test/CodeGen/builtin-stackaddress.c
+++ b/clang/test/CodeGen/builtin-stackaddress.c
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple i686-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=X86 %s
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=X86_64 %s
+// RUN: %clang_cc1 -triple riscv32-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_32 %s
+// RUN: %clang_cc1 -triple riscv64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_64 %s
 
 void* a() {
   // X86_64: [[INT_SP:%.*]] = call i64 @llvm.read_register.i64(metadata [[SPREG:![0-9]+]])
@@ -9,5 +11,13 @@ void* a() {
   // X86: [[INT_SP:%.*]] = call i32 @llvm.read_register.i32(metadata [[SPREG:![0-9]+]])
   // X86: inttoptr i32 [[INT_SP]]
   // X86: [[SPREG]] = !{!"esp"}
+  //
+  // RISCV_32: [[INT_SP:%.*]] = call i32 @llvm.read_register.i32(metadata [[SPREG:![0-9]+]])
+  // RISCV_32: inttoptr i32 [[INT_SP]]
+  // RISCV_32: [[SPREG]] = !{!"sp"}
+  //
+  // RISCV_64: [[INT_SP:%.*]] = call i64 @llvm.read_register.i64(metadata [[SPREG:![0-9]+]])
+  // RISCV_64: inttoptr i64 [[INT_SP]]
+  // RISCV_64: [[SPREG]] = !{!"sp"}
   return __builtin_stack_address();
 }

--- a/clang/test/CodeGen/builtin-stackaddress.c
+++ b/clang/test/CodeGen/builtin-stackaddress.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple i686-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=X86 %s
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=X86_64 %s
+
+void* a() {
+  // X86_64: [[INT_SP:%.*]] = call i64 @llvm.read_register.i64(metadata [[SPREG:![0-9]+]])
+  // X86_64: inttoptr i64 [[INT_SP]]
+  // X86_64: [[SPREG]] = !{!"rsp"}
+  //
+  // X86: [[INT_SP:%.*]] = call i32 @llvm.read_register.i32(metadata [[SPREG:![0-9]+]])
+  // X86: inttoptr i32 [[INT_SP]]
+  // X86: [[SPREG]] = !{!"esp"}
+  return __builtin_stack_address();
+}

--- a/clang/test/CodeGen/builtin-stackaddress.c
+++ b/clang/test/CodeGen/builtin-stackaddress.c
@@ -1,7 +1,9 @@
 // RUN: %clang_cc1 -triple i686-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=X86 %s
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=X86_64 %s
-// RUN: %clang_cc1 -triple riscv32-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_32 %s
-// RUN: %clang_cc1 -triple riscv64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_64 %s
+// RUN: %clang_cc1 -triple riscv32-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_ARM_32 %s
+// RUN: %clang_cc1 -triple riscv64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_ARM_64 %s
+// RUN: %clang_cc1 -triple arm-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_ARM_32 %s
+// RUN: %clang_cc1 -triple arm64-unknown-unknown -emit-llvm -o - %s | FileCheck -check-prefix=RISCV_ARM_64 %s
 
 void* a() {
   // X86_64: [[INT_SP:%.*]] = call i64 @llvm.read_register.i64(metadata [[SPREG:![0-9]+]])
@@ -12,12 +14,12 @@ void* a() {
   // X86: inttoptr i32 [[INT_SP]]
   // X86: [[SPREG]] = !{!"esp"}
   //
-  // RISCV_32: [[INT_SP:%.*]] = call i32 @llvm.read_register.i32(metadata [[SPREG:![0-9]+]])
-  // RISCV_32: inttoptr i32 [[INT_SP]]
-  // RISCV_32: [[SPREG]] = !{!"sp"}
+  // RISCV_ARM_32: [[INT_SP:%.*]] = call i32 @llvm.read_register.i32(metadata [[SPREG:![0-9]+]])
+  // RISCV_ARM_32: inttoptr i32 [[INT_SP]]
+  // RISCV_ARM_32: [[SPREG]] = !{!"sp"}
   //
-  // RISCV_64: [[INT_SP:%.*]] = call i64 @llvm.read_register.i64(metadata [[SPREG:![0-9]+]])
-  // RISCV_64: inttoptr i64 [[INT_SP]]
-  // RISCV_64: [[SPREG]] = !{!"sp"}
+  // RISCV_ARM_64: [[INT_SP:%.*]] = call i64 @llvm.read_register.i64(metadata [[SPREG:![0-9]+]])
+  // RISCV_ARM_64: inttoptr i64 [[INT_SP]]
+  // RISCV_ARM_64: [[SPREG]] = !{!"sp"}
   return __builtin_stack_address();
 }


### PR DESCRIPTION
This new builtin returns the value of the stack pointer register, mirroring GCC's [__builtin_stack_address()](https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html). This implementation initially supports the x86, x86_64, risc32, risc64, arm32, arm64 architectures. Support for other architectures can be added in future patches.

Referring: #82632 