### PR TITLE
[LLDB] Added support for cross compiling with host python

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -59,8 +59,23 @@ if (LLDB_ENABLE_PYTHON)
   set(cachestring_LLDB_PYTHON_EXT_SUFFIX
     "Filename extension for native code python modules")
 
+  set(LLDB_USE_HOST_PYTHON FALSE)
+  if(NOT CMAKE_CROSSCOMPILING)
+    set(LLDB_USE_HOST_PYTHON TRUE)
+  else()
+    # Used when cross-compiling LLDB with Python:
+    # - `_PYTHON_HOST_PLATFORM`: Specifies the host platform, e.g., 'linux-x86_64'.
+    # - `_PYTHON_SYSCONFIGDATA_NAME`: The name of the Python configuration module containing
+    #   platform, build, and configuration details (e.g., `_sysconfigdata__linux_x86_64-linux-gnu`).
+    # See: https://peps.python.org/pep-0720/#upstream-support
+    # If both environment variables are defined, we assume host Python can be used.
+    if(DEFINED ENV{_PYTHON_HOST_PLATFORM} AND DEFINED ENV{_PYTHON_SYSCONFIGDATA_NAME})
+      set(LLDB_USE_HOST_PYTHON TRUE)
+    endif()
+  endif()
+
   foreach(var LLDB_PYTHON_RELATIVE_PATH LLDB_PYTHON_EXE_RELATIVE_PATH LLDB_PYTHON_EXT_SUFFIX)
-    if(NOT DEFINED ${var} AND NOT CMAKE_CROSSCOMPILING)
+    if(NOT DEFINED ${var} AND LLDB_USE_HOST_PYTHON)
       execute_process(
         COMMAND ${Python3_EXECUTABLE}
           ${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/get-python-config.py

--- a/lldb/bindings/python/get-python-config.py
+++ b/lldb/bindings/python/get-python-config.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+# In this script, we should only use the following to retrieve configuration values:
+# - `sysconfig.get_config_var`
+# - `sysconfig.get_platform`
+# - `sysconfig.get_path`
+# This is because certain variables may return invalid data during cross-compilation, for example:
+# - sys.prefix -> Use sysconfig.get_config_var("prefix") instead.
+# - sys.executable -> Use sysconfig.get_config_var("EXENAME") instead.
+# - os.name -> Use sysconfig.get_platform() for platform detection.
+
 import os
 import sys
 import argparse
@@ -32,20 +41,25 @@ def main():
         # If not, you'll have to use lldb -P or lldb -print-script-interpreter-info
         # to figure out where it is.
         try:
-            print(relpath_nodots(sysconfig.get_path("platlib"), sys.prefix))
+            print(relpath_nodots(sysconfig.get_path("platlib"), sysconfig.get_config_var("prefix")))
         except ValueError:
             # Try to fall back to something reasonable if sysconfig's platlib
             # is outside of sys.prefix
             if os.name == "posix":
-                print("lib/python%d.%d/site-packages" % sys.version_info[:2])
+                print("lib/python%s/site-packages" % sysconfig.get_config_var("VERSION"))
             elif os.name == "nt":
                 print("Lib\\site-packages")
             else:
                 raise
     elif args.variable_name == "LLDB_PYTHON_EXE_RELATIVE_PATH":
         tried = list()
-        exe = sys.executable
-        prefix = os.path.realpath(sys.prefix)
+        exe = sysconfig.get_config_var("EXENAME")
+        if not exe:
+            # Fallback: 'EXENAME' is not available on Windows
+            exe_name = "python" + sysconfig.get_config_var("VERSION") + sysconfig.get_config_var("EXE")
+            exe = os.path.join(sysconfig.get_config_var("BINDIR"), exe_name)
+
+        prefix = os.path.realpath(sysconfig.get_config_var("prefix"))
         while True:
             try:
                 print(relpath_nodots(exe, prefix))
@@ -59,13 +73,13 @@ def main():
                     continue
                 else:
                     print(
-                        "Could not find a relative path to sys.executable under sys.prefix",
+                        "Could not find a relative path to sysconfig.get_config_var(\"EXENAME\") under sysconfig.get_config_var(\"prefix\")",
                         file=sys.stderr,
                     )
                     for e in tried:
                         print("tried:", e, file=sys.stderr)
-                    print("realpath(sys.prefix):", prefix, file=sys.stderr)
-                    print("sys.prefix:", sys.prefix, file=sys.stderr)
+                    print("realpath(sysconfig.get_config_var(\"prefix\")):", prefix, file=sys.stderr)
+                    print("sysconfig.get_config_var(\"prefix\"):", sysconfig.get_config_var("prefix"), file=sys.stderr)
                     sys.exit(1)
     elif args.variable_name == "LLDB_PYTHON_EXT_SUFFIX":
         print(sysconfig.get_config_var("EXT_SUFFIX"))


### PR DESCRIPTION
When the environment variables `_PYTHON_HOST_PLATFORM` and `_PYTHON_SYSCONFIGDATA_NAME` are set, the script `bindings/python/get-python-config.py` provides accurate data because the `sysconfig` module uses these variables internally. 

It is not well-documented in Python's official documentation and is only provided on a best-effort basis.
Some info here: [PEP 720 - Upstream Support](https://peps.python.org/pep-0720/#upstream-support).

Adding support for this environment variable in LLDB simplifies cross-compilation with Python, even though this functionality is not officially documented. Maintainers of various Linux distributions already use these environment variables, making it easier to build LLDB with Python support across different package distributions (eg: https://github.com/NixOS/nixpkgs/pull/375484 ).
