### PR TITLE
[bazel] minor formatting fixes

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -693,32 +693,33 @@ cc_library(
     ],
     includes = ["include"],
     textual_hdrs = [
-        "include/clang/Basic/arm_fp16.inc",
-        "include/clang/Basic/arm_mve_builtins.inc",
-        "include/clang/Basic/arm_immcheck_types.inc",
-        "include/clang/Basic/arm_mve_builtin_aliases.inc",
-        "include/clang/Basic/arm_mve_builtin_cg.inc",
-        "include/clang/Basic/arm_mve_builtin_sema.inc",
-        "include/clang/Basic/arm_sme_builtins.inc",
-        "include/clang/Basic/arm_sme_builtin_cg.inc",
-        "include/clang/Basic/arm_neon.inc",
+        # keep sorted
         "include/clang/Basic/AttrHasAttributeImpl.inc",
         "include/clang/Basic/AttrList.inc",
         "include/clang/Basic/AttrSubMatchRulesList.inc",
         "include/clang/Basic/DiagnosticASTKinds.inc",
-        "include/clang/Basic/DiagnosticGroups.inc",
-        "include/clang/Basic/DiagnosticRefactoringKinds.inc",
         "include/clang/Basic/DiagnosticAnalysisKinds.inc",
-        "include/clang/Basic/DiagnosticSemaKinds.inc",
         "include/clang/Basic/DiagnosticCommentKinds.inc",
-        "include/clang/Basic/DiagnosticParseKinds.inc",
-        "include/clang/Basic/DiagnosticLexKinds.inc",
-        "include/clang/Basic/DiagnosticSerializationKinds.inc",
-        "include/clang/Basic/DiagnosticFrontendKinds.inc",
-        "include/clang/Basic/DiagnosticDriverKinds.inc",
-        "include/clang/Basic/DiagnosticCrossTUKinds.inc",
         "include/clang/Basic/DiagnosticCommonKinds.inc",
+        "include/clang/Basic/DiagnosticCrossTUKinds.inc",
+        "include/clang/Basic/DiagnosticDriverKinds.inc",
+        "include/clang/Basic/DiagnosticFrontendKinds.inc",
+        "include/clang/Basic/DiagnosticGroups.inc",
         "include/clang/Basic/DiagnosticIndexName.inc",
+        "include/clang/Basic/DiagnosticLexKinds.inc",
+        "include/clang/Basic/DiagnosticParseKinds.inc",
+        "include/clang/Basic/DiagnosticRefactoringKinds.inc",
+        "include/clang/Basic/DiagnosticSemaKinds.inc",
+        "include/clang/Basic/DiagnosticSerializationKinds.inc",
+        "include/clang/Basic/arm_fp16.inc",
+        "include/clang/Basic/arm_immcheck_types.inc",
+        "include/clang/Basic/arm_mve_builtin_aliases.inc",
+        "include/clang/Basic/arm_mve_builtin_cg.inc",
+        "include/clang/Basic/arm_mve_builtin_sema.inc",
+        "include/clang/Basic/arm_mve_builtins.inc",
+        "include/clang/Basic/arm_neon.inc",
+        "include/clang/Basic/arm_sme_builtin_cg.inc",
+        "include/clang/Basic/arm_sme_builtins.inc",
     ] + glob([
         "include/clang/Basic/*.def",
     ]),
@@ -1034,9 +1035,7 @@ cc_library(
     ] + glob([
         "include/clang/AST/*.def",
     ]),
-    toolchains = [
-        ":workspace_root",
-    ],
+    toolchains = [":workspace_root"],
     deps = [
         ":ast_attr_gen",
         ":ast_bytecode_opcodes_gen",
@@ -1848,22 +1847,23 @@ builtin_headers = glob(
         "lib/Headers/ppc_wrappers/nmmintrin.h",
     ],
 ) + [
+    # keep sorted
+    "lib/Headers/arm_bf16.h",
     "lib/Headers/arm_cde.h",
     "lib/Headers/arm_fp16.h",
     "lib/Headers/arm_mve.h",
     "lib/Headers/arm_neon.h",
-    "lib/Headers/arm_sve.h",
     "lib/Headers/arm_sme.h",
+    "lib/Headers/arm_sve.h",
     "lib/Headers/arm_vector_types.h",
-    "lib/Headers/arm_bf16.h",
-    "lib/Headers/module.modulemap",
-    "lib/Headers/riscv_vector.h",
     "lib/Headers/cuda_wrappers/algorithm",
     "lib/Headers/cuda_wrappers/complex",
     "lib/Headers/cuda_wrappers/new",
+    "lib/Headers/module.modulemap",
     "lib/Headers/openmp_wrappers/cmath",
     "lib/Headers/openmp_wrappers/complex",
     "lib/Headers/openmp_wrappers/new",
+    "lib/Headers/riscv_vector.h",
 ]
 
 genrule(
@@ -1878,9 +1878,7 @@ genrule(
          cp $$src $$target
        done""",
     output_to_bindir = 1,
-    toolchains = [
-        ":workspace_root",
-    ],
+    toolchains = [":workspace_root"],
 )
 
 cc_library(
@@ -2606,9 +2604,7 @@ cc_binary(
         "-I$(GENDIR)/$(WORKSPACE_ROOT)/clang/tools/clang-linker-wrapper",
     ],
     stamp = 0,
-    toolchains = [
-        ":workspace_root",
-    ],
+    toolchains = [":workspace_root"],
     deps = [
         ":basic",
         ":linker_wrapper_opts_gen",


### PR DESCRIPTION
Added `# keep sorted` to a couple of long-ish lists of files that buildifier didn't automatically sort by default.

Changed a couple of one-element `toolchains` attributes to the single-line format.