### PR TITLE
Try to reproduce ubsan issue

### DIFF
--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -315,7 +315,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI size_t hash_code() const _NOEXCEPT { return __impl::__hash(__type_name); }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 bool operator==(const type_info& __arg) const _NOEXCEPT {
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX23 bool operator==(const type_info& __arg) const _NOEXCEPT {
     // When evaluated in a constant expression, both type infos simply can't come
     // from different translation units, so it is sufficient to compare their addresses.
     if (__libcpp_is_constant_evaluated()) {


### PR DESCRIPTION
This function isn't marked as always inline, so inline or not highly depends on compiler options.
I think it doesn't work when not inlined.

So to check this is true or not, it just needs to run libunwind + libcxx + libcxxabi tests with undefined sanitizer.