### PR TITLE
[AArch64][SME] Fix broken compiler check for SME2 support in compiler-rt

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -43,9 +43,9 @@ asm(\"cas w0, w1, [x2]\");
 builtin_check_c_compiler_source(COMPILER_RT_HAS_AARCH64_SME
 "
 void foo(void)  __arm_streaming_compatible {
-  asm(\".arch armv9-a+sme2\");
-  asm(\"smstart\");
-  asm(\"ldr zt0, [sp]\");
+  asm(\".arch armv9-a+sme2\\n\"
+      \"smstart\\n\"
+      \"ldr zt0, [sp]\");
 }
 ")
 


### PR DESCRIPTION
This compile time test uses inline asm with `.arch` directives to set the target feature. It is however broken and always fails, since each `asm()` construct in LLVM sets up a new AsmParser, and therefore the `.arch` directive has no effect on later `asm()` contents. To fix this we need to use a single inline `asm()` call with the entire code chunk to emit contained inside.