### PR TITLE
[lldb][test] Fix some 'import-std-module' tests

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
-    @skipIfLinux  # https://discourse.llvm.org/t/lldb-test-failures-on-linux/80095
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/array/main.cpp
+++ b/lldb/test/API/commands/expression/import-std-module/array/main.cpp
@@ -1,4 +1,9 @@
+#include <__verbose_abort>
 #include <array>
+
+// Some expressons from the test need this symbol to be compiled when libcxx is
+// built statically.
+void *libcpp_verbose_abort_ptr = (void *)&std::__libcpp_verbose_abort;
 
 struct DbgInfo {
   int v = 4;

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
@@ -14,7 +14,6 @@ class TestDbgInfoContentVector(TestBase):
     @skipIf(compiler="clang", compiler_version=["<", "12.0"])
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwin  # https://github.com/llvm/llvm-project/issues/106475
-    @skipIfLinux  # https://discourse.llvm.org/t/lldb-test-failures-on-linux/80095
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/main.cpp
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/main.cpp
@@ -1,4 +1,9 @@
+#include <__verbose_abort>
 #include <vector>
+
+// Some expressons from the test need this symbol to be compiled when libcxx is
+// built statically.
+void *libcpp_verbose_abort_ptr = (void *)&std::__libcpp_verbose_abort;
 
 struct Foo {
   int a;

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 class TestVectorOfVectors(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
-    @skipIfLinux  # https://discourse.llvm.org/t/lldb-test-failures-on-linux/80095
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/main.cpp
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/main.cpp
@@ -1,4 +1,9 @@
+#include <__verbose_abort>
 #include <vector>
+
+// Some expressons from the test need this symbol to be compiled when libcxx is
+// built statically.
+void *libcpp_verbose_abort_ptr = (void *)&std::__libcpp_verbose_abort;
 
 int main(int argc, char **argv) {
   std::vector<std::vector<int> > a = {{1, 2, 3}, {3, 2, 1}};


### PR DESCRIPTION
Some tests from 'import-std-module' used to fail on the builder
https://lab.llvm.org/staging/#/builders/195/builds/4470,
since libcxx is set up to be linked statically with test binaries
on it.

Thus, they were temporarily disabled in #112530. Here, this commit
is reverted.

Jitted expressions from the tests try to call __libcpp_verbose_abort
function that is not present in the process image, which causes
the failure.

Here, this symbol is explicitly referenced from the test source files.