### PR TITLE
[MLIR][LLVM] Improve inlining debug information

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
@@ -643,9 +643,9 @@ static Value handleByValArgument(OpBuilder &builder, Operation *callable,
       return argument;
   }
   uint64_t targetAlignment = std::max(requestedAlignment, minimumAlignment);
-  return handleByValArgumentInit(builder, func.getLoc(), argument, elementType,
-                                 dataLayout.getTypeSize(elementType),
-                                 targetAlignment);
+  return handleByValArgumentInit(
+      builder, argument.getLoc(), argument, elementType,
+      dataLayout.getTypeSize(elementType), targetAlignment);
 }
 
 namespace {

--- a/mlir/test/Dialect/LLVMIR/inlining-debuginfo.mlir
+++ b/mlir/test/Dialect/LLVMIR/inlining-debuginfo.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-opt %s -inline -mlir-print-debuginfo | FileCheck %s
+
+llvm.func @foo() -> !llvm.ptr
+
+llvm.func @with_byval_arg(%ptr : !llvm.ptr { llvm.byval = f64 }) {
+  llvm.return
+}
+
+// CHECK-LABEL: llvm.func @test_byval
+llvm.func @test_byval() {
+  // CHECK: %[[COPY:.+]] = llvm.alloca %{{.+}} x f64
+  // CHECK-SAME: loc(#[[LOC:.+]])
+  // CHECK: %[[ORIG:.+]] = llvm.call @foo() : () -> !llvm.ptr loc(#[[LOC]])
+  %0 = llvm.call @foo() : () -> !llvm.ptr loc("inlining-debuginfo.mlir":14:2)
+  // CHECK: "llvm.intr.memcpy"(%[[COPY]], %[[ORIG]]
+  // CHECK-SAME: loc(#[[LOC]])
+  llvm.call @with_byval_arg(%0) : (!llvm.ptr) -> ()
+  llvm.return
+}
+
+// CHECK: #[[LOC]] = loc("inlining-debuginfo.mlir":14:2)


### PR DESCRIPTION
This commit improves the debug information for `alloca` and `memcpy` operations generated by the LLVM dialect inlining interface.

When inlining by value parameters, the inliner creates `alloca` and `memcpy` operations. This revision sets the location of these created operations to the respective argument locations instead of the function location. This change enables users to better identify the source code location of the copied variables.