### PR TITLE
[Clang] Fix warning for non std functions with name `infinity`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -791,6 +791,8 @@ Improvements to Clang's diagnostics
     }
 - Diagnose invalid declarators in the declaration of constructors and destructors (#GH121706).
 
+- Fix false positives warning for non-std functions with name `infinity` (#123231).
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -8455,20 +8455,17 @@ static bool IsInfOrNanFunction(StringRef calleeName, MathCheck Check) {
 }
 
 static bool IsInfinityFunction(const FunctionDecl *FDecl) {
-  if (FDecl->getName() != "infinity") {
+  if (FDecl->getName() != "infinity")
     return false;
-  }
 
   if (const CXXMethodDecl *MDecl = dyn_cast<CXXMethodDecl>(FDecl)) {
     const CXXRecordDecl *RDecl = MDecl->getParent();
-    if (RDecl->getName() != "numeric_limits") {
+    if (RDecl->getName() != "numeric_limits")
       return false;
-    }
 
     if (const NamespaceDecl *NSDecl =
-            dyn_cast<NamespaceDecl>(RDecl->getDeclContext())) {
+            dyn_cast<NamespaceDecl>(RDecl->getDeclContext()))
       return NSDecl->isStdNamespace();
-    }
   }
 
   return false;
@@ -8476,9 +8473,8 @@ static bool IsInfinityFunction(const FunctionDecl *FDecl) {
 
 void Sema::CheckInfNaNFunction(const CallExpr *Call,
                                const FunctionDecl *FDecl) {
-  if (!FDecl->getIdentifier()) {
+  if (!FDecl->getIdentifier())
     return;
-  }
 
   FPOptions FPO = Call->getFPFeaturesInEffect(getLangOpts());
   if (FPO.getNoHonorNaNs() &&

--- a/clang/test/Sema/warn-infinity-nan-disabled-lnx.cpp
+++ b/clang/test/Sema/warn-infinity-nan-disabled-lnx.cpp
@@ -45,23 +45,47 @@ namespace std __attribute__((__visibility__("default"))) {
   isnan(double __x);
   bool
   isnan(long double __x);
-bool
+  bool
   isfinite(float __x);
   bool
   isfinite(double __x);
   bool
   isfinte(long double __x);
- bool
+  bool
   isunordered(float __x, float __y);
   bool
   isunordered(double __x, double __y);
   bool
   isunordered(long double __x, long double __y);
+
+template <class _Ty>
+class numeric_limits {
+public:
+    [[nodiscard]] static constexpr _Ty infinity() noexcept {
+        return _Ty();
+    }
+};
 } // namespace )
 }
 
 #define NAN (__builtin_nanf(""))
 #define INFINITY (__builtin_inff())
+
+template <>
+class std::numeric_limits<float>  {
+public:
+    [[nodiscard]] static constexpr float infinity() noexcept {
+        return __builtin_huge_val();
+    }
+};
+
+template <>
+class std::numeric_limits<double>  {
+public:
+    [[nodiscard]] static constexpr double infinity() noexcept {
+        return __builtin_huge_val();
+    }
+};
 
 template <class _Ty>
 class numeric_limits {
@@ -78,6 +102,7 @@ public:
         return __builtin_huge_val();
     }
 };
+
 template <>
 class numeric_limits<double>  {
 public:
@@ -85,6 +110,8 @@ public:
         return __builtin_huge_val();
     }
 };
+
+double infinity() { return 0; }
 
 int compareit(float a, float b) {
   volatile int i, j, k, l, m, n, o, p;
@@ -225,11 +252,18 @@ int compareit(float a, float b) {
 
 // no-inf-no-nan-warning@+2 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
 // no-inf-warning@+1 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
-  double y = i * numeric_limits<double>::infinity();
+  double y = i * std::numeric_limits<double>::infinity();
+
+  y = i * numeric_limits<double>::infinity(); // expected-no-diagnostics
 
 // no-inf-no-nan-warning@+2 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
 // no-inf-warning@+1 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
-  j = numeric_limits<float>::infinity();
+  j = std::numeric_limits<float>::infinity();
+
+  j = numeric_limits<float>::infinity(); // expected-no-diagnostics
+
+  y = infinity(); // expected-no-diagnostics
+
   return 0;
 
 }

--- a/clang/test/Sema/warn-infinity-nan-disabled-win.cpp
+++ b/clang/test/Sema/warn-infinity-nan-disabled-win.cpp
@@ -48,23 +48,48 @@ namespace std __attribute__((__visibility__("default"))) {
   isnan(double __x);
   bool
   isnan(long double __x);
-bool
+  bool
   isfinite(float __x);
   bool
   isfinite(double __x);
   bool
   isfinte(long double __x);
- bool
+  bool
   isunordered(float __x, float __y);
   bool
   isunordered(double __x, double __y);
   bool
   isunordered(long double __x, long double __y);
+
+template <class _Ty>
+class numeric_limits {
+public:
+    [[nodiscard]] static constexpr _Ty infinity() noexcept {
+        return _Ty();
+    }
+};
+
 } // namespace )
 }
 
 #define INFINITY ((float)(1e+300 * 1e+300))
 #define NAN      (-(float)(INFINITY * 0.0F))
+
+template <>
+class std::numeric_limits<float>  {
+public:
+    [[nodiscard]] static constexpr float infinity() noexcept {
+        return __builtin_huge_val();
+    }
+};
+
+template <>
+class std::numeric_limits<double>  {
+public:
+    [[nodiscard]] static constexpr double infinity() noexcept {
+        return __builtin_huge_val();
+    }
+};
 
 template <class _Ty>
 class numeric_limits {
@@ -81,6 +106,7 @@ public:
         return __builtin_huge_val();
     }
 };
+
 template <>
 class numeric_limits<double>  {
 public:
@@ -88,6 +114,8 @@ public:
         return __builtin_huge_val();
     }
 };
+
+double infinity() { return 0; }
 
 int compareit(float a, float b) {
   volatile int i, j, k, l, m, n, o, p;
@@ -216,11 +244,18 @@ int compareit(float a, float b) {
 
 // no-inf-no-nan-warning@+2 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
 // no-inf-warning@+1 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
-  double y = i * numeric_limits<double>::infinity();
+  double y = i * std::numeric_limits<double>::infinity();
+
+  y = i * numeric_limits<double>::infinity(); // expected-no-diagnostics
 
 // no-inf-no-nan-warning@+2 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
 // no-inf-warning@+1 {{use of infinity is undefined behavior due to the currently enabled floating-point options}}
-  j = numeric_limits<float>::infinity();
+  j = std::numeric_limits<float>::infinity();
+
+  j = numeric_limits<float>::infinity(); // expected-no-diagnostics
+
+  y = infinity(); // expected-no-diagnostics
+
   return 0;
 
 }


### PR DESCRIPTION
Fix reporting diagnostic for non std functions that has the name `infinity`

Fixes: #123231