### PR TITLE
[TableGen][NFC] Factor early-out range check.

### DIFF
--- a/llvm/test/TableGen/generic-tables-instruction.td
+++ b/llvm/test/TableGen/generic-tables-instruction.td
@@ -18,13 +18,11 @@ def Arch : Target { let InstructionSet = ArchInstrInfo; }
 // A contiguous primary (Instruction) key should get a direct lookup instead of
 // binary search.
 // CHECK: const MyInstr *getCustomEncodingHelper(unsigned Opcode) {
-// CHECK:   if ((Opcode < B) ||
-// CHECK:       (Opcode > D))
-// CHECK:     return nullptr;
+// CHECK: if ((unsigned)Opcode != std::clamp((unsigned)Opcode, (unsigned)B, (unsigned)D))
+// CHECK:   return nullptr;
 // CHECK:   auto Table = ArrayRef(InstrTable);
 // CHECK:   size_t Idx = Opcode - B;
 // CHECK:   return &Table[Idx];
-
 
 class MyInstr<int op> : Instruction {
   let OutOperandList = (outs);
@@ -56,8 +54,7 @@ def InstrTable : GenericTable {
 //
 // Verify contiguous check for SearchIndex.
 // const MyInfoEntry *getTable2ByValue(uint8_t Value) {
-// CHECK:   if ((Value < 0xB) ||
-// CHECK:      (Value > 0xD))
+// CHECK:   if ((uint8_t)Value != std::clamp((uint8_t)Value, (uint8_t)0xB, (uint8_t)0xD))
 // CHECK:    return nullptr;
 // CHECK:  auto Table = ArrayRef(Index);
 // CHECK:  size_t Idx = Value - 0xB;

--- a/llvm/test/TableGen/generic-tables.td
+++ b/llvm/test/TableGen/generic-tables.td
@@ -113,8 +113,7 @@ def lookupBTableByNameAndFlag : SearchIndex {
 // CHECK: const CEntry *lookupCEntry(StringRef Name, unsigned Kind);
 // CHECK-LABEL: GET_CTable_IMPL
 // CHECK: const CEntry *lookupCEntryByEncoding(uint16_t Encoding) {
-// CHECK:   if ((Encoding < 0xA) ||
-// CHECK:       (Encoding > 0xF))
+// CHECK:   if ((uint16_t)Encoding != std::clamp((uint16_t)Encoding, (uint16_t)0xA, (uint16_t)0xF))
 // CHECK:     return nullptr;
 
 // CHECK: const CEntry *lookupCEntry(StringRef Name, unsigned Kind) {


### PR DESCRIPTION
Combine the EarlyOut and IsContiguous range check.
Also avoid "comparison is always false" warnings in emitted code when the lower-bound check is against 0.