### PR TITLE
Rename [[clang::requires_explicit_initialization]] to [[clang::require_explicit_initialization]]

### DIFF
--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -1671,7 +1671,7 @@ protected:
     uint64_t HasNonTrivialToPrimitiveCopyCUnion : 1;
 
     /// True if any field is marked as requiring explicit initialization with
-    /// [[clang::requires_explicit_initialization]].
+    /// [[clang::require_explicit_initialization]].
     /// In C++, this is also set for types without a user-provided default
     /// constructor, and is propagated from any base classes and/or member
     /// variables whose types are aggregates.

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1903,7 +1903,7 @@ def Leaf : InheritableAttr {
 }
 
 def ExplicitInit : InheritableAttr {
-  let Spellings = [Clang<"requires_explicit_initialization">];
+  let Spellings = [Clang<"require_explicit_initialization">];
   let Subjects = SubjectList<[Field], ErrorDiag>;
   let Documentation = [ExplicitInitDocs];
   let SimpleHandler = 1;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1687,7 +1687,7 @@ is not specified.
 def ExplicitInitDocs : Documentation {
   let Category = DocCatField;
   let Content = [{
-The ``clang::requires_explicit_initialization`` attribute indicates that a
+The ``clang::require_explicit_initialization`` attribute indicates that a
 field of an aggregate must be initialized explicitly by the user when an object
 of the aggregate type is constructed. The attribute supports both C and C++,
 but its usage is invalid on non-aggregates.
@@ -1704,13 +1704,13 @@ initializers exist):
 .. code-block:: c++
 
   struct Buffer {
-    void *address [[clang::requires_explicit_initialization]];
-    size_t length [[clang::requires_explicit_initialization]] = 0;
+    void *address [[clang::require_explicit_initialization]];
+    size_t length [[clang::require_explicit_initialization]] = 0;
   };
 
   struct ArrayIOParams {
-    size_t count [[clang::requires_explicit_initialization]];
-    size_t element_size [[clang::requires_explicit_initialization]];
+    size_t count [[clang::require_explicit_initialization]];
+    size_t element_size [[clang::require_explicit_initialization]];
     int flags = 0;
   };
 

--- a/clang/test/Sema/uninit-variables.c
+++ b/clang/test/Sema/uninit-variables.c
@@ -554,16 +554,16 @@ struct full_of_empty empty_test_2(void) {
 
 struct with_explicit_field {
   int x;
-  int y [[clang::requires_explicit_initialization]]; // #FIELD_Y
+  int y [[clang::require_explicit_initialization]]; // #FIELD_Y
 };
 
 struct with_explicit_array {
-  [[clang::requires_explicit_initialization]] int arr[2]; // #FIELD_ARR
+  [[clang::require_explicit_initialization]] int arr[2]; // #FIELD_ARR
 };
 
 struct with_explicit_flex_array {
   int x;
-  [[clang::requires_explicit_initialization]] int flex_arr[]; // #FIELD_FLEX_ARR
+  [[clang::require_explicit_initialization]] int flex_arr[]; // #FIELD_FLEX_ARR
 };
 
 void aggregate() {

--- a/clang/test/SemaCXX/uninitialized.cpp
+++ b/clang/test/SemaCXX/uninitialized.cpp
@@ -1483,14 +1483,14 @@ struct Inherit : Bases... { // #TYPE_INHERIT
 
 template<class... Bases>
 struct InheritWithExplicit : Bases... { // #TYPE_INHERIT_WITH_EXPLICIT
-  int g2 [[clang::requires_explicit_initialization]]; // #FIELD_G2
+  int g2 [[clang::require_explicit_initialization]]; // #FIELD_G2
 };
 
 struct Special {};
 
 template<>
 struct Inherit<Special> {
-  int g3 [[clang::requires_explicit_initialization]]; // #FIELD_G3
+  int g3 [[clang::require_explicit_initialization]]; // #FIELD_G3
 };
 
 template<>
@@ -1501,23 +1501,23 @@ struct InheritWithExplicit<Special> {
 void aggregate() {
   struct NonAgg {
     NonAgg() { }
-    [[clang::requires_explicit_initialization]] int na;  // expected-warning {{'requires_explicit_initialization' attribute is ignored in non-aggregate type 'NonAgg'}}
+    [[clang::require_explicit_initialization]] int na;  // expected-warning {{'require_explicit_initialization' attribute is ignored in non-aggregate type 'NonAgg'}}
   };
   NonAgg nonagg;  // no-warning
   (void)nonagg;
 
   struct S {
-    [[clang::requires_explicit_initialization]] int s1; // #FIELD_S1
+    [[clang::require_explicit_initialization]] int s1; // #FIELD_S1
     int s2;
     int s3 = 12;
-    [[clang::requires_explicit_initialization]] int s4 = 100; // #FIELD_S4
+    [[clang::require_explicit_initialization]] int s4 = 100; // #FIELD_S4
     static void foo(S) { }
   };
 
   struct C {
 #if __cplusplus < 202002L
     // expected-warning@+1 {{explicit initialization of field 'c1' will not be enforced in C++20 and later because 'C' has a user-declared constructor, making the type no longer an aggregate}}
-    [[clang::requires_explicit_initialization]]
+    [[clang::require_explicit_initialization]]
 #endif
     int c1; // #FIELD_C1
     C() = default;  // Test pre-C++20 aggregates
@@ -1525,7 +1525,7 @@ void aggregate() {
 
   struct D : S { // #TYPE_D
     int d1;
-    int d2 [[clang::requires_explicit_initialization]]; // #FIELD_D2
+    int d2 [[clang::require_explicit_initialization]]; // #FIELD_D2
   };
 
   struct D2 : D {  // #TYPE_D2
@@ -1533,10 +1533,10 @@ void aggregate() {
 
   struct E {  // #TYPE_E
     int e1;
-    D e2 [[clang::requires_explicit_initialization]]; // #FIELD_E2
+    D e2 [[clang::require_explicit_initialization]]; // #FIELD_E2
     struct {
-      [[clang::requires_explicit_initialization]] D e3;
-      D2 e4 [[clang::requires_explicit_initialization]];
+      [[clang::require_explicit_initialization]] D e3;
+      D2 e4 [[clang::require_explicit_initialization]];
     };
   };
 
@@ -1636,7 +1636,7 @@ void aggregate() {
   InheritWithExplicit<> agg;  // expected-warning {{field in 'InheritWithExplicit<>' requires explicit initialization but is not explicitly initialized}} expected-note@#FIELD_G2 {{'g2' declared here}}
   (void)agg;
 
-  InheritWithExplicit<Polymorphic> polymorphic;  // expected-warning@#FIELD_G2 {{'requires_explicit_initialization' attribute is ignored in non-aggregate type 'InheritWithExplicit<Polymorphic>'}}
+  InheritWithExplicit<Polymorphic> polymorphic;  // expected-warning@#FIELD_G2 {{'require_explicit_initialization' attribute is ignored in non-aggregate type 'InheritWithExplicit<Polymorphic>'}}
   (void)polymorphic;
 
   Inherit<Special> specialized_explicit;  // expected-warning {{field in 'Inherit<Special>' requires explicit initialization but is not explicitly initialized}} expected-note@#FIELD_G3 {{'g3' declared here}}


### PR DESCRIPTION
This makes it consistent with `[[clang::require_constant_initialization]]`.

(The attribute was just added to Clang a few minutes ago, so there are no users yet.)