### PR TITLE
[llvm][Docs] Clarify release ABI/API compatibility rules

### DIFF
--- a/llvm/docs/HowToReleaseLLVM.rst
+++ b/llvm/docs/HowToReleaseLLVM.rst
@@ -349,7 +349,7 @@ Below are the rules regarding patching the release branch:
 
 #. *Bug fix releases* Patches should be limited to bug fixes or very safe
    and critical performance improvements.  Patches must maintain both API and
-   ABI compatibility with the previous release from the release branch.
+   ABI compatibility with the X.1.0 release.
 
 Release Final Tasks
 -------------------

--- a/llvm/docs/HowToReleaseLLVM.rst
+++ b/llvm/docs/HowToReleaseLLVM.rst
@@ -349,8 +349,7 @@ Below are the rules regarding patching the release branch:
 
 #. *Bug fix releases* Patches should be limited to bug fixes or very safe
    and critical performance improvements.  Patches must maintain both API and
-   ABI compatibility with the previous major release.
-
+   ABI compatibility with the previous release from the release branch.
 
 Release Final Tasks
 -------------------


### PR DESCRIPTION
If the current release branch is version X, the phrase "the previous major release." sounds to me as if it is referring to releases of X-1. Not to the last release from the current release branch, which is what I think it intends.

(if it meant X-1, then we could never change the ABI)