### PR TITLE
[libc] Fix return value of __cxa_thread_atexit_impl function.

### DIFF
--- a/libc/src/__support/threads/thread.cpp
+++ b/libc/src/__support/threads/thread.cpp
@@ -117,7 +117,9 @@ public:
 
   int add_callback(AtExitCallback *callback, void *obj) {
     cpp::lock_guard lock(mtx);
-    return callback_list.push_back({callback, obj});
+    if (callback_list.push_back({callback, obj}))
+      return 0;
+    return -1;
   }
 
   void call() {


### PR DESCRIPTION
This has been added in 0071a79532e8d664b734956a431d8c8c942cc25e to support TLS destructors. Return value of __cxa_thread_atexit is supposed to be the same as std::atexit - zero on success, non-zero on failure. Update the code to do just that (also be consistent with llvm-libc's existing atexit / at_quick_exit implementations).