### PR TITLE
[mlir][python][cmake] Remove unsupported argument from AddMLIRPython.

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -605,7 +605,6 @@ function(add_mlir_python_sources_target name)
 
       add_custom_command(
         OUTPUT "${_dest_path}"
-        PRE_BUILD
         COMMENT "Copying python source ${_src_path} -> ${_dest_path}"
         DEPENDS "${_src_path}"
         COMMAND "${CMAKE_COMMAND}" -E ${_link_or_copy}
@@ -702,7 +701,7 @@ function(add_mlir_python_extension libname extname)
           ${eh_rtti_enable}
       )
     endif()
-    
+
     if(APPLE)
       # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
       # doesn't declare this API as undefined in its linker flags. So we need to declare it as such


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/policy/CMP0175.html

> The `OUTPUT` form does not accept `PRE_BUILD`, `PRE_LINK`, or `POST_BUILD` keywords.

When using CMake version 3.31+, this results in ~2000 lines of warning spam in my downstream project:

```
CMake Warning (dev) at build-gcc/lib/cmake/mlir/AddMLIRPython.cmake:606 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(OUTPUT): PRE_BUILD.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
Call Stack (most recent call first):
  build-gcc/lib/cmake/mlir/AddMLIRPython.cmake:222 (add_mlir_python_sources_target)
  build-gcc/lib/cmake/mlir/AddMLIRPython.cmake:256 (_process_target)
  compiler/bindings/python/CMakeLists.txt:239 (add_mlir_python_modules)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

General docs: https://cmake.org/cmake/help/latest/command/add_custom_command.html. Note that `PRE_BUILD` only appears in the _second_ signature for the function (which takes `TARGET`) not the first (which takes `OUTPUT`).