### PR TITLE
Fixing FindUnusedPort method tcp_socket object creation with proper constructor parameter

### DIFF
--- a/lldb/source/Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.cpp
@@ -64,7 +64,7 @@ static Status DeleteForwardPortWithAdb(uint16_t local_port,
 
 static Status FindUnusedPort(uint16_t &port) {
   Status error;
-  std::unique_ptr<TCPSocket> tcp_socket(new TCPSocket(true, false));
+  std::unique_ptr<TCPSocket> tcp_socket(new TCPSocket(true));
   if (error.Fail())
     return error;
 


### PR DESCRIPTION
### Issue: 
 Currently lldb `platform connect unix-connect://localhost:43045/` is failing and showing "Failed to connect port" error message. 
 
![IMG_2492](https://github.com/user-attachments/assets/816931e2-8b06-427e-b11a-39b813094e36)


###  Cause:
 TCPSocket(bool should_close, bool child_processes_inherit) constructor was removed in commit [c1dff71](https://github.com/llvm/llvm-project/commit/c1dff7152592f1beee9059ee8e2cb3cc68baea4d#diff-91817651b505a466ea94ddc44eca856f62073e03b05d0d0d2f4a55dcfea0002eL20). However, the tcp_socket object creation still passes the deleted constructor parameters, which causes the invocation of the wrong constructor. As a result, the `FindUnusedPort` method is unable to resolve the local port and always returns 0.