### PR TITLE
[libc++] Enable experimental tzdb on Apple platforms

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -113,7 +113,7 @@ option(LIBCXX_ENABLE_MONOTONIC_CLOCK
 #
 # TODO TZDB make the default always ON when most platforms ship with the IANA
 # database.
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|Darwin")
   set(ENABLE_TIME_ZONE_DATABASE_DEFAULT ON)
 else()
   set(ENABLE_TIME_ZONE_DATABASE_DEFAULT OFF)

--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -73,6 +73,8 @@ Improvements and New Features
   optimized, resulting in a performance improvement of up to 2x for trivial element types (e.g., `std::vector<int>`),
   and up to 3.4x for non-trivial element types (e.g., `std::vector<std::vector<int>>`).
 
+- Experimental support for ``std::chrono::tzdb`` has now been implemented on Apple platforms.
+
 Deprecations and Removals
 -------------------------
 

--- a/libcxx/src/experimental/tzdb.cpp
+++ b/libcxx/src/experimental/tzdb.cpp
@@ -100,7 +100,7 @@ static void __matches(istream& __input, char __expected) {
   char __c = __input.get();
   if (std::tolower(__c) != __expected)
     std::__throw_runtime_error(
-        (string("corrupt tzdb: expected character '") + __expected + "', got '" + __c + "'").c_str());
+        (string("corrupt tzdb: expected character '") + __expected + "', got '" + __c + "' instead").c_str());
 }
 
 static void __matches(istream& __input, string_view __expected) {

--- a/libcxx/test/libcxx/time/time.zone/time.zone.db/leap_seconds.pass.cpp
+++ b/libcxx/test/libcxx/time/time.zone/time.zone.db/leap_seconds.pass.cpp
@@ -28,10 +28,20 @@
 #include "filesystem_test_helper.h"
 #include "test_tzdb.h"
 
+#if defined(__APPLE__)
+#  define TEST_USE_BINARY_LEAP_SECONDS
+#else
+#  define TEST_USE_LIST_LEAP_SECONDS
+#endif
+
 scoped_test_env env;
 [[maybe_unused]] const std::filesystem::path dir = env.create_dir("zoneinfo");
 const std::filesystem::path tzdata               = env.create_file("zoneinfo/tzdata.zi");
-const std::filesystem::path leap_seconds         = env.create_file("zoneinfo/leap-seconds.list");
+#ifdef TEST_USE_BINARY_LEAP_SECONDS
+const std::filesystem::path leap_seconds = env.create_file("zoneinfo/leapseconds");
+#else
+const std::filesystem::path leap_seconds = env.create_file("zoneinfo/leap-seconds.list");
+#endif
 
 std::string_view std::chrono::__libcpp_tzdb_directory() {
   static std::string result = dir.string();
@@ -65,21 +75,23 @@ static void test_exception(std::string_view input, [[maybe_unused]] std::string_
 }
 
 static void test_invalid() {
+#ifdef TEST_USE_BINARY_LEAP_SECONDS
+  test_exception("0", "corrupt tzdb: expected character 'l' from string 'leap', got '0' instead");
+  test_exception("Leap  x", "corrupt tzdb: expected a digit");
+  test_exception("Leap  1970  J", "corrupt tzdb month: invalid name");
+  test_exception("Leap  1970  Jan   1   23:59:60    x", "corrupt tzdb: invalid leap second sign x");
+#else
   test_exception("0", "corrupt tzdb: expected a non-zero digit");
-
   test_exception("1", "corrupt tzdb: expected whitespace");
-
   test_exception("1 ", "corrupt tzdb: expected a non-zero digit");
-
   test_exception("5764607523034234880 2", "corrupt tzdb: integral too large");
+#endif
 }
 
 static void test_leap_seconds() {
   using namespace std::chrono;
 
-  // Test whether loading also sorts the entries in the proper order.
-  const tzdb& result = parse(
-      R"(
+  std::string list_format = R"(
 2303683200  12  # 1 Jan 1973
 2287785600  11  # 1 Jul 1972
 2272060800  10  # 1 Jan 1972
@@ -91,7 +103,25 @@ static void test_leap_seconds() {
 
 # largest accepted value by the parser
 5764607523034234879 12
-)");
+)";
+
+  std::string binary_format = R"(
+Leap  1973  Jan   1   23:59:60    +   S
+Leap  1972  Jul   1   23:59:60    +   S
+Leap  1972  Jan   1   23:59:60    +   S
+Leap  1900  Jan   2   23:59:60    +   S # 2 Jan 1900 Dummy entry to test before 1970
+Leap  1900  Jan   2   00:00:01    +   S # 2 Jan 1900 Dummy entry to test before 1970
+
+Leap  1973  Jan   2   23:59:60    -   S # Fictional negative leap second
+Leap  32767 Jan   1   23:59:60    +   S # Largest year accepted by the parser
+)";
+
+  // Test whether loading also sorts the entries in the proper order.
+#ifdef TEST_USE_BINARY_LEAP_SECONDS
+  const tzdb& result = parse(binary_format);
+#else
+  const tzdb& result = parse(list_format);
+#endif
 
   assert(result.leap_seconds.size() == 6);
 

--- a/libcxx/test/libcxx/time/time.zone/time.zone.db/rules.pass.cpp
+++ b/libcxx/test/libcxx/time/time.zone/time.zone.db/rules.pass.cpp
@@ -20,9 +20,10 @@
 // ADDITIONAL_COMPILE_FLAGS: -I %{libcxx-dir}/src/experimental/include
 
 #include <chrono>
+#include <cstdio>
 #include <fstream>
-#include <string>
 #include <string_view>
+#include <string>
 #include <variant>
 
 #include "assert_macros.h"
@@ -96,7 +97,7 @@ static void test_invalid() {
   test_exception("R r 0 mix", "corrupt tzdb: expected whitespace");
   test_exception("R r 0 1", "corrupt tzdb: expected whitespace");
 
-  test_exception("R r 0 1 X", "corrupt tzdb: expected character '-'");
+  test_exception("R r 0 1 X", "corrupt tzdb: expected character '-', got 'X' instead");
 
   test_exception("R r 0 1 -", "corrupt tzdb: expected whitespace");
 
@@ -106,13 +107,17 @@ static void test_invalid() {
 
   test_exception("R r 0 1 - Ja +", "corrupt tzdb weekday: invalid name");
   test_exception("R r 0 1 - Ja 32", "corrupt tzdb day: value too large");
-  test_exception("R r 0 1 - Ja l", "corrupt tzdb: expected string 'last'");
+  test_exception(
+      "R r 0 1 - Ja l",
+      std::string{"corrupt tzdb: expected character 'a' from string 'last', got '"} + (char)EOF + "' instead");
   test_exception("R r 0 1 - Ja last", "corrupt tzdb weekday: invalid name");
   test_exception("R r 0 1 - Ja lastS", "corrupt tzdb weekday: invalid name");
   test_exception("R r 0 1 - Ja S", "corrupt tzdb weekday: invalid name");
   test_exception("R r 0 1 - Ja Su", "corrupt tzdb on: expected '>=' or '<='");
-  test_exception("R r 0 1 - Ja Su>", "corrupt tzdb: expected character '='");
-  test_exception("R r 0 1 - Ja Su<", "corrupt tzdb: expected character '='");
+  test_exception(
+      "R r 0 1 - Ja Su>", std::string{"corrupt tzdb: expected character '=', got '"} + (char)EOF + "' instead");
+  test_exception(
+      "R r 0 1 - Ja Su<", std::string{"corrupt tzdb: expected character '=', got '"} + (char)EOF + "' instead");
   test_exception("R r 0 1 - Ja Su>=+", "corrupt tzdb: expected a non-zero digit");
   test_exception("R r 0 1 - Ja Su>=0", "corrupt tzdb: expected a non-zero digit");
   test_exception("R r 0 1 - Ja Su>=32", "corrupt tzdb day: value too large");

--- a/libcxx/test/libcxx/time/time.zone/time.zone.db/version.pass.cpp
+++ b/libcxx/test/libcxx/time/time.zone/time.zone.db/version.pass.cpp
@@ -18,9 +18,10 @@
 // This is not part of the public tzdb interface.
 
 #include <chrono>
+#include <cstdio>
 #include <fstream>
-#include <string>
 #include <string_view>
+#include <string>
 
 #include "assert_macros.h"
 #include "concat_macros.h"
@@ -60,7 +61,7 @@ static void test_exception(std::string_view input, [[maybe_unused]] std::string_
 }
 
 int main(int, const char**) {
-  test_exception("", "corrupt tzdb: expected character '#'");
+  test_exception("", std::string{"corrupt tzdb: expected character '#', got '"} + (char)EOF + "' instead");
   test_exception("#version", "corrupt tzdb: expected whitespace");
   test("#version     \t                      ABCD", "ABCD");
   test("#Version     \t                      ABCD", "ABCD");


### PR DESCRIPTION
This patch implements binary parsing of the leapseconds file provided on Apple platforms and enables experimental tzdb support on Apple.

Fixes #117451 