### PR TITLE
Generate `DW_AT_RUST_short_backtrace` attributes for `DISubprogram` nodes

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1786,6 +1786,7 @@ CGDebugInfo::createInlinedTrapSubprogram(StringRef FuncName,
         /*ScopeLine=*/0,
         /*Flags=*/llvm::DINode::FlagArtificial,
         /*SPFlags=*/llvm::DISubprogram::SPFlagDefinition,
+        /*ShortBacktrace=*/std::nullopt,
         /*TParams=*/nullptr, /*ThrownTypes=*/nullptr, /*Annotations=*/nullptr);
   }
 
@@ -2166,7 +2167,7 @@ llvm::DISubprogram *CGDebugInfo::CreateCXXMemberFunction(
   llvm::DISubprogram *SP = DBuilder.createMethod(
       RecordTy, MethodName, MethodLinkageName, MethodDefUnit, MethodLine,
       MethodTy, VIndex, ThisAdjustment, ContainingType, Flags, SPFlags,
-      TParamsArray.get());
+      std::nullopt, TParamsArray.get());
 
   SPCache[Method->getCanonicalDecl()].reset(SP);
 
@@ -4165,13 +4166,13 @@ llvm::DISubprogram *CGDebugInfo::getFunctionFwdDeclOrStub(GlobalDecl GD,
     return DBuilder.createFunction(
         DContext, Name, LinkageName, Unit, Line,
         getOrCreateFunctionType(GD.getDecl(), FnType, Unit), 0, Flags, SPFlags,
-        TParamsArray.get(), getFunctionDeclaration(FD));
+        std::nullopt, TParamsArray.get(), getFunctionDeclaration(FD));
   }
 
   llvm::DISubprogram *SP = DBuilder.createTempFunctionFwdDecl(
       DContext, Name, LinkageName, Unit, Line,
       getOrCreateFunctionType(GD.getDecl(), FnType, Unit), 0, Flags, SPFlags,
-      TParamsArray.get(), getFunctionDeclaration(FD));
+      std::nullopt, TParamsArray.get(), getFunctionDeclaration(FD));
   const FunctionDecl *CanonDecl = FD->getCanonicalDecl();
   FwdDeclReplaceMap.emplace_back(std::piecewise_construct,
                                  std::make_tuple(CanonDecl),
@@ -4501,8 +4502,8 @@ void CGDebugInfo::emitFunctionStart(GlobalDecl GD, SourceLocation Loc,
   // are emitted as CU level entities by the backend.
   llvm::DISubprogram *SP = DBuilder.createFunction(
       FDContext, Name, LinkageName, Unit, LineNo, DIFnType, ScopeLine,
-      FlagsForDef, SPFlagsForDef, TParamsArray.get(), Decl, nullptr,
-      Annotations);
+      FlagsForDef, SPFlagsForDef, std::nullopt, TParamsArray.get(), Decl,
+      nullptr, Annotations);
   Fn->setSubprogram(SP);
   // We might get here with a VarDecl in the case we're generating
   // code for the initialization of globals. Do not record these decls
@@ -4565,7 +4566,7 @@ void CGDebugInfo::EmitFunctionDecl(GlobalDecl GD, SourceLocation Loc,
   llvm::DISubroutineType *STy = getOrCreateFunctionType(D, FnType, Unit);
   llvm::DISubprogram *SP = DBuilder.createFunction(
       FDContext, Name, LinkageName, Unit, LineNo, STy, ScopeLine, Flags,
-      SPFlags, TParamsArray.get(), nullptr, nullptr, Annotations);
+      SPFlags, std::nullopt, TParamsArray.get(), nullptr, nullptr, Annotations);
 
   // Preserve btf_decl_tag attributes for parameters of extern functions
   // for BPF target. The parameters created in this loop are attached as

--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -605,6 +605,7 @@ HANDLE_DW_AT(0x3b28, BORLAND_Delphi_ABI, 0, BORLAND)
 HANDLE_DW_AT(0x3b29, BORLAND_Delphi_return, 0, BORLAND)
 HANDLE_DW_AT(0x3b30, BORLAND_Delphi_frameptr, 0, BORLAND)
 HANDLE_DW_AT(0x3b31, BORLAND_closure, 0, BORLAND)
+
 // LLVM project extensions.
 HANDLE_DW_AT(0x3e00, LLVM_include_path, 0, LLVM)
 HANDLE_DW_AT(0x3e01, LLVM_config_macros, 0, LLVM)
@@ -619,6 +620,8 @@ HANDLE_DW_AT(0x3e09, LLVM_ptrauth_authenticates_null_values, 0, LLVM)
 HANDLE_DW_AT(0x3e0a, LLVM_ptrauth_authentication_mode, 0, LLVM)
 HANDLE_DW_AT(0x3e0b, LLVM_num_extra_inhabitants, 0, LLVM)
 HANDLE_DW_AT(0x3e0c, LLVM_stmt_sequence, 0, LLVM)
+HANDLE_DW_AT(0x3e0d, LLVM_short_backtrace, 0, LLVM)
+
 
 // Apple extensions.
 

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -808,16 +808,15 @@ namespace llvm {
     /// \param Annotations   Attribute Annotations.
     /// \param TargetFuncName The name of the target function if this is
     ///                       a trampoline.
-    DISubprogram *
-    createFunction(DIScope *Scope, StringRef Name, StringRef LinkageName,
-                   DIFile *File, unsigned LineNo, DISubroutineType *Ty,
-                   unsigned ScopeLine, DINode::DIFlags Flags = DINode::FlagZero,
-                   DISubprogram::DISPFlags SPFlags = DISubprogram::SPFlagZero,
-                   DITemplateParameterArray TParams = nullptr,
-                   DISubprogram *Decl = nullptr,
-                   DITypeArray ThrownTypes = nullptr,
-                   DINodeArray Annotations = nullptr,
-                   StringRef TargetFuncName = "");
+    DISubprogram *createFunction(
+        DIScope *Scope, StringRef Name, StringRef LinkageName, DIFile *File,
+        unsigned LineNo, DISubroutineType *Ty, unsigned ScopeLine,
+        DINode::DIFlags Flags = DINode::FlagZero,
+        DISubprogram::DISPFlags SPFlags = DISubprogram::SPFlagZero,
+        std::optional<ShortBacktraceAttr> ShortBacktrace = std::nullopt,
+        DITemplateParameterArray TParams = nullptr,
+        DISubprogram *Decl = nullptr, DITypeArray ThrownTypes = nullptr,
+        DINodeArray Annotations = nullptr, StringRef TargetFuncName = "");
 
     /// Identical to createFunction,
     /// except that the resulting DbgNode is meant to be RAUWed.
@@ -826,6 +825,7 @@ namespace llvm {
         unsigned LineNo, DISubroutineType *Ty, unsigned ScopeLine,
         DINode::DIFlags Flags = DINode::FlagZero,
         DISubprogram::DISPFlags SPFlags = DISubprogram::SPFlagZero,
+        std::optional<ShortBacktraceAttr> ShortBacktrace = std::nullopt,
         DITemplateParameterArray TParams = nullptr,
         DISubprogram *Decl = nullptr, DITypeArray ThrownTypes = nullptr);
 
@@ -848,15 +848,15 @@ namespace llvm {
     /// \param SPFlags       Additional flags specific to subprograms.
     /// \param TParams       Function template parameters.
     /// \param ThrownTypes   Exception types this function may throw.
-    DISubprogram *
-    createMethod(DIScope *Scope, StringRef Name, StringRef LinkageName,
-                 DIFile *File, unsigned LineNo, DISubroutineType *Ty,
-                 unsigned VTableIndex = 0, int ThisAdjustment = 0,
-                 DIType *VTableHolder = nullptr,
-                 DINode::DIFlags Flags = DINode::FlagZero,
-                 DISubprogram::DISPFlags SPFlags = DISubprogram::SPFlagZero,
-                 DITemplateParameterArray TParams = nullptr,
-                 DITypeArray ThrownTypes = nullptr);
+    DISubprogram *createMethod(
+        DIScope *Scope, StringRef Name, StringRef LinkageName, DIFile *File,
+        unsigned LineNo, DISubroutineType *Ty, unsigned VTableIndex = 0,
+        int ThisAdjustment = 0, DIType *VTableHolder = nullptr,
+        DINode::DIFlags Flags = DINode::FlagZero,
+        DISubprogram::DISPFlags SPFlags = DISubprogram::SPFlagZero,
+        std::optional<ShortBacktraceAttr> ShortBacktrace = std::nullopt,
+        DITemplateParameterArray TParams = nullptr,
+        DITypeArray ThrownTypes = nullptr);
 
     /// Create common block entry for a Fortran common block.
     /// \param Scope       Scope of this common block.

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1881,10 +1881,12 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
          HasThisAdj ? Record[16 + OffsetB] : 0,   // thisAdjustment
          Flags,                                   // flags
          SPFlags,                                 // SPFlags
-         HasUnit ? CUorFn : nullptr,              // unit
-         getMDOrNull(Record[13 + OffsetB]),       // templateParams
-         getMDOrNull(Record[14 + OffsetB]),       // declaration
-         getMDOrNull(Record[15 + OffsetB]),       // retainedNodes
+         // TODO: parse this from the record
+         std::nullopt,                      // shortBacktrace
+         HasUnit ? CUorFn : nullptr,        // unit
+         getMDOrNull(Record[13 + OffsetB]), // templateParams
+         getMDOrNull(Record[14 + OffsetB]), // declaration
+         getMDOrNull(Record[15 + OffsetB]), // retainedNodes
          HasThrownTypes ? getMDOrNull(Record[17 + OffsetB])
                         : nullptr, // thrownTypes
          HasAnnotations ? getMDOrNull(Record[18 + OffsetB])

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2552,6 +2552,7 @@ void DwarfDebug::endFunctionImpl(const MachineFunction *MF) {
   // subroutines inside it. But with -fdebug-info-for-profiling, the subprogram
   // is still needed as we need its source location.
   if (!TheCU.getCUNode()->getDebugInfoForProfiling() &&
+      !SP->getShortBacktrace().has_value() &&
       TheCU.getCUNode()->getEmissionKind() == DICompileUnit::LineTablesOnly &&
       LScopes.getAbstractScopesList().empty() && !IsDarwin) {
     for (const auto &R : Asm->MBBSectionRanges)

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1320,6 +1320,11 @@ void DwarfUnit::applySubprogramAttributes(const DISubprogram *SP, DIE &SPDie,
   if (!SkipSPSourceLocation)
     addSourceLine(SPDie, SP);
 
+  if (SP->getShortBacktrace().has_value()) {
+    addUInt(SPDie, dwarf::DW_AT_LLVM_short_backtrace, dwarf::DW_FORM_data1,
+            static_cast<uint64_t>(*SP->getShortBacktrace()));
+  }
+
   // Skip the rest of the attributes under -gmlt to save space.
   if (SkipSPAttributes)
     return;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2334,6 +2334,10 @@ static void writeDISubprogram(raw_ostream &Out, const DISubprogram *N,
   Printer.printInt("thisAdjustment", N->getThisAdjustment());
   Printer.printDIFlags("flags", N->getFlags());
   Printer.printDISPFlags("spFlags", N->getSPFlags());
+  if (N->getShortBacktrace().has_value())
+    Printer.printInt("shortBacktrace",
+                     static_cast<signed>(N->getShortBacktrace().value()),
+                     /* ShouldSkipZero */ false);
   Printer.printMetadata("unit", N->getRawUnit());
   Printer.printMetadata("templateParams", N->getRawTemplateParams());
   Printer.printMetadata("declaration", N->getRawDeclaration());

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -694,8 +694,8 @@ private:
           MDS->getContext(), FileAndScope, MDS->getName(), LinkageName,
           FileAndScope, MDS->getLine(), Type, MDS->getScopeLine(),
           ContainingType, MDS->getVirtualIndex(), MDS->getThisAdjustment(),
-          MDS->getFlags(), MDS->getSPFlags(), Unit, TemplateParams, Declaration,
-          Variables);
+          MDS->getFlags(), MDS->getSPFlags(), MDS->getShortBacktrace(), Unit,
+          TemplateParams, Declaration, Variables);
     };
 
     if (MDS->isDistinct())
@@ -705,7 +705,8 @@ private:
         MDS->getContext(), FileAndScope, MDS->getName(), LinkageName,
         FileAndScope, MDS->getLine(), Type, MDS->getScopeLine(), ContainingType,
         MDS->getVirtualIndex(), MDS->getThisAdjustment(), MDS->getFlags(),
-        MDS->getSPFlags(), Unit, TemplateParams, Declaration, Variables);
+        MDS->getSPFlags(), MDS->getShortBacktrace(), Unit, TemplateParams,
+        Declaration, Variables);
 
     StringRef OldLinkageName = MDS->getLinkageName();
 
@@ -1142,7 +1143,7 @@ LLVMMetadataRef LLVMDIBuilderCreateFunction(
       unwrapDI<DIScope>(Scope), {Name, NameLen}, {LinkageName, LinkageNameLen},
       unwrapDI<DIFile>(File), LineNo, unwrapDI<DISubroutineType>(Ty), ScopeLine,
       map_from_llvmDIFlags(Flags),
-      pack_into_DISPFlags(IsLocalToUnit, IsDefinition, IsOptimized), nullptr,
+      pack_into_DISPFlags(IsLocalToUnit, IsDefinition, IsOptimized), {},
       nullptr, nullptr));
 }
 

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -1026,10 +1026,12 @@ const char *DICompileUnit::nameTableKindString(DebugNameTableKind NTK) {
 DISubprogram::DISubprogram(LLVMContext &C, StorageType Storage, unsigned Line,
                            unsigned ScopeLine, unsigned VirtualIndex,
                            int ThisAdjustment, DIFlags Flags, DISPFlags SPFlags,
+                           std::optional<ShortBacktraceAttr> ShortBacktrace,
                            ArrayRef<Metadata *> Ops)
     : DILocalScope(C, DISubprogramKind, Storage, dwarf::DW_TAG_subprogram, Ops),
       Line(Line), ScopeLine(ScopeLine), VirtualIndex(VirtualIndex),
-      ThisAdjustment(ThisAdjustment), Flags(Flags), SPFlags(SPFlags) {
+      ThisAdjustment(ThisAdjustment), Flags(Flags), SPFlags(SPFlags),
+      ShortBacktrace(ShortBacktrace) {
   static_assert(dwarf::DW_VIRTUALITY_max < 4, "Virtuality out of range");
 }
 DISubprogram::DISPFlags
@@ -1128,7 +1130,8 @@ DISubprogram *DISubprogram::getImpl(
     LLVMContext &Context, Metadata *Scope, MDString *Name,
     MDString *LinkageName, Metadata *File, unsigned Line, Metadata *Type,
     unsigned ScopeLine, Metadata *ContainingType, unsigned VirtualIndex,
-    int ThisAdjustment, DIFlags Flags, DISPFlags SPFlags, Metadata *Unit,
+    int ThisAdjustment, DIFlags Flags, DISPFlags SPFlags,
+    std::optional<ShortBacktraceAttr> ShortBacktrace, Metadata *Unit,
     Metadata *TemplateParams, Metadata *Declaration, Metadata *RetainedNodes,
     Metadata *ThrownTypes, Metadata *Annotations, MDString *TargetFuncName,
     StorageType Storage, bool ShouldCreate) {
@@ -1160,10 +1163,10 @@ DISubprogram *DISubprogram::getImpl(
       }
     }
   }
-  DEFINE_GETIMPL_STORE_N(
-      DISubprogram,
-      (Line, ScopeLine, VirtualIndex, ThisAdjustment, Flags, SPFlags), Ops,
-      Ops.size());
+  DEFINE_GETIMPL_STORE_N(DISubprogram,
+                         (Line, ScopeLine, VirtualIndex, ThisAdjustment, Flags,
+                          SPFlags, ShortBacktrace),
+                         Ops, Ops.size());
 }
 
 bool DISubprogram::describes(const Function *F) const {

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -917,10 +917,10 @@ void coro::BaseCloner::create() {
             NewF->getName(), Decl->getFile(), Decl->getLine(), Decl->getType(),
             Decl->getScopeLine(), Decl->getContainingType(),
             Decl->getVirtualIndex(), Decl->getThisAdjustment(),
-            Decl->getFlags(), Decl->getSPFlags(), Decl->getUnit(),
-            Decl->getTemplateParams(), nullptr, Decl->getRetainedNodes(),
-            Decl->getThrownTypes(), Decl->getAnnotations(),
-            Decl->getTargetFuncName());
+            Decl->getFlags(), Decl->getSPFlags(), Decl->getShortBacktrace(),
+            Decl->getUnit(), Decl->getTemplateParams(), nullptr,
+            Decl->getRetainedNodes(), Decl->getThrownTypes(),
+            Decl->getAnnotations(), Decl->getTargetFuncName());
         SP->replaceDeclaration(NewDecl);
       }
     }

