### PR TITLE
[NFC][Offload] Structure/Readability of CMake cache

### DIFF
--- a/offload/cmake/caches/AMDGPUBot.cmake
+++ b/offload/cmake/caches/AMDGPUBot.cmake
@@ -1,17 +1,19 @@
-# This file is meant for test builds on one basic AMDGPU buildbot only.
+# This file is used across all AMDGPU-cmake builders
 
 # Install directory set to /tmp as this is a bot config
 set(CMAKE_INSTALL_PREFIX /tmp/llvm.install.test CACHE STRING "")
 
-set(LLVM_ENABLE_PROJECTS "clang;lld" CACHE STRING "")
-set(LLVM_ENABLE_RUNTIMES "compiler-rt;openmp;offload" CACHE STRING "")
-set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON CACHE BOOL "")
-set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "")
-set(LLVM_LIT_ARGS "-v --show-unsupported --timeout 100 --show-xfail -j 32" CACHE STRING "")
-set(LLVM_TARGETS_TO_BUILD "host;AMDGPU" CACHE STRING "")
-
-set(CLANG_DEFAULT_LINKER "lld" CACHE STRING "")
-
+# General settings
 set(CMAKE_BUILD_TYPE Release CACHE STRING "")
 set(CMAKE_C_COMPILER_LAUNCHER ccache CACHE STRING "")
 set(CMAKE_CXX_COMPILER_LAUNCHER ccache CACHE STRING "")
+
+set(LLVM_ENABLE_PROJECTS "clang;lld" CACHE STRING "")
+set(LLVM_ENABLE_RUNTIMES "compiler-rt;openmp;offload" CACHE STRING "")
+
+set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON CACHE BOOL "")
+set(LLVM_ENABLE_ASSERTIONS ON CACHE BOOL "")
+set(LLVM_TARGETS_TO_BUILD "host;AMDGPU" CACHE STRING "")
+set(LLVM_LIT_ARGS "-v --show-unsupported --timeout 100 --show-xfail -j 32" CACHE STRING "")
+
+set(CLANG_DEFAULT_LINKER "lld" CACHE STRING "")


### PR DESCRIPTION
Preparing to add more config options and want to group them all from most-common to project / component specific.