### PR TITLE
[OpenMP][FIX] Adjust test to be non-flaky

### DIFF
--- a/offload/test/sanitizer/kernel_crash_async.c
+++ b/offload/test/sanitizer/kernel_crash_async.c
@@ -36,4 +36,4 @@ int main(void) {
 // TRACE: Kernel {{.*}} (__omp_offloading_{{.*}}_main_l29)
 // TRACE:     launchKernel
 //
-// CHECK: Kernel {{[0-9]}}: {{.*}} (__omp_offloading_{{.*}}_main_l29)
+// CHECK: Kernel {{.*}} (__omp_offloading_{{.*}}_main_l29)


### PR DESCRIPTION
The test runs asynchronous kernels and depending on the timing the output is slightly different. We now only check for the common parts of the output.