### PR TITLE
[clang] Add test for CWG190 "Layout-compatible POD-struct types"

### DIFF
--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -1314,8 +1314,25 @@ namespace cwg188 { // cwg188: yes
   static_assert(sizeof(0, c) == 10, "");
 }
 
-// cwg190 FIXME: add codegen test for tbaa
-//              or implement C++20 std::is_layout_compatible and test it this way
+namespace cwg190 { // cwg190: 19
+struct A {
+  int a;
+  static double x;
+  int b;
+  void y();
+  int c;
+};
+
+struct B {
+  int a;
+  void y();
+  int b;
+  static double x;
+  int c;
+};
+
+static_assert(__is_layout_compatible(A, B), "");
+} // namespace cwg190
 
 int cwg191_j;
 namespace cwg191 { // cwg191: yes

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1185,7 +1185,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/190.html">190</a></td>
     <td>TC1</td>
     <td>Layout-compatible POD-struct types</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 19</td>
   </tr>
   <tr id="191">
     <td><a href="https://cplusplus.github.io/CWG/issues/191.html">191</a></td>


### PR DESCRIPTION
This patch adds test for [CWG190](https://cplusplus.github.io/CWG/issues/190.html), leveraging `__is_layout_compatible` intrinsic added for C++20 `std::is_layout_compatible`. I conservatively set the status to Clang 19, as it's the first release that implemented said intrinsic.