### PR TITLE
[RISCV] Return MILog2SEW for mask instructions getOperandLog2EEW. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -633,7 +633,7 @@ getOperandLog2EEW(const MachineOperand &MO, const MachineRegisterInfo *MRI) {
   case RISCV::VMSBF_M:
   case RISCV::VMSIF_M:
   case RISCV::VMSOF_M: {
-    return 0;
+    return MILog2SEW;
   }
 
   // Vector Iota Instruction


### PR DESCRIPTION
The SEW operand for these instructions should have a value of 0. This matches what was done for vcpop/vfirst.