### PR TITLE
[LLD][COFF] Silence GCC warning in Arm64XDynamicRelocEntry::getSize (NFC)

### DIFF
--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -1174,6 +1174,7 @@ size_t Arm64XDynamicRelocEntry::getSize() const {
   case IMAGE_DVRT_ARM64X_FIXUP_TYPE_ZEROFILL:
     llvm_unreachable("unsupported type");
   }
+  llvm_unreachable("invalid type");
 }
 
 void Arm64XDynamicRelocEntry::writeTo(uint8_t *buf) const {


### PR DESCRIPTION
Fixes 71bbafba31699bdabe289654d157ae961432e52a.