### PR TITLE
[analysis][NFC] clean unittest log

### DIFF
--- a/clang/unittests/Analysis/CFGBuildResult.h
+++ b/clang/unittests/Analysis/CFGBuildResult.h
@@ -65,8 +65,8 @@ public:
 template <typename FuncMatcherT = ast_matchers::internal::TrueMatcher>
 BuildResult BuildCFG(const char *Code, CFG::BuildOptions Options = {},
                      FuncMatcherT FuncMatcher = ast_matchers::anything()) {
-  std::vector<std::string> Args = {"-std=c++11",
-                                   "-fno-delayed-template-parsing"};
+  const std::vector<std::string> Args = {
+      "-std=c++11", "-fno-delayed-template-parsing", "-Wno-everything"};
   std::unique_ptr<ASTUnit> AST = tooling::buildASTFromCodeWithArgs(Code, Args);
   if (!AST)
     return BuildResult::ToolFailed;

--- a/clang/unittests/Analysis/CFGTest.cpp
+++ b/clang/unittests/Analysis/CFGTest.cpp
@@ -195,7 +195,6 @@ TEST(CFG, ElementRefIterator) {
   // Reverse, non-const version
   Index = MainBlockSize;
   for (CFGBlock::CFGElementRef ElementRef : MainBlock->rrefs()) {
-    llvm::errs() << Index << '\n';
     EXPECT_EQ(ElementRef.getParent(), MainBlock);
     EXPECT_EQ(ElementRef.getIndexInBlock(), Index);
     EXPECT_TRUE(ElementRef->getAs<CFGStmt>());


### PR DESCRIPTION
1. clean llvm::errs ouput
2. add -Wno-everything option to suppress clang warning during test
