### PR TITLE
[ubsan] Assert that each check only has one SanitizerKind

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -3603,6 +3603,8 @@ void CodeGenFunction::EmitCheck(
   llvm::Value *TrapCond = nullptr;
   bool NoMerge = false;
   for (int i = 0, n = Checked.size(); i < n; ++i) {
+    assert(Checked[i].second.isPowerOf2());
+
     llvm::Value *Check = Checked[i].first;
     // -fsanitize-trap= overrides -fsanitize-recover=.
     llvm::Value *&Cond =


### PR DESCRIPTION
The `Checked` parameter of `CodeGenFunction::EmitCheck` is of type `ArrayRef<std::pair<llvm::Value *, SanitizerMask>>`. In the general case, SanitizerMask is used to denote that zero or more sanitizers are enabled, but I believe that `EmitCheck` assumes there is exactly one sanitizer enabled per SanitizerMask (e.g., `SanitizeTrap.has(Checked[i].second)` is called, whereby `.has` checks that there is only one sanitizer enabled). This patch adds an assertion for this invariant.

This is not intended to change the functionality of UBSan, but will make it easier for maintainers to reason about and extend the `EmitCheck` function.