### PR TITLE
[IR] Provide array with poison-generating metadata IDs.

### DIFF
--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -503,10 +503,6 @@ public:
   /// Determine whether the the nneg flag is set.
   bool hasNonNeg() const LLVM_READONLY;
 
-  /// Metadata IDs that may generate poison.
-  constexpr static const unsigned PoisonGeneratingMetadataIDs[] = {
-      LLVMContext::MD_range, LLVMContext::MD_nonnull, LLVMContext::MD_align};
-
   /// Return true if this operator has flags which may cause this instruction
   /// to evaluate to poison despite having non-poison inputs.
   bool hasPoisonGeneratingFlags() const LLVM_READONLY;

--- a/llvm/include/llvm/IR/Instruction.h
+++ b/llvm/include/llvm/IR/Instruction.h
@@ -503,6 +503,10 @@ public:
   /// Determine whether the the nneg flag is set.
   bool hasNonNeg() const LLVM_READONLY;
 
+  /// Metadata IDs that may generate poison.
+  constexpr static const unsigned PoisonGeneratingMetadataIDs[] = {
+      LLVMContext::MD_range, LLVMContext::MD_nonnull, LLVMContext::MD_align};
+
   /// Return true if this operator has flags which may cause this instruction
   /// to evaluate to poison despite having non-poison inputs.
   bool hasPoisonGeneratingFlags() const LLVM_READONLY;

--- a/llvm/include/llvm/IR/Metadata.h
+++ b/llvm/include/llvm/IR/Metadata.h
@@ -138,6 +138,10 @@ public:
   void printAsOperand(raw_ostream &OS, ModuleSlotTracker &MST,
                       const Module *M = nullptr) const;
   /// @}
+
+  /// Metadata IDs that may generate poison.
+  constexpr static const unsigned PoisonGeneratingIDs[] = {
+      LLVMContext::MD_range, LLVMContext::MD_nonnull, LLVMContext::MD_align};
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -458,7 +458,7 @@ void Instruction::dropPoisonGeneratingFlags() {
 }
 
 bool Instruction::hasPoisonGeneratingMetadata() const {
-  return any_of(PoisonGeneratingMetadataIDs,
+  return any_of(Metadata::PoisonGeneratingIDs,
                 [this](unsigned ID) { return hasMetadata(ID); });
 }
 
@@ -486,7 +486,7 @@ bool Instruction::hasNonDebugLocLoopMetadata() const {
 }
 
 void Instruction::dropPoisonGeneratingMetadata() {
-  for (unsigned ID : PoisonGeneratingMetadataIDs)
+  for (unsigned ID : Metadata::PoisonGeneratingIDs)
     eraseMetadata(ID);
 }
 

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -458,9 +458,8 @@ void Instruction::dropPoisonGeneratingFlags() {
 }
 
 bool Instruction::hasPoisonGeneratingMetadata() const {
-  return hasMetadata(LLVMContext::MD_range) ||
-         hasMetadata(LLVMContext::MD_nonnull) ||
-         hasMetadata(LLVMContext::MD_align);
+  return any_of(PoisonGeneratingMetadataIDs,
+                [this](unsigned ID) { return hasMetadata(ID); });
 }
 
 bool Instruction::hasNonDebugLocLoopMetadata() const {
@@ -487,9 +486,8 @@ bool Instruction::hasNonDebugLocLoopMetadata() const {
 }
 
 void Instruction::dropPoisonGeneratingMetadata() {
-  eraseMetadata(LLVMContext::MD_range);
-  eraseMetadata(LLVMContext::MD_nonnull);
-  eraseMetadata(LLVMContext::MD_align);
+  for (unsigned ID : PoisonGeneratingMetadataIDs)
+    eraseMetadata(ID);
 }
 
 bool Instruction::hasPoisonGeneratingReturnAttributes() const {

--- a/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
+++ b/llvm/lib/Transforms/IPO/ArgumentPromotion.cpp
@@ -259,8 +259,7 @@ doPromotion(Function *F, FunctionAnalysisManager &FAM,
             // all promoted loads.
             if (LI->hasMetadata(LLVMContext::MD_noundef))
               LI->copyMetadata(*Pair.second.MustExecInstr,
-                               {LLVMContext::MD_range, LLVMContext::MD_nonnull,
-                                LLVMContext::MD_align});
+                               Metadata::PoisonGeneratingIDs);
           }
           Args.push_back(LI);
           ArgAttrVec.push_back(AttributeSet());


### PR DESCRIPTION
Add Metadata::PoisonGeneratingIDs containing IDs of poison-generating metadata to allow easier re-use.
