### PR TITLE
[lldb][AArch64] Add Guarded Control Stack registers

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
@@ -92,6 +92,7 @@ private:
   bool m_pac_mask_is_valid;
   bool m_tls_is_valid;
   size_t m_tls_size;
+  bool m_gcs_is_valid;
 
   struct user_pt_regs m_gpr_arm64; // 64-bit general purpose registers.
 
@@ -136,6 +137,12 @@ private:
 
   uint64_t m_fpmr_reg;
 
+  struct gcs_regs {
+    uint64_t features_enabled;
+    uint64_t features_locked;
+    uint64_t gcspr_e0;
+  } m_gcs_regs;
+
   bool IsGPR(unsigned reg) const;
 
   bool IsFPR(unsigned reg) const;
@@ -166,6 +173,10 @@ private:
 
   Status WriteZA();
 
+  Status ReadGCS();
+
+  Status WriteGCS();
+
   // No WriteZAHeader because writing only the header will disable ZA.
   // Instead use WriteZA and ensure you have the correct ZA buffer size set
   // beforehand if you wish to disable it.
@@ -187,6 +198,7 @@ private:
   bool IsMTE(unsigned reg) const;
   bool IsTLS(unsigned reg) const;
   bool IsFPMR(unsigned reg) const;
+  bool IsGCS(unsigned reg) const;
 
   uint64_t GetSVERegVG() { return m_sve_header.vl / 8; }
 
@@ -212,6 +224,8 @@ private:
 
   void *GetFPMRBuffer() { return &m_fpmr_reg; }
 
+  void *GetGCSBuffer() { return &m_gcs_regs; }
+
   size_t GetSVEHeaderSize() { return sizeof(m_sve_header); }
 
   size_t GetPACMaskSize() { return sizeof(m_pac_mask); }
@@ -233,6 +247,8 @@ private:
   size_t GetZTBufferSize() { return m_zt_reg.size(); }
 
   size_t GetFPMRBufferSize() { return sizeof(m_fpmr_reg); }
+
+  size_t GetGCSBufferSize() { return sizeof(m_gcs_regs); }
 
   llvm::Error ReadHardwareDebugInfo() override;
 

--- a/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.cpp
@@ -63,6 +63,10 @@ bool RegisterContextPOSIX_arm64::IsFPMR(unsigned reg) const {
   return m_register_info_up->IsFPMRReg(reg);
 }
 
+bool RegisterContextPOSIX_arm64::IsGCS(unsigned reg) const {
+  return m_register_info_up->IsGCSReg(reg);
+}
+
 RegisterContextPOSIX_arm64::RegisterContextPOSIX_arm64(
     lldb_private::Thread &thread,
     std::unique_ptr<RegisterInfoPOSIX_arm64> register_info)

--- a/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextPOSIX_arm64.h
@@ -59,6 +59,7 @@ protected:
   bool IsSME(unsigned reg) const;
   bool IsMTE(unsigned reg) const;
   bool IsFPMR(unsigned reg) const;
+  bool IsGCS(unsigned reg) const;
 
   bool IsSVEZ(unsigned reg) const { return m_register_info_up->IsSVEZReg(reg); }
   bool IsSVEP(unsigned reg) const { return m_register_info_up->IsSVEPReg(reg); }

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h
@@ -33,6 +33,7 @@ public:
     eRegsetMaskZA = 32,
     eRegsetMaskZT = 64,
     eRegsetMaskFPMR = 128,
+    eRegsetMaskGCS = 256,
     eRegsetMaskDynamic = ~1,
   };
 
@@ -113,6 +114,8 @@ public:
 
   void AddRegSetFPMR();
 
+  void AddRegSetGCS();
+
   uint32_t ConfigureVectorLengthSVE(uint32_t sve_vq);
 
   void ConfigureVectorLengthZA(uint32_t za_vq);
@@ -132,6 +135,7 @@ public:
   bool IsMTEPresent() const { return m_opt_regsets.AnySet(eRegsetMaskMTE); }
   bool IsTLSPresent() const { return m_opt_regsets.AnySet(eRegsetMaskTLS); }
   bool IsFPMRPresent() const { return m_opt_regsets.AnySet(eRegsetMaskFPMR); }
+  bool IsGCSPresent() const { return m_opt_regsets.AnySet(eRegsetMaskGCS); }
 
   bool IsSVEReg(unsigned reg) const;
   bool IsSVEZReg(unsigned reg) const;
@@ -144,6 +148,7 @@ public:
   bool IsSMERegZA(unsigned reg) const;
   bool IsSMERegZT(unsigned reg) const;
   bool IsFPMRReg(unsigned reg) const;
