### PR TITLE
[flang][acc] Add missing dependency to bbc tool

### DIFF
--- a/flang/tools/bbc/CMakeLists.txt
+++ b/flang/tools/bbc/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(bbc PRIVATE
   CUFDialect
   FIRDialect
   FIRDialectSupport
+  FIROpenACCSupport
   FIRSupport
   FIRTransforms
   FIRBuilder


### PR DESCRIPTION
The LLVM build here:
https://lab.llvm.org/buildbot/#/builders/89/builds/14359/steps/5/logs/stdio is failing with error:
/usr/bin/ld: tools/flang/tools/bbc/CMakeFiles/bbc.dir/bbc.cpp.o: undefined reference to symbol
'_ZN3fir3acc25registerOpenACCExtensionsERN4mlir15DialectRegistryE

Add missing dependency.