### PR TITLE
[Clang][Driver] Declare win32 threads on Windows

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1082,7 +1082,7 @@ bool ToolChain::isThreadModelSupported(const StringRef Model) const {
            Triple.getArch() == llvm::Triple::armeb ||
            Triple.getArch() == llvm::Triple::thumb ||
            Triple.getArch() == llvm::Triple::thumbeb || Triple.isWasm();
-  } else if (Model == "posix")
+  } else if (Model == "posix" || (Model == "win32" && Triple.isOSWindows()))
     return true;
 
   return false;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5792,7 +5792,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       Model = A->getValue();
     } else
       Model = TC.getThreadModel();
-    if (Model != "posix") {
+    if (Model != "posix" && Model != "win32") {
       CmdArgs.push_back("-mthread-model");
       CmdArgs.push_back(Args.MakeArgString(Model));
     }

--- a/clang/lib/Driver/ToolChains/MSVC.h
+++ b/clang/lib/Driver/ToolChains/MSVC.h
@@ -51,6 +51,8 @@ public:
   TranslateArgs(const llvm::opt::DerivedArgList &Args, StringRef BoundArch,
                 Action::OffloadKind DeviceOffloadKind) const override;
 
+  std::string getThreadModel() const override { return "win32"; }
+
   UnwindTableLevel
   getDefaultUnwindTableLevel(const llvm::opt::ArgList &Args) const override;
   bool isPICDefault() const override;

--- a/clang/lib/Driver/ToolChains/MinGW.h
+++ b/clang/lib/Driver/ToolChains/MinGW.h
@@ -66,6 +66,8 @@ public:
 
   bool HasNativeLLVMSupport() const override;
 
+  std::string getThreadModel() const override { return "win32"; }
+
   UnwindTableLevel
   getDefaultUnwindTableLevel(const llvm::opt::ArgList &Args) const override;
   bool isPICDefault() const override;

--- a/clang/test/Driver/thread-model.c
+++ b/clang/test/Driver/thread-model.c
@@ -8,9 +8,15 @@
 // SINGLE: Thread model: single
 // SINGLE: "-mthread-model" "single"
 // INVALID: error: invalid thread model 'silly' in '-mthread-model silly' for this target
+// WIN32: Thread model: win32
 
 // RUN: %clang -### -target wasm32-unknown-linux-gnu -c %s -v 2>&1 | FileCheck %s
 // RUN: %clang -### -target wasm32-unknown-linux-gnu -c %s -v -mthread-model single 2>&1 | FileCheck --check-prefix=SINGLE %s
 // RUN: %clang -### -target wasm32-unknown-linux-gnu -c %s -v -mthread-model posix 2>&1 | FileCheck %s
 // RUN: not %clang -### --target=wasm32-unknown-linux-gnu -c %s -v -mthread-model silly 2>&1 | FileCheck --check-prefix=INVALID %s
 // RUN: %clang -### -target wasm64-unknown-linux-gnu -c %s -v 2>&1 | FileCheck %s
+
+// RUN: %clang -### -target x86_64-pc-windows-gnu -c %s -v 2>&1 | FileCheck --check-prefix=WIN32 %s
+// RUN: %clang -### -target x86_64-pc-windows-gnu -c %s -v -mthread-model posix 2>&1 | FileCheck %s
+// RUN: %clang -### -target x86_64-pc-windows-gnu -c %s -v -mthread-model win32 2>&1 | FileCheck --check-prefix=WIN32 %s
+// RUN: %clang -### -target x86_64-pc-windows-msvc -c %s -v 2>&1 | FileCheck --check-prefix=WIN32 %s


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/10148

Recently I saw a user confused by it and thought Clang was using `winpthreads`.

Note: this does not change structures like https://github.com/llvm/llvm-project/blob/0cbe28df7100bf4384f84542d602f90cb783a2d4/clang/include/clang/Basic/LangOptions.h#L360 which still yield `posix`.