### PR TITLE
workflows/release-binaries: Restrict jobs based on owner instead of repo

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -49,7 +49,7 @@ jobs:
   prepare:
     name: Prepare to build binaries
     runs-on: ${{ inputs.runs-on }}
-    if: github.repository == 'llvm/llvm-project'
+    if: github.repository_owner == 'llvm'
     outputs:
       release-version: ${{ steps.vars.outputs.release-version }}
       ref: ${{ steps.vars.outputs.ref }}
@@ -177,7 +177,7 @@ jobs:
   build-release-package:
     name: "Build Release Package"
     needs: prepare
-    if: github.repository == 'llvm/llvm-project'
+    if: github.repository_owner == 'llvm'
     runs-on: ${{ needs.prepare.outputs.build-runs-on }}
     steps:
 
@@ -327,7 +327,7 @@ jobs:
       - prepare
       - build-release-package
     if: >-
-      github.repository == 'llvm/llvm-project'
+      github.repository_owner == 'llvm'
     runs-on: ${{ needs.prepare.outputs.test-runs-on }}
     steps:
     - name: Checkout Actions


### PR DESCRIPTION
Not really any functional change, just a clean up that could make it easier to share snippets with other repos.