### PR TITLE
[llvm-objdump] Remove leading whitespace for PT_GNU_PROPERTY.

### DIFF
--- a/llvm/test/tools/llvm-objdump/ELF/pt-gnu-property.test
+++ b/llvm/test/tools/llvm-objdump/ELF/pt-gnu-property.test
@@ -2,7 +2,7 @@
 # RUN: llvm-objdump -p %t | FileCheck %s
 
 # CHECK: Program Header:
-# CHECK-NEXT: {{ }}PROPERTY{{ }}
+# CHECK-NEXT: {{^}}PROPERTY{{ }}
 
 --- !ELF
 FileHeader:

--- a/llvm/tools/llvm-objdump/ELFDump.cpp
+++ b/llvm/tools/llvm-objdump/ELFDump.cpp
@@ -269,7 +269,7 @@ template <class ELFT> void ELFDumper<ELFT>::printProgramHeaders() {
       outs() << "   RELRO ";
       break;
     case ELF::PT_GNU_PROPERTY:
-      outs() << "   PROPERTY ";
+      outs() << "PROPERTY ";
       break;
     case ELF::PT_GNU_STACK:
       outs() << "   STACK ";


### PR DESCRIPTION
This fixes the misaligned display of addresses for this p_type.

Previous:

```
   STACK off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**64
         filesz 0x0000000000000000 memsz 0x0000000000000000 flags rw-
   PROPERTY off    0x0000000000000358 vaddr 0x0000000000000358 paddr 0x0000000000000358 align 2**3
         filesz 0x0000000000000020 memsz 0x0000000000000020 flags r--
    NOTE off    0x0000000000000334 vaddr 0x0000000000000334 paddr 0x0000000000000334 align 2**2
         filesz 0x0000000000000020 memsz 0x0000000000000020 flags r--
```

After:


```
   STACK off    0x0000000000000000 vaddr 0x0000000000000000 paddr 0x0000000000000000 align 2**64
         filesz 0x0000000000000000 memsz 0x0000000000000000 flags rw-
PROPERTY off    0x0000000000000358 vaddr 0x0000000000000358 paddr 0x0000000000000358 align 2**3
         filesz 0x0000000000000020 memsz 0x0000000000000020 flags r--
    NOTE off    0x0000000000000334 vaddr 0x0000000000000334 paddr 0x0000000000000334 align 2**2
         filesz 0x0000000000000020 memsz 0x0000000000000020 flags r--
```

