### PR TITLE
Add missing include to X86MCTargetDesc.h

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
@@ -14,6 +14,7 @@
 #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
 
 #include "llvm/ADT/SmallVector.h"
+#include <cstdint>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
In gcc-15, explicit includes of `<cstdint>` are required when fixed-size integers are used. In this file, this include only happened as a side effect of including SmallVector.h

Although llvm compiles fine, the root-project would benefit from explicitly including it here, so we can backport the patch.

Maybe interesting for @hahnjo and @vgvassilev 