### PR TITLE
[flang] WIP: attempting to add an atomicadd intrinsinc

### DIFF
--- a/flang/include/flang/Optimizer/Builder/IntrinsicCall.h
+++ b/flang/include/flang/Optimizer/Builder/IntrinsicCall.h
@@ -185,6 +185,7 @@ struct IntrinsicLibrary {
   mlir::Value genAnint(mlir::Type, llvm::ArrayRef<mlir::Value>);
   fir::ExtendedValue genAny(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genAtanpi(mlir::Type, llvm::ArrayRef<mlir::Value>);
+  mlir::Value genAtomicAdd(mlir::Type, llvm::ArrayRef<mlir::Value>);
   fir::ExtendedValue
       genCommandArgumentCount(mlir::Type, llvm::ArrayRef<fir::ExtendedValue>);
   mlir::Value genAsind(mlir::Type, llvm::ArrayRef<mlir::Value>);

--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -147,6 +147,7 @@ static constexpr IntrinsicHandler handlers[]{
     {"atan2pi", &I::genAtanpi},
     {"atand", &I::genAtand},
     {"atanpi", &I::genAtanpi},
+    {"atomicaddd", &I::genAtomicAdd, {}, /*isElemental=*/false},
     {"bessel_jn",
      &I::genBesselJn,
      {{{"n1", asValue}, {"n2", asValue}, {"x", asValue}}},
@@ -2572,6 +2573,15 @@ mlir::Value IntrinsicLibrary::genAtanpi(mlir::Type resultType,
       builder.createRealConstant(loc, mlir::Float64Type::get(context), inv_pi);
   mlir::Value factor = builder.createConvert(loc, resultType, dfactor);
   return builder.create<mlir::arith::MulFOp>(loc, atan, factor);
+}
+
+mlir::Value IntrinsicLibrary::genAtomicAdd(mlir::Type resultType,
+                                           llvm::ArrayRef<mlir::Value> args) {
+  assert(args.size() == 2);
+  llvm::errs() << "In genAtomicAdd\n";
+  return builder.create<mlir::LLVM::AtomicRMWOp>(
+      loc, mlir::LLVM::AtomicBinOp::add, args[0], args[1],
+      mlir::LLVM::AtomicOrdering::seq_cst);
 }
 
 // ASSOCIATED

--- a/flang/module/cudadevice.f90
+++ b/flang/module/cudadevice.f90
@@ -92,5 +92,38 @@ implicit none
     end function
   end interface
   public :: __fadd_ru
-  
+
+interface
+  attributes(device) real*8 function atomicaddd(address, val)
+  real*8, intent(inout) :: address
+  real*8 :: val
+  end function
+end interface
+public :: atomicaddd
+
+
+!interface atomicadd
+!  attributes(device) pure integer function atomicaddi(address, val)
+!!dir$ ignore_tkr (rd) address, (d) val
+!  integer, intent(inout) :: address
+!  integer, value :: val
+!  end function
+!  attributes(device) pure real function atomicaddf(address, val)
+!!dir$ ignore_tkr (rd) address, (d) val
+!  real, intent(inout) :: address
+!  real, value :: val
+!  end function
+!  attributes(device) pure real*8 function atomicaddd(address, val)
+!!dir$ ignore_tkr (rd) address, (d) val
+!  real*8, intent(inout) :: address
+!  real*8, value :: val
+!  end function
+!  attributes(device) pure integer(8) function atomicaddul(address, val)
+!!dir$ ignore_tkr (rd) address, (dk) val
+!  integer(8), intent(inout) :: address
+!  integer(8), value :: val
+!  end function
+!end interface 
+!public :: atomicadd
+
 end module


### PR DESCRIPTION
I am trying again to get an intrinsic call to be intercepted in ... semantics? And once again, I am unable to get it to work.
The code is considerably simplified because I am really only interested to get `genAtomicAdd` to be called. 
The test is
```
module atomictests
  contains
    attributes(global) subroutine testatomicdadd( a )
    real*8 :: a
    real*8 r,istat
    r = dble(threadIdx%x)
    istat = atomicaddd(a, r)
    return
    end subroutine testatomicdadd
end module atomictests
```

Can you see what I am missing?
Thank you

