### PR TITLE
[llvm-objcopy] fix in-place modification of archive when the file is on sambafs

### DIFF
--- a/llvm/include/llvm/ObjCopy/ObjCopy.h
+++ b/llvm/include/llvm/ObjCopy/ObjCopy.h
@@ -10,6 +10,8 @@
 #define LLVM_OBJCOPY_OBJCOPY_H
 
 #include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include <memory>
 
 namespace llvm {
 class raw_ostream;
@@ -27,7 +29,8 @@ class MultiFormatConfig;
 /// Writes a result in a file specified by \p Config.OutputFilename.
 /// \returns any Error encountered whilst performing the operation.
 Error executeObjcopyOnArchive(const MultiFormatConfig &Config,
-                              const object::Archive &Ar);
+                              const object::Archive &Ar,
+                              std::unique_ptr<MemoryBuffer> Buffer);
 
 /// Applies the transformations described by \p Config to \p In and writes
 /// the result into \p Out. This function does the dispatch based on the

--- a/llvm/tools/llvm-objcopy/llvm-objcopy.cpp
+++ b/llvm/tools/llvm-objcopy/llvm-objcopy.cpp
@@ -176,7 +176,9 @@ static Error executeObjcopy(ConfigManager &ConfigMgr) {
 
     if (Archive *Ar = dyn_cast<Archive>(BinaryHolder.getBinary())) {
       // Handle Archive.
-      if (Error E = executeObjcopyOnArchive(ConfigMgr, *Ar))
+      auto [Binary, MemBuf] = BinaryHolder.takeBinary();
+      Ar = dyn_cast<Archive>(Binary.get());
+      if (Error E = executeObjcopyOnArchive(ConfigMgr, *Ar, std::move(MemBuf)))
         return E;
     } else {
       // Handle llvm::object::Binary.


### PR DESCRIPTION
# Purpose

In Windows, the deleted file cannot be opened when they are deleted.

It is needed to free the old archive before move from the temp file

# Discover

This error is discover when I mount the sambafs from Windows (Server) to Linux (Client). And do llvm-obcopy over the code on the sambafs.