### PR TITLE
[libc++] Fix `tuple_cat` for element with unconstrained constructor

### DIFF
--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -1338,12 +1338,25 @@ struct __tuple_cat<tuple<_Types...>, __tuple_indices<_I0...>, __tuple_indices<_J
   }
 };
 
+template <class _TupleDst, class _TupleSrc, size_t... _Indices>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _TupleDst
+__tuple_cat_select_element_wise(_TupleSrc&& __src, __tuple_indices<_Indices...>) {
+  static_assert(tuple_size<_TupleDst>::value == tuple_size<_TupleSrc>::value,
+                "misuse of __tuple_cat_select_element_wise with tuples of different sizes");
+  return _TupleDst(std::get<_Indices>(std::forward<_TupleSrc>(__src))...);
+}
+
 template <class _Tuple0, class... _Tuples>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename __tuple_cat_return<_Tuple0, _Tuples...>::type
 tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls) {
-  using _T0 _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tuple0>;
-  return __tuple_cat<tuple<>, __tuple_indices<>, typename __make_tuple_indices<tuple_size<_T0>::value>::type>()(
-      tuple<>(), std::forward<_Tuple0>(__t0), std::forward<_Tuples>(__tpls)...);
+  using _T0 _LIBCPP_NODEBUG          = __libcpp_remove_reference_t<_Tuple0>;
+  using _TRet _LIBCPP_NODEBUG        = typename __tuple_cat_return<_Tuple0, _Tuples...>::type;
+  using _T0Indices _LIBCPP_NODEBUG   = typename __make_tuple_indices<tuple_size<_T0>::value>::type;
+  using _TRetIndices _LIBCPP_NODEBUG = typename __make_tuple_indices<tuple_size<_TRet>::value>::type;
+  return std::__tuple_cat_select_element_wise<_TRet>(
+      __tuple_cat<tuple<>, __tuple_indices<>, _T0Indice>()(
+          tuple<>(), std::forward<_Tuple0>(__t0), std::forward<_Tuples>(__tpls)...),
+      _TRetIndice());
 }
 
 template <class... _Tp, class _Alloc>

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -1354,9 +1354,9 @@ tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls) {
   using _T0Indices _LIBCPP_NODEBUG   = typename __make_tuple_indices<tuple_size<_T0>::value>::type;
   using _TRetIndices _LIBCPP_NODEBUG = typename __make_tuple_indices<tuple_size<_TRet>::value>::type;
   return std::__tuple_cat_select_element_wise<_TRet>(
-      __tuple_cat<tuple<>, __tuple_indices<>, _T0Indice>()(
+      __tuple_cat<tuple<>, __tuple_indices<>, _T0Indices>()(
           tuple<>(), std::forward<_Tuple0>(__t0), std::forward<_Tuples>(__tpls)...),
-      _TRetIndice());
+      _TRetIndices());
 }
 
 template <class... _Tp, class _Alloc>

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
@@ -38,56 +38,34 @@ struct Unconstrained {
   TEST_CONSTEXPR_CXX14 Unconstrained(Arg arg) : data(arg) {}
 };
 
-TEST_CONSTEXPR_CXX14 std::tuple<Unconstrained> test_cat_unary_lvalue() {
-  auto tup = std::tuple<Unconstrained>(Unconstrained(5));
-  return std::tuple_cat(tup);
-}
-
-TEST_CONSTEXPR_CXX14 std::tuple<Unconstrained> test_cat_unary_rvalue() {
-  return std::tuple_cat(std::tuple<Unconstrained>(Unconstrained(6)));
-}
-
-TEST_CONSTEXPR_CXX14 std::tuple<Unconstrained> test_cat_unary_and_nullary() {
-  return std::tuple_cat(std::tuple<Unconstrained>(Unconstrained(7)), std::tuple<>());
-}
-
-#if TEST_STD_VER >= 17
-constexpr auto test_cat_unary_lvalue_ctad() {
-  auto tup = std::tuple(Unconstrained(8));
-  return std::tuple_cat(tup);
-}
-
-constexpr auto test_cat_unary_rvalue_ctad() { return std::tuple_cat(std::tuple(Unconstrained(9))); }
-
-constexpr auto test_cat_unary_and_nullary_ctad() { return std::tuple_cat(std::tuple(Unconstrained(10)), std::tuple()); }
-#endif
-
 TEST_CONSTEXPR_CXX14 bool test_tuple_cat_with_unconstrained_constructor() {
   {
-    auto tup = test_cat_unary_lvalue();
+    auto tup_src = std::tuple<Unconstrained>(Unconstrained(5));
+    auto tup     = std::tuple_cat(tup_src);
     assert(std::get<0>(tup).data == 5);
   }
   {
-    auto tup = test_cat_unary_rvalue();
+    auto tup = std::tuple_cat(std::tuple<Unconstrained>(Unconstrained(6)));
     assert(std::get<0>(tup).data == 6);
   }
   {
-    auto tup = test_cat_unary_and_nullary();
+    auto tup = std::tuple_cat(std::tuple<Unconstrained>(Unconstrained(7)), std::tuple<>());
     assert(std::get<0>(tup).data == 7);
   }
 #if TEST_STD_VER >= 17
   {
-    auto tup = test_cat_unary_lvalue_ctad();
+    auto tup_src = std::tuple(Unconstrained(8));
+    auto tup     = std::tuple_cat(tup_src);
     ASSERT_SAME_TYPE(decltype(tup), std::tuple<Unconstrained>);
     assert(std::get<0>(tup).data == 8);
   }
   {
-    auto tup = test_cat_unary_rvalue_ctad();
+    auto tup = std::tuple_cat(std::tuple(Unconstrained(9)));
     ASSERT_SAME_TYPE(decltype(tup), std::tuple<Unconstrained>);
     assert(std::get<0>(tup).data == 9);
   }
   {
-    auto tup = test_cat_unary_and_nullary_ctad();
+    auto tup = std::tuple_cat(std::tuple(Unconstrained(10)), std::tuple());
     ASSERT_SAME_TYPE(decltype(tup), std::tuple<Unconstrained>);
     assert(std::get<0>(tup).data == 10);
   }


### PR DESCRIPTION
Currently, when the result type is 1-`tuple`, `tuple_cat` possibly tests an undesired constructor of the element, due to conversion from the reference tuple to the result type. If the element type has an unconstrained constructor template, there can be extraneous hard error which shouldn't happen.

This patch introduces a helper function template `__tuple_cat_select_element_wise` to select the element-wise constructor template of `tuple`, which can avoid such error.

Fixes #41034.