### PR TITLE
[TableGen] Inline a helper function that didn't seem necessary. NFC

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -592,7 +592,6 @@ private:
   void collectSchedRW();
 
   std::string genRWName(ArrayRef<unsigned> Seq, bool IsRead);
-  unsigned findRWForSequence(ArrayRef<unsigned> Seq, bool IsRead);
 
   void collectSchedClasses();
 


### PR DESCRIPTION
The function just called find_if and converted the iterator to an index. The caller then had to check the index being non-zero to know if the find succeeded.

Seems better to just do the find and distance in the caller.