### PR TITLE
[LLD][COFF] Simplify creation of .edata chunks (NFC)

### DIFF
--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -920,7 +920,7 @@ Chunk *DelayLoadContents::newThunkChunk(DefinedImportData *s,
   }
 }
 
-EdataContents::EdataContents(COFFLinkerContext &ctx) : ctx(ctx) {
+void createEdataChunks(COFFLinkerContext &ctx, std::vector<Chunk *> &chunks) {
   unsigned baseOrdinal = 1 << 16, maxOrdinal = 0;
   for (Export &e : ctx.config.exports) {
     baseOrdinal = std::min(baseOrdinal, (unsigned)e.ordinal);

--- a/lld/COFF/DLL.h
+++ b/lld/COFF/DLL.h
@@ -77,20 +77,8 @@ private:
   COFFLinkerContext &ctx;
 };
 
-// Windows-specific.
-// EdataContents creates all chunks for the DLL export table.
-class EdataContents {
-public:
-  EdataContents(COFFLinkerContext &ctx);
-  std::vector<Chunk *> chunks;
-
-  uint64_t getRVA() { return chunks[0]->getRVA(); }
-  uint64_t getSize() {
-    return chunks.back()->getRVA() + chunks.back()->getSize() - getRVA();
-  }
-
-  COFFLinkerContext &ctx;
-};
+// Create all chunks for the DLL export table.
+void createEdataChunks(COFFLinkerContext &ctx, std::vector<Chunk *> &chunks);
 
 } // namespace lld::coff
 

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -210,7 +210,7 @@ struct ChunkRange {
 class Writer {
 public:
   Writer(COFFLinkerContext &c)
-      : buffer(c.e.outputBuffer), delayIdata(c), edata(c), ctx(c) {}
+      : buffer(c.e.outputBuffer), delayIdata(c), ctx(c) {}
   void run();
 
 private:
@@ -298,7 +298,6 @@ private:
   Chunk *iatStart = nullptr;
   uint64_t iatSize = 0;
   DelayLoadContents delayIdata;
-  EdataContents edata;
   bool setNoSEHCharacteristic = false;
   uint32_t tlsAlignment = 0;
 
@@ -1325,7 +1324,9 @@ void Writer::createExportTable() {
     if (ctx.config.hadExplicitExports)
       Warn(ctx) << "literal .edata sections override exports";
   } else if (!ctx.config.exports.empty()) {
-    for (Chunk *c : edata.chunks)
+    std::vector<Chunk *> edataChunks;
+    createEdataChunks(ctx, edataChunks);
+    for (Chunk *c : edataChunks)
       edataSec->addChunk(c);
   }
   if (!edataSec->chunks.empty()) {


### PR DESCRIPTION
Since commit dadc6f2488684, only the constructor of the `EdataContents` class is used. Replace it with a function and skip the call when using a custom `.edata` section.