### PR TITLE
[libclc] Route int bitselect through CLC; add half

### DIFF
--- a/libclc/clc/lib/generic/relational/clc_bitselect.cl
+++ b/libclc/clc/lib/generic/relational/clc_bitselect.cl
@@ -53,3 +53,15 @@ FLOAT_BITSELECT(double, ulong, 8)
 FLOAT_BITSELECT(double, ulong, 16)
 
 #endif
+
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+FLOAT_BITSELECT(half, ushort, )
+FLOAT_BITSELECT(half, ushort, 2)
+FLOAT_BITSELECT(half, ushort, 3)
+FLOAT_BITSELECT(half, ushort, 4)
+FLOAT_BITSELECT(half, ushort, 8)
+FLOAT_BITSELECT(half, ushort, 16)
+
+#endif

--- a/libclc/generic/lib/relational/bitselect.cl
+++ b/libclc/generic/lib/relational/bitselect.cl
@@ -21,34 +21,10 @@
  */
 
 #include <clc/clc.h>
-#include <clc/clcmacro.h>
 #include <clc/relational/clc_bitselect.h>
 
 #define __CLC_BODY <bitselect.inc>
 #include <clc/integer/gentype.inc>
-#undef __CLC_BODY
 
-#define FLOAT_BITSELECT(f_type, i_type, width)                                 \
-  _CLC_OVERLOAD _CLC_DEF f_type##width bitselect(                              \
-      f_type##width x, f_type##width y, f_type##width z) {                     \
-    return __clc_bitselect(x, y, z);                                           \
-  }
-
-FLOAT_BITSELECT(float, uint, )
-FLOAT_BITSELECT(float, uint, 2)
-FLOAT_BITSELECT(float, uint, 3)
-FLOAT_BITSELECT(float, uint, 4)
-FLOAT_BITSELECT(float, uint, 8)
-FLOAT_BITSELECT(float, uint, 16)
-
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-
-FLOAT_BITSELECT(double, ulong, )
-FLOAT_BITSELECT(double, ulong, 2)
-FLOAT_BITSELECT(double, ulong, 3)
-FLOAT_BITSELECT(double, ulong, 4)
-FLOAT_BITSELECT(double, ulong, 8)
-FLOAT_BITSELECT(double, ulong, 16)
-
-#endif
+#define __CLC_BODY <bitselect.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/generic/lib/relational/bitselect.inc
+++ b/libclc/generic/lib/relational/bitselect.inc
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE bitselect(__CLC_GENTYPE x, __CLC_GENTYPE y, __CLC_GENTYPE z) {
-  return ((x) ^ ((z) & ((y) ^ (x))));
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE bitselect(__CLC_GENTYPE x, __CLC_GENTYPE y,
+                                               __CLC_GENTYPE z) {
+  return __clc_bitselect(x, y, z);
 }


### PR DESCRIPTION
The half variants were missing. The integer bitselect builtins weren't going through __clc_bitselect due to an oversight when the CLC version was introduced.