--- a/llvm/test/DebugInfo/backtrace-short.ll
+++ b/llvm/test/DebugInfo/backtrace-short.ll
@@ -1,0 +1,28 @@
+;; This test checks whether DWARF tag DW_AT_LLVM_short_backtrace is accepted and processed.
+; REQUIRES: object-emission
+; RUN: %llc_dwarf %s -filetype=obj -o - | llvm-dwarfdump --verbose - | FileCheck %s
+; CHECK: DW_AT_LLVM_short_backtrace [DW_FORM_data1]
+
+; ModuleID = 'backtrace.3cd23e1958f5234f-cgu.0'
+
+; backtrace::foo
+define void @_ZN9backtrace3foo17h79548ad6a76bdf6cE() unnamed_addr #0 !dbg !7 {
+start:
+  ret void, !dbg !12
+}
+
+attributes #0 = { "target-cpu"="x86-64" }
+
+!llvm.module.flags = !{!2, !3}
+!llvm.dbg.cu = !{!5}
+
+!2 = !{i32 2, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = distinct !DICompileUnit(language: DW_LANG_Rust, file: !6, producer: "clang LLVM (rustc version 1.85.0-dev (\1B[0;95mlove you love you love you\1B[0m))", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, splitDebugInlining: false, nameTableKind: None)
+!6 = !DIFile(filename: "backtrace.rs/@/backtrace.3cd23e1958f5234f-cgu.0", directory: "/home/jyn/src/example")
+!7 = distinct !DISubprogram(name: "foo", linkageName: "_ZN9backtrace3foo17h79548ad6a76bdf6cE", scope: !9, file: !8, line: 4, type: !10, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, shortBacktrace: 0, unit: !5, templateParams: !11)
+!8 = !DIFile(filename: "backtrace.rs", directory: "/home/jyn/src/example", checksumkind: CSK_MD5, checksum: "a2cf24d26a3fc1a5d0b6d8df3a534692")
+!9 = !DINamespace(name: "backtrace", scope: null)
+!10 = !DISubroutineType(types: !11)
+!11 = !{}
+!12 = !DILocation(line: 4, column: 16, scope: !7)

--- a/llvm/unittests/CodeGen/MachineInstrTest.cpp
+++ b/llvm/unittests/CodeGen/MachineInstrTest.cpp
@@ -213,7 +213,7 @@ TEST(MachineInstrPrintingTest, DebugLocPrinting) {
   DIFile *DIF = DIFile::getDistinct(Ctx, "filename", "");
   DISubprogram *DIS = DISubprogram::getDistinct(
       Ctx, nullptr, "", "", DIF, 0, nullptr, 0, nullptr, 0, 0, DINode::FlagZero,
-      DISubprogram::SPFlagZero, nullptr);
+      DISubprogram::SPFlagZero, std::nullopt, nullptr);
   DILocation *DIL = DILocation::get(Ctx, 1, 5, DIS);
   DebugLoc DL(DIL);
   MachineInstr *MI = MF->CreateMachineInstr(Table.MCID, DL);

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -419,7 +419,7 @@ TEST(DIBuilder, CreateSetType) {
   DIBuilder DIB(*M);
   DIScope *Scope = DISubprogram::getDistinct(
       Ctx, nullptr, "", "", nullptr, 0, nullptr, 0, nullptr, 0, 0,
-      DINode::FlagZero, DISubprogram::SPFlagZero, nullptr);
+      DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
   DIType *Type = DIB.createBasicType("Int", 64, dwarf::DW_ATE_signed);
   DIFile *F = DIB.createFile("main.c", "/");
 
@@ -433,7 +433,7 @@ TEST(DIBuilder, CreateStringType) {
   DIBuilder DIB(*M);
   DIScope *Scope = DISubprogram::getDistinct(
       Ctx, nullptr, "", "", nullptr, 0, nullptr, 0, nullptr, 0, 0,
-      DINode::FlagZero, DISubprogram::SPFlagZero, nullptr);
+      DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
   DIFile *F = DIB.createFile("main.c", "/");
   StringRef StrName = "string";
   DIVariable *StringLen = DIB.createAutoVariable(Scope, StrName, F, 0, nullptr,
@@ -1222,7 +1222,7 @@ TEST(DIBuilder, HashingDISubprogram) {
   DISubprogram *Definition = DIB.createFunction(
       ForwardDeclaredType.get(), "MethodName", "LinkageName", F, 0,
       DIB.createSubroutineType({}), 0, DINode::FlagZero,
-      llvm::DISubprogram::SPFlagDefinition, nullptr, Declaration);
+      llvm::DISubprogram::SPFlagDefinition, std::nullopt, nullptr, Declaration);
 
   // Produce the hash with the temporary scope.
   unsigned HashDeclaration =

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -866,8 +866,8 @@ TEST_F(IRBuilderTest, createFunction) {
   auto Error = DIB.getOrCreateArray({Int});
   auto Err = DIB.createFunction(
       CU, "err", "", File, 1, Type, 1, DINode::FlagZero,
-      DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized, nullptr,
-      nullptr, Error.get());
+      DISubprogram::SPFlagDefinition | DISubprogram::SPFlagOptimized,
+      std::nullopt, nullptr, nullptr, Error.get());
   EXPECT_TRUE(Err->getThrownTypes().get() == Error.get());
   DIB.finalize();
 }

--- a/llvm/unittests/IR/MetadataTest.cpp
+++ b/llvm/unittests/IR/MetadataTest.cpp
@@ -88,7 +88,7 @@ protected:
   DISubprogram *getSubprogram() {
     return DISubprogram::getDistinct(
         Context, nullptr, "", "", nullptr, 0, nullptr, 0, nullptr, 0, 0,
-        DINode::FlagZero, DISubprogram::SPFlagZero, nullptr);
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
   }
   DIFile *getFile() {
     return DIFile::getDistinct(Context, "file.c", "/path/to/dir");
@@ -123,6 +123,9 @@ protected:
     return Function::Create(
         FunctionType::get(Type::getVoidTy(Context), {}, false),
         Function::ExternalLinkage, Name, M);
+  }
+  std::optional<ShortBacktraceAttr> getShortBacktrace() {
+    return ShortBacktraceAttr::SkipFrame;
   }
 };
 typedef MetadataTest MDStringTest;
@@ -977,12 +980,12 @@ TEST_F(DILocationTest, Merge) {
   {
     // Different function, same inlined-at.
     auto *F = getFile();
-    auto *SP1 = DISubprogram::getDistinct(Context, F, "a", "a", F, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
-    auto *SP2 = DISubprogram::getDistinct(Context, F, "b", "b", F, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SP1 = DISubprogram::getDistinct(
+        Context, F, "a", "a", F, 0, nullptr, 0, nullptr, 0, 0, DINode::FlagZero,
+        DISubprogram::SPFlagZero, std::nullopt, nullptr);
+    auto *SP2 = DISubprogram::getDistinct(
+        Context, F, "b", "b", F, 0, nullptr, 0, nullptr, 0, 0, DINode::FlagZero,
+        DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *I = DILocation::get(Context, 2, 7, N);
     auto *A = DILocation::get(Context, 1, 6, SP1, I);
@@ -997,12 +1000,12 @@ TEST_F(DILocationTest, Merge) {
   {
     // Different function, inlined-at same line, but different column.
     auto *F = getFile();
-    auto *SP1 = DISubprogram::getDistinct(Context, F, "a", "a", F, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
-    auto *SP2 = DISubprogram::getDistinct(Context, F, "b", "b", F, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SP1 = DISubprogram::getDistinct(
+        Context, F, "a", "a", F, 0, nullptr, 0, nullptr, 0, 0, DINode::FlagZero,
+        DISubprogram::SPFlagZero, std::nullopt, nullptr);
+    auto *SP2 = DISubprogram::getDistinct(
+        Context, F, "b", "b", F, 0, nullptr, 0, nullptr, 0, 0, DINode::FlagZero,
+        DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *IA = DILocation::get(Context, 2, 7, N);
     auto *IB = DILocation::get(Context, 2, 8, N);
@@ -1034,17 +1037,17 @@ TEST_F(DILocationTest, Merge) {
     auto *FB = getFile();
     auto *FI = getFile();
 
-    auto *SPA = DISubprogram::getDistinct(Context, FA, "a", "a", FA, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPA = DISubprogram::getDistinct(
+        Context, FA, "a", "a", FA, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPB = DISubprogram::getDistinct(Context, FB, "b", "b", FB, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPB = DISubprogram::getDistinct(
+        Context, FB, "b", "b", FB, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPI = DISubprogram::getDistinct(Context, FI, "i", "i", FI, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPI = DISubprogram::getDistinct(
+        Context, FI, "i", "i", FI, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *I = DILocation::get(Context, 3, 8, SPI);
     auto *A = DILocation::get(Context, 2, 7, SPA, I);
@@ -1064,17 +1067,17 @@ TEST_F(DILocationTest, Merge) {
     auto *FB = getFile();
     auto *FI = getFile();
 
-    auto *SPA = DISubprogram::getDistinct(Context, FA, "a", "a", FA, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPA = DISubprogram::getDistinct(
+        Context, FA, "a", "a", FA, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPB = DISubprogram::getDistinct(Context, FB, "b", "b", FB, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPB = DISubprogram::getDistinct(
+        Context, FB, "b", "b", FB, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPI = DISubprogram::getDistinct(Context, FI, "i", "i", FI, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPI = DISubprogram::getDistinct(
+        Context, FI, "i", "i", FI, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *SPAScope = DILexicalBlock::getDistinct(Context, SPA, FA, 4, 9);
 
@@ -1097,17 +1100,17 @@ TEST_F(DILocationTest, Merge) {
     auto *FB = getFile();
     auto *FC = getFile();
 
-    auto *SPA = DISubprogram::getDistinct(Context, FA, "a", "a", FA, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPA = DISubprogram::getDistinct(
+        Context, FA, "a", "a", FA, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPB = DISubprogram::getDistinct(Context, FB, "b", "b", FB, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPB = DISubprogram::getDistinct(
+        Context, FB, "b", "b", FB, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPC = DISubprogram::getDistinct(Context, FC, "c", "c", FC, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPC = DISubprogram::getDistinct(
+        Context, FC, "c", "c", FC, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *A = DILocation::get(Context, 3, 2, SPA);
     auto *B = DILocation::get(Context, 2, 4, SPB, A);
@@ -1127,17 +1130,17 @@ TEST_F(DILocationTest, Merge) {
     auto *FB = getFile();
     auto *FC = getFile();
 
-    auto *SPA = DISubprogram::getDistinct(Context, FA, "a", "a", FA, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPA = DISubprogram::getDistinct(
+        Context, FA, "a", "a", FA, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPB = DISubprogram::getDistinct(Context, FB, "b", "b", FB, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPB = DISubprogram::getDistinct(
+        Context, FB, "b", "b", FB, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPC = DISubprogram::getDistinct(Context, FC, "c", "c", FC, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPC = DISubprogram::getDistinct(
+        Context, FC, "c", "c", FC, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *A = DILocation::get(Context, 10, 20, SPA);
     auto *B1 = DILocation::get(Context, 3, 2, SPB, A);
@@ -1165,13 +1168,13 @@ TEST_F(DILocationTest, Merge) {
     auto *FA = getFile();
     auto *FI = getFile();
 
-    auto *SPA = DISubprogram::getDistinct(Context, FA, "a", "a", FA, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPA = DISubprogram::getDistinct(
+        Context, FA, "a", "a", FA, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPI = DISubprogram::getDistinct(Context, FI, "i", "i", FI, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPI = DISubprogram::getDistinct(
+        Context, FI, "i", "i", FI, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     // Nearest common scope for the two locations in a.
     auto *SPAScope1 = DILexicalBlock::getDistinct(Context, SPA, FA, 4, 9);
@@ -1205,17 +1208,17 @@ TEST_F(DILocationTest, Merge) {
     auto *FB = getFile();
     auto *FI = getFile();
 
-    auto *SPA = DISubprogram::getDistinct(Context, FA, "a", "a", FA, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPA = DISubprogram::getDistinct(
+        Context, FA, "a", "a", FA, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPB = DISubprogram::getDistinct(Context, FB, "b", "b", FB, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPB = DISubprogram::getDistinct(
+        Context, FB, "b", "b", FB, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
-    auto *SPI = DISubprogram::getDistinct(Context, FI, "i", "i", FI, 0, nullptr,
-                                          0, nullptr, 0, 0, DINode::FlagZero,
-                                          DISubprogram::SPFlagZero, nullptr);
+    auto *SPI = DISubprogram::getDistinct(
+        Context, FI, "i", "i", FI, 0, nullptr, 0, nullptr, 0, 0,
+        DINode::FlagZero, DISubprogram::SPFlagZero, std::nullopt, nullptr);
 
     auto *SPAScope1 = DILexicalBlock::getDistinct(Context, SPA, FA, 4, 9);
     auto *SPAScope2 = DILexicalBlock::getDistinct(Context, SPA, FA, 8, 3);
@@ -2557,12 +2560,13 @@ TEST_F(DISubprogramTest, get) {
   assert(!IsLocalToUnit && IsDefinition && !IsOptimized &&
          "bools and SPFlags have to match");
   SPFlags |= DISubprogram::SPFlagDefinition;
+  std::optional<ShortBacktraceAttr> ShortBacktrace = getShortBacktrace();
 
-  auto *N = DISubprogram::get(
-      Context, Scope, Name, LinkageName, File, Line, Type, ScopeLine,
-      ContainingType, VirtualIndex, ThisAdjustment, Flags, SPFlags, Unit,
-      TemplateParams, Declaration, RetainedNodes, ThrownTypes, Annotations,
-      TargetFuncName);
+  auto *N = DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName);
 
   EXPECT_EQ(dwarf::DW_TAG_subprogram, N->getTag());
   EXPECT_EQ(Scope, N->getScope());
@@ -2587,125 +2591,130 @@ TEST_F(DISubprogramTest, get) {
   EXPECT_EQ(ThrownTypes, N->getThrownTypes().get());
   EXPECT_EQ(Annotations, N->getAnnotations().get());
   EXPECT_EQ(TargetFuncName, N->getTargetFuncName());
-  EXPECT_EQ(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, Declaration, RetainedNodes,
-                                 ThrownTypes, Annotations, TargetFuncName));
+  EXPECT_EQ(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName));
 
   EXPECT_NE(N, DISubprogram::get(Context, getCompositeType(), Name, LinkageName,
                                  File, Line, Type, ScopeLine, ContainingType,
                                  VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, "other", LinkageName, File,
-                                 Line, Type, ScopeLine, ContainingType,
-                                 VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, "other", File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, Declaration, RetainedNodes,
-                                 ThrownTypes, Annotations, TargetFuncName));
+                                 ShortBacktrace, Unit, TemplateParams,
+                                 Declaration, RetainedNodes, ThrownTypes,
+                                 Annotations, TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, "other", LinkageName, File, Line,
+                              Type, ScopeLine, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName));
+  EXPECT_NE(N, DISubprogram::get(
+                   Context, Scope, Name, "other", File, Line, Type, ScopeLine,
+                   ContainingType, VirtualIndex, ThisAdjustment, Flags, SPFlags,
+                   ShortBacktrace, Unit, TemplateParams, Declaration,
+                   RetainedNodes, ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, getFile(),
                                  Line, Type, ScopeLine, ContainingType,
                                  VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File,
-                                 Line + 1, Type, ScopeLine, ContainingType,
-                                 VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
+                                 ShortBacktrace, Unit, TemplateParams,
+                                 Declaration, RetainedNodes, ThrownTypes,
+                                 Annotations, TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line + 1,
+                              Type, ScopeLine, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
                                  getSubroutineType(), ScopeLine, ContainingType,
                                  VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
+                                 ShortBacktrace, Unit, TemplateParams,
+                                 Declaration, RetainedNodes, ThrownTypes,
+                                 Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(
                    Context, Scope, Name, LinkageName, File, Line, Type,
                    ScopeLine, ContainingType, VirtualIndex, ThisAdjustment,
-                   Flags, SPFlags ^ DISubprogram::SPFlagLocalToUnit, Unit,
-                   TemplateParams, Declaration, RetainedNodes, ThrownTypes,
-                   Annotations, TargetFuncName));
+                   Flags, SPFlags ^ DISubprogram::SPFlagLocalToUnit,
+                   ShortBacktrace, Unit, TemplateParams, Declaration,
+                   RetainedNodes, ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(
                    Context, Scope, Name, LinkageName, File, Line, Type,
                    ScopeLine, ContainingType, VirtualIndex, ThisAdjustment,
-                   Flags, SPFlags ^ DISubprogram::SPFlagDefinition, Unit,
-                   TemplateParams, Declaration, RetainedNodes, ThrownTypes,
-                   Annotations, TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine + 1, ContainingType,
-                                 VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, getCompositeType(),
-                                 VirtualIndex, ThisAdjustment, Flags, SPFlags,
-                                 Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
+                   Flags, SPFlags ^ DISubprogram::SPFlagDefinition,
+                   ShortBacktrace, Unit, TemplateParams, Declaration,
+                   RetainedNodes, ThrownTypes, Annotations, TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine + 1, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine, getCompositeType(), VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(
                    Context, Scope, Name, LinkageName, File, Line, Type,
                    ScopeLine, ContainingType, VirtualIndex, ThisAdjustment,
-                   Flags, SPFlags ^ DISubprogram::SPFlagVirtual, Unit,
-                   TemplateParams, Declaration, RetainedNodes, ThrownTypes,
-                   Annotations, TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType,
-                                 VirtualIndex + 1, ThisAdjustment, Flags,
-                                 SPFlags, Unit, TemplateParams, Declaration,
-                                 RetainedNodes, ThrownTypes, Annotations,
-                                 TargetFuncName));
+                   Flags, SPFlags ^ DISubprogram::SPFlagVirtual, ShortBacktrace,
+                   Unit, TemplateParams, Declaration, RetainedNodes,
+                   ThrownTypes, Annotations, TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine, ContainingType, VirtualIndex + 1,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(
                    Context, Scope, Name, LinkageName, File, Line, Type,
                    ScopeLine, ContainingType, VirtualIndex, ThisAdjustment,
-                   Flags, SPFlags ^ DISubprogram::SPFlagOptimized, Unit,
-                   TemplateParams, Declaration, RetainedNodes, ThrownTypes,
-                   Annotations, TargetFuncName));
+                   Flags, SPFlags ^ DISubprogram::SPFlagOptimized,
+                   ShortBacktrace, Unit, TemplateParams, Declaration,
+                   RetainedNodes, ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
                                  Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, nullptr,
-                                 TemplateParams, Declaration, RetainedNodes,
+                                 ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                                 nullptr, TemplateParams, Declaration,
+                                 RetainedNodes, ThrownTypes, Annotations,
+                                 TargetFuncName));
+  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                                 Type, ScopeLine, ContainingType, VirtualIndex,
+                                 ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                                 Unit, getTuple(), Declaration, RetainedNodes,
+                                 ThrownTypes, Annotations, TargetFuncName));
+  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                                 Type, ScopeLine, ContainingType, VirtualIndex,
+                                 ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                                 Unit, TemplateParams, getSubprogram(),
+                                 RetainedNodes, ThrownTypes, Annotations,
+                                 TargetFuncName));
+  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                                 Type, ScopeLine, ContainingType, VirtualIndex,
+                                 ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                                 Unit, TemplateParams, Declaration, getTuple(),
                                  ThrownTypes, Annotations, TargetFuncName));
   EXPECT_NE(N,
             DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
                               Type, ScopeLine, ContainingType, VirtualIndex,
-                              ThisAdjustment, Flags, SPFlags, Unit, getTuple(),
-                              Declaration, RetainedNodes, ThrownTypes,
-                              Annotations, TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, getSubprogram(), RetainedNodes,
-                                 ThrownTypes, Annotations, TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, Declaration, getTuple(),
-                                 ThrownTypes, Annotations, TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, Declaration, RetainedNodes,
-                                 getTuple(), Annotations, TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, Declaration, RetainedNodes,
-                                 ThrownTypes, getTuple(), TargetFuncName));
-  EXPECT_NE(N, DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
-                                 Type, ScopeLine, ContainingType, VirtualIndex,
-                                 ThisAdjustment, Flags, SPFlags, Unit,
-                                 TemplateParams, Declaration, RetainedNodes,
-                                 ThrownTypes, Annotations, "other"));
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              getTuple(), Annotations, TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, getTuple(), TargetFuncName));
+  EXPECT_NE(N,
+            DISubprogram::get(Context, Scope, Name, LinkageName, File, Line,
+                              Type, ScopeLine, ContainingType, VirtualIndex,
+                              ThisAdjustment, Flags, SPFlags, ShortBacktrace,
+                              Unit, TemplateParams, Declaration, RetainedNodes,
+                              ThrownTypes, Annotations, "other"));
 
   TempDISubprogram Temp = N->clone();
   EXPECT_EQ(N, MDNode::replaceWithUniqued(std::move(Temp)));


### PR DESCRIPTION
The Rust standard library has two [styles](https://doc.rust-lang.org/stable/std/panic/enum.BacktraceStyle.html) for printing backtraces at runtime:
1. Full backtraces. These work in the obvious way.
2. Short backtraces. These filter out "unimportant" frames that are likely not related to the developer's bug. For example, frames like `__libc_start_main`, `_Unwind_Resume`, and rust runtime internals like `std::rt::lang_start` are filtered out.

Currently, the Rust runtime determines "unimportant" frames by looking directly at un-mangled symbol names of generated functions. This is not extensible, and involves a state machine that requires the frames to be present at runtime; in particular the frames must be marked `noinline`, impeding optimizations.

This extends LLVM to encode short backtrace metadata in DWARF debuginfo. It currently does not attempt to add debuginfo to PDB, which was not designed to be extensible.

See https://github.com/rust-lang/compiler-team/issues/818 and [the rust zulip](https://rust-lang.zulipchat.com/#narrow/channel/187780-t-compiler.2Fwg-llvm/topic/create.20custom.20DWARF.20attribute.3F) for more background.

- Add a new category for Rust DWARF vendor extensions
- Add a new `enum ShortBacktraceAttr { SkipFrame, StartFrame, EndFrame }`. StartFrame and EndFrame correspond to the existing `__rust_start_short_backtrace` and `__rust_end_short_backtrace` symbols. SkipFrame currently has no analogue. Each of these values is mutually exclusive with the others, and generating multiple for the same function is a logical error.
- Update all callsites of `DISubprogram::getImpl` to pass in a `std::optional<ShortBacktraceAttr>`
- Emit `ShortBacktraceAttr` when creating DWARF debuginfo. Note that this also generates debuginfo in more cases than before: When using line-tables-only debuginfo, LLVM attempts to skip functions with 0 lexical scopes. But some shims in the Rust standard library, such as `std::ops::Fn::call`, are shims that never appear in Rust source code but still appear in the backtrace. Generate info for these functions if they have a short backtrace attribute, so that they are correctly skipped in backtraces.
- Parse and serialize the new attribute in .ll files
- Add a regression test

cc @adrian-prantl and @dwblaikie, i talked with @DianQK and he suggested consulting you about whether this is the best approach.