### PR TITLE
[ValueTracking] Squash compile-time regression from 66badf2

### DIFF
--- a/llvm/include/llvm/IR/CmpPredicate.h
+++ b/llvm/include/llvm/IR/CmpPredicate.h
@@ -54,9 +54,9 @@ public:
                                                  CmpPredicate B);
 
   /// Attempts to return a signed CmpInst::Predicate from the CmpPredicate. If
-  /// the CmpPredicate has samesign, return the signedness-flipped predicate
-  /// (which would be signed), dropping samesign information. Otherwise, return
-  /// the predicate, dropping samesign information.
+  /// the CmpPredicate has samesign, return ICmpInst::getSignedPredicate,
+  /// dropping samesign information. Otherwise, return the predicate, dropping
+  /// samesign information.
   CmpInst::Predicate getSignedPredicate() const;
 
   /// An operator== on the underlying Predicate.

--- a/llvm/include/llvm/IR/CmpPredicate.h
+++ b/llvm/include/llvm/IR/CmpPredicate.h
@@ -53,6 +53,12 @@ public:
   static std::optional<CmpPredicate> getMatching(CmpPredicate A,
                                                  CmpPredicate B);
 
+  /// Attempts to return a signed CmpInst::Predicate from the CmpPredicate. If
+  /// the CmpPredicate has samesign, return the signedness-flipped predicate
+  /// (which would be signed), dropping samesign information. Otherwise, return
+  /// the predicate, dropping samesign information.
+  CmpInst::Predicate getSignedPredicate() const;
+
   /// An operator== on the underlying Predicate.
   bool operator==(CmpInst::Predicate P) const { return Pred == P; }
   bool operator!=(CmpInst::Predicate P) const { return Pred != P; }

--- a/llvm/include/llvm/IR/CmpPredicate.h
+++ b/llvm/include/llvm/IR/CmpPredicate.h
@@ -57,7 +57,7 @@ public:
   /// the CmpPredicate has samesign, return ICmpInst::getSignedPredicate,
   /// dropping samesign information. Otherwise, return the predicate, dropping
   /// samesign information.
-  CmpInst::Predicate getSignedPredicate() const;
+  CmpInst::Predicate getPreferredSignedPredicate() const;
 
   /// An operator== on the underlying Predicate.
   bool operator==(CmpInst::Predicate P) const { return Pred == P; }

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9495,8 +9495,9 @@ isImpliedCondICmps(const ICmpInst *LHS, CmpPredicate RPred, const Value *R0,
   // must be positive if X >= Y and no overflow".
   // Take SGT as an example:  L0:x > L1:y and C >= 0
   //                      ==> R0:(x -nsw y) < R1:(-C) is false
-  if ((CmpPredicate::getMatching(LPred, ICmpInst::ICMP_SGT) ||
-       CmpPredicate::getMatching(LPred, ICmpInst::ICMP_SGE)) &&
+  CmpInst::Predicate SignedLPred = LPred.getSignedPredicate();
+  if ((SignedLPred == ICmpInst::ICMP_SGT ||
+       SignedLPred == ICmpInst::ICMP_SGE) &&
       match(R0, m_NSWSub(m_Specific(L0), m_Specific(L1)))) {
     if (match(R1, m_NonPositive()) &&
         isImpliedCondMatchingOperands(LPred, RPred) == false)
@@ -9505,8 +9506,8 @@ isImpliedCondICmps(const ICmpInst *LHS, CmpPredicate RPred, const Value *R0,
 
   // Take SLT as an example:  L0:x < L1:y and C <= 0
   //                      ==> R0:(x -nsw y) < R1:(-C) is true
-  if ((CmpPredicate::getMatching(LPred, ICmpInst::ICMP_SLT) ||
-       CmpPredicate::getMatching(LPred, ICmpInst::ICMP_SLE)) &&
+  if ((SignedLPred == ICmpInst::ICMP_SLT ||
+       SignedLPred == ICmpInst::ICMP_SLE) &&
       match(R0, m_NSWSub(m_Specific(L0), m_Specific(L1)))) {
     if (match(R1, m_NonNegative()) &&
         isImpliedCondMatchingOperands(LPred, RPred) == true)

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9495,7 +9495,7 @@ isImpliedCondICmps(const ICmpInst *LHS, CmpPredicate RPred, const Value *R0,
   // must be positive if X >= Y and no overflow".
   // Take SGT as an example:  L0:x > L1:y and C >= 0
   //                      ==> R0:(x -nsw y) < R1:(-C) is false
-  CmpInst::Predicate SignedLPred = LPred.getSignedPredicate();
+  CmpInst::Predicate SignedLPred = LPred.getPreferredSignedPredicate();
   if ((SignedLPred == ICmpInst::ICMP_SGT ||
        SignedLPred == ICmpInst::ICMP_SGE) &&
       match(R0, m_NSWSub(m_Specific(L0), m_Specific(L1)))) {

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -3939,7 +3939,7 @@ std::optional<CmpPredicate> CmpPredicate::getMatching(CmpPredicate A,
   return {};
 }
 
-CmpInst::Predicate CmpPredicate::getSignedPredicate() const {
+CmpInst::Predicate CmpPredicate::getPreferredSignedPredicate() const {
   return HasSameSign ? ICmpInst::getSignedPredicate(Pred) : Pred;
 }
 

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -3939,6 +3939,10 @@ std::optional<CmpPredicate> CmpPredicate::getMatching(CmpPredicate A,
   return {};
 }
 
+CmpInst::Predicate CmpPredicate::getSignedPredicate() const {
+  return HasSameSign ? ICmpInst::getFlippedSignednessPredicate(Pred) : Pred;
+}
+
 CmpPredicate CmpPredicate::get(const CmpInst *Cmp) {
   if (auto *ICI = dyn_cast<ICmpInst>(Cmp))
     return ICI->getCmpPredicate();

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -3940,7 +3940,7 @@ std::optional<CmpPredicate> CmpPredicate::getMatching(CmpPredicate A,
 }
 
 CmpInst::Predicate CmpPredicate::getSignedPredicate() const {
-  return HasSameSign ? ICmpInst::getFlippedSignednessPredicate(Pred) : Pred;
+  return HasSameSign ? ICmpInst::getSignedPredicate(Pred) : Pred;
 }
 
 CmpPredicate CmpPredicate::get(const CmpInst *Cmp) {


### PR DESCRIPTION
66badf2 (VT: teach a special-case optz about samesign) introduced a compile-time regression due to the use of CmpPredicate::getMatching, which is unnecessarily inefficient. Introduce CmpPredicate::getPreferredSignedPredicate, which alleviates the inefficiency problem and squashes the compile-time regression.