### PR TITLE
[z/OS] add tail padding to TypeLoc if needed

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -397,6 +397,7 @@ public:
     unsigned extraAlign = asDerived()->getExtraLocalDataAlignment();
     size = llvm::alignTo(size, extraAlign);
     size += asDerived()->getExtraLocalDataSize();
+    size = llvm::alignTo(size, asDerived()->getLocalDataAlignment());
     return size;
   }
 


### PR DESCRIPTION
The code in getLocalDataSize() returns the sum of the size of the LocalData plus the size of the extra data.  The start of the extra data is padded so it starts on a multiple of it's alignment.  We also need to be adding tail padding so the final size is a multiple of the alignment of the LocalData.  On most systems the alignment of the extra data is the same or greater than the alignment of the LocalData so you don't need the tail padding.  However, on z/OS, the alignment of the extra data is less than the alignment of the LocalData and thus you do need the tail padding to make the final size a multiple of the LocalData alignment.

The extra data is the WrittenBuiltinSpecs  struct.  This struct is just a struct of bitfields.  On most systems the alignment of the struct is determined by the type of the bitfields (eg. unsigned int -> align of 4).  On z/OS, all bitfields are 1 byte aligned.  Thus on z/OS WrittenBuiltinSpecs is only size 2 with alignment of 1 (verses 4 & 4).