### PR TITLE
[libc++] Fix ambiguous call in {ranges, std}::find

### DIFF
--- a/libcxx/include/__algorithm/find.h
+++ b/libcxx/include/__algorithm/find.h
@@ -106,10 +106,10 @@ __find_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_ty
   if (__first.__ctz_ != 0) {
     __storage_type __clz_f = static_cast<__storage_type>(__bits_per_word - __first.__ctz_);
     __storage_type __dn    = std::min(__clz_f, __n);
-    __storage_type __m     = (~__storage_type(0) << __first.__ctz_) & (~__storage_type(0) >> (__clz_f - __dn));
+    __storage_type __m     = std::__middle_mask<__storage_type>(__first.__ctz_, __clz_f - __dn);
     __storage_type __b     = std::__invert_if<!_ToFind>(*__first.__seg_) & __m;
     if (__b)
-      return _It(__first.__seg_, static_cast<unsigned>(std::__libcpp_ctz(__b)));
+      return _It(__first.__seg_, static_cast<unsigned>(std::__countr_zero(__b)));
     if (__n == __dn)
       return __first + __n;
     __n -= __dn;
@@ -119,14 +119,14 @@ __find_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_ty
   for (; __n >= __bits_per_word; ++__first.__seg_, __n -= __bits_per_word) {
     __storage_type __b = std::__invert_if<!_ToFind>(*__first.__seg_);
     if (__b)
-      return _It(__first.__seg_, static_cast<unsigned>(std::__libcpp_ctz(__b)));
+      return _It(__first.__seg_, static_cast<unsigned>(std::__countr_zero(__b)));
   }
   // do last partial word
   if (__n > 0) {
-    __storage_type __m = ~__storage_type(0) >> (__bits_per_word - __n);
+    __storage_type __m = std::__trailing_mask<__storage_type>(__bits_per_word - __n);
     __storage_type __b = std::__invert_if<!_ToFind>(*__first.__seg_) & __m;
     if (__b)
-      return _It(__first.__seg_, static_cast<unsigned>(std::__libcpp_ctz(__b)));
+      return _It(__first.__seg_, static_cast<unsigned>(std::__countr_zero(__b)));
   }
   return _It(__first.__seg_, static_cast<unsigned>(__n));
 }

