### PR TITLE
[sanitizer][NFCI] Add Options parameter to LowerAllowCheckPass

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -795,7 +795,7 @@ static void addSanitizers(const Triple &TargetTriple,
   }
 
   if (LowerAllowCheckPass::IsRequested()) {
-    LowerAllowCheckOptions Opts;
+    LowerAllowCheckPass::Options Opts;
     // We want to call it after inline, which is about OptimizerEarlyEPCallback.
     PB.registerOptimizerEarlyEPCallback([&Opts](ModulePassManager &MPM,
                                                 OptimizationLevel Level,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -795,11 +795,12 @@ static void addSanitizers(const Triple &TargetTriple,
   }
 
   if (LowerAllowCheckPass::IsRequested()) {
+    LowerAllowCheckOptions Opts;
     // We want to call it after inline, which is about OptimizerEarlyEPCallback.
-    PB.registerOptimizerEarlyEPCallback([](ModulePassManager &MPM,
+    PB.registerOptimizerEarlyEPCallback([&Opts](ModulePassManager &MPM,
                                            OptimizationLevel Level,
                                            ThinOrFullLTOPhase Phase) {
-      MPM.addPass(createModuleToFunctionPassAdaptor(LowerAllowCheckPass()));
+      MPM.addPass(createModuleToFunctionPassAdaptor(LowerAllowCheckPass(Opts)));
     });
   }
 }

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -798,8 +798,8 @@ static void addSanitizers(const Triple &TargetTriple,
     LowerAllowCheckOptions Opts;
     // We want to call it after inline, which is about OptimizerEarlyEPCallback.
     PB.registerOptimizerEarlyEPCallback([&Opts](ModulePassManager &MPM,
-                                           OptimizationLevel Level,
-                                           ThinOrFullLTOPhase Phase) {
+                                                OptimizationLevel Level,
+                                                ThinOrFullLTOPhase Phase) {
       MPM.addPass(createModuleToFunctionPassAdaptor(LowerAllowCheckPass(Opts)));
     });
   }

--- a/llvm/include/llvm/Transforms/Instrumentation/LowerAllowCheckPass.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/LowerAllowCheckPass.h
@@ -21,7 +21,7 @@
 namespace llvm {
 
 struct LowerAllowCheckOptions {
-   std::vector<double> placeholder; // TODO: cutoffs
+  std::vector<double> placeholder; // TODO: cutoffs
 };
 
 // This pass is responsible for removing optional traps, like llvm.ubsantrap
@@ -29,7 +29,7 @@ struct LowerAllowCheckOptions {
 class LowerAllowCheckPass : public PassInfoMixin<LowerAllowCheckPass> {
 public:
   explicit LowerAllowCheckPass(LowerAllowCheckOptions Options)
-      : Options(Options){};
+      : Options(Options) {};
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   static bool IsRequested();

--- a/llvm/include/llvm/Transforms/Instrumentation/LowerAllowCheckPass.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/LowerAllowCheckPass.h
@@ -20,22 +20,22 @@
 
 namespace llvm {
 
-struct LowerAllowCheckOptions {
-  std::vector<double> placeholder; // TODO: cutoffs
-};
-
 // This pass is responsible for removing optional traps, like llvm.ubsantrap
 // from the hot code.
 class LowerAllowCheckPass : public PassInfoMixin<LowerAllowCheckPass> {
 public:
-  explicit LowerAllowCheckPass(LowerAllowCheckOptions Options)
-      : Options(Options) {};
+  struct Options {
+    std::vector<unsigned int> placeholder; // TODO: cutoffs
+  };
+
+  explicit LowerAllowCheckPass(LowerAllowCheckPass::Options Opts)
+      : Opts(Opts) {};
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   static bool IsRequested();
 
 private:
-  LowerAllowCheckOptions Options;
+  LowerAllowCheckPass::Options Opts;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Instrumentation/LowerAllowCheckPass.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/LowerAllowCheckPass.h
@@ -20,13 +20,22 @@
 
 namespace llvm {
 
+struct LowerAllowCheckOptions {
+   std::vector<double> placeholder; // TODO: cutoffs
+};
+
 // This pass is responsible for removing optional traps, like llvm.ubsantrap
 // from the hot code.
 class LowerAllowCheckPass : public PassInfoMixin<LowerAllowCheckPass> {
 public:
+  explicit LowerAllowCheckPass(LowerAllowCheckOptions Options)
+      : Options(Options){};
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   static bool IsRequested();
+
+private:
+  LowerAllowCheckOptions Options;
 };
 
 } // namespace llvm

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -821,9 +821,9 @@ Expected<EmbedBitcodeOptions> parseEmbedBitcodePassOptions(StringRef Params) {
   return Result;
 }
 
-Expected<LowerAllowCheckOptions>
+Expected<LowerAllowCheckPass::Options>
 parseLowerAllowCheckPassOptions(StringRef Params) {
-  LowerAllowCheckOptions Result;
+  LowerAllowCheckPass::Options Result;
   while (!Params.empty()) {
     StringRef ParamName;
     std::tie(ParamName, Params) = Params.split(';');

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -821,7 +821,8 @@ Expected<EmbedBitcodeOptions> parseEmbedBitcodePassOptions(StringRef Params) {
   return Result;
 }
 
-Expected<LowerAllowCheckOptions> parseLowerAllowCheckPassOptions(StringRef Params) {
+Expected<LowerAllowCheckOptions>
+parseLowerAllowCheckPassOptions(StringRef Params) {
   LowerAllowCheckOptions Result;
   while (!Params.empty()) {
     StringRef ParamName;

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -821,6 +821,20 @@ Expected<EmbedBitcodeOptions> parseEmbedBitcodePassOptions(StringRef Params) {
   return Result;
 }
 
+Expected<LowerAllowCheckOptions> parseLowerAllowCheckPassOptions(StringRef Params) {
+  LowerAllowCheckOptions Result;
+  while (!Params.empty()) {
+    StringRef ParamName;
+    std::tie(ParamName, Params) = Params.split(';');
+
+    return make_error<StringError>(
+        formatv("invalid LowerAllowCheck pass parameter '{0}' ", ParamName)
+            .str(),
+        inconvertibleErrorCode());
+  }
+  return Result;
+}
+
 Expected<MemorySanitizerOptions> parseMSanPassOptions(StringRef Params) {
   MemorySanitizerOptions Result;
   while (!Params.empty()) {

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -402,7 +402,6 @@ FUNCTION_PASS("loop-load-elim", LoopLoadEliminationPass())
 FUNCTION_PASS("loop-simplify", LoopSimplifyPass())
 FUNCTION_PASS("loop-sink", LoopSinkPass())
 FUNCTION_PASS("loop-versioning", LoopVersioningPass())
-FUNCTION_PASS("lower-allow-check", LowerAllowCheckPass())
 FUNCTION_PASS("lower-atomic", LowerAtomicPass())
 FUNCTION_PASS("lower-constant-intrinsics", LowerConstantIntrinsicsPass())
 FUNCTION_PASS("lower-expect", LowerExpectIntrinsicPass())
@@ -553,6 +552,10 @@ FUNCTION_PASS_WITH_PARAMS(
     parseLoopVectorizeOptions,
     "no-interleave-forced-only;interleave-forced-only;no-vectorize-forced-only;"
     "vectorize-forced-only")
+FUNCTION_PASS_WITH_PARAMS(
+    "lower-allow-check", "LowerAllowCheckPass",
+    [](LowerAllowCheckOptions Opts) { return LowerAllowCheckPass(Opts); },
+    parseLowerAllowCheckPassOptions, "")
 FUNCTION_PASS_WITH_PARAMS(
     "lower-matrix-intrinsics", "LowerMatrixIntrinsicsPass",
     [](bool Minimal) { return LowerMatrixIntrinsicsPass(Minimal); },

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -554,7 +554,7 @@ FUNCTION_PASS_WITH_PARAMS(
     "vectorize-forced-only")
 FUNCTION_PASS_WITH_PARAMS(
     "lower-allow-check", "LowerAllowCheckPass",
-    [](LowerAllowCheckOptions Opts) { return LowerAllowCheckPass(Opts); },
+    [](LowerAllowCheckPass::Options Opts) { return LowerAllowCheckPass(Opts); },
     parseLowerAllowCheckPassOptions, "")
 FUNCTION_PASS_WITH_PARAMS(
     "lower-matrix-intrinsics", "LowerMatrixIntrinsicsPass",


### PR DESCRIPTION
This is glue code to convert LowerAllowCheckPass from a FUNCTION_PASS to FUNCTION_PASS_WITH_PARAMS. The parameters are currently unused.

Future work will plumb `-fsanitize-skip-hot-cutoff` (introduced in https://github.com/llvm/llvm-project/pull/121619) to LowerAllowCheckOptions.