### PR TITLE
[LLDB][NFC] Calculate the region size of an in memory image if size isn't specified

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1923,9 +1923,30 @@ public:
   ///     the instruction has completed executing.
   bool GetWatchpointReportedAfter();
 
+  /// Load a module image from memory.
+  ///
+  /// \param[in] file_spec
+  ///     The path to use to represent this module. This will show up in the
+  ///     the image list.
+  ///
+  /// \param[in] header_addr
+  ///     The address of the object file header.
+  ///
+  /// \param[in] size_to_read
+  ///     The number of contiguous bytes to read that can be used to provide
+  ///     all of the data for this module in memory. If this value is set to
+  ///     zero, the memory region that contains \a header_addr will be found
+  ///     and the size will be to the end address of this memory region. If
+  ///     there is no memory region info that contains \a header_addr, then
+  ///     default to 512 bytes.
+  ///
+  /// \return
+  ///     A valid module shared pointer if this succeeds, or an empty shared
+  ///     pointer if no ObjectFile plug-ins recognize the object file header or
+  ///     memory can not be read from \a header_addr.
   lldb::ModuleSP ReadModuleFromMemory(const FileSpec &file_spec,
                                       lldb::addr_t header_addr,
-                                      size_t size_to_read = 512);
+                                      size_t size_to_read = 0);
 
   /// Attempt to get the attributes for a region of memory in the process.
   ///

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -538,16 +538,7 @@ void DynamicLoaderPOSIXDYLD::LoadVDSO() {
 
   FileSpec file("[vdso]");
 
-  MemoryRegionInfo info;
-  Status status = m_process->GetMemoryRegionInfo(m_vdso_base, info);
-  if (status.Fail()) {
-    Log *log = GetLog(LLDBLog::DynamicLoader);
-    LLDB_LOG(log, "Failed to get vdso region info: {0}", status);
-    return;
-  }
-
-  if (ModuleSP module_sp = m_process->ReadModuleFromMemory(
-          file, m_vdso_base, info.GetRange().GetByteSize())) {
+  if (ModuleSP module_sp = m_process->ReadModuleFromMemory(file, m_vdso_base)) {
     UpdateLoadedSections(module_sp, LLDB_INVALID_ADDRESS, m_vdso_base, false);
     m_process->GetTarget().GetImages().AppendIfNeeded(module_sp);
   }

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2544,6 +2544,26 @@ ModuleSP Process::ReadModuleFromMemory(const FileSpec &file_spec,
       progress_up = std::make_unique<Progress>(
           "Reading binary from memory", file_spec.GetFilename().GetString());
 
+    if (size_to_read == 0) {
+      // No size was provided, figure out the size of the memory region that
+      // contains "header_addr"
+      MemoryRegionInfo header_region_info;
+      Status error(GetMemoryRegionInfo(header_addr, header_region_info));
+      // Default to 512 in case we can't find a memory region.
+      size_to_read = 512;
+      if (error.Success()) {
+        // We found a memory region, set the range of bytes ro read to read to
+        // the end of the memory region. This should be enough to contain the
+        // file header and important bits.
+        const auto &range = header_region_info.GetRange();
+        const addr_t end = range.GetRangeBase() + range.GetByteSize();
+        if (end > header_addr) {
+          const addr_t new_size = end - header_addr;
+          if (new_size > size_to_read)
+            size_to_read = new_size;
+        }
+      }
+    }
     ObjectFile *objfile = module_sp->GetMemoryObjectFile(
         shared_from_this(), header_addr, error, size_to_read);
     if (objfile)


### PR DESCRIPTION
This patch cleans up some code and allows users to not have to specify a size and now get a more realistic value when reading modules from memory. This patch is in preparation for starting to have the dynamic loader load files from memory when we have core files that contain enough memory for ELF or mach-o files.