### PR TITLE
[PS4/PS5][Driver] Observe <sysroot>/target/lib for libraries

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -490,7 +490,7 @@ toolchains::PS4PS5Base::PS4PS5Base(const Driver &D, const llvm::Triple &Triple,
 
   bool Linking = !Args.hasArg(options::OPT_E, options::OPT_c, options::OPT_S,
                               options::OPT_emit_ast);
-  if (!CustomSysroot && Linking) {
+  if (Linking) {
     SmallString<128> Dir(SDKLibraryRootDir);
     llvm::sys::path::append(Dir, "target/lib");
     if (CheckSDKPartExists(Dir, "system libraries"))

--- a/clang/test/Driver/ps4-sdk-root.c
+++ b/clang/test/Driver/ps4-sdk-root.c
@@ -1,10 +1,10 @@
 /// PS4 clang emits warnings when SDK headers (<SDKROOT>/target/include/) or
-/// libraries (<SDKROOT>/target/lib/) are missing, unless the user takes control
-/// of search paths, when corresponding existence checks are skipped.
+/// libraries (<SDKROOT>/target/lib/) are missing. If the the user takes control
+/// of header search paths, the existence check for <SDKROOT>/target/include is
+/// skipped.
 ///
 /// User control of header search is assumed if `--sysroot`, `-isysroot`,
-/// `-nostdinc` or `-nostdlibinc` is supplied. User control of library search
-/// is assumed if `--sysroot` is supplied.
+/// `-nostdinc` or `-nostdlibinc` is supplied.
 ///
 /// Warnings are emitted if a specified `-isysroot` or `--sysroot` does not
 /// exist.
@@ -46,22 +46,23 @@
 // RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s -c -isysroot . 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 // RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s -c --sysroot=. 2>&1 | FileCheck -check-prefixes=NO-WARN %s
 
-/// --sysroot disables the existence check for libraries and headers.
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=. 2>&1 | FileCheck -check-prefix=NO-WARN %s
+/// --sysroot disables the existence check for headers. The check for libraries
+/// remains.
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=. 2>&1 | FileCheck -check-prefixes=WARN-SYS-LIBS,NO-WARN %s
 
 /// -isysroot overrides --sysroot for header search, but not library search.
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s -isysroot . --sysroot=.. 2>&1 | FileCheck -check-prefixes=ISYSTEM,NO-WARN %s
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=.. -isysroot . 2>&1 | FileCheck -check-prefixes=ISYSTEM,NO-WARN %s
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s -isysroot . --sysroot=%t.inconly 2>&1 | FileCheck -check-prefixes=ISYSTEM,WARN-SYS-LIBS,NO-WARN %s
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=%t.inconly -isysroot . 2>&1 | FileCheck -check-prefixes=ISYSTEM,WARN-SYS-LIBS,NO-WARN %s
 
 /// Warnings are emitted if non-existent --sysroot/-isysroot are supplied.
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=foo -isysroot . 2>&1 | FileCheck -check-prefixes=WARN-SYSROOT,NO-WARN %s
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s -isysroot foo --sysroot=. 2>&1 | FileCheck -check-prefixes=WARN-SYSROOT,NO-WARN %s
-// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=foo -isysroot bar 2>&1 | FileCheck -check-prefixes=WARN-SYSROOT,WARN-SYSROOT2,NO-WARN %s
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=foo -isysroot %t.both 2>&1 | FileCheck -check-prefixes=WARN-SYSROOT,WARN-SYS-LIBS,NO-WARN %s
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s -isysroot foo --sysroot=%t.both 2>&1 | FileCheck -check-prefixes=WARN-SYSROOT,NO-WARN %s
+// RUN: env SCE_ORBIS_SDK_DIR=.. %clang @%t.rsp %s --sysroot=foo -isysroot bar 2>&1 | FileCheck -check-prefixes=WARN-SYSROOT,WARN-SYSROOT2,WARN-SYS-LIBS,NO-WARN %s
 
 // NO-WARN-NOT: {{warning:|error:}}
-// WARN-SYS-LIBS: warning: unable to find PS4 system libraries directory
-// WARN-SYS-HEADERS: warning: unable to find PS4 system headers directory
 // WARN-SYSROOT: warning: no such sysroot directory: 'foo'
 // WARN-SYSROOT2: warning: no such sysroot directory: 'bar'
+// WARN-SYS-LIBS: warning: unable to find PS4 system libraries directory
+// WARN-SYS-HEADERS: warning: unable to find PS4 system headers directory
 // NO-WARN-NOT: {{warning:|error:}}
 // ISYSTEM: "-cc1"{{.*}}"-internal-externc-isystem" "./target/include"

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -180,7 +180,7 @@
 
 // RUN: rm -rf %t.dir && mkdir %t.dir
 // RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
-// RUN: env SCE_PROSPERO_SDK_DIR=.      %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
+// RUN: %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
 
 // CHECK-NO-TARGETLIB: {{ld(\.exe)?}}"
 // CHECK-NO-TARGETLIB-SAME: "-Luser"
@@ -190,7 +190,7 @@
 // RUN: mkdir -p %t.dir/myroot/target/lib
 // RUN: touch %t.dir/myroot/target/lib/crti.o
 // RUN: env SCE_PROSPERO_SDK_DIR=%t.dir/myroot %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
-// RUN: env SCE_PROSPERO_SDK_DIR=.             %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir/myroot 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
+// RUN: %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir/myroot 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
 
 // CHECK-TARGETLIB: {{ld(\.exe)?}}"
 // CHECK-TARGETLIB-SAME: "-Luser"

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -174,25 +174,26 @@
 
 // Test implicit library search paths are supplied to the linker, after any
 // search paths specified by the user. <sdk-root>/target/lib is implicitly
-// added if it exists and no --sysroot is specified. CRT objects are found
-// there. "." is always implicitly added to library search paths. This is
-// long-standing behavior, unique to PlayStation toolchains.
+// added if it exists. CRT objects are found there. "." is always implicitly
+// added to library search paths. This is long-standing behavior, unique to
+// PlayStation toolchains.
 
 // RUN: rm -rf %t.dir && mkdir %t.dir
 // RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
-// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
+// RUN: env SCE_PROSPERO_SDK_DIR=.      %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
 
 // CHECK-NO-TARGETLIB: {{ld(\.exe)?}}"
 // CHECK-NO-TARGETLIB-SAME: "-Luser"
 // CHECK-NO-TARGETLIB-NOT: "-L{{.*[/\\]}}target/lib"
 // CHECK-NO-TARGETLIB-SAME: "-L."
 
-// RUN: mkdir -p %t.dir/target/lib
-// RUN: touch %t.dir/target/lib/crti.o
-// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
+// RUN: mkdir -p %t.dir/myroot/target/lib
+// RUN: touch %t.dir/myroot/target/lib/crti.o
+// RUN: env SCE_PROSPERO_SDK_DIR=%t.dir/myroot %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
+// RUN: env SCE_PROSPERO_SDK_DIR=.             %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir/myroot 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
 
 // CHECK-TARGETLIB: {{ld(\.exe)?}}"
 // CHECK-TARGETLIB-SAME: "-Luser"
-// CHECK-TARGETLIB-SAME: "-L{{.*[/\\]}}target/lib"
+// CHECK-TARGETLIB-SAME: "-L{{.*}}myroot{{/|\\\\}}target{{/|\\\\}}lib"
 // CHECK-TARGETLIB-SAME: "-L."
-// CHECK-TARGETLIB-SAME: "{{.*[/\\]}}target{{/|\\\\}}lib{{/|\\\\}}crti.o"
+// CHECK-TARGETLIB-SAME: "{{.*}}myroot{{/|\\\\}}target{{/|\\\\}}lib{{/|\\\\}}crti.o"


### PR DESCRIPTION
On PS5, if a custom --sysroot is supplied, `<sysroot>/target/lib` should be added to the library search paths (this already occurs if the default `--sysroot` is not overridden). Until now, this has been hardcoded as a downstream patch in lld. Add it to the driver so that the private patch can be removed.

On PS4 the library search paths remain unchanged. The proprietary linker will continue to handle this aspect.

On either platform, warn if `<sysroot>/target/lib` is absent. Previously, such warnings were emitted only when the default --sysroot was not overridden.

SIE tracker: TOOLCHAIN-16704