### PR TITLE
[libc] Make headers compatible with C++ < 11

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -39,7 +39,11 @@
 #define _Thread_local thread_local
 
 #undef __NOEXCEPT
+#if __cplusplus >= 201103L
 #define __NOEXCEPT noexcept
+#else
+#define __NOEXCEPT throw()
+#endif
 
 #else // not __cplusplus
 


### PR DESCRIPTION
C++11 introduced `noexcept`, but `throw()` can be used in older
versions of the language.
