### PR TITLE
[NFC] Fix a typo

### DIFF
--- a/lld/ELF/InputSection.h
+++ b/lld/ELF/InputSection.h
@@ -33,7 +33,7 @@ class SyntheticSection;
 template <class ELFT> class ObjFile;
 class OutputSection;
 
-// Returned by InputSectionBase::relsOrRelas. At most one member is empty.
+// Returned by InputSectionBase::relsOrRelas. At least two members are empty.
 template <class ELFT> struct RelsOrRelas {
   Relocs<typename ELFT::Rel> rels;
   Relocs<typename ELFT::Rela> relas;


### PR DESCRIPTION
If I read `InputSectionBase::relsOrRelas` correctly, it will make at most one array-ref non-empty; one-off counter (as debugging log) shows the number of empty member containers is 2 or 3 in a real build.  Fix the typo if this is the case.