### PR TITLE
[TySan] Intercept malloc_size on Apple platforms.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
@@ -37,7 +37,7 @@ struct DlSymAllocator {
     void *ptr = InternalAlloc(size_in_bytes, nullptr, align);
     CHECK(internal_allocator()->FromPrimary(ptr));
     Details::OnAllocate(ptr,
-                        internal_allocator()->GetActuallyAllocatedSize(ptr));
+                        Size(ptr));
     return ptr;
   }
 
@@ -45,12 +45,12 @@ struct DlSymAllocator {
     void *ptr = InternalCalloc(nmemb, size);
     CHECK(internal_allocator()->FromPrimary(ptr));
     Details::OnAllocate(ptr,
-                        internal_allocator()->GetActuallyAllocatedSize(ptr));
+                        Size(ptr));
     return ptr;
   }
 
   static void Free(void *ptr) {
-    uptr size = internal_allocator()->GetActuallyAllocatedSize(ptr);
+    uptr size = Size(ptr);
     Details::OnFree(ptr, size);
     InternalFree(ptr);
   }
@@ -63,7 +63,7 @@ struct DlSymAllocator {
       Free(ptr);
       return nullptr;
     }
-    uptr size = internal_allocator()->GetActuallyAllocatedSize(ptr);
+    uptr size = Size(ptr);
     uptr memcpy_size = Min(new_size, size);
     void *new_ptr = Allocate(new_size);
     if (new_ptr)
@@ -75,6 +75,10 @@ struct DlSymAllocator {
   static void *ReallocArray(void *ptr, uptr count, uptr size) {
     CHECK(!CheckForCallocOverflow(count, size));
     return Realloc(ptr, count * size);
+  }
+
+  static uptr Size(void *ptr) {
+    return internal_allocator()->GetActuallyAllocatedSize(ptr);
   }
 
   static void OnAllocate(const void *ptr, uptr size) {}

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
@@ -36,16 +36,14 @@ struct DlSymAllocator {
   static void *Allocate(uptr size_in_bytes, uptr align = kWordSize) {
     void *ptr = InternalAlloc(size_in_bytes, nullptr, align);
     CHECK(internal_allocator()->FromPrimary(ptr));
-    Details::OnAllocate(ptr,
-                        Size(ptr));
+    Details::OnAllocate(ptr, Size(ptr));
     return ptr;
   }
 
   static void *Callocate(usize nmemb, usize size) {
     void *ptr = InternalCalloc(nmemb, size);
     CHECK(internal_allocator()->FromPrimary(ptr));
-    Details::OnAllocate(ptr,
-                        Size(ptr));
+    Details::OnAllocate(ptr, Size(ptr));
     return ptr;
   }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_dlsym.h
@@ -36,19 +36,19 @@ struct DlSymAllocator {
   static void *Allocate(uptr size_in_bytes, uptr align = kWordSize) {
     void *ptr = InternalAlloc(size_in_bytes, nullptr, align);
     CHECK(internal_allocator()->FromPrimary(ptr));
-    Details::OnAllocate(ptr, Size(ptr));
+    Details::OnAllocate(ptr, GetSize(ptr));
     return ptr;
   }
 
   static void *Callocate(usize nmemb, usize size) {
     void *ptr = InternalCalloc(nmemb, size);
     CHECK(internal_allocator()->FromPrimary(ptr));
-    Details::OnAllocate(ptr, Size(ptr));
+    Details::OnAllocate(ptr, GetSize(ptr));
     return ptr;
   }
 
   static void Free(void *ptr) {
-    uptr size = Size(ptr);
+    uptr size = GetSize(ptr);
     Details::OnFree(ptr, size);
     InternalFree(ptr);
   }
@@ -61,7 +61,7 @@ struct DlSymAllocator {
       Free(ptr);
       return nullptr;
     }
-    uptr size = Size(ptr);
+    uptr size = GetSize(ptr);
     uptr memcpy_size = Min(new_size, size);
     void *new_ptr = Allocate(new_size);
     if (new_ptr)
@@ -75,7 +75,7 @@ struct DlSymAllocator {
     return Realloc(ptr, count * size);
   }
 
-  static uptr Size(void *ptr) {
+  static uptr GetSize(void *ptr) {
     return internal_allocator()->GetActuallyAllocatedSize(ptr);
   }
 

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -109,7 +109,7 @@ INTERCEPTOR(void *, malloc, uptr size) {
 }
 
 #if SANITIZER_APPLE
-INTERCEPTOR(uptr , malloc_size, void *ptr) {
+INTERCEPTOR(uptr, malloc_size, void *ptr) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Size(ptr);
   return REAL(malloc_size)(ptr);

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -108,6 +108,14 @@ INTERCEPTOR(void *, malloc, uptr size) {
   return res;
 }
 
+#if SANITIZER_APPLE
+INTERCEPTOR(uptr , malloc_size, void *ptr) {
+  if (DlsymAlloc::Use())
+    return DlsymAlloc::Size(ptr);
+  return REAL(malloc_size)(ptr);
+}
+#endif
+
 INTERCEPTOR(void *, realloc, void *ptr, uptr size) {
   if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Realloc(ptr, size);

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -110,7 +110,7 @@ INTERCEPTOR(void *, malloc, uptr size) {
 
 #if SANITIZER_APPLE
 INTERCEPTOR(uptr, malloc_size, void *ptr) {
-  if (DlsymAlloc::Use())
+  if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Size(ptr);
   return REAL(malloc_size)(ptr);
 }

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -110,7 +110,7 @@ INTERCEPTOR(void *, malloc, uptr size) {
 
 #if SANITIZER_APPLE
 INTERCEPTOR(uptr, malloc_size, void *ptr) {
-  if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))
+  if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Size(ptr);
   return REAL(malloc_size)(ptr);
 }

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -111,7 +111,7 @@ INTERCEPTOR(void *, malloc, uptr size) {
 #if SANITIZER_APPLE
 INTERCEPTOR(uptr, malloc_size, void *ptr) {
   if (DlsymAlloc::PointerIsMine(ptr))
-    return DlsymAlloc::Size(ptr);
+    return DlsymAlloc::GetSize(ptr);
   return REAL(malloc_size)(ptr);
 }
 #endif


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/120563 malloc_size also needs intercepting on Apple platforms, otherwise all type-sanitized binaries crash on startup with an objc error:
   realized class 0x12345 has corrupt data pointer: malloc_size(0x567) = 0

