### PR TITLE
[LLDB-DAP] Send Progress update message over DAP

### DIFF
--- a/lldb/test/API/tools/lldb-dap/progress/Makefile
+++ b/lldb/test/API/tools/lldb-dap/progress/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -1,0 +1,86 @@
+import inspect
+import optparse
+import shlex
+import sys
+import time
+
+import lldb
+
+
+class ProgressTesterCommand:
+    program = "test-progress"
+
+    @classmethod
+    def register_lldb_command(cls, debugger, module_name):
+        parser = cls.create_options()
+        cls.__doc__ = parser.format_help()
+        # Add any commands contained in this module to LLDB
+        command = "command script add -c %s.%s %s" % (
+            module_name,
+            cls.__name__,
+            cls.program,
+        )
+        debugger.HandleCommand(command)
+        print(
+            'The "{0}" command has been installed, type "help {0}" or "{0} '
+            '--help" for detailed help.'.format(cls.program)
+        )
+
+    @classmethod
+    def create_options(cls):
+        usage = "usage: %prog [options]"
+        description = "Jacob Lalonde's sbprogress testing tool"
+        # Opt parse is deprecated, but leaving this the way it is because it allows help formating
+        # Additionally all our commands use optparse right now, ideally we migrate them all in one go.
+        parser = optparse.OptionParser(
+            description=description, prog=cls.program, usage=usage
+        )
+
+        parser.add_option(
+            "--total", dest="total", help="Total to count up.", type="int"
+        )
+
+        parser.add_option(
+            "--seconds",
+            dest="seconds",
+            help="Total number of seconds to wait between increments",
+            type="int",
+        )
+
+        return parser
+
+    def get_short_help(self):
+        return "Progress Tester"
+
+    def get_long_help(self):
+        return self.help_string
+
+    def __init__(self, debugger, unused):
+        self.parser = self.create_options()
+        self.help_string = self.parser.format_help()
+
+    def __call__(self, debugger, command, exe_ctx, result):
+
+        command_args = shlex.split(command)
+        try:
+            (cmd_options, args) = self.parser.parse_args(command_args)
+        except:
+            result.SetError("option parsing failed")
+            return
+
+        total = cmd_options.total
+        progress = lldb.SBProgress("Progress tester", "Detail", total, debugger)
+
+        # This actually should start at 1 but it's 6:30 on a Friday...
+        for i in range(1, total):
+            progress.Increment(1, f"Step {i}")
+            time.sleep(cmd_options.seconds)
+
+
+def __lldb_init_module(debugger, dict):
+    # Register all classes that have a register_lldb_command method
+    for _name, cls in inspect.getmembers(sys.modules[__name__]):
+        if inspect.isclass(cls) and callable(
+            getattr(cls, "register_lldb_command", None)
+        ):
+            cls.register_lldb_command(debugger, __name__)

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -60,7 +60,6 @@ class ProgressTesterCommand:
         self.help_string = self.parser.format_help()
 
     def __call__(self, debugger, command, exe_ctx, result):
-
         command_args = shlex.split(command)
         try:
             (cmd_options, args) = self.parser.parse_args(command_args)

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -29,7 +29,7 @@ class ProgressTesterCommand:
     @classmethod
     def create_options(cls):
         usage = "usage: %prog [options]"
