### PR TITLE
[clang][bytecode] Fix rejecting invalid sizeof expressions

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2066,7 +2066,7 @@ bool Compiler<Emitter>::VisitUnaryExprOrTypeTraitExpr(
       Size = CharUnits::One();
     else {
       if (ArgType->isDependentType() || !ArgType->isConstantSizeType())
-        return false;
+        return this->emitInvalid(E);
 
       if (Kind == UETT_SizeOf)
         Size = ASTCtx.getTypeSizeInChars(ArgType);

--- a/clang/test/AST/ByteCode/literals.cpp
+++ b/clang/test/AST/ByteCode/literals.cpp
@@ -261,31 +261,26 @@ namespace SizeOf {
   }
 
 #if __cplusplus >= 201402L
-  constexpr int IgnoredRejected() { // ref-error {{never produces a constant expression}}
+  constexpr int IgnoredRejected() { // both-error {{never produces a constant expression}}
     int n = 0;
     sizeof(int[n++]); // both-warning {{expression result unused}} \
-                      // ref-note 2{{subexpression not valid in a constant expression}}
+                      // both-note 2{{subexpression not valid in a constant expression}}
     return n;
   }
-  /// FIXME: This is rejected because the parameter so sizeof() is not constant.
-  ///   produce a proper diagnostic.
   static_assert(IgnoredRejected() == 0, ""); // both-error {{not an integral constant expression}} \
-                                             // ref-note {{in call to 'IgnoredRejected()'}}
+                                             // both-note {{in call to 'IgnoredRejected()'}}
 #endif
 
 
 #if __cplusplus >= 202002L
   /// FIXME: The following code should be accepted.
-  consteval int foo(int n) { // ref-error {{consteval function never produces a constant expression}}
-    return sizeof(int[n]); // ref-note 3{{not valid in a constant expression}}
+  consteval int foo(int n) { // both-error {{consteval function never produces a constant expression}}
+    return sizeof(int[n]); // both-note 3{{not valid in a constant expression}}
   }
-  constinit int var = foo(5); // ref-error {{not a constant expression}} \
-                              // ref-note 2{{in call to}} \
-                              // ref-error {{does not have a constant initializer}} \
-                              // ref-note {{required by 'constinit' specifier}} \
-                              // expected-error  {{is not a constant expression}} \
-                              // expected-error {{does not have a constant initializer}} \
-                              // expected-note {{required by 'constinit' specifier}} \
+  constinit int var = foo(5); // both-error {{not a constant expression}} \
+                              // both-note 2{{in call to}} \
+                              // both-error {{does not have a constant initializer}} \
+                              // both-note {{required by 'constinit' specifier}}
 
 #endif
 };


### PR DESCRIPTION
Emit the invalid note instead of nothing.