### PR TITLE
[libc++] Fix bug in **tests** for std::atomic_ref<T*> increment and decrement operators

### DIFF
--- a/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
@@ -48,7 +48,6 @@ struct TestDoesNotHaveIncrementDecrement {
 template <typename T>
 struct TestIncrementDecrement {
   void operator()() const {
-    static_assert(std::is_integral_v<T> || std::is_pointer_v<T>);
     if constexpr (std::is_integral_v<T>) {
       T x(T(1));
       std::atomic_ref<T> const a(x);

--- a/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
@@ -49,36 +49,72 @@ template <typename T>
 struct TestIncrementDecrement {
   void operator()() const {
     static_assert(std::is_integral_v<T> || std::is_pointer_v<T>);
+    if constexpr (std::is_integral_v<T>) {
+      T x(T(1));
+      std::atomic_ref<T> const a(x);
 
-    T x(T(1));
-    std::atomic_ref<T> const a(x);
+      {
+        std::same_as<T> decltype(auto) y = ++a;
+        assert(y == T(2));
+        assert(x == T(2));
+        ASSERT_NOEXCEPT(++a);
+      }
 
-    {
-      std::same_as<T> decltype(auto) y = ++a;
-      assert(y == T(1) + 1);
-      assert(x == T(1) + 1);
-      ASSERT_NOEXCEPT(++a);
-    }
+      {
+        std::same_as<T> decltype(auto) y = --a;
+        assert(y == T(1));
+        assert(x == T(1));
+        ASSERT_NOEXCEPT(--a);
+      }
 
-    {
-      std::same_as<T> decltype(auto) y = --a;
-      assert(y == T(1));
-      assert(x == T(1));
-      ASSERT_NOEXCEPT(--a);
-    }
+      {
+        std::same_as<T> decltype(auto) y = a++;
+        assert(y == T(1));
+        assert(x == T(2));
+        ASSERT_NOEXCEPT(a++);
+      }
 
-    {
-      std::same_as<T> decltype(auto) y = a++;
-      assert(y == T(1));
-      assert(x == T(1) + 1);
-      ASSERT_NOEXCEPT(a++);
-    }
+      {
+        std::same_as<T> decltype(auto) y = a--;
+        assert(y == T(2));
+        assert(x == T(1));
+        ASSERT_NOEXCEPT(a--);
+      }
+    } else if constexpr (std::is_pointer_v<T>) {
+      using U = std::remove_pointer_t<T>;
+      U t[9]  = {};
+      T p{&t[1]};
+      std::atomic_ref<T> const a(p);
 
-    {
-      std::same_as<T> decltype(auto) y = a--;
-      assert(y == T(1) + 1);
-      assert(x == T(1));
-      ASSERT_NOEXCEPT(a--);
+      {
+        std::same_as<T> decltype(auto) y = ++a;
+        assert(y == &t[2]);
+        assert(p == &t[2]);
+        ASSERT_NOEXCEPT(++a);
+      }
+
+      {
+        std::same_as<T> decltype(auto) y = --a;
+        assert(y == &t[1]);
+        assert(p == &t[1]);
+        ASSERT_NOEXCEPT(--a);
+      }
+
+      {
+        std::same_as<T> decltype(auto) y = a++;
+        assert(y == &t[1]);
+        assert(p == &t[2]);
+        ASSERT_NOEXCEPT(a++);
+      }
+
+      {
+        std::same_as<T> decltype(auto) y = a--;
+        assert(y == &t[2]);
+        assert(p == &t[1]);
+        ASSERT_NOEXCEPT(a--);
+      }
+    } else {
+      static_assert(std::is_void_v<T>);
     }
   }
 };

--- a/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.ref/increment_decrement.pass.cpp
@@ -42,21 +42,21 @@ constexpr bool does_not_have_increment_nor_decrement_operators() {
 
 template <typename T>
 struct TestDoesNotHaveIncrementDecrement {
-  void operator()() const { static_assert(does_not_have_increment_nor_decrement_operators<T>()); }
+  void operator()() const { static_assert(does_not_have_increment_nor_decrement_operators<std::atomic_ref<T>>()); }
 };
 
 template <typename T>
 struct TestIncrementDecrement {
   void operator()() const {
-    static_assert(std::is_integral_v<T>);
+    static_assert(std::is_integral_v<T> || std::is_pointer_v<T>);
 
     T x(T(1));
     std::atomic_ref<T> const a(x);
 
     {
       std::same_as<T> decltype(auto) y = ++a;
-      assert(y == T(2));
-      assert(x == T(2));
+      assert(y == T(1) + 1);
+      assert(x == T(1) + 1);
       ASSERT_NOEXCEPT(++a);
     }
 
@@ -70,13 +70,13 @@ struct TestIncrementDecrement {
     {
       std::same_as<T> decltype(auto) y = a++;
       assert(y == T(1));
-      assert(x == T(2));
+      assert(x == T(1) + 1);
       ASSERT_NOEXCEPT(a++);
     }
 
     {
       std::same_as<T> decltype(auto) y = a--;
-      assert(y == T(2));
+      assert(y == T(1) + 1);
       assert(x == T(1));
       ASSERT_NOEXCEPT(a--);
     }
@@ -88,7 +88,7 @@ int main(int, char**) {
 
   TestEachFloatingPointType<TestDoesNotHaveIncrementDecrement>()();
 
-  TestEachPointerType<TestDoesNotHaveIncrementDecrement>()();
+  TestEachPointerType<TestIncrementDecrement>()();
 
   TestDoesNotHaveIncrementDecrement<bool>()();
   TestDoesNotHaveIncrementDecrement<UserAtomicType>()();


### PR DESCRIPTION
Fix https://github.com/llvm/llvm-project/pull/121414/files#r1908697882

The implementation is fine and has the proper increment/decrement operators defined
https://github.com/llvm/llvm-project/blob/b4e17d4a314ed87ff6b40b4b05397d4b25b6636a/libcxx/include/__atomic/atomic_ref.h#L364-L367

The issue is in the tests
* a typo (`T` instead of `std::atomic_ref<T>`) when ensuring that increment/decrement operators are not defined in the primary template and specialization for floating point types, and
* the specialization for pointer types miscategorized.