### PR TITLE
[LLVM][AArch64] Add new feature +sme-mop4 and +sme-tmop

### DIFF
--- a/clang/test/Driver/aarch64-implied-sme-features.c
+++ b/clang/test/Driver/aarch64-implied-sme-features.c
@@ -57,7 +57,7 @@
 // SVE-BITPERM: "-target-feature" "+sme" "-target-feature" "+sme2" "-target-feature" "+ssve-bitperm" "-target-feature" "+sve-bitperm"
 
 // RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+sme-tmop %s -### 2>&1 | FileCheck %s --check-prefix=SME-TMOP
-// SME-TMOP: "-target-feature" "+sme" "-target-feature" "+sme-tmop"
+// SME-TMOP: "-target-feature" "+sme" "-target-feature" "+sme-tmop" "-target-feature" "+sme2"
 
 // RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+sme-mop4 %s -### 2>&1 | FileCheck %s --check-prefix=SME-MOP4
-// SME-MOP4: "-target-feature" "+sme" "-target-feature" "+sme-mop4"
+// SME-MOP4: "-target-feature" "+sme" "-target-feature" "+sme-mop4" "-target-feature" "+sme2"

--- a/clang/test/Driver/aarch64-implied-sme-features.c
+++ b/clang/test/Driver/aarch64-implied-sme-features.c
@@ -53,5 +53,11 @@
 // RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+ssve-aes %s -### 2>&1 | FileCheck %s --check-prefix=SVE-AES
 // SVE-AES: "-target-feature" "+sme" "-target-feature" "+sme2" "-target-feature" "+ssve-aes" "-target-feature" "+sve-aes"
 
-+// RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+ssve-bitperm %s -### 2>&1 | FileCheck %s --check-prefix=SVE-BITPERM
-+// SVE-BITPERM: "-target-feature" "+sme" "-target-feature" "+sme2" "-target-feature" "+ssve-bitperm" "-target-feature" "+sve-bitperm"
+// RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+ssve-bitperm %s -### 2>&1 | FileCheck %s --check-prefix=SVE-BITPERM
+// SVE-BITPERM: "-target-feature" "+sme" "-target-feature" "+sme2" "-target-feature" "+ssve-bitperm" "-target-feature" "+sve-bitperm"
+
+// RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+sme-tmop %s -### 2>&1 | FileCheck %s --check-prefix=SME-TMOP
+// SME-TMOP: "-target-feature" "+sme" "-target-feature" "+sme-tmop"
+
+// RUN: %clang --target=aarch64-linux-gnu -march=armv8-a+sme-mop4 %s -### 2>&1 | FileCheck %s --check-prefix=SME-MOP4
+// SME-MOP4: "-target-feature" "+sme" "-target-feature" "+sme-mop4"

--- a/clang/test/Driver/print-supported-extensions-aarch64.c
+++ b/clang/test/Driver/print-supported-extensions-aarch64.c
@@ -51,8 +51,6 @@
 // CHECK-NEXT:     pcdphint            FEAT_PCDPHINT                                          Enable Armv9.6-A Producer Consumer Data Placement hints
 // CHECK-NEXT:     pmuv3               FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
 // CHECK-NEXT:     pops                FEAT_PoPS                                              Enable Armv9.6-A Point Of Physical Storage (PoPS) DC instructions
-// CHECK-NEXT:     sme-mop4            FEAT_SME_MOP4                                          Enable SME Quarter-tile outer product instructions
-// CHECK-NEXT:     sme-tmop            FEAT_SME_TMOP                                          Enable SME Structured sparsity outer product instructions
 // CHECK-NEXT:     predres             FEAT_SPECRES                                           Enable Armv8.5-A execution and data prediction invalidation instructions
 // CHECK-NEXT:     rng                 FEAT_RNG                                               Enable Random Number generation instructions
 // CHECK-NEXT:     ras                 FEAT_RAS, FEAT_RASv1p1                                 Enable Armv8.0-A Reliability, Availability and Serviceability Extensions
@@ -73,6 +71,8 @@
 // CHECK-NEXT:     sme-fa64            FEAT_SME_FA64                                          Enable the full A64 instruction set in streaming SVE mode
 // CHECK-NEXT:     sme-i16i64          FEAT_SME_I16I64                                        Enable Scalable Matrix Extension (SME) I16I64 instructions
 // CHECK-NEXT:     sme-lutv2           FEAT_SME_LUTv2                                         Enable Scalable Matrix Extension (SME) LUTv2 instructions
+// CHECK-NEXT:     sme-mop4            FEAT_SME_MOP4                                          Enable SME Quarter-tile outer product instructions
+// CHECK-NEXT:     sme-tmop            FEAT_SME_TMOP                                          Enable SME Structured sparsity outer product instructions
 // CHECK-NEXT:     sme2                FEAT_SME2                                              Enable Scalable Matrix Extension 2 (SME2) instructions
 // CHECK-NEXT:     sme2p1              FEAT_SME2p1                                            Enable Scalable Matrix Extension 2.1 instructions
 // CHECK-NEXT:     sme2p2              FEAT_SME2p2                                            Enable Armv9.6-A Scalable Matrix Extension 2.2 instructions

--- a/clang/test/Driver/print-supported-extensions-aarch64.c
+++ b/clang/test/Driver/print-supported-extensions-aarch64.c
@@ -51,6 +51,8 @@
 // CHECK-NEXT:     pcdphint            FEAT_PCDPHINT                                          Enable Armv9.6-A Producer Consumer Data Placement hints
 // CHECK-NEXT:     pmuv3               FEAT_PMUv3                                             Enable Armv8.0-A PMUv3 Performance Monitors extension
 // CHECK-NEXT:     pops                FEAT_PoPS                                              Enable Armv9.6-A Point Of Physical Storage (PoPS) DC instructions
+// CHECK-NEXT:     sme-mop4            FEAT_SME_MOP4                                          Enable SME Quarter-tile outer product instructions
+// CHECK-NEXT:     sme-tmop            FEAT_SME_TMOP                                          Enable SME Structured sparsity outer product instructions
 // CHECK-NEXT:     predres             FEAT_SPECRES                                           Enable Armv8.5-A execution and data prediction invalidation instructions
 // CHECK-NEXT:     rng                 FEAT_RNG                                               Enable Random Number generation instructions
 // CHECK-NEXT:     ras                 FEAT_RAS, FEAT_RASv1p1                                 Enable Armv8.0-A Reliability, Availability and Serviceability Extensions

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -75,7 +75,7 @@ def SVEUnsupported : AArch64Unsupported {
 
 let F = [HasSME2p2, HasSVE2p2orSME2p2, HasNonStreamingSVEorSME2p2,
          HasNonStreamingSVE2p2orSME2p2, HasNonStreamingSVE2orSSVE_BitPerm,
-         HasSME2p2orSME_MOP4, HasSME2p2orSME_TMOP] in
+         HasSME_MOP4, HasSME_TMOP] in
 def SME2p2Unsupported : AArch64Unsupported;
 
 def SME2p1Unsupported : AArch64Unsupported {

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -74,7 +74,8 @@ def SVEUnsupported : AArch64Unsupported {
 }
 
 let F = [HasSME2p2, HasSVE2p2orSME2p2, HasNonStreamingSVEorSME2p2,
-         HasNonStreamingSVE2p2orSME2p2, HasNonStreamingSVE2orSSVE_BitPerm] in
+         HasNonStreamingSVE2p2orSME2p2, HasNonStreamingSVE2orSSVE_BitPerm,
+         HasSME2p2orSME_MOP4, HasSME2p2orSME_TMOP] in
 def SME2p2Unsupported : AArch64Unsupported;
 
 def SME2p1Unsupported : AArch64Unsupported {

--- a/llvm/lib/Target/AArch64/AArch64Features.td
+++ b/llvm/lib/Target/AArch64/AArch64Features.td
@@ -570,6 +570,12 @@ def FeaturePoPS: ExtensionWithMArch<"pops", "PoPS", "FEAT_PoPS",
 def FeatureSSVE_BitPerm : ExtensionWithMArch<"ssve-bitperm", "SSVE_BitPerm", "FEAT_SSVE_BitPerm",
   "Enable Armv9.6-A SVE BitPerm support in streaming SVE mode", [FeatureSME2, FeatureSVEBitPerm]>;
 
+def FeatureSME_MOP4: ExtensionWithMArch<"sme-mop4", "SME_MOP4", "FEAT_SME_MOP4",
+  "Enable SME Quarter-tile outer product instructions", [FeatureSME2]>;
+
+def FeatureSME_TMOP: ExtensionWithMArch<"sme-tmop", "SME_TMOP", "FEAT_SME_TMOP",
+  "Enable SME Structured sparsity outer product instructions.", [FeatureSME2]>;
+
 //===----------------------------------------------------------------------===//
 //  Other Features
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -290,6 +290,14 @@ def HasNonStreamingSVE2orSSVE_BitPerm
     : Predicate<"(Subtarget->isSVEAvailable() && Subtarget->hasSVE2()) ||"
                 "(Subtarget->isSVEorStreamingSVEAvailable() && Subtarget->hasSSVE_BitPerm())">,
                 AssemblerPredicateWithAll<(any_of FeatureSVE2, FeatureSSVE_BitPerm), "sve2 or ssve-bitperm">;
+def HasSME2p2orSME_MOP4
+    : Predicate<"(Subtarget->isStreaming() &&"
+                "(Subtarget->hasSME2p2() || Subtarget->hasSME_MOP4()))">,
+                AssemblerPredicateWithAll<(any_of FeatureSME2p2, FeatureSME_MOP4), "sme2p2 or sme-mop4">;
+def HasSME2p2orSME_TMOP
+    : Predicate<"(Subtarget->isStreaming() &&"
+                "(Subtarget->hasSME2p2()) || Subtarget->hasSME_TMOP()))">,
+                AssemblerPredicateWithAll<(any_of FeatureSME2p2, FeatureSME_TMOP), "sme2p2 or sme-tmop">;
 
 // A subset of NEON instructions are legal in Streaming SVE execution mode,
 // so don't need the additional check for 'isNeonAvailable'.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -290,14 +290,12 @@ def HasNonStreamingSVE2orSSVE_BitPerm
     : Predicate<"(Subtarget->isSVEAvailable() && Subtarget->hasSVE2()) ||"
                 "(Subtarget->isSVEorStreamingSVEAvailable() && Subtarget->hasSSVE_BitPerm())">,
                 AssemblerPredicateWithAll<(any_of FeatureSVE2, FeatureSSVE_BitPerm), "sve2 or ssve-bitperm">;
-def HasSME2p2orSME_MOP4
-    : Predicate<"(Subtarget->isStreaming() &&"
-                "(Subtarget->hasSME2p2() || Subtarget->hasSME_MOP4()))">,
-                AssemblerPredicateWithAll<(any_of FeatureSME2p2, FeatureSME_MOP4), "sme2p2 or sme-mop4">;
-def HasSME2p2orSME_TMOP
-    : Predicate<"(Subtarget->isStreaming() &&"
-                "(Subtarget->hasSME2p2()) || Subtarget->hasSME_TMOP()))">,
-                AssemblerPredicateWithAll<(any_of FeatureSME2p2, FeatureSME_TMOP), "sme2p2 or sme-tmop">;
+def HasSME_MOP4
+    : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_MOP4())">,
+                AssemblerPredicateWithAll<(any_of FeatureSME_MOP4), "sme-mop4">;
+def HasSME_TMOP
+    : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_TMOP())">,
+                AssemblerPredicateWithAll<(any_of FeatureSME_TMOP), "sme-tmop">;
 
 // A subset of NEON instructions are legal in Streaming SVE execution mode,
 // so don't need the additional check for 'isNeonAvailable'.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -212,6 +212,10 @@ def HasSMEF8F16     : Predicate<"Subtarget->isStreaming() && Subtarget->hasSMEF8
                                  AssemblerPredicateWithAll<(all_of FeatureSMEF8F16), "sme-f8f16">;
 def HasSMEF8F32     : Predicate<"Subtarget->isStreaming() && Subtarget->hasSMEF8F32()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSMEF8F32), "sme-f8f32">;
+def HasSME_MOP4     : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_MOP4())">,
+                                 AssemblerPredicateWithAll<(all_of FeatureSME_MOP4), "sme-mop4">;
+def HasSME_TMOP      : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_TMOP())">,
+                                 AssemblerPredicateWithAll<(all_of FeatureSME_TMOP), "sme-tmop">;
 
 def HasCMPBR        : Predicate<"Subtarget->hasCMPBR()">,
                                  AssemblerPredicateWithAll<(all_of FeatureCMPBR), "cmpbr">;
@@ -290,12 +294,6 @@ def HasNonStreamingSVE2orSSVE_BitPerm
     : Predicate<"(Subtarget->isSVEAvailable() && Subtarget->hasSVE2()) ||"
                 "(Subtarget->isSVEorStreamingSVEAvailable() && Subtarget->hasSSVE_BitPerm())">,
                 AssemblerPredicateWithAll<(any_of FeatureSVE2, FeatureSSVE_BitPerm), "sve2 or ssve-bitperm">;
-def HasSME_MOP4
-    : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_MOP4())">,
-                AssemblerPredicateWithAll<(any_of FeatureSME_MOP4), "sme-mop4">;
-def HasSME_TMOP
-    : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_TMOP())">,
-                AssemblerPredicateWithAll<(any_of FeatureSME_TMOP), "sme-tmop">;
 
 // A subset of NEON instructions are legal in Streaming SVE execution mode,
 // so don't need the additional check for 'isNeonAvailable'.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -206,7 +206,7 @@ def HasSSVE_FP8DOT4  : Predicate<"Subtarget->hasSSVE_FP8DOT4() || "
                                  "ssve-fp8dot4 or (sve2 and fp8dot4)">;
 def HasLUT          : Predicate<"Subtarget->hasLUT()">,
                                  AssemblerPredicateWithAll<(all_of FeatureLUT), "lut">;
-def HasSME_LUTv2     : Predicate<"Subtarget->isStreaming() && Subtarget->hasSME_LUTv2()">,
+def HasSME_LUTv2    : Predicate<"Subtarget->isStreaming() && Subtarget->hasSME_LUTv2()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSME_LUTv2), "sme-lutv2">;
 def HasSMEF8F16     : Predicate<"Subtarget->isStreaming() && Subtarget->hasSMEF8F16()">,
                                  AssemblerPredicateWithAll<(all_of FeatureSMEF8F16), "sme-f8f16">;
@@ -214,7 +214,7 @@ def HasSMEF8F32     : Predicate<"Subtarget->isStreaming() && Subtarget->hasSMEF8
                                  AssemblerPredicateWithAll<(all_of FeatureSMEF8F32), "sme-f8f32">;
 def HasSME_MOP4     : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_MOP4())">,
                                  AssemblerPredicateWithAll<(all_of FeatureSME_MOP4), "sme-mop4">;
-def HasSME_TMOP      : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_TMOP())">,
+def HasSME_TMOP     : Predicate<"(Subtarget->isStreaming() && Subtarget->hasSME_TMOP())">,
                                  AssemblerPredicateWithAll<(all_of FeatureSME_TMOP), "sme-tmop">;
 
 def HasCMPBR        : Predicate<"Subtarget->hasCMPBR()">,

--- a/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
@@ -147,7 +147,7 @@ defm USMOPA_MPPZZ_D : sme_int_outer_product_i64<0b100, "usmopa", int_aarch64_sme
 defm USMOPS_MPPZZ_D : sme_int_outer_product_i64<0b101, "usmops", int_aarch64_sme_usmops_wide>;
 }
 
