### PR TITLE
[DeadMachineInstructionElim] NFC: Provide DeadMachineInstructionInfo

### DIFF
--- a/llvm/include/llvm/CodeGen/DeadMachineInstructionElim.h
+++ b/llvm/include/llvm/CodeGen/DeadMachineInstructionElim.h
@@ -9,9 +9,29 @@
 #ifndef LLVM_CODEGEN_DEADMACHINEINSTRUCTIONELIM_H
 #define LLVM_CODEGEN_DEADMACHINEINSTRUCTIONELIM_H
 
+#include "llvm/CodeGen/LiveRegUnits.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 
 namespace llvm {
+
+class DeadMachineInstructionInfo {
+private:
+  const MachineRegisterInfo *MRI = nullptr;
+
+public:
+  /// Check whether \p MI is dead. If \p LivePhysRegs is provided, it is assumed
+  /// to be at the position of MI and will be used to check the Liveness of
+  /// physical register defs. If \p LivePhysRegs is not provided, this will
+  /// pessimistically assume any PhysReg def is live.
+  bool isDead(const MachineInstr *MI,
+              LiveRegUnits *LivePhysRegs = nullptr) const;
+
+  /// Do a function walk over \p MF and delete any dead MachineInstrs. Uses
+  /// LivePhysRegs to track liveness of PhysRegs.
+  bool eliminateDeadMI(MachineFunction &MF);
+
+  DeadMachineInstructionInfo(const MachineRegisterInfo *MRI) : MRI(MRI) {}
+};
 
 class DeadMachineInstructionElimPass
     : public PassInfoMixin<DeadMachineInstructionElimPass> {


### PR DESCRIPTION
Provide DeadMachineInstructionInfo interface so independent passes have access to ad-hoc isDead queries / eliminateDeadMI walks. LivePhysRegs is optional in isDead for the case where a user wants to pessimistically check deadness of a single MI without doing the LivePhysReg walk.