### PR TITLE
[ubsan] Use internal_memcpy to copy ubsan bits size

### DIFF
--- a/compiler-rt/lib/ubsan/ubsan_value.h
+++ b/compiler-rt/lib/ubsan/ubsan_value.h
@@ -150,9 +150,12 @@ public:
 
   unsigned getIntegerBitCount() const {
     DCHECK(isIntegerTy());
-    if (isSignedBitIntTy())
-      return *reinterpret_cast<const u32 *>(getBitIntBitCountPointer());
-    else
+    if (isSignedBitIntTy()) {
+      u32 BitCountValue;
+      internal_memcpy(&BitCountValue, getBitIntBitCountPointer(),
+                      sizeof(BitCountValue));
+      return BitCountValue;
+    } else
       return getIntegerBitWidth();
   }
 


### PR DESCRIPTION
While fetching amounts of bits used to correctly display ubsan value reinterpret_cast was used, however as noted by Jakub Jelínek in https://github.com/llvm/llvm-project/pull/96240 discussion it might cause issues due to potentially unaligned memory access. The patch addresses this problem.