### PR TITLE
[Offload][PGO] Fix dump of array in ProfData

### DIFF
--- a/offload/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/offload/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -242,7 +242,7 @@ void GPUProfGlobals::dump() const {
 // Skip dumping the array for now.
 #define INSTR_PROF_DATA(Type, LLVMType, Name, Initializer)                     \
   if (sizeof(#Name) > 2 && #Name[sizeof(#Name) - 2] == ']') {                  \
-    outs() << " [...]";                                                        \
+    outs() << "[...] ";                                                        \
   } else {                                                                     \
     outs() << ProfData.Name << " ";                                            \
   }

--- a/offload/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/offload/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -237,6 +237,9 @@ void GPUProfGlobals::dump() const {
   outs() << "========== Data ===========\n";
   for (const auto &ProfData : Data) {
     outs() << "{ ";
+// The ProfData.Name maybe array, eg: NumValueSites[IPVK_Last+1] .
+// If we print out it directly, we are accessing out of bound data.
+// Skip dumping the array for now.
 #define INSTR_PROF_DATA(Type, LLVMType, Name, Initializer)                     \
   if (sizeof(#Name) > 2 && #Name[sizeof(#Name) - 2] == ']') {                  \
     outs() << " [...]";                                                        \

--- a/offload/plugins-nextgen/common/src/GlobalHandler.cpp
+++ b/offload/plugins-nextgen/common/src/GlobalHandler.cpp
@@ -238,7 +238,11 @@ void GPUProfGlobals::dump() const {
   for (const auto &ProfData : Data) {
     outs() << "{ ";
 #define INSTR_PROF_DATA(Type, LLVMType, Name, Initializer)                     \
-  outs() << ProfData.Name << " ";
+  if (sizeof(#Name) > 2 && #Name[sizeof(#Name) - 2] == ']') {                  \
+    outs() << " [...]";                                                        \
+  } else {                                                                     \
+    outs() << ProfData.Name << " ";                                            \
+  }
 #include "llvm/ProfileData/InstrProfData.inc"
     outs() << "}\n";
   }

--- a/offload/test/offloading/pgo1.c
+++ b/offload/test/offloading/pgo1.c
@@ -36,15 +36,15 @@ int main() {
 // CLANG-PGO-NEXT: { {{[0-9]*}} {{[0-9]*}}
 // CLANG-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
 // CLANG-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
-// CLANG-PGO-SAME: {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} }
+// CLANG-PGO-SAME: {{[0-9]*}} {{.*}} {{[0-9]*}} }
 // CLANG-PGO-NEXT: { {{[0-9]*}} {{[0-9]*}}
 // CLANG-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
 // CLANG-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
-// CLANG-PGO-SAME: {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} }
+// CLANG-PGO-SAME: {{[0-9]*}} {{.*}} {{[0-9]*}} }
 // CLANG-PGO-NEXT: { {{[0-9]*}} {{[0-9]*}}
 // CLANG-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
 // CLANG-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
-// CLANG-PGO-SAME: {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} }
+// CLANG-PGO-SAME: {{[0-9]*}} {{.*}} {{[0-9]*}} }
 // CLANG-PGO-NEXT: ======== Functions ========
 // CLANG-PGO-NEXT: pgo1.c:
 // CLANG-PGO-SAME: __omp_offloading_{{[_0-9a-zA-Z]*}}_main_{{[_0-9a-zA-Z]*}}
@@ -59,15 +59,15 @@ int main() {
 // LLVM-PGO-NEXT: { {{[0-9]*}} {{[0-9]*}}
 // LLVM-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
 // LLVM-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
-// LLVM-PGO-SAME: {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} }
+// LLVM-PGO-SAME: {{[0-9]*}} {{.*}} {{[0-9]*}} }
 // LLVM-PGO-NEXT: { {{[0-9]*}} {{[0-9]*}}
 // LLVM-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
 // LLVM-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
-// LLVM-PGO-SAME: {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} }
+// LLVM-PGO-SAME: {{[0-9]*}} {{.*}} {{[0-9]*}} }
 // LLVM-PGO-NEXT: { {{[0-9]*}} {{[0-9]*}}
 // LLVM-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
 // LLVM-PGO-SAME: {{0x[0-9a-fA-F]*}} {{0x[0-9a-fA-F]*}}
-// LLVM-PGO-SAME: {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} }
+// LLVM-PGO-SAME: {{[0-9]*}} {{.*}} {{[0-9]*}} }
 // LLVM-PGO-NEXT: ======== Functions ========
 // LLVM-PGO-NEXT: __omp_offloading_{{[_0-9a-zA-Z]*}}_main_{{[_0-9a-zA-Z]*}}
 // LLVM-PGO-NEXT: test1


### PR DESCRIPTION
Exposed by -Warray-bounds:

In file included from ../../../../../../../llvm/offload/plugins-nextgen/common/src/GlobalHandler.cpp:252:
../../../../../../../llvm/llvm/include/llvm/ProfileData/InstrProfData.inc:109:1: error: array index 4 is past the end of the array (that has type 'const std::remove_const<const uint16_t>::type[4]' (aka 'const unsigned short[4]')) [-Werror,-Warray-bounds]
  109 | INSTR_PROF_DATA(const uint16_t, Int16ArrayTy, NumValueSites[IPVK_Last+1], \
      | ^                                                           ~~~~~~~~~~~
../../../../../../../llvm/offload/plugins-nextgen/common/src/GlobalHandler.cpp:250:15: note: expanded from macro 'INSTR_PROF_DATA'
  250 |     outs() << ProfData.Name << " ";                                            \
      |               ^        ~~~~
../../../../../../../llvm/llvm/include/llvm/ProfileData/InstrProfData.inc:109:1: note: array 'NumValueSites' declared here
  109 | INSTR_PROF_DATA(const uint16_t, Int16ArrayTy, NumValueSites[IPVK_Last+1], \
      | ^
../../../../../../../llvm/offload/plugins-nextgen/common/include/GlobalHandler.h:62:3: note: expanded from macro 'INSTR_PROF_DATA'
   62 |   std::remove_const<Type>::type Name;

Avoid accessing out-of-bound data, but skip printing array data for now.
As there is no simple way to do this without hardcoding the NumValueSites field.
