### PR TITLE
[ValueTracking] Use assume to compute overflowResult.

### DIFF
--- a/llvm/test/Transforms/InstCombine/with_overflow.ll
+++ b/llvm/test/Transforms/InstCombine/with_overflow.ll
@@ -1064,3 +1064,160 @@ define i8 @smul_7(i8 %x, ptr %p) {
   store i1 %ov, ptr %p
   ret i8 %r
 }
+
+define i8 @uadd_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @uadd_assume_no_overflow(
+; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
+; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i8 [[CALL]]
+;
+  %call = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i8 %ret
+}
+
+define i8 @sadd_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @sadd_assume_no_overflow(
+; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
+; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i8 [[CALL]]
+;
+  %call = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i8 %ret
+}
+
+define i8 @usub_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @usub_assume_no_overflow(
+; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.usub.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
+; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i8 [[CALL]]
+;
+  %call = call { i8, i1 } @llvm.usub.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i8 %ret
+}
+
+define i8 @ssub_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @ssub_assume_no_overflow(
+; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.ssub.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
+; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i8 [[CALL]]
+;
+  %call = call { i8, i1 } @llvm.ssub.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i8 %ret
+}
+
+define i8 @umul_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @umul_assume_no_overflow(
+; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
+; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i8 [[CALL]]
+;
+  %call = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i8 %ret
+}
+
+define i8 @smul_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @smul_assume_no_overflow(
+; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
+; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i8 [[CALL]]
+;
+  %call = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i8 %ret
+}
+
+define i1 @ephemeral_call_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @ephemeral_call_assume_no_overflow(
+; CHECK-NEXT:    [[CALL:%.*]] = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL]], 1
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    ret i1 [[NOT]]
+;
+  %call = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  ret i1 %not
+}
+
+define i8 @neg_assume_overflow(i8 noundef %a, i8 noundef %b) {
+; CHECK-LABEL: @neg_assume_overflow(
+; CHECK-NEXT:    [[CALL:%.*]] = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL]], 1
+; CHECK-NEXT:    [[RET:%.*]] = extractvalue { i8, i1 } [[CALL]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[OVERFLOW]])
+; CHECK-NEXT:    ret i8 [[RET]]
+;
+  %call = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  call void @llvm.assume(i1 %overflow)
+  ret i8 %ret
+}
+
+define i8 @neg_assume_not_guaranteed_to_execute(i8 noundef %a, i8 noundef %b, i1 %cond) {
+; CHECK-LABEL: @neg_assume_not_guaranteed_to_execute(
+; CHECK-NEXT:    [[CALL:%.*]] = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
+; CHECK-NEXT:    br i1 [[COND:%.*]], label [[BB1:%.*]], label [[BB2:%.*]]
+; CHECK:       bb1:
+; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL]], 1
+; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
+; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    br label [[BB2]]
+; CHECK:       bb2:
+; CHECK-NEXT:    [[RET:%.*]] = extractvalue { i8, i1 } [[CALL]], 0
+; CHECK-NEXT:    ret i8 [[RET]]
+;
+  %call = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 %a, i8 %b)
+  %overflow = extractvalue { i8, i1 } %call, 1
+  %ret = extractvalue { i8, i1 } %call, 0
+  br i1 %cond, label %bb1, label %bb2
+bb1:
+  %not = xor i1 %overflow, true
+  call void @llvm.assume(i1 %not)
+  br label %bb2
+bb2:
+  ret i8 %ret
+}

--- a/llvm/test/Transforms/InstCombine/with_overflow.ll
+++ b/llvm/test/Transforms/InstCombine/with_overflow.ll
@@ -1067,11 +1067,7 @@ define i8 @smul_7(i8 %x, ptr %p) {
 
 define i8 @uadd_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @uadd_assume_no_overflow(
-; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    [[CALL:%.*]] = add nuw i8 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret i8 [[CALL]]
 ;
   %call = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 %a, i8 %b)
@@ -1084,11 +1080,7 @@ define i8 @uadd_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 
 define i8 @sadd_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @sadd_assume_no_overflow(
-; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    [[CALL:%.*]] = add nsw i8 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret i8 [[CALL]]
 ;
   %call = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 %a, i8 %b)
@@ -1101,11 +1093,7 @@ define i8 @sadd_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 
 define i8 @usub_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @usub_assume_no_overflow(
-; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.usub.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    [[CALL:%.*]] = sub nuw i8 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret i8 [[CALL]]
 ;
   %call = call { i8, i1 } @llvm.usub.with.overflow.i8(i8 %a, i8 %b)
@@ -1118,11 +1106,7 @@ define i8 @usub_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 
 define i8 @ssub_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @ssub_assume_no_overflow(
-; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.ssub.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    [[CALL:%.*]] = sub nsw i8 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret i8 [[CALL]]
 ;
   %call = call { i8, i1 } @llvm.ssub.with.overflow.i8(i8 %a, i8 %b)
@@ -1135,11 +1119,7 @@ define i8 @ssub_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 
 define i8 @umul_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @umul_assume_no_overflow(
-; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    [[CALL:%.*]] = mul nuw i8 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret i8 [[CALL]]
 ;
   %call = call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %a, i8 %b)
@@ -1152,11 +1132,7 @@ define i8 @umul_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 
 define i8 @smul_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @smul_assume_no_overflow(
-; CHECK-NEXT:    [[CALL1:%.*]] = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL1]], 1
-; CHECK-NEXT:    [[CALL:%.*]] = extractvalue { i8, i1 } [[CALL1]], 0
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
+; CHECK-NEXT:    [[CALL:%.*]] = mul nsw i8 [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    ret i8 [[CALL]]
 ;
   %call = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 %a, i8 %b)
@@ -1169,11 +1145,7 @@ define i8 @smul_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 
 define i1 @ephemeral_call_assume_no_overflow(i8 noundef %a, i8 noundef %b) {
 ; CHECK-LABEL: @ephemeral_call_assume_no_overflow(
-; CHECK-NEXT:    [[CALL:%.*]] = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 [[A:%.*]], i8 [[B:%.*]])
-; CHECK-NEXT:    [[OVERFLOW:%.*]] = extractvalue { i8, i1 } [[CALL]], 1
-; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[OVERFLOW]], true
-; CHECK-NEXT:    call void @llvm.assume(i1 [[NOT]])
-; CHECK-NEXT:    ret i1 [[NOT]]
+; CHECK-NEXT:    ret i1 true
 ;
   %call = call { i8, i1 } @llvm.smul.with.overflow.i8(i8 %a, i8 %b)
   %overflow = extractvalue { i8, i1 } %call, 1


### PR DESCRIPTION
Rust code have a lot of assumes with the overflow flag from WithOverflow Instructions as condition, this instruction can due to the assume be folded to the operation without overflow check.

e.g. the pattern that this PR look for:
```
  %call = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 %a, i8 %b)
  %overflow = extractvalue { i8, i1 } %call, 1
  %not = xor i1 %overflow, true
  call void @llvm.assume(i1 %not)
```
that can be folded to:
`%call = add nuw i8 %a, %b`

It is the hashbrown crate that have e.g. [this match with use of hint::unreachable_unchecked()](https://github.com/rust-lang/hashbrown/blob/16044fe2f8784f665a563849cc63867cbafb80c6/src/raw/mod.rs#L1364) together with the use of checked instructions in [calculate_layout_for](https://github.com/rust-lang/hashbrown/blob/16044fe2f8784f665a563849cc63867cbafb80c6/src/raw/mod.rs#L168) that after inlining and simplifyCfg result in this pattern.

Prof: https://alive2.llvm.org/ce/z/oRu3oi