### PR TITLE
[SelectionDAG] Use SDNode::op_iterator instead of SDNodeIterator. NFC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -2986,8 +2986,7 @@ bool TargetLowering::SimplifyDemandedBits(
       DemandedBits.isSubsetOf(Known.Zero | Known.One)) {
     // Avoid folding to a constant if any OpaqueConstant is involved.
     const SDNode *N = Op.getNode();
-    for (SDNode *Op :
-         llvm::make_range(SDNodeIterator::begin(N), SDNodeIterator::end(N))) {
+    for (SDValue Op : N->ops()) {
       if (auto *C = dyn_cast<ConstantSDNode>(Op))
         if (C->isOpaque())
           return false;

--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -2985,12 +2985,11 @@ bool TargetLowering::SimplifyDemandedBits(
   if (!isTargetCanonicalConstantNode(Op) &&
       DemandedBits.isSubsetOf(Known.Zero | Known.One)) {
     // Avoid folding to a constant if any OpaqueConstant is involved.
-    const SDNode *N = Op.getNode();
-    for (SDValue Op : N->ops()) {
-      if (auto *C = dyn_cast<ConstantSDNode>(Op))
-        if (C->isOpaque())
-          return false;
-    }
+    if (llvm::any_of(Op->ops(), [](SDValue V) {
+          auto *C = dyn_cast<ConstantSDNode>(V);
+          return C && C->isOpaque();
+        }))
+      return false;
     if (VT.isInteger())
       return TLO.CombineTo(Op, TLO.DAG.getConstant(Known.One, dl, VT));
     if (VT.isFloatingPoint())


### PR DESCRIPTION
I think SDNodeIterator primarily exists because GraphTraits requires an iterator that dereferences to SDNode*. op_iterator dereferences to SDUse* which is implicitly convertible to SDValue.

This piece of code can use SDValue instead of SDNode* so we should prefer to use the the more common op_iterator.