### PR TITLE
[mlir][python][cmake] Allows for specifying `NB_DOMAIN` in `add_mlir_python_extension`

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -174,6 +174,8 @@ configure_file(
 # disable all package setup and control it themselves.
 #-------------------------------------------------------------------------------
 
+set(MLIR_BINDINGS_PYTHON_NB_DOMAIN "mlir"
+  CACHE STRING "nanobind domain for MLIR python bindings.")
 set(MLIR_ENABLE_BINDINGS_PYTHON 0 CACHE BOOL
        "Enables building of Python bindings.")
 set(MLIR_DETECT_PYTHON_ENV_PRIME_SEARCH 1 CACHE BOOL

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -659,11 +659,11 @@ function(add_mlir_python_extension libname extname)
   endif ()
 
   # Avoids domain conflict with nanobind by specifying NB_DOMAIN.
-  if(NB_DOMAIN)
-    set(_nb_domain ${NB_DOMAIN})
+  if(MLIR_BINDINGS_PYTHON_NB_DOMAIN)
+    set(_nb_domain ${MLIR_BINDINGS_PYTHON_NB_DOMAIN})
   else()
     set(_nb_domain "mlir")
-  endif ()
+  endif()
 
   # The actual extension library produces a shared-object or DLL and has
   # sources that must be compiled in accordance with pybind11 needs (RTTI and

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -658,6 +658,13 @@ function(add_mlir_python_extension libname extname)
     set(eh_rtti_enable -frtti -fexceptions)
   endif ()
 
+  # Avoids domain conflict with nanobind by specifying NB_DOMAIN.
+  if(NB_DOMAIN)
+    set(_nb_domain ${NB_DOMAIN})
+  else()
+    set(_nb_domain "mlir")
+  endif ()
+
   # The actual extension library produces a shared-object or DLL and has
   # sources that must be compiled in accordance with pybind11 needs (RTTI and
   # exceptions).
@@ -667,7 +674,7 @@ function(add_mlir_python_extension libname extname)
     )
   elseif(ARG_PYTHON_BINDINGS_LIBRARY STREQUAL "nanobind")
     nanobind_add_module(${libname}
-      NB_DOMAIN mlir
+      NB_DOMAIN ${_nb_domain}
       FREE_THREADED
       ${ARG_SOURCES}
     )

--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -658,13 +658,6 @@ function(add_mlir_python_extension libname extname)
     set(eh_rtti_enable -frtti -fexceptions)
   endif ()
 
-  # Avoids domain conflict with nanobind by specifying NB_DOMAIN.
-  if(MLIR_BINDINGS_PYTHON_NB_DOMAIN)
-    set(_nb_domain ${MLIR_BINDINGS_PYTHON_NB_DOMAIN})
-  else()
-    set(_nb_domain "mlir")
-  endif()
-
   # The actual extension library produces a shared-object or DLL and has
   # sources that must be compiled in accordance with pybind11 needs (RTTI and
   # exceptions).
@@ -674,7 +667,7 @@ function(add_mlir_python_extension libname extname)
     )
   elseif(ARG_PYTHON_BINDINGS_LIBRARY STREQUAL "nanobind")
     nanobind_add_module(${libname}
-      NB_DOMAIN ${_nb_domain}
+      NB_DOMAIN ${MLIR_BINDINGS_PYTHON_NB_DOMAIN}
       FREE_THREADED
       ${ARG_SOURCES}
     )


### PR DESCRIPTION
This PR allows the users to specify the `NB_DOMAIN` for `add_mlir_python_extension`. This allows users to avoid nanobind domain conflicts, when python bindings from multiple `mlir` projects were imported. (https://nanobind.readthedocs.io/en/latest/faq.html#how-can-i-avoid-conflicts-with-other-projects-using-nanobind)