### PR TITLE
Allow packing fields into tail padding of record fields

### DIFF
--- a/clang/test/CodeGenCXX/no-unique-address-3.cpp
+++ b/clang/test/CodeGenCXX/no-unique-address-3.cpp
@@ -65,8 +65,8 @@ Bar J;
 // CHECK-NEXT:             | [sizeof=8, dsize=8, align=4,
 // CHECK-NEXT:             |  nvsize=8, nvalign=4]
 
-// CHECK-LABEL:   LLVMType:%class.IntFieldClass = type { [2 x i8], %class.Second.base, i32 }
-// CHECK-NEXT:    NonVirtualBaseLLVMType:%class.IntFieldClass = type { [2 x i8], %class.Second.base, i32 }
+// CHECK-LABEL:   LLVMType:%class.IntFieldClass = type { [2 x i8], %class.Second, i32 }
+// CHECK-NEXT:    NonVirtualBaseLLVMType:%class.IntFieldClass = type { [2 x i8], %class.Second, i32 }
 class IntFieldClass : Empty {
   [[no_unique_address]] Second Field;
   int C;


### PR DESCRIPTION
Don't use isPotentiallyOverlapping to control behavior that allows overwriting previous field data, because the `[[no_unique_address]]` attribute is not available in any debug info, DWARF or PDB. Instead, just trust the layout given by the frontend and use the smaller base subobject LLVM struct type when the layout requires it.

This extra complexity mainly exists to produce prettier LLVM struct types, which are very vestigial at this point. The main value of using the complete struct type is that it avoids disturbing all of the Clang tests cases that pattern match the existing LLVM struct layout patterns.