### PR TITLE
[AggressiveInstCombine] Add tests for memchr inline threshold (NFC)

### DIFF
--- a/llvm/test/Transforms/AggressiveInstCombine/memchr.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/memchr.ll
@@ -161,3 +161,17 @@ entry:
   %memchr = call ptr @memchr(ptr @str_long, i32 %x, i64 8)
   ret ptr %memchr
 }
+
+
+define ptr @test_memchr_non_constant_length2(i32 %x, i64 %len) {
+; CHECK-LABEL: define ptr @test_memchr_non_constant_length2(
+; CHECK-SAME: i32 [[X:%.*]], i64 [[LEN:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*:]]
+; CHECK-NEXT: ; We want to check that the compiler still calls memchr:
+; CHECK-NEXT:    [[MEMCHR:%.*]] = call ptr @memchr(ptr @str, i32 [[X]], i64 [[LEN]])
+; CHECK-NEXT:    ret ptr [[MEMCHR]]
+;
+entry:
+  %memchr = call ptr @memchr(ptr @str, i32 %x, i64 %len)
+  ret ptr %memchr
+}

--- a/llvm/test/Transforms/AggressiveInstCombine/memchr.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/memchr.ll
@@ -162,12 +162,11 @@ entry:
   ret ptr %memchr
 }
 
-
+; We want to check that the compiler still calls memchr if the length is non-constant:
 define ptr @test_memchr_non_constant_length2(i32 %x, i64 %len) {
 ; CHECK-LABEL: define ptr @test_memchr_non_constant_length2(
 ; CHECK-SAME: i32 [[X:%.*]], i64 [[LEN:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*:]]
-; CHECK-NEXT: ; We want to check that the compiler still calls memchr:
 ; CHECK-NEXT:    [[MEMCHR:%.*]] = call ptr @memchr(ptr @str, i32 [[X]], i64 [[LEN]])
 ; CHECK-NEXT:    ret ptr [[MEMCHR]]
 ;


### PR DESCRIPTION
(This adds a test checking that, if length=2, memchr is called. This is undesirable as it would be faster to directly compare the two array elements with the target element, rather than calling the external memchr function.)