### PR TITLE
[compiler-rt] Make Arm builtins aware of endianness in VMOVs

### DIFF
--- a/compiler-rt/lib/builtins/arm/adddf3vfp.S
+++ b/compiler-rt/lib/builtins/arm/adddf3vfp.S
@@ -19,10 +19,10 @@ DEFINE_COMPILERRT_FUNCTION(__adddf3vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vadd.f64 d0, d0, d1
 #else
-	vmov	d6, r0, r1		// move first param from r0/r1 pair into d6
-	vmov	d7, r2, r3		// move second param from r2/r3 pair into d7
+	VMOV_TO_DOUBLE(d6, r0, r1)		// move first param from r0/r1 pair into d6
+	VMOV_TO_DOUBLE(d7, r2, r3)		// move second param from r2/r3 pair into d7
 	vadd.f64 d6, d6, d7
-	vmov	r0, r1, d6		// move result back to r0/r1 pair
+	VMOV_FROM_DOUBLE(r0, r1, d6)		// move result back to r0/r1 pair
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__adddf3vfp)

--- a/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "../assembly.h"
-#include "../int_endianness.h"
 
 // int __aeabi_dcmp{eq,lt,le,ge,gt}(double a, double b) {
 //   int result = __{eq,lt,le,ge,gt}df2(a, b);
@@ -18,17 +17,10 @@
 //   }
 // }
 
-
 #if defined(COMPILER_RT_ARMHF_TARGET)
-#  if _YUGA_BIG_ENDIAN
-#    define CONVERT_DCMP_ARGS_TO_DF2_ARGS                  \
-        vmov      d0, r1, r0                     SEPARATOR \
-        vmov      d1, r3, r2
-#  else
-#    define CONVERT_DCMP_ARGS_TO_DF2_ARGS                  \
-        vmov      d0, r0, r1                     SEPARATOR \
-        vmov      d1, r2, r3
-#  endif
+#  define CONVERT_DCMP_ARGS_TO_DF2_ARGS \
+     VMOV_TO_DOUBLE(d0, r0, r1)         \
+     VMOV_TO_DOUBLE(d1, r2, r3)
 #else
 #  define CONVERT_DCMP_ARGS_TO_DF2_ARGS
 #endif

--- a/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "../assembly.h"
+#include "../int_endianness.h"
 
 // int __aeabi_dcmp{eq,lt,le,ge,gt}(double a, double b) {
 //   int result = __{eq,lt,le,ge,gt}df2(a, b);
@@ -17,10 +18,17 @@
 //   }
 // }
 
+
 #if defined(COMPILER_RT_ARMHF_TARGET)
-#  define CONVERT_DCMP_ARGS_TO_DF2_ARGS                    \
+#  if _YUGA_BIG_ENDIAN
+#    define CONVERT_DCMP_ARGS_TO_DF2_ARGS                  \
+        vmov      d0, r1, r0                     SEPARATOR \
+        vmov      d1, r3, r2
+#  else
+#    define CONVERT_DCMP_ARGS_TO_DF2_ARGS                  \
         vmov      d0, r0, r1                     SEPARATOR \
         vmov      d1, r2, r3
+#  endif
 #else
 #  define CONVERT_DCMP_ARGS_TO_DF2_ARGS
 #endif

--- a/compiler-rt/lib/builtins/arm/divdf3vfp.S
+++ b/compiler-rt/lib/builtins/arm/divdf3vfp.S
@@ -20,10 +20,10 @@ DEFINE_COMPILERRT_FUNCTION(__divdf3vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vdiv.f64 d0, d0, d1
 #else
-	vmov	d6, r0, r1		// move first param from r0/r1 pair into d6
-	vmov	d7, r2, r3		// move second param from r2/r3 pair into d7
+	VMOV_TO_DOUBLE(d6, r0, r1)		// move first param from r0/r1 pair into d6
+	VMOV_TO_DOUBLE(d7, r2, r3)		// move second param from r2/r3 pair into d7
 	vdiv.f64 d5, d6, d7
-	vmov	r0, r1, d5		// move result back to r0/r1 pair
+	VMOV_FROM_DOUBLE(r0, r1, d5)		// move result back to r0/r1 pair
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__divdf3vfp)

