### PR TITLE
[libc][test] fix memory leak pt.2

### DIFF
--- a/libc/test/UnitTest/FPExceptMatcher.cpp
+++ b/libc/test/UnitTest/FPExceptMatcher.cpp
@@ -44,7 +44,7 @@ FPExceptMatcher::FPExceptMatcher(FunctionCaller *func) {
   fputil::get_env(&oldEnv);
   if (sigsetjmp(jumpBuffer, 1) == 0)
     func->call();
-  free(func);
+  delete func;
   // We restore the previous floating point environment after
   // the call to the function which can potentially raise SIGFPE.
   fputil::set_env(&oldEnv);


### PR DESCRIPTION
These were created with operator new (see `Test::createCallable`), so operator
delete should be used instead of free().

Fixes: #122369
Fixes: #122378
