### PR TITLE
[mlir] Clarify type of optional operands in custom parse directive.

### DIFF
--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -867,7 +867,7 @@ declarative parameter to `parse` method argument is detailed below:
     -   Optional: `<Attribute-Storage-Type>(e.g. Attribute) &`
 *   Operand Variables
     -   Single: `OpAsmParser::UnresolvedOperand &`
-    -   Optional: `Optional<OpAsmParser::UnresolvedOperand> &`
+    -   Optional: `std::optional<OpAsmParser::UnresolvedOperand> &`
     -   Variadic: `SmallVectorImpl<OpAsmParser::UnresolvedOperand> &`
     -   VariadicOfVariadic:
         `SmallVectorImpl<SmallVector<OpAsmParser::UnresolvedOperand>> &`


### PR DESCRIPTION
A custom parse directive with optional operand has an `std::optional` argument - `Optional` is not valid in this context.