### PR TITLE
Remove mention of conditional branches in undefined values section.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4776,8 +4776,8 @@ allowing the '``or``' to be folded to -1.
       %B = undef
       %C = undef
 
-This set of examples shows that undefined '``select``' (and conditional
-branch) conditions can go *either way*, but they have to come from one
+This set of examples shows that undefined '``select``'
+conditions can go *either way*, but they have to come from one
 of the two operands. In the ``%A`` example, if ``%X`` and ``%Y`` were
 both known to have a clear low bit, then ``%A`` would have to have a
 cleared low bit. However, in the ``%C`` example, the optimizer is


### PR DESCRIPTION
This statement is somewhat confusing when paired with the later statement that says "Branching on an undefined value is undefined behavior". Furthermore, this example does not show any conditional branches, so this comment seems to be outdated.

See issue #122532 for more details.