### PR TITLE
[mlir] fix dialect conversion with no type converter

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -209,8 +209,11 @@ ConversionValueMapping::lookupOrDefault(Value from,
       }
     }
     if (next != current) {
-      // If at least one value was replaced, continue the lookup from there.
       current = std::move(next);
+      // Special case 1; return the most recently mapped values.
+      if (desiredTypes.empty())
+        break;
+      // If at least one value was replaced, continue the lookup from there.
       continue;
     }
 


### PR DESCRIPTION
`ConversionPatternRewriterImpl::remapValues` has a bug when no type converter is used for a 1:N dialect conversion:

```c++
if (!currentTypeConverter) {
  // The current pattern does not have a type converter. I.e., it does not
  // distinguish between legal and illegal types. For each operand, simply
  // pass through the most recently mapped values.
  remapped.push_back(mapping.lookupOrDefault(operand));
  continue;
}
```

Emphasis on `most recently mapped values`. 

But the implementation of `mapping.lookupOrDefault` in such a case does not coincide; it always recurses all the way back to the leaf values:

```c++
ValueVector
ConversionValueMapping::lookupOrDefault(...) const {
  ...
  do {
    ...
    if (TypeRange(ValueRange(current)) == desiredTypes)
      desiredValue = current;
    ....
    if (next != current) {
      // If at least one value was replaced, continue the lookup from there.
      current = std::move(next);
      continue;
    }
    ...
    if (it == mapping.end()) {
      // No mapping found: The lookup stops here.
      break;
    }
    current = it->second;
  } while (true);

  // If the desired values were found use them, otherwise default to the leaf values.
  return !desiredValue.empty() ? std::move(desiredValue) : std::move(current);
}
```

Note, that `desiredTypes` is empty and thus `desiredValue.empty()` is always true and thus `std::move(current)` is returned i.e., the leaf nodes. 

The fix is to simply do what it says it should do i.e.:

```
  /// - If the desired type range is empty, simply return the most recently
  ///   mapped values.
```
