### PR TITLE
[MLIR][LLVM] Fix inlining of a single block ending with unreachable

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIRDialect.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRDialect.cpp
@@ -44,7 +44,7 @@ struct FIRInlinerInterface : public mlir::DialectInlinerInterface {
   /// We handle the return (a Fortran FUNCTION) by replacing the values
   /// previously returned by the call operation with the operands of the
   /// return.
-  void handleTerminator(mlir::Operation *op,
+  void handleTerminator(mlir::Operation *op, mlir::OpBuilder &builder,
                         mlir::ValueRange valuesToRepl) const final {
     auto returnOp = llvm::cast<mlir::func::ReturnOp>(op);
     assert(returnOp.getNumOperands() == valuesToRepl.size());

--- a/mlir/examples/toy/Ch4/mlir/Dialect.cpp
+++ b/mlir/examples/toy/Ch4/mlir/Dialect.cpp
@@ -73,7 +73,8 @@ struct ToyInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator(toy.return) by replacing it with a new
   /// operation as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only "toy.return" needs to be handled here.
     auto returnOp = cast<ReturnOp>(op);
 

--- a/mlir/examples/toy/Ch5/mlir/Dialect.cpp
+++ b/mlir/examples/toy/Ch5/mlir/Dialect.cpp
@@ -73,7 +73,8 @@ struct ToyInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator(toy.return) by replacing it with a new
   /// operation as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only "toy.return" needs to be handled here.
     auto returnOp = cast<ReturnOp>(op);
 

--- a/mlir/examples/toy/Ch6/mlir/Dialect.cpp
+++ b/mlir/examples/toy/Ch6/mlir/Dialect.cpp
@@ -73,7 +73,8 @@ struct ToyInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator(toy.return) by replacing it with a new
   /// operation as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only "toy.return" needs to be handled here.
     auto returnOp = cast<ReturnOp>(op);
 

--- a/mlir/examples/toy/Ch7/mlir/Dialect.cpp
+++ b/mlir/examples/toy/Ch7/mlir/Dialect.cpp
@@ -79,7 +79,8 @@ struct ToyInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator(toy.return) by replacing it with a new
   /// operation as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only "toy.return" needs to be handled here.
     auto returnOp = cast<ReturnOp>(op);
 

--- a/mlir/include/mlir/Transforms/InliningUtils.h
+++ b/mlir/include/mlir/Transforms/InliningUtils.h
@@ -116,7 +116,7 @@ public:
   /// calls, these are directly replaced with the operands of the `return`
   /// operation). The given 'op' will be removed by the caller, after this
   /// function has been called.
-  virtual void handleTerminator(Operation *op,
+  virtual void handleTerminator(Operation *op, OpBuilder &builder,
                                 ValueRange valuesToReplace) const {
     llvm_unreachable(
         "must implement handleTerminator in the case of one inlined block");
@@ -212,7 +212,8 @@ public:
   //===--------------------------------------------------------------------===//
 
   virtual void handleTerminator(Operation *op, Block *newDest) const;
-  virtual void handleTerminator(Operation *op, ValueRange valuesToRepl) const;
+  virtual void handleTerminator(Operation *op, OpBuilder &builder,
+                                ValueRange valuesToRepl) const;
 
   virtual Value handleArgument(OpBuilder &builder, Operation *call,
                                Operation *callable, Value argument,

--- a/mlir/lib/Dialect/Func/Extensions/InlinerExtension.cpp
+++ b/mlir/lib/Dialect/Func/Extensions/InlinerExtension.cpp
@@ -67,7 +67,8 @@ struct FuncInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator by replacing it with a new operation
   /// as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only return needs to be handled here.
     auto returnOp = cast<ReturnOp>(op);
 

--- a/mlir/lib/Dialect/Linalg/IR/LinalgDialect.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgDialect.cpp
@@ -57,7 +57,8 @@ struct LinalgInlinerInterface : public DialectInlinerInterface {
   }
   // Handle the given inlined terminator by replacing it with a new operation
   // as necessary. Required when the region has only one block.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {}
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {}
 };
 
 } // namespace

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -51,7 +51,8 @@ struct SCFInlinerInterface : public DialectInlinerInterface {
   }
   // Handle the given inlined terminator by replacing it with a new operation
   // as necessary. Required when the region has only one block.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     auto retValOp = dyn_cast<scf::YieldOp>(op);
     if (!retValOp)
       return;

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVDialect.cpp
@@ -103,7 +103,8 @@ struct SPIRVInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator by replacing it with a new operation
   /// as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only spirv.ReturnValue needs to be handled here.
     auto retValOp = dyn_cast<spirv::ReturnValueOp>(op);
     if (!retValOp)

--- a/mlir/lib/Transforms/Utils/InliningUtils.cpp
+++ b/mlir/lib/Transforms/Utils/InliningUtils.cpp
@@ -111,11 +111,11 @@ void InlinerInterface::handleTerminator(Operation *op, Block *newDest) const {
 
 /// Handle the given inlined terminator by replacing it with a new operation
 /// as necessary.
-void InlinerInterface::handleTerminator(Operation *op,
+void InlinerInterface::handleTerminator(Operation *op, OpBuilder &builder,
                                         ValueRange valuesToRepl) const {
   auto *handler = getInterfaceFor(op);
   assert(handler && "expected valid dialect handler");
-  handler->handleTerminator(op, valuesToRepl);
+  handler->handleTerminator(op, builder, valuesToRepl);
 }
 
 Value InlinerInterface::handleArgument(OpBuilder &builder, Operation *call,
@@ -304,7 +304,7 @@ inlineRegionImpl(InlinerInterface &interface, Region *src, Block *inlineBlock,
                        firstBlockTerminator->getOperands());
 
     // Have the interface handle the terminator of this block.
-    interface.handleTerminator(firstBlockTerminator, resultsToReplace);
+    interface.handleTerminator(firstBlockTerminator, builder, resultsToReplace);
     firstBlockTerminator->erase();
 
     // Merge the post insert block into the cloned entry block.

--- a/mlir/test/Dialect/LLVMIR/inlining.mlir
+++ b/mlir/test/Dialect/LLVMIR/inlining.mlir
@@ -676,3 +676,18 @@ llvm.func @caller(%x : i32) -> i32 {
   %z = llvm.call @private_func(%x) : (i32) -> (i32)
   llvm.return %z : i32
 }
+
+// -----
+
+llvm.func @unreachable_func(%a : i32) -> i32 {
+  "llvm.intr.trap"() : () -> ()
+  llvm.unreachable
+}
+
+// CHECK-LABEL: func @caller
+llvm.func @caller(%x : i32) -> i32 {
+  // CHECK-NOT: llvm.call @unreachable_func
+  // CHECK: llvm.intr.trap
+  %z = llvm.call @unreachable_func(%x) : (i32) -> (i32)
+  llvm.return %z : i32
+}

--- a/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
@@ -316,7 +316,8 @@ struct TestInlinerInterface : public DialectInlinerInterface {
 
   /// Handle the given inlined terminator by replacing it with a new operation
   /// as necessary.
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
+  void handleTerminator(Operation *op, OpBuilder &builder,
+                        ValueRange valuesToRepl) const final {
     // Only handle "test.return" here.
     auto returnOp = dyn_cast<TestReturnOp>(op);
     if (!returnOp)


### PR DESCRIPTION
The inliner interface (for LLVM) assumes that a single-block fn can only end in a return.....asserting otherwise. 

```
julia: external/llvm-project/llvm/include/llvm/Support/Casting.h:578: decltype(auto) llvm::cast(From *) [To = mlir::LLVM::ReturnOp, From = mlir::Operation]: Assertion `isa<To>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

Thread 1 "julia" received signal SIGABRT, Aborted.
Download failed: Invalid argument.  Continuing without source file ./nptl/./nptl/pthread_kill.c.
__pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
warning: 44	./nptl/pthread_kill.c: No such file or directory
(gdb) up
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
78	in ./nptl/pthread_kill.c
(gdb) 
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
89	in ./nptl/pthread_kill.c
(gdb) 
Download failed: Invalid argument.  Continuing without source file ./signal/../sysdeps/posix/raise.c.
#3  0x00007ffff7c4526e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
warning: 26	../sysdeps/posix/raise.c: No such file or directory
(gdb) 
Download failed: Invalid argument.  Continuing without source file ./stdlib/./stdlib/abort.c.
#4  0x00007ffff7c288ff in __GI_abort () at ./stdlib/abort.c:79
warning: 79	./stdlib/abort.c: No such file or directory
(gdb) 
Download failed: Invalid argument.  Continuing without source file ./assert/./assert/assert.c.
#5  0x00007ffff7c2881b in __assert_fail_base (fmt=0x7ffff7dd01e8 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x7ffea216388a "isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"", 
    file=file@entry=0x7ffea21638c6 "external/llvm-project/llvm/include/llvm/Support/Casting.h", line=line@entry=578, function=function@entry=0x7ffea4999619 "decltype(auto) llvm::cast(From *) [To = mlir::LLVM::ReturnOp, From = mlir::Operation]")
    at ./assert/assert.c:94
warning: 94	./assert/assert.c: No such file or directory
(gdb) 
#6  0x00007ffff7c3b507 in __assert_fail (assertion=0x7ffea216388a "isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"", file=0x7ffea21638c6 "external/llvm-project/llvm/include/llvm/Support/Casting.h", line=578, 
    function=0x7ffea4999619 "decltype(auto) llvm::cast(From *) [To = mlir::LLVM::ReturnOp, From = mlir::Operation]") at ./assert/assert.c:103
103	in ./assert/assert.c
(gdb) 
#7  0x00007ffe98f4b1f8 in llvm::cast<mlir::LLVM::ReturnOp, mlir::Operation> (Val=0xa9d4e90) at external/llvm-project/llvm/include/llvm/Support/Casting.h:578
578	  assert(isa<To>(Val) && "cast<Ty>() argument of incompatible type!");
(gdb) 
#8  0x00007ffe98f99e51 in (anonymous namespace)::LLVMInlinerInterface::handleTerminator (this=0x4b1d4d0, op=0xa9d4e90, valuesToRepl=...) at external/llvm-project/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp:753
753	    auto returnOp = cast<LLVM::ReturnOp>(op);
(gdb) p op
$1 = (mlir::Operation *) 0xa9d4e90
(gdb) p op->dump()
"llvm.unreachable"() : () -> ()
$2 = void
(gdb) up
#9  0x00007ffea11236b5 in mlir::InlinerInterface::handleTerminator (this=0x7fffffff9d60, op=0xa9d4e90, valuesToRepl=...) at external/llvm-project/mlir/lib/Transforms/Utils/InliningUtils.cpp:118
118	  handler->handleTerminator(op, valuesToRepl);
(gdb) up
#10 0x00007ffea1124404 in inlineRegionImpl (interface=..., src=0xbc562b8, inlineBlock=0xbc3a750, inlinePoint=..., mapper=..., resultsToReplace=..., regionResultTypes=..., inlineLoc=std::optional = {...}, shouldCloneInlinedRegion=true, call=...)
    at external/llvm-project/mlir/lib/Transforms/Utils/InliningUtils.cpp:307
307	    interface.handleTerminator(firstBlockTerminator, resultsToReplace);
(gdb) up
#11 0x00007ffea11259d3 in mlir::inlineCall (interface=..., call=..., callable=..., src=0xbc562b8, shouldCloneInlinedRegion=true) at external/llvm-project/mlir/lib/Transforms/Utils/InliningUtils.cpp:520
520	  if (failed(inlineRegionImpl(interface, src, call->getBlock(),
(gdb) p src->dump()
Couldn't find method mlir::Region::dump
(gdb) up
#12 0x00007ffea0b7e909 in mlir::Inliner::Impl::inlineCallsInSCC (this=0x7fffffff9f10, inlinerIface=..., useList=..., currentSCC=...) at external/llvm-project/mlir/lib/Transforms/Utils/Inliner.cpp:654
654	        inlineCall(inlinerIface, call,
(gdb) up
#13 0x00007ffea0b7db1b in mlir::Inliner::Impl::inlineSCC (this=0x7fffffff9f10, inlinerIface=..., useList=..., currentSCC=..., context=0x25a7750) at external/llvm-project/mlir/lib/Transforms/Utils/Inliner.cpp:480
480	    if (failed(inlineCallsInSCC(inlinerIface, useList, currentSCC)))
(gdb) up
#14 0x00007ffea0b7da7f in mlir::Inliner::doInlining()::$_0::operator()((anonymous namespace)::CallGraphSCC&) const (this=0x7fffffff9cb0, scc=...) at external/llvm-project/mlir/lib/Transforms/Utils/Inliner.cpp:762
762	    return impl.inlineSCC(inlinerIface, useList, scc, context);
(gdb) 
#15 0x00007ffea0b7da3d in llvm::function_ref<llvm::LogicalResult ((anonymous namespace)::CallGraphSCC&)>::callback_fn<mlir::Inliner::doInlining()::$_0>(long, (anonymous namespace)::CallGraphSCC&) (callable=140737488329904, params=...)
    at external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46
46	    return (*reinterpret_cast<Callable*>(callable))(
(gdb) 
#16 0x00007ffea0b7cb51 in llvm::function_ref<llvm::LogicalResult ((anonymous namespace)::CallGraphSCC&)>::operator()((anonymous namespace)::CallGraphSCC&) const (this=0x7fffffff9c48, params=...)
    at external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69
69	    return callback(callable, std::forward<Params>(params)...);
(gdb) 

#17 0x00007ffea0b7a5e6 in runTransformOnCGSCCs(mlir::CallGraph const&, llvm::function_ref<llvm::LogicalResult ((anonymous namespace)::CallGraphSCC&)>) (cg=..., sccTransformer=...)
    at external/llvm-project/mlir/lib/Transforms/Utils/Inliner.cpp:295
295	    if (failed(sccTransformer(currentSCC)))
(gdb) 
#18 0x00007ffea0b79ef0 in mlir::Inliner::doInlining (this=0x7fffffffa028) at external/llvm-project/mlir/lib/Transforms/Utils/Inliner.cpp:761
761	  LogicalResult result = runTransformOnCGSCCs(cg, [&](CallGraphSCC &scc) {
(gdb) up
#19 0x00007ffea0b0ffa8 in (anonymous namespace)::InlinerPass::runOnOperation (this=0xbdff550) at external/llvm-project/mlir/lib/Transforms/InlinerPass.cpp:150
150	  if (failed(inliner.doInlining()))
(gdb) p getOpeQuit
(gdb) up
#20 0x00007ffea11615ab in mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_1::operator()() const (this=0x7fffffffa380) at external/llvm-project/mlir/lib/Pass/Pass.cpp:526
526	          pass->runOnOperation();
(gdb) up
#21 0x00007ffea1161545 in llvm::function_ref<void ()>::callback_fn<mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::$_1>(long) (callable=140737488331648)
    at external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46
46	    return (*reinterpret_cast<Callable*>(callable))(
(gdb) up
#22 0x00007ffe9283f559 in llvm::function_ref<void ()>::operator()() const (this=0x7fffffffa290) at external/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69
69	    return callback(callable, std::forward<Params>(params)...);
(gdb) 
#23 0x00007ffea11643e5 in mlir::MLIRContext::executeAction<mlir::PassExecutionAction, mlir::Pass&>(llvm::function_ref<void ()>, llvm::ArrayRef<mlir::IRUnit>, mlir::Pass&) (this=0x25a7750, actionFn=..., irUnits=..., args=...)
    at external/llvm-project/mlir/include/mlir/IR/MLIRContext.h:280
280	      actionFn();
(gdb) 
#24 0x00007ffea115bdb3 in mlir::detail::OpToOpPassAdaptor::run (pass=0xbdff550, op=0x2fd6020, am=..., verifyPasses=true, parentInitGeneration=1) at external/llvm-project/mlir/lib/Pass/Pass.cpp:520
520	  op->getContext()->executeAction<PassExecutionAction>(
```