### PR TITLE
[LLD] [ELF] Add support for linker script unary plus operator

### DIFF
--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -1489,6 +1489,8 @@ Expr ScriptParser::readPrimary() {
     Expr e = readPrimary();
     return [=] { return -e().getValue(); };
   }
+  if (consume("+"))
+    return readPrimary();
 
   StringRef tok = next();
   std::string location = getCurrentLocation();

--- a/lld/test/ELF/linkerscript/diag.test
+++ b/lld/test/ELF/linkerscript/diag.test
@@ -12,9 +12,9 @@ SECTIONS {
 }
 
 # RUN: not ld.lld -shared 0.o -T 1.lds 2>&1 | FileCheck %s --check-prefix=CHECK1 --match-full-lines --strict-whitespace
-#      CHECK1:{{.*}}:2: malformed number: +
+#      CHECK1:{{.*}}:2: malformed number: {
 # CHECK1-NEXT:>>>   .text + { *(.text) }
-# CHECK1-NEXT:>>>         ^
+# CHECK1-NEXT:>>>           ^
 
 #--- 2.lds
 

--- a/lld/test/ELF/linkerscript/operators.test
+++ b/lld/test/ELF/linkerscript/operators.test
@@ -73,6 +73,8 @@ SECTIONS {
   log2ceil100000000 = LOG2CEIL(0x100000000);
   log2ceil100000001 = LOG2CEIL(0x100000001);
   log2ceilmax = LOG2CEIL(0xffffffffffffffff);
+  unaryadd = +3 + ++5;
+  unaryadd_and_unaryminus = 15 + +-5 + -+7;
 }
 
 # CHECK:      0000000000000002 A unary
@@ -126,6 +128,8 @@ SECTIONS {
 # CHECK-NEXT: 0000000000000020 A log2ceil100000000
 # CHECK-NEXT: 0000000000000021 A log2ceil100000001
 # CHECK-NEXT: 0000000000000040 A log2ceilmax
+# CHECK-NEXT: 0000000000000008 A unaryadd
+# CHECK-NEXT: 0000000000000003 A unaryadd_and_unaryminus
 
 ## Mailformed number error.
 # RUN: echo "SECTIONS { . = 0x12Q41; }" > %t.script


### PR DESCRIPTION
This commit adds support for linker script unary plus ('+') operator. It is helpful for improving compatibility between LLD and GNU LD.

Closes #118047 