### PR TITLE
[Hexagon] Add default clang symlinks to CLANG_LINKS_TO_CREATE

### DIFF
--- a/clang/cmake/caches/hexagon-unknown-linux-musl-clang-cross.cmake
+++ b/clang/cmake/caches/hexagon-unknown-linux-musl-clang-cross.cmake
@@ -10,6 +10,9 @@ set(CLANG_LINKS_TO_CREATE
             hexagon-none-elf-clang
             hexagon-unknown-none-elf-clang++
             hexagon-unknown-none-elf-clang
+            clang++
+            clang-cl
+            clang-cpp
             CACHE STRING "")
 
 set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")


### PR DESCRIPTION
Since this cache value overrides the defaults, we end up with `clang` linked to `clang-20`, and some `${triple}-clang*` links, but we're missing `clang++`.  This makes for a toolchain with inconsistent behavior when used in someone's `$PATH`.

We'll add the default symlinks to our list so that C and C++ programs are both built as expected when `clang` and `clang++` are invoked.