### PR TITLE
[mlir][Vector] Refactor VectorEmulateNarrowType.cpp

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
@@ -1505,10 +1505,10 @@ static LogicalResult alignedConversionPrecondition(PatternRewriter &rewriter,
     return rewriter.notifyMatchFailure(op, "not a vector!");
 
   unsigned subByteBits = subByteVecTy.getElementTypeBitWidth();
-  unsigned multiByteBits = containerTy.getIntOrFloatBitWidth();
+  unsigned containerBits = containerTy.getIntOrFloatBitWidth();
 
   // Enforced by the common pre-conditions.
-  assert(multiByteBits % 8 == 0 && "Not a multi-byte scalar type!");
+  assert(containerBits % 8 == 0 && "Not a multi-byte scalar type!");
 
   // TODO: Add support other widths (when/if needed)
   if (subByteBits != 2 && subByteBits != 4)
@@ -1516,7 +1516,7 @@ static LogicalResult alignedConversionPrecondition(PatternRewriter &rewriter,
         op, "only 2-bit and 4-bit sub-byte type is supported at this moment");
 
   // Condition 1 ("per-element" alignment)
-  if (multiByteBits % subByteBits != 0)
+  if (containerBits % subByteBits != 0)
     return rewriter.notifyMatchFailure(op, "unalagined element types");
 
   // Condition 2 ("full" alignment)


### PR DESCRIPTION
This is PR refactors `alignedConversionPrecondition` and adds new helper
hooks.

**Update `alignedConversionPrecondition` (1)**

This method doesn't require the vector type for the "container" argument. The
underlying element type is sufficient. The corresponding argument has been
renamed as `containerTy` - this is meant as the multi-byte container element
type (`i8`, `i16`, `i32`, etc). With this change, the updated invocations of
`alignedConversionPrecondition` (in e.g. `RewriteAlignedSubByteIntExt`) make it
clear that the container element type is assumed to be `i8`.

**Update alignedConversionPrecondition (2):**

The final check in `alignedConversionPrecondition` has been replaced with a new
helper method, `isSubByteVecFittable`. This helper hook is now also re-used in
`ConvertVectorTransferRead` (to improve code re-use).

**Other updates**

Extended + unified comments.

**Implements**: https://github.com/llvm/llvm-project/issues/123630