### PR TITLE
[flang][AIX] filter out __builtin_c_devptr for generating packed type

### DIFF
--- a/flang/lib/Lower/ConvertType.cpp
+++ b/flang/lib/Lower/ConvertType.cpp
@@ -392,7 +392,7 @@ struct TypeBuilderImpl {
     // Always generate packed FIR struct type for bind(c) derived type for AIX
     if (targetTriple.getOS() == llvm::Triple::OSType::AIX &&
         tySpec.typeSymbol().attrs().test(Fortran::semantics::Attr::BIND_C) &&
-        !IsIsoCType(&tySpec)) {
+        !IsIsoCType(&tySpec) && !fir::isa_builtin_cdevptr_type(rec)) {
       rec.pack(true);
     }
 


### PR DESCRIPTION
Filter out the recently add `__builtin_c_devptr` type when generating packed type on AIX.