### PR TITLE
[builtins] Support building the 128-bit float functions on i386

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -356,6 +356,7 @@ if (NOT MSVC)
   set(i386_SOURCES
     ${GENERIC_SOURCES}
     ${x86_ARCH_SOURCES}
+    ${GENERIC_TF_SOURCES}
     i386/ashldi3.S
     i386/ashrdi3.S
     i386/divdi3.S
@@ -906,7 +907,7 @@ else ()
 
       # For RISCV32, we must force enable int128 for compiling long
       # double routines.
-      if(COMPILER_RT_ENABLE_SOFTWARE_INT128 OR "${arch}" STREQUAL "riscv32")
+      if(COMPILER_RT_ENABLE_SOFTWARE_INT128 OR "${arch}" STREQUAL "riscv32" OR "${arch}" STREQUAL "i386")
         list(APPEND BUILTIN_CFLAGS_${arch} -fforce-enable-int128)
       endif()
 

--- a/compiler-rt/lib/builtins/extendxftf2.c
+++ b/compiler-rt/lib/builtins/extendxftf2.c
@@ -12,7 +12,8 @@
 #define QUAD_PRECISION
 #include "fp_lib.h"
 
-#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 && defined(__x86_64__)
+#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 &&                     \
+    (defined(__x86_64__) || defined(__i386__))
 #define SRC_80
 #define DST_QUAD
 #include "fp_extend_impl.inc"

--- a/compiler-rt/lib/builtins/trunctfxf2.c
+++ b/compiler-rt/lib/builtins/trunctfxf2.c
@@ -12,7 +12,8 @@
 #define QUAD_PRECISION
 #include "fp_lib.h"
 
-#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 && defined(__x86_64__)
+#if defined(CRT_HAS_TF_MODE) && __LDBL_MANT_DIG__ == 64 &&                     \
+    (defined(__x86_64__) || defined(__i386__))
 
 #define SRC_QUAD
 #define DST_80

--- a/compiler-rt/test/builtins/Unit/extendxftf2_test.c
+++ b/compiler-rt/test/builtins/Unit/extendxftf2_test.c
@@ -1,10 +1,10 @@
-// RUN: %clang_builtins %s %librt -o %t && %run %t
+// RUN: %clang_builtins %s %librt -fforce-enable-int128 -o %t && %run %t
 // REQUIRES: librt_has_extendxftf2
 
 #include "int_lib.h"
 #include <stdio.h>
 
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
+#if __LDBL_MANT_DIG__ == 64 && (defined(__x86_64__) || defined(__i386__)) &&   \
     (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
 
 #include "fp_test.h"
@@ -28,7 +28,7 @@ char assumption_1[sizeof(long double) * CHAR_BIT == 128] = {0};
 #endif
 
 int main() {
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
+#if __LDBL_MANT_DIG__ == 64 && (defined(__x86_64__) || defined(__i386__)) &&   \
     (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
   // qNaN
   if (test__extendxftf2(makeQNaN80(), UINT64_C(0x7fff800000000000),

--- a/compiler-rt/test/builtins/Unit/trunctfxf2_test.c
+++ b/compiler-rt/test/builtins/Unit/trunctfxf2_test.c
@@ -1,10 +1,10 @@
-// RUN: %clang_builtins %s %librt -o %t && %run %t
+// RUN: %clang_builtins %s %librt -fforce-enable-int128 -o %t && %run %t
 // REQUIRES: librt_has_trunctfxf2
 
 #include "int_lib.h"
 #include <stdio.h>
 
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
+#if __LDBL_MANT_DIG__ == 64 && (defined(__x86_64__) || defined(__i386__)) &&   \
     (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
 
 #include "fp_test.h"
@@ -28,7 +28,7 @@ char assumption_1[sizeof(long double) * CHAR_BIT == 128] = {0};
 #endif
 
 int main() {
-#if __LDBL_MANT_DIG__ == 64 && defined(__x86_64__) &&                          \
+#if __LDBL_MANT_DIG__ == 64 && (defined(__x86_64__) || defined(__i386__)) &&   \
     (defined(__FLOAT128__) || defined(__SIZEOF_FLOAT128__))
   // qNaN
   if (test__trunctfxf2(makeQNaN128(), UINT64_C(0x7FFF),


### PR DESCRIPTION
GCC provides these functions (e.g.__subtf3) in libgcc on i386.
 Since Clang supports float128, we can also enable the existing code in i386 for ABI compatible.

https://github.com/llvm/llvm-project/issues/121757