### PR TITLE
[DebugInfo][DWARF] Utilize DW_AT_LLVM_stmt_sequence attr in line table lookups

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -254,14 +254,14 @@ public:
     /// \param Address - The starting address of the range.
     /// \param Size - The size of the address range.
     /// \param Result - The vector to fill with row indices.
-    /// \param Die - if provided, the function will check for a
-    /// DW_AT_LLVM_stmt_sequence attribute. If present, only rows from the
-    /// sequence starting at the matching offset will be added to the result.
+    /// \param StmtSequenceOffset - if provided, only rows from the sequence
+    /// starting at the matching offset will be added to the result.
     ///
     /// Returns true if any rows were found.
-    bool lookupAddressRange(object::SectionedAddress Address, uint64_t Size,
-                            std::vector<uint32_t> &Result,
-                            const DWARFDie *Die = nullptr) const;
+    bool lookupAddressRange(
+        object::SectionedAddress Address, uint64_t Size,
+        std::vector<uint32_t> &Result,
+        std::optional<uint64_t> StmtSequenceOffset = std::nullopt) const;
 
     bool hasFileAtIndex(uint64_t FileIndex) const {
       return Prologue.hasFileAtIndex(FileIndex);

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -210,7 +210,7 @@ public:
     bool Empty;
 
     /// The offset into the line table where this sequence begins
-    uint64_t Offset = 0;
+    uint64_t StmtSeqOffset = UINT64_MAX;
 
     void reset();
 
@@ -227,6 +227,8 @@ public:
       return SectionIndex == PC.SectionIndex &&
              (LowPC <= PC.Address && PC.Address < HighPC);
     }
