### PR TITLE
Revert "[ADT] Fix specialization of ValueIsPresent for PointerUnion"

### DIFF
--- a/llvm/include/llvm/Support/Casting.h
+++ b/llvm/include/llvm/Support/Casting.h
@@ -614,12 +614,12 @@ template <typename T> struct ValueIsPresent<std::optional<T>> {
   static inline decltype(auto) unwrapValue(std::optional<T> &t) { return *t; }
 };
 
-// If something is "nullable" then we just cast it to bool to see if it exists.
+// If something is "nullable" then we just compare it to nullptr to see if it
+// exists.
 template <typename T>
-struct ValueIsPresent<
-    T, std::enable_if_t<IsNullable<T> && std::is_constructible_v<bool, T>>> {
+struct ValueIsPresent<T, std::enable_if_t<IsNullable<T>>> {
   using UnwrappedType = T;
-  static inline bool isPresent(const T &t) { return static_cast<bool>(t); }
+  static inline bool isPresent(const T &t) { return t != T(nullptr); }
   static inline decltype(auto) unwrapValue(T &t) { return t; }
 };
 

--- a/llvm/lib/CodeGen/RegisterBankInfo.cpp
+++ b/llvm/lib/CodeGen/RegisterBankInfo.cpp
@@ -134,10 +134,10 @@ const TargetRegisterClass *RegisterBankInfo::constrainGenericRegister(
 
   // If the register already has a class, fallback to MRI::constrainRegClass.
   auto &RegClassOrBank = MRI.getRegClassOrRegBank(Reg);
-  if (isa_and_present<const TargetRegisterClass *>(RegClassOrBank))
+  if (isa<const TargetRegisterClass *>(RegClassOrBank))
     return MRI.constrainRegClass(Reg, &RC);
 
-  const auto *RB = dyn_cast_if_present<const RegisterBank *>(RegClassOrBank);
+  const RegisterBank *RB = cast<const RegisterBank *>(RegClassOrBank);
   // Otherwise, all we can do is ensure the bank covers the class, and set it.
   if (RB && !RB->covers(RC))
     return nullptr;

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -3708,10 +3708,10 @@ const TargetRegisterClass *
 SIRegisterInfo::getConstrainedRegClassForOperand(const MachineOperand &MO,
                                          const MachineRegisterInfo &MRI) const {
   const RegClassOrRegBank &RCOrRB = MRI.getRegClassOrRegBank(MO.getReg());
-  if (const auto *RB = dyn_cast_if_present<const RegisterBank *>(RCOrRB))
+  if (const RegisterBank *RB = dyn_cast<const RegisterBank *>(RCOrRB))
     return getRegClassForTypeOnBank(MRI.getType(MO.getReg()), *RB);
 
-  if (const auto *RC = dyn_cast_if_present<const TargetRegisterClass *>(RCOrRB))
+  if (const auto *RC = dyn_cast<const TargetRegisterClass *>(RCOrRB))
     return getAllocatableClass(RC);
 
   return nullptr;

--- a/llvm/unittests/ADT/PointerUnionTest.cpp
+++ b/llvm/unittests/ADT/PointerUnionTest.cpp
@@ -208,11 +208,6 @@ TEST_F(PointerUnionTest, NewCastInfra) {
   EXPECT_FALSE(isa<float *>(d4null));
   EXPECT_FALSE(isa<long long *>(d4null));
 
-  EXPECT_FALSE(isa_and_present<int *>(i4null));
-  EXPECT_FALSE(isa_and_present<float *>(f4null));
-  EXPECT_FALSE(isa_and_present<long long *>(l4null));
-  EXPECT_FALSE(isa_and_present<double *>(d4null));
-
   // test cast<>
   EXPECT_EQ(cast<float *>(a), &f);
   EXPECT_EQ(cast<int *>(b), &i);


### PR DESCRIPTION
Reverts llvm/llvm-project#121847

Causes compile time regressions and allegedly miscompilation.
