### PR TITLE
[APINotes] [NFC] Add tests for SWIFT_RETURNS_(UN)RETAINED for ObjC APIs

### DIFF
--- a/clang/test/APINotes/Inputs/Headers/SwiftReturnOwnershipForObjC.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/SwiftReturnOwnershipForObjC.apinotes
@@ -1,0 +1,17 @@
+---
+Name: SwiftImportAsForObjC
+Classes:
+  - Name:            MethodTest
+    Methods:
+      - Selector:        getUnowned
+        MethodKind:      Instance
+        SwiftReturnOwnership: unretained
+      - Selector:        getOwned
+        MethodKind:      Instance
+        SwiftReturnOwnership: retained
+
+Functions:
+  - Name:            getObjCUnowned
+    SwiftReturnOwnership: unretained
+  - Name:            getObjCOwned
+    SwiftReturnOwnership: retained

--- a/clang/test/APINotes/Inputs/Headers/SwiftReturnOwnershipForObjC.h
+++ b/clang/test/APINotes/Inputs/Headers/SwiftReturnOwnershipForObjC.h
@@ -1,0 +1,9 @@
+struct RefCountedType { int value; };
+
+@interface MethodTest
+- (struct RefCountedType *)getUnowned;
+- (struct RefCountedType *)getOwned;
+@end
+
+struct RefCountedType * getObjCUnowned(void);
+struct RefCountedType * getObjCOwned(void);

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -57,3 +57,7 @@ module Templates {
 module SwiftImportAs {
   header "SwiftImportAs.h"
 }
+
+module SwiftReturnOwnershipForObjC {
+  header "SwiftReturnOwnershipForObjC.h"
+}

--- a/clang/test/APINotes/swift-return-ownership.m
+++ b/clang/test/APINotes/swift-return-ownership.m
@@ -1,0 +1,11 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers %s
+// RUN: %clang_cc1 -ast-print %t/ModulesCache/SwiftReturnOwnershipForObjC.pcm | FileCheck %s
+#import <SwiftReturnOwnershipForObjC.h>
+
+// CHECK: @interface MethodTest
+// CHECK: - (struct RefCountedType *)getUnowned __attribute__((swift_attr("returns_unretained")));
+// CHECK: - (struct RefCountedType *)getOwned __attribute__((swift_attr("returns_retained")));
+// CHECK: @end
+// CHECK: __attribute__((swift_attr("returns_unretained"))) struct RefCountedType *getObjCUnowned(void);
+// CHECK: __attribute__((swift_attr("returns_retained"))) struct RefCountedType *getObjCOwned(void);


### PR DESCRIPTION
Adding test case to verify that SwiftReturnOwnership works correctly for ObjC functions and methods as well.

rdar://142504115