### PR TITLE
[Driver][OpenBSD] Remove riscv32 bit

### DIFF
--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -447,7 +447,6 @@ public:
     case llvm::Triple::sparcv9:
       this->MCountName = "_mcount";
       break;
-    case llvm::Triple::riscv32:
     case llvm::Triple::riscv64:
       break;
     }


### PR DESCRIPTION
Someone added riscv32 here. OpenBSD does not support riscv32.