### PR TITLE
[Github] Fix llvm project tests after default user changed in container

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -60,6 +60,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:latest') || null}}
+      # We run as the root user as when we need to install sccache, the action
+      # currently does not support running the installation commands using sudo.
+      options: --user root
       volumes:
         - /mnt/:/mnt/
     strategy:


### PR DESCRIPTION
This patch adjusts the default user for llvm-project-tests when running on Linux. A recent change to the container made the default user non-root which prevents sccache from being installed as the command does not use sudo when trying to write to /usr/local/bin. For now, just run as root as we figure out a better solution to the problem.