### PR TITLE
[libc] Fix sigset_t type definition

### DIFF
--- a/libc/include/llvm-libc-types/sigset_t.h
+++ b/libc/include/llvm-libc-types/sigset_t.h
@@ -13,8 +13,8 @@
 
 // This definition can be adjusted/specialized for different targets and
 // platforms as necessary. This definition works for Linux on most targets.
-struct sigset_t {
+typedef struct {
   unsigned long __signals[__NSIGSET_WORDS];
-};
+} sigset_t;
 
 #endif // LLVM_LIBC_TYPES_SIGSET_T_H

--- a/libc/include/llvm-libc-types/struct_sigaction.h
+++ b/libc/include/llvm-libc-types/struct_sigaction.h
@@ -17,7 +17,7 @@ struct sigaction {
     void (*sa_handler)(int);
     void (*sa_sigaction)(int, siginfo_t *, void *);
   };
-  struct sigset_t sa_mask;
+  sigset_t sa_mask;
   int sa_flags;
 #ifdef __linux__
   // This field is present on linux for most targets.


### PR DESCRIPTION
The libc headers are C, not C++.
