### PR TITLE
[Driver][FreeBSD] Remove FreeBSD/loongarch32 support

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -735,9 +735,6 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::Linux:
       return std::make_unique<LinuxTargetInfo<LoongArch32TargetInfo>>(Triple,
                                                                       Opts);
-    case llvm::Triple::FreeBSD:
-      return std::make_unique<FreeBSDTargetInfo<LoongArch32TargetInfo>>(Triple,
-                                                                        Opts);
     default:
       return std::make_unique<LoongArch32TargetInfo>(Triple, Opts);
     }

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -228,11 +228,8 @@ public:
     case llvm::Triple::arm:
       this->MCountName = "__mcount";
       break;
-    case llvm::Triple::riscv32:
-    case llvm::Triple::riscv64:
-      break;
-    case llvm::Triple::loongarch32:
     case llvm::Triple::loongarch64:
+    case llvm::Triple::riscv64:
       break;
     }
   }

--- a/clang/lib/Driver/ToolChains/FreeBSD.cpp
+++ b/clang/lib/Driver/ToolChains/FreeBSD.cpp
@@ -213,10 +213,6 @@ void freebsd::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-m");
     CmdArgs.push_back("elf64lriscv");
     break;
-  case llvm::Triple::loongarch32:
-    CmdArgs.push_back("-m");
-    CmdArgs.push_back("elf32loongarch");
-    break;
   case llvm::Triple::loongarch64:
     CmdArgs.push_back("-m");
     CmdArgs.push_back("elf64loongarch");

--- a/clang/test/Driver/freebsd.c
+++ b/clang/test/Driver/freebsd.c
@@ -79,9 +79,6 @@
 //
 // Check that LoongArch passes the correct linker emulation.
 //
-// RUN: %clang --target=loongarch32-freebsd -### %s %s 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-LA32-LD %s
-// CHECK-LA32-LD: ld{{.*}}" {{.*}} "-m" "elf32loongarch"
 // RUN: %clang --target=loongarch64-freebsd -### %s %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-LA64-LD %s
 // CHECK-LA64-LD: ld{{.*}}" {{.*}} "-m" "elf64loongarch"


### PR DESCRIPTION
FreeBSD going forward will not have 32-bit arch support.

Also missed a spot with removing riscv32 support.