### PR TITLE
[win] Enable test/CodeGen/MIR/AArch64 on Windows

### DIFF
--- a/llvm/test/CodeGen/MIR/AArch64/lit.local.cfg
+++ b/llvm/test/CodeGen/MIR/AArch64/lit.local.cfg
@@ -2,7 +2,3 @@ import re
 
 if not "AArch64" in config.root.targets:
     config.unsupported = True
-
-# For now we don't test arm64-win32.
-if re.search(r"cygwin|mingw32|win32|windows-gnu|windows-msvc", config.target_triple):
-    config.unsupported = True


### PR DESCRIPTION
Not sure why this was disabled in the first place (dates back to <https://github.com/llvm/llvm-project/commit/fbe9c04c5f72cf3eca39793aafc92071ef13c046>), but it appears to be working for me.