### PR TITLE
[flang] [unittests] Link to libMLIR in optimizer tests

### DIFF
--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -9,8 +9,6 @@ set(LIBS
   FIRDialectSupport
   FIRSupport
   HLFIRDialect
-  ${dialect_libs}
-  ${extension_libs}
   LLVMTargetParser
 )
 
@@ -47,3 +45,8 @@ DEPENDS
 target_link_libraries(FlangOptimizerTests
   PRIVATE
   ${LIBS})
+mlir_target_link_libraries(FlangOptimizerTests
+  PRIVATE
+  ${dialect_libs}
+  ${extension_libs}
+  )


### PR DESCRIPTION
Handle the one unittest executable that I've missed in #120966.