### PR TITLE
[libc++] Remove abandoned __append declaration in vector<bool>

### DIFF
--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -442,7 +442,6 @@ private:
   template <class _InputIterator, class _Sentinel>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   __construct_at_end(_InputIterator __first, _Sentinel __last, size_type __n);
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __append(size_type __n, const_reference __x);
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference __make_ref(size_type __pos) _NOEXCEPT {
     return reference(__begin_ + __pos / __bits_per_word, __storage_type(1) << __pos % __bits_per_word);
   }


### PR DESCRIPTION
The `vector<bool>` implementation in libcxx contains a declaration of a private `__append` function, which is neither defined nor used anywhere in the codebase. This PR aims to remove this abandoned declaration, as its presence is misleading and could lead to confusion during future maintenance.

I have no idea why we have a declaration without a definition. My guess is that the declaration might be inherited from the implementation of `vector<T>`, where `__append` is both necessary and properly defined. The declaration may have been inadvertently copied from `vector<T>` to `vector<bool>` and subsequently abandoned, as `vector<bool>` never needs it.