### PR TITLE
[MC] Unhide the target-abi option.

### DIFF
--- a/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
+++ b/llvm/lib/MC/MCTargetOptionsCommandFlags.cpp
@@ -156,7 +156,7 @@ llvm::mc::RegisterMCTargetOptionsFlags::RegisterMCTargetOptionsFlags() {
   MCBINDOPT(X86Sse2Avx);
 
   static cl::opt<std::string> ABIName(
-      "target-abi", cl::Hidden,
+      "target-abi",
       cl::desc("The name of the ABI to be targeted from the backend."),
       cl::init(""));
   MCBINDOPT(ABIName);


### PR DESCRIPTION
This option is very important for RISC-V as it controls calling convention and a field in the ELF header. It is used in a large number of RISC-V lit tests.

Expose the option to -help.

Fixes one issue raised in #123077