### PR TITLE
Remove StandaloneExtensionPybind11.cpp FT update as does not work with python 3.8 and old pybind11

### DIFF
--- a/mlir/examples/standalone/python/StandaloneExtensionPybind11.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionPybind11.cpp
@@ -12,11 +12,9 @@
 #include "Standalone-c/Dialects.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
-namespace py = pybind11;
-
 using namespace mlir::python::adaptors;
 
-PYBIND11_MODULE(_standaloneDialectsPybind11, m, py::mod_gil_not_used()) {
+PYBIND11_MODULE(_standaloneDialectsPybind11, m) {
   //===--------------------------------------------------------------------===//
   // standalone dialect
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Description:
- Remove StandaloneExtensionPybind11.cpp FT update as does not work with python 3.8 and old pybind11

This should also fix the failing toy.test: https://github.com/llvm/llvm-project/pull/122684#issuecomment-2586802692

cc @jpienaar 