### PR TITLE
[libc][test] remove C++ stdlib includes

### DIFF
--- a/libc/test/UnitTest/ExecuteFunctionUnix.cpp
+++ b/libc/test/UnitTest/ExecuteFunctionUnix.cpp
@@ -8,13 +8,13 @@
 
 #include "ExecuteFunction.h"
 #include "src/__support/macros/config.h"
-#include <cassert>
-#include <cstdlib>
-#include <cstring>
-#include <iostream>
-#include <memory>
+#include "test/UnitTest/ExecuteFunction.h" // FunctionCaller
+#include <assert.h>
 #include <poll.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -35,21 +35,20 @@ int ProcessStatus::get_fatal_signal() {
 }
 
 ProcessStatus invoke_in_subprocess(FunctionCaller *func, unsigned timeout_ms) {
-  std::unique_ptr<FunctionCaller> X(func);
   int pipe_fds[2];
   if (::pipe(pipe_fds) == -1)
     return ProcessStatus::error("pipe(2) failed");
 
   // Don't copy the buffers into the child process and print twice.
-  std::cout.flush();
-  std::cerr.flush();
+  ::fflush(stderr);
+  ::fflush(stdout);
   pid_t pid = ::fork();
   if (pid == -1)
     return ProcessStatus::error("fork(2) failed");
 
   if (!pid) {
     (*func)();
-    std::exit(0);
+    ::exit(0);
   }
   ::close(pipe_fds[1]);
 

--- a/libc/test/UnitTest/FPExceptMatcher.cpp
+++ b/libc/test/UnitTest/FPExceptMatcher.cpp
@@ -9,11 +9,11 @@
 #include "FPExceptMatcher.h"
 
 #include "src/__support/macros/config.h"
+#include "test/UnitTest/ExecuteFunction.h" // FunctionCaller
 #include "test/UnitTest/Test.h"
 
 #include "hdr/types/fenv_t.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
-#include <memory>
 #include <setjmp.h>
 #include <signal.h>
 
@@ -37,14 +37,13 @@ static void sigfpeHandler(int sig) {
 }
 
 FPExceptMatcher::FPExceptMatcher(FunctionCaller *func) {
-  auto oldSIGFPEHandler = signal(SIGFPE, &sigfpeHandler);
-  std::unique_ptr<FunctionCaller> funcUP(func);
+  sighandler_t oldSIGFPEHandler = signal(SIGFPE, &sigfpeHandler);
 
   caughtExcept = false;
   fenv_t oldEnv;
   fputil::get_env(&oldEnv);
   if (sigsetjmp(jumpBuffer, 1) == 0)
-    funcUP->call();
+    func->call();
   // We restore the previous floating point environment after
   // the call to the function which can potentially raise SIGFPE.
   fputil::set_env(&oldEnv);

--- a/libc/test/UnitTest/LibcDeathTestExecutors.cpp
+++ b/libc/test/UnitTest/LibcDeathTestExecutors.cpp
@@ -12,7 +12,7 @@
 #include "test/UnitTest/ExecuteFunction.h"
 #include "test/UnitTest/TestLogger.h"
 
-#include <cassert>
+#include <assert.h>
 
 namespace {
 constexpr unsigned TIMEOUT_MS = 10000;


### PR DESCRIPTION
These make cross compiling the test suite more difficult, as you need the
sysroot to contain these headers and libraries cross compiled for your target.
It's straightforward to stick with the corresponding C headers.
