### PR TITLE
[libc][docs] Add sys/resource header's implementation status

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -53,6 +53,7 @@ if (SPHINX_FOUND)
       string
       strings
       sys/mman
+      sys/resource
       threads
       uchar
       wchar

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -26,6 +26,7 @@ Implementation Status
    string
    strings
    sys/mman
+   sys/resource
    threads
    time
    uchar

--- a/libc/utils/docgen/sys/resource.yaml
+++ b/libc/utils/docgen/sys/resource.yaml
@@ -1,0 +1,43 @@
+functions:
+  getpriority:
+    in-latest-posix: ''
+  getrlimit:
+    in-latest-posix: ''
+  getrusage:
+    in-latest-posix: ''
+  setpriority:
+    in-latest-posix: ''
+  setrlimit:
+    in-latest-posix: ''
+
+macros:
+  PRIO_PROCESS:
+    in-latest-posix: ''
+  PRIO_PGRP:
+    in-latest-posix: ''
+  PRIO_USER:
+    in-latest-posix: ''
+  RLIM_INFINITY:
+    in-latest-posix: ''
+  RLIM_SAVED_MAX:
+    in-latest-posix: ''
+  RLIM_SAVED_CUR:
+    in-latest-posix: ''
+  RLIMIT_CORE:
+    in-latest-posix: ''
+  RLIMIT_CPU:
+    in-latest-posix: ''
+  RLIMIT_DATA:
+    in-latest-posix: ''
+  RLIMIT_FSIZE:
+    in-latest-posix: ''
+  RLIMIT_NOFILE:
+    in-latest-posix: ''
+  RLIMIT_STACK:
+    in-latest-posix: ''
+  RLIMIT_AS:
+    in-latest-posix: ''
+  RUSAGE_SELF:
+    in-latest-posix: ''
+  RUSAGE_CHILDREN:
+    in-latest-posix: ''


### PR DESCRIPTION
### Add sys/resource header's implementation status ( #122006 )

#### Changes:
1. **CMakeLists.txt**: Added `sys/resource` to the list of documentation directories.
2. **index.rst**: Included `sys/resource` in the documentation index.
3. **resource.yaml**: Created a new YAML file for `sys/resource` with functions and macros which manages system resources.

This PR adds documentation support for the `sys/resource` header, including functions and macros as per the latest POSIX standards.