### PR TITLE
[mlir] Link libraries that aren't included in libMLIR to libMLIR

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -305,7 +305,9 @@ endfunction()
 # EXCLUDE_FROM_LIBMLIR
 #   Don't include this library in libMLIR.so.  This option should be used
 #   for test libraries, executable-specific libraries, or rarely used libraries
-#   with large dependencies.
+#   with large dependencies.  When using it, please link libraries included
+#   in libMLIR via mlir_target_link_libraries(), to ensure that the library
+#   does not pull in static dependencies when MLIR_LINK_MLIR_DYLIB=ON is used.
 # OBJECT
 #   The library's object library is referenced using "obj.${name}". For this to
 #   work reliably, this flag ensures that the OBJECT library exists.

--- a/mlir/lib/CAPI/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/CAPI/ExecutionEngine/CMakeLists.txt
@@ -7,6 +7,10 @@ set(LLVM_LINK_COMPONENTS
 add_mlir_upstream_c_api_library(MLIRCAPIExecutionEngine
   ExecutionEngine.cpp
 
+  LINK_COMPONENTS
+  OrcJit
+  Support
+
   LINK_LIBS PUBLIC
   MLIRBuiltinToLLVMIRTranslation
   MLIRExecutionEngine

--- a/mlir/lib/CAPI/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/CAPI/ExecutionEngine/CMakeLists.txt
@@ -1,15 +1,13 @@
 set(LLVM_LINK_COMPONENTS
   nativecodegen
   native
+  orcjit
+  support
 )
   
 # Main API shared library.
 add_mlir_upstream_c_api_library(MLIRCAPIExecutionEngine
   ExecutionEngine.cpp
-
-  LINK_COMPONENTS
-  OrcJit
-  Support
 
   LINK_LIBS PUBLIC
   MLIRBuiltinToLLVMIRTranslation

--- a/mlir/lib/ExecutionEngine/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/CMakeLists.txt
@@ -88,8 +88,9 @@ add_mlir_library(MLIRExecutionEngine
   IPO
   Passes
   ${LLVM_JIT_LISTENER_LIB}
+  )
 
-  LINK_LIBS PUBLIC
+mlir_target_link_libraries(MLIRExecutionEngine PUBLIC
   MLIRBuiltinToLLVMIRTranslation
   MLIRExecutionEngineUtils
   MLIRLLVMDialect
@@ -136,8 +137,10 @@ add_mlir_library(MLIRJitRunner
   JITLink
 
   LINK_LIBS PUBLIC
-  ${dialect_libs}
   MLIRExecutionEngine
+)
+mlir_target_link_libraries(MLIRJitRunner PUBLIC
+  ${dialect_libs}
   MLIRFuncDialect
   MLIRFuncToLLVM
   MLIRIR

--- a/mlir/lib/ExecutionEngine/SparseTensor/CMakeLists.txt
+++ b/mlir/lib/ExecutionEngine/SparseTensor/CMakeLists.txt
@@ -11,8 +11,8 @@ add_mlir_library(MLIRSparseTensorRuntime
   Storage.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRSparseTensorRuntime PUBLIC
   MLIRSparseTensorEnums
   mlir_float16_utils
   )

--- a/mlir/test/lib/Analysis/CMakeLists.txt
+++ b/mlir/test/lib/Analysis/CMakeLists.txt
@@ -21,12 +21,18 @@ add_mlir_library(MLIRTestAnalysis
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+
+# Since this library is excluded from libMLIR, link it to the dylib
+# to ensure that it can be used in flang without implicitly pulling in
+# static libraries.
+mlir_target_link_libraries(MLIRTestAnalysis PUBLIC
   MLIRAffineDialect
   MLIRAnalysis
   MLIRFunctionInterfaces
   MLIRMemRefDialect
   MLIRPass
-  MLIRTestDialect
   )
 
 target_include_directories(MLIRTestAnalysis

--- a/mlir/test/lib/Analysis/CMakeLists.txt
+++ b/mlir/test/lib/Analysis/CMakeLists.txt
@@ -23,10 +23,6 @@ add_mlir_library(MLIRTestAnalysis
   LINK_LIBS PUBLIC
   MLIRTestDialect
   )
-
-# Since this library is excluded from libMLIR, link it to the dylib
-# to ensure that it can be used in flang without implicitly pulling in
-# static libraries.
 mlir_target_link_libraries(MLIRTestAnalysis PUBLIC
   MLIRAffineDialect
   MLIRAnalysis

--- a/mlir/test/lib/Conversion/ConvertToSPIRV/CMakeLists.txt
+++ b/mlir/test/lib/Conversion/ConvertToSPIRV/CMakeLists.txt
@@ -4,8 +4,8 @@ add_mlir_library(MLIRTestConvertToSPIRV
   TestSPIRVVectorUnrolling.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTestConvertToSPIRV PUBLIC
   MLIRArithDialect
   MLIRFuncDialect
   MLIRPass

--- a/mlir/test/lib/Conversion/FuncToLLVM/CMakeLists.txt
+++ b/mlir/test/lib/Conversion/FuncToLLVM/CMakeLists.txt
@@ -6,12 +6,14 @@ add_mlir_library(MLIRTestFuncToLLVM
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+mlir_target_link_libraries(MLIRTestFuncToLLVM PUBLIC
   MLIRFuncToLLVM
   MLIRLLVMCommonConversion
   MLIRLLVMDialect
   MLIRLLVMIRTransforms
   MLIRPass
-  MLIRTestDialect
   )
 
 target_include_directories(MLIRTestFuncToLLVM

--- a/mlir/test/lib/Conversion/MathToVCIX/CMakeLists.txt
+++ b/mlir/test/lib/Conversion/MathToVCIX/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRTestMathToVCIX
   TestMathToVCIXConversion.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRTestMathToVCIX PUBLIC
   MLIRArithDialect
   MLIRFuncDialect
   MLIRMathDialect

--- a/mlir/test/lib/Conversion/OneToNTypeConversion/CMakeLists.txt
+++ b/mlir/test/lib/Conversion/OneToNTypeConversion/CMakeLists.txt
@@ -4,13 +4,15 @@ add_mlir_library(MLIRTestOneToNTypeConversionPass
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+ )
+mlir_target_link_libraries(MLIRTestOneToNTypeConversionPass PUBLIC
   MLIRFuncDialect
   MLIRFuncTransforms
   MLIRIR
   MLIRPass
   MLIRSCFDialect
   MLIRSCFTransforms
-  MLIRTestDialect
   MLIRTransformUtils
  )
 

--- a/mlir/test/lib/Conversion/VectorToSPIRV/CMakeLists.txt
+++ b/mlir/test/lib/Conversion/VectorToSPIRV/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRTestVectorToSPIRV
   TestVectorReductionToSPIRVDotProd.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTestVectorToSPIRV PUBLIC
   MLIRVectorToSPIRV
   MLIRArithDialect
   MLIRFuncDialect

--- a/mlir/test/lib/Dialect/Affine/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Affine/CMakeLists.txt
@@ -21,6 +21,9 @@ add_mlir_library(MLIRAffineTransformsTestPasses
   Core
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+mlir_target_link_libraries(MLIRAffineTransformsTestPasses PUBLIC
   MLIRArithTransforms
   MLIRAffineAnalysis
   MLIRAffineTransforms
@@ -30,7 +33,6 @@ add_mlir_library(MLIRAffineTransformsTestPasses
   MLIRSupport
   MLIRMemRefDialect
   MLIRTensorDialect
-  MLIRTestDialect
   MLIRVectorUtils
   )
 

--- a/mlir/test/lib/Dialect/Arith/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Arith/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRArithTestPasses
   TestEmulateWideInt.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRArithTestPasses PUBLIC
   MLIRArithDialect
   MLIRArithTransforms
   MLIRFuncDialect

--- a/mlir/test/lib/Dialect/ArmNeon/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/ArmNeon/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRArmNeonTestPasses
   TestLowerToArmNeon.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRArmNeonTestPasses PUBLIC
   MLIRArmNeonDialect
   MLIRArmNeonTransforms
   MLIRIR

--- a/mlir/test/lib/Dialect/ArmSME/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/ArmSME/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRArmSMETestPasses
   TestLowerToArmSME.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRArmSMETestPasses PUBLIC
   MLIRArithToArmSME
   MLIRArmSMEToLLVM
   MLIRArmSMEToSCF

--- a/mlir/test/lib/Dialect/Bufferization/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Bufferization/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRBufferizationTestPasses
   TestTensorCopyInsertion.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRBufferizationTestPasses PUBLIC
   MLIRBufferizationDialect
   MLIRBufferizationTransforms
   MLIRIR

--- a/mlir/test/lib/Dialect/ControlFlow/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/ControlFlow/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRControlFlowTestPasses
   TestAssert.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRControlFlowTestPasses PUBLIC
   MLIRControlFlowToLLVM
   MLIRFuncDialect
   MLIRLLVMCommonConversion

--- a/mlir/test/lib/Dialect/DLTI/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/DLTI/CMakeLists.txt
@@ -5,9 +5,11 @@ add_mlir_library(MLIRDLTITestPasses
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+mlir_target_link_libraries(MLIRDLTITestPasses PUBLIC
   MLIRDLTIDialect
   MLIRPass
-  MLIRTestDialect
   )
 
 target_include_directories(MLIRDLTITestPasses

--- a/mlir/test/lib/Dialect/Func/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Func/CMakeLists.txt
@@ -5,10 +5,12 @@ add_mlir_library(MLIRFuncTestPasses
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+mlir_target_link_libraries(MLIRFuncTestPasses PUBLIC
   MLIRAffineDialect
   MLIRPass
   MLIRFuncTransforms
-  MLIRTestDialect
   MLIRTransformUtils
   )
 

--- a/mlir/test/lib/Dialect/GPU/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/GPU/CMakeLists.txt
@@ -36,8 +36,8 @@ add_mlir_library(MLIRGPUTestPasses
   TestGpuRewrite.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRGPUTestPasses PUBLIC
   ${LIBS}
   )
 

--- a/mlir/test/lib/Dialect/LLVM/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/LLVM/CMakeLists.txt
@@ -4,8 +4,8 @@ add_mlir_library(MLIRLLVMTestPasses
   TestPatterns.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRLLVMTestPasses PUBLIC
   MLIRAffineToStandard
   MLIRFuncDialect
   MLIRFuncToLLVM

--- a/mlir/test/lib/Dialect/Linalg/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Linalg/CMakeLists.txt
@@ -10,8 +10,8 @@ add_mlir_library(MLIRLinalgTestPasses
   TestPadFusion.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRLinalgTestPasses PUBLIC
   MLIRAffineDialect
   MLIRArithDialect
   MLIRArithTransforms

--- a/mlir/test/lib/Dialect/Math/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Math/CMakeLists.txt
@@ -5,8 +5,8 @@ add_mlir_library(MLIRMathTestPasses
   TestPolynomialApproximation.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRMathTestPasses PUBLIC
   MLIRMathTransforms
   MLIRPass
   MLIRTransformUtils

--- a/mlir/test/lib/Dialect/MemRef/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/MemRef/CMakeLists.txt
@@ -7,10 +7,12 @@ add_mlir_library(MLIRMemRefTestPasses
   EXCLUDE_FROM_LIBMLIR
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+mlir_target_link_libraries(MLIRMemRefTestPasses PUBLIC
   MLIRPass
   MLIRMemRefDialect
   MLIRMemRefTransforms
-  MLIRTestDialect
   )
 
 target_include_directories(MLIRMemRefTestPasses

--- a/mlir/test/lib/Dialect/Mesh/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Mesh/CMakeLists.txt
@@ -5,8 +5,8 @@ add_mlir_library(MLIRMeshTest
   TestSimplifications.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRMeshTest PUBLIC
   MLIRMeshDialect
   MLIRMeshTransforms
   MLIRPass

--- a/mlir/test/lib/Dialect/NVGPU/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/NVGPU/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRNVGPUTestPasses
   TestNVGPUTransforms.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRNVGPUTestPasses PUBLIC
   MLIRIR
   MLIRAffineDialect
   MLIRAnalysis

--- a/mlir/test/lib/Dialect/SCF/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/SCF/CMakeLists.txt
@@ -8,8 +8,8 @@ add_mlir_library(MLIRSCFTestPasses
   TestWhileOpBuilder.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRSCFTestPasses PUBLIC
   MLIRMemRefDialect
   MLIRPass
   MLIRSCFDialect

--- a/mlir/test/lib/Dialect/SPIRV/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/SPIRV/CMakeLists.txt
@@ -9,8 +9,8 @@ add_mlir_library(MLIRSPIRVTestPasses
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SPIRV
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRSPIRVTestPasses PUBLIC
   MLIRGPUDialect
   MLIRIR
   MLIRPass

--- a/mlir/test/lib/Dialect/Shape/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Shape/CMakeLists.txt
@@ -8,8 +8,8 @@ add_mlir_library(MLIRShapeTestPasses
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Shape
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRShapeTestPasses PUBLIC
   MLIRIR
   MLIRPass
   MLIRShapeOpsTransforms

--- a/mlir/test/lib/Dialect/Tensor/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Tensor/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRTensorTestPasses
   TestTensorTransforms.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTensorTestPasses PUBLIC
   MLIRArithDialect
   MLIRLinalgDialect
   MLIRPass

--- a/mlir/test/lib/Dialect/Test/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Test/CMakeLists.txt
@@ -68,8 +68,12 @@ add_mlir_library(MLIRTestDialect
   MLIRTestOpsIncGen
   MLIRTestOpsSyntaxIncGen
   MLIRTestOpsShardGen
+  )
 
-  LINK_LIBS PUBLIC
+# Since this library is excluded from libMLIR, link it to the dylib
+# to ensure that it can be used in flang without implicitly pulling in
+# static libraries.
+mlir_target_link_libraries(MLIRTestDialect PUBLIC
   MLIRControlFlowInterfaces
   MLIRDataLayoutInterfaces
   MLIRDerivedAttributeOpInterface

--- a/mlir/test/lib/Dialect/Test/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Test/CMakeLists.txt
@@ -69,10 +69,6 @@ add_mlir_library(MLIRTestDialect
   MLIRTestOpsSyntaxIncGen
   MLIRTestOpsShardGen
   )
-
-# Since this library is excluded from libMLIR, link it to the dylib
-# to ensure that it can be used in flang without implicitly pulling in
-# static libraries.
 mlir_target_link_libraries(MLIRTestDialect PUBLIC
   MLIRControlFlowInterfaces
   MLIRDataLayoutInterfaces

--- a/mlir/test/lib/Dialect/TestDyn/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/TestDyn/CMakeLists.txt
@@ -2,7 +2,7 @@ add_mlir_dialect_library(MLIRTestDynDialect
   TestDynDialect.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRTestDynDialect PUBLIC
   MLIRIR
 )

--- a/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Tosa/CMakeLists.txt
@@ -8,8 +8,8 @@ add_mlir_dialect_library(MLIRTosaTestPasses
 
   DEPENDS
   MLIRTosaPassIncGen
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTosaTestPasses PUBLIC
   MLIRFuncDialect
   MLIRPass
   MLIRTosaDialect

--- a/mlir/test/lib/Dialect/Transform/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Transform/CMakeLists.txt
@@ -15,8 +15,8 @@ add_mlir_library(MLIRTestTransformDialect
 
   DEPENDS
   MLIRTestTransformDialectExtensionIncGen
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRTestTransformDialect PUBLIC
   MLIRIR
   MLIRPass
   MLIRPDLDialect

--- a/mlir/test/lib/Dialect/Vector/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/Vector/CMakeLists.txt
@@ -3,8 +3,8 @@ add_mlir_library(MLIRVectorTestPasses
   TestVectorTransforms.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRVectorTestPasses PUBLIC
   MLIRAffineDialect
   MLIRAnalysis
   MLIRArithDialect

--- a/mlir/test/lib/IR/CMakeLists.txt
+++ b/mlir/test/lib/IR/CMakeLists.txt
@@ -28,10 +28,6 @@ add_mlir_library(MLIRTestIR
 
   EXCLUDE_FROM_LIBMLIR
   )
-
-# Since this library is excluded from libMLIR, link it to the dylib
-# to ensure that it can be used in flang without implicitly pulling in
-# static libraries.
 mlir_target_link_libraries(MLIRTestIR PUBLIC
   MLIRPass
   MLIRBytecodeReader

--- a/mlir/test/lib/IR/CMakeLists.txt
+++ b/mlir/test/lib/IR/CMakeLists.txt
@@ -27,8 +27,12 @@ add_mlir_library(MLIRTestIR
   TestVisitorsGeneric.cpp
 
   EXCLUDE_FROM_LIBMLIR
+  )
 
-  LINK_LIBS PUBLIC
+# Since this library is excluded from libMLIR, link it to the dylib
+# to ensure that it can be used in flang without implicitly pulling in
+# static libraries.
+mlir_target_link_libraries(MLIRTestIR PUBLIC
   MLIRPass
   MLIRBytecodeReader
   MLIRBytecodeWriter

--- a/mlir/test/lib/Interfaces/LoopLikeInterface/CMakeLists.txt
+++ b/mlir/test/lib/Interfaces/LoopLikeInterface/CMakeLists.txt
@@ -2,8 +2,8 @@ add_mlir_library(MLIRLoopLikeInterfaceTestPasses
   TestBlockInLoop.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRLoopLikeInterfaceTestPasses PUBLIC
   MLIRPass
   MLIRLoopLikeInterface
   MLIRFuncDialect

--- a/mlir/test/lib/Interfaces/TilingInterface/CMakeLists.txt
+++ b/mlir/test/lib/Interfaces/TilingInterface/CMakeLists.txt
@@ -10,8 +10,8 @@ add_mlir_library(MLIRTilingInterfaceTestPasses
   MLIRTestTilingInterfaceTransformOpsIncGen
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTilingInterfaceTestPasses PUBLIC
   MLIRAffineDialect
   MLIRArithDialect
   MLIRIndexDialect

--- a/mlir/test/lib/Pass/CMakeLists.txt
+++ b/mlir/test/lib/Pass/CMakeLists.txt
@@ -10,8 +10,8 @@ add_mlir_library(MLIRTestPass
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Pass
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTestPass PUBLIC
   ${conversion_libs}
   MLIRIR
   MLIRPass

--- a/mlir/test/lib/Reducer/CMakeLists.txt
+++ b/mlir/test/lib/Reducer/CMakeLists.txt
@@ -9,8 +9,8 @@ add_mlir_library(MLIRTestReducer
 
   LINK_COMPONENTS
   Core
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTestReducer PUBLIC
   MLIRIR
   MLIRPass
   MLIRSupport

--- a/mlir/test/lib/Rewrite/CMakeLists.txt
+++ b/mlir/test/lib/Rewrite/CMakeLists.txt
@@ -7,8 +7,8 @@ if (MLIR_ENABLE_PDL_IN_PATTERNMATCH)
 
     ADDITIONAL_HEADER_DIRS
     ${MLIR_MAIN_INCLUDE_DIR}/mlir/Rewrite
-
-    LINK_LIBS PUBLIC
+    )
+  mlir_target_link_libraries(MLIRTestRewrite PUBLIC
     MLIRIR
     MLIRPass
     MLIRSupport

--- a/mlir/test/lib/Tools/PDLL/CMakeLists.txt
+++ b/mlir/test/lib/Tools/PDLL/CMakeLists.txt
@@ -20,13 +20,15 @@ add_mlir_library(MLIRTestPDLL
   MLIRTestPDLLPatternsIncGen
 
   LINK_LIBS PUBLIC
+  MLIRTestDialect
+  )
+mlir_target_link_libraries(MLIRTestPDLL PUBLIC
   MLIRCastInterfaces
   MLIRIR
   MLIRPass
   MLIRPDLInterpDialect
   MLIRPDLDialect
   MLIRSupport
-  MLIRTestDialect
   MLIRTransformUtils
   )
 

--- a/mlir/test/lib/Transforms/CMakeLists.txt
+++ b/mlir/test/lib/Transforms/CMakeLists.txt
@@ -34,8 +34,8 @@ add_mlir_library(MLIRTestTransforms
 
   DEPENDS
   ${MLIRTestTransformsPDLDep}
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRTestTransforms PUBLIC
   MLIRAnalysis
   MLIRFuncDialect
   MLIRInferIntRangeInterface

--- a/mlir/test/python/lib/CMakeLists.txt
+++ b/mlir/test/python/lib/CMakeLists.txt
@@ -12,8 +12,8 @@ add_mlir_library(MLIRPythonTestDialect
 
   DEPENDS
   MLIRPythonTestIncGen
-
-  LINK_LIBS PUBLIC
+)
+mlir_target_link_libraries(MLIRPythonTestDialect PUBLIC
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRSupport

--- a/mlir/tools/mlir-opt/CMakeLists.txt
+++ b/mlir/tools/mlir-opt/CMakeLists.txt
@@ -91,8 +91,8 @@ add_mlir_library(MLIRMlirOptMain
   mlir-opt.cpp
 
   EXCLUDE_FROM_LIBMLIR
-
-  LINK_LIBS PUBLIC
+  )
+mlir_target_link_libraries(MLIRMlirOptMain PUBLIC
   ${LIBS}
   ${test_libs}
   )


### PR DESCRIPTION
Use `mlir_target_link_libraries()` to link dependencies of libraries that are not included in libMLIR, to ensure that they link to the dylib when they are used in Flang. Otherwise, they implicitly pull in all their static dependencies, effectively causing Flang binaries to simultaneously link to the dylib and to static libraries, which is never a good idea.

I have only covered the libraries that are used by Flang. If you wish, I can extend this approach to all non-libMLIR libraries in MLIR, making MLIR itself also link to the dylib consistently.

[v2 with fixed `-DBUILD_SHARED_LIBS=ON` build]