### PR TITLE
[clang][bytecode] Diagnose IntegralToPointer casts to non-void

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -2693,6 +2693,10 @@ template <PrimType Name, class T = typename PrimConv<Name>::T>
 inline bool GetIntPtr(InterpState &S, CodePtr OpPC, const Descriptor *Desc) {
   const T &IntVal = S.Stk.pop<T>();
 
+  if (Desc)
+    S.CCEDiag(S.Current->getSource(OpPC), diag::note_constexpr_invalid_cast)
+        << 2 << S.getLangOpts().CPlusPlus;
+
   S.Stk.push<Pointer>(static_cast<uint64_t>(IntVal), Desc);
   return true;
 }

--- a/clang/test/AST/ByteCode/constexpr.c
+++ b/clang/test/AST/ByteCode/constexpr.c
@@ -309,8 +309,8 @@ constexpr const int *V81 = &V80;
 constexpr int *V82 = 0;
 constexpr int *V83 = V82;
 constexpr int *V84 = 42;
-// ref-error@-1 {{constexpr variable 'V84' must be initialized by a constant expression}}
-// ref-note@-2 {{this conversion is not allowed in a constant expression}}
+// both-error@-1 {{constexpr variable 'V84' must be initialized by a constant expression}}
+// both-note@-2 {{this conversion is not allowed in a constant expression}}
 // both-error@-3 {{constexpr pointer initializer is not null}}
 constexpr int *V85 = nullptr;
 

--- a/clang/test/SemaCXX/builtin-assume-aligned.cpp
+++ b/clang/test/SemaCXX/builtin-assume-aligned.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -triple x86_64-linux-gnu %s
-// RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 -triple x86_64-linux-gnu %s -fexperimental-new-constant-interpreter
 
 int n;
 constexpr int *p = 0;


### PR DESCRIPTION
But keep evaluating. This is what the current interpreter does as well.