-let Predicates = [HasSME2p2orSME_MOP4] in {
+let Predicates = [HasSME_MOP4] in {
   defm SMOP4A  : sme_quarter_outer_product_i8_i32<0b0, 0b0, 0b0, "smop4a">;
   defm SMOP4S  : sme_quarter_outer_product_i8_i32<0b0, 0b0, 0b1, "smop4s">;
   defm SUMOP4A : sme_quarter_outer_product_i8_i32<0b0, 0b1, 0b0, "sumop4a">;
@@ -163,7 +163,7 @@ let Predicates = [HasSME2p2orSME_MOP4] in {
   defm UMOP4S : sme_quarter_outer_product_i16_i32<0b1, 0b1, "umop4s">;
 }
 
-let Predicates = [HasSME2p2orSME_MOP4, HasSMEI16I64] in {
+let Predicates = [HasSME_MOP4, HasSMEI16I64] in {
   defm SMOP4A : sme_quarter_outer_product_i64<0b0, 0b0, 0b0, "smop4a">;
   defm SMOP4S : sme_quarter_outer_product_i64<0b0, 0b0, 0b1, "smop4s">;
   defm SUMOP4A : sme_quarter_outer_product_i64<0b0, 0b1, 0b0, "sumop4a">;
@@ -174,7 +174,7 @@ let Predicates = [HasSME2p2orSME_MOP4, HasSMEI16I64] in {
   defm USMOP4S : sme_quarter_outer_product_i64<0b1, 0b0, 0b1, "usmop4s">;
 }
 
-let Predicates = [HasSME2p2orSME_TMOP] in {
+let Predicates = [HasSME_TMOP] in {
 def STMOPA_M2ZZZI_BtoS  : sme_int_sparse_outer_product_i32<0b00100, ZZ_b_mul_r, ZPR8,  "stmopa">;
 def STMOPA_M2ZZZI_HtoS  : sme_int_sparse_outer_product_i32<0b00101, ZZ_h_mul_r, ZPR16, "stmopa">;
 def UTMOPA_M2ZZZI_BtoS  : sme_int_sparse_outer_product_i32<0b11100, ZZ_b_mul_r, ZPR8,  "utmopa">;
@@ -1053,7 +1053,7 @@ let Predicates = [HasSME2, HasSVEBFSCALE] in {
   defm BFSCALE : sme2_bfscale_multi<"bfscale">;
 }
 
-let Predicates = [HasSME2p2orSME_MOP4] in {
+let Predicates = [HasSME_MOP4] in {
   defm BFMOP4A : sme2_bfmop4as_widening<0, "bfmop4a">;
   defm BFMOP4S : sme2_bfmop4as_widening<1, "bfmop4s">;
 
@@ -1064,7 +1064,7 @@ let Predicates = [HasSME2p2orSME_MOP4] in {
   defm FMOP4S : sme2_fmop4as_fp32_non_widening<1, "fmop4s">;
 }
 
-let Predicates = [HasSME2p2orSME_TMOP] in {
+let Predicates = [HasSME_TMOP] in {
   def FTMOPA_M2ZZZI_HtoS  : sme_tmopa_32b<0b11000, ZZ_h_mul_r, ZPR16, "ftmopa">;
   def FTMOPA_M2ZZZI_StoS  : sme_tmopa_32b<0b00000, ZZ_s_mul_r, ZPR32, "ftmopa">;
   def BFTMOPA_M2ZZZI_HtoS : sme_tmopa_32b<0b10000, ZZ_h_mul_r, ZPR16, "bftmopa">;
@@ -1078,27 +1078,27 @@ let Predicates = [HasSME2p2] in {
 
 } // [HasSME2p2]
 
-let Predicates = [HasSME2p2orSME_TMOP, HasSMEB16B16] in {
+let Predicates = [HasSME_TMOP, HasSMEB16B16] in {
   def BFTMOPA_M2ZZZI_HtoH : sme_tmopa_16b<0b11001, ZZ_h_mul_r, ZPR16, "bftmopa">;
 }
 
-let Predicates = [HasSME2p2orSME_TMOP, HasSMEF8F32], Uses = [FPMR, FPCR] in {
+let Predicates = [HasSME_TMOP, HasSMEF8F32], Uses = [FPMR, FPCR] in {
   def FTMOPA_M2ZZZI_BtoS : sme_tmopa_32b<0b01000, ZZ_b_mul_r, ZPR8, "ftmopa">;
 } 
 
-let Predicates = [HasSME2p2orSME_TMOP, HasSMEF8F16], Uses = [FPMR, FPCR] in {
+let Predicates = [HasSME_TMOP, HasSMEF8F16], Uses = [FPMR, FPCR] in {
   def FTMOPA_M2ZZZI_BtoH : sme_tmopa_16b<0b01001, ZZ_b_mul_r, ZPR8, "ftmopa">;
 }
 
-let Predicates = [HasSME2p2orSME_MOP4, HasSMEF8F16], Uses = [FPMR, FPCR] in {
+let Predicates = [HasSME_MOP4, HasSMEF8F16], Uses = [FPMR, FPCR] in {
   defm FMOP4A : sme2_fmop4a_fp8_fp16_2way<"fmop4a">;
 }
 
-let Predicates = [HasSME2p2orSME_TMOP, HasSMEF16F16] in {
+let Predicates = [HasSME_TMOP, HasSMEF16F16] in {
   def FTMOPA_M2ZZZI_HtoH : sme_tmopa_16b<0b10001, ZZ_h_mul_r, ZPR16, "ftmopa">;
 }
 
-let Predicates = [HasSME2p2orSME_MOP4, HasSMEF16F16] in {
+let Predicates = [HasSME_MOP4, HasSMEF16F16] in {
   defm FMOP4A : sme2_fmop4as_fp16_non_widening<0, "fmop4a">;
   defm FMOP4S : sme2_fmop4as_fp16_non_widening<1, "fmop4s">;
 }
@@ -1109,17 +1109,17 @@ let Predicates = [HasSME2, HasSVEBFSCALE] in {
 }
 
 let Uses = [FPMR, FPCR] in {
-let Predicates = [HasSME2p2orSME_MOP4, HasSMEF8F32] in {
+let Predicates = [HasSME_MOP4, HasSMEF8F32] in {
   defm FMOP4A : sme2_fmop4a_fp8_fp32_4way<"fmop4a">;
 }
 }
 
-let Predicates = [HasSME2p2orSME_MOP4, HasSMEB16B16] in {
+let Predicates = [HasSME_MOP4, HasSMEB16B16] in {
   defm BFMOP4A : sme2_bfmop4as_non_widening<0, "bfmop4a">;
   defm BFMOP4S : sme2_bfmop4as_non_widening<1, "bfmop4s">;
 }
 
-let Predicates = [HasSME2p2orSME_MOP4, HasSMEF64F64] in {
+let Predicates = [HasSME_MOP4, HasSMEF64F64] in {
   defm FMOP4A : sme2_fmop4as_fp64_non_widening<0, "fmop4a">;
   defm FMOP4S : sme2_fmop4as_fp64_non_widening<1, "fmop4s">;
 }

--- a/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SMEInstrInfo.td
@@ -147,7 +147,7 @@ defm USMOPA_MPPZZ_D : sme_int_outer_product_i64<0b100, "usmopa", int_aarch64_sme
 defm USMOPS_MPPZZ_D : sme_int_outer_product_i64<0b101, "usmops", int_aarch64_sme_usmops_wide>;
 }
 
-let Predicates = [HasSME2p2] in {
+let Predicates = [HasSME2p2orSME_MOP4] in {
   defm SMOP4A  : sme_quarter_outer_product_i8_i32<0b0, 0b0, 0b0, "smop4a">;
   defm SMOP4S  : sme_quarter_outer_product_i8_i32<0b0, 0b0, 0b1, "smop4s">;
   defm SUMOP4A : sme_quarter_outer_product_i8_i32<0b0, 0b1, 0b0, "sumop4a">;
@@ -163,7 +163,7 @@ let Predicates = [HasSME2p2] in {
   defm UMOP4S : sme_quarter_outer_product_i16_i32<0b1, 0b1, "umop4s">;
 }
 
-let Predicates = [HasSME2p2, HasSMEI16I64] in {
+let Predicates = [HasSME2p2orSME_MOP4, HasSMEI16I64] in {
   defm SMOP4A : sme_quarter_outer_product_i64<0b0, 0b0, 0b0, "smop4a">;
   defm SMOP4S : sme_quarter_outer_product_i64<0b0, 0b0, 0b1, "smop4s">;
   defm SUMOP4A : sme_quarter_outer_product_i64<0b0, 0b1, 0b0, "sumop4a">;
@@ -174,7 +174,7 @@ let Predicates = [HasSME2p2, HasSMEI16I64] in {
   defm USMOP4S : sme_quarter_outer_product_i64<0b1, 0b0, 0b1, "usmop4s">;
 }
 
-let Predicates = [HasSME2p2] in {
+let Predicates = [HasSME2p2orSME_TMOP] in {
 def STMOPA_M2ZZZI_BtoS  : sme_int_sparse_outer_product_i32<0b00100, ZZ_b_mul_r, ZPR8,  "stmopa">;
 def STMOPA_M2ZZZI_HtoS  : sme_int_sparse_outer_product_i32<0b00101, ZZ_h_mul_r, ZPR16, "stmopa">;
 def UTMOPA_M2ZZZI_BtoS  : sme_int_sparse_outer_product_i32<0b11100, ZZ_b_mul_r, ZPR8,  "utmopa">;
@@ -1053,41 +1053,52 @@ let Predicates = [HasSME2, HasSVEBFSCALE] in {
   defm BFSCALE : sme2_bfscale_multi<"bfscale">;
 }
 
-let Predicates = [HasSME2p2] in {
-  def FTMOPA_M2ZZZI_HtoS  : sme_tmopa_32b<0b11000, ZZ_h_mul_r, ZPR16, "ftmopa">;
-  def FTMOPA_M2ZZZI_StoS  : sme_tmopa_32b<0b00000, ZZ_s_mul_r, ZPR32, "ftmopa">;
-  def BFTMOPA_M2ZZZI_HtoS : sme_tmopa_32b<0b10000, ZZ_h_mul_r, ZPR16, "bftmopa">;
-
+let Predicates = [HasSME2p2orSME_MOP4] in {
   defm BFMOP4A : sme2_bfmop4as_widening<0, "bfmop4a">;
   defm BFMOP4S : sme2_bfmop4as_widening<1, "bfmop4s">;
 
+  defm FMOP4A : sme2_fmop4as_fp16_fp32_widening<0, "fmop4a">;
+  defm FMOP4S : sme2_fmop4as_fp16_fp32_widening<1, "fmop4s">;
+
+  defm FMOP4A : sme2_fmop4as_fp32_non_widening<0, "fmop4a">;
+  defm FMOP4S : sme2_fmop4as_fp32_non_widening<1, "fmop4s">;
+}
+
+let Predicates = [HasSME2p2orSME_TMOP] in {
+  def FTMOPA_M2ZZZI_HtoS  : sme_tmopa_32b<0b11000, ZZ_h_mul_r, ZPR16, "ftmopa">;
+  def FTMOPA_M2ZZZI_StoS  : sme_tmopa_32b<0b00000, ZZ_s_mul_r, ZPR32, "ftmopa">;
+  def BFTMOPA_M2ZZZI_HtoS : sme_tmopa_32b<0b10000, ZZ_h_mul_r, ZPR16, "bftmopa">;
+}
+
+let Predicates = [HasSME2p2] in {
   defm FMUL_2ZZ  : sme2_multi2_fmul_sm<"fmul">;
   defm FMUL_2Z2Z : sme2_multi2_fmul_mm< "fmul">;
   defm FMUL_4ZZ  : sme2_multi4_fmul_sm<"fmul">;
   defm FMUL_4Z4Z : sme2_multi4_fmul_mm< "fmul">;
 
-  defm FMOP4A : sme2_fmop4as_fp32_non_widening<0, "fmop4a">;
-  defm FMOP4S : sme2_fmop4as_fp32_non_widening<1, "fmop4s">;
+} // [HasSME2p2]
 
-  defm FMOP4A : sme2_fmop4as_fp16_fp32_widening<0, "fmop4a">;
-  defm FMOP4S : sme2_fmop4as_fp16_fp32_widening<1, "fmop4s">;
-}
-
-let Predicates = [HasSME2p2, HasSMEB16B16] in {
+let Predicates = [HasSME2p2orSME_TMOP, HasSMEB16B16] in {
   def BFTMOPA_M2ZZZI_HtoH : sme_tmopa_16b<0b11001, ZZ_h_mul_r, ZPR16, "bftmopa">;
 }
 
-let Predicates = [HasSME2p2, HasSMEF8F32], Uses = [FPMR, FPCR] in {
+let Predicates = [HasSME2p2orSME_TMOP, HasSMEF8F32], Uses = [FPMR, FPCR] in {
   def FTMOPA_M2ZZZI_BtoS : sme_tmopa_32b<0b01000, ZZ_b_mul_r, ZPR8, "ftmopa">;
+} 
+
+let Predicates = [HasSME2p2orSME_TMOP, HasSMEF8F16], Uses = [FPMR, FPCR] in {
+  def FTMOPA_M2ZZZI_BtoH : sme_tmopa_16b<0b01001, ZZ_b_mul_r, ZPR8, "ftmopa">;
 }
 
-let Predicates = [HasSME2p2, HasSMEF8F16], Uses = [FPMR, FPCR] in {
-  def FTMOPA_M2ZZZI_BtoH : sme_tmopa_16b<0b01001, ZZ_b_mul_r, ZPR8, "ftmopa">;
+let Predicates = [HasSME2p2orSME_MOP4, HasSMEF8F16], Uses = [FPMR, FPCR] in {
   defm FMOP4A : sme2_fmop4a_fp8_fp16_2way<"fmop4a">;
 }
 
-let Predicates = [HasSME2p2, HasSMEF16F16] in {
+let Predicates = [HasSME2p2orSME_TMOP, HasSMEF16F16] in {
   def FTMOPA_M2ZZZI_HtoH : sme_tmopa_16b<0b10001, ZZ_h_mul_r, ZPR16, "ftmopa">;
+}
+
+let Predicates = [HasSME2p2orSME_MOP4, HasSMEF16F16] in {
   defm FMOP4A : sme2_fmop4as_fp16_non_widening<0, "fmop4a">;
   defm FMOP4S : sme2_fmop4as_fp16_non_widening<1, "fmop4s">;
 }
@@ -1098,17 +1109,17 @@ let Predicates = [HasSME2, HasSVEBFSCALE] in {
 }
 
 let Uses = [FPMR, FPCR] in {
-let Predicates = [HasSME2p2, HasSMEF8F32] in {
+let Predicates = [HasSME2p2orSME_MOP4, HasSMEF8F32] in {
   defm FMOP4A : sme2_fmop4a_fp8_fp32_4way<"fmop4a">;
 }
 }
 
-let Predicates = [HasSME2p2, HasSMEB16B16] in {
+let Predicates = [HasSME2p2orSME_MOP4, HasSMEB16B16] in {
   defm BFMOP4A : sme2_bfmop4as_non_widening<0, "bfmop4a">;
   defm BFMOP4S : sme2_bfmop4as_non_widening<1, "bfmop4s">;
 }
 
-let Predicates = [HasSME2p2, HasSMEF64F64] in {
+let Predicates = [HasSME2p2orSME_MOP4, HasSMEF64F64] in {
   defm FMOP4A : sme2_fmop4as_fp64_non_widening<0, "fmop4a">;
   defm FMOP4S : sme2_fmop4as_fp64_non_widening<1, "fmop4s">;
 }

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -3831,6 +3831,8 @@ static const struct Extension {
     {"occmo", {AArch64::FeatureOCCMO}},
     {"pcdphint", {AArch64::FeaturePCDPHINT}},
     {"ssve-bitperm", {AArch64::FeatureSSVE_BitPerm}},
+    {"sme-mop4", {AArch64::FeatureSME_MOP4}},
+    {"sme-tmop", {AArch64::FeatureSME_TMOP}},
 };
 
 static void setRequiredFeatureString(FeatureBitset FBS, std::string &Str) {

--- a/llvm/test/MC/AArch64/SME2p2/bfmop4as-non-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/bfmop4as-non-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-b16b16 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-b16b16 < %s 2>&1 | FileCheck %s
 
 // BFMOP4A
 

--- a/llvm/test/MC/AArch64/SME2p2/bfmop4as-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/bfmop4as-non-widening.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-b16b16 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-b16b16 < %s \
@@ -19,19 +21,19 @@
 bfmop4a za0.h, z0.h, z16.h  // 10000001-00100000-00000000-00001000
 // CHECK-INST: bfmop4a za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81200008 <unknown>
 
 bfmop4a za1.h, z12.h, z24.h  // 10000001-00101000-00000001-10001001
 // CHECK-INST: bfmop4a za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x89,0x01,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81280189 <unknown>
 
 bfmop4a za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11001001
 // CHECK-INST: bfmop4a za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xc9,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 812e01c9 <unknown>
 
 // Single and multiple vectors
@@ -39,19 +41,19 @@ bfmop4a za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11001001
 bfmop4a za0.h, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00001000
 // CHECK-INST: bfmop4a za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81300008 <unknown>
 
 bfmop4a za1.h, z12.h, {z24.h-z25.h}  // 10000001-00111000-00000001-10001001
 // CHECK-INST: bfmop4a za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x01,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81380189 <unknown>
 
 bfmop4a za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11001001
 // CHECK-INST: bfmop4a za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 813e01c9 <unknown>
 
 // Multiple and single vectors
@@ -59,19 +61,19 @@ bfmop4a za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11001001
 bfmop4a za0.h, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00001000
 // CHECK-INST: bfmop4a za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81200208 <unknown>
 
 bfmop4a za1.h, {z12.h-z13.h}, z24.h  // 10000001-00101000-00000011-10001001
 // CHECK-INST: bfmop4a za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x89,0x03,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81280389 <unknown>
 
 bfmop4a za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11001001
 // CHECK-INST: bfmop4a za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc9,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 812e03c9 <unknown>
 
 // Multiple vectors
@@ -79,19 +81,19 @@ bfmop4a za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11001001
 bfmop4a za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00001000
 // CHECK-INST: bfmop4a za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81300208 <unknown>
 
 bfmop4a za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00111000-00000011-10001001
 // CHECK-INST: bfmop4a za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x03,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81380389 <unknown>
 
 bfmop4a za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11001001
 // CHECK-INST: bfmop4a za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 813e03c9 <unknown>
 
 
@@ -102,19 +104,19 @@ bfmop4a za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11001
 bfmop4s za0.h, z0.h, z16.h  // 10000001-00100000-00000000-00011000
 // CHECK-INST: bfmop4s za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81200018 <unknown>
 
 bfmop4s za1.h, z12.h, z24.h  // 10000001-00101000-00000001-10011001
 // CHECK-INST: bfmop4s za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x99,0x01,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81280199 <unknown>
 
 bfmop4s za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11011001
 // CHECK-INST: bfmop4s za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xd9,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 812e01d9 <unknown>
 
 // Single and multiple vectors
@@ -122,19 +124,19 @@ bfmop4s za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11011001
 bfmop4s za0.h, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00011000
 // CHECK-INST: bfmop4s za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81300018 <unknown>
 
 bfmop4s za1.h, z12.h, {z24.h-z25.h}  // 10000001-00111000-00000001-10011001
 // CHECK-INST: bfmop4s za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x01,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81380199 <unknown>
 
 bfmop4s za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11011001
 // CHECK-INST: bfmop4s za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 813e01d9 <unknown>
 
 // Multiple and single vectors
@@ -142,19 +144,19 @@ bfmop4s za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11011001
 bfmop4s za0.h, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00011000
 // CHECK-INST: bfmop4s za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81200218 <unknown>
 
 bfmop4s za1.h, {z12.h-z13.h}, z24.h  // 10000001-00101000-00000011-10011001
 // CHECK-INST: bfmop4s za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x99,0x03,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81280399 <unknown>
 
 bfmop4s za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11011001
 // CHECK-INST: bfmop4s za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd9,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 812e03d9 <unknown>
 
 // Multiple vectors
@@ -162,17 +164,17 @@ bfmop4s za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11011001
 bfmop4s za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00011000
 // CHECK-INST: bfmop4s za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81300218 <unknown>
 
 bfmop4s za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00111000-00000011-10011001
 // CHECK-INST: bfmop4s za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x03,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 81380399 <unknown>
 
 bfmop4s za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11011001
 // CHECK-INST: bfmop4s za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
 // CHECK-UNKNOWN: 813e03d9 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/bfmop4as-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/bfmop4as-non-widening.s
@@ -1,17 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-b16b16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-b16b16 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-b16b16 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-b16b16 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-b16b16 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-b16b16 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-b16b16 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-b16b16 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-b16b16 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-b16b16 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // BFMOP4A
@@ -21,19 +19,19 @@
 bfmop4a za0.h, z0.h, z16.h  // 10000001-00100000-00000000-00001000
 // CHECK-INST: bfmop4a za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81200008 <unknown>
 
 bfmop4a za1.h, z12.h, z24.h  // 10000001-00101000-00000001-10001001
 // CHECK-INST: bfmop4a za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x89,0x01,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81280189 <unknown>
 
 bfmop4a za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11001001
 // CHECK-INST: bfmop4a za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xc9,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 812e01c9 <unknown>
 
 // Single and multiple vectors
@@ -41,19 +39,19 @@ bfmop4a za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11001001
 bfmop4a za0.h, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00001000
 // CHECK-INST: bfmop4a za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81300008 <unknown>
 
 bfmop4a za1.h, z12.h, {z24.h-z25.h}  // 10000001-00111000-00000001-10001001
 // CHECK-INST: bfmop4a za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x01,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81380189 <unknown>
 
 bfmop4a za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11001001
 // CHECK-INST: bfmop4a za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 813e01c9 <unknown>
 
 // Multiple and single vectors
@@ -61,19 +59,19 @@ bfmop4a za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11001001
 bfmop4a za0.h, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00001000
 // CHECK-INST: bfmop4a za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81200208 <unknown>
 
 bfmop4a za1.h, {z12.h-z13.h}, z24.h  // 10000001-00101000-00000011-10001001
 // CHECK-INST: bfmop4a za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x89,0x03,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81280389 <unknown>
 
 bfmop4a za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11001001
 // CHECK-INST: bfmop4a za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc9,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 812e03c9 <unknown>
 
 // Multiple vectors
@@ -81,19 +79,19 @@ bfmop4a za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11001001
 bfmop4a za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00001000
 // CHECK-INST: bfmop4a za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81300208 <unknown>
 
 bfmop4a za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00111000-00000011-10001001
 // CHECK-INST: bfmop4a za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x03,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81380389 <unknown>
 
 bfmop4a za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11001001
 // CHECK-INST: bfmop4a za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 813e03c9 <unknown>
 
 
@@ -104,19 +102,19 @@ bfmop4a za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11001
 bfmop4s za0.h, z0.h, z16.h  // 10000001-00100000-00000000-00011000
 // CHECK-INST: bfmop4s za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81200018 <unknown>
 
 bfmop4s za1.h, z12.h, z24.h  // 10000001-00101000-00000001-10011001
 // CHECK-INST: bfmop4s za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x99,0x01,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81280199 <unknown>
 
 bfmop4s za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11011001
 // CHECK-INST: bfmop4s za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xd9,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 812e01d9 <unknown>
 
 // Single and multiple vectors
@@ -124,19 +122,19 @@ bfmop4s za1.h, z14.h, z30.h  // 10000001-00101110-00000001-11011001
 bfmop4s za0.h, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00011000
 // CHECK-INST: bfmop4s za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81300018 <unknown>
 
 bfmop4s za1.h, z12.h, {z24.h-z25.h}  // 10000001-00111000-00000001-10011001
 // CHECK-INST: bfmop4s za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x01,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81380199 <unknown>
 
 bfmop4s za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11011001
 // CHECK-INST: bfmop4s za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 813e01d9 <unknown>
 
 // Multiple and single vectors
@@ -144,19 +142,19 @@ bfmop4s za1.h, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11011001
 bfmop4s za0.h, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00011000
 // CHECK-INST: bfmop4s za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81200218 <unknown>
 
 bfmop4s za1.h, {z12.h-z13.h}, z24.h  // 10000001-00101000-00000011-10011001
 // CHECK-INST: bfmop4s za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x99,0x03,0x28,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81280399 <unknown>
 
 bfmop4s za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11011001
 // CHECK-INST: bfmop4s za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd9,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 812e03d9 <unknown>
 
 // Multiple vectors
@@ -164,17 +162,17 @@ bfmop4s za1.h, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11011001
 bfmop4s za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00011000
 // CHECK-INST: bfmop4s za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81300218 <unknown>
 
 bfmop4s za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00111000-00000011-10011001
 // CHECK-INST: bfmop4s za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x03,0x38,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 81380399 <unknown>
 
 bfmop4s za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11011001
 // CHECK-INST: bfmop4s za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-mop4
 // CHECK-UNKNOWN: 813e03d9 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/bfmop4as-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/bfmop4as-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4 < %s 2>&1 | FileCheck %s
 
 // BFMOP4A
 

--- a/llvm/test/MC/AArch64/SME2p2/bfmop4as-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/bfmop4as-widening.s
@@ -1,17 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // BFMOP4A
@@ -21,19 +19,19 @@
 bfmop4a za0.s, z0.h, z16.h  // 10000001-00000000-00000000-00000000
 // CHECK-INST: bfmop4a za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x00,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81000000 <unknown>
 
 bfmop4a za3.s, z14.h, z30.h  // 10000001-00001110-00000001-11000011
 // CHECK-INST: bfmop4a za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xc3,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e01c3 <unknown>
 
 bfmop4a za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01000001
 // CHECK-INST: bfmop4a za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x41,0x01,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81040141 <unknown>
 
 // Single and multiple vectors
@@ -41,19 +39,19 @@ bfmop4a za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01000001
 bfmop4a za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00000000
 // CHECK-INST: bfmop4a za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81100000 <unknown>
 
 bfmop4a za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11000011
 // CHECK-INST: bfmop4a za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e01c3 <unknown>
 
 bfmop4a za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10000010
 // CHECK-INST: bfmop4a za2.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x82,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81180182 <unknown>
 
 // Multiple and single vectors
@@ -61,19 +59,19 @@ bfmop4a za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10000010
 bfmop4a za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00000000
 // CHECK-INST: bfmop4a za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x00,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81000200 <unknown>
 
 bfmop4a za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11000011
 // CHECK-INST: bfmop4a za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc3,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e03c3 <unknown>
 
 bfmop4a za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10000010
 // CHECK-INST: bfmop4a za2.s, { z12.h, z13.h }, z28.h
 // CHECK-ENCODING: [0x82,0x03,0x0c,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810c0382 <unknown>
 
 // Multiple vectors
@@ -81,19 +79,19 @@ bfmop4a za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10000010
 bfmop4a za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00000000
 // CHECK-INST: bfmop4a za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81100200 <unknown>
 
 bfmop4a za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11000011
 // CHECK-INST: bfmop4a za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e03c3 <unknown>
 
 bfmop4a za2.s, {z12.h-z13.h}, {z26.h-z27.h}  // 10000001-00011010-00000011-10000010
 // CHECK-INST: bfmop4a za2.s, { z12.h, z13.h }, { z26.h, z27.h }
 // CHECK-ENCODING: [0x82,0x03,0x1a,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811a0382 <unknown>
 
 
@@ -104,19 +102,19 @@ bfmop4a za2.s, {z12.h-z13.h}, {z26.h-z27.h}  // 10000001-00011010-00000011-10000
 bfmop4s za0.s, z0.h, z16.h  // 10000001-00000000-00000000-00010000
 // CHECK-INST: bfmop4s za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x10,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81000010 <unknown>
 
 bfmop4s za3.s, z14.h, z30.h  // 10000001-00001110-00000001-11010011
 // CHECK-INST: bfmop4s za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xd3,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e01d3 <unknown>
 
 bfmop4s za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01010001
 // CHECK-INST: bfmop4s za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x51,0x01,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81040151 <unknown>
 
 // Single and multiple vectors
@@ -124,19 +122,19 @@ bfmop4s za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01010001
 bfmop4s za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00010000
 // CHECK-INST: bfmop4s za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81100010 <unknown>
 
 bfmop4s za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11010011
 // CHECK-INST: bfmop4s za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e01d3 <unknown>
 
 bfmop4s za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10010010
 // CHECK-INST: bfmop4s za2.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x92,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81180192 <unknown>
 
 // Multiple and single vectors
@@ -144,19 +142,19 @@ bfmop4s za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10010010
 bfmop4s za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00010000
 // CHECK-INST: bfmop4s za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x10,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81000210 <unknown>
 
 bfmop4s za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11010011
 // CHECK-INST: bfmop4s za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd3,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e03d3 <unknown>
 
 bfmop4s za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10010010
 // CHECK-INST: bfmop4s za2.s, { z12.h, z13.h }, z28.h
 // CHECK-ENCODING: [0x92,0x03,0x0c,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810c0392 <unknown>
 
 // Multiple vectors
@@ -164,17 +162,17 @@ bfmop4s za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10010010
 bfmop4s za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00010000
 // CHECK-INST: bfmop4s za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81100210 <unknown>
 
 bfmop4s za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11010011
 // CHECK-INST: bfmop4s za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e03d3 <unknown>
 
 bfmop4s za2.s, {z12.h-z13.h}, {z26.h-z27.h}  // 10000001-00011010-00000011-10010010
 // CHECK-INST: bfmop4s za2.s, { z12.h, z13.h }, { z26.h, z27.h }
 // CHECK-ENCODING: [0x92,0x03,0x1a,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811a0392 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/bfmop4as-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/bfmop4as-widening.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -19,19 +21,19 @@
 bfmop4a za0.s, z0.h, z16.h  // 10000001-00000000-00000000-00000000
 // CHECK-INST: bfmop4a za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x00,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81000000 <unknown>
 
 bfmop4a za3.s, z14.h, z30.h  // 10000001-00001110-00000001-11000011
 // CHECK-INST: bfmop4a za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xc3,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e01c3 <unknown>
 
 bfmop4a za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01000001
 // CHECK-INST: bfmop4a za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x41,0x01,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81040141 <unknown>
 
 // Single and multiple vectors
@@ -39,19 +41,19 @@ bfmop4a za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01000001
 bfmop4a za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00000000
 // CHECK-INST: bfmop4a za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81100000 <unknown>
 
 bfmop4a za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11000011
 // CHECK-INST: bfmop4a za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e01c3 <unknown>
 
 bfmop4a za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10000010
 // CHECK-INST: bfmop4a za2.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x82,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81180182 <unknown>
 
 // Multiple and single vectors
@@ -59,19 +61,19 @@ bfmop4a za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10000010
 bfmop4a za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00000000
 // CHECK-INST: bfmop4a za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x00,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81000200 <unknown>
 
 bfmop4a za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11000011
 // CHECK-INST: bfmop4a za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc3,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e03c3 <unknown>
 
 bfmop4a za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10000010
 // CHECK-INST: bfmop4a za2.s, { z12.h, z13.h }, z28.h
 // CHECK-ENCODING: [0x82,0x03,0x0c,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810c0382 <unknown>
 
 // Multiple vectors
@@ -79,19 +81,19 @@ bfmop4a za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10000010
 bfmop4a za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00000000
 // CHECK-INST: bfmop4a za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81100200 <unknown>
 
 bfmop4a za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11000011
 // CHECK-INST: bfmop4a za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e03c3 <unknown>
 
 bfmop4a za2.s, {z12.h-z13.h}, {z26.h-z27.h}  // 10000001-00011010-00000011-10000010
 // CHECK-INST: bfmop4a za2.s, { z12.h, z13.h }, { z26.h, z27.h }
 // CHECK-ENCODING: [0x82,0x03,0x1a,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811a0382 <unknown>
 
 
@@ -102,19 +104,19 @@ bfmop4a za2.s, {z12.h-z13.h}, {z26.h-z27.h}  // 10000001-00011010-00000011-10000
 bfmop4s za0.s, z0.h, z16.h  // 10000001-00000000-00000000-00010000
 // CHECK-INST: bfmop4s za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x10,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81000010 <unknown>
 
 bfmop4s za3.s, z14.h, z30.h  // 10000001-00001110-00000001-11010011
 // CHECK-INST: bfmop4s za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xd3,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e01d3 <unknown>
 
 bfmop4s za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01010001
 // CHECK-INST: bfmop4s za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x51,0x01,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81040151 <unknown>
 
 // Single and multiple vectors
@@ -122,19 +124,19 @@ bfmop4s za1.s, z10.h, z20.h  // 10000001-00000100-00000001-01010001
 bfmop4s za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00010000
 // CHECK-INST: bfmop4s za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81100010 <unknown>
 
 bfmop4s za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11010011
 // CHECK-INST: bfmop4s za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e01d3 <unknown>
 
 bfmop4s za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10010010
 // CHECK-INST: bfmop4s za2.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x92,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81180192 <unknown>
 
 // Multiple and single vectors
@@ -142,19 +144,19 @@ bfmop4s za2.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10010010
 bfmop4s za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00010000
 // CHECK-INST: bfmop4s za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x10,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81000210 <unknown>
 
 bfmop4s za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11010011
 // CHECK-INST: bfmop4s za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd3,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e03d3 <unknown>
 
 bfmop4s za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10010010
 // CHECK-INST: bfmop4s za2.s, { z12.h, z13.h }, z28.h
 // CHECK-ENCODING: [0x92,0x03,0x0c,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810c0392 <unknown>
 
 // Multiple vectors
@@ -162,17 +164,17 @@ bfmop4s za2.s, {z12.h-z13.h}, z28.h  // 10000001-00001100-00000011-10010010
 bfmop4s za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00010000
 // CHECK-INST: bfmop4s za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81100210 <unknown>
 
 bfmop4s za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11010011
 // CHECK-INST: bfmop4s za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e03d3 <unknown>
 
 bfmop4s za2.s, {z12.h-z13.h}, {z26.h-z27.h}  // 10000001-00011010-00000011-10010010
 // CHECK-INST: bfmop4s za2.s, { z12.h, z13.h }, { z26.h, z27.h }
 // CHECK-ENCODING: [0x92,0x03,0x1a,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811a0392 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/bftmopa-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/bftmopa-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-b16b16 2>&1 < %s| FileCheck %s
 
 // --------------------------------------------------------------------------//
 // Invalid ZA register (range)

--- a/llvm/test/MC/AArch64/SME2p2/bftmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/bftmopa.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-b16b16 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-b16b16 < %s \
@@ -17,19 +19,19 @@
 bftmopa za0.h, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01100000-00000000-00001000
 // CHECK-INST: bftmopa za0.h, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x00,0x60,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-b16b16
 // CHECK-UNKNOWN: 81600008 <unknown>
 
 bftmopa za1.h, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01101000-00001101-10111001
 // CHECK-INST: bftmopa za1.h, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb9,0x0d,0x68,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-b16b16
 // CHECK-UNKNOWN: 81680db9 <unknown>
 
 bftmopa za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11111001
 // CHECK-INST: bftmopa za1.h, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf9,0x1f,0x7f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-b16b16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-b16b16
 // CHECK-UNKNOWN: 817f1ff9 <unknown>
 
 // widening
@@ -37,17 +39,17 @@ bftmopa za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11111
 bftmopa za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01000000-00000000-00000000
 // CHECK-INST: bftmopa za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81400000 <unknown>
 
 bftmopa za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01001000-00001101-10110011
 // CHECK-INST: bftmopa za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81480db3 <unknown>
 
 bftmopa za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-00011111-11110011
 // CHECK-INST: bftmopa za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 815f1ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/bftmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/bftmopa.s
@@ -1,17 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-b16b16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-b16b16 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-b16b16 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-b16b16 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop,+sme-b16b16 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-tmop,+sme-b16b16 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop,+sme-b16b16 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-b16b16 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-b16b16 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-b16b16 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-tmop,+sme-b16b16 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // non-widening
@@ -19,19 +17,19 @@
 bftmopa za0.h, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01100000-00000000-00001000
 // CHECK-INST: bftmopa za0.h, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x00,0x60,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-tmop
 // CHECK-UNKNOWN: 81600008 <unknown>
 
 bftmopa za1.h, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01101000-00001101-10111001
 // CHECK-INST: bftmopa za1.h, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb9,0x0d,0x68,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-tmop
 // CHECK-UNKNOWN: 81680db9 <unknown>
 
 bftmopa za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11111001
 // CHECK-INST: bftmopa za1.h, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf9,0x1f,0x7f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-b16b16
+// CHECK-ERROR: instruction requires: sme-b16b16 sme-tmop
 // CHECK-UNKNOWN: 817f1ff9 <unknown>
 
 // widening
@@ -39,17 +37,17 @@ bftmopa za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11111
 bftmopa za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01000000-00000000-00000000
 // CHECK-INST: bftmopa za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81400000 <unknown>
 
 bftmopa za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01001000-00001101-10110011
 // CHECK-INST: bftmopa za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81480db3 <unknown>
 
 bftmopa za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-00011111-11110011
 // CHECK-INST: bftmopa za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 815f1ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/directive-arch-negative.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-arch-negative.s
@@ -2,6 +2,20 @@
 
 .arch armv9-a+sme2p2
 .arch armv9-a+nosme2p2
-ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
+fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
 // CHECK: error: instruction requires: sme2p2
-// CHECK: ftmopa za0.s, {z0.s-z1.s}, z0.s, z20[0]
+// CHECK: fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+
+
+.arch armv9-a+sme-tmop
+.arch armv9-a+nosme-tmop
+sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+// CHECK: error: instruction requires: sme-tmop
+// CHECK: sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+
+
+.arch armv9-a+sme-mop4
+.arch armv9-a+nosme-mop4
+usmop4s za0.s, z0.b, z16.b
+// CHECK: error: instruction requires: sme-mop4
+// CHECK: usmop4s za0.s, z0.b, z16.b

--- a/llvm/test/MC/AArch64/SME2p2/directive-arch.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-arch.s
@@ -3,3 +3,11 @@
 .arch armv9-a+sme2p2
 ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
 // CHECK: ftmopa za0.s, { z0.s, z1.s }, z0.s, z20[0]
+
+.arch armv9-a+sme-tmop
+ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
+// CHECK: ftmopa za0.s, { z0.s, z1.s }, z0.s, z20[0]
+
+.arch armv9-a+sme-mop4
+bfmop4a za0.s, z0.h, z16.h
+// CHECK: bfmop4a za0.s, z0.h, z16.h

--- a/llvm/test/MC/AArch64/SME2p2/directive-arch.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-arch.s
@@ -1,8 +1,8 @@
 // RUN: llvm-mc -triple aarch64 -o - %s 2>&1 | FileCheck %s
 
 .arch armv9-a+sme2p2
-ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
-// CHECK: ftmopa za0.s, { z0.s, z1.s }, z0.s, z20[0]
+fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+// CHECK: fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
 
 .arch armv9-a+sme-tmop
 ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]

--- a/llvm/test/MC/AArch64/SME2p2/directive-arch_extension-negative.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-arch_extension-negative.s
@@ -1,7 +1,20 @@
 // RUN: not llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
 
+
 .arch_extension sme2p2
 .arch_extension nosme2p2
-ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
+fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
 // CHECK: error: instruction requires: sme2p2
-// CHECK: ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
+// CHECK: fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+
+.arch_extension sme-tmop
+.arch_extension nosme-tmop
+sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+// CHECK: error: instruction requires: sme-tmop
+// CHECK: sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+
+.arch_extension sme-mop4
+.arch_extension nosme-mop4
+usmop4s za0.s, z0.b, z16.b
+// CHECK: error: instruction requires: sme-mop4
+// CHECK: usmop4s za0.s, z0.b, z16.b

--- a/llvm/test/MC/AArch64/SME2p2/directive-arch_extension.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-arch_extension.s
@@ -1,5 +1,13 @@
 // RUN: llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
 
 .arch_extension sme2p2
-ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
-// CHECK: ftmopa  za0.s, { z0.s, z1.s }, z0.s, z20[0]
+fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+// CHECK: fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+
+.arch_extension sme-tmop
+sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+// CHECK: sutmopa za1.s, { z10.b, z11.b }, z21.b, z29[1]
+
+.arch_extension sme-mop4
+usmop4s za0.s, z0.b, z16.b
+// CHECK: usmop4s za0.s, z0.b, z16.b

--- a/llvm/test/MC/AArch64/SME2p2/directive-cpu-negative.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-cpu-negative.s
@@ -2,6 +2,18 @@
 
 .cpu generic+sme2p2
 .cpu generic+nosme2p2
-ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
+fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
 // CHECK: error: instruction requires: sme2p2
-// CHECK: ftmopa za0.s, {z0.s-z1.s}, z0.s, z20[0]
+// CHECK: fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+
+.cpu generic+sme-tmop
+.cpu generic+nosme-tmop
+sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+// CHECK: error: instruction requires: sme-tmop
+// CHECK: sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+
+.cpu generic+sme-mop4
+.cpu generic+nosme-mop4
+usmop4s za0.s, z0.b, z16.b
+// CHECK: error: instruction requires: sme-mop4
+// CHECK: usmop4s za0.s, z0.b, z16.b

--- a/llvm/test/MC/AArch64/SME2p2/directive-cpu.s
+++ b/llvm/test/MC/AArch64/SME2p2/directive-cpu.s
@@ -1,5 +1,13 @@
 // RUN: llvm-mc -triple aarch64 -filetype asm -o - %s 2>&1 | FileCheck %s
 
 .cpu generic+sme2p2
-ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]
-// CHECK: ftmopa za0.s, { z0.s, z1.s }, z0.s, z20[0]
+fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+// CHECK: fmul    { z28.h - z31.h }, { z28.h - z31.h }, z15.h
+
+.cpu generic+sme-tmop
+sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]
+// CHECK: sutmopa za1.s, { z10.b, z11.b }, z21.b, z29[1]
+
+.cpu generic+sme-mop4
+usmop4s za0.s, z0.b, z16.b
+// CHECK: usmop4s za0.s, z0.b, z16.b

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f16 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f8f16 < %s 2>&1 | FileCheck %s
 
 // Single vectors
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f8f16 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f16 < %s \
@@ -17,19 +19,19 @@
 fmop4a  za0.h, z0.b, z16.b  // 10000000-00100000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.b, z16.b
 // CHECK-ENCODING: [0x08,0x00,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80200008 <unknown>
 
 fmop4a  za1.h, z12.b, z24.b  // 10000000-00101000-00000001-10001001
 // CHECK-INST: fmop4a  za1.h, z12.b, z24.b
 // CHECK-ENCODING: [0x89,0x01,0x28,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80280189 <unknown>
 
 fmop4a  za1.h, z14.b, z30.b  // 10000000-00101110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.b, z30.b
 // CHECK-ENCODING: [0xc9,0x01,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 802e01c9 <unknown>
 
 // Single and multiple vectors
@@ -37,19 +39,19 @@ fmop4a  za1.h, z14.b, z30.b  // 10000000-00101110-00000001-11001001
 fmop4a  za0.h, z0.b, {z16.b-z17.b}  // 10000000-00110000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x08,0x00,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80300008 <unknown>
 
 fmop4a  za1.h, z10.b, {z20.b-z21.b}  // 10000000-00110100-00000001-01001001
 // CHECK-INST: fmop4a  za1.h, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x49,0x01,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80340149 <unknown>
 
 fmop4a  za1.h, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc9,0x01,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 803e01c9 <unknown>
 
 // Multiple and single vectors
@@ -57,19 +59,19 @@ fmop4a  za1.h, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11001001
 fmop4a  za0.h, {z0.b-z1.b}, z16.b  // 10000000-00100000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x08,0x02,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80200208 <unknown>
 
 fmop4a  za1.h, {z10.b-z11.b}, z20.b  // 10000000-00100100-00000011-01001001
 // CHECK-INST: fmop4a  za1.h, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x49,0x03,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80240349 <unknown>
 
 fmop4a  za1.h, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc9,0x03,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 802e03c9 <unknown>
 
 
@@ -78,18 +80,18 @@ fmop4a  za1.h, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11001001
 fmop4a  za0.h, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x08,0x02,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80300208 <unknown>
 
 fmop4a  za1.h, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-00000011-01001001
 // CHECK-INST: fmop4a  za1.h, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x49,0x03,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 80340349 <unknown>
 
 fmop4a  za1.h, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc9,0x03,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
 // CHECK-UNKNOWN: 803e03c9 <unknown>
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp16-widening.s
@@ -1,17 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f16 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f8f16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f16 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f8f16 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f16 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f8f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-f8f16 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f8f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f16 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f8f16 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f16 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f8f16 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // Single vectors
@@ -19,19 +17,19 @@
 fmop4a  za0.h, z0.b, z16.b  // 10000000-00100000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.b, z16.b
 // CHECK-ENCODING: [0x08,0x00,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80200008 <unknown>
 
 fmop4a  za1.h, z12.b, z24.b  // 10000000-00101000-00000001-10001001
 // CHECK-INST: fmop4a  za1.h, z12.b, z24.b
 // CHECK-ENCODING: [0x89,0x01,0x28,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80280189 <unknown>
 
 fmop4a  za1.h, z14.b, z30.b  // 10000000-00101110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.b, z30.b
 // CHECK-ENCODING: [0xc9,0x01,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 802e01c9 <unknown>
 
 // Single and multiple vectors
@@ -39,19 +37,19 @@ fmop4a  za1.h, z14.b, z30.b  // 10000000-00101110-00000001-11001001
 fmop4a  za0.h, z0.b, {z16.b-z17.b}  // 10000000-00110000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x08,0x00,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80300008 <unknown>
 
 fmop4a  za1.h, z10.b, {z20.b-z21.b}  // 10000000-00110100-00000001-01001001
 // CHECK-INST: fmop4a  za1.h, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x49,0x01,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80340149 <unknown>
 
 fmop4a  za1.h, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc9,0x01,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 803e01c9 <unknown>
 
 // Multiple and single vectors
@@ -59,19 +57,19 @@ fmop4a  za1.h, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11001001
 fmop4a  za0.h, {z0.b-z1.b}, z16.b  // 10000000-00100000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x08,0x02,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80200208 <unknown>
 
 fmop4a  za1.h, {z10.b-z11.b}, z20.b  // 10000000-00100100-00000011-01001001
 // CHECK-INST: fmop4a  za1.h, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x49,0x03,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80240349 <unknown>
 
 fmop4a  za1.h, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc9,0x03,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 802e03c9 <unknown>
 
 
@@ -80,18 +78,18 @@ fmop4a  za1.h, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11001001
 fmop4a  za0.h, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x08,0x02,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80300208 <unknown>
 
 fmop4a  za1.h, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-00000011-01001001
 // CHECK-INST: fmop4a  za1.h, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x49,0x03,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 80340349 <unknown>
 
 fmop4a  za1.h, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc9,0x03,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-mop4
 // CHECK-UNKNOWN: 803e03c9 <unknown>
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp32-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp32-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f32 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f8f32 < %s 2>&1 | FileCheck %s
 
 // Single vectors
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp32-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp32-widening.s
@@ -1,17 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f8f32 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f32 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f8f32 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f32 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f8f32 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-f8f32 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f8f32 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f8f32 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f32 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f8f32 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // Single vectors
@@ -19,19 +17,19 @@
 fmop4a  za0.s, z0.b, z16.b  // 10000000-00100000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x00,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80200000 <unknown>
 
 fmop4a  za1.s, z10.b, z20.b  // 10000000-00100100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x01,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80240141 <unknown>
 
 fmop4a  za3.s, z14.b, z30.b  // 10000000-00101110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x01,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 802e01c3 <unknown>
 
 // Single and multiple vectors
@@ -39,19 +37,19 @@ fmop4a  za3.s, z14.b, z30.b  // 10000000-00101110-00000001-11000011
 fmop4a  za0.s, z0.b, {z16.b-z17.b}  // 10000000-00110000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x00,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80300000 <unknown>
 
 fmop4a  za1.s, z10.b, {z20.b-z21.b}  // 10000000-00110100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x01,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80340141 <unknown>
 
 fmop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x01,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 803e01c3 <unknown>
 
 // Multiple and single vectors
@@ -59,19 +57,19 @@ fmop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11000011
 fmop4a  za0.s, {z0.b-z1.b}, z16.b  // 10000000-00100000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x02,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80200200 <unknown>
 
 fmop4a  za1.s, {z10.b-z11.b}, z20.b  // 10000000-00100100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x03,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80240341 <unknown>
 
 fmop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x03,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 802e03c3 <unknown>
 
 // Multiple vectors
@@ -79,17 +77,17 @@ fmop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11000011
 fmop4a  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x02,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80300200 <unknown>
 
 fmop4a  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x03,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 80340341 <unknown>
 
 fmop4a  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x03,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-mop4
 // CHECK-UNKNOWN: 803e03c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp32-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4a-fp8-fp32-widening.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f8f32 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f32 < %s \
@@ -17,19 +19,19 @@
 fmop4a  za0.s, z0.b, z16.b  // 10000000-00100000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x00,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80200000 <unknown>
 
 fmop4a  za1.s, z10.b, z20.b  // 10000000-00100100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x01,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80240141 <unknown>
 
 fmop4a  za3.s, z14.b, z30.b  // 10000000-00101110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x01,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 802e01c3 <unknown>
 
 // Single and multiple vectors
@@ -37,19 +39,19 @@ fmop4a  za3.s, z14.b, z30.b  // 10000000-00101110-00000001-11000011
 fmop4a  za0.s, z0.b, {z16.b-z17.b}  // 10000000-00110000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x00,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80300000 <unknown>
 
 fmop4a  za1.s, z10.b, {z20.b-z21.b}  // 10000000-00110100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x01,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80340141 <unknown>
 
 fmop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x01,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 803e01c3 <unknown>
 
 // Multiple and single vectors
@@ -57,19 +59,19 @@ fmop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-00000001-11000011
 fmop4a  za0.s, {z0.b-z1.b}, z16.b  // 10000000-00100000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x02,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80200200 <unknown>
 
 fmop4a  za1.s, {z10.b-z11.b}, z20.b  // 10000000-00100100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x03,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80240341 <unknown>
 
 fmop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x03,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 802e03c3 <unknown>
 
 // Multiple vectors
@@ -77,17 +79,17 @@ fmop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-00000011-11000011
 fmop4a  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x02,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80300200 <unknown>
 
 fmop4a  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x03,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 80340341 <unknown>
 
 fmop4a  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x03,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f8f32
 // CHECK-UNKNOWN: 803e03c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-fp32-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-fp32-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4 < %s 2>&1 | FileCheck %s
 
 // FMOP4A
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-fp32-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-fp32-widening.s
@@ -1,18 +1,16 @@
 
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 
@@ -22,19 +20,19 @@
 fmop4a  za0.s, z0.h, z16.h  // 10000001-00100000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x00,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81200000 <unknown>
 
 fmop4a  za1.s, z10.h, z20.h  // 10000001-00100100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x41,0x01,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81240141 <unknown>
 
 fmop4a  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xc3,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e01c3 <unknown>
 
 // Single and multiple vectors
@@ -42,19 +40,19 @@ fmop4a  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11000011
 fmop4a  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81300000 <unknown>
 
 fmop4a  za1.s, z10.h, {z20.h-z21.h}  // 10000001-00110100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x41,0x01,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81340141 <unknown>
 
 fmop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e01c3 <unknown>
 
 // Multiple and single vectors
@@ -62,19 +60,19 @@ fmop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11000011
 fmop4a  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x00,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81200200 <unknown>
 
 fmop4a  za1.s, {z10.h-z11.h}, z20.h  // 10000001-00100100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x41,0x03,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81240341 <unknown>
 
 fmop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc3,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e03c3 <unknown>
 
 // Multiple vectors
@@ -82,19 +80,19 @@ fmop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11000011
 fmop4a  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81300200 <unknown>
 
 fmop4a  za1.s, {z10.h-z11.h}, {z20.h-z21.h}  // 10000001-00110100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x41,0x03,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81340341 <unknown>
 
 fmop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e03c3 <unknown>
 
 // FMOP4S
@@ -103,19 +101,19 @@ fmop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11000
 fmop4s  za0.s, z0.h, z16.h  // 10000001-00100000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x10,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81200010 <unknown>
 
 fmop4s  za1.s, z10.h, z20.h  // 10000001-00100100-00000001-01010001
 // CHECK-INST: fmop4s  za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x51,0x01,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81240151 <unknown>
 
 fmop4s  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xd3,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e01d3 <unknown>
 
 // Single and multiple vectors
@@ -123,19 +121,19 @@ fmop4s  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11010011
 fmop4s  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81300010 <unknown>
 
 fmop4s  za1.s, z10.h, {z20.h-z21.h}  // 10000001-00110100-00000001-01010001
 // CHECK-INST: fmop4s  za1.s, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x51,0x01,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81340151 <unknown>
 
 fmop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e01d3 <unknown>
 
 // Multiple and single vectors
@@ -143,19 +141,19 @@ fmop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11010011
 fmop4s  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x10,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81200210 <unknown>
 
 fmop4s  za1.s, {z10.h-z11.h}, z20.h  // 10000001-00100100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x51,0x03,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81240351 <unknown>
 
 fmop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd3,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e03d3 <unknown>
 
 // Multiple vectors
@@ -163,17 +161,17 @@ fmop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11010011
 fmop4s  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81300210 <unknown>
 
 fmop4s  za1.s, {z10.h-z11.h}, {z20.h-z21.h}  // 10000001-00110100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x51,0x03,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81340351 <unknown>
 
 fmop4s  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e03d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-fp32-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-fp32-widening.s
@@ -1,6 +1,8 @@
 
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -20,19 +22,19 @@
 fmop4a  za0.s, z0.h, z16.h  // 10000001-00100000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x00,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81200000 <unknown>
 
 fmop4a  za1.s, z10.h, z20.h  // 10000001-00100100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x41,0x01,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81240141 <unknown>
 
 fmop4a  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xc3,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e01c3 <unknown>
 
 // Single and multiple vectors
@@ -40,19 +42,19 @@ fmop4a  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11000011
 fmop4a  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81300000 <unknown>
 
 fmop4a  za1.s, z10.h, {z20.h-z21.h}  // 10000001-00110100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x41,0x01,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81340141 <unknown>
 
 fmop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e01c3 <unknown>
 
 // Multiple and single vectors
@@ -60,19 +62,19 @@ fmop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11000011
 fmop4a  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x00,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81200200 <unknown>
 
 fmop4a  za1.s, {z10.h-z11.h}, z20.h  // 10000001-00100100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x41,0x03,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81240341 <unknown>
 
 fmop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc3,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e03c3 <unknown>
 
 // Multiple vectors
@@ -80,19 +82,19 @@ fmop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11000011
 fmop4a  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x00,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81300200 <unknown>
 
 fmop4a  za1.s, {z10.h-z11.h}, {z20.h-z21.h}  // 10000001-00110100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x41,0x03,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81340341 <unknown>
 
 fmop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc3,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e03c3 <unknown>
 
 // FMOP4S
@@ -101,19 +103,19 @@ fmop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11000
 fmop4s  za0.s, z0.h, z16.h  // 10000001-00100000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x10,0x00,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81200010 <unknown>
 
 fmop4s  za1.s, z10.h, z20.h  // 10000001-00100100-00000001-01010001
 // CHECK-INST: fmop4s  za1.s, z10.h, z20.h
 // CHECK-ENCODING: [0x51,0x01,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81240151 <unknown>
 
 fmop4s  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xd3,0x01,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e01d3 <unknown>
 
 // Single and multiple vectors
@@ -121,19 +123,19 @@ fmop4s  za3.s, z14.h, z30.h  // 10000001-00101110-00000001-11010011
 fmop4s  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00110000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x00,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81300010 <unknown>
 
 fmop4s  za1.s, z10.h, {z20.h-z21.h}  // 10000001-00110100-00000001-01010001
 // CHECK-INST: fmop4s  za1.s, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x51,0x01,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81340151 <unknown>
 
 fmop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x01,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e01d3 <unknown>
 
 // Multiple and single vectors
@@ -141,19 +143,19 @@ fmop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00111110-00000001-11010011
 fmop4s  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00100000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x10,0x02,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81200210 <unknown>
 
 fmop4s  za1.s, {z10.h-z11.h}, z20.h  // 10000001-00100100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x51,0x03,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81240351 <unknown>
 
 fmop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd3,0x03,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e03d3 <unknown>
 
 // Multiple vectors
@@ -161,17 +163,17 @@ fmop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00101110-00000011-11010011
 fmop4s  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00110000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x10,0x02,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81300210 <unknown>
 
 fmop4s  za1.s, {z10.h-z11.h}, {z20.h-z21.h}  // 10000001-00110100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x51,0x03,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81340351 <unknown>
 
 fmop4s  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00111110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd3,0x03,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e03d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-non-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-non-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f16f16 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f16f16 < %s 2>&1 | FileCheck %s
 
 // FMOP4A
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-non-widening.s
@@ -1,18 +1,16 @@
 
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f16f16 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f16f16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f16f16 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f16f16 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f16f16 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f16f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-f16f16 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f16f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f16f16 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f16f16 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f16f16 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f16f16 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 
@@ -23,19 +21,19 @@
 fmop4a  za0.h, z0.h, z16.h  // 10000001-00000000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81000008 <unknown>
 
 fmop4a  za1.h, z12.h, z24.h  // 10000001-00001000-00000001-10001001
 // CHECK-INST: fmop4a  za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x89,0x01,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81080189 <unknown>
 
 fmop4a  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xc9,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 810e01c9 <unknown>
 
 // Single and multiple vectors
@@ -43,19 +41,19 @@ fmop4a  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11001001
 fmop4a  za0.h, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81100008 <unknown>
 
 fmop4a  za1.h, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10001001
 // CHECK-INST: fmop4a  za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81180189 <unknown>
 
 fmop4a  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 811e01c9 <unknown>
 
 // Multiple and single vectors
@@ -63,19 +61,19 @@ fmop4a  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11001001
 fmop4a  za0.h, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81000208 <unknown>
 
 fmop4a  za1.h, {z12.h-z13.h}, z24.h  // 10000001-00001000-00000011-10001001
 // CHECK-INST: fmop4a  za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x89,0x03,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81080389 <unknown>
 
 fmop4a  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc9,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 810e03c9 <unknown>
 
 // Multiple vectors
@@ -83,19 +81,19 @@ fmop4a  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11001001
 fmop4a  za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81100208 <unknown>
 
 fmop4a  za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-00000011-10001001
 // CHECK-INST: fmop4a  za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x03,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81180389 <unknown>
 
 fmop4a  za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 811e03c9 <unknown>
 
 // FMOP4S
@@ -105,19 +103,19 @@ fmop4a  za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11001
 fmop4s  za0.h, z0.h, z16.h  // 10000001-00000000-00000000-00011000
 // CHECK-INST: fmop4s  za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81000018 <unknown>
 
 fmop4s  za1.h, z12.h, z24.h  // 10000001-00001000-00000001-10011001
 // CHECK-INST: fmop4s  za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x99,0x01,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81080199 <unknown>
 
 fmop4s  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11011001
 // CHECK-INST: fmop4s  za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xd9,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 810e01d9 <unknown>
 
 // Single and multiple vectors
@@ -125,19 +123,19 @@ fmop4s  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11011001
 fmop4s  za0.h, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00011000
 // CHECK-INST: fmop4s  za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81100018 <unknown>
 
 fmop4s  za1.h, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10011001
 // CHECK-INST: fmop4s  za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81180199 <unknown>
 
 fmop4s  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11011001
 // CHECK-INST: fmop4s  za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 811e01d9 <unknown>
 
 // Multiple and single vectors
@@ -145,19 +143,19 @@ fmop4s  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11011001
 fmop4s  za0.h, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00011000
 // CHECK-INST: fmop4s  za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81000218 <unknown>
 
 fmop4s  za1.h, {z12.h-z13.h}, z24.h  // 10000001-00001000-00000011-10011001
 // CHECK-INST: fmop4s  za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x99,0x03,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81080399 <unknown>
 
 fmop4s  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11011001
 // CHECK-INST: fmop4s  za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd9,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 810e03d9 <unknown>
 
 // Multiple vectors
@@ -165,17 +163,17 @@ fmop4s  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11011001
 fmop4s  za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00011000
 // CHECK-INST: fmop4s  za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81100218 <unknown>
 
 fmop4s  za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-00000011-10011001
 // CHECK-INST: fmop4s  za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x03,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 81180399 <unknown>
 
 fmop4s  za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11011001
 // CHECK-INST: fmop4s  za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-mop4
 // CHECK-UNKNOWN: 811e03d9 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp16-non-widening.s
@@ -1,6 +1,8 @@
 
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f16f16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f16f16 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f16f16 < %s \
@@ -21,19 +23,19 @@
 fmop4a  za0.h, z0.h, z16.h  // 10000001-00000000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81000008 <unknown>
 
 fmop4a  za1.h, z12.h, z24.h  // 10000001-00001000-00000001-10001001
 // CHECK-INST: fmop4a  za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x89,0x01,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81080189 <unknown>
 
 fmop4a  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xc9,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 810e01c9 <unknown>
 
 // Single and multiple vectors
@@ -41,19 +43,19 @@ fmop4a  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11001001
 fmop4a  za0.h, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00001000
 // CHECK-INST: fmop4a  za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81100008 <unknown>
 
 fmop4a  za1.h, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10001001
 // CHECK-INST: fmop4a  za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81180189 <unknown>
 
 fmop4a  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11001001
 // CHECK-INST: fmop4a  za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 811e01c9 <unknown>
 
 // Multiple and single vectors
@@ -61,19 +63,19 @@ fmop4a  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11001001
 fmop4a  za0.h, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81000208 <unknown>
 
 fmop4a  za1.h, {z12.h-z13.h}, z24.h  // 10000001-00001000-00000011-10001001
 // CHECK-INST: fmop4a  za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x89,0x03,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81080389 <unknown>
 
 fmop4a  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xc9,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 810e03c9 <unknown>
 
 // Multiple vectors
@@ -81,19 +83,19 @@ fmop4a  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11001001
 fmop4a  za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00001000
 // CHECK-INST: fmop4a  za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81100208 <unknown>
 
 fmop4a  za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-00000011-10001001
 // CHECK-INST: fmop4a  za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x89,0x03,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81180389 <unknown>
 
 fmop4a  za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11001001
 // CHECK-INST: fmop4a  za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xc9,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 811e03c9 <unknown>
 
 // FMOP4S
@@ -103,19 +105,19 @@ fmop4a  za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11001
 fmop4s  za0.h, z0.h, z16.h  // 10000001-00000000-00000000-00011000
 // CHECK-INST: fmop4s  za0.h, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81000018 <unknown>
 
 fmop4s  za1.h, z12.h, z24.h  // 10000001-00001000-00000001-10011001
 // CHECK-INST: fmop4s  za1.h, z12.h, z24.h
 // CHECK-ENCODING: [0x99,0x01,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81080199 <unknown>
 
 fmop4s  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11011001
 // CHECK-INST: fmop4s  za1.h, z14.h, z30.h
 // CHECK-ENCODING: [0xd9,0x01,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 810e01d9 <unknown>
 
 // Single and multiple vectors
@@ -123,19 +125,19 @@ fmop4s  za1.h, z14.h, z30.h  // 10000001-00001110-00000001-11011001
 fmop4s  za0.h, z0.h, {z16.h-z17.h}  // 10000001-00010000-00000000-00011000
 // CHECK-INST: fmop4s  za0.h, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81100018 <unknown>
 
 fmop4s  za1.h, z12.h, {z24.h-z25.h}  // 10000001-00011000-00000001-10011001
 // CHECK-INST: fmop4s  za1.h, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x01,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81180199 <unknown>
 
 fmop4s  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11011001
 // CHECK-INST: fmop4s  za1.h, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x01,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 811e01d9 <unknown>
 
 // Multiple and single vectors
@@ -143,19 +145,19 @@ fmop4s  za1.h, z14.h, {z30.h-z31.h}  // 10000001-00011110-00000001-11011001
 fmop4s  za0.h, {z0.h-z1.h}, z16.h  // 10000001-00000000-00000010-00011000
 // CHECK-INST: fmop4s  za0.h, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81000218 <unknown>
 
 fmop4s  za1.h, {z12.h-z13.h}, z24.h  // 10000001-00001000-00000011-10011001
 // CHECK-INST: fmop4s  za1.h, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x99,0x03,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81080399 <unknown>
 
 fmop4s  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11011001
 // CHECK-INST: fmop4s  za1.h, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xd9,0x03,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 810e03d9 <unknown>
 
 // Multiple vectors
@@ -163,17 +165,17 @@ fmop4s  za1.h, {z14.h-z15.h}, z30.h  // 10000001-00001110-00000011-11011001
 fmop4s  za0.h, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-00000010-00011000
 // CHECK-INST: fmop4s  za0.h, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81100218 <unknown>
 
 fmop4s  za1.h, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-00000011-10011001
 // CHECK-INST: fmop4s  za1.h, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x99,0x03,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 81180399 <unknown>
 
 fmop4s  za1.h, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-00000011-11011001
 // CHECK-INST: fmop4s  za1.h, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xd9,0x03,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f16f16
 // CHECK-UNKNOWN: 811e03d9 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp32-non-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp32-non-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4 < %s 2>&1 | FileCheck %s
 
 // FMOP4A
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp32-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp32-non-widening.s
@@ -1,6 +1,8 @@
 
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -21,19 +23,19 @@
 fmop4a  za0.s, z0.s, z16.s  // 10000000-00000000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.s, z16.s
 // CHECK-ENCODING: [0x00,0x00,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80000000 <unknown>
 
 fmop4a  za3.s, z12.s, z24.s  // 10000000-00001000-00000001-10000011
 // CHECK-INST: fmop4a  za3.s, z12.s, z24.s
 // CHECK-ENCODING: [0x83,0x01,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80080183 <unknown>
 
 fmop4a  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.s, z30.s
 // CHECK-ENCODING: [0xc3,0x01,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e01c3 <unknown>
 
 // Single and multiple vectors
@@ -41,19 +43,19 @@ fmop4a  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11000011
 fmop4a  za0.s, z0.s, {z16.s-z17.s}  // 10000000-00010000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.s, { z16.s, z17.s }
 // CHECK-ENCODING: [0x00,0x00,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80100000 <unknown>
 
 fmop4a  za1.s, z10.s, {z20.s-z21.s}  // 10000000-00010100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.s, { z20.s, z21.s }
 // CHECK-ENCODING: [0x41,0x01,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80140141 <unknown>
 
 fmop4a  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.s, { z30.s, z31.s }
 // CHECK-ENCODING: [0xc3,0x01,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e01c3 <unknown>
 
 // Multiple and single vectors
@@ -61,19 +63,19 @@ fmop4a  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11000011
 fmop4a  za0.s, {z0.s-z1.s}, z16.s  // 10000000-00000000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.s, z1.s }, z16.s
 // CHECK-ENCODING: [0x00,0x02,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80000200 <unknown>
 
 fmop4a  za1.s, {z10.s-z11.s}, z20.s  // 10000000-00000100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.s, z11.s }, z20.s
 // CHECK-ENCODING: [0x41,0x03,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80040341 <unknown>
 
 fmop4a  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.s, z15.s }, z30.s
 // CHECK-ENCODING: [0xc3,0x03,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e03c3 <unknown>
 
 // Multiple vectors
@@ -81,19 +83,19 @@ fmop4a  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11000011
 fmop4a  za0.s, {z0.s-z1.s}, {z16.s-z17.s}  // 10000000-00010000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.s, z1.s }, { z16.s, z17.s }
 // CHECK-ENCODING: [0x00,0x02,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80100200 <unknown>
 
 fmop4a  za1.s, {z10.s-z11.s}, {z20.s-z21.s}  // 10000000-00010100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.s, z11.s }, { z20.s, z21.s }
 // CHECK-ENCODING: [0x41,0x03,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80140341 <unknown>
 
 fmop4a  za3.s, {z14.s-z15.s}, {z30.s-z31.s}  // 10000000-00011110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.s, z15.s }, { z30.s, z31.s }
 // CHECK-ENCODING: [0xc3,0x03,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e03c3 <unknown>
 
 // FMOP4S
@@ -103,19 +105,19 @@ fmop4a  za3.s, {z14.s-z15.s}, {z30.s-z31.s}  // 10000000-00011110-00000011-11000
 fmop4s  za0.s, z0.s, z16.s  // 10000000-00000000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.s, z16.s
 // CHECK-ENCODING: [0x10,0x00,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80000010 <unknown>
 
 fmop4s  za3.s, z12.s, z24.s  // 10000000-00001000-00000001-10010011
 // CHECK-INST: fmop4s  za3.s, z12.s, z24.s
 // CHECK-ENCODING: [0x93,0x01,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80080193 <unknown>
 
 fmop4s  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.s, z30.s
 // CHECK-ENCODING: [0xd3,0x01,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e01d3 <unknown>
 
 // Single and multiple vectors
@@ -123,19 +125,19 @@ fmop4s  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11010011
 fmop4s  za0.s, z0.s, {z16.s-z17.s}  // 10000000-00010000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.s, { z16.s, z17.s }
 // CHECK-ENCODING: [0x10,0x00,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80100010 <unknown>
 
 fmop4s  za1.s, z10.s, {z20.s-z21.s}  // 10000000-00010100-00000001-01010001
 // CHECK-INST: fmop4s  za1.s, z10.s, { z20.s, z21.s }
 // CHECK-ENCODING: [0x51,0x01,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80140151 <unknown>
 
 fmop4s  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.s, { z30.s, z31.s }
 // CHECK-ENCODING: [0xd3,0x01,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e01d3 <unknown>
 
 // Multiple and single vectors
@@ -143,19 +145,19 @@ fmop4s  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11010011
 fmop4s  za0.s, {z0.s-z1.s}, z16.s  // 10000000-00000000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.s, z1.s }, z16.s
 // CHECK-ENCODING: [0x10,0x02,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80000210 <unknown>
 
 fmop4s  za1.s, {z10.s-z11.s}, z20.s  // 10000000-00000100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.s, z11.s }, z20.s
 // CHECK-ENCODING: [0x51,0x03,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80040351 <unknown>
 
 fmop4s  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.s, z15.s }, z30.s
 // CHECK-ENCODING: [0xd3,0x03,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e03d3 <unknown>
 
 // Multiple vectors
@@ -163,17 +165,17 @@ fmop4s  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11010011
 fmop4s  za0.s, {z0.s-z1.s}, {z16.s-z17.s}  // 10000000-00010000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.s, z1.s }, { z16.s, z17.s }
 // CHECK-ENCODING: [0x10,0x02,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80100210 <unknown>
 
 fmop4s  za1.s, {z10.s-z11.s}, {z20.s-z21.s}  // 10000000-00010100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.s, z11.s }, { z20.s, z21.s }
 // CHECK-ENCODING: [0x51,0x03,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80140351 <unknown>
 
 fmop4s  za3.s, {z14.s-z15.s}, {z30.s-z31.s}  // 10000000-00011110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.s, z15.s }, { z30.s, z31.s }
 // CHECK-ENCODING: [0xd3,0x03,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e03d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp32-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp32-non-widening.s
@@ -1,18 +1,16 @@
 
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 
@@ -23,19 +21,19 @@
 fmop4a  za0.s, z0.s, z16.s  // 10000000-00000000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.s, z16.s
 // CHECK-ENCODING: [0x00,0x00,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80000000 <unknown>
 
 fmop4a  za3.s, z12.s, z24.s  // 10000000-00001000-00000001-10000011
 // CHECK-INST: fmop4a  za3.s, z12.s, z24.s
 // CHECK-ENCODING: [0x83,0x01,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80080183 <unknown>
 
 fmop4a  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.s, z30.s
 // CHECK-ENCODING: [0xc3,0x01,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e01c3 <unknown>
 
 // Single and multiple vectors
@@ -43,19 +41,19 @@ fmop4a  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11000011
 fmop4a  za0.s, z0.s, {z16.s-z17.s}  // 10000000-00010000-00000000-00000000
 // CHECK-INST: fmop4a  za0.s, z0.s, { z16.s, z17.s }
 // CHECK-ENCODING: [0x00,0x00,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80100000 <unknown>
 
 fmop4a  za1.s, z10.s, {z20.s-z21.s}  // 10000000-00010100-00000001-01000001
 // CHECK-INST: fmop4a  za1.s, z10.s, { z20.s, z21.s }
 // CHECK-ENCODING: [0x41,0x01,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80140141 <unknown>
 
 fmop4a  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11000011
 // CHECK-INST: fmop4a  za3.s, z14.s, { z30.s, z31.s }
 // CHECK-ENCODING: [0xc3,0x01,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e01c3 <unknown>
 
 // Multiple and single vectors
@@ -63,19 +61,19 @@ fmop4a  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11000011
 fmop4a  za0.s, {z0.s-z1.s}, z16.s  // 10000000-00000000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.s, z1.s }, z16.s
 // CHECK-ENCODING: [0x00,0x02,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80000200 <unknown>
 
 fmop4a  za1.s, {z10.s-z11.s}, z20.s  // 10000000-00000100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.s, z11.s }, z20.s
 // CHECK-ENCODING: [0x41,0x03,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80040341 <unknown>
 
 fmop4a  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.s, z15.s }, z30.s
 // CHECK-ENCODING: [0xc3,0x03,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e03c3 <unknown>
 
 // Multiple vectors
@@ -83,19 +81,19 @@ fmop4a  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11000011
 fmop4a  za0.s, {z0.s-z1.s}, {z16.s-z17.s}  // 10000000-00010000-00000010-00000000
 // CHECK-INST: fmop4a  za0.s, { z0.s, z1.s }, { z16.s, z17.s }
 // CHECK-ENCODING: [0x00,0x02,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80100200 <unknown>
 
 fmop4a  za1.s, {z10.s-z11.s}, {z20.s-z21.s}  // 10000000-00010100-00000011-01000001
 // CHECK-INST: fmop4a  za1.s, { z10.s, z11.s }, { z20.s, z21.s }
 // CHECK-ENCODING: [0x41,0x03,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80140341 <unknown>
 
 fmop4a  za3.s, {z14.s-z15.s}, {z30.s-z31.s}  // 10000000-00011110-00000011-11000011
 // CHECK-INST: fmop4a  za3.s, { z14.s, z15.s }, { z30.s, z31.s }
 // CHECK-ENCODING: [0xc3,0x03,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e03c3 <unknown>
 
 // FMOP4S
@@ -105,19 +103,19 @@ fmop4a  za3.s, {z14.s-z15.s}, {z30.s-z31.s}  // 10000000-00011110-00000011-11000
 fmop4s  za0.s, z0.s, z16.s  // 10000000-00000000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.s, z16.s
 // CHECK-ENCODING: [0x10,0x00,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80000010 <unknown>
 
 fmop4s  za3.s, z12.s, z24.s  // 10000000-00001000-00000001-10010011
 // CHECK-INST: fmop4s  za3.s, z12.s, z24.s
 // CHECK-ENCODING: [0x93,0x01,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80080193 <unknown>
 
 fmop4s  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.s, z30.s
 // CHECK-ENCODING: [0xd3,0x01,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e01d3 <unknown>
 
 // Single and multiple vectors
@@ -125,19 +123,19 @@ fmop4s  za3.s, z14.s, z30.s  // 10000000-00001110-00000001-11010011
 fmop4s  za0.s, z0.s, {z16.s-z17.s}  // 10000000-00010000-00000000-00010000
 // CHECK-INST: fmop4s  za0.s, z0.s, { z16.s, z17.s }
 // CHECK-ENCODING: [0x10,0x00,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80100010 <unknown>
 
 fmop4s  za1.s, z10.s, {z20.s-z21.s}  // 10000000-00010100-00000001-01010001
 // CHECK-INST: fmop4s  za1.s, z10.s, { z20.s, z21.s }
 // CHECK-ENCODING: [0x51,0x01,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80140151 <unknown>
 
 fmop4s  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11010011
 // CHECK-INST: fmop4s  za3.s, z14.s, { z30.s, z31.s }
 // CHECK-ENCODING: [0xd3,0x01,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e01d3 <unknown>
 
 // Multiple and single vectors
@@ -145,19 +143,19 @@ fmop4s  za3.s, z14.s, {z30.s-z31.s}  // 10000000-00011110-00000001-11010011
 fmop4s  za0.s, {z0.s-z1.s}, z16.s  // 10000000-00000000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.s, z1.s }, z16.s
 // CHECK-ENCODING: [0x10,0x02,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80000210 <unknown>
 
 fmop4s  za1.s, {z10.s-z11.s}, z20.s  // 10000000-00000100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.s, z11.s }, z20.s
 // CHECK-ENCODING: [0x51,0x03,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80040351 <unknown>
 
 fmop4s  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.s, z15.s }, z30.s
 // CHECK-ENCODING: [0xd3,0x03,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e03d3 <unknown>
 
 // Multiple vectors
@@ -165,17 +163,17 @@ fmop4s  za3.s, {z14.s-z15.s}, z30.s  // 10000000-00001110-00000011-11010011
 fmop4s  za0.s, {z0.s-z1.s}, {z16.s-z17.s}  // 10000000-00010000-00000010-00010000
 // CHECK-INST: fmop4s  za0.s, { z0.s, z1.s }, { z16.s, z17.s }
 // CHECK-ENCODING: [0x10,0x02,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80100210 <unknown>
 
 fmop4s  za1.s, {z10.s-z11.s}, {z20.s-z21.s}  // 10000000-00010100-00000011-01010001
 // CHECK-INST: fmop4s  za1.s, { z10.s, z11.s }, { z20.s, z21.s }
 // CHECK-ENCODING: [0x51,0x03,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80140351 <unknown>
 
 fmop4s  za3.s, {z14.s-z15.s}, {z30.s-z31.s}  // 10000000-00011110-00000011-11010011
 // CHECK-INST: fmop4s  za3.s, { z14.s, z15.s }, { z30.s, z31.s }
 // CHECK-ENCODING: [0xd3,0x03,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e03d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f64f64 < %s 2>&1 | FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f64f64 < %s 2>&1 | FileCheck %s
 
 // FMOP4A
 

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
@@ -1,6 +1,8 @@
 
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f64f64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f64f64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
@@ -21,19 +23,19 @@
 fmop4a  za0.d, z0.d, z16.d  // 10000000-11000000-00000000-00001000
 // CHECK-INST: fmop4a  za0.d, z0.d, z16.d
 // CHECK-ENCODING: [0x08,0x00,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c00008 <unknown>
 
 fmop4a  za5.d, z10.d, z20.d  // 10000000-11000100-00000001-01001101
 // CHECK-INST: fmop4a  za5.d, z10.d, z20.d
 // CHECK-ENCODING: [0x4d,0x01,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c4014d <unknown>
 
 fmop4a  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11001111
 // CHECK-INST: fmop4a  za7.d, z14.d, z30.d
 // CHECK-ENCODING: [0xcf,0x01,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80ce01cf <unknown>
 
 // Single and multiple vectors
@@ -41,19 +43,19 @@ fmop4a  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11001111
 fmop4a  za0.d, z0.d, {z16.d-z17.d}  // 10000000-11010000-00000000-00001000
 // CHECK-INST: fmop4a  za0.d, z0.d, { z16.d, z17.d }
 // CHECK-ENCODING: [0x08,0x00,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d00008 <unknown>
 
 fmop4a  za5.d, z10.d, {z20.d-z21.d}  // 10000000-11010100-00000001-01001101
 // CHECK-INST: fmop4a  za5.d, z10.d, { z20.d, z21.d }
 // CHECK-ENCODING: [0x4d,0x01,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d4014d <unknown>
 
 fmop4a  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11001111
 // CHECK-INST: fmop4a  za7.d, z14.d, { z30.d, z31.d }
 // CHECK-ENCODING: [0xcf,0x01,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80de01cf <unknown>
 
 // Multiple and single vectors
@@ -61,19 +63,19 @@ fmop4a  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11001111
 fmop4a  za0.d, {z0.d-z1.d}, z16.d  // 10000000-11000000-00000010-00001000
 // CHECK-INST: fmop4a  za0.d, { z0.d, z1.d }, z16.d
 // CHECK-ENCODING: [0x08,0x02,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c00208 <unknown>
 
 fmop4a  za5.d, {z10.d-z11.d}, z20.d  // 10000000-11000100-00000011-01001101
 // CHECK-INST: fmop4a  za5.d, { z10.d, z11.d }, z20.d
 // CHECK-ENCODING: [0x4d,0x03,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c4034d <unknown>
 
 fmop4a  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11001111
 // CHECK-INST: fmop4a  za7.d, { z14.d, z15.d }, z30.d
 // CHECK-ENCODING: [0xcf,0x03,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80ce03cf <unknown>
 
 // Multiple vectors
@@ -81,19 +83,19 @@ fmop4a  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11001111
 fmop4a  za0.d, {z0.d-z1.d}, {z16.d-z17.d}  // 10000000-11010000-00000010-00001000
 // CHECK-INST: fmop4a  za0.d, { z0.d, z1.d }, { z16.d, z17.d }
 // CHECK-ENCODING: [0x08,0x02,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d00208 <unknown>
 
 fmop4a  za5.d, {z10.d-z11.d}, {z20.d-z21.d}  // 10000000-11010100-00000011-01001101
 // CHECK-INST: fmop4a  za5.d, { z10.d, z11.d }, { z20.d, z21.d }
 // CHECK-ENCODING: [0x4d,0x03,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d4034d <unknown>
 
 fmop4a  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11001111
 // CHECK-INST: fmop4a  za7.d, { z14.d, z15.d }, { z30.d, z31.d }
 // CHECK-ENCODING: [0xcf,0x03,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80de03cf <unknown>
 
 
@@ -104,19 +106,19 @@ fmop4a  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11001
 fmop4s  za0.d, z0.d, z16.d  // 10000000-11000000-00000000-00011000
 // CHECK-INST: fmop4s  za0.d, z0.d, z16.d
 // CHECK-ENCODING: [0x18,0x00,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c00018 <unknown>
 
 fmop4s  za5.d, z10.d, z20.d  // 10000000-11000100-00000001-01011101
 // CHECK-INST: fmop4s  za5.d, z10.d, z20.d
 // CHECK-ENCODING: [0x5d,0x01,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c4015d <unknown>
 
 fmop4s  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11011111
 // CHECK-INST: fmop4s  za7.d, z14.d, z30.d
 // CHECK-ENCODING: [0xdf,0x01,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80ce01df <unknown>
 
 // Single and multiple vectors
@@ -124,19 +126,19 @@ fmop4s  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11011111
 fmop4s  za0.d, z0.d, {z16.d-z17.d}  // 10000000-11010000-00000000-00011000
 // CHECK-INST: fmop4s  za0.d, z0.d, { z16.d, z17.d }
 // CHECK-ENCODING: [0x18,0x00,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d00018 <unknown>
 
 fmop4s  za5.d, z10.d, {z20.d-z21.d}  // 10000000-11010100-00000001-01011101
 // CHECK-INST: fmop4s  za5.d, z10.d, { z20.d, z21.d }
 // CHECK-ENCODING: [0x5d,0x01,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d4015d <unknown>
 
 fmop4s  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11011111
 // CHECK-INST: fmop4s  za7.d, z14.d, { z30.d, z31.d }
 // CHECK-ENCODING: [0xdf,0x01,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80de01df <unknown>
 
 // Multiple and single vectors
@@ -144,19 +146,19 @@ fmop4s  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11011111
 fmop4s  za0.d, {z0.d-z1.d}, z16.d  // 10000000-11000000-00000010-00011000
 // CHECK-INST: fmop4s  za0.d, { z0.d, z1.d }, z16.d
 // CHECK-ENCODING: [0x18,0x02,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c00218 <unknown>
 
 fmop4s  za5.d, {z10.d-z11.d}, z20.d  // 10000000-11000100-00000011-01011101
 // CHECK-INST: fmop4s  za5.d, { z10.d, z11.d }, z20.d
 // CHECK-ENCODING: [0x5d,0x03,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80c4035d <unknown>
 
 fmop4s  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11011111
 // CHECK-INST: fmop4s  za7.d, { z14.d, z15.d }, z30.d
 // CHECK-ENCODING: [0xdf,0x03,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80ce03df <unknown>
 
 // Multiple vectors
@@ -164,17 +166,17 @@ fmop4s  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11011111
 fmop4s  za0.d, {z0.d-z1.d}, {z16.d-z17.d}  // 10000000-11010000-00000010-00011000
 // CHECK-INST: fmop4s  za0.d, { z0.d, z1.d }, { z16.d, z17.d }
 // CHECK-ENCODING: [0x18,0x02,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d00218 <unknown>
 
 fmop4s  za5.d, {z10.d-z11.d}, {z20.d-z21.d}  // 10000000-11010100-00000011-01011101
 // CHECK-INST: fmop4s  za5.d, { z10.d, z11.d }, { z20.d, z21.d }
 // CHECK-ENCODING: [0x5d,0x03,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80d4035d <unknown>
 
 fmop4s  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11011111
 // CHECK-INST: fmop4s  za7.d, { z14.d, z15.d }, { z30.d, z31.d }
 // CHECK-ENCODING: [0xdf,0x03,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f64f64
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
 // CHECK-UNKNOWN: 80de03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
+++ b/llvm/test/MC/AArch64/SME2p2/fmop4as-fp64-non-widening.s
@@ -1,18 +1,16 @@
 
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f64f64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f64f64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f64f64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f64f64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f64f64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-f64f64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-f64f64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f64f64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-f64f64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f64f64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-f64f64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 
@@ -23,19 +21,19 @@
 fmop4a  za0.d, z0.d, z16.d  // 10000000-11000000-00000000-00001000
 // CHECK-INST: fmop4a  za0.d, z0.d, z16.d
 // CHECK-ENCODING: [0x08,0x00,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c00008 <unknown>
 
 fmop4a  za5.d, z10.d, z20.d  // 10000000-11000100-00000001-01001101
 // CHECK-INST: fmop4a  za5.d, z10.d, z20.d
 // CHECK-ENCODING: [0x4d,0x01,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c4014d <unknown>
 
 fmop4a  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11001111
 // CHECK-INST: fmop4a  za7.d, z14.d, z30.d
 // CHECK-ENCODING: [0xcf,0x01,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80ce01cf <unknown>
 
 // Single and multiple vectors
@@ -43,19 +41,19 @@ fmop4a  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11001111
 fmop4a  za0.d, z0.d, {z16.d-z17.d}  // 10000000-11010000-00000000-00001000
 // CHECK-INST: fmop4a  za0.d, z0.d, { z16.d, z17.d }
 // CHECK-ENCODING: [0x08,0x00,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d00008 <unknown>
 
 fmop4a  za5.d, z10.d, {z20.d-z21.d}  // 10000000-11010100-00000001-01001101
 // CHECK-INST: fmop4a  za5.d, z10.d, { z20.d, z21.d }
 // CHECK-ENCODING: [0x4d,0x01,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d4014d <unknown>
 
 fmop4a  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11001111
 // CHECK-INST: fmop4a  za7.d, z14.d, { z30.d, z31.d }
 // CHECK-ENCODING: [0xcf,0x01,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80de01cf <unknown>
 
 // Multiple and single vectors
@@ -63,19 +61,19 @@ fmop4a  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11001111
 fmop4a  za0.d, {z0.d-z1.d}, z16.d  // 10000000-11000000-00000010-00001000
 // CHECK-INST: fmop4a  za0.d, { z0.d, z1.d }, z16.d
 // CHECK-ENCODING: [0x08,0x02,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c00208 <unknown>
 
 fmop4a  za5.d, {z10.d-z11.d}, z20.d  // 10000000-11000100-00000011-01001101
 // CHECK-INST: fmop4a  za5.d, { z10.d, z11.d }, z20.d
 // CHECK-ENCODING: [0x4d,0x03,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c4034d <unknown>
 
 fmop4a  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11001111
 // CHECK-INST: fmop4a  za7.d, { z14.d, z15.d }, z30.d
 // CHECK-ENCODING: [0xcf,0x03,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80ce03cf <unknown>
 
 // Multiple vectors
@@ -83,19 +81,19 @@ fmop4a  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11001111
 fmop4a  za0.d, {z0.d-z1.d}, {z16.d-z17.d}  // 10000000-11010000-00000010-00001000
 // CHECK-INST: fmop4a  za0.d, { z0.d, z1.d }, { z16.d, z17.d }
 // CHECK-ENCODING: [0x08,0x02,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d00208 <unknown>
 
 fmop4a  za5.d, {z10.d-z11.d}, {z20.d-z21.d}  // 10000000-11010100-00000011-01001101
 // CHECK-INST: fmop4a  za5.d, { z10.d, z11.d }, { z20.d, z21.d }
 // CHECK-ENCODING: [0x4d,0x03,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d4034d <unknown>
 
 fmop4a  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11001111
 // CHECK-INST: fmop4a  za7.d, { z14.d, z15.d }, { z30.d, z31.d }
 // CHECK-ENCODING: [0xcf,0x03,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80de03cf <unknown>
 
 
@@ -106,19 +104,19 @@ fmop4a  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11001
 fmop4s  za0.d, z0.d, z16.d  // 10000000-11000000-00000000-00011000
 // CHECK-INST: fmop4s  za0.d, z0.d, z16.d
 // CHECK-ENCODING: [0x18,0x00,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c00018 <unknown>
 
 fmop4s  za5.d, z10.d, z20.d  // 10000000-11000100-00000001-01011101
 // CHECK-INST: fmop4s  za5.d, z10.d, z20.d
 // CHECK-ENCODING: [0x5d,0x01,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c4015d <unknown>
 
 fmop4s  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11011111
 // CHECK-INST: fmop4s  za7.d, z14.d, z30.d
 // CHECK-ENCODING: [0xdf,0x01,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80ce01df <unknown>
 
 // Single and multiple vectors
@@ -126,19 +124,19 @@ fmop4s  za7.d, z14.d, z30.d  // 10000000-11001110-00000001-11011111
 fmop4s  za0.d, z0.d, {z16.d-z17.d}  // 10000000-11010000-00000000-00011000
 // CHECK-INST: fmop4s  za0.d, z0.d, { z16.d, z17.d }
 // CHECK-ENCODING: [0x18,0x00,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d00018 <unknown>
 
 fmop4s  za5.d, z10.d, {z20.d-z21.d}  // 10000000-11010100-00000001-01011101
 // CHECK-INST: fmop4s  za5.d, z10.d, { z20.d, z21.d }
 // CHECK-ENCODING: [0x5d,0x01,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d4015d <unknown>
 
 fmop4s  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11011111
 // CHECK-INST: fmop4s  za7.d, z14.d, { z30.d, z31.d }
 // CHECK-ENCODING: [0xdf,0x01,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80de01df <unknown>
 
 // Multiple and single vectors
@@ -146,19 +144,19 @@ fmop4s  za7.d, z14.d, {z30.d-z31.d}  // 10000000-11011110-00000001-11011111
 fmop4s  za0.d, {z0.d-z1.d}, z16.d  // 10000000-11000000-00000010-00011000
 // CHECK-INST: fmop4s  za0.d, { z0.d, z1.d }, z16.d
 // CHECK-ENCODING: [0x18,0x02,0xc0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c00218 <unknown>
 
 fmop4s  za5.d, {z10.d-z11.d}, z20.d  // 10000000-11000100-00000011-01011101
 // CHECK-INST: fmop4s  za5.d, { z10.d, z11.d }, z20.d
 // CHECK-ENCODING: [0x5d,0x03,0xc4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80c4035d <unknown>
 
 fmop4s  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11011111
 // CHECK-INST: fmop4s  za7.d, { z14.d, z15.d }, z30.d
 // CHECK-ENCODING: [0xdf,0x03,0xce,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80ce03df <unknown>
 
 // Multiple vectors
@@ -166,17 +164,17 @@ fmop4s  za7.d, {z14.d-z15.d}, z30.d  // 10000000-11001110-00000011-11011111
 fmop4s  za0.d, {z0.d-z1.d}, {z16.d-z17.d}  // 10000000-11010000-00000010-00011000
 // CHECK-INST: fmop4s  za0.d, { z0.d, z1.d }, { z16.d, z17.d }
 // CHECK-ENCODING: [0x18,0x02,0xd0,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d00218 <unknown>
 
 fmop4s  za5.d, {z10.d-z11.d}, {z20.d-z21.d}  // 10000000-11010100-00000011-01011101
 // CHECK-INST: fmop4s  za5.d, { z10.d, z11.d }, { z20.d, z21.d }
 // CHECK-ENCODING: [0x5d,0x03,0xd4,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80d4035d <unknown>
 
 fmop4s  za7.d, {z14.d-z15.d}, {z30.d-z31.d}  // 10000000-11011110-00000011-11011111
 // CHECK-INST: fmop4s  za7.d, { z14.d, z15.d }, { z30.d, z31.d }
 // CHECK-ENCODING: [0xdf,0x03,0xde,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4 sme-f64f64
+// CHECK-ERROR: instruction requires: sme-f64f64 sme-mop4
 // CHECK-UNKNOWN: 80de03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/ftmopa-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/ftmopa-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 2>&1 < %s| FileCheck %s
 
 // --------------------------------------------------------------------------//
 // Invalid ZA register (range)

--- a/llvm/test/MC/AArch64/SME2p2/ftmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/ftmopa.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
@@ -17,19 +19,19 @@
 ftmopa  za0.h, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01100000-00000000-00001000
 // CHECK-INST: ftmopa  za0.h, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x08,0x00,0x60,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f16
 // CHECK-UNKNOWN: 80600008 <unknown>
 
 ftmopa  za1.h, {z10.b-z11.b}, z21.b, z29[1]  // 10000000-01110101-00010101-01011001
 // CHECK-INST: ftmopa  za1.h, { z10.b, z11.b }, z21.b, z29[1]
 // CHECK-ENCODING: [0x59,0x15,0x75,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f16
 // CHECK-UNKNOWN: 80751559 <unknown>
 
 ftmopa  za1.h, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11111001
 // CHECK-INST: ftmopa  za1.h, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf9,0x1f,0x7f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f16
 // CHECK-UNKNOWN: 807f1ff9 <unknown>
 
 // 2-way, (fp16-to-fp32)
@@ -37,19 +39,19 @@ ftmopa  za1.h, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11111
 ftmopa  za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01100000-00000000-00000000
 // CHECK-INST: ftmopa  za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x60,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81600000 <unknown>
 
 ftmopa  za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01101000-00001101-10110011
 // CHECK-INST: ftmopa  za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x68,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81680db3 <unknown>
 
 ftmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11110011
 // CHECK-INST: ftmopa  za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x7f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 817f1ff3 <unknown>
 
 // 4-way
@@ -57,19 +59,19 @@ ftmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11110
 ftmopa  za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01100000-00000000-00000000
 // CHECK-INST: ftmopa  za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x60,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f32
 // CHECK-UNKNOWN: 80600000 <unknown>
 
 ftmopa  za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000000-01101000-00001101-10110011
 // CHECK-INST: ftmopa  za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x68,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f32
 // CHECK-UNKNOWN: 80680db3 <unknown>
 
 ftmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11110011
 // CHECK-INST: ftmopa  za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x7f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f8f32
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f32
 // CHECK-UNKNOWN: 807f1ff3 <unknown>
 
 // non-widening (half-precision)
@@ -77,19 +79,19 @@ ftmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11110
 ftmopa  za0.h, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01000000-00000000-00001000
 // CHECK-INST: ftmopa  za0.h, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x00,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f16f16
 // CHECK-UNKNOWN: 81400008 <unknown>
 
 ftmopa  za1.h, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01001000-00001101-10111001
 // CHECK-INST: ftmopa  za1.h, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb9,0x0d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f16f16
 // CHECK-UNKNOWN: 81480db9 <unknown>
 
 ftmopa  za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-00011111-11111011
 // CHECK-INST: ftmopa  za1.h, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf9,0x1f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 sme-f16f16
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f16f16
 // CHECK-UNKNOWN: 815f1ff9 <unknown>
 
 // non-widening (single-precision)
@@ -97,17 +99,17 @@ ftmopa  za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-00011111-11111
 ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]  // 10000000-01000000-00000000-00000000
 // CHECK-INST: ftmopa  za0.s, { z0.s, z1.s }, z0.s, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x40,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80400000 <unknown>
 
 ftmopa  za3.s, {z12.s-z13.s}, z8.s, z23[3]  // 10000000-01001000-00001101-10110011
 // CHECK-INST: ftmopa  za3.s, { z12.s, z13.s }, z8.s, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x48,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80480db3 <unknown>
 
 ftmopa  za3.s, {z30.s-z31.s}, z31.s, z31[3]  // 10000000-01011111-00011111-11110011
 // CHECK-INST: ftmopa  za3.s, { z30.s, z31.s }, z31.s, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x5f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 805f1ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/ftmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/ftmopa.s
@@ -1,17 +1,15 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-f8f32,+sme-f8f16,+sme-f16f16 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-tmop,+sme-f8f32,+sme-f8f16,+sme-f16f16 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 // 2-way (fp8-to-fp16)
@@ -19,19 +17,19 @@
 ftmopa  za0.h, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01100000-00000000-00001000
 // CHECK-INST: ftmopa  za0.h, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x08,0x00,0x60,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-tmop
 // CHECK-UNKNOWN: 80600008 <unknown>
 
 ftmopa  za1.h, {z10.b-z11.b}, z21.b, z29[1]  // 10000000-01110101-00010101-01011001
 // CHECK-INST: ftmopa  za1.h, { z10.b, z11.b }, z21.b, z29[1]
 // CHECK-ENCODING: [0x59,0x15,0x75,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-tmop
 // CHECK-UNKNOWN: 80751559 <unknown>
 
 ftmopa  za1.h, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11111001
 // CHECK-INST: ftmopa  za1.h, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf9,0x1f,0x7f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f16
+// CHECK-ERROR: instruction requires: sme-f8f16 sme-tmop
 // CHECK-UNKNOWN: 807f1ff9 <unknown>
 
 // 2-way, (fp16-to-fp32)
@@ -39,19 +37,19 @@ ftmopa  za1.h, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11111
 ftmopa  za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01100000-00000000-00000000
 // CHECK-INST: ftmopa  za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x60,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81600000 <unknown>
 
 ftmopa  za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01101000-00001101-10110011
 // CHECK-INST: ftmopa  za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x68,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81680db3 <unknown>
 
 ftmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11110011
 // CHECK-INST: ftmopa  za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x7f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 817f1ff3 <unknown>
 
 // 4-way
@@ -59,19 +57,19 @@ ftmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01111111-00011111-11110
 ftmopa  za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01100000-00000000-00000000
 // CHECK-INST: ftmopa  za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x60,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-tmop
 // CHECK-UNKNOWN: 80600000 <unknown>
 
 ftmopa  za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000000-01101000-00001101-10110011
 // CHECK-INST: ftmopa  za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x68,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-tmop
 // CHECK-UNKNOWN: 80680db3 <unknown>
 
 ftmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11110011
 // CHECK-INST: ftmopa  za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x7f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f8f32
+// CHECK-ERROR: instruction requires: sme-f8f32 sme-tmop
 // CHECK-UNKNOWN: 807f1ff3 <unknown>
 
 // non-widening (half-precision)
@@ -79,19 +77,19 @@ ftmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-00011111-11110
 ftmopa  za0.h, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01000000-00000000-00001000
 // CHECK-INST: ftmopa  za0.h, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x00,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-tmop
 // CHECK-UNKNOWN: 81400008 <unknown>
 
 ftmopa  za1.h, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01001000-00001101-10111001
 // CHECK-INST: ftmopa  za1.h, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xb9,0x0d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-tmop
 // CHECK-UNKNOWN: 81480db9 <unknown>
 
 ftmopa  za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-00011111-11111011
 // CHECK-INST: ftmopa  za1.h, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xf9,0x1f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop sme-f16f16
+// CHECK-ERROR: instruction requires: sme-f16f16 sme-tmop
 // CHECK-UNKNOWN: 815f1ff9 <unknown>
 
 // non-widening (single-precision)
@@ -99,17 +97,17 @@ ftmopa  za1.h, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-00011111-11111
 ftmopa  za0.s, {z0.s-z1.s}, z0.s, z20[0]  // 10000000-01000000-00000000-00000000
 // CHECK-INST: ftmopa  za0.s, { z0.s, z1.s }, z0.s, z20[0]
 // CHECK-ENCODING: [0x00,0x00,0x40,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80400000 <unknown>
 
 ftmopa  za3.s, {z12.s-z13.s}, z8.s, z23[3]  // 10000000-01001000-00001101-10110011
 // CHECK-INST: ftmopa  za3.s, { z12.s, z13.s }, z8.s, z23[3]
 // CHECK-ENCODING: [0xb3,0x0d,0x48,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80480db3 <unknown>
 
 ftmopa  za3.s, {z30.s-z31.s}, z31.s, z31[3]  // 10000000-01011111-00011111-11110011
 // CHECK-INST: ftmopa  za3.s, { z30.s, z31.s }, z31.s, z31[3]
 // CHECK-ENCODING: [0xf3,0x1f,0x5f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 805f1ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-16to32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 smop4a  za0.s, z0.h, z16.h  // 10000000-00000000-10000000-00001000
 // CHECK-INST: smop4a  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008008 <unknown>
 
 smop4a  za3.s, z12.h, z24.h  // 10000000-00001000-10000001-10001011
 // CHECK-INST: smop4a  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x8b,0x81,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8008818b <unknown>
 
 smop4a  za3.s, z14.h, z30.h  // 10000000-00001110-10000001-11001011
 // CHECK-INST: smop4a  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xcb,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e81cb <unknown>
 
 smop4a  za0.s, z0.h, {z16.h-z17.h}  // 10000000-00010000-10000000-00001000
 // CHECK-INST: smop4a  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108008 <unknown>
 
 smop4a  za3.s, z12.h, {z24.h-z25.h}  // 10000000-00011000-10000001-10001011
 // CHECK-INST: smop4a  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x81,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8018818b <unknown>
 
 smop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000000-00011110-10000001-11001011
 // CHECK-INST: smop4a  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e81cb <unknown>
 
 smop4a  za0.s, {z0.h-z1.h}, z16.h  // 10000000-00000000-10000010-00001000
 // CHECK-INST: smop4a  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008208 <unknown>
 
 smop4a  za3.s, {z12.h-z13.h}, z24.h  // 10000000-00001000-10000011-10001011
 // CHECK-INST: smop4a  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x8b,0x83,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8008838b <unknown>
 
 smop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000000-00001110-10000011-11001011
 // CHECK-INST: smop4a  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcb,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e83cb <unknown>
 
 smop4a  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000000-00010000-10000010-00001000
 // CHECK-INST: smop4a  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108208 <unknown>
 
 smop4a  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000000-00011000-10000011-10001011
 // CHECK-INST: smop4a  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x83,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8018838b <unknown>
 
 smop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000000-00011110-10000011-11001011
 // CHECK-INST: smop4a  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e83cb <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-16to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 smop4a  za0.s, z0.h, z16.h  // 10000000-00000000-10000000-00001000
 // CHECK-INST: smop4a  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008008 <unknown>
 
 smop4a  za3.s, z12.h, z24.h  // 10000000-00001000-10000001-10001011
 // CHECK-INST: smop4a  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x8b,0x81,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8008818b <unknown>
 
 smop4a  za3.s, z14.h, z30.h  // 10000000-00001110-10000001-11001011
 // CHECK-INST: smop4a  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xcb,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e81cb <unknown>
 
 smop4a  za0.s, z0.h, {z16.h-z17.h}  // 10000000-00010000-10000000-00001000
 // CHECK-INST: smop4a  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108008 <unknown>
 
 smop4a  za3.s, z12.h, {z24.h-z25.h}  // 10000000-00011000-10000001-10001011
 // CHECK-INST: smop4a  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x81,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8018818b <unknown>
 
 smop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000000-00011110-10000001-11001011
 // CHECK-INST: smop4a  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e81cb <unknown>
 
 smop4a  za0.s, {z0.h-z1.h}, z16.h  // 10000000-00000000-10000010-00001000
 // CHECK-INST: smop4a  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008208 <unknown>
 
 smop4a  za3.s, {z12.h-z13.h}, z24.h  // 10000000-00001000-10000011-10001011
 // CHECK-INST: smop4a  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x8b,0x83,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8008838b <unknown>
 
 smop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000000-00001110-10000011-11001011
 // CHECK-INST: smop4a  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcb,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e83cb <unknown>
 
 smop4a  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000000-00010000-10000010-00001000
 // CHECK-INST: smop4a  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108208 <unknown>
 
 smop4a  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000000-00011000-10000011-10001011
 // CHECK-INST: smop4a  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x83,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8018838b <unknown>
 
 smop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000000-00011110-10000011-11001011
 // CHECK-INST: smop4a  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e83cb <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 smop4a  za0.d, z0.h, z16.h  // 10100000-11000000-00000000-00001000
 // CHECK-INST: smop4a  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c00008 <unknown>
 
 smop4a  za5.d, z10.h, z20.h  // 10100000-11000100-00000001-01001101
 // CHECK-INST: smop4a  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c4014d <unknown>
 
 smop4a  za7.d, z14.h, z30.h  // 10100000-11001110-00000001-11001111
 // CHECK-INST: smop4a  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ce01cf <unknown>
 
 smop4a  za0.d, z0.h, {z16.h-z17.h}  // 10100000-11010000-00000000-00001000
 // CHECK-INST: smop4a  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d00008 <unknown>
 
 smop4a  za5.d, z10.h, {z20.h-z21.h}  // 10100000-11010100-00000001-01001101
 // CHECK-INST: smop4a  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d4014d <unknown>
 
 smop4a  za7.d, z14.h, {z30.h-z31.h}  // 10100000-11011110-00000001-11001111
 // CHECK-INST: smop4a  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0de01cf <unknown>
 
 smop4a  za0.d, {z0.h-z1.h}, z16.h  // 10100000-11000000-00000010-00001000
 // CHECK-INST: smop4a  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c00208 <unknown>
 
 smop4a  za5.d, {z10.h-z11.h}, z20.h  // 10100000-11000100-00000011-01001101
 // CHECK-INST: smop4a  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c4034d <unknown>
 
 smop4a  za7.d, {z14.h-z15.h}, z30.h  // 10100000-11001110-00000011-11001111
 // CHECK-INST: smop4a  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ce03cf <unknown>
 
 smop4a  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11010000-00000010-00001000
 // CHECK-INST: smop4a  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d00208 <unknown>
 
 smop4a  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11010100-00000011-01001101
 // CHECK-INST: smop4a  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d4034d <unknown>
 
 smop4a  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11011110-00000011-11001111
 // CHECK-INST: smop4a  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0de03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 smop4a  za0.d, z0.h, z16.h  // 10100000-11000000-00000000-00001000
 // CHECK-INST: smop4a  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c00008 <unknown>
 
 smop4a  za5.d, z10.h, z20.h  // 10100000-11000100-00000001-01001101
 // CHECK-INST: smop4a  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c4014d <unknown>
 
 smop4a  za7.d, z14.h, z30.h  // 10100000-11001110-00000001-11001111
 // CHECK-INST: smop4a  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ce01cf <unknown>
 
 smop4a  za0.d, z0.h, {z16.h-z17.h}  // 10100000-11010000-00000000-00001000
 // CHECK-INST: smop4a  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d00008 <unknown>
 
 smop4a  za5.d, z10.h, {z20.h-z21.h}  // 10100000-11010100-00000001-01001101
 // CHECK-INST: smop4a  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d4014d <unknown>
 
 smop4a  za7.d, z14.h, {z30.h-z31.h}  // 10100000-11011110-00000001-11001111
 // CHECK-INST: smop4a  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0de01cf <unknown>
 
 smop4a  za0.d, {z0.h-z1.h}, z16.h  // 10100000-11000000-00000010-00001000
 // CHECK-INST: smop4a  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c00208 <unknown>
 
 smop4a  za5.d, {z10.h-z11.h}, z20.h  // 10100000-11000100-00000011-01001101
 // CHECK-INST: smop4a  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c4034d <unknown>
 
 smop4a  za7.d, {z14.h-z15.h}, z30.h  // 10100000-11001110-00000011-11001111
 // CHECK-INST: smop4a  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ce03cf <unknown>
 
 smop4a  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11010000-00000010-00001000
 // CHECK-INST: smop4a  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d00208 <unknown>
 
 smop4a  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11010100-00000011-01001101
 // CHECK-INST: smop4a  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d4034d <unknown>
 
 smop4a  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11011110-00000011-11001111
 // CHECK-INST: smop4a  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0de03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-8to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 smop4a  za0.s, z0.b, z16.b  // 10000000-00000000-10000000-00000000
 // CHECK-INST: smop4a  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008000 <unknown>
 
 smop4a  za1.s, z10.b, z20.b  // 10000000-00000100-10000001-01000001
 // CHECK-INST: smop4a  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80048141 <unknown>
 
 smop4a  za3.s, z14.b, z30.b  // 10000000-00001110-10000001-11000011
 // CHECK-INST: smop4a  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e81c3 <unknown>
 
 smop4a  za0.s, z0.b, {z16.b-z17.b}  // 10000000-00010000-10000000-00000000
 // CHECK-INST: smop4a  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108000 <unknown>
 
 smop4a  za3.s, z12.b, {z24.b-z25.b}  // 10000000-00011000-10000001-10000011
 // CHECK-INST: smop4a  za3.s, z12.b, { z24.b, z25.b }
 // CHECK-ENCODING: [0x83,0x81,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80188183 <unknown>
 
 smop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00011110-10000001-11000011
 // CHECK-INST: smop4a  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e81c3 <unknown>
 
 smop4a  za0.s, {z0.b-z1.b}, z16.b  // 10000000-00000000-10000010-00000000
 // CHECK-INST: smop4a  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008200 <unknown>
 
 smop4a  za1.s, {z10.b-z11.b}, z20.b  // 10000000-00000100-10000011-01000001
 // CHECK-INST: smop4a  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80048341 <unknown>
 
 smop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00001110-10000011-11000011
 // CHECK-INST: smop4a  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e83c3 <unknown>
 
 smop4a  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00010000-10000010-00000000
 // CHECK-INST: smop4a  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108200 <unknown>
 
 smop4a  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00010100-10000011-01000001
 // CHECK-INST: smop4a  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80148341 <unknown>
 
 smop4a  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00011110-10000011-11000011
 // CHECK-INST: smop4a  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-8to32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 smop4a  za0.s, z0.b, z16.b  // 10000000-00000000-10000000-00000000
 // CHECK-INST: smop4a  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008000 <unknown>
 
 smop4a  za1.s, z10.b, z20.b  // 10000000-00000100-10000001-01000001
 // CHECK-INST: smop4a  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80048141 <unknown>
 
 smop4a  za3.s, z14.b, z30.b  // 10000000-00001110-10000001-11000011
 // CHECK-INST: smop4a  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e81c3 <unknown>
 
 smop4a  za0.s, z0.b, {z16.b-z17.b}  // 10000000-00010000-10000000-00000000
 // CHECK-INST: smop4a  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108000 <unknown>
 
 smop4a  za3.s, z12.b, {z24.b-z25.b}  // 10000000-00011000-10000001-10000011
 // CHECK-INST: smop4a  za3.s, z12.b, { z24.b, z25.b }
 // CHECK-ENCODING: [0x83,0x81,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80188183 <unknown>
 
 smop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00011110-10000001-11000011
 // CHECK-INST: smop4a  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e81c3 <unknown>
 
 smop4a  za0.s, {z0.b-z1.b}, z16.b  // 10000000-00000000-10000010-00000000
 // CHECK-INST: smop4a  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008200 <unknown>
 
 smop4a  za1.s, {z10.b-z11.b}, z20.b  // 10000000-00000100-10000011-01000001
 // CHECK-INST: smop4a  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80048341 <unknown>
 
 smop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00001110-10000011-11000011
 // CHECK-INST: smop4a  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e83c3 <unknown>
 
 smop4a  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00010000-10000010-00000000
 // CHECK-INST: smop4a  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108200 <unknown>
 
 smop4a  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00010100-10000011-01000001
 // CHECK-INST: smop4a  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80148341 <unknown>
 
 smop4a  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00011110-10000011-11000011
 // CHECK-INST: smop4a  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4a-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4a-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-16to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 smop4s  za0.s, z0.h, z16.h  // 10000000-00000000-10000000-00011000
 // CHECK-INST: smop4s  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008018 <unknown>
 
 smop4s  za3.s, z12.h, z24.h  // 10000000-00001000-10000001-10011011
 // CHECK-INST: smop4s  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x9b,0x81,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8008819b <unknown>
 
 smop4s  za3.s, z14.h, z30.h  // 10000000-00001110-10000001-11011011
 // CHECK-INST: smop4s  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xdb,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e81db <unknown>
 
 smop4s  za0.s, z0.h, {z16.h-z17.h}  // 10000000-00010000-10000000-00011000
 // CHECK-INST: smop4s  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108018 <unknown>
 
 smop4s  za3.s, z12.h, {z24.h-z25.h}  // 10000000-00011000-10000001-10011011
 // CHECK-INST: smop4s  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x9b,0x81,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8018819b <unknown>
 
 smop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000000-00011110-10000001-11011011
 // CHECK-INST: smop4s  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdb,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e81db <unknown>
 
 smop4s  za0.s, {z0.h-z1.h}, z16.h  // 10000000-00000000-10000010-00011000
 // CHECK-INST: smop4s  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008218 <unknown>
 
 smop4s  za3.s, {z12.h-z13.h}, z24.h  // 10000000-00001000-10000011-10011011
 // CHECK-INST: smop4s  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x9b,0x83,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8008839b <unknown>
 
 smop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000000-00001110-10000011-11011011
 // CHECK-INST: smop4s  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdb,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e83db <unknown>
 
 smop4s  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000000-00010000-10000010-00011000
 // CHECK-INST: smop4s  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108218 <unknown>
 
 smop4s  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000000-00011000-10000011-10011011
 // CHECK-INST: smop4s  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x9b,0x83,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8018839b <unknown>
 
 smop4s  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000000-00011110-10000011-11011011
 // CHECK-INST: smop4s  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdb,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e83db <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-16to32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 smop4s  za0.s, z0.h, z16.h  // 10000000-00000000-10000000-00011000
 // CHECK-INST: smop4s  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008018 <unknown>
 
 smop4s  za3.s, z12.h, z24.h  // 10000000-00001000-10000001-10011011
 // CHECK-INST: smop4s  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x9b,0x81,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8008819b <unknown>
 
 smop4s  za3.s, z14.h, z30.h  // 10000000-00001110-10000001-11011011
 // CHECK-INST: smop4s  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xdb,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e81db <unknown>
 
 smop4s  za0.s, z0.h, {z16.h-z17.h}  // 10000000-00010000-10000000-00011000
 // CHECK-INST: smop4s  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108018 <unknown>
 
 smop4s  za3.s, z12.h, {z24.h-z25.h}  // 10000000-00011000-10000001-10011011
 // CHECK-INST: smop4s  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x9b,0x81,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8018819b <unknown>
 
 smop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000000-00011110-10000001-11011011
 // CHECK-INST: smop4s  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdb,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e81db <unknown>
 
 smop4s  za0.s, {z0.h-z1.h}, z16.h  // 10000000-00000000-10000010-00011000
 // CHECK-INST: smop4s  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008218 <unknown>
 
 smop4s  za3.s, {z12.h-z13.h}, z24.h  // 10000000-00001000-10000011-10011011
 // CHECK-INST: smop4s  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x9b,0x83,0x08,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8008839b <unknown>
 
 smop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000000-00001110-10000011-11011011
 // CHECK-INST: smop4s  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdb,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e83db <unknown>
 
 smop4s  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000000-00010000-10000010-00011000
 // CHECK-INST: smop4s  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108218 <unknown>
 
 smop4s  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000000-00011000-10000011-10011011
 // CHECK-INST: smop4s  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x9b,0x83,0x18,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8018839b <unknown>
 
 smop4s  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000000-00011110-10000011-11011011
 // CHECK-INST: smop4s  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdb,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e83db <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 smop4s  za0.d, z0.h, z16.h  // 10100000-11000000-00000000-00011000
 // CHECK-INST: smop4s  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c00018 <unknown>
 
 smop4s  za5.d, z10.h, z20.h  // 10100000-11000100-00000001-01011101
 // CHECK-INST: smop4s  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c4015d <unknown>
 
 smop4s  za7.d, z14.h, z30.h  // 10100000-11001110-00000001-11011111
 // CHECK-INST: smop4s  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ce01df <unknown>
 
 smop4s  za0.d, z0.h, {z16.h-z17.h}  // 10100000-11010000-00000000-00011000
 // CHECK-INST: smop4s  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d00018 <unknown>
 
 smop4s  za5.d, z10.h, {z20.h-z21.h}  // 10100000-11010100-00000001-01011101
 // CHECK-INST: smop4s  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d4015d <unknown>
 
 smop4s  za7.d, z14.h, {z30.h-z31.h}  // 10100000-11011110-00000001-11011111
 // CHECK-INST: smop4s  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0de01df <unknown>
 
 smop4s  za0.d, {z0.h-z1.h}, z16.h  // 10100000-11000000-00000010-00011000
 // CHECK-INST: smop4s  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c00218 <unknown>
 
 smop4s  za5.d, {z10.h-z11.h}, z20.h  // 10100000-11000100-00000011-01011101
 // CHECK-INST: smop4s  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0c4035d <unknown>
 
 smop4s  za7.d, {z14.h-z15.h}, z30.h  // 10100000-11001110-00000011-11011111
 // CHECK-INST: smop4s  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ce03df <unknown>
 
 smop4s  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11010000-00000010-00011000
 // CHECK-INST: smop4s  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d00218 <unknown>
 
 smop4s  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11010100-00000011-01011101
 // CHECK-INST: smop4s  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0d4035d <unknown>
 
 smop4s  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11011110-00000011-11011111
 // CHECK-INST: smop4s  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0de03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 smop4s  za0.d, z0.h, z16.h  // 10100000-11000000-00000000-00011000
 // CHECK-INST: smop4s  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c00018 <unknown>
 
 smop4s  za5.d, z10.h, z20.h  // 10100000-11000100-00000001-01011101
 // CHECK-INST: smop4s  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c4015d <unknown>
 
 smop4s  za7.d, z14.h, z30.h  // 10100000-11001110-00000001-11011111
 // CHECK-INST: smop4s  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ce01df <unknown>
 
 smop4s  za0.d, z0.h, {z16.h-z17.h}  // 10100000-11010000-00000000-00011000
 // CHECK-INST: smop4s  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d00018 <unknown>
 
 smop4s  za5.d, z10.h, {z20.h-z21.h}  // 10100000-11010100-00000001-01011101
 // CHECK-INST: smop4s  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d4015d <unknown>
 
 smop4s  za7.d, z14.h, {z30.h-z31.h}  // 10100000-11011110-00000001-11011111
 // CHECK-INST: smop4s  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0de01df <unknown>
 
 smop4s  za0.d, {z0.h-z1.h}, z16.h  // 10100000-11000000-00000010-00011000
 // CHECK-INST: smop4s  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xc0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c00218 <unknown>
 
 smop4s  za5.d, {z10.h-z11.h}, z20.h  // 10100000-11000100-00000011-01011101
 // CHECK-INST: smop4s  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xc4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0c4035d <unknown>
 
 smop4s  za7.d, {z14.h-z15.h}, z30.h  // 10100000-11001110-00000011-11011111
 // CHECK-INST: smop4s  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xce,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ce03df <unknown>
 
 smop4s  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11010000-00000010-00011000
 // CHECK-INST: smop4s  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xd0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d00218 <unknown>
 
 smop4s  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11010100-00000011-01011101
 // CHECK-INST: smop4s  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xd4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0d4035d <unknown>
 
 smop4s  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11011110-00000011-11011111
 // CHECK-INST: smop4s  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xde,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0de03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-8to32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 smop4s  za0.s, z0.b, z16.b  // 10000000-00000000-10000000-00010000
 // CHECK-INST: smop4s  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008010 <unknown>
 
 smop4s  za1.s, z10.b, z20.b  // 10000000-00000100-10000001-01010001
 // CHECK-INST: smop4s  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80048151 <unknown>
 
 smop4s  za3.s, z14.b, z30.b  // 10000000-00001110-10000001-11010011
 // CHECK-INST: smop4s  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e81d3 <unknown>
 
 smop4s  za0.s, z0.b, {z16.b-z17.b}  // 10000000-00010000-10000000-00010000
 // CHECK-INST: smop4s  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108010 <unknown>
 
 smop4s  za1.s, z10.b, {z20.b-z21.b}  // 10000000-00010100-10000001-01010001
 // CHECK-INST: smop4s  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80148151 <unknown>
 
 smop4s  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00011110-10000001-11010011
 // CHECK-INST: smop4s  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e81d3 <unknown>
 
 smop4s  za0.s, {z0.b-z1.b}, z16.b  // 10000000-00000000-10000010-00010000
 // CHECK-INST: smop4s  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80008210 <unknown>
 
 smop4s  za1.s, {z10.b-z11.b}, z20.b  // 10000000-00000100-10000011-01010001
 // CHECK-INST: smop4s  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80048351 <unknown>
 
 smop4s  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00001110-10000011-11010011
 // CHECK-INST: smop4s  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 800e83d3 <unknown>
 
 smop4s  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00010000-10000010-00010000
 // CHECK-INST: smop4s  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80108210 <unknown>
 
 smop4s  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00010100-10000011-01010001
 // CHECK-INST: smop4s  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80148351 <unknown>
 
 smop4s  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00011110-10000011-11010011
 // CHECK-INST: smop4s  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 801e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-8to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 smop4s  za0.s, z0.b, z16.b  // 10000000-00000000-10000000-00010000
 // CHECK-INST: smop4s  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008010 <unknown>
 
 smop4s  za1.s, z10.b, z20.b  // 10000000-00000100-10000001-01010001
 // CHECK-INST: smop4s  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80048151 <unknown>
 
 smop4s  za3.s, z14.b, z30.b  // 10000000-00001110-10000001-11010011
 // CHECK-INST: smop4s  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e81d3 <unknown>
 
 smop4s  za0.s, z0.b, {z16.b-z17.b}  // 10000000-00010000-10000000-00010000
 // CHECK-INST: smop4s  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108010 <unknown>
 
 smop4s  za1.s, z10.b, {z20.b-z21.b}  // 10000000-00010100-10000001-01010001
 // CHECK-INST: smop4s  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80148151 <unknown>
 
 smop4s  za3.s, z14.b, {z30.b-z31.b}  // 10000000-00011110-10000001-11010011
 // CHECK-INST: smop4s  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e81d3 <unknown>
 
 smop4s  za0.s, {z0.b-z1.b}, z16.b  // 10000000-00000000-10000010-00010000
 // CHECK-INST: smop4s  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x00,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80008210 <unknown>
 
 smop4s  za1.s, {z10.b-z11.b}, z20.b  // 10000000-00000100-10000011-01010001
 // CHECK-INST: smop4s  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x04,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80048351 <unknown>
 
 smop4s  za3.s, {z14.b-z15.b}, z30.b  // 10000000-00001110-10000011-11010011
 // CHECK-INST: smop4s  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x0e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 800e83d3 <unknown>
 
 smop4s  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00010000-10000010-00010000
 // CHECK-INST: smop4s  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x10,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80108210 <unknown>
 
 smop4s  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00010100-10000011-01010001
 // CHECK-INST: smop4s  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x14,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80148351 <unknown>
 
 smop4s  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00011110-10000011-11010011
 // CHECK-INST: smop4s  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x1e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 801e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/smop4s-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/smop4s-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/stmopa-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/stmopa-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop 2>&1 < %s| FileCheck %s
 
 // --------------------------------------------------------------------------//
 // Invalid ZA register

--- a/llvm/test/MC/AArch64/SME2p2/stmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/stmopa.s
@@ -1,51 +1,49 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-tmop -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 stmopa  za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01000000-10000000-00000000
 // CHECK-INST: stmopa  za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x40,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80408000 <unknown>
 
 stmopa  za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000000-01001000-10001101-10110011
 // CHECK-INST: stmopa  za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x8d,0x48,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80488db3 <unknown>
 
 stmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01011111-10011111-11110011
 // CHECK-INST: stmopa  za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x5f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 805f9ff3 <unknown>
 
 stmopa  za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000000-01000000-10000000-00001000
 // CHECK-INST: stmopa  za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x80,0x40,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80408008 <unknown>
 
 stmopa  za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000000-01001000-10001101-10111011
 // CHECK-INST: stmopa  za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xbb,0x8d,0x48,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80488dbb <unknown>
 
 stmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000000-01011111-10011111-11111011
 // CHECK-INST: stmopa  za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xfb,0x9f,0x5f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 805f9ffb <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/stmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/stmopa.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,35 +17,35 @@
 stmopa  za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01000000-10000000-00000000
 // CHECK-INST: stmopa  za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x40,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80408000 <unknown>
 
 stmopa  za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000000-01001000-10001101-10110011
 // CHECK-INST: stmopa  za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x8d,0x48,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80488db3 <unknown>
 
 stmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01011111-10011111-11110011
 // CHECK-INST: stmopa  za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x5f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 805f9ff3 <unknown>
 
 stmopa  za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000000-01000000-10000000-00001000
 // CHECK-INST: stmopa  za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x80,0x40,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80408008 <unknown>
 
 stmopa  za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000000-01001000-10001101-10111011
 // CHECK-INST: stmopa  za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xbb,0x8d,0x48,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80488dbb <unknown>
 
 stmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000000-01011111-10011111-11111011
 // CHECK-INST: stmopa  za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xfb,0x9f,0x5f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 805f9ffb <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4a-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4a-32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 sumop4a za0.s, z0.b, z16.b  // 10000000-00100000-10000000-00000000
 // CHECK-INST: sumop4a za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80208000 <unknown>
 
 sumop4a za1.s, z10.b, z20.b  // 10000000-00100100-10000001-01000001
 // CHECK-INST: sumop4a za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80248141 <unknown>
 
 sumop4a za3.s, z14.b, z30.b  // 10000000-00101110-10000001-11000011
 // CHECK-INST: sumop4a za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 802e81c3 <unknown>
 
 sumop4a za0.s, z0.b, {z16.b-z17.b}  // 10000000-00110000-10000000-00000000
 // CHECK-INST: sumop4a za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80308000 <unknown>
 
 sumop4a za1.s, z10.b, {z20.b-z21.b}  // 10000000-00110100-10000001-01000001
 // CHECK-INST: sumop4a za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x81,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80348141 <unknown>
 
 sumop4a za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-10000001-11000011
 // CHECK-INST: sumop4a za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 803e81c3 <unknown>
 
 sumop4a za0.s, {z0.b-z1.b}, z16.b  // 10000000-00100000-10000010-00000000
 // CHECK-INST: sumop4a za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80208200 <unknown>
 
 sumop4a za1.s, {z10.b-z11.b}, z20.b  // 10000000-00100100-10000011-01000001
 // CHECK-INST: sumop4a za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80248341 <unknown>
 
 sumop4a za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-10000011-11000011
 // CHECK-INST: sumop4a za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 802e83c3 <unknown>
 
 sumop4a za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-10000010-00000000
 // CHECK-INST: sumop4a za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80308200 <unknown>
 
 sumop4a za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-10000011-01000001
 // CHECK-INST: sumop4a za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80348341 <unknown>
 
 sumop4a za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-10000011-11000011
 // CHECK-INST: sumop4a za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 803e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4a-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4a-32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 sumop4a za0.s, z0.b, z16.b  // 10000000-00100000-10000000-00000000
 // CHECK-INST: sumop4a za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80208000 <unknown>
 
 sumop4a za1.s, z10.b, z20.b  // 10000000-00100100-10000001-01000001
 // CHECK-INST: sumop4a za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80248141 <unknown>
 
 sumop4a za3.s, z14.b, z30.b  // 10000000-00101110-10000001-11000011
 // CHECK-INST: sumop4a za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 802e81c3 <unknown>
 
 sumop4a za0.s, z0.b, {z16.b-z17.b}  // 10000000-00110000-10000000-00000000
 // CHECK-INST: sumop4a za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80308000 <unknown>
 
 sumop4a za1.s, z10.b, {z20.b-z21.b}  // 10000000-00110100-10000001-01000001
 // CHECK-INST: sumop4a za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x81,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80348141 <unknown>
 
 sumop4a za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-10000001-11000011
 // CHECK-INST: sumop4a za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 803e81c3 <unknown>
 
 sumop4a za0.s, {z0.b-z1.b}, z16.b  // 10000000-00100000-10000010-00000000
 // CHECK-INST: sumop4a za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80208200 <unknown>
 
 sumop4a za1.s, {z10.b-z11.b}, z20.b  // 10000000-00100100-10000011-01000001
 // CHECK-INST: sumop4a za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80248341 <unknown>
 
 sumop4a za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-10000011-11000011
 // CHECK-INST: sumop4a za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 802e83c3 <unknown>
 
 sumop4a za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-10000010-00000000
 // CHECK-INST: sumop4a za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80308200 <unknown>
 
 sumop4a za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-10000011-01000001
 // CHECK-INST: sumop4a za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80348341 <unknown>
 
 sumop4a za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-10000011-11000011
 // CHECK-INST: sumop4a za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 803e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4a-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 sumop4a za0.d, z0.h, z16.h  // 10100000-11100000-00000000-00001000
 // CHECK-INST: sumop4a za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e00008 <unknown>
 
 sumop4a za5.d, z10.h, z20.h  // 10100000-11100100-00000001-01001101
 // CHECK-INST: sumop4a za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e4014d <unknown>
 
 sumop4a za7.d, z14.h, z30.h  // 10100000-11101110-00000001-11001111
 // CHECK-INST: sumop4a za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ee01cf <unknown>
 
 sumop4a za0.d, z0.h, {z16.h-z17.h}  // 10100000-11110000-00000000-00001000
 // CHECK-INST: sumop4a za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f00008 <unknown>
 
 sumop4a za5.d, z10.h, {z20.h-z21.h}  // 10100000-11110100-00000001-01001101
 // CHECK-INST: sumop4a za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f4014d <unknown>
 
 sumop4a za7.d, z14.h, {z30.h-z31.h}  // 10100000-11111110-00000001-11001111
 // CHECK-INST: sumop4a za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0fe01cf <unknown>
 
 sumop4a za0.d, {z0.h-z1.h}, z16.h  // 10100000-11100000-00000010-00001000
 // CHECK-INST: sumop4a za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e00208 <unknown>
 
 sumop4a za5.d, {z10.h-z11.h}, z20.h  // 10100000-11100100-00000011-01001101
 // CHECK-INST: sumop4a za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e4034d <unknown>
 
 sumop4a za7.d, {z14.h-z15.h}, z30.h  // 10100000-11101110-00000011-11001111
 // CHECK-INST: sumop4a za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ee03cf <unknown>
 
 sumop4a za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11110000-00000010-00001000
 // CHECK-INST: sumop4a za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f00208 <unknown>
 
 sumop4a za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11110100-00000011-01001101
 // CHECK-INST: sumop4a za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f4034d <unknown>
 
 sumop4a za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11111110-00000011-11001111
 // CHECK-INST: sumop4a za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0fe03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4a-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 sumop4a za0.d, z0.h, z16.h  // 10100000-11100000-00000000-00001000
 // CHECK-INST: sumop4a za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e00008 <unknown>
 
 sumop4a za5.d, z10.h, z20.h  // 10100000-11100100-00000001-01001101
 // CHECK-INST: sumop4a za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e4014d <unknown>
 
 sumop4a za7.d, z14.h, z30.h  // 10100000-11101110-00000001-11001111
 // CHECK-INST: sumop4a za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ee01cf <unknown>
 
 sumop4a za0.d, z0.h, {z16.h-z17.h}  // 10100000-11110000-00000000-00001000
 // CHECK-INST: sumop4a za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f00008 <unknown>
 
 sumop4a za5.d, z10.h, {z20.h-z21.h}  // 10100000-11110100-00000001-01001101
 // CHECK-INST: sumop4a za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f4014d <unknown>
 
 sumop4a za7.d, z14.h, {z30.h-z31.h}  // 10100000-11111110-00000001-11001111
 // CHECK-INST: sumop4a za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0fe01cf <unknown>
 
 sumop4a za0.d, {z0.h-z1.h}, z16.h  // 10100000-11100000-00000010-00001000
 // CHECK-INST: sumop4a za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e00208 <unknown>
 
 sumop4a za5.d, {z10.h-z11.h}, z20.h  // 10100000-11100100-00000011-01001101
 // CHECK-INST: sumop4a za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e4034d <unknown>
 
 sumop4a za7.d, {z14.h-z15.h}, z30.h  // 10100000-11101110-00000011-11001111
 // CHECK-INST: sumop4a za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ee03cf <unknown>
 
 sumop4a za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11110000-00000010-00001000
 // CHECK-INST: sumop4a za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f00208 <unknown>
 
 sumop4a za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11110100-00000011-01001101
 // CHECK-INST: sumop4a za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f4034d <unknown>
 
 sumop4a za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11111110-00000011-11001111
 // CHECK-INST: sumop4a za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0fe03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4a-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4a-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/sumop4s-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4s-32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 sumop4s za0.s, z0.b, z16.b  // 10000000-00100000-10000000-00010000
 // CHECK-INST: sumop4s za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80208010 <unknown>
 
 sumop4s za1.s, z10.b, z20.b  // 10000000-00100100-10000001-01010001
 // CHECK-INST: sumop4s za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80248151 <unknown>
 
 sumop4s za3.s, z14.b, z30.b  // 10000000-00101110-10000001-11010011
 // CHECK-INST: sumop4s za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 802e81d3 <unknown>
 
 sumop4s za0.s, z0.b, {z16.b-z17.b}  // 10000000-00110000-10000000-00010000
 // CHECK-INST: sumop4s za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80308010 <unknown>
 
 sumop4s za1.s, z10.b, {z20.b-z21.b}  // 10000000-00110100-10000001-01010001
 // CHECK-INST: sumop4s za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80348151 <unknown>
 
 sumop4s za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-10000001-11010011
 // CHECK-INST: sumop4s za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 803e81d3 <unknown>
 
 sumop4s za0.s, {z0.b-z1.b}, z16.b  // 10000000-00100000-10000010-00010000
 // CHECK-INST: sumop4s za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80208210 <unknown>
 
 sumop4s za1.s, {z10.b-z11.b}, z20.b  // 10000000-00100100-10000011-01010001
 // CHECK-INST: sumop4s za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80248351 <unknown>
 
 sumop4s za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-10000011-11010011
 // CHECK-INST: sumop4s za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 802e83d3 <unknown>
 
 sumop4s za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-10000010-00010000
 // CHECK-INST: sumop4s za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80308210 <unknown>
 
 sumop4s za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-10000011-01010001
 // CHECK-INST: sumop4s za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 80348351 <unknown>
 
 sumop4s za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-10000011-11010011
 // CHECK-INST: sumop4s za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 803e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4s-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4s-32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 sumop4s za0.s, z0.b, z16.b  // 10000000-00100000-10000000-00010000
 // CHECK-INST: sumop4s za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80208010 <unknown>
 
 sumop4s za1.s, z10.b, z20.b  // 10000000-00100100-10000001-01010001
 // CHECK-INST: sumop4s za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80248151 <unknown>
 
 sumop4s za3.s, z14.b, z30.b  // 10000000-00101110-10000001-11010011
 // CHECK-INST: sumop4s za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 802e81d3 <unknown>
 
 sumop4s za0.s, z0.b, {z16.b-z17.b}  // 10000000-00110000-10000000-00010000
 // CHECK-INST: sumop4s za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80308010 <unknown>
 
 sumop4s za1.s, z10.b, {z20.b-z21.b}  // 10000000-00110100-10000001-01010001
 // CHECK-INST: sumop4s za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80348151 <unknown>
 
 sumop4s za3.s, z14.b, {z30.b-z31.b}  // 10000000-00111110-10000001-11010011
 // CHECK-INST: sumop4s za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 803e81d3 <unknown>
 
 sumop4s za0.s, {z0.b-z1.b}, z16.b  // 10000000-00100000-10000010-00010000
 // CHECK-INST: sumop4s za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x20,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80208210 <unknown>
 
 sumop4s za1.s, {z10.b-z11.b}, z20.b  // 10000000-00100100-10000011-01010001
 // CHECK-INST: sumop4s za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x24,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80248351 <unknown>
 
 sumop4s za3.s, {z14.b-z15.b}, z30.b  // 10000000-00101110-10000011-11010011
 // CHECK-INST: sumop4s za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x2e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 802e83d3 <unknown>
 
 sumop4s za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000000-00110000-10000010-00010000
 // CHECK-INST: sumop4s za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x30,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80308210 <unknown>
 
 sumop4s za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000000-00110100-10000011-01010001
 // CHECK-INST: sumop4s za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x34,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 80348351 <unknown>
 
 sumop4s za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000000-00111110-10000011-11010011
 // CHECK-INST: sumop4s za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x3e,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 803e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4s-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 sumop4s za0.d, z0.h, z16.h  // 10100000-11100000-00000000-00011000
 // CHECK-INST: sumop4s za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e00018 <unknown>
 
 sumop4s za5.d, z10.h, z20.h  // 10100000-11100100-00000001-01011101
 // CHECK-INST: sumop4s za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e4015d <unknown>
 
 sumop4s za7.d, z14.h, z30.h  // 10100000-11101110-00000001-11011111
 // CHECK-INST: sumop4s za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ee01df <unknown>
 
 sumop4s za0.d, z0.h, {z16.h-z17.h}  // 10100000-11110000-00000000-00011000
 // CHECK-INST: sumop4s za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f00018 <unknown>
 
 sumop4s za5.d, z10.h, {z20.h-z21.h}  // 10100000-11110100-00000001-01011101
 // CHECK-INST: sumop4s za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f4015d <unknown>
 
 sumop4s za7.d, z14.h, {z30.h-z31.h}  // 10100000-11111110-00000001-11011111
 // CHECK-INST: sumop4s za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0fe01df <unknown>
 
 sumop4s za0.d, {z0.h-z1.h}, z16.h  // 10100000-11100000-00000010-00011000
 // CHECK-INST: sumop4s za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e00218 <unknown>
 
 sumop4s za5.d, {z10.h-z11.h}, z20.h  // 10100000-11100100-00000011-01011101
 // CHECK-INST: sumop4s za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0e4035d <unknown>
 
 sumop4s za7.d, {z14.h-z15.h}, z30.h  // 10100000-11101110-00000011-11011111
 // CHECK-INST: sumop4s za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0ee03df <unknown>
 
 sumop4s za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11110000-00000010-00011000
 // CHECK-INST: sumop4s za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f00218 <unknown>
 
 sumop4s za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11110100-00000011-01011101
 // CHECK-INST: sumop4s za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0f4035d <unknown>
 
 sumop4s za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11111110-00000011-11011111
 // CHECK-INST: sumop4s za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a0fe03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4s-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 sumop4s za0.d, z0.h, z16.h  // 10100000-11100000-00000000-00011000
 // CHECK-INST: sumop4s za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e00018 <unknown>
 
 sumop4s za5.d, z10.h, z20.h  // 10100000-11100100-00000001-01011101
 // CHECK-INST: sumop4s za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e4015d <unknown>
 
 sumop4s za7.d, z14.h, z30.h  // 10100000-11101110-00000001-11011111
 // CHECK-INST: sumop4s za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ee01df <unknown>
 
 sumop4s za0.d, z0.h, {z16.h-z17.h}  // 10100000-11110000-00000000-00011000
 // CHECK-INST: sumop4s za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f00018 <unknown>
 
 sumop4s za5.d, z10.h, {z20.h-z21.h}  // 10100000-11110100-00000001-01011101
 // CHECK-INST: sumop4s za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f4015d <unknown>
 
 sumop4s za7.d, z14.h, {z30.h-z31.h}  // 10100000-11111110-00000001-11011111
 // CHECK-INST: sumop4s za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0fe01df <unknown>
 
 sumop4s za0.d, {z0.h-z1.h}, z16.h  // 10100000-11100000-00000010-00011000
 // CHECK-INST: sumop4s za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xe0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e00218 <unknown>
 
 sumop4s za5.d, {z10.h-z11.h}, z20.h  // 10100000-11100100-00000011-01011101
 // CHECK-INST: sumop4s za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xe4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0e4035d <unknown>
 
 sumop4s za7.d, {z14.h-z15.h}, z30.h  // 10100000-11101110-00000011-11011111
 // CHECK-INST: sumop4s za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xee,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0ee03df <unknown>
 
 sumop4s za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100000-11110000-00000010-00011000
 // CHECK-INST: sumop4s za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xf0,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f00218 <unknown>
 
 sumop4s za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100000-11110100-00000011-01011101
 // CHECK-INST: sumop4s za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xf4,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0f4035d <unknown>
 
 sumop4s za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100000-11111110-00000011-11011111
 // CHECK-INST: sumop4s za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xfe,0xa0]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a0fe03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sumop4s-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/sumop4s-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/sutmopa-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/sutmopa-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop 2>&1 < %s| FileCheck %s
 
 // --------------------------------------------------------------------------//
 // Invalid ZA register

--- a/llvm/test/MC/AArch64/SME2p2/sutmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/sutmopa.s
@@ -1,33 +1,31 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-tmop -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 sutmopa za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01100000-10000000-00000000
 // CHECK-INST: sutmopa za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x60,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80608000 <unknown>
 
 sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]  // 10000000-01110101-10010101-01010001
 // CHECK-INST: sutmopa za1.s, { z10.b, z11.b }, z21.b, z29[1]
 // CHECK-ENCODING: [0x51,0x95,0x75,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 80759551 <unknown>
 
 sutmopa za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-10011111-11110011
 // CHECK-INST: sutmopa za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x7f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 807f9ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/sutmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/sutmopa.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,17 +17,17 @@
 sutmopa za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000000-01100000-10000000-00000000
 // CHECK-INST: sutmopa za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x60,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80608000 <unknown>
 
 sutmopa za1.s, {z10.b-z11.b}, z21.b, z29[1]  // 10000000-01110101-10010101-01010001
 // CHECK-INST: sutmopa za1.s, { z10.b, z11.b }, z21.b, z29[1]
 // CHECK-ENCODING: [0x51,0x95,0x75,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 80759551 <unknown>
 
 sutmopa za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000000-01111111-10011111-11110011
 // CHECK-INST: sutmopa za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x7f,0x80]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 807f9ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-16to32.s
@@ -1,88 +1,86 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 
 umop4a  za0.s, z0.h, z16.h  // 10000001-00000000-10000000-00001000
 // CHECK-INST: umop4a  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008008 <unknown>
 
 umop4a  za3.s, z12.h, z24.h  // 10000001-00001000-10000001-10001011
 // CHECK-INST: umop4a  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x8b,0x81,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8108818b <unknown>
 
 umop4a  za3.s, z14.h, z30.h  // 10000001-00001110-10000001-11001011
 // CHECK-INST: umop4a  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xcb,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e81cb <unknown>
 
 umop4a  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-10000000-00001000
 // CHECK-INST: umop4a  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108008 <unknown>
 
 umop4a  za3.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-10000001-10001011
 // CHECK-INST: umop4a  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x81,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8118818b <unknown>
 
 umop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-10000001-11001011
 // CHECK-INST: umop4a  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e81cb <unknown>
 
 umop4a  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-10000010-00001000
 // CHECK-INST: umop4a  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008208 <unknown>
 
 umop4a  za3.s, {z12.h-z13.h}, z24.h  // 10000001-00001000-10000011-10001011
 // CHECK-INST: umop4a  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x8b,0x83,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8108838b <unknown>
 
 umop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-10000011-11001011
 // CHECK-INST: umop4a  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcb,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e83cb <unknown>
 
 umop4a  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-10000010-00001000
 // CHECK-INST: umop4a  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108208 <unknown>
 
 umop4a  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-10000011-10001011
 // CHECK-INST: umop4a  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x83,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8118838b <unknown>
 
 umop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-10000011-11001011
 // CHECK-INST: umop4a  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e83cb <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-16to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -16,71 +18,71 @@
 umop4a  za0.s, z0.h, z16.h  // 10000001-00000000-10000000-00001000
 // CHECK-INST: umop4a  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81008008 <unknown>
 
 umop4a  za3.s, z12.h, z24.h  // 10000001-00001000-10000001-10001011
 // CHECK-INST: umop4a  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x8b,0x81,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8108818b <unknown>
 
 umop4a  za3.s, z14.h, z30.h  // 10000001-00001110-10000001-11001011
 // CHECK-INST: umop4a  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xcb,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e81cb <unknown>
 
 umop4a  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-10000000-00001000
 // CHECK-INST: umop4a  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81108008 <unknown>
 
 umop4a  za3.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-10000001-10001011
 // CHECK-INST: umop4a  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x81,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8118818b <unknown>
 
 umop4a  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-10000001-11001011
 // CHECK-INST: umop4a  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e81cb <unknown>
 
 umop4a  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-10000010-00001000
 // CHECK-INST: umop4a  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81008208 <unknown>
 
 umop4a  za3.s, {z12.h-z13.h}, z24.h  // 10000001-00001000-10000011-10001011
 // CHECK-INST: umop4a  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x8b,0x83,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8108838b <unknown>
 
 umop4a  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-10000011-11001011
 // CHECK-INST: umop4a  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcb,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e83cb <unknown>
 
 umop4a  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-10000010-00001000
 // CHECK-INST: umop4a  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81108208 <unknown>
 
 umop4a  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-10000011-10001011
 // CHECK-INST: umop4a  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x8b,0x83,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 8118838b <unknown>
 
 umop4a  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-10000011-11001011
 // CHECK-INST: umop4a  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcb,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e83cb <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 umop4a  za0.d, z0.h, z16.h  // 10100001-11100000-00000000-00001000
 // CHECK-INST: umop4a  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e00008 <unknown>
 
 umop4a  za5.d, z10.h, z20.h  // 10100001-11100100-00000001-01001101
 // CHECK-INST: umop4a  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e4014d <unknown>
 
 umop4a  za7.d, z14.h, z30.h  // 10100001-11101110-00000001-11001111
 // CHECK-INST: umop4a  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ee01cf <unknown>
 
 umop4a  za0.d, z0.h, {z16.h-z17.h}  // 10100001-11110000-00000000-00001000
 // CHECK-INST: umop4a  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f00008 <unknown>
 
 umop4a  za5.d, z10.h, {z20.h-z21.h}  // 10100001-11110100-00000001-01001101
 // CHECK-INST: umop4a  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f4014d <unknown>
 
 umop4a  za7.d, z14.h, {z30.h-z31.h}  // 10100001-11111110-00000001-11001111
 // CHECK-INST: umop4a  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1fe01cf <unknown>
 
 umop4a  za0.d, {z0.h-z1.h}, z16.h  // 10100001-11100000-00000010-00001000
 // CHECK-INST: umop4a  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e00208 <unknown>
 
 umop4a  za5.d, {z10.h-z11.h}, z20.h  // 10100001-11100100-00000011-01001101
 // CHECK-INST: umop4a  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e4034d <unknown>
 
 umop4a  za7.d, {z14.h-z15.h}, z30.h  // 10100001-11101110-00000011-11001111
 // CHECK-INST: umop4a  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ee03cf <unknown>
 
 umop4a  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11110000-00000010-00001000
 // CHECK-INST: umop4a  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f00208 <unknown>
 
 umop4a  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11110100-00000011-01001101
 // CHECK-INST: umop4a  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f4034d <unknown>
 
 umop4a  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11111110-00000011-11001111
 // CHECK-INST: umop4a  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1fe03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 umop4a  za0.d, z0.h, z16.h  // 10100001-11100000-00000000-00001000
 // CHECK-INST: umop4a  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e00008 <unknown>
 
 umop4a  za5.d, z10.h, z20.h  // 10100001-11100100-00000001-01001101
 // CHECK-INST: umop4a  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e4014d <unknown>
 
 umop4a  za7.d, z14.h, z30.h  // 10100001-11101110-00000001-11001111
 // CHECK-INST: umop4a  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ee01cf <unknown>
 
 umop4a  za0.d, z0.h, {z16.h-z17.h}  // 10100001-11110000-00000000-00001000
 // CHECK-INST: umop4a  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f00008 <unknown>
 
 umop4a  za5.d, z10.h, {z20.h-z21.h}  // 10100001-11110100-00000001-01001101
 // CHECK-INST: umop4a  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f4014d <unknown>
 
 umop4a  za7.d, z14.h, {z30.h-z31.h}  // 10100001-11111110-00000001-11001111
 // CHECK-INST: umop4a  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1fe01cf <unknown>
 
 umop4a  za0.d, {z0.h-z1.h}, z16.h  // 10100001-11100000-00000010-00001000
 // CHECK-INST: umop4a  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e00208 <unknown>
 
 umop4a  za5.d, {z10.h-z11.h}, z20.h  // 10100001-11100100-00000011-01001101
 // CHECK-INST: umop4a  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e4034d <unknown>
 
 umop4a  za7.d, {z14.h-z15.h}, z30.h  // 10100001-11101110-00000011-11001111
 // CHECK-INST: umop4a  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ee03cf <unknown>
 
 umop4a  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11110000-00000010-00001000
 // CHECK-INST: umop4a  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f00208 <unknown>
 
 umop4a  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11110100-00000011-01001101
 // CHECK-INST: umop4a  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f4034d <unknown>
 
 umop4a  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11111110-00000011-11001111
 // CHECK-INST: umop4a  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1fe03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-8to32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 umop4a  za0.s, z0.b, z16.b  // 10000001-00100000-10000000-00000000
 // CHECK-INST: umop4a  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81208000 <unknown>
 
 umop4a  za1.s, z10.b, z20.b  // 10000001-00100100-10000001-01000001
 // CHECK-INST: umop4a  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81248141 <unknown>
 
 umop4a  za3.s, z14.b, z30.b  // 10000001-00101110-10000001-11000011
 // CHECK-INST: umop4a  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e81c3 <unknown>
 
 umop4a  za0.s, z0.b, {z16.b-z17.b}  // 10000001-00110000-10000000-00000000
 // CHECK-INST: umop4a  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81308000 <unknown>
 
 umop4a  za1.s, z10.b, {z20.b-z21.b}  // 10000001-00110100-10000001-01000001
 // CHECK-INST: umop4a  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x81,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81348141 <unknown>
 
 umop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000001-00111110-10000001-11000011
 // CHECK-INST: umop4a  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e81c3 <unknown>
 
 umop4a  za0.s, {z0.b-z1.b}, z16.b  // 10000001-00100000-10000010-00000000
 // CHECK-INST: umop4a  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81208200 <unknown>
 
 umop4a  za1.s, {z10.b-z11.b}, z20.b  // 10000001-00100100-10000011-01000001
 // CHECK-INST: umop4a  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81248341 <unknown>
 
 umop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000001-00101110-10000011-11000011
 // CHECK-INST: umop4a  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e83c3 <unknown>
 
 umop4a  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00110000-10000010-00000000
 // CHECK-INST: umop4a  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81308200 <unknown>
 
 umop4a  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00110100-10000011-01000001
 // CHECK-INST: umop4a  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81348341 <unknown>
 
 umop4a  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00111110-10000011-11000011
 // CHECK-INST: umop4a  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-8to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 umop4a  za0.s, z0.b, z16.b  // 10000001-00100000-10000000-00000000
 // CHECK-INST: umop4a  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81208000 <unknown>
 
 umop4a  za1.s, z10.b, z20.b  // 10000001-00100100-10000001-01000001
 // CHECK-INST: umop4a  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81248141 <unknown>
 
 umop4a  za3.s, z14.b, z30.b  // 10000001-00101110-10000001-11000011
 // CHECK-INST: umop4a  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e81c3 <unknown>
 
 umop4a  za0.s, z0.b, {z16.b-z17.b}  // 10000001-00110000-10000000-00000000
 // CHECK-INST: umop4a  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81308000 <unknown>
 
 umop4a  za1.s, z10.b, {z20.b-z21.b}  // 10000001-00110100-10000001-01000001
 // CHECK-INST: umop4a  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x81,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81348141 <unknown>
 
 umop4a  za3.s, z14.b, {z30.b-z31.b}  // 10000001-00111110-10000001-11000011
 // CHECK-INST: umop4a  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e81c3 <unknown>
 
 umop4a  za0.s, {z0.b-z1.b}, z16.b  // 10000001-00100000-10000010-00000000
 // CHECK-INST: umop4a  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81208200 <unknown>
 
 umop4a  za1.s, {z10.b-z11.b}, z20.b  // 10000001-00100100-10000011-01000001
 // CHECK-INST: umop4a  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81248341 <unknown>
 
 umop4a  za3.s, {z14.b-z15.b}, z30.b  // 10000001-00101110-10000011-11000011
 // CHECK-INST: umop4a  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e83c3 <unknown>
 
 umop4a  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00110000-10000010-00000000
 // CHECK-INST: umop4a  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81308200 <unknown>
 
 umop4a  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00110100-10000011-01000001
 // CHECK-INST: umop4a  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81348341 <unknown>
 
 umop4a  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00111110-10000011-11000011
 // CHECK-INST: umop4a  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4a-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4a-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/umop4s-16to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4s-16to32.s
@@ -1,85 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 umop4s  za0.s, z0.h, z16.h  // 10000001-00000000-10000000-00011000
 // CHECK-INST: umop4s  za0.s, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008018 <unknown>
 
 umop4s  za3.s, z12.h, z24.h  // 10000001-00001000-10000001-10011011
 // CHECK-INST: umop4s  za3.s, z12.h, z24.h
 // CHECK-ENCODING: [0x9b,0x81,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8108819b <unknown>
 
 umop4s  za3.s, z14.h, z30.h  // 10000001-00001110-10000001-11011011
 // CHECK-INST: umop4s  za3.s, z14.h, z30.h
 // CHECK-ENCODING: [0xdb,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e81db <unknown>
 
 umop4s  za0.s, z0.h, {z16.h-z17.h}  // 10000001-00010000-10000000-00011000
 // CHECK-INST: umop4s  za0.s, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108018 <unknown>
 
 umop4s  za3.s, z12.h, {z24.h-z25.h}  // 10000001-00011000-10000001-10011011
 // CHECK-INST: umop4s  za3.s, z12.h, { z24.h, z25.h }
 // CHECK-ENCODING: [0x9b,0x81,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8118819b <unknown>
 
 umop4s  za3.s, z14.h, {z30.h-z31.h}  // 10000001-00011110-10000001-11011011
 // CHECK-INST: umop4s  za3.s, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdb,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e81db <unknown>
 
 umop4s  za0.s, {z0.h-z1.h}, z16.h  // 10000001-00000000-10000010-00011000
 // CHECK-INST: umop4s  za0.s, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008218 <unknown>
 
 umop4s  za3.s, {z12.h-z13.h}, z24.h  // 10000001-00001000-10000011-10011011
 // CHECK-INST: umop4s  za3.s, { z12.h, z13.h }, z24.h
 // CHECK-ENCODING: [0x9b,0x83,0x08,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8108839b <unknown>
 
 umop4s  za3.s, {z14.h-z15.h}, z30.h  // 10000001-00001110-10000011-11011011
 // CHECK-INST: umop4s  za3.s, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdb,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e83db <unknown>
 
 umop4s  za0.s, {z0.h-z1.h}, {z16.h-z17.h}  // 10000001-00010000-10000010-00011000
 // CHECK-INST: umop4s  za0.s, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108218 <unknown>
 
 umop4s  za3.s, {z12.h-z13.h}, {z24.h-z25.h}  // 10000001-00011000-10000011-10011011
 // CHECK-INST: umop4s  za3.s, { z12.h, z13.h }, { z24.h, z25.h }
 // CHECK-ENCODING: [0x9b,0x83,0x18,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 8118839b <unknown>
 
 umop4s  za3.s, {z14.h-z15.h}, {z30.h-z31.h}  // 10000001-00011110-10000011-11011011
 // CHECK-INST: umop4s  za3.s, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdb,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e83db <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4s-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 umop4s  za0.d, z0.h, z16.h  // 10100001-11100000-00000000-00011000
 // CHECK-INST: umop4s  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e00018 <unknown>
 
 umop4s  za5.d, z10.h, z20.h  // 10100001-11100100-00000001-01011101
 // CHECK-INST: umop4s  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e4015d <unknown>
 
 umop4s  za7.d, z14.h, z30.h  // 10100001-11101110-00000001-11011111
 // CHECK-INST: umop4s  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ee01df <unknown>
 
 umop4s  za0.d, z0.h, {z16.h-z17.h}  // 10100001-11110000-00000000-00011000
 // CHECK-INST: umop4s  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f00018 <unknown>
 
 umop4s  za5.d, z10.h, {z20.h-z21.h}  // 10100001-11110100-00000001-01011101
 // CHECK-INST: umop4s  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f4015d <unknown>
 
 umop4s  za7.d, z14.h, {z30.h-z31.h}  // 10100001-11111110-00000001-11011111
 // CHECK-INST: umop4s  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1fe01df <unknown>
 
 umop4s  za0.d, {z0.h-z1.h}, z16.h  // 10100001-11100000-00000010-00011000
 // CHECK-INST: umop4s  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e00218 <unknown>
 
 umop4s  za5.d, {z10.h-z11.h}, z20.h  // 10100001-11100100-00000011-01011101
 // CHECK-INST: umop4s  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1e4035d <unknown>
 
 umop4s  za7.d, {z14.h-z15.h}, z30.h  // 10100001-11101110-00000011-11011111
 // CHECK-INST: umop4s  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ee03df <unknown>
 
 umop4s  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11110000-00000010-00011000
 // CHECK-INST: umop4s  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f00218 <unknown>
 
 umop4s  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11110100-00000011-01011101
 // CHECK-INST: umop4s  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1f4035d <unknown>
 
 umop4s  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11111110-00000011-11011111
 // CHECK-INST: umop4s  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1fe03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4s-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 umop4s  za0.d, z0.h, z16.h  // 10100001-11100000-00000000-00011000
 // CHECK-INST: umop4s  za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e00018 <unknown>
 
 umop4s  za5.d, z10.h, z20.h  // 10100001-11100100-00000001-01011101
 // CHECK-INST: umop4s  za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e4015d <unknown>
 
 umop4s  za7.d, z14.h, z30.h  // 10100001-11101110-00000001-11011111
 // CHECK-INST: umop4s  za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ee01df <unknown>
 
 umop4s  za0.d, z0.h, {z16.h-z17.h}  // 10100001-11110000-00000000-00011000
 // CHECK-INST: umop4s  za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f00018 <unknown>
 
 umop4s  za5.d, z10.h, {z20.h-z21.h}  // 10100001-11110100-00000001-01011101
 // CHECK-INST: umop4s  za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f4015d <unknown>
 
 umop4s  za7.d, z14.h, {z30.h-z31.h}  // 10100001-11111110-00000001-11011111
 // CHECK-INST: umop4s  za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1fe01df <unknown>
 
 umop4s  za0.d, {z0.h-z1.h}, z16.h  // 10100001-11100000-00000010-00011000
 // CHECK-INST: umop4s  za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xe0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e00218 <unknown>
 
 umop4s  za5.d, {z10.h-z11.h}, z20.h  // 10100001-11100100-00000011-01011101
 // CHECK-INST: umop4s  za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xe4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1e4035d <unknown>
 
 umop4s  za7.d, {z14.h-z15.h}, z30.h  // 10100001-11101110-00000011-11011111
 // CHECK-INST: umop4s  za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xee,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ee03df <unknown>
 
 umop4s  za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11110000-00000010-00011000
 // CHECK-INST: umop4s  za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xf0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f00218 <unknown>
 
 umop4s  za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11110100-00000011-01011101
 // CHECK-INST: umop4s  za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xf4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1f4035d <unknown>
 
 umop4s  za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11111110-00000011-11011111
 // CHECK-INST: umop4s  za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xfe,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1fe03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4s-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4s-8to32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 umop4s  za0.s, z0.b, z16.b  // 10000001-00100000-10000000-00010000
 // CHECK-INST: umop4s  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81208010 <unknown>
 
 umop4s  za1.s, z10.b, z20.b  // 10000001-00100100-10000001-01010001
 // CHECK-INST: umop4s  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81248151 <unknown>
 
 umop4s  za3.s, z14.b, z30.b  // 10000001-00101110-10000001-11010011
 // CHECK-INST: umop4s  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e81d3 <unknown>
 
 umop4s  za0.s, z0.b, {z16.b-z17.b}  // 10000001-00110000-10000000-00010000
 // CHECK-INST: umop4s  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81308010 <unknown>
 
 umop4s  za1.s, z10.b, {z20.b-z21.b}  // 10000001-00110100-10000001-01010001
 // CHECK-INST: umop4s  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81348151 <unknown>
 
 umop4s  za3.s, z14.b, {z30.b-z31.b}  // 10000001-00111110-10000001-11010011
 // CHECK-INST: umop4s  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e81d3 <unknown>
 
 umop4s  za0.s, {z0.b-z1.b}, z16.b  // 10000001-00100000-10000010-00010000
 // CHECK-INST: umop4s  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81208210 <unknown>
 
 umop4s  za1.s, {z10.b-z11.b}, z20.b  // 10000001-00100100-10000011-01010001
 // CHECK-INST: umop4s  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81248351 <unknown>
 
 umop4s  za3.s, {z14.b-z15.b}, z30.b  // 10000001-00101110-10000011-11010011
 // CHECK-INST: umop4s  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 812e83d3 <unknown>
 
 umop4s  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00110000-10000010-00010000
 // CHECK-INST: umop4s  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81308210 <unknown>
 
 umop4s  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00110100-10000011-01010001
 // CHECK-INST: umop4s  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81348351 <unknown>
 
 umop4s  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00111110-10000011-11010011
 // CHECK-INST: umop4s  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 813e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4s-8to32.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4s-8to32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 umop4s  za0.s, z0.b, z16.b  // 10000001-00100000-10000000-00010000
 // CHECK-INST: umop4s  za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81208010 <unknown>
 
 umop4s  za1.s, z10.b, z20.b  // 10000001-00100100-10000001-01010001
 // CHECK-INST: umop4s  za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81248151 <unknown>
 
 umop4s  za3.s, z14.b, z30.b  // 10000001-00101110-10000001-11010011
 // CHECK-INST: umop4s  za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e81d3 <unknown>
 
 umop4s  za0.s, z0.b, {z16.b-z17.b}  // 10000001-00110000-10000000-00010000
 // CHECK-INST: umop4s  za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81308010 <unknown>
 
 umop4s  za1.s, z10.b, {z20.b-z21.b}  // 10000001-00110100-10000001-01010001
 // CHECK-INST: umop4s  za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81348151 <unknown>
 
 umop4s  za3.s, z14.b, {z30.b-z31.b}  // 10000001-00111110-10000001-11010011
 // CHECK-INST: umop4s  za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e81d3 <unknown>
 
 umop4s  za0.s, {z0.b-z1.b}, z16.b  // 10000001-00100000-10000010-00010000
 // CHECK-INST: umop4s  za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x20,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81208210 <unknown>
 
 umop4s  za1.s, {z10.b-z11.b}, z20.b  // 10000001-00100100-10000011-01010001
 // CHECK-INST: umop4s  za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x24,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81248351 <unknown>
 
 umop4s  za3.s, {z14.b-z15.b}, z30.b  // 10000001-00101110-10000011-11010011
 // CHECK-INST: umop4s  za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x2e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 812e83d3 <unknown>
 
 umop4s  za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00110000-10000010-00010000
 // CHECK-INST: umop4s  za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x30,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81308210 <unknown>
 
 umop4s  za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00110100-10000011-01010001
 // CHECK-INST: umop4s  za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x34,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81348351 <unknown>
 
 umop4s  za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00111110-10000011-11010011
 // CHECK-INST: umop4s  za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x3e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 813e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/umop4s-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/umop4s-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/usmop4a-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4a-32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 usmop4a za0.s, z0.b, z16.b  // 10000001-00000000-10000000-00000000
 // CHECK-INST: usmop4a za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81008000 <unknown>
 
 usmop4a za1.s, z10.b, z20.b  // 10000001-00000100-10000001-01000001
 // CHECK-INST: usmop4a za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81048141 <unknown>
 
 usmop4a za3.s, z14.b, z30.b  // 10000001-00001110-10000001-11000011
 // CHECK-INST: usmop4a za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e81c3 <unknown>
 
 usmop4a za0.s, z0.b, {z16.b-z17.b}  // 10000001-00010000-10000000-00000000
 // CHECK-INST: usmop4a za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81108000 <unknown>
 
 usmop4a za1.s, z10.b, {z20.b-z21.b}  // 10000001-00010100-10000001-01000001
 // CHECK-INST: usmop4a za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x81,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81148141 <unknown>
 
 usmop4a za3.s, z14.b, {z30.b-z31.b}  // 10000001-00011110-10000001-11000011
 // CHECK-INST: usmop4a za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e81c3 <unknown>
 
 usmop4a za0.s, {z0.b-z1.b}, z16.b  // 10000001-00000000-10000010-00000000
 // CHECK-INST: usmop4a za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81008200 <unknown>
 
 usmop4a za1.s, {z10.b-z11.b}, z20.b  // 10000001-00000100-10000011-01000001
 // CHECK-INST: usmop4a za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81048341 <unknown>
 
 usmop4a za3.s, {z14.b-z15.b}, z30.b  // 10000001-00001110-10000011-11000011
 // CHECK-INST: usmop4a za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e83c3 <unknown>
 
 usmop4a za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00010000-10000010-00000000
 // CHECK-INST: usmop4a za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81108200 <unknown>
 
 usmop4a za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00010100-10000011-01000001
 // CHECK-INST: usmop4a za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81148341 <unknown>
 
 usmop4a za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00011110-10000011-11000011
 // CHECK-INST: usmop4a za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4a-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4a-32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 usmop4a za0.s, z0.b, z16.b  // 10000001-00000000-10000000-00000000
 // CHECK-INST: usmop4a za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x00,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008000 <unknown>
 
 usmop4a za1.s, z10.b, z20.b  // 10000001-00000100-10000001-01000001
 // CHECK-INST: usmop4a za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x41,0x81,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81048141 <unknown>
 
 usmop4a za3.s, z14.b, z30.b  // 10000001-00001110-10000001-11000011
 // CHECK-INST: usmop4a za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xc3,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e81c3 <unknown>
 
 usmop4a za0.s, z0.b, {z16.b-z17.b}  // 10000001-00010000-10000000-00000000
 // CHECK-INST: usmop4a za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108000 <unknown>
 
 usmop4a za1.s, z10.b, {z20.b-z21.b}  // 10000001-00010100-10000001-01000001
 // CHECK-INST: usmop4a za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x81,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81148141 <unknown>
 
 usmop4a za3.s, z14.b, {z30.b-z31.b}  // 10000001-00011110-10000001-11000011
 // CHECK-INST: usmop4a za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e81c3 <unknown>
 
 usmop4a za0.s, {z0.b-z1.b}, z16.b  // 10000001-00000000-10000010-00000000
 // CHECK-INST: usmop4a za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x00,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008200 <unknown>
 
 usmop4a za1.s, {z10.b-z11.b}, z20.b  // 10000001-00000100-10000011-01000001
 // CHECK-INST: usmop4a za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x41,0x83,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81048341 <unknown>
 
 usmop4a za3.s, {z14.b-z15.b}, z30.b  // 10000001-00001110-10000011-11000011
 // CHECK-INST: usmop4a za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xc3,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e83c3 <unknown>
 
 usmop4a za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00010000-10000010-00000000
 // CHECK-INST: usmop4a za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x00,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108200 <unknown>
 
 usmop4a za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00010100-10000011-01000001
 // CHECK-INST: usmop4a za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x41,0x83,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81148341 <unknown>
 
 usmop4a za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00011110-10000011-11000011
 // CHECK-INST: usmop4a za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xc3,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e83c3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4a-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 usmop4a za0.d, z0.h, z16.h  // 10100001-11000000-00000000-00001000
 // CHECK-INST: usmop4a za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c00008 <unknown>
 
 usmop4a za5.d, z10.h, z20.h  // 10100001-11000100-00000001-01001101
 // CHECK-INST: usmop4a za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c4014d <unknown>
 
 usmop4a za7.d, z14.h, z30.h  // 10100001-11001110-00000001-11001111
 // CHECK-INST: usmop4a za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ce01cf <unknown>
 
 usmop4a za0.d, z0.h, {z16.h-z17.h}  // 10100001-11010000-00000000-00001000
 // CHECK-INST: usmop4a za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d00008 <unknown>
 
 usmop4a za5.d, z10.h, {z20.h-z21.h}  // 10100001-11010100-00000001-01001101
 // CHECK-INST: usmop4a za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d4014d <unknown>
 
 usmop4a za7.d, z14.h, {z30.h-z31.h}  // 10100001-11011110-00000001-11001111
 // CHECK-INST: usmop4a za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1de01cf <unknown>
 
 usmop4a za0.d, {z0.h-z1.h}, z16.h  // 10100001-11000000-00000010-00001000
 // CHECK-INST: usmop4a za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c00208 <unknown>
 
 usmop4a za5.d, {z10.h-z11.h}, z20.h  // 10100001-11000100-00000011-01001101
 // CHECK-INST: usmop4a za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c4034d <unknown>
 
 usmop4a za7.d, {z14.h-z15.h}, z30.h  // 10100001-11001110-00000011-11001111
 // CHECK-INST: usmop4a za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ce03cf <unknown>
 
 usmop4a za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11010000-00000010-00001000
 // CHECK-INST: usmop4a za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d00208 <unknown>
 
 usmop4a za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11010100-00000011-01001101
 // CHECK-INST: usmop4a za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d4034d <unknown>
 
 usmop4a za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11011110-00000011-11001111
 // CHECK-INST: usmop4a za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1de03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4a-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4a-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 usmop4a za0.d, z0.h, z16.h  // 10100001-11000000-00000000-00001000
 // CHECK-INST: usmop4a za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x08,0x00,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c00008 <unknown>
 
 usmop4a za5.d, z10.h, z20.h  // 10100001-11000100-00000001-01001101
 // CHECK-INST: usmop4a za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x4d,0x01,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c4014d <unknown>
 
 usmop4a za7.d, z14.h, z30.h  // 10100001-11001110-00000001-11001111
 // CHECK-INST: usmop4a za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xcf,0x01,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ce01cf <unknown>
 
 usmop4a za0.d, z0.h, {z16.h-z17.h}  // 10100001-11010000-00000000-00001000
 // CHECK-INST: usmop4a za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x00,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d00008 <unknown>
 
 usmop4a za5.d, z10.h, {z20.h-z21.h}  // 10100001-11010100-00000001-01001101
 // CHECK-INST: usmop4a za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x01,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d4014d <unknown>
 
 usmop4a za7.d, z14.h, {z30.h-z31.h}  // 10100001-11011110-00000001-11001111
 // CHECK-INST: usmop4a za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x01,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1de01cf <unknown>
 
 usmop4a za0.d, {z0.h-z1.h}, z16.h  // 10100001-11000000-00000010-00001000
 // CHECK-INST: usmop4a za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x08,0x02,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c00208 <unknown>
 
 usmop4a za5.d, {z10.h-z11.h}, z20.h  // 10100001-11000100-00000011-01001101
 // CHECK-INST: usmop4a za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x4d,0x03,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c4034d <unknown>
 
 usmop4a za7.d, {z14.h-z15.h}, z30.h  // 10100001-11001110-00000011-11001111
 // CHECK-INST: usmop4a za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xcf,0x03,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ce03cf <unknown>
 
 usmop4a za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11010000-00000010-00001000
 // CHECK-INST: usmop4a za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x08,0x02,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d00208 <unknown>
 
 usmop4a za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11010100-00000011-01001101
 // CHECK-INST: usmop4a za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x4d,0x03,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d4034d <unknown>
 
 usmop4a za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11011110-00000011-11001111
 // CHECK-INST: usmop4a za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xcf,0x03,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1de03cf <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4a-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4a-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/usmop4s-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4s-32.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 usmop4s za0.s, z0.b, z16.b  // 10000001-00000000-10000000-00010000
 // CHECK-INST: usmop4s za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008010 <unknown>
 
 usmop4s za1.s, z10.b, z20.b  // 10000001-00000100-10000001-01010001
 // CHECK-INST: usmop4s za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81048151 <unknown>
 
 usmop4s za3.s, z14.b, z30.b  // 10000001-00001110-10000001-11010011
 // CHECK-INST: usmop4s za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e81d3 <unknown>
 
 usmop4s za0.s, z0.b, {z16.b-z17.b}  // 10000001-00010000-10000000-00010000
 // CHECK-INST: usmop4s za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108010 <unknown>
 
 usmop4s za1.s, z10.b, {z20.b-z21.b}  // 10000001-00010100-10000001-01010001
 // CHECK-INST: usmop4s za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81148151 <unknown>
 
 usmop4s za3.s, z14.b, {z30.b-z31.b}  // 10000001-00011110-10000001-11010011
 // CHECK-INST: usmop4s za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e81d3 <unknown>
 
 usmop4s za0.s, {z0.b-z1.b}, z16.b  // 10000001-00000000-10000010-00010000
 // CHECK-INST: usmop4s za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81008210 <unknown>
 
 usmop4s za1.s, {z10.b-z11.b}, z20.b  // 10000001-00000100-10000011-01010001
 // CHECK-INST: usmop4s za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81048351 <unknown>
 
 usmop4s za3.s, {z14.b-z15.b}, z30.b  // 10000001-00001110-10000011-11010011
 // CHECK-INST: usmop4s za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 810e83d3 <unknown>
 
 usmop4s za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00010000-10000010-00010000
 // CHECK-INST: usmop4s za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81108210 <unknown>
 
 usmop4s za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00010100-10000011-01010001
 // CHECK-INST: usmop4s za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 81148351 <unknown>
 
 usmop4s za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00011110-10000011-11010011
 // CHECK-INST: usmop4s za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-mop4
 // CHECK-UNKNOWN: 811e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4s-32.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4s-32.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,71 +17,71 @@
 usmop4s za0.s, z0.b, z16.b  // 10000001-00000000-10000000-00010000
 // CHECK-INST: usmop4s za0.s, z0.b, z16.b
 // CHECK-ENCODING: [0x10,0x80,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81008010 <unknown>
 
 usmop4s za1.s, z10.b, z20.b  // 10000001-00000100-10000001-01010001
 // CHECK-INST: usmop4s za1.s, z10.b, z20.b
 // CHECK-ENCODING: [0x51,0x81,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81048151 <unknown>
 
 usmop4s za3.s, z14.b, z30.b  // 10000001-00001110-10000001-11010011
 // CHECK-INST: usmop4s za3.s, z14.b, z30.b
 // CHECK-ENCODING: [0xd3,0x81,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e81d3 <unknown>
 
 usmop4s za0.s, z0.b, {z16.b-z17.b}  // 10000001-00010000-10000000-00010000
 // CHECK-INST: usmop4s za0.s, z0.b, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x80,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81108010 <unknown>
 
 usmop4s za1.s, z10.b, {z20.b-z21.b}  // 10000001-00010100-10000001-01010001
 // CHECK-INST: usmop4s za1.s, z10.b, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x81,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81148151 <unknown>
 
 usmop4s za3.s, z14.b, {z30.b-z31.b}  // 10000001-00011110-10000001-11010011
 // CHECK-INST: usmop4s za3.s, z14.b, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x81,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e81d3 <unknown>
 
 usmop4s za0.s, {z0.b-z1.b}, z16.b  // 10000001-00000000-10000010-00010000
 // CHECK-INST: usmop4s za0.s, { z0.b, z1.b }, z16.b
 // CHECK-ENCODING: [0x10,0x82,0x00,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81008210 <unknown>
 
 usmop4s za1.s, {z10.b-z11.b}, z20.b  // 10000001-00000100-10000011-01010001
 // CHECK-INST: usmop4s za1.s, { z10.b, z11.b }, z20.b
 // CHECK-ENCODING: [0x51,0x83,0x04,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81048351 <unknown>
 
 usmop4s za3.s, {z14.b-z15.b}, z30.b  // 10000001-00001110-10000011-11010011
 // CHECK-INST: usmop4s za3.s, { z14.b, z15.b }, z30.b
 // CHECK-ENCODING: [0xd3,0x83,0x0e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 810e83d3 <unknown>
 
 usmop4s za0.s, {z0.b-z1.b}, {z16.b-z17.b}  // 10000001-00010000-10000010-00010000
 // CHECK-INST: usmop4s za0.s, { z0.b, z1.b }, { z16.b, z17.b }
 // CHECK-ENCODING: [0x10,0x82,0x10,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81108210 <unknown>
 
 usmop4s za1.s, {z10.b-z11.b}, {z20.b-z21.b}  // 10000001-00010100-10000011-01010001
 // CHECK-INST: usmop4s za1.s, { z10.b, z11.b }, { z20.b, z21.b }
 // CHECK-ENCODING: [0x51,0x83,0x14,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 81148351 <unknown>
 
 usmop4s za3.s, {z14.b-z15.b}, {z30.b-z31.b}  // 10000001-00011110-10000011-11010011
 // CHECK-INST: usmop4s za3.s, { z14.b, z15.b }, { z30.b, z31.b }
 // CHECK-ENCODING: [0xd3,0x83,0x1e,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: 811e83d3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4s-64.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
@@ -15,71 +17,71 @@
 usmop4s za0.d, z0.h, z16.h  // 10100001-11000000-00000000-00011000
 // CHECK-INST: usmop4s za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c00018 <unknown>
 
 usmop4s za5.d, z10.h, z20.h  // 10100001-11000100-00000001-01011101
 // CHECK-INST: usmop4s za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c4015d <unknown>
 
 usmop4s za7.d, z14.h, z30.h  // 10100001-11001110-00000001-11011111
 // CHECK-INST: usmop4s za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ce01df <unknown>
 
 usmop4s za0.d, z0.h, {z16.h-z17.h}  // 10100001-11010000-00000000-00011000
 // CHECK-INST: usmop4s za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d00018 <unknown>
 
 usmop4s za5.d, z10.h, {z20.h-z21.h}  // 10100001-11010100-00000001-01011101
 // CHECK-INST: usmop4s za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d4015d <unknown>
 
 usmop4s za7.d, z14.h, {z30.h-z31.h}  // 10100001-11011110-00000001-11011111
 // CHECK-INST: usmop4s za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1de01df <unknown>
 
 usmop4s za0.d, {z0.h-z1.h}, z16.h  // 10100001-11000000-00000010-00011000
 // CHECK-INST: usmop4s za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c00218 <unknown>
 
 usmop4s za5.d, {z10.h-z11.h}, z20.h  // 10100001-11000100-00000011-01011101
 // CHECK-INST: usmop4s za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1c4035d <unknown>
 
 usmop4s za7.d, {z14.h-z15.h}, z30.h  // 10100001-11001110-00000011-11011111
 // CHECK-INST: usmop4s za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1ce03df <unknown>
 
 usmop4s za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11010000-00000010-00011000
 // CHECK-INST: usmop4s za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d00218 <unknown>
 
 usmop4s za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11010100-00000011-01011101
 // CHECK-INST: usmop4s za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1d4035d <unknown>
 
 usmop4s za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11011110-00000011-11011111
 // CHECK-INST: usmop4s za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
 // CHECK-UNKNOWN: a1de03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4s-64.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4s-64.s
@@ -1,87 +1,85 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2,+sme-i16i64 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-mop4,+sme-i16i64 - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-mop4,+sme-i16i64 < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-mop4 - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2,+sme-i16i64 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-mop4,+sme-i16i64 -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 usmop4s za0.d, z0.h, z16.h  // 10100001-11000000-00000000-00011000
 // CHECK-INST: usmop4s za0.d, z0.h, z16.h
 // CHECK-ENCODING: [0x18,0x00,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c00018 <unknown>
 
 usmop4s za5.d, z10.h, z20.h  // 10100001-11000100-00000001-01011101
 // CHECK-INST: usmop4s za5.d, z10.h, z20.h
 // CHECK-ENCODING: [0x5d,0x01,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c4015d <unknown>
 
 usmop4s za7.d, z14.h, z30.h  // 10100001-11001110-00000001-11011111
 // CHECK-INST: usmop4s za7.d, z14.h, z30.h
 // CHECK-ENCODING: [0xdf,0x01,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ce01df <unknown>
 
 usmop4s za0.d, z0.h, {z16.h-z17.h}  // 10100001-11010000-00000000-00011000
 // CHECK-INST: usmop4s za0.d, z0.h, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x00,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d00018 <unknown>
 
 usmop4s za5.d, z10.h, {z20.h-z21.h}  // 10100001-11010100-00000001-01011101
 // CHECK-INST: usmop4s za5.d, z10.h, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x01,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d4015d <unknown>
 
 usmop4s za7.d, z14.h, {z30.h-z31.h}  // 10100001-11011110-00000001-11011111
 // CHECK-INST: usmop4s za7.d, z14.h, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x01,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1de01df <unknown>
 
 usmop4s za0.d, {z0.h-z1.h}, z16.h  // 10100001-11000000-00000010-00011000
 // CHECK-INST: usmop4s za0.d, { z0.h, z1.h }, z16.h
 // CHECK-ENCODING: [0x18,0x02,0xc0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c00218 <unknown>
 
 usmop4s za5.d, {z10.h-z11.h}, z20.h  // 10100001-11000100-00000011-01011101
 // CHECK-INST: usmop4s za5.d, { z10.h, z11.h }, z20.h
 // CHECK-ENCODING: [0x5d,0x03,0xc4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1c4035d <unknown>
 
 usmop4s za7.d, {z14.h-z15.h}, z30.h  // 10100001-11001110-00000011-11011111
 // CHECK-INST: usmop4s za7.d, { z14.h, z15.h }, z30.h
 // CHECK-ENCODING: [0xdf,0x03,0xce,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1ce03df <unknown>
 
 usmop4s za0.d, {z0.h-z1.h}, {z16.h-z17.h}  // 10100001-11010000-00000010-00011000
 // CHECK-INST: usmop4s za0.d, { z0.h, z1.h }, { z16.h, z17.h }
 // CHECK-ENCODING: [0x18,0x02,0xd0,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d00218 <unknown>
 
 usmop4s za5.d, {z10.h-z11.h}, {z20.h-z21.h}  // 10100001-11010100-00000011-01011101
 // CHECK-INST: usmop4s za5.d, { z10.h, z11.h }, { z20.h, z21.h }
 // CHECK-ENCODING: [0x5d,0x03,0xd4,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1d4035d <unknown>
 
 usmop4s za7.d, {z14.h-z15.h}, {z30.h-z31.h}  // 10100001-11011110-00000011-11011111
 // CHECK-INST: usmop4s za7.d, { z14.h, z15.h }, { z30.h, z31.h }
 // CHECK-ENCODING: [0xdf,0x03,0xde,0xa1]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-mop4
+// CHECK-ERROR: instruction requires: sme-i16i64 sme-mop4
 // CHECK-UNKNOWN: a1de03df <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/usmop4s-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/usmop4s-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2,+sme-i16i64 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-mop4,+sme-i16i64 2>&1 < %s| FileCheck %s
 
 // ------------------------------------------------------------------------- //
 // Invalid tile

--- a/llvm/test/MC/AArch64/SME2p2/ustmopa-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/ustmopa-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop 2>&1 < %s| FileCheck %s
 
 // --------------------------------------------------------------------------//
 // Invalid ZA register

--- a/llvm/test/MC/AArch64/SME2p2/ustmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/ustmopa.s
@@ -1,33 +1,31 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-tmop -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 ustmopa za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000001-01000000-10000000-00000000
 // CHECK-INST: ustmopa za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81408000 <unknown>
 
 ustmopa za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000001-01001000-10001101-10110011
 // CHECK-INST: ustmopa za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x8d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81488db3 <unknown>
 
 ustmopa za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000001-01011111-10011111-11110011
 // CHECK-INST: ustmopa za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 815f9ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/ustmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/ustmopa.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,17 +17,17 @@
 ustmopa za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000001-01000000-10000000-00000000
 // CHECK-INST: ustmopa za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81408000 <unknown>
 
 ustmopa za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000001-01001000-10001101-10110011
 // CHECK-INST: ustmopa za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x8d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81488db3 <unknown>
 
 ustmopa za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000001-01011111-10011111-11110011
 // CHECK-INST: ustmopa za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 815f9ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/utmopa-diagnostics.s
+++ b/llvm/test/MC/AArch64/SME2p2/utmopa-diagnostics.s
@@ -1,4 +1,4 @@
-// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 2>&1 < %s| FileCheck %s
+// RUN: not llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop 2>&1 < %s| FileCheck %s
 
 // --------------------------------------------------------------------------//
 // Invalid ZA register

--- a/llvm/test/MC/AArch64/SME2p2/utmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/utmopa.s
@@ -1,51 +1,49 @@
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
-// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=+sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
-// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
-// RUN:        | llvm-objdump -d --mattr=-sme2p2 --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=+sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme-tmop < %s \
+// RUN:        | llvm-objdump -d --mattr=-sme-tmop --no-print-imm-hex - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 // Disassemble encoding and check the re-encoding (-show-encoding) matches.
-// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
 // RUN:        | sed '/.text/d' | sed 's/.*encoding: //g' \
-// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme2p2 -disassemble -show-encoding \
+// RUN:        | llvm-mc -triple=aarch64 -mattr=+sme-tmop -disassemble -show-encoding \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 
 utmopa  za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01000000-10000000-00001000
 // CHECK-INST: utmopa  za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x80,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81408008 <unknown>
 
 utmopa  za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01001000-10001101-10111011
 // CHECK-INST: utmopa  za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xbb,0x8d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81488dbb <unknown>
 
 utmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-10011111-11111011
 // CHECK-INST: utmopa  za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xfb,0x9f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 815f9ffb <unknown>
 
 utmopa  za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000001-01100000-10000000-00000000
 // CHECK-INST: utmopa  za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x60,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81608000 <unknown>
 
 utmopa  za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000001-01101000-10001101-10110011
 // CHECK-INST: utmopa  za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x8d,0x68,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 81688db3 <unknown>
 
 utmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000001-01111111-10011111-11110011
 // CHECK-INST: utmopa  za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x7f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
+// CHECK-ERROR: instruction requires: sme-tmop
 // CHECK-UNKNOWN: 817f9ff3 <unknown>

--- a/llvm/test/MC/AArch64/SME2p2/utmopa.s
+++ b/llvm/test/MC/AArch64/SME2p2/utmopa.s
@@ -1,5 +1,7 @@
 // RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme2p2 < %s \
 // RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+// RUN: llvm-mc -triple=aarch64 -show-encoding -mattr=+sme-tmop < %s \
+// RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 // RUN: not llvm-mc -triple=aarch64 -show-encoding < %s 2>&1 \
 // RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
 // RUN: llvm-mc -triple=aarch64 -filetype=obj -mattr=+sme2p2 < %s \
@@ -15,35 +17,35 @@
 utmopa  za0.s, {z0.h-z1.h}, z0.h, z20[0]  // 10000001-01000000-10000000-00001000
 // CHECK-INST: utmopa  za0.s, { z0.h, z1.h }, z0.h, z20[0]
 // CHECK-ENCODING: [0x08,0x80,0x40,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81408008 <unknown>
 
 utmopa  za3.s, {z12.h-z13.h}, z8.h, z23[3]  // 10000001-01001000-10001101-10111011
 // CHECK-INST: utmopa  za3.s, { z12.h, z13.h }, z8.h, z23[3]
 // CHECK-ENCODING: [0xbb,0x8d,0x48,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81488dbb <unknown>
 
 utmopa  za3.s, {z30.h-z31.h}, z31.h, z31[3]  // 10000001-01011111-10011111-11111011
 // CHECK-INST: utmopa  za3.s, { z30.h, z31.h }, z31.h, z31[3]
 // CHECK-ENCODING: [0xfb,0x9f,0x5f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 815f9ffb <unknown>
 
 utmopa  za0.s, {z0.b-z1.b}, z0.b, z20[0]  // 10000001-01100000-10000000-00000000
 // CHECK-INST: utmopa  za0.s, { z0.b, z1.b }, z0.b, z20[0]
 // CHECK-ENCODING: [0x00,0x80,0x60,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81608000 <unknown>
 
 utmopa  za3.s, {z12.b-z13.b}, z8.b, z23[3]  // 10000001-01101000-10001101-10110011
 // CHECK-INST: utmopa  za3.s, { z12.b, z13.b }, z8.b, z23[3]
 // CHECK-ENCODING: [0xb3,0x8d,0x68,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 81688db3 <unknown>
 
 utmopa  za3.s, {z30.b-z31.b}, z31.b, z31[3]  // 10000001-01111111-10011111-11110011
 // CHECK-INST: utmopa  za3.s, { z30.b, z31.b }, z31.b, z31[3]
 // CHECK-ENCODING: [0xf3,0x9f,0x7f,0x81]
-// CHECK-ERROR: instruction requires: sme2p2
+// CHECK-ERROR: instruction requires: sme2p2 or sme-tmop
 // CHECK-UNKNOWN: 817f9ff3 <unknown>

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1343,7 +1343,8 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
       AArch64::AEK_FPRCVT,       AArch64::AEK_CMPBR,
       AArch64::AEK_LSUI,         AArch64::AEK_OCCMO,
       AArch64::AEK_PCDPHINT,     AArch64::AEK_POPS,
-      AArch64::AEK_SVEAES,       AArch64::AEK_SVEBITPERM,
+      AArch64::AEK_SVEAES,       AArch64::AEK_SME_MOP4,
+      AArch64::AEK_SME_TMOP,      AArch64::AEK_SVEBITPERM,
       AArch64::AEK_SSVE_BITPERM,
   };
 
@@ -1452,6 +1453,8 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
   EXPECT_TRUE(llvm::is_contained(Features, "+occmo"));
   EXPECT_TRUE(llvm::is_contained(Features, "+pcdphint"));
   EXPECT_TRUE(llvm::is_contained(Features, "+pops"));
+  EXPECT_TRUE(llvm::is_contained(Features, "+sme-mop4"));
+  EXPECT_TRUE(llvm::is_contained(Features, "+sme-tmop"));
 
   // Assuming we listed every extension above, this should produce the same
   // result.
@@ -1611,6 +1614,8 @@ TEST(TargetParserTest, AArch64ArchExtFeature) {
       {"occmo", "nooccmo", "+occmo", "-occmo"},
       {"pcdphint", "nopcdphint", "+pcdphint", "-pcdphint"},
       {"pops", "nopops", "+pops", "-pops"},
+      {"sme-mop4", "nosme-mop4", "+sme-mop4", "-sme-mop4"},
+      {"sme-tmop", "nosme-tmop", "+sme-tmop", "-sme-tmop"},
   };
 
   for (unsigned i = 0; i < std::size(ArchExt); i++) {

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1344,7 +1344,7 @@ TEST(TargetParserTest, AArch64ExtensionFeatures) {
       AArch64::AEK_LSUI,         AArch64::AEK_OCCMO,
       AArch64::AEK_PCDPHINT,     AArch64::AEK_POPS,
       AArch64::AEK_SVEAES,       AArch64::AEK_SME_MOP4,
-      AArch64::AEK_SME_TMOP,      AArch64::AEK_SVEBITPERM,
+      AArch64::AEK_SME_TMOP,     AArch64::AEK_SVEBITPERM,
       AArch64::AEK_SSVE_BITPERM,
   };
 

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2041,8 +2041,8 @@ AArch64ExtensionDependenciesBaseArchTestParams
          {"sve2-aes", "sve-aes"}},
 
         // sme-tmop -> sme
-        {AArch64::ARMV8A, {"nosme", "sme-tmop"}, {"sme", "sme-tmop"}, {}},
-        {AArch64::ARMV8A, {"sme-tmop", "nosme"}, {}, {"sme", "sme-tmop"}},
+        {AArch64::ARMV8A, {"nosme2", "sme-tmop"}, {"sme2", "sme-tmop"}, {}},
+        {AArch64::ARMV8A, {"sme-tmop", "nosme2"}, {}, {"sme2", "sme-tmop"}},
 
         // sme-mop4 -> sme
         {AArch64::ARMV8A, {"nosme", "sme-mop4"}, {"sme", "sme-mop4"}, {}},

--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -2038,7 +2038,15 @@ AArch64ExtensionDependenciesBaseArchTestParams
         {AArch64::ARMV9_6A,
          {"sve2", "sve-aes", "nosve2-aes"},
          {"sve2"},
-         {"sve2-aes", "sve-aes"}}};
+         {"sve2-aes", "sve-aes"}},
+
+        // sme-tmop -> sme
+        {AArch64::ARMV8A, {"nosme", "sme-tmop"}, {"sme", "sme-tmop"}, {}},
+        {AArch64::ARMV8A, {"sme-tmop", "nosme"}, {}, {"sme", "sme-tmop"}},
+
+        // sme-mop4 -> sme
+        {AArch64::ARMV8A, {"nosme", "sme-mop4"}, {"sme", "sme-mop4"}, {}},
+        {AArch64::ARMV8A, {"sme-mop4", "nosme"}, {}, {"sme", "sme-mop4"}}};
 
 INSTANTIATE_TEST_SUITE_P(
     AArch64ExtensionDependenciesBaseArch,


### PR DESCRIPTION
The 2024-12 ISA spec release[1] add these features:
 FEAT_SME_MOP4(sme-mop4) to enable SME Quarter-tile outer product instructions
and
 FEAT_SME_TMOP(sme-tmop) to enable SME Structured sparsity outer product instructions
to allow these instructions to be available outside Armv9.6/sme2p2

[1] https://developer.arm.com/Architectures/A-Profile%20Architecture#Downloads