### PR TITLE
[libc][complex] fix compiler support matrix for cfloat128

### DIFF
--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -19,25 +19,26 @@
 // TODO: Update the complex variant of C23 `_Float128` type detection again when
 // clang supports it.
 #if !defined(__clang__)
-    #if defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)
-        #if defined(__GNUC__) && !defined(__cplusplus)
-            #define LIBC_TYPES_HAS_CFLOAT128
-            typedef _Complex _Float128 cfloat128;
-        #elif defined(__GNUC__) && __GNUC__ >= 13
-            #define LIBC_TYPES_HAS_CFLOAT128
-            typedef _Complex _Float128 cfloat128;
-        #endif
-    #endif
-#elif (__clang_major__ >= 11) && (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
-    // Use _Complex __float128 type. clang uses __SIZEOF_FLOAT128__ or __FLOAT128__
-    // macro to notify the availability of __float128 type:
-    // https://reviews.llvm.org/D15120
-    #define LIBC_TYPES_HAS_CFLOAT128
-    typedef _Complex __float128 cfloat128;
+#if defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)
+#if defined(__GNUC__) && !defined(__cplusplus)
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex _Float128 cfloat128;
+#elif defined(__GNUC__) && __GNUC__ >= 13
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex _Float128 cfloat128;
+#endif
+#endif
+#elif (__clang_major__ >= 11) &&                                               \
+    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+// Use _Complex __float128 type. clang uses __SIZEOF_FLOAT128__ or __FLOAT128__
+// macro to notify the availability of __float128 type:
+// https://reviews.llvm.org/D15120
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex __float128 cfloat128;
 #elif (LDBL_MANT_DIG == 113)
-    #define LIBC_TYPES_HAS_CFLOAT128
-    #define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
-    typedef _Complex long double cfloat128;
+#define LIBC_TYPES_HAS_CFLOAT128
+#define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
+typedef _Complex long double cfloat128;
 #endif
 
 #endif // LLVM_LIBC_TYPES_CFLOAT128_H

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -18,27 +18,16 @@
 //
 // TODO: Update the complex variant of C23 `_Float128` type detection again when
 // clang supports it.
-#if !defined(__clang__)
-#if defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)
-#if defined(__GNUC__) && !defined(__cplusplus)
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex _Float128 cfloat128;
-#elif defined(__GNUC__) && __GNUC__ >= 13
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex _Float128 cfloat128;
-#endif
-#endif
-#elif (__clang_major__ >= 11) &&                                               \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
-// Use _Complex __float128 type. clang uses __SIZEOF_FLOAT128__ or __FLOAT128__
-// macro to notify the availability of __float128 type:
-// https://reviews.llvm.org/D15120
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex __float128 cfloat128;
+#if defined(__clang__) && (__clang_major__ >= 11) && (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+    #define LIBC_TYPES_HAS_CFLOAT128
+    typedef _Complex __float128 cfloat128;
+#elif defined(__GNUC__) && (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) && (__GNUC__ >= 13 || (!defined(__cplusplus)))
+    #define LIBC_TYPES_HAS_CFLOAT128
+    typedef _Complex _Float128 cfloat128;
 #elif (LDBL_MANT_DIG == 113)
-#define LIBC_TYPES_HAS_CFLOAT128
-#define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
-typedef _Complex long double cfloat128;
+    #define LIBC_TYPES_HAS_CFLOAT128
+    #define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
+    typedef _Complex long double cfloat128;
 #endif
 
 #endif // LLVM_LIBC_TYPES_CFLOAT128_H

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -18,19 +18,21 @@
 //
 // TODO: Update the complex variant of C23 `_Float128` type detection again when
 // clang supports it.
-#if defined(__clang__) && (__clang_major__ >= 11) &&                           \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex __float128 cfloat128;
-#elif defined(__GNUC__) &&                                                     \
-    (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) &&   \
-    (__GNUC__ >= 13 || (!defined(__cplusplus)))
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex _Float128 cfloat128;
-#elif (LDBL_MANT_DIG == 113)
+#ifdef __clang__
+  #if (__clang_major__ >= 11) && (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
     #define LIBC_TYPES_HAS_CFLOAT128
-    #define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
-    typedef _Complex long double cfloat128;
+    typedef _Complex __float128 cfloat128;
+  #endif
+#elif defined(__GNUC__)
+  #if (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) &&    \
+      (__GNUC__ >= 13 || (!defined(__cplusplus)))
+    #define LIBC_TYPES_HAS_CFLOAT128
+    typedef _Complex _Float128 cfloat128;
+  #endif
+#elif (LDBL_MANT_DIG == 113)
+#define LIBC_TYPES_HAS_CFLOAT128
+#define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
+typedef _Complex long double cfloat128;
 #endif
 
 #endif // LLVM_LIBC_TYPES_CFLOAT128_H

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -19,17 +19,20 @@
 // TODO: Update the complex variant of C23 `_Float128` type detection again when
 // clang supports it.
 #ifdef __clang__
