### PR TITLE
[clang] Rename ReadPCHAndPreprocessAction (NFC)

### DIFF
--- a/clang/include/clang/Frontend/FrontendActions.h
+++ b/clang/include/clang/Frontend/FrontendActions.h
@@ -32,8 +32,8 @@ public:
   bool usesPreprocessorOnly() const override { return false; }
 };
 
-/// Preprocessor-based frontend action that also loads PCH files.
-class ReadPCHAndPreprocessAction : public FrontendAction {
+/// Preprocessor-based frontend action that is used for dependency scanning.
+class DependencyScanningFrontendAction : public FrontendAction {
   void ExecuteAction() override;
 
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -85,7 +85,7 @@ void DependencyScanningFrontendAction::ExecuteAction() {
 
 std::unique_ptr<ASTConsumer>
 DependencyScanningFrontendAction::CreateASTConsumer(CompilerInstance &CI,
-                                              StringRef InFile) {
+                                                    StringRef InFile) {
   return std::make_unique<ASTConsumer>();
 }
 

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -69,7 +69,7 @@ void InitOnlyAction::ExecuteAction() {
 }
 
 // Basically PreprocessOnlyAction::ExecuteAction.
-void ReadPCHAndPreprocessAction::ExecuteAction() {
+void DependencyScanningFrontendAction::ExecuteAction() {
   Preprocessor &PP = getCompilerInstance().getPreprocessor();
 
   // Ignore unknown pragmas.
@@ -84,7 +84,7 @@ void ReadPCHAndPreprocessAction::ExecuteAction() {
 }
 
 std::unique_ptr<ASTConsumer>
-ReadPCHAndPreprocessAction::CreateASTConsumer(CompilerInstance &CI,
+DependencyScanningFrontendAction::CreateASTConsumer(CompilerInstance &CI,
                                               StringRef InFile) {
   return std::make_unique<ASTConsumer>();
 }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -439,7 +439,7 @@ public:
     else if (ModuleName)
       Action = std::make_unique<GetDependenciesByModuleNameAction>(*ModuleName);
     else
-      Action = std::make_unique<ReadPCHAndPreprocessAction>();
+      Action = std::make_unique<DependencyScanningFrontendAction>();
 
     if (ScanInstance.getDiagnostics().hasErrorOccurred())
       return false;


### PR DESCRIPTION
Rename `ReadPCHAndPreprocessAction` class. This frontend action is used
for dependency scanning only and the current name is confusing for what
it actually does. Rename the class to `DependencyScanningFrontendAction`
to be clear for its usage.
