### PR TITLE
[clang][bytecode] Fix diagnostic mismatch with current interpreter

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -321,7 +321,7 @@ bool CheckLive(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
 
     if (Ptr.isDynamic()) {
       S.FFDiag(Src, diag::note_constexpr_access_deleted_object) << AK;
-    } else {
+    } else if (!S.checkingPotentialConstantExpression()) {
       bool IsTemp = Ptr.isTemporary();
       S.FFDiag(Src, diag::note_constexpr_lifetime_ended, 1) << AK << !IsTemp;
 

--- a/clang/test/AST/ByteCode/lifetimes.cpp
+++ b/clang/test/AST/ByteCode/lifetimes.cpp
@@ -7,15 +7,15 @@ struct Foo {
   int a;
 };
 
-constexpr int dead1() { // expected-error {{never produces a constant expression}}
+constexpr int dead1() {
 
   Foo *F2 = nullptr;
   {
-    Foo F{12}; // expected-note 2{{declared here}}
+    Foo F{12}; // expected-note {{declared here}}
     F2 = &F;
   } // Ends lifetime of F.
 
-  return F2->a; // expected-note 2{{read of variable whose lifetime has ended}} \
+  return F2->a; // expected-note {{read of variable whose lifetime has ended}} \
                 // ref-note {{read of object outside its lifetime is not allowed in a constant expression}}
 }
 static_assert(dead1() == 1, ""); // both-error {{not an integral constant expression}} \


### PR DESCRIPTION
Don't report dead pointers if we've checking for a potential constant expression.