### PR TITLE
[PowerPC] Fix saving of Link Register when using ROP Protect

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -909,7 +909,7 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
   // If the offset can not be encoded into the store instruction, we also have
   // to save LR here.
   // If we are using ROP Protection we need to save the LR here as we cannot
-  // move the hasst instruction past the point where we get the stack frame.
+  // move the hashst instruction past the point where we get the stack frame.
   if (MustSaveLR && !HasFastMFLR &&
       (HasSTUX || !isInt<16>(FrameSize + LROffset) || HasROPProtect))
     SaveLR(LROffset);

--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -646,7 +646,7 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
   bool HasFP = hasFP(MF);
   bool HasBP = RegInfo->hasBasePointer(MF);
   bool HasRedZone = isPPC64 || !isSVR4ABI;
-  bool HasROPProtect = Subtarget.hasROPProtect();
+  const bool HasROPProtect = Subtarget.hasROPProtect();
   bool HasPrivileged = Subtarget.hasPrivileged();
 
   Register SPReg       = isPPC64 ? PPC::X1  : PPC::R1;
@@ -908,8 +908,10 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
   // in ScratchReg.
   // If the offset can not be encoded into the store instruction, we also have
   // to save LR here.
+  // If we are using ROP Protection we need to save the LR here as we cannot
+  // move the hasst instruction past the point where we get the stack frame.
   if (MustSaveLR && !HasFastMFLR &&
-      (HasSTUX || !isInt<16>(FrameSize + LROffset)))
+      (HasSTUX || !isInt<16>(FrameSize + LROffset) || HasROPProtect))
     SaveLR(LROffset);
 
   // If FrameSize <= TLI.getStackProbeSize(MF), as POWER ABI requires backchain
@@ -1100,7 +1102,8 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
   }
 
   // Save the LR now.
-  if (!HasSTUX && MustSaveLR && !HasFastMFLR && isInt<16>(FrameSize + LROffset))
+  if (!HasSTUX && MustSaveLR && !HasFastMFLR && isInt<16>(FrameSize + LROffset)
+      && !HasROPProtect)
     SaveLR(LROffset + FrameSize);
 
   // Add Call Frame Information for the instructions we generated above.

--- a/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFrameLowering.cpp
@@ -1102,8 +1102,8 @@ void PPCFrameLowering::emitPrologue(MachineFunction &MF,
   }
 
   // Save the LR now.
-  if (!HasSTUX && MustSaveLR && !HasFastMFLR && isInt<16>(FrameSize + LROffset)
-      && !HasROPProtect)
+  if (!HasSTUX && MustSaveLR && !HasFastMFLR &&
+      isInt<16>(FrameSize + LROffset) && !HasROPProtect)
     SaveLR(LROffset + FrameSize);
 
   // Add Call Frame Information for the instructions we generated above.

--- a/llvm/test/CodeGen/PowerPC/ppc64-rop-protection-aix.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-rop-protection-aix.ll
@@ -66,9 +66,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P9-LABEL: caller:
 ; BE-P9:       # %bb.0: # %entry
 ; BE-P9-NEXT:    mflr r0
-; BE-P9-NEXT:    stdu r1, -128(r1)
-; BE-P9-NEXT:    std r0, 144(r1)
+; BE-P9-NEXT:    std r0, 16(r1)
 ; BE-P9-NEXT:    hashst r0, -16(r1)
+; BE-P9-NEXT:    stdu r1, -128(r1)
 ; BE-P9-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    mr r31, r4
 ; BE-P9-NEXT:    bl .callee[PR]
@@ -85,9 +85,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P8-LABEL: caller:
 ; BE-P8:       # %bb.0: # %entry
 ; BE-P8-NEXT:    mflr r0
-; BE-P8-NEXT:    stdu r1, -128(r1)
-; BE-P8-NEXT:    std r0, 144(r1)
+; BE-P8-NEXT:    std r0, 16(r1)
 ; BE-P8-NEXT:    hashst r0, -16(r1)
+; BE-P8-NEXT:    stdu r1, -128(r1)
 ; BE-P8-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    mr r31, r4
 ; BE-P8-NEXT:    bl .callee[PR]
@@ -122,9 +122,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-32BIT-P9-LABEL: caller:
 ; BE-32BIT-P9:       # %bb.0: # %entry
 ; BE-32BIT-P9-NEXT:    mflr r0
-; BE-32BIT-P9-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P9-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P9-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P9-NEXT:    hashst r0, -16(r1)
+; BE-32BIT-P9-NEXT:    stwu r1, -80(r1)
 ; BE-32BIT-P9-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    mr r31, r4
 ; BE-32BIT-P9-NEXT:    bl .callee[PR]
@@ -140,9 +140,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-32BIT-P8-LABEL: caller:
 ; BE-32BIT-P8:       # %bb.0: # %entry
 ; BE-32BIT-P8-NEXT:    mflr r0
-; BE-32BIT-P8-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P8-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P8-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P8-NEXT:    hashst r0, -16(r1)
+; BE-32BIT-P8-NEXT:    stwu r1, -80(r1)
 ; BE-32BIT-P8-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    mr r31, r4
 ; BE-32BIT-P8-NEXT:    bl .callee[PR]
@@ -177,9 +177,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P9-PRIV-LABEL: caller:
 ; BE-P9-PRIV:       # %bb.0: # %entry
 ; BE-P9-PRIV-NEXT:    mflr r0
-; BE-P9-PRIV-NEXT:    stdu r1, -128(r1)
-; BE-P9-PRIV-NEXT:    std r0, 144(r1)
+; BE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P9-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-P9-PRIV-NEXT:    stdu r1, -128(r1)
 ; BE-P9-PRIV-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    mr r31, r4
 ; BE-P9-PRIV-NEXT:    bl .callee[PR]
@@ -196,9 +196,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P8-PRIV-LABEL: caller:
 ; BE-P8-PRIV:       # %bb.0: # %entry
 ; BE-P8-PRIV-NEXT:    mflr r0
