### PR TITLE
[clang-tidy] Add ClangQueryChecks config option

### DIFF
--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 add_clang_library(clangTidy STATIC
   ClangTidy.cpp
   ClangTidyCheck.cpp
+  ClangQueryCheck.cpp
   ClangTidyModule.cpp
   ClangTidyDiagnosticConsumer.cpp
   ClangTidyOptions.cpp
@@ -38,6 +39,7 @@ clang_target_link_libraries(clangTidy
   clangSerialization
   clangTooling
   clangToolingCore
+  clangQuery
   )
 
 if(CLANG_TIDY_ENABLE_STATIC_ANALYZER)

--- a/clang-tools-extra/clang-tidy/ClangQueryCheck.cpp
+++ b/clang-tools-extra/clang-tidy/ClangQueryCheck.cpp
@@ -1,0 +1,30 @@
+//===--- ClangQueryCheck.cpp - clang-tidy ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ClangQueryCheck.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::misc {
+
+void ClangQueryCheck::registerMatchers(MatchFinder *Finder) {
+  for (const auto &Matcher : Matchers) {
+    bool Ok = Finder->addDynamicMatcher(Matcher, this);
+    assert(Ok && "Expected to get top level matcher from query parser");
+  }
+}
+
+void ClangQueryCheck::check(const MatchFinder::MatchResult &Result) {
+  auto Map = Result.Nodes.getMap();
+  for (const auto &[k, v] : Map) {
+    diag(v.getSourceRange().getBegin(), k) << v.getSourceRange();
+  }
+}
+
+} // namespace clang::tidy::misc

--- a/clang-tools-extra/clang-tidy/ClangQueryCheck.h
+++ b/clang-tools-extra/clang-tidy/ClangQueryCheck.h
@@ -1,0 +1,43 @@
+//===--- ClangQueryCheck.h - clang-tidy --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGQUERYCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGQUERYCHECK_H
+
+#include "ClangTidyCheck.h"
+#include "clang/ASTMatchers/Dynamic/VariantValue.h"
+#include <vector>
+
+namespace clang::query {
+class QuerySession;
+} // namespace clang::query
+
+namespace clang::tidy::misc {
+
+/// A check that matches a given matchers printing their binds as warnings
+class ClangQueryCheck : public ClangTidyCheck {
+  using MatcherVec = std::vector<ast_matchers::dynamic::DynTypedMatcher>;
+
+public:
+  ClangQueryCheck(StringRef Name, ClangTidyContext *Context,
+                  MatcherVec Matchers)
+      : ClangTidyCheck(Name, Context), Matchers(std::move(Matchers)) {}
+
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+    return LangOpts.CPlusPlus;
+  }
+
+private:
+  MatcherVec Matchers;
+};
+
+} // namespace clang::tidy::misc
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGQUERYCHECK_H

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ClangTidy.h"
+#include "ClangQueryCheck.h"
 #include "ClangTidyCheck.h"
 #include "ClangTidyDiagnosticConsumer.h"
 #include "ClangTidyModuleRegistry.h"
@@ -349,6 +350,13 @@ ClangTidyASTConsumerFactory::ClangTidyASTConsumerFactory(
   for (ClangTidyModuleRegistry::entry E : ClangTidyModuleRegistry::entries()) {
     std::unique_ptr<ClangTidyModule> Module = E.instantiate();
     Module->addCheckFactories(*CheckFactories);
+  }
+
+  for (const auto &[k, v] : Context.getOptions().ClangQueryChecks) {
+    CheckFactories->registerCheckFactory(k, [v](StringRef Name,
+                                                ClangTidyContext *Context) {
+      return std::make_unique<misc::ClangQueryCheck>(Name, Context, v.Matchers);
+    });
   }
 }
 

--- a/clang-tools-extra/clang-tidy/ClangTidyOptions.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyOptions.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDYOPTIONS_H
 #define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CLANGTIDYOPTIONS_H
 
