### PR TITLE
[clang-tidy] Refactor: removed typos in 'AllowedTypes' option in various checks

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assert-side-effect.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assert-side-effect.rst
@@ -26,8 +26,8 @@ Options
 
    A semicolon-separated list of the names of functions or methods to be
    considered as not having side-effects. Regular expressions are accepted,
-   e.g. `[Rr]ef(erence)?$` matches every type with suffix `Ref`, `ref`,
-   `Reference` and `reference`. The default is empty. If a name in the list
-   contains the sequence `::` it is matched against the qualified typename
-   (i.e. `namespace::Type`, otherwise it is matched against only
-   the type name (i.e. `Type`).
+   e.g. ``[Rr]ef(erence)?$`` matches every type with suffix ``Ref``, ``ref``,
+   ``Reference`` and ``reference``. The default is empty. If a name in the list
+   contains the sequence `::` it is matched against the qualified type name
+   (i.e. ``namespace::Type``), otherwise it is matched against only
+   the type name (i.e. ``Type``).

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
@@ -23,14 +23,15 @@ Options
 
 .. option:: WarnOnAllAutoCopies
 
-   When `true`, warns on any use of `auto` as the type of the range-based for
+   When `true`, warns on any use of ``auto`` as the type of the range-based for
    loop variable. Default is `false`.
 
 .. option:: AllowedTypes
 
    A semicolon-separated list of names of types allowed to be copied in each
-   iteration. Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches
-   every type with suffix `Ref`, `ref`, `Reference` and `reference`. The default
-   is empty. If a name in the list contains the sequence `::`, it is matched
-   against the qualified type name (i.e. ``namespace::Type``), otherwise it is
-   matched against only the type name (i.e. ``Type``).
+   iteration. Regular expressions are accepted, e.g. ``[Rr]ef(erence)?$``
+   matches every type with suffix ``Ref``, ``ref``, ``Reference`` and
+   ``reference``. The default is empty. If a name in the list contains the
+   sequence `::`, it is matched against the qualified type name
+   (i.e. ``namespace::Type``), otherwise it is matched against only the
+   type name (i.e. ``Type``).

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
@@ -32,5 +32,5 @@ Options
    iteration. Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches
    every type with suffix `Ref`, `ref`, `Reference` and `reference`. The default
    is empty. If a name in the list contains the sequence `::` it is matched
-   against the qualified typename (i.e. `namespace::Type`, otherwise it is
+   against the qualified typename (i.e. `namespace::Type`), otherwise it is
    matched against only the type name (i.e. `Type`).

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/for-range-copy.rst
@@ -31,6 +31,6 @@ Options
    A semicolon-separated list of names of types allowed to be copied in each
    iteration. Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches
    every type with suffix `Ref`, `ref`, `Reference` and `reference`. The default
-   is empty. If a name in the list contains the sequence `::` it is matched
-   against the qualified typename (i.e. `namespace::Type`), otherwise it is
-   matched against only the type name (i.e. `Type`).
+   is empty. If a name in the list contains the sequence `::`, it is matched
+   against the qualified type name (i.e. ``namespace::Type``), otherwise it is
+   matched against only the type name (i.e. ``Type``).

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
@@ -42,11 +42,11 @@ Options
 .. option:: AllowedTypes
 
    A semicolon-separated list of names of types allowed to be initialized by
-   copying. Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches
-   every type with suffix `Ref`, `ref`, `Reference` and `reference`. The default
-   is empty. If a name in the list contains the sequence `::`, it is matched
-   against the qualified type name (i.e. ``namespace::Type``), otherwise it is
-   matched against only the type name (i.e. ``Type``).
+   copying. Regular expressions are accepted, e.g. ``[Rr]ef(erence)?$`` matches
+   every type with suffix ``Ref``, ``ref``, ``Reference`` and ``reference``.
+   The default is empty. If a name in the list contains the sequence `::`, it
+   is matched against the qualified type name (i.e. ``namespace::Type``),
+   otherwise it is matched against only the type name (i.e. ``Type``).
 
 .. option:: ExcludedContainerTypes
 

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
@@ -44,9 +44,9 @@ Options
    A semicolon-separated list of names of types allowed to be initialized by
    copying. Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches
    every type with suffix `Ref`, `ref`, `Reference` and `reference`. The default
-   is empty. If a name in the list contains the sequence `::` it is matched
-   against the qualified typename (i.e. `namespace::Type`), otherwise it is
-   matched against only the type name (i.e. `Type`).
+   is empty. If a name in the list contains the sequence `::`, it is matched
+   against the qualified type name (i.e. ``namespace::Type``), otherwise it is
+   matched against only the type name (i.e. ``Type``).
 
 .. option:: ExcludedContainerTypes
 

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-copy-initialization.rst
@@ -45,7 +45,7 @@ Options
    copying. Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches
    every type with suffix `Ref`, `ref`, `Reference` and `reference`. The default
    is empty. If a name in the list contains the sequence `::` it is matched
-   against the qualified typename (i.e. `namespace::Type`, otherwise it is
+   against the qualified typename (i.e. `namespace::Type`), otherwise it is
    matched against only the type name (i.e. `Type`).
 
 .. option:: ExcludedContainerTypes

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -65,8 +65,8 @@ Options
 .. option:: AllowedTypes
 
    A semicolon-separated list of names of types allowed to be passed by value.
-   Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches every type
-   with suffix `Ref`, `ref`, `Reference` and `reference`. The default is
-   empty. If a name in the list contains the sequence `::`, it is matched against
-   the qualified type name (i.e. ``namespace::Type``), otherwise it is matched
-   against only the type name (i.e. ``Type``).
+   Regular expressions are accepted, e.g. ``[Rr]ef(erence)?$`` matches every
+   type with suffix ``Ref``, ``ref``, ``Reference`` and ``reference``. The
+   default is empty. If a name in the list contains the sequence `::`, it is
+   matched against the qualified type name (i.e. ``namespace::Type``),
+   otherwise it is matched against only the type name (i.e. ``Type``).

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -68,5 +68,5 @@ Options
    Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches every type
    with suffix `Ref`, `ref`, `Reference` and `reference`. The default is
    empty. If a name in the list contains the sequence `::` it is matched against
-   the qualified typename (i.e. `namespace::Type`, otherwise it is matched
+   the qualified typename (i.e. `namespace::Type`), otherwise it is matched
    against only the type name (i.e. `Type`).

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/unnecessary-value-param.rst
@@ -67,6 +67,6 @@ Options
    A semicolon-separated list of names of types allowed to be passed by value.
    Regular expressions are accepted, e.g. `[Rr]ef(erence)?$` matches every type
    with suffix `Ref`, `ref`, `Reference` and `reference`. The default is
-   empty. If a name in the list contains the sequence `::` it is matched against
-   the qualified typename (i.e. `namespace::Type`), otherwise it is matched
-   against only the type name (i.e. `Type`).
+   empty. If a name in the list contains the sequence `::`, it is matched against
+   the qualified type name (i.e. ``namespace::Type``), otherwise it is matched
+   against only the type name (i.e. ``Type``).


### PR DESCRIPTION
Added right parenthesis to match left one in description of 'AllowedTypes' option.