### PR TITLE
[lit] Cope with more cat variants

### DIFF
--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -18,7 +18,7 @@
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
 # CHECK-NOT: --
-# CHECK: cat{{(_64)?(\.exe)?}}: {{cannot open does-not-exist|does-not-exist: No such file or directory}}
+# CHECK: cat{{(_64)?(\.exe)?}}: {{.*does-not-exist.*}}: No such file or directory
 # CHECK: --
 
 # CHECK: FAIL: shtest-format :: external_shell/fail_with_bad_encoding.txt


### PR DESCRIPTION
BusyBox `cat` has yet another slight variation of error formatting:

```console
$ cat --help 2>&1 | head -1
BusyBox v1.37.0 (2024-09-30 10:39:57 UTC) multi-call binary.

$ cat does-not-exist
cat: can't open 'does-not-exist': No such file or directory
```

Rather than extend the test result regex with a third case,
recognise that we only really care about the filename and errno string.
Weaken the regex to ignore all "noise" around the filename.

Note this also corrects what looks like a bug with the previous regex.
Previously, the `cannot open does-not-exist` alternate did not assert
the following errno message.  This was introduced in
https://reviews.llvm.org/D60553 (apparently) due to differences in the
`cat` command on AIX.  That bug doesn't include the specific
AIX output, so it's unclear if this omission was intended.