### PR TITLE
[Clang][AArch64]Make Tuple Size Optional for svluti4_lane Intrinsics

### DIFF
--- a/clang/include/clang/Basic/arm_sve.td
+++ b/clang/include/clang/Basic/arm_sve.td
@@ -1954,13 +1954,13 @@ let SVETargetGuard = "sve2,lut", SMETargetGuard = "sme2,lut" in {
   def SVLUTI4_B : SInst<"svluti4_lane[_{d}]", "dd[i", "cUc", MergeNone, "aarch64_sve_luti4_lane", [VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_1>]>;
   def SVLUTI4_H : SInst<"svluti4_lane[_{d}]", "dd[i", "sUsh", MergeNone, "aarch64_sve_luti4_lane", [VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_3>]>;
 
-  def SVLUTI4_x2 : SInst<"svluti4_lane[_{d}]_x2", "d2.d[i", "sUsh", MergeNone, "aarch64_sve_luti4_lane_x2", [VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_3>]>;
+  def SVLUTI4_x2 : SInst<"svluti4_lane[_{d}_x2]", "d2.d[i", "sUsh", MergeNone, "aarch64_sve_luti4_lane_x2", [VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_3>]>;
 }
 
 let SVETargetGuard = "sve2,lut,bf16", SMETargetGuard = "sme2,lut,bf16" in {
   def SVLUTI2_BF16 : SInst<"svluti2_lane[_{d}]", "dd[i", "b", MergeNone, "aarch64_sve_luti2_lane", [ VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_7>]>;
   def SVLUTI4_BF16 : SInst<"svluti4_lane[_{d}]", "dd[i", "b", MergeNone, "aarch64_sve_luti4_lane", [ VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_3>]>;
-  def SVLUTI4_BF16_x2 : SInst<"svluti4_lane[_{d}]_x2", "d2.d[i", "b", MergeNone, "aarch64_sve_luti4_lane_x2", [ VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_3>]>;
+  def SVLUTI4_BF16_x2 : SInst<"svluti4_lane[_{d}_x2]", "d2.d[i", "b", MergeNone, "aarch64_sve_luti4_lane_x2", [ VerifyRuntimeMode], [ImmCheck<2, ImmCheck0_3>]>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/clang/test/CodeGen/AArch64/sve2-intrinsics/acle_sve2_luti.c
+++ b/clang/test/CodeGen/AArch64/sve2-intrinsics/acle_sve2_luti.c
@@ -19,9 +19,9 @@
 
 #ifdef SVE_OVERLOADED_FORMS
 // A simple used,unused... macro, long enough to represent any SVE builtin.
-#define SVE_ACLE_FUNC(A1,A2_UNUSED,A3) A1##A3
+#define SVE_ACLE_FUNC(A1,A2_UNUSED) A1
 #else
-#define SVE_ACLE_FUNC(A1,A2,A3) A1##A2##A3
+#define SVE_ACLE_FUNC(A1,A2) A1##A2
 #endif
 
 // SME-CHECK-LABEL: @test_svluti2_lane_s8(
@@ -39,7 +39,7 @@
 // CPP-CHECK-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
 //
 svint8_t test_svluti2_lane_s8(svint8_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti2_lane,_s8,)(table, indices, 0);
+    return SVE_ACLE_FUNC(svluti2_lane,_s8)(table, indices, 0);
 }
 
 // SME-CHECK-LABEL: @test_svluti2_lane_u8(
@@ -57,7 +57,7 @@ svint8_t test_svluti2_lane_s8(svint8_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
 //
 svuint8_t test_svluti2_lane_u8(svuint8_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti2_lane,_u8,)(table, indices, 3);
+    return SVE_ACLE_FUNC(svluti2_lane,_u8)(table, indices, 3);
 }
 
 // SME-CHECK-LABEL: @test_svluti2_lane_s16(
@@ -75,7 +75,7 @@ svuint8_t test_svluti2_lane_u8(svuint8_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
 //
 svint16_t test_svluti2_lane_s16(svint16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti2_lane,_s16,)(table, indices, 0);
+    return SVE_ACLE_FUNC(svluti2_lane,_s16)(table, indices, 0);
 }
 
 // SME-CHECK-LABEL: @test_svluti2_lane_u16(
