### PR TITLE
[M68k] Use M68010 cpu as target for SR move test

### DIFF
--- a/llvm/test/MC/M68k/Data/Classes/MxMoveSR.s
+++ b/llvm/test/MC/M68k/Data/Classes/MxMoveSR.s
@@ -1,4 +1,4 @@
-; RUN: llvm-mc -triple=m68k -mcpu=M68000 -show-encoding %s | FileCheck %s
+; RUN: llvm-mc -triple=m68k -mcpu=M68010 -show-encoding %s | FileCheck %s
 
 ; CHECK:      move.w  %d1, %sr
 ; CHECK-SAME: encoding: [0x46,0xc1]


### PR DESCRIPTION
Fixes the test introduced in #111145.

It would also make sense to throw an error when the user attempts to use a move-from-sr on an unsupported architecture. Currently the encoder generates garbage instructions for a 68000 because the AsmMatcher is able to match the move against a MOV16rr:

```
> llvm-mc -triple=m68k -mcpu=M68000 -show-encoding MxMoveSR.s --debug
...
Trying to match opcode MOV16ar
  Matching formal operand class MCK_Reg against actual operand at index 1 (%7): match success using generic matcher
  Matching formal operand class MCK_AReg against actual operand at index 2 (%25): Opcode result: multiple operand mismatches, ignoring this opcode
Trying to match opcode MOV16rr
  Matching formal operand class MCK_Reg against actual operand at index 1 (%7): match success using generic matcher
  Matching formal operand class MCK_Reg against actual operand at index 2 (%25): match success using generic matcher
  Matching formal operand class InvalidMatchClass against actual operand at index 3: actual operand index out of range
Opcode result: complete match, selecting this opcode
EncodeInstruction: MOV16rr(901)
        move.w  %sr, %d1                        ; encoding: [0x32,0x00]
```

I haven't found a solution for this yet, so any ideas you have would be greatly appreciated.

@mshockwave @knickish