### PR TITLE
[flang][runtime] Don't buffer unit 0

### DIFF
--- a/flang/runtime/file.cpp
+++ b/flang/runtime/file.cpp
@@ -134,7 +134,7 @@ void OpenFile::Open(OpenStatus status, Fortran::common::optional<Action> action,
   if (fd_ >= 0 && position == Position::Append && !RawSeekToEnd()) {
     handler.SignalError(IostatOpenBadAppend);
   }
-  isTerminal_ = fd_ >= 0 && IsATerminal(fd_) == 1;
+  isTerminal_ = fd_ >= 0 && IsATerminal(fd_);
   mayRead_ = *action != Action::Write;
   mayWrite_ = *action != Action::Read;
   if (status == OpenStatus::Old || status == OpenStatus::Unknown) {
@@ -163,7 +163,7 @@ void OpenFile::Predefine(int fd) {
   knownSize_.reset();
   nextId_ = 0;
   pending_.reset();
-  isTerminal_ = IsATerminal(fd_) == 1;
+  isTerminal_ = fd == 2 || IsATerminal(fd_);
   mayRead_ = fd == 0;
   mayWrite_ = fd != 0;
   mayPosition_ = false;


### PR DESCRIPTION
Always assume that predefined unit 0 is a terminal, so that output to it is never buffered.