### PR TITLE
[mlir-cpu-runner] Pass --exclude-libs to linker when building runner

### DIFF
--- a/mlir/tools/mlir-cpu-runner/CMakeLists.txt
+++ b/mlir/tools/mlir-cpu-runner/CMakeLists.txt
@@ -26,3 +26,14 @@ target_link_libraries(mlir-cpu-runner PRIVATE
   MLIRExecutionEngine
   MLIRJitRunner
   )
+
+# Preventing re-export of symbols causes link errors with ASan and UBSan libs.
+if (NOT LLVM_USE_SANITIZER)
+  target_link_options(mlir-cpu-runner
+    PRIVATE
+      # On Linux, disable re-export of any static linked libraries that came
+      # through. This prevents our LLVM build from interfering with the version
+      # of LLVM included in certain graphics drivers.
+      $<$<PLATFORM_ID:Linux>:LINKER:--exclude-libs,ALL>
+  )
+endif()


### PR DESCRIPTION
This fixes a conflict between the version of LLVM linked against by the runner and the unrelated version of LLVM that may be dynamically loaded by a graphics driver. (Relevant to #73457: fixes loading certain Vulkan drivers.)

Recommit of f879da799b4e112d79243dde6d299259d8359eeb, which had been reverted by d8d30a96031bfdad3e2c424e14a4247c14980cb5 due to it causing UBSan/ASan/HWASan/MSan build failures.