### PR TITLE
[Flang][PPC] XFAIL `-funroll-loops` to include both powerpc64 and powerpc64le target

### DIFF
--- a/flang/test/HLFIR/unroll-loops.fir
+++ b/flang/test/HLFIR/unroll-loops.fir
@@ -4,7 +4,7 @@
 // RUN: %flang_fc1 -emit-llvm -O1 -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 
 // FIXME: https://github.com/llvm/llvm-project/issues/123668
-// XFAIL: powerpc64-target-arch
+// XFAIL: powerpc64{{(le)?}}-target-arch
 
 // CHECK-LABEL: @unroll
 // CHECK-SAME: (ptr nocapture writeonly %[[ARG0:.*]])

--- a/flang/test/HLFIR/unroll-loops.fir
+++ b/flang/test/HLFIR/unroll-loops.fir
@@ -4,7 +4,7 @@
 // RUN: %flang_fc1 -emit-llvm -O1 -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 
 // FIXME: https://github.com/llvm/llvm-project/issues/123668
-// XFAIL: powerpc64{{(le)?}}-target-arch
+// XFAIL: target=powerpc64{{.*}}
 
 // CHECK-LABEL: @unroll
 // CHECK-SAME: (ptr nocapture writeonly %[[ARG0:.*]])

--- a/flang/test/Integration/unroll-loops.f90
+++ b/flang/test/Integration/unroll-loops.f90
@@ -4,7 +4,7 @@
 ! RUN: %flang_fc1 -emit-llvm -O1 -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 
 ! FIXME: https://github.com/llvm/llvm-project/issues/123668
-! XFAIL: powerpc64{{(le)?}}-target-arch
+! XFAIL: target=powerpc64{{.*}}
 
 ! CHECK-LABEL: @unroll
 ! CHECK-SAME: (ptr nocapture writeonly %[[ARG0:.*]])

--- a/flang/test/Integration/unroll-loops.f90
+++ b/flang/test/Integration/unroll-loops.f90
@@ -4,7 +4,7 @@
 ! RUN: %flang_fc1 -emit-llvm -O1 -mllvm -force-vector-width=2 -o- %s | FileCheck %s --check-prefixes=CHECK,NO-UNROLL
 
 ! FIXME: https://github.com/llvm/llvm-project/issues/123668
-! XFAIL: powerpc64-target-arch
+! XFAIL: powerpc64{{(le)?}}-target-arch
 
 ! CHECK-LABEL: @unroll
 ! CHECK-SAME: (ptr nocapture writeonly %[[ARG0:.*]])


### PR DESCRIPTION
Include both `powerpc64` and `powerpc64le` target to XFAIL for the 2 test cases that are currently failing on `ppc64-flang-aix` and `ppc64le-flang-rhel-clang`.

```
FAIL: Flang::unroll-loops.fir
FAIL: Flang::unroll-loops.f90
```
