### PR TITLE
[IR][unittests] Replace of PointerType::get(Type) with opaque version (NFC)

### DIFF
--- a/llvm/unittests/CodeGen/LowLevelTypeTest.cpp
+++ b/llvm/unittests/CodeGen/LowLevelTypeTest.cpp
@@ -304,10 +304,10 @@ TEST(LowLevelTypeTest, Pointer) {
       EXPECT_FALSE(VTy != VTy);
 
       // Test Type->LLT conversion.
-      Type *IRTy = PointerType::get(IntegerType::get(C, 8), AS);
+      Type *IRTy = PointerType::get(C, AS);
       EXPECT_EQ(Ty, getLLTForType(*IRTy, DL));
       Type *IRVTy =
-          VectorType::get(PointerType::get(IntegerType::get(C, 8), AS), EC);
+          VectorType::get(PointerType::get(C, AS), EC);
       EXPECT_EQ(VTy, getLLTForType(*IRVTy, DL));
     }
   }

--- a/llvm/unittests/CodeGen/LowLevelTypeTest.cpp
+++ b/llvm/unittests/CodeGen/LowLevelTypeTest.cpp
@@ -306,8 +306,7 @@ TEST(LowLevelTypeTest, Pointer) {
       // Test Type->LLT conversion.
       Type *IRTy = PointerType::get(C, AS);
       EXPECT_EQ(Ty, getLLTForType(*IRTy, DL));
-      Type *IRVTy =
-          VectorType::get(PointerType::get(C, AS), EC);
+      Type *IRVTy = VectorType::get(PointerType::get(C, AS), EC);
       EXPECT_EQ(VTy, getLLTForType(*IRVTy, DL));
     }
   }

