### PR TITLE
[llvm-opt-report] Show scalable vectorization factors

### DIFF
--- a/llvm/test/tools/llvm-opt-report/Inputs/scalable.c
+++ b/llvm/test/tools/llvm-opt-report/Inputs/scalable.c
@@ -1,0 +1,9 @@
+#include <stddef.h>
+
+void foo(size_t N, float A[restrict N], float B[N]) {
+  #pragma clang loop vectorize_width(4, scalable)
+  for (size_t i = 0; i < N; i++) {
+    A[i] = B[i] * 42.f;
+  }
+}
+

--- a/llvm/test/tools/llvm-opt-report/Inputs/scalable.yaml
+++ b/llvm/test/tools/llvm-opt-report/Inputs/scalable.yaml
@@ -1,0 +1,12 @@
+--- !Passed
+Pass:            loop-vectorize
+Name:            Vectorized
+DebugLoc:        { File: './Inputs/scalable.c', Line: 5, Column: 3 }
+Function:        foo
+Args:
+  - String:          'vectorized loop (vectorization width: '
+  - VectorizationFactor: vscale x 4
+  - String:          ', interleaved count: '
+  - InterleaveCount: '2'
+  - String:          ')'
+...

--- a/llvm/test/tools/llvm-opt-report/scalabe.test
+++ b/llvm/test/tools/llvm-opt-report/scalabe.test
@@ -1,0 +1,12 @@
+RUN: llvm-opt-report -r %p %p/Inputs/scalable.yaml | FileCheck -strict-whitespace %s
+
+; CHECK: < {{.*[/\]}}scalable.c
+; CHECK-NEXT:  1        | #include <stddef.h>
+; CHECK-NEXT:  2        | 
+; CHECK-NEXT:  3        | void foo(size_t N, float A[restrict N], float B[N]) {
+; CHECK-NEXT:  4        |   #pragma clang loop vectorize_width(4, scalable)
+; CHECK-NEXT:  5 VNx4,2 |   for (size_t i = 0; i < N; i++) {
+; CHECK-NEXT:  6        |     A[i] = B[i] * 42.f;
+; CHECK-NEXT:  7        |   }
+; CHECK-NEXT:  8        | }
+; CHECK-NEXT:  9        | 


### PR DESCRIPTION
Scalable vectorization factors are printed as "vscale x VF" where VF is the known minimum number of elements, a integer. Currently, llvm-opt-report always expects a integer (like for vectorization with fixed-sized vectors), and does not display any vectorization factor in the output (just 'V', but without a number).

This patch adds support for scalable vectorization factors and prints them as "VNx<VF>", so for example "VNx4". The "Nx" is used to differentiate between fixed-sized and scalable factors, and is consistent with the way LLVM mangles scalable vectors in other places.