+  bool IsGCSReg(unsigned reg) const;
 
   uint32_t GetRegNumSVEZ0() const;
   uint32_t GetRegNumSVEFFR() const;
@@ -156,6 +161,7 @@ public:
   uint32_t GetTLSOffset() const;
   uint32_t GetSMEOffset() const;
   uint32_t GetFPMROffset() const;
+  uint32_t GetGCSOffset() const;
 
 private:
   typedef std::map<uint32_t, std::vector<lldb_private::RegisterInfo>>
@@ -188,6 +194,7 @@ private:
   std::vector<uint32_t> m_tls_regnum_collection;
   std::vector<uint32_t> m_sme_regnum_collection;
   std::vector<uint32_t> m_fpmr_regnum_collection;
+  std::vector<uint32_t> m_gcs_regnum_collection;
 };
 
 #endif

--- a/lldb/test/API/linux/aarch64/gcs/TestAArch64LinuxGCS.py
+++ b/lldb/test/API/linux/aarch64/gcs/TestAArch64LinuxGCS.py
@@ -219,11 +219,11 @@ class AArch64LinuxGCSTestCase(TestBase):
         # Now to prove we can write gcs_features_enabled, disable GCS and continue
         # past the fault we caused. Note that although the libc likely locked the
         # ability to disable GCS, ptrace bypasses the lock bits.
-        gcs_enabled &= ~1
-        self.runCmd(f"register write gcs_features_enabled {gcs_enabled}")
+        enabled &= ~1
+        self.runCmd(f"register write gcs_features_enabled {enabled}")
         self.expect(
             "register read gcs_features_enabled",
-            substrs=[f"gcs_features_enabled = 0x{gcs_enabled:016x}"],
+            substrs=[f"gcs_features_enabled = 0x{enabled:016x}"],
         )
 
         # With GCS disabled, the invalid guarded control stack pointer is not

--- a/lldb/test/API/linux/aarch64/gcs/TestAArch64LinuxGCS.py
+++ b/lldb/test/API/linux/aarch64/gcs/TestAArch64LinuxGCS.py
@@ -83,3 +83,137 @@ class AArch64LinuxGCSTestCase(TestBase):
                 "stop reason = signal SIGSEGV: control protection fault",
             ],
         )
