### PR TITLE
[llvm-exegesis] Remove implicit conversions of MCRegister to unsigned. NFC

### DIFF
--- a/llvm/unittests/tools/llvm-exegesis/X86/SnippetGeneratorTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SnippetGeneratorTest.cpp
@@ -183,7 +183,7 @@ TEST_F(X86SerialSnippetGeneratorTest,
     ASSERT_THAT(IT.getVariableValues(), SizeIs(3));
     for (const auto &Var : IT.getVariableValues()) {
       if (Var.isReg()) {
-        EXPECT_FALSE(ForbiddenRegisters[Var.getReg()]);
+        EXPECT_FALSE(ForbiddenRegisters[Var.getReg().id()]);
       }
     }
   }
@@ -288,8 +288,8 @@ TEST_F(X86ParallelSnippetGeneratorTest, ReadAfterWrite_CMOV32rr) {
     EXPECT_THAT(CT.Info, HasSubstr("avoiding Read-After-Write issue"));
     EXPECT_THAT(CT.Execution, ExecutionMode::UNKNOWN);
     ASSERT_GT(CT.Instructions.size(), 1U);
-    std::unordered_set<unsigned> AllDefRegisters;
-    std::unordered_set<unsigned> AllUseRegisters;
+    std::set<MCRegister> AllDefRegisters;
+    std::set<MCRegister> AllUseRegisters;
     for (const auto &IT : CT.Instructions) {
       ASSERT_THAT(IT.getVariableValues(), SizeIs(3));
       AllDefRegisters.insert(IT.getVariableValues()[0].getReg());
@@ -328,8 +328,8 @@ TEST_F(X86ParallelSnippetGeneratorTest, ReadAfterWrite_VFMADD132PDr) {
     EXPECT_THAT(CT.Info, HasSubstr("avoiding Read-After-Write issue"));
     EXPECT_THAT(CT.Execution, ExecutionMode::UNKNOWN);
     ASSERT_GT(CT.Instructions.size(), 1U);
-    std::unordered_set<unsigned> AllDefRegisters;
-    std::unordered_set<unsigned> AllUseRegisters;
+    std::set<MCRegister> AllDefRegisters;
+    std::set<MCRegister> AllUseRegisters;
     for (const auto &IT : CT.Instructions) {
       ASSERT_THAT(IT.getVariableValues(), SizeIs(3));
       AllDefRegisters.insert(IT.getVariableValues()[0].getReg());
@@ -412,9 +412,9 @@ TEST_F(X86ParallelSnippetGeneratorTest, MemoryUse) {
     EXPECT_THAT(IT.getOpcode(), Opcode);
     ASSERT_THAT(IT.getVariableValues(), SizeIs(6));
     EXPECT_EQ(IT.getVariableValues()[2].getImm(), 1);
-    EXPECT_EQ(IT.getVariableValues()[3].getReg(), 0u);
+    EXPECT_FALSE(IT.getVariableValues()[3].getReg().isValid());
     EXPECT_EQ(IT.getVariableValues()[4].getImm(), 0);
-    EXPECT_EQ(IT.getVariableValues()[5].getReg(), 0u);
+    EXPECT_FALSE(IT.getVariableValues()[5].getReg().isValid());
   }
 }
 


### PR DESCRIPTION
-Use MCRegister::id() for BitVector index.
-Replace std::unordered_set<unsigned> with std::set<MCRegister.
 There are other std::sets for Register. None for MCRegister before this.
 I'm assuming we can have operator<(MCRegister, MCRegister). This avoids
 needing to add std::hash<MCRegister>.
-Use MCRegister::isValid() to avoid comparing to 0.