### PR TITLE
[NFC][SandboxVectorizer] Disable default copy CTOR/assigment for SchedBundle.

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -79,6 +79,10 @@ public:
     for (auto *N : this->Nodes)
       N->setSchedBundle(*this);
   }
+  /// Copy CTOR (unimplemented).
+  SchedBundle(const SchedBundle &Other) = delete;
+  /// Copy Assignment (unimplemented).
+  SchedBundle &operator=(const SchedBundle &Other) = delete;
   ~SchedBundle() {
     for (auto *N : this->Nodes)
       N->clearSchedBundle();


### PR DESCRIPTION
Explicitly disable copy CTOR/assigment for SchedBundle to avoid acsidentional
usage of default versions that do not handle Nodes copies properly.
A developer will need to implement them once required.
