### PR TITLE
[C++20] [Modules] Make sure vtable are generated for explicit template instantiation definition

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -7198,6 +7198,8 @@ void ASTRecordWriter::AddCXXDefinitionData(const CXXRecordDecl *D) {
 
   bool ModulesCodegen =
       !D->isDependentType() &&
+      D->getTemplateSpecializationKind() !=
+          TSK_ExplicitInstantiationDeclaration &&
       (Writer->getLangOpts().ModulesDebugInfo || D->isInNamedModule());
   Record->push_back(ModulesCodegen);
   if (ModulesCodegen)

--- a/clang/test/Modules/vtable-in-explicit-instantiation.cppm
+++ b/clang/test/Modules/vtable-in-explicit-instantiation.cppm
@@ -1,0 +1,34 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 %t/a.cppm -triple %itanium_abi_triple -emit-module-interface -o %t/a.pcm
+// RUN: %clang_cc1 -std=c++20 %t/a.cc -triple %itanium_abi_triple -fmodule-file=a=%t/a.pcm -emit-llvm -o - | FileCheck %t/a.cc
+//
+// RUN: %clang_cc1 -std=c++20 %t/a.cppm -triple %itanium_abi_triple -emit-reduced-module-interface -o %t/a.pcm
+// RUN: %clang_cc1 -std=c++20 %t/a.cc -triple %itanium_abi_triple -fmodule-file=a=%t/a.pcm -emit-llvm -o - | FileCheck %t/a.cc
+
+//--- a.cppm
+export module a;
+class base {
+public:
+    ~base() = default;
+    virtual void foo();
+};
+
+template <class T>
+class a : public base {
+public:
+    virtual void foo() override;
+};
+
+extern template class a<int>;
+
+//--- a.cc
+module a;
+
+template <class T>
+void a<T>::foo() {}
+
+template class a<int>;
+// CHECK: _ZTVW1a1aIiE


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/123719

The reason is, we thought the external explicit template instantiation declaration as the external definition incorrectly.