### PR TITLE
[InstrProf] Add frontend temporal profiling flag

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -3035,6 +3035,38 @@ indexed format, regardeless whether it is produced by frontend or the IR pass.
   overhead. ``prefer-atomic`` will be transformed to ``atomic`` when supported
   by the target, or ``single`` otherwise.
 
+.. option:: -fprofile-generate-temporal
+
+  Enables the temporal profiling extension for IRPGO to improve startup time by
+  reducing ``.text`` section page faults. To do this, we instrument function
+  timestamps to measure when each function is called for the first time and use
+  this data to generate a function order to improve startup.
+
+  The profile is generated as normal.
+
+  .. code-block:: console
+
+    $ clang++ -O2 -fprofile-generate -fprofile-generate-temporal code.cc -o code
+    $ ./code
+    $ llvm-profdata merge -o code.profdata yyy/zzz
+
+  Using the resulting profile, we can either generate a function order to pass
+  to the linker.
+
+  .. code-block:: console
+
+    $ llvm-profdata order code.profdata -o code.orderfile
+    $ clang++ -O2 -Wl,--symbol-ordering-file=code.orderfile code.cc -o code
+
+  Or it can be passed to the linker directly.
+
+  .. code-block:: console
+
+    $ clang++ -O2 -Wl,--irpgo-profile=code.profdata,--bp-startup-sort=function code.cc -o code
+
+  For more information, please read the RFC:
+  https://discourse.llvm.org/t/rfc-temporal-profiling-extension-for-irpgo/68068
+
 Fine Tuning Profile Collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -3035,7 +3035,7 @@ indexed format, regardeless whether it is produced by frontend or the IR pass.
   overhead. ``prefer-atomic`` will be transformed to ``atomic`` when supported
   by the target, or ``single`` otherwise.
 
-.. option:: -fprofile-generate-temporal
+.. option:: -ftemporal-profile
 
   Enables the temporal profiling extension for IRPGO to improve startup time by
   reducing ``.text`` section page faults. To do this, we instrument function
@@ -3046,23 +3046,23 @@ indexed format, regardeless whether it is produced by frontend or the IR pass.
 
   .. code-block:: console
 
-    $ clang++ -O2 -fprofile-generate -fprofile-generate-temporal code.cc -o code
+    $ clang++ -O2 -fprofile-generate -ftemporal-profile code.cc -o code
     $ ./code
     $ llvm-profdata merge -o code.profdata yyy/zzz
 
-  Using the resulting profile, we can either generate a function order to pass
-  to the linker.
+  Using the resulting profile, we can generate a function order to pass to the
+  linker via `--symbol-ordering-file` for ELF or `-order_file` for Mach-O.
 
   .. code-block:: console
 
     $ llvm-profdata order code.profdata -o code.orderfile
     $ clang++ -O2 -Wl,--symbol-ordering-file=code.orderfile code.cc -o code
 
-  Or it can be passed to the linker directly.
+  Or the profile can be passed to LLD directly.
 
   .. code-block:: console
 
-    $ clang++ -O2 -Wl,--irpgo-profile=code.profdata,--bp-startup-sort=function code.cc -o code
+    $ clang++ -O2 -fuse-ld=lld -Wl,--irpgo-profile=code.profdata,--bp-startup-sort=function code.cc -o code
 
   For more information, please read the RFC:
   https://discourse.llvm.org/t/rfc-temporal-profiling-extension-for-irpgo/68068

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1796,9 +1796,9 @@ def fprofile_generate_cold_function_coverage : Flag<["-"], "fprofile-generate-co
 def fprofile_generate_cold_function_coverage_EQ : Joined<["-"], "fprofile-generate-cold-function-coverage=">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>, MetaVarName<"<directory>">,
     HelpText<"Generate instrumented code to collect coverage info for cold functions into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
-def fprofile_generate_temporal_instrumentation : Flag<["-"], "fprofile-generate-temporal-instrumentation">,
+def fprofile_generate_temporal : Flag<["-"], "fprofile-generate-temporal">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>,
-    HelpText<"Generate instrumented code to collect temporal information. See this RFC for details: https://discourse.llvm.org/t/rfc-temporal-profiling-extension-for-irpgo/68068">;
+    HelpText<"Generate instrumented code to collect temporal information">;
 def fprofile_instr_generate : Flag<["-"], "fprofile-instr-generate">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>,
     HelpText<"Generate instrumented code to collect execution counts into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)">;
