### PR TITLE
[InstCombine] Fold `(ct{t,l}z Pow2)` -> `Log2(Pow2)`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -590,18 +590,15 @@ static Instruction *foldCttzCtlz(IntrinsicInst &II, InstCombinerImpl &IC) {
 
   // cttz(Pow2) -> Log2(Pow2)
   // ctlz(Pow2) -> BitWidth - 1 - Log2(Pow2)
-  if (IsTZ) {
-    if (auto *R = IC.tryGetLog2(Op0, match(Op1, m_One()))) {
-      if (IsTZ)
-        return IC.replaceInstUsesWith(II, R);
-      BinaryOperator *BO = BinaryOperator::CreateSub(
-          ConstantInt::get(R->getType(),
-                           R->getType()->getScalarSizeInBits() - 1),
-          R);
-      BO->setHasNoSignedWrap();
-      BO->setHasNoUnsignedWrap();
-      return BO;
-    }
+  if (auto *R = IC.tryGetLog2(Op0, match(Op1, m_One()))) {
+    if (IsTZ)
+      return IC.replaceInstUsesWith(II, R);
+    BinaryOperator *BO = BinaryOperator::CreateSub(
+        ConstantInt::get(R->getType(), R->getType()->getScalarSizeInBits() - 1),
+        R);
+    BO->setHasNoSignedWrap();
+    BO->setHasNoUnsignedWrap();
+    return BO;
   }
 
   KnownBits Known = IC.computeKnownBits(Op0, 0, &II);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -590,7 +590,7 @@ static Instruction *foldCttzCtlz(IntrinsicInst &II, InstCombinerImpl &IC) {
 
   // cttz(Pow2) -> Log2(Pow2)
   // ctlz(Pow2) -> BitWidth - 1 - Log2(Pow2)
-  if (IsTZ || II.hasOneUse()) {
+  if (IsTZ) {
     if (auto *R = IC.tryGetLog2(Op0, match(Op1, m_One()))) {
       if (IsTZ)
         return IC.replaceInstUsesWith(II, R);

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -588,6 +588,22 @@ static Instruction *foldCttzCtlz(IntrinsicInst &II, InstCombinerImpl &IC) {
     }
   }
 
+  // cttz(Pow2) -> Log2(Pow2)
+  // ctlz(Pow2) -> BitWidth - 1 - Log2(Pow2)
+  if (IsTZ || II.hasOneUse()) {
+    if (auto *R = IC.tryGetLog2(Op0, match(Op1, m_One()))) {
+      if (IsTZ)
+        return IC.replaceInstUsesWith(II, R);
+      BinaryOperator *BO = BinaryOperator::CreateSub(
+          ConstantInt::get(R->getType(),
+                           R->getType()->getScalarSizeInBits() - 1),
+          R);
+      BO->setHasNoSignedWrap();
+      BO->setHasNoUnsignedWrap();
+      return BO;
+    }
+  }
+
   KnownBits Known = IC.computeKnownBits(Op0, 0, &II);
 
   // Create a mask for bits above (ctlz) or below (cttz) the first known one.

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -313,6 +313,19 @@ define i8 @fold_ctz_log2(i8 %x) {
   ret i8 %r
 }
 
+define i9 @fold_ctz_log2_i9_okay(i9 %x) {
+; CHECK-LABEL: @fold_ctz_log2_i9_okay(
+; CHECK-NEXT:    [[P2:%.*]] = shl nuw i9 1, [[X:%.*]]
+; CHECK-NEXT:    [[V:%.*]] = call i9 @llvm.umin.i9(i9 [[P2]], i9 32)
+; CHECK-NEXT:    [[R:%.*]] = call range(i9 0, 10) i9 @llvm.cttz.i9(i9 [[V]], i1 true)
+; CHECK-NEXT:    ret i9 [[R]]
+;
+  %p2 = shl i9 1, %x
+  %v = call i9 @llvm.umin(i9 %p2, i9 32)
+  %r = call i9 @llvm.cttz(i9 %v, i1 false)
+  ret i9 %r
+}
+
 define i8 @fold_ctz_log2_maybe_z(i8 %x, i8 %y, i1 %c) {
 ; CHECK-LABEL: @fold_ctz_log2_maybe_z(
 ; CHECK-NEXT:    [[V:%.*]] = shl i8 2, [[V_V:%.*]]
@@ -356,8 +369,8 @@ define i8 @fold_clz_log2(i8 %x) {
   ret i8 %r
 }
 
-define i8 @fold_clz_log2_multiuse(i8 %x) {
-; CHECK-LABEL: @fold_clz_log2_multiuse(
+define i8 @fold_clz_log2_multiuse_fail(i8 %x) {
+; CHECK-LABEL: @fold_clz_log2_multiuse_fail(
 ; CHECK-NEXT:    [[V:%.*]] = shl i8 2, [[X:%.*]]
 ; CHECK-NEXT:    call void @use.i8(i8 [[V]])
 ; CHECK-NEXT:    [[R:%.*]] = call range(i8 0, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
@@ -370,8 +383,8 @@ define i8 @fold_clz_log2_multiuse(i8 %x) {
 }
 
 
-  define i9 @fold_clz_log2_i9(i9 %x) {
-; CHECK-LABEL: @fold_clz_log2_i9(
+define i9 @fold_clz_log2_i9_fail(i9 %x) {
+; CHECK-LABEL: @fold_clz_log2_i9_fail(
 ; CHECK-NEXT:    [[P2:%.*]] = shl nuw i9 1, [[X:%.*]]
 ; CHECK-NEXT:    [[V:%.*]] = call i9 @llvm.umin.i9(i9 [[P2]], i9 32)
 ; CHECK-NEXT:    [[R:%.*]] = call range(i9 3, 10) i9 @llvm.ctlz.i9(i9 [[V]], i1 true)
@@ -379,6 +392,6 @@ define i8 @fold_clz_log2_multiuse(i8 %x) {
 ;
   %p2 = shl i9 1, %x
   %v = call i9 @llvm.umin(i9 %p2, i9 32)
-  %r = call i9 @llvm.ctlz(i9 %v, i1 false)
+  %r = call i9 @llvm.ctlz(i9 %v, i1 true)
   ret i9 %r
 }

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -313,9 +313,7 @@ define i8 @fold_ctz_log2(i8 %x) {
 
 define i9 @fold_ctz_log2_i9_okay(i9 %x) {
 ; CHECK-LABEL: @fold_ctz_log2_i9_okay(
-; CHECK-NEXT:    [[P2:%.*]] = shl nuw i9 1, [[X:%.*]]
-; CHECK-NEXT:    [[V:%.*]] = call i9 @llvm.umin.i9(i9 [[P2]], i9 32)
-; CHECK-NEXT:    [[R:%.*]] = call range(i9 0, 10) i9 @llvm.cttz.i9(i9 [[V]], i1 true)
+; CHECK-NEXT:    [[R:%.*]] = call i9 @llvm.umin.i9(i9 [[X:%.*]], i9 5)
 ; CHECK-NEXT:    ret i9 [[R]]
 ;
   %p2 = shl i9 1, %x
@@ -355,8 +353,9 @@ define i8 @fold_ctz_log2_maybe_z_okay(i8 %x, i8 %y, i1 %c) {
 
 define i8 @fold_clz_log2(i8 %x) {
 ; CHECK-LABEL: @fold_clz_log2(
-; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.umin.i8(i8 [[X:%.*]], i8 5)
-; CHECK-NEXT:    [[R:%.*]] = xor i8 [[TMP1]], 7
+; CHECK-NEXT:    [[P2:%.*]] = shl nuw i8 1, [[X:%.*]]
+; CHECK-NEXT:    [[V:%.*]] = call i8 @llvm.umin.i8(i8 [[P2]], i8 32)
+; CHECK-NEXT:    [[R:%.*]] = call range(i8 2, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %p2 = shl i8 1, %x

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -353,9 +353,8 @@ define i8 @fold_ctz_log2_maybe_z_okay(i8 %x, i8 %y, i1 %c) {
 
 define i8 @fold_clz_log2(i8 %x) {
 ; CHECK-LABEL: @fold_clz_log2(
-; CHECK-NEXT:    [[P2:%.*]] = shl nuw i8 1, [[X:%.*]]
-; CHECK-NEXT:    [[V:%.*]] = call i8 @llvm.umin.i8(i8 [[P2]], i8 32)
-; CHECK-NEXT:    [[R:%.*]] = call range(i8 2, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.umin.i8(i8 [[X:%.*]], i8 5)
+; CHECK-NEXT:    [[R:%.*]] = xor i8 [[TMP1]], 7
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %p2 = shl i8 1, %x
@@ -382,9 +381,8 @@ define i8 @fold_clz_log2_multiuse_fail(i8 %x) {
 
 define i9 @fold_clz_log2_i9(i9 %x) {
 ; CHECK-LABEL: @fold_clz_log2_i9(
-; CHECK-NEXT:    [[P2:%.*]] = shl nuw i9 1, [[X:%.*]]
-; CHECK-NEXT:    [[V:%.*]] = call i9 @llvm.umin.i9(i9 [[P2]], i9 32)
-; CHECK-NEXT:    [[R:%.*]] = call range(i9 3, 10) i9 @llvm.ctlz.i9(i9 [[V]], i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i9 @llvm.umin.i9(i9 [[X:%.*]], i9 5)
+; CHECK-NEXT:    [[R:%.*]] = sub nuw nsw i9 8, [[TMP1]]
 ; CHECK-NEXT:    ret i9 [[R]]
 ;
   %p2 = shl i9 1, %x

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -302,9 +302,7 @@ define i16 @cttz_assume(i16 %x) {
 declare void @use.i8(i8)
 define i8 @fold_ctz_log2(i8 %x) {
 ; CHECK-LABEL: @fold_ctz_log2(
-; CHECK-NEXT:    [[P2:%.*]] = shl nuw i8 1, [[X:%.*]]
-; CHECK-NEXT:    [[V:%.*]] = call i8 @llvm.umin.i8(i8 [[P2]], i8 32)
-; CHECK-NEXT:    [[R:%.*]] = call range(i8 0, 9) i8 @llvm.cttz.i8(i8 [[V]], i1 true)
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.umin.i8(i8 [[X:%.*]], i8 5)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %p2 = shl i8 1, %x
@@ -343,11 +341,10 @@ define i8 @fold_ctz_log2_maybe_z(i8 %x, i8 %y, i1 %c) {
 
 define i8 @fold_ctz_log2_maybe_z_okay(i8 %x, i8 %y, i1 %c) {
 ; CHECK-LABEL: @fold_ctz_log2_maybe_z_okay(
-; CHECK-NEXT:    [[X:%.*]] = shl i8 2, [[X1:%.*]]
-; CHECK-NEXT:    [[Y:%.*]] = shl i8 4, [[Y1:%.*]]
+; CHECK-NEXT:    [[X:%.*]] = add i8 [[X1:%.*]], 1
+; CHECK-NEXT:    [[Y:%.*]] = add i8 [[Y1:%.*]], 2
 ; CHECK-NEXT:    [[V_V:%.*]] = select i1 [[C:%.*]], i8 [[X]], i8 [[Y]]
-; CHECK-NEXT:    [[R:%.*]] = call range(i8 1, 9) i8 @llvm.cttz.i8(i8 [[V_V]], i1 true)
-; CHECK-NEXT:    ret i8 [[R]]
+; CHECK-NEXT:    ret i8 [[V_V]]
 ;
   %p2 = shl i8 2, %x
   %p2_2 = shl i8 4, %y
@@ -358,9 +355,8 @@ define i8 @fold_ctz_log2_maybe_z_okay(i8 %x, i8 %y, i1 %c) {
 
 define i8 @fold_clz_log2(i8 %x) {
 ; CHECK-LABEL: @fold_clz_log2(
-; CHECK-NEXT:    [[P2:%.*]] = shl nuw i8 1, [[X:%.*]]
-; CHECK-NEXT:    [[V:%.*]] = call i8 @llvm.umin.i8(i8 [[P2]], i8 32)
-; CHECK-NEXT:    [[R:%.*]] = call range(i8 2, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = call i8 @llvm.umin.i8(i8 [[X:%.*]], i8 5)
+; CHECK-NEXT:    [[R:%.*]] = xor i8 [[TMP1]], 7
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %p2 = shl i8 1, %x

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -371,20 +371,22 @@ define i8 @fold_clz_log2(i8 %x) {
 
 define i8 @fold_clz_log2_multiuse_fail(i8 %x) {
 ; CHECK-LABEL: @fold_clz_log2_multiuse_fail(
-; CHECK-NEXT:    [[V:%.*]] = shl i8 2, [[X:%.*]]
+; CHECK-NEXT:    [[P2:%.*]] = shl nuw i8 2, [[X:%.*]]
+; CHECK-NEXT:    [[V:%.*]] = call i8 @llvm.umin.i8(i8 [[P2]], i8 32)
 ; CHECK-NEXT:    call void @use.i8(i8 [[V]])
-; CHECK-NEXT:    [[R:%.*]] = call range(i8 0, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
+; CHECK-NEXT:    [[R:%.*]] = call range(i8 2, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
-  %v = shl i8 2, %x
+  %p2 = shl nuw i8 2, %x
+  %v = call i8 @llvm.umin(i8 %p2, i8 32)
   call void @use.i8(i8 %v)
   %r = call i8 @llvm.ctlz(i8 %v, i1 true)
   ret i8 %r
 }
 
 
-define i9 @fold_clz_log2_i9_fail(i9 %x) {
-; CHECK-LABEL: @fold_clz_log2_i9_fail(
+define i9 @fold_clz_log2_i9(i9 %x) {
+; CHECK-LABEL: @fold_clz_log2_i9(
 ; CHECK-NEXT:    [[P2:%.*]] = shl nuw i9 1, [[X:%.*]]
 ; CHECK-NEXT:    [[V:%.*]] = call i9 @llvm.umin.i9(i9 [[P2]], i9 32)
 ; CHECK-NEXT:    [[R:%.*]] = call range(i9 3, 10) i9 @llvm.ctlz.i9(i9 [[V]], i1 true)

--- a/llvm/test/Transforms/InstCombine/cttz.ll
+++ b/llvm/test/Transforms/InstCombine/cttz.ll
@@ -356,17 +356,29 @@ define i8 @fold_clz_log2(i8 %x) {
   ret i8 %r
 }
 
-define i8 @fold_clz_log2_fail_multi_use(i8 %x) {
-; CHECK-LABEL: @fold_clz_log2_fail_multi_use(
-; CHECK-NEXT:    [[P2:%.*]] = shl nuw i8 1, [[X:%.*]]
-; CHECK-NEXT:    [[V:%.*]] = call i8 @llvm.umin.i8(i8 [[P2]], i8 32)
-; CHECK-NEXT:    [[R:%.*]] = call range(i8 2, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
-; CHECK-NEXT:    call void @use.i8(i8 [[R]])
+define i8 @fold_clz_log2_multiuse(i8 %x) {
+; CHECK-LABEL: @fold_clz_log2_multiuse(
+; CHECK-NEXT:    [[V:%.*]] = shl i8 2, [[X:%.*]]
+; CHECK-NEXT:    call void @use.i8(i8 [[V]])
+; CHECK-NEXT:    [[R:%.*]] = call range(i8 0, 9) i8 @llvm.ctlz.i8(i8 [[V]], i1 true)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
-  %p2 = shl i8 1, %x
-  %v = call i8 @llvm.umin(i8 %p2, i8 32)
-  %r = call i8 @llvm.ctlz(i8 %v, i1 false)
-  call void @use.i8(i8 %r)
+  %v = shl i8 2, %x
+  call void @use.i8(i8 %v)
+  %r = call i8 @llvm.ctlz(i8 %v, i1 true)
   ret i8 %r
+}
+
+
+  define i9 @fold_clz_log2_i9(i9 %x) {
+; CHECK-LABEL: @fold_clz_log2_i9(
+; CHECK-NEXT:    [[P2:%.*]] = shl nuw i9 1, [[X:%.*]]
+; CHECK-NEXT:    [[V:%.*]] = call i9 @llvm.umin.i9(i9 [[P2]], i9 32)
+; CHECK-NEXT:    [[R:%.*]] = call range(i9 3, 10) i9 @llvm.ctlz.i9(i9 [[V]], i1 true)
+; CHECK-NEXT:    ret i9 [[R]]
+;
+  %p2 = shl i9 1, %x
+  %v = call i9 @llvm.umin(i9 %p2, i9 32)
+  %r = call i9 @llvm.ctlz(i9 %v, i1 false)
+  ret i9 %r
 }


### PR DESCRIPTION
- **[InstCombine] Add tests for folding `(ct{t,l}z Pow2)`; NFC**
- **[InstCombine] Fold `(ct{t,l}z Pow2)` -> `Log2(Pow2)`**

Do so we can find `Log2(Pow2)` for "free" with `takeLog2`

https://alive2.llvm.org/ce/z/CL77fo