### PR TITLE
[mlir][Transforms] Detect mapping overwrites during block signature conversion

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -1533,11 +1533,10 @@ Value ConversionPatternRewriterImpl::findOrBuildReplacementValue(
   Value castValue =
       buildUnresolvedMaterialization(MaterializationKind::Source,
                                      computeInsertPoint(repl), value.getLoc(),
-                                     /*valuesToMap=*/{value}, /*inputs=*/repl,
+                                     /*valuesToMap=*/repl, /*inputs=*/repl,
                                      /*outputType=*/value.getType(),
                                      /*originalType=*/Type(), converter)
           .front();
-  mapping.map(value, castValue);
   return castValue;
 }
 


### PR DESCRIPTION
Add extra assertions to make sure that a value in the conversion value mapping is not overwritten during `applySignatureConversion`.

Depends on #121644.
