### PR TITLE
[mutation analyzer] enhance stability for `hasAnyInit` matcher

### DIFF
--- a/clang/lib/Analysis/ExprMutationAnalyzer.cpp
+++ b/clang/lib/Analysis/ExprMutationAnalyzer.cpp
@@ -104,6 +104,8 @@ AST_MATCHER_P(Stmt, canResolveToExpr, const Stmt *, Inner) {
 AST_MATCHER_P(InitListExpr, hasAnyInit, ast_matchers::internal::Matcher<Expr>,
               InnerMatcher) {
   for (const Expr *Arg : Node.inits()) {
+    if (Arg == nullptr)
+      continue;
     ast_matchers::internal::BoundNodesTreeBuilder Result(*Builder);
     if (InnerMatcher.matches(*Arg, Finder, &Result)) {
       *Builder = std::move(Result);


### PR DESCRIPTION
I cannot minimal produce it, but when I run clangd with `misc-const-correctness` check in a big project
clangd crashed due to deref nullptr here.
clang may pass a nullptr to `InitExprs` when meets some error cases.
