### PR TITLE
[Github] Add Zlib at build time to CI container

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
     ninja-build \
     python3 \
     git \
-    curl
+    curl \
+    zlib1g-dev
 
 RUN curl -O -L https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-$LLVM_VERSION.tar.gz && tar -xf llvmorg-$LLVM_VERSION.tar.gz
 


### PR DESCRIPTION
This patch adds zlib at build time to the CI container. This is needed to make an lldb test pass that defaults to using the system lld if it is not explicitly enabled in LLVM_ENABLE_PROJECTS.

Fixes #123479 (by fixing the proximal cause).