### PR TITLE
[AIX] [lit] Fix shtest-format.py to account for behaviour on AIX

### DIFF
--- a/llvm/utils/lit/tests/shtest-format.py
+++ b/llvm/utils/lit/tests/shtest-format.py
@@ -18,7 +18,7 @@
 # CHECK: Command Output (stderr):
 # CHECK-NEXT: --
 # CHECK-NOT: --
-# CHECK: cat{{(_64)?(\.exe)?}}: {{.*does-not-exist.*}}: No such file or directory
+# CHECK: cat{{(_64)?(\.exe)?}}: {{(cannot open does-not-exist|.*does-not-exist.*: No such file or directory)}}
 # CHECK: --
 
 # CHECK: FAIL: shtest-format :: external_shell/fail_with_bad_encoding.txt


### PR DESCRIPTION
The changes from https://github.com/llvm/llvm-project/pull/121376 has broken the ppc64 aix bot: https://lab.llvm.org/buildbot/#/builders/64/builds/1835. Adjusted the testcase to account for `cat` behaviour on AIX prior to the changes