### PR TITLE
[Flang] Use a module directory to avoid race condition

### DIFF
--- a/flang/test/Lower/module_use.f90
+++ b/flang/test/Lower/module_use.f90
@@ -1,5 +1,6 @@
-! RUN: bbc -emit-fir %S/module_definition.f90
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: rm -fr %t && mkdir %t
+! RUN: bbc -emit-fir -module %t %S/module_definition.f90
+! RUN: bbc -emit-fir -J %t %s -o - | FileCheck %s
 
 ! Test use of module data not defined in this file.
 ! The modules are defined in module_definition.f90

--- a/flang/test/Lower/module_use.f90
+++ b/flang/test/Lower/module_use.f90
@@ -1,4 +1,4 @@
-! RUN: rm -fr %t && mkdir %t
+! RUN: rm -fr %t && mkdir -p %t
 ! RUN: bbc -emit-fir -module %t %S/module_definition.f90
 ! RUN: bbc -emit-fir -J %t %s -o - | FileCheck %s
 


### PR DESCRIPTION
Use a module directory in a test that uses another fortran test to avoid race conditions in module creation.