### PR TITLE
[libc][test] fix memory leak

### DIFF
--- a/libc/test/UnitTest/ExecuteFunctionUnix.cpp
+++ b/libc/test/UnitTest/ExecuteFunctionUnix.cpp
@@ -36,18 +36,23 @@ int ProcessStatus::get_fatal_signal() {
 
 ProcessStatus invoke_in_subprocess(FunctionCaller *func, unsigned timeout_ms) {
   int pipe_fds[2];
-  if (::pipe(pipe_fds) == -1)
+  if (::pipe(pipe_fds) == -1) {
+    ::free(func);
     return ProcessStatus::error("pipe(2) failed");
+  }
 
   // Don't copy the buffers into the child process and print twice.
   ::fflush(stderr);
   ::fflush(stdout);
   pid_t pid = ::fork();
-  if (pid == -1)
+  if (pid == -1) {
+    ::free(func);
     return ProcessStatus::error("fork(2) failed");
+  }
 
   if (!pid) {
     (*func)();
+    ::free(func);
     ::exit(0);
   }
   ::close(pipe_fds[1]);
@@ -57,11 +62,14 @@ ProcessStatus invoke_in_subprocess(FunctionCaller *func, unsigned timeout_ms) {
   };
   // No events requested so this call will only return after the timeout or if
   // the pipes peer was closed, signaling the process exited.
-  if (::poll(&poll_fd, 1, timeout_ms) == -1)
+  if (::poll(&poll_fd, 1, timeout_ms) == -1) {
+    ::free(func);
     return ProcessStatus::error("poll(2) failed");
+  }
   // If the pipe wasn't closed by the child yet then timeout has expired.
   if (!(poll_fd.revents & POLLHUP)) {
     ::kill(pid, SIGKILL);
+    ::free(func);
     return ProcessStatus::timed_out_ps();
   }
 
@@ -69,9 +77,12 @@ ProcessStatus invoke_in_subprocess(FunctionCaller *func, unsigned timeout_ms) {
   // Wait on the pid of the subprocess here so it gets collected by the system
   // and doesn't turn into a zombie.
   pid_t status = ::waitpid(pid, &wstatus, 0);
-  if (status == -1)
+  if (status == -1) {
+    ::free(func);
     return ProcessStatus::error("waitpid(2) failed");
+  }
   assert(status == pid);
+  ::free(func);
   return {wstatus};
 }
 

--- a/libc/test/UnitTest/FPExceptMatcher.cpp
+++ b/libc/test/UnitTest/FPExceptMatcher.cpp
@@ -44,6 +44,7 @@ FPExceptMatcher::FPExceptMatcher(FunctionCaller *func) {
   fputil::get_env(&oldEnv);
   if (sigsetjmp(jumpBuffer, 1) == 0)
     func->call();
+  free(func);
   // We restore the previous floating point environment after
   // the call to the function which can potentially raise SIGFPE.
   fputil::set_env(&oldEnv);


### PR DESCRIPTION
Looks like the smart pointer I removed was being used to free the underlying
object.

Fixes: #122369