--- a/libcxx/include/__algorithm/find.h
+++ b/libcxx/include/__algorithm/find.h
@@ -106,7 +106,7 @@ __find_bool(__bit_iterator<_Cp, _IsConst> __first, typename __size_difference_ty
   if (__first.__ctz_ != 0) {
     __storage_type __clz_f = static_cast<__storage_type>(__bits_per_word - __first.__ctz_);
     __storage_type __dn    = std::min(__clz_f, __n);
-    __storage_type __m     = std::__middle_mask<__storage_type>(__first.__ctz_, __clz_f - __dn);
+    __storage_type __m     = std::__middle_mask<__storage_type>(__clz_f - __dn, __first.__ctz_);
     __storage_type __b     = std::__invert_if<!_ToFind>(*__first.__seg_) & __m;
     if (__b)
       return _It(__first.__seg_, static_cast<unsigned>(std::__countr_zero(__b)));

--- a/libcxx/include/__bit/countr.h
+++ b/libcxx/include/__bit/countr.h
@@ -46,7 +46,6 @@ template <class _Tp>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int __countr_zero_impl(_Tp __t) _NOEXCEPT {
   _LIBCPP_ASSERT_INTERNAL(__t != 0, "__countr_zero_impl called with zero value");
   static_assert(is_unsigned<_Tp>::value, "__countr_zero_impl only works with unsigned types");
-  // Use constexpr if as a C++17 extension for clang
   if _LIBCPP_CONSTEXPR (sizeof(_Tp) <= sizeof(unsigned int)) {
     return std::__libcpp_ctz(static_cast<unsigned int>(__t));
   } else if _LIBCPP_CONSTEXPR (sizeof(_Tp) <= sizeof(unsigned long)) {
@@ -55,7 +54,6 @@ template <class _Tp>
     return std::__libcpp_ctz(static_cast<unsigned long long>(__t));
   } else {
 #if _LIBCPP_STD_VER == 11
-    // A constexpr implementation for C++11 using variable declaration as a C++14 extension for clang
     unsigned long long __ull       = static_cast<unsigned long long>(__t);
     const unsigned int __ulldigits = numeric_limits<unsigned long long>::digits;
     return __ull == 0ull ? __ulldigits + std::__countr_zero_impl<_Tp>(__t >> __ulldigits) : std::__libcpp_ctz(__ull);
@@ -74,7 +72,7 @@ template <class _Tp>
 template <class _Tp>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int __countr_zero(_Tp __t) _NOEXCEPT {
   static_assert(is_unsigned<_Tp>::value, "__countr_zero only works with unsigned types");
-#if __has_builtin(__builtin_ctzg)
+#if __has_builtin(__builtin_ctzg) // TODO (LLVM 21): This can be dropped once we only support Clang >= 19.
   return __builtin_ctzg(__t, numeric_limits<_Tp>::digits);
 #else
   return __t != 0 ? std::__countr_zero_impl(__t) : numeric_limits<_Tp>::digits;

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -18,7 +18,6 @@
 #include <__algorithm/min.h>
 #include <__assert>
 #include <__bit/countr.h>
-#include <__bit/invert_if.h>
 #include <__compare/ordering.h>
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
@@ -68,12 +67,21 @@ struct __size_difference_type_traits<_Cp, __void_t<typename _Cp::difference_type
   using size_type       = typename _Cp::size_type;
 };
 
+// The `__x_mask` functions are designed to work exclusively with any unsigned `_StorageType`s, including small
+// integral types such as unsigned char/short, `uint8_t`, and `uint16_t`. To prevent undefined behaviors or
+// ambiguities due to integral promotions for the small integral types, all bitwise operations are explicitly
+// cast back to the unsigned `_StorageType`.
+
+// Creates a mask of type `_StorageType` with a specified number of leading zeros (__clz) and sets all remaining
+// bits to one
 template <class _StorageType>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __trailing_mask(unsigned __clz) {
   static_assert(is_unsigned<_StorageType>::value, "__trailing_mask only works with unsigned types");
   return static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) >> __clz);
 }
 
+// Creates a mask of type `_StorageType` with a specified number of leading zeros (__clz), a specified number of
+// trailing zeros (__ctz), and sets all bits in between to one
 template <class _StorageType>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __middle_mask(unsigned __clz, unsigned __ctz) {
   static_assert(is_unsigned<_StorageType>::value, "__middle_mask only works with unsigned types");

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -68,31 +68,29 @@ struct __size_difference_type_traits<_Cp, __void_t<typename _Cp::difference_type
 };
 
 // The `__x_mask` functions are designed to work exclusively with any unsigned `_StorageType`s, including small
-// integral types such as unsigned char/short, `uint8_t`, and `uint16_t`. To prevent undefined behaviors or
-// ambiguities due to integral promotions for the small integral types, all bitwise operations are explicitly
-// cast back to the unsigned `_StorageType`.
+// integral types such as unsigned char/short, `uint8_t`, and `uint16_t`. To prevent undefined behavior or
+// ambiguities due to integral promotions for the small integral types, all intermediate bitwise operations are
+// explicitly cast back to the unsigned `_StorageType`.
 
 // Creates a mask of type `_StorageType` with a specified number of leading zeros (__clz) and sets all remaining
-// bits to one
+// bits to one.
 template <class _StorageType>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __trailing_mask(unsigned __clz) {
   static_assert(is_unsigned<_StorageType>::value, "__trailing_mask only works with unsigned types");
-  return static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) >> __clz);
+  return static_cast<_StorageType>(~static_cast<_StorageType>(0)) >> __clz;
 }
 
 // Creates a mask of type `_StorageType` with a specified number of leading zeros (__clz), a specified number of
-// trailing zeros (__ctz), and sets all bits in between to one
+// trailing zeros (__ctz), and sets all bits in between to one.
 template <class _StorageType>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __middle_mask(unsigned __clz, unsigned __ctz) {
   static_assert(is_unsigned<_StorageType>::value, "__middle_mask only works with unsigned types");
-  return static_cast<_StorageType>(
-      static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) << __ctz) &
-      std::__trailing_mask<_StorageType>(__clz));
+  return (static_cast<_StorageType>(~static_cast<_StorageType>(0)) << __ctz) &
+         std::__trailing_mask<_StorageType>(__clz);
 }
 
 // This function is designed to operate correctly even for smaller integral types like `uint8_t`, `uint16_t`,
-// or `unsigned short`. Casting back to _StorageType is crucial to prevent undefined behavior that can arise
-// from integral promotions.
+// or `unsigned short`.
 // See https://github.com/llvm/llvm-project/pull/122410.
 template <class _StoragePointer>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
