### PR TITLE
[libcxx] Use local names for the operator new impl symbols

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -804,6 +804,14 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_WEAK __attribute__((__weak__))
 #  endif
 
+#  ifndef _LIBCPP_WEAK_IMPORT
+#    define _LIBCPP_WEAK_IMPORT __attribute__((weak_import))
+#  endif
+
+#  ifndef _LIBCPP_ALIAS
+#    define _LIBCPP_ALIAS(x) __attribute__((alias(x)))
+#  endif
+
 // Thread API
 // clang-format off
 #  if _LIBCPP_HAS_THREADS &&                                                                                           \

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -62,6 +62,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
+    _LIBCPP_WEAK type name arglist;                                                                                    \
     _LIBCPP_WEAK_IMPORT extern type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                              \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
@@ -69,7 +70,7 @@ _LIBCPP_END_NAMESPACE_STD
       return static_cast<type(*) arglist>(name) != symbol;                                                             \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    _LIBCPP_WEAK type name arglist
+    type name arglist
 
 #elif defined(_LIBCPP_OBJECT_FORMAT_ELF)
 
@@ -82,6 +83,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
+    _LIBCPP_WEAK type name arglist;                                                                                    \
     _LIBCPP_ALIAS(_LIBCPP_TOSTRING(symbol)) static type symbol arglist __asm__(".L." _LIBCPP_TOSTRING(symbol));        \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
@@ -89,7 +91,7 @@ _LIBCPP_END_NAMESPACE_STD
       return static_cast<type(*) arglist>(name) != symbol;                                                             \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    _LIBCPP_WEAK type name arglist
+    type name arglist
 
 #else
 

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -63,11 +63,11 @@ _LIBCPP_END_NAMESPACE_STD
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
     _LIBCPP_WEAK type name arglist;                                                                                    \
-    _LIBCPP_WEAK_IMPORT extern type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                              \
+    _LIBCPP_WEAK_IMPORT extern type symbol##_impl arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                       \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \
-      return static_cast<type(*) arglist>(name) != symbol;                                                             \
+      return static_cast<type(*) arglist>(name) != symbol##_impl;                                                      \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
     type name arglist
@@ -84,11 +84,11 @@ _LIBCPP_END_NAMESPACE_STD
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
     _LIBCPP_WEAK type name arglist;                                                                                    \
-    _LIBCPP_ALIAS(_LIBCPP_TOSTRING(symbol)) static type symbol arglist __asm__(".L." _LIBCPP_TOSTRING(symbol));        \
+    _LIBCPP_ALIAS(_LIBCPP_TOSTRING(symbol)) static type symbol##_impl arglist __asm__(".L." _LIBCPP_TOSTRING(symbol)); \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \
-      return static_cast<type(*) arglist>(name) != symbol;                                                             \
+      return static_cast<type(*) arglist>(name) != symbol##_impl;                                                      \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
     type name arglist

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -42,12 +42,11 @@
 // -------------------
 //
 // Let's say we want to check whether a weak function `f` has been overridden by the user.
-// The general mechanism works by defining an internal symbol `.L.f` and a weak alias `f`
-// via the _LIBCPP_OVERRIDABLE_FUNCTION macro.
-//
-// Then, when comes the time to check whether the function has been overridden, we take
-// the address of the function `f` and we check whether it is different from `.L.f`.
-// If so it means the function was overriden by the user.
+// The general mechanism works by defining an internal symbol and a weak alias `f` via the
+// _LIBCPP_OVERRIDABLE_FUNCTION macro. Then, when comes the time to check whether the
+// function has been overridden, we take the address of the internal symbol and the weak
+// alias `f` and check whether they're different. If so it means the function was overriden
+// by the user.
 //
 // Important note
 // --------------
@@ -67,17 +66,14 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
-    [[gnu::used]] static type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                                    \
-    __asm__(".globl _" _LIBCPP_TOSTRING(symbol));                                                                      \
-    __asm__(".weak_definition _" _LIBCPP_TOSTRING(symbol));                                                            \
-    [[clang::weak_import]] extern type name arglist;                                                                   \
+    [[clang::weak_import]] extern type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                           \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \
       return static_cast<type(*) arglist>(name) != symbol;                                                             \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    static type symbol arglist
+    type name arglist
 
 #elif defined(_LIBCPP_OBJECT_FORMAT_ELF)
 

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -13,10 +13,6 @@
 #include <__config>
 #include <cstdint>
 
