### PR TITLE
[Support] Remove an unnecessary include

### DIFF
--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -44,8 +44,6 @@
 #include <system_error>
 #include <vector>
 
-#include <sys/stat.h>
-
 namespace llvm {
 namespace sys {
 namespace fs {

--- a/llvm/lib/Support/ErrorHandling.cpp
+++ b/llvm/lib/Support/ErrorHandling.cpp
@@ -33,7 +33,7 @@
 #if defined(HAVE_UNISTD_H)
 # include <unistd.h>
 #endif
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 # include <io.h>
 # include <fcntl.h>
 #endif


### PR DESCRIPTION
In 1e53f9523d3d5fcb2993b4b6540f1ed8d743380b, the FileSystem.h header was changed to always include <sys/stat.h>, while it previously only was included if HAVE_SYS_STAT_H was defined.

HAVE_SYS_STAT_H was defined in llvm/Config/config.h, while this header only included llvm/Config/llvm-config.h. Thus, <sys/stat.h> was only being included in some but not all cases.

The change to always include <sys/stat.h> broke compiling LLDB for MinGW targets, because the MinGW <sys/stat.h> header adds an "#define fstat _fstat64" define, which breaks LLDBs use of a struct with a member named "fstat".

Remove the include of <sys/stat.h> in FileSystem.h, as it seems to not be necessary in practice.

Change one instance of defined(_MSC_VER) into defined(_WIN32) in ErrorHandling.cpp to get <io.h> included; this source file did include config.h before transitively including FileSystem.h. The include of <sys/stat.h> in FileSystem.h would bring in <io.h> (needed for ::write()), explaining why this ifdef didn't need to cover MinGW before.