### PR TITLE
[clang][bytecode] Revisit global variables separately

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6210,8 +6210,20 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
           return revisit(VD);
 
         if ((VD->hasGlobalStorage() || VD->isStaticDataMember()) &&
-            typeShouldBeVisited(VD->getType()))
+            typeShouldBeVisited(VD->getType())) {
+          if (const Expr *Init = VD->getAnyInitializer();
+              Init && !Init->isValueDependent()) {
+            // Whether or not the evaluation is successul doesn't really matter
+            // here -- we will create a global variable in any case, and that
+            // will have the state of initializer evaluation attached.
+            APValue V;
+            SmallVector<PartialDiagnosticAt> Notes;
+            (void)Init->EvaluateAsInitializer(V, Ctx.getASTContext(), VD, Notes,
+                                              true);
+            return this->visitDeclRef(D, E);
+          }
           return revisit(VD);
+        }
 
         // FIXME: The evaluateValue() check here is a little ridiculous, since
         // it will ultimately call into Context::evaluateAsInitializer(). In

--- a/clang/test/AST/ByteCode/cxx98.cpp
+++ b/clang/test/AST/ByteCode/cxx98.cpp
@@ -59,3 +59,8 @@ struct PR65784s{
   int *ptr;
 } const PR65784[] = {(int *)""};
 PR65784s PR65784f() { return *PR65784; }
+
+const int b = 1 / 0; // both-warning {{division by zero is undefined}} \
+                     // both-note {{declared here}}
+_Static_assert(b, ""); // both-error {{not an integral constant expression}} \
+                       // both-note {{initializer of 'b' is not a constant expression}}


### PR DESCRIPTION
Call `EvaluateAsInitializer()` explicitly here, so we don't abort the evaluation of the `DeflRefExpr` just because the initializer of that global variable failed.