### PR TITLE
[NFC][flang] Add missing dependency for shared builds

### DIFF
--- a/flang/lib/Optimizer/OpenMP/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenMP/CMakeLists.txt
@@ -22,6 +22,7 @@ add_flang_library(FlangOpenMPTransforms
   FIRDialectSupport
   FIRSupport
   FortranCommon
+  FortranEvaluate
   MLIRFuncDialect
   MLIROpenMPDialect
   HLFIRDialect


### PR DESCRIPTION
FortranEvaluate is required for Fortran::lower::genImplicitBoundsOps