### PR TITLE
[SandboxVec][Legality] Implement ShuffleMask

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -36,6 +36,8 @@ class BottomUpVec final : public FunctionPass {
   /// Erases all dead instructions from the dead instruction candidates
   /// collected during vectorization.
   void tryEraseDeadInstrs();
+  /// Creates a shuffle instruction that shuffles \p VecOp according to \p Mask.
+  Value *createShuffle(Value *VecOp, const ShuffleMask &Mask);
   /// Packs all elements of \p ToPack into a vector and returns that vector.
   Value *createPack(ArrayRef<Value *> ToPack);
   void collectPotentiallyDeadInstrs(ArrayRef<Value *> Bndl);

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Legality.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Legality.cpp
@@ -20,6 +20,11 @@ namespace llvm::sandboxir {
 #define DEBUG_TYPE "SBVec:Legality"
 
 #ifndef NDEBUG
+void ShuffleMask::dump() const {
+  print(dbgs());
+  dbgs() << "\n";
+}
+
 void LegalityResult::dump() const {
   print(dbgs());
   dbgs() << "\n";
@@ -213,13 +218,12 @@ const LegalityResult &LegalityAnalysis::canVectorize(ArrayRef<Value *> Bndl,
   auto CollectDescrs = getHowToCollectValues(Bndl);
   if (CollectDescrs.hasVectorInputs()) {
     if (auto ValueShuffleOpt = CollectDescrs.getSingleInput()) {
-      auto [Vec, NeedsShuffle] = *ValueShuffleOpt;
-      if (!NeedsShuffle)
+      auto [Vec, Mask] = *ValueShuffleOpt;
+      if (Mask.isIdentity())
         return createLegalityResult<DiamondReuse>(Vec);
-      llvm_unreachable("TODO: Unimplemented");
-    } else {
-      llvm_unreachable("TODO: Unimplemented");
+      return createLegalityResult<DiamondReuseWithShuffle>(Vec, Mask);
     }
+    llvm_unreachable("TODO: Unimplemented");
   }
 
   if (auto ReasonOpt = notVectorizableBasedOnOpcodesAndTypes(Bndl))

--- a/llvm/test/Transforms/SandboxVectorizer/bottomup_basic.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/bottomup_basic.ll
@@ -221,3 +221,24 @@ define void @diamond(ptr %ptr) {
   store float %sub1, ptr %ptr1
   ret void
 }
+
+define void @diamondWithShuffle(ptr %ptr) {
+; CHECK-LABEL: define void @diamondWithShuffle(
+; CHECK-SAME: ptr [[PTR:%.*]]) {
+; CHECK-NEXT:    [[PTR0:%.*]] = getelementptr float, ptr [[PTR]], i32 0
+; CHECK-NEXT:    [[VECL:%.*]] = load <2 x float>, ptr [[PTR0]], align 4
+; CHECK-NEXT:    [[VSHUF:%.*]] = shufflevector <2 x float> [[VECL]], <2 x float> [[VECL]], <2 x i32> <i32 1, i32 0>
+; CHECK-NEXT:    [[VEC:%.*]] = fsub <2 x float> [[VECL]], [[VSHUF]]
+; CHECK-NEXT:    store <2 x float> [[VEC]], ptr [[PTR0]], align 4
+; CHECK-NEXT:    ret void
+;
+  %ptr0 = getelementptr float, ptr %ptr, i32 0
+  %ptr1 = getelementptr float, ptr %ptr, i32 1
+  %ld0 = load float, ptr %ptr0
+  %ld1 = load float, ptr %ptr1
+  %sub0 = fsub float %ld0, %ld1
+  %sub1 = fsub float %ld1, %ld0
+  store float %sub0, ptr %ptr0
+  store float %sub1, ptr %ptr1
+  ret void
+}

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/LegalityTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/LegalityTest.cpp
@@ -19,6 +19,7 @@
 #include "llvm/SandboxIR/Instruction.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/InstrMaps.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
@@ -321,7 +322,7 @@ define void @foo(ptr %ptr) {
     sandboxir::CollectDescr CD(std::move(Descrs));
     EXPECT_TRUE(CD.getSingleInput());
     EXPECT_EQ(CD.getSingleInput()->first, VLd);
-    EXPECT_EQ(CD.getSingleInput()->second, false);
+    EXPECT_THAT(CD.getSingleInput()->second, testing::ElementsAre(0, 1));
     EXPECT_TRUE(CD.hasVectorInputs());
   }
   {
@@ -331,7 +332,7 @@ define void @foo(ptr %ptr) {
     sandboxir::CollectDescr CD(std::move(Descrs));
     EXPECT_TRUE(CD.getSingleInput());
     EXPECT_EQ(CD.getSingleInput()->first, VLd);
-    EXPECT_EQ(CD.getSingleInput()->second, true);
+    EXPECT_THAT(CD.getSingleInput()->second, testing::ElementsAre(1, 0));
     EXPECT_TRUE(CD.hasVectorInputs());
   }
   {
@@ -351,4 +352,96 @@ define void @foo(ptr %ptr) {
     EXPECT_FALSE(CD.getSingleInput());
     EXPECT_FALSE(CD.hasVectorInputs());
   }
+}
+
+TEST_F(LegalityTest, ShuffleMask) {
+  {
+    // Check SmallVector constructor.
+    SmallVector<int> Indices({0, 1, 2, 3});
+    sandboxir::ShuffleMask Mask(std::move(Indices));
+    EXPECT_THAT(Mask, testing::ElementsAre(0, 1, 2, 3));
+  }
+  {
+    // Check initializer_list constructor.
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    EXPECT_THAT(Mask, testing::ElementsAre(0, 1, 2, 3));
+  }
+  {
+    // Check ArrayRef constructor.
+    sandboxir::ShuffleMask Mask(ArrayRef<int>({0, 1, 2, 3}));
+    EXPECT_THAT(Mask, testing::ElementsAre(0, 1, 2, 3));
+  }
+  {
+    // Check operator ArrayRef<int>().
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    ArrayRef<int> Array = Mask;
+    EXPECT_THAT(Array, testing::ElementsAre(0, 1, 2, 3));
+  }
+  {
+    // Check getIdentity().
+    auto IdentityMask = sandboxir::ShuffleMask::getIdentity(4);
+    EXPECT_THAT(IdentityMask, testing::ElementsAre(0, 1, 2, 3));
+    EXPECT_TRUE(IdentityMask.isIdentity());
+  }
+  {
+    // Check isIdentity().
+    sandboxir::ShuffleMask Mask1({0, 1, 2, 3});
+    EXPECT_TRUE(Mask1.isIdentity());
+    sandboxir::ShuffleMask Mask2({1, 2, 3, 4});
+    EXPECT_FALSE(Mask2.isIdentity());
+  }
+  {
+    // Check operator==().
+    sandboxir::ShuffleMask Mask1({0, 1, 2, 3});
+    sandboxir::ShuffleMask Mask2({0, 1, 2, 3});
+    EXPECT_TRUE(Mask1 == Mask2);
+    EXPECT_FALSE(Mask1 != Mask2);
+  }
+  {
+    // Check operator!=().
+    sandboxir::ShuffleMask Mask1({0, 1, 2, 3});
+    sandboxir::ShuffleMask Mask2({0, 1, 2, 4});
+    EXPECT_TRUE(Mask1 != Mask2);
+    EXPECT_FALSE(Mask1 == Mask2);
+  }
+  {
+    // Check size().
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    EXPECT_EQ(Mask.size(), 4u);
+  }
+  {
+    // Check operator[].
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    for (auto [Idx, Elm] : enumerate(Mask)) {
+      EXPECT_EQ(Elm, Mask[Idx]);
+    }
+  }
+  {
+    // Check begin(), end().
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    sandboxir::ShuffleMask::const_iterator Begin = Mask.begin();
+    sandboxir::ShuffleMask::const_iterator End = Mask.begin();
+    int Idx = 0;
+    for (auto It = Begin; It != End; ++It) {
+      EXPECT_EQ(*It, Mask[Idx++]);
+    }
+  }
+#ifndef NDEBUG
+  {
+    // Check print(OS).
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    std::string Str;
+    raw_string_ostream OS(Str);
+    Mask.print(OS);
+    EXPECT_EQ(Str, "0,1,2,3");
+  }
+  {
+    // Check operator<<().
+    sandboxir::ShuffleMask Mask({0, 1, 2, 3});
+    std::string Str;
+    raw_string_ostream OS(Str);
+    OS << Mask;
+    EXPECT_EQ(Str, "0,1,2,3");
+  }
+#endif // NDEBUG
 }


### PR DESCRIPTION
This patch implements a helper ShuffleMask data structure that helps describe shuffles of elements across lanes.