### PR TITLE
[AArch64] Add DC CIGDPAPA and DC CIPAPA instructions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -246,6 +246,11 @@ def : DC<"CIPAE",   0b100, 0b0111, 0b1110, 0b000>;
 def : DC<"CIGDPAE", 0b100, 0b0111, 0b1110, 0b111>;
 }
 
+let Requires = [{ {AArch64::FeatureRME} }] in {
+def : DC<"CIGDPAPA", 0b110, 0b0111, 0b1110, 0b101>;
+def : DC<"CIPAPA",   0b110, 0b0111, 0b1110, 0b001>;
+}
+
 let Requires = [{ {AArch64::FeatureOCCMO} }] in {
 // Outer cacheable CMO (FEAT_OCCMO)
 def : DC<"CIVAOC", 0b011, 0b0111, 0b1111, 0b000>;

--- a/llvm/test/MC/AArch64/armv9.1a-rme.s
+++ b/llvm/test/MC/AArch64/armv9.1a-rme.s
@@ -68,3 +68,8 @@ sys #6, c8, c7, #4
 // CHECK-NO-RME: sys #6, c8, c4, #7
 // CHECK-NO-RME: sys #6, c8, c1, #4
 // CHECK-NO-RME: sys #6, c8, c7, #4
+
+dc cigdpapa, x0
+dc cipapa, x0
+// CHECK: dc cigdpapa, x0                    // encoding: [0xa0,0x7e,0x0e,0xd5]
+// CHECK: dc cipapa, x0                      // encoding: [0x20,0x7e,0x0e,0xd5]

--- a/llvm/test/MC/Disassembler/AArch64/armv9a-rme.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9a-rme.txt
@@ -23,3 +23,10 @@
 # CHECK-NO-RME: sys #6, c8, c4, #7
 # CHECK-NO-RME: sys #6, c8, c1, #4
 # CHECK-NO-RME: sys #6, c8, c7, #4
+
+[0xa0,0x7e,0x0e,0xd5]
+[0x20,0x7e,0x0e,0xd5]
+# CHECK: dc cigdpapa, x0
+# CHECK: dc cipapa, x0
+# CHECK-NO-RME: sys #6, c7, c14, #5, x0
+# CHECK-NO-RME: sys #6, c7, c14, #1, x0


### PR DESCRIPTION
Add `DC CIGDPAPA` and `DC CIPAPA` instructions, for the RME extension, which was added as part of Armv9.1-A, but these instructions were missed.