### PR TITLE
[clang] Add test for CWG794 "Base-derived conversion in member type of pointer-to-member conversion"

### DIFF
--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -337,3 +337,15 @@ template <typename... T>
 void h(int i = 0, T ...args, int j = 1) {}
 #endif
 }
+
+namespace cwg794 { // cwg794: 2.7
+struct B {};
+struct D : B {};
+struct X {
+  D d;
+};
+struct Y : X {};
+B Y::*pm = &X::d;
+// expected-error@-1 {{cannot initialize a variable of type 'B Y::*' with an rvalue of type 'D cwg794::X::*': different classes ('Y' vs 'cwg794::X')}}
+// FIXME: why diagnostic says just `Y` and not `cwg794::Y`, like `cwg794::X`?
+} // namespace cwg794

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -4775,7 +4775,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/794.html">794</a></td>
     <td>NAD</td>
     <td>Base-derived conversion in member type of pointer-to-member conversion</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="795">
     <td><a href="https://cplusplus.github.io/CWG/issues/795.html">795</a></td>


### PR DESCRIPTION
This patch adds a test for [CWG794](https://cplusplus.github.io/CWG/issues/794.html), which is an NB comment closed as NAD. Author was asked to bring a paper to Evolution, which never happened. So we test for the absence of base-derived conversion in pointer-to-member conversion.