### PR TITLE
[libc++] Enable _LIBCPP_NODEBUG again

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1166,9 +1166,7 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_NOESCAPE
 #  endif
 
-// FIXME: Expand this to [[__gnu__::__nodebug__]] again once the testcase reported in
-// https://github.com/llvm/llvm-project/pull/118710 has been analyzed
-#  define _LIBCPP_NODEBUG
+#  define _LIBCPP_NODEBUG [[__gnu__::__nodebug__]]
 
 #  if __has_attribute(__standalone_debug__)
 #    define _LIBCPP_STANDALONE_DEBUG __attribute__((__standalone_debug__))

--- a/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
+++ b/libcxx/test/tools/clang_tidy_checks/libcpp_module.cpp
@@ -27,7 +27,7 @@ public:
     check_factories.registerCheck<libcpp::header_exportable_declarations>("libcpp-header-exportable-declarations");
     check_factories.registerCheck<libcpp::hide_from_abi>("libcpp-hide-from-abi");
     check_factories.registerCheck<libcpp::internal_ftm_use>("libcpp-internal-ftms");
-    // check_factories.registerCheck<libcpp::nodebug_on_aliases>("libcpp-nodebug-on-aliases");
+    check_factories.registerCheck<libcpp::nodebug_on_aliases>("libcpp-nodebug-on-aliases");
     check_factories.registerCheck<libcpp::proper_version_checks>("libcpp-cpp-version-check");
     check_factories.registerCheck<libcpp::robust_against_adl_check>("libcpp-robust-against-adl");
     check_factories.registerCheck<libcpp::uglify_attributes>("libcpp-uglify-attributes");


### PR DESCRIPTION
`_LIBCPP_NODEBUG` has been disabled temporarily, since there were a few problems when adding a bunch of annotations throughout the code base. They have been resolved now, so we can enable all the annotations again.

Reverts llvm/llvm-project#122393
