### PR TITLE
[TableGen] Use std::pair instead of std::make_pair. NFC.

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1816,7 +1816,7 @@ public:
     assert(!CorrespondingDefInit &&
            "changing type of record after it has been referenced");
     assert(!isSubClassOf(R) && "Already subclassing record!");
-    SuperClasses.push_back(std::pair(R, Range));
+    SuperClasses.emplace_back(R, Range);
   }
 
   /// If there are any field references that refer to fields that have been
@@ -1972,21 +1972,19 @@ public:
 
   void addClass(std::unique_ptr<Record> R) {
     bool Ins =
-        Classes.insert(std::pair(std::string(R->getName()), std::move(R)))
-            .second;
+        Classes.try_emplace(std::string(R->getName()), std::move(R)).second;
     (void)Ins;
     assert(Ins && "Class already exists");
   }
 
   void addDef(std::unique_ptr<Record> R) {
-    bool Ins =
-        Defs.insert(std::pair(std::string(R->getName()), std::move(R))).second;
+    bool Ins = Defs.try_emplace(std::string(R->getName()), std::move(R)).second;
     (void)Ins;
     assert(Ins && "Record already exists");
   }
 
   void addExtraGlobal(StringRef Name, const Init *I) {
-    bool Ins = ExtraGlobals.insert(std::pair(std::string(Name), I)).second;
+    bool Ins = ExtraGlobals.try_emplace(std::string(Name), I).second;
     (void)Ins;
     assert(!getDef(Name));
     assert(Ins && "Global already exists");
@@ -2072,14 +2070,14 @@ struct LessRecordRegister {
       for (size_t I = 0, E = Rec.size(); I != E; ++I, ++Len) {
         bool IsDigit = isDigit(Curr[I]);
         if (IsDigit != IsDigitPart) {
-          Parts.push_back(std::pair(IsDigitPart, StringRef(Start, Len)));
+          Parts.emplace_back(IsDigitPart, StringRef(Start, Len));
           Len = 0;
           Start = &Curr[I];
           IsDigitPart = isDigit(Curr[I]);
         }
       }
       // Push the last part.
-      Parts.push_back(std::pair(IsDigitPart, StringRef(Start, Len)));
+      Parts.emplace_back(IsDigitPart, StringRef(Start, Len));
     }
 
     size_t size() { return Parts.size(); }

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1816,7 +1816,7 @@ public:
     assert(!CorrespondingDefInit &&
            "changing type of record after it has been referenced");
     assert(!isSubClassOf(R) && "Already subclassing record!");
-    SuperClasses.push_back(std::make_pair(R, Range));
+    SuperClasses.push_back(std::pair(R, Range));
   }
 
   /// If there are any field references that refer to fields that have been
