### PR TITLE
[libcxx][test] Fix a test for the range of file offsets on ARMv7 Linux targets.

### DIFF
--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -31,7 +31,7 @@
 // By default, off_t is typically a 32-bit integer on ARMv7 Linux systems,
 // meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
-// XFAIL: target=armv7{{.*}}-{{.+}}-linux{{.*}}
+// UNSUPPORTED: target=armv7-unknown-linux-gnueabihf
 
 #include <fstream>
 #include <iostream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -28,6 +28,11 @@
 //
 // XFAIL: target=powerpc-{{.+}}-aix{{.*}}
 
+// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems, 
+// meaning it can represent file sizes up to 2GB (2^31 bytes) only.
+//
+// XFAIL: target=armv7{{.*}}-{{.+}}-linux{{.*}}
+
 #include <fstream>
 #include <iostream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -28,7 +28,7 @@
 //
 // XFAIL: target=powerpc-{{.+}}-aix{{.*}}
 
-// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems, 
+// By default, off_t is typically a 32-bit integer on ARMv7 Linux systems,
 // meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
 // XFAIL: target=armv7{{.*}}-{{.+}}-linux{{.*}}


### PR DESCRIPTION
Mark the `offset_range` test as UNSUPPORTED for the `armv7-unknown-linux-gnueabihf` target (32-bit).

Ref PR #122798