### PR TITLE
[lldb] Remove (unused) SymbolContext::Dump

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -91,15 +91,6 @@ public:
   /// their default state.
   void Clear(bool clear_target);
 
-  /// Dump a description of this object to a Stream.
-  ///
-  /// Dump a description of the contents of this object to the supplied stream
-  /// \a s.
-  ///
-  /// \param[in] s
-  ///     The stream to which to dump the object description.
-  void Dump(Stream *s, Target *target) const;
-
   /// Dump the stop context in this object to a Stream.
   ///
   /// Dump the best description of this object to the stream. The information

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -317,65 +317,6 @@ uint32_t SymbolContext::GetResolvedMask() const {
   return resolved_mask;
 }
 
-void SymbolContext::Dump(Stream *s, Target *target) const {
-  *s << this << ": ";
-  s->Indent();
-  s->PutCString("SymbolContext");
-  s->IndentMore();
-  s->EOL();
-  s->IndentMore();
-  s->Indent();
-  *s << "Module       = " << module_sp.get() << ' ';
-  if (module_sp)
-    module_sp->GetFileSpec().Dump(s->AsRawOstream());
-  s->EOL();
-  s->Indent();
-  *s << "CompileUnit  = " << comp_unit;
-  if (comp_unit != nullptr)
-    s->Format(" {{{0:x-16}} {1}", comp_unit->GetID(),
-              comp_unit->GetPrimaryFile());
-  s->EOL();
-  s->Indent();
-  *s << "Function     = " << function;
-  if (function != nullptr) {
-    s->Format(" {{{0:x-16}} {1}, address-range = ", function->GetID(),
-              function->GetType()->GetName());
-    function->GetAddressRange().Dump(s, target, Address::DumpStyleLoadAddress,
-                                     Address::DumpStyleModuleWithFileAddress);
-    s->EOL();
-    s->Indent();
-    Type *func_type = function->GetType();
-    if (func_type) {
-      *s << "        Type = ";
-      func_type->Dump(s, false);
-    }
-  }
-  s->EOL();
-  s->Indent();
-  *s << "Block        = " << block;
-  if (block != nullptr)
-    s->Format(" {{{0:x-16}}", block->GetID());
-  s->EOL();
-  s->Indent();
-  *s << "LineEntry    = ";
-  line_entry.Dump(s, target, true, Address::DumpStyleLoadAddress,
-                  Address::DumpStyleModuleWithFileAddress, true);
-  s->EOL();
-  s->Indent();
-  *s << "Symbol       = " << symbol;
-  if (symbol != nullptr && symbol->GetMangled())
-    *s << ' ' << symbol->GetName().AsCString();
-  s->EOL();
-  *s << "Variable     = " << variable;
-  if (variable != nullptr) {
-    s->Format(" {{{0:x-16}} {1}", variable->GetID(),
-              variable->GetType()->GetName());
-    s->EOL();
-  }
-  s->IndentLess();
-  s->IndentLess();
-}
-
 bool lldb_private::operator==(const SymbolContext &lhs,
                               const SymbolContext &rhs) {
   return lhs.function == rhs.function && lhs.symbol == rhs.symbol &&


### PR DESCRIPTION
We still have GetDescription and DumpStopContext which serve a similar purpose.

(The main reason this is bothering me is because I'm working through the uses of (deprecated) Function::GetAddressRange.)