### PR TITLE
[clang-reorder-fields] Do not reorder macro expansions.

### DIFF
--- a/clang-tools-extra/clang-reorder-fields/ReorderFieldsAction.cpp
+++ b/clang-tools-extra/clang-reorder-fields/ReorderFieldsAction.cpp
@@ -167,10 +167,18 @@ static bool reorderFieldsInDefinition(
     const auto FieldIndex = Field->getFieldIndex();
     if (FieldIndex == NewFieldsOrder[FieldIndex])
       continue;
-    addReplacement(
-        getFullFieldSourceRange(*Field, Context),
-        getFullFieldSourceRange(*Fields[NewFieldsOrder[FieldIndex]], Context),
-        Context, Replacements);
+
+    const auto FromRange = getFullFieldSourceRange(*Field, Context);
+    const auto ToRange =
+        getFullFieldSourceRange(*Fields[NewFieldsOrder[FieldIndex]], Context);
+
+    if (FromRange.getBegin().isMacroID()) {
+      llvm::errs() << "Cannot reorder field `" << Field->getName()
+                   << "` defined within a macro expansion\n";
+      return false;
+    }
+
+    addReplacement(FromRange, ToRange, Context, Replacements);
   }
   return true;
 }

--- a/clang-tools-extra/test/clang-reorder-fields/MacroExpansions.cpp
+++ b/clang-tools-extra/test/clang-reorder-fields/MacroExpansions.cpp
@@ -1,0 +1,12 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order y,x %s -- | FileCheck %s
+
+#define DEFINE_FIELD(name) \
+    int name
+
+// We should not reorder given that the definition of `x` is in a macro
+// expansion.
+class Foo {
+  DEFINE_FIELD(x); // CHECK:      DEFINE_FIELD(x);
+  int y;           // CHECK-NEXT: int y;
+};
+


### PR DESCRIPTION
When a field definition comes from a macro expansion, reordering completely messes up the file. There is no good way to fix this, since we can't modify the macro itself. Emit a warning instead.