### PR TITLE
[Github][CI] Remove premerge container

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -18,11 +18,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
-    container:
-      image: ghcr.io/llvm/ci-ubuntu-22.04:latest
-    defaults:
-      run:
-        shell: bash
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@v4


### PR DESCRIPTION
This patch removes the container from the premerge job. We are moving away from the kubernetes executor back to executing everything in the same container due to reliability issues. This patch updates everything in the premerge job to work.

This is part of a temp fix to https://github.com/llvm/llvm-zorg/issues/362.