### PR TITLE
[libclc] Don't rely on fp16 pragma guards in headers

### DIFF
--- a/libclc/clc/include/clc/clcmacro.h
+++ b/libclc/clc/include/clc/clcmacro.h
@@ -207,10 +207,6 @@
     return BUILTIN(x);                                                         \
   }
 
-#ifdef cl_khr_fp16
-
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-
 #define _CLC_DEFINE_UNARY_BUILTIN_FP16(FUNCTION)                               \
   _CLC_DEF _CLC_OVERLOAD half FUNCTION(half x) {                               \
     return (half)FUNCTION((float)x);                                           \
@@ -222,12 +218,5 @@
     return (half)FUNCTION((float)x, (float)y);                                 \
   }                                                                            \
   _CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, FUNCTION, half, half)
-
-#else
-
-#define _CLC_DEFINE_UNARY_BUILTIN_FP16(FUNCTION)
-#define _CLC_DEFINE_BINARY_BUILTIN_FP16(FUNCTION)
-
-#endif
 
 #endif // __CLC_CLCMACRO_H__

--- a/libclc/clc/include/clc/clcmacro.h
+++ b/libclc/clc/include/clc/clcmacro.h
@@ -207,6 +207,10 @@
     return BUILTIN(x);                                                         \
   }
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 #define _CLC_DEFINE_UNARY_BUILTIN_FP16(FUNCTION)                               \
   _CLC_DEF _CLC_OVERLOAD half FUNCTION(half x) {                               \
     return (half)FUNCTION((float)x);                                           \
@@ -218,5 +222,14 @@
     return (half)FUNCTION((float)x, (float)y);                                 \
   }                                                                            \
   _CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, half, FUNCTION, half, half)
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : disable
+
+#else
+
+#define _CLC_DEFINE_UNARY_BUILTIN_FP16(FUNCTION)
+#define _CLC_DEFINE_BINARY_BUILTIN_FP16(FUNCTION)
+
+#endif
 
 #endif // __CLC_CLCMACRO_H__

--- a/libclc/generic/lib/math/acos.cl
+++ b/libclc/generic/lib/math/acos.cl
@@ -172,4 +172,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, acos, double);
 
 #endif // cl_khr_fp64
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(acos)
+
+#endif

--- a/libclc/generic/lib/math/acosh.cl
+++ b/libclc/generic/lib/math/acosh.cl
@@ -126,4 +126,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, acosh, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(acosh)
+
+#endif

--- a/libclc/generic/lib/math/acospi.cl
+++ b/libclc/generic/lib/math/acospi.cl
@@ -171,4 +171,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, acospi, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(acospi)
+
+#endif

--- a/libclc/generic/lib/math/asinh.cl
+++ b/libclc/generic/lib/math/asinh.cl
@@ -292,4 +292,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, asinh, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(asinh)
+
+#endif

--- a/libclc/generic/lib/math/atan.cl
+++ b/libclc/generic/lib/math/atan.cl
@@ -182,5 +182,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, atan, double);
 
 #endif // cl_khr_fp64
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
 _CLC_DEFINE_UNARY_BUILTIN_FP16(atan)
+
+#endif

--- a/libclc/generic/lib/math/atan2.cl
+++ b/libclc/generic/lib/math/atan2.cl
@@ -236,4 +236,10 @@ _CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, atan2, double, double);
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_BINARY_BUILTIN_FP16(atan2)
+
+#endif

--- a/libclc/generic/lib/math/atan2pi.cl
+++ b/libclc/generic/lib/math/atan2pi.cl
@@ -220,4 +220,10 @@ _CLC_BINARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, atan2pi, double, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_BINARY_BUILTIN_FP16(atan2pi)
+
+#endif

--- a/libclc/generic/lib/math/atanh.cl
+++ b/libclc/generic/lib/math/atanh.cl
@@ -112,4 +112,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, atanh, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(atanh)
+
+#endif

--- a/libclc/generic/lib/math/atanpi.cl
+++ b/libclc/generic/lib/math/atanpi.cl
@@ -181,4 +181,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, atanpi, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(atanpi)
+
+#endif

--- a/libclc/generic/lib/math/cbrt.cl
+++ b/libclc/generic/lib/math/cbrt.cl
@@ -150,4 +150,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, cbrt, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(cbrt)
+
+#endif

--- a/libclc/generic/lib/math/cos.cl
+++ b/libclc/generic/lib/math/cos.cl
@@ -76,4 +76,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, cos, double);
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(cos)
+
+#endif

--- a/libclc/generic/lib/math/cosh.cl
+++ b/libclc/generic/lib/math/cosh.cl
@@ -191,4 +191,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, cosh, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(cosh)
+
+#endif

--- a/libclc/generic/lib/math/cospi.cl
+++ b/libclc/generic/lib/math/cospi.cl
@@ -135,4 +135,10 @@ _CLC_OVERLOAD _CLC_DEF double cospi(double x) {
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, cospi, double);
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(cospi)
+
+#endif

--- a/libclc/generic/lib/math/exp.cl
+++ b/libclc/generic/lib/math/exp.cl
@@ -89,4 +89,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, exp, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(exp)
+
+#endif

--- a/libclc/generic/lib/math/expm1.cl
+++ b/libclc/generic/lib/math/expm1.cl
@@ -141,4 +141,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, expm1, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(expm1)
+
+#endif

--- a/libclc/generic/lib/math/lgamma.cl
+++ b/libclc/generic/lib/math/lgamma.cl
@@ -43,4 +43,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, lgamma, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(lgamma)
+
+#endif

--- a/libclc/generic/lib/math/log1p.cl
+++ b/libclc/generic/lib/math/log1p.cl
@@ -176,4 +176,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, log1p, double);
 
 #endif // cl_khr_fp64
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(log1p)
+
+#endif

--- a/libclc/generic/lib/math/logb.cl
+++ b/libclc/generic/lib/math/logb.cl
@@ -30,4 +30,10 @@ _CLC_OVERLOAD _CLC_DEF double logb(double x) {
 _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, logb, double)
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(logb)
+
+#endif

--- a/libclc/generic/lib/math/sin.cl
+++ b/libclc/generic/lib/math/sin.cl
@@ -78,4 +78,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, sin, double);
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(sin)
+
+#endif

--- a/libclc/generic/lib/math/sinh.cl
+++ b/libclc/generic/lib/math/sinh.cl
@@ -190,4 +190,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, sinh, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(sinh)
+
+#endif

--- a/libclc/generic/lib/math/sinpi.cl
+++ b/libclc/generic/lib/math/sinpi.cl
@@ -130,4 +130,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, sinpi, double)
 
 #endif
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(sinpi)
+
+#endif

--- a/libclc/generic/lib/math/tanh.cl
+++ b/libclc/generic/lib/math/tanh.cl
@@ -145,4 +145,10 @@ _CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, tanh, double);
 
 #endif // cl_khr_fp64
 
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
 _CLC_DEFINE_UNARY_BUILTIN_FP16(tanh)
+
+#endif


### PR DESCRIPTION
Having the fp16 pragmas enabled in the header file is risky. The macros defined by that header don't (and can't) include the pragmas that make fp16 types themselves legal, and another header may disable the fp16 pragma before the macro's use.

The safest thing to do is the use of pragmas surrounding each use of the macro in the implementation files. This pattern is also far more common across the codebase.