### PR TITLE
[ORC][llvm-jitlink] Add SimpleLazyReexportsSpeculator, use in llvm-ji…

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/JITLinkReentryTrampolines.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/JITLinkReentryTrampolines.h
@@ -65,7 +65,8 @@ private:
 Expected<std::unique_ptr<LazyReexportsManager>>
 createJITLinkLazyReexportsManager(ObjectLinkingLayer &ObjLinkingLayer,
                                   RedirectableSymbolManager &RSMgr,
-                                  JITDylib &PlatformJD);
+                                  JITDylib &PlatformJD,
+                                  LazyReexportsManager::Listener *L = nullptr);
 
 } // namespace llvm::orc
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/LazyReexports.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/LazyReexports.h
@@ -179,6 +179,37 @@ class LazyReexportsManager : public ResourceManager {
   lazyReexports(LazyReexportsManager &, SymbolAliasMap);
 
 public:
+  struct CallThroughInfo {
+    JITDylibSP JD;
+    SymbolStringPtr Name;
+    SymbolStringPtr BodyName;
+  };
+
+  class Listener {
+  public:
+    using CallThroughInfo = LazyReexportsManager::CallThroughInfo;
+
+    virtual ~Listener();
+
+    /// Called under the session lock when new lazy reexports are created.
+    virtual void onLazyReexportsCreated(JITDylib &JD, ResourceKey K,
+                                        const SymbolAliasMap &Reexports) = 0;
+
+    /// Called under the session lock when lazy reexports have their ownership
+    /// transferred to a new ResourceKey.
+    virtual void onLazyReexportsTransfered(JITDylib &JD, ResourceKey DstK,
+                                           ResourceKey SrcK) = 0;
+
+    /// Called under the session lock when lazy reexports are removed.
+    virtual Error onLazyReexportsRemoved(JITDylib &JD, ResourceKey K) = 0;
+
+    /// Called outside the session lock when a lazy reexport is called.
+    /// NOTE: Since this is called outside the session lock there is a chance
+    ///       that the reexport referred to has already been removed. Listeners
+    ///       must be prepared to handle requests for stale reexports.
+    virtual void onLazyReexportCalled(const CallThroughInfo &CTI) = 0;
+  };
+
   using OnTrampolinesReadyFn = unique_function<void(
       Expected<std::vector<ExecutorSymbolDef>> EntryAddrs)>;
   using EmitTrampolinesFn =
@@ -189,7 +220,7 @@ public:
   /// This will work both in-process and out-of-process.
   static Expected<std::unique_ptr<LazyReexportsManager>>
   Create(EmitTrampolinesFn EmitTrampolines, RedirectableSymbolManager &RSMgr,
-         JITDylib &PlatformJD);
+         JITDylib &PlatformJD, Listener *L = nullptr);
 
   LazyReexportsManager(LazyReexportsManager &&) = delete;
   LazyReexportsManager &operator=(LazyReexportsManager &&) = delete;
@@ -199,12 +230,6 @@ public:
                                ResourceKey SrcK) override;
 
 private:
-  struct CallThroughInfo {
-    SymbolStringPtr Name;
-    SymbolStringPtr BodyName;
-    JITDylibSP JD;
-  };
-
   class MU;
   class Plugin;
 
@@ -213,7 +238,7 @@ private:
 
   LazyReexportsManager(EmitTrampolinesFn EmitTrampolines,
                        RedirectableSymbolManager &RSMgr, JITDylib &PlatformJD,
-                       Error &Err);
+                       Listener *L, Error &Err);
 
   std::unique_ptr<MaterializationUnit>
   createLazyReexports(SymbolAliasMap Reexports);
@@ -229,6 +254,7 @@ private:
   ExecutionSession &ES;
   EmitTrampolinesFn EmitTrampolines;
   RedirectableSymbolManager &RSMgr;
+  Listener *L;
 
   DenseMap<ResourceKey, std::vector<ExecutorAddr>> KeyToReentryAddrs;
   DenseMap<ExecutorAddr, CallThroughInfo> CallThroughs;
@@ -241,6 +267,66 @@ inline std::unique_ptr<MaterializationUnit>
 lazyReexports(LazyReexportsManager &LRM, SymbolAliasMap Reexports) {
   return LRM.createLazyReexports(std::move(Reexports));
 }
