### PR TITLE
[lldb] Handle a byte size of zero in CompilerType::GetValueAsScalar

### DIFF
--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1105,8 +1105,11 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
       return false;
 
     std::optional<uint64_t> byte_size = GetByteSize(exe_scope);
+    // A bit or byte size of 0 is not a bug, but it doesn't make sense to read a
+    // scalar of zero size.
     if (!byte_size || *byte_size == 0)
       return false;
+
     lldb::offset_t offset = data_byte_offset;
     switch (encoding) {
     case lldb::eEncodingInvalid:

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -1105,7 +1105,7 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
       return false;
 
     std::optional<uint64_t> byte_size = GetByteSize(exe_scope);
-    if (!byte_size)
+    if (!byte_size || *byte_size == 0)
       return false;
     lldb::offset_t offset = data_byte_offset;
     switch (encoding) {


### PR DESCRIPTION
A bit or byte size of 0 is not a bug. It can legitimately (and frequently) happen in Swift and C, just not in C++. However, it doesn't make sense to read a scalar of zero bytes.

Currently, when this happens, we trigger an `lldb_assert` in the data extractor and return 0, which isn't accurate. I have a bunch of reports of the assert triggering, but nobody has been able to provide me with a reproducer that I can turn into a test and I wasn't able to concoct a test case by reverse-engineering the code. 

rdar://141630334