### PR TITLE
[mlir-cpu-runner] Pass --exclude-libs to linker when building runner

### DIFF
--- a/mlir/tools/mlir-cpu-runner/CMakeLists.txt
+++ b/mlir/tools/mlir-cpu-runner/CMakeLists.txt
@@ -26,3 +26,10 @@ target_link_libraries(mlir-cpu-runner PRIVATE
   MLIRExecutionEngine
   MLIRJitRunner
   )
+target_link_options(mlir-cpu-runner
+  PRIVATE
+    # On Linux, disable re-export of any static linked libraries that came
+    # through. This prevents our LLVM build from interfering with the version of
+    # LLVM included in certain graphics drivers.
+    $<$<PLATFORM_ID:Linux>:LINKER:--exclude-libs,ALL>
+)


### PR DESCRIPTION
This fixes a conflict between the version of LLVM linked against by the runner and the unrelated version of LLVM that may be dynamically loaded by a graphics driver. (Relevant to #73457: fixes loading certain Vulkan drivers.)