### PR TITLE
Fix std::initializer_list recognition if it's exported out of a module

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1123,7 +1123,8 @@ Bug Fixes to C++ Support
 - Fixed assertion failure by skipping the analysis of an invalid field declaration. (#GH99868)
 - Fix an issue with dependent source location expressions (#GH106428), (#GH81155), (#GH80210), (#GH85373)
 - Fix handling of ``_`` as the name of a lambda's init capture variable. (#GH107024)
-
+- Fixed recognition of ``std::initializer_list`` when it's surrounded with ``extern "C++"`` and exported
+  out of a module (which is the case e.g. in MSVC's implementation of ``std`` module). (#GH118218)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -11919,7 +11919,7 @@ bool Sema::isStdInitializerList(QualType Ty, QualType *Element) {
     if (TemplateClass->getIdentifier() !=
             &PP.getIdentifierTable().get("initializer_list") ||
         !getStdNamespace()->InEnclosingNamespaceSetOf(
-            TemplateClass->getDeclContext()))
+            TemplateClass->getNonTransparentDeclContext()))
       return false;
     // This is a template called std::initializer_list, but is it the right
     // template?

--- a/clang/test/Modules/initializer-list-recognition-through-export-and-linkage-issue-118218.cpp
+++ b/clang/test/Modules/initializer-list-recognition-through-export-and-linkage-issue-118218.cpp
@@ -1,0 +1,39 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/std.cppm -emit-module-interface -o %t/std.pcm
+// RUN: %clang_cc1 -std=c++20 %t/mod.cppm -fprebuilt-module-path=%t -emit-module-interface -o %t/mod.pcm
+// RUN: %clang_cc1 -std=c++20 -fprebuilt-module-path=%t -verify %t/main.cpp
+
+//--- std.cppm
+export module std;
+
+extern "C++" {
+  namespace std {
+  export template <class E>
+  class initializer_list {
+    const E* _1;
+    const E* _2;
+  };
+  }
+}
+
+//--- mod.cppm
+export module mod;
+
+import std;
+
+export struct A {
+  void func(std::initializer_list<int>) {}
+};
+
+//--- main.cpp
+// expected-no-diagnostics
+import std;
+import mod;
+
+int main() {
+  A{}.func({1,1});
+  return 0;
+}


### PR DESCRIPTION
- Add implementation
- Add a regression test
- Add release notes

The following commits from main were incorporated into this PR:
- 9f1e9f6