### PR TITLE
[clang] Add test for CWG192 "Name lookup in parameters"

### DIFF
--- a/clang/test/CXX/drs/cwg1xx.cpp
+++ b/clang/test/CXX/drs/cwg1xx.cpp
@@ -1347,6 +1347,14 @@ namespace cwg191 { // cwg191: yes
   }
 }
 
+namespace cwg192 { // cwg192: 2.7
+struct S {
+  void f(I i) { }
+  // expected-error@-1 {{unknown type name 'I'}}
+  typedef int I;
+};
+} // namespace cwg192
+
 // cwg193 is in cwg193.cpp
 
 namespace cwg194 { // cwg194: yes

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1197,7 +1197,7 @@
     <td><a href="https://cplusplus.github.io/CWG/issues/192.html">192</a></td>
     <td>NAD</td>
     <td>Name lookup in parameters</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="193">
     <td><a href="https://cplusplus.github.io/CWG/issues/193.html">193</a></td>


### PR DESCRIPTION
This patch adds a rather simple test for [CWG192](https://cplusplus.github.io/CWG/issues/192.html). Parameter declarations of member functions are not complete-class contexts (unlike default arguments), so the example in the issue is ill-formed. Changes in [CWG1352](https://cplusplus.github.io/CWG/issues/1352.html) which resolved the issue, are superseded by the notion of complete-class context (https://eel.is/c++draft/class.mem#def:complete-class_context).