### PR TITLE
[Flang] Promote FortranEvaluateTesting library

### DIFF
--- a/flang/include/flang/Testing/fp-testing.h
+++ b/flang/include/flang/Testing/fp-testing.h
@@ -1,5 +1,13 @@
-#ifndef FORTRAN_TEST_EVALUATE_FP_TESTING_H_
-#define FORTRAN_TEST_EVALUATE_FP_TESTING_H_
+//===-- include/flang/Testing/fp-testing.h ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_TESTING_FP_TESTING_H_
+#define FORTRAN_TESTING_FP_TESTING_H_
 
 #include "flang/Common/target-rounding.h"
 #include <fenv.h>
@@ -24,4 +32,4 @@ private:
 #endif
 };
 
-#endif // FORTRAN_TEST_EVALUATE_FP_TESTING_H_
+#endif /* FORTRAN_TESTING_FP_TESTING_H_ */

--- a/flang/include/flang/Testing/testing.h
+++ b/flang/include/flang/Testing/testing.h
@@ -1,5 +1,13 @@
-#ifndef FORTRAN_EVALUATE_TESTING_H_
-#define FORTRAN_EVALUATE_TESTING_H_
+//===-- include/flang/Testing/testing.h -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_TESTING_TESTING_H_
+#define FORTRAN_TESTING_TESTING_H_
 
 #include <cinttypes>
 #include <string>
@@ -33,4 +41,4 @@ FailureDetailPrinter Match(const char *file, int line, const std::string &want,
 FailureDetailPrinter Compare(const char *file, int line, const char *xs,
     const char *rel, const char *ys, std::uint64_t x, std::uint64_t y);
 } // namespace testing
-#endif // FORTRAN_EVALUATE_TESTING_H_
+#endif /* FORTRAN_TESTING_TESTING_H_ */

--- a/flang/lib/CMakeLists.txt
+++ b/flang/lib/CMakeLists.txt
@@ -8,3 +8,7 @@ add_subdirectory(Frontend)
 add_subdirectory(FrontendTool)
 
 add_subdirectory(Optimizer)
+
+if (FLANG_INCLUDE_TESTS)
+  add_subdirectory(Testing)
+endif ()

--- a/flang/lib/Testing/CMakeLists.txt
+++ b/flang/lib/Testing/CMakeLists.txt
@@ -1,0 +1,20 @@
+#===-- lib/Testing/CMakeLists.txt ------------------------------------------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+
+add_library(NonGTestTesting EXCLUDE_FROM_ALL
+    testing.cpp
+    fp-testing.cpp
+)
+set_target_properties(NonGTestTesting PROPERTIES FOLDER "Flang/Tests")
+
+if (LLVM_LINK_LLVM_DYLIB)
+  set(llvm_libs LLVM)
+else()
+  llvm_map_components_to_libnames(llvm_libs Support)
+endif()
+target_link_libraries(NonGTestTesting ${llvm_libs})

--- a/flang/lib/Testing/fp-testing.cpp
+++ b/flang/lib/Testing/fp-testing.cpp
@@ -1,4 +1,12 @@
-#include "fp-testing.h"
+//===-- lib/Testing/fp-testing.cpp ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Testing/fp-testing.h"
 #include "llvm/Support/Errno.h"
 #include <cstdio>
 #include <cstdlib>

--- a/flang/lib/Testing/testing.cpp
+++ b/flang/lib/Testing/testing.cpp
@@ -1,4 +1,12 @@
-#include "testing.h"
+//===-- lib/Testing/testing.cpp ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Testing/testing.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdarg>
 #include <cstdio>

