### PR TITLE
[YAML] Init local var not set by some branches

### DIFF
--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -1588,7 +1588,7 @@ static bool isInteger(StringRef Val) {
 
 void MappingTraits<std::unique_ptr<ELFYAML::Chunk>>::mapping(
     IO &IO, std::unique_ptr<ELFYAML::Chunk> &Section) {
-  ELFYAML::ELF_SHT Type;
+  ELFYAML::ELF_SHT Type = ELF::ET_NONE;
   StringRef TypeStr;
   if (IO.outputting()) {
     if (auto *S = dyn_cast<ELFYAML::Section>(Section.get()))


### PR DESCRIPTION
It will not be set if:

1. `(TypeStr.starts_with("SHT_") || isInteger(TypeStr)) == false`: here we want go to switch default.
2. `IO.mapRequired("Type", Type);` fail parsing. It sets error internally, so probably not important what happen next, so it's go to the switch