### PR TITLE
[ValueTracking] Handle flipped strictness cases in `matchSelectPattern`

### DIFF
--- a/clang/test/CodeGen/attr-counted-by-pr110385.c
+++ b/clang/test/CodeGen/attr-counted-by-pr110385.c
@@ -33,11 +33,10 @@ void init(void * __attribute__((pass_dynamic_object_size(0))));
 // CHECK-NEXT:    [[ARRAY:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP0]], i64 12
 // CHECK-NEXT:    [[COUNTED_BY_GEP:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP0]], i64 8
 // CHECK-NEXT:    [[COUNTED_BY_LOAD:%.*]] = load i32, ptr [[COUNTED_BY_GEP]], align 4
-// CHECK-NEXT:    [[TMP1:%.*]] = sext i32 [[COUNTED_BY_LOAD]] to i64
-// CHECK-NEXT:    [[TMP2:%.*]] = shl nsw i64 [[TMP1]], 1
-// CHECK-NEXT:    [[TMP3:%.*]] = icmp sgt i32 [[COUNTED_BY_LOAD]], -1
-// CHECK-NEXT:    [[TMP4:%.*]] = select i1 [[TMP3]], i64 [[TMP2]], i64 0
-// CHECK-NEXT:    tail call void @init(ptr noundef nonnull [[ARRAY]], i64 noundef [[TMP4]]) #[[ATTR2:[0-9]+]]
+// CHECK-NEXT:    [[COUNT:%.*]] = sext i32 [[COUNTED_BY_LOAD]] to i64
+// CHECK-NEXT:    [[FLEXIBLE_ARRAY_MEMBER_SIZE:%.*]] = shl nsw i64 [[COUNT]], 1
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call i64 @llvm.smax.i64(i64 [[FLEXIBLE_ARRAY_MEMBER_SIZE]], i64 0)
+// CHECK-NEXT:    tail call void @init(ptr noundef nonnull [[ARRAY]], i64 noundef [[TMP1]]) #[[ATTR3:[0-9]+]]
 // CHECK-NEXT:    ret void
 //
 void test1(struct bucket *foo) {
@@ -50,11 +49,10 @@ void test1(struct bucket *foo) {
 // CHECK-NEXT:    [[ARRAY:%.*]] = getelementptr inbounds nuw i8, ptr [[FOO]], i64 16
 // CHECK-NEXT:    [[COUNTED_BY_GEP:%.*]] = getelementptr inbounds nuw i8, ptr [[FOO]], i64 12
 // CHECK-NEXT:    [[COUNTED_BY_LOAD:%.*]] = load i32, ptr [[COUNTED_BY_GEP]], align 4
-// CHECK-NEXT:    [[TMP0:%.*]] = sext i32 [[COUNTED_BY_LOAD]] to i64
-// CHECK-NEXT:    [[TMP1:%.*]] = shl nsw i64 [[TMP0]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = icmp sgt i32 [[COUNTED_BY_LOAD]], -1
-// CHECK-NEXT:    [[TMP3:%.*]] = select i1 [[TMP2]], i64 [[TMP1]], i64 0
-// CHECK-NEXT:    tail call void @init(ptr noundef nonnull [[ARRAY]], i64 noundef [[TMP3]]) #[[ATTR2]]
+// CHECK-NEXT:    [[COUNT:%.*]] = sext i32 [[COUNTED_BY_LOAD]] to i64
+// CHECK-NEXT:    [[FLEXIBLE_ARRAY_MEMBER_SIZE:%.*]] = shl nsw i64 [[COUNT]], 1
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.smax.i64(i64 [[FLEXIBLE_ARRAY_MEMBER_SIZE]], i64 0)
+// CHECK-NEXT:    tail call void @init(ptr noundef nonnull [[ARRAY]], i64 noundef [[TMP0]]) #[[ATTR3]]
 // CHECK-NEXT:    ret void
 //
 void test2(struct bucket2 *foo) {

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8518,7 +8518,7 @@ static SelectPatternResult matchMinMax(CmpInst::Predicate Pred,
   RHS = FalseVal;
 
   // Handle constant RHS cases like X < 3 ? 2 : X -> max(X, 2)
-  auto *CmpRHSC = dyn_cast<ConstantInt>(CmpRHS);
+  auto *CmpRHSC = dyn_cast<Constant>(CmpRHS);
   if (ICmpInst::isRelational(Pred) && CmpRHSC) {
     if (auto Flipped =
             getFlippedStrictnessPredicateAndConstant(Pred, CmpRHSC)) {

--- a/llvm/test/CodeGen/RISCV/selectcc-to-shiftand.ll
+++ b/llvm/test/CodeGen/RISCV/selectcc-to-shiftand.ll
@@ -60,11 +60,27 @@ define i32 @neg_sel_variable_and_zero(i32 signext %a, i32 signext %b) {
 ; Compare if not positive and select the same variable as being compared:
 ; smin(a, 0).
 define i32 @not_pos_sel_same_variable(i32 signext %a) {
-; CHECK-LABEL: not_pos_sel_same_variable:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    srai a1, a0, 31
-; CHECK-NEXT:    and a0, a1, a0
-; CHECK-NEXT:    ret
+; RV32I-LABEL: not_pos_sel_same_variable:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    srai a1, a0, 31
+; RV32I-NEXT:    and a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV64I-LABEL: not_pos_sel_same_variable:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    srai a1, a0, 31
+; RV64I-NEXT:    and a0, a1, a0
+; RV64I-NEXT:    ret
+;
+; RV32ZBB-LABEL: not_pos_sel_same_variable:
+; RV32ZBB:       # %bb.0:
+; RV32ZBB-NEXT:    min a0, a0, zero
+; RV32ZBB-NEXT:    ret
+;
+; RV64ZBB-LABEL: not_pos_sel_same_variable:
+; RV64ZBB:       # %bb.0:
+; RV64ZBB-NEXT:    min a0, a0, zero
+; RV64ZBB-NEXT:    ret
   %tmp = icmp slt i32 %a, 1
   %min = select i1 %tmp, i32 %a, i32 0
   ret i32 %min

--- a/llvm/test/Transforms/CorrelatedValuePropagation/switch.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/switch.ll
@@ -199,11 +199,13 @@ define i32 @test_unreachable_default_cond_may_be_undef(i32 %num) {
 ; CHECK:       sw.bb4:
 ; CHECK-NEXT:    [[CALL5:%.*]] = call i32 @call2()
 ; CHECK-NEXT:    br label [[CLEANUP]]
+; CHECK:       default.unreachable:
+; CHECK-NEXT:    unreachable
 ; CHECK:       sw.default:
 ; CHECK-NEXT:    [[CALL6:%.*]] = call i32 @call3()
 ; CHECK-NEXT:    br label [[CLEANUP]]
 ; CHECK:       cleanup:
-; CHECK-NEXT:    [[RETVAL_0:%.*]] = phi i32 [ [[CALL6]], [[SW_DEFAULT]] ], [ [[CALL5]], [[SW_BB4]] ], [ [[CALL3]], [[SW_BB2]] ], [ [[CALL]], [[SW_BB]] ]
+; CHECK-NEXT:    [[RETVAL_0:%.*]] = phi i32 [ [[CALL6]], [[SW_DEFAULT1:%.*]] ], [ [[CALL5]], [[SW_BB4]] ], [ [[CALL3]], [[SW_BB2]] ], [ [[CALL]], [[SW_BB]] ]
 ; CHECK-NEXT:    ret i32 [[RETVAL_0]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/minmax-fp.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fp.ll
@@ -265,6 +265,44 @@ define double @t17(i32 %x) {
   ret double %sel
 }
 
+define double @t17_commuted1(i32 %x) {
+; CHECK-LABEL: @t17_commuted1(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[X:%.*]], 3
+; CHECK-NEXT:    [[CST:%.*]] = sitofp i32 [[X]] to double
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double 2.000000e+00, double [[CST]]
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp = icmp slt i32 %x, 3
+  %cst = sitofp i32 %x to double
+  %sel = select i1 %cmp, double 2.0, double %cst
+  ret double %sel
+}
+
+define double @t17_commuted2(i32 %x) {
+; CHECK-LABEL: @t17_commuted2(
+; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smin.i32(i32 [[X:%.*]], i32 2)
+; CHECK-NEXT:    [[SEL:%.*]] = sitofp i32 [[SEL1]] to double
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp = icmp sgt i32 %x, 2
+  %cst = sitofp i32 %x to double
+  %sel = select i1 %cmp, double 2.0, double %cst
+  ret double %sel
+}
+
+define double @t17_commuted3(i32 %x) {
+; CHECK-LABEL: @t17_commuted3(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[X:%.*]], 3
+; CHECK-NEXT:    [[CST:%.*]] = sitofp i32 [[X]] to double
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[CST]], double 2.000000e+00
+; CHECK-NEXT:    ret double [[SEL]]
+;
+  %cmp = icmp slt i32 %x, 3
+  %cst = sitofp i32 %x to double
+  %sel = select i1 %cmp, double %cst, double 2.0
+  ret double %sel
+}
+
 define float @fneg_fmax(float %x, float %y) {
 ; CHECK-LABEL: @fneg_fmax(
 ; CHECK-NEXT:    [[COND:%.*]] = fcmp nnan olt float [[X:%.*]], [[Y:%.*]]

--- a/llvm/test/Transforms/InstCombine/minmax-fp.ll
+++ b/llvm/test/Transforms/InstCombine/minmax-fp.ll
@@ -267,9 +267,8 @@ define double @t17(i32 %x) {
 
 define double @t17_commuted1(i32 %x) {
 ; CHECK-LABEL: @t17_commuted1(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[X:%.*]], 3
-; CHECK-NEXT:    [[CST:%.*]] = sitofp i32 [[X]] to double
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double 2.000000e+00, double [[CST]]
+; CHECK-NEXT:    [[SEL1:%.*]] = call i32 @llvm.smax.i32(i32 [[X:%.*]], i32 2)
+; CHECK-NEXT:    [[SEL:%.*]] = uitofp nneg i32 [[SEL1]] to double
 ; CHECK-NEXT:    ret double [[SEL]]
 ;
   %cmp = icmp slt i32 %x, 3
@@ -292,10 +291,9 @@ define double @t17_commuted2(i32 %x) {
 
 define double @t17_commuted3(i32 %x) {
 ; CHECK-LABEL: @t17_commuted3(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[X:%.*]], 3
+; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.smin.i32(i32 [[X1:%.*]], i32 2)
 ; CHECK-NEXT:    [[CST:%.*]] = sitofp i32 [[X]] to double
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], double [[CST]], double 2.000000e+00
-; CHECK-NEXT:    ret double [[SEL]]
+; CHECK-NEXT:    ret double [[CST]]
 ;
   %cmp = icmp slt i32 %x, 3
   %cst = sitofp i32 %x to double

--- a/llvm/test/Transforms/InstCombine/preserve-sminmax.ll
+++ b/llvm/test/Transforms/InstCombine/preserve-sminmax.ll
@@ -22,8 +22,7 @@ define i32 @foo(i32 %h) {
 define i32 @foo_commuted(i32 %h) {
 ; CHECK-LABEL: @foo_commuted(
 ; CHECK-NEXT:    [[SD:%.*]] = sdiv i32 [[H:%.*]], 2
-; CHECK-NEXT:    [[T:%.*]] = icmp sgt i32 [[H]], 1
-; CHECK-NEXT:    [[R:%.*]] = select i1 [[T]], i32 1, i32 [[SD]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.smin.i32(i32 [[SD]], i32 1)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %sd = sdiv i32 %h, 2

--- a/llvm/test/Transforms/InstCombine/preserve-sminmax.ll
+++ b/llvm/test/Transforms/InstCombine/preserve-sminmax.ll
@@ -19,6 +19,30 @@ define i32 @foo(i32 %h) {
   ret i32 %r
 }
 
+define <2 x i32> @foo_vec(<2 x i32> %h) {
+; CHECK-LABEL: @foo_vec(
+; CHECK-NEXT:    [[SD:%.*]] = sdiv <2 x i32> [[H:%.*]], splat (i32 2)
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i32> @llvm.smin.v2i32(<2 x i32> [[SD]], <2 x i32> splat (i32 1))
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %sd = sdiv <2 x i32> %h, splat(i32 2)
+  %t = icmp slt <2 x i32> %sd, splat(i32 1)
+  %r = select <2 x i1> %t, <2 x i32> %sd, <2 x i32> splat(i32 1)
+  ret <2 x i32> %r
+}
+
+define <2 x i32> @foo_vec_nonsplat(<2 x i32> %h) {
+; CHECK-LABEL: @foo_vec_nonsplat(
+; CHECK-NEXT:    [[SD:%.*]] = sdiv <2 x i32> [[H:%.*]], splat (i32 2)
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i32> @llvm.smin.v2i32(<2 x i32> [[SD]], <2 x i32> <i32 1, i32 0>)
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %sd = sdiv <2 x i32> %h, splat(i32 2)
+  %t = icmp slt <2 x i32> %sd, <i32 1, i32 0>
+  %r = select <2 x i1> %t, <2 x i32> %sd, <2 x i32> <i32 1, i32 0>
+  ret <2 x i32> %r
+}
+
 define i32 @foo_commuted(i32 %h) {
 ; CHECK-LABEL: @foo_commuted(
 ; CHECK-NEXT:    [[SD:%.*]] = sdiv i32 [[H:%.*]], 2
@@ -29,6 +53,30 @@ define i32 @foo_commuted(i32 %h) {
   %t = icmp sgt i32 %sd, 0
   %r = select i1 %t, i32 1, i32 %sd
   ret i32 %r
+}
+
+define <2 x i32> @foo_commuted_vec(<2 x i32> %h) {
+; CHECK-LABEL: @foo_commuted_vec(
+; CHECK-NEXT:    [[SD:%.*]] = sdiv <2 x i32> [[H:%.*]], splat (i32 2)
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i32> @llvm.smin.v2i32(<2 x i32> [[SD]], <2 x i32> splat (i32 1))
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %sd = sdiv <2 x i32> %h, splat(i32 2)
+  %t = icmp sgt <2 x i32> %sd, zeroinitializer
+  %r = select <2 x i1> %t, <2 x i32> splat(i32 1), <2 x i32> %sd
+  ret <2 x i32> %r
+}
+
+define <2 x i32> @foo_commuted_vec_nonsplat(<2 x i32> %h) {
+; CHECK-LABEL: @foo_commuted_vec_nonsplat(
+; CHECK-NEXT:    [[SD:%.*]] = sdiv <2 x i32> [[H:%.*]], splat (i32 2)
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i32> @llvm.smin.v2i32(<2 x i32> [[SD]], <2 x i32> <i32 1, i32 0>)
+; CHECK-NEXT:    ret <2 x i32> [[R]]
+;
+  %sd = sdiv <2 x i32> %h, splat(i32 2)
+  %t = icmp sgt <2 x i32> %sd, <i32 0, i32 -1>
+  %r = select <2 x i1> %t, <2 x i32> <i32 1, i32 0>, <2 x i32> %sd
+  ret <2 x i32> %r
 }
 
 define i32 @bar(i32 %h) {

--- a/llvm/test/Transforms/InstCombine/preserve-sminmax.ll
+++ b/llvm/test/Transforms/InstCombine/preserve-sminmax.ll
@@ -19,6 +19,19 @@ define i32 @foo(i32 %h) {
   ret i32 %r
 }
 
+define i32 @foo_commuted(i32 %h) {
+; CHECK-LABEL: @foo_commuted(
+; CHECK-NEXT:    [[SD:%.*]] = sdiv i32 [[H:%.*]], 2
+; CHECK-NEXT:    [[T:%.*]] = icmp sgt i32 [[H]], 1
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[T]], i32 1, i32 [[SD]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %sd = sdiv i32 %h, 2
+  %t = icmp sgt i32 %sd, 0
+  %r = select i1 %t, i32 1, i32 %sd
+  ret i32 %r
+}
+
 define i32 @bar(i32 %h) {
 ; CHECK-LABEL: @bar(
 ; CHECK-NEXT:    [[SD:%.*]] = sdiv i32 [[H:%.*]], 2

--- a/llvm/test/Transforms/PhaseOrdering/ARM/arm_mult_q15.ll
+++ b/llvm/test/Transforms/PhaseOrdering/ARM/arm_mult_q15.ll
@@ -12,22 +12,22 @@ define void @arm_mult_q15(ptr %pSrcA, ptr %pSrcB, ptr noalias %pDst, i32 %blockS
 ; CHECK-LABEL: @arm_mult_q15(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[CMP_NOT2:%.*]] = icmp eq i32 [[BLOCKSIZE:%.*]], 0
-; CHECK-NEXT:    br i1 [[CMP_NOT2]], label [[WHILE_END:%.*]], label [[WHILE_BODY_PREHEADER:%.*]]
+; CHECK-NEXT:    br i1 [[CMP_NOT2]], label [[WHILE_END:%.*]], label [[VECTOR_PH:%.*]]
 ; CHECK:       while.body.preheader:
 ; CHECK-NEXT:    [[MIN_ITERS_CHECK:%.*]] = icmp ult i32 [[BLOCKSIZE]], 8
-; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label [[WHILE_BODY_PREHEADER15:%.*]], label [[VECTOR_PH:%.*]]
+; CHECK-NEXT:    br i1 [[MIN_ITERS_CHECK]], label [[WHILE_BODY_PREHEADER15:%.*]], label [[VECTOR_PH1:%.*]]
 ; CHECK:       vector.ph:
 ; CHECK-NEXT:    [[N_VEC:%.*]] = and i32 [[BLOCKSIZE]], -8
-; CHECK-NEXT:    [[IND_END:%.*]] = and i32 [[BLOCKSIZE]], 7
-; CHECK-NEXT:    [[TMP0:%.*]] = shl i32 [[N_VEC]], 1
-; CHECK-NEXT:    [[IND_END7:%.*]] = getelementptr i8, ptr [[PSRCA:%.*]], i32 [[TMP0]]
+; CHECK-NEXT:    [[TMP0:%.*]] = and i32 [[BLOCKSIZE]], 7
 ; CHECK-NEXT:    [[TMP1:%.*]] = shl i32 [[N_VEC]], 1
-; CHECK-NEXT:    [[IND_END9:%.*]] = getelementptr i8, ptr [[PDST:%.*]], i32 [[TMP1]]
-; CHECK-NEXT:    [[TMP2:%.*]] = shl i32 [[N_VEC]], 1
-; CHECK-NEXT:    [[IND_END11:%.*]] = getelementptr i8, ptr [[PSRCB:%.*]], i32 [[TMP2]]
+; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr i8, ptr [[PSRCA:%.*]], i32 [[TMP1]]
+; CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[N_VEC]], 1
+; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr i8, ptr [[PDST:%.*]], i32 [[TMP3]]
+; CHECK-NEXT:    [[TMP5:%.*]] = shl i32 [[N_VEC]], 1
+; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr i8, ptr [[PSRCB:%.*]], i32 [[TMP5]]
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]
 ; CHECK:       vector.body:
-; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
+; CHECK-NEXT:    [[INDEX:%.*]] = phi i32 [ 0, [[VECTOR_PH1]] ], [ [[INDEX_NEXT:%.*]], [[VECTOR_BODY]] ]
 ; CHECK-NEXT:    [[OFFSET_IDX:%.*]] = shl i32 [[INDEX]], 1
 ; CHECK-NEXT:    [[NEXT_GEP:%.*]] = getelementptr i8, ptr [[PSRCA]], i32 [[OFFSET_IDX]]
 ; CHECK-NEXT:    [[OFFSET_IDX13:%.*]] = shl i32 [[INDEX]], 1
@@ -35,14 +35,14 @@ define void @arm_mult_q15(ptr %pSrcA, ptr %pSrcB, ptr noalias %pDst, i32 %blockS
 ; CHECK-NEXT:    [[OFFSET_IDX15:%.*]] = shl i32 [[INDEX]], 1
 ; CHECK-NEXT:    [[NEXT_GEP16:%.*]] = getelementptr i8, ptr [[PSRCB]], i32 [[OFFSET_IDX15]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <8 x i16>, ptr [[NEXT_GEP]], align 2
-; CHECK-NEXT:    [[TMP3:%.*]] = sext <8 x i16> [[WIDE_LOAD]] to <8 x i32>
-; CHECK-NEXT:    [[WIDE_LOAD17:%.*]] = load <8 x i16>, ptr [[NEXT_GEP16]], align 2
-; CHECK-NEXT:    [[TMP4:%.*]] = sext <8 x i16> [[WIDE_LOAD17]] to <8 x i32>
-; CHECK-NEXT:    [[TMP5:%.*]] = mul nsw <8 x i32> [[TMP4]], [[TMP3]]
-; CHECK-NEXT:    [[TMP6:%.*]] = ashr <8 x i32> [[TMP5]], splat (i32 15)
-; CHECK-NEXT:    [[TMP7:%.*]] = tail call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[TMP6]], <8 x i32> splat (i32 32767))
-; CHECK-NEXT:    [[TMP8:%.*]] = trunc <8 x i32> [[TMP7]] to <8 x i16>
-; CHECK-NEXT:    store <8 x i16> [[TMP8]], ptr [[NEXT_GEP14]], align 2
+; CHECK-NEXT:    [[TMP7:%.*]] = sext <8 x i16> [[WIDE_LOAD]] to <8 x i32>
+; CHECK-NEXT:    [[WIDE_LOAD11:%.*]] = load <8 x i16>, ptr [[NEXT_GEP16]], align 2
+; CHECK-NEXT:    [[TMP8:%.*]] = sext <8 x i16> [[WIDE_LOAD11]] to <8 x i32>
+; CHECK-NEXT:    [[TMP13:%.*]] = mul nsw <8 x i32> [[TMP8]], [[TMP7]]
+; CHECK-NEXT:    [[TMP10:%.*]] = ashr <8 x i32> [[TMP13]], splat (i32 15)
+; CHECK-NEXT:    [[TMP11:%.*]] = tail call <8 x i32> @llvm.smin.v8i32(<8 x i32> [[TMP10]], <8 x i32> splat (i32 32767))
+; CHECK-NEXT:    [[TMP12:%.*]] = trunc <8 x i32> [[TMP11]] to <8 x i16>
+; CHECK-NEXT:    store <8 x i16> [[TMP12]], ptr [[NEXT_GEP14]], align 2
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i32 [[INDEX]], 8
 ; CHECK-NEXT:    [[TMP9:%.*]] = icmp eq i32 [[INDEX_NEXT]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[TMP9]], label [[MIDDLE_BLOCK:%.*]], label [[VECTOR_BODY]], !llvm.loop [[LOOP0:![0-9]+]]
@@ -50,10 +50,10 @@ define void @arm_mult_q15(ptr %pSrcA, ptr %pSrcB, ptr noalias %pDst, i32 %blockS
 ; CHECK-NEXT:    [[CMP_N:%.*]] = icmp eq i32 [[BLOCKSIZE]], [[N_VEC]]
 ; CHECK-NEXT:    br i1 [[CMP_N]], label [[WHILE_END]], label [[WHILE_BODY_PREHEADER15]]
 ; CHECK:       while.body.preheader15:
-; CHECK-NEXT:    [[BLKCNT_06_PH:%.*]] = phi i32 [ [[BLOCKSIZE]], [[WHILE_BODY_PREHEADER]] ], [ [[IND_END]], [[MIDDLE_BLOCK]] ]
-; CHECK-NEXT:    [[PSRCA_ADDR_05_PH:%.*]] = phi ptr [ [[PSRCA]], [[WHILE_BODY_PREHEADER]] ], [ [[IND_END7]], [[MIDDLE_BLOCK]] ]
-; CHECK-NEXT:    [[PDST_ADDR_04_PH:%.*]] = phi ptr [ [[PDST]], [[WHILE_BODY_PREHEADER]] ], [ [[IND_END9]], [[MIDDLE_BLOCK]] ]
-; CHECK-NEXT:    [[PSRCB_ADDR_03_PH:%.*]] = phi ptr [ [[PSRCB]], [[WHILE_BODY_PREHEADER]] ], [ [[IND_END11]], [[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[BLKCNT_06_PH:%.*]] = phi i32 [ [[BLOCKSIZE]], [[VECTOR_PH]] ], [ [[TMP0]], [[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[PSRCA_ADDR_05_PH:%.*]] = phi ptr [ [[PSRCA]], [[VECTOR_PH]] ], [ [[TMP2]], [[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[PDST_ADDR_04_PH:%.*]] = phi ptr [ [[PDST]], [[VECTOR_PH]] ], [ [[TMP4]], [[MIDDLE_BLOCK]] ]
+; CHECK-NEXT:    [[PSRCB_ADDR_03_PH:%.*]] = phi ptr [ [[PSRCB]], [[VECTOR_PH]] ], [ [[TMP6]], [[MIDDLE_BLOCK]] ]
 ; CHECK-NEXT:    br label [[WHILE_BODY:%.*]]
 ; CHECK:       while.body:
 ; CHECK-NEXT:    [[BLKCNT_06:%.*]] = phi i32 [ [[DEC:%.*]], [[WHILE_BODY]] ], [ [[BLKCNT_06_PH]], [[WHILE_BODY_PREHEADER15]] ]
@@ -61,11 +61,11 @@ define void @arm_mult_q15(ptr %pSrcA, ptr %pSrcB, ptr noalias %pDst, i32 %blockS
 ; CHECK-NEXT:    [[PDST_ADDR_04:%.*]] = phi ptr [ [[INCDEC_PTR4:%.*]], [[WHILE_BODY]] ], [ [[PDST_ADDR_04_PH]], [[WHILE_BODY_PREHEADER15]] ]
 ; CHECK-NEXT:    [[PSRCB_ADDR_03:%.*]] = phi ptr [ [[INCDEC_PTR1:%.*]], [[WHILE_BODY]] ], [ [[PSRCB_ADDR_03_PH]], [[WHILE_BODY_PREHEADER15]] ]
 ; CHECK-NEXT:    [[INCDEC_PTR]] = getelementptr inbounds nuw i8, ptr [[PSRCA_ADDR_05]], i32 2
-; CHECK-NEXT:    [[TMP10:%.*]] = load i16, ptr [[PSRCA_ADDR_05]], align 2
-; CHECK-NEXT:    [[CONV:%.*]] = sext i16 [[TMP10]] to i32
+; CHECK-NEXT:    [[TMP14:%.*]] = load i16, ptr [[PSRCA_ADDR_05]], align 2
+; CHECK-NEXT:    [[CONV:%.*]] = sext i16 [[TMP14]] to i32
 ; CHECK-NEXT:    [[INCDEC_PTR1]] = getelementptr inbounds nuw i8, ptr [[PSRCB_ADDR_03]], i32 2
-; CHECK-NEXT:    [[TMP11:%.*]] = load i16, ptr [[PSRCB_ADDR_03]], align 2
-; CHECK-NEXT:    [[CONV2:%.*]] = sext i16 [[TMP11]] to i32
+; CHECK-NEXT:    [[TMP15:%.*]] = load i16, ptr [[PSRCB_ADDR_03]], align 2
+; CHECK-NEXT:    [[CONV2:%.*]] = sext i16 [[TMP15]] to i32
 ; CHECK-NEXT:    [[MUL:%.*]] = mul nsw i32 [[CONV2]], [[CONV]]
 ; CHECK-NEXT:    [[SHR:%.*]] = ashr i32 [[MUL]], 15
 ; CHECK-NEXT:    [[SPEC_SELECT_I:%.*]] = tail call i32 @llvm.smin.i32(i32 [[SHR]], i32 32767)


### PR DESCRIPTION
This patch converts constant RHS cases like `X < 3 ? 2 : X` back into the strictness flipped form `X <= 2 ? 2 : X` to recognize more select patterns.
Closes https://github.com/llvm/llvm-project/issues/121772.
Closes https://github.com/llvm/llvm-project/issues/121786.
