### PR TITLE
[NFC][clang][HIP] Remove flag from SPIR-V Translator invocation

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -176,7 +176,6 @@ void AMDGCN::Linker::constructLinkAndEmitSpirvCommand(
   llvm::opt::ArgStringList TrArgs{
       "--spirv-max-version=1.6",
       "--spirv-ext=+all",
-      "--spirv-allow-extra-diexpressions",
       "--spirv-allow-unknown-intrinsics",
       "--spirv-lower-const-expr",
       "--spirv-preserve-auxdata",


### PR DESCRIPTION
Remove spurious `--spirv-allow-extra-diexpressions` flag from the translator invocation, as it's already implied by using `nonsemantic-shader-200`.