### PR TITLE
[analyzer][NFC] Update stale test after #97265

### DIFF
--- a/clang/test/Analysis/z3/crosscheck-statistics.c
+++ b/clang/test/Analysis/z3/crosscheck-statistics.c
@@ -28,6 +28,6 @@ int rejecting(int n, int x) {
 // CHECK-NEXT:  1 BugReporter         - Number of reports passed Z3
 // CHECK-NEXT:  1 BugReporter         - Number of reports refuted by Z3
 
-// CHECK:       1 Z3CrosscheckVisitor - Number of Z3 queries accepting a report
-// CHECK-NEXT:  1 Z3CrosscheckVisitor - Number of Z3 queries rejecting a report
-// CHECK-NEXT:  2 Z3CrosscheckVisitor - Number of Z3 queries done
+// CHECK:       1 Z3CrosscheckOracle - Number of Z3 queries accepting a report
+// CHECK-NEXT:  1 Z3CrosscheckOracle - Number of Z3 queries rejecting a report
+// CHECK-NEXT:  2 Z3CrosscheckOracle - Number of Z3 queries done


### PR DESCRIPTION
In my patch there, I left a test expectation stale. Tests with `REQUIRES: Z3` never run because no bots check such configurations.

Here I'm adjusting the test expectations to meet reality.