### PR TITLE
[libc][docs] Add netinet/in header documentation by referring to POSIX standards

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -18,6 +18,7 @@ if (SPHINX_FOUND)
     # shell.
     file(MAKE_DIRECTORY
       "${CMAKE_CURRENT_BINARY_DIR}/headers/arpa/"
+      "${CMAKE_CURRENT_BINARY_DIR}/headers/netinet/"
       "${CMAKE_CURRENT_BINARY_DIR}/headers/sys/"
     )
 
@@ -40,6 +41,7 @@ if (SPHINX_FOUND)
       float
       inttypes
       locale
+      netinet/in
       setjmp
       signal
       stdbit

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -14,6 +14,7 @@ Implementation Status
    inttypes
    locale
    math/index.rst
+   netinet/in
    search
    setjmp
    signal

--- a/libc/utils/docgen/netinet/in.yaml
+++ b/libc/utils/docgen/netinet/in.yaml
@@ -13,6 +13,8 @@ macros:
     in-latest-posix: ''
   INADDR_ANY:
     in-latest-posix: ''
+  INET6_ADDRSTRLEN:
+    in-latest-posix: ''
   INADDR_BROADCAST:
     in-latest-posix: ''
   INET_ADDRSTRLEN:

--- a/libc/utils/docgen/netinet/in.yaml
+++ b/libc/utils/docgen/netinet/in.yaml
@@ -1,0 +1,57 @@
+macros:
+  IPPROTO_IP:
+    in-latest-posix: ''
+  IPPROTO_IPV6:
+    in-latest-posix: ''
+  IPPROTO_ICMP:
+    in-latest-posix: ''
+  IPPROTO_RAW:
+    in-latest-posix: ''
+  IPPROTO_TCP:
+    in-latest-posix: ''
+  IPPROTO_UDP:
+    in-latest-posix: ''
+  INADDR_ANY:
+    in-latest-posix: ''
+  INADDR_BROADCAST:
+    in-latest-posix: ''
+  INET_ADDRSTRLEN:
+    in-latest-posix: ''
+  IPV6_JOIN_GROUP:
+    in-latest-posix: ''
+  IPV6_LEAVE_GROUP:
+    in-latest-posix: ''
+  IPV6_MULTICAST_HOPS:
+    in-latest-posix: ''
+  IPV6_MULTICAST_IF:
+    in-latest-posix: ''
+  IPV6_MULTICAST_LOOP:
+    in-latest-posix: ''
+  IPV6_UNICAST_HOPS:
+    in-latest-posix: ''
+  IPV6_V6ONLY:
+    in-latest-posix: ''
+  IN6_IS_ADDR_UNSPECIFIED:
+    in-latest-posix: ''
+  IN6_IS_ADDR_LOOPBACK:
+    in-latest-posix: ''
+  IN6_IS_ADDR_MULTICAST:
+    in-latest-posix: ''
+  IN6_IS_ADDR_LINKLOCAL:
+    in-latest-posix: ''
+  IN6_IS_ADDR_SITELOCAL:
+    in-latest-posix: ''
+  IN6_IS_ADDR_V4MAPPED:
+    in-latest-posix: ''
+  IN6_IS_ADDR_V4COMPAT:
+    in-latest-posix: ''
+  IN6_IS_ADDR_MC_NODELOCAL:
+    in-latest-posix: ''
+  IN6_IS_ADDR_MC_LINKLOCAL:
+    in-latest-posix: ''
+  IN6_IS_ADDR_MC_SITELOCAL:
+    in-latest-posix: ''
+  IN6_IS_ADDR_MC_ORGLOCAL:
+    in-latest-posix: ''
+  IN6_IS_ADDR_MC_GLOBAL:
+    in-latest-posix: ''


### PR DESCRIPTION
This pull request introduces the following changes to the project with reference to ( #122006 ):

1. **Documentation Update**:
   - Added a new YAML file `in.yaml` to document network protocol and address macros.
   - The `in.yaml` file includes the following macros:
     - `IPPROTO_IP`
     - `IPPROTO_IPV6`
     - `IPPROTO_ICMP`
     - `IPPROTO_RAW`
     - `IPPROTO_TCP`
     - `IPPROTO_UDP`
     - `INADDR_ANY`
     - `INADDR_BROADCAST`
     - `INET_ADDRSTRLEN`
     - `IPV6_JOIN_GROUP`
     - `IPV6_LEAVE_GROUP`
     - `IPV6_MULTICAST_HOPS`
     - `IPV6_MULTICAST_IF`
     - `IPV6_MULTICAST_LOOP`
     - `IPV6_UNICAST_HOPS`
     - `IPV6_V6ONLY`
     - `IN6_IS_ADDR_UNSPECIFIED`
     - `IN6_IS_ADDR_LOOPBACK`
     - `IN6_IS_ADDR_MULTICAST`
     - `IN6_IS_ADDR_LINKLOCAL`
     - `IN6_IS_ADDR_SITELOCAL`
     - `IN6_IS_ADDR_V4MAPPED`
     - `IN6_IS_ADDR_V4COMPAT`
     - `IN6_IS_ADDR_MC_NODELOCAL`
     - `IN6_IS_ADDR_MC_LINKLOCAL`
     - `IN6_IS_ADDR_MC_SITELOCAL`
     - `IN6_IS_ADDR_MC_ORGLOCAL`
     - `IN6_IS_ADDR_MC_GLOBAL`

_I believe, all these macros are necessary and should be documented._

2. **CMake Configuration Update**:
   - Updated the `CMakeLists.txt` file to create the necessary directory for the `netinet` headers.
   - Included the `netinet/in` documentation in the Sphinx build configuration.

3. **Index Update**:
   - Updated the `index.rst` file to include a reference to the newly added `netinet/in` documentation.

**Purpose**:
- This pull request adds documentation for network protocol and address macros in the `netinet/in` header.
- Updates the CMake configuration to support the new documentation.

**Testing**:
- Verified that the new YAML file is correctly referenced in the `index.rst`.
- Ensured that the documentation builds without errors and includes the new network interface documentation.

This pull request ensures that the `netinet/in` header macros are documented and included in the project's documentation, and updates the CMake configuration to support these changes.