### PR TITLE
[Offload] Enable shared-libs; compiler-rt as default RTLIB

### DIFF
--- a/offload/cmake/caches/AMDGPUBot.cmake
+++ b/offload/cmake/caches/AMDGPUBot.cmake
@@ -5,6 +5,7 @@ set(CMAKE_INSTALL_PREFIX /tmp/llvm.install.test CACHE STRING "")
 
 # General settings
 set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+set(BUILD_SHARED_LIBS ON CACHE BOOL "")
 set(CMAKE_C_COMPILER_LAUNCHER ccache CACHE STRING "")
 set(CMAKE_CXX_COMPILER_LAUNCHER ccache CACHE STRING "")
 
@@ -17,3 +18,4 @@ set(LLVM_TARGETS_TO_BUILD "host;AMDGPU" CACHE STRING "")
 set(LLVM_LIT_ARGS "-v --show-unsupported --timeout 100 --show-xfail -j 32" CACHE STRING "")
 
 set(CLANG_DEFAULT_LINKER "lld" CACHE STRING "")
+set(CLANG_DEFAULT_RTLIB "compiler-rt" STRING "")


### PR DESCRIPTION
This is the next step to move the CMake cache file builder closer to the build configuration we care about downstream.