### PR TITLE
[libc] Add --write-if-changed switch to hdrgen/main.py

### DIFF
--- a/libc/cmake/modules/LLVMLibCHeaderRules.cmake
+++ b/libc/cmake/modules/LLVMLibCHeaderRules.cmake
@@ -113,6 +113,7 @@ function(add_gen_header target_name)
     COMMAND ${Python3_EXECUTABLE} "${LIBC_SOURCE_DIR}/utils/hdrgen/main.py"
             --output ${out_file}
             --depfile ${dep_file}
+            --write-if-changed
             ${entry_points}
             ${yaml_file}
     DEPENDS ${yaml_file} ${fq_data_files}

--- a/libc/utils/hdrgen/main.py
+++ b/libc/utils/hdrgen/main.py
@@ -38,6 +38,12 @@ def main():
         type=Path,
     )
     parser.add_argument(
+        "--write-if-changed",
+        help="Write the output file only if its contents have changed",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "-e",
         "--entry-point",
         help="Entry point to include; may be given many times",
@@ -72,9 +78,13 @@ def main():
 
     write_depfile()
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    with open(args.output, "w") as out:
-        out.write(contents)
+    if (
+        not args.write_if_changed
+        or not args.output.exists()
+        or args.output.read_text() != contents
+    ):
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(contents)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This avoids touching the output file when it hasn't changed.  The
cmake build integration now uses this so that touching a .yaml or
.h.def file in ways that don't affect the generated header output
won't cause unnecessary recompilations.
