### PR TITLE
[lldb] Add APIs enabling OperatingSystem plugins to update ThreadPlanStack

### DIFF
--- a/lldb/include/lldb/Target/OperatingSystem.h
+++ b/lldb/include/lldb/Target/OperatingSystem.h
@@ -14,6 +14,7 @@
 #include "lldb/lldb-private.h"
 
 namespace lldb_private {
+class ThreadPlanStackMap;
 
 /// \class OperatingSystem OperatingSystem.h "lldb/Target/OperatingSystem.h"
 /// A plug-in interface definition class for halted OS helpers.
@@ -45,7 +46,8 @@ public:
   // Plug-in Methods
   virtual bool UpdateThreadList(ThreadList &old_thread_list,
                                 ThreadList &real_thread_list,
-                                ThreadList &new_thread_list) = 0;
+                                ThreadList &new_thread_list,
+                                ThreadPlanStackMap &plan_stack_map) = 0;
 
   virtual void ThreadWasSelected(Thread *thread) = 0;
 

--- a/lldb/include/lldb/Target/ThreadPlanStack.h
+++ b/lldb/include/lldb/Target/ThreadPlanStack.h
@@ -179,6 +179,13 @@ public:
                        
   bool PrunePlansForTID(lldb::tid_t tid);
 
+  std::vector<lldb::tid_t> GetKnownTIDs() const {
+    std::vector<lldb::tid_t> TIDs;
+    for (auto &plan_stack : m_plans_up_container)
+      TIDs.push_back(plan_stack->GetTID());
+    return TIDs;
+  }
+
 private:
   Process &m_process;
   mutable std::recursive_mutex m_stack_map_mutex;

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -163,7 +163,8 @@ DynamicRegisterInfo *OperatingSystemPython::GetDynamicRegisterInfo() {
 
 bool OperatingSystemPython::UpdateThreadList(ThreadList &old_thread_list,
                                              ThreadList &core_thread_list,
-                                             ThreadList &new_thread_list) {
+                                             ThreadList &new_thread_list,
+                                             ThreadPlanStackMap &) {
   if (!m_interpreter || !m_operating_system_interface_sp)
     return false;
 

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.h
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.h
@@ -44,9 +44,11 @@ public:
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
   // lldb_private::OperatingSystem Methods
-  bool UpdateThreadList(lldb_private::ThreadList &old_thread_list,
-                        lldb_private::ThreadList &real_thread_list,
-                        lldb_private::ThreadList &new_thread_list) override;
+  bool
+  UpdateThreadList(lldb_private::ThreadList &old_thread_list,
+                   lldb_private::ThreadList &real_thread_list,
+                   lldb_private::ThreadList &new_thread_list,
+                   lldb_private::ThreadPlanStackMap &plan_stack_map) override;
 
   void ThreadWasSelected(lldb_private::Thread *thread) override;
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1202,8 +1202,9 @@ void Process::UpdateThreadListIfNeeded() {
               real_thread_list, // The actual thread list full of threads
                                 // created by each lldb_private::Process
                                 // subclass
-              new_thread_list); // The new thread list that we will show to the
+              new_thread_list,  // The new thread list that we will show to the
                                 // user that gets filled in
+              m_thread_plans);
 
           if (saved_prefer_dynamic != lldb::eNoDynamicValues)
             target.SetPreferDynamicValue(saved_prefer_dynamic);


### PR DESCRIPTION
At the end of Process::UpdateThreadListIfNeeded, we see this comment:
```
      // Now update the plan stack map.
      // If we do have an OS plugin, any absent real threads in the
      // m_thread_list have already been removed from the ThreadPlanStackMap.
      // So any remaining threads are OS Plugin threads, and those we want to
      // preserve in case they show up again.
      m_thread_plans.Update(m_thread_list, clear_unused_threads);
```

In other words, if a OS plugin maps a real thread to a plugin thread, the plugin is expected to remove the thread plan of the real thread from `m_thread_plans`.
However, it is impossible to do so today: the APIs are simply not there. In fact, plugins don't even have access to `m_thread_plans`. This is not a problem for plugins who "report all threads", since LLDB will then clean up plans for any threads that are not present in the new list of threads (mapped real threads won't be in the new list). For plugins that do _not_ report all threads, this is a problem.

There are two pieces missing here:
A) The `OperatingSystem::UpdateThreadList` function needs access to m_thread_plans.
B) ThreadPlanStack needs to expose the TIDs it currently knows about, since its methods (like Find, Erase) are all TID-based.

This commit provides these pieces so that future commits (and plugins) may make use of them.

Point A is currently addressed by passing m_thread_plans as a function argument to OperatingSystem::UpdateThreadList, however it would have been possible to make it public through an accessor method in Process.