### PR TITLE
[libcxx] replaces `sqrt(complex<T>)` implementation with builtin

### DIFF
--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -1059,17 +1059,11 @@ inline _LIBCPP_HIDE_FROM_ABI complex<_Tp> log10(const complex<_Tp>& __x) {
 
 // sqrt
 
-_LIBCPP_HIDE_FROM_ABI inline _Complex float __csqrt(_Complex float __v) {
-  return __builtin_csqrtf(__v);
-}
+_LIBCPP_HIDE_FROM_ABI inline _Complex float __csqrt(_Complex float __v) { return __builtin_csqrtf(__v); }
 
-_LIBCPP_HIDE_FROM_ABI inline _Complex double __csqrt(_Complex double __v) {
-  return __builtin_csqrt(__v);
-}
+_LIBCPP_HIDE_FROM_ABI inline _Complex double __csqrt(_Complex double __v) { return __builtin_csqrt(__v); }
 
-_LIBCPP_HIDE_FROM_ABI inline _Complex long double __csqrt(_Complex long double __v) {
-  return __builtin_csqrtl(__v);
-}
+_LIBCPP_HIDE_FROM_ABI inline _Complex long double __csqrt(_Complex long double __v) { return __builtin_csqrtl(__v); }
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI complex<_Tp> sqrt(const complex<_Tp>& __x) {

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -1059,16 +1059,21 @@ inline _LIBCPP_HIDE_FROM_ABI complex<_Tp> log10(const complex<_Tp>& __x) {
 
 // sqrt
 
+_LIBCPP_HIDE_FROM_ABI inline _Complex float __csqrt(_Complex float __v) {
+  return __builtin_csqrtf(__v);
+}
+
+_LIBCPP_HIDE_FROM_ABI inline _Complex double __csqrt(_Complex double __v) {
+  return __builtin_csqrt(__v);
+}
+
+_LIBCPP_HIDE_FROM_ABI inline _Complex long double __csqrt(_Complex long double __v) {
+  return __builtin_csqrtl(__v);
+}
+
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI complex<_Tp> sqrt(const complex<_Tp>& __x) {
-  if (std::isinf(__x.imag()))
-    return complex<_Tp>(_Tp(INFINITY), __x.imag());
-  if (std::isinf(__x.real())) {
-    if (__x.real() > _Tp(0))
-      return complex<_Tp>(__x.real(), std::isnan(__x.imag()) ? __x.imag() : std::copysign(_Tp(0), __x.imag()));
-    return complex<_Tp>(std::isnan(__x.imag()) ? __x.imag() : _Tp(0), std::copysign(__x.real(), __x.imag()));
-  }
-  return std::polar(std::sqrt(std::abs(__x)), std::arg(__x) / _Tp(2));
+  return complex<_Tp>(__from_builtin_tag(), std::__csqrt(__x.__builtin()));
 }
 
 // exp


### PR DESCRIPTION
This significantly improves the accuracy of the function.

Fixes #122172