+
+class SimpleLazyReexportsSpeculator : public LazyReexportsManager::Listener {
+  friend std::shared_ptr<SimpleLazyReexportsSpeculator> std::make_shared();
+
+public:
+  using RecordExecutionFunction =
+      unique_function<void(const CallThroughInfo &CTI)>;
+
+  static std::shared_ptr<SimpleLazyReexportsSpeculator>
+  Create(ExecutionSession &ES, RecordExecutionFunction RecordExec = {}) {
+    class make_shared_helper : public SimpleLazyReexportsSpeculator {
+    public:
+      make_shared_helper(ExecutionSession &ES,
+                         RecordExecutionFunction RecordExec)
+          : SimpleLazyReexportsSpeculator(ES, std::move(RecordExec)) {}
+    };
+
+    auto Instance =
+        std::make_shared<make_shared_helper>(ES, std::move(RecordExec));
+    Instance->WeakThis = Instance;
+    return Instance;
+  }
+
+  SimpleLazyReexportsSpeculator(SimpleLazyReexportsSpeculator &&) = delete;
+  SimpleLazyReexportsSpeculator &
+  operator=(SimpleLazyReexportsSpeculator &&) = delete;
+  ~SimpleLazyReexportsSpeculator() override;
+
+  void onLazyReexportsCreated(JITDylib &JD, ResourceKey K,
+                              const SymbolAliasMap &Reexports) override;
+
+  void onLazyReexportsTransfered(JITDylib &JD, ResourceKey DstK,
+                                 ResourceKey SrcK) override;
+
+  Error onLazyReexportsRemoved(JITDylib &JD, ResourceKey K) override;
+
+  void onLazyReexportCalled(const CallThroughInfo &CTI) override;
+
+  void addSpeculationSuggestions(
+      std::vector<std::pair<std::string, SymbolStringPtr>> NewSuggestions);
+
+private:
+  SimpleLazyReexportsSpeculator(ExecutionSession &ES,
+                                RecordExecutionFunction RecordExec)
+      : ES(ES), RecordExec(std::move(RecordExec)) {}
+
+  bool doNextSpeculativeLookup();
+
+  class SpeculateTask;
+
+  using KeyToFunctionBodiesMap =
+      DenseMap<ResourceKey, std::vector<SymbolStringPtr>>;
+
+  ExecutionSession &ES;
+  RecordExecutionFunction RecordExec;
+  std::weak_ptr<SimpleLazyReexportsSpeculator> WeakThis;
+  DenseMap<JITDylib *, KeyToFunctionBodiesMap> LazyReexports;
+  std::deque<std::pair<std::string, SymbolStringPtr>> SpeculateSuggestions;
+  bool SpeculateTaskActive = false;
+};
 
 } // End namespace orc
 } // End namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/Orc/TaskDispatch.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TaskDispatch.h
@@ -92,6 +92,16 @@ makeGenericNamedTask(FnT &&Fn, const char *Desc = nullptr) {
                                                      Desc);
 }
 
+/// IdleTask can be used as the basis for low-priority tasks, e.g. speculative
+/// lookup.
+class IdleTask : public RTTIExtends<IdleTask, Task> {
+public:
+  static char ID;
+
+private:
+  void anchor() override;
+};
+
 /// Abstract base for classes that dispatch ORC Tasks.
 class TaskDispatcher {
 public:
@@ -118,9 +128,13 @@ public:
   DynamicThreadPoolTaskDispatcher(
       std::optional<size_t> MaxMaterializationThreads)
       : MaxMaterializationThreads(MaxMaterializationThreads) {}
+
   void dispatch(std::unique_ptr<Task> T) override;
   void shutdown() override;
 private:
+  bool canRunMaterializationTaskNow();
+  bool canRunIdleTaskNow();
+
   std::mutex DispatchMutex;
   bool Shutdown = false;
   size_t Outstanding = 0;
@@ -129,6 +143,7 @@ private:
   std::optional<size_t> MaxMaterializationThreads;
   size_t NumMaterializationThreads = 0;
   std::deque<std::unique_ptr<Task>> MaterializationTaskQueue;
+  std::deque<std::unique_ptr<Task>> IdleTaskQueue;
 };
 
 #endif // LLVM_ENABLE_THREADS

