### PR TITLE
[flang][OMP] change malloc.h to stdlib.h in collapse_test.inc (NFC)

### DIFF
--- a/openmp/runtime/test/worksharing/for/collapse_test.inc
+++ b/openmp/runtime/test/worksharing/for/collapse_test.inc
@@ -1,5 +1,5 @@
 #include <omp.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <memory.h>
 


### PR DESCRIPTION
`malloc.h` is in `.../usr/include/malloc/malloc.h` on MacOS. Using `stdlib.h` works for Mac and other platforms.