-#if __has_feature(ptrauth_calls)
-#  include <ptrauth.h>
-#endif
-
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif
@@ -66,14 +62,14 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
-    [[clang::weak_import]] extern type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                           \
+    _LIBCPP_WEAK_IMPORT extern type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                              \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \
       return static_cast<type(*) arglist>(name) != symbol;                                                             \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    type name arglist
+    _LIBCPP_WEAK type name arglist
 
 #elif defined(_LIBCPP_OBJECT_FORMAT_ELF)
 
@@ -86,15 +82,14 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
-    [[gnu::weak]] type name arglist;                                                                                   \
-    [[gnu::alias(_LIBCPP_TOSTRING(symbol))]] static type symbol arglist __asm__(".L." _LIBCPP_TOSTRING(symbol));       \
+    _LIBCPP_ALIAS(_LIBCPP_TOSTRING(symbol)) static type symbol arglist __asm__(".L." _LIBCPP_TOSTRING(symbol));        \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \
       return static_cast<type(*) arglist>(name) != symbol;                                                             \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    type name arglist
+    _LIBCPP_WEAK type name arglist
 
 #else
 

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -90,8 +90,8 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
-    static type symbol##_impl__ arglist __asm__(_LIBCPP_TOSTRING(symbol##_impl__));                                    \
-    [[gnu::weak, gnu::alias(_LIBCPP_TOSTRING(symbol##_impl__))]] type name arglist;                                    \
+    static type symbol##_impl__ arglist __asm__(".L" _LIBCPP_TOSTRING(symbol));                                        \
+    [[gnu::weak, gnu::alias(".L" _LIBCPP_TOSTRING(symbol))]] type name arglist;                                        \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -90,7 +90,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
-    type symbol##_impl__ arglist __asm__(".L" _LIBCPP_TOSTRING(symbol));                                               \
+    static type symbol##_impl__ arglist __asm__(".L" _LIBCPP_TOSTRING(symbol));                                        \
     [[gnu::weak, gnu::alias(".L" _LIBCPP_TOSTRING(symbol))]] type name arglist;                                        \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
@@ -98,7 +98,7 @@ _LIBCPP_END_NAMESPACE_STD
       return static_cast<type(*) arglist>(name) != symbol##_impl__;                                                    \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    type symbol##_impl__ arglist
+    static type symbol##_impl__ arglist
 
 #else
 

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -70,7 +70,7 @@ _LIBCPP_END_NAMESPACE_STD
     [[gnu::used]] static type symbol arglist __asm__("_" _LIBCPP_TOSTRING(symbol));                                    \
     __asm__(".globl _" _LIBCPP_TOSTRING(symbol));                                                                      \
     __asm__(".weak_definition _" _LIBCPP_TOSTRING(symbol));                                                            \
-    extern type name arglist __attribute__((weak_import));                                                             \
+    [[clang::weak_import]] extern type name arglist;                                                                   \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
     inline bool __is_function_overridden<static_cast<type(*) arglist>(name)>() {                                       \

--- a/libcxx/src/include/overridable_function.h
+++ b/libcxx/src/include/overridable_function.h
@@ -90,7 +90,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_CAN_DETECT_OVERRIDDEN_FUNCTION 1
 #  define _LIBCPP_OVERRIDABLE_FUNCTION(symbol, type, name, arglist)                                                    \
-    static type symbol##_impl__ arglist __asm__(".L" _LIBCPP_TOSTRING(symbol));                                        \
+    type symbol##_impl__ arglist __asm__(".L" _LIBCPP_TOSTRING(symbol));                                               \
     [[gnu::weak, gnu::alias(".L" _LIBCPP_TOSTRING(symbol))]] type name arglist;                                        \
     _LIBCPP_BEGIN_NAMESPACE_STD                                                                                        \
     template <>                                                                                                        \
@@ -98,7 +98,7 @@ _LIBCPP_END_NAMESPACE_STD
       return static_cast<type(*) arglist>(name) != symbol##_impl__;                                                    \
     }                                                                                                                  \
     _LIBCPP_END_NAMESPACE_STD                                                                                          \
-    static type symbol##_impl__ arglist
+    type symbol##_impl__ arglist
 
 #else
 


### PR DESCRIPTION
This way the impl symbols don't even make it into the symbol table which is important for symbolization since we want the symbolizer to always pick up the public symbol (which has the same address as the impl one).