### PR TITLE
[SPIR-V] Fix an undefined behaviour in the SPIRV emit-intrinsics pass

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -2475,8 +2475,10 @@ void SPIRVEmitIntrinsics::parseFunDeclarations(Module &M) {
     if (DemangledName.empty())
       continue;
     // allow only OpGroupAsyncCopy use case at the moment
-    auto [Grp, Opcode, ExtNo] =
-        SPIRV::mapBuiltinToOpcode(DemangledName, InstrSet);
+    auto [Grp, Opcode, ExtNo] = SPIRV::mapBuiltinToOpcode(
+        DemangledName, TM->getSubtarget<SPIRVSubtarget>(F).isOpenCLEnv()
+                           ? SPIRV::InstructionSet::OpenCL_std
+                           : SPIRV::InstructionSet::GLSL_std_450);
     if (Opcode != SPIRV::OpGroupAsyncCopy)
       continue;
     // find pointer arguments


### PR DESCRIPTION
Adding SPIRV to LLVM_ALL_TARGETS (https://github.com/llvm/llvm-project/pull/119653) revealed a series of minor compilation problems and sanitizer complaints. This PR is to address the problem of the undefined behaviour in the SPIRV emit-intrinsics pass. 

I can see no more SPIR-V Builder-related fails in sanitizers, checked locally as:

```
mkdir sanitizer
cd sanitizer/
git clone https://github.com/llvm/llvm-zorg.git
BUILDBOT_MONO_REPO_PATH=/path-to-the-fixed-locally-sources/llvm-project llvm-zorg/zorg/buildbot/builders/sanitizers/buildbot_fast.sh
```