### PR TITLE
[bazel] Remove //clang:basic_internal_headers target (NFC)

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -666,19 +666,6 @@ py_binary(
     main = "utils/bundle_resources.py",
 )
 
-# A hacky library to expose some internal headers of the `basic` library to its
-# own implementation source files using a stripped include prefix rather than
-# file-relative-inclusion. This is inherently non-modular as these headers will
-# be repeated in the sources below for file-relative-inclusion.
-cc_library(
-    name = "basic_internal_headers",
-    hdrs = glob([
-        "lib/Basic/*.h",
-    ]),
-    features = ["-header_modules"],
-    strip_include_prefix = "lib/Basic",
-)
-
 cc_library(
     name = "basic",
     srcs = [
@@ -696,6 +683,7 @@ cc_library(
     copts = [
         "-DHAVE_VCS_VERSION_INC",
         "$(STACK_FRAME_UNLIMITED)",
+        "-I$(WORKSPACE_ROOT)/clang/lib/Basic",
     ],
     includes = ["include"],
     textual_hdrs = [
@@ -729,6 +717,7 @@ cc_library(
     ] + glob([
         "include/clang/Basic/*.def",
     ]),
+    toolchains = [":workspace_root"],
     deps = [
         ":basic_arm_cde_gen",
         ":basic_arm_fp16_inc_gen",
@@ -748,7 +737,6 @@ cc_library(
         ":basic_builtins_spirv_gen",
         ":basic_builtins_x86_64_gen",
         ":basic_builtins_x86_gen",
-        ":basic_internal_headers",
         ":basic_riscv_sifive_vector_builtins_gen",
         ":basic_riscv_vector_builtin_cg_gen",
         ":basic_riscv_vector_builtins_gen",


### PR DESCRIPTION
This target exists to allow `#include "Header.h"` for headers in lib/Basic rather than using file-relative inclusion. This is rather hacky and results in having two targets that claim the same headers.

Instead, we can pass a `-I` flag in the `copts` for //clang:basic, to adjust the include path to keep those `#include "Header.h"` directives working. There are other targets in this file already doing a similar thing for generated files.