### PR TITLE
[InstrProf] Fix format issue in user manual

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -3051,7 +3051,7 @@ indexed format, regardeless whether it is produced by frontend or the IR pass.
     $ llvm-profdata merge -o code.profdata yyy/zzz
 
   Using the resulting profile, we can generate a function order to pass to the
-  linker via `--symbol-ordering-file` for ELF or `-order_file` for Mach-O.
+  linker via ``--symbol-ordering-file`` for ELF or ``-order_file`` for Mach-O.
 
   .. code-block:: console
 


### PR DESCRIPTION
Fix a small formatting issue in the user manual after #122385.

https://clang.llvm.org/docs/UsersManual.html#cmdoption-ftemporal-profile