### PR TITLE
Revert "[compiler-rt][rtsan] fopencookie support."

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -297,12 +297,6 @@ INTERCEPTOR(FILE *, fdopen, int fd, const char *mode) {
   return REAL(fdopen)(fd, mode);
 }
 
-INTERCEPTOR(FILE *, fopencookie, void *cookie, const char *mode,
-            cookie_io_functions_t funcs) {
-  __rtsan_notify_intercepted_call("fopencookie");
-  return REAL(fopencookie)(cookie, mode, funcs);
-}
-
 #if SANITIZER_INTERCEPT_OPEN_MEMSTREAM
 INTERCEPTOR(FILE *, open_memstream, char **buf, size_t *size) {
   __rtsan_notify_intercepted_call("open_memstream");
@@ -978,7 +972,6 @@ void __rtsan::InitializeInterceptors() {
   INTERCEPT_FUNCTION(fputs);
   INTERCEPT_FUNCTION(fdopen);
   INTERCEPT_FUNCTION(freopen);
-  INTERCEPT_FUNCTION(fopencookie);
   RTSAN_MAYBE_INTERCEPT_OPEN_MEMSTREAM;
   RTSAN_MAYBE_INTERCEPT_FMEMOPEN;
   INTERCEPT_FUNCTION(lseek);

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -353,29 +353,6 @@ TEST_F(RtsanFileTest, FopenDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
-TEST_F(RtsanFileTest, FopenCookieDieWhenRealtime) {
-  FILE *f = fopen(GetTemporaryFilePath(), "w");
-  EXPECT_THAT(f, Ne(nullptr));
-  struct fholder {
-    FILE *fp;
-    size_t read;
-  } fh = {f, 0};
-  auto CookieRead = [this](void *cookie, char *buf, size_t size) {
-    fholder *p = reinterpret_cast<fholder *>(cookie);
-    p->read = fread(static_cast<void *>(buf), 1, size, p->fp);
-    EXPECT_NE(0, p->read);
-  };
-  cookie_io_functions_t funcs = {(cookie_read_function_t *)&CookieRead, nullptr,
-                                 nullptr, nullptr};
-  auto Func = [&fh, &funcs]() {
-    FILE *f = fopencookie(&fh, "w", funcs);
-    EXPECT_THAT(f, Ne(nullptr));
-  };
-
-  ExpectRealtimeDeath(Func, "fopencookie");
-  ExpectNonRealtimeSurvival(Func);
-}
-
 #if SANITIZER_INTERCEPT_OPEN_MEMSTREAM
 TEST_F(RtsanFileTest, OpenMemstreamDiesWhenRealtime) {
   char *buffer;


### PR DESCRIPTION
Reverts llvm/llvm-project#120864 because it broke building compiler-rt on Mac.
https://luci-milo.appspot.com/ui/p/fuchsia/builders/toolchain.ci/clang-mac-arm64/b8726812736235038609/overview
