### PR TITLE
[clang][bytecode] Mark global decls with diagnostics invalid

### DIFF
--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -402,14 +402,13 @@ namespace NoInitMapLeak {
 
   constexpr int a[] = {1,2,3,4/0,5}; // both-error {{must be initialized by a constant expression}} \
                                      // both-note {{division by zero}} \
-                                     // ref-note {{declared here}}
+                                     // both-note {{declared here}}
 
-  /// FIXME: This should fail in the new interpreter as well.
-  constexpr int b = a[0]; // ref-error {{must be initialized by a constant expression}} \
-                          // ref-note {{is not a constant expression}} \
-                          // ref-note {{declared here}}
-  static_assert(b == 1, ""); // ref-error {{not an integral constant expression}} \
-                             // ref-note {{not a constant expression}}
+  constexpr int b = a[0]; // both-error {{must be initialized by a constant expression}} \
+                          // both-note {{is not a constant expression}} \
+                          // both-note {{declared here}}
+  static_assert(b == 1, ""); // both-error {{not an integral constant expression}} \
+                             // both-note {{not a constant expression}}
 
   constexpr int f() { // both-error {{never produces a constant expression}}
     int a[] = {19,2,3/0,4}; // both-note 2{{division by zero}} \

--- a/clang/test/AST/ByteCode/cxx23.cpp
+++ b/clang/test/AST/ByteCode/cxx23.cpp
@@ -217,16 +217,13 @@ namespace UndefinedThreeWay {
                                                 // all-note {{undefined function 'operator<=>' cannot be used in a constant expression}}
 }
 
-/// FIXME: The new interpreter is missing the "initializer of q is not a constant expression" diagnostics.a
-/// That's because the cast from void* to int* is considered fine, but diagnosed. So we don't consider
-/// q to be uninitialized.
 namespace VoidCast {
   constexpr void* p = nullptr;
   constexpr int* q = static_cast<int*>(p); // all-error {{must be initialized by a constant expression}} \
                                            // all-note {{cast from 'void *' is not allowed in a constant expression}} \
-                                           // ref-note {{declared here}}
-  static_assert(q == nullptr); // ref-error {{not an integral constant expression}} \
-                               // ref-note {{initializer of 'q' is not a constant expression}}
+                                           // all-note {{declared here}}
+  static_assert(q == nullptr); // all-error {{not an integral constant expression}} \
+                               // all-note {{initializer of 'q' is not a constant expression}}
 }
 
 namespace ExplicitLambdaInstancePointer {


### PR DESCRIPTION
Even if their evaluation succeeds, mark them as invalid. This fixes some long standing differences to the ast walker interpeter.