### PR TITLE
[flang] EOF goes to ERR= in READ(..., REC=)

### DIFF
--- a/flang/runtime/io-api.cpp
+++ b/flang/runtime/io-api.cpp
@@ -623,6 +623,7 @@ bool IODEF(SetRec)(Cookie cookie, std::int64_t rec) {
       handler.SignalError(
           IostatBadOpOnChildUnit, "REC= specifier on child I/O");
     } else {
+      handler.HasRec();
       unit->SetDirectRec(rec, handler);
     }
   } else if (!io.get_if<ErroneousIoStatementState>()) {

--- a/flang/runtime/io-error.cpp
+++ b/flang/runtime/io-error.cpp
@@ -25,7 +25,9 @@ void IoErrorHandler::SignalError(int iostatOrErrno, const char *msg, ...) {
   case IostatOk:
     return;
   case IostatEnd:
-    if (flags_ & (hasIoStat | hasEnd)) {
+    if ((flags_ & (hasIoStat | hasEnd)) ||
+        ((flags_ & hasErr) && (flags_ & hasRec))) {
+      // EOF goes to ERR= when REC= is present
       if (ioStat_ == IostatOk || ioStat_ < IostatEnd) {
         ioStat_ = IostatEnd;
       }

--- a/flang/runtime/io-error.h
+++ b/flang/runtime/io-error.h
@@ -33,6 +33,7 @@ public:
   RT_API_ATTRS void HasEndLabel() { flags_ |= hasEnd; }
   RT_API_ATTRS void HasEorLabel() { flags_ |= hasEor; }
   RT_API_ATTRS void HasIoMsg() { flags_ |= hasIoMsg; }
+  RT_API_ATTRS void HasRec() { flags_ |= hasRec; }
 
   RT_API_ATTRS bool InError() const {
     return ioStat_ != IostatOk || pendingError_ != IostatOk;
@@ -70,6 +71,7 @@ private:
     hasEnd = 4, // END=
     hasEor = 8, // EOR=
     hasIoMsg = 16, // IOMSG=
+    hasRec = 32, // REC=
   };
   std::uint8_t flags_{0};
   int ioStat_{IostatOk};


### PR DESCRIPTION
A direct access READ that tries to read past the end of the file must recover the error via an ERR= label, not an END= label (which is not allowed to be present).

Fixes https://github.com/llvm/llvm-project/issues/122150.