### PR TITLE
[llvm][Docs] Fix incorrect command linking compile_commands.json

### DIFF
--- a/llvm/docs/MyFirstTypoFix.rst
+++ b/llvm/docs/MyFirstTypoFix.rst
@@ -164,7 +164,7 @@ into ``llvm-project/``:
 
 .. code:: console
 
-   $ ln -s build/compile_commands.json ../
+   $ ln -s build/compile_commands.json ./
 
 (This isn't strictly necessary for building and testing, but allows
 tools like clang-tidy, clang-query, and clangd to work in your source


### PR DESCRIPTION
This command is being run from the `llvm-project` directory, so it should use the current directory, not the parent directory.