### PR TITLE
[gwp_asan] Soft-transition ZXTEST_USE_STREAMABLE_MACROS removal

### DIFF
--- a/compiler-rt/lib/gwp_asan/tests/harness.h
+++ b/compiler-rt/lib/gwp_asan/tests/harness.h
@@ -12,7 +12,9 @@
 #include <stdarg.h>
 
 #if defined(__Fuchsia__)
+#ifndef ZXTEST_USE_STREAMABLE_MACROS
 #define ZXTEST_USE_STREAMABLE_MACROS
+#endif
 #include <zxtest/zxtest.h>
 namespace testing = zxtest;
 // zxtest defines a different ASSERT_DEATH, taking a lambda and an error message


### PR DESCRIPTION
Soft-transition the removal of setting ZXTEST_USE_STREAMABLE_MACROS, by only setting the macro if not already defined. A future PR will remove setting the macro entirely in harness.h.