### PR TITLE
[vim] Improve `iskeyword` for MLIR

### DIFF
--- a/mlir/utils/vim/ftplugin/mlir.vim
+++ b/mlir/utils/vim/ftplugin/mlir.vim
@@ -10,3 +10,12 @@ let b:did_ftplugin = 1
 setlocal softtabstop=2 shiftwidth=2
 setlocal expandtab
 setlocal comments+=://
+setlocal commentstring=//\ %s
+" We treat sequences of the following characters as forming 'keywords', with
+" the aim of easing movement around MLIR identifiers:
+" * identifier prefixes: '%' and '@' (@-@)
+" * all characters where isalpha() returns TRUE (@)
+" * the digits 0-9 (48-57)
+" * other characters that may form identifiers: '_', '.', '-', '$'
+" Comment this out to restore the default behaviour
+setlocal iskeyword=%,@-@,@,48-57,_,.,-,$


### PR DESCRIPTION
Define keywords for the MLIR syntax. This allows better recognition of semantic constructs such as SSA value identification e.g. `%foo` which gives improved motion handling when using 'word based' such as `w, e`.

This is based on the work done for the LLVM IR in
8c46413f343d0a5b8db48d958890b9038f03b70d.