### PR TITLE
[CUDA][HIP] improve error message for missing cmath

### DIFF
--- a/clang/lib/Headers/cuda_wrappers/cmath
+++ b/clang/lib/Headers/cuda_wrappers/cmath
@@ -24,7 +24,11 @@
 #ifndef __CLANG_CUDA_WRAPPERS_CMATH
 #define __CLANG_CUDA_WRAPPERS_CMATH
 
+#if __has_include_next(<cmath>)
 #include_next <cmath>
+#else
+#error "Could not find standard C++ header 'cmath'. Add -v to your compilation command to check the include paths being searched. You may need to install the appropriate standard C++ library package corresponding to the search path."
+#endif
 
 #if defined(_LIBCPP_STD_VER)
 


### PR DESCRIPTION
One common error seen in CUDA/HIP compilation is:

fatal error: 'cmath' file not found

which is due to inproper installation of standard C++ libraries.

Since it happens with #include_next, users may feel confusing which cmath is not found and how to fix it.

Add an error directive to help users resolve this issue.