### PR TITLE
[LLD][COFF] Skip sections marked as IMAGE_SCN_LNK_INFO in the output image

### DIFF
--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -355,7 +355,7 @@ SectionChunk *ObjFile::readSection(uint32_t sectionNumber,
     MergeChunk::addSection(symtab.ctx, c);
   else if (name == ".rsrc" || name.starts_with(".rsrc$"))
     resourceChunks.push_back(c);
-  else
+  else if (!(sec->Characteristics & llvm::COFF::IMAGE_SCN_LNK_INFO))
     chunks.push_back(c);
 
   return c;

--- a/lld/test/COFF/info-sec.s
+++ b/lld/test/COFF/info-sec.s
@@ -1,0 +1,10 @@
+// REQUIRES: x86
+// Check that sections marked as IMAGE_SCN_LNK_INFO are excluded from the output.
+
+// RUN: llvm-mc -filetype=obj -triple=x86_64-windows %s -o %t.obj
+// RUN: lld-link -machine:amd64 -dll -noentry %t.obj -out:%t.dll
+// RUN: llvm-readobj --headers %t.dll | FileCheck %s
+// CHECK-NOT: Name: .test
+
+        .section .test,"i"
+        .long 1


### PR DESCRIPTION
Fixes #106275.