### PR TITLE
[clang][Serialization] Stop including Frontend headers from Serialization (NFC)

### DIFF
--- a/clang/lib/Serialization/GeneratePCH.cpp
+++ b/clang/lib/Serialization/GeneratePCH.cpp
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/ASTContext.h"
-#include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/HeaderSearchOptions.h"
 #include "clang/Lex/Preprocessor.h"

--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2148,7 +2148,6 @@ cc_library(
         "include/clang/Serialization/AttrPCHRead.inc",
         "include/clang/Serialization/AttrPCHWrite.inc",
     ] + glob([
-        "include/clang/Frontend/*.h",
         "lib/Serialization/*.cpp",
         "lib/Serialization/*.h",
     ]),
@@ -2160,15 +2159,11 @@ cc_library(
         "include/clang/Serialization/*.def",
     ]),
     deps = [
-        ":apinotes",
         ":ast",
         ":basic",
-        ":driver",
         ":lex",
         ":sema",
         ":serialization_attr_gen",
-        ":static_analyzer_core_options",
-        ":support",
         ":type_nodes_gen",
         "//llvm:BitReader",
         "//llvm:BitWriter",


### PR DESCRIPTION
The Frontend library depends on Serialization. This is an explicit dependency encoded in the CMake target. However, Serialization currently has an implicit dependency on Frontend, as it includes one of its headers. This is not reflected in the CMake build rules, but Bazel is stricter so, in order to avoid a dependency cycle, it hackily declares the Frontend headers as source files for Serialization.

Fortunately, the only Frontend header used by Serialization is clang/Frontend/FrontendDiagnostic.h, which is a legacy header that just includes clang/Basic/DiagnosticFrontend since d076608d58d1ec55016eb747a995511e3a3f72aa, back in 2018.

This commit changes Serialization to use the underlying header from Basic instead. Both Serialization and Frontend depend on Basic, so this breaks the dependency cycle.