### PR TITLE
[flang] Improve module file error message wording

### DIFF
--- a/flang/lib/Semantics/mod-file.h
+++ b/flang/lib/Semantics/mod-file.h
@@ -102,7 +102,7 @@ public:
 private:
   SemanticsContext &context_;
 
-  parser::Message &Say(SourceName, const std::string &,
+  parser::Message &Say(const char *verb, SourceName, const std::string &,
       parser::MessageFixedText &&, const std::string &);
 };
 

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -12,8 +12,8 @@
 ! WITHOUT-NOT: 'ieee_arithmetic.mod' was not found
 ! WITHOUT-NOT: 'iso_fortran_env.mod' was not found
 
-! GIVEN: error: Cannot read module file for module 'ieee_arithmetic': File has invalid checksum
-! GIVEN: error: Cannot read module file for module 'iso_fortran_env': File has invalid checksum
+! GIVEN: error: Cannot use module file for module 'ieee_arithmetic': File has invalid checksum
+! GIVEN: error: Cannot use module file for module 'iso_fortran_env': File has invalid checksum
 
 
 program test_intrinsic_module_path

--- a/flang/test/Driver/use-module.f90
+++ b/flang/test/Driver/use-module.f90
@@ -32,14 +32,14 @@
 
 ! INCLUDED-NOT: error
 
-! MISSING_MOD2-NOT:error: Cannot read module file for module 'basictestmoduleone''
+! MISSING_MOD2-NOT:error: Cannot parse module file for module 'basictestmoduleone''
 ! MISSING_MOD2-NOT:error: Derived type 't1' not found
-! MISSING_MOD2:error: Cannot read module file for module 'basictestmoduletwo'
+! MISSING_MOD2:error: Cannot parse module file for module 'basictestmoduletwo'
 ! MISSING_MOD2:error: Derived type 't2' not found
 
-! SINGLEINCLUDE-NOT:error: Cannot read module file for module 'basictestmoduleone'
+! SINGLEINCLUDE-NOT:error: Cannot parse module file for module 'basictestmoduleone'
 ! SINGLEINCLUDE:error: Derived type 't1' not found
-! SINGLEINCLUDE-NOT:error: Cannot read module file for module 'basictestmoduletwo'
+! SINGLEINCLUDE-NOT:error: Cannot parse module file for module 'basictestmoduletwo'
 ! SINGLEINCLUDE-NOT:error: Derived type 't2' not found
 
 

--- a/flang/test/Semantics/modfile43.f90
+++ b/flang/test/Semantics/modfile43.f90
@@ -18,13 +18,13 @@ module m4
   use :: iso_fortran_env, only: user_defined_123
 end module
 module m5
-  !ERROR: Cannot read module file for module 'ieee_arithmetic': Source file 'ieee_arithmetic.mod' was not found
+  !ERROR: Cannot parse module file for module 'ieee_arithmetic': Source file 'ieee_arithmetic.mod' was not found
   use, non_intrinsic :: ieee_arithmetic, only: ieee_selected_real_kind
 end module
 module notAnIntrinsicModule
 end module
 module m6
-  !ERROR: Cannot read module file for module 'notanintrinsicmodule': Source file 'notanintrinsicmodule.mod' was not found
+  !ERROR: Cannot parse module file for module 'notanintrinsicmodule': Source file 'notanintrinsicmodule.mod' was not found
   use, intrinsic :: notAnIntrinsicModule
 end module
 

--- a/flang/test/Semantics/modfile63.f90
+++ b/flang/test/Semantics/modfile63.f90
@@ -13,4 +13,4 @@ use modfile63b
 call s2
 end
 
-! ERROR: Cannot read module file for module 'modfile63a': File is not the right module file for 'modfile63a':
+! ERROR: Cannot use module file for module 'modfile63a': File is not the right module file for 'modfile63a':

--- a/flang/test/Semantics/modfile70.f90
+++ b/flang/test/Semantics/modfile70.f90
@@ -2,4 +2,4 @@
 end
 
 ! RUN: not %flang_fc1 -fsyntax-only -J%S/Inputs -w %s 2>&1 | FileCheck --check-prefix=ERROR %s
-! ERROR: Cannot read module file for module 'modfile70': File has invalid checksum:
+! ERROR: Cannot use module file for module 'modfile70': File has invalid checksum:

--- a/flang/test/Semantics/resolve12.f90
+++ b/flang/test/Semantics/resolve12.f90
@@ -6,7 +6,7 @@ subroutine sub
 end
 
 use m1
-!ERROR: Cannot read module file for module 'm2': Source file 'm2.mod' was not found
+!ERROR: Cannot parse module file for module 'm2': Source file 'm2.mod' was not found
 use m2
 !ERROR: 'sub' is not a module
 use sub

--- a/flang/test/Semantics/resolve26.f90
+++ b/flang/test/Semantics/resolve26.f90
@@ -16,10 +16,10 @@ end
 submodule(m1) s1
 end
 
-!ERROR: Cannot read module file for submodule 's1' of module 'm2': Source file 'm2-s1.mod' was not found
+!ERROR: Cannot parse module file for submodule 's1' of module 'm2': Source file 'm2-s1.mod' was not found
 submodule(m2:s1) s2
 end
 
-!ERROR: Cannot read module file for module 'm3': Source file 'm3.mod' was not found
+!ERROR: Cannot parse module file for module 'm3': Source file 'm3.mod' was not found
 submodule(m3:s1) s3
 end


### PR DESCRIPTION
Instead of "Cannot read ...", distinguish true errors in finding and parsing module files from problems with unexpected hash codes by using "Cannot parse" or "Cannot use" wording as appropriate.