### PR TITLE
[lld-macho] Document '-icf' flag options

### DIFF
--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -82,8 +82,12 @@ def print_dylib_search: Flag<["--"], "print-dylib-search">,
     HelpText<"Print which paths lld searched when trying to find dylibs">,
     Group<grp_lld>;
 def icf_eq: Joined<["--"], "icf=">,
-    HelpText<"Set level for identical code folding (default: none)">,
-    MetaVarName<"[none,safe,all]">,
+    HelpText<"Set level for identical code folding (default: none). Possible values:\n"
+            "  none        - Disable ICF\n"
+            "  safe        - Only folds non-address significant functions (as described by `__addrsig` section)\n"
+            "  safe_thunks - Like safe, but replaces address-significant functions with thunks\n"
+            "  all         - Fold all identical functions">,
+    MetaVarName<"[none,safe,safe_thunks,all]">,
     Group<grp_lld>;
 def keep_icf_stabs: Joined<["--"], "keep-icf-stabs">,
     HelpText<"Generate STABS entries for symbols folded by ICF. These entries can then be used by dsymutil to discover the address range where folded symbols are located.">,


### PR DESCRIPTION
Adding the `safe_thunks` option in `Options.td` as it was missing there - mentioned by @Colibrow in https://github.com/llvm/llvm-project/pull/106573 
Also documenting what the various options mean. 

Help now looks like this:
```
..........
  --error-limit=<value>   Maximum number of errors to print before exiting (default: 20)
  --help-hidden           Display help for hidden options
  --icf=[none,safe,safe_thunks,all]
                          Set level for identical code folding (default: none). Possible values:
                            none        - Disable ICF
                            safe        - Only folds non-address significant functions (as described by `__addrsig` section)
                            safe_thunks - Like safe, but replaces address-significant functions with thunks
                            all         - Fold all identical functions
  --ignore-auto-link-option=<value>
                          Ignore a single auto-linked library or framework. Useful to ignore invalid options that ld64 ignores
  --irpgo-profile-sort=<profile>
                          Deprecated. Please use --irpgo-profile and --bp-startup-sort=function
..........
```