### PR TITLE
Update Developer Policy for copyright notices

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -1154,6 +1154,13 @@ acceptable for their contributions.  We feel that a high burden for relicensing
 is good for the project, because contributors do not have to fear that their
 code will be used in a way with which they disagree.
 
+Embedded Copyright Statements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The LLVM project does not accept contributions that include in-source copyright
+notices except where such notices are part of a larger external project being
+added as a vendored dependency.
+
 Relicensing
 -----------
 

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -1163,6 +1163,8 @@ added as a vendored dependency.
 
 LLVM source code lives for a long time and is edited by many people, the best
 way to track contributions is through revision control history.
+See the `Attribution of Changes`_ section for more information about attributing
+changes to authors other than the committer.
 
 Relicensing
 -----------

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -1154,12 +1154,15 @@ acceptable for their contributions.  We feel that a high burden for relicensing
 is good for the project, because contributors do not have to fear that their
 code will be used in a way with which they disagree.
 
-Embedded Copyright Statements
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Embedded Copyright or 'Contributed by' Statements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The LLVM project does not accept contributions that include in-source copyright
 notices except where such notices are part of a larger external project being
 added as a vendored dependency.
+
+LLVM source code lives for a long time and is edited by many people, the best
+way to track contributions is through revision control history.
 
 Relicensing
 -----------


### PR DESCRIPTION
This updates the developer policy to align with established community norms for copyright notices in source code contributed to LLVM.

The updates clearly state that we do not accept code contianing explicit copyright notices in source except where such code is a pre-existing part of an external dependency that is being vendored into LLVM.

Explicit copyright notices in source add no value to the project since copyright ownership is well tracked through git. Our policy already requires that contributions made not by the original author have appropriate attribution in git commit messsages or metadata.

Further, explicit copyright notices in code can easily get out of date as the code is refactored, updated by additional authors or otherwise changed over time. This leads to misleading out-of-date copyright notices which do more harm than good.

This change should be viewed as a clarification and statement of existing established policy, not a change in policy since it represents the way the project has been operating.