### PR TITLE
[libc++] Fix hardening checks in std::string operator[]

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -1342,7 +1342,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 const_reference operator[](size_type __pos) const _NOEXCEPT {
-    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__pos <= size(), "string index out of bounds");
+    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__pos < size(), "string index out of bounds");
     if (__builtin_constant_p(__pos) && !__fits_in_sso(__pos)) {
       return *(__get_long_pointer() + __pos);
     }
@@ -1350,7 +1350,7 @@ public:
   }
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 reference operator[](size_type __pos) _NOEXCEPT {
-    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__pos <= size(), "string index out of bounds");
+    _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(__pos < size(), "string index out of bounds");
     if (__builtin_constant_p(__pos) && !__fits_in_sso(__pos)) {
       return *(__get_long_pointer() + __pos);
     }

--- a/libcxx/test/libcxx/containers/strings/basic.string/assert.index.oob.pass.cpp
+++ b/libcxx/test/libcxx/containers/strings/basic.string/assert.index.oob.pass.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <string>
+
+// Index string out of bounds.
+
+// REQUIRES: has-unix-headers
+// UNSUPPORTED: c++03
+// UNSUPPORTED: libcpp-hardening-mode=none
+// XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
+
+#include <string>
+#include <cassert>
+
+#include "check_assertion.h"
+#include "min_allocator.h"
+
+int main(int, char**) {
+  // Test the const overloads.
+  {
+    using C = std::basic_string<char, std::char_traits<char>, safe_allocator<char> >;
+    const C c;
+    TEST_LIBCPP_ASSERT_FAILURE(c[0], "string index out of bounds");
+    TEST_LIBCPP_ASSERT_FAILURE(c[1], "string index out of bounds");
+  }
+  {
+    using C   = std::basic_string<char, std::char_traits<char>, safe_allocator<char> >;
+    const C c = "abc";
+    TEST_LIBCPP_ASSERT_FAILURE(c[3], "string index out of bounds");
+    TEST_LIBCPP_ASSERT_FAILURE(c[4], "string index out of bounds");
+    TEST_LIBCPP_ASSERT_FAILURE(c[100], "string index out of bounds");
+  }
+
+  // Test the nonconst overloads.
+  {
+    using C = std::basic_string<char, std::char_traits<char>, safe_allocator<char> >;
+    C c;
+    TEST_LIBCPP_ASSERT_FAILURE(c[0], "string index out of bounds");
+    TEST_LIBCPP_ASSERT_FAILURE(c[1], "string index out of bounds");
+  }
+  {
+    using C = std::basic_string<char, std::char_traits<char>, safe_allocator<char> >;
+    C c     = "abc";
+    TEST_LIBCPP_ASSERT_FAILURE(c[3], "string index out of bounds");
+    TEST_LIBCPP_ASSERT_FAILURE(c[4], "string index out of bounds");
+    TEST_LIBCPP_ASSERT_FAILURE(c[100], "string index out of bounds");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The current `valid-element-access` hardening checks in the `operator[]` for `basic_string` are improperly implemented, which do not trap accesses one past the end of the string. This PR corrects the issue and adds corresponding assertion tests to validate the checks.