### PR TITLE
[StaticAnalyzer] Migrate away from PointerUnion::dyn_cast (NFC)

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -226,7 +226,7 @@ void ExplodedNode::NodeGroup::addNode(ExplodedNode *N, ExplodedGraph &G) {
     return;
   }
 
-  ExplodedNodeVector *V = dyn_cast_if_present<ExplodedNodeVector *>(Storage);
+  ExplodedNodeVector *V = dyn_cast<ExplodedNodeVector *>(Storage);
 
   if (!V) {
     // Switch from single-node to multi-node representation.
@@ -251,8 +251,7 @@ unsigned ExplodedNode::NodeGroup::size() const {
   const GroupStorage &Storage = reinterpret_cast<const GroupStorage &>(P);
   if (Storage.isNull())
     return 0;
-  if (ExplodedNodeVector *V =
-          dyn_cast_if_present<ExplodedNodeVector *>(Storage))
+  if (ExplodedNodeVector *V = dyn_cast<ExplodedNodeVector *>(Storage))
     return V->size();
   return 1;
 }
@@ -264,8 +263,7 @@ ExplodedNode * const *ExplodedNode::NodeGroup::begin() const {
   const GroupStorage &Storage = reinterpret_cast<const GroupStorage &>(P);
   if (Storage.isNull())
     return nullptr;
-  if (ExplodedNodeVector *V =
-          dyn_cast_if_present<ExplodedNodeVector *>(Storage))
+  if (ExplodedNodeVector *V = dyn_cast<ExplodedNodeVector *>(Storage))
     return V->begin();
   return Storage.getAddrOfPtr1();
 }
@@ -277,8 +275,7 @@ ExplodedNode * const *ExplodedNode::NodeGroup::end() const {
   const GroupStorage &Storage = reinterpret_cast<const GroupStorage &>(P);
   if (Storage.isNull())
     return nullptr;
-  if (ExplodedNodeVector *V =
-          dyn_cast_if_present<ExplodedNodeVector *>(Storage))
+  if (ExplodedNodeVector *V = dyn_cast<ExplodedNodeVector *>(Storage))
     return V->end();
   return Storage.getAddrOfPtr1() + 1;
 }

--- a/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExplodedGraph.cpp
@@ -226,7 +226,7 @@ void ExplodedNode::NodeGroup::addNode(ExplodedNode *N, ExplodedGraph &G) {
     return;
   }
 
-  ExplodedNodeVector *V = Storage.dyn_cast<ExplodedNodeVector *>();
+  ExplodedNodeVector *V = dyn_cast_if_present<ExplodedNodeVector *>(Storage);
 
   if (!V) {
     // Switch from single-node to multi-node representation.
@@ -251,7 +251,8 @@ unsigned ExplodedNode::NodeGroup::size() const {
   const GroupStorage &Storage = reinterpret_cast<const GroupStorage &>(P);
   if (Storage.isNull())
     return 0;
-  if (ExplodedNodeVector *V = Storage.dyn_cast<ExplodedNodeVector *>())
+  if (ExplodedNodeVector *V =
+          dyn_cast_if_present<ExplodedNodeVector *>(Storage))
     return V->size();
   return 1;
 }
@@ -263,7 +264,8 @@ ExplodedNode * const *ExplodedNode::NodeGroup::begin() const {
   const GroupStorage &Storage = reinterpret_cast<const GroupStorage &>(P);
   if (Storage.isNull())
     return nullptr;
-  if (ExplodedNodeVector *V = Storage.dyn_cast<ExplodedNodeVector *>())
+  if (ExplodedNodeVector *V =
+          dyn_cast_if_present<ExplodedNodeVector *>(Storage))
     return V->begin();
   return Storage.getAddrOfPtr1();
 }
@@ -275,7 +277,8 @@ ExplodedNode * const *ExplodedNode::NodeGroup::end() const {
   const GroupStorage &Storage = reinterpret_cast<const GroupStorage &>(P);
   if (Storage.isNull())
     return nullptr;
-  if (ExplodedNodeVector *V = Storage.dyn_cast<ExplodedNodeVector *>())
+  if (ExplodedNodeVector *V =
+          dyn_cast_if_present<ExplodedNodeVector *>(Storage))
     return V->end();
   return Storage.getAddrOfPtr1() + 1;
 }


### PR DESCRIPTION
Note that PointerUnion::dyn_cast has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

Literal migration would result in dyn_cast_if_present (see the
definition of PointerUnion::dyn_cast), but this patch uses dyn_cast
because we expect Storage to be nonnull.
