### PR TITLE
[InstCombine] Further relax one-use constraint in `foldICmpBinOp`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCompares.cpp
@@ -5435,7 +5435,6 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
   }
 
   if (BO0 && BO1 && BO0->getOpcode() == BO1->getOpcode() &&
-      (BO0->hasOneUse() || BO1->hasOneUse()) &&
       BO0->getOperand(1) == BO1->getOperand(1)) {
     switch (BO0->getOpcode()) {
     default:
@@ -5468,7 +5467,8 @@ Instruction *InstCombinerImpl::foldICmpBinOp(ICmpInst &I,
         break;
 
       const APInt *C;
-      if (match(BO0->getOperand(1), m_APInt(C)) && !C->isZero() &&
+      if (BO0->hasOneUse() && BO1->hasOneUse() &&
+          match(BO0->getOperand(1), m_APInt(C)) && !C->isZero() &&
           !C->isOne()) {
         // icmp eq/ne (X * C), (Y * C) --> icmp (X & Mask), (Y & Mask)
         // Mask = -1 >> count-trailing-zeros(C).

--- a/llvm/test/Transforms/InstCombine/icmp-mul.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-mul.ll
@@ -3,6 +3,7 @@
 
 declare void @llvm.assume(i1)
 declare void @use(i8)
+declare void @use32(i32)
 declare void @usev2xi8(<2 x i8>)
 
 
@@ -776,6 +777,39 @@ define i1 @eq_mul_constants_with_tz(i32 %x, i32 %y) {
 ;
   %A = mul i32 %x, 12
   %B = mul i32 %y, 12
+  %C = icmp ne i32 %A, %B
+  ret i1 %C
+}
+
+define i1 @eq_mul_constants_with_tz_extra_use1(i32 %x, i32 %y) {
+; CHECK-LABEL: @eq_mul_constants_with_tz_extra_use1(
+; CHECK-NEXT:    [[A:%.*]] = mul i32 [[X:%.*]], 12
+; CHECK-NEXT:    call void @use32(i32 [[A]])
+; CHECK-NEXT:    [[TMP1:%.*]] = xor i32 [[X]], [[Y:%.*]]
+; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 1073741823
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[TMP2]], 0
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %A = mul i32 %x, 12
+  call void @use32(i32 %A)
+  %B = mul i32 %y, 12
+  %C = icmp ne i32 %A, %B
+  ret i1 %C
+}
+
+define i1 @eq_mul_constants_with_tz_extra_use2(i32 %x, i32 %y) {
+; CHECK-LABEL: @eq_mul_constants_with_tz_extra_use2(
+; CHECK-NEXT:    [[A:%.*]] = mul i32 [[X:%.*]], 12
+; CHECK-NEXT:    call void @use32(i32 [[A]])
+; CHECK-NEXT:    [[B:%.*]] = mul i32 [[Y:%.*]], 12
+; CHECK-NEXT:    call void @use32(i32 [[B]])
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[A]], [[B]]
+; CHECK-NEXT:    ret i1 [[C]]
+;
+  %A = mul i32 %x, 12
+  call void @use32(i32 %A)
+  %B = mul i32 %y, 12
+  call void @use32(i32 %B)
   %C = icmp ne i32 %A, %B
   ret i1 %C
 }

--- a/llvm/test/Transforms/InstCombine/icmp-mul.ll
+++ b/llvm/test/Transforms/InstCombine/icmp-mul.ll
@@ -785,9 +785,8 @@ define i1 @eq_mul_constants_with_tz_extra_use1(i32 %x, i32 %y) {
 ; CHECK-LABEL: @eq_mul_constants_with_tz_extra_use1(
 ; CHECK-NEXT:    [[A:%.*]] = mul i32 [[X:%.*]], 12
 ; CHECK-NEXT:    call void @use32(i32 [[A]])
-; CHECK-NEXT:    [[TMP1:%.*]] = xor i32 [[X]], [[Y:%.*]]
-; CHECK-NEXT:    [[TMP2:%.*]] = and i32 [[TMP1]], 1073741823
-; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[TMP2]], 0
+; CHECK-NEXT:    [[B:%.*]] = mul i32 [[Y:%.*]], 12
+; CHECK-NEXT:    [[C:%.*]] = icmp ne i32 [[A]], [[B]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
   %A = mul i32 %x, 12

--- a/llvm/test/Transforms/InstCombine/icmp.ll
+++ b/llvm/test/Transforms/InstCombine/icmp.ll
@@ -849,7 +849,7 @@ define i1 @test46_multiuse3(i32 %X, i32 %Y, i32 %Z) {
 ; CHECK-NEXT:    call void @use_i32(i32 [[A]])
 ; CHECK-NEXT:    [[B:%.*]] = ashr exact i32 [[Y:%.*]], [[Z]]
 ; CHECK-NEXT:    call void @use_i32(i32 [[B]])
-; CHECK-NEXT:    [[C:%.*]] = icmp ult i32 [[A]], [[B]]
+; CHECK-NEXT:    [[C:%.*]] = icmp ult i32 [[X]], [[Y]]
 ; CHECK-NEXT:    ret i1 [[C]]
 ;
   %A = ashr exact i32 %X, %Z


### PR DESCRIPTION
Addresses regressions introduced by https://github.com/llvm/llvm-project/pull/121892.
It also fixes a multi-use issue introduced by https://github.com/llvm/llvm-project/pull/76384 (tested in `eq_mul_constants_with_tz_extra_use1`).
