### PR TITLE
Thread Safety Analysis: Support warning on taking address of guarded variables

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -789,7 +789,7 @@ Improvements to Clang's diagnostics
     }
 
 - The :doc:`ThreadSafetyAnalysis` now supports ``-Wthread-safety-addressof``,
-  which enables warning if the address of guarded variables is obtained.
+  which enables warning on taking the address of guarded variables.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -788,6 +788,9 @@ Improvements to Clang's diagnostics
       require(scope); // Warning!  Requires mu1.
     }
 
+- The :doc:`ThreadSafetyAnalysis` now supports ``-Wthread-safety-addressof``,
+  which enables warning if the address of guarded variables is obtained.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -788,8 +788,9 @@ Improvements to Clang's diagnostics
       require(scope); // Warning!  Requires mu1.
     }
 
-- The :doc:`ThreadSafetyAnalysis` now supports ``-Wthread-safety-addressof``,
-  which enables warning on taking the address of guarded variables.
+- The :doc:`ThreadSafetyAnalysis` now supports ``-Wthread-safety-addressof``
+  (with ``-Wthread-safety-beta``), which enables warning on taking the address
+  of guarded variables.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -515,8 +515,16 @@ Warning flags
   + ``-Wthread-safety-analysis``: The core analysis.
   + ``-Wthread-safety-precise``: Requires that mutex expressions match precisely.
        This warning can be disabled for code which has a lot of aliases.
-  + ``-Wthread-safety-reference``: Checks when guarded members are passed by reference.
+  + ``-Wthread-safety-reference``: Checks when guarded variables are passed by reference.
 
+* ``-Wthread-safety-addressof``: Warn when the address of guarded variables is
+  obtained (``&var``). Since obtaining the address of a variable doesn't
+  necessarily imply a read or write, the warning is off by default. In
+  codebases that prefer passing pointers rather than references (for C++
+  codebases), or passing pointers is ubiquitous (for C codebases), enabling
+  this warning will result in fewer false negatives; for example, where the
+  manipulation of common data structures is done via functions that take
+  pointers to instances of the data structure.
 
 :ref:`negative` are an experimental feature, which are enabled with:
 

--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -518,13 +518,15 @@ Warning flags
   + ``-Wthread-safety-reference``: Checks when guarded variables are passed by reference.
 
 * ``-Wthread-safety-addressof``: Warn when the address of guarded variables is
-  obtained (``&var``). Since obtaining the address of a variable doesn't
-  necessarily imply a read or write, the warning is off by default. In
-  codebases that prefer passing pointers rather than references (for C++
-  codebases), or passing pointers is ubiquitous (for C codebases), enabling
-  this warning will result in fewer false negatives; for example, where the
-  manipulation of common data structures is done via functions that take
-  pointers to instances of the data structure.
+  obtained (``&var``). Since obtaining the address of a variable does *not
+  necessarily imply a read or write*, the warning is off by default to avoid
+  false positives. In codebases that prefer passing pointers rather than
+  references (for C++ codebases), or passing pointers is ubiquitous (for C
+  codebases), enabling this warning will result in fewer false negatives; for
+  example, where the manipulation of common data structures is done via
+  functions that take pointers to instances of the data structure. Note,
+  however, that the analysis does not track pointers, and false positives *and*
+  negatives are still possible.
 
 :ref:`negative` are an experimental feature, which are enabled with:
 

--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -518,7 +518,7 @@ Warning flags
   + ``-Wthread-safety-reference``: Checks when guarded variables are passed by reference.
 
 * ``-Wthread-safety-addressof``: Warn when the address of guarded variables is