+
+    @skipUnlessArch("aarch64")
+    @skipUnlessPlatform(["linux"])
+    def test_gcs_registers(self):
+        if not self.isAArch64GCS():
+            self.skipTest("Target must support GCS.")
+
+        self.build()
+        self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
+
+        self.runCmd("b test_func")
+        self.runCmd("b test_func2")
+        self.runCmd("run", RUN_SUCCEEDED)
+
+        if self.process().GetState() == lldb.eStateExited:
+            self.fail("Test program failed to run.")
+
+        self.expect(
+            "thread list",
+            STOPPED_DUE_TO_BREAKPOINT,
+            substrs=["stopped", "stop reason = breakpoint"],
+        )
+
+        self.expect("register read --all", substrs=["Guarded Control Stack Registers:"])
+
+        def check_gcs_registers(
+            expected_gcs_features_enabled=None,
+            expected_gcs_features_locked=None,
+            expected_gcspr_el0=None,
+        ):
+            thread = self.dbg.GetSelectedTarget().process.GetThreadAtIndex(0)
+            registerSets = thread.GetFrameAtIndex(0).GetRegisters()
+            gcs_registers = registerSets.GetFirstValueByName(
+                r"Guarded Control Stack Registers"
+            )
+
+            gcs_features_enabled = gcs_registers.GetChildMemberWithName(
+                "gcs_features_enabled"
+            ).GetValueAsUnsigned()
+            if expected_gcs_features_enabled is not None:
+                self.assertEqual(expected_gcs_features_enabled, gcs_features_enabled)
+
+            gcs_features_locked = gcs_registers.GetChildMemberWithName(
+                "gcs_features_locked"
+            ).GetValueAsUnsigned()
+            if expected_gcs_features_locked is not None:
+                self.assertEqual(expected_gcs_features_locked, gcs_features_locked)
+
+            gcspr_el0 = gcs_registers.GetChildMemberWithName(
+                "gcspr_el0"
+            ).GetValueAsUnsigned()
+            if expected_gcspr_el0 is not None:
+                self.assertEqual(expected_gcspr_el0, gcspr_el0)
+
+            return gcs_features_enabled, gcs_features_locked, gcspr_el0
+
+        enabled, locked, spr_el0 = check_gcs_registers()
+
+        # Features enabled should have at least the enable bit set, it could have
+        # others depending on what the C library did.
+        self.assertTrue(enabled & 1, "Expected GCS enable bit to be set.")
+
+        # Features locked we cannot predict, we will just assert that it remains
+        # the same as we continue.
+
+        # spr_el0 will point to some memory region that is a shadow stack region.
+        self.expect(f"memory region {spr_el0}", substrs=["shadow stack: yes"])
+
+        # Continue into test_func2, where the GCS pointer should have been
+        # decremented, and the other registers remain the same.
+        self.runCmd("continue")
+
+        self.expect(
+            "thread list",
+            STOPPED_DUE_TO_BREAKPOINT,
+            substrs=["stopped", "stop reason = breakpoint"],
+        )
+
+        _, _, spr_el0 = check_gcs_registers(enabled, locked, spr_el0 - 8)
+
+        # Modify the control stack pointer to cause a fault.
+        spr_el0 += 8
+        self.runCmd(f"register write gcspr_el0 {spr_el0}")
+        self.expect(
+            "register read gcspr_el0", substrs=[f"gcspr_el0 = 0x{spr_el0:016x}"]
+        )
+
+        # If we wrote it back correctly, we will now fault but don't pass this
+        # signal to the application.
+        self.runCmd("process handle SIGSEGV --pass false")
+        self.runCmd("continue")
+
+        self.expect(
+            "thread list",
+            "Expected stopped by SIGSEGV.",
+            substrs=[
+                "stopped",
+                "stop reason = signal SIGSEGV: control protection fault",
+            ],
+        )
+
+        # Any combination of lock bits could be set. Flip then restore one of them.
+        STACK_PUSH = 2
+        stack_push = bool((locked >> STACK_PUSH) & 1)
+        new_locked = (locked & ~(1 << STACK_PUSH)) | (int(not stack_push) << STACK_PUSH)
+        self.runCmd(f"register write gcs_features_locked 0x{new_locked:x}")
+        self.expect(
+            f"register read gcs_features_locked",
+            substrs=[f"gcs_features_locked = 0x{new_locked:016x}"],
+        )
+
+        # We could prove the write made it to hardware by trying to prctl to change
+        # the feature here, but we cannot know if the libc locked it or not.
+        # Given that we know the other registers in the set write correctly, we
+        # can assume this one does.
+
+        self.runCmd(f"register write gcs_features_locked 0x{locked:x}")
+
+        # Now to prove we can write gcs_features_enabled, disable GCS and continue
+        # past the fault.
+        enabled &= ~1
+        self.runCmd(f"register write gcs_features_enabled {enabled}")
+        self.expect(
+            "register read gcs_features_enabled",
+            substrs=[f"gcs_features_enabled = 0x{enabled:016x}"],
+        )
+
+        self.runCmd("continue")
+        self.expect(
+            "process status",
+            substrs=[
+                "exited with status = 0",
+            ],
+        )

--- a/lldb/test/API/linux/aarch64/gcs/TestAArch64LinuxGCS.py
+++ b/lldb/test/API/linux/aarch64/gcs/TestAArch64LinuxGCS.py
@@ -108,6 +108,8 @@ class AArch64LinuxGCSTestCase(TestBase):
 
         self.expect("register read --all", substrs=["Guarded Control Stack Registers:"])
 
