### PR TITLE
[MLIR] Add [[maybe_unused]] to variables on used in assert

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
@@ -1291,7 +1291,7 @@ using ExtractNBitsFn =
 /// bitwise ops to avoid leaving LLVM to scramble with peephole optimizations.
 static Value rewriteI4ToI8Ext(PatternRewriter &rewriter, Location loc,
                               Value srcValue, const ExtractNBitsFn &extFn) {
-  auto srcVecType = cast<VectorType>(srcValue.getType());
+  [[maybe_unused]] auto srcVecType = cast<VectorType>(srcValue.getType());
   assert(srcVecType.getElementType().isSignlessInteger(4) &&
          "Expected i4 type");
 
@@ -1311,7 +1311,7 @@ static Value rewriteI4ToI8Ext(PatternRewriter &rewriter, Location loc,
 /// bitwise ops to avoid leaving LLVM to scramble with peephole optimizations.
 static Value rewriteI2ToI8Ext(PatternRewriter &rewriter, Location loc,
                               Value srcValue, const ExtractNBitsFn &extFn) {
-  VectorType srcVecType = cast<VectorType>(srcValue.getType());
+  [[maybe_unused]] VectorType srcVecType = cast<VectorType>(srcValue.getType());
   assert(srcVecType.getElementType().isSignlessInteger(2) &&
          "Expected i2 type");
 


### PR DESCRIPTION
Add [[maybe_unused]] to suppresses warnings when  `-NDEBUG` is enabled
