### PR TITLE
[libc] fix generic __stack_check_fail for fuchsia

### DIFF
--- a/libc/src/compiler/generic/__stack_chk_fail.cpp
+++ b/libc/src/compiler/generic/__stack_chk_fail.cpp
@@ -9,6 +9,7 @@
 #include "src/compiler/__stack_chk_fail.h"
 #include "src/__support/OSUtil/io.h"
 #include "src/stdlib/abort.h"
+#include <stdint.h> // For uintptr_t
 
 extern "C" {
 


### PR DESCRIPTION
Fixes this build: https://lab.llvm.org/buildbot/#/builders/11/builds/10339/steps/6/logs/stdio after #121121 was merged.