--- a/llvm/unittests/FuzzMutate/OperationsTest.cpp
+++ b/llvm/unittests/FuzzMutate/OperationsTest.cpp
@@ -93,8 +93,7 @@ TEST(OperationsTest, SourcePreds) {
   Constant *v8i1 = ConstantVector::getSplat(ElementCount::getFixed(8), i1);
   Constant *v8i8 = ConstantVector::getSplat(ElementCount::getFixed(8), i8);
   Constant *v4f16 = ConstantVector::getSplat(ElementCount::getFixed(4), f16);
-  Constant *p0i32 =
-      ConstantPointerNull::get(PointerType::get(Ctx, 0));
+  Constant *p0i32 = ConstantPointerNull::get(PointerType::get(Ctx, 0));
   Constant *v8p0i32 =
       ConstantVector::getSplat(ElementCount::getFixed(8), p0i32);
   Constant *vni32 = ConstantVector::getSplat(ElementCount::getScalable(8), i32);

--- a/llvm/unittests/FuzzMutate/OperationsTest.cpp
+++ b/llvm/unittests/FuzzMutate/OperationsTest.cpp
@@ -94,7 +94,7 @@ TEST(OperationsTest, SourcePreds) {
   Constant *v8i8 = ConstantVector::getSplat(ElementCount::getFixed(8), i8);
   Constant *v4f16 = ConstantVector::getSplat(ElementCount::getFixed(4), f16);
   Constant *p0i32 =
-      ConstantPointerNull::get(PointerType::get(i32->getType(), 0));
+      ConstantPointerNull::get(PointerType::get(Ctx, 0));
   Constant *v8p0i32 =
       ConstantVector::getSplat(ElementCount::getFixed(8), p0i32);
   Constant *vni32 = ConstantVector::getSplat(ElementCount::getScalable(8), i32);

--- a/llvm/unittests/FuzzMutate/RandomIRBuilderTest.cpp
+++ b/llvm/unittests/FuzzMutate/RandomIRBuilderTest.cpp
@@ -328,7 +328,7 @@ TEST(RandomIRBuilderTest, createStackMemory) {
       Int64Ty,
       DoubleTy,
       PointerType::get(Ctx, 0),
-      PointerType::get(Int32Ty, 0),
+      PointerType::get(Ctx, 0),
       VectorType::get(Int32Ty, 4, false),
       StructType::create({Int32Ty, DoubleTy, Int64Ty}),
       ArrayType::get(Int64Ty, 4),

--- a/llvm/unittests/FuzzMutate/RandomIRBuilderTest.cpp
+++ b/llvm/unittests/FuzzMutate/RandomIRBuilderTest.cpp
@@ -323,26 +323,24 @@ TEST(RandomIRBuilderTest, createStackMemory) {
   Type *DoubleTy = Type::getDoubleTy(Ctx);
   Constant *Double_0 =
       ConstantFP::get(Ctx, APFloat::getZero(DoubleTy->getFltSemantics()));
-  std::array<Type *, 8> Types = {
+  std::array<Type *, 7> Types = {
       Int32Ty,
       Int64Ty,
       DoubleTy,
-      PointerType::get(Ctx, 0),
       PointerType::get(Ctx, 0),
       VectorType::get(Int32Ty, 4, false),
       StructType::create({Int32Ty, DoubleTy, Int64Ty}),
       ArrayType::get(Int64Ty, 4),
   };
-  std::array<Value *, 8> Inits = {
+  std::array<Value *, 7> Inits = {
       Int32_1,
       Int64_42,
       Double_0,
       UndefValue::get(Types[3]),
-      UndefValue::get(Types[4]),
       ConstantVector::get({Int32_1, Int32_1, Int32_1, Int32_1}),
-      ConstantStruct::get(cast<StructType>(Types[6]),
+      ConstantStruct::get(cast<StructType>(Types[5]),
                           {Int32_1, Double_0, Int64_42}),
-      ConstantArray::get(cast<ArrayType>(Types[7]),
+      ConstantArray::get(cast<ArrayType>(Types[6]),
                          {Int64_42, Int64_42, Int64_42, Int64_42}),
   };
   ASSERT_EQ(Types.size(), Inits.size());

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -315,7 +315,7 @@ TEST(ConstantsTest, GEPReplaceWithConstant) {
   std::unique_ptr<Module> M(new Module("MyModule", Context));
 
   Type *IntTy = Type::getInt32Ty(Context);
-  Type *PtrTy = PointerType::get(IntTy, 0);
+  Type *PtrTy = PointerType::get(Context, 0);
   auto *C1 = ConstantInt::get(IntTy, 1);
   auto *Placeholder = new GlobalVariable(
       *M, IntTy, false, GlobalValue::ExternalWeakLinkage, nullptr);
@@ -342,7 +342,7 @@ TEST(ConstantsTest, AliasCAPI) {
       parseAssemblyString("@g = global i32 42", Error, Context);
   GlobalVariable *G = M->getGlobalVariable("g");
   Type *I16Ty = Type::getInt16Ty(Context);
-  Type *I16PTy = PointerType::get(I16Ty, 0);
+  Type *I16PTy = PointerType::get(Context, 0);
   Constant *Aliasee = ConstantExpr::getBitCast(G, I16PTy);
   LLVMValueRef AliasRef =
       LLVMAddAlias2(wrap(M.get()), wrap(I16Ty), 0, wrap(Aliasee), "a");
@@ -421,7 +421,7 @@ TEST(ConstantsTest, BitcastToGEP) {
 
   auto *G =
       new GlobalVariable(*M, S, false, GlobalValue::ExternalLinkage, nullptr);
-  auto *PtrTy = PointerType::get(i32, 0);
+  auto *PtrTy = PointerType::get(Context, 0);
   auto *C = ConstantExpr::getBitCast(G, PtrTy);
   /* With opaque pointers, no cast is necessary. */
   EXPECT_EQ(C, G);

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -220,11 +220,11 @@ TEST(InstructionsTest, CastInst) {
   Type *VScaleV4Int16Ty = ScalableVectorType::get(Int16Ty, 4);
   Type *VScaleV1Int16Ty = ScalableVectorType::get(Int16Ty, 1);
 
-  Type *Int32PtrTy = PointerType::get(Int32Ty, 0);
-  Type *Int64PtrTy = PointerType::get(Int64Ty, 0);
+  Type *Int32PtrTy = PointerType::get(C, 0);
+  Type *Int64PtrTy = PointerType::get(C, 0);
 
-  Type *Int32PtrAS1Ty = PointerType::get(Int32Ty, 1);
-  Type *Int64PtrAS1Ty = PointerType::get(Int64Ty, 1);
+  Type *Int32PtrAS1Ty = PointerType::get(C, 1);
+  Type *Int64PtrAS1Ty = PointerType::get(C, 1);
 
   Type *V2Int32PtrAS1Ty = FixedVectorType::get(Int32PtrAS1Ty, 2);
   Type *V2Int64PtrAS1Ty = FixedVectorType::get(Int64PtrAS1Ty, 2);
@@ -406,8 +406,8 @@ TEST(InstructionsTest, CastCAPI) {
   Type *FloatTy = Type::getFloatTy(C);
   Type *DoubleTy = Type::getDoubleTy(C);
 
-  Type *Int8PtrTy = PointerType::get(Int8Ty, 0);
-  Type *Int32PtrTy = PointerType::get(Int32Ty, 0);
+  Type *Int8PtrTy = PointerType::get(C, 0);
+  Type *Int32PtrTy = PointerType::get(C, 0);
 
   const Constant *C8 = Constant::getNullValue(Int8Ty);
   const Constant *C64 = Constant::getNullValue(Int64Ty);
@@ -448,7 +448,7 @@ TEST(InstructionsTest, CastCAPI) {
   EXPECT_EQ(LLVMTrunc, LLVMGetCastOpcode(wrap(CV64), true, wrap(V8x8Ty), true));
   EXPECT_EQ(LLVMSExt, LLVMGetCastOpcode(wrap(CV8), true, wrap(V8x64Ty), true));
 
-  Type *Int32PtrAS1Ty = PointerType::get(Int32Ty, 1);
+  Type *Int32PtrAS1Ty = PointerType::get(C, 1);
   Type *V2Int32PtrAS1Ty = FixedVectorType::get(Int32PtrAS1Ty, 2);
   Type *V2Int32PtrTy = FixedVectorType::get(Int32PtrTy, 2);
   const Constant *CV2ptr32 = Constant::getNullValue(V2Int32PtrTy);
@@ -463,8 +463,8 @@ TEST(InstructionsTest, VectorGep) {
   // Type Definitions
   Type *I8Ty = IntegerType::get(C, 8);
   Type *I32Ty = IntegerType::get(C, 32);
-  PointerType *Ptri8Ty = PointerType::get(I8Ty, 0);
-  PointerType *Ptri32Ty = PointerType::get(I32Ty, 0);
+  PointerType *Ptri8Ty = PointerType::get(C, 0);
+  PointerType *Ptri32Ty = PointerType::get(C, 0);
 
   VectorType *V2xi8PTy = FixedVectorType::get(Ptri8Ty, 2);
   VectorType *V2xi32PTy = FixedVectorType::get(Ptri32Ty, 2);

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -253,9 +253,8 @@ TEST(InstructionsTest, CastInst) {
             CastInst::getCastOpcode(v2ptr32, true, V2PtrAS1Ty, true));
 
   // Test mismatched number of elements for pointers
-  EXPECT_FALSE(CastInst::isBitCastable(V2PtrTy, V2PtrTy));
-  EXPECT_FALSE(CastInst::isBitCastable(V2PtrAS1Ty, V2PtrAS1Ty));
   EXPECT_FALSE(CastInst::isBitCastable(V2PtrAS1Ty, V4PtrAS1Ty));
+  EXPECT_FALSE(CastInst::isBitCastable(V4PtrAS1Ty, V2PtrAS1Ty));
   EXPECT_FALSE(CastInst::isBitCastable(PtrTy, V2PtrTy));
   EXPECT_FALSE(CastInst::isBitCastable(V2PtrTy, PtrTy));
 

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -220,29 +220,22 @@ TEST(InstructionsTest, CastInst) {
   Type *VScaleV4Int16Ty = ScalableVectorType::get(Int16Ty, 4);
   Type *VScaleV1Int16Ty = ScalableVectorType::get(Int16Ty, 1);
 
-  Type *Int32PtrTy = PointerType::get(C, 0);
-  Type *Int64PtrTy = PointerType::get(C, 0);
+  Type *PtrTy = PointerType::get(C, 0);
+  Type *PtrAS1Ty = PointerType::get(C, 1);
 
-  Type *Int32PtrAS1Ty = PointerType::get(C, 1);
-  Type *Int64PtrAS1Ty = PointerType::get(C, 1);
+  Type *V2PtrAS1Ty = FixedVectorType::get(PtrAS1Ty, 2);
+  Type *V4PtrAS1Ty = FixedVectorType::get(PtrAS1Ty, 4);
+  Type *VScaleV4PtrAS1Ty = ScalableVectorType::get(PtrAS1Ty, 4);
 
-  Type *V2Int32PtrAS1Ty = FixedVectorType::get(Int32PtrAS1Ty, 2);
-  Type *V2Int64PtrAS1Ty = FixedVectorType::get(Int64PtrAS1Ty, 2);
-  Type *V4Int32PtrAS1Ty = FixedVectorType::get(Int32PtrAS1Ty, 4);
-  Type *VScaleV4Int32PtrAS1Ty = ScalableVectorType::get(Int32PtrAS1Ty, 4);
-  Type *V4Int64PtrAS1Ty = FixedVectorType::get(Int64PtrAS1Ty, 4);
-
-  Type *V2Int64PtrTy = FixedVectorType::get(Int64PtrTy, 2);
-  Type *V2Int32PtrTy = FixedVectorType::get(Int32PtrTy, 2);
-  Type *VScaleV2Int32PtrTy = ScalableVectorType::get(Int32PtrTy, 2);
-  Type *V4Int32PtrTy = FixedVectorType::get(Int32PtrTy, 4);
-  Type *VScaleV4Int32PtrTy = ScalableVectorType::get(Int32PtrTy, 4);
-  Type *VScaleV4Int64PtrTy = ScalableVectorType::get(Int64PtrTy, 4);
+  Type *V2PtrTy = FixedVectorType::get(PtrTy, 2);
+  Type *V4PtrTy = FixedVectorType::get(PtrTy, 4);
+  Type *VScaleV2PtrTy = ScalableVectorType::get(PtrTy, 2);
+  Type *VScaleV4PtrTy = ScalableVectorType::get(PtrTy, 4);
 
   const Constant* c8 = Constant::getNullValue(V8x8Ty);
   const Constant* c64 = Constant::getNullValue(V8x64Ty);
 
-  const Constant *v2ptr32 = Constant::getNullValue(V2Int32PtrTy);
+  const Constant *v2ptr32 = Constant::getNullValue(V2PtrTy);
 
   EXPECT_EQ(CastInst::Trunc, CastInst::getCastOpcode(c64, true, V8x8Ty, true));
   EXPECT_EQ(CastInst::SExt, CastInst::getCastOpcode(c8, true, V8x64Ty, true));
@@ -251,23 +244,22 @@ TEST(InstructionsTest, CastInst) {
   EXPECT_FALSE(CastInst::isBitCastable(V8x8Ty, V8x64Ty));
 
   // Check address space casts are rejected since we don't know the sizes here
-  EXPECT_FALSE(CastInst::isBitCastable(Int32PtrTy, Int32PtrAS1Ty));
-  EXPECT_FALSE(CastInst::isBitCastable(Int32PtrAS1Ty, Int32PtrTy));
-  EXPECT_FALSE(CastInst::isBitCastable(V2Int32PtrTy, V2Int32PtrAS1Ty));
-  EXPECT_FALSE(CastInst::isBitCastable(V2Int32PtrAS1Ty, V2Int32PtrTy));
-  EXPECT_TRUE(CastInst::isBitCastable(V2Int32PtrAS1Ty, V2Int64PtrAS1Ty));
-  EXPECT_EQ(CastInst::AddrSpaceCast, CastInst::getCastOpcode(v2ptr32, true,
-                                                             V2Int32PtrAS1Ty,
-                                                             true));
+  EXPECT_FALSE(CastInst::isBitCastable(PtrTy, PtrAS1Ty));
+  EXPECT_FALSE(CastInst::isBitCastable(PtrAS1Ty, PtrTy));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrTy, V2PtrAS1Ty));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrAS1Ty, V2PtrTy));
+  EXPECT_TRUE(CastInst::isBitCastable(V2PtrAS1Ty, V2PtrAS1Ty));
+  EXPECT_EQ(CastInst::AddrSpaceCast,
+            CastInst::getCastOpcode(v2ptr32, true, V2PtrAS1Ty, true));
 
   // Test mismatched number of elements for pointers
-  EXPECT_FALSE(CastInst::isBitCastable(V2Int32PtrAS1Ty, V4Int64PtrAS1Ty));
-  EXPECT_FALSE(CastInst::isBitCastable(V4Int64PtrAS1Ty, V2Int32PtrAS1Ty));
-  EXPECT_FALSE(CastInst::isBitCastable(V2Int32PtrAS1Ty, V4Int32PtrAS1Ty));
-  EXPECT_FALSE(CastInst::isBitCastable(Int32PtrTy, V2Int32PtrTy));
-  EXPECT_FALSE(CastInst::isBitCastable(V2Int32PtrTy, Int32PtrTy));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrTy, V2PtrTy));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrAS1Ty, V2PtrAS1Ty));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrAS1Ty, V4PtrAS1Ty));
+  EXPECT_FALSE(CastInst::isBitCastable(PtrTy, V2PtrTy));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrTy, PtrTy));
 
-  EXPECT_TRUE(CastInst::isBitCastable(Int32PtrTy, Int64PtrTy));
+  EXPECT_TRUE(CastInst::isBitCastable(PtrTy, PtrTy));
   EXPECT_FALSE(CastInst::isBitCastable(DoubleTy, FloatTy));
   EXPECT_FALSE(CastInst::isBitCastable(FloatTy, DoubleTy));
   EXPECT_TRUE(CastInst::isBitCastable(FloatTy, FloatTy));
@@ -281,55 +273,48 @@ TEST(InstructionsTest, CastInst) {
   EXPECT_FALSE(CastInst::isBitCastable(Int32Ty, Int64Ty));
   EXPECT_FALSE(CastInst::isBitCastable(Int64Ty, Int32Ty));
 
-  EXPECT_FALSE(CastInst::isBitCastable(V2Int32PtrTy, Int64Ty));
-  EXPECT_FALSE(CastInst::isBitCastable(Int64Ty, V2Int32PtrTy));
-  EXPECT_TRUE(CastInst::isBitCastable(V2Int64PtrTy, V2Int32PtrTy));
-  EXPECT_TRUE(CastInst::isBitCastable(V2Int32PtrTy, V2Int64PtrTy));
+  EXPECT_FALSE(CastInst::isBitCastable(V2PtrTy, Int64Ty));
+  EXPECT_FALSE(CastInst::isBitCastable(Int64Ty, V2PtrTy));
   EXPECT_FALSE(CastInst::isBitCastable(V2Int32Ty, V2Int64Ty));
   EXPECT_FALSE(CastInst::isBitCastable(V2Int64Ty, V2Int32Ty));
 
-
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V4Int32PtrTy),
-                                     V2Int32PtrTy));
+                                     Constant::getNullValue(V4PtrTy), V2PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
-                                     Constant::getNullValue(V2Int32PtrTy),
-                                     V4Int32PtrTy));
+                                     Constant::getNullValue(V2PtrTy), V4PtrTy));
 
