### PR TITLE
[flang][PPC] XFAIL unroll-loops on PPC

### DIFF
--- a/flang/test/HLFIR/unroll-loops.fir
+++ b/flang/test/HLFIR/unroll-loops.fir
@@ -3,6 +3,9 @@
 // RUN: %flang_fc1 -emit-llvm -O1 -fno-unroll-loops -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 // RUN: %flang_fc1 -emit-llvm -O1 -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 
+// FIXME: https://github.com/llvm/llvm-project/issues/123668
+// XFAIL: powerpc64-target-arch
+
 // CHECK-LABEL: @unroll
 // CHECK-SAME: (ptr nocapture writeonly %[[ARG0:.*]])
 func.func @unroll(%arg0: !fir.ref<!fir.array<1000 x index>> {fir.bindc_name = "a"}) {

--- a/flang/test/Integration/unroll-loops.f90
+++ b/flang/test/Integration/unroll-loops.f90
@@ -3,6 +3,9 @@
 ! RUN: %flang_fc1 -emit-llvm -O1 -fno-unroll-loops -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 ! RUN: %flang_fc1 -emit-llvm -O1 -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 
+! FIXME: https://github.com/llvm/llvm-project/issues/123668
+! XFAIL: powerpc64-target-arch
+
 ! CHECK-LABEL: @unroll
 ! CHECK-SAME: (ptr nocapture writeonly %[[ARG0:.*]])
 subroutine unroll(a)


### PR DESCRIPTION
xfail the following 2 test cases that are currently failing on `ppc64-flang-aix` and `ppc64le-flang-rhel-clang` starting on https://github.com/llvm/llvm-project/pull/122906

```
FAIL: Flang::unroll-loops.fir
FAIL: Flang::unroll-loops.f90
```