### PR TITLE
[RISCV] Enable Zbb ANDN/ORN/XNOR for more 64-bit constants

### DIFF
--- a/llvm/test/CodeGen/RISCV/zbb-logic-neg-imm.ll
+++ b/llvm/test/CodeGen/RISCV/zbb-logic-neg-imm.ll
@@ -330,10 +330,9 @@ define i64 @andnofff(i64 %x) {
 ;
 ; RV64-LABEL: andnofff:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    li a1, -1
-; RV64-NEXT:    slli a1, a1, 56
-; RV64-NEXT:    addi a1, a1, 255
-; RV64-NEXT:    and a0, a0, a1
+; RV64-NEXT:    lui a1, 1048560
+; RV64-NEXT:    srli a1, a1, 8
+; RV64-NEXT:    andn a0, a0, a1
 ; RV64-NEXT:    ret
   %and = and i64 %x, -72057594037927681
   ret i64 %and
@@ -349,10 +348,9 @@ define i64 @ornofff(i64 %x) {
 ;
 ; NOZBS64-LABEL: ornofff:
 ; NOZBS64:       # %bb.0:
-; NOZBS64-NEXT:    li a1, -1
-; NOZBS64-NEXT:    slli a1, a1, 63
-; NOZBS64-NEXT:    addi a1, a1, 2047
-; NOZBS64-NEXT:    or a0, a0, a1
+; NOZBS64-NEXT:    lui a1, 1048575
+; NOZBS64-NEXT:    srli a1, a1, 1
+; NOZBS64-NEXT:    orn a0, a0, a1
 ; NOZBS64-NEXT:    ret
 ;
 ; ZBS32-LABEL: ornofff:
@@ -380,10 +378,9 @@ define i64 @xornofff(i64 %x) {
 ;
 ; RV64-LABEL: xornofff:
 ; RV64:       # %bb.0:
-; RV64-NEXT:    li a1, -1
-; RV64-NEXT:    slli a1, a1, 60
-; RV64-NEXT:    addi a1, a1, 255
-; RV64-NEXT:    xor a0, a0, a1
+; RV64-NEXT:    lui a1, 1048575
+; RV64-NEXT:    srli a1, a1, 4
+; RV64-NEXT:    xnor a0, a0, a1
 ; RV64-NEXT:    ret
   %xor = xor i64 %x, -1152921504606846721
   ret i64 %xor


### PR DESCRIPTION
This extends PR #120221 to 64-bit constants that don't match the 12-low-bits-set pattern.