### PR TITLE
Move RemoveRedundantDbgInstrs outside of inner loop in JumpThreading

### DIFF
--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -371,7 +371,7 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
     EverChanged |= Changed;
   } while (Changed);
 
-  // Jump threading may have introduced redundant debug values into BB which
+  // Jump threading may have introduced redundant debug values into F which
   // should be removed.
   if (EverChanged)
     for (auto &BB : *F) {

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -330,11 +330,6 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
       while (processBlock(&BB)) // Thread all of the branches we can over BB.
         Changed = ChangedSinceLastAnalysisUpdate = true;
 
-      // Jump threading may have introduced redundant debug values into BB
-      // which should be removed.
-      if (Changed)
-        RemoveRedundantDbgInstrs(&BB);
-
       // Stop processing BB if it's the entry or is now deleted. The following
       // routines attempt to eliminate BB and locating a suitable replacement
       // for the entry is non-trivial.
@@ -366,7 +361,6 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
             // detect and transform nested loops later.
             !LoopHeaders.count(&BB) && !LoopHeaders.count(Succ) &&
             TryToSimplifyUncondBranchFromEmptyBlock(&BB, DTU.get())) {
-          RemoveRedundantDbgInstrs(Succ);
           // BB is valid for cleanup here because we passed in DTU. F remains
           // BB's parent until a DTU->getDomTree() event.
           LVI->eraseBlock(&BB);
@@ -376,6 +370,13 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
     }
     EverChanged |= Changed;
   } while (Changed);
+
+  // Jump threading may have introduced redundant debug values into BB which
+  // should be removed.
+  if (EverChanged)
+    for (auto &BB : *F) {
+      RemoveRedundantDbgInstrs(&BB);
+    }
 
   LoopHeaders.clear();
   return EverChanged;

--- a/llvm/test/Transforms/JumpThreading/thread-debug-info.ll
+++ b/llvm/test/Transforms/JumpThreading/thread-debug-info.ll
@@ -92,10 +92,6 @@ exit:                                             ; preds = %bb.f4, %bb.f3, %bb.
   ret void, !dbg !29
 }
 
-; Test for the cloning of dbg.values on elided instructions -- down one path
-; being threaded, the `and` in the function below is optimised away, but its
-; debug-info should still be preserved.
-; Similarly, the call to f1 gets cloned, its dbg.value should be cloned too.
 define void @test16(i1 %c, i1 %c2, i1 %c3, i1 %c4) nounwind ssp !dbg !30 {
 ; CHECK-LABEL: define void @test16(i1
 entry:
@@ -109,7 +105,6 @@ lor.lhs.false.i:
   br i1 %c3, label %land.end, label %land.end, !dbg !33
 
 ; CHECK-LABEL: land.end.thr_comm:
-; CHECK-NEXT:  #dbg_value(i32 0,
 ; CHECK-NEXT:  #dbg_value(i32 1,
 ; CHECK-NEXT:  call void @f1()
 ; CHECK-NEXT:  br i1 %c4,

--- a/llvm/test/Transforms/JumpThreading/thread-debug-info.ll
+++ b/llvm/test/Transforms/JumpThreading/thread-debug-info.ll
@@ -92,6 +92,12 @@ exit:                                             ; preds = %bb.f4, %bb.f3, %bb.
   ret void, !dbg !29
 }
 
+; Test for the cloning of dbg.values on elided instructions -- down one path
+; being threaded, the `and` in the function below is optimised away, but its
+; debug-info should still be preserved.
+; Similarly, the call to f1 gets cloned, its dbg.value should be cloned too.
+; Duplicated debug value in land.end.thr_comm is removed by
+; RemoveRedundantDbgInstrs pass at the end.
 define void @test16(i1 %c, i1 %c2, i1 %c3, i1 %c4) nounwind ssp !dbg !30 {
 ; CHECK-LABEL: define void @test16(i1
 entry:


### PR DESCRIPTION
This cleanup action only needs to be performed once when the entire optimization is converged. Doing it in every iteration has a very high time-complexity, as it queries every dbg value in a dense map

Compare before and after for one internal source file with many basic blocks

![image](https://github.com/user-attachments/assets/1dac76a9-a974-4068-9aa1-4041f963fa8e)
![image](https://github.com/user-attachments/assets/73ea2ef1-d1f4-4064-8826-8c13fb539b8d)

>90% reduction in this extreme case.
