### PR TITLE
[mlir][python] declare `_PyClassMethod_New` undefined at link time

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -687,7 +687,7 @@ function(add_mlir_python_extension libname extname)
     if(APPLE)
       # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
       # doesn't declare this API as undefined in its linker flags. So we need to declare it as such
-      # for downstream users that do not do something like -undefined dynamic_lookup
+      # for downstream users that do not do something like `-undefined dynamic_lookup`.
       set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-U -Wl,_PyClassMethod_New")
     endif()
   endif()

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -688,7 +688,7 @@ function(add_mlir_python_extension libname extname)
   target_compile_options(${libname} PRIVATE ${eh_rtti_enable})
   if(APPLE)
     # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
-    # doesn't declare this API as undefined in its linker flags. so we need to declare it as such
+    # doesn't declare this API as undefined in its linker flags. So we need to declare it as such
     # for downstream users that do not do something like -undefined dynamic_lookup
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-U -Wl,_PyClassMethod_New")
   endif()

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -683,15 +683,16 @@ function(add_mlir_python_extension libname extname)
           ${eh_rtti_enable}
       )
     endif()
+    
+    if(APPLE)
+      # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
+      # doesn't declare this API as undefined in its linker flags. So we need to declare it as such
+      # for downstream users that do not do something like -undefined dynamic_lookup
+      set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-U -Wl,_PyClassMethod_New")
+    endif()
   endif()
 
   target_compile_options(${libname} PRIVATE ${eh_rtti_enable})
-  if(APPLE)
-    # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
-    # doesn't declare this API as undefined in its linker flags. So we need to declare it as such
-    # for downstream users that do not do something like -undefined dynamic_lookup
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-U -Wl,_PyClassMethod_New")
-  endif()
 
   # Configure the output to match python expectations.
   set_target_properties(

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -686,6 +686,12 @@ function(add_mlir_python_extension libname extname)
   endif()
 
   target_compile_options(${libname} PRIVATE ${eh_rtti_enable})
+  if(APPLE)
+    # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
+    # doesn't declare this API as undefined in its linker flags. so we need to declare it as such
+    # for downstream users that do not do something like -undefined dynamic_lookup
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-U -Wl,_PyClassMethod_New")
+  endif()
 
   # Configure the output to match python expectations.
   set_target_properties(


### PR DESCRIPTION
`NanobindAdaptors.h` uses `PyClassMethod_New` to build `pure_subclass`es but nanobind doesn't declare this API as undefined in its linker flags. So we need to declare it as such for downstream users that do not do something like `-undefined dynamic_lookup`

See https://github.com/iree-org/iree/issues/19591#issuecomment-2569591755.