### PR TITLE
[Darwin][CompilerRT] Set compiler ID to 'Clang' for Compiler RT Tests for Apple Clang

### DIFF
--- a/compiler-rt/cmake/base-config-ix.cmake
+++ b/compiler-rt/cmake/base-config-ix.cmake
@@ -89,6 +89,11 @@ else()
   set(COMPILER_RT_TEST_COMPILER_ID GNU)
 endif()
 
+# AppleClang expects 'Clang' as compiler-rt test compiler ID.
+if ("${COMPILER_RT_TEST_COMPILER_ID}" STREQUAL "AppleClang")
+  set(COMPILER_RT_TEST_COMPILER_ID Clang)
+endif()
+
 if(NOT DEFINED COMPILER_RT_OS_DIR)
   if(ANDROID)
     # The CMAKE_SYSTEM_NAME for Android is Android, but the OS is Linux and the


### PR DESCRIPTION
This patch restores previous behavior. Even when the Compiler ID is set to AppleClang, we expect Compiler RT Tests to use Clang as the compiler ID. This impacts various make and lit commands.

Caused by: https://github.com/llvm/llvm-project/pull/117812/files

rdar://141548700