-  EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(V4Int32PtrAS1Ty),
-                                     V2Int32PtrTy));
-  EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(V2Int32PtrTy),
-                                     V4Int32PtrAS1Ty));
+  EXPECT_FALSE(CastInst::castIsValid(
+      Instruction::AddrSpaceCast, Constant::getNullValue(V4PtrAS1Ty), V2PtrTy));
+  EXPECT_FALSE(CastInst::castIsValid(
+      Instruction::AddrSpaceCast, Constant::getNullValue(V2PtrTy), V4PtrAS1Ty));
 
   // Address space cast of fixed/scalable vectors of pointers to scalable/fixed
   // vector of pointers.
-  EXPECT_FALSE(CastInst::castIsValid(
-      Instruction::AddrSpaceCast, Constant::getNullValue(VScaleV4Int32PtrAS1Ty),
-      V4Int32PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(V4Int32PtrTy),
-                                     VScaleV4Int32PtrAS1Ty));
+                                     Constant::getNullValue(VScaleV4PtrAS1Ty),
+                                     V4PtrTy));
+  EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
+                                     Constant::getNullValue(V4PtrTy),
+                                     VScaleV4PtrAS1Ty));
   // Address space cast of scalable vectors of pointers to scalable vector of
   // pointers.
-  EXPECT_FALSE(CastInst::castIsValid(
-      Instruction::AddrSpaceCast, Constant::getNullValue(VScaleV4Int32PtrAS1Ty),
-      VScaleV2Int32PtrTy));
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(VScaleV2Int32PtrTy),
-                                     VScaleV4Int32PtrAS1Ty));
+                                     Constant::getNullValue(VScaleV4PtrAS1Ty),
+                                     VScaleV2PtrTy));
+  EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
+                                     Constant::getNullValue(VScaleV2PtrTy),
+                                     VScaleV4PtrAS1Ty));
   EXPECT_TRUE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                    Constant::getNullValue(VScaleV4Int64PtrTy),
