### PR TITLE
[SCEV] Do not attempt to collect loop guards for loops without predecessor.

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -15328,6 +15328,8 @@ ScalarEvolution::LoopGuards::collect(const Loop *L, ScalarEvolution &SE) {
   BasicBlock *Header = L->getHeader();
   BasicBlock *Pred = L->getLoopPredecessor();
   LoopGuards Guards(SE);
+  if (!Pred)
+    return Guards;
   SmallPtrSet<const BasicBlock *, 8> VisitedBlocks;
   collectFromBlock(SE, Guards, Header, Pred, VisitedBlocks);
   return Guards;

--- a/llvm/test/Analysis/ScalarEvolution/backedge-taken-count-guard-info-with-multiple-predecessors.ll
+++ b/llvm/test/Analysis/ScalarEvolution/backedge-taken-count-guard-info-with-multiple-predecessors.ll
@@ -347,7 +347,7 @@ define void @pr122913() {
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is i1 false
 ; CHECK-NEXT:  Loop %header: Trip multiple is 1
 entry:
-  br label %header
+  br i1 1, label %bb, label %header
 
 bb:
   br i1 1, label %exit, label %header

--- a/llvm/test/Analysis/ScalarEvolution/backedge-taken-count-guard-info-with-multiple-predecessors.ll
+++ b/llvm/test/Analysis/ScalarEvolution/backedge-taken-count-guard-info-with-multiple-predecessors.ll
@@ -336,3 +336,31 @@ exit:
   ret void
 
 }
+
+; Checks correct traversal for loops without a unique predecessor
+; outside the loop.
+define void @pr122913() {
+; CHECK-LABEL: pr122913
+; CHECK-NEXT:  Determining loop execution counts for: @pr122913
+; CHECK-NEXT:  Loop %header: backedge-taken count is i1 false
+; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i1 false
+; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is i1 false
+; CHECK-NEXT:  Loop %header: Trip multiple is 1
+entry:
+  br label %header
+
+bb:
+  br i1 1, label %exit, label %header
+
+header:
+  %0 = phi i32 [ %1, %body ], [ 0, %bb ], [ 0, %entry ]
+  br label %body
+
+body:
+  %1 = add i32 %0, 1
+  %2 = icmp ult i32 %1, 0
+  br i1 %2, label %header, label %exit
+
+exit:
+  ret void
+}


### PR DESCRIPTION
Attempting to collect loop guards for loops without a predecessor can lead to non-terminating recursion trying to construct a SCEV.

Fixes https://github.com/llvm/llvm-project/issues/122913.