### PR TITLE
Update cloning of the DirectXShaderCompiler repo to not include DXC tests

### DIFF
--- a/llvm/tools/dxil-dis/CMakeLists.txt
+++ b/llvm/tools/dxil-dis/CMakeLists.txt
@@ -38,7 +38,7 @@ ExternalProject_Add(DXC
                     ${GIT_SETTINGS}
                     SOURCE_DIR ${SOURCE_DIR}
                     BINARY_DIR ${BINARY_DIR}
-                    CMAKE_ARGS -C ${SOURCE_DIR}/cmake/caches/PredefinedParams.cmake -DLLVM_INCLUDE_TESTS=On -DLLVM_INCLUDE_TESTS=Off -DCLANG_INCLUDE_TESTS=Off -DHLSL_INCLUDE_TESTS=Off
+                    CMAKE_ARGS -C ${SOURCE_DIR}/cmake/caches/PredefinedParams.cmake -DLLVM_INCLUDE_TESTS=Off -DCLANG_INCLUDE_TESTS=Off -DHLSL_INCLUDE_TESTS=Off
                     BUILD_COMMAND ${CMAKE_COMMAND} --build ${BINARY_DIR} --target llvm-dis
                     BUILD_BYPRODUCTS ${BINARY_DIR}/bin/llvm-dis
                     INSTALL_COMMAND ""

--- a/llvm/tools/dxil-dis/CMakeLists.txt
+++ b/llvm/tools/dxil-dis/CMakeLists.txt
@@ -38,7 +38,7 @@ ExternalProject_Add(DXC
                     ${GIT_SETTINGS}
                     SOURCE_DIR ${SOURCE_DIR}
                     BINARY_DIR ${BINARY_DIR}
-                    CMAKE_ARGS -C ${SOURCE_DIR}/cmake/caches/PredefinedParams.cmake -DLLVM_INCLUDE_TESTS=On
+                    CMAKE_ARGS -C ${SOURCE_DIR}/cmake/caches/PredefinedParams.cmake -DLLVM_INCLUDE_TESTS=On -DLLVM_INCLUDE_TESTS=Off -DCLANG_INCLUDE_TESTS=Off -DHLSL_INCLUDE_TESTS=Off
                     BUILD_COMMAND ${CMAKE_COMMAND} --build ${BINARY_DIR} --target llvm-dis
                     BUILD_BYPRODUCTS ${BINARY_DIR}/bin/llvm-dis
                     INSTALL_COMMAND ""


### PR DESCRIPTION
This prevents any unnecessary dependency on TAEF when building as it's not used for dxil-dis testing