### PR TITLE
[libc++] Remove redundant assignments in bitset string-like constructors

### DIFF
--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -736,7 +736,6 @@ private:
       _CharT __c   = __str[__mp - 1 - __i];
       (*this)[__i] = _Traits::eq(__c, __one);
     }
-    std::fill(__base::__make_iter(__i), __base::__make_iter(_Size), false);
   }
 
   _LIBCPP_HIDE_FROM_ABI size_t __hash_code() const _NOEXCEPT { return __base::__hash_code(); }


### PR DESCRIPTION
The following three string-like constructors for `std::bitset` 
- `bitset(const CharT* str, std::size_t n, CharT zero, CharT one)`;
- `bitset(const std::basic_string<CharT, Traits, Alloc>& str, typename std::basic_string<CharT, Traits, Alloc>::size_type pos, CharT zero, CharT one)`;
- `bitset(std::basic_string_view<CharT, Traits> str, std::size_t pos, std::size_t n, CharT zero, CharT one)`

already initialize the underlying storage array to all zeroes via default-constructor of the base class `__bitset`. Therefore, re-assigning the storage array to zeroes via `std::fill_n` in the string-like constructors is truly redundant. 