### PR TITLE
[libc++] Document that internal aliases should be marked _LIBCPP_NODEBUG

### DIFF
--- a/libcxx/docs/CodingGuidelines.rst
+++ b/libcxx/docs/CodingGuidelines.rst
@@ -184,3 +184,13 @@ headers (which is sometimes required for ``constexpr`` support).
 
 When defining a function at the ABI boundary, it can also be useful to consider which attributes (like ``[[gnu::pure]]``
 and ``[[clang::noescape]]``) can be added to the function to improve the compiler's ability to optimize.
+
+Library-internal type aliases should be annotated with ``_LIBCPP_NODEBUG``
+==========================================================================
+
+Libc++ has lots of internal type aliases. Accumulated, these can result in significant amounts of debug information that
+users generally don't care about, since users don't try to debug standard library facilities in most cases. For that
+reason, all library-internal type aliases that aren't function-local should be annotated with ``_LIBCPP_NODEBUG`` to
+prevent compilers from generating said debug information.
+
+This is enforced by the clang-tidy check ``libcpp-nodebug-on-aliases``.


### PR DESCRIPTION
In #118710 we've added ``_LIBCPP_NODEBUG`` to all internal aliases, but didn't actually document it. This patch adds documentation by adding the new requirement and reasoning to the coding guidelines.
