### PR TITLE
[lldb] Update two API tests to fix x86 Darwin failures

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -1410,7 +1410,17 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
             p_response = context.get("p_response")
             self.assertIsNotNone(p_response)
             self.assertTrue(len(p_response) > 0)
-            self.assertFalse(p_response[0] == "E")
+
+            # on x86 Darwin, 4 GPR registers are often
+            # unavailable, this is expected and correct.
+            if (
+                self.getArchitecture() == "x86_64"
+                and self.platformIsDarwin()
+                and p_response[0] == "E"
+            ):
+                values[reg_index] = 0
+            else:
+                self.assertFalse(p_response[0] == "E")
 
             values[reg_index] = unpack_register_hex_unsigned(endian, p_response)
 

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -58,6 +58,13 @@ class RegisterCommandsTestCase(TestBase):
             # could not be read.  This is expected.
             error_str_matched = True
 
+        if self.getArchitecture() == "x86_64" and self.platformIsDarwin():
+            # debugserver on x86 will provide ds/es/ss/gsbase when the
+            # kernel provides them, but most of the time they will be
+            # unavailable.  So "register read -a" will report that
+            # 4 registers were unavailable, it is expected.
+            error_str_matched = True
+
         self.expect(
             "register read -a",
             MISSING_EXPECTED_REGISTERS,


### PR DESCRIPTION
The Intel Darwin CI bots had their Xcode updated, which brought in a debugserver with Brendan Shanks' change from September 7281e0cb3bbcce396aab8b3ea0967d7a17cd287a
https://github.com/llvm/llvm-project/pull/108663 where four general purpose registers are sent by debugserver when in certain process states.  But most processes (nearly all in the testsuite) do not have these registers available, so we will get register read failures when requesting those four.  These two tests would flag those as errors.  There would have been an additional problem with the g/G packet (which lldb doesn't use w/ debugserver, but the testsuite tests) if placeholder values were not included in the full register context bytes; I fixed that issue with the SME patch to debugserver recently already.