### PR TITLE
[llvm-gsymutil] Don't warn about non-increasing line tables with merged functions

### DIFF
--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -147,7 +147,7 @@ class GsymCreator {
   bool IsSegment = false;
   bool Finalized = false;
   bool Quiet;
-
+  bool UseMergedFuncs = false;
 
   /// Get the first function start address.
   ///
@@ -486,6 +486,9 @@ public:
   /// encode.
   llvm::Expected<std::unique_ptr<GsymCreator>>
   createSegment(uint64_t SegmentSize, size_t &FuncIdx) const;
+
+  bool getUseMergedFunctions() const { return UseMergedFuncs; }
+  void setUseMergedFunctions(bool Enable) { UseMergedFuncs = Enable; }
 };
 
 } // namespace gsym

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -405,7 +405,7 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
           OS << "warning: duplicate line table detected for DIE:\n";
           Die.dump(OS, 0, DIDumpOptions::getForSingleDIE());
         });
-      else
+      else if (!Gsym.getUseMergedFunctions())
         Out.Report("Non-monotonically increasing addresses",
                    [&](raw_ostream &OS) {
                      OS << "error: line table has addresses that do not "

--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -22,7 +22,7 @@ using namespace llvm;
 using namespace gsym;
 
 GsymCreator::GsymCreator(bool Quiet)
-    : StrTab(StringTableBuilder::ELF), Quiet(Quiet) {
+    : StrTab(StringTableBuilder::ELF), Quiet(Quiet), UseMergedFuncs(false) {
   insertFile(StringRef());
 }
 

--- a/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
+++ b/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
@@ -3,12 +3,15 @@
 # RUN: split-file %s %t
 # RUN: yaml2obj %t/merged_callsites.dSYM.yaml -o %t/merged_callsites.dSYM
 
-# RUN: llvm-gsymutil --convert=%t/merged_callsites.dSYM --merged-functions --callsites-yaml-file=%t/callsites.yaml -o %t/call_sites_dSYM.gsym
-# RUN: llvm-gsymutil --convert=%t/merged_callsites.dSYM --merged-functions --dwarf-callsites -o %t/dwarf_call_sites_dSYM.gsym
+# RUN: llvm-gsymutil --convert=%t/merged_callsites.dSYM --merged-functions --callsites-yaml-file=%t/callsites.yaml -o %t/call_sites_dSYM.gsym | FileCheck --check-prefix=CHECK-CONVERT %s
+# RUN: llvm-gsymutil --convert=%t/merged_callsites.dSYM --merged-functions --dwarf-callsites -o %t/dwarf_call_sites_dSYM.gsym | FileCheck --check-prefix=CHECK-CONVERT %s
 
 # Dump the GSYM file and check the output for callsite information
 # RUN: llvm-gsymutil %t/call_sites_dSYM.gsym | FileCheck --check-prefix=CHECK-MERGED-CALLSITES %s
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym | FileCheck --check-prefix=CHECK-MERGED-CALLSITES %s
+
+# CHECK-CONVERT-NOT: line table has addresses that do not monotonically increase
+# CHECK-CONVERT-NOT: Non-monotonically increasing addresses occurred
 
 # CHECK-MERGED-CALLSITES:      FunctionInfo @ 0x[[#%x,FUNC4_1:]]: [0x[[#%x,FUNC4_1_START:]] - 0x[[#%x,FUNC4_1_END:]]) "function4_copy1"
 # CHECK-MERGED-CALLSITES:      ++ Merged FunctionInfos[0]:

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -331,6 +331,7 @@ static llvm::Error handleObjectFile(ObjectFile &Obj, const std::string &OutFile,
       NumThreads > 0 ? NumThreads : std::thread::hardware_concurrency();
 
   GsymCreator Gsym(Quiet);
+  Gsym.setUseMergedFunctions(UseMergedFunctions);
 
   // See if we can figure out the base address for a given object file, and if
   // we can, then set the base address to use to this value. This will ease


### PR DESCRIPTION
When converting a dSYM to gSYM, if the dSYM contains merged functions, it is expected that the dSYM contain line tables with non-monotonically increasing addresses.

This isn't an issue and we shouldn't emit an error or warning in such cases.

With this change we don't emit such messages when converting a dSYM to gSYM with merged functions enabled. 