### PR TITLE
[SelectionDAG][AMDGPU] Negative offset when selecting scratch sv offsets

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -1926,7 +1926,8 @@ bool AMDGPUDAGToDAGISel::checkFlatScratchSVSSwizzleBug(
   KnownBits VKnown = CurDAG->computeKnownBits(VAddr);
   KnownBits SKnown =
       KnownBits::add(CurDAG->computeKnownBits(SAddr),
-                     KnownBits::makeConstant(APInt(32, ImmOffset)));
+                     KnownBits::makeConstant(APInt(32, ImmOffset,
+                                                   /*isSigned=*/true)));
   uint64_t VMax = VKnown.getMaxValue().getZExtValue();
   uint64_t SMax = SKnown.getMaxValue().getZExtValue();
   return (VMax & 3) + (SMax & 3) >= 4;


### PR DESCRIPTION
APInt will fail when given a negative offset. SelectScratchSVAddr utilizes this function and can be given a negative offset as well, so this change modifies it to use APSInt instead.