@@ -1894,7 +1894,7 @@ defm pseudo_probe_for_profiling : BoolFOption<"pseudo-probe-for-profiling",
           " pseudo probes for sample profiling">>;
 def forder_file_instrumentation : Flag<["-"], "forder-file-instrumentation">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,
-    HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var). Deprecated, please use -fprofile-generate-temporal-instrumentation">;
+    HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var). Deprecated, please use -fprofile-generate-temporal">;
 def fprofile_list_EQ : Joined<["-"], "fprofile-list=">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,
     HelpText<"Filename defining the list of functions/files to instrument. "

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1796,7 +1796,7 @@ def fprofile_generate_cold_function_coverage : Flag<["-"], "fprofile-generate-co
 def fprofile_generate_cold_function_coverage_EQ : Joined<["-"], "fprofile-generate-cold-function-coverage=">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>, MetaVarName<"<directory>">,
     HelpText<"Generate instrumented code to collect coverage info for cold functions into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
-def fprofile_generate_temporal : Flag<["-"], "fprofile-generate-temporal">,
+def ftemporal_profile : Flag<["-"], "ftemporal-profile">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>,
     HelpText<"Generate instrumented code to collect temporal information">;
 def fprofile_instr_generate : Flag<["-"], "fprofile-instr-generate">,
@@ -1894,7 +1894,7 @@ defm pseudo_probe_for_profiling : BoolFOption<"pseudo-probe-for-profiling",
           " pseudo probes for sample profiling">>;
 def forder_file_instrumentation : Flag<["-"], "forder-file-instrumentation">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,
-    HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var). Deprecated, please use -fprofile-generate-temporal">;
+    HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var). Deprecated, please use -ftemporal-profile">;
 def fprofile_list_EQ : Joined<["-"], "fprofile-list=">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,
     HelpText<"Filename defining the list of functions/files to instrument. "

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1796,6 +1796,9 @@ def fprofile_generate_cold_function_coverage : Flag<["-"], "fprofile-generate-co
 def fprofile_generate_cold_function_coverage_EQ : Joined<["-"], "fprofile-generate-cold-function-coverage=">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>, MetaVarName<"<directory>">,
     HelpText<"Generate instrumented code to collect coverage info for cold functions into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)">;
+def fprofile_generate_temporal_instrumentation : Flag<["-"], "fprofile-generate-temporal-instrumentation">,
+    Group<f_Group>, Visibility<[ClangOption, CLOption]>,
+    HelpText<"Generate instrumented code to collect temporal information. See this RFC for details: https://discourse.llvm.org/t/rfc-temporal-profiling-extension-for-irpgo/68068">;
 def fprofile_instr_generate : Flag<["-"], "fprofile-instr-generate">,
     Group<f_Group>, Visibility<[ClangOption, CLOption]>,
     HelpText<"Generate instrumented code to collect execution counts into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)">;
@@ -1891,7 +1894,7 @@ defm pseudo_probe_for_profiling : BoolFOption<"pseudo-probe-for-profiling",
           " pseudo probes for sample profiling">>;
 def forder_file_instrumentation : Flag<["-"], "forder-file-instrumentation">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,
-    HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var). Deprecated, please use temporal profiling.">;
+    HelpText<"Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var). Deprecated, please use -fprofile-generate-temporal-instrumentation">;
 def fprofile_list_EQ : Joined<["-"], "fprofile-list=">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option, CLOption]>,
     HelpText<"Filename defining the list of functions/files to instrument. "

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -662,6 +662,15 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
     CmdArgs.push_back("--pgo-function-entry-coverage");
   }
 
+  if (auto *A = Args.getLastArg(
+          options::OPT_fprofile_generate_temporal_instrumentation)) {
+    if (!PGOGenerateArg && !CSPGOGenerateArg)
+      D.Diag(clang::diag::err_drv_argument_only_allowed_with)
+          << A->getSpelling() << "-fprofile-generate or -fcs-profile-generate";
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back("--pgo-temporal-instrumentation");
+  }
+
   Arg *PGOGenArg = nullptr;
   if (PGOGenerateArg) {
     assert(!CSPGOGenerateArg);
@@ -8050,7 +8059,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           Args.getLastArg(options::OPT_forder_file_instrumentation)) {
     D.Diag(diag::warn_drv_deprecated_arg)
         << A->getAsString(Args) << /*hasReplacement=*/true
-        << "-mllvm -pgo-temporal-instrumentation";
+        << "-fprofile-generate-temporal-instrumentation";
     CmdArgs.push_back("-forder-file-instrumentation");
     // Enable order file instrumentation when ThinLTO is not on. When ThinLTO is
     // on, we need to pass these flags as linker flags and that will be handled

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -662,7 +662,7 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
     CmdArgs.push_back("--pgo-function-entry-coverage");
   }
 