@@ -102,12 +100,11 @@ __fill_masked_range(_StoragePointer __word, unsigned __clz, unsigned __ctz, bool
   using _StorageType = typename pointer_traits<_StoragePointer>::element_type;
   _LIBCPP_ASSERT_VALID_INPUT_RANGE(
       __ctz + __clz < sizeof(_StorageType) * CHAR_BIT, "__fill_masked_range called with invalid range");
-  _StorageType __m = static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) >> __clz) &
-                     static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) << __ctz);
+  _StorageType __m = std::__middle_mask<_StorageType>(__clz, __ctz);
   if (__fill_val)
     *__word |= __m;
   else
-    *__word &= static_cast<_StorageType>(~__m);
+    *__word &= ~__m;
 }
 
 template <class _Cp, bool = __has_storage_type<_Cp>::value>

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -18,6 +18,7 @@
 #include <__algorithm/min.h>
 #include <__assert>
 #include <__bit/countr.h>
+#include <__bit/invert_if.h>
 #include <__compare/ordering.h>
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
@@ -66,6 +67,20 @@ struct __size_difference_type_traits<_Cp, __void_t<typename _Cp::difference_type
   using difference_type = typename _Cp::difference_type;
   using size_type       = typename _Cp::size_type;
 };
+
+template <class _StorageType>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __trailing_mask(unsigned __clz) {
+  static_assert(is_unsigned<_StorageType>::value, "__trailing_mask only works with unsigned types");
+  return static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) >> __clz);
+}
+
+template <class _StorageType>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __middle_mask(unsigned __clz, unsigned __ctz) {
+  static_assert(is_unsigned<_StorageType>::value, "__middle_mask only works with unsigned types");
+  return static_cast<_StorageType>(
+      static_cast<_StorageType>(static_cast<_StorageType>(~static_cast<_StorageType>(0)) << __ctz) &
+      std::__trailing_mask<_StorageType>(__clz));
+}
 
 // This function is designed to operate correctly even for smaller integral types like `uint8_t`, `uint16_t`,
 // or `unsigned short`. Casting back to _StorageType is crucial to prevent undefined behavior that can arise

--- a/libcxx/include/__fwd/bit_reference.h
+++ b/libcxx/include/__fwd/bit_reference.h
@@ -10,9 +10,6 @@
 #define _LIBCPP___FWD_BIT_REFERENCE_H
 
 #include <__config>
-#include <__memory/pointer_traits.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/is_unsigned.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -29,6 +26,12 @@ struct __size_difference_type_traits;
 template <class _StoragePointer>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 void
 __fill_masked_range(_StoragePointer __word, unsigned __ctz, unsigned __clz, bool __fill_val);
+
+template <class _StorageType>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __trailing_mask(unsigned __clz);
+
+template <class _StorageType>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _StorageType __middle_mask(unsigned __clz, unsigned __ctz);
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
@@ -16,6 +16,7 @@
 // ADDITIONAL_COMPILE_FLAGS(cl-style-warnings): /wd4245 /wd4305 /wd4310 /wd4389 /wd4805
 // ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=20000000
 // ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-ops-limit): -fconstexpr-ops-limit=80000000
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
 
 // <algorithm>
 
@@ -31,6 +32,7 @@
 #include <vector>
 #include <type_traits>
 
+#include "sized_allocator.h"
 #include "test_macros.h"
 #include "test_iterators.h"
 #include "type_algorithms.h"
@@ -209,6 +211,33 @@ struct TestIntegerPromotions {
   }
 };
 
