### PR TITLE
[flang] Build a dedicated fir-test-opt for testing

### DIFF
--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-1.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-1.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Testing : "_QPtest"
 // CHECK-DAG: alloca_1#0 <-> address_of#0: NoAlias

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-2.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-2.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Testing : "_QFPtest"
 

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-3.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-3.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // module m
 //   type t

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-4.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-4.fir
@@ -2,7 +2,7 @@
 
 // use --mlir-disable-threading so that the AA queries are serialised
 // as well as its diagnostic output.
-// RUN: fir-opt %s --test-fir-alias-analysis -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s --test-fir-alias-analysis -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // designate for a derived type component:
 // module m

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-5.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-5.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Testing : "_QPtest1"
 // CHECK: arraya(ii)#0 <-> arrayc(ii)#0: NoAlias

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-6.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-6.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' 2>&1 | FileCheck %s
 
 // CHECK: test_y(1)#0 <-> test_x(1)#0: MayAlias
 func.func @_QPtest(%arg0: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "y"}) {

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-7.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-7.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' 2>&1 | FileCheck %s
 
 // leslie3d case with two allocatable module variables
 // that cannot alias:

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-8.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-8.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' 2>&1 | FileCheck %s
 
 // Exercise that a box reference does not alias with the address loaded from the box
 // module mm

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-9.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-9.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Fortran source code:
 // program TestTmpArrayAssignment

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-host-assoc.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-host-assoc.fir
@@ -1,5 +1,5 @@
 // Test alias analysis queries for host associated accesses.
-// RUN: fir-opt %s --test-fir-alias-analysis -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s --test-fir-alias-analysis -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // subroutine test1
 //   integer :: x(10)

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-private-allocatable.mlir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-private-allocatable.mlir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Fortran code before simplification:
 // SUBROUTINE mysub(ns,ne)

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-target-1.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-target-1.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Fortran source code:
 //

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-target-2.fir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-target-2.fir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Fortran source code:
 //

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-teams-distribute-private-ptr.mlir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-teams-distribute-private-ptr.mlir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Fortran code:
 // program main

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-teams-distribute-private.mlir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-omp-teams-distribute-private.mlir
@@ -1,6 +1,6 @@
 // Use --mlir-disable-threading so that the AA queries are serialized
 // as well as its diagnostic output.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 // Fortran code:
 //

--- a/flang/test/Analysis/AliasAnalysis/modref-call-after-inlining.fir
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-after-inlining.fir
@@ -1,4 +1,4 @@
-// RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+// RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 // RUN:  --mlir-disable-threading %s -o /dev/null 2>&1 | FileCheck %s
 
 // Test fir.call modref with internal procedures after the host function has been inlined in

--- a/flang/test/Analysis/AliasAnalysis/modref-call-args.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-args.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-hlfir %s -o - | %python %S/gen_mod_ref_test.py | \
-! RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+! RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 ! RUN:  --mlir-disable-threading -o /dev/null 2>&1 | FileCheck %s
 
 ! Test fir.call modref when arguments are passed to the call. This focus

--- a/flang/test/Analysis/AliasAnalysis/modref-call-dummies.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-dummies.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-hlfir %s -o - | %python %S/gen_mod_ref_test.py | \
-! RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+! RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 ! RUN:  --mlir-disable-threading -o /dev/null 2>&1 | FileCheck %s
 
 ! Test fir.call modref for dummy argument variables. This focus on

--- a/flang/test/Analysis/AliasAnalysis/modref-call-equivalence.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-equivalence.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-hlfir %s -o - | %python %S/gen_mod_ref_test.py | \
-! RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+! RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 ! RUN:  --mlir-disable-threading -o /dev/null 2>&1 | FileCheck %s
 
 ! Test that mod ref effects for variables captured in internal procedures

--- a/flang/test/Analysis/AliasAnalysis/modref-call-globals.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-globals.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-hlfir %s -o - | %python %S/gen_mod_ref_test.py | \
-! RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+! RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 ! RUN:  --mlir-disable-threading -o /dev/null 2>&1 | FileCheck %s
 
 ! Test fir.call modref for global variables (module, saved, common).

--- a/flang/test/Analysis/AliasAnalysis/modref-call-internal-proc.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-internal-proc.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-hlfir %s -o - | %python %S/gen_mod_ref_test.py | \
-! RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+! RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 ! RUN:  --mlir-disable-threading -o /dev/null 2>&1 | FileCheck %s
 
 ! Test fir.call modref with internal procedures

--- a/flang/test/Analysis/AliasAnalysis/modref-call-locals.f90
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-locals.f90
@@ -1,5 +1,5 @@
 ! RUN: bbc -emit-hlfir %s -o - | %python %S/gen_mod_ref_test.py | \
-! RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+! RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 ! RUN:  --mlir-disable-threading -o /dev/null 2>&1 | FileCheck %s
 
 ! Test fir.call modref for local variables.

--- a/flang/test/Analysis/AliasAnalysis/modref-call-not-fortran.fir
+++ b/flang/test/Analysis/AliasAnalysis/modref-call-not-fortran.fir
@@ -1,4 +1,4 @@
-// RUN:  fir-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
+// RUN:  fir-test-opt -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis-modref))' \
 // RUN:  --mlir-disable-threading %s -o /dev/null 2>&1 | FileCheck %s
 
 // Test that fir.call modref is conservative when it cannot enusre it is

--- a/flang/test/Analysis/AliasAnalysis/ptr-component.fir
+++ b/flang/test/Analysis/AliasAnalysis/ptr-component.fir
@@ -5,7 +5,7 @@
 // is via fir.coordinate_of instead of hlfir.designate.  We would like alias
 // analysis results to be the same in both versions.
 
-// RUN: fir-opt %s -split-input-file -o /dev/null --mlir-disable-threading  \
+// RUN: fir-test-opt %s -split-input-file -o /dev/null --mlir-disable-threading  \
 // RUN:   -pass-pipeline='builtin.module(func.func(test-fir-alias-analysis))' \
 // RUN:   2>&1 | FileCheck -match-full-lines %s
 

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -65,6 +65,7 @@ set(FLANG_TEST_DEPENDS
   not
   module_files
   fir-opt
+  fir-test-opt
   tco
   bbc
   llvm-dis

--- a/flang/test/Fir/OpenACC/openacc-mappable.fir
+++ b/flang/test/Fir/OpenACC/openacc-mappable.fir
@@ -1,5 +1,5 @@
 // Use --mlir-disable-threading so that the diagnostic printing is serialized.
-// RUN: fir-opt %s -pass-pipeline='builtin.module(test-fir-openacc-interfaces)' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+// RUN: fir-test-opt %s -pass-pipeline='builtin.module(test-fir-openacc-interfaces)' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, !llvm.ptr<270> = dense<32> : vector<4xi64>, f64 = dense<64> : vector<2xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, "dlti.endianness" = "little", "dlti.stack_alignment" = 128 : i64>, fir.defaultkind = "a1c4d8i4l4r4", fir.kindmap = "", llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"} {
   func.func @_QPsub() {

--- a/flang/test/HLFIR/assign-side-effects.fir
+++ b/flang/test/HLFIR/assign-side-effects.fir
@@ -1,5 +1,5 @@
 // Test side effects of hlfir.assign op.
-// RUN: fir-opt %s --test-side-effects --verify-diagnostics
+// RUN: fir-test-opt %s --test-side-effects --verify-diagnostics
 
 func.func @test1(%x: !fir.ref<i32>, %i: i32) {
   // expected-remark @below {{found an instance of 'write' on a op operand, on resource '<Default>'}}

--- a/flang/test/HLFIR/memory-effects.fir
+++ b/flang/test/HLFIR/memory-effects.fir
@@ -1,4 +1,4 @@
-// RUN: fir-opt %s --test-side-effects --verify-diagnostics
+// RUN: fir-test-opt %s --test-side-effects --verify-diagnostics
 
 func.func @concat(%arg0: !fir.ref<!fir.char<1,10>>, %arg1: !fir.ref<!fir.char<1, 20>>) {
 // expected-remark@+1 {{operation has no memory effects}}

--- a/flang/tools/fir-opt/CMakeLists.txt
+++ b/flang/tools/fir-opt/CMakeLists.txt
@@ -3,15 +3,10 @@ llvm_update_compile_flags(fir-opt)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 
-if(FLANG_INCLUDE_TESTS)
-  set(test_libs
-    FIRTestAnalysis
-    FIRTestOpenACCInterfaces
-    MLIRTestIR
-    )
-endif()
+add_library(fir-opt-common INTERFACE)
+target_link_libraries(fir-opt PRIVATE fir-opt-common)
 
-target_link_libraries(fir-opt PRIVATE
+target_link_libraries(fir-opt-common INTERFACE
   CUFAttrs
   CUFDialect
   FIRDialect
@@ -23,10 +18,9 @@ target_link_libraries(fir-opt PRIVATE
   FIROpenACCSupport
   FlangOpenMPTransforms
   FIRAnalysis
-  ${test_libs}
 )
 
-mlir_target_link_libraries(fir-opt PRIVATE
+mlir_target_link_libraries(fir-opt-common INTERFACE
   ${dialect_libs}
   ${extension_libs}
 
@@ -45,3 +39,15 @@ mlir_target_link_libraries(fir-opt PRIVATE
   MLIRVectorToLLVM
   MLIROptLib
 )
+
+if(FLANG_INCLUDE_TESTS)
+  add_flang_executable(fir-test-opt fir-opt.cpp)
+  llvm_update_compile_flags(fir-test-opt)
+  target_compile_definitions(fir-test-opt PRIVATE FIR_TEST_OPT)
+  target_link_libraries(fir-test-opt PRIVATE
+    fir-opt-common
+    FIRTestAnalysis
+    FIRTestOpenACCInterfaces
+    MLIRTestIR
+  )
+endif()

--- a/flang/tools/fir-opt/fir-opt.cpp
+++ b/flang/tools/fir-opt/fir-opt.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
   fir::registerOptTransformPasses();
   hlfir::registerHLFIRPasses();
   flangomp::registerFlangOpenMPPasses();
-#ifdef FLANG_INCLUDE_TESTS
+#ifdef FIR_TEST_OPT
   fir::test::registerTestFIRAliasAnalysisPass();
   fir::test::registerTestFIROpenACCInterfacesPass();
   mlir::registerSideEffectTestPasses();


### PR DESCRIPTION
Rather than having different passes inside `fir-opt` depending on the value of `FLANG_INCLUDE_TESTS`, build two separate executables: regular `fir-opt` tool that is going to be installed, and a `fir-test-opt` to be used in the test suite.  This ensures that `fir-opt` behaves consistently independently of `FLANG_INCLUDE_TESTS` value used during the build, and a test-enabled build can be used on production.

Fixes #121202