### PR TITLE
[CMake][OCaml] Make OCaml bindings suitable for out-of-tree install

### DIFF
--- a/llvm/bindings/ocaml/README.txt
+++ b/llvm/bindings/ocaml/README.txt
@@ -19,9 +19,8 @@ The bindings can also be built out-of-tree, i.e. targeting a preinstalled
 LLVM. To do this, configure the LLVM build tree as follows:
 
     $ cmake -DLLVM_OCAML_OUT_OF_TREE=TRUE \
-            -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=[llvm-config --libdir] \
-            -DCMAKE_INSTALL_PREFIX=[Preinstalled LLVM path] \
-            -DLLVM_OCAML_INSTALL_PATH=[OCaml install prefix] \
+            -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=[LLVM libdir, e.g. `llvm-config --libdir`] \
+            -DLLVM_OCAML_INSTALL_PATH=[OCaml install prefix, e.g. `opam var lib`] \
             [... any other options]
 
 then build and install it as:

--- a/llvm/bindings/ocaml/README.txt
+++ b/llvm/bindings/ocaml/README.txt
@@ -19,6 +19,7 @@ The bindings can also be built out-of-tree, i.e. targeting a preinstalled
 LLVM. To do this, configure the LLVM build tree as follows:
 
     $ cmake -DLLVM_OCAML_OUT_OF_TREE=TRUE \
+            -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR=[llvm-config --libdir] \
             -DCMAKE_INSTALL_PREFIX=[Preinstalled LLVM path] \
             -DLLVM_OCAML_INSTALL_PATH=[OCaml install prefix] \
             [... any other options]

--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -38,10 +38,18 @@ function(add_ocaml_library name)
   set(ocaml_inputs)
 
   set(ocaml_outputs "${bin}/${name}.cma")
+  # Always use -custom when building in-tree
+  if( (NOT LLVM_OCAML_OUT_OF_TREE) OR LLVM_OCAML_CUSTOM )
+    set(ocaml_custom TRUE)
+  else()
+    set(ocaml_custom FALSE)
+  endif()
+
   if( ARG_C )
+    # ocamlmklib outputs .a and .so
     list(APPEND ocaml_outputs
          "${bin}/lib${name}.a")
-    if ( BUILD_SHARED_LIBS )
+    if ( NOT ocaml_custom )
       list(APPEND ocaml_outputs
            "${bin}/dll${name}.so")
     endif()
@@ -67,7 +75,7 @@ function(add_ocaml_library name)
     list(APPEND ocaml_flags ${dep_ocaml_flags})
   endforeach()
 
-  if( NOT BUILD_SHARED_LIBS )
+  if( ocaml_custom )
     list(APPEND ocaml_flags "-custom")
   endif()
 

--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -40,10 +40,10 @@ function(add_ocaml_library name)
   set(ocaml_outputs "${bin}/${name}.cma")
   if( ARG_C )
     list(APPEND ocaml_outputs
-         "${bin}/lib${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+         "${bin}/lib${name}.a")
     if ( BUILD_SHARED_LIBS )
       list(APPEND ocaml_outputs
-           "${bin}/dll${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+           "${bin}/dll${name}.so")
     endif()
   endif()
   if( HAVE_OCAMLOPT )
@@ -52,7 +52,12 @@ function(add_ocaml_library name)
          "${bin}/${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
   endif()
 
-  set(ocaml_flags "-lstdc++" "-ldopt" "-L${LLVM_LIBRARY_DIR}"
+  if ( LLVM_OCAML_OUT_OF_TREE )
+    set(ocaml_llvm_libdir "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}")
+  else()
+    set(ocaml_llvm_libdir "-L${LLVM_LIBRARY_DIR}")
+  endif()
+  set(ocaml_flags "-lstdc++" "${ocaml_llvm_libdir}"
                   "-ccopt" "-L\\$CAMLORIGIN/../.."
                   "-ccopt" "-Wl,-rpath,\\$CAMLORIGIN/../.."
                   ${ocaml_pkgs})
@@ -67,7 +72,7 @@ function(add_ocaml_library name)
   endif()
 
   if(LLVM_LINK_LLVM_DYLIB)
-    list(APPEND ocaml_flags "-lLLVM")
+    list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}")
   else()
     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
     foreach( llvm_lib ${llvm_libs} )

--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -206,9 +206,9 @@ function(add_ocaml_library name)
     if( NOT (ext STREQUAL ".cmo" OR
              ext STREQUAL ".ml" OR
              ext STREQUAL CMAKE_C_OUTPUT_EXTENSION OR
-             ext STREQUAL CMAKE_SHARED_LIBRARY_SUFFIX) )
+             ext STREQUAL ".so") )
       list(APPEND install_files "${ocaml_output}")