--- a/compiler-rt/lib/builtins/arm/eqdf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/eqdf2vfp.S
@@ -20,8 +20,8 @@ DEFINE_COMPILERRT_FUNCTION(__eqdf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov	d6, r0, r1	// load r0/r1 pair in double register
-	vmov	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/arm/extendsfdf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/extendsfdf2vfp.S
@@ -23,7 +23,7 @@ DEFINE_COMPILERRT_FUNCTION(__extendsfdf2vfp)
 #else
 	vmov	s15, r0      // load float register from R0
 	vcvt.f64.f32 d7, s15 // convert single to double
-	vmov	r0, r1, d7   // return result in r0/r1 pair
+	VMOV_FROM_DOUBLE(r0, r1, d7)   // return result in r0/r1 pair
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__extendsfdf2vfp)

--- a/compiler-rt/lib/builtins/arm/fixdfsivfp.S
+++ b/compiler-rt/lib/builtins/arm/fixdfsivfp.S
@@ -22,7 +22,7 @@ DEFINE_COMPILERRT_FUNCTION(__fixdfsivfp)
 	vcvt.s32.f64 s0, d0
 	vmov r0, s0
 #else
-	vmov	d7, r0, r1    // load double register from R0/R1
+	VMOV_TO_DOUBLE(d7, r0, r1)    // load double register from R0/R1
 	vcvt.s32.f64 s15, d7  // convert double to 32-bit int into s15
 	vmov	r0, s15	      // move s15 to result register
 #endif

--- a/compiler-rt/lib/builtins/arm/fixunsdfsivfp.S
+++ b/compiler-rt/lib/builtins/arm/fixunsdfsivfp.S
@@ -23,7 +23,7 @@ DEFINE_COMPILERRT_FUNCTION(__fixunsdfsivfp)
 	vcvt.u32.f64 s0, d0
 	vmov r0, s0
 #else
-	vmov	d7, r0, r1    // load double register from R0/R1
+	VMOV_TO_DOUBLE(d7, r0, r1)    // load double register from R0/R1
 	vcvt.u32.f64 s15, d7  // convert double to 32-bit int into s15
 	vmov	r0, s15	      // move s15 to result register
 #endif

--- a/compiler-rt/lib/builtins/arm/floatsidfvfp.S
+++ b/compiler-rt/lib/builtins/arm/floatsidfvfp.S
@@ -24,7 +24,7 @@ DEFINE_COMPILERRT_FUNCTION(__floatsidfvfp)
 #else
 	vmov	s15, r0        // move int to float register s15
 	vcvt.f64.s32 d7, s15   // convert 32-bit int in s15 to double in d7
-	vmov	r0, r1, d7     // move d7 to result register pair r0/r1
+	VMOV_FROM_DOUBLE(r0, r1, d7)     // move d7 to result register pair r0/r1
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__floatsidfvfp)

--- a/compiler-rt/lib/builtins/arm/floatunssidfvfp.S
+++ b/compiler-rt/lib/builtins/arm/floatunssidfvfp.S
@@ -24,7 +24,7 @@ DEFINE_COMPILERRT_FUNCTION(__floatunssidfvfp)
 #else
 	vmov	s15, r0        // move int to float register s15
 	vcvt.f64.u32 d7, s15   // convert 32-bit int in s15 to double in d7
-	vmov	r0, r1, d7     // move d7 to result register pair r0/r1
+	VMOV_FROM_DOUBLE(r0, r1, r7) // move d7 to result register pair r0/r1
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__floatunssidfvfp)

