### PR TITLE
[FMV][GlobalOpt] Do not statically resolve non-FMV callers.

### DIFF
--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2785,7 +2785,15 @@ static bool OptimizeNonTrivialIFuncs(
       } else {
         // We can't reason much about non-FMV callers. Just pick the highest
         // priority callee if it matches, otherwise bail.
-        if (I > 0 || !implies(CallerBits, CalleeBits))
+        //if (I > 0 || !implies(CallerBits, CalleeBits))
+        //
+        // FIXME: This is causing a regression in the llvm test suite,
+        // specifically a 'predres' version is unexpectedly trapping on
+        // GravitonG4. My explanation is that when the caller in not a
+        // versioned function, the compiler exclusively relies on the
+        // command line option, or target attribute to deduce whether a
+        // feature is available. However, there is no guarantee that in
+        // reality the host supports those implied features.
           continue;
       }
       auto &Calls = CallSites[Caller];

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2785,7 +2785,7 @@ static bool OptimizeNonTrivialIFuncs(
       } else {
         // We can't reason much about non-FMV callers. Just pick the highest
         // priority callee if it matches, otherwise bail.
-        //if (I > 0 || !implies(CallerBits, CalleeBits))
+        // if (I > 0 || !implies(CallerBits, CalleeBits))
         //
         // FIXME: This is causing a regression in the llvm test suite,
         // specifically a 'predres' version is unexpectedly trapping on
@@ -2794,7 +2794,7 @@ static bool OptimizeNonTrivialIFuncs(
         // command line option, or target attribute to deduce whether a
         // feature is available. However, there is no guarantee that in
         // reality the host supports those implied features.
-          continue;
+        continue;
       }
       auto &Calls = CallSites[Caller];
       for (CallBase *CS : Calls)

--- a/llvm/test/Transforms/GlobalOpt/resolve-fmv-ifunc.ll
+++ b/llvm/test/Transforms/GlobalOpt/resolve-fmv-ifunc.ll
@@ -221,7 +221,7 @@ resolver_entry:
 define i32 @caller4() #8 {
 ; CHECK-LABEL: define i32 @caller4(
 ; CHECK-SAME: ) local_unnamed_addr #[[ATTR7:[0-9]+]] {
-; CHECK:    [[CALL:%.*]] = tail call i32 @test_non_fmv_caller._Maes()
+; CHECK:    [[CALL:%.*]] = tail call i32 @test_non_fmv_caller()
 ;
 entry:
   %call = tail call i32 @test_non_fmv_caller()


### PR DESCRIPTION
This fixes a runtime regression in the llvm testsuite:

https://lab.llvm.org/buildbot/#/builders/198/builds/1237

On clang-aarch64-sve2-vla:

predres
        FAIL

A 'predres' version is unexpectedly trapping on GravitonG4. My explanation is that when the caller in not a versioned function, the compiler exclusively relies on the command line option, or target attribute to deduce whether a feature is available. However, there is no guarantee that in reality the host supports those implied features.

This is a quickfix. We may rather change the mcpu option in the llvm testsuite build instead.