### PR TITLE
[coff] Don't try to write the obj if the assembler has errors

### DIFF
--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -1193,6 +1193,11 @@ void WinCOFFObjectWriter::recordRelocation(MCAssembler &Asm,
 }
 
 uint64_t WinCOFFObjectWriter::writeObject(MCAssembler &Asm) {
+  // If the assember had an error, then layout will not have completed, so we
+  // cannot write an object file.
+  if (Asm.getContext().hadError())
+    return 0;
+
   uint64_t TotalSize = ObjWriter->writeObject(Asm);
   if (DwoWriter)
     TotalSize += DwoWriter->writeObject(Asm);


### PR DESCRIPTION
The ASAN and MSAN tests have been failing after #122777 because some fields are now set in `executePostLayoutBinding` which is skipped by the assembler if it had errors but read in `writeObject`

Since the compilation has failed anyway, skip `writeObject` if the assembler had errors.