### PR TITLE
[clang-tidy] Add EnableQtSupport option to modernize-use-integer-sign-comprison

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.cpp
@@ -80,11 +80,13 @@ UseIntegerSignComparisonCheck::UseIntegerSignComparisonCheck(
     : ClangTidyCheck(Name, Context),
       IncludeInserter(Options.getLocalOrGlobal("IncludeStyle",
                                                utils::IncludeSorter::IS_LLVM),
-                      areDiagsSelfContained()) {}
+                      areDiagsSelfContained()),
+      QtFrameworkEnabled(Options.get("QtEnabled", false)) {}
 
 void UseIntegerSignComparisonCheck::storeOptions(
     ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IncludeStyle", IncludeInserter.getStyle());
+  Options.store(Opts, "QtEnabled", QtFrameworkEnabled);
 }
 
 void UseIntegerSignComparisonCheck::registerMatchers(MatchFinder *Finder) {
@@ -154,8 +156,16 @@ void UseIntegerSignComparisonCheck::check(
   DiagnosticBuilder Diag =
       diag(BinaryOp->getBeginLoc(),
            "comparison between 'signed' and 'unsigned' integers");
-  const std::string CmpNamespace = ("std::" + parseOpCode(OpCode)).str();
-  const std::string CmpHeader = "<utility>";
+  std::string CmpNamespace;
+  std::string CmpHeader;
+  if (getLangOpts().CPlusPlus17 && QtFrameworkEnabled) {
+    CmpHeader = "<QtCore/q20utility.h>";
+    CmpNamespace = llvm::Twine("q20::" + parseOpCode(OpCode)).str();
+  }
+  if (getLangOpts().CPlusPlus20) {
+    CmpHeader = "<utility>";
+    CmpNamespace = llvm::Twine("std::" + parseOpCode(OpCode)).str();
+  }
   // Prefer modernize-use-integer-sign-comparison when C++20 is available!
   Diag << FixItHint::CreateReplacement(
       CharSourceRange(R1, SubExprLHS != nullptr),

--- a/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.h
@@ -30,12 +30,12 @@ public:
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return LangOpts.CPlusPlus20 || (LangOpts.CPlusPlus17 && QtFrameworkEnabled);
+    return LangOpts.CPlusPlus20 || (LangOpts.CPlusPlus17 && EnableQtSupport);
   }
 
 private:
   utils::IncludeInserter IncludeInserter;
-  const bool QtFrameworkEnabled;
+  const bool EnableQtSupport;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.h
@@ -30,11 +30,12 @@ public:
   void registerMatchers(ast_matchers::MatchFinder *Finder) override;
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
-    return LangOpts.CPlusPlus20;
+    return LangOpts.CPlusPlus20 || (LangOpts.CPlusPlus17 && QtFrameworkEnabled);
   }
 
 private:
   utils::IncludeInserter IncludeInserter;
+  const bool QtFrameworkEnabled;
 };
 
 } // namespace clang::tidy::modernize

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -303,7 +303,7 @@ Changes in existing checks
 
 - Improved :doc:`modernize-use-integer-sign-comparison
   <clang-tidy/checks/modernize/use-integer-sign-comparison>` check to
-  add an option ``QtEnabled``, that makes C++17 ``q20::cmp_*`` alternative
+  add an option ``EnableQtSupport``, that makes C++17 ``q20::cmp_*`` alternative
   available for Qt-based applications.
 
 - Improved :doc:`modernize-use-nullptr

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -301,6 +301,11 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-designated-initializers>` check to fix a
   crash when a class is declared but not defined.
 
+- Improved :doc:`modernize-use-integer-sign-comparison
+  <clang-tidy/checks/modernize/use-integer-sign-comparison>` check to
+  add an option ``QtEnabled``, that makes C++17 ``q20::cmp_*`` alternative
+  available for Qt-based applications.
+
 - Improved :doc:`modernize-use-nullptr
   <clang-tidy/checks/modernize/use-nullptr>` check to also recognize
   ``NULL``/``__null`` (but not ``0``) when used with a templated type.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
@@ -35,7 +35,7 @@ Options
   A string specifying which include-style is used, `llvm` or `google`.
   Default is `llvm`.
 
-.. option:: QtEnabled
+.. option:: EnableQtSupport
 
   Makes C++17 ``q20::cmp_*`` alternative available for Qt-based
   applications. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
@@ -34,3 +34,7 @@ Options
 
   A string specifying which include-style is used, `llvm` or `google`.
   Default is `llvm`.
