### PR TITLE
[include-cleaner] Add special mappings for operator new/delete

### DIFF
--- a/clang-tools-extra/include-cleaner/unittests/FindHeadersTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/FindHeadersTest.cpp
@@ -655,12 +655,12 @@ TEST_F(HeadersForSymbolTest, GlobalOperatorNewDelete) {
   V.TraverseDecl(AST->context().getTranslationUnitDecl());
   ASSERT_TRUE(V.New) << "Couldn't find global new!";
   ASSERT_TRUE(V.Delete) << "Couldn't find global delete!";
-  EXPECT_THAT(headersForSymbol(*V.New, AST->sourceManager(), &PI),
-              UnorderedElementsAre(
-                  Header(*tooling::stdlib::Header::named("<new>"))));
-  EXPECT_THAT(headersForSymbol(*V.Delete, AST->sourceManager(), &PI),
-              UnorderedElementsAre(
-                  Header(*tooling::stdlib::Header::named("<new>"))));
+  EXPECT_THAT(
+      headersForSymbol(*V.New, AST->sourceManager(), &PI),
+      UnorderedElementsAre(Header(*tooling::stdlib::Header::named("<new>"))));
+  EXPECT_THAT(
+      headersForSymbol(*V.Delete, AST->sourceManager(), &PI),
+      UnorderedElementsAre(Header(*tooling::stdlib::Header::named("<new>"))));
 }
 
 TEST_F(HeadersForSymbolTest, StandardHeaders) {


### PR DESCRIPTION
Our stdlib mappings are based on names, hence they can't handle special
symbols like oprators.

Global operator new/delete show up often enough in practice to create
some user frustration, so we map these to <new>.
