### PR TITLE
[clang] Add tests from CWG156 to CWG1111 (dual-scope lookup for conversion-function-ids)

### DIFF
--- a/clang/test/CXX/drs/cwg11xx.cpp
+++ b/clang/test/CXX/drs/cwg11xx.cpp
@@ -19,7 +19,7 @@ decltype(return_T<B<int>>())* b;
 #endif
 } // namespace cwg1110
 
-namespace cwg1111 { // cwg1111: 3.2
+namespace cwg1111 { // cwg1111: partial
 namespace example1 {
 template <typename> struct set; // #cwg1111-struct-set
 
@@ -57,6 +57,48 @@ void baz() {
   a.operator A();
 }
 } // namespace example2
+
+namespace example3 {
+struct A {
+  operator int();
+} a;
+void foo() {
+  typedef int T;
+  a.operator T(); // T is found using unqualified lookup
+                  // after qualified lookup in A fails.
+}
+} // namespace example3
+
+namespace example4 {
+struct A {
+  typedef int T; // #cwg1111-A-T
+  operator T();
+};
+struct B : A {
+  operator T();
+} b;
+void foo() {
+  b.A::operator T(); // FIXME: qualified lookup should find T in A.
+  // expected-error@-1 {{unknown type name 'T'}}
+  //   expected-note@#cwg1111-A-T {{'A::T' declared here}}
+}
+} // namespace example4
+
+namespace example5 {
+template <class T1> struct A {
+  operator T1();
+};
+template <class T2> struct B : A<T2> {
+  operator T2();
+  void foo() {
+    // In both cases, during instantiation, qualified lookup for T2 wouldn't be able
+    // to find anything, so T2 has to be found by unqualified lookup.
+    // After that, 'operator T2()' is found in A<T2> by qualfied lookup.
+    T2 a = A<T2>::operator T2();
+    T2 b = ((A<T2> *)this)->operator T2();
+  }
+};
+} // namespace example5
 } // namespace cwg1111
 
 namespace cwg1113 { // cwg1113: partial

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -922,6 +922,49 @@ namespace cwg155 { // cwg155: dup 632
   // expected-warning@-1 {{braces around scalar initializer}}
 }
 
+namespace cwg156 { // cwg156: partial
+namespace ex1 {
+struct A {
+  operator int();
+} a;
+void foo() {
+  typedef int T;
+  a.operator T(); // T is found using unqualified lookup
+                  // after qualified lookup in A fails.
+}
+} // namespace ex1
+
+namespace ex2 {
+struct A {
+  typedef int T;
+  operator T();
+};
+struct B : A {
+  operator T();
+} b;
+void foo() {
+  b.A::operator T(); // FIXME: qualified lookup should find T in A.
+  // expected-error@-1 {{unknown type name 'T'}}
+}
+} // namespace ex2
+
+namespace ex3 {
+template <class T1> struct A {
+  operator T1();
+};
+template <class T2> struct B : A<T2> {
+  operator T2();
+  void foo() {
+    // In both cases, during instantiation, qualified lookup for T2 wouldn't be able
+    // to find anything, so T2 has to be found by unqualified lookup.
+    // After that, 'operator T2()' is found in A<T2> by qualfied lookup.
+    T2 a = A<T2>::operator T2();
+    T2 b = ((A<T2> *)this)->operator T2();
+  }
+};
+} // namespace ex3
+} // namespace cwg156
+
 // cwg158 is in cwg158.cpp
 
 namespace cwg159 { // cwg159: 3.5

--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -922,49 +922,7 @@ namespace cwg155 { // cwg155: dup 632
   // expected-warning@-1 {{braces around scalar initializer}}
 }
 
-namespace cwg156 { // cwg156: partial
-namespace ex1 {
-struct A {
-  operator int();
-} a;
-void foo() {
-  typedef int T;
-  a.operator T(); // T is found using unqualified lookup
-                  // after qualified lookup in A fails.
-}
-} // namespace ex1
-
-namespace ex2 {
-struct A {
-  typedef int T;
-  operator T();
-};
-struct B : A {
-  operator T();
-} b;
-void foo() {
-  b.A::operator T(); // FIXME: qualified lookup should find T in A.
-  // expected-error@-1 {{unknown type name 'T'}}
-}
-} // namespace ex2
-
-namespace ex3 {
-template <class T1> struct A {
-  operator T1();
-};
-template <class T2> struct B : A<T2> {
-  operator T2();
-  void foo() {
-    // In both cases, during instantiation, qualified lookup for T2 wouldn't be able
-    // to find anything, so T2 has to be found by unqualified lookup.
-    // After that, 'operator T2()' is found in A<T2> by qualfied lookup.
-    T2 a = A<T2>::operator T2();
-    T2 b = ((A<T2> *)this)->operator T2();
-  }
-};
-} // namespace ex3
-} // namespace cwg156
-
+// cwg156: sup 1111
 // cwg158 is in cwg158.cpp
 
 namespace cwg159 { // cwg159: 3.5

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -981,7 +981,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/156.html">156</a></td>
     <td>NAD</td>
     <td>Name lookup for conversion functions</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="partial" align="center">Partial</td>
   </tr>
   <tr class="open" id="157">
     <td><a href="https://cplusplus.github.io/CWG/issues/157.html">157</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -981,7 +981,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/156.html">156</a></td>
     <td>NAD</td>
     <td>Name lookup for conversion functions</td>
-    <td class="partial" align="center">Partial</td>
+    <td class="partial-superseded" align="center">Superseded by <a href="#1111">1111</a></td>
   </tr>
   <tr class="open" id="157">
     <td><a href="https://cplusplus.github.io/CWG/issues/157.html">157</a></td>
@@ -6485,7 +6485,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1111.html">1111</a></td>
     <td>C++11</td>
     <td>Remove dual-scope lookup of member template names</td>
-    <td class="full" align="center">Clang 3.2</td>
+    <td class="partial" align="center">Partial</td>
   </tr>
   <tr id="1112">
     <td><a href="https://cplusplus.github.io/CWG/issues/1112.html">1112</a></td>


### PR DESCRIPTION
This patch adds test from [CWG156](https://cplusplus.github.io/CWG/issues/156.html) to [CWG1111](https://cplusplus.github.io/CWG/issues/1111.html) test, and downgrades the latter to partial availability. The most relevant piece of current wording is [[basic.lookup.unqual]/5](https://eel.is/c++draft/basic.lookup#unqual-5):
> An unqualified name that is a component name ([[expr.prim.id.unqual]](https://eel.is/c++draft/expr.prim.id.unqual)) of a [type-specifier](https://eel.is/c++draft/dcl.type.general#nt:type-specifier) or [ptr-operator](https://eel.is/c++draft/dcl.decl.general#nt:ptr-operator) of a [conversion-type-id](https://eel.is/c++draft/class.conv.fct#nt:conversion-type-id) is looked up in the same fashion as the [conversion-function-id](https://eel.is/c++draft/class.conv.fct#nt:conversion-function-id) in which it appears[.](https://eel.is/c++draft/basic.lookup#unqual-5.sentence-1)
If that lookup finds nothing, it undergoes unqualified name lookup; in each case, only names that denote types or templates whose specializations are types are considered[.](https://eel.is/c++draft/basic.lookup#unqual-5.sentence-2)

Per resolution of [CWG1111](https://cplusplus.github.io/CWG/issues/1111.html), additional lookup in the context of the entire postfix-expression, which originally was intended to cross-check lookup in the context of object-expression, was effectively turned into a fallback for it.

Check out "Calling a conversion function" example in [P1787R6](https://wg21.link/p1787r6) for step-by-step explanation of the current lookup mechanics for conversion functions.

Clang rejects one of the well-formed examples, hence partial status. Clang is the only implementation which rejects it: https://godbolt.org/z/ohhbx8Mfs