### PR TITLE
[bazel] Allow SupportTests to be built remotely and cached

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
@@ -697,7 +697,7 @@ cc_test(
     ],
     linkstatic = 1,
     tags = [
-        "local",  # Not compatible with the sandbox on MacOS
+        "no-sandbox",  # FileSystemTest.permissions not compatible with the sandbox on MacOS
     ],
     deps = [
         "//llvm:AllTargetsCodeGens",


### PR DESCRIPTION
`SupportTests` fails in the bazel macOS sandbox, because
`FileSystemTest.permissions` expects to be able to modify file
permissions on some otherwise protected files.

Previously this test was marked `local` in bazel, which has
additional undesirable effects such as skipping remote build and cache.

Tighten the bazel tags to just `no-sandbox`.  Note in particular, that
this allows the test to build, execute, and cache remotely (if
configured).

Testing:
- Verified this test fails (as expected) on macOS with no tags, and
  passes with `no-sandbox`.
- Verified this test passes when executed remotely (using an Engflow RBE
  setup) with `no-sandbox`.