+TEST_CONSTEXPR_CXX20 void test_bititer_with_custom_sized_types() {
+  {
+    using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
+    std::vector<bool, Alloc> in(100, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::find(in.begin(), in.end(), true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::find(in.begin(), in.end(), true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint32_t, std::int32_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::find(in.begin(), in.end(), true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::find(in.begin(), in.end(), true) == in.end() - 2);
+  }
+}
+
 TEST_CONSTEXPR_CXX20 bool test() {
   types::for_each(types::integer_types(), TestTypes<char>());
   types::for_each(types::integer_types(), TestTypes<int>());
@@ -227,6 +256,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 #endif
 
   types::for_each(types::integral_types(), TestIntegerPromotions());
+  test_bititer_with_custom_sized_types();
 
   { // Test vector<bool>::iterator optimization
     std::vector<bool> vec(256 + 8);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
@@ -211,7 +211,7 @@ struct TestIntegerPromotions {
   }
 };
 
-TEST_CONSTEXPR_CXX20 void test_bititer_with_custom_sized_types() {
+TEST_CONSTEXPR_CXX20 void test_bit_iterator_with_custom_sized_types() {
   {
     using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
     std::vector<bool, Alloc> in(100, false, Alloc(1));
@@ -220,7 +220,7 @@ TEST_CONSTEXPR_CXX20 void test_bititer_with_custom_sized_types() {
   }
   {
     using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
-    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    std::vector<bool, Alloc> in(199, false, Alloc(1));
     in[in.size() - 2] = true;
     assert(std::find(in.begin(), in.end(), true) == in.end() - 2);
   }
@@ -232,7 +232,7 @@ TEST_CONSTEXPR_CXX20 void test_bititer_with_custom_sized_types() {
   }
   {
     using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
-    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    std::vector<bool, Alloc> in(257, false, Alloc(1));
     in[in.size() - 2] = true;
     assert(std::find(in.begin(), in.end(), true) == in.end() - 2);
   }
@@ -256,7 +256,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 #endif
 
   types::for_each(types::integral_types(), TestIntegerPromotions());
-  test_bititer_with_custom_sized_types();
+  test_bit_iterator_with_custom_sized_types();
 
   { // Test vector<bool>::iterator optimization
     std::vector<bool> vec(256 + 8);

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -124,33 +124,6 @@ public:
   bool operator==(const TriviallyComparable&) const = default;
 };
 
-constexpr void test_bit_iterator_with_custom_sized_types() {
-  {
-    using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
-    std::vector<bool, Alloc> in(100, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-  {
-    using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
-    std::vector<bool, Alloc> in(199, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-  {
-    using Alloc = sized_allocator<bool, std::uint32_t, std::int32_t>;
-    std::vector<bool, Alloc> in(200, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-  {
-    using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
-    std::vector<bool, Alloc> in(257, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-}
-
 constexpr bool test() {
   types::for_each(types::type_list<char, wchar_t, int, long, TriviallyComparable<char>, TriviallyComparable<wchar_t>>{},
                   []<class T> {
@@ -245,7 +218,32 @@ constexpr bool test() {
     }
   }
 
-  test_bititer_with_custom_sized_types();
+  // Verify that the std::vector<bool>::iterator optimization works properly for allocators with custom size types
+  // See https://github.com/llvm/llvm-project/issues/122528
+  {
+    using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
+    std::vector<bool, Alloc> in(100, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
+    std::vector<bool, Alloc> in(199, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint32_t, std::int32_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
+    std::vector<bool, Alloc> in(257, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
 
   return true;
 }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -203,7 +203,8 @@ constexpr bool test() {
     }
   }
 
-  { // Test vector<bool>::iterator optimization
+  {
+    // Test vector<bool>::iterator optimization
     std::vector<bool> vec(256 + 8);
     for (ptrdiff_t i = 8; i <= 256; i *= 2) {
       for (size_t offset = 0; offset < 8; offset += 2) {
@@ -216,33 +217,39 @@ constexpr bool test() {
                std::ranges::begin(vec) + offset + i);
       }
     }
-  }
 
-  // Verify that the std::vector<bool>::iterator optimization works properly for allocators with custom size types
-  // See https://github.com/llvm/llvm-project/issues/122528
-  {
-    using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
-    std::vector<bool, Alloc> in(100, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-  {
-    using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
-    std::vector<bool, Alloc> in(199, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-  {
-    using Alloc = sized_allocator<bool, std::uint32_t, std::int32_t>;
-    std::vector<bool, Alloc> in(200, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
-  }
-  {
-    using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
-    std::vector<bool, Alloc> in(257, false, Alloc(1));
-    in[in.size() - 2] = true;
-    assert(std::ranges::find(in, true) == in.end() - 2);
+    // Verify that the std::vector<bool>::iterator optimization works properly for allocators with custom size types
+    // See https://github.com/llvm/llvm-project/issues/122528
+    {
+      using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
+      std::vector<bool, Alloc> in(100, false, Alloc(1));
+      in[in.size() - 2] = true;
+      assert(std::ranges::find(in, true) == in.end() - 2);
+    }
+    {
+      using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
+      std::vector<bool, Alloc> in(199, false, Alloc(1));
+      in[in.size() - 2] = true;
+      assert(std::ranges::find(in, true) == in.end() - 2);
+    }
+    {
+      using Alloc = sized_allocator<bool, unsigned short, short>;
+      std::vector<bool, Alloc> in(200, false, Alloc(1));
+      in[in.size() - 2] = true;
+      assert(std::ranges::find(in, true) == in.end() - 2);
+    }
+    {
+      using Alloc = sized_allocator<bool, std::uint32_t, std::int32_t>;
+      std::vector<bool, Alloc> in(205, false, Alloc(1));
+      in[in.size() - 2] = true;
+      assert(std::ranges::find(in, true) == in.end() - 2);
+    }
+    {
+      using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
+      std::vector<bool, Alloc> in(257, false, Alloc(1));
+      in[in.size() - 2] = true;
+      assert(std::ranges::find(in, true) == in.end() - 2);
+    }
   }
 
   return true;

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -124,7 +124,7 @@ public:
   bool operator==(const TriviallyComparable&) const = default;
 };
 
-constexpr void test_bititer_with_custom_sized_types() {
+constexpr void test_bit_iterator_with_custom_sized_types() {
   {
     using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
     std::vector<bool, Alloc> in(100, false, Alloc(1));
@@ -133,7 +133,7 @@ constexpr void test_bititer_with_custom_sized_types() {
   }
   {
     using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
-    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    std::vector<bool, Alloc> in(199, false, Alloc(1));
     in[in.size() - 2] = true;
     assert(std::ranges::find(in, true) == in.end() - 2);
   }
@@ -145,7 +145,7 @@ constexpr void test_bititer_with_custom_sized_types() {
   }
   {
     using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
-    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    std::vector<bool, Alloc> in(257, false, Alloc(1));
     in[in.size() - 2] = true;
     assert(std::ranges::find(in, true) == in.end() - 2);
   }

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "almost_satisfies_types.h"
+#include "sized_allocator.h"
 #include "test_iterators.h"
 
 struct NotEqualityComparable {};
@@ -122,6 +123,33 @@ public:
   TEST_CONSTEXPR TriviallyComparable(ElementT el) : el_(el) {}
   bool operator==(const TriviallyComparable&) const = default;
 };
+
+constexpr void test_bititer_with_custom_sized_types() {
+  {
+    using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
+    std::vector<bool, Alloc> in(100, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint16_t, std::int16_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint32_t, std::int32_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+  {
+    using Alloc = sized_allocator<bool, std::uint64_t, std::int64_t>;
+    std::vector<bool, Alloc> in(200, false, Alloc(1));
+    in[in.size() - 2] = true;
+    assert(std::ranges::find(in, true) == in.end() - 2);
+  }
+}
 
 constexpr bool test() {
   types::for_each(types::type_list<char, wchar_t, int, long, TriviallyComparable<char>, TriviallyComparable<wchar_t>>{},
@@ -216,6 +244,8 @@ constexpr bool test() {
       }
     }
   }
+
+  test_bititer_with_custom_sized_types();
 
   return true;
 }

--- a/libcxx/test/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
+++ b/libcxx/test/std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// ADDITIONAL_COMPILE_FLAGS(has-fconstexpr-steps): -fconstexpr-steps=15000000
+
 // bitset<N>& operator<<=(size_t pos); // constexpr since C++23
 
 #include <bitset>
@@ -18,20 +20,20 @@
 
 template <std::size_t N>
 TEST_CONSTEXPR_CXX23 bool test_left_shift() {
-    std::vector<std::bitset<N> > const cases = get_test_cases<N>();
-    for (std::size_t c = 0; c != cases.size(); ++c) {
-        for (std::size_t s = 0; s <= N+1; ++s) {
-            std::bitset<N> v1 = cases[c];
-            std::bitset<N> v2 = v1;
-            v1 <<= s;
-            for (std::size_t i = 0; i < v1.size(); ++i)
-                if (i < s)
-                    assert(v1[i] == 0);
-                else
-                    assert(v1[i] == v2[i-s]);
-        }
+  std::vector<std::bitset<N> > const cases = get_test_cases<N>();
+  for (std::size_t c = 0; c != cases.size(); ++c) {
+    for (std::size_t s = 0; s <= N + 1; ++s) {
+      std::bitset<N> v1 = cases[c];
+      std::bitset<N> v2 = v1;
+      v1 <<= s;
+      for (std::size_t i = 0; i < v1.size(); ++i)
+        if (i < s)
+          assert(v1[i] == 0);
+        else
+          assert(v1[i] == v2[i - s]);
     }
-    return true;
+  }
+  return true;
 }
 
 int main(int, char**) {


### PR DESCRIPTION
This PR fixes an ambiguous call encountered when using the `std::ranges::find` or `std::find` algorithms with `vector<bool>` with small `allocator_traits::size_type`s, an issue reported in #122528. The ambiguity arises from integral promotions during the internal bitwise arithmetic of the `find` algorithms when applied to `vector<bool>` with small integral `size_type`s. This leads to multiple viable candidates for small integral types: __libcpp_ctz(unsigned), __libcpp_ctz(unsigned long), and __libcpp_ctz(unsigned long long), none of which represent a single best viable match, resulting in an  ambiguous call error.

To resolve this, we propose invoking an internal function `__countr_zero` as a dispatcher that directs the call to the appropriate overload of `__libcpp_ctz`. Necessary amendments have also been made to `__countr_zero`.
