### PR TITLE
[Clang] FunctionEffects: Correctly navigate through array types in FunctionEffectsRef::get().

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -8838,15 +8838,11 @@ void FixedPointValueToString(SmallVectorImpl<char> &Str, llvm::APSInt Val,
 inline FunctionEffectsRef FunctionEffectsRef::get(QualType QT) {
   const Type *TypePtr = QT.getTypePtr();
   while (true) {
-    // Note that getPointeeType() seems to successfully navigate some constructs
-    // for which isAnyPointerType() returns false (e.g.
-    // pointer-to-member-function).
-    QualType Pointee = TypePtr->getPointeeType();
-    if (Pointee.isNull()) {
-      if (TypePtr->isArrayType()) {
-        TypePtr = TypePtr->getBaseElementTypeUnsafe();
-        continue;
-      }
+    if (QualType Pointee = TypePtr->getPointeeType())
+      TypePtr = Pointee.getTypePtr();
+    else if (TypePtr->isArrayType())
+      TypePtr = TypePtr->getBaseElementTypeUnsafe();
+    else
       break;
     }
     TypePtr = Pointee.getTypePtr();

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -8838,14 +8838,12 @@ void FixedPointValueToString(SmallVectorImpl<char> &Str, llvm::APSInt Val,
 inline FunctionEffectsRef FunctionEffectsRef::get(QualType QT) {
   const Type *TypePtr = QT.getTypePtr();
   while (true) {
-    if (QualType Pointee = TypePtr->getPointeeType())
+    if (QualType Pointee = TypePtr->getPointeeType(); !Pointee.isNull())
       TypePtr = Pointee.getTypePtr();
     else if (TypePtr->isArrayType())
       TypePtr = TypePtr->getBaseElementTypeUnsafe();
     else
       break;
-    }
-    TypePtr = Pointee.getTypePtr();
   }
   if (const auto *FPT = TypePtr->getAs<FunctionProtoType>())
     return FPT->getFunctionEffects();

--- a/clang/test/Sema/attr-nonblocking-constraints.cpp
+++ b/clang/test/Sema/attr-nonblocking-constraints.cpp
@@ -250,10 +250,11 @@ void PTMFTester::convert() [[clang::nonblocking]]
 void nb14(unsigned idx) [[clang::nonblocking]]
 {
 	using FP = void (*)() [[clang::nonblocking]];
+	using FPArray = FP[2];
 	auto nb = +[]() [[clang::nonblocking]] {};
 
-	FP array[4] = { nb, nb, nb, nb };
-	FP f = array[idx]; // This should not generate a warning.
+	FPArray src{ nb, nullptr };
+	FP f = src[idx]; // This should not generate a warning.
 }
 
 // Block variables

--- a/clang/test/Sema/attr-nonblocking-constraints.cpp
+++ b/clang/test/Sema/attr-nonblocking-constraints.cpp
@@ -246,6 +246,16 @@ void PTMFTester::convert() [[clang::nonblocking]]
 	(this->*mConvertFunc)();
 }
 
+// Allow implicit conversion from array to pointer.
+void nb14(unsigned idx) [[clang::nonblocking]]
+{
+	using FP = void (*)() [[clang::nonblocking]];
+	auto nb = +[]() [[clang::nonblocking]] {};
+
+	FP array[4] = { nb, nb, nb, nb };
+	FP f = array[idx]; // This should not generate a warning.
+}
+
 // Block variables
 void nb17(void (^blk)() [[clang::nonblocking]]) [[clang::nonblocking]] {
 	blk();

--- a/clang/test/Sema/attr-nonblocking-constraints.cpp
+++ b/clang/test/Sema/attr-nonblocking-constraints.cpp
@@ -255,6 +255,15 @@ void nb14(unsigned idx) [[clang::nonblocking]]
 
 	FPArray src{ nb, nullptr };
 	FP f = src[idx]; // This should not generate a warning.
+
+	FP twoDim[2][2] = {};
+	FP g = twoDim[1][1];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla-extension"
+	FP vla[idx];
+#pragma clang diagnostic pop
+	FP h = vla[0];
 }
 
 // Block variables

--- a/clang/test/Sema/attr-nonblocking-constraints.cpp
+++ b/clang/test/Sema/attr-nonblocking-constraints.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fblocks -fcxx-exceptions -std=c++20 -verify -Wfunction-effects %s
+// RUN: %clang_cc1 -fsyntax-only -fblocks -fcxx-exceptions -std=c++20 -verify -Wfunction-effects -Wno-vla-extension %s
 // These are in a separate file because errors (e.g. incompatible attributes) currently prevent
 // the FXAnalysis pass from running at all.
 
@@ -259,10 +259,7 @@ void nb14(unsigned idx) [[clang::nonblocking]]
 	FP twoDim[2][2] = {};
 	FP g = twoDim[1][1];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvla-extension"
 	FP vla[idx];
-#pragma clang diagnostic pop
 	FP h = vla[0];
 }
 


### PR DESCRIPTION
`FunctionEffectsRef::get()` is supposed to strip off layers of indirection (pointers/references, type sugar) to get to a `FunctionProtoType` (if any) and return its effects (if any).

It wasn't correctly dealing with situations where the compiler implicitly converts an array to a pointer.