### PR TITLE
[lldb] Improve user expression diagnostics

### DIFF
--- a/lldb/source/Expression/LLVMUserExpression.cpp
+++ b/lldb/source/Expression/LLVMUserExpression.cpp
@@ -187,18 +187,22 @@ LLVMUserExpression::DoExecute(DiagnosticManager &diagnostic_manager,
     if (execution_result == lldb::eExpressionInterrupted ||
         execution_result == lldb::eExpressionHitBreakpoint) {
       const char *error_desc = nullptr;
+      const char *explanation = execution_result == lldb::eExpressionInterrupted
+                                    ? "was interrupted"
+                                    : "hit a breakpoint";
 
       if (user_expression_plan) {
         if (auto real_stop_info_sp = user_expression_plan->GetRealStopInfo())
           error_desc = real_stop_info_sp->GetDescription();
       }
+
       if (error_desc)
         diagnostic_manager.Printf(lldb::eSeverityError,
-                                  "Execution was interrupted, reason: %s.",
+                                  "Expression execution %s: %s.", explanation,
                                   error_desc);
       else
-        diagnostic_manager.PutString(lldb::eSeverityError,
-                                     "Execution was interrupted.");
+        diagnostic_manager.Printf(lldb::eSeverityError,
+                                  "Expression execution %s.", explanation);
 
       if ((execution_result == lldb::eExpressionInterrupted &&
            options.DoesUnwindOnError()) ||
@@ -212,31 +216,35 @@ LLVMUserExpression::DoExecute(DiagnosticManager &diagnostic_manager,
           user_expression_plan->TransferExpressionOwnership();
         diagnostic_manager.AppendMessageToDiagnostic(
             "The process has been left at the point where it was "
-            "interrupted, "
-            "use \"thread return -x\" to return to the state before "
-            "expression evaluation.");
+            "interrupted, use \"thread return -x\" to return to the state "
+            "before expression evaluation.");
       }
 
       return execution_result;
-    } else if (execution_result == lldb::eExpressionStoppedForDebug) {
+    }
+
+    if (execution_result == lldb::eExpressionStoppedForDebug) {
       diagnostic_manager.PutString(
           lldb::eSeverityInfo,
-          "Execution was halted at the first instruction of the expression "
-          "function because \"debug\" was requested.\n"
+          "Expression execution was halted at the first instruction of the "
+          "expression function because \"debug\" was requested.\n"
           "Use \"thread return -x\" to return to the state before expression "
           "evaluation.");
       return execution_result;
-    } else if (execution_result == lldb::eExpressionThreadVanished) {
-      diagnostic_manager.Printf(
-          lldb::eSeverityError,
-          "Couldn't complete execution; the thread "
-          "on which the expression was being run: 0x%" PRIx64
-          " exited during its execution.",
-          expr_thread_id);
-      return execution_result;
-    } else if (execution_result != lldb::eExpressionCompleted) {
+    }
+
+    if (execution_result == lldb::eExpressionThreadVanished) {
       diagnostic_manager.Printf(lldb::eSeverityError,
-                                "Couldn't execute function; result was %s",
+                                "Couldn't execute expression: the thread on "
+                                "which the expression was being run (0x%" PRIx64
+                                ") exited during its execution.",
+                                expr_thread_id);
+      return execution_result;
+    }
+
+    if (execution_result != lldb::eExpressionCompleted) {
+      diagnostic_manager.Printf(lldb::eSeverityError,
+                                "Couldn't execute expression: result was %s",
                                 toString(execution_result).c_str());
       return execution_result;
     }
@@ -245,9 +253,9 @@ LLVMUserExpression::DoExecute(DiagnosticManager &diagnostic_manager,
   if (FinalizeJITExecution(diagnostic_manager, exe_ctx, result,
                            function_stack_bottom, function_stack_top)) {
     return lldb::eExpressionCompleted;
-  } else {
-    return lldb::eExpressionResultUnavailable;
   }
+
+  return lldb::eExpressionResultUnavailable;
 }
 
 bool LLVMUserExpression::FinalizeJITExecution(

--- a/lldb/test/API/commands/expression/call-function/TestCallStopAndContinue.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStopAndContinue.py
@@ -31,7 +31,7 @@ class ExprCommandCallStopContinueTestCase(TestBase):
         self.expect(
             "expr -i false -- returnsFive()",
             error=True,
-            substrs=["Execution was interrupted, reason: breakpoint"],
+            substrs=["Expression execution hit a breakpoint: breakpoint"],
         )
 
         self.runCmd("continue", "Continue completed")

--- a/lldb/test/API/commands/expression/unwind_expression/TestUnwindExpression.py
+++ b/lldb/test/API/commands/expression/unwind_expression/TestUnwindExpression.py
@@ -2,7 +2,6 @@
 Test stopping at a breakpoint in an expression, and unwinding from there.
 """
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -71,7 +70,7 @@ class UnwindFromExpressionTest(TestBase):
         self.assertTrue(val.GetError().Fail(), "We did not complete the execution.")
         error_str = val.GetError().GetCString()
         self.assertIn(
-            "Execution was interrupted, reason: breakpoint",
+            "Expression execution hit a breakpoint: breakpoint",
             error_str,
             "And the reason was right.",
         )


### PR DESCRIPTION
This patch rewords some of the user expression diagnostics.

 - Differentiate between being interrupted and hitting a breakpoint.
 - Use "expression execution" to make it more obvious that the diagnostic is associated with the user expression.
 - Consistently use a colon instead of semicolons and commas.

rdar://143059974