### PR TITLE
[MemProf] Disable cloning of callsites in recursive cycles by default

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -122,9 +122,9 @@ static cl::opt<unsigned>
                         cl::desc("Max depth to recursively search for missing "
                                  "frames through tail calls."));
 
-// By default enable cloning of callsites involved with recursive cycles
+// Optionally enable cloning of callsites involved with recursive cycles
 static cl::opt<bool> AllowRecursiveCallsites(
-    "memprof-allow-recursive-callsites", cl::init(true), cl::Hidden,
+    "memprof-allow-recursive-callsites", cl::init(false), cl::Hidden,
     cl::desc("Allow cloning of callsites involved in recursive cycles"));
 
 // When disabled, try to detect and prevent cloning of recursive contexts.


### PR DESCRIPTION
This disables the support added in PR121985 by default while we
investigate a compile time crash.
