### PR TITLE
[lldb] Rename lldb_assert -> _lldb_assert (NFC)

### DIFF
--- a/lldb/include/lldb/Utility/LLDBAssert.h
+++ b/lldb/include/lldb/Utility/LLDBAssert.h
@@ -19,24 +19,30 @@
 // __FILE__ but only renders the last path component (the filename) instead of
 // an invocation dependent full path to that file.
 #define lldbassert(x)                                                          \
-  lldb_private::lldb_assert(static_cast<bool>(x), #x, __FUNCTION__,            \
-                            __FILE_NAME__, __LINE__)
+  lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__,           \
+                             __FILE_NAME__, __LINE__)
 #else
 #define lldbassert(x)                                                          \
-  lldb_private::lldb_assert(static_cast<bool>(x), #x, __FUNCTION__, __FILE__,  \
-                            __LINE__)
+  lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__, __FILE__, \
+                             __LINE__)
 #endif
 #endif
 
 namespace lldb_private {
+
+/// Don't use _lldb_assert directly. Use the lldbassert macro instead so that
+/// LLDB asserts become regular asserts in NDEBUG builds.
 void _lldb_assert(bool expression, const char *expr_text, const char *func,
                   const char *file, unsigned int line);
 
+/// The default LLDB assert callback, which prints to stderr.
 typedef void (*LLDBAssertCallback)(llvm::StringRef message,
                                    llvm::StringRef backtrace,
                                    llvm::StringRef prompt);
 
+/// Replace the LLDB assert callback.
 void SetLLDBAssertCallback(LLDBAssertCallback callback);
+
 } // namespace lldb_private
 
 #endif // LLDB_UTILITY_LLDBASSERT_H

--- a/lldb/include/lldb/Utility/LLDBAssert.h
+++ b/lldb/include/lldb/Utility/LLDBAssert.h
@@ -29,8 +29,8 @@
 #endif
 
 namespace lldb_private {
-void lldb_assert(bool expression, const char *expr_text, const char *func,
-                 const char *file, unsigned int line);
+void _lldb_assert(bool expression, const char *expr_text, const char *func,
+                  const char *file, unsigned int line);
 
 typedef void (*LLDBAssertCallback)(llvm::StringRef message,
                                    llvm::StringRef backtrace,

--- a/lldb/source/Utility/LLDBAssert.cpp
+++ b/lldb/source/Utility/LLDBAssert.cpp
@@ -20,6 +20,7 @@
 
 namespace lldb_private {
 
+/// The default callback prints to stderr.
 static void DefaultAssertCallback(llvm::StringRef message,
                                   llvm::StringRef backtrace,
                                   llvm::StringRef prompt) {
@@ -31,8 +32,8 @@ static void DefaultAssertCallback(llvm::StringRef message,
 static std::atomic<LLDBAssertCallback> g_lldb_assert_callback =
     &DefaultAssertCallback;
 
-void lldb_assert(bool expression, const char *expr_text, const char *func,
-                 const char *file, unsigned int line) {
+void _lldb_assert(bool expression, const char *expr_text, const char *func,
+                  const char *file, unsigned int line) {
   if (LLVM_LIKELY(expression))
     return;
 
@@ -44,8 +45,6 @@ void lldb_assert(bool expression, const char *expr_text, const char *func,
   }
 #endif
 
-  // Print a warning and encourage the user to file a bug report, similar to
-  // LLVM’s crash handler, and then return execution.
   std::string buffer;
   llvm::raw_string_ostream backtrace(buffer);
   llvm::sys::PrintStackTrace(backtrace);
@@ -54,7 +53,7 @@ void lldb_assert(bool expression, const char *expr_text, const char *func,
       llvm::formatv("Assertion failed: ({0}), function {1}, file {2}, line {3}",
                     expr_text, func, file, line)
           .str(),
-      buffer,
+      backtrace.str(),
       "Please file a bug report against lldb reporting this failure log, and "
       "as many details as possible");
 }


### PR DESCRIPTION
Rename `lldb_assert` to `_lldb_assert` to make it more obvious that you shouldn't be using this function directly. Instead, you should use the `lldbassert` macro which becomes a regular assert in a debug/asserts build.