### PR TITLE
[DirectX] Set Shader Flag DisableOptimizations.

### DIFF
--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -37,6 +37,7 @@ struct ModuleMetadataInfo {
   Triple::EnvironmentType ShaderProfile{Triple::UnknownEnvironment};
   VersionTuple ValidatorVersion{};
   SmallVector<EntryProperties> EntryPropertyVec{};
+  bool DisableOptimizations{false};
   void print(raw_ostream &OS) const;
 };
 

--- a/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
+++ b/llvm/lib/Analysis/DXILMetadataAnalysis.cpp
@@ -68,6 +68,22 @@ static ModuleMetadataInfo collectMetadataInfo(Module &M) {
     }
     MMDAI.EntryPropertyVec.push_back(EFP);
   }
+
+  // Set shader flags based on Module properties
+  SmallVector<llvm::Module::ModuleFlagEntry> FlagEntries;
+  M.getModuleFlagsMetadata(FlagEntries);
+  for (const auto &Flag : FlagEntries) {
+    if (Flag.Behavior != Module::ModFlagBehavior::Override)
+      continue;
+    if (Flag.Key->getString().compare("dx.disable_optimizations") == 0) {
+      const auto *V = mdconst::extract<llvm::ConstantInt>(Flag.Val);
+      if (V->isOne()) {
+        MMDAI.DisableOptimizations = true;
+        break;
+      }
+    }
+  }
+
   return MMDAI;
 }
 

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.h
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_TARGET_DIRECTX_DXILSHADERFLAGS_H
 #define LLVM_TARGET_DIRECTX_DXILSHADERFLAGS_H
 
+#include "llvm/Analysis/DXILMetadataAnalysis.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
@@ -83,7 +84,8 @@ struct ComputedShaderFlags {
 };
 
 struct ModuleShaderFlags {
-  void initialize(Module &, DXILResourceTypeMap &DRTM);
+  void initialize(Module &, DXILResourceTypeMap &DRTM,
+                  const ModuleMetadataInfo &MMDI);
   const ComputedShaderFlags &getFunctionFlags(const Function *) const;
   const ComputedShaderFlags &getCombinedFlags() const { return CombinedSFMask; }
 

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/disable-opt.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/disable-opt.ll
@@ -1,0 +1,25 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+
+target triple = "dxilv1.6-unknown-shadermodel6.6-library"
+
+; CHECK: ; Combined Shader Flags for Module
+; CHECK-NEXT: ; Shader Flags Value: 0x00000001
+
+; CHECK: ; Note: extra DXIL module flags:
+; CHECK-NEXT: ;       D3D11_1_SB_GLOBAL_FLAG_SKIP_OPTIMIZATION
+
+; CHECK: ; Shader Flags for Module Functions
+
+target triple = "dxilv1.6-unknown-shadermodel6.6-library"
+
+; CHECK: ; Function main : 0x00000000
+define void @main() {
+entry:
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 4, !"dx.disable_optimizations", i32 1}
+
+

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/disable-opt.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/disable-opt.ll
@@ -18,8 +18,10 @@ entry:
   ret void
 }
 
+; CHECK-NOT: llvm.module.flags
 !llvm.module.flags = !{!0}
 
+; CHECK-NOT: "dx.disable_optimizations"
 !0 = !{i32 4, !"dx.disable_optimizations", i32 1}
 
 

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -23,8 +23,8 @@
 ; CHECK-NEXT:     Scalarize vector operations
 ; CHECK-NEXT:   DXIL Resource Binding Analysis
 ; CHECK-NEXT:   DXIL resource Information
-; CHECK-NEXT:   DXIL Shader Flag Analysis
 ; CHECK-NEXT:   DXIL Module Metadata analysis
+; CHECK-NEXT:   DXIL Shader Flag Analysis
 ; CHECK-NEXT:   DXIL Translate Metadata
 ; CHECK-NEXT:   DXIL Op Lowering
 ; CHECK-NEXT:   DXIL Prepare Module


### PR DESCRIPTION
Disabling optimizations using the option `-Od` to `clang-dxc` results in generation of named metadata "dx.disable_optimizations" - as tested [here](https://github.com/llvm/llvm-project/blob/main/clang/test/CodeGenHLSL/disable_opt.hlsl).

- Following changes facilitate setting of Shader Flag `DisableOptimizations`.

  - Detect metadata "dx.disable_optimizations" as part of Metadata Analysis pass and set a new `bool` field 
   `ModuleMetadatainfo::DisableOptimization` accordingly.
  - Add `DXILMetadataAnalysis` as required pass for the pass `DXILShaderFlags` that sets shader flags mask.
  - Set shader flag `DisableOptimizations` based on the value of `ModuleMetadatainfo::DisableOptimizations`.

- Added test to verify setting of shader flag `DisableOptimizations`.
- Updated `llc-pipeline.ll` to reflect changes in output resulting from addition of Metadata Analysis pass as required by `DXILShaderFlags` pass.

NOTE: An [alternative implementation](https://github.com/llvm/llvm-project/compare/main...bharadwajy:llvm-project:shader-flags/disable-opt-flag) that 
  1. does not detect presence of metadata "dx.disable_optimizations" in Metadata Analysis pass and thus does not add the pass as a pre-requisite pass for `DXILShaderFlags` but
  2. detects presence of metadata "dx.disable_optimizations" directly in `DXILShaderFlags` pass

has been considered. However, Metadata Analysis pass seemed appropriate for detection of metadata relevant to setting the shader flag `DisableOptimizations`. Hence this PR.

Closes #112263 