-                                    VScaleV4Int32PtrAS1Ty));
+                                    Constant::getNullValue(VScaleV4PtrTy),
+                                    VScaleV4PtrAS1Ty));
   // Same number of lanes, different address space.
-  EXPECT_TRUE(CastInst::castIsValid(
-      Instruction::AddrSpaceCast, Constant::getNullValue(VScaleV4Int32PtrAS1Ty),
-      VScaleV4Int32PtrTy));
+  EXPECT_TRUE(CastInst::castIsValid(Instruction::AddrSpaceCast,
+                                    Constant::getNullValue(VScaleV4PtrAS1Ty),
+                                    VScaleV4PtrTy));
   // Same number of lanes, same address space.
   EXPECT_FALSE(CastInst::castIsValid(Instruction::AddrSpaceCast,
-                                     Constant::getNullValue(VScaleV4Int64PtrTy),
-                                     VScaleV4Int32PtrTy));
+                                     Constant::getNullValue(VScaleV4PtrTy),
+                                     VScaleV4PtrTy));
 
   // Bit casting fixed/scalable vector to scalable/fixed vectors.
   EXPECT_FALSE(CastInst::castIsValid(Instruction::BitCast,
@@ -377,10 +362,10 @@ TEST(InstructionsTest, CastInst) {
   // pointers
   // First form
   BasicBlock *BB = BasicBlock::Create(C);
-  Constant *NullV2I32Ptr = Constant::getNullValue(V2Int32PtrTy);
+  Constant *NullV2I32Ptr = Constant::getNullValue(V2PtrTy);
   auto Inst1 = CastInst::CreatePointerCast(NullV2I32Ptr, V2Int32Ty, "foo", BB);
 
-  Constant *NullVScaleV2I32Ptr = Constant::getNullValue(VScaleV2Int32PtrTy);
+  Constant *NullVScaleV2I32Ptr = Constant::getNullValue(VScaleV2PtrTy);
   auto Inst1VScale = CastInst::CreatePointerCast(
       NullVScaleV2I32Ptr, VScaleV2Int32Ty, "foo.vscale", BB);
 
@@ -400,14 +385,12 @@ TEST(InstructionsTest, CastCAPI) {
   LLVMContext C;
 
   Type *Int8Ty = Type::getInt8Ty(C);
-  Type *Int32Ty = Type::getInt32Ty(C);
   Type *Int64Ty = Type::getInt64Ty(C);
 
   Type *FloatTy = Type::getFloatTy(C);
   Type *DoubleTy = Type::getDoubleTy(C);
 
-  Type *Int8PtrTy = PointerType::get(C, 0);
-  Type *Int32PtrTy = PointerType::get(C, 0);
+  Type *PtrTy = PointerType::get(C, 0);
 
   const Constant *C8 = Constant::getNullValue(Int8Ty);
   const Constant *C64 = Constant::getNullValue(Int64Ty);
@@ -433,12 +416,11 @@ TEST(InstructionsTest, CastCAPI) {
   EXPECT_EQ(LLVMFPExt,
             LLVMGetCastOpcode(wrap(CF32), true, wrap(DoubleTy), true));
 
-  const Constant *CPtr8 = Constant::getNullValue(Int8PtrTy);
+  const Constant *CPtr8 = Constant::getNullValue(PtrTy);
 
   EXPECT_EQ(LLVMPtrToInt,
             LLVMGetCastOpcode(wrap(CPtr8), true, wrap(Int8Ty), true));
-  EXPECT_EQ(LLVMIntToPtr,
-            LLVMGetCastOpcode(wrap(C8), true, wrap(Int8PtrTy), true));
+  EXPECT_EQ(LLVMIntToPtr, LLVMGetCastOpcode(wrap(C8), true, wrap(PtrTy), true));
 
   Type *V8x8Ty = FixedVectorType::get(Int8Ty, 8);
   Type *V8x64Ty = FixedVectorType::get(Int64Ty, 8);
@@ -448,26 +430,22 @@ TEST(InstructionsTest, CastCAPI) {
   EXPECT_EQ(LLVMTrunc, LLVMGetCastOpcode(wrap(CV64), true, wrap(V8x8Ty), true));
   EXPECT_EQ(LLVMSExt, LLVMGetCastOpcode(wrap(CV8), true, wrap(V8x64Ty), true));
 
-  Type *Int32PtrAS1Ty = PointerType::get(C, 1);
-  Type *V2Int32PtrAS1Ty = FixedVectorType::get(Int32PtrAS1Ty, 2);
-  Type *V2Int32PtrTy = FixedVectorType::get(Int32PtrTy, 2);
-  const Constant *CV2ptr32 = Constant::getNullValue(V2Int32PtrTy);
+  Type *PtrAS1Ty = PointerType::get(C, 1);
+  Type *V2PtrAS1Ty = FixedVectorType::get(PtrAS1Ty, 2);
+  Type *V2PtrTy = FixedVectorType::get(PtrTy, 2);
+  const Constant *CV2Ptr = Constant::getNullValue(V2PtrTy);
 
-  EXPECT_EQ(LLVMAddrSpaceCast, LLVMGetCastOpcode(wrap(CV2ptr32), true,
-                                                 wrap(V2Int32PtrAS1Ty), true));
+  EXPECT_EQ(LLVMAddrSpaceCast,
+            LLVMGetCastOpcode(wrap(CV2Ptr), true, wrap(V2PtrAS1Ty), true));
 }
 
 TEST(InstructionsTest, VectorGep) {
   LLVMContext C;
 
   // Type Definitions
-  Type *I8Ty = IntegerType::get(C, 8);
   Type *I32Ty = IntegerType::get(C, 32);
-  PointerType *Ptri8Ty = PointerType::get(C, 0);
-  PointerType *Ptri32Ty = PointerType::get(C, 0);
-
-  VectorType *V2xi8PTy = FixedVectorType::get(Ptri8Ty, 2);
-  VectorType *V2xi32PTy = FixedVectorType::get(Ptri32Ty, 2);
+  PointerType *PtrTy = PointerType::get(C, 0);
+  VectorType *V2xPTy = FixedVectorType::get(PtrTy, 2);
 
   // Test different aspects of the vector-of-pointers type
   // and GEPs which use this type.
@@ -478,8 +456,8 @@ TEST(InstructionsTest, VectorGep) {
   Constant *C2xi32a = ConstantVector::get(ConstVa);
   Constant *C2xi32b = ConstantVector::get(ConstVb);
 
-  CastInst *PtrVecA = new IntToPtrInst(C2xi32a, V2xi32PTy);
-  CastInst *PtrVecB = new IntToPtrInst(C2xi32b, V2xi32PTy);
+  CastInst *PtrVecA = new IntToPtrInst(C2xi32a, V2xPTy);
+  CastInst *PtrVecB = new IntToPtrInst(C2xi32b, V2xPTy);
 
   ICmpInst *ICmp0 = new ICmpInst(ICmpInst::ICMP_SGT, PtrVecA, PtrVecB);
   ICmpInst *ICmp1 = new ICmpInst(ICmpInst::ICMP_ULT, PtrVecA, PtrVecB);
@@ -495,10 +473,10 @@ TEST(InstructionsTest, VectorGep) {
   GetElementPtrInst *Gep2 = GetElementPtrInst::Create(I32Ty, PtrVecB, C2xi32a);
   GetElementPtrInst *Gep3 = GetElementPtrInst::Create(I32Ty, PtrVecB, C2xi32b);
 
-  CastInst *BTC0 = new BitCastInst(Gep0, V2xi8PTy);
-  CastInst *BTC1 = new BitCastInst(Gep1, V2xi8PTy);
-  CastInst *BTC2 = new BitCastInst(Gep2, V2xi8PTy);
-  CastInst *BTC3 = new BitCastInst(Gep3, V2xi8PTy);
+  CastInst *BTC0 = new BitCastInst(Gep0, V2xPTy);
+  CastInst *BTC1 = new BitCastInst(Gep1, V2xPTy);
+  CastInst *BTC2 = new BitCastInst(Gep2, V2xPTy);
+  CastInst *BTC3 = new BitCastInst(Gep3, V2xPTy);
 
   Value *S0 = BTC0->stripPointerCasts();
   Value *S1 = BTC1->stripPointerCasts();

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -76,7 +76,7 @@ TEST(VerifierTest, Freeze) {
   FI_dbl->eraseFromParent();
 
   // Valid type : freeze(i32*)
-  PointerType *PT = PointerType::get(ITy, 0);
+  PointerType *PT = PointerType::get(C, 0);
   ConstantPointerNull *CPN = ConstantPointerNull::get(PT);
   FreezeInst *FI_ptr = new FreezeInst(CPN);
   FI_ptr->insertBefore(RI);

--- a/llvm/unittests/Linker/LinkModulesTest.cpp
+++ b/llvm/unittests/Linker/LinkModulesTest.cpp
@@ -160,7 +160,7 @@ static Module *getInternal(LLVMContext &Ctx) {
   IRBuilder<> Builder(BB);
   Builder.CreateRetVoid();
 
-  StructType *STy = StructType::create(Ctx, PointerType::get(FTy, 0));
+  StructType *STy = StructType::create(Ctx, PointerType::get(Ctx, 0));
 
   GlobalVariable *GV =
       new GlobalVariable(*InternalM, STy, false /*=isConstant*/,

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -949,7 +949,7 @@ TEST_F(VPRecipeTest, CastVPWidenSelectRecipeToVPUserAndVPDef) {
 TEST_F(VPRecipeTest, CastVPWidenGEPRecipeToVPUserAndVPDef) {
   VPlan &Plan = getPlan();
   IntegerType *Int32 = IntegerType::get(C, 32);
-  PointerType *Int32Ptr = PointerType::get(Int32, 0);
+  PointerType *Int32Ptr = PointerType::get(C, 0);
   auto *GEP = GetElementPtrInst::Create(Int32, PoisonValue::get(Int32Ptr),
                                         PoisonValue::get(Int32));
   VPValue *Op1 = Plan.getOrAddLiveIn(ConstantInt::get(Int32, 1));
@@ -1034,7 +1034,7 @@ TEST_F(VPRecipeTest, CastVPBranchOnMaskRecipeToVPUser) {
 TEST_F(VPRecipeTest, CastVPWidenMemoryRecipeToVPUserAndVPDef) {
   VPlan &Plan = getPlan();
   IntegerType *Int32 = IntegerType::get(C, 32);
-  PointerType *Int32Ptr = PointerType::get(Int32, 0);
+  PointerType *Int32Ptr = PointerType::get(C, 0);
   auto *Load =
       new LoadInst(Int32, PoisonValue::get(Int32Ptr), "", false, Align(1));
   VPValue *Addr = Plan.getOrAddLiveIn(ConstantInt::get(Int32, 1));
@@ -1055,7 +1055,7 @@ TEST_F(VPRecipeTest, CastVPWidenMemoryRecipeToVPUserAndVPDef) {
 TEST_F(VPRecipeTest, MayHaveSideEffectsAndMayReadWriteMemory) {
   IntegerType *Int1 = IntegerType::get(C, 1);
   IntegerType *Int32 = IntegerType::get(C, 32);
-  PointerType *Int32Ptr = PointerType::get(Int32, 0);
+  PointerType *Int32Ptr = PointerType::get(C, 0);
   VPlan &Plan = getPlan();
 
   {


### PR DESCRIPTION
In accordance with https://github.com/llvm/llvm-project/issues/123569