### PR TITLE
[SPIR-V] Prefer SPV_INTEL_optnone over SPV_EXT_optnone when both extensions are available

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1807,12 +1807,12 @@ static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,
           SPIRV::ExecutionMode::VecTypeHint, ST);
 
     if (F.hasOptNone()) {
-      if (ST.canUseExtension(SPIRV::Extension::SPV_EXT_optnone)) {
-        MAI.Reqs.addExtension(SPIRV::Extension::SPV_EXT_optnone);
-        MAI.Reqs.addCapability(SPIRV::Capability::OptNoneEXT);
-      } else if (ST.canUseExtension(SPIRV::Extension::SPV_INTEL_optnone)) {
+      if (ST.canUseExtension(SPIRV::Extension::SPV_INTEL_optnone)) {
         MAI.Reqs.addExtension(SPIRV::Extension::SPV_INTEL_optnone);
         MAI.Reqs.addCapability(SPIRV::Capability::OptNoneINTEL);
+      } else if (ST.canUseExtension(SPIRV::Extension::SPV_EXT_optnone)) {
+        MAI.Reqs.addExtension(SPIRV::Extension::SPV_EXT_optnone);
+        MAI.Reqs.addCapability(SPIRV::Capability::OptNoneEXT);
       }
     }
   }

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_EXT_optnone.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_EXT_optnone.ll
@@ -4,12 +4,21 @@
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_EXT_optnone %s -o - -filetype=obj | spirv-val %}
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_EXT_optnone,+SPV_INTEL_optnone %s -o - | FileCheck %s --check-prefixes=CHECK-TWO-EXTENSIONS
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=all %s -o - | FileCheck %s --check-prefixes=CHECK-ALL-EXTENSIONS
+
 ; CHECK-EXTENSION: OpCapability OptNoneEXT
 ; CHECK-EXTENSION: OpExtension "SPV_EXT_optnone"
 ; CHECK-NO-EXTENSION-NOT: OpCapability OptNoneINTEL
 ; CHECK-NO-EXTENSION-NOT: OpCapability OptNoneEXT
 ; CHECK-NO-EXTENSION-NOT: OpExtension "SPV_INTEL_optnone"
 ; CHECK-NO-EXTENSION-NOT: OpExtension "SPV_EXT_optnone"
+
+; CHECK-TWO-EXTENSIONS: OpCapability OptNoneEXT
+; CHECK-TWO-EXTENSIONS: OpExtension "SPV_INTEL_optnone"
+
+; CHECK-ALL-EXTENSIONS: OpCapability OptNoneEXT
+; CHECK-ALL-EXTENSIONS: OpExtension "SPV_INTEL_optnone"
 
 define spir_func void @foo() #0 {
 ; CHECK-EXTENSION: %[[#]] = OpFunction %[[#]] DontInline|OptNoneEXT %[[#]]

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_EXT_optnone.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_EXT_optnone.ll
@@ -14,10 +14,7 @@
 ; CHECK-NO-EXTENSION-NOT: OpExtension "SPV_INTEL_optnone"
 ; CHECK-NO-EXTENSION-NOT: OpExtension "SPV_EXT_optnone"
 
-; CHECK-TWO-EXTENSIONS: OpCapability OptNoneEXT
 ; CHECK-TWO-EXTENSIONS: OpExtension "SPV_INTEL_optnone"
-
-; CHECK-ALL-EXTENSIONS: OpCapability OptNoneEXT
 ; CHECK-ALL-EXTENSIONS: OpExtension "SPV_INTEL_optnone"
 
 define spir_func void @foo() #0 {


### PR DESCRIPTION
This PR fixes https://github.com/llvm/llvm-project/issues/122075. We prefer SPV_INTEL_optnone over SPV_EXT_optnone when both extensions are available, otherwise, when a target specifies a required extension explicitly rather than allowing any of those (e.g., by providing --spirv-ext=all command line argument), the Backend's behavior remains unchanged. An existing test case is updated to check the case of 2 alternative extensions available at the same time.