### PR TITLE
[Modules] Delay deserialization of preferred_name attribute at r…

### DIFF
--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -60,6 +60,8 @@ protected:
   unsigned IsLateParsed : 1;
   LLVM_PREFERRED_TYPE(bool)
   unsigned InheritEvenIfAlreadyPresent : 1;
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned DeferDeserialization : 1;
 
   void *operator new(size_t bytes) noexcept {
     llvm_unreachable("Attrs cannot be allocated with regular 'new'.");
@@ -80,10 +82,11 @@ public:
 
 protected:
   Attr(ASTContext &Context, const AttributeCommonInfo &CommonInfo,
-       attr::Kind AK, bool IsLateParsed)
+       attr::Kind AK, bool IsLateParsed, bool DeferDeserialization = false)
       : AttributeCommonInfo(CommonInfo), AttrKind(AK), Inherited(false),
         IsPackExpansion(false), Implicit(false), IsLateParsed(IsLateParsed),
-        InheritEvenIfAlreadyPresent(false) {}
+        InheritEvenIfAlreadyPresent(false),
+        DeferDeserialization(DeferDeserialization) {}
 
 public:
   attr::Kind getKind() const { return static_cast<attr::Kind>(AttrKind); }
@@ -104,6 +107,8 @@ public:
 
   void setPackExpansion(bool PE) { IsPackExpansion = PE; }
   bool isPackExpansion() const { return IsPackExpansion; }
+
+  bool shouldDeferDeserialization() const { return DeferDeserialization; }
 
   // Clone this attribute.
   Attr *clone(ASTContext &C) const;
