### PR TITLE
[MLIR] Allow setting call stack limit for SourceMgrDiagnosticHandler

### DIFF
--- a/mlir/include/mlir/IR/Diagnostics.h
+++ b/mlir/include/mlir/IR/Diagnostics.h
@@ -578,6 +578,9 @@ public:
   void emitDiagnostic(Location loc, Twine message, DiagnosticSeverity kind,
                       bool displaySourceLine = true);
 
+  /// Set the maximum depth that a call stack will be printed. Defaults to 10.
+  void setCallStackLimit(unsigned limit);
+
 protected:
   /// Emit the given diagnostic with the held source manager.
   void emitDiagnostic(Diagnostic &diag);
@@ -605,7 +608,6 @@ private:
   std::optional<Location> findLocToShow(Location loc);
 
   /// The maximum depth that a call stack will be printed.
-  /// TODO: This should be a tunable flag.
   unsigned callStackLimit = 10;
 
   std::unique_ptr<detail::SourceMgrDiagnosticHandlerImpl> impl;

--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -519,6 +519,10 @@ void SourceMgrDiagnosticHandler::emitDiagnostic(Diagnostic &diag) {
   }
 }
 
+void SourceMgrDiagnosticHandler::setCallStackLimit(unsigned limit) {
+  callStackLimit = limit;
+}
+
 /// Get a memory buffer for the given file, or nullptr if one is not found.
 const llvm::MemoryBuffer *
 SourceMgrDiagnosticHandler::getBufferForFile(StringRef filename) {


### PR DESCRIPTION
Otherwise for deeply nested code, the callstack will always be truncated