### PR TITLE
[lldb] Regularize DWARFDIE::Get{TypeLookup,Decl}Context names

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -412,7 +412,7 @@ static void GetDeclContextImpl(DWARFDIE die,
       push_ctx(CompilerContextKind::Function, die.GetName());
       break;
     case DW_TAG_variable:
-      push_ctx(CompilerContextKind::Variable, die.GetPubname());
+      push_ctx(CompilerContextKind::Variable, die.GetName());
       break;
     case DW_TAG_typedef:
       push_ctx(CompilerContextKind::Typedef, die.GetName());
@@ -457,7 +457,7 @@ static void GetTypeLookupContextImpl(DWARFDIE die,
       push_ctx(CompilerContextKind::Enum, die.GetName());
       break;
     case DW_TAG_variable:
-      push_ctx(CompilerContextKind::Variable, die.GetPubname());
+      push_ctx(CompilerContextKind::Variable, die.GetName());
       break;
     case DW_TAG_typedef:
       push_ctx(CompilerContextKind::Typedef, die.GetName());


### PR DESCRIPTION
The functions call GetName for everything except variables, where they call GetPubname instead. The difference is that the latter prefers to return the linkage name, if it is available.

This doesn't seem particularly useful given that the linkage name already kind of contains the context of the variable, and I doubt that anything depends on it as these functions are currently called on type and subprogram DIEs -- not variables.

This makes it easier to simplify/deduplicate these functions later.