### PR TITLE
[CI] Always send a heartbeat metric

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -151,11 +151,11 @@ def upload_metrics(workflow_metrics, metrics_userid, api_key):
 def make_heartbeat_metric():
     return JobMetrics(
         "metrics_container_heartbeat",
-        1, # queue time seconds
-        2, # run time seconds
-        3, # job result
-        time.time_ns(), # created at ns
-        0, # workflow run ID
+        1,  # queue time seconds
+        2,  # run time seconds
+        3,  # job result
+        time.time_ns(),  # created at ns
+        0,  # workflow run ID
     )
 
 

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -147,15 +147,17 @@ def upload_metrics(workflow_metrics, metrics_userid, api_key):
             f"Failed to submit data to Grafana: {response.status_code}", file=sys.stderr
         )
 
+
 def make_heartbeat_metric():
-  return JobMetrics(
-      "metrics_container_heartbeat",
-      1, # queue time seconds
-      2, # run time seconds
-      3, # job result
-      time.time_ns(), # created at ns
-      0, # workflow run ID
-  )
+    return JobMetrics(
+        "metrics_container_heartbeat",
+        1, # queue time seconds
+        2, # run time seconds
+        3, # job result
+        time.time_ns(), # created at ns
+        0, # workflow run ID
+    )
+
 
 def main():
     # Authenticate with Github


### PR DESCRIPTION
This script was setup to only upload metrics to Grafana when a new workflow was available.
If either the Grafana or github token becomes stale, no metrics would get recorded either.

We have alerting in place to detect a lack of update, but because we only uploaded metrics on new workflows, we could have normal cases were no data would get uploaded for a few hours (example, late night weekend).
For those reasons, the delay before alerting for no-data had to be set quite high.

By adding a fixed heartbeat in the uploaded metrics, we know we MUST receive at least 1 metric every 5 minutes, and can have a more reactive monitoring.