### PR TITLE
[lldb][Posix] Remove unused includes in file system

### DIFF
--- a/lldb/source/Host/posix/FileSystemPosix.cpp
+++ b/lldb/source/Host/posix/FileSystemPosix.cpp
@@ -9,12 +9,7 @@
 #include "lldb/Host/FileSystem.h"
 
 // C includes
-#include <dirent.h>
 #include <fcntl.h>
-#include <sys/mount.h>
-#include <sys/param.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 #if defined(__NetBSD__)
 #include <sys/statvfs.h>


### PR DESCRIPTION
You could remove unistd.h and it will still build, but only because something else included it. So I've left it in in the spirit of "include what you use".

Tested on Linux and FreeBSD.