### PR TITLE
[clang-tidy][NFC] clean `LangOpts` parameter in `explicitMarkUnused` matcher

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UnusedLocalNonTrivialVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedLocalNonTrivialVariableCheck.cpp
@@ -15,6 +15,7 @@
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/ASTMatchers/ASTMatchersMacros.h"
+#include "clang/Basic/LangOptions.h"
 
 using namespace clang::ast_matchers;
 using namespace clang::tidy::matchers;
@@ -29,9 +30,10 @@ static constexpr StringRef DefaultIncludeTypeRegex =
 
 AST_MATCHER(VarDecl, isLocalVarDecl) { return Node.isLocalVarDecl(); }
 AST_MATCHER(VarDecl, isReferenced) { return Node.isReferenced(); }
-AST_MATCHER_P(VarDecl, explicitMarkUnused, LangOptions, LangOpts) {
+AST_MATCHER(VarDecl, explicitMarkUnused) {
   // Implementations should not emit a warning that a name-independent
   // declaration is used or unused.
+  LangOptions const &LangOpts = Finder->getASTContext().getLangOpts();
   return Node.hasAttr<UnusedAttr>() ||
          (LangOpts.CPlusPlus26 && Node.isPlaceholderVar(LangOpts));
 }
@@ -66,7 +68,7 @@ void UnusedLocalNonTrivialVariableCheck::registerMatchers(MatchFinder *Finder) {
       varDecl(isLocalVarDecl(), unless(isReferenced()),
               unless(isExceptionVariable()), hasLocalStorage(), isDefinition(),
               unless(hasType(isReferenceType())), unless(hasType(isTrivial())),
-              unless(explicitMarkUnused(getLangOpts())),
+              unless(explicitMarkUnused()),
               hasType(hasUnqualifiedDesugaredType(
                   anyOf(recordType(hasDeclaration(namedDecl(
                             matchesAnyListedName(IncludeTypes),


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/121783#discussion_r1907847579