### PR TITLE
[Clang] Add the `annotate_decl` attribute.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -962,6 +962,14 @@ def Annotate : InheritableParamOrStmtAttr {
   let Documentation = [Undocumented];
 }
 
+def AnnotateDecl : Attr {
+  let Spellings = [CXX11<"clang", "annotate_decl">, C23<"clang", "annotate_decl">];
+  let Args = [StringArgument<"Annotation">, VariadicExprArgument<"Args">];
+  let HasCustomParsing = 1;
+  let AcceptsExprPack = 1;
+  let Documentation = [AnnotateDeclDocs];
+}
+
 def AnnotateType : TypeAttr {
   let Spellings = [CXX11<"clang", "annotate_type">, C23<"clang", "annotate_type">];
   let Args = [StringArgument<"Annotation">, VariadicExprArgument<"Args">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -8146,14 +8146,45 @@ and copied back to the argument after the callee returns.
   }];
 }
 
+def AnnotateDeclDocs : Documentation {
+  let Category = DocCatType;
+  let Heading = "annotate_decl";
+  let Content = [{
+This attribute is used to add annotations to declarations, typically for use by
+static analysis tools that are not integrated into the core Clang compiler
+(e.g., Clang-Tidy checks or out-of-tree Clang-based tools). See also the
+`annotate_type` attribute, which serves the same purpose, but for types.
+
+The attribute takes a mandatory string literal argument specifying the
+annotation category and an arbitrary number of optional arguments that provide
+additional information specific to the annotation category. The optional
+arguments must be constant expressions of arbitrary type.
+
+For example:
+
+.. code-block:: c++
+
+  [[clang::annotate_decl("category", "foo", 1)]] int i;
+
+The attribute does not have any effect on the semantics of the declaration or
+the code that should be produced for it.
+
+There is no requirement that different declarations of an entity (i.e.
+redeclarations) use the same `annotate_decl` annotations, so that the annotation
+can be used as flexibly as possible. If a Clang-based tool wants to impose
+additional rules for specific annotations, it needs to check for and enforce
+these itself.
+  }];
+}
+
 def AnnotateTypeDocs : Documentation {
   let Category = DocCatType;
   let Heading = "annotate_type";
   let Content = [{
 This attribute is used to add annotations to types, typically for use by static
 analysis tools that are not integrated into the core Clang compiler (e.g.,
-Clang-Tidy checks or out-of-tree Clang-based tools). It is a counterpart to the
-`annotate` attribute, which serves the same purpose, but for declarations.
+Clang-Tidy checks or out-of-tree Clang-based tools). See also the
+`annotate_decl` attribute, which serves the same purpose, but for declarations.
 
 The attribute takes a mandatory string literal argument specifying the
 annotation category and an arbitrary number of optional arguments that provide

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4113,6 +4113,32 @@ static void handleAnnotateAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   }
 }
 
+static void handleAnnotateDeclAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  if (AL.getNumArgs() < 1) {
+    S.Diag(AL.getLoc(), diag::err_attribute_too_few_arguments) << AL << 1;
+    return;
+  }
+
+  // Make sure that there is a string literal as the annotation's first
+  // argument.
+  StringRef Str;
+  if (!S.checkStringLiteralArgumentAttr(AL, 0, Str))
+    return;
+
+  llvm::SmallVector<Expr *, 4> Args;
+  Args.reserve(AL.getNumArgs() - 1);
+  for (unsigned Idx = 1; Idx < AL.getNumArgs(); Idx++) {
+    assert(!AL.isArgIdent(Idx));
+    Args.push_back(AL.getArgAsExpr(Idx));
+  }
+  if (!S.ConstantFoldAttrArgs(AL, Args))
+    return;
+  if (auto *AnnotateDeclAttr = AnnotateDeclAttr::Create(
+          S.Context, Str, Args.data(), Args.size(), AL)) {
+    D->addAttr(AnnotateDeclAttr);
+  }
+}
+
 static void handleAlignValueAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   S.AddAlignValueAttr(D, AL, AL.getArgAsExpr(0));
 }
@@ -6723,6 +6749,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     break;
   case ParsedAttr::AT_Annotate:
     handleAnnotateAttr(S, D, AL);
+    break;
+  case ParsedAttr::AT_AnnotateDecl:
+    handleAnnotateDeclAttr(S, D, AL);
     break;
   case ParsedAttr::AT_Availability:
     handleAvailabilityAttr(S, D, AL);

--- a/clang/test/SemaCXX/annotate-decl.cpp
+++ b/clang/test/SemaCXX/annotate-decl.cpp
@@ -1,0 +1,48 @@
+// RUN: %clang_cc1 %s -std=c++17 -fsyntax-only -fcxx-exceptions -verify
+
+[[clang::annotate_decl("foo")]] int global1;
+int [[clang::annotate_decl("foo")]] global2; // expected-error {{'annotate_decl' attribute cannot be applied to types}}
+
+// Redeclarations.
+
+// A declaration that originally didn't have an `annotate_decl` attribute
+// can be redeclared with one.
+extern int global3;
+[[clang::annotate_decl("foo")]] extern int global3;
+
+// A declaration that originally had an `annotate_decl` attribute can be
+// redeclared without one.
+[[clang::annotate_decl("foo")]] extern int global4;
+extern int global4;
+
+// A declaration that originally had an `annotate_decl` attribute with one
+// set of arguments can be redeclared with another set of arguments.
+[[clang::annotate_decl("foo", "arg1", 1)]] extern int global5;
+[[clang::annotate_decl("foo", "arg2", 2)]] extern int global5;
+
+// Different types of declarations.
+[[clang::annotate_decl("foo")]] void f();
+namespace [[clang::annotate_decl("foo")]] my_namespace {}
+struct [[clang::annotate_decl("foo")]] S;
+struct [[clang::annotate_decl("foo")]] S{
+  [[clang::annotate_decl("foo")]] int member;
+};
+template <class T>
+[[clang::annotate_decl("foo")]] T var_template;
+extern "C" [[clang::annotate_decl("foo")]] int extern_c_func();
+[[clang::annotate_decl("foo")]] extern "C" int extern_c_func(); // expected-error {{an attribute list cannot appear here}}
+
+// Declarations within functions.
+void f2() {
+  [[clang::annotate_decl("foo")]] int i;
+  [[clang::annotate_decl("foo")]] i = 1; // expected-error {{'annotate_decl' attribute cannot be applied to a statement}}
+
+  // Test various cases where a declaration can appear inside a statement.
+  for ([[clang::annotate_decl("foo")]] int i = 0; i < 42; ++i) {}
+  for (; [[clang::annotate_decl("foo")]] bool b = false;) {}
+  while ([[clang::annotate_decl("foo")]] bool b = false) {}
+  if ([[clang::annotate_decl("foo")]] bool b = false) {}
+  try {
+  } catch ([[clang::annotate_decl("foo")]] int i) {
+  }
+}


### PR DESCRIPTION
This attribute is intended as a general-purpose mechanism to add annotations for
use by Clang-based tools. People have been using the existing `annotate`
attribute for this purpose, but this can interfere with optimizations -- see
https://github.com/llvm/llvm-project/issues/55190.

For details, see this RFC:

https://discourse.llvm.org/t/rfc-new-attribute-annotate-decl/84006
