### PR TITLE
[DirectX] Set the EnableRawAndStructuredBuffers shader flag

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainerConstants.def
+++ b/llvm/include/llvm/BinaryFormat/DXContainerConstants.def
@@ -58,7 +58,7 @@ SHADER_FEATURE_FLAG(31, 36, NextUnusedBit, "Next reserved shader flag bit (not a
 DXIL_MODULE_FLAG( 0,  DisableOptimizations,   "D3D11_1_SB_GLOBAL_FLAG_SKIP_OPTIMIZATION")
 DXIL_MODULE_FLAG( 1,  DisableMathRefactoring, "D3D10_SB_GLOBAL_FLAG_REFACTORING_ALLOWED")
 DXIL_MODULE_FLAG( 3,  ForceEarlyDepthStencil, "D3D11_SB_GLOBAL_FLAG_FORCE_EARLY_DEPTH_STENCIL")
-DXIL_MODULE_FLAG( 4,  EnableRawAndStructuredBuffers, "D3D11_SB_GLOBAL_FLAG_ENABLE_RAW_AND_STRUCTURED_BUFFERS")
+DXIL_MODULE_FLAG( 4,  EnableRawAndStructuredBuffers, "Raw and Structured buffers")
 DXIL_MODULE_FLAG( 5,  LowPrecisionPresent, "D3D11_1_SB_GLOBAL_FLAG_ENABLE_MINIMUM_PRECISION")
 DXIL_MODULE_FLAG( 8,  AllResourcesBound, "D3D12_SB_GLOBAL_FLAG_ALL_RESOURCES_BOUND")
 DXIL_MODULE_FLAG(23,  UseNativeLowPrecision, "Native 16bit types enabled")

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -54,11 +54,22 @@ static void updateFunctionFlags(ComputedShaderFlags &CSF, const Instruction &I,
     switch (II->getIntrinsicID()) {
     default:
       break;
+    case Intrinsic::dx_resource_handlefrombinding:
+      switch (DRTM[cast<TargetExtType>(II->getType())].getResourceKind()) {
+      case dxil::ResourceKind::StructuredBuffer:
+      case dxil::ResourceKind::RawBuffer:
+        CSF.EnableRawAndStructuredBuffers = true;
+        break;
+      default:
+        break;
+      }
+      break;
     case Intrinsic::dx_resource_load_typedbuffer: {
       dxil::ResourceTypeInfo &RTI =
           DRTM[cast<TargetExtType>(II->getArgOperand(0)->getType())];
       if (RTI.isTyped())
         CSF.TypedUAVLoadAdditionalFormats |= RTI.getTyped().ElementCount > 1;
+      break;
     }
     }
   }

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/raw-and-structured-buffers.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/raw-and-structured-buffers.ll
@@ -1,0 +1,42 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+
+; Note: there is no feature flag here (only a module flag), so we don't have an
+; object test.
+
+target triple = "dxil-pc-shadermodel6.7-library"
+
+; CHECK:      Combined Shader Flags for Module
+; CHECK-NEXT: Shader Flags Value: 0x00000010
+
+; CHECK: Note: shader requires additional functionality:
+; CHECK:       Raw and Structured buffers
+
+; CHECK: Function rawbuf : 0x00000010
+define float @rawbuf() "hlsl.export" {
+  %buffer = call target("dx.RawBuffer", i8, 0, 0, 0)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, i1 false)
+  %load = call {float, i1} @llvm.dx.resource.load.rawbuffer.f32(
+      target("dx.RawBuffer", i8, 0, 0, 0) %buffer, i32 0, i32 0)
+  %data = extractvalue {float, i1} %load, 0
+  ret float %data
+}
+
+; CHECK: Function structbuf : 0x00000010
+define float @structbuf() "hlsl.export" {
+  %buffer = call target("dx.RawBuffer", float, 0, 0, 0)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, i1 false)
+  %load = call {float, i1} @llvm.dx.resource.load.rawbuffer.f32(
+      target("dx.RawBuffer", float, 0, 0, 0) %buffer, i32 0, i32 0)
+  %data = extractvalue {float, i1} %load, 0
+  ret float %data
+}
+
+; CHECK: Function typedbuf : 0x00000000
+define float @typedbuf(<4 x float> %val) "hlsl.export" {
+  %buffer = call target("dx.TypedBuffer", float, 0, 0, 0)
+      @llvm.dx.resource.handlefrombinding(i32 0, i32 0, i32 1, i32 0, i1 false)
+  %load = call {float, i1} @llvm.dx.resource.load.typedbuffer(
+      target("dx.TypedBuffer", float, 0, 0, 0) %buffer, i32 0)
+  %data = extractvalue {float, i1} %load, 0
+  ret float %data
+}


### PR DESCRIPTION
When raw or structured buffers are used, we need to set the DXIL flag saying so.

Fixes #122663.