-; BE-P8-PRIV-NEXT:    stdu r1, -128(r1)
-; BE-P8-PRIV-NEXT:    std r0, 144(r1)
+; BE-P8-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P8-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-P8-PRIV-NEXT:    stdu r1, -128(r1)
 ; BE-P8-PRIV-NEXT:    std r31, 120(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    mr r31, r4
 ; BE-P8-PRIV-NEXT:    bl .callee[PR]
@@ -233,9 +233,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-32BIT-P9-PRIV-LABEL: caller:
 ; BE-32BIT-P9-PRIV:       # %bb.0: # %entry
 ; BE-32BIT-P9-PRIV-NEXT:    mflr r0
-; BE-32BIT-P9-PRIV-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P9-PRIV-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P9-PRIV-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P9-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-32BIT-P9-PRIV-NEXT:    stwu r1, -80(r1)
 ; BE-32BIT-P9-PRIV-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    mr r31, r4
 ; BE-32BIT-P9-PRIV-NEXT:    bl .callee[PR]
@@ -251,9 +251,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-32BIT-P8-PRIV-LABEL: caller:
 ; BE-32BIT-P8-PRIV:       # %bb.0: # %entry
 ; BE-32BIT-P8-PRIV-NEXT:    mflr r0
-; BE-32BIT-P8-PRIV-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P8-PRIV-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P8-PRIV-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-32BIT-P8-PRIV-NEXT:    stwu r1, -80(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    mr r31, r4
 ; BE-32BIT-P8-PRIV-NEXT:    bl .callee[PR]
@@ -406,39 +406,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P9-LABEL: spill:
 ; BE-P9:       # %bb.0: # %entry
-; BE-P9-NEXT:    mfcr r12
 ; BE-P9-NEXT:    mflr r0
+; BE-P9-NEXT:    mfcr r12
 ; BE-P9-NEXT:    stw r12, 8(r1)
-; BE-P9-NEXT:    stdu r1, -624(r1)
-; BE-P9-NEXT:    std r0, 640(r1)
+; BE-P9-NEXT:    std r0, 16(r1)
 ; BE-P9-NEXT:    hashst r0, -488(r1)
+; BE-P9-NEXT:    stdu r1, -624(r1)
+; BE-P9-NEXT:    lwz r4, 12(r3)
 ; BE-P9-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    stxv v20, 144(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    stxv v21, 160(r1) # 16-byte Folded Spill
-; BE-P9-NEXT:    lwz r4, 12(r3)
-; BE-P9-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    stxv v22, 176(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
@@ -533,62 +533,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P8-LABEL: spill:
 ; BE-P8:       # %bb.0: # %entry
+; BE-P8-NEXT:    mflr r0
 ; BE-P8-NEXT:    mfcr r12
 ; BE-P8-NEXT:    stw r12, 8(r1)
-; BE-P8-NEXT:    mflr r0
+; BE-P8-NEXT:    std r0, 16(r1)
+; BE-P8-NEXT:    hashst r0, -488(r1)
 ; BE-P8-NEXT:    stdu r1, -624(r1)
 ; BE-P8-NEXT:    li r4, 144
-; BE-P8-NEXT:    std r0, 640(r1)
-; BE-P8-NEXT:    hashst r0, -488(r1)
 ; BE-P8-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 160
 ; BE-P8-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 160
 ; BE-P8-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 176
 ; BE-P8-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 176
 ; BE-P8-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 192
 ; BE-P8-NEXT:    std r31, 472(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f14, 480(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 192
 ; BE-P8-NEXT:    stfd f15, 488(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f16, 496(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f17, 504(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f18, 512(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 208
 ; BE-P8-NEXT:    stfd f19, 520(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f20, 528(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 208
 ; BE-P8-NEXT:    stfd f21, 536(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f22, 544(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f23, 552(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f24, 560(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 224
 ; BE-P8-NEXT:    stfd f25, 568(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f26, 576(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 224
 ; BE-P8-NEXT:    stfd f27, 584(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f28, 592(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f29, 600(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f30, 608(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 240
 ; BE-P8-NEXT:    stfd f31, 616(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r3, 120(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 240
 ; BE-P8-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; BE-P8-NEXT:    li r4, 256
 ; BE-P8-NEXT:    stxvd2x v27, r1, r4 # 16-byte Folded Spill
@@ -812,39 +812,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-32BIT-P9-LABEL: spill:
 ; BE-32BIT-P9:       # %bb.0: # %entry
-; BE-32BIT-P9-NEXT:    mfcr r12
 ; BE-32BIT-P9-NEXT:    mflr r0
+; BE-32BIT-P9-NEXT:    mfcr r12
 ; BE-32BIT-P9-NEXT:    stw r12, 4(r1)
-; BE-32BIT-P9-NEXT:    stwu r1, -496(r1)
-; BE-32BIT-P9-NEXT:    stw r0, 504(r1)
+; BE-32BIT-P9-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P9-NEXT:    hashst r0, -424(r1)
+; BE-32BIT-P9-NEXT:    stwu r1, -496(r1)
+; BE-32BIT-P9-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P9-NEXT:    stw r13, 276(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stw r14, 280(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stxv v20, 80(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stxv v21, 96(r1) # 16-byte Folded Spill
-; BE-32BIT-P9-NEXT:    lwz r4, 12(r3)
-; BE-32BIT-P9-NEXT:    stw r14, 280(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stxv v22, 112(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r15, 284(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v23, 128(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r16, 288(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v24, 144(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v23, 128(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r17, 292(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v25, 160(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v24, 144(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r18, 296(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v25, 160(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r19, 300(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v26, 176(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r20, 304(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v27, 192(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v26, 176(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r21, 308(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v28, 208(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v27, 192(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r22, 312(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v28, 208(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r23, 316(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v29, 224(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r24, 320(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v30, 240(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v29, 224(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r25, 324(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-NEXT:    stxv v31, 256(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v30, 240(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r26, 328(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-NEXT:    stxv v31, 256(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r27, 332(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r28, 336(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r29, 340(r1) # 4-byte Folded Spill
@@ -940,62 +940,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-32BIT-P8-LABEL: spill:
 ; BE-32BIT-P8:       # %bb.0: # %entry
+; BE-32BIT-P8-NEXT:    mflr r0
 ; BE-32BIT-P8-NEXT:    mfcr r12
 ; BE-32BIT-P8-NEXT:    stw r12, 4(r1)
-; BE-32BIT-P8-NEXT:    mflr r0
+; BE-32BIT-P8-NEXT:    stw r0, 8(r1)
+; BE-32BIT-P8-NEXT:    hashst r0, -424(r1)
 ; BE-32BIT-P8-NEXT:    stwu r1, -496(r1)
 ; BE-32BIT-P8-NEXT:    li r4, 80
-; BE-32BIT-P8-NEXT:    stw r0, 504(r1)
-; BE-32BIT-P8-NEXT:    hashst r0, -424(r1)
 ; BE-32BIT-P8-NEXT:    stw r13, 276(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r14, 280(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r15, 284(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r16, 288(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r17, 292(r1) # 4-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 96
 ; BE-32BIT-P8-NEXT:    stw r18, 296(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r19, 300(r1) # 4-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 96
 ; BE-32BIT-P8-NEXT:    stw r20, 304(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r21, 308(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r22, 312(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r23, 316(r1) # 4-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 112
 ; BE-32BIT-P8-NEXT:    stw r24, 320(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r25, 324(r1) # 4-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 112
 ; BE-32BIT-P8-NEXT:    stw r26, 328(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r27, 332(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r28, 336(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r29, 340(r1) # 4-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 128
 ; BE-32BIT-P8-NEXT:    stw r30, 344(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r31, 348(r1) # 4-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 128
 ; BE-32BIT-P8-NEXT:    stfd f14, 352(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f15, 360(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f16, 368(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f17, 376(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 144
 ; BE-32BIT-P8-NEXT:    stfd f18, 384(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f19, 392(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 144
 ; BE-32BIT-P8-NEXT:    stfd f20, 400(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f21, 408(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f22, 416(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f23, 424(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 160
 ; BE-32BIT-P8-NEXT:    stfd f24, 432(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f25, 440(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 160
 ; BE-32BIT-P8-NEXT:    stfd f26, 448(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f27, 456(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f28, 464(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f29, 472(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 176
 ; BE-32BIT-P8-NEXT:    stfd f30, 480(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f31, 488(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 176
 ; BE-32BIT-P8-NEXT:    stw r3, 64(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    li r4, 192
@@ -1219,39 +1219,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P9-PRIV-LABEL: spill:
 ; BE-P9-PRIV:       # %bb.0: # %entry
-; BE-P9-PRIV-NEXT:    mfcr r12
 ; BE-P9-PRIV-NEXT:    mflr r0
+; BE-P9-PRIV-NEXT:    mfcr r12
 ; BE-P9-PRIV-NEXT:    stw r12, 8(r1)
-; BE-P9-PRIV-NEXT:    stdu r1, -624(r1)
-; BE-P9-PRIV-NEXT:    std r0, 640(r1)
+; BE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P9-PRIV-NEXT:    hashstp r0, -488(r1)
+; BE-P9-PRIV-NEXT:    stdu r1, -624(r1)
+; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P9-PRIV-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    stxv v20, 144(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    stxv v21, 160(r1) # 16-byte Folded Spill
-; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
-; BE-P9-PRIV-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    stxv v22, 176(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
@@ -1346,62 +1346,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P8-PRIV-LABEL: spill:
 ; BE-P8-PRIV:       # %bb.0: # %entry
+; BE-P8-PRIV-NEXT:    mflr r0
 ; BE-P8-PRIV-NEXT:    mfcr r12
 ; BE-P8-PRIV-NEXT:    stw r12, 8(r1)
-; BE-P8-PRIV-NEXT:    mflr r0
+; BE-P8-PRIV-NEXT:    std r0, 16(r1)
+; BE-P8-PRIV-NEXT:    hashstp r0, -488(r1)
 ; BE-P8-PRIV-NEXT:    stdu r1, -624(r1)
 ; BE-P8-PRIV-NEXT:    li r4, 144
-; BE-P8-PRIV-NEXT:    std r0, 640(r1)
-; BE-P8-PRIV-NEXT:    hashstp r0, -488(r1)
 ; BE-P8-PRIV-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 160
 ; BE-P8-PRIV-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 160
 ; BE-P8-PRIV-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 176
 ; BE-P8-PRIV-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 176
 ; BE-P8-PRIV-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 192
 ; BE-P8-PRIV-NEXT:    std r31, 472(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f14, 480(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 192
 ; BE-P8-PRIV-NEXT:    stfd f15, 488(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f16, 496(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f17, 504(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f18, 512(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 208
 ; BE-P8-PRIV-NEXT:    stfd f19, 520(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f20, 528(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 208
 ; BE-P8-PRIV-NEXT:    stfd f21, 536(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f22, 544(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f23, 552(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f24, 560(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 224
 ; BE-P8-PRIV-NEXT:    stfd f25, 568(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f26, 576(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 224
 ; BE-P8-PRIV-NEXT:    stfd f27, 584(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f28, 592(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f29, 600(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f30, 608(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 240
 ; BE-P8-PRIV-NEXT:    stfd f31, 616(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r3, 120(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 240
 ; BE-P8-PRIV-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    li r4, 256
 ; BE-P8-PRIV-NEXT:    stxvd2x v27, r1, r4 # 16-byte Folded Spill
@@ -1625,39 +1625,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-32BIT-P9-PRIV-LABEL: spill:
 ; BE-32BIT-P9-PRIV:       # %bb.0: # %entry
-; BE-32BIT-P9-PRIV-NEXT:    mfcr r12
 ; BE-32BIT-P9-PRIV-NEXT:    mflr r0
+; BE-32BIT-P9-PRIV-NEXT:    mfcr r12
 ; BE-32BIT-P9-PRIV-NEXT:    stw r12, 4(r1)
-; BE-32BIT-P9-PRIV-NEXT:    stwu r1, -496(r1)
-; BE-32BIT-P9-PRIV-NEXT:    stw r0, 504(r1)
+; BE-32BIT-P9-PRIV-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P9-PRIV-NEXT:    hashstp r0, -424(r1)
+; BE-32BIT-P9-PRIV-NEXT:    stwu r1, -496(r1)
+; BE-32BIT-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P9-PRIV-NEXT:    stw r13, 276(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stw r14, 280(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stxv v20, 80(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stxv v21, 96(r1) # 16-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    lwz r4, 12(r3)
-; BE-32BIT-P9-PRIV-NEXT:    stw r14, 280(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stxv v22, 112(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r15, 284(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v23, 128(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r16, 288(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v24, 144(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v23, 128(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r17, 292(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v25, 160(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v24, 144(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r18, 296(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v25, 160(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r19, 300(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v26, 176(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r20, 304(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v27, 192(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v26, 176(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r21, 308(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v28, 208(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v27, 192(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r22, 312(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v28, 208(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r23, 316(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v29, 224(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r24, 320(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v30, 240(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v29, 224(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r25, 324(r1) # 4-byte Folded Spill
-; BE-32BIT-P9-PRIV-NEXT:    stxv v31, 256(r1) # 16-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v30, 240(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r26, 328(r1) # 4-byte Folded Spill
+; BE-32BIT-P9-PRIV-NEXT:    stxv v31, 256(r1) # 16-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r27, 332(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r28, 336(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    stw r29, 340(r1) # 4-byte Folded Spill
@@ -1753,62 +1753,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-32BIT-P8-PRIV-LABEL: spill:
 ; BE-32BIT-P8-PRIV:       # %bb.0: # %entry
+; BE-32BIT-P8-PRIV-NEXT:    mflr r0
 ; BE-32BIT-P8-PRIV-NEXT:    mfcr r12
 ; BE-32BIT-P8-PRIV-NEXT:    stw r12, 4(r1)
-; BE-32BIT-P8-PRIV-NEXT:    mflr r0
+; BE-32BIT-P8-PRIV-NEXT:    stw r0, 8(r1)
+; BE-32BIT-P8-PRIV-NEXT:    hashstp r0, -424(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    stwu r1, -496(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    li r4, 80
-; BE-32BIT-P8-PRIV-NEXT:    stw r0, 504(r1)
-; BE-32BIT-P8-PRIV-NEXT:    hashstp r0, -424(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    stw r13, 276(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r14, 280(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r15, 284(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r16, 288(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r17, 292(r1) # 4-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    li r4, 96
 ; BE-32BIT-P8-PRIV-NEXT:    stw r18, 296(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r19, 300(r1) # 4-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    li r4, 96
 ; BE-32BIT-P8-PRIV-NEXT:    stw r20, 304(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r21, 308(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r22, 312(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r23, 316(r1) # 4-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    li r4, 112
 ; BE-32BIT-P8-PRIV-NEXT:    stw r24, 320(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r25, 324(r1) # 4-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    li r4, 112
 ; BE-32BIT-P8-PRIV-NEXT:    stw r26, 328(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r27, 332(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r28, 336(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r29, 340(r1) # 4-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    li r4, 128
 ; BE-32BIT-P8-PRIV-NEXT:    stw r30, 344(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stw r31, 348(r1) # 4-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    li r4, 128
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f14, 352(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f15, 360(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f16, 368(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f17, 376(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    li r4, 144
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f18, 384(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f19, 392(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    li r4, 144
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f20, 400(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f21, 408(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f22, 416(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f23, 424(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    li r4, 160
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f24, 432(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f25, 440(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    li r4, 160
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f26, 448(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f27, 456(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f28, 464(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f29, 472(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-PRIV-NEXT:    li r4, 176
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f30, 480(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stfd f31, 488(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-PRIV-NEXT:    li r4, 176
 ; BE-32BIT-P8-PRIV-NEXT:    stw r3, 64(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    li r4, 192
@@ -1954,12 +1954,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P9-NEXT:    beq cr0, L..BB2_2
 ; BE-P9-NEXT:  # %bb.1: # %if.end
 ; BE-P9-NEXT:    mflr r0
-; BE-P9-NEXT:    stdu r1, -144(r1)
-; BE-P9-NEXT:    std r0, 160(r1)
+; BE-P9-NEXT:    std r0, 16(r1)
 ; BE-P9-NEXT:    hashst r0, -16(r1)
+; BE-P9-NEXT:    stdu r1, -144(r1)
+; BE-P9-NEXT:    lwz r4, 12(r3)
 ; BE-P9-NEXT:    std r31, 136(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    mr r31, r3
-; BE-P9-NEXT:    lwz r4, 12(r3)
 ; BE-P9-NEXT:    stw r4, 124(r1)
 ; BE-P9-NEXT:    addi r4, r1, 124
 ; BE-P9-NEXT:    mr r3, r4
@@ -1984,12 +1984,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P8-NEXT:    beq cr0, L..BB2_2
 ; BE-P8-NEXT:  # %bb.1: # %if.end
 ; BE-P8-NEXT:    mflr r0
-; BE-P8-NEXT:    stdu r1, -144(r1)
-; BE-P8-NEXT:    std r0, 160(r1)
+; BE-P8-NEXT:    std r0, 16(r1)
 ; BE-P8-NEXT:    hashst r0, -16(r1)
+; BE-P8-NEXT:    stdu r1, -144(r1)
+; BE-P8-NEXT:    lwz r4, 12(r3)
 ; BE-P8-NEXT:    std r31, 136(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    mr r31, r3
-; BE-P8-NEXT:    lwz r4, 12(r3)
 ; BE-P8-NEXT:    stw r4, 124(r1)
 ; BE-P8-NEXT:    addi r4, r1, 124
 ; BE-P8-NEXT:    mr r3, r4
@@ -2043,12 +2043,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-32BIT-P9-NEXT:    beq cr0, L..BB2_2
 ; BE-32BIT-P9-NEXT:  # %bb.1: # %if.end
 ; BE-32BIT-P9-NEXT:    mflr r0
-; BE-32BIT-P9-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P9-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P9-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P9-NEXT:    hashst r0, -16(r1)
+; BE-32BIT-P9-NEXT:    stwu r1, -80(r1)
+; BE-32BIT-P9-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P9-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    mr r31, r3
-; BE-32BIT-P9-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P9-NEXT:    stw r4, 60(r1)
 ; BE-32BIT-P9-NEXT:    addi r4, r1, 60
 ; BE-32BIT-P9-NEXT:    mr r3, r4
@@ -2072,12 +2072,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-32BIT-P8-NEXT:    beq cr0, L..BB2_2
 ; BE-32BIT-P8-NEXT:  # %bb.1: # %if.end
 ; BE-32BIT-P8-NEXT:    mflr r0
-; BE-32BIT-P8-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P8-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P8-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P8-NEXT:    hashst r0, -16(r1)
+; BE-32BIT-P8-NEXT:    stwu r1, -80(r1)
+; BE-32BIT-P8-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P8-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    mr r31, r3
-; BE-32BIT-P8-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P8-NEXT:    stw r4, 60(r1)
 ; BE-32BIT-P8-NEXT:    addi r4, r1, 60
 ; BE-32BIT-P8-NEXT:    mr r3, r4
@@ -2131,12 +2131,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P9-PRIV-NEXT:    beq cr0, L..BB2_2
 ; BE-P9-PRIV-NEXT:  # %bb.1: # %if.end
 ; BE-P9-PRIV-NEXT:    mflr r0
-; BE-P9-PRIV-NEXT:    stdu r1, -144(r1)
-; BE-P9-PRIV-NEXT:    std r0, 160(r1)
+; BE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P9-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-P9-PRIV-NEXT:    stdu r1, -144(r1)
+; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P9-PRIV-NEXT:    std r31, 136(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    mr r31, r3
-; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P9-PRIV-NEXT:    stw r4, 124(r1)
 ; BE-P9-PRIV-NEXT:    addi r4, r1, 124
 ; BE-P9-PRIV-NEXT:    mr r3, r4
@@ -2161,12 +2161,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P8-PRIV-NEXT:    beq cr0, L..BB2_2
 ; BE-P8-PRIV-NEXT:  # %bb.1: # %if.end
 ; BE-P8-PRIV-NEXT:    mflr r0
-; BE-P8-PRIV-NEXT:    stdu r1, -144(r1)
-; BE-P8-PRIV-NEXT:    std r0, 160(r1)
+; BE-P8-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P8-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-P8-PRIV-NEXT:    stdu r1, -144(r1)
+; BE-P8-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P8-PRIV-NEXT:    std r31, 136(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    mr r31, r3
-; BE-P8-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P8-PRIV-NEXT:    stw r4, 124(r1)
 ; BE-P8-PRIV-NEXT:    addi r4, r1, 124
 ; BE-P8-PRIV-NEXT:    mr r3, r4
@@ -2220,12 +2220,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-32BIT-P9-PRIV-NEXT:    beq cr0, L..BB2_2
 ; BE-32BIT-P9-PRIV-NEXT:  # %bb.1: # %if.end
 ; BE-32BIT-P9-PRIV-NEXT:    mflr r0
-; BE-32BIT-P9-PRIV-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P9-PRIV-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P9-PRIV-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P9-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-32BIT-P9-PRIV-NEXT:    stwu r1, -80(r1)
+; BE-32BIT-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P9-PRIV-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-PRIV-NEXT:    mr r31, r3
-; BE-32BIT-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P9-PRIV-NEXT:    stw r4, 60(r1)
 ; BE-32BIT-P9-PRIV-NEXT:    addi r4, r1, 60
 ; BE-32BIT-P9-PRIV-NEXT:    mr r3, r4
@@ -2249,12 +2249,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-32BIT-P8-PRIV-NEXT:    beq cr0, L..BB2_2
 ; BE-32BIT-P8-PRIV-NEXT:  # %bb.1: # %if.end
 ; BE-32BIT-P8-PRIV-NEXT:    mflr r0
-; BE-32BIT-P8-PRIV-NEXT:    stwu r1, -80(r1)
-; BE-32BIT-P8-PRIV-NEXT:    stw r0, 88(r1)
+; BE-32BIT-P8-PRIV-NEXT:    stw r0, 8(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    hashstp r0, -16(r1)
+; BE-32BIT-P8-PRIV-NEXT:    stwu r1, -80(r1)
+; BE-32BIT-P8-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P8-PRIV-NEXT:    stw r31, 76(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-PRIV-NEXT:    mr r31, r3
-; BE-32BIT-P8-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-32BIT-P8-PRIV-NEXT:    stw r4, 60(r1)
 ; BE-32BIT-P8-PRIV-NEXT:    addi r4, r1, 60
 ; BE-32BIT-P8-PRIV-NEXT:    mr r3, r4

--- a/llvm/test/CodeGen/PowerPC/ppc64-rop-protection.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-rop-protection.ll
@@ -84,9 +84,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; LE-P9:       # %bb.0: # %entry
 ; LE-P9-NEXT:    mflr r0
 ; LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stdu r1, -64(r1)
-; LE-P9-NEXT:    std r0, 80(r1)
+; LE-P9-NEXT:    std r0, 16(r1)
 ; LE-P9-NEXT:    hashst r0, -24(r1)
+; LE-P9-NEXT:    stdu r1, -64(r1)
 ; LE-P9-NEXT:    mr r30, r4
 ; LE-P9-NEXT:    bl callee
 ; LE-P9-NEXT:    nop
@@ -103,9 +103,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; LE-P8:       # %bb.0: # %entry
 ; LE-P8-NEXT:    mflr r0
 ; LE-P8-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stdu r1, -64(r1)
-; LE-P8-NEXT:    std r0, 80(r1)
+; LE-P8-NEXT:    std r0, 16(r1)
 ; LE-P8-NEXT:    hashst r0, -24(r1)
+; LE-P8-NEXT:    stdu r1, -64(r1)
 ; LE-P8-NEXT:    mr r30, r4
 ; LE-P8-NEXT:    bl callee
 ; LE-P8-NEXT:    nop
@@ -144,9 +144,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; LE-P9-O0-LABEL: caller:
 ; LE-P9-O0:       # %bb.0: # %entry
 ; LE-P9-O0-NEXT:    mflr r0
-; LE-P9-O0-NEXT:    stdu r1, -112(r1)
-; LE-P9-O0-NEXT:    std r0, 128(r1)
+; LE-P9-O0-NEXT:    std r0, 16(r1)
 ; LE-P9-O0-NEXT:    hashst r0, -8(r1)
+; LE-P9-O0-NEXT:    stdu r1, -112(r1)
 ; LE-P9-O0-NEXT:    # kill: def $r4 killed $r4 killed $x4
 ; LE-P9-O0-NEXT:    stw r4, 100(r1) # 4-byte Folded Spill
 ; LE-P9-O0-NEXT:    # kill: def $r3 killed $r3 killed $x3
@@ -165,9 +165,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; LE-P8-O0-LABEL: caller:
 ; LE-P8-O0:       # %bb.0: # %entry
 ; LE-P8-O0-NEXT:    mflr r0
-; LE-P8-O0-NEXT:    stdu r1, -112(r1)
-; LE-P8-O0-NEXT:    std r0, 128(r1)
+; LE-P8-O0-NEXT:    std r0, 16(r1)
 ; LE-P8-O0-NEXT:    hashst r0, -8(r1)
+; LE-P8-O0-NEXT:    stdu r1, -112(r1)
 ; LE-P8-O0-NEXT:    # kill: def $r4 killed $r4 killed $x4
 ; LE-P8-O0-NEXT:    stw r4, 100(r1) # 4-byte Folded Spill
 ; LE-P8-O0-NEXT:    # kill: def $r3 killed $r3 killed $x3
@@ -205,9 +205,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P9-LABEL: caller:
 ; BE-P9:       # %bb.0: # %entry
 ; BE-P9-NEXT:    mflr r0
-; BE-P9-NEXT:    stdu r1, -144(r1)
-; BE-P9-NEXT:    std r0, 160(r1)
+; BE-P9-NEXT:    std r0, 16(r1)
 ; BE-P9-NEXT:    hashst r0, -24(r1)
+; BE-P9-NEXT:    stdu r1, -144(r1)
 ; BE-P9-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    mr r30, r4
 ; BE-P9-NEXT:    bl callee
@@ -224,9 +224,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P8-LABEL: caller:
 ; BE-P8:       # %bb.0: # %entry
 ; BE-P8-NEXT:    mflr r0
-; BE-P8-NEXT:    stdu r1, -144(r1)
-; BE-P8-NEXT:    std r0, 160(r1)
+; BE-P8-NEXT:    std r0, 16(r1)
 ; BE-P8-NEXT:    hashst r0, -24(r1)
+; BE-P8-NEXT:    stdu r1, -144(r1)
 ; BE-P8-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    mr r30, r4
 ; BE-P8-NEXT:    bl callee
@@ -260,9 +260,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-32BIT-P9-LABEL: caller:
 ; BE-32BIT-P9:       # %bb.0: # %entry
 ; BE-32BIT-P9-NEXT:    mflr r0
-; BE-32BIT-P9-NEXT:    stwu r1, -32(r1)
-; BE-32BIT-P9-NEXT:    stw r0, 36(r1)
+; BE-32BIT-P9-NEXT:    stw r0, 4(r1)
 ; BE-32BIT-P9-NEXT:    hashst r0, -16(r1)
+; BE-32BIT-P9-NEXT:    stwu r1, -32(r1)
 ; BE-32BIT-P9-NEXT:    stw r30, 24(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    mr r30, r4
 ; BE-32BIT-P9-NEXT:    bl callee
@@ -277,9 +277,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-32BIT-P8-LABEL: caller:
 ; BE-32BIT-P8:       # %bb.0: # %entry
 ; BE-32BIT-P8-NEXT:    mflr r0
-; BE-32BIT-P8-NEXT:    stwu r1, -32(r1)
-; BE-32BIT-P8-NEXT:    stw r0, 36(r1)
+; BE-32BIT-P8-NEXT:    stw r0, 4(r1)
 ; BE-32BIT-P8-NEXT:    hashst r0, -16(r1)
+; BE-32BIT-P8-NEXT:    stwu r1, -32(r1)
 ; BE-32BIT-P8-NEXT:    stw r30, 24(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    mr r30, r4
 ; BE-32BIT-P8-NEXT:    bl callee
@@ -313,9 +313,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; LE-P9-PRIV:       # %bb.0: # %entry
 ; LE-P9-PRIV-NEXT:    mflr r0
 ; LE-P9-PRIV-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stdu r1, -64(r1)
-; LE-P9-PRIV-NEXT:    std r0, 80(r1)
+; LE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; LE-P9-PRIV-NEXT:    hashstp r0, -24(r1)
+; LE-P9-PRIV-NEXT:    stdu r1, -64(r1)
 ; LE-P9-PRIV-NEXT:    mr r30, r4
 ; LE-P9-PRIV-NEXT:    bl callee
 ; LE-P9-PRIV-NEXT:    nop
@@ -332,9 +332,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; LE-P8-PRIV:       # %bb.0: # %entry
 ; LE-P8-PRIV-NEXT:    mflr r0
 ; LE-P8-PRIV-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stdu r1, -64(r1)
-; LE-P8-PRIV-NEXT:    std r0, 80(r1)
+; LE-P8-PRIV-NEXT:    std r0, 16(r1)
 ; LE-P8-PRIV-NEXT:    hashstp r0, -24(r1)
+; LE-P8-PRIV-NEXT:    stdu r1, -64(r1)
 ; LE-P8-PRIV-NEXT:    mr r30, r4
 ; LE-P8-PRIV-NEXT:    bl callee
 ; LE-P8-PRIV-NEXT:    nop
@@ -369,9 +369,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P9-PRIV-LABEL: caller:
 ; BE-P9-PRIV:       # %bb.0: # %entry
 ; BE-P9-PRIV-NEXT:    mflr r0
-; BE-P9-PRIV-NEXT:    stdu r1, -144(r1)
-; BE-P9-PRIV-NEXT:    std r0, 160(r1)
+; BE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P9-PRIV-NEXT:    hashstp r0, -24(r1)
+; BE-P9-PRIV-NEXT:    stdu r1, -144(r1)
 ; BE-P9-PRIV-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    mr r30, r4
 ; BE-P9-PRIV-NEXT:    bl callee
@@ -388,9 +388,9 @@ define dso_local zeroext i32 @caller(i32 zeroext %in, i32 zeroext %add_after) #0
 ; BE-P8-PRIV-LABEL: caller:
 ; BE-P8-PRIV:       # %bb.0: # %entry
 ; BE-P8-PRIV-NEXT:    mflr r0
-; BE-P8-PRIV-NEXT:    stdu r1, -144(r1)
-; BE-P8-PRIV-NEXT:    std r0, 160(r1)
+; BE-P8-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P8-PRIV-NEXT:    hashstp r0, -24(r1)
+; BE-P8-PRIV-NEXT:    stdu r1, -144(r1)
 ; BE-P8-PRIV-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    mr r30, r4
 ; BE-P8-PRIV-NEXT:    bl callee
@@ -542,39 +542,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; LE-P9-LABEL: spill:
 ; LE-P9:       # %bb.0: # %entry
-; LE-P9-NEXT:    mfcr r12
 ; LE-P9-NEXT:    mflr r0
+; LE-P9-NEXT:    mfcr r12
 ; LE-P9-NEXT:    stw r12, 8(r1)
-; LE-P9-NEXT:    stdu r1, -544(r1)
-; LE-P9-NEXT:    std r0, 560(r1)
+; LE-P9-NEXT:    std r0, 16(r1)
 ; LE-P9-NEXT:    hashst r0, -488(r1)
+; LE-P9-NEXT:    stdu r1, -544(r1)
+; LE-P9-NEXT:    lwz r4, 12(r3)
 ; LE-P9-NEXT:    std r14, 256(r1) # 8-byte Folded Spill
+; LE-P9-NEXT:    std r15, 264(r1) # 8-byte Folded Spill
 ; LE-P9-NEXT:    stxv v20, 64(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    stxv v21, 80(r1) # 16-byte Folded Spill
-; LE-P9-NEXT:    lwz r4, 12(r3)
-; LE-P9-NEXT:    std r15, 264(r1) # 8-byte Folded Spill
 ; LE-P9-NEXT:    stxv v22, 96(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r16, 272(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v23, 112(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r17, 280(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v24, 128(r1) # 16-byte Folded Spill
+; LE-P9-NEXT:    stxv v23, 112(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r18, 288(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v25, 144(r1) # 16-byte Folded Spill
+; LE-P9-NEXT:    stxv v24, 128(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r19, 296(r1) # 8-byte Folded Spill
+; LE-P9-NEXT:    stxv v25, 144(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r20, 304(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v26, 160(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r21, 312(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v27, 176(r1) # 16-byte Folded Spill
+; LE-P9-NEXT:    stxv v26, 160(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r22, 320(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v28, 192(r1) # 16-byte Folded Spill
+; LE-P9-NEXT:    stxv v27, 176(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r23, 328(r1) # 8-byte Folded Spill
+; LE-P9-NEXT:    stxv v28, 192(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r24, 336(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v29, 208(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r25, 344(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v30, 224(r1) # 16-byte Folded Spill
+; LE-P9-NEXT:    stxv v29, 208(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r26, 352(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stxv v31, 240(r1) # 16-byte Folded Spill
+; LE-P9-NEXT:    stxv v30, 224(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r27, 360(r1) # 8-byte Folded Spill
+; LE-P9-NEXT:    stxv v31, 240(r1) # 16-byte Folded Spill
 ; LE-P9-NEXT:    std r28, 368(r1) # 8-byte Folded Spill
 ; LE-P9-NEXT:    std r29, 376(r1) # 8-byte Folded Spill
 ; LE-P9-NEXT:    std r30, 384(r1) # 8-byte Folded Spill
@@ -669,62 +669,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; LE-P8-LABEL: spill:
 ; LE-P8:       # %bb.0: # %entry
+; LE-P8-NEXT:    mflr r0
 ; LE-P8-NEXT:    mfcr r12
 ; LE-P8-NEXT:    stw r12, 8(r1)
-; LE-P8-NEXT:    mflr r0
+; LE-P8-NEXT:    std r0, 16(r1)
+; LE-P8-NEXT:    hashst r0, -488(r1)
 ; LE-P8-NEXT:    stdu r1, -544(r1)
 ; LE-P8-NEXT:    li r4, 64
-; LE-P8-NEXT:    std r0, 560(r1)
-; LE-P8-NEXT:    hashst r0, -488(r1)
 ; LE-P8-NEXT:    std r14, 256(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r15, 264(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r16, 272(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r17, 280(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r18, 288(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; LE-P8-NEXT:    li r4, 80
 ; LE-P8-NEXT:    std r19, 296(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r20, 304(r1) # 8-byte Folded Spill
+; LE-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; LE-P8-NEXT:    li r4, 80
 ; LE-P8-NEXT:    std r21, 312(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r22, 320(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r23, 328(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r24, 336(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; LE-P8-NEXT:    li r4, 96
 ; LE-P8-NEXT:    std r25, 344(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r26, 352(r1) # 8-byte Folded Spill
+; LE-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; LE-P8-NEXT:    li r4, 96
 ; LE-P8-NEXT:    std r27, 360(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r28, 368(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r29, 376(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r30, 384(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; LE-P8-NEXT:    li r4, 112
 ; LE-P8-NEXT:    std r31, 392(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f14, 400(r1) # 8-byte Folded Spill
+; LE-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; LE-P8-NEXT:    li r4, 112
 ; LE-P8-NEXT:    stfd f15, 408(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f16, 416(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f17, 424(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f18, 432(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; LE-P8-NEXT:    li r4, 128
 ; LE-P8-NEXT:    stfd f19, 440(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f20, 448(r1) # 8-byte Folded Spill
+; LE-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; LE-P8-NEXT:    li r4, 128
 ; LE-P8-NEXT:    stfd f21, 456(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f22, 464(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f23, 472(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f24, 480(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; LE-P8-NEXT:    li r4, 144
 ; LE-P8-NEXT:    stfd f25, 488(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f26, 496(r1) # 8-byte Folded Spill
+; LE-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; LE-P8-NEXT:    li r4, 144
 ; LE-P8-NEXT:    stfd f27, 504(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f28, 512(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f29, 520(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    stfd f30, 528(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; LE-P8-NEXT:    li r4, 160
 ; LE-P8-NEXT:    stfd f31, 536(r1) # 8-byte Folded Spill
 ; LE-P8-NEXT:    std r3, 40(r1) # 8-byte Folded Spill
+; LE-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; LE-P8-NEXT:    li r4, 160
 ; LE-P8-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; LE-P8-NEXT:    li r4, 176
 ; LE-P8-NEXT:    stxvd2x v27, r1, r4 # 16-byte Folded Spill
@@ -951,9 +951,9 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P9-O0-NEXT:    mflr r0
 ; LE-P9-O0-NEXT:    mfcr r12
 ; LE-P9-O0-NEXT:    stw r12, 8(r1)
-; LE-P9-O0-NEXT:    stdu r1, -608(r1)
-; LE-P9-O0-NEXT:    std r0, 624(r1)
+; LE-P9-O0-NEXT:    std r0, 16(r1)
 ; LE-P9-O0-NEXT:    hashst r0, -488(r1)
+; LE-P9-O0-NEXT:    stdu r1, -608(r1)
 ; LE-P9-O0-NEXT:    std r14, 320(r1) # 8-byte Folded Spill
 ; LE-P9-O0-NEXT:    std r15, 328(r1) # 8-byte Folded Spill
 ; LE-P9-O0-NEXT:    std r16, 336(r1) # 8-byte Folded Spill
@@ -1079,9 +1079,9 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; LE-P8-O0-NEXT:    mflr r0
 ; LE-P8-O0-NEXT:    mfcr r12
 ; LE-P8-O0-NEXT:    stw r12, 8(r1)
-; LE-P8-O0-NEXT:    stdu r1, -608(r1)
-; LE-P8-O0-NEXT:    std r0, 624(r1)
+; LE-P8-O0-NEXT:    std r0, 16(r1)
 ; LE-P8-O0-NEXT:    hashst r0, -488(r1)
+; LE-P8-O0-NEXT:    stdu r1, -608(r1)
 ; LE-P8-O0-NEXT:    std r14, 320(r1) # 8-byte Folded Spill
 ; LE-P8-O0-NEXT:    std r15, 328(r1) # 8-byte Folded Spill
 ; LE-P8-O0-NEXT:    std r16, 336(r1) # 8-byte Folded Spill
@@ -1355,39 +1355,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P9-LABEL: spill:
 ; BE-P9:       # %bb.0: # %entry
-; BE-P9-NEXT:    mfcr r12
 ; BE-P9-NEXT:    mflr r0
+; BE-P9-NEXT:    mfcr r12
 ; BE-P9-NEXT:    stw r12, 8(r1)
-; BE-P9-NEXT:    stdu r1, -624(r1)
-; BE-P9-NEXT:    std r0, 640(r1)
+; BE-P9-NEXT:    std r0, 16(r1)
 ; BE-P9-NEXT:    hashst r0, -488(r1)
+; BE-P9-NEXT:    stdu r1, -624(r1)
+; BE-P9-NEXT:    lwz r4, 12(r3)
 ; BE-P9-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    stxv v20, 144(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    stxv v21, 160(r1) # 16-byte Folded Spill
-; BE-P9-NEXT:    lwz r4, 12(r3)
-; BE-P9-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    stxv v22, 176(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
-; BE-P9-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
+; BE-P9-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
+; BE-P9-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
 ; BE-P9-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
@@ -1482,62 +1482,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P8-LABEL: spill:
 ; BE-P8:       # %bb.0: # %entry
+; BE-P8-NEXT:    mflr r0
 ; BE-P8-NEXT:    mfcr r12
 ; BE-P8-NEXT:    stw r12, 8(r1)
-; BE-P8-NEXT:    mflr r0
+; BE-P8-NEXT:    std r0, 16(r1)
+; BE-P8-NEXT:    hashst r0, -488(r1)
 ; BE-P8-NEXT:    stdu r1, -624(r1)
 ; BE-P8-NEXT:    li r4, 144
-; BE-P8-NEXT:    std r0, 640(r1)
-; BE-P8-NEXT:    hashst r0, -488(r1)
 ; BE-P8-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 160
 ; BE-P8-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 160
 ; BE-P8-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 176
 ; BE-P8-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 176
 ; BE-P8-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 192
 ; BE-P8-NEXT:    std r31, 472(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f14, 480(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 192
 ; BE-P8-NEXT:    stfd f15, 488(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f16, 496(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f17, 504(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f18, 512(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 208
 ; BE-P8-NEXT:    stfd f19, 520(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f20, 528(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 208
 ; BE-P8-NEXT:    stfd f21, 536(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f22, 544(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f23, 552(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f24, 560(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 224
 ; BE-P8-NEXT:    stfd f25, 568(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f26, 576(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 224
 ; BE-P8-NEXT:    stfd f27, 584(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f28, 592(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f29, 600(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    stfd f30, 608(r1) # 8-byte Folded Spill
-; BE-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-P8-NEXT:    li r4, 240
 ; BE-P8-NEXT:    stfd f31, 616(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    std r3, 120(r1) # 8-byte Folded Spill
+; BE-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-P8-NEXT:    li r4, 240
 ; BE-P8-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; BE-P8-NEXT:    li r4, 256
 ; BE-P8-NEXT:    stxvd2x v27, r1, r4 # 16-byte Folded Spill
@@ -1759,10 +1759,10 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P9-LABEL: spill:
 ; BE-32BIT-P9:       # %bb.0: # %entry
 ; BE-32BIT-P9-NEXT:    mflr r0
+; BE-32BIT-P9-NEXT:    stw r0, 4(r1)
+; BE-32BIT-P9-NEXT:    hashst r0, -424(r1)
 ; BE-32BIT-P9-NEXT:    stwu r1, -448(r1)
 ; BE-32BIT-P9-NEXT:    mfcr r12
-; BE-32BIT-P9-NEXT:    stw r0, 452(r1)
-; BE-32BIT-P9-NEXT:    hashst r0, -424(r1)
 ; BE-32BIT-P9-NEXT:    stw r14, 232(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r15, 236(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    stw r16, 240(r1) # 4-byte Folded Spill
@@ -1884,11 +1884,11 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P8-LABEL: spill:
 ; BE-32BIT-P8:       # %bb.0: # %entry
 ; BE-32BIT-P8-NEXT:    mflr r0
+; BE-32BIT-P8-NEXT:    stw r0, 4(r1)
+; BE-32BIT-P8-NEXT:    hashst r0, -424(r1)
 ; BE-32BIT-P8-NEXT:    stwu r1, -448(r1)
 ; BE-32BIT-P8-NEXT:    li r4, 32
 ; BE-32BIT-P8-NEXT:    mfcr r12
-; BE-32BIT-P8-NEXT:    stw r0, 452(r1)
-; BE-32BIT-P8-NEXT:    hashst r0, -424(r1)
 ; BE-32BIT-P8-NEXT:    stw r14, 232(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r15, 236(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r16, 240(r1) # 4-byte Folded Spill
@@ -1917,26 +1917,26 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ; BE-32BIT-P8-NEXT:    stfd f14, 304(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f15, 312(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f16, 320(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 96
 ; BE-32BIT-P8-NEXT:    stfd f17, 328(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f18, 336(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 96
 ; BE-32BIT-P8-NEXT:    stfd f19, 344(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f20, 352(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f21, 360(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f22, 368(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 112
 ; BE-32BIT-P8-NEXT:    stfd f23, 376(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f24, 384(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 112
 ; BE-32BIT-P8-NEXT:    stfd f25, 392(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f26, 400(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f27, 408(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f28, 416(r1) # 8-byte Folded Spill
-; BE-32BIT-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-32BIT-P8-NEXT:    li r4, 128
 ; BE-32BIT-P8-NEXT:    stfd f29, 424(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stfd f30, 432(r1) # 8-byte Folded Spill
+; BE-32BIT-P8-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-32BIT-P8-NEXT:    li r4, 128
 ; BE-32BIT-P8-NEXT:    stfd f31, 440(r1) # 8-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stw r3, 16(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
@@ -2158,39 +2158,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; LE-P9-PRIV-LABEL: spill:
 ; LE-P9-PRIV:       # %bb.0: # %entry
-; LE-P9-PRIV-NEXT:    mfcr r12
 ; LE-P9-PRIV-NEXT:    mflr r0
+; LE-P9-PRIV-NEXT:    mfcr r12
 ; LE-P9-PRIV-NEXT:    stw r12, 8(r1)
-; LE-P9-PRIV-NEXT:    stdu r1, -544(r1)
-; LE-P9-PRIV-NEXT:    std r0, 560(r1)
+; LE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; LE-P9-PRIV-NEXT:    hashstp r0, -488(r1)
+; LE-P9-PRIV-NEXT:    stdu r1, -544(r1)
+; LE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; LE-P9-PRIV-NEXT:    std r14, 256(r1) # 8-byte Folded Spill
+; LE-P9-PRIV-NEXT:    std r15, 264(r1) # 8-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    stxv v20, 64(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    stxv v21, 80(r1) # 16-byte Folded Spill
-; LE-P9-PRIV-NEXT:    lwz r4, 12(r3)
-; LE-P9-PRIV-NEXT:    std r15, 264(r1) # 8-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    stxv v22, 96(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r16, 272(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v23, 112(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r17, 280(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v24, 128(r1) # 16-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v23, 112(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r18, 288(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v25, 144(r1) # 16-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v24, 128(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r19, 296(r1) # 8-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v25, 144(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r20, 304(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v26, 160(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r21, 312(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v27, 176(r1) # 16-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v26, 160(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r22, 320(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v28, 192(r1) # 16-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v27, 176(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r23, 328(r1) # 8-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v28, 192(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r24, 336(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v29, 208(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r25, 344(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v30, 224(r1) # 16-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v29, 208(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r26, 352(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stxv v31, 240(r1) # 16-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v30, 224(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r27, 360(r1) # 8-byte Folded Spill
+; LE-P9-PRIV-NEXT:    stxv v31, 240(r1) # 16-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r28, 368(r1) # 8-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r29, 376(r1) # 8-byte Folded Spill
 ; LE-P9-PRIV-NEXT:    std r30, 384(r1) # 8-byte Folded Spill
@@ -2285,62 +2285,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; LE-P8-PRIV-LABEL: spill:
 ; LE-P8-PRIV:       # %bb.0: # %entry
+; LE-P8-PRIV-NEXT:    mflr r0
 ; LE-P8-PRIV-NEXT:    mfcr r12
 ; LE-P8-PRIV-NEXT:    stw r12, 8(r1)
-; LE-P8-PRIV-NEXT:    mflr r0
+; LE-P8-PRIV-NEXT:    std r0, 16(r1)
+; LE-P8-PRIV-NEXT:    hashstp r0, -488(r1)
 ; LE-P8-PRIV-NEXT:    stdu r1, -544(r1)
 ; LE-P8-PRIV-NEXT:    li r4, 64
-; LE-P8-PRIV-NEXT:    std r0, 560(r1)
-; LE-P8-PRIV-NEXT:    hashstp r0, -488(r1)
 ; LE-P8-PRIV-NEXT:    std r14, 256(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r15, 264(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r16, 272(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r17, 280(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r18, 288(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; LE-P8-PRIV-NEXT:    li r4, 80
 ; LE-P8-PRIV-NEXT:    std r19, 296(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r20, 304(r1) # 8-byte Folded Spill
+; LE-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; LE-P8-PRIV-NEXT:    li r4, 80
 ; LE-P8-PRIV-NEXT:    std r21, 312(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r22, 320(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r23, 328(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r24, 336(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; LE-P8-PRIV-NEXT:    li r4, 96
 ; LE-P8-PRIV-NEXT:    std r25, 344(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r26, 352(r1) # 8-byte Folded Spill
+; LE-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; LE-P8-PRIV-NEXT:    li r4, 96
 ; LE-P8-PRIV-NEXT:    std r27, 360(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r28, 368(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r29, 376(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r30, 384(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; LE-P8-PRIV-NEXT:    li r4, 112
 ; LE-P8-PRIV-NEXT:    std r31, 392(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f14, 400(r1) # 8-byte Folded Spill
+; LE-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; LE-P8-PRIV-NEXT:    li r4, 112
 ; LE-P8-PRIV-NEXT:    stfd f15, 408(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f16, 416(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f17, 424(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f18, 432(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; LE-P8-PRIV-NEXT:    li r4, 128
 ; LE-P8-PRIV-NEXT:    stfd f19, 440(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f20, 448(r1) # 8-byte Folded Spill
+; LE-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; LE-P8-PRIV-NEXT:    li r4, 128
 ; LE-P8-PRIV-NEXT:    stfd f21, 456(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f22, 464(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f23, 472(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f24, 480(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; LE-P8-PRIV-NEXT:    li r4, 144
 ; LE-P8-PRIV-NEXT:    stfd f25, 488(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f26, 496(r1) # 8-byte Folded Spill
+; LE-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; LE-P8-PRIV-NEXT:    li r4, 144
 ; LE-P8-PRIV-NEXT:    stfd f27, 504(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f28, 512(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f29, 520(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    stfd f30, 528(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; LE-P8-PRIV-NEXT:    li r4, 160
 ; LE-P8-PRIV-NEXT:    stfd f31, 536(r1) # 8-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    std r3, 40(r1) # 8-byte Folded Spill
+; LE-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; LE-P8-PRIV-NEXT:    li r4, 160
 ; LE-P8-PRIV-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; LE-P8-PRIV-NEXT:    li r4, 176
 ; LE-P8-PRIV-NEXT:    stxvd2x v27, r1, r4 # 16-byte Folded Spill
@@ -2563,39 +2563,39 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P9-PRIV-LABEL: spill:
 ; BE-P9-PRIV:       # %bb.0: # %entry
-; BE-P9-PRIV-NEXT:    mfcr r12
 ; BE-P9-PRIV-NEXT:    mflr r0
+; BE-P9-PRIV-NEXT:    mfcr r12
 ; BE-P9-PRIV-NEXT:    stw r12, 8(r1)
-; BE-P9-PRIV-NEXT:    stdu r1, -624(r1)
-; BE-P9-PRIV-NEXT:    std r0, 640(r1)
+; BE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P9-PRIV-NEXT:    hashstp r0, -488(r1)
+; BE-P9-PRIV-NEXT:    stdu r1, -624(r1)
+; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P9-PRIV-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    stxv v20, 144(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    stxv v21, 160(r1) # 16-byte Folded Spill
-; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
-; BE-P9-PRIV-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    stxv v22, 176(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v23, 192(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v24, 208(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v25, 224(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v26, 240(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v27, 256(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v28, 272(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v29, 288(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
-; BE-P9-PRIV-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v30, 304(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
+; BE-P9-PRIV-NEXT:    stxv v31, 320(r1) # 16-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
@@ -2690,62 +2690,62 @@ define dso_local zeroext i32 @spill(ptr nocapture readonly %in) #0 {
 ;
 ; BE-P8-PRIV-LABEL: spill:
 ; BE-P8-PRIV:       # %bb.0: # %entry
+; BE-P8-PRIV-NEXT:    mflr r0
 ; BE-P8-PRIV-NEXT:    mfcr r12
 ; BE-P8-PRIV-NEXT:    stw r12, 8(r1)
-; BE-P8-PRIV-NEXT:    mflr r0
+; BE-P8-PRIV-NEXT:    std r0, 16(r1)
+; BE-P8-PRIV-NEXT:    hashstp r0, -488(r1)
 ; BE-P8-PRIV-NEXT:    stdu r1, -624(r1)
 ; BE-P8-PRIV-NEXT:    li r4, 144
-; BE-P8-PRIV-NEXT:    std r0, 640(r1)
-; BE-P8-PRIV-NEXT:    hashstp r0, -488(r1)
 ; BE-P8-PRIV-NEXT:    std r14, 336(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r15, 344(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r16, 352(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r17, 360(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r18, 368(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 160
 ; BE-P8-PRIV-NEXT:    std r19, 376(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r20, 384(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v20, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 160
 ; BE-P8-PRIV-NEXT:    std r21, 392(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r22, 400(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r23, 408(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r24, 416(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 176
 ; BE-P8-PRIV-NEXT:    std r25, 424(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r26, 432(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v21, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 176
 ; BE-P8-PRIV-NEXT:    std r27, 440(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r28, 448(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r29, 456(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r30, 464(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 192
 ; BE-P8-PRIV-NEXT:    std r31, 472(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f14, 480(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v22, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 192
 ; BE-P8-PRIV-NEXT:    stfd f15, 488(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f16, 496(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f17, 504(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f18, 512(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 208
 ; BE-P8-PRIV-NEXT:    stfd f19, 520(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f20, 528(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v23, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 208
 ; BE-P8-PRIV-NEXT:    stfd f21, 536(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f22, 544(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f23, 552(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f24, 560(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 224
 ; BE-P8-PRIV-NEXT:    stfd f25, 568(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f26, 576(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v24, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 224
 ; BE-P8-PRIV-NEXT:    stfd f27, 584(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f28, 592(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f29, 600(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    stfd f30, 608(r1) # 8-byte Folded Spill
-; BE-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
-; BE-P8-PRIV-NEXT:    li r4, 240
 ; BE-P8-PRIV-NEXT:    stfd f31, 616(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    std r3, 120(r1) # 8-byte Folded Spill
+; BE-P8-PRIV-NEXT:    stxvd2x v25, r1, r4 # 16-byte Folded Spill
+; BE-P8-PRIV-NEXT:    li r4, 240
 ; BE-P8-PRIV-NEXT:    stxvd2x v26, r1, r4 # 16-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    li r4, 256
 ; BE-P8-PRIV-NEXT:    stxvd2x v27, r1, r4 # 16-byte Folded Spill
@@ -2890,11 +2890,11 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; LE-P9-NEXT:  # %bb.1: # %if.end
 ; LE-P9-NEXT:    mflr r0
 ; LE-P9-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P9-NEXT:    stdu r1, -64(r1)
-; LE-P9-NEXT:    std r0, 80(r1)
+; LE-P9-NEXT:    std r0, 16(r1)
 ; LE-P9-NEXT:    hashst r0, -24(r1)
-; LE-P9-NEXT:    mr r30, r3
+; LE-P9-NEXT:    stdu r1, -64(r1)
 ; LE-P9-NEXT:    lwz r4, 12(r3)
+; LE-P9-NEXT:    mr r30, r3
 ; LE-P9-NEXT:    stw r4, 36(r1)
 ; LE-P9-NEXT:    addi r4, r1, 36
 ; LE-P9-NEXT:    mr r3, r4
@@ -2920,11 +2920,11 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; LE-P8-NEXT:  # %bb.1: # %if.end
 ; LE-P8-NEXT:    mflr r0
 ; LE-P8-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P8-NEXT:    stdu r1, -64(r1)
-; LE-P8-NEXT:    std r0, 80(r1)
+; LE-P8-NEXT:    std r0, 16(r1)
 ; LE-P8-NEXT:    hashst r0, -24(r1)
-; LE-P8-NEXT:    mr r30, r3
+; LE-P8-NEXT:    stdu r1, -64(r1)
 ; LE-P8-NEXT:    lwz r4, 12(r3)
+; LE-P8-NEXT:    mr r30, r3
 ; LE-P8-NEXT:    stw r4, 36(r1)
 ; LE-P8-NEXT:    addi r4, r1, 36
 ; LE-P8-NEXT:    mr r3, r4
@@ -2978,9 +2978,9 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; LE-P9-O0-LABEL: shrinkwrap:
 ; LE-P9-O0:       # %bb.0: # %entry
 ; LE-P9-O0-NEXT:    mflr r0
-; LE-P9-O0-NEXT:    stdu r1, -128(r1)
-; LE-P9-O0-NEXT:    std r0, 144(r1)
+; LE-P9-O0-NEXT:    std r0, 16(r1)
 ; LE-P9-O0-NEXT:    hashst r0, -8(r1)
+; LE-P9-O0-NEXT:    stdu r1, -128(r1)
 ; LE-P9-O0-NEXT:    mr. r4, r3
 ; LE-P9-O0-NEXT:    std r4, 104(r1) # 8-byte Folded Spill
 ; LE-P9-O0-NEXT:    li r3, 0
@@ -3010,9 +3010,9 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; LE-P8-O0-LABEL: shrinkwrap:
 ; LE-P8-O0:       # %bb.0: # %entry
 ; LE-P8-O0-NEXT:    mflr r0
-; LE-P8-O0-NEXT:    stdu r1, -128(r1)
-; LE-P8-O0-NEXT:    std r0, 144(r1)
+; LE-P8-O0-NEXT:    std r0, 16(r1)
 ; LE-P8-O0-NEXT:    hashst r0, -8(r1)
+; LE-P8-O0-NEXT:    stdu r1, -128(r1)
 ; LE-P8-O0-NEXT:    mr. r4, r3
 ; LE-P8-O0-NEXT:    std r4, 104(r1) # 8-byte Folded Spill
 ; LE-P8-O0-NEXT:    li r3, 0
@@ -3075,12 +3075,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P9-NEXT:    beq cr0, .LBB2_2
 ; BE-P9-NEXT:  # %bb.1: # %if.end
 ; BE-P9-NEXT:    mflr r0
-; BE-P9-NEXT:    stdu r1, -144(r1)
-; BE-P9-NEXT:    std r0, 160(r1)
+; BE-P9-NEXT:    std r0, 16(r1)
 ; BE-P9-NEXT:    hashst r0, -24(r1)
+; BE-P9-NEXT:    stdu r1, -144(r1)
+; BE-P9-NEXT:    lwz r4, 12(r3)
 ; BE-P9-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P9-NEXT:    mr r30, r3
-; BE-P9-NEXT:    lwz r4, 12(r3)
 ; BE-P9-NEXT:    stw r4, 116(r1)
 ; BE-P9-NEXT:    addi r4, r1, 116
 ; BE-P9-NEXT:    mr r3, r4
@@ -3105,12 +3105,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P8-NEXT:    beq cr0, .LBB2_2
 ; BE-P8-NEXT:  # %bb.1: # %if.end
 ; BE-P8-NEXT:    mflr r0
-; BE-P8-NEXT:    stdu r1, -144(r1)
-; BE-P8-NEXT:    std r0, 160(r1)
+; BE-P8-NEXT:    std r0, 16(r1)
 ; BE-P8-NEXT:    hashst r0, -24(r1)
+; BE-P8-NEXT:    stdu r1, -144(r1)
+; BE-P8-NEXT:    lwz r4, 12(r3)
 ; BE-P8-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P8-NEXT:    mr r30, r3
-; BE-P8-NEXT:    lwz r4, 12(r3)
 ; BE-P8-NEXT:    stw r4, 116(r1)
 ; BE-P8-NEXT:    addi r4, r1, 116
 ; BE-P8-NEXT:    mr r3, r4
@@ -3161,10 +3161,10 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-32BIT-P9-LABEL: shrinkwrap:
 ; BE-32BIT-P9:       # %bb.0: # %entry
 ; BE-32BIT-P9-NEXT:    mflr r0
+; BE-32BIT-P9-NEXT:    stw r0, 4(r1)
+; BE-32BIT-P9-NEXT:    hashst r0, -16(r1)
 ; BE-32BIT-P9-NEXT:    stwu r1, -32(r1)
 ; BE-32BIT-P9-NEXT:    cmplwi r3, 0
-; BE-32BIT-P9-NEXT:    stw r0, 36(r1)
-; BE-32BIT-P9-NEXT:    hashst r0, -16(r1)
 ; BE-32BIT-P9-NEXT:    stw r30, 24(r1) # 4-byte Folded Spill
 ; BE-32BIT-P9-NEXT:    beq cr0, .LBB2_2
 ; BE-32BIT-P9-NEXT:  # %bb.1: # %if.end
@@ -3190,10 +3190,10 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-32BIT-P8-LABEL: shrinkwrap:
 ; BE-32BIT-P8:       # %bb.0: # %entry
 ; BE-32BIT-P8-NEXT:    mflr r0
+; BE-32BIT-P8-NEXT:    stw r0, 4(r1)
+; BE-32BIT-P8-NEXT:    hashst r0, -16(r1)
 ; BE-32BIT-P8-NEXT:    stwu r1, -32(r1)
 ; BE-32BIT-P8-NEXT:    cmplwi r3, 0
-; BE-32BIT-P8-NEXT:    stw r0, 36(r1)
-; BE-32BIT-P8-NEXT:    hashst r0, -16(r1)
 ; BE-32BIT-P8-NEXT:    stw r30, 24(r1) # 4-byte Folded Spill
 ; BE-32BIT-P8-NEXT:    beq cr0, .LBB2_2
 ; BE-32BIT-P8-NEXT:  # %bb.1: # %if.end
@@ -3252,11 +3252,11 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; LE-P9-PRIV-NEXT:  # %bb.1: # %if.end
 ; LE-P9-PRIV-NEXT:    mflr r0
 ; LE-P9-PRIV-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P9-PRIV-NEXT:    stdu r1, -64(r1)
-; LE-P9-PRIV-NEXT:    std r0, 80(r1)
+; LE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; LE-P9-PRIV-NEXT:    hashstp r0, -24(r1)
-; LE-P9-PRIV-NEXT:    mr r30, r3
+; LE-P9-PRIV-NEXT:    stdu r1, -64(r1)
 ; LE-P9-PRIV-NEXT:    lwz r4, 12(r3)
+; LE-P9-PRIV-NEXT:    mr r30, r3
 ; LE-P9-PRIV-NEXT:    stw r4, 36(r1)
 ; LE-P9-PRIV-NEXT:    addi r4, r1, 36
 ; LE-P9-PRIV-NEXT:    mr r3, r4
@@ -3282,11 +3282,11 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; LE-P8-PRIV-NEXT:  # %bb.1: # %if.end
 ; LE-P8-PRIV-NEXT:    mflr r0
 ; LE-P8-PRIV-NEXT:    std r30, -16(r1) # 8-byte Folded Spill
-; LE-P8-PRIV-NEXT:    stdu r1, -64(r1)
-; LE-P8-PRIV-NEXT:    std r0, 80(r1)
+; LE-P8-PRIV-NEXT:    std r0, 16(r1)
 ; LE-P8-PRIV-NEXT:    hashstp r0, -24(r1)
-; LE-P8-PRIV-NEXT:    mr r30, r3
+; LE-P8-PRIV-NEXT:    stdu r1, -64(r1)
 ; LE-P8-PRIV-NEXT:    lwz r4, 12(r3)
+; LE-P8-PRIV-NEXT:    mr r30, r3
 ; LE-P8-PRIV-NEXT:    stw r4, 36(r1)
 ; LE-P8-PRIV-NEXT:    addi r4, r1, 36
 ; LE-P8-PRIV-NEXT:    mr r3, r4
@@ -3341,12 +3341,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P9-PRIV-NEXT:    beq cr0, .LBB2_2
 ; BE-P9-PRIV-NEXT:  # %bb.1: # %if.end
 ; BE-P9-PRIV-NEXT:    mflr r0
-; BE-P9-PRIV-NEXT:    stdu r1, -144(r1)
-; BE-P9-PRIV-NEXT:    std r0, 160(r1)
+; BE-P9-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P9-PRIV-NEXT:    hashstp r0, -24(r1)
+; BE-P9-PRIV-NEXT:    stdu r1, -144(r1)
+; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P9-PRIV-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P9-PRIV-NEXT:    mr r30, r3
-; BE-P9-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P9-PRIV-NEXT:    stw r4, 116(r1)
 ; BE-P9-PRIV-NEXT:    addi r4, r1, 116
 ; BE-P9-PRIV-NEXT:    mr r3, r4
@@ -3371,12 +3371,12 @@ define dso_local zeroext i32 @shrinkwrap(ptr readonly %in) #0 {
 ; BE-P8-PRIV-NEXT:    beq cr0, .LBB2_2
 ; BE-P8-PRIV-NEXT:  # %bb.1: # %if.end
 ; BE-P8-PRIV-NEXT:    mflr r0
-; BE-P8-PRIV-NEXT:    stdu r1, -144(r1)
-; BE-P8-PRIV-NEXT:    std r0, 160(r1)
+; BE-P8-PRIV-NEXT:    std r0, 16(r1)
 ; BE-P8-PRIV-NEXT:    hashstp r0, -24(r1)
+; BE-P8-PRIV-NEXT:    stdu r1, -144(r1)
+; BE-P8-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P8-PRIV-NEXT:    std r30, 128(r1) # 8-byte Folded Spill
 ; BE-P8-PRIV-NEXT:    mr r30, r3
-; BE-P8-PRIV-NEXT:    lwz r4, 12(r3)
 ; BE-P8-PRIV-NEXT:    stw r4, 116(r1)
 ; BE-P8-PRIV-NEXT:    addi r4, r1, 116
 ; BE-P8-PRIV-NEXT:    mr r3, r4


### PR DESCRIPTION
An optimization was added that tries to move the uses of the mflr instruction away from the instruction itself. However, this doesn't work when we are using the hashst instruction because that instruction needs to be run before the stack frame is obtained.

This patch disables moving instructions away from the mflr in the case where ROP protection is being used.