### PR TITLE
[Support] Remove ciso646 include

### DIFF
--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -18,7 +18,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/Support/Compiler.h"
-#include <ciso646> // So we can check the C++ standard lib macros.
 #include <optional>
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
This header has been removed in C++20 and causes a large amount of deprecation spam when building against libstdc++ 15 in C++17 mode.

As far as I understand, we just need to include *some* STL header to get access to the version macros, and as this header also includes <optional> nowadays we can just drop the <cstd646> include entirely.