### PR TITLE
[AMDGPU] Emit AMDHSA kernel descriptors to `.amdhsa.kd` section

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -980,7 +980,12 @@ void AMDGPUTargetELFStreamer::EmitAmdhsaKernelDescriptor(
   if (KernelCodeSymbol->getVisibility() == ELF::STV_DEFAULT)
     KernelCodeSymbol->setVisibility(ELF::STV_PROTECTED);
 
+  Streamer.pushSection();
+  Streamer.switchSection(Context.getELFSection(
+      ".amdhsa.kd", ELF::SHT_PROGBITS, ELF::SHF_ALLOC | ELF::SHF_GNU_RETAIN));
   Streamer.emitLabel(KernelDescriptorSymbol);
+  Streamer.emitValueToAlignment(Align(alignof(amdhsa::kernel_descriptor_t)), 0,
+                                1, 0);
   Streamer.emitValue(
       KernelDescriptor.group_segment_fixed_size,
       sizeof(amdhsa::kernel_descriptor_t::group_segment_fixed_size));
@@ -1020,4 +1025,5 @@ void AMDGPUTargetELFStreamer::EmitAmdhsaKernelDescriptor(
                      sizeof(amdhsa::kernel_descriptor_t::kernarg_preload));
   for (uint32_t i = 0; i < sizeof(amdhsa::kernel_descriptor_t::reserved3); ++i)
     Streamer.emitInt8(0u);
+  Streamer.popSection();
 }

--- a/llvm/test/CodeGen/AMDGPU/amdhsa-kernarg-preload-num-sgprs.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdhsa-kernarg-preload-num-sgprs.ll
@@ -1,7 +1,7 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -filetype=obj < %s | llvm-objdump -s -j .rodata - | FileCheck --check-prefix=OBJDUMP %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -filetype=obj < %s | llvm-objdump -s -j .amdhsa.kd - | FileCheck --check-prefix=OBJDUMP %s
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 < %s | FileCheck --check-prefix=ASM %s
 
-; OBJDUMP: Contents of section .rodata:
+; OBJDUMP: Contents of section .amdhsa.kd:
 ; OBJDUMP-NEXT: 0000 00000000 00000000 10010000 00000000  ................
 ; OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000  ................
 ; OBJDUMP-NEXT: 0020 00000000 00000000 00000000 00000000  ................

