### PR TITLE
[Offload][NFC] Factor out and rename the `__tgt_offload_entry` struct

### DIFF
--- a/llvm/include/llvm/Frontend/Offloading/Utility.h
+++ b/llvm/include/llvm/Frontend/Offloading/Utility.h
@@ -21,6 +21,16 @@
 namespace llvm {
 namespace offloading {
 
+/// This is the record of an object that just be registered with the offloading
+/// runtime.
+struct EntryTy {
+  void *Address;
+  char *SymbolName;
+  size_t Size;
+  int32_t Flags;
+  int32_t Data;
+};
+
 /// Offloading entry flags for CUDA / HIP. The first three bits indicate the
 /// type of entry while the others are a bit field for additional information.
 enum OffloadEntryKindFlag : uint32_t {
@@ -47,15 +57,6 @@ StructType *getEntryTy(Module &M);
 
 /// Create an offloading section struct used to register this global at
 /// runtime.
-///
-/// Type struct __tgt_offload_entry {
-///   void    *addr;      // Pointer to the offload entry info.
-///                       // (function or global)
-///   char    *name;      // Name of the function or global.
-///   size_t  size;       // Size of the entry info (0 if it a function).
-///   int32_t flags;
-///   int32_t data;
-/// };
 ///
 /// \param M The module to be used
 /// \param Addr The pointer to the global being registered.

--- a/offload/docs/declare_target_indirect.md
+++ b/offload/docs/declare_target_indirect.md
@@ -25,7 +25,7 @@ The offload entries table that is created for the host and for each of the devic
 
 Compiler will also produce an entry for each procedure listed in **indirect** clause of **declare target** construct:
 ```C++
-struct __tgt_offload_entry {
+struct llvm::offloading::EntryTy {
   void *addr;       // Pointer to the function
   char *name;       // Name of the function
   size_t size;      // 0 for function
@@ -82,7 +82,7 @@ struct __omp_offloading_fptr_map_ty {
 };
 ```
 
-Where `host_ptr` is `__tgt_offload_entry::addr` in a **host** offload entry, and `tgt_ptr` is `__tgt_offload_entry::addr` in the corresponding **device** offload entry (which may be found using the populated `Device.HostDataToTargetMap`).
+Where `host_ptr` is `llvm::offloading::EntryTy::addr` in a **host** offload entry, and `tgt_ptr` is `llvm::offloading::EntryTy::addr` in the corresponding **device** offload entry (which may be found using the populated `Device.HostDataToTargetMap`).
 
 When all `__omp_offloading_function_ptr_map_ty` entries are collected in a single host array, `libomptarget` sorts the table by `host_ptr` values and passes it to the device plugin for registration, if plugin supports optional `__tgt_rtl_set_function_ptr_map` API.
 

--- a/offload/include/OffloadEntry.h
+++ b/offload/include/OffloadEntry.h
@@ -22,24 +22,25 @@ class DeviceImageTy;
 
 class OffloadEntryTy {
   DeviceImageTy &DeviceImage;
-  __tgt_offload_entry &OffloadEntry;
+  llvm::offloading::EntryTy &OffloadEntry;
 
 public:
-  OffloadEntryTy(DeviceImageTy &DeviceImage, __tgt_offload_entry &OffloadEntry)
+  OffloadEntryTy(DeviceImageTy &DeviceImage,
+                 llvm::offloading::EntryTy &OffloadEntry)
       : DeviceImage(DeviceImage), OffloadEntry(OffloadEntry) {}
 
   bool isGlobal() const { return getSize() != 0; }
-  size_t getSize() const { return OffloadEntry.size; }
+  size_t getSize() const { return OffloadEntry.Size; }
 
-  void *getAddress() const { return OffloadEntry.addr; }
-  llvm::StringRef getName() const { return OffloadEntry.name; }
-  const char *getNameAsCStr() const { return OffloadEntry.name; }
+  void *getnAddress() const { return OffloadEntry.Address; }
+  llvm::StringRef getName() const { return OffloadEntry.SymbolName; }
+  const char *getNameAsCStr() const { return OffloadEntry.SymbolName; }
   __tgt_bin_desc *getBinaryDescription() const;
 
   bool isLink() const { return hasFlags(OMP_DECLARE_TARGET_LINK); }
 
   bool hasFlags(OpenMPOffloadingDeclareTargetFlags Flags) const {
-    return Flags & OffloadEntry.flags;
+    return Flags & OffloadEntry.Flags;
   }
 };
 

--- a/offload/include/PluginManager.h
+++ b/offload/include/PluginManager.h
@@ -81,7 +81,8 @@ struct PluginManager {
   HostEntriesBeginToTransTableTy HostEntriesBeginToTransTable;
   std::mutex TrlTblMtx; ///< For Translation Table
   /// Host offload entries in order of image registration
-  llvm::SmallVector<__tgt_offload_entry *> HostEntriesBeginRegistrationOrder;
+  llvm::SmallVector<llvm::offloading::EntryTy *>
+      HostEntriesBeginRegistrationOrder;
 
   /// Map from ptrs on the host to an entry in the Translation Table
   HostPtrToTableMapTy HostPtrToTableMap;

--- a/offload/include/Shared/APITypes.h
+++ b/offload/include/Shared/APITypes.h
@@ -17,28 +17,20 @@
 #include "Environment.h"
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Frontend/Offloading/Utility.h"
 
 #include <cstddef>
 #include <cstdint>
 
 extern "C" {
 
-/// This struct is a record of an entry point or global. For a function
-/// entry point the size is expected to be zero
-struct __tgt_offload_entry {
-  void *addr;       // Pointer to the offload entry info (function or global)
-  char *name;       // Name of the function or global
-  size_t size;      // Size of the entry info (0 if it is a function)
-  int32_t flags;    // Flags associated with the entry, e.g. 'link'.
-  int32_t data;     // Extra data associated with the entry.
-};
-
 /// This struct is a record of the device image information
 struct __tgt_device_image {
-  void *ImageStart;                  // Pointer to the target code start
-  void *ImageEnd;                    // Pointer to the target code end
-  __tgt_offload_entry *EntriesBegin; // Begin of table with all target entries
-  __tgt_offload_entry *EntriesEnd;   // End of table (non inclusive)
+  void *ImageStart; // Pointer to the target code start
+  void *ImageEnd;   // Pointer to the target code end
+  llvm::offloading::EntryTy
+      *EntriesBegin; // Begin of table with all target entries
+  llvm::offloading::EntryTy *EntriesEnd; // End of table (non inclusive)
 };
 
 struct __tgt_device_info {
@@ -51,14 +43,16 @@ struct __tgt_device_info {
 struct __tgt_bin_desc {
   int32_t NumDeviceImages;          // Number of device types supported
   __tgt_device_image *DeviceImages; // Array of device images (1 per dev. type)
-  __tgt_offload_entry *HostEntriesBegin; // Begin of table with all host entries
-  __tgt_offload_entry *HostEntriesEnd;   // End of table (non inclusive)
+  llvm::offloading::EntryTy
+      *HostEntriesBegin; // Begin of table with all host entries
+  llvm::offloading::EntryTy *HostEntriesEnd; // End of table (non inclusive)
 };
 
 /// This struct contains the offload entries identified by the target runtime
 struct __tgt_target_table {
-  __tgt_offload_entry *EntriesBegin; // Begin of the table with all the entries
-  __tgt_offload_entry
+  llvm::offloading::EntryTy
+      *EntriesBegin; // Begin of the table with all the entries
+  llvm::offloading::EntryTy
       *EntriesEnd; // End of the table with all the entries (non inclusive)
 };
 
@@ -107,9 +101,9 @@ struct KernelArgsTy {
   } Flags = {0, 0, 0};
   // The number of teams (for x,y,z dimension).
   uint32_t NumTeams[3] = {0, 0, 0};
-   // The number of threads (for x,y,z dimension).
+  // The number of threads (for x,y,z dimension).
   uint32_t ThreadLimit[3] = {0, 0, 0};
-  uint32_t DynCGroupMem = 0;     // Amount of dynamic cgroup memory requested.
+  uint32_t DynCGroupMem = 0; // Amount of dynamic cgroup memory requested.
 };
 static_assert(sizeof(KernelArgsTy().Flags) == sizeof(uint64_t),
               "Invalid struct size");

--- a/offload/include/rtl.h
+++ b/offload/include/rtl.h
@@ -22,7 +22,7 @@
 
 /// Map between the host entry begin and the translation table. Each
 /// registered library gets one TranslationTable. Use the map from
-/// __tgt_offload_entry so that we may quickly determine whether we
+/// llvm::offloading::EntryTy so that we may quickly determine whether we
 /// are trying to (re)register an existing lib or really have a new one.
 struct TranslationTable {
   __tgt_target_table HostTable;
@@ -33,14 +33,14 @@ struct TranslationTable {
       TargetsImages; // One image per device ID.
 
   // Arrays of entries active on the device.
-  llvm::SmallVector<llvm::SmallVector<__tgt_offload_entry>>
+  llvm::SmallVector<llvm::SmallVector<llvm::offloading::EntryTy>>
       TargetsEntries; // One table per device ID.
 
   // Table of entry points or NULL if it was not already computed.
   llvm::SmallVector<__tgt_target_table *>
       TargetsTable; // One table per device ID.
 };
-typedef std::map<__tgt_offload_entry *, TranslationTable>
+typedef std::map<llvm::offloading::EntryTy *, TranslationTable>
     HostEntriesBeginToTransTableTy;
 
 /// Map between the host ptr and a table index

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -376,24 +376,24 @@ setupIndirectCallTable(GenericPluginTy &Plugin, GenericDeviceTy &Device,
                        DeviceImageTy &Image) {
   GenericGlobalHandlerTy &Handler = Plugin.getGlobalHandler();
 
-  llvm::ArrayRef<__tgt_offload_entry> Entries(Image.getTgtImage()->EntriesBegin,
-                                              Image.getTgtImage()->EntriesEnd);
+  llvm::ArrayRef<llvm::offloading::EntryTy> Entries(
+      Image.getTgtImage()->EntriesBegin, Image.getTgtImage()->EntriesEnd);
   llvm::SmallVector<std::pair<void *, void *>> IndirectCallTable;
   for (const auto &Entry : Entries) {
-    if (Entry.size == 0 || !(Entry.flags & OMP_DECLARE_TARGET_INDIRECT))
+    if (Entry.Size == 0 || !(Entry.Flags & OMP_DECLARE_TARGET_INDIRECT))
       continue;
 
-    assert(Entry.size == sizeof(void *) && "Global not a function pointer?");
+    assert(Entry.Size == sizeof(void *) && "Global not a function pointer?");
     auto &[HstPtr, DevPtr] = IndirectCallTable.emplace_back();
 
-    GlobalTy DeviceGlobal(Entry.name, Entry.size);
+    GlobalTy DeviceGlobal(Entry.SymbolName, Entry.Size);
     if (auto Err =
             Handler.getGlobalMetadataFromDevice(Device, Image, DeviceGlobal))
       return std::move(Err);
 
-    HstPtr = Entry.addr;
+    HstPtr = Entry.Address;
     if (auto Err = Device.dataRetrieve(&DevPtr, DeviceGlobal.getPtr(),
-                                       Entry.size, nullptr))
+                                       Entry.Size, nullptr))
       return std::move(Err);
   }
 

--- a/offload/src/omptarget.cpp
+++ b/offload/src/omptarget.cpp
@@ -977,9 +977,9 @@ TableMap *getTableMap(void *HostPtr) {
     TranslationTable *TransTable = &Itr->second;
     // iterate over all the host table entries to see if we can locate the
     // host_ptr.
-    __tgt_offload_entry *Cur = TransTable->HostTable.EntriesBegin;
+    llvm::offloading::EntryTy *Cur = TransTable->HostTable.EntriesBegin;
     for (uint32_t I = 0; Cur < TransTable->HostTable.EntriesEnd; ++Cur, ++I) {
-      if (Cur->addr != HostPtr)
+      if (Cur->Address != HostPtr)
         continue;
       // we got a match, now fill the HostPtrToTableMap so that we
       // may avoid this search next time.
@@ -1437,9 +1437,10 @@ int target(ident_t *Loc, DeviceTy &Device, void *HostPtr,
   }
 
   // Launch device execution.
-  void *TgtEntryPtr = TargetTable->EntriesBegin[TM->Index].addr;
+  void *TgtEntryPtr = TargetTable->EntriesBegin[TM->Index].Address;
   DP("Launching target execution %s with pointer " DPxMOD " (index=%d).\n",
-     TargetTable->EntriesBegin[TM->Index].name, DPxPTR(TgtEntryPtr), TM->Index);
+     TargetTable->EntriesBegin[TM->Index].SymbolName, DPxPTR(TgtEntryPtr),
+     TM->Index);
 
   {
     assert(KernelArgs.NumArgs == TgtArgs.size() && "Argument count mismatch!");
@@ -1525,9 +1526,10 @@ int target_replay(ident_t *Loc, DeviceTy &Device, void *HostPtr,
 
   // Retrieve the target kernel pointer, allocate and store the recorded device
   // memory data, and launch device execution.
-  void *TgtEntryPtr = TargetTable->EntriesBegin[TM->Index].addr;
+  void *TgtEntryPtr = TargetTable->EntriesBegin[TM->Index].Address;
   DP("Launching target execution %s with pointer " DPxMOD " (index=%d).\n",
-     TargetTable->EntriesBegin[TM->Index].name, DPxPTR(TgtEntryPtr), TM->Index);
+     TargetTable->EntriesBegin[TM->Index].SymbolName, DPxPTR(TgtEntryPtr),
+     TM->Index);
 
   void *TgtPtr = Device.allocData(DeviceMemorySize, /*HstPtr=*/nullptr,
                                   TARGET_ALLOC_DEFAULT);


### PR DESCRIPTION
Summary:
This patch is an NFC renaming to make using the offloading entry type
more portable between other targets. Right now this is just moving its
definition to LLVM so others can use it. Future work will rework the
struct layout.
