### PR TITLE
[flang][OpenMP] Fix `omp-declarative-allocate-align.f90` expectations

### DIFF
--- a/flang/test/Lower/OpenMP/Todo/omp-declarative-allocate-align.f90
+++ b/flang/test/Lower/OpenMP/Todo/omp-declarative-allocate-align.f90
@@ -1,10 +1,10 @@
 ! This test checks lowering of OpenMP allocate Directive with align clause.
 
-// RUN: not flang -fc1 -emit-fir -fopenmp %s 2>&1 | FileCheck %s
+! RUN: not %flang_fc1 -emit-fir -fopenmp -fopenmp-version=51 %s 2>&1 | FileCheck %s
 
 program main
   integer :: x
 
-  // CHECK: not yet implemented: OpenMPDeclarativeAllocate
+  ! CHECK: not yet implemented: OpenMPDeclarativeAllocate
   !$omp allocate(x) align(32)
 end


### PR DESCRIPTION
The test was effectively a no-op since we used `//` instead of `!` for `RUN` and `CHECK` lines. Also, we have to specify the proper OpenMP version.