-    elseif( ext STREQUAL CMAKE_SHARED_LIBRARY_SUFFIX)
+    elseif( ext STREQUAL ".so")
       list(APPEND install_shlibs "${ocaml_output}")
     endif()
   endforeach()

--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -38,13 +38,6 @@ function(add_ocaml_library name)
   set(ocaml_inputs)
 
   set(ocaml_outputs "${bin}/${name}.cma")
-  # Always use -custom when building in-tree
-  if( (NOT LLVM_OCAML_OUT_OF_TREE) OR LLVM_OCAML_CUSTOM )
-    set(ocaml_custom TRUE)
-  else()
-    set(ocaml_custom FALSE)
-  endif()
-
   if( ARG_C )
     # ocamlmklib outputs .a and .so
     list(APPEND ocaml_outputs
@@ -75,7 +68,14 @@ function(add_ocaml_library name)
     list(APPEND ocaml_flags ${dep_ocaml_flags})
   endforeach()
 
-  if( ocaml_custom )
+  # Not passing the -custom flag is necessary for the bytecode to work when
+  # installing the bindings for an out-of-tree build.
+  #
+  # However, the -custom flag is necessary when running the in-tree
+  # test suite, otherwise multiple libraries will link to the same libLLVM and
+  # runtime errors of the form
+  # "CommandLine Error: Option *opt* registered more than once!" will occur.
+  if( NOT LLVM_OCAML_OUT_OF_TREE AND NOT BUILD_SHARED_LIBS )
     list(APPEND ocaml_flags "-custom")
   endif()
 

--- a/llvm/cmake/modules/AddOCaml.cmake
+++ b/llvm/cmake/modules/AddOCaml.cmake
@@ -38,6 +38,20 @@ function(add_ocaml_library name)
   set(ocaml_inputs)
 
   set(ocaml_outputs "${bin}/${name}.cma")
+
+  # The -custom flag causes bytecode executables to fail upon creating the
+  # runtime when installing the bindings for an out-of-tree build.
+  #
+  # However, the -custom flag is necessary when running the in-tree
+  # test suite, otherwise multiple libraries will link to the same libLLVM and
+  # runtime errors of the form
+  # "CommandLine Error: Option *opt* registered more than once!" will occur.
+  if (NOT LLVM_OCAML_OUT_OF_TREE AND NOT BUILD_SHARED_LIBS)
+    set(ocaml_custom TRUE)
+  else()
+    set(ocaml_custom FALSE)
+  endif()
+
   if( ARG_C )
     # ocamlmklib outputs .a and .so
     list(APPEND ocaml_outputs
@@ -68,14 +82,7 @@ function(add_ocaml_library name)
     list(APPEND ocaml_flags ${dep_ocaml_flags})
   endforeach()
 
-  # Not passing the -custom flag is necessary for the bytecode to work when
-  # installing the bindings for an out-of-tree build.
-  #
-  # However, the -custom flag is necessary when running the in-tree
-  # test suite, otherwise multiple libraries will link to the same libLLVM and
-  # runtime errors of the form
-  # "CommandLine Error: Option *opt* registered more than once!" will occur.
-  if( NOT LLVM_OCAML_OUT_OF_TREE AND NOT BUILD_SHARED_LIBS )
+  if(ocaml_custom)
     list(APPEND ocaml_flags "-custom")
   endif()
 


### PR DESCRIPTION
- CMAKE_{STATIC,SHARED}_LIBRARY_SUFFIX reports incorrect suffixes for Mac. Use .so and .a for both Mac and Linux.
- Add LLVM_OCAML_EXTERNAL_LLVM_LIBDIR option.
- LLVM dynamic library is always suffixed with major version