### PR TITLE
[lldb][AIX] Added support for AIX in HostInfo section

### DIFF
--- a/lldb/include/lldb/Host/HostInfo.h
+++ b/lldb/include/lldb/Host/HostInfo.h
@@ -55,6 +55,9 @@
 #elif defined(__APPLE__)
 #include "lldb/Host/macosx/HostInfoMacOSX.h"
 #define HOST_INFO_TYPE HostInfoMacOSX
+#elif defined(_AIX)
+#include "lldb/Host/aix/HostInfoAIX.h"
+#define HOST_INFO_TYPE HostInfoAIX
 #else
 #include "lldb/Host/posix/HostInfoPosix.h"
 #define HOST_INFO_TYPE HostInfoPosix


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX.

Link to discussions on llvm discourse and github:

1. https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640
https://github.com/llvm/llvm-project/issues/101657
2. The complete changes for porting are present in this draft PR:
https://github.com/llvm/llvm-project/pull/102601
Added support for AIX in HostInfo section

Review Request : @DavidSpickett @labath @DhruvSrivastavaX