--- a/llvm/lib/ExecutionEngine/Orc/JITLinkReentryTrampolines.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITLinkReentryTrampolines.cpp
@@ -173,7 +173,8 @@ void JITLinkReentryTrampolines::emit(ResourceTrackerSP RT,
 Expected<std::unique_ptr<LazyReexportsManager>>
 createJITLinkLazyReexportsManager(ObjectLinkingLayer &ObjLinkingLayer,
                                   RedirectableSymbolManager &RSMgr,
-                                  JITDylib &PlatformJD) {
+                                  JITDylib &PlatformJD,
+                                  LazyReexportsManager::Listener *L) {
   auto JLT = JITLinkReentryTrampolines::Create(ObjLinkingLayer);
   if (!JLT)
     return JLT.takeError();
@@ -184,7 +185,7 @@ createJITLinkLazyReexportsManager(ObjectLinkingLayer &ObjLinkingLayer,
                                   OnTrampolinesReady) mutable {
         JLT->emit(std::move(RT), NumTrampolines, std::move(OnTrampolinesReady));
       },
-      RSMgr, PlatformJD);
+      RSMgr, PlatformJD, L);
 }
 
 } // namespace llvm::orc

--- a/llvm/lib/ExecutionEngine/Orc/LazyReexports.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LazyReexports.cpp
@@ -280,31 +280,34 @@ private:
   std::mutex M;
 };
 
