### PR TITLE
[bazel] Add llvm_zlib to system include path

### DIFF
--- a/utils/bazel/third_party_build/zlib-ng.BUILD
+++ b/utils/bazel/third_party_build/zlib-ng.BUILD
@@ -101,6 +101,10 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    includes = select({
+        ":llvm_zlib_enabled": ["."],
+        "//conditions:default": [],
+    }),
     # Clang includes zlib with angled instead of quoted includes, so we need
     # strip_include_prefix here.
     strip_include_prefix = ".",


### PR DESCRIPTION
LLVM codebase expects to find zlib using (angle brackets) `<zlib.h>`.
This means llvm_zlib needs to be exposed on the system include path
(`-isystem` not `-iquote`).  Tell bazel to do that.