@@ -93,7 +93,7 @@ svint16_t test_svluti2_lane_s16(svint16_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
 //
 svuint16_t test_svluti2_lane_u16(svuint16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti2_lane,_u16,)(table, indices, 7);
+    return SVE_ACLE_FUNC(svluti2_lane,_u16)(table, indices, 7);
 }
 
 // SME-CHECK-LABEL: @test_svluti2_lane_f16(
@@ -111,7 +111,7 @@ svuint16_t test_svluti2_lane_u16(svuint16_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 8 x half> [[TMP0]]
 //
 svfloat16_t test_svluti2_lane_f16(svfloat16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti2_lane,_f16,)(table, indices, 5);
+    return SVE_ACLE_FUNC(svluti2_lane,_f16)(table, indices, 5);
 }
 
 // SME-CHECK-LABEL: @test_svluti2_lane_bf16(
@@ -129,7 +129,7 @@ svfloat16_t test_svluti2_lane_f16(svfloat16_t table, svuint8_t indices) MODE_ATT
 // CPP-CHECK-NEXT:    ret <vscale x 8 x bfloat> [[TMP0]]
 //
 svbfloat16_t test_svluti2_lane_bf16(svbfloat16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti2_lane,_bf16,)(table, indices, 2);
+    return SVE_ACLE_FUNC(svluti2_lane,_bf16)(table, indices, 2);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_s8(
@@ -147,7 +147,7 @@ svbfloat16_t test_svluti2_lane_bf16(svbfloat16_t table, svuint8_t indices) MODE_
 // CPP-CHECK-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
 //
 svint8_t test_svluti4_lane_s8(svint8_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_s8,)(table, indices, 0);
+    return SVE_ACLE_FUNC(svluti4_lane,_s8)(table, indices, 0);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_u8(
@@ -165,7 +165,7 @@ svint8_t test_svluti4_lane_s8(svint8_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 16 x i8> [[TMP0]]
 //
 svuint8_t test_svluti4_lane_u8(svuint8_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_u8,)(table, indices, 1);
+    return SVE_ACLE_FUNC(svluti4_lane,_u8)(table, indices, 1);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_s16(
@@ -183,7 +183,7 @@ svuint8_t test_svluti4_lane_u8(svuint8_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
 //
 svint16_t test_svluti4_lane_s16(svint16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_s16,)(table, indices, 0);
+    return SVE_ACLE_FUNC(svluti4_lane,_s16)(table, indices, 0);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_u16(
@@ -201,7 +201,7 @@ svint16_t test_svluti4_lane_s16(svint16_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
 //
 svuint16_t test_svluti4_lane_u16(svuint16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_u16,)(table, indices, 3);
+    return SVE_ACLE_FUNC(svluti4_lane,_u16)(table, indices, 3);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_f16(
@@ -219,7 +219,7 @@ svuint16_t test_svluti4_lane_u16(svuint16_t table, svuint8_t indices) MODE_ATTR{
 // CPP-CHECK-NEXT:    ret <vscale x 8 x half> [[TMP0]]
 //
 svfloat16_t test_svluti4_lane_f16(svfloat16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_f16,)(table, indices, 2);
+    return SVE_ACLE_FUNC(svluti4_lane,_f16)(table, indices, 2);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_bf16(
@@ -237,7 +237,7 @@ svfloat16_t test_svluti4_lane_f16(svfloat16_t table, svuint8_t indices) MODE_ATT
 // CPP-CHECK-NEXT:    ret <vscale x 8 x bfloat> [[TMP0]]
 //
 svbfloat16_t test_svluti4_lane_bf16(svbfloat16_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_bf16,)(table, indices, 1);
+    return SVE_ACLE_FUNC(svluti4_lane,_bf16)(table, indices, 1);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_s16_x2(
@@ -257,7 +257,7 @@ svbfloat16_t test_svluti4_lane_bf16(svbfloat16_t table, svuint8_t indices) MODE_
 // CPP-CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
 //
 svint16_t test_svluti4_lane_s16_x2(svint16x2_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_s16,_x2)(table, indices, 0);
+    return SVE_ACLE_FUNC(svluti4_lane,_s16_x2)(table, indices, 0);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_u16_x2(
@@ -277,7 +277,7 @@ svint16_t test_svluti4_lane_s16_x2(svint16x2_t table, svuint8_t indices) MODE_AT
 // CPP-CHECK-NEXT:    ret <vscale x 8 x i16> [[TMP0]]
 //
 svuint16_t test_svluti4_lane_u16_x2(svuint16x2_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_u16,_x2)(table, indices, 3);
+    return SVE_ACLE_FUNC(svluti4_lane,_u16_x2)(table, indices, 3);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_f16_x2(
@@ -297,7 +297,7 @@ svuint16_t test_svluti4_lane_u16_x2(svuint16x2_t table, svuint8_t indices) MODE_
 // CPP-CHECK-NEXT:    ret <vscale x 8 x half> [[TMP0]]
 //
 svfloat16_t test_svluti4_lane_f16_x2(svfloat16x2_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_f16,_x2)(table, indices, 2);
+    return SVE_ACLE_FUNC(svluti4_lane,_f16_x2)(table, indices, 2);
 }
 
 // SME-CHECK-LABEL: @test_svluti4_lane_bf16_x2(
@@ -317,5 +317,5 @@ svfloat16_t test_svluti4_lane_f16_x2(svfloat16x2_t table, svuint8_t indices) MOD
 // CPP-CHECK-NEXT:    ret <vscale x 8 x bfloat> [[TMP0]]
 //
 svbfloat16_t test_svluti4_lane_bf16_x2(svbfloat16x2_t table, svuint8_t indices) MODE_ATTR{
-    return SVE_ACLE_FUNC(svluti4_lane,_bf16,_x2)(table, indices, 1);
+    return SVE_ACLE_FUNC(svluti4_lane,_bf16_x2)(table, indices, 1);
 }

--- a/clang/test/Sema/aarch64-sve2-intrinsics/acle_sve2_imm_lane.cpp
+++ b/clang/test/Sema/aarch64-sve2-intrinsics/acle_sve2_imm_lane.cpp
@@ -5,9 +5,9 @@
 
 #ifdef SVE_OVERLOADED_FORMS
 // A simple used,unused... macro, long enough to represent any SVE builtin.
-#define SVE_ACLE_FUNC(A1,A2_UNUSED,A3,A4_UNUSED) A1##A3
+#define SVE_ACLE_FUNC(A1, A2_UNUSED) A1
 #else
-#define SVE_ACLE_FUNC(A1,A2,A3,A4) A1##A2##A3##A4
+#define SVE_ACLE_FUNC(A1,A2) A1##A2
 #endif
 
 #include <arm_sve.h>
@@ -15,201 +15,201 @@
 void test_range_0_7()
 {
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmla_lane,_s16,,)(svundef_s16(), svundef_s16(), svundef_s16(), 8);
+  SVE_ACLE_FUNC(svmla_lane,_s16)(svundef_s16(), svundef_s16(), svundef_s16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmla_lane,_u16,,)(svundef_u16(), svundef_u16(), svundef_u16(), -1);
+  SVE_ACLE_FUNC(svmla_lane,_u16)(svundef_u16(), svundef_u16(), svundef_u16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlalb_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svmlalb_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlalb_lane,_u32,,)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
+  SVE_ACLE_FUNC(svmlalb_lane,_u32)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlalb_lane,_f32,,)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
+  SVE_ACLE_FUNC(svmlalb_lane,_f32)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlalt_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svmlalt_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlalt_lane,_u32,,)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
+  SVE_ACLE_FUNC(svmlalt_lane,_u32)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlalt_lane,_f32,,)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
+  SVE_ACLE_FUNC(svmlalt_lane,_f32)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmls_lane,_s16,,)(svundef_s16(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svmls_lane,_s16)(svundef_s16(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmls_lane,_u16,,)(svundef_u16(), svundef_u16(), svundef_u16(), 8);
+  SVE_ACLE_FUNC(svmls_lane,_u16)(svundef_u16(), svundef_u16(), svundef_u16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlslb_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(),  -1);
+  SVE_ACLE_FUNC(svmlslb_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(),  -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlslb_lane,_u32,,)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
+  SVE_ACLE_FUNC(svmlslb_lane,_u32)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlslb_lane,_f32,,)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
+  SVE_ACLE_FUNC(svmlslb_lane,_f32)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlslt_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svmlslt_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlslt_lane,_u32,,)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
+  SVE_ACLE_FUNC(svmlslt_lane,_u32)(svundef_u32(), svundef_u16(), svundef_u16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmlslt_lane,_f32,,)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
+  SVE_ACLE_FUNC(svmlslt_lane,_f32)(svundef_f32(), svundef_f16(), svundef_f16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmul_lane,_s16,,)(svundef_s16(), svundef_s16(), 8);
+  SVE_ACLE_FUNC(svmul_lane,_s16)(svundef_s16(), svundef_s16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmul_lane,_u16,,)(svundef_u16(), svundef_u16(), -1);
+  SVE_ACLE_FUNC(svmul_lane,_u16)(svundef_u16(), svundef_u16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmullb_lane,_s32,,)(svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svmullb_lane,_s32)(svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmullb_lane,_u32,,)(svundef_u16(), svundef_u16(), 8);
+  SVE_ACLE_FUNC(svmullb_lane,_u32)(svundef_u16(), svundef_u16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmullt_lane,_s32,,)(svundef_s16(), svundef_s16(), 8);
+  SVE_ACLE_FUNC(svmullt_lane,_s32)(svundef_s16(), svundef_s16(), 8);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svmullt_lane,_u32,,)(svundef_u16(), svundef_u16(), -1);
+  SVE_ACLE_FUNC(svmullt_lane,_u32)(svundef_u16(), svundef_u16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmlalb_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmlalb_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmlalt_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmlalt_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmulh_lane,_s16,,)(svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmulh_lane,_s16)(svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmlslb_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmlslb_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmlslt_lane,_s32,,)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmlslt_lane,_s32)(svundef_s32(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmullb_lane,_s32,,)(svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmullb_lane,_s32)(svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqdmullt_lane,_s32,,)(svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqdmullt_lane,_s32)(svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqrdmlah_lane,_s16,,)(svundef_s16(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqrdmlah_lane,_s16)(svundef_s16(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqrdmlsh_lane,_s16,,)(svundef_s16(), svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqrdmlsh_lane,_s16)(svundef_s16(), svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svqrdmulh_lane,_s16,,)(svundef_s16(), svundef_s16(), -1);
+  SVE_ACLE_FUNC(svqrdmulh_lane,_s16)(svundef_s16(), svundef_s16(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svluti2_lane,_s16,,)(svundef_s16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti2_lane,_s16)(svundef_s16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svluti2_lane,_u16,,)(svundef_u16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti2_lane,_u16)(svundef_u16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svluti2_lane,_f16,,)(svundef_f16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti2_lane,_f16)(svundef_f16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 7]}}
-  SVE_ACLE_FUNC(svluti2_lane,_bf16,,)(svundef_bf16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti2_lane,_bf16)(svundef_bf16(), svundef_u8(), -1);
 }
 
 void test_range_0_3()
 {
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svcdot_lane,_s32,,)(svundef_s32(), svundef_s8(), svundef_s8(), -1, 0);
+  SVE_ACLE_FUNC(svcdot_lane,_s32)(svundef_s32(), svundef_s8(), svundef_s8(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svcmla_lane,_s16,,)(svundef_s16(), svundef_s16(), svundef_s16(), -1, 0);
+  SVE_ACLE_FUNC(svcmla_lane,_s16)(svundef_s16(), svundef_s16(), svundef_s16(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svcmla_lane,_u16,,)(svundef_u16(), svundef_u16(), svundef_u16(), -1, 0);
+  SVE_ACLE_FUNC(svcmla_lane,_u16)(svundef_u16(), svundef_u16(), svundef_u16(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmla_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmla_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmla_lane,_u32,,)(svundef_u32(), svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmla_lane,_u32)(svundef_u32(), svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlalb_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmlalb_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlalb_lane,_u64,,)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmlalb_lane,_u64)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlalt_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmlalt_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlalt_lane,_u64,,)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmlalt_lane,_u64)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmls_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svmls_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmls_lane,_u32,,)(svundef_u32(), svundef_u32(), svundef_u32(), -1);
+  SVE_ACLE_FUNC(svmls_lane,_u32)(svundef_u32(), svundef_u32(), svundef_u32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlslb_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmlslb_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlslb_lane,_u64,,)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmlslb_lane,_u64)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlslt_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmlslt_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmlslt_lane,_u64,,)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmlslt_lane,_u64)(svundef_u64(), svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmul_lane,_s32,,)(svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmul_lane,_s32)(svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmul_lane,_u32,,)(svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmul_lane,_u32)(svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmullb_lane,_s64,,)(svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svmullb_lane,_s64)(svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmullb_lane,_u64,,)(svundef_u32(), svundef_u32(), -1);
+  SVE_ACLE_FUNC(svmullb_lane,_u64)(svundef_u32(), svundef_u32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmullt_lane,_s64,,)(svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svmullt_lane,_s64)(svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svmullt_lane,_u64,,)(svundef_u32(), svundef_u32(), 4);
+  SVE_ACLE_FUNC(svmullt_lane,_u64)(svundef_u32(), svundef_u32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmulh_lane,_s32,,)(svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqdmulh_lane,_s32)(svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqrdcmlah_lane,_s16,,)(svundef_s16(), svundef_s16(), svundef_s16(), -1, 0);
+  SVE_ACLE_FUNC(svqrdcmlah_lane,_s16)(svundef_s16(), svundef_s16(), svundef_s16(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqrdmlah_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqrdmlah_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmlalb_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqdmlalb_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmlalt_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqdmlalt_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqrdmlsh_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqrdmlsh_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmlslb_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqdmlslb_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmlslt_lane,_s64,,)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqdmlslt_lane,_s64)(svundef_s64(), svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqrdmulh_lane,_s32,,)(svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqrdmulh_lane,_s32)(svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmullb_lane,_s64,,)(svundef_s32(), svundef_s32(), 4);
+  SVE_ACLE_FUNC(svqdmullb_lane,_s64)(svundef_s32(), svundef_s32(), 4);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svqdmullt_lane,_s64,,)(svundef_s32(), svundef_s32(), -1);
+  SVE_ACLE_FUNC(svqdmullt_lane,_s64)(svundef_s32(), svundef_s32(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti2_lane,_s8,,)(svundef_s8(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti2_lane,_s8)(svundef_s8(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti2_lane,_u8,,)(svundef_u8(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti2_lane,_u8)(svundef_u8(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_s16,,)(svundef_s16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_s16)(svundef_s16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_u16,,)(svundef_u16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_u16)(svundef_u16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_f16,,)(svundef_f16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_f16)(svundef_f16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_bf16,,)(svundef_bf16(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_bf16)(svundef_bf16(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_s16,_x2,)(svcreate2_s16(svundef_s16(),svundef_s16()), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_s16_x2)(svcreate2_s16(svundef_s16(),svundef_s16()), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_u16,_x2,)(svcreate2_u16(svundef_u16(),svundef_u16()), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_u16_x2)(svcreate2_u16(svundef_u16(),svundef_u16()), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_f16,_x2,)(svcreate2_f16(svundef_f16(),svundef_f16()), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_f16_x2)(svcreate2_f16(svundef_f16(),svundef_f16()), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 3]}}
-  SVE_ACLE_FUNC(svluti4_lane,_bf16,_x2,)(svcreate2_bf16(svundef_bf16(),svundef_bf16()), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_bf16_x2)(svcreate2_bf16(svundef_bf16(),svundef_bf16()), svundef_u8(), -1);
 }
 
 void test_range_0_1()
 {
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svcdot_lane,_s64,,)(svundef_s64(), svundef_s16(), svundef_s16(), -1, 0);
+  SVE_ACLE_FUNC(svcdot_lane,_s64)(svundef_s64(), svundef_s16(), svundef_s16(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svcmla_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), -1, 0);
+  SVE_ACLE_FUNC(svcmla_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svcmla_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), 2, 0);
+  SVE_ACLE_FUNC(svcmla_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), 2, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svcmla_lane,_u32,,)(svundef_u32(), svundef_u32(), svundef_u32(), -1, 0);
+  SVE_ACLE_FUNC(svcmla_lane,_u32)(svundef_u32(), svundef_u32(), svundef_u32(), -1, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svmla_lane,_s64,,)(svundef_s64(), svundef_s64(), svundef_s64(), 2);
+  SVE_ACLE_FUNC(svmla_lane,_s64)(svundef_s64(), svundef_s64(), svundef_s64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svmla_lane,_u64,,)(svundef_u64(), svundef_u64(), svundef_u64(), -1);
+  SVE_ACLE_FUNC(svmla_lane,_u64)(svundef_u64(), svundef_u64(), svundef_u64(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svmls_lane,_s64,,)(svundef_s64(), svundef_s64(), svundef_s64(), -1);
+  SVE_ACLE_FUNC(svmls_lane,_s64)(svundef_s64(), svundef_s64(), svundef_s64(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svmls_lane,_u64,,)(svundef_u64(), svundef_u64(), svundef_u64(), 2);
+  SVE_ACLE_FUNC(svmls_lane,_u64)(svundef_u64(), svundef_u64(), svundef_u64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svmul_lane,_s64,,)(svundef_s64(), svundef_s64(), 2);
+  SVE_ACLE_FUNC(svmul_lane,_s64)(svundef_s64(), svundef_s64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svmul_lane,_u64,,)(svundef_u64(), svundef_u64(), -1);
+  SVE_ACLE_FUNC(svmul_lane,_u64)(svundef_u64(), svundef_u64(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svqdmulh_lane,_s64,,)(svundef_s64(), svundef_s64(), 2);
+  SVE_ACLE_FUNC(svqdmulh_lane,_s64)(svundef_s64(), svundef_s64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svqrdcmlah_lane,_s32,,)(svundef_s32(), svundef_s32(), svundef_s32(), 2, 0);
+  SVE_ACLE_FUNC(svqrdcmlah_lane,_s32)(svundef_s32(), svundef_s32(), svundef_s32(), 2, 0);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svqrdmlah_lane,_s64,,)(svundef_s64(), svundef_s64(), svundef_s64(), 2);
+  SVE_ACLE_FUNC(svqrdmlah_lane,_s64)(svundef_s64(), svundef_s64(), svundef_s64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svqrdmlsh_lane,_s64,,)(svundef_s64(), svundef_s64(), svundef_s64(), 2);
+  SVE_ACLE_FUNC(svqrdmlsh_lane,_s64)(svundef_s64(), svundef_s64(), svundef_s64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svqrdmulh_lane,_s64,,)(svundef_s64(), svundef_s64(), 2);
+  SVE_ACLE_FUNC(svqrdmulh_lane,_s64)(svundef_s64(), svundef_s64(), 2);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svluti4_lane,_s8,,)(svundef_s8(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_s8)(svundef_s8(), svundef_u8(), -1);
   // expected-error-re@+1 {{argument value {{[0-9]+}} is outside the valid range [0, 1]}}
-  SVE_ACLE_FUNC(svluti4_lane,_u8,,)(svundef_u8(), svundef_u8(), -1);
+  SVE_ACLE_FUNC(svluti4_lane,_u8)(svundef_u8(), svundef_u8(), -1);
 }


### PR DESCRIPTION
The svluti4_lane intrinsic currently requires the tuple size to be specified in the intrinsic name when using a tuple type input.

According to the ACLE specification, the svluti4_lane intrinsic with a tuple type input, such as:

svint16_t svluti4_lane[_s16_x2(svint16x2_t table, svuint8_t indices, uint64_t imm_idx);

should allow the tuple size of the input type to be optional.