-  obtained (``&var``). Since obtaining the address of a variable does *not
+  taken (``&var``). Since taking the address of a variable does *not
   necessarily imply a read or write*, the warning is off by default to avoid
   false positives. In codebases that prefer passing pointers rather than
   references (for C++ codebases), or passing pointers is ubiquitous (for C

--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -517,17 +517,6 @@ Warning flags
        This warning can be disabled for code which has a lot of aliases.
   + ``-Wthread-safety-reference``: Checks when guarded variables are passed by reference.
 
-* ``-Wthread-safety-addressof``: Warn when the address of guarded variables is
-  taken (``&var``). Since taking the address of a variable does *not
-  necessarily imply a read or write*, the warning is off by default to avoid
-  false positives. In codebases that prefer passing pointers rather than
-  references (for C++ codebases), or passing pointers is ubiquitous (for C
-  codebases), enabling this warning will result in fewer false negatives; for
-  example, where the manipulation of common data structures is done via
-  functions that take pointers to instances of the data structure. Note,
-  however, that the analysis does not track pointers, and false positives *and*
-  negatives are still possible.
-
 :ref:`negative` are an experimental feature, which are enabled with:
 
 * ``-Wthread-safety-negative``:  Negative capabilities.  Off by default.
@@ -538,6 +527,16 @@ for a period of time, after which they are migrated into the standard analysis.
 
 * ``-Wthread-safety-beta``:  New features.  Off by default.
 
+  + ``-Wthread-safety-addressof``: Warn when the address of guarded variables
+    is taken (``&var``). Since taking the address of a variable does *not
+    necessarily imply a read or write*, the warning is off by default to avoid
+    false positives. In codebases that prefer passing pointers rather than
+    references (for C++ codebases), or passing pointers is ubiquitous (for C
+    codebases), enabling this warning will result in fewer false negatives; for
+    example, where the manipulation of common data structures is done via
+    functions that take pointers to instances of the data structure. Note,
+    however, that the analysis does not track pointers, and false positives
+    *and* negatives are still possible.
 
 .. _negative:
 

--- a/clang/include/clang/Analysis/Analyses/ThreadSafety.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafety.h
@@ -54,6 +54,9 @@ enum ProtectedOperationKind {
 
   /// Returning a pt-guarded variable by reference.
   POK_PtReturnByRef,
+
+  /// Obtaining address of a variable (e.g. &x).
+  POK_AddressOf,
 };
 
 /// This enum distinguishes between different kinds of lock actions. For

--- a/clang/include/clang/Analysis/Analyses/ThreadSafety.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafety.h
@@ -55,7 +55,7 @@ enum ProtectedOperationKind {
   /// Returning a pt-guarded variable by reference.
   POK_PtReturnByRef,
 
-  /// Obtaining address of a variable (e.g. &x).
+  /// Taking address of a variable (e.g. &x).
   POK_AddressOf,
 };
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1126,6 +1126,7 @@ def ThreadSafetyReferenceReturn  : DiagGroup<"thread-safety-reference-return">;
 def ThreadSafetyReference  : DiagGroup<"thread-safety-reference",
                                              [ThreadSafetyReferenceReturn]>;
 def ThreadSafetyNegative   : DiagGroup<"thread-safety-negative">;
+def ThreadSafetyAddressof  : DiagGroup<"thread-safety-addressof">;
 def ThreadSafety : DiagGroup<"thread-safety",
                              [ThreadSafetyAttributes,
                               ThreadSafetyAnalysis,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4142,10 +4142,10 @@ def note_guarded_by_declared_here : Note<"guarded_by declared here">;
 
 // Thread safety warnings on addressof
 def warn_addressof_requires_any_lock : Warning<
-  "obtaining address of variable %0 requires holding any mutex">,
+  "taking address of variable %0 requires holding any mutex">,
   InGroup<ThreadSafetyAddressof>, DefaultIgnore;
 def warn_addressof_requires_lock : Warning<
-  "obtaining address of variable %1 requires holding %0 '%2'">,
+  "taking address of variable %1 requires holding %0 '%2'">,
   InGroup<ThreadSafetyAddressof>, DefaultIgnore;
 
 // Dummy warning that will trigger "beta" warnings from the analysis if enabled.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4140,6 +4140,14 @@ def warn_thread_safety_verbose : Warning<"thread safety verbose warning">,
 def note_thread_warning_in_fun : Note<"thread warning in function %0">;
 def note_guarded_by_declared_here : Note<"guarded_by declared here">;
 
+// Thread safety warnings on addressof
+def warn_addressof_requires_any_lock : Warning<
+  "obtaining address of variable %0 requires holding any mutex">,
+  InGroup<ThreadSafetyAddressof>, DefaultIgnore;
+def warn_addressof_requires_lock : Warning<
+  "obtaining address of variable %1 requires holding %0 '%2'">,
+  InGroup<ThreadSafetyAddressof>, DefaultIgnore;
+
 // Dummy warning that will trigger "beta" warnings from the analysis if enabled.
 def warn_thread_safety_beta : Warning<"thread safety beta warning">,
   InGroup<ThreadSafetyBeta>, DefaultIgnore;

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2080,6 +2080,9 @@ void BuildLockset::VisitUnaryOperator(const UnaryOperator *UO) {
     case UO_PreInc:
       checkAccess(UO->getSubExpr(), AK_Written);
       break;
+    case UO_AddrOf:
+      checkAccess(UO->getSubExpr(), AK_Read, POK_AddressOf);
+      break;
     default:
       break;
   }

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -2081,7 +2081,8 @@ void BuildLockset::VisitUnaryOperator(const UnaryOperator *UO) {
       checkAccess(UO->getSubExpr(), AK_Written);
       break;
     case UO_AddrOf:
-      checkAccess(UO->getSubExpr(), AK_Read, POK_AddressOf);
+      if (Analyzer->Handler.issueBetaWarnings())
+        checkAccess(UO->getSubExpr(), AK_Read, POK_AddressOf);
       break;
     default:
       break;

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -1995,7 +1995,7 @@ class ThreadSafetyReporter : public clang::threadSafety::ThreadSafetyHandler {
       DiagID = diag::warn_addressof_requires_any_lock;
       break;
     default:
-      assert(false && "Only works for variables");
+      llvm_unreachable("Only works for variables");
       break;
     }
     PartialDiagnosticAt Warning(Loc, S.PDiag(DiagID)

--- a/clang/test/Sema/warn-thread-safety-analysis.c
+++ b/clang/test/Sema/warn-thread-safety-analysis.c
@@ -136,7 +136,7 @@ int main(void) {
 
 #ifdef CHECK_ADDRESSOF
   set_value(&a_, 0); // expected-warning{{calling function 'set_value' requires holding mutex 'foo_.mu_' exclusively}} \
-                        expected-warning{{obtaining address of variable 'a_' requires holding mutex 'foo_.mu_'}}
+                        expected-warning{{taking address of variable 'a_' requires holding mutex 'foo_.mu_'}}
 #else
   set_value(&a_, 0); // expected-warning{{calling function 'set_value' requires holding mutex 'foo_.mu_' exclusively}}
 #endif
@@ -187,7 +187,7 @@ int main(void) {
   late_parsing.a_value_defined_before = 1; // expected-warning{{writing variable 'a_value_defined_before' requires holding mutex 'a_mutex_defined_late' exclusively}}
   late_parsing.a_ptr_defined_before = 0;
 # ifdef CHECK_ADDRESSOF
-  (void)&late_parsing.a_value_defined_before; // expected-warning{{obtaining address of variable 'a_value_defined_before' requires holding mutex 'a_mutex_defined_late'}}
+  (void)&late_parsing.a_value_defined_before; // expected-warning{{taking address of variable 'a_value_defined_before' requires holding mutex 'a_mutex_defined_late'}}
 # else
   (void)&late_parsing.a_value_defined_before; // no warning
 # endif

--- a/clang/test/Sema/warn-thread-safety-analysis.c
+++ b/clang/test/Sema/warn-thread-safety-analysis.c
@@ -1,6 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -Wthread-safety -Wthread-safety-beta %s
-// RUN: %clang_cc1 -fsyntax-only -verify -Wthread-safety -Wthread-safety-beta -fexperimental-late-parse-attributes -DLATE_PARSING %s
-// RUN: %clang_cc1 -fsyntax-only -verify -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof -fexperimental-late-parse-attributes -DLATE_PARSING -DCHECK_ADDRESSOF %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof -fexperimental-late-parse-attributes -DLATE_PARSING %s
 
 #define LOCKABLE            __attribute__ ((lockable))
 #define SCOPED_LOCKABLE     __attribute__ ((scoped_lockable))
@@ -134,12 +133,8 @@ int main(void) {
 
   Foo_func3(5);
 
-#ifdef CHECK_ADDRESSOF
-  set_value(&a_, 0); // expected-warning{{calling function 'set_value' requires holding mutex 'foo_.mu_' exclusively}} \
-                        expected-warning{{taking address of variable 'a_' requires holding mutex 'foo_.mu_'}}
-#else
   set_value(&a_, 0); // expected-warning{{calling function 'set_value' requires holding mutex 'foo_.mu_' exclusively}}
-#endif
+                     // expected-warning@-1{{taking address of variable 'a_' requires holding mutex 'foo_.mu_'}}
   get_value(b_); // expected-warning{{calling function 'get_value' requires holding mutex 'foo_.mu_'}}
   mutex_exclusive_lock(foo_.mu_);
   set_value(&a_, 1);
@@ -186,11 +181,7 @@ int main(void) {
 #ifdef LATE_PARSING
   late_parsing.a_value_defined_before = 1; // expected-warning{{writing variable 'a_value_defined_before' requires holding mutex 'a_mutex_defined_late' exclusively}}
   late_parsing.a_ptr_defined_before = 0;
-# ifdef CHECK_ADDRESSOF
   (void)&late_parsing.a_value_defined_before; // expected-warning{{taking address of variable 'a_value_defined_before' requires holding mutex 'a_mutex_defined_late'}}
-# else
-  (void)&late_parsing.a_value_defined_before; // no warning
-# endif
   mutex_exclusive_lock(late_parsing.a_mutex_defined_late);
   mutex_exclusive_lock(late_parsing.a_mutex_defined_early); // expected-warning{{mutex 'a_mutex_defined_early' must be acquired before 'a_mutex_defined_late'}}
   mutex_exclusive_unlock(late_parsing.a_mutex_defined_early);

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -4953,8 +4953,8 @@ public:
     --data_;              // expected-warning {{writing variable 'data_' requires holding mutex 'mu_' exclusively}}
     data_--;              // expected-warning {{writing variable 'data_' requires holding mutex 'mu_' exclusively}}
 #ifdef CHECK_ADDRESSOF
-    (void)&data_;         // expected-warning {{obtaining address of variable 'data_' requires holding mutex 'mu_'}}
-    (void)&datap1_;       // expected-warning {{obtaining address of variable 'datap1_' requires holding mutex 'mu_'}}
+    (void)&data_;         // expected-warning {{taking address of variable 'data_' requires holding mutex 'mu_'}}
+    (void)&datap1_;       // expected-warning {{taking address of variable 'datap1_' requires holding mutex 'mu_'}}
 #else
     (void)&data_;         // no warning
     (void)&datap1_;       // no warning
@@ -5903,7 +5903,7 @@ class Foo {
 
   void ptr_test() {
 #ifdef CHECK_ADDRESSOF
-    int *b = &a;           // expected-warning {{obtaining address of variable 'a' requires holding mutex 'mu'}}
+    int *b = &a;           // expected-warning {{taking address of variable 'a' requires holding mutex 'mu'}}
 #else
     int *b = &a;           // no warning
 #endif
@@ -6126,7 +6126,7 @@ class Return {
   
   Foo *returns_ptr() {
 #ifdef CHECK_ADDRESSOF
-    return &foo;              // expected-warning {{obtaining address of variable 'foo' requires holding mutex 'mu'}}
+    return &foo;              // expected-warning {{taking address of variable 'foo' requires holding mutex 'mu'}}
 #else
     return &foo;              // no warning
 #endif

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -4907,7 +4907,7 @@ public:
     a = (*datap2_).getValue(); // \
       // expected-warning {{reading the value pointed to by 'datap2_' requires holding mutex 'mu_'}}
 
-    // Calls operator&, and does not obtain the address.
+    // Calls operator&, and does not take the address.
     (void)&data_ao_; // expected-warning {{reading variable 'data_ao_' requires holding mutex 'mu_'}}
     (void)__builtin_addressof(data_ao_); // expected-warning {{passing variable 'data_ao_' by reference requires holding mutex 'mu_'}}
 

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -1,9 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=0 %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=1 %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-beta -Wno-thread-safety-negative -Wthread-safety-addressof -fcxx-exceptions -DUSE_CAPABILITY=1 -DCHECK_ADDRESSOF %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=0 %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-beta -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=1 %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-beta -Wno-thread-safety-negative -Wthread-safety-addressof -fcxx-exceptions -DUSE_CAPABILITY=1 -DCHECK_ADDRESSOF %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=0 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=1 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=0 %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++17 -Wthread-safety -Wthread-safety-beta -Wthread-safety-addressof -Wno-thread-safety-negative -fcxx-exceptions -DUSE_CAPABILITY=1 %s
 
 // FIXME: should also run  %clang_cc1 -fsyntax-only -verify -Wthread-safety -std=c++11 -Wc++98-compat %s
 // FIXME: should also run  %clang_cc1 -fsyntax-only -verify -Wthread-safety %s
@@ -4952,13 +4950,8 @@ public:
     data_++;              // expected-warning {{writing variable 'data_' requires holding mutex 'mu_' exclusively}}
     --data_;              // expected-warning {{writing variable 'data_' requires holding mutex 'mu_' exclusively}}
     data_--;              // expected-warning {{writing variable 'data_' requires holding mutex 'mu_' exclusively}}
-#ifdef CHECK_ADDRESSOF
     (void)&data_;         // expected-warning {{taking address of variable 'data_' requires holding mutex 'mu_'}}
     (void)&datap1_;       // expected-warning {{taking address of variable 'datap1_' requires holding mutex 'mu_'}}
-#else
-    (void)&data_;         // no warning
-    (void)&datap1_;       // no warning
-#endif
     (void)(&*datap1_);    // expected-warning {{reading variable 'datap1_' requires holding mutex 'mu_'}}
 
     data_[0] = 0;         // expected-warning {{reading variable 'data_' requires holding mutex 'mu_'}}
@@ -5902,11 +5895,7 @@ class Foo {
   }
 
   void ptr_test() {
-#ifdef CHECK_ADDRESSOF
     int *b = &a;           // expected-warning {{taking address of variable 'a' requires holding mutex 'mu'}}
-#else
-    int *b = &a;           // no warning
-#endif
     *b = 0;                // no expected warning yet
   }
 
@@ -6125,11 +6114,7 @@ class Return {
   }
   
   Foo *returns_ptr() {
-#ifdef CHECK_ADDRESSOF
     return &foo;              // expected-warning {{taking address of variable 'foo' requires holding mutex 'mu'}}
-#else
-    return &foo;              // no warning
-#endif
   }
 
   Foo &returns_ref2() {


### PR DESCRIPTION
**Note:** This PR has been superseded by https://github.com/llvm/llvm-project/pull/127396, which takes a different approach, but coverage should be comparable with less risk of false positives.

----------

Add the optional ability, via `-Wthread-safety-addressof`, to warn when taking the address of guarded variables.

The motivation is to avoid false negatives in large C codebases, where data structures are typically implemented through helpers that take pointers to instances of a data structure. While taking the address itself does *not yet constitute a race* (in the presence of missing locking), placing the requirement on the pointer-recipient to obtain locks to access the pointed-to data is most likely poor style.

When passing pointers to functions, the additional warning is analogous to warning about passing reference to functions. However, unlike the existing analysis for references, the analysis is unable to track pointers precisely. Given the trade-offs, the user needs to explicitly decide if the remaining false positives and negatives are an acceptable cost for detecting potentially unsafe passing of pointers to guarded variables. Given that existing codebases using `-Wthread-safety` likely have cases where taking the pointer to a guarded variable is benign, the feature is *not* enabled by default but requires explicit opt-in.