### PR TITLE
[lld] Migrate away from PointerUnion::dyn_cast (NFC)

### DIFF
--- a/lld/MachO/Arch/ARM64.cpp
+++ b/lld/MachO/Arch/ARM64.cpp
@@ -205,7 +205,7 @@ InputSection *ARM64::getThunkBranchTarget(InputSection *thunk) const {
   assert(isa<InputSection *>(reloc.referent) &&
          "ARM64 thunk reloc is expected to point to an InputSection");
 
-  return dyn_cast_if_present<InputSection *>(reloc.referent);
+  return reloc.referent.dyn_cast<InputSection *>();
 }
 
 uint32_t ARM64::getICFSafeThunkSize() const { return sizeof(icfSafeThunkCode); }

--- a/lld/MachO/Arch/ARM64.cpp
+++ b/lld/MachO/Arch/ARM64.cpp
@@ -205,7 +205,7 @@ InputSection *ARM64::getThunkBranchTarget(InputSection *thunk) const {
   assert(isa<InputSection *>(reloc.referent) &&
          "ARM64 thunk reloc is expected to point to an InputSection");
 
-  return reloc.referent.dyn_cast<InputSection *>();
+  return dyn_cast_if_present<InputSection *>(reloc.referent);
 }
 
 uint32_t ARM64::getICFSafeThunkSize() const { return sizeof(icfSafeThunkCode); }

