### PR TITLE
[RISCV][NFC] Clarify getRISCVInstructionCost usage

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -48,6 +48,11 @@ class RISCVTTIImpl : public BasicTTIImplBase<RISCVTTIImpl> {
   /// actual target hardware.
   unsigned getEstimatedVLFor(VectorType *Ty);
 
+  /// This function calculates the costs for one or more RVV opcodes based
+  /// on the vtype and the cost kind.
+  /// \param Opcodes A list of opcodes of the RVV instruction to evaluate.
+  /// \param VT The MVT of vtype associated with the RVV instructions.
+  /// \param CostKind The type of cost to compute.
   InstructionCost getRISCVInstructionCost(ArrayRef<unsigned> OpCodes, MVT VT,
                                           TTI::TargetCostKind CostKind);
 

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -52,6 +52,9 @@ class RISCVTTIImpl : public BasicTTIImplBase<RISCVTTIImpl> {
   /// on the vtype and the cost kind.
   /// \param Opcodes A list of opcodes of the RVV instruction to evaluate.
   /// \param VT The MVT of vtype associated with the RVV instructions.
+  /// For widening/narrowing instructions where the result and source types
+  /// differ, it is important to check the spec to determine whether the vtype
+  /// refers to the result or source type.
   /// \param CostKind The type of cost to compute.
   InstructionCost getRISCVInstructionCost(ArrayRef<unsigned> OpCodes, MVT VT,
                                           TTI::TargetCostKind CostKind);


### PR DESCRIPTION
This patch adds a comment to explicitly state that getRISCVInstructionCost uses vtype associated with widening and narrowing instructions.
For example, vtype = (SEW):
For vfwcvt.f.f.v, the source is (SEW), the destination is (2 * SEW)
For vfncvt.f.f.w, the source is (2 * SEW), the destination is (SEW).
In these cases, the type passed to `getRISCVInstructionCost` differs
- The source type is used for `vfwcvt.f.f.v`.
- The destination type is used for `vfncvt.f.f.w`.