### PR TITLE
[gcov] Set current_working_directory to . for GCC>=9

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp
@@ -973,8 +973,10 @@ bool GCOVProfiler::emitProfileNotes(
         out.write(Tmp, 4);
       }
       write(Stamp);
+      // getcwd() breaks local determinism and is not easy to adjust with
+      // -ffile-prefix-map. Just write "." to appease GCC's gcov.
       if (Version >= 90)
-        writeString(""); // unuseful current_working_directory
+        writeString(".");
       if (Version >= 80)
         write(0); // unuseful has_unexecuted_blocks
 


### PR DESCRIPTION
GCC 9 changed the gcov format to set current_working_directory to be
used by gcov --json-format
(https://github.com/linux-test-project/lcov/issues/38).

This change breaks local determinism, which we value more than strict
GCC compatibility. Just write "." to appease GCC's gcov.

Fix #121368
