### PR TITLE
[FileCheck] Use move semantics instead of std::swap. NFC.

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -1933,7 +1933,7 @@ bool FileCheck::readCheckFile(
     }
 
     // Okay, add the string we captured to the output vector and move on.
-    CheckStrings.emplace_back(P, UsedPrefix, PatternLoc,
+    CheckStrings.emplace_back(std::move(P), UsedPrefix, PatternLoc,
                               std::move(DagNotMatches));
     DagNotMatches = ImplicitNegativeChecks;
   }

--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -1933,8 +1933,8 @@ bool FileCheck::readCheckFile(
     }
 
     // Okay, add the string we captured to the output vector and move on.
-    CheckStrings.emplace_back(P, UsedPrefix, PatternLoc);
-    std::swap(DagNotMatches, CheckStrings.back().DagNotStrings);
+    CheckStrings.emplace_back(P, UsedPrefix, PatternLoc,
+                              std::move(DagNotMatches));
     DagNotMatches = ImplicitNegativeChecks;
   }
 
@@ -1963,8 +1963,8 @@ bool FileCheck::readCheckFile(
   if (!DagNotMatches.empty()) {
     CheckStrings.emplace_back(
         Pattern(Check::CheckEOF, PatternContext.get(), LineNumber + 1),
-        *Req.CheckPrefixes.begin(), SMLoc::getFromPointer(Buffer.data()));
-    std::swap(DagNotMatches, CheckStrings.back().DagNotStrings);
+        *Req.CheckPrefixes.begin(), SMLoc::getFromPointer(Buffer.data()),
+        std::move(DagNotMatches));
   }
 
   return false;

--- a/llvm/lib/FileCheck/FileCheckImpl.h
+++ b/llvm/lib/FileCheck/FileCheckImpl.h
@@ -837,9 +837,9 @@ struct FileCheckString {
   /// Hold the DAG/NOT strings occurring in the input file.
   std::vector<DagNotPrefixInfo> DagNotStrings;
 
-  FileCheckString(const Pattern &P, StringRef S, SMLoc L,
+  FileCheckString(Pattern &&P, StringRef S, SMLoc L,
                   std::vector<DagNotPrefixInfo> &&D)
-      : Pat(P), Prefix(S), Loc(L), DagNotStrings(std::move(D)) {}
+      : Pat(std::move(P)), Prefix(S), Loc(L), DagNotStrings(std::move(D)) {}
 
   /// Matches check string and its "not strings" and/or "dag strings".
   size_t Check(const SourceMgr &SM, StringRef Buffer, bool IsLabelScanMode,

--- a/llvm/lib/FileCheck/FileCheckImpl.h
+++ b/llvm/lib/FileCheck/FileCheckImpl.h
@@ -837,8 +837,9 @@ struct FileCheckString {
   /// Hold the DAG/NOT strings occurring in the input file.
   std::vector<DagNotPrefixInfo> DagNotStrings;
 
-  FileCheckString(const Pattern &P, StringRef S, SMLoc L)
-      : Pat(P), Prefix(S), Loc(L) {}
+  FileCheckString(const Pattern &P, StringRef S, SMLoc L,
+                  std::vector<DagNotPrefixInfo> &&D)
+      : Pat(P), Prefix(S), Loc(L), DagNotStrings(std::move(D)) {}
 
   /// Matches check string and its "not strings" and/or "dag strings".
   size_t Check(const SourceMgr &SM, StringRef Buffer, bool IsLabelScanMode,


### PR DESCRIPTION
This code was using a pre-move-semantics trick of using std::swap to
avoid expensive vector copies.