+        # This helper reads all the GCS registers and optionally compares them
+        # against a previous state, then returns the current register values.
         def check_gcs_registers(
             expected_gcs_features_enabled=None,
             expected_gcs_features_locked=None,
@@ -142,7 +144,8 @@ class AArch64LinuxGCSTestCase(TestBase):
         enabled, locked, spr_el0 = check_gcs_registers()
 
         # Features enabled should have at least the enable bit set, it could have
-        # others depending on what the C library did.
+        # others depending on what the C library did, but we can't rely on always
+        # having them.
         self.assertTrue(enabled & 1, "Expected GCS enable bit to be set.")
 
         # Features locked we cannot predict, we will just assert that it remains
@@ -163,15 +166,44 @@ class AArch64LinuxGCSTestCase(TestBase):
 
         _, _, spr_el0 = check_gcs_registers(enabled, locked, spr_el0 - 8)
 
-        # Modify the control stack pointer to cause a fault.
+        # Any combination of GCS feature lock bits might have been set by the C
+        # library, and could be set to 0 or 1. To check that we can modify them,
+        # invert one of those bits then write it back to the lock register.
+        # The stack pushing feature is bit 2 of that register.
+        STACK_PUSH = 2
+        # Get the original value of the stack push lock bit.
+        stack_push = bool((locked >> STACK_PUSH) & 1)
+        # Invert the value and put it back into the set of lock bits.
+        new_locked = (locked & ~(1 << STACK_PUSH)) | (int(not stack_push) << STACK_PUSH)
+        # Write the new lock bits, which are the same as before, only with stack
+        # push locked (if it was previously unlocked), or unlocked (if it was
+        # previously locked).
+        self.runCmd(f"register write gcs_features_locked 0x{new_locked:x}")
+        # We should be able to read back this new set of lock bits.
+        self.expect(
+            f"register read gcs_features_locked",
+            substrs=[f"gcs_features_locked = 0x{new_locked:016x}"],
+        )
+
+        # We could prove the write made it to hardware by trying to prctl() to
+        # enable or disable the stack push feature here, but because the libc
+        # may or may not have locked it, it's tricky to coordinate this. Given
+        # that we know the other registers can be written and their values are
+        # seen by the process, we can assume this is too.
+
+        # Restore the original lock bits, as the libc may rely on being able
+        # to use certain features during program execution.
+        self.runCmd(f"register write gcs_features_locked 0x{locked:x}")
+
+        # Modify the guarded control stack pointer to cause a fault.
         spr_el0 += 8
         self.runCmd(f"register write gcspr_el0 {spr_el0}")
         self.expect(
             "register read gcspr_el0", substrs=[f"gcspr_el0 = 0x{spr_el0:016x}"]
         )
 
-        # If we wrote it back correctly, we will now fault but don't pass this
-        # signal to the application.
+        # If we wrote it back correctly, we will now fault. Don't pass this signal
+        # to the application, as we will continue past it later.
         self.runCmd("process handle SIGSEGV --pass false")
         self.runCmd("continue")
 
@@ -184,32 +216,18 @@ class AArch64LinuxGCSTestCase(TestBase):
             ],
         )
 
-        # Any combination of lock bits could be set. Flip then restore one of them.
-        STACK_PUSH = 2
-        stack_push = bool((locked >> STACK_PUSH) & 1)
-        new_locked = (locked & ~(1 << STACK_PUSH)) | (int(not stack_push) << STACK_PUSH)
-        self.runCmd(f"register write gcs_features_locked 0x{new_locked:x}")
-        self.expect(
-            f"register read gcs_features_locked",
-            substrs=[f"gcs_features_locked = 0x{new_locked:016x}"],
-        )
-
-        # We could prove the write made it to hardware by trying to prctl to change
-        # the feature here, but we cannot know if the libc locked it or not.
-        # Given that we know the other registers in the set write correctly, we
-        # can assume this one does.
-
-        self.runCmd(f"register write gcs_features_locked 0x{locked:x}")
-
         # Now to prove we can write gcs_features_enabled, disable GCS and continue
-        # past the fault.
-        enabled &= ~1
-        self.runCmd(f"register write gcs_features_enabled {enabled}")
+        # past the fault we caused. Note that although the libc likely locked the
+        # ability to disable GCS, ptrace bypasses the lock bits.
+        gcs_enabled &= ~1
+        self.runCmd(f"register write gcs_features_enabled {gcs_enabled}")
         self.expect(
             "register read gcs_features_enabled",
-            substrs=[f"gcs_features_enabled = 0x{enabled:016x}"],
+            substrs=[f"gcs_features_enabled = 0x{gcs_enabled:016x}"],
         )
 
+        # With GCS disabled, the invalid guarded control stack pointer is not
+        # checked, so the program can finish normally.
         self.runCmd("continue")
         self.expect(
             "process status",


### PR DESCRIPTION
The Guarded Control Stack extension implements a shadow stack and the Linux kernel provides access to 3 registers for it via ptrace.

struct user_gcs {
	__u64 features_enabled;
	__u64 features_locked;
	__u64 gcspr_el0;
};

This commit adds support for reading those from a live process.

The first 2 are pseudo registers based on the real control register and the 3rd is a real register. This is the stack pointer for the guarded stack.

I have added a "gcs_" prefix to the "features" registers so that they have a clear name when shown individually. Also this means they will tab complete from "gcs", and be next to gcspr_el0 in any sorted lists of registers.

Guarded Control Stack Registers:
  gcs_features_enabled = 0x0000000000000000
  gcs_features_locked = 0x0000000000000000
  gcspr_el0 = 0x0000000000000000

Testing is more of the usual, where possible I'm writing a register then doing something in the program to confirm the value was actually sent to ptrace.