### PR TITLE
[OpenMP][Flang] Workaround omp_lib error

### DIFF
--- a/flang/test/Lower/OpenMP/Todo/allocate-clause-allocator.f90
+++ b/flang/test/Lower/OpenMP/Todo/allocate-clause-allocator.f90
@@ -4,7 +4,8 @@
 ! CHECK: not yet implemented: Unhandled clause allocate in omp.parallel
 ! CHECK: LLVM Translation failed for operation: omp.parallel
 program p
-  use omp_lib
+  !use omp_lib
+  integer(8),parameter::omp_default_mem_alloc=1_8
   integer :: x
   integer :: a
   integer :: i


### PR DESCRIPTION
It appears that omp_lib is not correctly (or maybe not at all?) found from the build directory. This made a few buildbots break after [PR#121356](https://github.com/llvm/llvm-project/pull/121356) landed.
This is a workaround to unblock the buildbots.

https://lab.llvm.org/staging/#/builders/130/builds/12654
https://lab.llvm.org/buildbot/#/builders/140/builds/15102
https://lab.llvm.org/staging/#/builders/105/builds/13855