### PR TITLE
[libc] Keep framepointers for baremetal

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -30,10 +30,5 @@
     "LIBC_CONF_MATH_OPTIMIZATIONS": {
       "value": "(LIBC_MATH_SKIP_ACCURATE_PASS | LIBC_MATH_SMALL_TABLES)"
     }
-  },
-  "codegen": {
-    "LIBC_CONF_KEEP_FRAME_POINTER": {
-      "value": false
-    }
   }
 }


### PR DESCRIPTION
Keep framepointers enabled by default for the default baremetal libc
builds.

Frame pointers help unwind the stack and unwinding without frame pointer
is complex and increaseis the code size. This code size increase is
potentially larger than the savings achieved by disabling frame
pointers. Retaining the original behavior of retaining frame pointers as
the default behavior.