+
+.. option:: QtEnabled
+  Makes C++17 ``q20::cmp_*`` alternative available for Qt-based
+  applications. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.rst
@@ -36,5 +36,6 @@ Options
   Default is `llvm`.
 
 .. option:: QtEnabled
+
   Makes C++17 ``q20::cmp_*`` alternative available for Qt-based
   applications. Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
@@ -1,6 +1,6 @@
 // CHECK-FIXES: #include <QtCore/q20utility.h>
 // RUN: %check_clang_tidy -std=c++17 %s modernize-use-integer-sign-comparison %t -- \
-// RUN: -config="{CheckOptions: {modernize-use-integer-sign-comparison.QtEnabled: true}}"
+// RUN: -config="{CheckOptions: {modernize-use-integer-sign-comparison.EnableQtSupport: true}}"
 
 // The code that triggers the check
 #define MAX_MACRO(a, b) (a < b) ? b : a

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
@@ -1,0 +1,123 @@
+// CHECK-FIXES: #include <QtCore/q20utility.h>
+// RUN: %check_clang_tidy -std=c++17 %s modernize-use-integer-sign-comparison %t -- \
+// RUN: -config="{CheckOptions: {modernize-use-integer-sign-comparison.QtEnabled: true}}"
+
+// The code that triggers the check
+#define MAX_MACRO(a, b) (a < b) ? b : a
+
+unsigned int FuncParameters(int bla) {
+    unsigned int result = 0;
+    if (result == bla)
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_equal(result , bla))
+
+    return 1;
+}
+
+template <typename T>
+void TemplateFuncParameter(T val) {
+    unsigned long uL = 0;
+    if (val >= uL)
+        return;
+// CHECK-MESSAGES-NOT: warning:
+}
+
+template <typename T1, typename T2>
+int TemplateFuncParameters(T1 val1, T2 val2) {
+    if (val1 >= val2)
+        return 0;
+// CHECK-MESSAGES-NOT: warning:
+    return 1;
+}
+
+int AllComparisons() {
+    unsigned int uVar = 42;
+    unsigned short uArray[7] = {0, 1, 2, 3, 9, 7, 9};
+
+    int sVar = -42;
+    short sArray[7] = {-1, -2, -8, -94, -5, -4, -6};
+
+    enum INT_TEST {
+      VAL1 = 0,
+      VAL2 = -1
+    };
+
+    char ch = 'a';
+    unsigned char uCh = 'a';
+    signed char sCh = 'a';
+    bool bln = false;
+
+    if (bln == sVar)
+      return 0;
+// CHECK-MESSAGES-NOT: warning:
+
+    if (ch > uCh)
+      return 0;
+// CHECK-MESSAGES-NOT: warning:
+
+    if (sVar <= INT_TEST::VAL2)
+      return 0;
+// CHECK-MESSAGES-NOT: warning:
+
+    if (uCh < sCh)
+      return -1;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_less(uCh , sCh))
+
+    if ((int)uVar < sVar)
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_less(uVar, sVar))
+
+    (uVar != sVar) ? uVar = sVar
+                   : sVar = uVar;
+// CHECK-MESSAGES: :[[@LINE-2]]:6: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: (q20::cmp_not_equal(uVar , sVar)) ? uVar = sVar
+
+    while (uArray[0] <= sArray[0])
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:12: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: while (q20::cmp_less_equal(uArray[0] , sArray[0]))
+
+    if (uArray[1] > sArray[1])
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_greater(uArray[1] , sArray[1]))
+
+    MAX_MACRO(uVar, sArray[0]);
+// CHECK-MESSAGES: :[[@LINE-1]]:15: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+
+    if (static_cast<unsigned int>(uArray[2]) < static_cast<int>(sArray[2]))
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_less(uArray[2],sArray[2]))
+
+    if ((unsigned int)uArray[3] < (int)sArray[3])
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_less(uArray[3],sArray[3]))
+
+    if ((unsigned int)(uArray[4]) < (int)(sArray[4]))
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_less((uArray[4]),(sArray[4])))
+
+    if (uArray[5] > sArray[5])
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_greater(uArray[5] , sArray[5]))
+
+    #define VALUE sArray[6]
+    if (uArray[6] > VALUE)
+        return 0;
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: comparison between 'signed' and 'unsigned' integers [modernize-use-integer-sign-comparison]
+// CHECK-FIXES: if (q20::cmp_greater(uArray[6] , VALUE))
+
+
+    FuncParameters(uVar);
+    TemplateFuncParameter(sVar);
+    TemplateFuncParameters(uVar, sVar);
+
+    return 0;
+}


### PR DESCRIPTION
- add an option ``QtEnabled``, that makes C++17 ``q20::cmp_*`` alternative available for Qt-based applications.