--- a/compiler-rt/lib/builtins/arm/floatunssidfvfp.S
+++ b/compiler-rt/lib/builtins/arm/floatunssidfvfp.S
@@ -24,7 +24,7 @@ DEFINE_COMPILERRT_FUNCTION(__floatunssidfvfp)
 #else
 	vmov	s15, r0        // move int to float register s15
 	vcvt.f64.u32 d7, s15   // convert 32-bit int in s15 to double in d7
-	VMOV_FROM_DOUBLE(r0, r1, r7) // move d7 to result register pair r0/r1
+	VMOV_FROM_DOUBLE(r0, r1, d7) // move d7 to result register pair r0/r1
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__floatunssidfvfp)

--- a/compiler-rt/lib/builtins/arm/gedf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/gedf2vfp.S
@@ -21,8 +21,8 @@ DEFINE_COMPILERRT_FUNCTION(__gedf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov 	d6, r0, r1	// load r0/r1 pair in double register
-	vmov 	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/arm/gtdf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/gtdf2vfp.S
@@ -21,8 +21,8 @@ DEFINE_COMPILERRT_FUNCTION(__gtdf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov 	d6, r0, r1	// load r0/r1 pair in double register
-	vmov 	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/arm/ledf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/ledf2vfp.S
@@ -21,8 +21,8 @@ DEFINE_COMPILERRT_FUNCTION(__ledf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov 	d6, r0, r1	// load r0/r1 pair in double register
-	vmov 	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/arm/ltdf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/ltdf2vfp.S
@@ -21,8 +21,8 @@ DEFINE_COMPILERRT_FUNCTION(__ltdf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov 	d6, r0, r1	// load r0/r1 pair in double register
-	vmov 	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/arm/muldf3vfp.S
+++ b/compiler-rt/lib/builtins/arm/muldf3vfp.S
@@ -20,10 +20,10 @@ DEFINE_COMPILERRT_FUNCTION(__muldf3vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vmul.f64 d0, d0, d1
 #else
-	vmov 	d6, r0, r1         // move first param from r0/r1 pair into d6
-	vmov 	d7, r2, r3         // move second param from r2/r3 pair into d7
+	VMOV_TO_DOUBLE(d6, r0, r1)         // move first param from r0/r1 pair into d6
+	VMOV_TO_DOUBLE(d7, r2, r3)         // move second param from r2/r3 pair into d7
 	vmul.f64 d6, d6, d7
-	vmov 	r0, r1, d6         // move result back to r0/r1 pair
+	VMOV_FROM_DOUBLE(r0, r1, d6)         // move result back to r0/r1 pair
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__muldf3vfp)

--- a/compiler-rt/lib/builtins/arm/nedf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/nedf2vfp.S
@@ -20,8 +20,8 @@ DEFINE_COMPILERRT_FUNCTION(__nedf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov 	d6, r0, r1	// load r0/r1 pair in double register
-	vmov 	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/arm/subdf3vfp.S
+++ b/compiler-rt/lib/builtins/arm/subdf3vfp.S
@@ -20,10 +20,10 @@ DEFINE_COMPILERRT_FUNCTION(__subdf3vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vsub.f64 d0, d0, d1
 #else
-	vmov 	d6, r0, r1         // move first param from r0/r1 pair into d6
-	vmov 	d7, r2, r3         // move second param from r2/r3 pair into d7
+	VMOV_TO_DOUBLE(d6, r0, r1)         // move first param from r0/r1 pair into d6
+	VMOV_TO_DOUBLE(d7, r2, r3)         // move second param from r2/r3 pair into d7
 	vsub.f64 d6, d6, d7
-	vmov 	r0, r1, d6         // move result back to r0/r1 pair
+	VMOV_FROM_DOUBLE(r0, r1, d6)         // move result back to r0/r1 pair
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__subdf3vfp)

--- a/compiler-rt/lib/builtins/arm/truncdfsf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/truncdfsf2vfp.S
@@ -21,7 +21,7 @@ DEFINE_COMPILERRT_FUNCTION(__truncdfsf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcvt.f32.f64 s0, d0
 #else
-	vmov 	d7, r0, r1   // load double from r0/r1 pair
+	VMOV_TO_DOUBLE(d7, r0, r1)   // load double from r0/r1 pair
 	vcvt.f32.f64 s15, d7 // convert double to single (trucate precision)
 	vmov 	r0, s15      // return result in r0
 #endif

--- a/compiler-rt/lib/builtins/arm/unorddf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/unorddf2vfp.S
@@ -21,8 +21,8 @@ DEFINE_COMPILERRT_FUNCTION(__unorddf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vcmp.f64 d0, d1
 #else
-	vmov 	d6, r0, r1	// load r0/r1 pair in double register
-	vmov 	d7, r2, r3	// load r2/r3 pair in double register
+	VMOV_TO_DOUBLE(d6, r0, r1)	// load r0/r1 pair in double register
+	VMOV_TO_DOUBLE(d7, r2, r3)	// load r2/r3 pair in double register
 	vcmp.f64 d6, d7
 #endif
 	vmrs	apsr_nzcv, fpscr

--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -290,4 +290,20 @@
   CFI_END
 #endif
 
+#ifdef __arm__
+#include "int_endianness.h"
+
+#if __YUGA_BIG_ENDIAN
+#  define VMOV_TO_DOUBLE(dst, src0, src1) \
+      vmov dst, src1, src0 SEPARATOR
+#  define VMOV_FROM_DOUBLE(dst0, dst1, src) \
+      vmov dst1, dst0, src SEPARATOR
+#else
+#  define VMOV_TO_DOUBLE(dst, src0, src1) \
+      vmov dst, src0, src1 SEPARATOR
+#  define VMOV_FROM_DOUBLE(dst0, dst1, src) \
+      vmov dst0, dst1, src SEPARATOR
+#endif
+#endif
+
 #endif // COMPILERRT_ASSEMBLY_H

--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -293,7 +293,7 @@
 #ifdef __arm__
 #include "int_endianness.h"
 
-#if __YUGA_BIG_ENDIAN
+#if _YUGA_BIG_ENDIAN
 #define VMOV_TO_DOUBLE(dst, src0, src1) vmov dst, src1, src0 SEPARATOR
 #define VMOV_FROM_DOUBLE(dst0, dst1, src) vmov dst1, dst0, src SEPARATOR
 #else

--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -294,15 +294,11 @@
 #include "int_endianness.h"
 
 #if __YUGA_BIG_ENDIAN
-#  define VMOV_TO_DOUBLE(dst, src0, src1) \
-      vmov dst, src1, src0 SEPARATOR
-#  define VMOV_FROM_DOUBLE(dst0, dst1, src) \
-      vmov dst1, dst0, src SEPARATOR
+#define VMOV_TO_DOUBLE(dst, src0, src1) vmov dst, src1, src0 SEPARATOR
+#define VMOV_FROM_DOUBLE(dst0, dst1, src) vmov dst1, dst0, src SEPARATOR
 #else
-#  define VMOV_TO_DOUBLE(dst, src0, src1) \
-      vmov dst, src0, src1 SEPARATOR
-#  define VMOV_FROM_DOUBLE(dst0, dst1, src) \
-      vmov dst0, dst1, src SEPARATOR
+#define VMOV_TO_DOUBLE(dst, src0, src1) vmov dst, src0, src1 SEPARATOR
+#define VMOV_FROM_DOUBLE(dst0, dst1, src) vmov dst0, dst1, src SEPARATOR
 #endif
 #endif
 


### PR DESCRIPTION
This patch makes Arm builtins aware of endianness in VMOVs.

Before this patch, the functions' definitions assumed little endian, which made any program compiler for big endian incorrect.