### PR TITLE
[lit] Ignore src permissions when copying lit_test_times

### DIFF
--- a/llvm/utils/lit/tests/reorder.py
+++ b/llvm/utils/lit/tests/reorder.py
@@ -1,6 +1,6 @@
 ## Check that we can reorder test runs.
 
-# RUN: cp %{inputs}/reorder/lit_test_times %{inputs}/reorder/.lit_test_times.txt
+# RUN: cat %{inputs}/reorder/lit_test_times > %{inputs}/reorder/.lit_test_times.txt
 # RUN: not %{lit-no-order-opt} %{inputs}/reorder > %t.out
 # RUN: FileCheck --check-prefix=TIMES < %{inputs}/reorder/.lit_test_times.txt %s
 # RUN: FileCheck < %t.out %s


### PR DESCRIPTION
`cp` will attempt to re-produce the source permissions on the
destination file.

When the input files are read-only (0444) - eg when building in a bazel
sandbox - this means the .lit_test_times.txt tmpfile is also 0444.
When `TestTimes.py` is run a second time, it fails (permission denied)
to write to this read-only file.

Rather than attempt to navigate portable `cp` command line options to
disable this, just copy using a naive `cat src > dst` instead.

For posterity, the failure appeared as:
```
Command Output (stdout):
--
cp Inputs/reorder/lit_test_times Inputs/reorder/.lit_test_times.txt
not env -u FILECHECK_OPTS "/var/lib/engflow/worker/work/27/exec/bazel-out/k8-fastbuild/bin/external/llvm-project/llvm/utils/lit/tests/reorder.py.test.runfiles/python_3_12_x86_64-unknown-linux-gnu/bin/python3" /var/lib/engflow/worker/work/27/exec/bazel-out/k8-fastbuild/bin/external/llvm-project/llvm/utils/lit/tests/reorder.py.test.runfiles/__main__/external/llvm-project/llvm/utils/lit/lit.py -j1 Inputs/reorder > /var/lib/engflow/worker/work/27/exec/bazel-out/k8-fastbuild/bin/external/llvm-project/llvm/utils/lit/tests/reorder.py.test.runfiles/__main__/external/llvm-project/llvm/utils/lit/tests/Output/reorder.py.tmp.out
FileCheck --check-prefix=TIMES < Inputs/reorder/.lit_test_times.txt /var/lib/engflow/worker/work/27/exec/bazel-out/k8-fastbuild/bin/external/llvm-project/llvm/utils/lit/tests/reorder.py.test.runfiles/__main__/external/llvm-project/llvm/utils/lit/tests/reorder.py
--
```