### PR TITLE
[mlir][Transforms] Fix mapping in `findOrBuildReplacementValue`

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -1533,11 +1533,10 @@ Value ConversionPatternRewriterImpl::findOrBuildReplacementValue(
   Value castValue =
       buildUnresolvedMaterialization(MaterializationKind::Source,
                                      computeInsertPoint(repl), value.getLoc(),
-                                     /*valuesToMap=*/{value}, /*inputs=*/repl,
+                                     /*valuesToMap=*/repl, /*inputs=*/repl,
                                      /*outputType=*/value.getType(),
                                      /*originalType=*/Type(), converter)
           .front();
-  mapping.map(value, castValue);
   return castValue;
 }
 


### PR DESCRIPTION
Fixes two minor issues in `findOrBuildReplacementValue`:
* Remove a redundant `mapping.map`.
* Map `repl` instead of `value`. We used to overwrite an existing mapping, which could introduce extra materializations.

Note: We generally do not want to overwrite mappings, but create a chain of mappings. There are still a few more places, where a mapping is overwritten. Once those are fixed, I will put an assertion into `ConversionValueMapping::map`.