+
+    void SetSequenceOffset(uint64_t Offset) { StmtSeqOffset = Offset; }
   };
 
   struct LineTable {
@@ -403,16 +405,8 @@ private:
     ParsingState(struct LineTable *LT, uint64_t TableOffset,
                  function_ref<void(Error)> ErrorHandler);
 
-    void resetRowAndSequence();
-
-    /// Append the current Row to the LineTable's matrix of rows and update the
-    /// current Sequence information.
-    ///
-    /// \param LineTableOffset - the offset into the line table where the
-    /// current sequence of rows begins. This offset is stored in the Sequence
-    /// to allow filtering rows based on their originating sequence when a
-    /// DW_AT_LLVM_stmt_sequence attribute is present.
-    void appendRowToMatrix(uint64_t LineTableOffset);
+    void resetRowAndSequence(uint64_t Offset = UINT64_MAX);
+    void appendRowToMatrix();
 
     struct AddrOpIndexDelta {
       uint64_t AddrOffset;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -405,7 +405,7 @@ private:
     ParsingState(struct LineTable *LT, uint64_t TableOffset,
                  function_ref<void(Error)> ErrorHandler);
 
-    void resetRowAndSequence(uint64_t Offset = UINT64_MAX);
+    void resetRowAndSequence(uint64_t Offset);
     void appendRowToMatrix();
 
     struct AddrOpIndexDelta {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -227,8 +227,6 @@ public:
       return SectionIndex == PC.SectionIndex &&
              (LowPC <= PC.Address && PC.Address < HighPC);
     }
-
-    void SetSequenceOffset(uint64_t Offset) { StmtSeqOffset = Offset; }
   };
 
   struct LineTable {

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1374,15 +1374,8 @@ DWARFDebugLine::LineTable::lookupAddressImpl(object::SectionedAddress Address,
 
 bool DWARFDebugLine::LineTable::lookupAddressRange(
     object::SectionedAddress Address, uint64_t Size,
-    std::vector<uint32_t> &Result, const DWARFDie *Die) const {
-
-  // If DIE is provided, check for DW_AT_LLVM_stmt_sequence
-  std::optional<uint64_t> StmtSequenceOffset;
-  if (Die) {
-    if (auto StmtSeqAttr = Die->find(dwarf::DW_AT_LLVM_stmt_sequence)) {
-      StmtSequenceOffset = toSectionOffset(StmtSeqAttr);
-    }
-  }
+    std::vector<uint32_t> &Result,
+    std::optional<uint64_t> StmtSequenceOffset) const {
 
   // Search for relocatable addresses
   if (lookupAddressRangeImpl(Address, Size, Result, StmtSequenceOffset))

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -562,16 +562,12 @@ void DWARFDebugLine::LineTable::clear() {
 DWARFDebugLine::ParsingState::ParsingState(
     struct LineTable *LT, uint64_t TableOffset,
     function_ref<void(Error)> ErrorHandler)
-    : LineTable(LT), LineTableOffset(TableOffset), ErrorHandler(ErrorHandler) {
-  resetRowAndSequence();
-}
+    : LineTable(LT), LineTableOffset(TableOffset), ErrorHandler(ErrorHandler) {}
 
 void DWARFDebugLine::ParsingState::resetRowAndSequence(uint64_t Offset) {
   Row.reset(LineTable->Prologue.DefaultIsStmt);
   Sequence.reset();
-  if (Offset != UINT64_MAX) {
-    Sequence.SetSequenceOffset(Offset);
-  }
+  Sequence.SetSequenceOffset(Offset);
 }
 
 void DWARFDebugLine::ParsingState::appendRowToMatrix() {
@@ -854,7 +850,7 @@ Error DWARFDebugLine::LineTable::parse(
   }
   // *OffsetPtr points to the end of the prologue - i.e. the start of the first
   // sequence. So initialize the first sequence offset accordingly.
-  State.Sequence.SetSequenceOffset(*OffsetPtr);
+  State.resetRowAndSequence(*OffsetPtr);
 
   bool TombstonedAddress = false;
   auto EmitRow = [&] {

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
@@ -2140,27 +2140,31 @@ TEST_F(DebugLineBasicFixture, LookupAddressRangeWithStmtSequenceOffset) {
     std::vector<uint32_t> Rows;
     bool Found;
 
-    // Look up using Sub3Die, which has an invalid DW_AT_LLVM_stmt_sequence
+    // Look up using Sub3Die's invalid stmt_sequence offset
+    auto StmtSeqAttr3 = Sub3Die.find(dwarf::DW_AT_LLVM_stmt_sequence);
+    ASSERT_TRUE(StmtSeqAttr3);
     Found = Table->lookupAddressRange(
         {0x1000, object::SectionedAddress::UndefSection}, /*Size=*/1, Rows,
-        &Sub3Die);
+        toSectionOffset(StmtSeqAttr3));
     EXPECT_FALSE(Found);
 
-    // Look up using Sub1Die, which has a valid DW_AT_LLVM_stmt_sequence and
-    // should return row 0
+    // Look up using Sub1Die's valid stmt_sequence offset
+    auto StmtSeqAttr1 = Sub1Die.find(dwarf::DW_AT_LLVM_stmt_sequence);
+    ASSERT_TRUE(StmtSeqAttr1);
     Found = Table->lookupAddressRange(
         {0x1000, object::SectionedAddress::UndefSection}, /*Size=*/1, Rows,
-        &Sub1Die);
+        toSectionOffset(StmtSeqAttr1));
     EXPECT_TRUE(Found);
     ASSERT_EQ(Rows.size(), 1u);
     EXPECT_EQ(Rows[0], 0U);
 
-    // Look up using Sub2Die, which has a valid DW_AT_LLVM_stmt_sequence and
-    // should return row 3
+    // Look up using Sub2Die's valid stmt_sequence offset
     Rows.clear();
+    auto StmtSeqAttr2 = Sub2Die.find(dwarf::DW_AT_LLVM_stmt_sequence);
+    ASSERT_TRUE(StmtSeqAttr2);
     Found = Table->lookupAddressRange(
         {0x1000, object::SectionedAddress::UndefSection}, /*Size=*/1, Rows,
-        &Sub2Die);
+        toSectionOffset(StmtSeqAttr2));
     EXPECT_TRUE(Found);
     ASSERT_EQ(Rows.size(), 1u);
     EXPECT_EQ(Rows[0], 3u);

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
@@ -2059,25 +2059,25 @@ TEST_F(DebugLineBasicFixture, LookupAddressRangeWithStmtSequenceOffset) {
   dwarfgen::CompileUnit &CU = Gen->addCompileUnit();
   dwarfgen::DIE CUDie = CU.getUnitDIE();
 
-  CUDie.addAttribute(DW_AT_name, DW_FORM_strp, "/tmp/main.c");
+  CUDie.addAttribute(DW_AT_name, DW_FORM_string, "/tmp/main.c");
   CUDie.addAttribute(DW_AT_language, DW_FORM_data2, DW_LANG_C);
 
   dwarfgen::DIE SD1 = CUDie.addChild(DW_TAG_subprogram);
-  SD1.addAttribute(DW_AT_name, DW_FORM_strp, "sub1");
+  SD1.addAttribute(DW_AT_name, DW_FORM_string, "sub1");
   SD1.addAttribute(DW_AT_low_pc, DW_FORM_addr, 0x1000U);
   SD1.addAttribute(DW_AT_high_pc, DW_FORM_addr, 0x1032U);
   // DW_AT_LLVM_stmt_sequence points to the first sequence
   SD1.addAttribute(DW_AT_LLVM_stmt_sequence, DW_FORM_sec_offset, 0x2e);
 
   dwarfgen::DIE SD2 = CUDie.addChild(DW_TAG_subprogram);
-  SD2.addAttribute(DW_AT_name, DW_FORM_strp, "sub2");
+  SD2.addAttribute(DW_AT_name, DW_FORM_string, "sub2");
   SD2.addAttribute(DW_AT_low_pc, DW_FORM_addr, 0x1000U);
   SD2.addAttribute(DW_AT_high_pc, DW_FORM_addr, 0x1032U);
   // DW_AT_LLVM_stmt_sequence points to the second sequence
   SD2.addAttribute(DW_AT_LLVM_stmt_sequence, DW_FORM_sec_offset, 0x42);
 
   dwarfgen::DIE SD3 = CUDie.addChild(DW_TAG_subprogram);
-  SD3.addAttribute(DW_AT_name, DW_FORM_strp, "sub3");
+  SD3.addAttribute(DW_AT_name, DW_FORM_string, "sub3");
   SD3.addAttribute(DW_AT_low_pc, DW_FORM_addr, 0x1000U);
   SD3.addAttribute(DW_AT_high_pc, DW_FORM_addr, 0x1032U);
   // Invalid DW_AT_LLVM_stmt_sequence
@@ -2153,7 +2153,7 @@ TEST_F(DebugLineBasicFixture, LookupAddressRangeWithStmtSequenceOffset) {
         &Sub1Die);
     EXPECT_TRUE(Found);
     ASSERT_EQ(Rows.size(), 1u);
-    EXPECT_EQ(Rows[0], 0);
+    EXPECT_EQ(Rows[0], 0U);
 
     // Look up using Sub2Die, which has a valid DW_AT_LLVM_stmt_sequence and
     // should return row 3
@@ -2163,7 +2163,7 @@ TEST_F(DebugLineBasicFixture, LookupAddressRangeWithStmtSequenceOffset) {
         &Sub2Die);
     EXPECT_TRUE(Found);
     ASSERT_EQ(Rows.size(), 1u);
-    EXPECT_EQ(Rows[0], 3);
+    EXPECT_EQ(Rows[0], 3u);
   }
 }
 } // end anonymous namespace


### PR DESCRIPTION
**Summary**
Add support for filtering line table entries based on `DW_AT_LLVM_stmt_sequence` attribute when looking up address ranges. This ensures that line entries are correctly attributed to their corresponding functions, even when multiple functions share the same address range due to optimizations.

**Background**
In https://github.com/llvm/llvm-project/pull/110192 we added support to clang to generate the `DW_AT_LLVM_stmt_sequence` attribute for `DW_TAG_subprogram`'s.  Corresponding RFC: [New DWARF Attribute for Symbolication of Merged Functions](https://discourse.llvm.org/t/rfc-new-dwarf-attribute-for-symbolication-of-merged-functions/79434)

The `DW_AT_LLVM_stmt_sequence` attribute allows accurate attribution of line number information to their corresponding functions, even in scenarios where functions are merged or share the same address space due to optimizations like Identical Code Folding (ICF) in the linker.

**Implementation Details**
The patch modifies `DWARFDebugLine::lookupAddressRange` to accept an optional DWARFDie parameter. When provided, the function checks if the `DIE` has a `DW_AT_LLVM_stmt_sequence` attribute. This attribute contains an offset into the line table that marks where the line entries for this DIE's function begin.

If the attribute is present, the function filters the results to only include line entries from the sequence that starts at the specified offset. This ensures that even when multiple functions share the same address range, we return only the line entries that actually belong to the function represented by the DIE.

The implementation:
- Adds an optional DWARFDie parameter to lookupAddressRange
- Extracts the `DW_AT_LLVM_stmt_sequence` offset if present
- Modifies the address range lookup logic to filter sequences based on their offset
- Returns only line entries from the matching sequence


