### PR TITLE
[mlir][linalg] Add vectorization to the e2e test for tensor.unpack

### DIFF
--- a/mlir/test/Integration/Dialect/Linalg/CPU/pack-dynamic-inner-tile.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/pack-dynamic-inner-tile.mlir
@@ -121,11 +121,11 @@ module @transforms attributes { transform.with_named_sequence } {
       transform.apply_patterns.canonicalization
     } : !transform.op<"func.func">
 
-    // 3. Bufferize before lowering to LLVM
+    // 4. Bufferize before lowering to LLVM
     %bufferize = transform.bufferization.one_shot_bufferize %module
       {bufferize_function_boundaries=true} : (!transform.any_op) -> !transform.any_op
 
-    // 4. Canonicalize
+    // 5. Canonicalize
     %func_op_bufferized = transform.structured.match ops{["func.func"]} in %bufferize : (!transform.any_op) -> !transform.op<"func.func">
     transform.apply_patterns to %func_op_bufferized {
       transform.apply_patterns.canonicalization

--- a/mlir/test/Integration/Dialect/Linalg/CPU/unpack-dynamic-inner-tile.mlir
+++ b/mlir/test/Integration/Dialect/Linalg/CPU/unpack-dynamic-inner-tile.mlir
@@ -99,11 +99,11 @@ module @transforms attributes { transform.with_named_sequence } {
     %slice = transform.structured.match ops{["tensor.insert_slice"]} in %func_op : (!transform.op<"func.func">) -> !transform.any_op
     transform.structured.vectorize %slice vector_sizes [8, 1] : !transform.any_op
 
-    // 3. Bufferize before lowering to LLVM
+    // 4. Bufferize before lowering to LLVM
     %bufferize = transform.bufferization.one_shot_bufferize %module
       {bufferize_function_boundaries=true} : (!transform.any_op) -> !transform.any_op
 
-    // 4. Canonicalize
+    // 5. Canonicalize
     %func_op_bufferized = transform.structured.match ops{["func.func"]} in %bufferize : (!transform.any_op) -> !transform.op<"func.func">
     transform.apply_patterns to %func_op_bufferized {
       transform.apply_patterns.canonicalization


### PR DESCRIPTION
Following on from #122927 + #123031 that added support for masked
vectorization of `tensor.insert_slice`, this PR extends the e2e test for
`tensor.unpack` to leverage the new functionality.