### PR TITLE
[mlir] DCE `friend Dialect::registerDialect`

### DIFF
--- a/mlir/include/mlir/IR/Dialect.h
+++ b/mlir/include/mlir/IR/Dialect.h
@@ -368,7 +368,6 @@ private:
   DenseSet<std::pair<TypeID, TypeID>> unresolvedPromisedInterfaces;
 
   friend class DialectRegistry;
-  friend void registerDialect();
   friend class MLIRContext;
 };
 


### PR DESCRIPTION
There's no implementation for this decl. Should've been removed here 

https://github.com/llvm/llvm-project/commit/b72e13c242d9bbe1a4c7e471da98718bde85fa78#diff-fad55ed6dd6c9cae07409d354d6cfdef35cef1550b568d6b57d946590b14a6cdL256

I guess.