### PR TITLE
[ML Inliner] Fix inconsistancy between CallGraph and FunctionLevels

### DIFF
--- a/llvm/lib/Analysis/MLInlineAdvisor.cpp
+++ b/llvm/lib/Analysis/MLInlineAdvisor.cpp
@@ -189,9 +189,10 @@ MLInlineAdvisor::MLInlineAdvisor(
 }
 
 unsigned MLInlineAdvisor::getInitialFunctionLevel(const Function &F) const {
-  return FunctionLevels.find(CG.lookup(F)) != FunctionLevels.end()
-             ? FunctionLevels.at(CG.lookup(F))
-             : 0;
+  auto It = FunctionLevels.find(CG.lookup(F));
+  if (It == FunctionLevels.end())
+    return 0;
+  return *It;
 }
 
 void MLInlineAdvisor::onPassEntry(LazyCallGraph::SCC *CurSCC) {

--- a/llvm/lib/Analysis/MLInlineAdvisor.cpp
+++ b/llvm/lib/Analysis/MLInlineAdvisor.cpp
@@ -189,7 +189,9 @@ MLInlineAdvisor::MLInlineAdvisor(
 }
 
 unsigned MLInlineAdvisor::getInitialFunctionLevel(const Function &F) const {
-  return CG.lookup(F) ? FunctionLevels.at(CG.lookup(F)) : 0;
+  return FunctionLevels.find(CG.lookup(F)) != FunctionLevels.end()
+             ? FunctionLevels.at(CG.lookup(F))
+             : 0;
 }
 
 void MLInlineAdvisor::onPassEntry(LazyCallGraph::SCC *CurSCC) {


### PR DESCRIPTION
When building our internal code, one of the function annotated with `co_await` (c++20) will cause inconsistancy: The function exists in CG but not FunctionLevels.

This patch fixes it by using FunctionLevels only.