### PR TITLE
[SYCL] Correct misplaced sycl_kernel_entry_point attribute in a namespace declaration of a negative test.

### DIFF
--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
@@ -170,7 +170,7 @@ struct B3 {
 };
 
 // expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions}}
-namespace bad4 [[clang::sycl_kernel_entry_point(BADKN<4>)]] {}
+namespace [[clang::sycl_kernel_entry_point(BADKN<4>)]] bad4 {}
 
 #if __cplusplus >= 202002L
 // expected-error@+2 {{'sycl_kernel_entry_point' attribute only applies to functions}}


### PR DESCRIPTION
Commit 1a73654b3212b623ac21b9deb3aeaadc6906b7e4 added a missing diagnostic for incorrect placement of an attribute in a namespace declaration. This change corrects a SYCL test that inadvertently exercised the `sycl_kernel_entry_point` attribute in the wrong declaration location.