### PR TITLE
[AMDGPU][CodeGen] SILowerWWMCopies: Declare used analyses

### DIFF
--- a/llvm/lib/Target/AMDGPU/SILowerWWMCopies.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerWWMCopies.cpp
@@ -43,6 +43,9 @@ public:
   StringRef getPassName() const override { return "SI Lower WWM Copies"; }
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addUsedIfAvailable<LiveIntervalsWrapperPass>();
+    AU.addUsedIfAvailable<SlotIndexesWrapperPass>();
+    AU.addUsedIfAvailable<VirtRegMapWrapperLegacy>();
     AU.setPreservesAll();
     MachineFunctionPass::getAnalysisUsage(AU);
   }


### PR DESCRIPTION
This prevents legacy PM from mistakenly removing these analyses if `SILowerWWMCopies` is the last user of them. (it removes dead analyses after its last use)