### PR TITLE
[clang] [NFC] explicitly check if ParentMap contains key

### DIFF
--- a/clang/lib/AST/ParentMap.cpp
+++ b/clang/lib/AST/ParentMap.cpp
@@ -34,13 +34,13 @@ static void BuildParentMap(MapTy& M, Stmt* S,
   case Stmt::PseudoObjectExprClass: {
     PseudoObjectExpr *POE = cast<PseudoObjectExpr>(S);
 
-    if (OVMode == OV_Opaque && M[POE->getSyntacticForm()])
+    if (OVMode == OV_Opaque && M.contains(POE->getSyntacticForm()))
       break;
 
     // If we are rebuilding the map, clear out any existing state.
-    if (M[POE->getSyntacticForm()])
+    if (M.contains(POE->getSyntacticForm()))
       for (Stmt *SubStmt : S->children())
-        M[SubStmt] = nullptr;
+        M.erase(SubStmt);
 
     M[POE->getSyntacticForm()] = S;
     BuildParentMap(M, POE->getSyntacticForm(), OV_Transparent);
@@ -78,7 +78,7 @@ static void BuildParentMap(MapTy& M, Stmt* S,
     // The right thing to do is to give the OpaqueValueExpr its syntactic
     // parent, then not reassign that when traversing the semantic expressions.
     OpaqueValueExpr *OVE = cast<OpaqueValueExpr>(S);
-    if (OVMode == OV_Transparent || !M[OVE->getSourceExpr()]) {
+    if (OVMode == OV_Transparent || !M.contains(OVE->getSourceExpr())) {
       M[OVE->getSourceExpr()] = S;
       BuildParentMap(M, OVE->getSourceExpr(), OV_Transparent);
     }

--- a/clang/lib/AST/ParentMap.cpp
+++ b/clang/lib/AST/ParentMap.cpp
@@ -33,17 +33,19 @@ static void BuildParentMap(MapTy& M, Stmt* S,
   switch (S->getStmtClass()) {
   case Stmt::PseudoObjectExprClass: {
     PseudoObjectExpr *POE = cast<PseudoObjectExpr>(S);
+    Expr *SF = POE->getSyntacticForm();
 
-    if (OVMode == OV_Opaque && M.contains(POE->getSyntacticForm()))
-      break;
-
-    // If we are rebuilding the map, clear out any existing state.
-    if (M.contains(POE->getSyntacticForm()))
+    auto [Iter, Inserted] = M.try_emplace(SF, S);
+    if (!Inserted) {
+      // Nothing more to do in opaque mode if we are updating an existing map.
+      if (OVMode == OV_Opaque)
+        break;
+      // Update the entry in transparent mode, and clear existing state.
+      Iter->second = SF;
       for (Stmt *SubStmt : S->children())
         M.erase(SubStmt);
-
-    M[POE->getSyntacticForm()] = S;
-    BuildParentMap(M, POE->getSyntacticForm(), OV_Transparent);
+    }
+    BuildParentMap(M, SF, OV_Transparent);
 
     for (PseudoObjectExpr::semantics_iterator I = POE->semantics_begin(),
                                               E = POE->semantics_end();
@@ -78,10 +80,15 @@ static void BuildParentMap(MapTy& M, Stmt* S,
     // The right thing to do is to give the OpaqueValueExpr its syntactic
     // parent, then not reassign that when traversing the semantic expressions.
     OpaqueValueExpr *OVE = cast<OpaqueValueExpr>(S);
-    if (OVMode == OV_Transparent || !M.contains(OVE->getSourceExpr())) {
-      M[OVE->getSourceExpr()] = S;
-      BuildParentMap(M, OVE->getSourceExpr(), OV_Transparent);
+    Expr *SrcExpr = OVE->getSourceExpr();
+    auto [Iter, Inserted] = M.try_emplace(SrcExpr, S);
+    // Force update in transparent mode.
+    if (!Inserted && OVMode == OV_Transparent) {
+      Iter->second = S;
+      Inserted = true;
     }
+    if (Inserted)
+      BuildParentMap(M, SrcExpr, OV_Transparent);
     break;
   }
   case Stmt::CapturedStmtClass:


### PR DESCRIPTION
The implementation of ParentMap assumes that the key is absent if it is mapped to nullptr. This breaks when trying to store a tuple as the value type. Remove this assumption by explicit uses of `contains()` and `erase()`.