### PR TITLE
[X86][AMX-AVX512][NFC] Remove P from intrinsic and instruction name

### DIFF
--- a/clang/include/clang/Basic/BuiltinsX86_64.td
+++ b/clang/include/clang/Basic/BuiltinsX86_64.td
@@ -295,8 +295,8 @@ let Features = "amx-complex,amx-transpose", Attributes = [NoThrow] in {
 
 let Features = "amx-avx512,avx10.2-512", Attributes = [NoThrow] in {
   def tcvtrowd2ps_internal : X86Builtin<"_Vector<16, float>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
-  def tcvtrowps2pbf16h_internal : X86Builtin<"_Vector<32, __bf16>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
-  def tcvtrowps2pbf16l_internal : X86Builtin<"_Vector<32, __bf16>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
+  def tcvtrowps2bf16h_internal : X86Builtin<"_Vector<32, __bf16>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
+  def tcvtrowps2bf16l_internal : X86Builtin<"_Vector<32, __bf16>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
   def tcvtrowps2phh_internal : X86Builtin<"_Vector<32, _Float16>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
   def tcvtrowps2phl_internal : X86Builtin<"_Vector<32, _Float16>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
   def tilemovrow_internal : X86Builtin<"_Vector<16, int>(unsigned short, unsigned short, _Vector<256, int>, unsigned int)">;
@@ -387,8 +387,8 @@ let Features = "amx-complex,amx-transpose", Attributes = [NoThrow] in {
 
 let Features = "amx-avx512,avx10.2-512", Attributes = [NoThrow] in {
   def tcvtrowd2ps : X86Builtin<"_Vector<16, float>(_Constant unsigned char, unsigned int)">;
-  def tcvtrowps2pbf16h : X86Builtin<"_Vector<32, __bf16>(_Constant unsigned char, unsigned int)">;
-  def tcvtrowps2pbf16l : X86Builtin<"_Vector<32, __bf16>(_Constant unsigned char, unsigned int)">;
+  def tcvtrowps2bf16h : X86Builtin<"_Vector<32, __bf16>(_Constant unsigned char, unsigned int)">;
+  def tcvtrowps2bf16l : X86Builtin<"_Vector<32, __bf16>(_Constant unsigned char, unsigned int)">;
   def tcvtrowps2phh : X86Builtin<"_Vector<32, _Float16>(_Constant unsigned char, unsigned int)">;
   def tcvtrowps2phl : X86Builtin<"_Vector<32, _Float16>(_Constant unsigned char, unsigned int)">;
   def tilemovrow : X86Builtin<"_Vector<16, int>(_Constant unsigned char, unsigned int)">;

--- a/clang/lib/Headers/amxavx512intrin.h
+++ b/clang/lib/Headers/amxavx512intrin.h
@@ -60,7 +60,7 @@
 /// \headerfile <x86intrin.h>
 ///
 /// \code
-/// __m512i _tile_cvtrowps2pbf16h(__tile tsrc, unsigned int row);
+/// __m512i _tile_cvtrowps2bf16h(__tile tsrc, unsigned int row);
 /// \endcode
 ///
 /// \code{.operation}
@@ -80,14 +80,14 @@
 /// zero_tileconfig_start()
 /// \endcode
 ///
-/// This intrinsic corresponds to the \c TCVTROWPS2PBF16H instruction.
+/// This intrinsic corresponds to the \c TCVTROWPS2BF16H instruction.
 ///
 /// \param tsrc
 ///    The source tile. Max size is 1024 Bytes.
 /// \param row
 ///    The the row of the source tile.
-#define _tile_cvtrowps2pbf16h(tsrc, row)                                       \
-  __builtin_ia32_tcvtrowps2pbf16h(tsrc, row)
+#define _tile_cvtrowps2bf16h(tsrc, row)                                        \
+  __builtin_ia32_tcvtrowps2bf16h(tsrc, row)
 
 /// Moves a row from a tile register to a zmm destination register, converting
 ///    the fp32 source elements to bf16. It places the resulting bf16 elements
@@ -97,7 +97,7 @@
 /// \headerfile <x86intrin.h>
 ///
 /// \code
-/// __m512i _tile_cvtrowps2pbf16l(__tile tsrc, unsigned int row);
+/// __m512i _tile_cvtrowps2bf16l(__tile tsrc, unsigned int row);
 /// \endcode
 ///
 /// \code{.operation}
@@ -117,14 +117,14 @@
 /// zero_tileconfig_start()
 /// \endcode
 ///
-/// This intrinsic corresponds to the \c TCVTROWPS2PBF16L instruction.
+/// This intrinsic corresponds to the \c TCVTROWPS2BF16L instruction.
 ///
 /// \param tsrc
 ///    The source tile. Max size is 1024 Bytes.
 /// \param row
 ///    The the row of the source tile.
-#define _tile_cvtrowps2pbf16l(tsrc, row)                                       \
-  __builtin_ia32_tcvtrowps2pbf16l(tsrc, row)
+#define _tile_cvtrowps2bf16l(tsrc, row)                                        \
+  __builtin_ia32_tcvtrowps2bf16l(tsrc, row)
 
 /// Moves a row from a tile register to a zmm destination register, converting
 ///    the fp32 source elements to fp16. It places the resulting fp16 elements
@@ -238,15 +238,15 @@ static __inline__ __m512 __DEFAULT_FN_ATTRS_AVX512 _tile_cvtrowd2ps_internal(
 }
 
 static __inline__ __m512bh __DEFAULT_FN_ATTRS_AVX512
-_tile_cvtrowps2pbf16h_internal(unsigned short m, unsigned short n,
-                               _tile1024i src, unsigned u) {
-  return __builtin_ia32_tcvtrowps2pbf16h_internal(m, n, src, u);
+_tile_cvtrowps2bf16h_internal(unsigned short m, unsigned short n,
+                              _tile1024i src, unsigned u) {
+  return __builtin_ia32_tcvtrowps2bf16h_internal(m, n, src, u);
 }
 
 static __inline__ __m512bh __DEFAULT_FN_ATTRS_AVX512
-_tile_cvtrowps2pbf16l_internal(unsigned short m, unsigned short n,
-                               _tile1024i src, unsigned u) {
-  return __builtin_ia32_tcvtrowps2pbf16l_internal(m, n, src, u);
+_tile_cvtrowps2bf16l_internal(unsigned short m, unsigned short n,
+                              _tile1024i src, unsigned u) {
+  return __builtin_ia32_tcvtrowps2bf16l_internal(m, n, src, u);
 }
 
 static __inline__ __m512h __DEFAULT_FN_ATTRS_AVX512 _tile_cvtrowps2phh_internal(
@@ -290,7 +290,7 @@ static __m512 __tile_cvtrowd2ps(__tile1024i src0, unsigned src1) {
 ///
 /// \headerfile <immintrin.h>
 ///
-/// This intrinsic corresponds to the <c> TCVTROWPS2PBF16H </c> instruction.
+/// This intrinsic corresponds to the <c> TCVTROWPS2BF16H </c> instruction.
 ///
 /// \param src0
 ///    The 1st source tile. Max size is 1024 Bytes.
@@ -299,8 +299,8 @@ static __m512 __tile_cvtrowd2ps(__tile1024i src0, unsigned src1) {
 /// \returns
 ///    The destination v32bf16 data. Size is 64 Bytes.
 __DEFAULT_FN_ATTRS_AVX512
-static __m512bh __tile_cvtrowps2pbf16h(__tile1024i src0, unsigned src1) {
-  return _tile_cvtrowps2pbf16h_internal(src0.row, src0.col, src0.tile, src1);
+static __m512bh __tile_cvtrowps2bf16h(__tile1024i src0, unsigned src1) {
+  return _tile_cvtrowps2bf16h_internal(src0.row, src0.col, src0.tile, src1);
 }
 
 /// Move a row from a tile (src0) to a v32bf16 dst, converting the fp32 source
@@ -309,7 +309,7 @@ static __m512bh __tile_cvtrowps2pbf16h(__tile1024i src0, unsigned src1) {
 ///
 /// \headerfile <immintrin.h>
 ///
-/// This intrinsic corresponds to the <c> TCVTROWPS2PBF16L </c> instruction.
+/// This intrinsic corresponds to the <c> TCVTROWPS2BF16L </c> instruction.
 ///
 /// \param src0
 ///    The 1st source tile. Max size is 1024 Bytes.
@@ -318,8 +318,8 @@ static __m512bh __tile_cvtrowps2pbf16h(__tile1024i src0, unsigned src1) {
 /// \returns
 ///    The destination v32bf16 data. Size is 64 Bytes.
 __DEFAULT_FN_ATTRS_AVX512
-static __m512bh __tile_cvtrowps2pbf16l(__tile1024i src0, unsigned src1) {
-  return _tile_cvtrowps2pbf16l_internal(src0.row, src0.col, src0.tile, src1);
+static __m512bh __tile_cvtrowps2bf16l(__tile1024i src0, unsigned src1) {
+  return _tile_cvtrowps2bf16l_internal(src0.row, src0.col, src0.tile, src1);
 }
 
 /// Move a row from a tile (src0) to a v32fp16 dst, converting the fp32 source

--- a/clang/lib/Sema/SemaX86.cpp
+++ b/clang/lib/Sema/SemaX86.cpp
@@ -641,8 +641,8 @@ bool SemaX86::CheckBuiltinTileArguments(unsigned BuiltinID, CallExpr *TheCall) {
   case X86::BI__builtin_ia32_t2rpntlvwz1rs:
   case X86::BI__builtin_ia32_t2rpntlvwz1rst1:
   case X86::BI__builtin_ia32_t2rpntlvwz0rs:
-  case X86::BI__builtin_ia32_tcvtrowps2pbf16h:
-  case X86::BI__builtin_ia32_tcvtrowps2pbf16l:
+  case X86::BI__builtin_ia32_tcvtrowps2bf16h:
+  case X86::BI__builtin_ia32_tcvtrowps2bf16l:
   case X86::BI__builtin_ia32_tcvtrowps2phh:
   case X86::BI__builtin_ia32_tcvtrowps2phl:
   case X86::BI__builtin_ia32_tcvtrowd2ps:

--- a/clang/test/CodeGen/X86/amx_avx512_api.c
+++ b/clang/test/CodeGen/X86/amx_avx512_api.c
@@ -16,18 +16,18 @@ __m512 test_tile_cvtrowd2ps(__tile1024i a, unsigned b) {
  return __tile_cvtrowd2ps(a, b);
 }
 
-__m512bh test_tile_cvtrowps2pbf16h(__tile1024i a, unsigned b) {
-  //CHECK-LABEL: @test_tile_cvtrowps2pbf16h
+__m512bh test_tile_cvtrowps2bf16h(__tile1024i a, unsigned b) {
+  //CHECK-LABEL: @test_tile_cvtrowps2bf16h
   //CHECK-DAG: call x86_amx @llvm.x86.cast.vector.to.tile.v256i32(<256 x i32> {{%.*}})
-  //CHECK-DAG: call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h.internal
- return __tile_cvtrowps2pbf16h(a, b);
+  //CHECK-DAG: call <32 x bfloat> @llvm.x86.tcvtrowps2bf16h.internal
+ return __tile_cvtrowps2bf16h(a, b);
 }
 
-__m512bh test_tile_cvtrowps2pbf16l(__tile1024i a, unsigned b) {
-  //CHECK-LABEL: @test_tile_cvtrowps2pbf16l
+__m512bh test_tile_cvtrowps2bf16l(__tile1024i a, unsigned b) {
+  //CHECK-LABEL: @test_tile_cvtrowps2bf16l
   //CHECK-DAG: call x86_amx @llvm.x86.cast.vector.to.tile.v256i32(<256 x i32> {{%.*}})
-  //CHECK-DAG: call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l.internal
- return __tile_cvtrowps2pbf16l(a, b);
+  //CHECK-DAG: call <32 x bfloat> @llvm.x86.tcvtrowps2bf16l.internal
+ return __tile_cvtrowps2bf16l(a, b);
 }
 
 __m512h test_tile_cvtrowps2phh(__tile1024i a, unsigned b) {

--- a/clang/test/CodeGen/X86/amxavx512-builtins.c
+++ b/clang/test/CodeGen/X86/amxavx512-builtins.c
@@ -10,16 +10,16 @@ __m512 test_tile_cvtrowd2ps(unsigned int A) {
   return _tile_cvtrowd2ps(1, A);
 }
 
-__m512bh test_tile_cvtrowps2pbf16h(unsigned int A) {
-  // CHECK-LABEL: @test_tile_cvtrowps2pbf16h(
-  // CHECK: call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h(i8 1, i32 %{{.*}})
-  return _tile_cvtrowps2pbf16h(1, A);
+__m512bh test_tile_cvtrowps2bf16h(unsigned int A) {
+  // CHECK-LABEL: @test_tile_cvtrowps2bf16h(
+  // CHECK: call <32 x bfloat> @llvm.x86.tcvtrowps2bf16h(i8 1, i32 %{{.*}})
+  return _tile_cvtrowps2bf16h(1, A);
 }
 
-__m512bh test_tile_cvtrowps2pbf16l(unsigned int A) {
-  // CHECK-LABEL: @test_tile_cvtrowps2pbf16l(
-  // CHECK: call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l(i8 1, i32 %{{.*}})
-  return _tile_cvtrowps2pbf16l(1, A);
+__m512bh test_tile_cvtrowps2bf16l(unsigned int A) {
+  // CHECK-LABEL: @test_tile_cvtrowps2bf16l(
+  // CHECK: call <32 x bfloat> @llvm.x86.tcvtrowps2bf16l(i8 1, i32 %{{.*}})
+  return _tile_cvtrowps2bf16l(1, A);
 }
 
 __m512h test_tile_cvtrowps2phh(unsigned int A) {

--- a/llvm/include/llvm/IR/IntrinsicsX86.td
+++ b/llvm/include/llvm/IR/IntrinsicsX86.td
@@ -5999,10 +5999,10 @@ let TargetPrefix = "x86" in {
   def int_x86_tcvtrowd2ps : ClangBuiltin<"__builtin_ia32_tcvtrowd2ps">,
               Intrinsic<[llvm_v16f32_ty], [llvm_i8_ty, llvm_i32_ty],
                         [ImmArg<ArgIndex<0>>]>;
-  def int_x86_tcvtrowps2pbf16h : ClangBuiltin<"__builtin_ia32_tcvtrowps2pbf16h">,
+  def int_x86_tcvtrowps2bf16h : ClangBuiltin<"__builtin_ia32_tcvtrowps2bf16h">,
               Intrinsic<[llvm_v32bf16_ty], [llvm_i8_ty, llvm_i32_ty],
                         [ImmArg<ArgIndex<0>>]>;
-  def int_x86_tcvtrowps2pbf16l : ClangBuiltin<"__builtin_ia32_tcvtrowps2pbf16l">,
+  def int_x86_tcvtrowps2bf16l : ClangBuiltin<"__builtin_ia32_tcvtrowps2bf16l">,
               Intrinsic<[llvm_v32bf16_ty], [llvm_i8_ty, llvm_i32_ty],
                         [ImmArg<ArgIndex<0>>]>;
   def int_x86_tcvtrowps2phh : ClangBuiltin<"__builtin_ia32_tcvtrowps2phh">,
@@ -6181,13 +6181,13 @@ let TargetPrefix = "x86" in {
               Intrinsic<[llvm_v16f32_ty],
                         [llvm_i16_ty, llvm_i16_ty, llvm_x86amx_ty, llvm_i32_ty],
                         []>;
-  def int_x86_tcvtrowps2pbf16h_internal :
-              ClangBuiltin<"__builtin_ia32_tcvtrowps2pbf16h_internal">,
+  def int_x86_tcvtrowps2bf16h_internal :
+              ClangBuiltin<"__builtin_ia32_tcvtrowps2bf16h_internal">,
               Intrinsic<[llvm_v32bf16_ty],
                         [llvm_i16_ty, llvm_i16_ty, llvm_x86amx_ty, llvm_i32_ty],
                         []>;
-  def int_x86_tcvtrowps2pbf16l_internal :
-              ClangBuiltin<"__builtin_ia32_tcvtrowps2pbf16l_internal">,
+  def int_x86_tcvtrowps2bf16l_internal :
+              ClangBuiltin<"__builtin_ia32_tcvtrowps2bf16l_internal">,
               Intrinsic<[llvm_v32bf16_ty],
                         [llvm_i16_ty, llvm_i16_ty, llvm_x86amx_ty, llvm_i32_ty],
                         []>;

--- a/llvm/lib/Target/X86/X86ExpandPseudo.cpp
+++ b/llvm/lib/Target/X86/X86ExpandPseudo.cpp
@@ -563,10 +563,10 @@ bool X86ExpandPseudo::expandMI(MachineBasicBlock &MBB,
   case X86::PTILELOADDRST1V:
   case X86::PTCVTROWD2PSrreV:
   case X86::PTCVTROWD2PSrriV:
-  case X86::PTCVTROWPS2PBF16HrreV:
-  case X86::PTCVTROWPS2PBF16HrriV:
-  case X86::PTCVTROWPS2PBF16LrreV:
-  case X86::PTCVTROWPS2PBF16LrriV:
+  case X86::PTCVTROWPS2BF16HrreV:
+  case X86::PTCVTROWPS2BF16HrriV:
+  case X86::PTCVTROWPS2BF16LrreV:
+  case X86::PTCVTROWPS2BF16LrriV:
   case X86::PTCVTROWPS2PHHrreV:
   case X86::PTCVTROWPS2PHHrriV:
   case X86::PTCVTROWPS2PHLrreV:
@@ -595,17 +595,17 @@ bool X86ExpandPseudo::expandMI(MachineBasicBlock &MBB,
     case X86::PTCVTROWD2PSrriV:
       Opc = X86::TCVTROWD2PSrri;
       break;
-    case X86::PTCVTROWPS2PBF16HrreV:
-      Opc = X86::TCVTROWPS2PBF16Hrre;
+    case X86::PTCVTROWPS2BF16HrreV:
+      Opc = X86::TCVTROWPS2BF16Hrre;
       break;
-    case X86::PTCVTROWPS2PBF16HrriV:
-      Opc = X86::TCVTROWPS2PBF16Hrri;
+    case X86::PTCVTROWPS2BF16HrriV:
+      Opc = X86::TCVTROWPS2BF16Hrri;
       break;
-    case X86::PTCVTROWPS2PBF16LrreV:
-      Opc = X86::TCVTROWPS2PBF16Lrre;
+    case X86::PTCVTROWPS2BF16LrreV:
+      Opc = X86::TCVTROWPS2BF16Lrre;
       break;
-    case X86::PTCVTROWPS2PBF16LrriV:
-      Opc = X86::TCVTROWPS2PBF16Lrri;
+    case X86::PTCVTROWPS2BF16LrriV:
+      Opc = X86::TCVTROWPS2BF16Lrri;
       break;
     case X86::PTCVTROWPS2PHHrreV:
       Opc = X86::TCVTROWPS2PHHrre;

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -37890,8 +37890,8 @@ X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     MI.eraseFromParent(); // The pseudo is gone now.
     return BB;
   }
-  case X86::PTCVTROWPS2PBF16Hrri:
-  case X86::PTCVTROWPS2PBF16Lrri:
+  case X86::PTCVTROWPS2BF16Hrri:
+  case X86::PTCVTROWPS2BF16Lrri:
   case X86::PTCVTROWPS2PHHrri:
   case X86::PTCVTROWPS2PHLrri:
   case X86::PTCVTROWD2PSrri:
@@ -37904,14 +37904,14 @@ X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     case X86::PTCVTROWD2PSrri:
       Opc = X86::TCVTROWD2PSrri;
       break;
-    case X86::PTCVTROWPS2PBF16Hrri:
-      Opc = X86::TCVTROWPS2PBF16Hrri;
+    case X86::PTCVTROWPS2BF16Hrri:
+      Opc = X86::TCVTROWPS2BF16Hrri;
       break;
     case X86::PTCVTROWPS2PHHrri:
       Opc = X86::TCVTROWPS2PHHrri;
       break;
-    case X86::PTCVTROWPS2PBF16Lrri:
-      Opc = X86::TCVTROWPS2PBF16Lrri;
+    case X86::PTCVTROWPS2BF16Lrri:
+      Opc = X86::TCVTROWPS2BF16Lrri;
       break;
     case X86::PTCVTROWPS2PHLrri:
       Opc = X86::TCVTROWPS2PHLrri;
@@ -37928,8 +37928,8 @@ X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     MI.eraseFromParent(); // The pseudo is gone now.
     return BB;
   }
-  case X86::PTCVTROWPS2PBF16Hrre:
-  case X86::PTCVTROWPS2PBF16Lrre:
+  case X86::PTCVTROWPS2BF16Hrre:
+  case X86::PTCVTROWPS2BF16Lrre:
   case X86::PTCVTROWPS2PHHrre:
   case X86::PTCVTROWPS2PHLrre:
   case X86::PTCVTROWD2PSrre:
@@ -37942,11 +37942,11 @@ X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     case X86::PTCVTROWD2PSrre:
       Opc = X86::TCVTROWD2PSrre;
       break;
-    case X86::PTCVTROWPS2PBF16Hrre:
-      Opc = X86::TCVTROWPS2PBF16Hrre;
+    case X86::PTCVTROWPS2BF16Hrre:
+      Opc = X86::TCVTROWPS2BF16Hrre;
       break;
-    case X86::PTCVTROWPS2PBF16Lrre:
-      Opc = X86::TCVTROWPS2PBF16Lrre;
+    case X86::PTCVTROWPS2BF16Lrre:
+      Opc = X86::TCVTROWPS2BF16Lrre;
       break;
     case X86::PTCVTROWPS2PHHrre:
       Opc = X86::TCVTROWPS2PHHrre;

--- a/llvm/lib/Target/X86/X86InstrAMX.td
+++ b/llvm/lib/Target/X86/X86InstrAMX.td
@@ -590,26 +590,26 @@ let Predicates = [HasAMXAVX512, HasAVX10_2_512, In64BitMode] in {
                                    [(set VR512: $dst,
                                      (int_x86_tcvtrowd2ps_internal GR16:$src1, GR16:$src2,
                                       TILE:$src3, GR32:$src4))]>;
-    def PTCVTROWPS2PBF16HrriV : PseudoI<(outs VR512:$dst),
-                                        (ins GR16:$src1, GR16:$src2, TILE:$src3, i32u8imm:$src4),
-                                        [(set VR512: $dst,
-                                          (int_x86_tcvtrowps2pbf16h_internal GR16:$src1, GR16:$src2,
-                                           TILE:$src3, imm:$src4))]>;
-    def PTCVTROWPS2PBF16HrreV : PseudoI<(outs VR512:$dst),
-                                        (ins GR16:$src1, GR16:$src2, TILE:$src3, GR32:$src4),
-                                        [(set VR512: $dst,
-                                          (int_x86_tcvtrowps2pbf16h_internal GR16:$src1, GR16:$src2,
-                                           TILE:$src3, GR32:$src4))]>;
-    def PTCVTROWPS2PBF16LrriV : PseudoI<(outs VR512:$dst),
-                                        (ins GR16:$src1, GR16:$src2, TILE:$src3, i32u8imm:$src4),
-                                        [(set VR512: $dst,
-                                          (int_x86_tcvtrowps2pbf16l_internal GR16:$src1, GR16:$src2,
-                                           TILE:$src3, imm:$src4))]>;
-    def PTCVTROWPS2PBF16LrreV : PseudoI<(outs VR512:$dst),
-                                        (ins GR16:$src1, GR16:$src2, TILE:$src3, GR32:$src4),
-                                        [(set VR512: $dst,
-                                          (int_x86_tcvtrowps2pbf16l_internal GR16:$src1, GR16:$src2,
-                                           TILE:$src3, GR32:$src4))]>;
+    def PTCVTROWPS2BF16HrriV : PseudoI<(outs VR512:$dst),
+                                       (ins GR16:$src1, GR16:$src2, TILE:$src3, i32u8imm:$src4),
+                                       [(set VR512: $dst,
+                                         (int_x86_tcvtrowps2bf16h_internal GR16:$src1, GR16:$src2,
+                                          TILE:$src3, imm:$src4))]>;
+    def PTCVTROWPS2BF16HrreV : PseudoI<(outs VR512:$dst),
+                                       (ins GR16:$src1, GR16:$src2, TILE:$src3, GR32:$src4),
+                                       [(set VR512: $dst,
+                                         (int_x86_tcvtrowps2bf16h_internal GR16:$src1, GR16:$src2,
+                                          TILE:$src3, GR32:$src4))]>;
+    def PTCVTROWPS2BF16LrriV : PseudoI<(outs VR512:$dst),
+                                       (ins GR16:$src1, GR16:$src2, TILE:$src3, i32u8imm:$src4),
+                                       [(set VR512: $dst,
+                                         (int_x86_tcvtrowps2bf16l_internal GR16:$src1, GR16:$src2,
+                                          TILE:$src3, imm:$src4))]>;
+    def PTCVTROWPS2BF16LrreV : PseudoI<(outs VR512:$dst),
+                                       (ins GR16:$src1, GR16:$src2, TILE:$src3, GR32:$src4),
+                                       [(set VR512: $dst,
+                                         (int_x86_tcvtrowps2bf16l_internal GR16:$src1, GR16:$src2,
+                                          TILE:$src3, GR32:$src4))]>;
     def PTCVTROWPS2PHHrriV : PseudoI<(outs VR512:$dst),
                                      (ins GR16:$src1, GR16:$src2, TILE:$src3, i32u8imm:$src4),
                                      [(set VR512: $dst,
@@ -659,8 +659,8 @@ multiclass AMXAVX512_BASE<bits<8> Opcode1, bits<8> Opcode2, string Opstr,
 
 defm TCVTROWPS2PHH : AMXAVX512_BASE<0x6d, 0x07, "tcvtrowps2phh", PS, PS>;
 defm TCVTROWPS2PHL : AMXAVX512_BASE<0x6d, 0x77, "tcvtrowps2phl", PD, XD>;
-defm TCVTROWPS2PBF16H : AMXAVX512_BASE<0x6d, 0x07, "tcvtrowps2pbf16h", XD, XD>;
-defm TCVTROWPS2PBF16L : AMXAVX512_BASE<0x6d, 0x77, "tcvtrowps2pbf16l", XS, XS>;
+defm TCVTROWPS2BF16H : AMXAVX512_BASE<0x6d, 0x07, "tcvtrowps2bf16h", XD, XD>;
+defm TCVTROWPS2BF16L : AMXAVX512_BASE<0x6d, 0x77, "tcvtrowps2bf16l", XS, XS>;
 
 multiclass m_tilemovrow {
   let Predicates = [HasAMXAVX512, HasAVX10_2_512, In64BitMode] in {

--- a/llvm/lib/Target/X86/X86LowerAMXType.cpp
+++ b/llvm/lib/Target/X86/X86LowerAMXType.cpp
@@ -273,8 +273,8 @@ std::pair<Value *, Value *> ShapeCalculator::getShape(IntrinsicInst *II,
     break;
   }
   case Intrinsic::x86_tcvtrowd2ps_internal:
-  case Intrinsic::x86_tcvtrowps2pbf16h_internal:
-  case Intrinsic::x86_tcvtrowps2pbf16l_internal:
+  case Intrinsic::x86_tcvtrowps2bf16h_internal:
+  case Intrinsic::x86_tcvtrowps2bf16l_internal:
   case Intrinsic::x86_tcvtrowps2phh_internal:
   case Intrinsic::x86_tcvtrowps2phl_internal:
   case Intrinsic::x86_tilemovrow_internal: {

--- a/llvm/lib/Target/X86/X86PreTileConfig.cpp
+++ b/llvm/lib/Target/X86/X86PreTileConfig.cpp
@@ -122,10 +122,10 @@ class X86PreTileConfig : public MachineFunctionPass {
     case X86::PTILESTOREDV:
     case X86::PTCVTROWD2PSrreV:
     case X86::PTCVTROWD2PSrriV:
-    case X86::PTCVTROWPS2PBF16HrreV:
-    case X86::PTCVTROWPS2PBF16HrriV:
-    case X86::PTCVTROWPS2PBF16LrreV:
-    case X86::PTCVTROWPS2PBF16LrriV:
+    case X86::PTCVTROWPS2BF16HrreV:
+    case X86::PTCVTROWPS2BF16HrriV:
+    case X86::PTCVTROWPS2BF16LrreV:
+    case X86::PTCVTROWPS2BF16LrriV:
     case X86::PTCVTROWPS2PHHrreV:
     case X86::PTCVTROWPS2PHHrriV:
     case X86::PTCVTROWPS2PHLrreV:

--- a/llvm/test/CodeGen/X86/amx-avx512-intrinsics.ll
+++ b/llvm/test/CodeGen/X86/amx-avx512-intrinsics.ll
@@ -20,43 +20,43 @@ define <16 x float> @test_tcvtrowd2psi() {
 }
 declare <16 x float> @llvm.x86.tcvtrowd2ps(i8 %A, i32 %B)
 
-define <32 x bfloat> @test_tcvtrowps2pbf16h(i32 %A) {
-; CHECK-LABEL: test_tcvtrowps2pbf16h:
+define <32 x bfloat> @test_tcvtrowps2bf16h(i32 %A) {
+; CHECK-LABEL: test_tcvtrowps2bf16h:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    tcvtrowps2pbf16h %edi, %tmm1, %zmm0 # encoding: [0x62,0xf2,0x47,0x48,0x6d,0xc1]
+; CHECK-NEXT:    tcvtrowps2bf16h %edi, %tmm1, %zmm0 # encoding: [0x62,0xf2,0x47,0x48,0x6d,0xc1]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
-  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h(i8 1, i32 %A)
+  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2bf16h(i8 1, i32 %A)
   ret <32 x bfloat> %ret
 }
 
-define <32 x bfloat> @test_tcvtrowps2pbf16hi() {
-; CHECK-LABEL: test_tcvtrowps2pbf16hi:
+define <32 x bfloat> @test_tcvtrowps2bf16hi() {
+; CHECK-LABEL: test_tcvtrowps2bf16hi:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    tcvtrowps2pbf16h $127, %tmm1, %zmm0 # encoding: [0x62,0xf3,0x7f,0x48,0x07,0xc1,0x7f]
+; CHECK-NEXT:    tcvtrowps2bf16h $127, %tmm1, %zmm0 # encoding: [0x62,0xf3,0x7f,0x48,0x07,0xc1,0x7f]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
-  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h(i8 1, i32 127)
+  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2bf16h(i8 1, i32 127)
   ret <32 x bfloat> %ret
 }
-declare <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h(i8 %A, i32 %B)
+declare <32 x bfloat> @llvm.x86.tcvtrowps2bf16h(i8 %A, i32 %B)
 
-define <32 x bfloat> @test_tcvtrowps2pbf16l(i32 %A) {
-; CHECK-LABEL: test_tcvtrowps2pbf16l:
+define <32 x bfloat> @test_tcvtrowps2bf16l(i32 %A) {
+; CHECK-LABEL: test_tcvtrowps2bf16l:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    tcvtrowps2pbf16l %edi, %tmm1, %zmm0 # encoding: [0x62,0xf2,0x46,0x48,0x6d,0xc1]
+; CHECK-NEXT:    tcvtrowps2bf16l %edi, %tmm1, %zmm0 # encoding: [0x62,0xf2,0x46,0x48,0x6d,0xc1]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
-  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l(i8 1, i32 %A)
+  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2bf16l(i8 1, i32 %A)
   ret <32 x bfloat> %ret
 }
 
-define <32 x bfloat> @test_tcvtrowps2pbf16li() {
-; CHECK-LABEL: test_tcvtrowps2pbf16li:
+define <32 x bfloat> @test_tcvtrowps2bf16li() {
+; CHECK-LABEL: test_tcvtrowps2bf16li:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    tcvtrowps2pbf16l $127, %tmm1, %zmm0 # encoding: [0x62,0xf3,0x7e,0x48,0x77,0xc1,0x7f]
+; CHECK-NEXT:    tcvtrowps2bf16l $127, %tmm1, %zmm0 # encoding: [0x62,0xf3,0x7e,0x48,0x77,0xc1,0x7f]
 ; CHECK-NEXT:    retq # encoding: [0xc3]
-  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l(i8 1, i32 127)
+  %ret = call <32 x bfloat> @llvm.x86.tcvtrowps2bf16l(i8 1, i32 127)
   ret <32 x bfloat> %ret
 }
-declare <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l(i8 %A, i32 %B)
+declare <32 x bfloat> @llvm.x86.tcvtrowps2bf16l(i8 %A, i32 %B)
 
 define <32 x half> @test_tcvtrowps2phh(i32 %A) {
 ; CHECK-LABEL: test_tcvtrowps2phh:

--- a/llvm/test/CodeGen/X86/amx-tile-avx512-internals.ll
+++ b/llvm/test/CodeGen/X86/amx-tile-avx512-internals.ll
@@ -15,10 +15,10 @@ define void @test_amx(i8* %pointer, i8* %base, i32 %index, i64 %stride) {
 ; CHECK-NEXT:    tileloadd (%rsi,%rcx), %tmm0
 ; CHECK-NEXT:    tcvtrowd2ps %edx, %tmm0, %zmm0
 ; CHECK-NEXT:    tcvtrowd2ps $16, %tmm0, %zmm0
-; CHECK-NEXT:    tcvtrowps2pbf16h %edx, %tmm0, %zmm0
-; CHECK-NEXT:    tcvtrowps2pbf16h $16, %tmm0, %zmm0
-; CHECK-NEXT:    tcvtrowps2pbf16l %edx, %tmm0, %zmm0
-; CHECK-NEXT:    tcvtrowps2pbf16l $16, %tmm0, %zmm0
+; CHECK-NEXT:    tcvtrowps2bf16h %edx, %tmm0, %zmm0
+; CHECK-NEXT:    tcvtrowps2bf16h $16, %tmm0, %zmm0
+; CHECK-NEXT:    tcvtrowps2bf16l %edx, %tmm0, %zmm0
+; CHECK-NEXT:    tcvtrowps2bf16l $16, %tmm0, %zmm0
 ; CHECK-NEXT:    tcvtrowps2phh %edx, %tmm0, %zmm0
 ; CHECK-NEXT:    tcvtrowps2phh $16, %tmm0, %zmm0
 ; CHECK-NEXT:    tcvtrowps2phl %edx, %tmm0, %zmm0
@@ -33,10 +33,10 @@ define void @test_amx(i8* %pointer, i8* %base, i32 %index, i64 %stride) {
   %a = call x86_amx @llvm.x86.tileloadd64.internal(i16 8, i16 8, i8* %base, i64 %stride)
   call <16 x float> @llvm.x86.tcvtrowd2ps.internal(i16 8, i16 8, x86_amx %a, i32 %index)
   call <16 x float> @llvm.x86.tcvtrowd2ps.internal(i16 8, i16 8, x86_amx %a, i32 16)
-  call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h.internal(i16 8, i16 8, x86_amx %a, i32 %index)
-  call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h.internal(i16 8, i16 8, x86_amx %a, i32 16)
-  call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l.internal(i16 8, i16 8, x86_amx %a, i32 %index)
-  call <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l.internal(i16 8, i16 8, x86_amx %a, i32 16)
+  call <32 x bfloat> @llvm.x86.tcvtrowps2bf16h.internal(i16 8, i16 8, x86_amx %a, i32 %index)
+  call <32 x bfloat> @llvm.x86.tcvtrowps2bf16h.internal(i16 8, i16 8, x86_amx %a, i32 16)
+  call <32 x bfloat> @llvm.x86.tcvtrowps2bf16l.internal(i16 8, i16 8, x86_amx %a, i32 %index)
+  call <32 x bfloat> @llvm.x86.tcvtrowps2bf16l.internal(i16 8, i16 8, x86_amx %a, i32 16)
   call <32 x half> @llvm.x86.tcvtrowps2phh.internal(i16 8, i16 8, x86_amx %a, i32 %index)
   call <32 x half> @llvm.x86.tcvtrowps2phh.internal(i16 8, i16 8, x86_amx %a, i32 16)
   call <32 x half> @llvm.x86.tcvtrowps2phl.internal(i16 8, i16 8, x86_amx %a, i32 %index)
@@ -54,8 +54,8 @@ declare x86_amx @llvm.x86.tileloaddt164.internal(i16, i16, i8*, i64)
 declare void @llvm.x86.tilestored64.internal(i16, i16, i8*, i64, x86_amx)
 
 declare <16 x float> @llvm.x86.tcvtrowd2ps.internal(i16, i16, x86_amx, i32)
-declare <32 x bfloat> @llvm.x86.tcvtrowps2pbf16h.internal(i16, i16, x86_amx, i32)
-declare <32 x bfloat> @llvm.x86.tcvtrowps2pbf16l.internal(i16, i16, x86_amx, i32)
+declare <32 x bfloat> @llvm.x86.tcvtrowps2bf16h.internal(i16, i16, x86_amx, i32)
+declare <32 x bfloat> @llvm.x86.tcvtrowps2bf16l.internal(i16, i16, x86_amx, i32)
 declare <32 x half> @llvm.x86.tcvtrowps2phh.internal(i16, i16, x86_amx, i32)
 declare <32 x half> @llvm.x86.tcvtrowps2phl.internal(i16, i16, x86_amx, i32)
 declare <16 x i32> @llvm.x86.tilemovrow.internal(i16, i16, x86_amx, i32)

--- a/llvm/test/MC/Disassembler/X86/amx-avx512.txt
+++ b/llvm/test/MC/Disassembler/X86/amx-avx512.txt
@@ -17,36 +17,36 @@
 # INTEL:      tcvtrowd2ps zmm22, tmm2, 123
 0x62,0xe3,0x7e,0x48,0x07,0xf2,0x7b
 
-# ATT:        tcvtrowps2pbf16h %ecx, %tmm5, %zmm22
-# INTEL:      tcvtrowps2pbf16h zmm22, tmm5, ecx
+# ATT:        tcvtrowps2bf16h %ecx, %tmm5, %zmm22
+# INTEL:      tcvtrowps2bf16h zmm22, tmm5, ecx
 0x62,0xe2,0x77,0x48,0x6d,0xf5
 
-# ATT:        tcvtrowps2pbf16h %ecx, %tmm2, %zmm22
-# INTEL:      tcvtrowps2pbf16h zmm22, tmm2, ecx
+# ATT:        tcvtrowps2bf16h %ecx, %tmm2, %zmm22
+# INTEL:      tcvtrowps2bf16h zmm22, tmm2, ecx
 0x62,0xe2,0x77,0x48,0x6d,0xf2
 
-# ATT:        tcvtrowps2pbf16h $123, %tmm5, %zmm22
-# INTEL:      tcvtrowps2pbf16h zmm22, tmm5, 123
+# ATT:        tcvtrowps2bf16h $123, %tmm5, %zmm22
+# INTEL:      tcvtrowps2bf16h zmm22, tmm5, 123
 0x62,0xe3,0x7f,0x48,0x07,0xf5,0x7b
 
-# ATT:        tcvtrowps2pbf16h $123, %tmm2, %zmm22
-# INTEL:      tcvtrowps2pbf16h zmm22, tmm2, 123
+# ATT:        tcvtrowps2bf16h $123, %tmm2, %zmm22
+# INTEL:      tcvtrowps2bf16h zmm22, tmm2, 123
 0x62,0xe3,0x7f,0x48,0x07,0xf2,0x7b
 
-# ATT:        tcvtrowps2pbf16l %ecx, %tmm5, %zmm22
-# INTEL:      tcvtrowps2pbf16l zmm22, tmm5, ecx
+# ATT:        tcvtrowps2bf16l %ecx, %tmm5, %zmm22
+# INTEL:      tcvtrowps2bf16l zmm22, tmm5, ecx
 0x62,0xe2,0x76,0x48,0x6d,0xf5
 
-# ATT:        tcvtrowps2pbf16l %ecx, %tmm2, %zmm22
-# INTEL:      tcvtrowps2pbf16l zmm22, tmm2, ecx
+# ATT:        tcvtrowps2bf16l %ecx, %tmm2, %zmm22
+# INTEL:      tcvtrowps2bf16l zmm22, tmm2, ecx
 0x62,0xe2,0x76,0x48,0x6d,0xf2
 
-# ATT:        tcvtrowps2pbf16l $123, %tmm5, %zmm22
-# INTEL:      tcvtrowps2pbf16l zmm22, tmm5, 123
+# ATT:        tcvtrowps2bf16l $123, %tmm5, %zmm22
+# INTEL:      tcvtrowps2bf16l zmm22, tmm5, 123
 0x62,0xe3,0x7e,0x48,0x77,0xf5,0x7b
 
-# ATT:        tcvtrowps2pbf16l $123, %tmm2, %zmm22
-# INTEL:      tcvtrowps2pbf16l zmm22, tmm2, 123
+# ATT:        tcvtrowps2bf16l $123, %tmm2, %zmm22
+# INTEL:      tcvtrowps2bf16l zmm22, tmm2, 123
 0x62,0xe3,0x7e,0x48,0x77,0xf2,0x7b
 
 # ATT:        tcvtrowps2phh %ecx, %tmm5, %zmm22

--- a/llvm/test/MC/X86/amx-avx512-att.s
+++ b/llvm/test/MC/X86/amx-avx512-att.s
@@ -16,37 +16,37 @@
 // CHECK: encoding: [0x62,0xe3,0x7e,0x48,0x07,0xf2,0x7b]
           tcvtrowd2ps $123, %tmm2, %zmm22
 
-// CHECK: tcvtrowps2pbf16h %ecx, %tmm5, %zmm22
+// CHECK: tcvtrowps2bf16h %ecx, %tmm5, %zmm22
 // CHECK: encoding: [0x62,0xe2,0x77,0x48,0x6d,0xf5]
-          tcvtrowps2pbf16h %ecx, %tmm5, %zmm22
+          tcvtrowps2bf16h %ecx, %tmm5, %zmm22
 
-// CHECK: tcvtrowps2pbf16h %ecx, %tmm2, %zmm22
+// CHECK: tcvtrowps2bf16h %ecx, %tmm2, %zmm22
 // CHECK: encoding: [0x62,0xe2,0x77,0x48,0x6d,0xf2]
-          tcvtrowps2pbf16h %ecx, %tmm2, %zmm22
+          tcvtrowps2bf16h %ecx, %tmm2, %zmm22
 
-// CHECK: tcvtrowps2pbf16h $123, %tmm5, %zmm22
+// CHECK: tcvtrowps2bf16h $123, %tmm5, %zmm22
 // CHECK: encoding: [0x62,0xe3,0x7f,0x48,0x07,0xf5,0x7b]
-          tcvtrowps2pbf16h $123, %tmm5, %zmm22
+          tcvtrowps2bf16h $123, %tmm5, %zmm22
 
-// CHECK: tcvtrowps2pbf16h $123, %tmm2, %zmm22
+// CHECK: tcvtrowps2bf16h $123, %tmm2, %zmm22
 // CHECK: encoding: [0x62,0xe3,0x7f,0x48,0x07,0xf2,0x7b]
-          tcvtrowps2pbf16h $123, %tmm2, %zmm22
+          tcvtrowps2bf16h $123, %tmm2, %zmm22
 
-// CHECK: tcvtrowps2pbf16l %ecx, %tmm5, %zmm22
+// CHECK: tcvtrowps2bf16l %ecx, %tmm5, %zmm22
 // CHECK: encoding: [0x62,0xe2,0x76,0x48,0x6d,0xf5]
-          tcvtrowps2pbf16l %ecx, %tmm5, %zmm22
+          tcvtrowps2bf16l %ecx, %tmm5, %zmm22
 
-// CHECK: tcvtrowps2pbf16l %ecx, %tmm2, %zmm22
+// CHECK: tcvtrowps2bf16l %ecx, %tmm2, %zmm22
 // CHECK: encoding: [0x62,0xe2,0x76,0x48,0x6d,0xf2]
-          tcvtrowps2pbf16l %ecx, %tmm2, %zmm22
+          tcvtrowps2bf16l %ecx, %tmm2, %zmm22
 
-// CHECK: tcvtrowps2pbf16l $123, %tmm5, %zmm22
+// CHECK: tcvtrowps2bf16l $123, %tmm5, %zmm22
 // CHECK: encoding: [0x62,0xe3,0x7e,0x48,0x77,0xf5,0x7b]
-          tcvtrowps2pbf16l $123, %tmm5, %zmm22
+          tcvtrowps2bf16l $123, %tmm5, %zmm22
 
-// CHECK: tcvtrowps2pbf16l $123, %tmm2, %zmm22
+// CHECK: tcvtrowps2bf16l $123, %tmm2, %zmm22
 // CHECK: encoding: [0x62,0xe3,0x7e,0x48,0x77,0xf2,0x7b]
-          tcvtrowps2pbf16l $123, %tmm2, %zmm22
+          tcvtrowps2bf16l $123, %tmm2, %zmm22
 
 // CHECK: tcvtrowps2phh %ecx, %tmm5, %zmm22
 // CHECK: encoding: [0x62,0xe2,0x74,0x48,0x6d,0xf5]

--- a/llvm/test/MC/X86/amx-avx512-intel.s
+++ b/llvm/test/MC/X86/amx-avx512-intel.s
@@ -16,37 +16,37 @@
 // CHECK: encoding: [0x62,0xe3,0x7e,0x48,0x07,0xf2,0x7b]
           tcvtrowd2ps zmm22, tmm2, 123
 
-// CHECK: tcvtrowps2pbf16h zmm22, tmm5, ecx
+// CHECK: tcvtrowps2bf16h zmm22, tmm5, ecx
 // CHECK: encoding: [0x62,0xe2,0x77,0x48,0x6d,0xf5]
-          tcvtrowps2pbf16h zmm22, tmm5, ecx
+          tcvtrowps2bf16h zmm22, tmm5, ecx
 
-// CHECK: tcvtrowps2pbf16h zmm22, tmm2, ecx
+// CHECK: tcvtrowps2bf16h zmm22, tmm2, ecx
 // CHECK: encoding: [0x62,0xe2,0x77,0x48,0x6d,0xf2]
-          tcvtrowps2pbf16h zmm22, tmm2, ecx
+          tcvtrowps2bf16h zmm22, tmm2, ecx
 
-// CHECK: tcvtrowps2pbf16h zmm22, tmm5, 123
+// CHECK: tcvtrowps2bf16h zmm22, tmm5, 123
 // CHECK: encoding: [0x62,0xe3,0x7f,0x48,0x07,0xf5,0x7b]
-          tcvtrowps2pbf16h zmm22, tmm5, 123
+          tcvtrowps2bf16h zmm22, tmm5, 123
 
-// CHECK: tcvtrowps2pbf16h zmm22, tmm2, 123
+// CHECK: tcvtrowps2bf16h zmm22, tmm2, 123
 // CHECK: encoding: [0x62,0xe3,0x7f,0x48,0x07,0xf2,0x7b]
-          tcvtrowps2pbf16h zmm22, tmm2, 123
+          tcvtrowps2bf16h zmm22, tmm2, 123
 
-// CHECK: tcvtrowps2pbf16l zmm22, tmm5, ecx
+// CHECK: tcvtrowps2bf16l zmm22, tmm5, ecx
 // CHECK: encoding: [0x62,0xe2,0x76,0x48,0x6d,0xf5]
-          tcvtrowps2pbf16l zmm22, tmm5, ecx
+          tcvtrowps2bf16l zmm22, tmm5, ecx
 
-// CHECK: tcvtrowps2pbf16l zmm22, tmm2, ecx
+// CHECK: tcvtrowps2bf16l zmm22, tmm2, ecx
 // CHECK: encoding: [0x62,0xe2,0x76,0x48,0x6d,0xf2]
-          tcvtrowps2pbf16l zmm22, tmm2, ecx
+          tcvtrowps2bf16l zmm22, tmm2, ecx
 
-// CHECK: tcvtrowps2pbf16l zmm22, tmm5, 123
+// CHECK: tcvtrowps2bf16l zmm22, tmm5, 123
 // CHECK: encoding: [0x62,0xe3,0x7e,0x48,0x77,0xf5,0x7b]
-          tcvtrowps2pbf16l zmm22, tmm5, 123
+          tcvtrowps2bf16l zmm22, tmm5, 123
 
-// CHECK: tcvtrowps2pbf16l zmm22, tmm2, 123
+// CHECK: tcvtrowps2bf16l zmm22, tmm2, 123
 // CHECK: encoding: [0x62,0xe3,0x7e,0x48,0x77,0xf2,0x7b]
-          tcvtrowps2pbf16l zmm22, tmm2, 123
+          tcvtrowps2bf16l zmm22, tmm2, 123
 
 // CHECK: tcvtrowps2phh zmm22, tmm5, ecx
 // CHECK: encoding: [0x62,0xe2,0x74,0x48,0x6d,0xf5]


### PR DESCRIPTION
Ref.: https://cdrdv2.intel.com/v1/dl/getContent/828965