### PR TITLE
[HLSL] Fix build warning after #116331

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2102,7 +2102,10 @@ void CodeGenFunction::EmitBranchOnBoolExpr(
          MDHelper.createConstant(BranchHintConstant)});
     BrInst->setMetadata("hlsl.controlflow.hint",
                         llvm::MDNode::get(CGM.getLLVMContext(), Vals));
-  } break;
+    break;
+  }
+  case HLSLControlFlowHintAttr::SpellingNotCalculated:
+    break;
   }
 }
 


### PR DESCRIPTION
After #116331 is always SpellingNotCalculated,
so I assume doing nothing is expected.