-  #if (__clang_major__ >= 11) && (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
-    #define LIBC_TYPES_HAS_CFLOAT128
-    typedef _Complex __float128 cfloat128;
-  #endif
+#if (__clang_major__ >= 11) &&                                                 \
+    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex __float128 cfloat128;
+#endif
 #elif defined(__GNUC__)
-  #if (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) &&    \
-      (__GNUC__ >= 13 || (!defined(__cplusplus)))
-    #define LIBC_TYPES_HAS_CFLOAT128
-    typedef _Complex _Float128 cfloat128;
-  #endif
-#elif (LDBL_MANT_DIG == 113)
+#if (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) &&   \
+    (__GNUC__ >= 13 || (!defined(__cplusplus)))
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex _Float128 cfloat128;
+#endif
+#endif
+
+#if !defined(LIBC_TYPES_HAS_CFLOAT128) && (LDBL_MANT_DIG == 113)
 #define LIBC_TYPES_HAS_CFLOAT128
 #define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
 typedef _Complex long double cfloat128;

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -21,6 +21,9 @@
 #ifdef __clang__
 #if (__clang_major__ >= 11) &&                                                 \
     (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+// Use _Complex __float128 type. clang uses __SIZEOF_FLOAT128__ or __FLOAT128__
+// macro to notify the availability of __float128 type:
+// https://reviews.llvm.org/D15120
 #define LIBC_TYPES_HAS_CFLOAT128
 typedef _Complex __float128 cfloat128;
 #endif

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -18,25 +18,26 @@
 //
 // TODO: Update the complex variant of C23 `_Float128` type detection again when
 // clang supports it.
-#if defined(__STDC_IEC_60559_COMPLEX__) && !defined(__clang__)
-#if !defined(__cplusplus)
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex _Float128 cfloat128;
-#elif defined(__GNUC__) && __GNUC__ >= 13
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex _Float128 cfloat128;
-#endif
-#elif __clang_major__ >= 11 &&                                                 \
-    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
-// Use _Complex __float128 type. clang uses __SIZEOF_FLOAT128__ or __FLOAT128__
-// macro to notify the availability of __float128 type:
-// https://reviews.llvm.org/D15120
-#define LIBC_TYPES_HAS_CFLOAT128
-typedef _Complex __float128 cfloat128;
+#if !defined(__clang__)
+    #if defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)
+        #if defined(__GNUC__) && !defined(__cplusplus)
+            #define LIBC_TYPES_HAS_CFLOAT128
+            typedef _Complex _Float128 cfloat128;
+        #elif defined(__GNUC__) && __GNUC__ >= 13
+            #define LIBC_TYPES_HAS_CFLOAT128
+            typedef _Complex _Float128 cfloat128;
+        #endif
+    #endif
+#elif (__clang_major__ >= 11) && (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+    // Use _Complex __float128 type. clang uses __SIZEOF_FLOAT128__ or __FLOAT128__
+    // macro to notify the availability of __float128 type:
+    // https://reviews.llvm.org/D15120
+    #define LIBC_TYPES_HAS_CFLOAT128
+    typedef _Complex __float128 cfloat128;
 #elif (LDBL_MANT_DIG == 113)
-#define LIBC_TYPES_HAS_CFLOAT128
-#define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
-typedef _Complex long double cfloat128;
+    #define LIBC_TYPES_HAS_CFLOAT128
+    #define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
+    typedef _Complex long double cfloat128;
 #endif
 
 #endif // LLVM_LIBC_TYPES_CFLOAT128_H

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -18,12 +18,15 @@
 //
 // TODO: Update the complex variant of C23 `_Float128` type detection again when
 // clang supports it.
-#if defined(__clang__) && (__clang_major__ >= 11) && (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
-    #define LIBC_TYPES_HAS_CFLOAT128
-    typedef _Complex __float128 cfloat128;
-#elif defined(__GNUC__) && (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) && (__GNUC__ >= 13 || (!defined(__cplusplus)))
-    #define LIBC_TYPES_HAS_CFLOAT128
-    typedef _Complex _Float128 cfloat128;
+#if defined(__clang__) && (__clang_major__ >= 11) &&                           \
+    (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex __float128 cfloat128;
+#elif defined(__GNUC__) &&                                                     \
+    (defined(__STDC_IEC_60559_COMPLEX__) || defined(__SIZEOF_FLOAT128__)) &&   \
+    (__GNUC__ >= 13 || (!defined(__cplusplus)))
+#define LIBC_TYPES_HAS_CFLOAT128
+typedef _Complex _Float128 cfloat128;
 #elif (LDBL_MANT_DIG == 113)
     #define LIBC_TYPES_HAS_CFLOAT128
     #define LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE


### PR DESCRIPTION
Before this patch, [godbolt](https://godbolt.org/z/6PPsvv9qd) failed to compile `cfloat128` with `-ffreestanding` but with the patch, the compilation succeeds, [godbolt](https://godbolt.org/z/4M8zzejss).

Fixes: #122500

cc: @nickdesaulniers 