### PR TITLE
[CUF] Moving __fadd_rd and __fadd_ru to cudadevice.f90 as they are symbol already known upstream.

### DIFF
--- a/flang/module/__cuda_device.f90
+++ b/flang/module/__cuda_device.f90
@@ -14,19 +14,4 @@ implicit none
   ! Set PRIVATE by default to explicitly only export what is meant
   ! to be exported by this MODULE.
 
-  interface
-    attributes(device) function __fadd_rd(x, y) bind(c, name='__nv_fadd_rd')
-      real, intent(in), value :: x, y
-      real :: __fadd_rd
-    end function
-  end interface
-  public :: __fadd_rd
-
-  interface
-    attributes(device) function __fadd_ru(x, y) bind(c, name='__nv_fadd_ru')
-      real, intent(in), value :: x, y
-      real :: __fadd_ru
-    end function
-  end interface
-  public :: __fadd_ru
 end module

--- a/flang/module/cudadevice.f90
+++ b/flang/module/cudadevice.f90
@@ -75,6 +75,8 @@ implicit none
   end interface
   public :: threadfence_system
 
+  ! Math API
+
   interface
     attributes(device) function __fadd_rd(x, y) bind(c, name='__nv_fadd_rd')
       real, intent(in), value :: x, y

--- a/flang/module/cudadevice.f90
+++ b/flang/module/cudadevice.f90
@@ -75,4 +75,20 @@ implicit none
   end interface
   public :: threadfence_system
 
+  interface
+    attributes(device) function __fadd_rd(x, y) bind(c, name='__nv_fadd_rd')
+      real, intent(in), value :: x, y
+      real :: __fadd_rd
+    end function
+  end interface
+  public :: __fadd_rd
+
+  interface
+    attributes(device) function __fadd_ru(x, y) bind(c, name='__nv_fadd_ru')
+      real, intent(in), value :: x, y
+      real :: __fadd_ru
+    end function
+  end interface
+  public :: __fadd_ru
+  
 end module


### PR DESCRIPTION
They are defined under `__clang_cuda_device_functions.h` 