### PR TITLE
[clang-tidy] Fix misc-unused-parameters on params with attrs

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
@@ -9,8 +9,11 @@
 #include "UnusedParametersCheck.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTLambda.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
 #include "llvm/ADT/STLExtras.h"
 #include <unordered_map>
@@ -27,7 +30,7 @@ bool isOverrideMethod(const FunctionDecl *Function) {
   return false;
 }
 
-bool hasAttrAfterParam(const clang::SourceManager *SourceManager,
+bool hasAttrAfterParam(const SourceManager *SourceManager,
                        const ParmVarDecl *Param) {
   for (const auto *Attr : Param->attrs()) {
     if (SourceManager->isBeforeInTranslationUnit(Param->getLocation(),

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -33,6 +33,10 @@ void f(void (*fn)()) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: parameter 'fn' is unused [misc-unused-parameters]
 // CHECK-FIXES: {{^}}void f(void (* /*fn*/)()) {;}{{$}}
 
+int *k([[clang::lifetimebound]] int *i) {;}
+// CHECK-MESSAGES: :[[@LINE-1]]:38: warning: parameter 'i' is unused [misc-unused-parameters]
+// CHECK-FIXES: {{^}}int *k({{\[\[clang::lifetimebound\]\]}} int * /*i*/) {;}{{$}}
+
 // Unchanged cases
 // ===============
 void f(int i); // Don't remove stuff in declarations
@@ -41,6 +45,7 @@ void h(int i[]);
 void s(int i[1]);
 void u(void (*fn)());
 void w(int i) { (void)i; } // Don't remove used parameters
+int *x(int *i [[clang::lifetimebound]]) { return nullptr; } // Don't reanchor attribute to the type.
 
 bool useLambda(int (*fn)(int));
 static bool static_var = useLambda([] (int a) { return a; });

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -37,6 +37,12 @@ int *k([[clang::lifetimebound]] int *i) {;}
 // CHECK-MESSAGES: :[[@LINE-1]]:38: warning: parameter 'i' is unused [misc-unused-parameters]
 // CHECK-FIXES: {{^}}int *k({{\[\[clang::lifetimebound\]\]}} int * /*i*/) {;}{{$}}
 
+#define ATTR_BEFORE(x) [[clang::lifetimebound]] x
+int* m(ATTR_BEFORE(const int *i)) { return nullptr; }
+// CHECK-MESSAGES: :[[@LINE-1]]:31: warning: parameter 'i' is unused [misc-unused-parameters]
+// CHECK-FIXES: {{^}}int* m(ATTR_BEFORE(const int * /*i*/)) { return nullptr; }{{$}}
+#undef ATTR_BEFORE
+
 // Unchanged cases
 // ===============
 void f(int i); // Don't remove stuff in declarations
@@ -45,7 +51,12 @@ void h(int i[]);
 void s(int i[1]);
 void u(void (*fn)());
 void w(int i) { (void)i; } // Don't remove used parameters
-int *x(int *i [[clang::lifetimebound]]) { return nullptr; } // Don't reanchor attribute to the type.
+
+// Don't reanchor the attribute to the type:
+int *x(int *i [[clang::lifetimebound]]) { return nullptr; }
+#define ATTR_AFTER(x) x [[clang::lifetimebound]]
+int* y(ATTR_AFTER(const int *i)) { return nullptr; }
+#undef ATTR_AFTER
 
 bool useLambda(int (*fn)(int));
 static bool static_var = useLambda([] (int a) { return a; });


### PR DESCRIPTION
Don't suggest to comment-out the parameter name if the parameter has an attribute that's spelled after the parameter name.

This prevents the parameter's attributes from being wrongly applied to the parameter's type.

This fixes #122191.