### PR TITLE
[Clang][Arch] Disable mve.fp when explicit -mfpu option

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -748,6 +748,15 @@ fp16_fml_fallthrough:
       Features.push_back("-crc");
   }
 
+  // Invalid value of the __ARM_FEATURE_MVE macro when an explicit -mfpu= option
+  // disables MVE-FP -mfpu=fpv5-d16 or -mfpu=fpv5-sp-d16 disables the scalar
+  // half-precision floating-point operations feature. Therefore, because the
+  // M-profile Vector Extension (MVE) floating-point feature requires the scalar
+  // half-precision floating-point operations, this option also disables the MVE
+  // floating-point feature: -mve.fp
+  if (FPUKind == llvm::ARM::FK_FPV5_D16 || FPUKind == llvm::ARM::FK_FPV5_SP_D16)
+    Features.push_back("-mve.fp");
+
   // For Arch >= ARMv8.0 && A or R profile:  crypto = sha2 + aes
   // Rather than replace within the feature vector, determine whether each
   // algorithm is enabled and append this to the end of the vector.

--- a/clang/test/Preprocessor/arm-target-features.c
+++ b/clang/test/Preprocessor/arm-target-features.c
@@ -978,3 +978,11 @@
 // CHECK-V83-OR-LATER: __ARM_FEATURE_COMPLEX 1
 // CHECK-V81-OR-LATER: __ARM_FEATURE_QRDMX 1
 // CHECK-BEFORE-V83-NOT: __ARM_FEATURE_COMPLEX 1
+
+// Check if MVE floating-point feature is disabled (-mve.fp) during explicit fpv5-d16 or fpv5-sp-d16
+// RUN: %clang -target arm-arm-none-eabi -march=armv8.1-m.main+mve.fp -mfpu=fpv5-d16 -x c -E -dM %s -o - | FileCheck -check-prefix=CHECK-MVE1 %s
+// CHECK-MVE1: #define __ARM_FEATURE_MVE 1
+// RUN: %clang -target arm-arm-none-eabi -march=armv8.1-m.main+mve.fp -mfpu=fpv5-sp-d16 -x c -E -dM %s -o - | FileCheck -check-prefix=CHECK-MVE1_2 %s
+// CHECK-MVE1_2: #define __ARM_FEATURE_MVE 1
+// RUN: %clang -target arm-arm-none-eabi -march=armv8.1-m.main+mve.fp -x c -E -dM %s -o - | FileCheck -check-prefix=CHECK-MVE3 %s
+// CHECK-MVE3: #define __ARM_FEATURE_MVE 3


### PR DESCRIPTION
-mfpu=fpv5-d16 or -mfpu=fpv5-sp-d16 disables the scalar half-precision floating-point operations feature. Therefore, because the M-profile Vector Extension (MVE) floating-point feature requires the scalar half-precision floating-point operations, this option also disables the MVE floating-point feature, -mve.fp