### PR TITLE
[flang][acc] Fix FIRTestOpenACCInterfaces dependency

### DIFF
--- a/flang/test/lib/OpenACC/CMakeLists.txt
+++ b/flang/test/lib/OpenACC/CMakeLists.txt
@@ -3,19 +3,19 @@ add_flang_library(FIRTestOpenACCInterfaces
 
   DEPENDS
   FIRDialect
-  FIRBuilder
-  FIROpenACCSupport
-  FIRSupport
-  FIRTransforms
-  MLIROpenACCDialect
-
-  LINK_LIBS
-  FIRDialect
-  FIRBuilder
   FIROpenACCSupport
   FIRSupport
   MLIRIR
   MLIROpenACCDialect
+  MLIRPass
   MLIRSupport
-  MLIRFuncDialect
+
+  LINK_LIBS
+  FIRDialect
+  FIROpenACCSupport
+  FIRSupport
+  MLIRIR
+  MLIROpenACCDialect
+  MLIRPass
+  MLIRSupport
 )


### PR DESCRIPTION
According to one of the LLVM builds:
https://github.com/llvm/llvm-project/pull/122495#issuecomment-2590897971 The linking to various "mlir::Pass::" methods is failing. Ensure dependency is properly setup.