-        description = "Jacob Lalonde's sbprogress testing tool"
+        description = "SBProgress testing tool"
         # Opt parse is deprecated, but leaving this the way it is because it allows help formating
         # Additionally all our commands use optparse right now, ideally we migrate them all in one go.
         parser = optparse.OptionParser(
@@ -70,7 +70,6 @@ class ProgressTesterCommand:
         total = cmd_options.total
         progress = lldb.SBProgress("Progress tester", "Detail", total, debugger)
 
-        # This actually should start at 1 but it's 6:30 on a Friday...
         for i in range(1, total):
             progress.Increment(1, f"Step {i}")
             time.sleep(cmd_options.seconds)

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -1,0 +1,49 @@
+"""
+Test lldb-dap output events
+"""
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import os
+import time
+
+import lldbdap_testcase
+
+
+class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
+    @skipIfWindows
+    def test_output(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
+        print(f"Progress emitter path: {progress_emitter}")
+        source = "main.cpp"
+        # Set breakpoint in the thread function so we can step the threads
+        breakpoint_ids = self.set_source_breakpoints(
+            source, [line_number(source, "// break here")]
+        )
+        self.continue_to_breakpoints(breakpoint_ids)
+        self.dap_server.request_evaluate(
+            f"`command script import {progress_emitter}", context="repl"
+        )
+        self.dap_server.request_evaluate(
+            "`test-progress --total 3 --seconds 1", context="repl"
+        )
+
+        self.dap_server.wait_for_event("progressEnd", 15)
+        # Expect at least a start, an update, and end event
+        # However because the progress is an RAII object and we can't guaruntee
+        # it's deterministic destruction in the python API, we verify just start and update
+        # otherwise this test could be flakey.
+        self.assertTrue(len(self.dap_server.progress_events) > 0)
+        start_found = False
+        update_found = False
+        for event in self.dap_server.progress_events:
+            event_type = event["event"]
+            if "progressStart" in event_type:
+                start_found = True
+            if "progressUpdate" in event_type:
+                update_found = True
+
+        self.assertTrue(start_found)
+        self.assertTrue(update_found)

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -32,7 +32,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
 
         self.dap_server.wait_for_event("progressEnd", 15)
         # Expect at least a start, an update, and end event
-        # However because the progress is an RAII object and we can't guaruntee
+        # However because the underlying Progress instance is an RAII object and we can't guaruntee
         # it's deterministic destruction in the python API, we verify just start and update
         # otherwise this test could be flakey.
         self.assertTrue(len(self.dap_server.progress_events) > 0)

--- a/lldb/test/API/tools/lldb-dap/progress/main.cpp
+++ b/lldb/test/API/tools/lldb-dap/progress/main.cpp
@@ -1,0 +1,5 @@
+int main() {
+  char *ptr = "unused";
+  // break here
+  return 0;
+}

--- a/lldb/tools/lldb-dap/ProgressEvent.cpp
+++ b/lldb/tools/lldb-dap/ProgressEvent.cpp
@@ -117,9 +117,8 @@ json::Value ProgressEvent::ToJSON() const {
     body.try_emplace("cancellable", false);
   }
 
-  if (m_event_type == progressUpdate) {
+  if (m_event_type == progressUpdate)
     EmplaceSafeString(body, "message", m_message);
-  }
 
   std::string timestamp(llvm::formatv("{0:f9}", m_creation_time.count()));
   EmplaceSafeString(body, "timestamp", timestamp);
@@ -168,11 +167,10 @@ const ProgressEvent &ProgressEventManager::GetMostRecentEvent() const {
   return m_last_update_event ? *m_last_update_event : m_start_event;
 }
 
-void ProgressEventManager::Update(uint64_t progress_id, const char *message,
+void ProgressEventManager::Update(uint64_t progress_id, llvm::StringRef message,
                                   uint64_t completed, uint64_t total) {
-  if (std::optional<ProgressEvent> event =
-          ProgressEvent::Create(progress_id, StringRef(message), completed,
-                                total, &GetMostRecentEvent())) {
+  if (std::optional<ProgressEvent> event = ProgressEvent::Create(
+          progress_id, message, completed, total, &GetMostRecentEvent())) {
     if (event->GetEventType() == progressEnd)
       m_finished = true;
 
@@ -232,7 +230,7 @@ void ProgressEventReporter::Push(uint64_t progress_id, const char *message,
       m_unreported_start_events.push(event_manager);
     }
   } else {
-    it->second->Update(progress_id, message, completed, total);
+    it->second->Update(progress_id, StringRef(message), completed, total);
     if (it->second->Finished())
       m_event_managers.erase(it);
   }

--- a/lldb/tools/lldb-dap/ProgressEvent.h
+++ b/lldb/tools/lldb-dap/ProgressEvent.h
@@ -99,7 +99,8 @@ public:
 
   /// Receive a new progress event for the start event and try to report it if
   /// appropriate.
-  void Update(uint64_t progress_id, uint64_t completed, uint64_t total);
+  void Update(uint64_t progress_id, const char *message, uint64_t completed,
+              uint64_t total);
 
   /// \return
   ///     \b true if a \a progressEnd event has been notified. There's no

--- a/lldb/tools/lldb-dap/ProgressEvent.h
+++ b/lldb/tools/lldb-dap/ProgressEvent.h
@@ -99,7 +99,7 @@ public:
 
   /// Receive a new progress event for the start event and try to report it if
   /// appropriate.
-  void Update(uint64_t progress_id, const char *message, uint64_t completed,
+  void Update(uint64_t progress_id, llvm::StringRef message, uint64_t completed,
               uint64_t total);
 
   /// \return


### PR DESCRIPTION
When testing my SBProgress DAP PR (#123826), I noticed Progress update messages aren't sent over DAP. This patch adds the lldb progress event's message to the body when sent over DAP.

Before 
![image](https://github.com/user-attachments/assets/404adaa8-b784-4f23-895f-cd3625fdafad)


Now
![image](https://github.com/user-attachments/assets/eb1c3235-0936-4e36-96e5-0a0ee60dabb8)

Tested with my [progress tester command](https://gist.github.com/Jlalond/48d85e75a91f7a137e3142e6a13d0947), testing 10 events 5 seconds apart 1-10