### PR TITLE
[lldb][test] Remove compiler version check and use regex

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-dbg-info-content/TestDbgInfoContentVectorFromStdModule.py
@@ -23,13 +23,6 @@ class TestDbgInfoContentVector(TestBase):
 
         self.runCmd("settings set target.import-std-module true")
 
-        if self.expectedCompiler(["clang"]) and self.expectedCompilerVersion(
-            [">", "16.0"]
-        ):
-            vector_type = "std::vector<Foo>"
-        else:
-            vector_type = "std::vector<Foo, std::allocator<Foo> >"
-
         size_type = "size_type"
         value_type = "value_type"
         iterator = "iterator"
@@ -41,13 +34,14 @@ class TestDbgInfoContentVector(TestBase):
             ValueCheck(name="current"),
         ]
 
-        self.expect_expr(
-            "a",
-            result_type=vector_type,
-            result_children=[
-                ValueCheck(children=[ValueCheck(value="3")]),
-                ValueCheck(children=[ValueCheck(value="1")]),
-                ValueCheck(children=[ValueCheck(value="2")]),
+        self.expect(
+            "expr a",
+            patterns=[
+                """\(std::vector<Foo(, std::allocator<Foo> )*>\) \$0 = size=3 \{
+  \[0\] = \(a = 3\)
+  \[1\] = \(a = 1\)
+  \[2\] = \(a = 2\)
+\}"""
             ],
         )
 

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
@@ -17,42 +17,26 @@ class TestVectorOfVectors(TestBase):
             self, "// Set break point at this line.", lldb.SBFileSpec("main.cpp")
         )
 
-        if self.expectedCompiler(["clang"]) and self.expectedCompilerVersion(
-            [">", "16.0"]
-        ):
-            vector_type = "std::vector<int>"
-            vector_of_vector_type = "std::vector<std::vector<int> >"
-        else:
-            vector_type = "std::vector<int>"
-            vector_of_vector_type = (
-                "std::vector<std::vector<int>, std::allocator<std::vector<int> > >"
-            )
-
         size_type = "size_type"
         value_type = "value_type"
 
         self.runCmd("settings set target.import-std-module true")
 
-        self.expect_expr(
-            "a",
-            result_type=vector_of_vector_type,
-            result_children=[
-                ValueCheck(
-                    type=vector_type,
-                    children=[
-                        ValueCheck(value="1"),
-                        ValueCheck(value="2"),
-                        ValueCheck(value="3"),
-                    ],
-                ),
-                ValueCheck(
-                    type=vector_type,
-                    children=[
-                        ValueCheck(value="3"),
-                        ValueCheck(value="2"),
-                        ValueCheck(value="1"),
-                    ],
-                ),
+        self.expect(
+            "expr a",
+            patterns=[
+                """\(std::vector<std::vector<int>(, std::allocator<std::vector<int> )* >\) \$0 = size=2 \{
+  \[0\] = size=3 \{
+    \[0\] = 1
+    \[1\] = 2
+    \[2\] = 3
+  \}
+  \[1\] = size=3 \{
+    \[0\] = 3
+    \[1\] = 2
+    \[2\] = 1
+  \}
+\}"""
             ],
         )
         self.expect_expr("a.size()", result_type=size_type, result_value="2")


### PR DESCRIPTION
The test checks specific compiler version to determine the output. However, the compiler version string is always set to 15.0.0 for our local build. Remove this check and use regex match instead.

## Test Plan
```
./bin/llvm-lit -sva /home/wanyi/llvm-sand/external/llvm-project/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
...
Skipping the following test categories: ['dsym', 'gmodules', 'debugserver', 'objc']

--
Command Output (stderr):
--
UNSUPPORTED: LLDB (/home/wanyi/llvm-sand/build/Release+Distribution/fbcode-x86_64/toolchain/bin/clang-x86_64) :: test_dsym (TestVectorOfVectorsFromStdModule.TestVectorOfVectors) (test case does not fall in any category of interest for this run) 
PASS: LLDB (/home/wanyi/llvm-sand/build/Release+Distribution/fbcode-x86_64/toolchain/bin/clang-x86_64) :: test_dwarf (TestVectorOfVectorsFromStdModule.TestVectorOfVectors)
PASS: LLDB (/home/wanyi/llvm-sand/build/Release+Distribution/fbcode-x86_64/toolchain/bin/clang-x86_64) :: test_dwo (TestVectorOfVectorsFromStdModule.TestVectorOfVectors)
----------------------------------------------------------------------
Ran 3 tests in 4.636s

OK (skipped=1)

--

********************

Testing Time: 4.97s

Total Discovered Tests: 1
  Passed: 1 (100.00%)
```