### PR TITLE
[clang] Add test for CWG170 "Pointer-to-member conversions"

### DIFF
--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -1074,6 +1074,26 @@ namespace cwg169 { // cwg169: yes
   };
 }
 
+namespace cwg170 { // cwg170: 3.1
+#if __cplusplus >= 201103L
+struct A {};
+struct B : A { int i; };
+struct C : A {};
+struct D : C {};
+
+constexpr int f(int A::*) { return 0; }
+constexpr int g(int C::*) { return 0; }
+constexpr int h(int D::*) { return 0; }
+
+constexpr auto p = static_cast<int A::*>(&B::i);
+constexpr auto q = f(p);
+constexpr auto r = g(p);
+// since-cxx11-error@-1 {{constexpr variable 'r' must be initialized by a constant expression}}
+constexpr auto s = h(p);
+// since-cxx11-error@-1 {{constexpr variable 's' must be initialized by a constant expression}}
+#endif
+} // namespace cwg170
+
 namespace { // cwg171: 3.4
   int cwg171a;
 }

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1065,7 +1065,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/170.html">170</a></td>
     <td>DRWP</td>
     <td>Pointer-to-member conversions</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.1</td>
   </tr>
   <tr id="171">
     <td><a href="https://cplusplus.github.io/CWG/issues/171.html">171</a></td>


### PR DESCRIPTION
This patch adds test for [CWG170](https://cplusplus.github.io/CWG/issues/170.html). The resolution adds explicit undefined behavior, so I think the best we can do is to put the test into constexpr evaluator. Change to [expr.static.cast] is not tested, because it was a drive-by fix that removed an impossible case (I confirmed it using minutes). Minutes mention several times a comprehensive paper in this design space which no one seem to remember. I believe it's [P0149R0](https://wg21.link/p0149r0) "Generalised member pointers".