### PR TITLE
[AST] Migrate away from PointerUnion::dyn_cast (NFC)

### DIFF
--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -368,10 +368,10 @@ LLVM_DUMP_METHOD void EvaluationResult::dump() const {
   case LValue: {
     assert(Source);
     QualType SourceType;
-    if (const auto *D = Source.dyn_cast<const Decl *>()) {
+    if (const auto *D = dyn_cast_if_present<const Decl *>(Source)) {
       if (const auto *VD = dyn_cast<ValueDecl>(D))
         SourceType = VD->getType();
-    } else if (const auto *E = Source.dyn_cast<const Expr *>()) {
+    } else if (const auto *E = dyn_cast_if_present<const Expr *>(Source)) {
       SourceType = E->getType();
     }
 

--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -368,10 +368,10 @@ LLVM_DUMP_METHOD void EvaluationResult::dump() const {
   case LValue: {
     assert(Source);
     QualType SourceType;
-    if (const auto *D = dyn_cast_if_present<const Decl *>(Source)) {
+    if (const auto *D = dyn_cast<const Decl *>(Source)) {
       if (const auto *VD = dyn_cast<ValueDecl>(D))
         SourceType = VD->getType();
-    } else if (const auto *E = dyn_cast_if_present<const Expr *>(Source)) {
+    } else if (const auto *E = dyn_cast<const Expr *>(Source)) {
       SourceType = E->getType();
     }
 


### PR DESCRIPTION
Note that PointerUnion::dyn_cast has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

Literal migration would result in dyn_cast_if_present (see the
definition of PointerUnion::dyn_cast), but this patch uses dyn_cast
because we expect Source to be nonnull.
