### PR TITLE
[SPIR-V] Ensure that Module resource is managed locally wrt. a unit test case and fix a memory leak

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -134,9 +134,8 @@ SPIRVTranslateModule(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   TargetOptions Options;
   std::optional<Reloc::Model> RM;
   std::optional<CodeModel::Model> CM;
-  std::unique_ptr<TargetMachine> Target =
-      std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
-          TargetTriple.getTriple(), "", "", Options, RM, CM, OLevel));
+  std::unique_ptr<TargetMachine> Target(TheTarget->createTargetMachine(
+      TargetTriple.getTriple(), "", "", Options, RM, CM, OLevel));
   if (!Target) {
     ErrMsg = "Could not allocate target machine!";
     return false;
@@ -158,10 +157,10 @@ SPIRVTranslateModule(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   TargetLibraryInfoImpl TLII(Triple(M->getTargetTriple()));
   legacy::PassManager PM;
   PM.add(new TargetLibraryInfoWrapperPass(TLII));
-  MachineModuleInfoWrapperPass *MMIWP =
-      new MachineModuleInfoWrapperPass(Target.get());
+  std::unique_ptr<MachineModuleInfoWrapperPass> MMIWP(
+      new MachineModuleInfoWrapperPass(Target.get()));
   const_cast<TargetLoweringObjectFile *>(Target->getObjFileLowering())
-      ->Initialize(MMIWP->getMMI().getContext(), *Target);
+      ->Initialize(MMIWP.get()->getMMI().getContext(), *Target);
 
   SmallString<4096> OutBuffer;
   raw_svector_ostream OutStream(OutBuffer);

--- a/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
+++ b/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
@@ -36,7 +36,9 @@ protected:
                const std::vector<std::string> &AllowExtNames,
                const std::vector<std::string> &Opts) {
     SMDiagnostic ParseError;
-    M = parseAssemblyString(Assembly, ParseError, Context);
+    LLVMContext Context;
+    std::unique_ptr<Module> M =
+        parseAssemblyString(Assembly, ParseError, Context);
     if (!M) {
       ParseError.print("IR parsing failed: ", errs());
       report_fatal_error("Can't parse input assembly.");
@@ -47,9 +49,6 @@ protected:
       errs() << ErrMsg;
     return Status;
   }
-
-  LLVMContext Context;
-  std::unique_ptr<Module> M;
 
   static constexpr StringRef ExtensionAssembly = R"(
     define dso_local spir_func void @test1() {


### PR DESCRIPTION
Adding SPIRV to LLVM_ALL_TARGETS (https://github.com/llvm/llvm-project/pull/119653) revealed a series of minor compilation problems and sanitizer complaints. This PR is to move unit tests resources (a Module ptr) from the class-scope to a local scope of the class member function to be sure that before the test env is teared down the ptr is released.
