### PR TITLE
[libclc] Move degrees/radians to CLC library & optimize

### DIFF
--- a/libclc/clc/include/clc/common/clc_degrees.h
+++ b/libclc/clc/include/clc/common/clc_degrees.h
@@ -1,0 +1,12 @@
+#ifndef __CLC_MATH_CLC_DEGREES_H__
+#define __CLC_MATH_CLC_DEGREES_H__
+
+#define __CLC_BODY <clc/math/unary_decl.inc>
+#define __CLC_FUNCTION __clc_degrees
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_DEGREES_H__

--- a/libclc/clc/include/clc/common/clc_radians.h
+++ b/libclc/clc/include/clc/common/clc_radians.h
@@ -1,0 +1,12 @@
+#ifndef __CLC_MATH_CLC_RADIANS_H__
+#define __CLC_MATH_CLC_RADIANS_H__
+
+#define __CLC_BODY <clc/math/unary_decl.inc>
+#define __CLC_FUNCTION __clc_radians
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_RADIANS_H__

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -1,3 +1,5 @@
+common/clc_degrees.cl
+common/clc_radians.cl
 common/clc_smoothstep.cl
 geometric/clc_dot.cl
 integer/clc_abs.cl

--- a/libclc/clc/lib/generic/common/clc_degrees.cl
+++ b/libclc/clc/lib/generic/common/clc_degrees.cl
@@ -20,22 +20,37 @@
  * THE SOFTWARE.
  */
 
-#include <clc/clc.h>
 #include <clc/clcmacro.h>
-#include <clc/common/clc_degrees.h>
+#include <clc/internal/clc.h>
 
