### PR TITLE
[llvm][Docs] Add a release note about the lldb DWARF indexing speedup

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -449,6 +449,8 @@ Changes to LLDB
           _regexp-bt        -- Show backtrace of the current thread's call ...
           _regexp-display   -- Evaluate an expression at every stop (see 'h...
   ```
+* DWARF indexing speed (for binaries not using the debug_names index) increased
+  by 30-60%, depending on the configuration.
 
 Changes to BOLT
 ---------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -450,7 +450,7 @@ Changes to LLDB
           _regexp-display   -- Evaluate an expression at every stop (see 'h...
   ```
 * DWARF indexing speed (for binaries not using the debug_names index) increased
-  by 30-60%, depending on the configuration.
+  by [30-60%](https://github.com/llvm/llvm-project/pull/118657).
 
 Changes to BOLT
 ---------------------------------


### PR DESCRIPTION
The figure includes works that's already committed. In does not include the WIP/RFC proposal in
https://discourse.llvm.org/t/rfc-speeding-up-dwarf-indexing-again/83979.