+LazyReexportsManager::Listener::~Listener() = default;
+
 Expected<std::unique_ptr<LazyReexportsManager>>
 LazyReexportsManager::Create(EmitTrampolinesFn EmitTrampolines,
                              RedirectableSymbolManager &RSMgr,
-                             JITDylib &PlatformJD) {
+                             JITDylib &PlatformJD, Listener *L) {
   Error Err = Error::success();
   std::unique_ptr<LazyReexportsManager> LRM(new LazyReexportsManager(
-      std::move(EmitTrampolines), RSMgr, PlatformJD, Err));
+      std::move(EmitTrampolines), RSMgr, PlatformJD, L, Err));
   if (Err)
     return std::move(Err);
   return std::move(LRM);
 }
 
 Error LazyReexportsManager::handleRemoveResources(JITDylib &JD, ResourceKey K) {
-  JD.getExecutionSession().runSessionLocked([&]() {
+  return JD.getExecutionSession().runSessionLocked([&]() -> Error {
     auto I = KeyToReentryAddrs.find(K);
-    if (I != KeyToReentryAddrs.end()) {
-      auto &ReentryAddrs = I->second;
-      for (auto &ReentryAddr : ReentryAddrs) {
-        assert(CallThroughs.count(ReentryAddr) && "CallTrhough missing");
-        CallThroughs.erase(ReentryAddr);
-      }
-      KeyToReentryAddrs.erase(I);
+    if (I == KeyToReentryAddrs.end())
+      return Error::success();
+
+    auto &ReentryAddrs = I->second;
+    for (auto &ReentryAddr : ReentryAddrs) {
+      assert(CallThroughs.count(ReentryAddr) && "CallTrhough missing");
+      CallThroughs.erase(ReentryAddr);
     }
+    KeyToReentryAddrs.erase(I);
+    return L ? L->onLazyReexportsRemoved(JD, K) : Error::success();
   });
-  return Error::success();
 }
 
 void LazyReexportsManager::handleTransferResources(JITDylib &JD,
@@ -323,14 +326,17 @@ void LazyReexportsManager::handleTransferResources(JITDylib &JD,
       DstAddrs.insert(DstAddrs.end(), SrcAddrs.begin(), SrcAddrs.end());
       KeyToReentryAddrs.erase(I);
     }
+    if (L)
+      L->onLazyReexportsTransfered(JD, DstK, SrcK);
   }
 }
 
 LazyReexportsManager::LazyReexportsManager(EmitTrampolinesFn EmitTrampolines,
                                            RedirectableSymbolManager &RSMgr,
-                                           JITDylib &PlatformJD, Error &Err)
+                                           JITDylib &PlatformJD, Listener *L,
+                                           Error &Err)
     : ES(PlatformJD.getExecutionSession()),
-      EmitTrampolines(std::move(EmitTrampolines)), RSMgr(RSMgr) {
+      EmitTrampolines(std::move(EmitTrampolines)), RSMgr(RSMgr), L(L) {
 
   using namespace shared;
 
@@ -384,17 +390,22 @@ void LazyReexportsManager::emitRedirectableSymbols(
     Redirs[Name] = (*ReentryPoints)[I++];
 
   I = 0;
-  if (auto Err = MR->withResourceKeyDo([&](ResourceKey K) {
-        for (auto &[Name, AI] : Reexports) {
-          const auto &ReentryPoint = (*ReentryPoints)[I++];
-          CallThroughs[ReentryPoint.getAddress()] = {Name, AI.Aliasee,
-                                                     &MR->getTargetJITDylib()};
-          KeyToReentryAddrs[K].push_back(ReentryPoint.getAddress());
-        }
-      })) {
-    MR->getExecutionSession().reportError(std::move(Err));
-    MR->failMaterialization();
-    return;
+  if (!Reexports.empty()) {
+    if (auto Err = MR->withResourceKeyDo([&](ResourceKey K) {
+          auto &JD = MR->getTargetJITDylib();
+          auto &ReentryAddrsForK = KeyToReentryAddrs[K];
+          for (auto &[Name, AI] : Reexports) {
+            const auto &ReentryPoint = (*ReentryPoints)[I++];
+            CallThroughs[ReentryPoint.getAddress()] = {&JD, Name, AI.Aliasee};
+            ReentryAddrsForK.push_back(ReentryPoint.getAddress());
+          }
+          if (L)
+            L->onLazyReexportsCreated(JD, K, Reexports);
+        })) {
+      MR->getExecutionSession().reportError(std::move(Err));
+      MR->failMaterialization();
+      return;
+    }
   }
 
   RSMgr.emitRedirectableSymbols(std::move(MR), std::move(Redirs));
@@ -415,6 +426,9 @@ void LazyReexportsManager::resolve(ResolveSendResultFn SendResult,
     LandingInfo = I->second;
   });
 
+  if (L)
+    L->onLazyReexportCalled(LandingInfo);
+
   SymbolInstance LandingSym(LandingInfo.JD, std::move(LandingInfo.BodyName));
   LandingSym.lookupAsync([this, JD = std::move(LandingInfo.JD),
                           ReentryName = std::move(LandingInfo.Name),
@@ -430,6 +444,169 @@ void LazyReexportsManager::resolve(ResolveSendResultFn SendResult,
     } else
       SendResult(std::move(Result));
   });
+}
+
+class SimpleLazyReexportsSpeculator::SpeculateTask : public IdleTask {
+public:
+  SpeculateTask(std::weak_ptr<SimpleLazyReexportsSpeculator> Speculator)
+      : Speculator(std::move(Speculator)) {}
+
+  void printDescription(raw_ostream &OS) override {
+    OS << "Speculative Lookup Task";
+  }
+
+  void run() override {
+    if (auto S = Speculator.lock())
+      S->doNextSpeculativeLookup();
+  }
+
+private:
+  std::weak_ptr<SimpleLazyReexportsSpeculator> Speculator;
+};
+
+SimpleLazyReexportsSpeculator::~SimpleLazyReexportsSpeculator() {
+  for (auto &[JD, _] : LazyReexports)
+    JITDylibSP(JD)->Release();
+}
+
+void SimpleLazyReexportsSpeculator::onLazyReexportsCreated(
+    JITDylib &JD, ResourceKey K, const SymbolAliasMap &Reexports) {
+  if (!LazyReexports.count(&JD))
+    JD.Retain();
+  auto &BodiesVec = LazyReexports[&JD][K];
+  for (auto &[Name, AI] : Reexports)
+    BodiesVec.push_back(AI.Aliasee);
+  if (!SpeculateTaskActive) {
+    SpeculateTaskActive = true;
+    ES.dispatchTask(std::make_unique<SpeculateTask>(WeakThis));
+  }
+}
+
+void SimpleLazyReexportsSpeculator::onLazyReexportsTransfered(
+    JITDylib &JD, ResourceKey DstK, ResourceKey SrcK) {
+
+  auto I = LazyReexports.find(&JD);
+  if (I == LazyReexports.end())
+    return;
+
+  auto &MapForJD = I->second;
+  auto J = MapForJD.find(SrcK);
+  if (J == MapForJD.end())
+    return;
+
+  // We have something to transfer.
+  auto K = MapForJD.find(DstK);
+  if (K == MapForJD.end()) {
+    auto Tmp = std::move(J->second);
+    MapForJD.erase(J);
+    MapForJD[DstK] = std::move(Tmp);
+  } else {
+    auto &SrcNames = J->second;
+    auto &DstNames = K->second;
+    DstNames.insert(DstNames.end(), SrcNames.begin(), SrcNames.end());
+    MapForJD.erase(J);
+  }
+}
+
+Error SimpleLazyReexportsSpeculator::onLazyReexportsRemoved(JITDylib &JD,
+                                                            ResourceKey K) {
+
+  auto I = LazyReexports.find(&JD);
+  if (I == LazyReexports.end())
+    return Error::success();
+
+  auto &MapForJD = I->second;
+  MapForJD.erase(K);
+
+  if (MapForJD.empty()) {
+    LazyReexports.erase(I);
+    JD.Release();
+  }
+
+  return Error::success();
+}
+
+void SimpleLazyReexportsSpeculator::onLazyReexportCalled(
+    const CallThroughInfo &CTI) {
+  if (RecordExec)
+    RecordExec(CTI);
+}
+
+void SimpleLazyReexportsSpeculator::addSpeculationSuggestions(
+    std::vector<std::pair<std::string, SymbolStringPtr>> NewSuggestions) {
+  ES.runSessionLocked([&]() {
+    for (auto &[JDName, SymbolName] : NewSuggestions)
+      SpeculateSuggestions.push_back(
+          {std::move(JDName), std::move(SymbolName)});
+  });
+}
+
+bool SimpleLazyReexportsSpeculator::doNextSpeculativeLookup() {
+  // Use existing speculation queue if available, otherwise take the next
+  // element from LazyReexports.
+  JITDylibSP SpeculateJD = nullptr;
+  SymbolStringPtr SpeculateFn;
+
+  auto SpeculateAgain = ES.runSessionLocked([&]() {
+    while (!SpeculateSuggestions.empty()) {
+      auto [JDName, SymbolName] = std::move(SpeculateSuggestions.front());
+      SpeculateSuggestions.pop_front();
+
+      if (auto *JD = ES.getJITDylibByName(JDName)) {
+        SpeculateJD = JD;
+        SpeculateFn = std::move(SymbolName);
+        break;
+      }
+    }
+
+    if (!SpeculateJD) {
+      assert(!LazyReexports.empty() && "LazyReexports map is empty");
+      auto LRItr =
+          std::next(LazyReexports.begin(), rand() % LazyReexports.size());
+      auto &[JD, KeyToFnBodies] = *LRItr;
+
+      assert(!KeyToFnBodies.empty() && "Key to function bodies map empty");
+      auto KeyToFnBodiesItr =
+          std::next(KeyToFnBodies.begin(), rand() % KeyToFnBodies.size());
+      auto &[Key, FnBodies] = *KeyToFnBodiesItr;
+
+      assert(!FnBodies.empty() && "Function bodies list empty");
+      auto FnBodyItr = std::next(FnBodies.begin(), rand() % FnBodies.size());
+
+      SpeculateJD = JITDylibSP(JD);
+      SpeculateFn = std::move(*FnBodyItr);
+
+      FnBodies.erase(FnBodyItr);
+      if (FnBodies.empty()) {
+        KeyToFnBodies.erase(KeyToFnBodiesItr);
+        if (KeyToFnBodies.empty()) {
+          LRItr->first->Release();
+          LazyReexports.erase(LRItr);
+        }
+      }
+    }
+
+    SpeculateTaskActive =
+        !SpeculateSuggestions.empty() || !LazyReexports.empty();
+    return SpeculateTaskActive;
+  });
+
+  LLVM_DEBUG({
+    dbgs() << "Issuing speculative lookup for ( " << SpeculateJD->getName()
+           << ", " << SpeculateFn << " )...\n";
+  });
+
+  ES.lookup(
+      LookupKind::Static, makeJITDylibSearchOrder(SpeculateJD.get()),
+      {{std::move(SpeculateFn), SymbolLookupFlags::WeaklyReferencedSymbol}},
+      SymbolState::Ready,
+      [](Expected<SymbolMap> Result) { consumeError(Result.takeError()); },
+      NoDependenciesToRegister);
+
+  if (SpeculateAgain)
+    ES.dispatchTask(std::make_unique<SpeculateTask>(WeakThis));
+
+  return false;
 }
 
 } // End namespace orc.

--- a/llvm/lib/ExecutionEngine/Orc/TaskDispatch.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TaskDispatch.cpp
@@ -15,9 +15,13 @@ namespace orc {
 
 char Task::ID = 0;
 char GenericNamedTask::ID = 0;
+char IdleTask::ID = 0;
+
 const char *GenericNamedTask::DefaultDescription = "Generic Task";
 
 void Task::anchor() {}
+void IdleTask::anchor() {}
+
 TaskDispatcher::~TaskDispatcher() = default;
 
 void InPlaceTaskDispatcher::dispatch(std::unique_ptr<Task> T) { T->run(); }
@@ -26,7 +30,15 @@ void InPlaceTaskDispatcher::shutdown() {}
 
 #if LLVM_ENABLE_THREADS
 void DynamicThreadPoolTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
-  bool IsMaterializationTask = isa<MaterializationTask>(*T);
+
+  enum { Normal, Materialization, Idle } TaskKind;
+
+  if (isa<MaterializationTask>(*T))
+    TaskKind = Materialization;
+  else if (isa<IdleTask>(*T))
+    TaskKind = Idle;
+  else
+    TaskKind = Normal;
 
   {
     std::lock_guard<std::mutex> Lock(DispatchMutex);
@@ -35,24 +47,24 @@ void DynamicThreadPoolTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
     if (Shutdown)
       return;
 
-    if (IsMaterializationTask) {
+    if (TaskKind == Materialization) {
 
       // If this is a materialization task and there are too many running
       // already then queue this one up and return early.
-      if (MaxMaterializationThreads &&
-          NumMaterializationThreads == *MaxMaterializationThreads) {
-        MaterializationTaskQueue.push_back(std::move(T));
-        return;
-      }
+      if (!canRunMaterializationTaskNow())
+        return MaterializationTaskQueue.push_back(std::move(T));
 
       // Otherwise record that we have a materialization task running.
       ++NumMaterializationThreads;
+    } else if (TaskKind == Idle) {
+      if (!canRunIdleTaskNow())
+        return IdleTaskQueue.push_back(std::move(T));
     }
 
     ++Outstanding;
   }
 
-  std::thread([this, T = std::move(T), IsMaterializationTask]() mutable {
+  std::thread([this, T = std::move(T), TaskKind]() mutable {
     while (true) {
 
       // Run the task.
@@ -67,18 +79,24 @@ void DynamicThreadPoolTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
       // Check the work queue state and either proceed with the next task or
       // end this thread.
       std::lock_guard<std::mutex> Lock(DispatchMutex);
-      if (!MaterializationTaskQueue.empty()) {
+
+      if (TaskKind == Materialization)
+        --NumMaterializationThreads;
+      --Outstanding;
+
+      if (!MaterializationTaskQueue.empty() && canRunMaterializationTaskNow()) {
         // If there are any materialization tasks running then steal that work.
         T = std::move(MaterializationTaskQueue.front());
         MaterializationTaskQueue.pop_front();
-        if (!IsMaterializationTask) {
-          ++NumMaterializationThreads;
-          IsMaterializationTask = true;
-        }
+        TaskKind = Materialization;
+        ++NumMaterializationThreads;
+        ++Outstanding;
+      } else if (!IdleTaskQueue.empty() && canRunIdleTaskNow()) {
+        T = std::move(IdleTaskQueue.front());
+        IdleTaskQueue.pop_front();
+        TaskKind = Idle;
+        ++Outstanding;
       } else {
-        if (IsMaterializationTask)
-          --NumMaterializationThreads;
-        --Outstanding;
         if (Outstanding == 0)
           OutstandingCV.notify_all();
         return;
@@ -92,6 +110,17 @@ void DynamicThreadPoolTaskDispatcher::shutdown() {
   Shutdown = true;
   OutstandingCV.wait(Lock, [this]() { return Outstanding == 0; });
 }
+
+bool DynamicThreadPoolTaskDispatcher::canRunMaterializationTaskNow() {
+  return !MaxMaterializationThreads ||
+         (NumMaterializationThreads < *MaxMaterializationThreads);
+}
+
+bool DynamicThreadPoolTaskDispatcher::canRunIdleTaskNow() {
+  return !MaxMaterializationThreads ||
+         (Outstanding < *MaxMaterializationThreads);
+}
+
 #endif
 
 } // namespace orc

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.h
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.h
@@ -33,13 +33,17 @@ namespace llvm {
 struct Session {
 
   struct LazyLinkingSupport {
-    LazyLinkingSupport(std::unique_ptr<orc::RedirectableSymbolManager> RSMgr,
-                       std::unique_ptr<orc::LazyReexportsManager> LRMgr,
-                       orc::ObjectLinkingLayer &ObjLinkingLayer)
-        : RSMgr(std::move(RSMgr)), LRMgr(std::move(LRMgr)),
+    LazyLinkingSupport(
+        std::unique_ptr<orc::RedirectableSymbolManager> RSMgr,
+        std::shared_ptr<orc::SimpleLazyReexportsSpeculator> Speculator,
+        std::unique_ptr<orc::LazyReexportsManager> LRMgr,
+        orc::ObjectLinkingLayer &ObjLinkingLayer)
+        : RSMgr(std::move(RSMgr)), Speculator(std::move(Speculator)),
+          LRMgr(std::move(LRMgr)),
           LazyObjLinkingLayer(ObjLinkingLayer, *this->LRMgr) {}
 
     std::unique_ptr<orc::RedirectableSymbolManager> RSMgr;
+    std::shared_ptr<orc::SimpleLazyReexportsSpeculator> Speculator;
     std::unique_ptr<orc::LazyReexportsManager> LRMgr;
     orc::LazyObjectLinkingLayer LazyObjLinkingLayer;
   };
@@ -52,6 +56,7 @@ struct Session {
   std::unique_ptr<LazyLinkingSupport> LazyLinking;
   orc::JITDylibSearchOrder JDSearchOrder;
   SubtargetFeatures Features;
+  std::vector<std::pair<std::string, orc::SymbolStringPtr>> LazyFnExecOrder;
 
   ~Session();
 


### PR DESCRIPTION
…tlink.

Also adds a new IdleTask type and updates DynamicThreadPoolTaskDispatcher to schedule IdleTasks whenever the total number of threads running is less than the maximum number of MaterializationThreads.

A SimpleLazyReexportsSpeculator instance maintains a list of speculation suggestions ((JITDylib, Function) pairs) and registered lazy reexports. When speculation opportunities are available (having been added via addSpeculationSuggestions or when lazy reexports were created) it schedules an IdleTask that triggers the next speculative lookup as soon as resources are available. Speculation suggestions are processed first, followed by lookups for lazy reexport bodies. A callback can be registered at object construction time to record lazy reexport executions as they happen, and these executions can be fed back into the speculator as suggestions on subsequent executions.

The llvm-jitlink tool is updated to support speculation when lazy linking is used via three new arguments:

 -speculate=[none|simple] : When the 'simple' value is specified a
                            SimpleLazyReexportsSpeculator instances is used
                            for speculation.

 -speculate-order <path> : Specifies a path to a CSV containing
                           (jit dylib name, function name) triples to use
                           as speculative suggestions in the current run.

 -record-lazy-execs <path> : Specifies a path in which to record lazy function
                             executions as a CSV of (jit dylib name, function
                             name) pairs, suitable for use with
                             -speculate-order.

The same path can be passed to -speculate-order and -record-lazy-execs, in which case the file will be overwritten at the end of the execution.

No testcase yet: Speculative linking is difficult to test (since by definition execution behavior should be unaffected by speculation) and this is an new prototype of the concept*. Tests will be added in the future once the interface and behavior settle down.

* An earlier implementation of the speculation concept can be found in llvm/include/llvm/ExecutionEngine/Orc/Speculation.h. Both systems have the same goal (hiding compilation latency) but different mechanisms. This patch relies entirely on information available in the controller, where the old system could receive additional information from the JIT'd runtime via callbacks. I aim to combine the two in the future, but want to gain more practical experience with speculation first.