### PR TITLE
[BOLT][binary-analysis] Add initial pac-ret gadget scanner

### DIFF
--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -28,7 +28,7 @@ pac-ret, shadow stacks, arm64e, and many more.
 
 These mitigations guarantee a so-called "security property" on the binaries they
 produce. For example, for stack canaries, the security property is roughly that
-a canary is located on the stack between the set of saved variables and the set
+a canary is located on the stack between the set of saved registers and the set
 of local variables. For pac-ret, it is roughly that either the return address is
 never stored/retrieved to/from memory; or, there are no writes to the register
 containing the return address between an instruction authenticating it and a
@@ -67,7 +67,7 @@ examples.
 `pac-ret` protection is a security hardening scheme implemented in compilers
 such as GCC and Clang, using the command line option
 `-mbranch-protection=pac-ret`. This option is enabled by default on most widely
-used linux distributions.
+used Linux distributions.
 
 The hardening scheme mitigates
 [Return-Oriented Programming (ROP)](https://llsoftsec.github.io/llsoftsecbook/#return-oriented-programming)
@@ -82,7 +82,7 @@ The hardening scheme relies on compilers producing appropriate code sequences wh
 processing return addresses, especially when these are stored to and retrieved
 from memory.
 
-The 'pac-ret' binary analysis can be invoked using the command line option
+The `pac-ret` binary analysis can be invoked using the command line option
 `--scanners=pac-ret`. It makes `llvm-bolt-binary-analysis` scan through the
 provided binary, checking each function for the following security property:
 
@@ -173,7 +173,7 @@ The following are current known cases of false positives:
         ret     x16
    ```
 
-The folowing are current known cases of false negatives:
+The following are current known cases of false negatives:
 
 1. Not handling functions for which the CFG cannot be reconstructed by BOLT. The
    plan is to implement support for this, picking up the implementation from the

--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -65,7 +65,7 @@ examples.
 #### pac-ret analysis
 
 `pac-ret` protection is a security hardening scheme implemented in compilers
-such as gcc and clang, using the command line option
+such as GCC and Clang, using the command line option
 `-mbranch-protection=pac-ret`. This option is enabled by default on most widely
 used linux distributions.
 
@@ -78,7 +78,7 @@ in the upper bits of the pointer. This makes it substantially harder for
 attackers to divert control flow by overwriting a return address with a
 different value.
 
-The hardening scheme relies on compilers producing different code sequences when
+The hardening scheme relies on compilers producing appropriate code sequences when
 processing return addresses, especially when these are stored to and retrieved
 from memory.
 
@@ -86,24 +86,24 @@ The 'pac-ret' binary analysis can be invoked using the command line option
 `--scanners=pac-ret`. It makes `llvm-bolt-binary-analysis` scan through the
 provided binary, checking each function for the following security property:
 
-For each procedure and exception return instruction, the destination register
-must have one of the following properties:
-
-1. be immutable within the function, or
-2. the last write to the register must be by an authenticating instruction. This
-   includes combined authentication and return instructions such as `RETAA`.
+> For each procedure and exception return instruction, the destination register
+> must have one of the following properties:
+>
+> 1. be immutable within the function, or
+> 2. the last write to the register must be by an authenticating instruction. This
+>    includes combined authentication and return instructions such as `RETAA`.
 
 ##### Example 1
 
 For example, a typical non-pac-ret-protected function looks as follows:
 
 ```
-stp     x29, x30, [sp, #-0x10]!
-mov     x29, sp
-bl      g@PLT
-add     x0, x0, #0x3
-ldp     x29, x30, [sp], #0x10
-ret
+        stp     x29, x30, [sp, #-0x10]!
+        mov     x29, sp
+        bl      g@PLT
+        add     x0, x0, #0x3
+        ldp     x29, x30, [sp], #0x10
+        ret
 ```
 
 The return instruction `ret` implicitly uses register `x30` as the address to
@@ -135,8 +135,8 @@ instructions of a register follows:
 
 ```
         paciasp
-        stp     x29, x30, [sp, #-16]!
-        ldp     x29, x30, [sp], #16
+        stp     x29, x30, [sp, #-0x10]!
+        ldp     x29, x30, [sp], #0x10
         cbnz    x0, 1f
         autiasp
 1:
@@ -168,9 +168,9 @@ The following are current known cases of false positives:
    For example, the scanner currently produces a false negative for the following
    code sequence:
    ```
-   autiasp
-   mov     x16, x30
-   ret
+        autiasp
+        mov     x16, x30
+        ret     x16
    ```
 
 The folowing are current known cases of false negatives:

--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -163,6 +163,15 @@ The following are current known cases of false positives:
 1. Not handling "no-return" functions. See issue
    [#115154](https://github.com/llvm/llvm-project/issues/115154) for details and
    pointers to open PRs to fix this.
+2. Not recognizing that a move of a properly authenticated value between registers,
+   results in the destination register having a properly authenticated value.
+   For example, the scanner currently produces a false negative for the following
+   code sequence:
+   ```
+   autiasp
+   mov     x16, x30
+   ret
+   ```
 
 The folowing are current known cases of false negatives:
 

--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -9,9 +9,168 @@ analyses implemented in the BOLT libraries.
 
 ## Which binary analyses are implemented?
 
-At the moment, no binary analyses are implemented.
+* [Security scanners](#security-scanners)
+  * [pac-ret analysis](#pac-ret-analysis)
 
-The goal is to make it easy using a plug-in framework to add your own analyses.
+### Security scanners
+
+For the past 25 years, a large numbers of exploits have been built and used in
+the wild to undermine computer security. The majority of these exploits abuse
+memory vulnerabilities in programs, see evidence from
+[Microsoft](https://youtu.be/PjbGojjnBZQ?si=oCHCa0SHgaSNr6Gr&t=836),
+[Chromium](https://www.chromium.org/Home/chromium-security/memory-safety/) and
+[Android](https://security.googleblog.com/2021/01/data-driven-security-hardening-in.html).
+
+It is not surprising therefore, that a large number of mitigations have been
+added to instruction sets and toolchains to make it harder to build an exploit
+using a memory vulnerability. Examples are: stack canaries, stack clash,
+pac-ret, shadow stacks, arm64e, and many more.
+
+These mitigations guarantee a so-called "security property" on the binaries they
+produce. For example, for stack canaries, the security property is roughly that
+a canary is located on the stack between the set of saved variables and set of
+local variables. For pac-ret, it is roughly that there are no writes to the
+register containing the return address after either an authenticating
+instruction or a Branch-and-link instruction.
+
+From time to time, however, a bug gets found in the implementation of such
+mitigations in toolchains. Also, code that is written in assembler by hand
+requires the developer to ensure these security properties by hand.
+
+In short, it is sometimes found that a few places in the binary code are not
+protected as expected given the requested mitigations. Attackers could make use
+of those places (sometimes called gadgets) to circumvent to protection that the
+mitigation should give.
+
+One of the reasons that such gadgets, or holes in the mitigation implementation,
+exist is that typically the amount of testing and verification for these
+security properties is pretty limited.
+
+In comparison, for testing functional correctness, or for testing performance,
+toolchain and software in general typically get tested with large test suites
+and benchmarks and testing and benchmarking plans. In contrast, this typically
+does not get done for testing the security properties of binary code.
+
+The security scanners implemented in `llvm-bolt-binary-analysis` aim to enable
+better testing of security hardening implementations that require compilers to
+somehow generate assembly code with specific security properties.
+
+#### pac-ret analysis
+
+`pac-ret` protection is a security hardening scheme implemented in compilers
+such as gcc and clang, using the command line option
+`-mbranch-protection=pac-ret`. This option is enabled by default on most widely
+used distributions.
+
+The hardening scheme mitigates
+[Return-Oriented Programming (ROP)](https://llsoftsec.github.io/llsoftsecbook/#return-oriented-programming)
+attacks by making sure that return addresses are only ever stored to memory with
+a cryptographic hash, called a
+["Pointer Authentication Code" (PAC)](https://llsoftsec.github.io/llsoftsecbook/#pointer-authentication),
+in the upper bits of the pointer. This makes it substantially harder for
+attackers to divert control flow by overwriting a return address with a
+different value.
+
+The hardening scheme relies on compilers producing different code sequences when
+processing return addresses, especially when these are stored to and retrieved
+from memory.
+
+The 'pac-ret' binary analysis can be invoked using the command line option
+`--scanners=pac-ret`. It makes `llvm-bolt-binary-analysis` scan through the
+provided binary and check the following property:
+
+The security property that is checked is:
+
+When a register is used as the address to jump to in a return instruction,
+that register must either:
+
+1. never be changed within this function, i.e. have the same value as when the
+   function started, or
+2. the last write to the register must be by an authenticating instruction.
+
+##### Example 1
+
+For example, a typical non-pac-ret-protected function looks as follows:
+
+```
+stp     x29, x30, [sp, #-0x10]!
+mov     x29, sp
+bl      g@PLT
+add     x0, x0, #0x3
+ldp     x29, x30, [sp], #0x10
+ret
+```
+
+The return instruction `ret` uses register `x30` as containing the address to
+return to. Register `x30` was last written by instruction `ldp`, which is not an
+authenticating instruction. `llvm-bolt-binary-analysis --scanners=pac-ret` will
+report this as follows:
+
+```
+GS-PACRET: non-protected ret found in function f1, basic block .LBB00, at address 10310
+  The return instruction is     00010310:       ret # pacret-gadget: pac-ret-gadget<Ret:MCInstBBRef<BB:.LBB00:6>, Overwriting:[MCInstBBRef<BB:.LBB00:5> ]>
+  The 1 instructions that write to the return register after any authentication are:
+  1.     0001030c:      ldp     x29, x30, [sp], #0x10
+  This happens in the following basic block:
+    000102fc:   stp     x29, x30, [sp, #-0x10]!
+    00010300:   mov     x29, sp
+    00010304:   bl      g@PLT
+    00010308:   add     x0, x0, #0x3
+    0001030c:   ldp     x29, x30, [sp], #0x10
+    00010310:   ret # pacret-gadget: pac-ret-gadget<Ret:MCInstBBRef<BB:.LBB00:6>, Overwriting:[MCInstBBRef<BB:.LBB00:5> ]>
+```
+
+The exact format of how `llvm-bolt-binary-analysis` reports this is expected to
+evolve over time.
+
+##### Example 2: multiple "last-overwriting" instructions
+
+A simple example that show how there can be a set of "last overwriting"
+instructions of a register is the following:
+
+```
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        ldp     x29, x30, [sp], #16
+        cbnz    x0, 1f
+        autiasp
+1:
+        ret
+```
+
+This will produce the following diagnostic:
+
+```
+GS-PACRET: non-protected ret found in function f_crossbb1, basic block .Ltmp0, at address 102dc
+  The return instruction is     000102dc:       ret # pacret-gadget: pac-ret-gadget<Ret:MCInstBBRef<BB:.Ltmp0:0>, Overwriting:[MCInstBBRef<BB:.LFT0:0> MCInstBBRef<BB:.LBB00:2> ]>
+  The 2 instructions that write to the return register after any authentication are:
+  1.     000102d0:      ldp     x29, x30, [sp], #0x10
+  2.     000102d8:      autiasp
+```
+
+(Yes, this diagnostic could be improved because the second "overwriting"
+instruction, `autiasp`, is an authenticating instruction...)
+
+##### Known false positives or negatives
+
+The following are current known cases of false positives:
+
+1. Not handling "no-return" functions. See issue
+   [#115154](https://github.com/llvm/llvm-project/issues/115154) for details and
+   pointers to open PRs to fix this.
+
+The folowing are current known cases of false negatives:
+
+1. Not handling functions for which the CFG cannot be reconstructed by BOLT. The
+   plan is to implement support for this, picking up the implementation from the
+   [prototype branch](
+   https://github.com/llvm/llvm-project/compare/main...kbeyls:llvm-project:bolt-gadget-scanner-prototype).
+
+BOLT cannot currently handle functions with `cfi_negate_ra_state` correctly,
+i.e. any binaries built with `-mbranch-protection=pac-ret`. The scanner is meant
+to be used on specifically such binaries, so this is a major limitation! Work is
+going on in PR [#120064](https://github.com/llvm/llvm-project/pull/120064) to
+fix this.
 
 ## How to add your own binary analysis
 

--- a/bolt/docs/BinaryAnalysis.md
+++ b/bolt/docs/BinaryAnalysis.md
@@ -28,39 +28,46 @@ pac-ret, shadow stacks, arm64e, and many more.
 
 These mitigations guarantee a so-called "security property" on the binaries they
 produce. For example, for stack canaries, the security property is roughly that
-a canary is located on the stack between the set of saved variables and set of
-local variables. For pac-ret, it is roughly that there are no writes to the
-register containing the return address after either an authenticating
-instruction or a Branch-and-link instruction.
+a canary is located on the stack between the set of saved variables and the set
+of local variables. For pac-ret, it is roughly that either the return address is
+never stored/retrieved to/from memory; or, there are no writes to the register
+containing the return address between an instruction authenticating it and a
+return instruction using it.
 
 From time to time, however, a bug gets found in the implementation of such
 mitigations in toolchains. Also, code that is written in assembler by hand
 requires the developer to ensure these security properties by hand.
 
 In short, it is sometimes found that a few places in the binary code are not
-protected as expected given the requested mitigations. Attackers could make use
-of those places (sometimes called gadgets) to circumvent to protection that the
-mitigation should give.
+protected as well as expected given the requested mitigations. Attackers could
+make use of those places (sometimes called gadgets) to circumvent the protection
+that the mitigation should give.
 
 One of the reasons that such gadgets, or holes in the mitigation implementation,
 exist is that typically the amount of testing and verification for these
-security properties is pretty limited.
+security properties is limited to checking results on specific examples.
 
 In comparison, for testing functional correctness, or for testing performance,
 toolchain and software in general typically get tested with large test suites
-and benchmarks and testing and benchmarking plans. In contrast, this typically
-does not get done for testing the security properties of binary code.
+and benchmarks. In contrast, this typically does not get done for testing the
+security properties of binary code.
+
+Unlike functional correctness where compilation errors result in test failures,
+and performance where speed and size differences are measurable, broken security
+properties cannot be easily observed using existing testing and benchmarking
+tools.
 
 The security scanners implemented in `llvm-bolt-binary-analysis` aim to enable
-better testing of security hardening implementations that require compilers to
-somehow generate assembly code with specific security properties.
+the testing of security hardening in arbitrary programs and not just specific
+examples.
+
 
 #### pac-ret analysis
 
 `pac-ret` protection is a security hardening scheme implemented in compilers
 such as gcc and clang, using the command line option
 `-mbranch-protection=pac-ret`. This option is enabled by default on most widely
-used distributions.
+used linux distributions.
 
 The hardening scheme mitigates
 [Return-Oriented Programming (ROP)](https://llsoftsec.github.io/llsoftsecbook/#return-oriented-programming)
@@ -77,16 +84,14 @@ from memory.
 
 The 'pac-ret' binary analysis can be invoked using the command line option
 `--scanners=pac-ret`. It makes `llvm-bolt-binary-analysis` scan through the
-provided binary and check the following property:
+provided binary, checking each function for the following security property:
 
-The security property that is checked is:
+For each procedure and exception return instruction, the destination register
+must have one of the following properties:
 
-When a register is used as the address to jump to in a return instruction,
-that register must either:
-
-1. never be changed within this function, i.e. have the same value as when the
-   function started, or
-2. the last write to the register must be by an authenticating instruction.
+1. be immutable within the function, or
+2. the last write to the register must be by an authenticating instruction. This
+   includes combined authentication and return instructions such as `RETAA`.
 
 ##### Example 1
 
@@ -101,7 +106,7 @@ ldp     x29, x30, [sp], #0x10
 ret
 ```
 
-The return instruction `ret` uses register `x30` as containing the address to
+The return instruction `ret` implicitly uses register `x30` as the address to
 return to. Register `x30` was last written by instruction `ldp`, which is not an
 authenticating instruction. `llvm-bolt-binary-analysis --scanners=pac-ret` will
 report this as follows:
@@ -125,8 +130,8 @@ evolve over time.
 
 ##### Example 2: multiple "last-overwriting" instructions
 
-A simple example that show how there can be a set of "last overwriting"
-instructions of a register is the following:
+A simple example that shows how there can be a set of "last overwriting"
+instructions of a register follows:
 
 ```
         paciasp

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -551,7 +551,7 @@ public:
     return Analysis->isReturn(Inst);
   }
 
-  virtual MCPhysReg getAuthenticatedReg(const MCInst &Inst) const {
+  virtual ErrorOr<MCPhysReg> getAuthenticatedReg(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
     return getNoRegister();
   }
@@ -562,7 +562,7 @@ public:
     return false;
   }
 
-  virtual MCPhysReg getRegUsedAsRetDest(const MCInst &Inst) const {
+  virtual ErrorOr<MCPhysReg> getRegUsedAsRetDest(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
     return getNoRegister();
   }

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -550,6 +550,22 @@ public:
     return Analysis->isReturn(Inst);
   }
 
+  virtual MCPhysReg getAuthenticatedReg(const MCInst &Inst) const {
+    llvm_unreachable("not implemented");
+    return false;
+  }
+
+  virtual bool isAuthenticationOfReg(const MCInst &Inst,
+                                     const unsigned RegAuthenticated) const {
+    llvm_unreachable("not implemented");
+    return false;
+  }
+
+  virtual llvm::MCPhysReg getRegUsedAsRetDest(const MCInst &Inst) const {
+    llvm_unreachable("not implemented");
+    return getNoRegister();
+  }
+
   virtual bool isTerminator(const MCInst &Inst) const;
 
   virtual bool isNoop(const MCInst &Inst) const {

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -27,6 +27,7 @@
 #include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -552,16 +553,16 @@ public:
 
   virtual MCPhysReg getAuthenticatedReg(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
-    return false;
+    return getNoRegister();
   }
 
   virtual bool isAuthenticationOfReg(const MCInst &Inst,
-                                     const unsigned RegAuthenticated) const {
+                                     MCPhysReg AuthenticatedReg) const {
     llvm_unreachable("not implemented");
     return false;
   }
 
-  virtual llvm::MCPhysReg getRegUsedAsRetDest(const MCInst &Inst) const {
+  virtual MCPhysReg getRegUsedAsRetDest(const MCInst &Inst) const {
     llvm_unreachable("not implemented");
     return getNoRegister();
   }

--- a/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
+++ b/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
@@ -68,7 +68,7 @@ struct MCInstInBFReference {
   uint64_t Offset;
   MCInstInBFReference(BinaryFunction *BF, uint64_t Offset)
       : BF(BF), Offset(Offset) {}
-  MCInstInBFReference() : BF(nullptr) {}
+  MCInstInBFReference() : BF(nullptr), Offset(0) {}
   bool operator==(const MCInstInBFReference &RHS) const {
     return BF == RHS.BF && Offset == RHS.Offset;
   }
@@ -200,7 +200,6 @@ struct Annotation {
   virtual ~Annotation() {}
   virtual void generateReport(raw_ostream &OS,
                               const BinaryContext &BC) const = 0;
-  virtual void print(raw_ostream &OS) const;
 };
 
 struct Gadget : public Annotation {
@@ -214,7 +213,6 @@ struct Gadget : public Annotation {
       : Annotation(RetInst), OverwritingRetRegInst(OverwritingRetRegInst) {}
   virtual void generateReport(raw_ostream &OS,
                               const BinaryContext &BC) const override;
-  virtual void print(raw_ostream &OS) const override;
 };
 
 struct GenDiag : public Annotation {
@@ -226,12 +224,7 @@ struct GenDiag : public Annotation {
       : Annotation(RetInst), Diag(Text) {}
   virtual void generateReport(raw_ostream &OS,
                               const BinaryContext &BC) const override;
-  virtual void print(raw_ostream &OS) const override;
 };
-
-raw_ostream &operator<<(raw_ostream &OS, const Gadget &G);
-raw_ostream &operator<<(raw_ostream &OS, const GenDiag &Diag);
-raw_ostream &operator<<(raw_ostream &OS, const Annotation &A);
 
 class PacRetAnalysis;
 

--- a/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
+++ b/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
@@ -65,8 +65,8 @@ raw_ostream &operator<<(raw_ostream &OS, const MCInstInBBReference &);
 
 struct MCInstInBFReference {
   BinaryFunction *BF;
-  uint32_t Offset;
-  MCInstInBFReference(BinaryFunction *BF, uint32_t Offset)
+  uint64_t Offset;
+  MCInstInBFReference(BinaryFunction *BF, uint64_t Offset)
       : BF(BF), Offset(Offset) {}
   MCInstInBFReference() : BF(nullptr) {}
   bool operator==(const MCInstInBFReference &RHS) const {
@@ -102,9 +102,9 @@ struct MCInstReference {
       : ParentKind(BasicBlockParent), U(BBRef) {}
   MCInstReference(MCInstInBFReference BFRef)
       : ParentKind(FunctionParent), U(BFRef) {}
-  MCInstReference(class BinaryBasicBlock *BB, int64_t BBIndex)
+  MCInstReference(BinaryBasicBlock *BB, int64_t BBIndex)
       : MCInstReference(MCInstInBBReference(BB, BBIndex)) {}
-  MCInstReference(class BinaryFunction *BF, uint32_t Offset)
+  MCInstReference(BinaryFunction *BF, uint32_t Offset)
       : MCInstReference(MCInstInBFReference(BF, Offset)) {}
 
   bool operator<(const MCInstReference &RHS) const {

--- a/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
+++ b/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
@@ -36,7 +36,7 @@ struct MCInstInBBReference {
   static MCInstInBBReference get(const MCInst *Inst, BinaryFunction &BF) {
     for (BinaryBasicBlock &BB : BF)
       for (size_t I = 0; I < BB.size(); ++I)
-        if (Inst == &(BB.getInstructionAtIndex(I)))
+        if (Inst == &BB.getInstructionAtIndex(I))
           return MCInstInBBReference(&BB, I);
     return {};
   }
@@ -53,7 +53,7 @@ struct MCInstInBBReference {
     return BB->getInstructionAtIndex(BBIndex);
   }
   uint64_t getAddress() const {
-    // 4 bytes per instruction on AArch64;
+    // 4 bytes per instruction on AArch64.
     // FIXME: the assumption of 4 byte per instruction needs to be fixed before
     // this method gets used on any non-AArch64 binaries (but should be fine for
     // pac-ret analysis, as that is an AArch64-specific feature).
@@ -79,7 +79,7 @@ struct MCInstInBFReference {
   }
   operator MCInst &() const {
     assert(BF != nullptr);
-    return *(BF->getInstructionAtOffset(Offset));
+    return *BF->getInstructionAtOffset(Offset);
   }
 
   uint64_t getOffset() const { return Offset; }

--- a/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
+++ b/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
@@ -1,0 +1,209 @@
+//===- bolt/Passes/NonPacProtectedRetAnalysis.h -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BOLT_PASSES_NONPACPROTECTEDRETANALYSIS_H
+#define BOLT_PASSES_NONPACPROTECTEDRETANALYSIS_H
+
+#include "bolt/Core/BinaryContext.h"
+#include "bolt/Core/BinaryFunction.h"
+#include "bolt/Passes/BinaryPasses.h"
+#include "llvm/ADT/SmallSet.h"
+
+namespace llvm {
+namespace bolt {
+
+/// @brief  MCInstReference represents a reference to an MCInst as stored either
+/// in a BinaryFunction (i.e. before a CFG is created), or in a BinaryBasicBlock
+/// (after a CFG is created). It aims to store the necessary information to be
+/// able to find the specific MCInst in either the BinaryFunction or
+/// BinaryBasicBlock data structures later, so that e.g. the InputAddress of
+/// the corresponding instruction can be computed.
+
+struct MCInstInBBReference {
+  BinaryBasicBlock *BB;
+  int64_t BBIndex;
+  MCInstInBBReference(BinaryBasicBlock *BB, int64_t BBIndex)
+      : BB(BB), BBIndex(BBIndex) {}
+  MCInstInBBReference() : BB(nullptr), BBIndex(0) {}
+  static MCInstInBBReference get(const MCInst *Inst, BinaryFunction &BF) {
+    for (BinaryBasicBlock& BB : BF)
+      for (size_t I = 0; I < BB.size(); ++I)
+        if (Inst == &(BB.getInstructionAtIndex(I)))
+          return MCInstInBBReference(&BB, I);
+    return {};
+  }
+  bool operator==(const MCInstInBBReference &RHS) const {
+    return BB == RHS.BB && BBIndex == RHS.BBIndex;
+  }
+  bool operator<(const MCInstInBBReference &RHS) const {
+    if (BB != RHS.BB)
+      return BB < RHS.BB;
+    return BBIndex < RHS.BBIndex;
+  }
+  operator MCInst &() const {
+    assert(BB != nullptr);
+    return BB->getInstructionAtIndex(BBIndex);
+  }
+  uint64_t getAddress() const {
+    // 4 bytes per instruction on AArch64;
+    return BB->getFunction()->getAddress() + BB->getOffset() + BBIndex * 4;
+  }
+};
+
+raw_ostream &operator<<(raw_ostream &OS, const MCInstInBBReference &);
+
+struct MCInstInBFReference {
+  BinaryFunction *BF;
+  uint32_t Offset;
+  MCInstInBFReference(BinaryFunction *BF, uint32_t Offset)
+      : BF(BF), Offset(Offset) {}
+  MCInstInBFReference() : BF(nullptr) {}
+  bool operator==(const MCInstInBFReference &RHS) const {
+    return BF == RHS.BF && Offset == RHS.Offset;
+  }
+  bool operator<(const MCInstInBFReference &RHS) const {
+    if (BF != RHS.BF)
+      return BF < RHS.BF;
+    return Offset < RHS.Offset;
+  }
+  operator MCInst &() const {
+    assert(BF != nullptr);
+    return *(BF->getInstructionAtOffset(Offset));
+  }
+
+  uint64_t getOffset() const { return Offset; }
+
+  uint64_t getAddress() const {
+    return BF->getAddress() + getOffset();
+  }
+};
+
+raw_ostream &operator<<(raw_ostream &OS, const MCInstInBFReference &);
+
+struct MCInstReference {
+  enum StoredIn { _BinaryFunction, _BinaryBasicBlock };
+  StoredIn CurrentLocation;
+  union U {
+    MCInstInBBReference BBRef;
+    MCInstInBFReference BFRef;
+    U(MCInstInBBReference BBRef) : BBRef(BBRef) {}
+    U(MCInstInBFReference BFRef) : BFRef(BFRef) {}
+  } U;
+  MCInstReference(MCInstInBBReference BBRef)
+      : CurrentLocation(_BinaryBasicBlock), U(BBRef) {}
+  MCInstReference(MCInstInBFReference BFRef)
+      : CurrentLocation(_BinaryFunction), U(BFRef) {}
+  MCInstReference(BinaryBasicBlock *BB, int64_t BBIndex)
+      : MCInstReference(MCInstInBBReference(BB, BBIndex)) {}
+  MCInstReference(BinaryFunction *BF, uint32_t Offset)
+      : MCInstReference(MCInstInBFReference(BF, Offset)) {}
+
+  bool operator<(const MCInstReference &RHS) const {
+    if (CurrentLocation != RHS.CurrentLocation)
+      return CurrentLocation < RHS.CurrentLocation;
+    switch (CurrentLocation) {
+    case _BinaryBasicBlock:
+      return U.BBRef < RHS.U.BBRef;
+    case _BinaryFunction:
+      return U.BFRef < RHS.U.BFRef;
+    }
+    llvm_unreachable("");
+  }
+
+  bool operator==(const MCInstReference &RHS) const {
+    if (CurrentLocation != RHS.CurrentLocation)
+      return false;
+    switch (CurrentLocation) {
+    case _BinaryBasicBlock:
+      return U.BBRef == RHS.U.BBRef;
+    case _BinaryFunction:
+      return U.BFRef == RHS.U.BFRef;
+    }
+    llvm_unreachable("");
+  }
+
+  operator MCInst &() const {
+    switch (CurrentLocation) {
+    case _BinaryBasicBlock:
+      return U.BBRef;
+    case _BinaryFunction:
+      return U.BFRef;
+    }
+    llvm_unreachable("");
+  }
+
+  uint64_t getAddress() const {
+    switch (CurrentLocation) {
+    case _BinaryBasicBlock:
+      return U.BBRef.getAddress();
+    case _BinaryFunction:
+      return U.BFRef.getAddress();
+    }
+    llvm_unreachable("");
+  }
+
+  BinaryFunction *getFunction() const {
+    switch (CurrentLocation) {
+    case _BinaryFunction:
+      return U.BFRef.BF;
+    case _BinaryBasicBlock:
+      return U.BBRef.BB->getFunction();
+    }
+    llvm_unreachable("");
+  }
+
+  BinaryBasicBlock *getBasicBlock() const {
+    switch (CurrentLocation) {
+    case _BinaryFunction:
+      return nullptr;
+    case _BinaryBasicBlock:
+      return U.BBRef.BB;
+    }
+    llvm_unreachable("");
+  }
+};
+
+raw_ostream &operator<<(raw_ostream &OS, const MCInstReference &);
+
+struct NonPacProtectedRetGadget {
+  MCInstReference RetInst;
+  std::vector<MCInstReference> OverwritingRetRegInst;
+  bool operator==(const NonPacProtectedRetGadget &RHS) const {
+    return RetInst == RHS.RetInst &&
+           OverwritingRetRegInst == RHS.OverwritingRetRegInst;
+  }
+  NonPacProtectedRetGadget(
+      MCInstReference RetInst,
+      const std::vector<MCInstReference>& OverwritingRetRegInst)
+      : RetInst(RetInst), OverwritingRetRegInst(OverwritingRetRegInst) {}
+};
+
+raw_ostream &operator<<(raw_ostream &OS, const NonPacProtectedRetGadget &NPPRG);
+class PacRetAnalysis;
+
+class NonPacProtectedRetAnalysis : public BinaryFunctionPass {
+  void runOnFunction(BinaryFunction &Function,
+                     MCPlusBuilder::AllocatorIdTy AllocatorId);
+  SmallSet<MCPhysReg, 1>
+  computeDfState(PacRetAnalysis &PRA, BinaryFunction &BF,
+                 MCPlusBuilder::AllocatorIdTy AllocatorId);
+  unsigned GadgetAnnotationIndex;
+
+public:
+  explicit NonPacProtectedRetAnalysis() : BinaryFunctionPass(false) {}
+
+  const char *getName() const override { return "non-pac-protected-rets"; }
+
+  /// Pass entry point
+  Error runOnFunctions(BinaryContext &BC) override;
+};
+
+} // namespace bolt
+} // namespace llvm
+
+#endif

--- a/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
+++ b/bolt/include/bolt/Passes/NonPacProtectedRetAnalysis.h
@@ -31,7 +31,7 @@ struct MCInstInBBReference {
       : BB(BB), BBIndex(BBIndex) {}
   MCInstInBBReference() : BB(nullptr), BBIndex(0) {}
   static MCInstInBBReference get(const MCInst *Inst, BinaryFunction &BF) {
-    for (BinaryBasicBlock& BB : BF)
+    for (BinaryBasicBlock &BB : BF)
       for (size_t I = 0; I < BB.size(); ++I)
         if (Inst == &(BB.getInstructionAtIndex(I)))
           return MCInstInBBReference(&BB, I);
@@ -78,9 +78,7 @@ struct MCInstInBFReference {
 
   uint64_t getOffset() const { return Offset; }
 
-  uint64_t getAddress() const {
-    return BF->getAddress() + getOffset();
-  }
+  uint64_t getAddress() const { return BF->getAddress() + getOffset(); }
 };
 
 raw_ostream &operator<<(raw_ostream &OS, const MCInstInBFReference &);
@@ -179,7 +177,7 @@ struct NonPacProtectedRetGadget {
   }
   NonPacProtectedRetGadget(
       MCInstReference RetInst,
-      const std::vector<MCInstReference>& OverwritingRetRegInst)
+      const std::vector<MCInstReference> &OverwritingRetRegInst)
       : RetInst(RetInst), OverwritingRetRegInst(OverwritingRetRegInst) {}
 };
 

--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -80,6 +80,10 @@ extern llvm::cl::opt<unsigned> Verbosity;
 /// Return true if we should process all functions in the binary.
 bool processAllFunctions();
 
+enum GadgetScannerKind { GS_PACRET, GS_ALL };
+
+extern llvm::cl::list<GadgetScannerKind> GadgetScannersToRun;
+
 } // namespace opts
 
 namespace llvm {

--- a/bolt/lib/Passes/CMakeLists.txt
+++ b/bolt/lib/Passes/CMakeLists.txt
@@ -23,6 +23,7 @@ add_llvm_library(LLVMBOLTPasses
   LoopInversionPass.cpp
   LivenessAnalysis.cpp
   MCF.cpp
+  NonPacProtectedRetAnalysis.cpp
   PatchEntries.cpp
   PettisAndHansen.cpp
   PLTCall.cpp

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -278,8 +278,13 @@ protected:
 
     State Next = Cur;
     BitVector Written = BitVector(NumRegs, false);
-    // Assume a call can clobber all registers, as functions may not respect
-    // the AAPCS ABI rules...
+    // Assume a call can clobber all registers, including callee-saved
+    // registers. There's a good chance that callee-saved registers will be
+    // saved on the stack at some point during execution of the callee.
+    // Therefore they should also be considered as potentially modified by an
+    // attacker/written to.
+    // Also, not all functions may respect the AAPCS ABI rules about
+    // caller/callee-saved registers.
     if (BC.MIB->isCall(Point))
       Written.set();
     else

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -47,11 +47,11 @@ raw_ostream &operator<<(raw_ostream &OS, const MCInstInBFReference &Ref) {
 }
 
 raw_ostream &operator<<(raw_ostream &OS, const MCInstReference &Ref) {
-  switch (Ref.CurrentLocation) {
-  case MCInstReference::BinaryBasicBlock:
+  switch (Ref.ParentKind) {
+  case MCInstReference::BasicBlockParent:
     OS << Ref.U.BBRef;
     return OS;
-  case MCInstReference::BinaryFunction:
+  case MCInstReference::FunctionParent:
     OS << Ref.U.BFRef;
     return OS;
   }
@@ -432,8 +432,8 @@ void reportFoundGadgetInSingleBBSingleOverwInst(const BinaryContext &BC,
                                                 const MCInstReference OverwInst,
                                                 const MCInstReference RetInst) {
   BinaryBasicBlock *BB = RetInst.getBasicBlock();
-  assert(OverwInst.CurrentLocation == MCInstReference::BinaryBasicBlock);
-  assert(RetInst.CurrentLocation == MCInstReference::BinaryBasicBlock);
+  assert(OverwInst.ParentKind == MCInstReference::BasicBlockParent);
+  assert(RetInst.ParentKind == MCInstReference::BasicBlockParent);
   MCInstInBBReference OverwInstBB = OverwInst.U.BBRef;
   if (BB == OverwInstBB.BB) {
     // overwriting inst and ret instruction are in the same basic block.
@@ -479,7 +479,7 @@ void reportFoundGadget(const BinaryContext &BC, const MCInst &Inst,
   });
   if (NPPRG.OverwritingRetRegInst.size() == 1) {
     const MCInstReference OverwInst = NPPRG.OverwritingRetRegInst[0];
-    assert(OverwInst.CurrentLocation == MCInstReference::BinaryBasicBlock);
+    assert(OverwInst.ParentKind == MCInstReference::BasicBlockParent);
     reportFoundGadgetInSingleBBSingleOverwInst(BC, OverwInst, RetInst);
   }
 }

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -281,7 +281,12 @@ protected:
 
     State Next = Cur;
     BitVector Written = BitVector(NumRegs, false);
-    BC.MIB->getWrittenRegs(Point, Written);
+    // Assume a call can clobber all registers, as functions may not respect
+    // the AAPCS ABI rules...
+    if (BC.MIB->isCall(Point))
+      Written.set();
+    else
+      BC.MIB->getWrittenRegs(Point, Written);
     Next.NonAutClobRegs |= Written;
     // Keep track of this instruction if it writes to any of the registers we
     // need to track that for:

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -101,7 +101,8 @@ void NonPacProtectedRetGenDiag::print(raw_ostream &OS) const { OS << *this; }
 // exactly the registers containing values that should not be trusted (as they
 // could have changed since the last time they were authenticated). For pac-ret,
 // any return instruction using such a register is a gadget to be reported. For
-// PAuthABI, any indirect control flow using such a register should be reported?
+// PAuthABI, probably at least any indirect control flow using such a register
+// should be reported.
 
 // Furthermore, when producing a diagnostic for a found non-pac-ret protected
 // return, the analysis also lists the last instructions that wrote to the

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -202,8 +202,8 @@ public:
                  const std::vector<MCPhysReg> &RegsToTrackInstsFor)
       : Parent(BF, AllocId), NumRegs(BF.getBinaryContext().MRI->getNumRegs()),
         RegsToTrackInstsFor(RegsToTrackInstsFor),
-        TrackingLastInsts(RegsToTrackInstsFor.size() != 0),
-        Reg2StateIdx(RegsToTrackInstsFor.size() == 0
+        TrackingLastInsts(!RegsToTrackInstsFor.empty()),
+        Reg2StateIdx(RegsToTrackInstsFor.empty()
                          ? 0
                          : *llvm::max_element(RegsToTrackInstsFor) + 1,
                      -1) {
@@ -223,11 +223,9 @@ protected:
   std::vector<uint16_t> Reg2StateIdx;
 
   bool isTrackingReg(MCPhysReg Reg) const {
-    for (auto R : RegsToTrackInstsFor)
-      if (R == Reg)
-        return true;
-    return false;
+    return llvm::is_contained(RegsToTrackInstsFor, Reg);
   }
+
   uint16_t reg2StateIdx(MCPhysReg Reg) const {
     assert(Reg < Reg2StateIdx.size());
     return Reg2StateIdx[Reg];

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -1,0 +1,520 @@
+//===- bolt/Passes/NonPacProtectedRetAnalysis.cpp -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass that looks for any AArch64 return instructions
+// that may not be protected by PAuth authentication instructions when needed.
+//
+// When needed = the register used to return (almost always X30), is potentially
+// written to between the AUThentication instruction and the RETurn instruction.
+//
+//===----------------------------------------------------------------------===//
+
+#include "bolt/Passes/NonPacProtectedRetAnalysis.h"
+#include "bolt/Core/ParallelUtilities.h"
+#include "bolt/Passes/DataflowAnalysis.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/Support/Format.h"
+
+#define DEBUG_TYPE "bolt-nonpacprotectedret"
+
+namespace llvm {
+namespace bolt {
+
+raw_ostream &operator<<(raw_ostream &OS, const MCInstInBBReference &Ref) {
+  OS << "MCInstBBRef<";
+  if (Ref.BB == nullptr)
+    OS << "BB:(null)";
+  else
+    OS << "BB:" << Ref.BB->getName() << ":" << Ref.BBIndex;
+  OS << ">";
+  return OS;
+}
+
+raw_ostream &operator<<(raw_ostream &OS, const MCInstInBFReference &Ref) {
+  OS << "MCInstBFRef<";
+  if (Ref.BF == nullptr)
+    OS << "BF:(null)";
+  else
+    OS << "BF:" << Ref.BF->getPrintName() << ":" << Ref.getOffset();
+  OS << ">";
+  return OS;
+}
+
+raw_ostream &operator<<(raw_ostream &OS, const MCInstReference &Ref) {
+  switch (Ref.CurrentLocation) {
+  case MCInstReference::_BinaryBasicBlock:
+    OS << Ref.U.BBRef;
+    return OS;
+  case MCInstReference::_BinaryFunction:
+    OS << Ref.U.BFRef;
+    return OS;
+  }
+  llvm_unreachable("");
+}
+
+raw_ostream &operator<<(raw_ostream &OS,
+                        const NonPacProtectedRetGadget &NPPRG) {
+  OS << "pac-ret-gadget<";
+  OS << "Ret:" << NPPRG.RetInst << ", ";
+  OS << "Overwriting:[";
+  for (auto Ref : NPPRG.OverwritingRetRegInst)
+    OS << Ref << " ";
+  OS << "]>";
+  return OS;
+}
+
+// The security property that is checked is:
+// When a register is used as the address to jump to in a return instruction,
+// that register must either:
+// (a) never be changed within this function, i.e. have the same value as when
+//     the function started, or
+// (b) the last write to the register must be by an authentication instruction.
+
+// This property is checked by using data flow analysis to keep track of which
+// registers have been written (def-ed), since last authenticated. Those are
+// exactly the registers containing values that should not be trusted (as they
+// could have changed since the last time they were authenticated). For pac-ret,
+// any return instruction using such a register is a gadget to be reported. For
+// PAuthABI, any indirect control flow using such a register should be reported?
+
+// This security property is verified using a dataflow analysis.
+
+// Furthermore, when producing a diagnostic for a found non-pac-ret protected
+// return, the analysis also lists the last instructions that wrote to the
+// register used in the return instruction.
+// The total set of registers used in return instructions in a given function is
+// small. It almost always is just `X30`.
+// In order to reduce the memory consumption of storing this additional state
+// during the dataflow analysis, this is computed by running the dataflow
+// analysis twice:
+// 1. In the first run, the dataflow analysis only keeps track of the security
+//    property: i.e. which registers have been overwritten since the last
+//    time they've been authenticated.
+// 2. If the first run finds any return instructions using a
+//    written-to-last-by-an-non-authenticating instruction, the data flow
+//    analysis will be run a second time. The first run will return which
+//    registers are used in the gadgets to be reported. This information is
+//    used in the second run to also track with instructions last wrote to
+//    those registers.
+
+struct State {
+  /// A BitVector containing the registers that have been clobbered, and
+  /// not authenticated.
+  BitVector NonAutClobRegs;
+  /// A vector of sets, only used in the second data flow run.
+  /// Each element in the vector represent one registers for which we
+  /// track the set of last instructions that wrote to this register.
+  /// For pac-ret analysis, the expectations is that almost all return
+  /// instructions only use register `X30`, and therefore, this vector
+  /// will have length 1 in the second run.
+  std::vector<SmallPtrSet<const MCInst *, 4>> LastInstWritingReg;
+  State() {}
+  State(uint16_t NumRegs, uint16_t NumRegsToTrack)
+      : NonAutClobRegs(NumRegs), LastInstWritingReg(NumRegsToTrack) {}
+  State &operator|=(const State &StateIn) {
+    NonAutClobRegs |= StateIn.NonAutClobRegs;
+    for (unsigned I = 0; I < LastInstWritingReg.size(); ++I)
+      for (const MCInst *J : StateIn.LastInstWritingReg[I])
+        LastInstWritingReg[I].insert(J);
+    return *this;
+  }
+  bool operator==(const State &RHS) const {
+    return NonAutClobRegs == RHS.NonAutClobRegs &&
+           LastInstWritingReg == RHS.LastInstWritingReg;
+  }
+  bool operator!=(const State &RHS) const { return !((*this) == RHS); }
+};
+
+static void printLastInsts(
+    raw_ostream &OS,
+    const std::vector<SmallPtrSet<const MCInst *, 4>> &LastInstWritingReg) {
+  OS << "Insts: ";
+  for (unsigned I = 0; I < LastInstWritingReg.size(); ++I) {
+    auto Set = LastInstWritingReg[I];
+    OS << "[" << I << "](";
+    for (const MCInst *MCInstP : Set)
+      OS << MCInstP << " ";
+    OS << ")";
+  }
+}
+
+raw_ostream &operator<<(raw_ostream &OS, const State &S) {
+  OS << "pacret-state<";
+  OS << "NonAutClobRegs: " << S.NonAutClobRegs;
+  OS << "Insts: ";
+  printLastInsts(OS, S.LastInstWritingReg);
+  OS << ">";
+  return OS;
+}
+
+class PacStatePrinter {
+public:
+  void print(raw_ostream &OS, const State &State) const;
+  explicit PacStatePrinter(const BinaryContext &BC) : BC(BC) {}
+
+private:
+  const BinaryContext &BC;
+};
+
+void PacStatePrinter::print(raw_ostream &OS, const State &S) const {
+  RegStatePrinter RegStatePrinter(BC);
+  OS << "pacret-state<";
+  OS << "NonAutClobRegs: ";
+  RegStatePrinter.print(OS, S.NonAutClobRegs);
+  OS << "Insts: ";
+  printLastInsts(OS, S.LastInstWritingReg);
+  OS << ">";
+}
+
+class PacRetAnalysis
+    : public DataflowAnalysis<PacRetAnalysis, State, false /*Backward*/,
+                              PacStatePrinter> {
+  using Parent =
+      DataflowAnalysis<PacRetAnalysis, State, false, PacStatePrinter>;
+  friend Parent;
+
+public:
+  PacRetAnalysis(BinaryFunction &BF, MCPlusBuilder::AllocatorIdTy AllocId,
+                 const std::vector<MCPhysReg> &RegsToTrackInstsFor)
+      : Parent(BF, AllocId), NumRegs(BF.getBinaryContext().MRI->getNumRegs()),
+        RegsToTrackInstsFor(RegsToTrackInstsFor),
+        TrackingLastInsts(RegsToTrackInstsFor.size() != 0),
+        Reg2StateIdx(RegsToTrackInstsFor.size() == 0
+                         ? 0
+                         : *std::max_element(RegsToTrackInstsFor.begin(),
+                                             RegsToTrackInstsFor.end()) +
+                               1,
+                     -1) {
+    for (unsigned I = 0; I < RegsToTrackInstsFor.size(); ++I)
+      Reg2StateIdx[RegsToTrackInstsFor[I]] = I;
+  }
+  virtual ~PacRetAnalysis() {}
+
+  void run() { Parent::run(); }
+
+protected:
+  const uint16_t NumRegs;
+  /// RegToTrackInstsFor is the set of registers for which the dataflow analysis
+  /// must compute which the last set of instructions writing to it are.
+  const std::vector<MCPhysReg> RegsToTrackInstsFor;
+  const bool TrackingLastInsts;
+  /// Reg2StateIdx maps Register to the index in the vector used in State to
+  /// track which instructions last wrote to this register.
+  std::vector<uint16_t> Reg2StateIdx;
+
+  bool trackReg(MCPhysReg Reg) {
+    for (auto R : RegsToTrackInstsFor)
+      if (R == Reg)
+        return true;
+    return false;
+  }
+  uint16_t reg2StateIdx(MCPhysReg Reg) const {
+    assert(Reg < Reg2StateIdx.size());
+    return Reg2StateIdx[Reg];
+  }
+
+  void preflight() {}
+
+  State getStartingStateAtBB(const BinaryBasicBlock &BB) {
+    return State(NumRegs, RegsToTrackInstsFor.size());
+  }
+
+  State getStartingStateAtPoint(const MCInst &Point) {
+    return State(NumRegs, RegsToTrackInstsFor.size());
+  }
+
+  void doConfluence(State &StateOut, const State &StateIn) {
+    PacStatePrinter P(BC);
+    LLVM_DEBUG({
+      dbgs() << " PacRetAnalysis::Confluence(\n";
+      dbgs() << "   State 1: ";
+      P.print(dbgs(), StateOut);
+      dbgs() << "\n";
+      dbgs() << "   State 2: ";
+      P.print(dbgs(), StateIn);
+      dbgs() << ")\n";
+    });
+
+    StateOut |= StateIn;
+
+    LLVM_DEBUG({
+      dbgs() << "   merged state: ";
+      P.print(dbgs(), StateOut);
+      dbgs() << "\n";
+    });
+  }
+
+  State computeNext(const MCInst &Point, const State &Cur) {
+    PacStatePrinter P(BC);
+    LLVM_DEBUG({
+      dbgs() << " PacRetAnalysis::ComputeNext(";
+      BC.InstPrinter->printInst(&const_cast<MCInst &>(Point), 0, "", *BC.STI,
+                                dbgs());
+      dbgs() << ", ";
+      P.print(dbgs(), Cur);
+      dbgs() << ")\n";
+    });
+
+    State Next = Cur;
+    BitVector Written = BitVector(NumRegs, false);
+    BC.MIB->getWrittenRegs(Point, Written);
+    Next.NonAutClobRegs |= Written;
+    // Keep track of this instruction if it writes to any of the registers we
+    // need to track that for:
+    if (TrackingLastInsts) {
+      for (auto WrittenReg : Written.set_bits()) {
+        if (trackReg(WrittenReg)) {
+          Next.LastInstWritingReg[reg2StateIdx(WrittenReg)] = {};
+          Next.LastInstWritingReg[reg2StateIdx(WrittenReg)].insert(&Point);
+        }
+      }
+    }
+
+    MCPhysReg AutReg = BC.MIB->getAuthenticatedReg(Point);
+    if (AutReg != BC.MIB->getNoRegister()) {
+      Next.NonAutClobRegs.reset(
+          BC.MIB->getAliases(AutReg, /*OnlySmaller=*/true));
+      if (TrackingLastInsts && trackReg(AutReg))
+        Next.LastInstWritingReg[reg2StateIdx(AutReg)] = {};
+    }
+
+    LLVM_DEBUG({
+      dbgs() << "  .. result: (";
+      P.print(dbgs(), Next);
+      dbgs() << ")\n";
+    });
+
+    return Next;
+  }
+
+  StringRef getAnnotationName() const { return StringRef("PacRetAnalysis"); }
+
+public:
+  std::vector<MCInstReference>
+  getLastClobberingInsts(const MCInst Ret, BinaryFunction &BF,
+                         const BitVector &DirtyRawRegs) const {
+    if (!TrackingLastInsts)
+      return {};
+    if (auto MaybeState = getStateAt(Ret)) {
+      const State &S = *MaybeState;
+      // Due to aliasing registers, multiple registers may have
+      // been tracked.
+      std::set<const MCInst *> LastWritingInsts;
+      for (MCPhysReg TrackedReg : DirtyRawRegs.set_bits()) {
+        for (const MCInst *LastInstWriting :
+             S.LastInstWritingReg[reg2StateIdx(TrackedReg)])
+          LastWritingInsts.insert(LastInstWriting);
+      }
+      std::vector<MCInstReference> Result;
+      for (const MCInst *LastInstWriting : LastWritingInsts) {
+        MCInstInBBReference Ref = MCInstInBBReference::get(LastInstWriting, BF);
+        assert(Ref.BB != nullptr && "Expected Inst to be found");
+        Result.push_back(MCInstReference(Ref));
+      }
+      return Result;
+    }
+    llvm_unreachable("Expected State to be present");
+  }
+};
+
+SmallSet<MCPhysReg, 1> NonPacProtectedRetAnalysis::computeDfState(
+    PacRetAnalysis &PRA, BinaryFunction &BF,
+    MCPlusBuilder::AllocatorIdTy AllocatorId) {
+  PRA.run();
+  LLVM_DEBUG({
+    dbgs() << " After PacRetAnalysis:\n";
+    BF.dump();
+  });
+  // Now scan the CFG for non-authenticating return instructions that use an
+  // overwritten, non-authenticated register as return address.
+  SmallSet<MCPhysReg, 1> RetRegsWithGadgets;
+  BinaryContext &BC = BF.getBinaryContext();
+  for (BinaryBasicBlock &BB : BF) {
+    for (int64_t I = BB.size() - 1; I >= 0; --I) {
+      MCInst &Inst = BB.getInstructionAtIndex(I);
+      if (BC.MIB->isReturn(Inst)) {
+        MCPhysReg RetReg = BC.MIB->getRegUsedAsRetDest(Inst);
+        LLVM_DEBUG({
+          dbgs() << "  Found RET inst: ";
+          BC.printInstruction(dbgs(), Inst);
+          dbgs() << "    RetReg: " << BC.MRI->getName(RetReg)
+                 << "; authenticatesReg: "
+                 << BC.MIB->isAuthenticationOfReg(Inst, RetReg) << "\n";
+        });
+        if (BC.MIB->isAuthenticationOfReg(Inst, RetReg))
+          break;
+        BitVector DirtyRawRegs = PRA.getStateAt(Inst)->NonAutClobRegs;
+        LLVM_DEBUG({
+          dbgs() << "  DirtyRawRegs at Ret: ";
+          RegStatePrinter RSP(BC);
+          RSP.print(dbgs(), DirtyRawRegs);
+          dbgs() << "\n";
+        });
+        DirtyRawRegs &= BC.MIB->getAliases(RetReg, /*OnlySmaller=*/true);
+        LLVM_DEBUG({
+          dbgs() << "  Intersection with RetReg: ";
+          RegStatePrinter RSP(BC);
+          RSP.print(dbgs(), DirtyRawRegs);
+          dbgs() << "\n";
+        });
+        if (DirtyRawRegs.any()) {
+          // This return instruction needs to be reported
+          // First remove the annotation that the first, fast run of
+          // the dataflow analysis may have added.
+          if (BC.MIB->hasAnnotation(Inst, GadgetAnnotationIndex))
+            BC.MIB->removeAnnotation(Inst, GadgetAnnotationIndex);
+          BC.MIB->addAnnotation(
+              Inst, GadgetAnnotationIndex,
+              NonPacProtectedRetGadget(
+                  MCInstInBBReference(&BB, I),
+                  PRA.getLastClobberingInsts(Inst, BF, DirtyRawRegs)),
+              AllocatorId);
+          LLVM_DEBUG({
+            dbgs() << "  Added gadget info annotation: ";
+            BC.printInstruction(dbgs(), Inst, 0, &BF);
+            dbgs() << "\n";
+          });
+          for (MCPhysReg RetRegWithGadget : DirtyRawRegs.set_bits())
+            RetRegsWithGadgets.insert(RetRegWithGadget);
+        }
+      }
+    }
+  }
+  return RetRegsWithGadgets;
+}
+
+void NonPacProtectedRetAnalysis::runOnFunction(
+    BinaryFunction &BF, MCPlusBuilder::AllocatorIdTy AllocatorId) {
+  LLVM_DEBUG({
+    dbgs() << "Analyzing in function " << BF.getPrintName() << ", AllocatorId "
+           << AllocatorId << "\n";
+  });
+  LLVM_DEBUG({ BF.dump(); });
+
+  if (BF.hasCFG()) {
+    PacRetAnalysis PRA(BF, AllocatorId, {});
+    SmallSet<MCPhysReg, 1> RetRegsWithGadgets =
+        computeDfState(PRA, BF, AllocatorId);
+    if (!RetRegsWithGadgets.empty()) {
+      // Redo the analysis, but now also track which instructions last wrote
+      // to any of the registers in RetRegsWithGadgets, so that better
+      // diagnostics can be produced.
+      std::vector<MCPhysReg> RegsToTrack;
+      for (MCPhysReg R : RetRegsWithGadgets)
+        RegsToTrack.push_back(R);
+      PacRetAnalysis PRWIA(BF, AllocatorId, RegsToTrack);
+      SmallSet<MCPhysReg, 1> RetRegsWithGadgets =
+          computeDfState(PRWIA, BF, AllocatorId);
+    }
+  }
+}
+
+void printBB(const BinaryContext &BC, const BinaryBasicBlock *BB,
+             size_t StartIndex = 0, size_t EndIndex = -1) {
+  if (EndIndex == (size_t)-1)
+    EndIndex = BB->size() - 1;
+  const BinaryFunction *BF = BB->getFunction();
+  for (unsigned I = StartIndex; I <= EndIndex; ++I) {
+    uint64_t Address = BB->getOffset() + BF->getAddress() + 4 * I;
+    const MCInst &Inst = BB->getInstructionAtIndex(I);
+    if (BC.MIB->isCFI(Inst))
+      continue;
+    BC.printInstruction(outs(), Inst, Address, BF);
+  }
+}
+
+void reportFoundGadgetInSingleBBSingleOverwInst(const BinaryContext &BC,
+                                                const MCInstReference OverwInst,
+                                                const MCInstReference RetInst) {
+  BinaryBasicBlock *BB = RetInst.getBasicBlock();
+  assert(OverwInst.CurrentLocation == MCInstReference::_BinaryBasicBlock);
+  assert(RetInst.CurrentLocation == MCInstReference::_BinaryBasicBlock);
+  MCInstInBBReference OverwInstBB = OverwInst.U.BBRef;
+  if (BB == OverwInstBB.BB) {
+    // overwriting inst and ret instruction are in the same basic block.
+    assert(OverwInstBB.BBIndex < RetInst.U.BBRef.BBIndex);
+    outs() << "  This happens in the following basic block:\n";
+    printBB(BC, BB);
+  }
+}
+
+void reportFoundGadget(const BinaryContext &BC, const MCInst &Inst,
+                       unsigned int GadgetAnnotationIndex) {
+  auto NPPRG = BC.MIB->getAnnotationAs<NonPacProtectedRetGadget>(
+      Inst, GadgetAnnotationIndex);
+  MCInstReference RetInst = NPPRG.RetInst;
+  BinaryFunction *BF = RetInst.getFunction();
+  BinaryBasicBlock *BB = RetInst.getBasicBlock();
+
+  outs() << "\nGS-PACRET: " << "non-protected ret found in function "
+         << BF->getPrintName();
+  if (BB)
+    outs() << ", basic block " << BB->getName();
+  outs() << ", at address " << llvm::format("%x", RetInst.getAddress()) << "\n";
+  outs() << "  The return instruction is ";
+  BC.printInstruction(outs(), RetInst, RetInst.getAddress(), BF);
+  outs() << "  The " << NPPRG.OverwritingRetRegInst.size()
+         << " instructions that write to the return register after any "
+            "authentication are:\n";
+  // Sort by address to ensure output is deterministic.
+  std::sort(std::begin(NPPRG.OverwritingRetRegInst),
+            std::end(NPPRG.OverwritingRetRegInst),
+            [](const MCInstReference &A, const MCInstReference &B) {
+              return A.getAddress() < B.getAddress();
+            });
+  for (unsigned I = 0; I < NPPRG.OverwritingRetRegInst.size(); ++I) {
+    MCInstReference InstRef = NPPRG.OverwritingRetRegInst[I];
+    outs() << "  " << (I + 1) << ". ";
+    BC.printInstruction(outs(), InstRef, InstRef.getAddress(), BF);
+  };
+  LLVM_DEBUG({
+    dbgs() << "  .. OverWritingRetRegInst:\n";
+    for (MCInstReference Ref : NPPRG.OverwritingRetRegInst) {
+      dbgs() << "    " << Ref << "\n";
+    }
+  });
+  if (NPPRG.OverwritingRetRegInst.size() == 1) {
+    const MCInstReference OverwInst = NPPRG.OverwritingRetRegInst[0];
+    assert(OverwInst.CurrentLocation == MCInstReference::_BinaryBasicBlock);
+    reportFoundGadgetInSingleBBSingleOverwInst(BC, OverwInst, RetInst);
+  }
+}
+
+Error NonPacProtectedRetAnalysis::runOnFunctions(BinaryContext &BC) {
+  GadgetAnnotationIndex = BC.MIB->getOrCreateAnnotationIndex("pacret-gadget");
+
+  ParallelUtilities::WorkFuncWithAllocTy WorkFun =
+      [&](BinaryFunction &BF, MCPlusBuilder::AllocatorIdTy AllocatorId) {
+        runOnFunction(BF, AllocatorId);
+      };
+
+  ParallelUtilities::PredicateTy SkipFunc = [&](const BinaryFunction &BF) {
+    return false; // BF.shouldPreserveNops();
+  };
+
+  ParallelUtilities::runOnEachFunctionWithUniqueAllocId(
+      BC, ParallelUtilities::SchedulingPolicy::SP_INST_LINEAR, WorkFun,
+      SkipFunc, "NonPacProtectedRetAnalysis");
+
+  for (BinaryFunction *BF : BC.getAllBinaryFunctions())
+    if (BF->hasCFG()) {
+      for (BinaryBasicBlock &BB : *BF) {
+        for (int64_t I = BB.size() - 1; I >= 0; --I) {
+          MCInst &Inst = BB.getInstructionAtIndex(I);
+          if (BC.MIB->hasAnnotation(Inst, GadgetAnnotationIndex)) {
+            reportFoundGadget(BC, Inst, GadgetAnnotationIndex);
+          }
+        }
+      }
+    }
+  return Error::success();
+}
+
+} // namespace bolt
+} // namespace llvm

--- a/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
+++ b/bolt/lib/Passes/NonPacProtectedRetAnalysis.cpp
@@ -204,7 +204,7 @@ protected:
   /// track which instructions last wrote to this register.
   std::vector<uint16_t> Reg2StateIdx;
 
-  bool doTrackReg(MCPhysReg Reg) const {
+  bool isTrackingReg(MCPhysReg Reg) const {
     for (auto R : RegsToTrackInstsFor)
       if (R == Reg)
         return true;
@@ -265,7 +265,7 @@ protected:
     // need to track that for:
     if (TrackingLastInsts) {
       for (auto WrittenReg : Written.set_bits()) {
-        if (doTrackReg(WrittenReg)) {
+        if (isTrackingReg(WrittenReg)) {
           Next.LastInstWritingReg[reg2StateIdx(WrittenReg)] = {};
           Next.LastInstWritingReg[reg2StateIdx(WrittenReg)].insert(&Point);
         }
@@ -276,7 +276,7 @@ protected:
     if (AutReg != BC.MIB->getNoRegister()) {
       Next.NonAutClobRegs.reset(
           BC.MIB->getAliases(AutReg, /*OnlySmaller=*/true));
-      if (TrackingLastInsts && doTrackReg(AutReg))
+      if (TrackingLastInsts && isTrackingReg(AutReg))
         Next.LastInstWritingReg[reg2StateIdx(AutReg)] = {};
     }
 

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3510,7 +3510,8 @@ void RewriteInstance::runBinaryAnalyses() {
     opts::GadgetScannersToRun.addValue(GSK::GS_ALL);
   for (GSK ScannerToRun : opts::GadgetScannersToRun) {
     if (ScannerToRun == GSK::GS_PACRET || ScannerToRun == GSK::GS_ALL)
-      Manager.registerPass(std::make_unique<NonPacProtectedRetAnalysis::Analysis>());
+      Manager.registerPass(
+          std::make_unique<NonPacProtectedRetAnalysis::Analysis>());
   }
 
   BC->logBOLTErrorsAndQuitOnFatal(Manager.runPasses());

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3506,7 +3506,7 @@ void RewriteInstance::runBinaryAnalyses() {
   // and therefore, analysis is most likely to be less accurate.
   using GSK = opts::GadgetScannerKind;
   // if no command line option was given, act as if "all" was specified.
-  if (opts::GadgetScannersToRun.size() == 0)
+  if (opts::GadgetScannersToRun.empty())
     opts::GadgetScannersToRun.addValue(GSK::GS_ALL);
   for (GSK ScannerToRun : opts::GadgetScannersToRun) {
     if (ScannerToRun == GSK::GS_PACRET || ScannerToRun == GSK::GS_ALL)

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3510,7 +3510,7 @@ void RewriteInstance::runBinaryAnalyses() {
     opts::GadgetScannersToRun.addValue(GSK::GS_ALL);
   for (GSK ScannerToRun : opts::GadgetScannersToRun) {
     if (ScannerToRun == GSK::GS_PACRET || ScannerToRun == GSK::GS_ALL)
-      Manager.registerPass(std::make_unique<NonPacProtectedRetAnalysis>());
+      Manager.registerPass(std::make_unique<NonPacProtectedRetAnalysis::Analysis>());
   }
 
   BC->logBOLTErrorsAndQuitOnFatal(Manager.runPasses());

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -246,11 +246,12 @@ static cl::opt<bool> WriteBoltInfoSection(
     "bolt-info", cl::desc("write bolt info section in the output binary"),
     cl::init(true), cl::Hidden, cl::cat(BoltOutputCategory));
 
-cl::list<GadgetScannerKind> GadgetScannersToRun(
-    "scanners", cl::desc("which gadget scanners to run"),
-    cl::values(clEnumValN(GS_PACRET, "pacret", "pac-ret"),
-               clEnumValN(GS_ALL, "all", "all")),
-    cl::ZeroOrMore, cl::CommaSeparated, cl::cat(BinaryAnalysisCategory));
+cl::list<GadgetScannerKind>
+    GadgetScannersToRun("scanners", cl::desc("which gadget scanners to run"),
+                        cl::values(clEnumValN(GS_PACRET, "pacret", "pac-ret"),
+                                   clEnumValN(GS_ALL, "all", "all")),
+                        cl::ZeroOrMore, cl::CommaSeparated,
+                        cl::cat(BinaryAnalysisCategory));
 
 } // namespace opts
 

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -20,6 +20,7 @@
 #include "bolt/Passes/BinaryPasses.h"
 #include "bolt/Passes/CacheMetrics.h"
 #include "bolt/Passes/IdenticalCodeFolding.h"
+#include "bolt/Passes/NonPacProtectedRetAnalysis.h"
 #include "bolt/Passes/ReorderFunctions.h"
 #include "bolt/Profile/BoltAddressTranslation.h"
 #include "bolt/Profile/DataAggregator.h"
@@ -244,6 +245,12 @@ SequentialDisassembly("sequential-disassembly",
 static cl::opt<bool> WriteBoltInfoSection(
     "bolt-info", cl::desc("write bolt info section in the output binary"),
     cl::init(true), cl::Hidden, cl::cat(BoltOutputCategory));
+
+cl::list<GadgetScannerKind> GadgetScannersToRun(
+    "scanners", cl::desc("which gadget scanners to run"),
+    cl::values(clEnumValN(GS_PACRET, "pacret", "pac-ret"),
+               clEnumValN(GS_ALL, "all", "all")),
+    cl::ZeroOrMore, cl::CommaSeparated, cl::cat(BinaryAnalysisCategory));
 
 } // namespace opts
 
@@ -3490,7 +3497,23 @@ void RewriteInstance::runOptimizationPasses() {
   BC->logBOLTErrorsAndQuitOnFatal(BinaryFunctionPassManager::runAllPasses(*BC));
 }
 
-void RewriteInstance::runBinaryAnalyses() {}
+void RewriteInstance::runBinaryAnalyses() {
+  NamedRegionTimer T("runBinaryAnalyses", "run binary analysis passes",
+                     TimerGroupName, TimerGroupDesc, opts::TimeRewrite);
+  BinaryFunctionPassManager Manager(*BC);
+  // FIXME: add a pass that warns about which functions do not have CFG,
+  // and therefore, analysis is most likely to be less accurate.
+  using GSK = opts::GadgetScannerKind;
+  // if no command line option was given, act as if "all" was specified.
+  if (opts::GadgetScannersToRun.size() == 0)
+    opts::GadgetScannersToRun.addValue(GSK::GS_ALL);
+  for (GSK ScannerToRun : opts::GadgetScannersToRun) {
+    if (ScannerToRun == GSK::GS_PACRET || ScannerToRun == GSK::GS_ALL)
+      Manager.registerPass(std::make_unique<NonPacProtectedRetAnalysis>());
+  }
+
+  BC->logBOLTErrorsAndQuitOnFatal(Manager.runPasses());
+}
 
 void RewriteInstance::preregisterSections() {
   // Preregister sections before emission to set their order in the output.

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -191,15 +191,7 @@ public:
     assert(isReturn(Inst));
     switch (Inst.getOpcode()) {
     case AArch64::RET:
-      // There should be one register that the return reads, and
-      // that's the one being used as the jump target?
-      for (unsigned OpIdx = 0, EndIdx = Inst.getNumOperands(); OpIdx < EndIdx;
-           ++OpIdx) {
-        const MCOperand &MO = Inst.getOperand(OpIdx);
-        if (MO.isReg())
-          return MO.getReg();
-      }
-      return getNoRegister();
+      return Inst.getOperand(0).getReg();
     case AArch64::RETAA:
     case AArch64::RETAB:
     case AArch64::ERETAA:

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -217,6 +217,10 @@ public:
       return Inst.getOperand(0).getReg();
     case AArch64::RETAA:
     case AArch64::RETAB:
+    case AArch64::RETAASPPCi:
+    case AArch64::RETABSPPCi:
+    case AArch64::RETAASPPCr:
+    case AArch64::RETABSPPCr:
       return AArch64::LR;
     case AArch64::ERET:
     case AArch64::ERETAA:

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -23,6 +23,7 @@
 #include "llvm/MC/MCFixupKindInfo.h"
 #include "llvm/MC/MCInstBuilder.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Debug.h"
@@ -172,7 +173,6 @@ public:
     case AArch64::AUTIZB:
     case AArch64::AUTDZA:
     case AArch64::AUTDZB:
-      assert(Inst.getOperand(0).isReg());
       return Inst.getOperand(0).getReg();
 
     default:
@@ -181,13 +181,13 @@ public:
   }
 
   bool isAuthenticationOfReg(const MCInst &Inst,
-                             const unsigned RegAuthenticated) const override {
-    if (RegAuthenticated == getNoRegister())
+                             MCPhysReg AuthenticatedReg) const override {
+    if (AuthenticatedReg == getNoRegister())
       return false;
-    return getAuthenticatedReg(Inst) == RegAuthenticated;
+    return getAuthenticatedReg(Inst) == AuthenticatedReg;
   }
 
-  llvm::MCPhysReg getRegUsedAsRetDest(const MCInst &Inst) const override {
+  MCPhysReg getRegUsedAsRetDest(const MCInst &Inst) const override {
     assert(isReturn(Inst));
     switch (Inst.getOpcode()) {
     case AArch64::RET:

--- a/bolt/test/binary-analysis/AArch64/cmdline-args.test
+++ b/bolt/test/binary-analysis/AArch64/cmdline-args.test
@@ -13,7 +13,7 @@ NONEXISTINGFILEARG:       llvm-bolt-binary-analysis: 'non-existing-file': No suc
 RUN: not llvm-bolt-binary-analysis %p/Inputs/dummy.txt 2>&1 | FileCheck -check-prefix=NOELFFILEARG %s
 NOELFFILEARG:       llvm-bolt-binary-analysis: '{{.*}}/Inputs/dummy.txt': The file was not recognized as a valid object file.
 
-RUN: %clang %cflags %p/../../Inputs/asm_foo.s %p/../../Inputs/asm_main.c -o %t.exe
+RUN: %clang %cflags -Wl,--emit-relocs %p/../../Inputs/asm_foo.s %p/../../Inputs/asm_main.c -o %t.exe
 RUN: llvm-bolt-binary-analysis %t.exe 2>&1 | FileCheck -check-prefix=VALIDELFFILEARG --allow-empty %s
 # Check that there are no BOLT-WARNING or BOLT-ERROR output lines
 VALIDELFFILEARG:     BOLT-INFO:
@@ -29,5 +29,11 @@ HELP-EMPTY:
 HELP-NEXT:  USAGE: llvm-bolt-binary-analysis [options] <executable>
 HELP-EMPTY:
 HELP-NEXT:  OPTIONS:
+HELP-EMPTY:
+HELP-NEXT:  BinaryAnalysis options:
+HELP-EMPTY:
+HELP-NEXT:   --scanners=<value> - which gadget scanners to run
+HELP-NEXT:   =pacret - pac-ret
+HELP-NEXT:   =all - all
 HELP-EMPTY:
 HELP-NEXT:  Generic Options:

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -215,6 +215,10 @@ f_callclobbered_calleesaved:
         // does respect the AAPCS rules, so the scanner should assume x19 can
         // get overwritten, and report a gadget if the code does not properly
         // deal with that.
+        // Furthermore, there's a good chance that callee-saved registers have
+        // been saved on the stack at some point during execution of the callee,
+        // and so should be considered as potentially modified by an
+        // attacker/written to.
         ret x19
         .size f_callclobbered_calleesaved, .-f_callclobbered_calleesaved
 

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -183,6 +183,40 @@ f_nonx30_ret_ok:
         ret     x16
         .size f_nonx30_ret_ok, .-f_nonx30_ret_ok
 
+        .globl  f_detect_clobbered_x30_passed_to_other
+        .type   f_detect_clobbered_x30_passed_to_other,@function
+f_detect_clobbered_x30_passed_to_other:
+        str x30, [sp]
+        ldr x30, [sp]
+// FIXME: Ideally, the pac-ret scanner would report on the following instruction, which
+// performs a tail call, that x30 might be attacker-controlled.
+// CHECK-NOT: function f_detect_clobbered_x30_passed_to_other
+        b   f_tail_called
+        .size f_callclobbered_x30, .-f_callclobbered_x30
+
+        .globl  f_tail_called
+        .type   f_tail_called,@function
+f_tail_called:
+        ret
+        .size f_tail_called, .-f_tail_called
+
+        .globl  f_nonx30_ret_non_auted
+        .type   f_nonx30_ret_non_auted,@function
+f_nonx30_ret_non_auted:
+// FIXME: x1 is not authenticated, so should this be reported?
+//        Note that we assume it's fine for x30 to not be authenticated before
+//        returning to, as assuming that x30 is not attacker controlled at function
+//        entry is part (implicitly) of the pac-ret hardening scheme.
+//        It's probably an open question whether for other hardening schemes, such as
+//        PAuthABI, which registers should be considered "clean" or not at function entry.
+//        In other words, which registers have to be authenticated before being used as
+//        a pointer and which ones not?
+//        For a more detailed discussion, see
+//        https://github.com/llvm/llvm-project/pull/122304#discussion_r1923662744
+// CHECK-NOT: f_nonx30_ret_non_auted
+        ret     x1
+        .size f_nonx30_ret_non_auted, .-f_nonx30_ret_non_auted
+
 
         .globl  f_callclobbered_x30
         .type   f_callclobbered_x30,@function

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -6,7 +6,7 @@
         .globl  f1
         .type   f1,@function
 f1:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -32,7 +32,7 @@ f1:
         .globl  f_intermediate_overwrite1
         .type   f_intermediate_overwrite1,@function
 f_intermediate_overwrite1:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -58,7 +58,7 @@ f_intermediate_overwrite1:
         .globl  f_intermediate_overwrite2
         .type   f_intermediate_overwrite2,@function
 f_intermediate_overwrite2:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -86,7 +86,7 @@ f_intermediate_overwrite2:
         .globl  f_intermediate_read
         .type   f_intermediate_read,@function
 f_intermediate_read:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -101,7 +101,7 @@ f_intermediate_read:
         .globl  f_intermediate_overwrite3
         .type   f_intermediate_overwrite3,@function
 f_intermediate_overwrite3:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -129,7 +129,7 @@ f_intermediate_overwrite3:
         .globl  f_nonx30_ret
         .type   f_nonx30_ret,@function
 f_nonx30_ret:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -160,7 +160,7 @@ f_nonx30_ret:
         .globl  f_autiasp
         .type   f_autiasp,@function
 f_autiasp:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -174,7 +174,7 @@ f_autiasp:
         .globl  f_autibsp
         .type   f_autibsp,@function
 f_autibsp:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -188,7 +188,7 @@ f_autibsp:
         .globl  f_autiaz
         .type   f_autiaz,@function
 f_autiaz:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -202,7 +202,7 @@ f_autiaz:
         .globl  f_autibz
         .type   f_autibz,@function
 f_autibz:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -216,7 +216,7 @@ f_autibz:
         .globl  f_autia1716
         .type   f_autia1716,@function
 f_autia1716:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -242,7 +242,7 @@ f_autia1716:
         .globl  f_autib1716
         .type   f_autib1716,@function
 f_autib1716:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -268,7 +268,7 @@ f_autib1716:
         .globl  f_autiax12
         .type   f_autiax12,@function
 f_autiax12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -294,7 +294,7 @@ f_autiax12:
         .globl  f_autibx12
         .type   f_autibx12,@function
 f_autibx12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -320,7 +320,7 @@ f_autibx12:
         .globl  f_autiax30
         .type   f_autiax30,@function
 f_autiax30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -334,7 +334,7 @@ f_autiax30:
         .globl  f_autibx30
         .type   f_autibx30,@function
 f_autibx30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -349,7 +349,7 @@ f_autibx30:
         .globl  f_autdax12
         .type   f_autdax12,@function
 f_autdax12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -375,7 +375,7 @@ f_autdax12:
         .globl  f_autdbx12
         .type   f_autdbx12,@function
 f_autdbx12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -401,7 +401,7 @@ f_autdbx12:
         .globl  f_autdax30
         .type   f_autdax30,@function
 f_autdax30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -415,7 +415,7 @@ f_autdax30:
         .globl  f_autdbx30
         .type   f_autdbx30,@function
 f_autdbx30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -430,7 +430,7 @@ f_autdbx30:
         .globl  f_autizax12
         .type   f_autizax12,@function
 f_autizax12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -456,7 +456,7 @@ f_autizax12:
         .globl  f_autizbx12
         .type   f_autizbx12,@function
 f_autizbx12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -482,7 +482,7 @@ f_autizbx12:
         .globl  f_autizax30
         .type   f_autizax30,@function
 f_autizax30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -496,7 +496,7 @@ f_autizax30:
         .globl  f_autizbx30
         .type   f_autizbx30,@function
 f_autizbx30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -511,7 +511,7 @@ f_autizbx30:
         .globl  f_autdzax12
         .type   f_autdzax12,@function
 f_autdzax12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -537,7 +537,7 @@ f_autdzax12:
         .globl  f_autdzbx12
         .type   f_autdzbx12,@function
 f_autdzbx12:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -563,7 +563,7 @@ f_autdzbx12:
         .globl  f_autdzax30
         .type   f_autdzax30,@function
 f_autdzax30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -577,7 +577,7 @@ f_autdzax30:
         .globl  f_autdzbx30
         .type   f_autdzbx30,@function
 f_autdzbx30:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -591,7 +591,7 @@ f_autdzbx30:
         .globl  f_retaa
         .type   f_retaa,@function
 f_retaa:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -604,7 +604,7 @@ f_retaa:
         .globl  f_retab
         .type   f_retab,@function
 f_retab:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -617,7 +617,7 @@ f_retab:
         .globl  f_eretaa
         .type   f_eretaa,@function
 f_eretaa:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -631,7 +631,7 @@ f_eretaa:
         .globl  f_eretab
         .type   f_eretab,@function
 f_eretab:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -645,7 +645,7 @@ f_eretab:
         .globl  f_eret
         .type   f_eret,@function
 f_eret:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -675,7 +675,7 @@ f_movx30reg:
 f_autiasppci:
 0:
         pacnbiasppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -691,7 +691,7 @@ f_autiasppci:
 f_autibsppci:
 0:
         pacnbibsppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -708,7 +708,7 @@ f_autibsppci:
 f_autiasppcr:
 0:
         pacnbiasppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -723,7 +723,7 @@ f_autiasppcr:
 f_autibsppcr:
 0:
         pacnbibsppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -740,7 +740,7 @@ f_autibsppcr:
 f_retaasppci:
 0:
         pacnbiasppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -755,7 +755,7 @@ f_retaasppci:
 f_retabsppci:
 0:
         pacnbibsppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -771,7 +771,7 @@ f_retabsppci:
 f_retaasppcr:
 0:
         pacnbiasppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -785,7 +785,7 @@ f_retaasppcr:
 f_retabsppcr:
 0:
         pacnbibsppc
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -799,7 +799,7 @@ f_retabsppcr:
         .globl  f_autia171615
         .type   f_autia171615,@function
 f_autia171615:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g
@@ -825,7 +825,7 @@ f_autia171615:
         .globl  f_autib171615
         .type   f_autib171615,@function
 f_autib171615:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         mov     x29, sp
         bl      g

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -623,7 +623,8 @@ f_eretaa:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-// CHECK-NOT: function f_eretaa
+// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eretaa, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:   The return instruction is     {{[0-9a-f]+}}:       eretaa
         eretaa
         .size f_eretaa, .-f_eretaa
 
@@ -636,7 +637,8 @@ f_eretab:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-// CHECK-NOT: function f_eretab
+// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eretab, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:   The return instruction is     {{[0-9a-f]+}}:       eretab
         eretab
         .size f_eretab, .-f_eretab
 
@@ -649,18 +651,8 @@ f_eret:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_eret, basic block .LBB{{[0-9]+}}, at address
-// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       eret
-// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
-// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
-// CHECK-NEXT:  This happens in the following basic block:
-// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
-// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
-// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
-// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
-// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
-// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
-// CHECK-NEXT: {{[0-9a-f]+}}:   eret
+// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eret, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:   The return instruction is     {{[0-9a-f]+}}:       eret
         eret
         .size f_eret, .-f_eret
 
@@ -677,5 +669,8 @@ f_movx30reg:
         mov     x30, x22
         ret
         .size f_movx30reg, .-f_movx30reg
+
+// FIXME: add regression tests for the instructions added in v9.5: AUTI{A,B}SPPC{i,r}, RETI{A,B}SPPC{i,r}, AUTI{A,B}171615.
+
 
 // TODO: add test to see if registers clobbered by a call are picked up.

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -154,6 +154,35 @@ f_nonx30_ret:
         ret     x16
         .size f_nonx30_ret, .-f_nonx30_ret
 
+        .globl  f_nonx30_ret_ok
+        .type   f_nonx30_ret_ok,@function
+f_nonx30_ret_ok:
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        // FIXME: Should the scanner understand that an authenticated register (below x30,
+        //        after the autiasp instruction), is OK to be moved to another register
+        //        and then that register being used to return?
+        //        This respects that pac-ret hardening intent, but the scanner currently
+        //        will produce a false positive for this.
+        //        Is it worthwhile to make the scanner more complex for this case?
+        //        So far, scanning many millions of instructions across a linux distro,
+        //        I haven't encountered such an example.
+        //        The ".if 0" block below tests this case and currently fails.
+.if 0
+        autiasp
+        mov     x16, x30
+.else
+        mov     x16, x30
+        autia   x16, sp
+.endif
+// CHECK-NOT: function f_nonx30_ret_ok
+        ret     x16
+        .size f_nonx30_ret_ok, .-f_nonx30_ret_ok
+
 
 /// Now do a basic sanity check on every different Authentication instruction:
 

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -march=armv8.3-a -mbranch-protection=pac-ret %s %p/../../Inputs/asm_main.c -o %t.exe
-// RUN: llvm-bolt-binary-analysis --scanners=pacret %t.exe 2>&1 | FileCheck -check-prefix=CHECK --allow-empty %s
+// RUN: llvm-bolt-binary-analysis --scanners=pacret %t.exe 2>&1 | FileCheck %s
 
         .text
 
@@ -208,7 +208,7 @@ f_autibz:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-        autiaz
+        autibz
 // CHECK-NOT: function f_autibz
         ret
         .size f_autibz, .-f_autibz

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -192,7 +192,7 @@ f_detect_clobbered_x30_passed_to_other:
 // performs a tail call, that x30 might be attacker-controlled.
 // CHECK-NOT: function f_detect_clobbered_x30_passed_to_other
         b   f_tail_called
-        .size f_callclobbered_x30, .-f_callclobbered_x30
+        .size f_detect_clobbered_x30_passed_to_other, .-f_detect_clobbered_x30_passed_to_other
 
         .globl  f_tail_called
         .type   f_tail_called,@function

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -1,0 +1,681 @@
+// RUN: %clang %cflags -march=armv8.3-a -mbranch-protection=pac-ret %s %p/../../Inputs/asm_main.c -o %t.exe
+// RUN: llvm-bolt-binary-analysis --scanners=pacret %t.exe 2>&1 | FileCheck -check-prefix=CHECK --allow-empty %s
+
+        .text
+
+        .globl  f1
+        .type   f1,@function
+f1:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        // autiasp
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f1, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f1, .-f1
+
+
+        .globl  f_intermediate_overwrite1
+        .type   f_intermediate_overwrite1,@function
+f_intermediate_overwrite1:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        autiasp
+        ldp     x29, x30, [sp], #16
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite1, basic block .LBB
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   autiasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_intermediate_overwrite1, .-f_intermediate_overwrite1
+
+        .globl  f_intermediate_overwrite2
+        .type   f_intermediate_overwrite2,@function
+f_intermediate_overwrite2:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiasp
+        mov     x30, x0
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite2, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: mov     x30, x0
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autiasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x30, x0
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_intermediate_overwrite2, .-f_intermediate_overwrite2
+
+        .globl  f_intermediate_read
+        .type   f_intermediate_read,@function
+f_intermediate_read:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiasp
+        mov     x0, x30
+// CHECK-NOT: function f_intermediate_read
+        ret
+        .size f_intermediate_read, .-f_intermediate_read
+
+        .globl  f_intermediate_overwrite3
+        .type   f_intermediate_overwrite3,@function
+f_intermediate_overwrite3:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiasp
+        mov     w30, w0
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite3, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: mov     w30, w0
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autiasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     w30, w0
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_intermediate_overwrite3, .-f_intermediate_overwrite3
+
+        .globl  f_nonx30_ret
+        .type   f_nonx30_ret,@function
+f_nonx30_ret:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        mov     x16, x30
+        autiasp
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_nonx30_ret, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret     x16
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: mov     x16, x30
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x16, x30
+// CHECK-NEXT: {{[0-9a-f]+}}:   autiasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret     x16
+        ret     x16
+        .size f_nonx30_ret, .-f_nonx30_ret
+
+
+/// Now do a basic sanity check on every different Authentication instruction:
+
+        .globl  f_autiasp
+        .type   f_autiasp,@function
+f_autiasp:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiasp
+// CHECK-NOT: function f_autiasp
+        ret
+        .size f_autiasp, .-f_autiasp
+
+        .globl  f_autibsp
+        .type   f_autibsp,@function
+f_autibsp:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autibsp
+// CHECK-NOT: function f_autibsp
+        ret
+        .size f_autibsp, .-f_autibsp
+
+        .globl  f_autiaz
+        .type   f_autiaz,@function
+f_autiaz:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiaz
+// CHECK-NOT: function f_autiaz
+        ret
+        .size f_autiaz, .-f_autiaz
+
+        .globl  f_autibz
+        .type   f_autibz,@function
+f_autibz:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiaz
+// CHECK-NOT: function f_autibz
+        ret
+        .size f_autibz, .-f_autibz
+
+        .globl  f_autia1716
+        .type   f_autia1716,@function
+f_autia1716:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autia1716
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autia1716, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autia1716
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autia1716, .-f_autia1716
+
+        .globl  f_autib1716
+        .type   f_autib1716,@function
+f_autib1716:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autib1716
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autib1716, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autib1716
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autib1716, .-f_autib1716
+
+        .globl  f_autiax12
+        .type   f_autiax12,@function
+f_autiax12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autia   x12, sp
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autiax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autia   x12, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autiax12, .-f_autiax12
+
+        .globl  f_autibx12
+        .type   f_autibx12,@function
+f_autibx12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autib   x12, sp
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autibx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autib   x12, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autibx12, .-f_autibx12
+
+        .globl  f_autiax30
+        .type   f_autiax30,@function
+f_autiax30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autia   x30, sp
+// CHECK-NOT: function f_autiax30
+        ret
+        .size f_autiax30, .-f_autiax30
+
+        .globl  f_autibx30
+        .type   f_autibx30,@function
+f_autibx30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autib   x30, sp
+// CHECK-NOT: function f_autibx30
+        ret
+        .size f_autibx30, .-f_autibx30
+
+
+        .globl  f_autdax12
+        .type   f_autdax12,@function
+f_autdax12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autda   x12, sp
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autda   x12, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autdax12, .-f_autdax12
+
+        .globl  f_autdbx12
+        .type   f_autdbx12,@function
+f_autdbx12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autdb   x12, sp
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdbx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autdb   x12, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autdbx12, .-f_autdbx12
+
+        .globl  f_autdax30
+        .type   f_autdax30,@function
+f_autdax30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autda   x30, sp
+// CHECK-NOT: function f_autdax30
+        ret
+        .size f_autdax30, .-f_autdax30
+
+        .globl  f_autdbx30
+        .type   f_autdbx30,@function
+f_autdbx30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autdb   x30, sp
+// CHECK-NOT: function f_autdbx30
+        ret
+        .size f_autdbx30, .-f_autdbx30
+
+
+        .globl  f_autizax12
+        .type   f_autizax12,@function
+f_autizax12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiza  x12
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autizax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autiza  x12
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autizax12, .-f_autizax12
+
+        .globl  f_autizbx12
+        .type   f_autizbx12,@function
+f_autizbx12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autizb  x12
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autizbx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autizb  x12
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autizbx12, .-f_autizbx12
+
+        .globl  f_autizax30
+        .type   f_autizax30,@function
+f_autizax30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autiza  x30
+// CHECK-NOT: function f_autizax30
+        ret
+        .size f_autizax30, .-f_autizax30
+
+        .globl  f_autizbx30
+        .type   f_autizbx30,@function
+f_autizbx30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autizb  x30
+// CHECK-NOT: function f_autizbx30
+        ret
+        .size f_autizbx30, .-f_autizbx30
+
+
+        .globl  f_autdzax12
+        .type   f_autdzax12,@function
+f_autdzax12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autdza  x12
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdzax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autdza  x12
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autdzax12, .-f_autdzax12
+
+        .globl  f_autdzbx12
+        .type   f_autdzbx12,@function
+f_autdzbx12:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autdzb  x12
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdzbx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   autdzb  x12
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        ret
+        .size f_autdzbx12, .-f_autdzbx12
+
+        .globl  f_autdzax30
+        .type   f_autdzax30,@function
+f_autdzax30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autdza  x30
+// CHECK-NOT: function f_autdzax30
+        ret
+        .size f_autdzax30, .-f_autdzax30
+
+        .globl  f_autdzbx30
+        .type   f_autdzbx30,@function
+f_autdzbx30:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+        autdzb  x30
+// CHECK-NOT: function f_autdzbx30
+        ret
+        .size f_autdzbx30, .-f_autdzbx30
+
+        .globl  f_retaa
+        .type   f_retaa,@function
+f_retaa:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+// CHECK-NOT: function f_retaa
+        retaa
+        .size f_retaa, .-f_retaa
+
+        .globl  f_retab
+        .type   f_retab,@function
+f_retab:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+// CHECK-NOT: function f_retab
+        retab
+        .size f_retab, .-f_retab
+
+        .globl  f_eretaa
+        .type   f_eretaa,@function
+f_eretaa:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+// CHECK-NOT: function f_eretaa
+        eretaa
+        .size f_eretaa, .-f_eretaa
+
+        .globl  f_eretab
+        .type   f_eretab,@function
+f_eretab:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+// CHECK-NOT: function f_eretab
+        eretab
+        .size f_eretab, .-f_eretab
+
+        .globl  f_eret
+        .type   f_eret,@function
+f_eret:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+        bl      g
+        add     x0, x0, #3
+        ldp     x29, x30, [sp], #16
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_eret, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       eret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   paciasp
+// CHECK-NEXT: {{[0-9a-f]+}}:   stp     x29, x30, [sp, #-0x10]!
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x29, sp
+// CHECK-NEXT: {{[0-9a-f]+}}:   bl      g@PLT
+// CHECK-NEXT: {{[0-9a-f]+}}:   add     x0, x0, #0x3
+// CHECK-NEXT: {{[0-9a-f]+}}:   ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT: {{[0-9a-f]+}}:   eret
+        eret
+        .size f_eret, .-f_eret
+
+        .globl f_movx30reg
+        .type   f_movx30reg,@function
+f_movx30reg:
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_movx30reg, basic block .LBB{{[0-9]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1. {{[0-9a-f]+}}: mov x30, x22
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT: {{[0-9a-f]+}}:   mov     x30, x22
+// CHECK-NEXT: {{[0-9a-f]+}}:   ret
+        mov     x30, x22
+        ret
+        .size f_movx30reg, .-f_movx30reg
+
+// TODO: add test to see if registers clobbered by a call are picked up.

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
@@ -7,7 +7,7 @@
         .globl f_crossbb1
         .type   f_crossbb1,@function
 f_crossbb1:
-        hint    #25
+        paciasp
         stp     x29, x30, [sp, #-16]!
         ldp     x29, x30, [sp], #16
         cbnz    x0, 1f
@@ -26,7 +26,7 @@ f_crossbb1:
         .globl f_mergebb1
         .type   f_mergebb1,@function
 f_mergebb1:
-        hint    #25
+        paciasp
 2:
         stp     x29, x30, [sp, #-16]!
         ldp     x29, x30, [sp], #16
@@ -41,6 +41,35 @@ f_mergebb1:
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
+
+        .globl f_shrinkwrapping
+        .type   f_shrinkwrapping,@function
+f_shrinkwrapping:
+        cbz     x0, 1f
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        ldp     x29, x30, [sp], #16
+        autiasp
+1:
+        ret
+        .size f_shrinkwrapping, .-f_shrinkwrapping
+// CHECK-NOT: f_shrinkwrapping
+
+        .globl f_multi_auth_insts
+        .type   f_multi_auth_insts,@function
+f_multi_auth_insts:
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        ldp     x29, x30, [sp], #16
+        cbnz x0, 1f
+        autibsp
+        b 2f
+1:
+        autiasp
+2:
+        ret
+        .size f_multi_auth_insts, .-f_multi_auth_insts
+// CHECK-NOT: f_multi_auth_insts
 
 // TODO: also verify that false negatives exist in across-BB gadgets in functions
 // for which bolt cannot reconstruct the call graph.

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
@@ -1,5 +1,5 @@
 // RUN: %clang %cflags -march=armv8.3-a -mbranch-protection=pac-ret %s %p/../../Inputs/asm_main.c -o %t.exe
-// RUN: llvm-bolt-binary-analysis --scanners=pacret %t.exe 2>&1 | FileCheck -check-prefix=CHECK --allow-empty %s
+// RUN: llvm-bolt-binary-analysis --scanners=pacret %t.exe 2>&1 | FileCheck %s
 
 
 // Verify that we can also detect gadgets across basic blocks

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
@@ -1,0 +1,46 @@
+// RUN: %clang %cflags -march=armv8.3-a -mbranch-protection=pac-ret %s %p/../../Inputs/asm_main.c -o %t.exe
+// RUN: llvm-bolt-binary-analysis --scanners=pacret %t.exe 2>&1 | FileCheck -check-prefix=CHECK --allow-empty %s
+
+
+// Verify that we can also detect gadgets across basic blocks
+
+        .globl f_crossbb1
+        .type   f_crossbb1,@function
+f_crossbb1:
+        hint    #25
+        stp     x29, x30, [sp, #-16]!
+        ldp     x29, x30, [sp], #16
+        cbnz    x0, 1f
+        autiasp
+1:
+        ret
+        .size f_crossbb1, .-f_crossbb1
+// CHECK-LABEL:     GS-PACRET: non-protected ret found in function f_crossbb1, basic block .L{{[^,]+}}, at address
+// CHECK-NEXT:  The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:  The 2 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
+// CHECK-NEXT:  2.     {{[0-9a-f]+}}:      autiasp
+
+// A test that checks that the dataflow state tracking across when merging BBs
+// seems to work:
+        .globl f_mergebb1
+        .type   f_mergebb1,@function
+f_mergebb1:
+        hint    #25
+2:
+        stp     x29, x30, [sp, #-16]!
+        ldp     x29, x30, [sp], #16
+        sub     x0, x0, #1
+        cbnz    x0, 1f
+        autiasp
+        b       2b
+1:
+        ret
+        .size f_mergebb1, .-f_mergebb1
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_mergebb1, basic block .L{{[^,]+}}, at address
+// CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
+// CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
+// CHECK-NEXT:    1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
+
+// TODO: also verify that false negatives exist in across-BB gadgets in functions
+// for which bolt cannot reconstruct the call graph.

--- a/bolt/test/binary-analysis/AArch64/lit.local.cfg
+++ b/bolt/test/binary-analysis/AArch64/lit.local.cfg
@@ -1,7 +1,7 @@
 if "AArch64" not in config.root.targets:
     config.unsupported = True
 
-flags = "--target=aarch64-linux-gnu -nostartfiles -nostdlib -ffreestanding -Wl,--emit-relocs"
+flags = "--target=aarch64-linux-gnu -nostartfiles -nostdlib -ffreestanding"
 
 config.substitutions.insert(0, ("%cflags", f"%cflags {flags}"))
 config.substitutions.insert(0, ("%cxxflags", f"%cxxflags {flags}"))

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -2022,6 +2022,8 @@ let Predicates = [HasPAuthLR] in {
     //                              opcode2, opcode,   asm
     def AUTIASPPCr : SignAuthOneReg<0b00001, 0b100100, "autiasppcr">;
     def AUTIBSPPCr : SignAuthOneReg<0b00001, 0b100101, "autibsppcr">;
+  }
+  let Defs = [X17], Uses = [X15, X16, X17] in {
     //                                  opcode2, opcode,   asm
     def PACIA171615 : SignAuthFixedRegs<0b00001, 0b100010, "pacia171615">;
     def PACIB171615 : SignAuthFixedRegs<0b00001, 0b100011, "pacib171615">;


### PR DESCRIPTION
This adds an initial pac-ret gadget scanner to the llvm-bolt-binary-analysis-tool.

The scanner is taken from the prototype that was published last year at https://github.com/llvm/llvm-project/compare/main...kbeyls:llvm-project:bolt-gadget-scanner-prototype, and has been discussed in RFC
https://discourse.llvm.org/t/rfc-bolt-based-binary-analysis-tool-to-verify-correctness-of-security-hardening/78148 and in the EuroLLVM 2024 keynote "Does LLVM implement security hardenings correctly? A BOLT-based static analyzer to the rescue?" [Video](https://youtu.be/Sn_Fxa0tdpY) [Slides](https://llvm.org/devmtg/2024-04/slides/Keynote/Beyls_EuroLLVM2024_security_hardening_keynote.pdf)

In the spirit of incremental development, this PR aims to add a minimal implementation that is "fully working" on its own, but has major limitations, as described in the bolt/docs/BinaryAnalysis.md documentation in this proposed commit.  These and other limitations will be fixed in follow-on PRs, mostly based on code already existing in the prototype branch. I hope incrementally upstreaming will make it easier to review the code.

That being said, this patch isn't really small.

I believe that this patch needs 2 "kinds" of reviewers:
1. People familiar with BOLT internals.
2. People familiar with the pac-ret hardening scheme and AArch64.

I expect people familiar with the pac-ret hardening scheme might need to focus on reviewing mostly what is in file
`NonPacProtectedRetAnalysis.cpp`, `AArch64MCPlusBuilder.cpp`  and the unit tests.

I expect people familiar with BOLT might mainly need to focus on the other parts, and the high-level structure of
`NonPacProtectedRetAnalysis.cpp`.

The patch is not very polished currently, but I think it's in the right shape to start getting it reviewed.

Note that I believe that this could also form the basis of a scanner to analyze correct implementation of PAuthABI.