### PR TITLE
[clang-format] Handle leading C++11 attribute in QualifierAlignment

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -386,7 +386,8 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeLeft(
   // For left qualifiers preceeded by nothing, a template declaration, or *,&,&&
   // we only perform sorting.
   if (!TypeToken || TypeToken->isPointerOrReference() ||
-      TypeToken->ClosesRequiresClause || TypeToken->ClosesTemplateDeclaration) {
+      TypeToken->ClosesRequiresClause || TypeToken->ClosesTemplateDeclaration ||
+      TypeToken->is(tok::r_square)) {
 
     // Don't sort past a non-configured qualifier token.
     const FormatToken *FirstQual = Tok;

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -1279,6 +1279,18 @@ TEST_F(QualifierFixerTest, WithConstraints) {
                Style);
 }
 
+TEST_F(QualifierFixerTest, WithCpp11Attribute) {
+  FormatStyle Style = getLLVMStyle();
+  Style.QualifierAlignment = FormatStyle::QAS_Custom;
+  Style.QualifierOrder = {"static", "constexpr", "inline", "type"};
+
+  verifyFormat("[[nodiscard]] static constexpr inline int func() noexcept {}",
+               "[[nodiscard]] inline constexpr static int func() noexcept {}",
+               Style);
+  verifyFormat("[[maybe_unused]] static constexpr int A",
+               "[[maybe_unused]] constexpr static int A", Style);
+}
+
 TEST_F(QualifierFixerTest, DisableRegions) {
   FormatStyle Style = getLLVMStyle();
   Style.QualifierAlignment = FormatStyle::QAS_Custom;


### PR DESCRIPTION
Fixes #123573.