--- a/flang/unittests/Evaluate/CMakeLists.txt
+++ b/flang/unittests/Evaluate/CMakeLists.txt
@@ -1,47 +1,34 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_library(FortranEvaluateTesting
-  testing.cpp
-  fp-testing.cpp
-)
-set_target_properties(FortranEvaluateTesting PROPERTIES FOLDER "Flang/Tests")
-if (LLVM_LINK_LLVM_DYLIB)
-  set(llvm_libs LLVM)
-else()
-  llvm_map_components_to_libnames(llvm_libs Support)
-endif()
-
-target_link_libraries(FortranEvaluateTesting
-  ${llvm_libs})
 
 add_flang_nongtest_unittest(leading-zero-bit-count
-  FortranEvaluateTesting
+  NonGTestTesting
 )
 
 add_flang_nongtest_unittest(bit-population-count
-  FortranEvaluateTesting
+  NonGTestTesting
 )
 
 add_flang_nongtest_unittest(uint128
-  FortranEvaluateTesting
+  NonGTestTesting
 )
 
 add_flang_nongtest_unittest(expression
   FortranSupport
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranSemantics
   FortranParser
 )
 
 add_flang_nongtest_unittest(integer
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranSemantics
 )
 
 add_flang_nongtest_unittest(intrinsics
   FortranSupport
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranDecimal
   FortranSemantics
@@ -50,7 +37,7 @@ add_flang_nongtest_unittest(intrinsics
 )
 
 add_flang_nongtest_unittest(logical
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranSemantics
 )
@@ -62,7 +49,7 @@ add_flang_nongtest_unittest(logical
 set(LLVM_REQUIRES_EH ON)
 set(LLVM_REQUIRES_RTTI ON)
 add_flang_nongtest_unittest(real
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranDecimal
   FortranSemantics
@@ -70,14 +57,14 @@ add_flang_nongtest_unittest(real
 llvm_update_compile_flags(real.test)
 
 add_flang_nongtest_unittest(reshape
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranSemantics
   FortranEvaluate
   FortranRuntime
 )
 
 add_flang_nongtest_unittest(ISO-Fortran-binding
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranSemantics
   FortranRuntime
@@ -85,7 +72,7 @@ add_flang_nongtest_unittest(ISO-Fortran-binding
 
 add_flang_nongtest_unittest(folding
   FortranSupport
-  FortranEvaluateTesting
+  NonGTestTesting
   FortranEvaluate
   FortranSemantics
 )

--- a/flang/unittests/Evaluate/ISO-Fortran-binding.cpp
+++ b/flang/unittests/Evaluate/ISO-Fortran-binding.cpp
@@ -1,6 +1,6 @@
-#include "testing.h"
 #include "flang/Common/ISO_Fortran_binding_wrapper.h"
 #include "flang/Runtime/descriptor.h"
+#include "flang/Testing/testing.h"
 #include "llvm/Support/raw_ostream.h"
 #include <type_traits>
 

--- a/flang/unittests/Evaluate/bit-population-count.cpp
+++ b/flang/unittests/Evaluate/bit-population-count.cpp
@@ -1,5 +1,5 @@
 #include "flang/Common/bit-population-count.h"
-#include "testing.h"
+#include "flang/Testing/testing.h"
 
 using Fortran::common::BitPopulationCount;
 using Fortran::common::Parity;

--- a/flang/unittests/Evaluate/expression.cpp
+++ b/flang/unittests/Evaluate/expression.cpp
@@ -1,10 +1,10 @@
 #include "flang/Evaluate/expression.h"
-#include "testing.h"
 #include "flang/Evaluate/fold.h"
 #include "flang/Evaluate/intrinsics.h"
 #include "flang/Evaluate/target.h"
 #include "flang/Evaluate/tools.h"
 #include "flang/Parser/message.h"
+#include "flang/Testing/testing.h"
 #include <cstdio>
 #include <cstdlib>
 #include <string>

--- a/flang/unittests/Evaluate/folding.cpp
+++ b/flang/unittests/Evaluate/folding.cpp
@@ -1,4 +1,3 @@
-#include "testing.h"
 #include "../../lib/Evaluate/host.h"
 #include "flang/Evaluate/call.h"
 #include "flang/Evaluate/expression.h"
@@ -7,6 +6,7 @@
 #include "flang/Evaluate/intrinsics.h"
 #include "flang/Evaluate/target.h"
 #include "flang/Evaluate/tools.h"
+#include "flang/Testing/testing.h"
 #include <tuple>
 
 using namespace Fortran::evaluate;

--- a/flang/unittests/Evaluate/integer.cpp
+++ b/flang/unittests/Evaluate/integer.cpp
@@ -1,5 +1,5 @@
 #include "flang/Evaluate/integer.h"
-#include "testing.h"
+#include "flang/Testing/testing.h"
 #include <cstdio>
 #include <string>
 

--- a/flang/unittests/Evaluate/intrinsics.cpp
+++ b/flang/unittests/Evaluate/intrinsics.cpp
@@ -1,10 +1,10 @@
 #include "flang/Evaluate/intrinsics.h"
-#include "testing.h"
 #include "flang/Evaluate/common.h"
 #include "flang/Evaluate/expression.h"
 #include "flang/Evaluate/target.h"
 #include "flang/Evaluate/tools.h"
 #include "flang/Parser/provenance.h"
+#include "flang/Testing/testing.h"
 #include "llvm/Support/raw_ostream.h"
 #include <initializer_list>
 #include <map>

--- a/flang/unittests/Evaluate/leading-zero-bit-count.cpp
+++ b/flang/unittests/Evaluate/leading-zero-bit-count.cpp
@@ -1,5 +1,5 @@
 #include "flang/Common/leading-zero-bit-count.h"
-#include "testing.h"
+#include "flang/Testing/testing.h"
 
 using Fortran::common::LeadingZeroBitCount;
 

--- a/flang/unittests/Evaluate/logical.cpp
+++ b/flang/unittests/Evaluate/logical.cpp
@@ -1,5 +1,5 @@
-#include "testing.h"
 #include "flang/Evaluate/type.h"
+#include "flang/Testing/testing.h"
 #include <cstdio>
 
 template <int KIND> void testKind() {

--- a/flang/unittests/Evaluate/real.cpp
+++ b/flang/unittests/Evaluate/real.cpp
@@ -1,6 +1,6 @@
-#include "fp-testing.h"
-#include "testing.h"
 #include "flang/Evaluate/type.h"
+#include "flang/Testing/fp-testing.h"
+#include "flang/Testing/testing.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cmath>
 #include <cstdio>

--- a/flang/unittests/Evaluate/reshape.cpp
+++ b/flang/unittests/Evaluate/reshape.cpp
@@ -1,6 +1,6 @@
-#include "testing.h"
 #include "flang/Runtime/descriptor.h"
 #include "flang/Runtime/transformational.h"
+#include "flang/Testing/testing.h"
 #include <cinttypes>
 
 using namespace Fortran::common;

--- a/flang/unittests/Evaluate/uint128.cpp
+++ b/flang/unittests/Evaluate/uint128.cpp
@@ -1,6 +1,6 @@
 #define AVOID_NATIVE_UINT128_T 1
 #include "flang/Common/uint128.h"
-#include "testing.h"
+#include "flang/Testing/testing.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 


### PR DESCRIPTION
The non-GTest library will be shared by unittests of Flang and Flang-RT. Promote it as a regular library for use by both projects.

Extracted out of #110217

In the long term, we may want to convert these to regular GTest checks to avoid having multiple testing frameworks.