-  if (auto *A = Args.getLastArg(options::OPT_fprofile_generate_temporal)) {
+  if (auto *A = Args.getLastArg(options::OPT_ftemporal_profile)) {
     if (!PGOGenerateArg && !CSPGOGenerateArg)
       D.Diag(clang::diag::err_drv_argument_only_allowed_with)
           << A->getSpelling() << "-fprofile-generate or -fcs-profile-generate";
@@ -8058,7 +8058,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           Args.getLastArg(options::OPT_forder_file_instrumentation)) {
     D.Diag(diag::warn_drv_deprecated_arg)
         << A->getAsString(Args) << /*hasReplacement=*/true
-        << "-fprofile-generate-temporal";
+        << "-ftemporal-profile";
     CmdArgs.push_back("-forder-file-instrumentation");
     // Enable order file instrumentation when ThinLTO is not on. When ThinLTO is
     // on, we need to pass these flags as linker flags and that will be handled

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -662,8 +662,7 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
     CmdArgs.push_back("--pgo-function-entry-coverage");
   }
 
-  if (auto *A = Args.getLastArg(
-          options::OPT_fprofile_generate_temporal_instrumentation)) {
+  if (auto *A = Args.getLastArg(options::OPT_fprofile_generate_temporal)) {
     if (!PGOGenerateArg && !CSPGOGenerateArg)
       D.Diag(clang::diag::err_drv_argument_only_allowed_with)
           << A->getSpelling() << "-fprofile-generate or -fcs-profile-generate";
@@ -8059,7 +8058,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           Args.getLastArg(options::OPT_forder_file_instrumentation)) {
     D.Diag(diag::warn_drv_deprecated_arg)
         << A->getAsString(Args) << /*hasReplacement=*/true
-        << "-fprofile-generate-temporal-instrumentation";
+        << "-fprofile-generate-temporal";
     CmdArgs.push_back("-forder-file-instrumentation");
     // Enable order file instrumentation when ThinLTO is not on. When ThinLTO is
     // on, we need to pass these flags as linker flags and that will be handled

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -424,7 +424,7 @@
 // CHECK-WARNING-DAG: optimization flag '-fno-devirtualize-speculatively' is not supported
 // CHECK-WARNING-DAG: the flag '-fslp-vectorize-aggressive' has been deprecated and will be ignored
 // CHECK-WARNING-DAG: the flag '-fno-slp-vectorize-aggressive' has been deprecated and will be ignored
-// CHECK-WARNING-DAG: argument '-forder-file-instrumentation' is deprecated, use '-mllvm -pgo-temporal-instrumentation' instead
+// CHECK-WARNING-DAG: argument '-forder-file-instrumentation' is deprecated, use '-fprofile-generate-temporal-instrumentation' instead
 
 // Test that we mute the warning on these
 // RUN: %clang -### -finline-limit=1000 -Wno-invalid-command-line-argument              \

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -424,7 +424,7 @@
 // CHECK-WARNING-DAG: optimization flag '-fno-devirtualize-speculatively' is not supported
 // CHECK-WARNING-DAG: the flag '-fslp-vectorize-aggressive' has been deprecated and will be ignored
 // CHECK-WARNING-DAG: the flag '-fno-slp-vectorize-aggressive' has been deprecated and will be ignored
-// CHECK-WARNING-DAG: argument '-forder-file-instrumentation' is deprecated, use '-fprofile-generate-temporal-instrumentation' instead
+// CHECK-WARNING-DAG: argument '-forder-file-instrumentation' is deprecated, use '-fprofile-generate-temporal' instead
 
 // Test that we mute the warning on these
 // RUN: %clang -### -finline-limit=1000 -Wno-invalid-command-line-argument              \

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -424,7 +424,7 @@
 // CHECK-WARNING-DAG: optimization flag '-fno-devirtualize-speculatively' is not supported
 // CHECK-WARNING-DAG: the flag '-fslp-vectorize-aggressive' has been deprecated and will be ignored
 // CHECK-WARNING-DAG: the flag '-fno-slp-vectorize-aggressive' has been deprecated and will be ignored
-// CHECK-WARNING-DAG: argument '-forder-file-instrumentation' is deprecated, use '-fprofile-generate-temporal' instead
+// CHECK-WARNING-DAG: argument '-forder-file-instrumentation' is deprecated, use '-ftemporal-profile' instead
 
 // Test that we mute the warning on these
 // RUN: %clang -### -finline-limit=1000 -Wno-invalid-command-line-argument              \

--- a/clang/test/Driver/fprofile-generate-temporal-instrumentation.c
+++ b/clang/test/Driver/fprofile-generate-temporal-instrumentation.c
@@ -1,7 +1,0 @@
-// RUN: %clang -### -c -fprofile-generate -fprofile-generate-temporal-instrumentation %s 2>&1 | FileCheck %s
-// RUN: %clang -### -c -fcs-profile-generate -fprofile-generate-temporal-instrumentation %s 2>&1 | FileCheck %s
-// RUN: not %clang -### -c -fprofile-generate-temporal-instrumentation %s 2>&1 | FileCheck %s --check-prefix=ERR
-
-// CHECK: "-mllvm" "--pgo-temporal-instrumentation"
-
-// ERR: '-fprofile-generate-temporal-instrumentation' only allowed with '-fprofile-generate or -fcs-profile-generate'

--- a/clang/test/Driver/fprofile-generate-temporal-instrumentation.c
+++ b/clang/test/Driver/fprofile-generate-temporal-instrumentation.c
@@ -1,0 +1,7 @@
+// RUN: %clang -### -c -fprofile-generate -fprofile-generate-temporal-instrumentation %s 2>&1 | FileCheck %s
+// RUN: %clang -### -c -fcs-profile-generate -fprofile-generate-temporal-instrumentation %s 2>&1 | FileCheck %s
+// RUN: not %clang -### -c -fprofile-generate-temporal-instrumentation %s 2>&1 | FileCheck %s --check-prefix=ERR
+
+// CHECK: "-mllvm" "--pgo-temporal-instrumentation"
+
+// ERR: '-fprofile-generate-temporal-instrumentation' only allowed with '-fprofile-generate or -fcs-profile-generate'

--- a/clang/test/Driver/fprofile-generate-temporal.c
+++ b/clang/test/Driver/fprofile-generate-temporal.c
@@ -1,0 +1,7 @@
+// RUN: %clang -### -c -fprofile-generate -fprofile-generate-temporal %s 2>&1 | FileCheck %s
+// RUN: %clang -### -c -fcs-profile-generate -fprofile-generate-temporal %s 2>&1 | FileCheck %s
+// RUN: not %clang -### -c -fprofile-generate-temporal %s 2>&1 | FileCheck %s --check-prefix=ERR
+
+// CHECK: "-mllvm" "--pgo-temporal-instrumentation"
+
+// ERR: '-fprofile-generate-temporal' only allowed with '-fprofile-generate or -fcs-profile-generate'

--- a/clang/test/Driver/fprofile-generate-temporal.c
+++ b/clang/test/Driver/fprofile-generate-temporal.c
@@ -1,7 +1,7 @@
-// RUN: %clang -### -c -fprofile-generate -fprofile-generate-temporal %s 2>&1 | FileCheck %s
-// RUN: %clang -### -c -fcs-profile-generate -fprofile-generate-temporal %s 2>&1 | FileCheck %s
-// RUN: not %clang -### -c -fprofile-generate-temporal %s 2>&1 | FileCheck %s --check-prefix=ERR
+// RUN: %clang -### -c -fprofile-generate -ftemporal-profile %s 2>&1 | FileCheck %s
+// RUN: %clang -### -c -fcs-profile-generate -ftemporal-profile %s 2>&1 | FileCheck %s
+// RUN: not %clang -### -c -ftemporal-profile %s 2>&1 | FileCheck %s --check-prefix=ERR
 
 // CHECK: "-mllvm" "--pgo-temporal-instrumentation"
 
-// ERR: '-fprofile-generate-temporal' only allowed with '-fprofile-generate or -fcs-profile-generate'
+// ERR: error: invalid argument '-ftemporal-profile' only allowed with '-fprofile-generate or -fcs-profile-generate'


### PR DESCRIPTION
As discussed in https://github.com/llvm/llvm-project/pull/121514 add the frontend flag `-ftemporal-profile` to enable temporal profiling (https://discourse.llvm.org/t/rfc-temporal-profiling-extension-for-irpgo/68068) as a replacement for `-forder-file-instrumentation` (https://discourse.llvm.org/t/deprecate-forder-file-instrumentation-in-favor-of-temporal-profiling/83903)