### PR TITLE
[lldb] Add SymbolContext::GetFunctionOrSymbolAddress

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -165,8 +165,8 @@ public:
   ///     eSymbolContextSymbol is set in \a scope
   ///
   /// \param[in] scope
-  ///     A mask of symbol context bits telling this function which
-  ///     address ranges it can use when trying to extract one from
+  ///     A mask bits from the \b SymbolContextItem enum telling this function
+  ///     which address ranges it can use when trying to extract one from
   ///     the valid (non-nullptr) symbol context classes.
   ///
   /// \param[in] range_idx
@@ -191,6 +191,13 @@ public:
   ///     an address range, \b false otherwise.
   bool GetAddressRange(uint32_t scope, uint32_t range_idx,
                        bool use_inline_block_range, AddressRange &range) const;
+
+  /// Get the address of the function or symbol represented by this symbol
+  /// context.
+  ///
+  /// If both fields are present, the address of the function is returned. If
+  /// both are empty, the result is an invalid address.
+  Address GetFunctionOrSymbolAddress() const;
 
   llvm::Error GetAddressRangeFromHereToEndLine(uint32_t end_line,
                                                AddressRange &range);

--- a/lldb/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Hexagon-DYLD/DynamicLoaderHexagonDYLD.cpp
@@ -426,9 +426,7 @@ DynamicLoaderHexagonDYLD::GetStepThroughTrampolinePlan(Thread &thread,
   typedef std::vector<lldb::addr_t> AddressVector;
   AddressVector addrs;
   for (const SymbolContext &context : target_symbols) {
-    AddressRange range;
-    context.GetAddressRange(eSymbolContextEverything, 0, false, range);
-    lldb::addr_t addr = range.GetBaseAddress().GetLoadAddress(&target);
+    addr_t addr = context.GetFunctionOrSymbolAddress().GetLoadAddress(&target);
     if (addr != LLDB_INVALID_ADDRESS)
       addrs.push_back(addr);
   }

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -939,13 +939,10 @@ DynamicLoaderDarwin::GetStepThroughTrampolinePlan(Thread &thread,
         images.FindSymbolsWithNameAndType(trampoline_name, eSymbolTypeCode,
                                           code_symbols);
         for (const SymbolContext &context : code_symbols) {
-          AddressRange addr_range;
-          context.GetAddressRange(eSymbolContextEverything, 0, false,
-                                  addr_range);
-          addresses.push_back(addr_range.GetBaseAddress());
+          Address addr = context.GetFunctionOrSymbolAddress();
+          addresses.push_back(addr);
           if (log) {
-            addr_t load_addr =
-                addr_range.GetBaseAddress().GetLoadAddress(target_sp.get());
+            addr_t load_addr = addr.GetLoadAddress(target_sp.get());
 
             LLDB_LOGF(log, "Found a trampoline target symbol at 0x%" PRIx64 ".",
                       load_addr);
@@ -980,13 +977,10 @@ DynamicLoaderDarwin::GetStepThroughTrampolinePlan(Thread &thread,
                                           indirect_symbols);
 
         for (const SymbolContext &context : indirect_symbols) {
-          AddressRange addr_range;
-          context.GetAddressRange(eSymbolContextEverything, 0, false,
-                                  addr_range);
-          addresses.push_back(addr_range.GetBaseAddress());
+          Address addr = context.GetFunctionOrSymbolAddress();
+          addresses.push_back(addr);
           if (log) {
-            addr_t load_addr =
-                addr_range.GetBaseAddress().GetLoadAddress(target_sp.get());
+            addr_t load_addr = addr.GetLoadAddress(target_sp.get());
 
             LLDB_LOGF(log, "Found an indirect target symbol at 0x%" PRIx64 ".",
                       load_addr);

--- a/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
+++ b/lldb/source/Plugins/DynamicLoader/POSIX-DYLD/DynamicLoaderPOSIXDYLD.cpp
@@ -512,9 +512,7 @@ DynamicLoaderPOSIXDYLD::GetStepThroughTrampolinePlan(Thread &thread,
   typedef std::vector<lldb::addr_t> AddressVector;
   AddressVector addrs;
   for (const SymbolContext &context : target_symbols) {
-    AddressRange range;
-    context.GetAddressRange(eSymbolContextEverything, 0, false, range);
-    lldb::addr_t addr = range.GetBaseAddress().GetLoadAddress(&target);
+    addr_t addr = context.GetFunctionOrSymbolAddress().GetLoadAddress(&target);
     if (addr != LLDB_INVALID_ADDRESS)
       addrs.push_back(addr);
   }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -142,10 +142,7 @@ line_entry_helper(Target &target, const SymbolContext &sc, Symbol *symbol,
 
   CPPLanguageRuntime::LibCppStdFunctionCallableInfo optional_info;
 
-  AddressRange range;
-  sc.GetAddressRange(eSymbolContextEverything, 0, false, range);
-
-  Address address = range.GetBaseAddress();
+  Address address = sc.GetFunctionOrSymbolAddress();
 
   Address addr;
   if (target.ResolveLoadAddress(address.GetCallableLoadAddress(&target),

--- a/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
+++ b/lldb/source/Plugins/Process/Utility/InferiorCallPOSIX.cpp
@@ -52,9 +52,6 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
   if (count > 0) {
     SymbolContext sc;
     if (sc_list.GetContextAtIndex(0, sc)) {
-      const uint32_t range_scope =
-          eSymbolContextFunction | eSymbolContextSymbol;
-      const bool use_inline_block_range = false;
       EvaluateExpressionOptions options;
       options.SetStopOthers(true);
       options.SetUnwindOnError(true);
@@ -77,9 +74,8 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
           prot_arg |= PROT_WRITE;
       }
 
-      AddressRange mmap_range;
-      if (sc.GetAddressRange(range_scope, 0, use_inline_block_range,
-                             mmap_range)) {
+      Address mmap_addr = sc.GetFunctionOrSymbolAddress();
+      if (mmap_addr.IsValid()) {
         auto type_system_or_err =
             process->GetTarget().GetScratchTypeSystemForLanguage(
                 eLanguageTypeC);
@@ -96,9 +92,8 @@ bool lldb_private::InferiorCallMmap(Process *process, addr_t &allocated_addr,
         MmapArgList args =
             process->GetTarget().GetPlatform()->GetMmapArgumentList(
                 arch, addr, length, prot_arg, flags, fd, offset);
-        lldb::ThreadPlanSP call_plan_sp(
-            new ThreadPlanCallFunction(*thread, mmap_range.GetBaseAddress(),
-                                       void_ptr_type, args, options));
+        lldb::ThreadPlanSP call_plan_sp(new ThreadPlanCallFunction(
+            *thread, mmap_addr, void_ptr_type, args, options));
         if (call_plan_sp) {
           DiagnosticManager diagnostics;
 
@@ -149,9 +144,6 @@ bool lldb_private::InferiorCallMunmap(Process *process, addr_t addr,
   if (count > 0) {
     SymbolContext sc;
     if (sc_list.GetContextAtIndex(0, sc)) {
-      const uint32_t range_scope =
-          eSymbolContextFunction | eSymbolContextSymbol;
-      const bool use_inline_block_range = false;
       EvaluateExpressionOptions options;
       options.SetStopOthers(true);
       options.SetUnwindOnError(true);
@@ -161,13 +153,11 @@ bool lldb_private::InferiorCallMunmap(Process *process, addr_t addr,
       options.SetTimeout(process->GetUtilityExpressionTimeout());
       options.SetTrapExceptions(false);
 
-      AddressRange munmap_range;
-      if (sc.GetAddressRange(range_scope, 0, use_inline_block_range,
-                             munmap_range)) {
+      Address munmap_addr = sc.GetFunctionOrSymbolAddress();
+      if (munmap_addr.IsValid()) {
         lldb::addr_t args[] = {addr, length};
-        lldb::ThreadPlanSP call_plan_sp(
-            new ThreadPlanCallFunction(*thread, munmap_range.GetBaseAddress(),
-                                       CompilerType(), args, options));
+        lldb::ThreadPlanSP call_plan_sp(new ThreadPlanCallFunction(
+            *thread, munmap_addr, CompilerType(), args, options));
         if (call_plan_sp) {
           DiagnosticManager diagnostics;
 

--- a/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/SystemRuntimeMacOSX.cpp
@@ -632,10 +632,8 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
     sc_list.GetContextAtIndex(0, sc);
-    AddressRange addr_range;
-    sc.GetAddressRange(eSymbolContextSymbol, 0, false, addr_range);
-    queue_info_version_address =
-        addr_range.GetBaseAddress().GetLoadAddress(&target);
+    Address addr = sc.GetFunctionOrSymbolAddress();
+    queue_info_version_address = addr.GetLoadAddress(&target);
   }
   sc_list.Clear();
 
@@ -646,10 +644,8 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
     sc_list.GetContextAtIndex(0, sc);
-    AddressRange addr_range;
-    sc.GetAddressRange(eSymbolContextSymbol, 0, false, addr_range);
-    queue_info_data_offset_address =
-        addr_range.GetBaseAddress().GetLoadAddress(&target);
+    Address addr = sc.GetFunctionOrSymbolAddress();
+    queue_info_data_offset_address = addr.GetLoadAddress(&target);
   }
   sc_list.Clear();
 
@@ -660,10 +656,8 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
     sc_list.GetContextAtIndex(0, sc);
-    AddressRange addr_range;
-    sc.GetAddressRange(eSymbolContextSymbol, 0, false, addr_range);
-    item_info_version_address =
-        addr_range.GetBaseAddress().GetLoadAddress(&target);
+    Address addr = sc.GetFunctionOrSymbolAddress();
+    item_info_version_address = addr.GetLoadAddress(&target);
   }
   sc_list.Clear();
 
@@ -674,10 +668,8 @@ bool SystemRuntimeMacOSX::BacktraceRecordingHeadersInitialized() {
   if (!sc_list.IsEmpty()) {
     SymbolContext sc;
     sc_list.GetContextAtIndex(0, sc);
-    AddressRange addr_range;
-    sc.GetAddressRange(eSymbolContextSymbol, 0, false, addr_range);
-    item_info_data_offset_address =
-        addr_range.GetBaseAddress().GetLoadAddress(&target);
+    Address addr = sc.GetFunctionOrSymbolAddress();
+    item_info_data_offset_address = addr.GetLoadAddress(&target);
   }
 
   if (queue_info_version_address != LLDB_INVALID_ADDRESS &&

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -370,6 +370,16 @@ bool SymbolContext::GetAddressRange(uint32_t scope, uint32_t range_idx,
   return false;
 }
 
+Address SymbolContext::GetFunctionOrSymbolAddress() const {
+  if (function)
+    return function->GetAddress();
+
+  if (symbol)
+    return symbol->GetAddress();
+
+  return Address();
+}
+
 LanguageType SymbolContext::GetLanguage() const {
   LanguageType lang;
   if (function && (lang = function->GetLanguage()) != eLanguageTypeUnknown) {


### PR DESCRIPTION
Many uses of SC::GetAddressRange were not interested in the range, but in the address of the function/symbol contained inside the symbol context. They were getting that by calling the GetBaseAddress on the returned range, which worked well enough so far, but isn't compatible with discontinuous functions, whose address (entry point) may not be the lowest address in the range.

To resolve this problem, this PR creates a new function whose purpose is return the address of the function or symbol inside the symbol context.  It also changes all of the callers of GetAddressRange which do not actually care about the range to call this function instead.
