### PR TITLE
[Support][LLD] .time-trace.json Default File Extension

### DIFF
--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -54,6 +54,8 @@ Breaking changes
   in line with GNU ld, but is a change in behavior from previous LLD
   releases.
   
+* The default extension for time trace files is now ``.time-trace.json``.
+
 COFF Improvements
 -----------------
 

--- a/lld/test/COFF/time-trace.s
+++ b/lld/test/COFF/time-trace.s
@@ -4,7 +4,7 @@
 
 # Test implicit trace file name
 # RUN: lld-link %t.obj /entry:main /out:%t1.exe --time-trace --time-trace-granularity=0
-# RUN: cat %t1.exe.time-trace \
+# RUN: cat %t1.exe.time-trace.json \
 # RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 # RUN:   | FileCheck %s
 

--- a/lld/test/ELF/lto/thinlto-time-trace.ll
+++ b/lld/test/ELF/lto/thinlto-time-trace.ll
@@ -6,13 +6,13 @@
 
 ; Test single-threaded
 ; RUN: ld.lld --thinlto-jobs=1 --time-trace --time-trace-granularity=0 -shared %t1.o %t2.o -o %t3.so
-; RUN: cat %t3.so.time-trace \
+; RUN: cat %t3.so.time-trace.json \
 ; RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 ; RUN:   | FileCheck %s
 
 ; Test multi-threaded
 ; RUN: ld.lld --time-trace --time-trace-granularity=0 -shared %t1.o %t2.o -o %t4.so
-; RUN: cat %t4.so.time-trace \
+; RUN: cat %t4.so.time-trace.json \
 ; RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 ; RUN:   | FileCheck %s
 

--- a/lld/test/ELF/time-trace.s
+++ b/lld/test/ELF/time-trace.s
@@ -3,7 +3,7 @@
 
 # Test implicit trace file name
 # RUN: ld.lld --time-trace --time-trace-granularity=0 -o %t1.elf %t.o
-# RUN: cat %t1.elf.time-trace \
+# RUN: cat %t1.elf.time-trace.json \
 # RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 # RUN:   | FileCheck %s
 

--- a/lld/test/MachO/map-file.s
+++ b/lld/test/MachO/map-file.s
@@ -15,7 +15,7 @@
 ## Also check that we don't have redundant EH_Frame symbols (regression test)
 # RUN: cat %t/objdump %t/map | FileCheck %s --implicit-check-not _hello_world \
 # RUN:   --implicit-check-not EH_Frame
-# RUN: FileCheck %s --check-prefix=MAPFILE < %t/test.time-trace
+# RUN: FileCheck %s --check-prefix=MAPFILE < %t/test.time-trace.json
 
 # CHECK:       Sections:
 # CHECK-NEXT:  Idx  Name         Size     VMA               Type

--- a/lld/test/MachO/thinlto-time-trace.ll
+++ b/lld/test/MachO/thinlto-time-trace.ll
@@ -5,7 +5,7 @@
 ; RUN: opt -module-summary %t/f.s -o %t/f.o
 ; RUN: opt -module-summary %t/g.s -o %t/g.o
 ; RUN: %lld --time-trace --time-trace-granularity=0 -dylib %t/f.o %t/g.o -o %t/libTest.dylib
-; RUN: cat %t/libTest.dylib.time-trace \
+; RUN: cat %t/libTest.dylib.time-trace.json \
 ; RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 ; RUN:   | FileCheck %s
 

--- a/lld/test/MachO/time-trace.s
+++ b/lld/test/MachO/time-trace.s
@@ -7,7 +7,7 @@
 
 ## Test implicit trace file name
 # RUN: %lld --time-trace --time-trace-granularity=0 -o %t1.macho %t.o
-# RUN: cat %t1.macho.time-trace \
+# RUN: cat %t1.macho.time-trace.json \
 # RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 # RUN:   | FileCheck %s
 

--- a/llvm/include/llvm/Support/TimeProfiler.h
+++ b/llvm/include/llvm/Support/TimeProfiler.h
@@ -84,6 +84,8 @@ namespace llvm {
 
 class raw_pwrite_stream;
 
+static constexpr const auto TimeTraceFileExtension = ".time-trace.json";
+
 // Type of the time trace event.
 enum class TimeTraceEventType {
   // Complete events have a duration (start and end time points) and are marked
@@ -138,7 +140,7 @@ LLVM_ABI void timeTraceProfilerWrite(raw_pwrite_stream &OS);
 
 /// Write profiling data to a file.
 /// The function will write to \p PreferredFileName if provided, if not
-/// then will write to \p FallbackFileName appending .time-trace.
+/// then will write to \p FallbackFileName appending .time-trace.json.
 /// Returns a StringError indicating a failure if the function is
 /// unable to open the file for writing.
 LLVM_ABI Error timeTraceProfilerWrite(StringRef PreferredFileName,

--- a/llvm/include/llvm/Support/TimeProfiler.h
+++ b/llvm/include/llvm/Support/TimeProfiler.h
@@ -84,8 +84,6 @@ namespace llvm {
 
 class raw_pwrite_stream;
 
-static constexpr const auto TimeTraceFileExtension = ".time-trace.json";
-
 // Type of the time trace event.
 enum class TimeTraceEventType {
   // Complete events have a duration (start and end time points) and are marked

--- a/llvm/lib/Support/TimeProfiler.cpp
+++ b/llvm/lib/Support/TimeProfiler.cpp
@@ -434,7 +434,7 @@ Error llvm::timeTraceProfilerWrite(StringRef PreferredFileName,
   std::string Path = PreferredFileName.str();
   if (Path.empty()) {
     Path = FallbackFileName == "-" ? "out" : FallbackFileName.str();
-    Path += ".time-trace";
+    Path += TimeTraceFileExtension;
   }
 
   std::error_code EC;

--- a/llvm/lib/Support/TimeProfiler.cpp
+++ b/llvm/lib/Support/TimeProfiler.cpp
@@ -49,6 +49,8 @@ TimeTraceProfilerInstances &getTimeTraceProfilerInstances() {
   return Instances;
 }
 
+static const char TimeTraceFileExtension[] = ".time-trace.json";
+
 } // anonymous namespace
 
 // Per Thread instance


### PR DESCRIPTION
* Addresses the LLD portion of https://github.com/llvm/llvm-project/issues/96339
* Changes the default file extension in `lld` from `.time-trace` to `.time-trace.json`.
  * As mentioned in the issue, another option worth considering is `.lld.time-trace.json` though I've refrained from doing so in this PR to keep changes minimal.