--- a/llvm/test/CodeGen/AMDGPU/code-object-v3.ll
+++ b/llvm/test/CodeGen/AMDGPU/code-object-v3.ll
@@ -51,7 +51,7 @@
 ; OSABI-AMDHSA-ELF: .text   PROGBITS {{[0-9]+}} {{[0-9]+}} {{[0-9a-f]+}} {{[0-9]+}} AX {{[0-9]+}} {{[0-9]+}} 256
 ; OSABI-AMDHSA-ELF: .rodata PROGBITS {{[0-9]+}} {{[0-9]+}} {{[0-9a-f]+}} {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
 
-; OSABI-AMDHSA-ELF: Relocation section '.rela.rodata' at offset
+; OSABI-AMDHSA-ELF: Relocation section '.rela.amdhsa.kd' at offset
 ; OSABI-AMDHSA-ELF: R_AMDGPU_REL64 0000000000000000 fadd + 10
 ; OSABI-AMDHSA-ELF: R_AMDGPU_REL64 0000000000000100 fsub + 10
 ; OSABI-AMDHSA-ELF: R_AMDGPU_REL64 0000000000000200 empty + 10

--- a/llvm/test/CodeGen/AMDGPU/tid-kd-xnack-any.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-kd-xnack-any.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck --check-prefixes=ASM %s
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a --filetype=obj < %s | llvm-objdump -s -j .rodata - | FileCheck --check-prefixes=OBJ %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a --filetype=obj < %s | llvm-objdump -s -j .amdhsa.kd - | FileCheck --check-prefixes=OBJ %s
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a --filetype=obj < %s | llvm-readelf --notes - | FileCheck --check-prefixes=ELF %s
 
 ; TODO: Update to check for granulated sgpr count directive once one is added.
@@ -10,7 +10,7 @@ define amdgpu_kernel void @kern() #0 {
 ; ASM: .amdhsa_reserve_xnack_mask 1
 
 ; Verify that an extra SGPR block is reserved with XNACK "any" tid setting.
-; OBJ: Contents of section .rodata:
+; OBJ: Contents of section .amdhsa.kd:
 ; OBJ-NEXT: 0000 00000000 00000000 00000000 00000000  ................
 ; OBJ-NEXT: 0010 00000000 00000000 00000000 00000000  ................
 ; OBJ-NEXT: 0020 00000000 00000000 00000000 00000000  ................

--- a/llvm/test/CodeGen/AMDGPU/tid-kd-xnack-off.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-kd-xnack-off.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=-xnack < %s | FileCheck --check-prefixes=ASM %s
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=-xnack --filetype=obj < %s | llvm-objdump -s -j .rodata - | FileCheck --check-prefixes=OBJ %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=-xnack --filetype=obj < %s | llvm-objdump -s -j .amdhsa.kd - | FileCheck --check-prefixes=OBJ %s
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=-xnack --filetype=obj < %s | llvm-readelf --notes - | FileCheck --check-prefixes=ELF %s
 
 ; TODO: Update to check for granulated sgpr count directive once one is added.
@@ -10,7 +10,7 @@ define amdgpu_kernel void @kern() #0 {
 ; ASM: .amdhsa_reserve_xnack_mask 0
 
 ; Verify that an extra SGPR block is not reserved with XNACK "off" tid setting.
-; OBJ: Contents of section .rodata:
+; OBJ: Contents of section .amdhsa.kd:
 ; OBJ-NEXT: 0000 00000000 00000000 00000000 00000000  ................
 ; OBJ-NEXT: 0010 00000000 00000000 00000000 00000000  ................
 ; OBJ-NEXT: 0020 00000000 00000000 00000000 00000000  ................

--- a/llvm/test/CodeGen/AMDGPU/tid-kd-xnack-on.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-kd-xnack-on.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack < %s | FileCheck --check-prefixes=ASM %s
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack --filetype=obj < %s | llvm-objdump -s -j .rodata - | FileCheck --check-prefixes=OBJ %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack --filetype=obj < %s | llvm-objdump -s -j .amdhsa.kd - | FileCheck --check-prefixes=OBJ %s
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack --filetype=obj < %s | llvm-readelf --notes - | FileCheck --check-prefixes=ELF %s
 
 ; TODO: Update to check for granulated sgpr count directive once one is added.
@@ -10,7 +10,7 @@ define amdgpu_kernel void @kern() #0 {
 ; ASM: .amdhsa_reserve_xnack_mask 1
 
 ; Verify that an extra SGPR block is reserved with XNACK "on" tid setting.
-; OBJ: Contents of section .rodata:
+; OBJ: Contents of section .amdhsa.kd:
 ; OBJ-NEXT: 0000 00000000 00000000 00000000 00000000  ................
 ; OBJ-NEXT: 0010 00000000 00000000 00000000 00000000  ................
 ; OBJ-NEXT: 0020 00000000 00000000 00000000 00000000  ................

--- a/llvm/test/MC/AMDGPU/amdhsa-kd-kernarg-preload.s
+++ b/llvm/test/MC/AMDGPU/amdhsa-kd-kernarg-preload.s
@@ -1,4 +1,4 @@
-// RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx940 -filetype=obj < %s -o - | llvm-objdump -s -j .rodata - | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx940 -filetype=obj < %s -o - | llvm-objdump -s -j .amdhsa.kd - | FileCheck --check-prefix=OBJDUMP %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx940"
 
@@ -6,7 +6,7 @@
 
 // Account for preload kernarg SGPRs in KD field GRANULATED_WAVEFRONT_SGPR_COUNT.
 
-// OBJDUMP:      Contents of section .rodata:
+// OBJDUMP:      Contents of section .amdhsa.kd:
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000  ................
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000  ................
 // OBJDUMP-NEXT: 0020 00000000 00000000 00000000 00000000  ................

--- a/llvm/test/MC/AMDGPU/hsa-amdgpu-exprs.s
+++ b/llvm/test/MC/AMDGPU/hsa-amdgpu-exprs.s
@@ -1,6 +1,6 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx90a -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // OBJDUMP:       0000 00000000 0f000000 00000000 00000000
 

--- a/llvm/test/MC/AMDGPU/hsa-gfx12-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-gfx12-v4.s
@@ -1,13 +1,14 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1200 < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1200 -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // READOBJ: Section Headers
 // READOBJ: .text   PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9]+}} AX {{[0-9]+}} {{[0-9]+}} 256
-// READOBJ: .rodata PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000100 {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
+// READOBJ: .rodata PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000000 {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
+// READOBJ: .amdhsa.kd PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000100 {{[0-9]+}}  AR {{[0-9]+}} {{[0-9]+}} 8
 
-// READOBJ: Relocation section '.rela.rodata' at offset
+// READOBJ: Relocation section '.rela.amdhsa.kd' at offset
 // READOBJ: 0000000000000010 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 10
 // READOBJ: 0000000000000050 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 110
 // READOBJ: 0000000000000090 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 210
@@ -18,12 +19,12 @@
 // READOBJ-NEXT: 0000000000000100  0 FUNC    LOCAL  PROTECTED 2 complete
 // READOBJ-NEXT: 0000000000000200  0 FUNC    LOCAL  PROTECTED 2 special_sgpr
 // READOBJ-NEXT: 0000000000000300  0 FUNC    LOCAL  PROTECTED 2 disabled_user_sgpr
-// READOBJ-NEXT: 0000000000000000 64 OBJECT  LOCAL  DEFAULT   3 minimal.kd
-// READOBJ-NEXT: 0000000000000040 64 OBJECT  LOCAL  DEFAULT   3 complete.kd
-// READOBJ-NEXT: 0000000000000080 64 OBJECT  LOCAL  DEFAULT   3 special_sgpr.kd
-// READOBJ-NEXT: 00000000000000c0 64 OBJECT  LOCAL  DEFAULT   3 disabled_user_sgpr.kd
+// READOBJ-NEXT: 0000000000000000 64 OBJECT LOCAL DEFAULT 4 minimal.kd 
+// READOBJ-NEXT: 0000000000000040 64 OBJECT LOCAL DEFAULT 4 complete.kd 
+// READOBJ-NEXT: 0000000000000080 64 OBJECT LOCAL DEFAULT 4 special_sgpr.kd 
+// READOBJ-NEXT: 00000000000000c0 64 OBJECT LOCAL DEFAULT 4 disabled_user_sgpr.kd 
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // Note, relocation for KERNEL_CODE_ENTRY_BYTE_OFFSET is not resolved here.
 // minimal
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sgpr-init-bug-v3.s
+++ b/llvm/test/MC/AMDGPU/hsa-sgpr-init-bug-v3.s
@@ -1,10 +1,10 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx802 -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // Check that SGPR init bug on gfx803 is corrected by the assembler, setting
 // GRANULATED_WAVEFRONT_SGPR_COUNT to 11.
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 0020 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx10.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx10.s
@@ -1,11 +1,11 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1010 < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1010 -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // When going from asm -> asm, the expressions should remain the same (i.e., symbolic).
 // When going from asm -> obj, the expressions should get resolved (through fixups),
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // expr_defined_later
 // OBJDUMP-NEXT: 0000 2b000000 2c000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx11.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx11.s
@@ -1,11 +1,11 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1100 < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1100 -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // When going from asm -> asm, the expressions should remain the same (i.e., symbolic).
 // When going from asm -> obj, the expressions should get resolved (through fixups),
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // expr_defined_later
 // OBJDUMP-NEXT: 0000 2b000000 2c000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx12.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx12.s
@@ -1,11 +1,11 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1200 < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx1200 -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // When going from asm -> asm, the expressions should remain the same (i.e., symbolic).
 // When going from asm -> obj, the expressions should get resolved (through fixups),
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // expr_defined_later
 // OBJDUMP-NEXT: 0000 2b000000 2c000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx7.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx7.s
@@ -1,11 +1,11 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx700 < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx700 -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // When going from asm -> asm, the expressions should remain the same (i.e., symbolic).
 // When going from asm -> obj, the expressions should get resolved (through fixups),
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // expr_defined_later
 // OBJDUMP-NEXT: 0000 2b000000 2c000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx8.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx8.s
@@ -1,12 +1,12 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx801 < %s | FileCheck --check-prefix=ASM %s
 
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx801 -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // When going from asm -> asm, the expressions should remain the same (i.e., symbolic).
 // When going from asm -> obj, the expressions should get resolved (through fixups),
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd 
 // expr_defined_later
 // OBJDUMP-NEXT: 0000 2b000000 2c000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx90a.s
+++ b/llvm/test/MC/AMDGPU/hsa-sym-exprs-gfx90a.s
@@ -1,11 +1,11 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx90a -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // When going from asm -> asm, the expressions should remain the same (i.e., symbolic).
 // When going from asm -> obj, the expressions should get resolved (through fixups),
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // expr_defined_later
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-tg-split.s
+++ b/llvm/test/MC/AMDGPU/hsa-tg-split.s
@@ -1,8 +1,8 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack,+tgsplit < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx90a -mattr=+xnack,+tgsplit -filetype=obj < %s > %t
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000
 // OBJDUMP-NEXT: 0020 00000000 00000000 00000000 00000100

--- a/llvm/test/MC/AMDGPU/hsa-v4.s
+++ b/llvm/test/MC/AMDGPU/hsa-v4.s
@@ -1,13 +1,14 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // READOBJ: Section Headers
 // READOBJ: .text   PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9]+}} AX {{[0-9]+}} {{[0-9]+}} 256
-// READOBJ: .rodata PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000100 {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
+// READOBJ: .rodata PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000000 {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
+// READOBJ: .amdhsa.kd PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000100 {{[0-9]+}}  AR {{[0-9]+}} {{[0-9]+}} 8
 
-// READOBJ: Relocation section '.rela.rodata' at offset
+// READOBJ: Relocation section '.rela.amdhsa.kd' at offset
 // READOBJ: 0000000000000010 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 10
 // READOBJ: 0000000000000050 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 110
 // READOBJ: 0000000000000090 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 210
@@ -18,12 +19,12 @@
 // READOBJ-NEXT: 0000000000000100  0 FUNC    LOCAL  PROTECTED 2 complete
 // READOBJ-NEXT: 0000000000000200  0 FUNC    LOCAL  PROTECTED 2 special_sgpr
 // READOBJ-NEXT: 0000000000000300  0 FUNC    LOCAL  PROTECTED 2 disabled_user_sgpr
-// READOBJ-NEXT: 0000000000000000 64 OBJECT  LOCAL  DEFAULT   3 minimal.kd
-// READOBJ-NEXT: 0000000000000040 64 OBJECT  LOCAL  DEFAULT   3 complete.kd
-// READOBJ-NEXT: 0000000000000080 64 OBJECT  LOCAL  DEFAULT   3 special_sgpr.kd
-// READOBJ-NEXT: 00000000000000c0 64 OBJECT  LOCAL  DEFAULT   3 disabled_user_sgpr.kd
+// READOBJ-NEXT: 0000000000000000 64 OBJECT LOCAL DEFAULT 4 minimal.kd 
+// READOBJ-NEXT: 0000000000000040 64 OBJECT LOCAL DEFAULT 4 complete.kd 
+// READOBJ-NEXT: 0000000000000080 64 OBJECT LOCAL DEFAULT 4 special_sgpr.kd 
+// READOBJ-NEXT: 00000000000000c0 64 OBJECT LOCAL DEFAULT 4 disabled_user_sgpr.kd 
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // Note, relocation for KERNEL_CODE_ENTRY_BYTE_OFFSET is not resolved here.
 // minimal
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000

--- a/llvm/test/MC/AMDGPU/hsa-v5-uses-dynamic-stack.s
+++ b/llvm/test/MC/AMDGPU/hsa-v5-uses-dynamic-stack.s
@@ -1,18 +1,19 @@
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx904 -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx904 --amdhsa-code-object-version=6 -mattr=+xnack < %s | FileCheck --check-prefix=ASM %s
 // RUN: llvm-mc -triple amdgcn-amd-amdhsa -mcpu=gfx904 --amdhsa-code-object-version=6 -mattr=+xnack -filetype=obj < %s > %t
 // RUN: llvm-readelf -S -r -s %t | FileCheck --check-prefix=READOBJ %s
-// RUN: llvm-objdump -s -j .rodata %t | FileCheck --check-prefix=OBJDUMP %s
+// RUN: llvm-objdump -s -j .amdhsa.kd %t | FileCheck --check-prefix=OBJDUMP %s
 
 // READOBJ: Section Headers
 // READOBJ: .text   PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9]+}} AX {{[0-9]+}} {{[0-9]+}} 256
-// READOBJ: .rodata PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000100 {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
+// READOBJ: .rodata PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000000 {{[0-9]+}}  A {{[0-9]+}} {{[0-9]+}} 64
+// READOBJ: .amdhsa.kd PROGBITS {{[0-9a-f]+}} {{[0-9a-f]+}}        000100 {{[0-9]+}}  AR {{[0-9]+}} {{[0-9]+}} 8
 
-// READOBJ: Relocation section '.rela.rodata' at offset
+// READOBJ: Relocation section '.rela.amdhsa.kd' at offset
 // READOBJ: 0000000000000010 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 10
 // READOBJ: 0000000000000050 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 110
 // READOBJ: 0000000000000090 {{[0-9a-f]+}}00000005 R_AMDGPU_REL64 0000000000000000 .text + 210
@@ -23,12 +24,12 @@
 // READOBJ-NEXT: 0000000000000100  0 FUNC    LOCAL  PROTECTED 2 complete
 // READOBJ-NEXT: 0000000000000200  0 FUNC    LOCAL  PROTECTED 2 special_sgpr
 // READOBJ-NEXT: 0000000000000300  0 FUNC    LOCAL  PROTECTED 2 disabled_user_sgpr
-// READOBJ-NEXT: 0000000000000000 64 OBJECT  LOCAL  DEFAULT   3 minimal.kd
-// READOBJ-NEXT: 0000000000000040 64 OBJECT  LOCAL  DEFAULT   3 complete.kd
-// READOBJ-NEXT: 0000000000000080 64 OBJECT  LOCAL  DEFAULT   3 special_sgpr.kd
-// READOBJ-NEXT: 00000000000000c0 64 OBJECT  LOCAL  DEFAULT   3 disabled_user_sgpr.kd
+// READOBJ-NEXT: 0000000000000000 64 OBJECT LOCAL DEFAULT 4 minimal.kd 
+// READOBJ-NEXT: 0000000000000040 64 OBJECT LOCAL DEFAULT 4 complete.kd 
+// READOBJ-NEXT: 0000000000000080 64 OBJECT LOCAL DEFAULT 4 special_sgpr.kd 
+// READOBJ-NEXT: 00000000000000c0 64 OBJECT LOCAL DEFAULT 4 disabled_user_sgpr.kd 
 
-// OBJDUMP: Contents of section .rodata
+// OBJDUMP: Contents of section .amdhsa.kd
 // Note, relocation for KERNEL_CODE_ENTRY_BYTE_OFFSET is not resolved here.
 // minimal
 // OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-cov5.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-cov5.s
@@ -1,17 +1,17 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/5/g' %s \
 ; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/4/g' %s \
 ; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV4,CHECK
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV4,CHECK
 
 ;; Make sure we override the default COV in the disassembler on COV6 (there
 ;; currently aren't any differences between 5 and 6, so set the default to 4 so
 ;; we can verify that the default is at least overridden)
 ; RUN: sed 's/CODE_OBJECT_VERSION/6/g' %s \
 ; RUN:   | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj > %t.o
-; RUN: llvm-objdump -mllvm --amdhsa-code-object-version=4 --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
+; RUN: llvm-objdump --section=.amdhsa.kd -mllvm --amdhsa-code-object-version=4 --disassemble-symbols=kernel.kd %t.o | FileCheck %s --check-prefixes=COV5,CHECK
 
 ;; Verify that .amdhsa_uses_dynamic_stack is only printed on COV5+.
 

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx10.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx10.s
@@ -5,7 +5,7 @@
 ;--- 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1010 < 1.s > 1.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1010 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -61,7 +61,7 @@
 ;--- 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 2.s > 2.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -117,7 +117,7 @@
 ;--- 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 3.s > 3.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -173,7 +173,7 @@
 ;--- 4.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 4.s > 4.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 4-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 4.o | tail -n +7 | tee -a 4-disasm.s | FileCheck 4.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 4.o | tail -n +7 | tee -a 4-disasm.s | FileCheck 4.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack,+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1010 < 4-disasm.s > 4-disasm.o
 ; RUN: cmp 4.o 4-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx11.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx11.s
@@ -5,7 +5,7 @@
 ;--- 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1100 < 1.s > 1.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1100 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -62,7 +62,7 @@
 ;--- 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1100 < 2.s > 2.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1100 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -119,7 +119,7 @@
 ;--- 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1100 < 3.s > 3.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1100 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -176,7 +176,7 @@
 ;--- 4.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1100 < 4.s > 4.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 4-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 4.o | tail -n +7 | tee -a 4-disasm.s | FileCheck 4.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 4.o | tail -n +7 | tee -a 4-disasm.s | FileCheck 4.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize64,-wavefrontsize32 -filetype=obj -mcpu=gfx1100 < 4-disasm.s > 4-disasm.o
 ; RUN: cmp 4.o 4-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx12.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx12.s
@@ -5,7 +5,7 @@
 ;--- 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1200 < 1.s > 1.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=+wavefrontsize32,-wavefrontsize64 -filetype=obj -mcpu=gfx1200 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -59,7 +59,7 @@
 ;--- 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-wavefrontsize32,+wavefrontsize64 -filetype=obj -mcpu=gfx1200 < 2.s > 2.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-wavefrontsize32,+wavefrontsize64 -filetype=obj -mcpu=gfx1200 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx90a.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx90a.s
@@ -5,7 +5,7 @@
 ;--- 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx90a < 1.s > 1.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx90a < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -58,7 +58,7 @@
 ;--- 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx90a < 2.s > 2.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx90a < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -111,7 +111,7 @@
 ;--- 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx90a < 3.s > 3.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx90a < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx950.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-gfx950.s
@@ -4,7 +4,7 @@
 
 ;--- 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx950 < 1.s > 1.o
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx950 < 1-disasm.s > 1-disasm.o
 ; FIxMe: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-sgpr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-sgpr.s
@@ -6,7 +6,7 @@
 ;; Only set next_free_sgpr.
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 1.s > 1.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -60,7 +60,7 @@
 ;; Only set other directives.
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 2.s > 2.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -114,7 +114,7 @@
 ;; Set all affecting directives.
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 3.s > 3.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-vgpr.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-vgpr.s
@@ -5,7 +5,7 @@
 ;--- 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 1.s > 1.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 1-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 1.o | tail -n +7 | tee -a 1-disasm.s | FileCheck 1.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 1-disasm.s > 1-disasm.o
 ; RUN: cmp 1.o 1-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -55,7 +55,7 @@
 ;--- 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 2.s > 2.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 2-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 2.o | tail -n +7 | tee -a 2-disasm.s | FileCheck 2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 2-disasm.s > 2-disasm.o
 ; RUN: cmp 2.o 2-disasm.o
 ; CHECK: .amdhsa_kernel kernel
@@ -105,7 +105,7 @@
 ;--- 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 3.s > 3.o
 ; RUN: echo '.amdhsa_code_object_version 5' > 3-disasm.s
-; RUN: llvm-objdump --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=kernel.kd 3.o | tail -n +7 | tee -a 3-disasm.s | FileCheck 3.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mattr=-xnack -filetype=obj -mcpu=gfx908 < 3-disasm.s > 3-disasm.o
 ; RUN: cmp 3.o 3-disasm.o
 ; CHECK: .amdhsa_kernel kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx10.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx10.s
@@ -1,7 +1,7 @@
 ;; Entirely zeroed kernel descriptor (for GFX10).
 
 ; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx1010 -mattr=-xnack -filetype=obj -o %t
-; RUN: llvm-objdump -s -d -j .text %t | FileCheck --check-prefix=OBJDUMP %s
+; RUN: llvm-objdump --section=.amdhsa.kd -s -d -j .text %t | FileCheck --check-prefix=OBJDUMP %s
 
 ;; TODO:
 ;; This file and kd-zeroed-raw.s should produce the same output for the kernel
@@ -11,14 +11,14 @@
 
 ;; Check the raw bytes right now.
 
-; OBJDUMP-LABEL: Contents of section .text:
+; OBJDUMP-LABEL: Contents of section .amdhsa.kd:
 ; OBJDUMP-NEXT: 0000 00000000 00000000 00000000 00000000
 ; OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000
 ; OBJDUMP-NEXT: 0020 00000000 00000000 00000000 00000000
 ; OBJDUMP-NEXT: 0030 01000000 00000000 00000000 00000000
 ; OBJDUMP-EMPTY:
 
-; OBJDUMP-LABEL: Disassembly of section .text:
+; OBJDUMP-LABEL: Disassembly of section .amdhsa.kd:
 ; OBJDUMP-EMPTY:
 ; OBJDUMP-NEXT: 0000000000000000 <my_kernel.kd>:
 ; OBJDUMP-NEXT: .amdhsa_kernel my_kernel

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx9.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-gfx9.s
@@ -2,11 +2,11 @@
 
 ; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=-xnack -filetype=obj -o %t1
 ; RUN: echo '.amdhsa_code_object_version 5' > %t2.s
-; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 | tail -n +7 >> %t2.s
+; RUN: llvm-objdump --section=.amdhsa.kd --disassemble-symbols=my_kernel.kd %t1 | tail -n +7 >> %t2.s
 ; RUN: llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=-xnack -filetype=obj -o %t2 %t2.s
 ; RUN: diff %t1 %t2
 
-; RUN: llvm-objdump -s -j .text %t1 | FileCheck --check-prefix=OBJDUMP %s
+; RUN: llvm-objdump --section=.amdhsa.kd -s -j .text %t1 | FileCheck --check-prefix=OBJDUMP %s
 
 ; OBJDUMP:      0000 00000000 00000000 00000000 00000000
 ; OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-raw.s
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/kd-zeroed-raw.s
@@ -1,7 +1,7 @@
 ; RUN: llvm-mc %s --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=-xnack -filetype=obj -o %t1
 ; RUN: llvm-objdump --disassemble-symbols=my_kernel.kd %t1 \
 ; RUN: | tail -n +7 | llvm-mc --triple=amdgcn-amd-amdhsa -mcpu=gfx908 -mattr=-xnack -filetype=obj -o %t2
-; RUN: llvm-objdump -s -j .text %t2 | FileCheck --check-prefix=OBJDUMP %s
+; RUN: llvm-objdump -s -j .amdhsa.kd %t2 | FileCheck --check-prefix=OBJDUMP %s
 
 ;; Not running lit-test over gfx10 (see kd-zeroed-gfx10.s for details).
 ;; kd-zeroed-raw.s and kd-zeroed-*.s should produce the same output for the
@@ -9,7 +9,7 @@
 
 ;; The disassembly will produce the contents of kd-zeroed-*.s which on being
 ;; assembled contains additional relocation info. A diff over the entire object
-;; will fail in this case. So we check by looking the bytes in .text.
+;; will fail in this case. So we check by looking the bytes in .amdhsa.kd.
 
 ; OBJDUMP:      0000 00000000 00000000 00000000 00000000
 ; OBJDUMP-NEXT: 0010 00000000 00000000 00000000 00000000

--- a/llvm/test/tools/llvm-objdump/ELF/AMDGPU/subtarget.ll
+++ b/llvm/test/tools/llvm-objdump/ELF/AMDGPU/subtarget.ll
@@ -7,225 +7,225 @@ define amdgpu_kernel void @test_kernel() {
 ; ----------------------------------GFX12--------------------------------------
 ;
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa --amdhsa-code-object-version=6 -mcpu=gfx12-generic -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx12-generic %t.o > %t-specify.txt
-; RUN: llvm-objdump -D -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx12-generic %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 ;
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1201 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1201 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1201 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 ;
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1200 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1200 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1200 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; ----------------------------------GFX11--------------------------------------
 ;
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa --amdhsa-code-object-version=6 -mcpu=gfx11-generic -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx11-generic %t.o > %t-specify.txt
-; RUN: llvm-objdump -D -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx11-generic %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1153 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1153 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1153 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1152 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1152 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1152 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1151 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1151 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1151 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1150 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1150 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1150 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1103 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1103 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1103 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1102 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1102 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1102 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1101 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1101 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1101 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1100 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1100 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1100 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; ----------------------------------GFX10--------------------------------------
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa --amdhsa-code-object-version=6 -mcpu=gfx10-3-generic -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx10-3-generic %t.o > %t-specify.txt
-; RUN: llvm-objdump -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx10-3-generic %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1036 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1036 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1036 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1035 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1035 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1035 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1034 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1034 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1034 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1033 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1033 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1033 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1032 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1032 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1032 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1031 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1031 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1031 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1030 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1030 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1030 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa --amdhsa-code-object-version=6 -mcpu=gfx10-1-generic -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx10-1-generic %t.o > %t-specify.txt
-; RUN: llvm-objdump -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx10-1-generic %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1013 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1013 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1013 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1012 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1012 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1012 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1011 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1011 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1011 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1010 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx1010 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx1010 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 
 ; ----------------------------------GFX9---------------------------------------
 ;
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa --amdhsa-code-object-version=6 -mcpu=gfx9-4-generic -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx9-4-generic %t.o > %t-specify.txt
-; RUN: llvm-objdump -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx9-4-generic %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa --amdhsa-code-object-version=6 -mcpu=gfx9-generic -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx9-generic %t.o > %t-specify.txt
-; RUN: llvm-objdump -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn -mllvm --amdhsa-code-object-version=6 --mcpu=gfx9-generic %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D  -mllvm --amdhsa-code-object-version=6 %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx950 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx950 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx942 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx942 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx941 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx941 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx941 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx940 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx940 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90c -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx90c %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx90c %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx90a %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx90a %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx909 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx909 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx909 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx908 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx908 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx906 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx906 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx906 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx904 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx904 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx904 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx902 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx902 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx902 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx900 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx900 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 
 ; ----------------------------------GFX8---------------------------------------
 ;
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx810 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx810 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx810 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx803 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx803 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx803 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx802 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx802 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx802 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt
 
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx801 -filetype=obj -O0 -o %t.o %s
-; RUN: llvm-objdump -D --arch-name=amdgcn --mcpu=gfx801 %t.o > %t-specify.txt
-; RUN: llvm-objdump -D %t.o > %t-detect.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D --arch-name=amdgcn --mcpu=gfx801 %t.o > %t-specify.txt
+; RUN: llvm-objdump --section=.amdhsa.kd -D %t.o > %t-detect.txt
 ; RUN: diff %t-specify.txt %t-detect.txt


### PR DESCRIPTION
Summary:
This patch emits all kernel descriptors to a new section rather than
mixing  them in with the other symbols in `.rodata` or `.text`. The
advantage to this approach is that it will allow the runtime to memcpy
the whole section rather than copying individual symbols whose names end
in `.kd`.

Additionally, this fixes an issue where `--gc-sections` will trim these
symbols as they are not used by anything and simply exist as metadata.
Adding the `SHF_GNU_RETAIN` prevents this entirely.

Fixes: https://github.com/llvm/llvm-project/issues/119479