--- a/lld/MachO/Arch/ARM64Common.cpp
+++ b/lld/MachO/Arch/ARM64Common.cpp
@@ -143,7 +143,8 @@ void macho::reportUnalignedLdrStr(void *loc, const lld::macho::Reloc &r,
   uint64_t off = reinterpret_cast<const uint8_t *>(loc) - in.bufferStart;
   const InputSection *isec = offsetToInputSection(&off);
   std::string locStr = isec ? isec->getLocation(off) : "(invalid location)";
-  ::reportUnalignedLdrStr(locStr, va, align, r.referent.dyn_cast<Symbol *>());
+  ::reportUnalignedLdrStr(locStr, va, align,
+                          llvm::dyn_cast_if_present<Symbol *>(r.referent));
 }
 
 void macho::reportUnalignedLdrStr(void *loc, lld::macho::SymbolDiagnostic d,

--- a/lld/MachO/BPSectionOrderer.h
+++ b/lld/MachO/BPSectionOrderer.h
@@ -132,7 +132,7 @@ private:
     if (isec)
       kind = uint64_t(isec->kind());
 
-    if (auto *sym = reloc.referent.dyn_cast<Symbol *>()) {
+    if (auto *sym = llvm::dyn_cast_if_present<Symbol *>(reloc.referent)) {
       kind = (kind << 8) | uint8_t(sym->kind());
       if (auto *d = llvm::dyn_cast<Defined>(sym))
         value = d->value;

--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -343,7 +343,7 @@ void ICF::run() {
     parallelForEach(icfInputs, [&](ConcatInputSection *isec) {
       uint32_t hash = isec->icfEqClass[icfPass % 2];
       for (const Reloc &r : isec->relocs) {
-        if (auto *sym = r.referent.dyn_cast<Symbol *>()) {
+        if (auto *sym = dyn_cast_if_present<Symbol *>(r.referent)) {
           if (auto *defined = dyn_cast<Defined>(sym)) {
             if (defined->isec()) {
               if (auto *referentIsec =
@@ -473,7 +473,7 @@ void macho::markAddrSigSymbols() {
     const InputSection *isec = addrSigSection->subsections[0].isec;
 
     for (const Reloc &r : isec->relocs) {
-      if (auto *sym = r.referent.dyn_cast<Symbol *>())
+      if (auto *sym = dyn_cast_if_present<Symbol *>(r.referent))
         markSymAsAddrSig(sym);
       else
         error(toString(isec) + ": unexpected section relocation");

--- a/lld/MachO/InputFiles.cpp
+++ b/lld/MachO/InputFiles.cpp
@@ -1162,7 +1162,8 @@ void ObjFile::registerCompactUnwind(Section &compactUnwindSection) {
         continue;
       }
       uint64_t add = r.addend;
-      if (auto *sym = cast_or_null<Defined>(r.referent.dyn_cast<Symbol *>())) {
+      if (auto *sym = cast_or_null<Defined>(
+              dyn_cast_if_present<Symbol *>(r.referent))) {
         // Check whether the symbol defined in this file is the prevailing one.
         // Skip if it is e.g. a weak def that didn't prevail.
         if (sym->getFile() != this) {
@@ -1172,8 +1173,8 @@ void ObjFile::registerCompactUnwind(Section &compactUnwindSection) {
         add += sym->value;
         referentIsec = cast<ConcatInputSection>(sym->isec());
       } else {
-        referentIsec =
-            cast<ConcatInputSection>(r.referent.dyn_cast<InputSection *>());
+        referentIsec = cast<ConcatInputSection>(
+            dyn_cast_if_present<InputSection *>(r.referent));
       }
       // Unwind info lives in __DATA, and finalization of __TEXT will occur
       // before finalization of __DATA. Moreover, the finalization of unwind
@@ -1339,8 +1340,8 @@ targetSymFromCanonicalSubtractor(const InputSection *isec,
   // Note: pcSym may *not* be exactly at the PC; there's usually a non-zero
   // addend.
   auto *pcSym = cast<Defined>(cast<macho::Symbol *>(subtrahend.referent));
-  Defined *target =
-      cast_or_null<Defined>(minuend.referent.dyn_cast<macho::Symbol *>());
+  Defined *target = cast_or_null<Defined>(
+      dyn_cast_if_present<macho::Symbol *>(minuend.referent));
   if (!pcSym) {
     auto *targetIsec =
         cast<ConcatInputSection>(cast<InputSection *>(minuend.referent));

--- a/lld/MachO/InputSection.cpp
+++ b/lld/MachO/InputSection.cpp
@@ -229,7 +229,7 @@ void ConcatInputSection::writeTo(uint8_t *buf) {
       const Symbol *fromSym = cast<Symbol *>(r.referent);
       const Reloc &minuend = relocs[++i];
       uint64_t minuendVA;
-      if (const Symbol *toSym = minuend.referent.dyn_cast<Symbol *>())
+      if (const Symbol *toSym = dyn_cast_if_present<Symbol *>(minuend.referent))
         minuendVA = toSym->getVA() + minuend.addend;
       else {
         auto *referentIsec = cast<InputSection *>(minuend.referent);
@@ -237,7 +237,7 @@ void ConcatInputSection::writeTo(uint8_t *buf) {
         minuendVA = referentIsec->getVA(minuend.addend);
       }
       referentVA = minuendVA - fromSym->getVA();
-    } else if (auto *referentSym = r.referent.dyn_cast<Symbol *>()) {
+    } else if (auto *referentSym = dyn_cast_if_present<Symbol *>(r.referent)) {
       if (target->hasAttr(r.type, RelocAttrBits::LOAD) &&
           !referentSym->isInGot())
         target->relaxGotLoad(loc, r.type);
@@ -259,7 +259,8 @@ void ConcatInputSection::writeTo(uint8_t *buf) {
         writeChainedFixup(loc, referentSym, r.addend);
         continue;
       }
-    } else if (auto *referentIsec = r.referent.dyn_cast<InputSection *>()) {
+    } else if (auto *referentIsec =
+                   dyn_cast_if_present<InputSection *>(r.referent)) {
       assert(!::shouldOmitFromOutput(referentIsec));
       referentVA = referentIsec->getVA(r.addend);
 

--- a/lld/MachO/MarkLive.cpp
+++ b/lld/MachO/MarkLive.cpp
@@ -157,7 +157,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
 
       // Mark all symbols listed in the relocation table for this section.
       for (const Reloc &r : isec->relocs) {
-        if (auto *s = r.referent.dyn_cast<Symbol *>())
+        if (auto *s = dyn_cast_if_present<Symbol *>(r.referent))
           addSym(s, entry);
         else
           enqueue(cast<InputSection *>(r.referent), r.addend, entry);
@@ -175,7 +175,7 @@ void MarkLiveImpl<RecordWhyLive>::markTransitively() {
         continue;
 
       for (const Reloc &r : isec->relocs) {
-        if (auto *s = r.referent.dyn_cast<Symbol *>()) {
+        if (auto *s = dyn_cast_if_present<Symbol *>(r.referent)) {
           if (s->isLive()) {
             InputSection *referentIsec = nullptr;
             if (auto *d = dyn_cast<Defined>(s))

--- a/lld/MachO/ObjC.cpp
+++ b/lld/MachO/ObjC.cpp
@@ -543,7 +543,7 @@ ObjcCategoryMerger::tryGetSymbolAtIsecOffset(const ConcatInputSection *isec,
   if (!reloc)
     return nullptr;
 
-  Symbol *sym = reloc->referent.dyn_cast<Symbol *>();
+  Symbol *sym = dyn_cast_if_present<Symbol *>(reloc->referent);
 
   if (reloc->addend && sym) {
     assert(isa<Defined>(sym) && "Expected defined for non-zero addend");
@@ -769,8 +769,8 @@ bool ObjcCategoryMerger::parsePointerListInfo(const ConcatInputSection *isec,
     const Reloc *reloc = ptrListSym->isec()->getRelocAt(off);
     assert(reloc && "No reloc found at pointer list offset");
 
-    auto *listSym =
-        dyn_cast_or_null<Defined>(reloc->referent.dyn_cast<Symbol *>());
+    auto *listSym = dyn_cast_or_null<Defined>(
+        dyn_cast_if_present<Symbol *>(reloc->referent));
     // Sometimes, the reloc points to a StringPiece (InputSection + addend)
     // instead of a symbol.
     // TODO: Skip these cases for now, but we should fix this.
@@ -1158,7 +1158,7 @@ DenseSet<const Symbol *> ObjcCategoryMerger::collectNlCategories() {
       continue;
 
     for (auto &r : sec->relocs) {
-      const Symbol *sym = r.referent.dyn_cast<Symbol *>();
+      const Symbol *sym = dyn_cast_if_present<Symbol *>(r.referent);
       nlCategories.insert(sym);
     }
   }

--- a/lld/MachO/SyntheticSections.cpp
+++ b/lld/MachO/SyntheticSections.cpp
@@ -837,7 +837,7 @@ void ObjCSelRefsHelper::initialize() {
     // might be aggregated.
     assert(isec->relocs.size() == 1);
     auto Reloc = isec->relocs[0];
-    if (const auto *sym = Reloc.referent.dyn_cast<Symbol *>()) {
+    if (const auto *sym = dyn_cast_if_present<Symbol *>(Reloc.referent)) {
       if (const auto *d = dyn_cast<Defined>(sym)) {
         auto *cisec = cast<CStringInputSection>(d->isec());
         auto methname = cisec->getStringRefAtOffset(d->value);
@@ -1958,7 +1958,7 @@ void InitOffsetsSection::writeTo(uint8_t *buf) const {
   // FIXME: Add function specified by -init when that argument is implemented.
   for (ConcatInputSection *isec : sections) {
     for (const Reloc &rel : isec->relocs) {
-      const Symbol *referent = rel.referent.dyn_cast<Symbol *>();
+      const Symbol *referent = dyn_cast_if_present<Symbol *>(rel.referent);
       assert(referent && "section relocation should have been rejected");
       uint64_t offset = referent->getVA() - in.header->addr;
       // FIXME: Can we handle this gracefully?
@@ -1994,7 +1994,7 @@ void InitOffsetsSection::setUp() {
         error(isec->getLocation(rel.offset) +
               ": unexpected section relocation");
 
-      Symbol *sym = rel.referent.dyn_cast<Symbol *>();
+      Symbol *sym = dyn_cast_if_present<Symbol *>(rel.referent);
       if (auto *undefined = dyn_cast<Undefined>(sym))
         treatUndefinedSymbol(*undefined, isec, rel.offset);
       if (needsBinding(sym))

--- a/lld/MachO/UnwindInfoSection.cpp
+++ b/lld/MachO/UnwindInfoSection.cpp
@@ -239,7 +239,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
     // Since compact unwind sections aren't part of the inputSections vector,
     // they don't get canonicalized by scanRelocations(), so we have to do the
     // canonicalization here.
-    if (auto *referentIsec = r.referent.dyn_cast<InputSection *>())
+    if (auto *referentIsec = dyn_cast_if_present<InputSection *>(r.referent))
       r.referent = referentIsec->canonical();
 
     // Functions and LSDA entries always reside in the same object file as the
@@ -249,7 +249,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
     if (r.offset != cuLayout.personalityOffset)
       continue;
 
-    if (auto *s = r.referent.dyn_cast<Symbol *>()) {
+    if (auto *s = dyn_cast_if_present<Symbol *>(r.referent)) {
       // Personality functions are nearly always system-defined (e.g.,
       // ___gxx_personality_v0 for C++) and relocated as dylib symbols.  When an
       // application provides its own personality function, it might be
@@ -294,7 +294,7 @@ void UnwindInfoSectionImpl::prepareRelocations(ConcatInputSection *isec) {
       continue;
     }
 
-    if (auto *referentIsec = r.referent.dyn_cast<InputSection *>()) {
+    if (auto *referentIsec = dyn_cast_if_present<InputSection *>(r.referent)) {
       assert(!isCoalescedWeak(referentIsec));
       // Personality functions can be referenced via section relocations
       // if they live in the same object file. Create placeholder synthetic

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -711,7 +711,7 @@ void Writer::scanRelocations() {
 
       // Canonicalize the referent so that later accesses in Writer won't
       // have to worry about it.
-      if (auto *referentIsec = r.referent.dyn_cast<InputSection *>())
+      if (auto *referentIsec = dyn_cast_if_present<InputSection *>(r.referent))
         r.referent = referentIsec->canonical();
 
       if (target->hasAttr(r.type, RelocAttrBits::SUBTRAHEND)) {
@@ -721,11 +721,12 @@ void Writer::scanRelocations() {
         ++it;
         // Canonicalize the referent so that later accesses in Writer won't
         // have to worry about it.
-        if (auto *referentIsec = it->referent.dyn_cast<InputSection *>())
+        if (auto *referentIsec =
+                dyn_cast_if_present<InputSection *>(it->referent))
           it->referent = referentIsec->canonical();
         continue;
       }
-      if (auto *sym = r.referent.dyn_cast<Symbol *>()) {
+      if (auto *sym = dyn_cast_if_present<Symbol *>(r.referent)) {
         if (auto *undefined = dyn_cast<Undefined>(sym))
           treatUndefinedSymbol(*undefined, isec, r.offset);
         // treatUndefinedSymbol() can replace sym with a DylibSymbol; re-check.


### PR DESCRIPTION
Note that PointerUnion::dyn_cast has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>
