### PR TITLE
[ADT] Deprecate PointerUnion::{is,get} (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -148,7 +148,7 @@ public:
 
   /// Test if the Union currently holds the type matching T.
   template <typename T>
-  LLVM_DEPRECATED("Use isa instead", "isa")
+  [[deprecated("Use isa instead")]]
   inline bool is() const {
     return isa<T>(*this);
   }
@@ -157,7 +157,7 @@ public:
   ///
   /// If the specified pointer type is incorrect, assert.
   template <typename T>
-  LLVM_DEPRECATED("Use cast instead", "cast")
+  [[deprecated("Use cast instead")]]
   inline T get() const {
     assert(isa<T>(*this) && "Invalid accessor called");
     return cast<T>(*this);

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -147,12 +147,18 @@ public:
   //        isa<T>, cast<T> and the llvm::dyn_cast<T>
 
   /// Test if the Union currently holds the type matching T.
-  template <typename T> inline bool is() const { return isa<T>(*this); }
+  template <typename T>
+  LLVM_DEPRECATED("Use isa instead", "isa")
+  inline bool is() const {
+    return isa<T>(*this);
+  }
 
   /// Returns the value of the specified pointer type.
   ///
   /// If the specified pointer type is incorrect, assert.
-  template <typename T> inline T get() const {
+  template <typename T>
+  LLVM_DEPRECATED("Use cast instead", "cast")
+  inline T get() const {
     assert(isa<T>(*this) && "Invalid accessor called");
     return cast<T>(*this);
   }


### PR DESCRIPTION
PointerUnion::{is,get} have been soft deprecated in PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

This patch actually deprecates them with [[deprecated]].

I'm not touching PointerUnion::dyn_cast for now because we have not
migrated away from it yet.
