### PR TITLE
[libc++] Avoid unnecessary instantiations for __copy_cvref_t

### DIFF
--- a/libcxx/include/__type_traits/copy_cvref.h
+++ b/libcxx/include/__type_traits/copy_cvref.h
@@ -20,23 +20,26 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-template <class _From, class _To>
+template <class _From>
 struct __copy_cvref {
-  using type = __copy_cv_t<_From, _To>;
+  template <class _To>
+  using __apply _LIBCPP_NODEBUG = __copy_cv_t<_From, _To>;
+};
+
+template <class _From>
+struct __copy_cvref<_From&> {
+  template <class _To>
+  using __apply _LIBCPP_NODEBUG = __add_lvalue_reference_t<__copy_cv_t<_From, _To> >;
+};
+
+template <class _From>
+struct __copy_cvref<_From&&> {
+  template <class _To>
+  using __apply _LIBCPP_NODEBUG = __add_rvalue_reference_t<__copy_cv_t<_From, _To> >;
 };
 
 template <class _From, class _To>
-struct __copy_cvref<_From&, _To> {
-  using type = __add_lvalue_reference_t<__copy_cv_t<_From, _To> >;
-};
-
-template <class _From, class _To>
-struct __copy_cvref<_From&&, _To> {
-  using type = __add_rvalue_reference_t<__copy_cv_t<_From, _To> >;
-};
-
-template <class _From, class _To>
-using __copy_cvref_t _LIBCPP_NODEBUG = typename __copy_cvref<_From, _To>::type;
+using __copy_cvref_t _LIBCPP_NODEBUG = typename __copy_cvref<_From>::template __apply<_To>;
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
This changes the implementation of `__copy_cvref_t` to only template the implementation class on the `_From` parameter, avoiding instantiations for every combination of `_From` and `_To`.
