### PR TITLE
[llvm-diff] add optional call to IRNormalizer

### DIFF
--- a/llvm/test/tools/llvm-diff/help.test
+++ b/llvm/test/tools/llvm-diff/help.test
@@ -2,4 +2,5 @@
 
 # HELP: USAGE
 # HELP: Color Options
+# HELP: Diff Options
 # HELP: Generic Options

--- a/llvm/test/tools/llvm-diff/ir-normalizer.ll
+++ b/llvm/test/tools/llvm-diff/ir-normalizer.ll
@@ -1,0 +1,29 @@
+; Check that commutative operations are considered equal after normalization when parameters are exchanged.
+;
+; Replace '%a, %b' with '%b, %a' in 'or' (commutative) and 'sub' (non-commutative) operations.
+;
+; RUN: rm -f %t.ll
+; RUN: cat %s | sed -e 's/^\(  .*\) i1 %a, %b$/\1 i1 %b, %a/' > %t.ll
+; RUN: not llvm-diff                        %s %t.ll 2>&1 | FileCheck %s --check-prefix DEFAULT
+; RUN: not llvm-diff --enable-ir-normalizer %s %t.ll 2>&1 | FileCheck %s --check-prefix NORMALIZE
+
+; DEFAULT:      in function choice:
+; DEFAULT-NEXT:   in block %entry:
+; DEFAULT-NEXT:     >   %0 = or i1 %b, %a
+; DEFAULT-NEXT:     >   %1 = sub i1 %b, %a
+; DEFAULT-NEXT:     >   ret i1 %0
+; DEFAULT-NEXT:     <   %0 = or i1 %a, %b
+; DEFAULT-NEXT:     <   %1 = sub i1 %a, %b
+; DEFAULT-NEXT:     <   ret i1 %0
+
+; NORMALIZE:      in function choice:
+; NORMALIZE-NEXT:   in block [[BB:%bb[0-9]+]]:
+; NORMALIZE-NEXT:     >   %0 = sub i1 %a1, %a0
+; NORMALIZE-NEXT:     <   %0 = sub i1 %a0, %a1
+
+define i1 @choice(i1 %a, i1 %b) {
+entry:
+  %0 = or i1 %a, %b
+  %1 = sub i1 %a, %b
+  ret i1 %0
+}

--- a/llvm/tools/llvm-diff/CMakeLists.txt
+++ b/llvm/tools/llvm-diff/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(LLVM_LINK_COMPONENTS
   Core
   IRReader
+  Passes
   Support
+  TransformUtils
   )
 
 add_llvm_tool(llvm-diff


### PR DESCRIPTION
Sometimes some LLVM optimizations change the order of instruction parameters, so that two files can differ by only one line, but llvm-diff displays many of them. Because since llvm-diff considers two variables to be different, all uses of those variables are considered different.

```diff
$ llvm-diff test1.ll test2.ll
in function choice:
  in block %entry:
    >   %0 = or i1 %b, %a
    > … // there can be many lines
    >   ret i1 %0
    <   %0 = or i1 %a, %b
    < … // same lines there
    <   ret i1 %0
```