### PR TITLE
[hlsl] Pin hlsl-test-all resusable workflow to main branch

### DIFF
--- a/.github/workflows/hlsl-matrix.yaml
+++ b/.github/workflows/hlsl-matrix.yaml
@@ -23,7 +23,7 @@ jobs:
         runs-on:
           - hlsl-macos
 
-    uses: ./.github/workflows/hlsl-test-all.yaml
+    uses: llvm/llvm-project/.github/workflows/hlsl-test-all.yaml@main
     with:
       SKU: hlsl-macos
       TestTarget: check-hlsl-clang-mtl # TODO: This target changes based on SKU


### PR DESCRIPTION
This will cause each hlsl test workflow to load the hlsl-test-all file from the main branch instead of from the source branch of the PR.

PROs:
 * We can constrain use of the self-hosted Offload Runners to the hlsl-test-all workflow.
 * This will protect the runners from "Script Kiddie" attacks where someone submits a PR with a malicious workflow to many repositories at once.

CONs:
 * This *will not* protect the Offload Runners from someone submitting a PR that modifies the LLVM source to execute malicious code when built.
 * It will not be possible to test changes to the hlsl-test-all workflow in a PR.  We would need to set up some other process for doing this e.g. a special branch name that can be pushed to to test changes.