### PR TITLE
[compiler-rt] Install libc++ and libc++abi in build_symbolizer.sh

### DIFF
--- a/compiler-rt/lib/sanitizer_common/symbolizer/scripts/build_symbolizer.sh
+++ b/compiler-rt/lib/sanitizer_common/symbolizer/scripts/build_symbolizer.sh
@@ -88,7 +88,7 @@ make -j libz.a
 
 # Build and install libcxxabi and libcxx.
 if [[ ! -f ${LLVM_BUILD}/build.ninja ]]; then
-  rm -rf ${LIBCXX_BUILD}
+  rm -rf "${LIBCXX_BUILD}" "${LIBCXX_INSTALL}"
   mkdir -p ${LIBCXX_BUILD} ${LIBCXX_INSTALL}
   cd ${LIBCXX_BUILD}
   LIBCXX_FLAGS="${FLAGS} -Wno-macro-redefined"

--- a/compiler-rt/lib/sanitizer_common/symbolizer/scripts/build_symbolizer.sh
+++ b/compiler-rt/lib/sanitizer_common/symbolizer/scripts/build_symbolizer.sh
@@ -55,6 +55,7 @@ cd $BUILD_DIR
 
 ZLIB_BUILD=${BUILD_DIR}/zlib
 LIBCXX_BUILD=${BUILD_DIR}/libcxx
+LIBCXX_INSTALL=${BUILD_DIR}/libcxx-install
 LLVM_BUILD=${BUILD_DIR}/llvm
 SYMBOLIZER_BUILD=${BUILD_DIR}/symbolizer
 
@@ -88,10 +89,11 @@ make -j libz.a
 # Build and install libcxxabi and libcxx.
 if [[ ! -f ${LLVM_BUILD}/build.ninja ]]; then
   rm -rf ${LIBCXX_BUILD}
-  mkdir -p ${LIBCXX_BUILD}
+  mkdir -p ${LIBCXX_BUILD} ${LIBCXX_INSTALL}
   cd ${LIBCXX_BUILD}
   LIBCXX_FLAGS="${FLAGS} -Wno-macro-redefined"
   cmake -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${LIBCXX_INSTALL}" \
     -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER_WORKS=ON \
@@ -114,11 +116,11 @@ if [[ ! -f ${LLVM_BUILD}/build.ninja ]]; then
   $LLVM_SRC/../runtimes
 fi
 cd ${LIBCXX_BUILD}
-ninja cxx cxxabi
+ninja cxx cxxabi && ninja install-cxx install-cxxabi
 
 FLAGS="${FLAGS} -fno-rtti -fno-exceptions"
 LLVM_CFLAGS="${FLAGS} -Wno-global-constructors"
-LLVM_CXXFLAGS="${LLVM_CFLAGS} -nostdinc++ -I${ZLIB_BUILD} -isystem ${LIBCXX_BUILD}/include -isystem ${LIBCXX_BUILD}/include/c++/v1"
+LLVM_CXXFLAGS="${LLVM_CFLAGS} -nostdinc++ -I${ZLIB_BUILD} -isystem ${LIBCXX_INSTALL}/include -isystem ${LIBCXX_INSTALL}/include/c++/v1"
 
 # Build LLVM.
 if [[ ! -f ${LLVM_BUILD}/build.ninja ]]; then
@@ -134,7 +136,7 @@ if [[ ! -f ${LLVM_BUILD}/build.ninja ]]; then
     -DLLVM_ENABLE_LIBCXX=ON \
     -DCMAKE_C_FLAGS_RELEASE="${LLVM_CFLAGS}" \
     -DCMAKE_CXX_FLAGS_RELEASE="${LLVM_CXXFLAGS}" \
-    -DCMAKE_EXE_LINKER_FLAGS="$LINKFLAGS -stdlib=libc++ -L${LIBCXX_BUILD}/lib" \
+    -DCMAKE_EXE_LINKER_FLAGS="$LINKFLAGS -stdlib=libc++ -L${LIBCXX_INSTALL}/lib" \
     -DLLVM_TABLEGEN=$TBLGEN \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DLLVM_ENABLE_ZLIB=ON \
@@ -163,7 +165,7 @@ SYMBOLIZER_API_LIST+=,__sanitizer_symbolize_demangle
 SYMBOLIZER_API_LIST+=,__sanitizer_symbolize_set_demangle
 SYMBOLIZER_API_LIST+=,__sanitizer_symbolize_set_inline_frames
 
-LIBCXX_ARCHIVE_DIR=$(dirname $(find $LIBCXX_BUILD -name libc++.a | head -n1))
+LIBCXX_ARCHIVE_DIR=$(dirname $(find $LIBCXX_INSTALL -name libc++.a | head -n1))
 
 # Merge all the object files together and copy the resulting library back.
 $LINK $LIBCXX_ARCHIVE_DIR/libc++.a \


### PR DESCRIPTION
This ensures that the directory layout of the libc++/libc++abi matches exactly what we would get on a real installation. Currently the build directory happens to match the install directory layout, but this will no longer be true in the future.