+#include "clang/ASTMatchers/Dynamic/VariantValue.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
@@ -126,8 +127,15 @@ struct ClangTidyOptions {
   using StringPair = std::pair<std::string, std::string>;
   using OptionMap = llvm::StringMap<ClangTidyValue>;
 
+  struct QueryCheckValue {
+    std::string Source;
+    std::vector<ast_matchers::dynamic::DynTypedMatcher> Matchers;
+  };
+  using QueryCheckMap = llvm::StringMap<QueryCheckValue>;
+
   /// Key-value mapping used to store check-specific options.
   OptionMap CheckOptions;
+  QueryCheckMap ClangQueryChecks;
 
   using ArgList = std::vector<std::string>;
 

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -60,6 +60,18 @@ Configuration files:
   Checks                       - Same as '--checks'. Additionally, the list of
                                  globs can be specified as a list instead of a
                                  string.
+  ClangQueryChecks             - List of key-value pairs. Key specifies a name
+                                  of the new check and value specifies a list
+                                  of matchers in the form of clang-query
+                                  syntax. Example:
+                                    ClangQueryChecks:
+                                      custom-check: |
+                                        let matcher varDecl(
+                                          hasTypeLoc(
+                                            typeLoc().bind("Custom message")
+                                          )
+                                        )
+                                        match matcher
   ExcludeHeaderFilterRegex     - Same as '--exclude-header-filter'.
   ExtraArgs                    - Same as '--extra-arg'.
   ExtraArgsBefore              - Same as '--extra-arg-before'.
@@ -483,7 +495,8 @@ static StringRef closest(StringRef Value, const StringSet<> &Allowed) {
   return Closest;
 }
 
-static constexpr StringLiteral VerifyConfigWarningEnd = " [-verify-config]\n";
+static constexpr llvm::StringLiteral VerifyConfigWarningEnd =
+    " [-verify-config]\n";
 
 static bool verifyChecks(const StringSet<> &AllChecks, StringRef CheckGlob,
                          StringRef Source) {

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -140,6 +140,9 @@ Improvements to clang-tidy
   :doc:`readability-redundant-access-specifiers <clang-tidy/checks/readability/redundant-access-specifiers>`, CheckFirstDeclaration
   :doc:`readability-redundant-casting <clang-tidy/checks/readability/redundant-casting>`, IgnoreTypeAliases
 
+- New :program:`clang-tidy` config property `ClangQueryChecks` that allows adding
+  custom checks based on a :program:`clang-query` syntax
+
 New checks
 ^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -292,6 +292,18 @@ An overview of all the command-line options:
     Checks                       - Same as '--checks'. Additionally, the list of
                                    globs can be specified as a list instead of a
                                    string.
+    ClangQueryChecks             - List of key-value pairs. Key specifies a name
+                                   of the new check and value specifies a list
+                                   of matchers in the form of clang-query
+                                   syntax. Example:
+                                     ClangQueryChecks:
+                                       custom-check: |
+                                         let matcher varDecl(
+                                           hasTypeLoc(
+                                             typeLoc().bind("Custom message")
+                                           )
+                                         )
+                                         match matcher
     ExcludeHeaderFilterRegex     - Same as '--exclude-header-filter'.
     ExtraArgs                    - Same as '--extra-arg'.
     ExtraArgsBefore              - Same as '--extra-arg-before'.

--- a/clang-tools-extra/test/clang-tidy/infrastructure/query-checks.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/query-checks.cpp
@@ -1,0 +1,53 @@
+// DEFINE: %{custom-call-yaml} = custom-call: 'm callExpr().bind(\"Custom message\")'
+//
+// DEFINE: %{custom-let-call-yaml} = custom-let-call: \"         \
+// DEFINE:     let expr varDecl(                                 \
+// DEFINE:       hasType(asString(\\\"long long\\\")),           \
+// DEFINE:       hasTypeLoc(typeLoc().bind(\\\"Let message\\\")) \
+// DEFINE:     ) \n                                              \
+// DEFINE:     match expr\"
+//
+// DEFINE: %{full-config} = "{ClangQueryChecks: {%{custom-call-yaml},%{custom-let-call-yaml}}}"
+
+//Check single match expression
+// RUN: clang-tidy %s -checks='-*, custom-*'                  \
+// RUN:   -config="{ClangQueryChecks: {%{custom-call-yaml}}}" \
+// RUN:   -- | FileCheck %s -check-prefix=CHECK-CUSTOM-CALL
+
+void a() {
+}
+
+// CHECK-CUSTOM-CALL: warning: Custom message [custom-call]
+// CHECK-CUSTOM-CALL-NEXT: a();{{$}}
+void b() {
+    a();
+}
+
+//Check let with match expression
+// RUN: clang-tidy %s -checks='-*, custom-*'                      \
+// RUN:   -config="{ClangQueryChecks: {%{custom-let-call-yaml}}}" \
+// RUN:   -- | FileCheck %s -check-prefix=CHECK-CUSTOM-LET
+void c() {
+    // CHECK-CUSTOM-LET: warning: Let message [custom-let-call]
+    // CHECK-CUSTOM-LET-NEXT: long long test_long_long = 0;{{$}}
+    long long test_long_long_nolint = 0; //NOLINT(custom-let-call)
+    long long test_long_long = 0;
+}
+
+//Check multiple checks in one config
+// RUN: clang-tidy %s -checks='-*, custom-*' \
+// RUN:   -config=%{full-config}             \
+// RUN:   -- | FileCheck %s -check-prefixes=CHECK-CUSTOM-CALL,CHECK-CUSTOM-LET
+
+//Check multiple checks in one config but only one enabled
+// RUN: clang-tidy %s -checks='-*, custom-call' \
+// RUN:   -config=%{full-config}                \
+// RUN:   -- | FileCheck %s -check-prefixes=CHECK-CUSTOM-CALL --implicit-check-not warning:
+
+//Check config dump
+// RUN: clang-tidy -dump-config -checks='-*, custom-*' \
+// RUN:   -config=%{full-config}                       \
+// RUN:   -- | FileCheck %s -check-prefix=CHECK-CONFIG
+// CHECK-CONFIG: ClangQueryChecks:
+// CHECK-CONFIG-DAG: custom-let-call:
+// CHECK-CONFIG-DAG: custom-call:  |{{$[[:space:]]}} m callExpr().bind("Custom message")


### PR DESCRIPTION
This addresses the #107680. 

This pull request adds new config option that allows to define new checks using the [matchers](https://clang.llvm.org/docs/LibASTMatchersReference.html) syntax by incorporating clang-query parser

Example:
``` yaml
Checks: -*,custom-*
ClangQueryChecks:
  custom-math: |
    let expr callExpr(
        callee(functionDecl(
            hasAnyName("acos", "asin", "atan", "atan2", "cos", "sin", "tan", "cosh", "sinh", "tanh", "ctan"),
            anyOf(
                hasDeclContext(namespaceDecl(hasName("std"))),
                unless(hasParent(namespaceDecl()))
            )
        ))
    ).bind("Please use different math functions")

    match expr
    
  custom-sort: |
    match callExpr(
        callee(functionDecl(
            hasAnyName("sort", "nth_element", "partial_sort", "partition"),
            anyOf(
                hasDeclContext(namespaceDecl(hasName("std"))),
                unless(hasParent(namespaceDecl()))
            )
        ))
    ).bind("Please use different sort functions")
    
  custom-long: |
    match varDecl(
        hasType(asString("long")),
        hasTypeLoc(typeLoc().bind("Please use int instead of long"))
    )
```

## Unimplemented ideas
- Let queries could be made global so that checks defined at the bottom could reuse let expressions from the checks at the top. Currently let query is local to the defined check
- File queries are disabled. But they can be used to implement the initial idea of using the clang-query files for custom checks. But as I understand clang tools use VFS interface to access files which might not correspond to a real filesystem and I haven't explored deep how to access that interface during clang-tidy configuration parsing so I left it as a FIXME comment

## Some thoughts on further possible work

If [transformers](https://clang.llvm.org/docs/ClangTransformerTutorial.html) parser will be implemented in the future(it [seems](https://github.com/llvm/llvm-project/blob/7acad6893b9b3b43e5e4a8e56404b1b19c07c79f/clang/include/clang/Tooling/Transformer/Parsing.h#L11-L12) like in the past there were some work on it being done by @ymand) it can be added to clang-query and as a consequence it can be made that custom checks defined by this new option will support automatic fixes being provided
```
makeRule(declRefExpr(to(functionDecl(hasName("MkX")))),
         changeTo(cat("MakeX")),
         cat("MkX has been renamed MakeX"));
```