### PR TITLE
[Clang] Fixed a crash when __PRETTY_FUNCTION__ or __FUNCSIG__ (clang-cl) appears in the trailing return type of the lambda 

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -926,6 +926,7 @@ Bug Fixes to C++ Support
   (`LWG3929 <https://wg21.link/LWG3929>`__.) (#GH121278)
 - Clang now identifies unexpanded parameter packs within the type constraint on a non-type template parameter. (#GH88866)
 - Fixed an issue while resolving type of expression indexing into a pack of values of non-dependent type (#GH121242)
+- Fixed a crash when __PRETTY_FUNCTION__ or __FUNCSIG__ (clang-cl) appears in the trailing return type of the lambda (#GH121274)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -775,6 +775,9 @@ std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
     if (const FunctionDecl* Pattern = FD->getTemplateInstantiationPattern())
       Decl = Pattern;
 
+    // Bail out if the type of the function has not been set yet.
+    // This can notably happen in the trailing return type of a lambda
+    // expression.
     const Type *Ty = Decl->getType().getTypePtrOrNull();
     if (!Ty)
       return "";

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -774,7 +774,12 @@ std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
     const FunctionDecl *Decl = FD;
     if (const FunctionDecl* Pattern = FD->getTemplateInstantiationPattern())
       Decl = Pattern;
-    const FunctionType *AFT = Decl->getType()->getAs<FunctionType>();
+
+    const Type *Ty = Decl->getType().getTypePtrOrNull();
+    if (!Ty)
+      return "";
+
+    const FunctionType *AFT = Ty->getAs<FunctionType>();
     const FunctionProtoType *FT = nullptr;
     if (FD->hasWrittenPrototype())
       FT = dyn_cast<FunctionProtoType>(AFT);

--- a/clang/test/SemaCXX/crash-GH121274.cpp
+++ b/clang/test/SemaCXX/crash-GH121274.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -std=c++11 -verify %s
+// expected-no-diagnostics
+
+// Do not crash when __PRETTY_FUNCTION__ appears in the trailing return type of the lambda
+void foo() {
+	[]() -> decltype(static_cast<const char*>(__PRETTY_FUNCTION__)) {
+		return nullptr;
+	}();
+
+#ifdef MS
+	[]() -> decltype(static_cast<const char*>(__FUNCSIG__)) {
+		return nullptr;
+	}();
+#endif
+}


### PR DESCRIPTION
The (function) type of the lambda function is null while parsing trailing return type. The type is filled-in when the lambda body is entered. So, resolving `__PRETTY_FUNCTION__` before the lambda body is entered causes the crash. 

Fixes #121274. 