### PR TITLE
[llvm-gsymutil] Don't warn about duplicate debug info for merged functions

### DIFF
--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -296,7 +296,7 @@ public:
   /// Construct a GsymCreator object.
   ///
   /// \param Quiet Whether to suppress warning messages
-  /// \param InputHasMergedFunctions Weather the input might contain merged
+  /// \param InputHasMergedFunctions Whether the input might contain merged
   /// functions - functions with identical address ranges.
   GsymCreator(bool Quiet = false, bool InputHasMergedFunctions = false);
 

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -147,7 +147,8 @@ class GsymCreator {
   bool IsSegment = false;
   bool Finalized = false;
   bool Quiet;
-
+  // Specifies weather the input might contain merged functions
+  bool InputHasMergedFunctions;
 
   /// Get the first function start address.
   ///
@@ -292,7 +293,12 @@ class GsymCreator {
   }
 
 public:
-  GsymCreator(bool Quiet = false);
+  /// Construct a GsymCreator object.
+  ///
+  /// \param Quiet Whether to suppress warning messages
+  /// \param InputHasMergedFunctions Weather the input might contain merged
+  /// functions - functions with identical address ranges.
+  GsymCreator(bool Quiet = false, bool InputHasMergedFunctions = false);
 
   /// Save a GSYM file to a stand alone file.
   ///

--- a/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
+++ b/llvm/include/llvm/DebugInfo/GSYM/GsymCreator.h
@@ -147,7 +147,7 @@ class GsymCreator {
   bool IsSegment = false;
   bool Finalized = false;
   bool Quiet;
-  // Specifies weather the input might contain merged functions
+  // Specifies whether the input might contain merged functions
   bool InputHasMergedFunctions;
 
   /// Get the first function start address.

--- a/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-merged-funcs-dwarf.yaml
+++ b/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-merged-funcs-dwarf.yaml
@@ -1,16 +1,18 @@
 # RUN: yaml2obj %s -o %t.dSYM
 
 ## Verify that we don't keep merged functions by default
-# RUN: llvm-gsymutil --num-threads=1 --convert %t.dSYM --out-file=%t.default.gSYM
+# RUN: llvm-gsymutil --num-threads=1 --convert %t.dSYM --out-file=%t.default.gSYM | FileCheck --check-prefix=CHECK-GSYM-CREATE-NOMERGE %s
 # RUN: llvm-gsymutil --verify --verbose %t.default.gSYM | FileCheck --check-prefix=CHECK-GSYM-DEFAULT %s
 
 ## Verify that we keep merged functions when specyfing --merged-functions
-# RUN: llvm-gsymutil --num-threads=1 --convert %t.dSYM --out-file=%t.keep.gSYM --merged-functions
+# RUN: llvm-gsymutil --num-threads=1 --convert %t.dSYM --out-file=%t.keep.gSYM --merged-functions | FileCheck --check-prefix=CHECK-GSYM-CREATE-MERGE %s
 # RUN: llvm-gsymutil --verify --verbose %t.keep.gSYM | FileCheck --check-prefix=CHECK-GSYM-KEEP %s
 
 ## Note: For identical functions, the dSYM / gSYM cannot be counted on to be deterministic.
 ## So we can only match the general structure, not exact function names / offsets
 
+# CHECK-GSYM-CREATE-NOMERGE: warning: same address range contains different debug info.
+# CHECK-GSYM-CREATE-MERGE-NOT: warning: same address range contains different debug info.
 
 # CHECK-GSYM-DEFAULT-NOT: Merged FunctionInfos
 # CHECK-GSYM-DEFAULT:      FunctionInfo @ 0x{{[0-9a-fA-F]+}}: [0x{{[0-9a-fA-F]+}} - 0x{{[0-9a-fA-F]+}}) "my_func_03"

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -349,7 +349,7 @@ static llvm::Error handleObjectFile(ObjectFile &Obj, const std::string &OutFile,
   auto ThreadCount =
       NumThreads > 0 ? NumThreads : std::thread::hardware_concurrency();
 
-  GsymCreator Gsym(Quiet);
+  GsymCreator Gsym(Quiet, UseMergedFunctions);
 
   // See if we can figure out the base address for a given object file, and if
   // we can, then set the base address to use to this value. This will ease


### PR DESCRIPTION
When the input has merged functions, it's expected for the same address range to contain duplicate (and different) debug information. Don't warn about this when merged functions are expected in the input. 