-_CLC_DEFINE_UNARY_BUILTIN(float, degrees, __clc_degrees, float)
+#define DEGREES_SINGLE_DEF(TYPE, LITERAL)                                      \
+  _CLC_OVERLOAD _CLC_DEF TYPE __clc_degrees(TYPE radians) {                    \
+    return (TYPE)LITERAL * radians;                                            \
+  }
+
+#define DEGREES_DEF(TYPE, LITERAL)                                             \
+  DEGREES_SINGLE_DEF(TYPE, LITERAL)                                            \
+  DEGREES_SINGLE_DEF(TYPE##2, LITERAL)                                         \
+  DEGREES_SINGLE_DEF(TYPE##3, LITERAL)                                         \
+  DEGREES_SINGLE_DEF(TYPE##4, LITERAL)                                         \
+  DEGREES_SINGLE_DEF(TYPE##8, LITERAL)                                         \
+  DEGREES_SINGLE_DEF(TYPE##16, LITERAL)
+
+// 180/pi = ~57.29577951308232087685 or 0x1.ca5dc1a63c1f8p+5 or 0x1.ca5dc2p+5F
+DEGREES_DEF(float, 0x1.ca5dc2p+5F)
 
 #ifdef cl_khr_fp64
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN(double, degrees, __clc_degrees, double)
+// 180/pi = ~57.29577951308232087685 or 0x1.ca5dc1a63c1f8p+5 or 0x1.ca5dc2p+5F
+DEGREES_DEF(double, 0x1.ca5dc1a63c1f8p+5)
 
 #endif
 
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN(half, degrees, __clc_degrees, half)
+// 180/pi = ~57.29577951308232087685 or 0x1.ca5dc1a63c1f8p+5 or 0x1.ca5dc2p+5F
+DEGREES_DEF(half, (half)0x1.ca5dc1a63c1f8p+5)
 
 #endif

--- a/libclc/clc/lib/generic/common/clc_radians.cl
+++ b/libclc/clc/lib/generic/common/clc_radians.cl
@@ -20,22 +20,37 @@
  * THE SOFTWARE.
  */
 
-#include <clc/clc.h>
 #include <clc/clcmacro.h>
-#include <clc/common/clc_degrees.h>
+#include <clc/internal/clc.h>
 
-_CLC_DEFINE_UNARY_BUILTIN(float, degrees, __clc_degrees, float)
+#define RADIANS_SINGLE_DEF(TYPE, LITERAL)                                      \
+  _CLC_OVERLOAD _CLC_DEF TYPE __clc_radians(TYPE radians) {                    \
+    return (TYPE)LITERAL * radians;                                            \
+  }
+
+#define RADIANS_DEF(TYPE, LITERAL)                                             \
+  RADIANS_SINGLE_DEF(TYPE, LITERAL)                                            \
+  RADIANS_SINGLE_DEF(TYPE##2, LITERAL)                                         \
+  RADIANS_SINGLE_DEF(TYPE##3, LITERAL)                                         \
+  RADIANS_SINGLE_DEF(TYPE##4, LITERAL)                                         \
+  RADIANS_SINGLE_DEF(TYPE##8, LITERAL)                                         \
+  RADIANS_SINGLE_DEF(TYPE##16, LITERAL)
+
+// pi/180 = ~0.01745329251994329577 or 0x1.1df46a2529d39p-6 or 0x1.1df46ap-6F
+RADIANS_DEF(float, 0x1.1df46ap-6F)
 
 #ifdef cl_khr_fp64
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN(double, degrees, __clc_degrees, double)
+// pi/180 = ~0.01745329251994329577 or 0x1.1df46a2529d39p-6 or 0x1.1df46ap-6F
+RADIANS_DEF(double, 0x1.1df46a2529d39p-6)
 
 #endif
 
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_DEFINE_UNARY_BUILTIN(half, degrees, __clc_degrees, half)
+// pi/180 = ~0.01745329251994329577 or 0x1.1df46a2529d39p-6 or 0x1.1df46ap-6F
+RADIANS_DEF(half, (half)0x1.1df46a2529d39p-6)
 
 #endif

--- a/libclc/clc/lib/spirv/SOURCES
+++ b/libclc/clc/lib/spirv/SOURCES
@@ -1,3 +1,5 @@
+../generic/common/clc_degrees.cl
+../generic/common/clc_radians.cl
 ../generic/common/clc_smoothstep.cl
 ../generic/geometric/clc_dot.cl
 ../generic/math/clc_ceil.cl

--- a/libclc/clc/lib/spirv64/SOURCES
+++ b/libclc/clc/lib/spirv64/SOURCES
@@ -1,3 +1,5 @@
+../generic/common/clc_degrees.cl
+../generic/common/clc_radians.cl
 ../generic/common/clc_smoothstep.cl
 ../generic/geometric/clc_dot.cl
 ../generic/math/clc_ceil.cl

--- a/libclc/generic/lib/common/radians.cl
+++ b/libclc/generic/lib/common/radians.cl
@@ -22,23 +22,20 @@
 
 #include <clc/clc.h>
 #include <clc/clcmacro.h>
+#include <clc/common/clc_radians.h>
 
-_CLC_OVERLOAD _CLC_DEF float radians(float degrees) {
-  // pi/180 = ~0.01745329251994329577 or 0x1.1df46a2529d39p-6 or 0x1.1df46ap-6F
-  return 0x1.1df46ap-6F * degrees;
-}
-
-_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, float, radians, float);
-
+_CLC_DEFINE_UNARY_BUILTIN(float, radians, __clc_radians, float)
 
 #ifdef cl_khr_fp64
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-_CLC_OVERLOAD _CLC_DEF double radians(double degrees) {
-  // pi/180 = ~0.01745329251994329577 or 0x1.1df46a2529d39p-6 or 0x1.1df46ap-6F
-  return 0x1.1df46a2529d39p-6 * degrees;
-}
+_CLC_DEFINE_UNARY_BUILTIN(double, radians, __clc_radians, double)
 
-_CLC_UNARY_VECTORIZE(_CLC_OVERLOAD _CLC_DEF, double, radians, double);
+#endif
+
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+_CLC_DEFINE_UNARY_BUILTIN(half, radians, __clc_radians, half)
 
 #endif


### PR DESCRIPTION
Missing half variants were also added.

The builtins are now consistently emitted in vector form (i.e., with a splat of the literal to the appropriate vector size).