### PR TITLE
SCEV: cover a codepath in isImpliedCondBalancedTypes

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -11872,7 +11872,6 @@ bool ScalarEvolution::isImpliedCondBalancedTypes(
   // FIXME: use CmpPredicate::getMatching here.
   if (ICmpInst::getSwappedCmpPredicate(FoundPred) ==
       static_cast<CmpInst::Predicate>(Pred)) {
-    return false;
     // We can write the implication
     // 0.  LHS Pred      RHS  <-   FoundLHS SwapPred  FoundRHS
     // using one of the following ways:

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -11872,6 +11872,7 @@ bool ScalarEvolution::isImpliedCondBalancedTypes(
   // FIXME: use CmpPredicate::getMatching here.
   if (ICmpInst::getSwappedCmpPredicate(FoundPred) ==
       static_cast<CmpInst::Predicate>(Pred)) {
+    return false;
     // We can write the implication
     // 0.  LHS Pred      RHS  <-   FoundLHS SwapPred  FoundRHS
     // using one of the following ways:

--- a/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
+++ b/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
@@ -411,3 +411,56 @@ header:
 exit:
   ret void
 }
+
+define void @swapped_predicate(i32 %n) nounwind {
+; Prove that (n >= 1) ===> (0 >= -n / 2).
+; CHECK-LABEL: 'swapped_predicate'
+; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate
+; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 * (0 smin (-1 + (-1 * %n.div.2)<nsw>)<nsw>))<nsw>
+; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
+; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 * (0 smin (-1 + (-1 * %n.div.2)<nsw>)<nsw>))<nsw>
+; CHECK-NEXT:  Loop %header: Trip multiple is 1
+;
+entry:
+  %cmp1 = icmp sge i32 %n, 1
+  %n.div.2 = sdiv i32 %n, 2
+  call void(i1, ...) @llvm.experimental.guard(i1 %cmp1) [ "deopt"() ]
+  br label %header
+
+header:
+  %indvar = phi i32 [ %indvar.next, %header ], [ 0, %entry ]
+  %indvar.next = add i32 %indvar, 1
+  %minus.indvar = sub nsw i32 0, %indvar
+  %minus.n.div.2 = sub nsw i32 0, %n.div.2
+  %exitcond = icmp sge i32 %minus.indvar, %minus.n.div.2
+  br i1 %exitcond, label %header, label %exit
+
+exit:
+  ret void
+}
+
+define void @swapped_predicate_neg(i32 %n) nounwind {
+; Prove that (n >= 1) =\=> (-n / 2 >= 0).
+; CHECK-LABEL: 'swapped_predicate_neg'
+; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate_neg
+; CHECK-NEXT:  Loop %header: Unpredictable backedge-taken count.
+; CHECK-NEXT:  Loop %header: Unpredictable constant max backedge-taken count.
+; CHECK-NEXT:  Loop %header: Unpredictable symbolic max backedge-taken count.
+;
+entry:
+  %cmp1 = icmp sge i32 %n, 1
+  %n.div.2 = sdiv i32 %n, 2
+  call void(i1, ...) @llvm.experimental.guard(i1 %cmp1) [ "deopt"() ]
+  br label %header
+
+header:
+  %indvar = phi i32 [ %indvar.next, %header ], [ 0, %entry ]
+  %indvar.next = add i32 %indvar, 1
+  %minus.indvar = sub nsw i32 0, %indvar
+  %minus.n.div.2 = sub nsw i32 0, %n.div.2
+  %exitcond = icmp sge i32 %minus.n.div.2, %minus.indvar
+  br i1 %exitcond, label %header, label %exit
+
+exit:
+  ret void
+}

--- a/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
+++ b/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
@@ -413,7 +413,7 @@ exit:
 }
 
 define void @swapped_predicate(i32 %n) {
-; Prove that (n >= 1) ===> (0 >= -n / 2).
+; Prove that (n s>= 1) ===> (0 s>= -n / 2).
 ; CHECK-LABEL: 'swapped_predicate'
 ; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nuw><nsw>
@@ -440,7 +440,7 @@ exit:
 }
 
 define void @swapped_predicate_neg(i32 %n) {
-; Prove that (n >= 1) =\=> (-n / 2 >= 0).
+; Prove that (n s>= 1) =\=> (-n / 2 s>= 0).
 ; CHECK-LABEL: 'swapped_predicate_neg'
 ; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate_neg
 ; CHECK-NEXT:  Loop %header: Unpredictable backedge-taken count.

--- a/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
+++ b/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
@@ -412,19 +412,19 @@ exit:
   ret void
 }
 
-define void @swapped_predicate(i32 %n) nounwind {
+define void @swapped_predicate(i32 %n) {
 ; Prove that (n >= 1) ===> (0 >= -n / 2).
 ; CHECK-LABEL: 'swapped_predicate'
 ; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate
-; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
+; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nuw><nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
+; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nuw><nsw>
 ; CHECK-NEXT:  Loop %header: Trip multiple is 1
 ;
 entry:
   %cmp1 = icmp sge i32 %n, 1
   %n.div.2 = sdiv i32 %n, 2
-  call void(i1, ...) @llvm.experimental.guard(i1 %cmp1) [ "deopt"() ]
+  call void @llvm.assume(i1 %cmp1)
   br label %header
 
 header:
@@ -439,7 +439,7 @@ exit:
   ret void
 }
 
-define void @swapped_predicate_neg(i32 %n) nounwind {
+define void @swapped_predicate_neg(i32 %n) {
 ; Prove that (n >= 1) =\=> (-n / 2 >= 0).
 ; CHECK-LABEL: 'swapped_predicate_neg'
 ; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate_neg
@@ -450,7 +450,7 @@ define void @swapped_predicate_neg(i32 %n) nounwind {
 entry:
   %cmp1 = icmp sge i32 %n, 1
   %n.div.2 = sdiv i32 %n, 2
-  call void(i1, ...) @llvm.experimental.guard(i1 %cmp1) [ "deopt"() ]
+  call void @llvm.assume(i1 %cmp1)
   br label %header
 
 header:

--- a/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
+++ b/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
@@ -416,9 +416,9 @@ define void @swapped_predicate(i32 %n) nounwind {
 ; Prove that (n >= 1) ===> (0 >= -n / 2).
 ; CHECK-LABEL: 'swapped_predicate'
 ; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate
-; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 * (0 smin (-1 + (-1 * %n.div.2)<nsw>)<nsw>))<nsw>
+; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 * (0 smin (-1 + (-1 * %n.div.2)<nsw>)<nsw>))<nsw>
+; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: Trip multiple is 1
 ;
 entry:


### PR DESCRIPTION
The code that checks a predicate against a swapped predicate in isImpliedCondBalancedTypes is not covered by any existing test, within any Analysis or Transform. Fix this by adding a test to SCEV.