### PR TITLE
[X86] Add verifyTargetSDNode for x86 target specific nodes

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -61009,3 +61009,31 @@ Align X86TargetLowering::getPrefLoopAlignment(MachineLoop *ML) const {
     return Align(1ULL << ExperimentalPrefInnermostLoopAlignment);
   return TargetLowering::getPrefLoopAlignment();
 }
+
+#ifndef NDEBUG
+void X86TargetLowering::verifyTargetSDNode(const SDNode *N) const {
+  switch (N->getOpcode()) {
+  default:
+    break;
+  case X86ISD::KSHIFTL:
+  case X86ISD::KSHIFTR: {
+    EVT VT = N->getValueType(0);
+    auto *Amt = cast<ConstantSDNode>(N->getOperand(1));
+    assert(Amt->getAPIntValue().ult(VT.getVectorNumElements()) &&
+           "Out of range KSHIFT shift amount");
+    break;
+  }
+  case X86ISD::PSADBW: {
+    EVT VT = N->getValueType(0);
+    SDValue LHS = N->getOperand(0);
+    SDValue RHS = N->getOperand(1);
+    assert((VT == MVT::v2i64 || VT == MVT::v4i64 || VT == MVT::v8i64) &&
+           LHS.getValueType() == RHS.getValueType() &&
+           LHS.getValueSizeInBits() == VT.getSizeInBits() &&
+           LHS.getValueType().getScalarType() == MVT::i8 &&
+           "Unexpected PSADBW types");
+    break;
+  }
+  }
+}
+#endif

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -1658,6 +1658,10 @@ namespace llvm {
       return TargetLoweringBase::getTypeToTransformTo(Context, VT);
     }
 
+#ifndef NDEBUG
+    void verifyTargetSDNode(const SDNode *N) const override;
+#endif
+
   protected:
     std::pair<const TargetRegisterClass *, uint8_t>
     findRepresentativeClass(const TargetRegisterInfo *TRI,


### PR DESCRIPTION
This allows us to verify/assert the node's validity on creation instead of waiting for when its used in a combine/analysis.

Added some initial verification for X86ISD::KSHIFL\R and X86ISD::PSADBW types - more to follow.