### PR TITLE
Revert "[YAML] Init local var not set by some branches"

### DIFF
--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -1588,7 +1588,7 @@ static bool isInteger(StringRef Val) {
 
 void MappingTraits<std::unique_ptr<ELFYAML::Chunk>>::mapping(
     IO &IO, std::unique_ptr<ELFYAML::Chunk> &Section) {
-  ELFYAML::ELF_SHT Type = ELF::ET_NONE;
+  ELFYAML::ELF_SHT Type;
   StringRef TypeStr;
   if (IO.outputting()) {
     if (auto *S = dyn_cast<ELFYAML::Section>(Section.get()))


### PR DESCRIPTION
Reverts llvm/llvm-project#123137

It's a bug according to https://github.com/llvm/llvm-project/pull/123137#pullrequestreview-2555328813