### PR TITLE
[LV][NFC] Refactor structures used to maintain uncountable exit info

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
+++ b/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
@@ -457,7 +457,7 @@ public:
     return CountableExitingBlocks;
   }
 
-  /// Returns the loop edge with an uncountable exit, or std::nullopt if there
+  /// Returns the loop edge to an uncountable exit, or std::nullopt if there
   /// isn't a single such edge.
   std::optional<std::pair<BasicBlock *, BasicBlock *>>
   getUncountableEdge() const {
@@ -649,7 +649,7 @@ private:
   /// the exact backedge taken count is not computable.
   SmallVector<BasicBlock *, 4> CountableExitingBlocks;
 
-  /// Keep track of the loop edge with an uncountable exit, comprising a pair
+  /// Keep track of the loop edge to an uncountable exit, comprising a pair
   /// of (Exiting, Exit) blocks, if there is exactly one early exit.
   std::optional<std::pair<BasicBlock *, BasicBlock *>> UncountableEdge;
 };

--- a/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
+++ b/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
@@ -391,24 +391,22 @@ public:
 
   /// Returns true if the loop has an uncountable early exit, i.e. an
   /// uncountable exit that isn't the latch block.
-  bool hasUncountableEarlyExit() const { return getUncountableEdges().size(); }
+  bool hasUncountableEarlyExit() const {
+    return getUncountableEdge().has_value();
+  }
 
   /// Returns the uncountable early exiting block.
   BasicBlock *getUncountableEarlyExitingBlock() const {
     if (!hasUncountableEarlyExit())
       return nullptr;
-    assert(getUncountableEdges().size() == 1 &&
-           "Expected only a single uncountable exiting block");
-    return getUncountableEdges()[0].first;
+    return (*getUncountableEdge()).first;
   }
 
   /// Returns the destination of an uncountable early exiting block.
   BasicBlock *getUncountableEarlyExitBlock() const {
     if (!hasUncountableEarlyExit())
       return nullptr;
-    assert(getUncountableEdges().size() == 1 &&
-           "Expected only a single uncountable exit block");
-    return getUncountableEdges()[0].second;
+    return (*getUncountableEdge()).second;
   }
 
   /// Returns true if vector representation of the instruction \p I
@@ -462,10 +460,10 @@ public:
     return CountableExitingBlocks;
   }
 
-  /// Returns all the loop edges that have an uncountable exit.
-  const SmallVector<std::pair<BasicBlock *, BasicBlock *>, 4> &
-  getUncountableEdges() const {
-    return UncountableEdges;
+  /// Returns the loop edge with an uncountable exit.
+  std::optional<std::pair<BasicBlock *, BasicBlock *>>
+  getUncountableEdge() const {
+    return UncountableEdge;
   }
 
 private:
@@ -653,9 +651,9 @@ private:
   /// the exact backedge taken count is not computable.
   SmallVector<BasicBlock *, 4> CountableExitingBlocks;
 
-  /// Keep track of all the loop edges with uncountable exits, where each entry
-  /// is a pair of (Exiting, Exit) blocks.
-  SmallVector<std::pair<BasicBlock *, BasicBlock *>, 4> UncountableEdges;
+  /// Keep track of the loop edge with an uncountable exit, comprising a pair
+  /// of (Exiting, Exit) blocks.
+  std::optional<std::pair<BasicBlock *, BasicBlock *>> UncountableEdge;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
+++ b/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
@@ -389,24 +389,21 @@ public:
     return LAI->getDepChecker().getMaxSafeVectorWidthInBits();
   }
 
-  /// Returns true if the loop has an uncountable early exit, i.e. an
+  /// Returns true if the loop has exactly one uncountable early exit, i.e. an
   /// uncountable exit that isn't the latch block.
   bool hasUncountableEarlyExit() const {
     return getUncountableEdge().has_value();
   }
 
-  /// Returns the uncountable early exiting block.
+  /// Returns the uncountable early exiting block, if there is exactly one.
   BasicBlock *getUncountableEarlyExitingBlock() const {
-    if (!hasUncountableEarlyExit())
-      return nullptr;
-    return (*getUncountableEdge()).first;
+    return hasUncountableEarlyExit() ? getUncountableEdge()->first : nullptr;
   }
 
-  /// Returns the destination of an uncountable early exiting block.
+  /// Returns the destination of the uncountable early exiting block, if there
+  /// is exactly one.
   BasicBlock *getUncountableEarlyExitBlock() const {
-    if (!hasUncountableEarlyExit())
-      return nullptr;
-    return (*getUncountableEdge()).second;
+    return hasUncountableEarlyExit() ? getUncountableEdge()->second : nullptr;
   }
 
   /// Returns true if vector representation of the instruction \p I
@@ -460,7 +457,8 @@ public:
     return CountableExitingBlocks;
   }
 
-  /// Returns the loop edge with an uncountable exit.
+  /// Returns the loop edge with an uncountable exit, or std::nullopt if there
+  /// isn't a single such edge.
   std::optional<std::pair<BasicBlock *, BasicBlock *>>
   getUncountableEdge() const {
     return UncountableEdge;
@@ -652,7 +650,7 @@ private:
   SmallVector<BasicBlock *, 4> CountableExitingBlocks;
 
   /// Keep track of the loop edge with an uncountable exit, comprising a pair
-  /// of (Exiting, Exit) blocks.
+  /// of (Exiting, Exit) blocks, if there is exactly one early exit.
   std::optional<std::pair<BasicBlock *, BasicBlock *>> UncountableEdge;
 };
 


### PR DESCRIPTION
I've removed the HasUncountableEarlyExit variable, since we can
already determine whether or not a loop has an early exit by seeing
if we found an uncountable exit.

I have also deleted the old UncountableExitingBlocks and
UncountableExitBlocks lists and replaced them with a single
uncountable edge. This means we don't need to worry about keeping the
list entries in sync and makes it clear which exiting block
corresponds to which exit block.