### PR TITLE
[flang] Fix crash in module file generation

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1780,8 +1780,8 @@ bool SubprogramSymbolCollector::NeedImport(
     return found->has<UseDetails>() && found->owner() != scope_;
   } else {
     // "found" can be null in the case of a use-associated derived type's
-    // parent type
-    CHECK(symbol.has<DerivedTypeDetails>());
+    // parent type, and also in the case of an object (like a dummy argument)
+    // used to define a length or bound of a nested interface.
     return false;
   }
 }

--- a/flang/test/Semantics/bug123534.f90
+++ b/flang/test/Semantics/bug123534.f90
@@ -1,0 +1,33 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+! Simplified regression test for crashreported in
+! https://github.com/llvm/llvm-project/issues/123534.
+module m
+  interface
+    ! f1 returns a pointer to a procedure whose result characteristics
+    ! depend on the value of a dummy argument.
+    function f1()
+      interface
+        function f2(n)
+          integer, intent(in) :: n
+          character(n), pointer :: f2
+        end
+      end interface
+      procedure (f2), pointer :: f1
+    end
+  end interface
+end
+
+!Expect: m.mod
+!module m
+!interface
+!function f1()
+!interface
+!function f2(n)
+!integer(4),intent(in)::n
+!character(n,1),pointer::f2
+!end
+!end interface
+!procedure(f2),pointer::f1
+!end
+!end interface
+!end


### PR DESCRIPTION
An assertion in module file generation didn't allow for a case that has arisen in a test; remove it, extend commentary, and add a regression test.

Fixes https://github.com/llvm/llvm-project/issues/123534.