@@ -146,8 +151,9 @@ class InheritableAttr : public Attr {
 protected:
   InheritableAttr(ASTContext &Context, const AttributeCommonInfo &CommonInfo,
                   attr::Kind AK, bool IsLateParsed,
-                  bool InheritEvenIfAlreadyPresent)
-      : Attr(Context, CommonInfo, AK, IsLateParsed) {
+                  bool InheritEvenIfAlreadyPresent,
+                  bool DeferDeserialization = false)
+      : Attr(Context, CommonInfo, AK, IsLateParsed, DeferDeserialization) {
     this->InheritEvenIfAlreadyPresent = InheritEvenIfAlreadyPresent;
   }
 

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -713,6 +713,10 @@ class Attr {
   // attribute may be documented under multiple categories, more than one
   // Documentation entry may be listed.
   list<Documentation> Documentation;
+  // Set to true if deserialization of this attribute must be deferred until 
+  // the parent Decl is fully deserialized (during header module file
+  // deserialization).
+  bit DeferDeserialization = 0;
 }
 
 /// Used to define a set of mutually exclusive attributes.
@@ -3240,6 +3244,7 @@ def PreferredName : InheritableAttr {
   let InheritEvenIfAlreadyPresent = 1;
   let MeaningfulToClassTemplateDefinition = 1;
   let TemplateDependent = 1;
+  let DeferDeserialization = 1;
 }
 
 def PreserveMost : DeclOrTypeAttr {

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -715,7 +715,9 @@ class Attr {
   list<Documentation> Documentation;
   // Set to true if deserialization of this attribute must be deferred until 
   // the parent Decl is fully deserialized (during header module file
-  // deserialization).
+  // deserialization). E.g., this is the case for the preferred_name attribute,
+  // since its type deserialization depends on its target Decl type.
+  // (See https://github.com/llvm/llvm-project/issues/56490 for details).
   bit DeferDeserialization = 0;
 }
 
@@ -3244,6 +3246,10 @@ def PreferredName : InheritableAttr {
   let InheritEvenIfAlreadyPresent = 1;
   let MeaningfulToClassTemplateDefinition = 1;
   let TemplateDependent = 1;
+  // Type of this attribute depends on the target Decl type.
+  // Therefore, its deserialization must be deferred until
+  // deserialization of the target Decl is complete
+  // (for header modules).
   let DeferDeserialization = 1;
 }
 

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1212,9 +1212,10 @@ private:
   /// More attributes that store TypeSourceInfo might be potentially affected,
   /// see https://github.com/llvm/llvm-project/issues/56490 for details.
   struct DeferredAttribute {
+    // Index of the deferred attribute in the Record of the TargetedDecl.
     uint64_t RecordIdx;
     // Decl to attach a deferred attribute to.
-    Decl *ParentDecl;
+    Decl *TargetedDecl;
   };
 
   /// The collection of Decls that have been loaded but some of their attributes

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -1205,6 +1205,23 @@ private:
   /// been completed.
   std::deque<PendingDeclContextInfo> PendingDeclContextInfos;
 
+  /// Deserialization of some attributes must be deferred since they refer
+  /// to themselves in their type (e.g., preferred_name attribute refers to the
+  /// typedef that refers back to the template specialization of the template
+  /// that the attribute is attached to).
+  /// More attributes that store TypeSourceInfo might be potentially affected,
+  /// see https://github.com/llvm/llvm-project/issues/56490 for details.
+  struct DeferredAttribute {
+    uint64_t RecordIdx;
+    // Decl to attach a deferred attribute to.
+    Decl *ParentDecl;
+  };
+
+  /// The collection of Decls that have been loaded but some of their attributes
+  /// have been deferred, paired with the index inside the record pointing
+  /// at the skipped attribute.
+  SmallVector<DeferredAttribute> PendingDeferredAttributes;
+
   template <typename DeclTy>
   using DuplicateObjCDecls = std::pair<DeclTy *, DeclTy *>;
 
@@ -1551,6 +1568,7 @@ private:
   void loadPendingDeclChain(Decl *D, uint64_t LocalOffset);
   void loadObjCCategories(GlobalDeclID ID, ObjCInterfaceDecl *D,
                           unsigned PreviousGeneration = 0);
+  void loadDeferredAttribute(const DeferredAttribute &DA);
 
   RecordLocation getLocalBitOffset(uint64_t GlobalOffset);
   uint64_t getGlobalBitOffset(ModuleFile &M, uint64_t LocalOffset);

--- a/clang/include/clang/Serialization/ASTRecordReader.h
+++ b/clang/include/clang/Serialization/ASTRecordReader.h
@@ -337,6 +337,12 @@ public:
   /// Reads attributes from the current stream position, advancing Idx.
   void readAttributes(AttrVec &Attrs);
 
+  /// Reads one attribute from the current stream position, advancing Idx.
+  Attr *readOrDeferAttr(Decl *D);
+
+  /// Reads attributes from the current stream position, advancing Idx.
+  void readOrDeferAttributes(AttrVec &Attrs, Decl *D);
+
   /// Read an BTFTypeTagAttr object.
   BTFTypeTagAttr *readBTFTypeTagAttr() {
     return cast<BTFTypeTagAttr>(readAttr());
@@ -355,6 +361,10 @@ public:
   SwitchCase *getSwitchCaseWithID(unsigned ID) {
     return Reader->getSwitchCaseWithID(ID);
   }
+
+private:
+  Attr *readOrDeferAttrImpl(Decl *D);
+  void readOrDeferAttributesImpl(AttrVec &Attrs, Decl *D);
 };
 
 /// Helper class that saves the current stream position and

--- a/clang/include/clang/Serialization/ASTRecordReader.h
+++ b/clang/include/clang/Serialization/ASTRecordReader.h
@@ -83,8 +83,11 @@ public:
   /// Returns the current value in this record, without advancing.
   uint64_t peekInt() { return Record[Idx]; }
 
-  /// Returns the next value in this record, without advancing.
-  uint64_t peekNextInt() { return Record[Idx + 1]; }
+  /// Returns the next N values in this record, without advancing.
+  uint64_t peekInts(unsigned N) { return Record[Idx + N]; }
+
+  /// Skips the current value.
+  void skipInt() { Idx += 1; }
 
   /// Skips the specified number of values.
   void skipInts(unsigned N) { Idx += N; }

--- a/clang/include/clang/Serialization/ASTRecordReader.h
+++ b/clang/include/clang/Serialization/ASTRecordReader.h
@@ -83,6 +83,9 @@ public:
   /// Returns the current value in this record, without advancing.
   uint64_t peekInt() { return Record[Idx]; }
 
+  /// Returns the next value in this record, without advancing.
+  uint64_t peekNextInt() { return Record[Idx + 1]; }
+
   /// Skips the specified number of values.
   void skipInts(unsigned N) { Idx += N; }
 
@@ -343,7 +346,9 @@ public:
   Attr *readOrDeferAttrFor(Decl *D);
 
   /// Read an BTFTypeTagAttr object.
-  BTFTypeTagAttr *readBTFTypeTagAttr();
+  BTFTypeTagAttr *readBTFTypeTagAttr() {
+    return cast<BTFTypeTagAttr>(readAttr());
+  }
 
   /// Reads a token out of a record, advancing Idx.
   Token readToken() {

--- a/clang/include/clang/Serialization/ASTRecordReader.h
+++ b/clang/include/clang/Serialization/ASTRecordReader.h
@@ -335,18 +335,15 @@ public:
   Attr *readAttr();
 
   /// Reads attributes from the current stream position, advancing Idx.
-  void readAttributes(AttrVec &Attrs);
+  /// For some attributes (where type depends on itself recursively), defer
+  /// reading the attribute until the type has been read.
+  void readAttributes(AttrVec &Attrs, Decl *D = nullptr);
 
   /// Reads one attribute from the current stream position, advancing Idx.
-  Attr *readOrDeferAttr(Decl *D);
-
-  /// Reads attributes from the current stream position, advancing Idx.
-  void readOrDeferAttributes(AttrVec &Attrs, Decl *D);
+  Attr *readOrDeferAttrFor(Decl *D);
 
   /// Read an BTFTypeTagAttr object.
-  BTFTypeTagAttr *readBTFTypeTagAttr() {
-    return cast<BTFTypeTagAttr>(readAttr());
-  }
+  BTFTypeTagAttr *readBTFTypeTagAttr();
 
   /// Reads a token out of a record, advancing Idx.
   Token readToken() {
@@ -361,10 +358,6 @@ public:
   SwitchCase *getSwitchCaseWithID(unsigned ID) {
     return Reader->getSwitchCaseWithID(ID);
   }
-
-private:
-  Attr *readOrDeferAttrImpl(Decl *D);
-  void readOrDeferAttributesImpl(AttrVec &Attrs, Decl *D);
 };
 
 /// Helper class that saves the current stream position and

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -10079,6 +10079,11 @@ void ASTReader::finishPendingActions() {
     }
     PendingDeducedVarTypes.clear();
 
+    // Load the delayed preferred name attributes.
+    for (unsigned I = 0; I != PendingDeferredAttributes.size(); ++I)
+      loadDeferredAttribute(PendingDeferredAttributes[I]);
+    PendingDeferredAttributes.clear();
+
     // For each decl chain that we wanted to complete while deserializing, mark
     // it as "still needs to be completed".
     for (unsigned I = 0; I != PendingIncompleteDeclChains.size(); ++I) {

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3173,7 +3173,6 @@ void ASTRecordReader::readAttributes(AttrVec &Attrs, Decl *D) {
       Attrs.push_back(A);
 }
 
-
 /// Reads one attribute from the current stream position, advancing Idx.
 /// For some attributes (where type depends on itself recursively), defer
 /// reading the attribute until the type has been read.

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3194,7 +3194,9 @@ void ASTRecordReader::readAttributes(AttrVec &Attrs) {
 /// Reads one attribute from the current stream position, advancing Idx.
 /// For some attributes (where type depends on itself recursively), defer
 /// reading the attribute until the type has been read.
-Attr *ASTRecordReader::readOrDeferAttr(Decl *D) { return readOrDeferAttrImpl(D); }
+Attr *ASTRecordReader::readOrDeferAttr(Decl *D) {
+  return readOrDeferAttrImpl(D);
+}
 
 /// Reads attributes from the current stream position, advancing Idx.
 /// For some attributes (where type depends on itself recursively), defer
@@ -4461,8 +4463,7 @@ void ASTReader::loadPendingDeclChain(Decl *FirstLocal, uint64_t LocalOffset) {
   ASTDeclReader::attachLatestDecl(CanonDecl, MostRecent);
 }
 
-void ASTReader::loadDeferredAttribute(
-    const DeferredAttribute &DA) {
+void ASTReader::loadDeferredAttribute(const DeferredAttribute &DA) {
   Decl *D = DA.ParentDecl;
   ModuleFile *M = getOwningModuleFile(D);
 

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3088,9 +3088,7 @@ public:
     return Reader.readInt();
   }
 
-  uint64_t peekNextInt() {
-    return Reader.peekNextInt();
-  }
+  uint64_t peekNextInt() { return Reader.peekNextInt(); }
 
   bool readBool() { return Reader.readBool(); }
 
@@ -3136,7 +3134,7 @@ public:
 Attr *ASTRecordReader::readAttr() {
   AttrReader Record(*this);
   auto V = Record.readInt();
-   if (!V)
+  if (!V)
     return nullptr;
 
   // Read and ignore the skip count, since attribute deserialization is not

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3088,7 +3088,7 @@ public:
     return Reader.readInt();
   }
 
-  uint64_t peekNextInt() { return Reader.peekNextInt(); }
+  uint64_t peekInts(unsigned N) { return Reader.peekInts(N); }
 
   bool readBool() { return Reader.readBool(); }
 
@@ -3120,6 +3120,8 @@ public:
     return Reader.readVersionTuple();
   }
 
+  void skipInt() { Reader.skipInts(1); }
+
   void skipInts(unsigned N) { Reader.skipInts(N); }
 
   unsigned getCurrentIdx() { return Reader.getIdx(); }
@@ -3139,7 +3141,7 @@ Attr *ASTRecordReader::readAttr() {
 
   // Read and ignore the skip count, since attribute deserialization is not
   // deferred on this pass.
-  Record.readInt();
+  Record.skipInt();
 
   Attr *New = nullptr;
   // Kind is stored as a 1-based integer because 0 is used to indicate a null
@@ -3184,7 +3186,7 @@ void ASTRecordReader::readAttributes(AttrVec &Attrs, Decl *D) {
 /// reading the attribute until the type has been read.
 Attr *ASTRecordReader::readOrDeferAttrFor(Decl *D) {
   AttrReader Record(*this);
-  unsigned SkipCount = Record.peekNextInt();
+  unsigned SkipCount = Record.peekInts(1);
   if (!SkipCount)
     return readAttr();
   Reader->PendingDeferredAttributes.push_back({Record.getCurrentIdx(), D});

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -4910,11 +4910,11 @@ void ASTRecordWriter::AddAttr(const Attr *A) {
   if (!A)
     return Record.push_back(0);
 
+  Record.push_back(A->getKind() + 1); // FIXME: stable encoding, target attrs
+
   auto SkipIdx = Record.size();
   // Add placeholder for the size of deferred attribute.
   Record.push_back(0);
-
-  Record.push_back(A->getKind() + 1); // FIXME: stable encoding, target attrs
   Record.AddIdentifierRef(A->getAttrName());
   Record.AddIdentifierRef(A->getScopeName());
   Record.AddSourceRange(A->getRange());
@@ -4927,9 +4927,9 @@ void ASTRecordWriter::AddAttr(const Attr *A) {
 #include "clang/Serialization/AttrPCHWrite.inc"
 
   if (A->shouldDeferDeserialization()) {
-    // Record the actual size of deferred attribute (-1 to count the size bit
-    // itself).
-    Record[SkipIdx] = Record.size() - SkipIdx - 1;
+    // Record the actual size of deferred attribute (+ 1 to count the attribute
+    // kind).
+    Record[SkipIdx] = Record.size() - SkipIdx + 1;
   }
 }
 

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -4910,14 +4910,11 @@ void ASTRecordWriter::AddAttr(const Attr *A) {
   if (!A)
     return Record.push_back(0);
 
-  Record.push_back(A->getKind() + 1); // FIXME: stable encoding, target attrs
-
   auto SkipIdx = Record.size();
-  if (A->getKind() == attr::PreferredName) {
-    // Add placeholder for the size of preferred_name attribute.
-    Record.push_back(0);
-  }
+  // Add placeholder for the size of deferred attribute.
+  Record.push_back(0);
 
+  Record.push_back(A->getKind() + 1); // FIXME: stable encoding, target attrs
   Record.AddIdentifierRef(A->getAttrName());
   Record.AddIdentifierRef(A->getScopeName());
   Record.AddSourceRange(A->getRange());
@@ -4929,9 +4926,9 @@ void ASTRecordWriter::AddAttr(const Attr *A) {
 
 #include "clang/Serialization/AttrPCHWrite.inc"
 
-  if (A->getKind() == attr::PreferredName) {
-    // Record the actual size of preferred_name attribute (-1 to count the
-    // placeholder).
+  if (A->shouldDeferDeserialization()) {
+    // Record the actual size of deferred attribute (-1 to count the size bit
+    // itself).
     Record[SkipIdx] = Record.size() - SkipIdx - 1;
   }
 }

--- a/clang/test/Modules/preferred_name.cppm
+++ b/clang/test/Modules/preferred_name.cppm
@@ -53,10 +53,16 @@ import A;
 export using ::foo_templ;
 
 //--- Use1.cpp
-import A;         // expected-warning@foo.h:8 {{attribute declaration must precede definition}}
-#include "foo.h"  // expected-note@foo.h:9 {{previous definition is here}}
-
+// expected-no-diagnostics
+import A;
+#include "foo.h"
 //--- Use2.cpp
 // expected-no-diagnostics
 #include "foo.h"
 import A;
+
+//--- Use3.cpp
+#include "foo.h"
+import A;
+foo test;
+int size = test.size(); // expected-error {{no member named 'size' in 'foo'}}

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3043,6 +3043,10 @@ static void emitAttributes(const RecordKeeper &Records, raw_ostream &OS,
            << (R.getValueAsBit("InheritEvenIfAlreadyPresent") ? "true"
                                                               : "false");
       }
+      if (R.getValueAsBit("DeferDeserialization")) {
+        OS << ", "
+           << "/*DeferDeserialization=*/true";
+      }
       OS << ")\n";
 
       for (auto const &ai : Args) {


### PR DESCRIPTION
…ecord level.

This fixes the incorrect diagnostic emitted when compiling the following snippet

```
// string_view.h
template<class _CharT>
class basic_string_view;

typedef basic_string_view<char> string_view;

template<class _CharT>
class
__attribute__((__preferred_name__(string_view)))
basic_string_view {
public:
    basic_string_view() 
    {
    }
};

inline basic_string_view<char> foo()
{
  return basic_string_view<char>();
}
// A.cppm
module;
#include "string_view.h"
export module A;

// Use.cppm
module;
#include "string_view.h"
export module Use;
import A;
```

The diagnostic is 
```
string_view.h:11:5: error: 'basic_string_view<char>::basic_string_view' from module 'A.<global>' is not present in definition of 'string_view' provided earlier
```

The underlying issue is that deserialization of the `preferred_name` attribute triggers deserialization of `basic_string_view<char>`, which triggers the deserialization of the `preferred_name` attribute again (since it's attached to the `basic_string_view` template). 
The deserialization logic is implemented in a way that prevents it from going on a loop in a literal sense (it detects early on that it has already seen the `string_view` typedef when trying to start its deserialization for the second time), but leaves the typedef deserialization in an unfinished state. Subsequently, the `string_view` typedef from the deserialized module cannot be merged with the same typedef from `string_view.h`, resulting in the above diagnostic.

This PR resolves the problem by delaying the deserialization of the `preferred_name` attribute until the deserialization of the `basic_string_view` template is completed. As a result of deferring, the deserialization of the `preferred_name` attribute doesn't need to go on a loop since the type of the `string_view` typedef is already known when it's deserialized.
