### PR TITLE
EmitC: Allow arrays of size zero

### DIFF
--- a/mlir/docs/Dialects/emitc.md
+++ b/mlir/docs/Dialects/emitc.md
@@ -16,6 +16,8 @@ The following convention is followed:
     floating types.
 *   If `__bf16` is used, the code requires a compiler that supports it, such as 
     GCC or Clang.
+*   If `emitc.array` with a dimension of size zero is used, then the code
+    requires [a GCC extension](https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html).
 *   Else the generated code is compatible with C99.
 
 These restrictions are neither inherent to the EmitC dialect itself nor to the

--- a/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
+++ b/mlir/lib/Dialect/EmitC/IR/EmitC.cpp
@@ -971,8 +971,8 @@ LogicalResult emitc::ArrayType::verify(
     return emitError() << "shape must not be empty";
 
   for (int64_t dim : shape) {
-    if (dim <= 0)
-      return emitError() << "dimensions must have positive size";
+    if (dim < 0)
+      return emitError() << "dimensions must have non-negative size";
   }
 
   if (!elementType)

--- a/mlir/test/Dialect/EmitC/invalid_types.mlir
+++ b/mlir/test/Dialect/EmitC/invalid_types.mlir
@@ -36,14 +36,6 @@ func.func @illegal_array_missing_x(
 
 // -----
 
-func.func @illegal_array_non_positive_dimenson(
-    // expected-error @+1 {{dimensions must have positive size}}
-    %arg0: !emitc.array<0xi32>
-) {
-}
-
-// -----
-
 func.func @illegal_array_missing_type(
     // expected-error @+1 {{expected non-function type}}
     %arg0: !emitc.array<10x>

--- a/mlir/test/Dialect/EmitC/types.mlir
+++ b/mlir/test/Dialect/EmitC/types.mlir
@@ -17,7 +17,9 @@ func.func @array_types(
   // CHECK-SAME: !emitc.array<30x!emitc.ssize_t>
   %arg5: !emitc.array<30x!emitc.ssize_t>,
   // CHECK-SAME: !emitc.array<30x!emitc.ptrdiff_t>
-  %arg6: !emitc.array<30x!emitc.ptrdiff_t>
+  %arg6: !emitc.array<30x!emitc.ptrdiff_t>,
+  // CHECK-SAME: !emitc.array<0xi64>
+  %arg7: !emitc.array<0xi64>
 ) {
   return
 }


### PR DESCRIPTION
This is allowed as a GCC extension, see https://gcc.gnu.org/onlinedocs/gcc/Zero-Length.html.