### PR TITLE
[msan] Add debugging for handleUnknownIntrinsic

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -3048,14 +3048,15 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
   }
 
   bool handleUnknownIntrinsic(IntrinsicInst &I) {
-    bool success = handleUnknownIntrinsicUnlogged(I);
-    if (ClDumpStrictIntrinsics)
-      dumpInst(I);
+    if (handleUnknownIntrinsicUnlogged(I)) {
+      if (ClDumpStrictIntrinsics)
+        dumpInst(I);
 
-    LLVM_DEBUG(dbgs() << "UNKNOWN INTRINSIC HANDLED HEURISTICALLY: " << I
-                      << "\n");
-
-    return success;
+      LLVM_DEBUG(dbgs() << "UNKNOWN INTRINSIC HANDLED HEURISTICALLY: " << I
+                        << "\n");
+      return true;
+    } else
+      return false;
   }
 
   void handleInvariantGroup(IntrinsicInst &I) {

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -3027,13 +3027,15 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     bool success = false;
     if (NumArgOperands == 0) {
       // No-op
-    } else if (NumArgOperands == 2 && I.getArgOperand(0)->getType()->isPointerTy() &&
-        I.getArgOperand(1)->getType()->isVectorTy() &&
-        I.getType()->isVoidTy() && !I.onlyReadsMemory()) {
+    } else if (NumArgOperands == 2 &&
+               I.getArgOperand(0)->getType()->isPointerTy() &&
+               I.getArgOperand(1)->getType()->isVectorTy() &&
+               I.getType()->isVoidTy() && !I.onlyReadsMemory()) {
       // This looks like a vector store.
       success = handleVectorStoreIntrinsic(I);
-    } else if (NumArgOperands == 1 && I.getArgOperand(0)->getType()->isPointerTy() &&
-        I.getType()->isVectorTy() && I.onlyReadsMemory()) {
+    } else if (NumArgOperands == 1 &&
+               I.getArgOperand(0)->getType()->isPointerTy() &&
+               I.getType()->isVectorTy() && I.onlyReadsMemory()) {
       // This looks like a vector load.
       success = handleVectorLoadIntrinsic(I);
     } else if (I.doesNotAccessMemory())
@@ -3042,7 +3044,8 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     if (success && ClDumpStrictIntrinsics)
       dumpInst(I);
 
-    LLVM_DEBUG(dbgs() << "UNKNOWN INTRINSIC HANDLED HEURISTICALLY: " << I << "\n");
+    LLVM_DEBUG(dbgs() << "UNKNOWN INTRINSIC HANDLED HEURISTICALLY: " << I
+                      << "\n");
 
     // FIXME: detect and handle SSE maskstore/maskload
     return success;
@@ -4041,7 +4044,6 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
   void visitIntrinsicInst(IntrinsicInst &I) {
     switch (I.getIntrinsicID()) {
-#if 0
     case Intrinsic::uadd_with_overflow:
     case Intrinsic::sadd_with_overflow:
     case Intrinsic::usub_with_overflow:
@@ -4454,7 +4456,6 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
       handleNEONVectorMultiplyIntrinsic(I);
       break;
     }
-#endif
 
     default:
       if (!handleUnknownIntrinsic(I))


### PR DESCRIPTION
This adds an experimental flag, msan-dump-strict-intrinsics (modeled after msan-dump-strict-instructions), which prints out any intrinsics that are heuristically handled. Additionally, MSan will print out heuristically handled intrinsics when -debug is passed as a flag in debug builds.

MSan's intrinsic handling can be broken down into:

1) special cases (usually highly accurate)
2) heuristic handling (sometimes erroneous)
3) not handled

This patch's -msan-dump-strict-intrinsics is intended to help debug Case 2. Case 3) (which includes all the heuristics that are not handled by special cases nor heuristics) can be debugged using the existing -msan-dump-strict-instructions.