### PR TITLE
[llvm-gsymutil] Ensure gSYM creation determinism with merged functions

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymCreator.cpp
@@ -275,8 +275,9 @@ llvm::Error GsymCreator::finalize(OutputAggregator &Out) {
   // object.
   if (!IsSegment) {
     if (NumBefore > 1) {
-      // Sort function infos so we can emit sorted functions.
-      llvm::sort(Funcs);
+      // Sort function infos so we can emit sorted functions. Use stable sort to
+      // ensure determinism.
+      llvm::stable_sort(Funcs);
       std::vector<FunctionInfo> FinalizedFuncs;
       FinalizedFuncs.reserve(Funcs.size());
       FinalizedFuncs.emplace_back(std::move(Funcs.front()));


### PR DESCRIPTION
We were seeing occasional test failures with expensive checks enabled. The issue was tracked down to a `sort` which should instead be a `stable_sort` to ensure determinism. Checked locally and the non-determinism went away. 