### PR TITLE
[libc][fuzz] workaround gcc's constexpr capture issue in sort fuzzer

### DIFF
--- a/libc/test/src/stdlib/SortingTest.h
+++ b/libc/test/src/stdlib/SortingTest.h
@@ -301,7 +301,10 @@ public:
     // incorrect association between alignment and element size.
     alignas(1) uint8_t buf[BUF_SIZE];
 
-    const auto fill_buf = [&buf](size_t elem_size) {
+    // GCC still requires capturing the constant ARRAY_INITIAL_VALS in the
+    // lambda hence, let's use & to implicitly capture all needed variables
+    // automatically.
+    const auto fill_buf = [&](size_t elem_size) {
       for (size_t i = 0; i < BUF_SIZE; ++i) {
         buf[i] = 0;
       }


### PR DESCRIPTION
Fix the build problem at https://lab.llvm.org/buildbot/#/builders/131/builds/13255