### PR TITLE
[OpenMP] Remove hack around missing atomic load

### DIFF
--- a/offload/DeviceRTL/include/Synchronization.h
+++ b/offload/DeviceRTL/include/Synchronization.h
@@ -66,7 +66,7 @@ V add(Ty *Address, V Val, atomic::OrderingTy Ordering) {
 
 template <typename Ty, typename V = utils::remove_addrspace_t<Ty>>
 V load(Ty *Address, atomic::OrderingTy Ordering) {
-  return add(Address, Ty(0), Ordering);
+  return __scoped_atomic_load_n(Address, Ordering, __MEMORY_SCOPE_DEVICE);
 }
 
 template <typename Ty, typename V = utils::remove_addrspace_t<Ty>>


### PR DESCRIPTION
Summary:
We used to do a fetch add of zero to approximate a load. This is because
the NVPTX backend didn't handle this properly. It's not an issue anymore
so simply use the proper atomic builtin.
