### PR TITLE
[libc][docs] disable pthreads docs

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -45,7 +45,8 @@ if (SPHINX_FOUND)
       locale
       net/if
       netinet/in
-      pthread
+      # TODO: https://github.com/llvm/llvm-project/issues/123821
+      # pthread
       setjmp
       signal
       stdbit

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -17,7 +17,6 @@ Implementation Status
    math/index.rst
    net/if
    netinet/in
-   pthread
    search
    setjmp
    signal
@@ -37,3 +36,6 @@ Implementation Status
    uchar
    wchar
    wctype
+..
+   TODO: https://github.com/llvm/llvm-project/issues/123821
+   pthread


### PR DESCRIPTION
Having a target named pthreads is breaking when multiple runtimes are enabled.
Disable this target for now so that the builds go back to green (and sites get
updated).

Link: https://github.com/llvm/llvm-zorg/issues/359#issuecomment-2600285688
Link: #122006
Link: #122497
Link: #123821
