### PR TITLE
[Github] Fix LLVM Project Tests Workflow on Linux

### DIFF
--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -37,5 +37,5 @@ jobs:
       projects: clang
       # There is an issue running on "windows-2019".
       # See https://github.com/llvm/llvm-project/issues/76601#issuecomment-1873049082.
-      os_list: '["ubuntu-latest"]'
+      os_list: '["ubuntu-22.04"]'
       python_version: ${{ matrix.python-version }}

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -39,7 +39,12 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        default: '["ubuntu-latest", "windows-2019", "macOS-13"]'
+        # Use ubuntu-22.04 rather than ubuntu-latest to match the ubuntu
+        # version in the CI container. Without this, setup-python tries
+        # to install a python version linked against a newer version of glibc.
+        # TODO(boomanaiden154): Bump the Ubuntu version once the version in the
+        # container is bumped.
+        default: '["ubuntu-22.04", "windows-2019", "macOS-13"]'
 
       python_version:
         required: false
@@ -113,7 +118,8 @@ jobs:
         run: |
           if [ "${{ runner.os }}" == "Linux" ]; then
             builddir="/mnt/build/"
-            mkdir -p $builddir
+            sudo mkdir -p $builddir
+            sudo chown gha $builddir
             extra_cmake_args="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang"
           else
             builddir="$(pwd)"/build


### PR DESCRIPTION
This patch fixes the LLVM project tests workflow on Linux. Two changes were needed. Firstly, some commands need to be performed with sudo now that the container executes as a non-root user. Second, we needed to change from `ubuntu-latest` to `ubuntu-22.04` as `ubuntu-latest` not defaults to `ubuntu-24.04` which causes `setup-python` to install a python executable linked against a newer version of glibc that is not found on ubuntu 22.04, which causes failures when CMake cannot execute the python interpreter that it finds.