### PR TITLE
[RISCV][llvm-exegesis] Disable pseudo instructions in allowAsBackToBack.

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -124,6 +124,10 @@ public:
 
   ArrayRef<unsigned> getUnavailableRegisters() const override;
 
+  bool allowAsBackToBack(const Instruction &Instr) const override {
+    return !Instr.Description.isPseudo();
+  }
+
   Error randomizeTargetMCOperand(const Instruction &Instr, const Variable &Var,
                                  MCOperand &AssignedValue,
                                  const BitVector &ForbiddenRegs) const override;


### PR DESCRIPTION
Prevents crashes trying to encode pseudo instuctions. Tested on HiFive Premier P550.

Fixes #122974