@@ -1971,21 +1971,22 @@ public:
   }
 
   void addClass(std::unique_ptr<Record> R) {
-    bool Ins = Classes.insert(std::make_pair(std::string(R->getName()),
-                                             std::move(R))).second;
+    bool Ins =
+        Classes.insert(std::pair(std::string(R->getName()), std::move(R)))
+            .second;
     (void)Ins;
     assert(Ins && "Class already exists");
   }
 
   void addDef(std::unique_ptr<Record> R) {
-    bool Ins = Defs.insert(std::make_pair(std::string(R->getName()),
-                                          std::move(R))).second;
+    bool Ins =
+        Defs.insert(std::pair(std::string(R->getName()), std::move(R))).second;
     (void)Ins;
     assert(Ins && "Record already exists");
   }
 
   void addExtraGlobal(StringRef Name, const Init *I) {
-    bool Ins = ExtraGlobals.insert(std::make_pair(std::string(Name), I)).second;
+    bool Ins = ExtraGlobals.insert(std::pair(std::string(Name), I)).second;
     (void)Ins;
     assert(!getDef(Name));
     assert(Ins && "Global already exists");
@@ -2071,14 +2072,14 @@ struct LessRecordRegister {
       for (size_t I = 0, E = Rec.size(); I != E; ++I, ++Len) {
         bool IsDigit = isDigit(Curr[I]);
         if (IsDigit != IsDigitPart) {
-          Parts.push_back(std::make_pair(IsDigitPart, StringRef(Start, Len)));
+          Parts.push_back(std::pair(IsDigitPart, StringRef(Start, Len)));
           Len = 0;
           Start = &Curr[I];
           IsDigitPart = isDigit(Curr[I]);
         }
       }
       // Push the last part.
-      Parts.push_back(std::make_pair(IsDigitPart, StringRef(Start, Len)));
+      Parts.push_back(std::pair(IsDigitPart, StringRef(Start, Len)));
     }
 
     size_t size() { return Parts.size(); }

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -671,7 +671,7 @@ const StringInit *StringInit::get(RecordKeeper &RK, StringRef V,
   detail::RecordKeeperImpl &RKImpl = RK.getImpl();
   auto &InitMap = Fmt == SF_String ? RKImpl.StringInitStringPool
                                    : RKImpl.StringInitCodePool;
-  auto &Entry = *InitMap.insert(std::make_pair(V, nullptr)).first;
+  auto &Entry = *InitMap.insert(std::pair(V, nullptr)).first;
   if (!Entry.second)
     Entry.second = new (RKImpl.Allocator) StringInit(RK, Entry.getKey(), Fmt);
   return Entry.second;
@@ -1674,7 +1674,7 @@ static const Init *ForeachDagApply(const Init *LHS, const DagInit *MHSd,
     else
       NewArg = ItemApply(LHS, Arg, RHS, CurRec);
 
-    NewArgs.push_back(std::make_pair(NewArg, ArgName));
+    NewArgs.push_back(std::pair(NewArg, ArgName));
     if (Arg != NewArg)
       Change = true;
   }
@@ -2260,7 +2260,7 @@ const VarInit *VarInit::get(StringRef VN, const RecTy *T) {
 
 const VarInit *VarInit::get(const Init *VN, const RecTy *T) {
   detail::RecordKeeperImpl &RK = T->getRecordKeeper().getImpl();
-  VarInit *&I = RK.TheVarInitPool[std::make_pair(T, VN)];
+  VarInit *&I = RK.TheVarInitPool[std::pair(T, VN)];
   if (!I)
     I = new (RK.Allocator) VarInit(VN, T);
   return I;
@@ -2285,7 +2285,7 @@ const Init *VarInit::resolveReferences(Resolver &R) const {
 
 const VarBitInit *VarBitInit::get(const TypedInit *T, unsigned B) {
   detail::RecordKeeperImpl &RK = T->getRecordKeeper().getImpl();
-  VarBitInit *&I = RK.TheVarBitInitPool[std::make_pair(T, B)];
+  VarBitInit *&I = RK.TheVarBitInitPool[std::pair(T, B)];
   if (!I)
     I = new (RK.Allocator) VarBitInit(T, B);
   return I;
@@ -2461,7 +2461,7 @@ std::string VarDefInit::getAsString() const {
 
 const FieldInit *FieldInit::get(const Init *R, const StringInit *FN) {
   detail::RecordKeeperImpl &RK = R->getRecordKeeper().getImpl();
-  FieldInit *&I = RK.TheFieldInitPool[std::make_pair(R, FN)];
+  FieldInit *&I = RK.TheFieldInitPool[std::pair(R, FN)];
   if (!I)
     I = new (RK.Allocator) FieldInit(R, FN);
   return I;

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -671,7 +671,7 @@ const StringInit *StringInit::get(RecordKeeper &RK, StringRef V,
   detail::RecordKeeperImpl &RKImpl = RK.getImpl();
   auto &InitMap = Fmt == SF_String ? RKImpl.StringInitStringPool
                                    : RKImpl.StringInitCodePool;
-  auto &Entry = *InitMap.insert(std::pair(V, nullptr)).first;
+  auto &Entry = *InitMap.try_emplace(V, nullptr).first;
   if (!Entry.second)
     Entry.second = new (RKImpl.Allocator) StringInit(RK, Entry.getKey(), Fmt);
   return Entry.second;
@@ -1674,7 +1674,7 @@ static const Init *ForeachDagApply(const Init *LHS, const DagInit *MHSd,
     else
       NewArg = ItemApply(LHS, Arg, RHS, CurRec);
 
-    NewArgs.push_back(std::pair(NewArg, ArgName));
+    NewArgs.emplace_back(NewArg, ArgName);
     if (Arg != NewArg)
       Change = true;
   }
@@ -2260,7 +2260,7 @@ const VarInit *VarInit::get(StringRef VN, const RecTy *T) {
 
 const VarInit *VarInit::get(const Init *VN, const RecTy *T) {
   detail::RecordKeeperImpl &RK = T->getRecordKeeper().getImpl();
-  VarInit *&I = RK.TheVarInitPool[std::pair(T, VN)];
+  VarInit *&I = RK.TheVarInitPool[{T, VN}];
   if (!I)
     I = new (RK.Allocator) VarInit(VN, T);
   return I;
@@ -2285,7 +2285,7 @@ const Init *VarInit::resolveReferences(Resolver &R) const {
 
 const VarBitInit *VarBitInit::get(const TypedInit *T, unsigned B) {
   detail::RecordKeeperImpl &RK = T->getRecordKeeper().getImpl();
-  VarBitInit *&I = RK.TheVarBitInitPool[std::pair(T, B)];
+  VarBitInit *&I = RK.TheVarBitInitPool[{T, B}];
   if (!I)
     I = new (RK.Allocator) VarBitInit(T, B);
   return I;
@@ -2461,7 +2461,7 @@ std::string VarDefInit::getAsString() const {
 
 const FieldInit *FieldInit::get(const Init *R, const StringInit *FN) {
   detail::RecordKeeperImpl &RK = R->getRecordKeeper().getImpl();
-  FieldInit *&I = RK.TheFieldInitPool[std::pair(R, FN)];
+  FieldInit *&I = RK.TheFieldInitPool[{R, FN}];
   if (!I)
     I = new (RK.Allocator) FieldInit(R, FN);
   return I;

--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -234,7 +234,7 @@ public:
   std::pair<int64_t, unsigned> getCurBinaryIntVal() const {
     assert(CurCode == tgtok::BinaryIntVal &&
            "This token isn't a binary integer");
-    return std::pair(CurIntVal, (CurPtr - TokStart) - 2);
+    return {CurIntVal, (CurPtr - TokStart) - 2};
   }
 
   SMLoc getLoc() const;

--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -234,7 +234,7 @@ public:
   std::pair<int64_t, unsigned> getCurBinaryIntVal() const {
     assert(CurCode == tgtok::BinaryIntVal &&
            "This token isn't a binary integer");
-    return std::make_pair(CurIntVal, (CurPtr - TokStart)-2);
+    return std::pair(CurIntVal, (CurPtr - TokStart) - 2);
   }
 
   SMLoc getLoc() const;

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3162,7 +3162,7 @@ void TGParser::ParseDagArgList(
         Lex.Lex();  // eat the VarName.
       }
 
-      Result.push_back(std::make_pair(Val, VarName));
+      Result.push_back(std::pair(Val, VarName));
     }
     if (!consume(tgtok::comma))
       break;
@@ -4152,9 +4152,8 @@ bool TGParser::ParseMultiClass() {
     return TokError("expected identifier after multiclass for name");
   std::string Name = Lex.getCurStrVal();
 
-  auto Result =
-    MultiClasses.insert(std::make_pair(Name,
-                    std::make_unique<MultiClass>(Name, Lex.getLoc(),Records)));
+  auto Result = MultiClasses.insert(std::pair(
+      Name, std::make_unique<MultiClass>(Name, Lex.getLoc(), Records)));
 
   if (!Result.second)
     return TokError("multiclass '" + Name + "' already defined");

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3162,7 +3162,7 @@ void TGParser::ParseDagArgList(
         Lex.Lex();  // eat the VarName.
       }
 
-      Result.push_back(std::pair(Val, VarName));
+      Result.emplace_back(Val, VarName);
     }
     if (!consume(tgtok::comma))
       break;
@@ -4152,8 +4152,8 @@ bool TGParser::ParseMultiClass() {
     return TokError("expected identifier after multiclass for name");
   std::string Name = Lex.getCurStrVal();
 
-  auto Result = MultiClasses.insert(std::pair(
-      Name, std::make_unique<MultiClass>(Name, Lex.getLoc(), Records)));
+  auto Result = MultiClasses.try_emplace(
+      Name, std::make_unique<MultiClass>(Name, Lex.getLoc(), Records));
 
   if (!Result.second)
     return TokError("multiclass '" + Name + "' already defined");

--- a/llvm/lib/TableGen/TGParser.h
+++ b/llvm/lib/TableGen/TGParser.h
@@ -131,7 +131,7 @@ public:
   }
 
   void addVar(StringRef Name, const Init *I) {
-    bool Ins = Vars.insert(std::pair(std::string(Name), I)).second;
+    bool Ins = Vars.try_emplace(std::string(Name), I).second;
     (void)Ins;
     assert(Ins && "Local variable already exists");
   }

--- a/llvm/lib/TableGen/TGParser.h
+++ b/llvm/lib/TableGen/TGParser.h
@@ -131,7 +131,7 @@ public:
   }
 
   void addVar(StringRef Name, const Init *I) {
-    bool Ins = Vars.insert(std::make_pair(std::string(Name), I)).second;
+    bool Ins = Vars.insert(std::pair(std::string(Name), I)).second;
     (void)Ins;
     assert(Ins && "Local variable already exists");
   }

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -1299,7 +1299,7 @@ void AsmMatcherInfo::buildRegisterClasses(
 
     if (!ContainingSet.empty()) {
       RegisterSets.insert(ContainingSet);
-      RegisterMap.insert(std::pair(CGR.TheDef, ContainingSet));
+      RegisterMap.try_emplace(CGR.TheDef, ContainingSet);
     }
   }
 
@@ -1320,7 +1320,7 @@ void AsmMatcherInfo::buildRegisterClasses(
     CI->DiagnosticType = "";
     CI->IsOptional = false;
     CI->DefaultMethod = ""; // unused
-    RegisterSetClasses.insert(std::pair(RS, CI));
+    RegisterSetClasses.try_emplace(RS, CI);
     ++Index;
   }
 
@@ -1362,7 +1362,7 @@ void AsmMatcherInfo::buildRegisterClasses(
     if (!CI->DiagnosticString.empty() && CI->DiagnosticType.empty())
       CI->DiagnosticType = RC.getName();
 
-    RegisterClassClasses.insert(std::pair(Def, CI));
+    RegisterClassClasses.try_emplace(Def, CI);
   }
 
   // Populate the map for individual registers.
@@ -2823,7 +2823,7 @@ emitMnemonicAliasVariant(raw_ostream &OS, const AsmMatcherInfo &Info,
 
     MatchCode += "return;";
 
-    Cases.push_back(std::pair(AliasEntry.first, MatchCode));
+    Cases.emplace_back(AliasEntry.first, MatchCode);
   }
   StringMatcher("Mnemonic", Cases, OS).Emit(Indent);
 }

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -144,14 +144,14 @@ static void EmitInstructions(std::vector<AsmWriterInst> &Insts, raw_ostream &O,
       O << "    switch (MI->getOpcode()) {\n";
       O << "    default: llvm_unreachable(\"Unexpected opcode.\");\n";
       std::vector<std::pair<std::string, AsmWriterOperand>> OpsToPrint;
-      OpsToPrint.push_back(std::pair(FirstInst.CGI->Namespace.str() + "::" +
-                                         FirstInst.CGI->TheDef->getName().str(),
-                                     FirstInst.Operands[i]));
+      OpsToPrint.emplace_back(FirstInst.CGI->Namespace.str() +
+                                  "::" + FirstInst.CGI->TheDef->getName().str(),
+                              FirstInst.Operands[i]);
 
       for (const AsmWriterInst &AWI : SimilarInsts) {
-        OpsToPrint.push_back(std::pair(
-            AWI.CGI->Namespace.str() + "::" + AWI.CGI->TheDef->getName().str(),
-            AWI.Operands[i]));
+        OpsToPrint.emplace_back(AWI.CGI->Namespace.str() +
+                                    "::" + AWI.CGI->TheDef->getName().str(),
+                                AWI.Operands[i]);
       }
       std::reverse(OpsToPrint.begin(), OpsToPrint.end());
       while (!OpsToPrint.empty())
@@ -722,7 +722,7 @@ public:
   void addOperand(StringRef Op, int OpIdx, int PrintMethodIdx = -1) {
     assert(OpIdx >= 0 && OpIdx < 0xFE && "Idx out of range");
     assert(PrintMethodIdx >= -1 && PrintMethodIdx < 0xFF && "Idx out of range");
-    OpMap[Op] = std::pair(OpIdx, PrintMethodIdx);
+    OpMap[Op] = {OpIdx, PrintMethodIdx};
   }
 
   unsigned getNumMIOps() { return NumMIOps; }
@@ -753,7 +753,7 @@ public:
       Next = I;
     }
 
-    return std::pair(StringRef(Start, I - Start), Next);
+    return {StringRef(Start, I - Start), Next};
   }
 
   std::string formatAliasString(uint32_t &UnescapedSize) {
@@ -854,8 +854,8 @@ void AsmWriterEmitter::EmitPrintAliasInstruction(raw_ostream &O) {
       continue; // Aliases with priority 0 are never emitted.
 
     const DagInit *DI = R->getValueAsDag("ResultInst");
-    AliasMap[getQualifiedName(DI->getOperatorAsDef(R->getLoc()))].insert(
-        std::pair(CodeGenInstAlias(R, Target), Priority));
+    AliasMap[getQualifiedName(DI->getOperatorAsDef(R->getLoc()))].emplace(
+        CodeGenInstAlias(R, Target), Priority);
   }
 
   // A map of which conditions need to be met for each instruction operand

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -495,7 +495,7 @@ static void emitLeafTable(const DirectiveLanguage &DirLang, raw_ostream &OS,
   DenseMap<const Record *, int> DirId; // Record * -> llvm::omp::Directive
 
   for (auto [Idx, Rec] : enumerate(Directives))
-    DirId.insert(std::make_pair(Rec, Idx));
+    DirId.insert(std::pair(Rec, Idx));
 
   using LeafList = std::vector<int>;
   int MaxLeafCount = getMaxLeafCount(DirLang);
@@ -675,7 +675,7 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
                       D.getAssociation()->getName() + "'");
     }
     if (AS != Association::FromLeaves) {
-      AsMap.insert(std::make_pair(R, AS));
+      AsMap.insert(std::pair(R, AS));
       return AS;
     }
     // Compute the association from leaf constructs.
@@ -701,7 +701,7 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
 
     assert(Result != Association::Invalid);
     assert(Result != Association::FromLeaves);
-    AsMap.insert(std::make_pair(R, Result));
+    AsMap.insert(std::pair(R, Result));
     return Result;
   };
 

--- a/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/DirectiveEmitter.cpp
@@ -495,7 +495,7 @@ static void emitLeafTable(const DirectiveLanguage &DirLang, raw_ostream &OS,
   DenseMap<const Record *, int> DirId; // Record * -> llvm::omp::Directive
 
   for (auto [Idx, Rec] : enumerate(Directives))
-    DirId.insert(std::pair(Rec, Idx));
+    DirId.try_emplace(Rec, Idx);
 
   using LeafList = std::vector<int>;
   int MaxLeafCount = getMaxLeafCount(DirLang);
@@ -675,7 +675,7 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
                       D.getAssociation()->getName() + "'");
     }
     if (AS != Association::FromLeaves) {
-      AsMap.insert(std::pair(R, AS));
+      AsMap.try_emplace(R, AS);
       return AS;
     }
     // Compute the association from leaf constructs.
@@ -701,7 +701,7 @@ static void generateGetDirectiveAssociation(const DirectiveLanguage &DirLang,
 
     assert(Result != Association::Invalid);
     assert(Result != Association::FromLeaves);
-    AsMap.insert(std::pair(R, Result));
+    AsMap.try_emplace(R, Result);
     return Result;
   };
 

--- a/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
@@ -241,7 +241,7 @@ static void emitRISCVExtensionBitmask(const RecordKeeper &RK, raw_ostream &OS) {
     ExtName.consume_front("experimental-");
 
 #ifndef NDEBUG
-    assert(Seen.insert(std::make_pair(GroupIDVal, BitPosVal)).second &&
+    assert(Seen.insert(std::pair(GroupIDVal, BitPosVal)).second &&
            "duplicated bitmask");
 #endif
 

--- a/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
@@ -241,8 +241,7 @@ static void emitRISCVExtensionBitmask(const RecordKeeper &RK, raw_ostream &OS) {
     ExtName.consume_front("experimental-");
 
 #ifndef NDEBUG
-    assert(Seen.insert(std::pair(GroupIDVal, BitPosVal)).second &&
-           "duplicated bitmask");
+    assert(Seen.insert({GroupIDVal, BitPosVal}).second && "duplicated bitmask");
 #endif
 
     OS.indent(4) << "{"

--- a/llvm/utils/TableGen/Basic/SequenceToOffsetTable.h
+++ b/llvm/utils/TableGen/Basic/SequenceToOffsetTable.h
@@ -93,7 +93,7 @@ public:
     if (I != Seqs.end() && isSuffix(Seq, I->first))
       return;
 
-    I = Seqs.insert(I, std::pair(Seq, 0u));
+    I = Seqs.insert(I, {Seq, 0u});
 
     // The entry before I may be a suffix of Seq that can now be erased.
     if (I != Seqs.begin() && isSuffix((--I)->first, Seq))

--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -338,11 +338,11 @@ CodeEmitterGen::getInstructionCases(const Record *R,
         Append("      }\n");
       }
       Append("      }\n");
-      return std::pair(std::move(Case), std::move(BitOffsetCase));
+      return {std::move(Case), std::move(BitOffsetCase)};
     }
   }
   addInstructionCasesForEncoding(R, R, Target, Case, BitOffsetCase);
-  return std::pair(std::move(Case), std::move(BitOffsetCase));
+  return {std::move(Case), std::move(BitOffsetCase)};
 }
 
 void CodeEmitterGen::addInstructionCasesForEncoding(

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -3006,7 +3006,7 @@ TreePatternNodePtr TreePattern::ParseTreePattern(const Init *TheInit,
       // Check that the ComplexPattern uses are consistent: "(MY_PAT $a, $b)"
       // and "(MY_PAT $b, $a)" should not be allowed in the same pattern;
       // neither should "(MY_PAT_1 $a, $b)" and "(MY_PAT_2 $a, $b)".
-      auto OperandId = std::make_pair(Operator, i);
+      auto OperandId = std::pair(Operator, i);
       auto [PrevOp, Inserted] =
           ComplexPatternOperands.try_emplace(Child->getName(), OperandId);
       if (!Inserted && PrevOp->getValue() != OperandId) {

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -3218,7 +3218,7 @@ void CodeGenDAGPatterns::ParseNodeInfo() {
   const CodeGenHwModes &CGH = getTargetInfo().getHwModes();
 
   for (const Record *R : reverse(Records.getAllDerivedDefinitions("SDNode")))
-    SDNodes.insert(std::pair(R, SDNodeInfo(R, CGH)));
+    SDNodes.try_emplace(R, SDNodeInfo(R, CGH));
 
   // Get the builtin intrinsic nodes.
   intrinsic_void_sdnode = getSDNodeNamed("intrinsic_void");
@@ -3348,8 +3348,7 @@ void CodeGenDAGPatterns::ParseDefaultOperands() {
     // SomeSDnode so that we can parse this.
     std::vector<std::pair<const Init *, const StringInit *>> Ops;
     for (unsigned op = 0, e = DefaultInfo->getNumArgs(); op != e; ++op)
-      Ops.push_back(
-          std::pair(DefaultInfo->getArg(op), DefaultInfo->getArgName(op)));
+      Ops.emplace_back(DefaultInfo->getArg(op), DefaultInfo->getArgName(op));
     const DagInit *DI = DagInit::get(SomeSDNode, nullptr, Ops);
 
     // Create a TreePattern to parse this.

--- a/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
@@ -51,7 +51,7 @@ HwModeSelect::HwModeSelect(const Record *R, CodeGenHwModes &CGH) {
   }
   for (auto [Mode, Object] : zip_equal(Modes, Objects)) {
     unsigned ModeId = CGH.getHwModeId(Mode);
-    Items.push_back(std::pair(ModeId, Object));
+    Items.emplace_back(ModeId, Object);
   }
 }
 
@@ -70,13 +70,13 @@ CodeGenHwModes::CodeGenHwModes(const RecordKeeper &RK) : Records(RK) {
     if (R->getName() == DefaultModeName)
       continue;
     Modes.emplace_back(R);
-    ModeIds.insert(std::pair(R, Modes.size()));
+    ModeIds.try_emplace(R, Modes.size());
   }
 
   assert(Modes.size() <= 32 && "number of HwModes exceeds maximum of 32");
 
   for (const Record *R : Records.getAllDerivedDefinitions("HwModeSelect")) {
-    auto P = ModeSelects.emplace(std::pair(R, HwModeSelect(R, *this)));
+    auto P = ModeSelects.emplace(R, HwModeSelect(R, *this));
     assert(P.second);
     (void)P;
   }

--- a/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstAlias.cpp
@@ -229,7 +229,7 @@ CodeGenInstAlias::CodeGenInstAlias(const Record *R, const CodeGenTarget &T)
                              InstOpRec->getValueAsDef("ParserMatchClass")
                                      ->getValueAsString("Name") != "Imm")) {
         ResultOperands.push_back(std::move(ResOp));
-        ResultInstOperandIndex.push_back(std::pair(i, -1));
+        ResultInstOperandIndex.emplace_back(i, -1);
         ++AliasOpNo;
 
         // Otherwise, we need to match each of the suboperands individually.
@@ -244,7 +244,7 @@ CodeGenInstAlias::CodeGenInstAlias(const Record *R, const CodeGenTarget &T)
               Result->getArgName(AliasOpNo)->getAsUnquotedString() + "." +
                   MIOI->getArgName(SubOp)->getAsUnquotedString(),
               SubRec);
-          ResultInstOperandIndex.push_back(std::pair(i, SubOp));
+          ResultInstOperandIndex.emplace_back(i, SubOp);
         }
         ++AliasOpNo;
       }
@@ -262,7 +262,7 @@ CodeGenInstAlias::CodeGenInstAlias(const Record *R, const CodeGenTarget &T)
         if (tryAliasOpMatch(Result, AliasOpNo, SubRec, false, R->getLoc(), T,
                             ResOp)) {
           ResultOperands.push_back(ResOp);
-          ResultInstOperandIndex.push_back(std::pair(i, SubOp));
+          ResultInstOperandIndex.emplace_back(i, SubOp);
           ++AliasOpNo;
         } else {
           PrintFatalError(

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.cpp
@@ -175,7 +175,7 @@ CGIOperandList::CGIOperandList(const Record *R) : TheDef(R) {
         }
 
         OpInfo.SubOpNames[j] = SubArgName;
-        SubOpAliases[SubArgName] = std::pair(i, j);
+        SubOpAliases[SubArgName] = {i, j};
       }
     } else if (!EncoderMethod.empty()) {
       // If we have no explicit sub-op dag, but have an top-level encoder
@@ -276,7 +276,7 @@ CGIOperandList::ParseOperandName(StringRef Op, bool AllowWholeOp) {
                           Op + "'");
 
     // Otherwise, return the operand.
-    return std::pair(OpIdx, 0U);
+    return {OpIdx, 0U};
   }
 
   // Find the suboperand number involved.
@@ -289,13 +289,13 @@ CGIOperandList::ParseOperandName(StringRef Op, bool AllowWholeOp) {
   // Find the operand with the right name.
   for (unsigned i = 0, e = MIOpInfo->getNumArgs(); i != e; ++i)
     if (MIOpInfo->getArgNameStr(i) == SubOpName)
-      return std::pair(OpIdx, i);
+      return {OpIdx, i};
 
   // Otherwise, didn't find it!
   PrintFatalError(TheDef->getLoc(), TheDef->getName() +
                                         ": unknown suboperand name in '" + Op +
                                         "'");
-  return std::pair(0U, 0U);
+  return {0U, 0U};
 }
 
 static void ParseConstraint(StringRef CStr, CGIOperandList &Ops,

--- a/llvm/utils/TableGen/Common/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.h
@@ -204,7 +204,7 @@ public:
     for (unsigned i = 0;; ++i) {
       assert(i < OperandList.size() && "Invalid flat operand #");
       if (OperandList[i].MIOperandNo + OperandList[i].MINumOperands > Op)
-        return std::pair(i, Op - OperandList[i].MIOperandNo);
+        return {i, Op - OperandList[i].MIOperandNo};
     }
   }
 

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -287,13 +287,13 @@ CodeGenRegister::computeSubRegs(CodeGenRegBank &RegBank) {
     CodeGenSubRegIndex *Idx = ExplicitSubRegIndices[i];
     if (!SR->Artificial)
       Idx->Artificial = false;
-    if (!SubRegs.insert(std::pair(Idx, SR)).second)
+    if (!SubRegs.try_emplace(Idx, SR).second)
       PrintFatalError(TheDef->getLoc(), "SubRegIndex " + Idx->getName() +
                                             " appears twice in Register " +
                                             getName());
     // Map explicit sub-registers first, so the names take precedence.
     // The inherited sub-registers are mapped below.
-    SubReg2Idx.insert(std::pair(SR, Idx));
+    SubReg2Idx.try_emplace(SR, Idx);
   }
 
   // Keep track of inherited subregs and how they can be reached.
@@ -333,7 +333,7 @@ CodeGenRegister::computeSubRegs(CodeGenRegBank &RegBank) {
       if (SubRegs.count(Comp.second) || !Orphans.erase(SRI->second))
         continue;
       // We found a new name for the orphaned sub-register.
-      SubRegs.insert(std::pair(Comp.second, SRI->second));
+      SubRegs.try_emplace(Comp.second, SRI->second);
       Indices.push_back(Comp.second);
     }
   }
@@ -380,7 +380,7 @@ CodeGenRegister::computeSubRegs(CodeGenRegBank &RegBank) {
 
     // Ensure that every sub-register has a unique name.
     DenseMap<const CodeGenRegister *, CodeGenSubRegIndex *>::iterator Ins =
-        SubReg2Idx.insert(std::pair(SubReg.second, SubReg.first)).first;
+        SubReg2Idx.try_emplace(SubReg.second, SubReg.first).first;
     if (Ins->second == SubReg.first)
       continue;
     // Trouble: Two different names for SubReg.second.
@@ -532,8 +532,8 @@ void CodeGenRegister::computeSecondarySubRegs(CodeGenRegBank &RegBank) {
       // a sub-register with a concatenated sub-register index.
       CodeGenSubRegIndex *Concat =
           RegBank.getConcatSubRegIndex(Parts, RegBank.getHwModes());
-      std::pair<CodeGenSubRegIndex *, CodeGenRegister *> NewSubReg =
-          std::pair(Concat, Cand);
+      std::pair<CodeGenSubRegIndex *, CodeGenRegister *> NewSubReg = {Concat,
+                                                                      Cand};
 
       if (!SubRegs.insert(NewSubReg).second)
         continue;
@@ -541,7 +541,7 @@ void CodeGenRegister::computeSecondarySubRegs(CodeGenRegBank &RegBank) {
       // We inserted a new subregister.
       NewSubRegs.push_back(NewSubReg);
       SubRegQueue.push(NewSubReg);
-      SubReg2Idx.insert(std::pair(Cand, Concat));
+      SubReg2Idx.try_emplace(Cand, Concat);
     }
   }
 
@@ -1098,7 +1098,7 @@ CodeGenRegisterClass::getMatchingSubClassWithSubRegs(
     BitVector SuperRegClassesBV(RegClasses.size());
     RC.getSuperRegClasses(SubIdx, SuperRegClassesBV);
     if (SuperRegClassesBV.any())
-      SuperRegClasses.push_back(std::pair(&RC, SuperRegClassesBV));
+      SuperRegClasses.emplace_back(&RC, SuperRegClassesBV);
   }
   llvm::stable_sort(SuperRegClasses,
                     [&](const std::pair<CodeGenRegisterClass *, BitVector> &A,
@@ -1247,8 +1247,7 @@ CodeGenRegBank::CodeGenRegBank(const RecordKeeper &Records,
     // causes some failures in MIPS - perhaps they have duplicate register name
     // entries? (or maybe there's a reason for it - I don't know much about this
     // code, just drive-by refactoring)
-    RegistersByName.insert(
-        std::pair(Reg.TheDef->getValueAsString("AsmName"), &Reg));
+    RegistersByName.try_emplace(Reg.TheDef->getValueAsString("AsmName"), &Reg);
 
   // Precompute all sub-register maps.
   // This will create Composite entries for all inferred sub-register indices.
@@ -1260,10 +1259,10 @@ CodeGenRegBank::CodeGenRegBank(const RecordKeeper &Records,
   for (CodeGenSubRegIndex &SRI : SubRegIndices) {
     SRI.computeConcatTransitiveClosure();
     if (!SRI.ConcatenationOf.empty())
-      ConcatIdx.insert(
-          std::pair(SmallVector<CodeGenSubRegIndex *, 8>(
-                        SRI.ConcatenationOf.begin(), SRI.ConcatenationOf.end()),
-                    &SRI));
+      ConcatIdx.try_emplace(
+          SmallVector<CodeGenSubRegIndex *, 8>(SRI.ConcatenationOf.begin(),
+                                               SRI.ConcatenationOf.end()),
+          &SRI);
   }
 
   // Infer even more sub-registers by combining leading super-registers.
@@ -1353,12 +1352,12 @@ CodeGenRegister *CodeGenRegBank::getReg(const Record *Def) {
 
 void CodeGenRegBank::addToMaps(CodeGenRegisterClass *RC) {
   if (const Record *Def = RC->getDef())
-    Def2RC.insert(std::pair(Def, RC));
+    Def2RC.try_emplace(Def, RC);
 
   // Duplicate classes are rejected by insert().
   // That's OK, we only care about the properties handled by CGRC::Key.
   CodeGenRegisterClass::Key K(*RC);
-  Key2RC.insert(std::pair(K, RC));
+  Key2RC.try_emplace(K, RC);
 }
 
 // Create a synthetic sub-class if it is missing.
@@ -1509,7 +1508,7 @@ void CodeGenRegBank::computeComposites() {
   SmallSet<CompositePair, 4> UserDefined;
   for (const CodeGenSubRegIndex &Idx : SubRegIndices)
     for (auto P : Idx.getComposites())
-      UserDefined.insert(std::pair(&Idx, P.first));
+      UserDefined.insert({&Idx, P.first});
 
   // Keep track of TopoSigs visited. We only need to visit each TopoSig once,
   // and many registers will share TopoSigs on regular architectures.

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.h
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.h
@@ -110,7 +110,7 @@ public:
   CodeGenSubRegIndex *addComposite(CodeGenSubRegIndex *A, CodeGenSubRegIndex *B,
                                    const CodeGenHwModes &CGH) {
     assert(A && B);
-    std::pair<CompMap::iterator, bool> Ins = Composed.insert(std::pair(A, B));
+    std::pair<CompMap::iterator, bool> Ins = Composed.try_emplace(A, B);
 
     // Synthetic subreg indices that aren't contiguous (for instance ARM
     // register tuples) don't have a bit range, so it's OK to let
@@ -729,7 +729,7 @@ public:
   // This function is only for use by CodeGenRegister::computeSuperRegs().
   // Others should simply use Reg->getTopoSig().
   unsigned getTopoSig(const TopoSigId &Id) {
-    return TopoSigs.insert(std::pair(Id, TopoSigs.size())).first->second;
+    return TopoSigs.try_emplace(Id, TopoSigs.size()).first->second;
   }
 
   // Create a native register unit that is associated with one or two root

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -334,7 +334,7 @@ static void processSTIPredicate(STIPredicateFunction &Fn,
   APInt DefaultProcMask(ProcModelMap.size(), 0);
   APInt DefaultPredMask(NumUniquePredicates, 0);
   for (std::pair<APInt, APInt> &MaskPair : OpcodeMasks)
-    MaskPair = std::pair(DefaultProcMask, DefaultPredMask);
+    MaskPair = {DefaultProcMask, DefaultPredMask};
 
   // Construct a OpcodeInfo object for every unique opcode declared by an
   // InstructionEquivalenceClass definition.
@@ -384,7 +384,7 @@ static void processSTIPredicate(STIPredicateFunction &Fn,
 
         auto PopulationCountAndLeftBit =
             [](const APInt &Other) -> std::pair<int, int> {
-          return std::pair<int, int>(Other.popcount(), -Other.countl_zero());
+          return {Other.popcount(), -Other.countl_zero()};
         };
         auto lhsmask_first = PopulationCountAndLeftBit(LhsMasks.first);
         auto rhsmask_first = PopulationCountAndLeftBit(RhsMasks.first);
@@ -545,7 +545,7 @@ void CodeGenSchedModels::collectProcModels() {
 /// ProcessorItineraries.
 void CodeGenSchedModels::addProcModel(const Record *ProcDef) {
   const Record *ModelKey = getModelOrItinDef(ProcDef);
-  if (!ProcModelMap.insert(std::pair(ModelKey, ProcModels.size())).second)
+  if (!ProcModelMap.try_emplace(ModelKey, ProcModels.size()).second)
     return;
 
   std::string Name = std::string(ModelKey->getName());

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -840,8 +840,7 @@ Error RuleMatcher::defineComplexSubOperand(StringRef SymbolicName,
     return Error::success();
   }
 
-  ComplexSubOperands[SymbolicName] =
-      std::tuple(ComplexPattern, RendererID, SubOperandID);
+  ComplexSubOperands[SymbolicName] = {ComplexPattern, RendererID, SubOperandID};
   ComplexSubOperandsParentName[SymbolicName] = std::move(ParentName);
 
   return Error::success();

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -233,7 +233,7 @@ public:
   unsigned allocateLabelID() { return CurrentLabelID++; }
 
   void defineLabel(unsigned LabelID) {
-    LabelMap.insert(std::pair(LabelID, CurrentSize));
+    LabelMap.try_emplace(LabelID, CurrentSize);
   }
 
   unsigned getLabelIndex(unsigned LabelID) const {

--- a/llvm/utils/TableGen/Common/InfoByHwMode.cpp
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.cpp
@@ -71,9 +71,9 @@ MVT &ValueTypeByHwMode::getOrCreateTypeForMode(unsigned Mode, MVT Type) {
   // make a copy of it for Mode and return it.
   auto D = Map.begin();
   if (D != Map.end() && D->first == DefaultMode)
-    return Map.insert(std::pair(Mode, D->second)).first->second;
+    return Map.try_emplace(Mode, D->second).first->second;
   // If default mode is not present either, use provided Type.
-  return Map.insert(std::pair(Mode, Type)).first->second;
+  return Map.try_emplace(Mode, Type).first->second;
 }
 
 StringRef ValueTypeByHwMode::getMVTName(MVT T) {

--- a/llvm/utils/TableGen/Common/InfoByHwMode.h
+++ b/llvm/utils/TableGen/Common/InfoByHwMode.h
@@ -144,7 +144,7 @@ template <typename InfoT> struct InfoByHwMode {
     assert(hasMode(Mode) || hasDefault());
     InfoT I = get(Mode);
     Map.clear();
-    Map.insert(std::pair(DefaultMode, I));
+    Map.try_emplace(DefaultMode, I);
   }
 
 protected:
@@ -212,7 +212,7 @@ struct RegSizeInfoByHwMode : public InfoByHwMode<RegSizeInfo> {
   void writeToStream(raw_ostream &OS) const;
 
   void insertRegSizeForMode(unsigned Mode, RegSizeInfo Info) {
-    Map.insert(std::pair(Mode, Info));
+    Map.try_emplace(Mode, Info);
   }
 };
 
@@ -233,7 +233,7 @@ struct SubRegRangeByHwMode : public InfoByHwMode<SubRegRange> {
   SubRegRangeByHwMode() = default;
 
   void insertSubRegRangeForMode(unsigned Mode, SubRegRange Info) {
-    Map.insert(std::pair(Mode, Info));
+    Map.try_emplace(Mode, Info);
   }
 };
 

--- a/llvm/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherGen.cpp
@@ -252,7 +252,7 @@ void MatcherGen::EmitLeafMatchCode(const TreePatternNode &N) {
   if (LeafRec->isSubClassOf("Register")) {
     AddMatcher(new RecordMatcher("physreg input " + LeafRec->getName().str(),
                                  NextRecordedOperandNo));
-    PhysRegInputs.push_back(std::pair(LeafRec, NextRecordedOperandNo++));
+    PhysRegInputs.emplace_back(LeafRec, NextRecordedOperandNo++);
     return;
   }
 
@@ -272,7 +272,7 @@ void MatcherGen::EmitLeafMatchCode(const TreePatternNode &N) {
     // Remember this ComplexPattern so that we can emit it after all the other
     // structural matches are done.
     unsigned InputOperand = VariableMap[N.getName()] - 1;
-    MatchedComplexPatterns.push_back(std::pair(&N, InputOperand));
+    MatchedComplexPatterns.emplace_back(&N, InputOperand);
     return;
   }
 

--- a/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherOpt.cpp
@@ -426,7 +426,7 @@ static void FactorNodes(std::unique_ptr<Matcher> &InputMatcherPtr) {
       CheckOpcodeMatcher *COM = cast<CheckOpcodeMatcher>(OptionsToMatch[i]);
       assert(Opcodes.insert(COM->getOpcode().getEnumName()).second &&
              "Duplicate opcodes not factored?");
-      Cases.push_back(std::pair(&COM->getOpcode(), COM->takeNext()));
+      Cases.emplace_back(&COM->getOpcode(), COM->takeNext());
       delete COM;
     }
 
@@ -463,7 +463,7 @@ static void FactorNodes(std::unique_ptr<Matcher> &InputMatcherPtr) {
       }
 
       Entry = Cases.size() + 1;
-      Cases.push_back(std::pair(CTMTy, MatcherWithoutCTM));
+      Cases.emplace_back(CTMTy, MatcherWithoutCTM);
     }
 
     // Make sure we recursively factor any scopes we may have created.

--- a/llvm/utils/TableGen/DFAEmitter.cpp
+++ b/llvm/utils/TableGen/DFAEmitter.cpp
@@ -349,7 +349,7 @@ void CustomDfaEmitter::printActionType(raw_ostream &OS) { OS << TypeName; }
 void CustomDfaEmitter::printActionValue(action_type A, raw_ostream &OS) {
   const ActionTuple &AT = Actions[A];
   if (AT.size() > 1)
-    OS << "std::tuple(";
+    OS << "{";
   ListSeparator LS;
   for (const auto &SingleAction : AT) {
     OS << LS;
@@ -361,7 +361,7 @@ void CustomDfaEmitter::printActionValue(action_type A, raw_ostream &OS) {
       OS << std::get<unsigned>(SingleAction);
   }
   if (AT.size() > 1)
-    OS << ")";
+    OS << "}";
 }
 
 static TableGen::Emitter::OptClass<AutomatonEmitter>

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -640,11 +640,11 @@ void Filter::recurse() {
 
     // Delegates to an inferior filter chooser for further processing on this
     // group of instructions whose segment values are variable.
-    FilterChooserMap.insert(std::pair(
+    FilterChooserMap.try_emplace(
         NO_FIXED_SEGMENTS_SENTINEL,
         std::make_unique<FilterChooser>(Owner->AllInstructions,
                                         VariableInstructions, Owner->Operands,
-                                        BitValueArray, *Owner)));
+                                        BitValueArray, *Owner));
   }
 
   // No need to recurse for a singleton filtered instruction.
@@ -667,10 +667,10 @@ void Filter::recurse() {
 
     // Delegates to an inferior filter chooser for further processing on this
     // category of instructions.
-    FilterChooserMap.insert(
-        std::pair(Inst.first, std::make_unique<FilterChooser>(
-                                  Owner->AllInstructions, Inst.second,
-                                  Owner->Operands, BitValueArray, *Owner)));
+    FilterChooserMap.try_emplace(Inst.first,
+                                 std::make_unique<FilterChooser>(
+                                     Owner->AllInstructions, Inst.second,
+                                     Owner->Operands, BitValueArray, *Owner));
   }
 }
 
@@ -1943,7 +1943,7 @@ static void parseVarLenInstOperand(const Record &Def,
       int TiedReg = TiedTo[OpSubOpPair.first];
       if (TiedReg != -1) {
         unsigned OpIdx = CGI.Operands.getFlattenedOperandNumber(
-            std::pair(TiedReg, OpSubOpPair.second));
+            {TiedReg, OpSubOpPair.second});
         Operands[OpIdx].addField(CurrBitPos, EncodingSegment.BitWidth, Offset);
       }
     }
@@ -2039,9 +2039,9 @@ populateInstruction(const CodeGenTarget &Target, const Record &EncodingDef,
   const DagInit *Out = Def.getValueAsDag("OutOperandList");
   const DagInit *In = Def.getValueAsDag("InOperandList");
   for (const auto &[Idx, Arg] : enumerate(Out->getArgs()))
-    InOutOperands.push_back(std::pair(Arg, Out->getArgNameStr(Idx)));
+    InOutOperands.emplace_back(Arg, Out->getArgNameStr(Idx));
   for (const auto &[Idx, Arg] : enumerate(In->getArgs()))
-    InOutOperands.push_back(std::pair(Arg, In->getArgNameStr(Idx)));
+    InOutOperands.emplace_back(Arg, In->getArgNameStr(Idx));
 
   // Search for tied operands, so that we can correctly instantiate
   // operands that are not explicitly represented in the encoding.
@@ -2587,7 +2587,7 @@ namespace llvm {
       if (!NumberedEncoding.HwModeName.empty())
         DecoderNamespace +=
             std::string("_") + NumberedEncoding.HwModeName.str();
-      OpcMap[std::pair(DecoderNamespace, Size)].emplace_back(
+      OpcMap[{DecoderNamespace, Size}].emplace_back(
           NEI, Target.getInstrIntValue(Def));
     } else {
       NumEncodingsOmitted++;

--- a/llvm/utils/TableGen/FastISelEmitter.cpp
+++ b/llvm/utils/TableGen/FastISelEmitter.cpp
@@ -593,7 +593,7 @@ void FastISelMap::collectPatterns(const CodeGenDAGPatterns &CGP) {
     int complexity = Pattern.getPatternComplexity(CGP);
 
     auto inserted_simple_pattern = SimplePatternsCheck.insert(
-        std::tuple(Operands, OpcodeName, VT, RetVT, PredicateCheck));
+        {Operands, OpcodeName, VT, RetVT, PredicateCheck});
     if (!inserted_simple_pattern.second) {
       PrintFatalError(Pattern.getSrcRecord()->getLoc(),
                       "Duplicate predicate in FastISel table!");

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -2653,10 +2653,10 @@ GICombinerEmitter::buildMatchTable(MutableArrayRef<RuleMatcher> Rules) {
                                                const Matcher *B) {
     auto *L = static_cast<const RuleMatcher *>(A);
     auto *R = static_cast<const RuleMatcher *>(B);
-    return std::make_tuple(OpcodeOrder[L->getOpcode()],
-                           L->insnmatchers_front().getNumOperandMatchers()) <
-           std::make_tuple(OpcodeOrder[R->getOpcode()],
-                           R->insnmatchers_front().getNumOperandMatchers());
+    return std::tuple(OpcodeOrder[L->getOpcode()],
+                      L->insnmatchers_front().getNumOperandMatchers()) <
+           std::tuple(OpcodeOrder[R->getOpcode()],
+                      R->insnmatchers_front().getNumOperandMatchers());
   });
 
   for (Matcher *Rule : InputRules)

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -259,8 +259,7 @@ void InstrInfoEmitter::initOperandMapData(
       StrUintMapIter I = Operands.find(Info.Name);
 
       if (I == Operands.end()) {
-        I = Operands.insert(Operands.begin(), std::pair<std::string, unsigned>(
-                                                  Info.Name, NumOperands++));
+        I = Operands.insert(Operands.begin(), {Info.Name, NumOperands++});
       }
       OpList[I->second] = Info.MIOperandNo;
     }

--- a/llvm/utils/TableGen/OptionParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptionParserEmitter.cpp
@@ -232,8 +232,7 @@ static void emitHelpTextsForVariants(
     assert(Visibilities.size() <= MaxVisibilityPerHelp &&
            "Too many visibilities to store in an "
            "OptTable::HelpTextsForVariants entry");
-    OS << "std::make_pair(std::array<unsigned, " << MaxVisibilityPerHelp
-       << ">{{";
+    OS << "std::pair(std::array<unsigned, " << MaxVisibilityPerHelp << ">{{";
 
     auto VisibilityEnd = Visibilities.cend();
     for (auto Visibility = Visibilities.cbegin(); Visibility != VisibilityEnd;
@@ -516,8 +515,8 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
       for (const Init *Visibility : Visibilities)
         VisibilityNames.push_back(Visibility->getAsUnquotedString());
 
-      HelpTextsForVariants.push_back(std::make_pair(
-          VisibilityNames, VisibilityHelp->getValueAsString("Text")));
+      HelpTextsForVariants.push_back(
+          std::pair(VisibilityNames, VisibilityHelp->getValueAsString("Text")));
     }
     emitHelpTextsForVariants(OS, std::move(HelpTextsForVariants));
 

--- a/llvm/utils/TableGen/OptionParserEmitter.cpp
+++ b/llvm/utils/TableGen/OptionParserEmitter.cpp
@@ -232,7 +232,7 @@ static void emitHelpTextsForVariants(
     assert(Visibilities.size() <= MaxVisibilityPerHelp &&
            "Too many visibilities to store in an "
            "OptTable::HelpTextsForVariants entry");
-    OS << "std::pair(std::array<unsigned, " << MaxVisibilityPerHelp << ">{{";
+    OS << "{std::array<unsigned, " << MaxVisibilityPerHelp << ">{{";
 
     auto VisibilityEnd = Visibilities.cend();
     for (auto Visibility = Visibilities.cbegin(); Visibility != VisibilityEnd;
@@ -248,7 +248,7 @@ static void emitHelpTextsForVariants(
       writeCstring(OS, Help);
     else
       OS << "nullptr";
-    OS << ")";
+    OS << "}";
 
     if (std::next(VisibilityHelp) != VisibilityHelpEnd)
       OS << ", ";
@@ -515,8 +515,8 @@ static void emitOptionParser(const RecordKeeper &Records, raw_ostream &OS) {
       for (const Init *Visibility : Visibilities)
         VisibilityNames.push_back(Visibility->getAsUnquotedString());
 
-      HelpTextsForVariants.push_back(
-          std::pair(VisibilityNames, VisibilityHelp->getValueAsString("Text")));
+      HelpTextsForVariants.emplace_back(
+          VisibilityNames, VisibilityHelp->getValueAsString("Text"));
     }
     emitHelpTextsForVariants(OS, std::move(HelpTextsForVariants));
 

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -1882,9 +1882,8 @@ void RegisterInfoEmitter::debugDump(raw_ostream &OS) {
     OS << '\n';
     OS << "\tCoveredBySubregs: " << R.CoveredBySubRegs << '\n';
     OS << "\tHasDisjunctSubRegs: " << R.HasDisjunctSubRegs << '\n';
-    for (std::pair<CodeGenSubRegIndex *, CodeGenRegister *> P :
-         R.getSubRegs()) {
-      OS << "\tSubReg " << P.first->getName() << " = " << P.second->getName()
+    for (auto &[SubIdx, SubReg] : R.getSubRegs()) {
+      OS << "\tSubReg " << SubIdx->getName() << " = " << SubReg->getName()
          << '\n';
     }
   }

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -642,7 +642,7 @@ void SearchableTableEmitter::collectEnumEntries(
       Value = getInt(EntryRec, ValueField);
 
     Enum.Entries.push_back(std::make_unique<GenericEnum::Entry>(Name, Value));
-    Enum.EntryMap.insert(std::pair(EntryRec, Enum.Entries.back().get()));
+    Enum.EntryMap.try_emplace(EntryRec, Enum.Entries.back().get());
   }
 
   if (ValueField.empty()) {
@@ -745,7 +745,7 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
 
     collectEnumEntries(*Enum, NameField, ValueField,
                        Records.getAllDerivedDefinitions(FilterClass));
-    EnumMap.insert(std::pair(EnumRec, Enum.get()));
+    EnumMap.try_emplace(EnumRec, Enum.get());
     Enums.emplace_back(std::move(Enum));
   }
 
@@ -814,7 +814,7 @@ void SearchableTableEmitter::run(raw_ostream &OS) {
                         });
     }
 
-    TableMap.insert(std::pair(TableRec, Table.get()));
+    TableMap.try_emplace(TableRec, Table.get());
     Tables.emplace_back(std::move(Table));
   }
 

--- a/llvm/utils/TableGen/WebAssemblyDisassemblerEmitter.cpp
+++ b/llvm/utils/TableGen/WebAssemblyDisassemblerEmitter.cpp
@@ -75,7 +75,7 @@ void llvm::emitWebAssemblyDisassemblerTables(
       }
     }
     // Set this instruction as the one to use.
-    CGIP = std::pair(I, &CGI);
+    CGIP = {I, &CGI};
   }
   OS << "#include \"MCTargetDesc/WebAssemblyMCTargetDesc.h\"\n";
   OS << "\n";

--- a/llvm/utils/TableGen/X86DisassemblerTables.cpp
+++ b/llvm/utils/TableGen/X86DisassemblerTables.cpp
@@ -874,7 +874,7 @@ void DisassemblerTables::emitInstructionInfo(raw_ostream &o,
     for (auto Operand : InstructionSpecifiers[Index].operands) {
       OperandEncoding Encoding = (OperandEncoding)Operand.encoding;
       OperandType Type = (OperandType)Operand.type;
-      OperandList.push_back(std::pair(Encoding, Type));
+      OperandList.emplace_back(Encoding, Type);
     }
     unsigned &N = OperandSets[OperandList];
     if (N != 0)
@@ -906,7 +906,7 @@ void DisassemblerTables::emitInstructionInfo(raw_ostream &o,
     for (auto Operand : InstructionSpecifiers[index].operands) {
       OperandEncoding Encoding = (OperandEncoding)Operand.encoding;
       OperandType Type = (OperandType)Operand.type;
-      OperandList.push_back(std::pair(Encoding, Type));
+      OperandList.emplace_back(Encoding, Type);
     }
     o.indent(i * 2) << (OperandSets[OperandList] - 1) << ",\n";
 

--- a/llvm/utils/TableGen/X86InstrMappingEmitter.cpp
+++ b/llvm/utils/TableGen/X86InstrMappingEmitter.cpp
@@ -236,7 +236,7 @@ void X86InstrMappingEmitter::emitCompressEVEXTable(
     if (!NewInst)
       continue;
 
-    Table.push_back(std::pair(Inst, NewInst));
+    Table.emplace_back(Inst, NewInst);
     auto Predicates = NewInst->TheDef->getValueAsListOfDefs("Predicates");
     auto It = llvm::find_if(Predicates, [](const Record *R) {
       StringRef Name = R->getName();
@@ -293,7 +293,7 @@ void X86InstrMappingEmitter::emitNFTransformTable(
         report_fatal_error("EFLAGS should be clobbered by " +
                            NewRec->getName());
 #endif
-      Table.push_back(std::pair(&Target.getInstruction(NewRec), Inst));
+      Table.emplace_back(&Target.getInstruction(NewRec), Inst);
     }
   }
   printTable(Table, "X86NFTransformTable", "GET_X86_NF_TRANSFORM_TABLE", OS);
@@ -321,7 +321,7 @@ void X86InstrMappingEmitter::emitND2NonNDTable(
       const auto *NewRec = Records.getDef(ManualMap.at(Rec->getName()));
       assert(NewRec && "Instruction not found!");
       auto &NewInst = Target.getInstruction(NewRec);
-      Table.push_back(std::pair(Inst, &NewInst));
+      Table.emplace_back(Inst, &NewInst);
       continue;
     }
 
@@ -332,7 +332,7 @@ void X86InstrMappingEmitter::emitND2NonNDTable(
       continue;
     const auto &NewInst = Target.getInstruction(NewRec);
     if (isRegisterOperand(NewInst.Operands[0].Rec))
-      Table.push_back(std::pair(Inst, &NewInst));
+      Table.emplace_back(Inst, &NewInst);
   }
   printTable(Table, "X86ND2NonNDTable", "GET_X86_ND2NONND_TABLE", OS);
 }
@@ -355,7 +355,7 @@ void X86InstrMappingEmitter::emitSSE2AVXTable(
       const auto *NewRec = Records.getDef(ManualMap.at(Rec->getName()));
       assert(NewRec && "Instruction not found!");
       const auto &NewInst = Target.getInstruction(NewRec);
-      Table.push_back(std::pair(Inst, &NewInst));
+      Table.emplace_back(Inst, &NewInst);
       continue;
     }
 
@@ -364,7 +364,7 @@ void X86InstrMappingEmitter::emitSSE2AVXTable(
     if (!AVXRec)
       continue;
     auto &AVXInst = Target.getInstruction(AVXRec);
-    Table.push_back(std::pair(Inst, &AVXInst));
+    Table.emplace_back(Inst, &AVXInst);
   }
   printTable(Table, "X86SSE2AVXTable", "GET_X86_SSE2AVX_TABLE", OS);
 }


### PR DESCRIPTION
Also use brace initialization and emplace to avoid explicitly 
constructing std::pair, and the same for std::tuple.