### PR TITLE
[TargetParser] Add missing include to modulemap

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -348,6 +348,7 @@ extern module LLVM_Extern_Utils_DataTypes "module.extern.modulemap"
 module TargetParserGen {
   module AArch64TargetParserDef {
     textual header "llvm/TargetParser/AArch64CPUFeatures.inc"
+    textual header "llvm/TargetParser/AArch64FeatPriorities.inc"
     header "llvm/TargetParser/AArch64TargetParser.h"
     extern module LLVM_Extern_TargetParser_Gen "module.extern.modulemap"
     export *


### PR DESCRIPTION
Resolves warning when building with `LLVM_ENABLE_MODULES`

```
AArch64TargetParser.h:39:2: warning: missing submodule 'LLVM_Utils.TargetParser.AArch64FeatPriorities' [-Wincomplete-umbrella]
   39 | #include "llvm/TargetParser/AArch64FeatPriorities.inc"
      |  ^       ~~~~~~~
```