### PR TITLE
[MCA] Use MCInstrAnalysis to analyse call/return instructions

### DIFF
--- a/llvm/lib/MCA/InstrBuilder.cpp
+++ b/llvm/lib/MCA/InstrBuilder.cpp
@@ -219,11 +219,10 @@ static void initializeUsedResources(InstrDesc &ID,
   });
 }
 
-static void computeMaxLatency(InstrDesc &ID, const MCInstrDesc &MCDesc,
-                              const MCSchedClassDesc &SCDesc,
-                              const MCSubtargetInfo &STI,
-                              unsigned CallLatency) {
-  if (MCDesc.isCall()) {
+static void computeMaxLatency(InstrDesc &ID, const MCSchedClassDesc &SCDesc,
+                              const MCSubtargetInfo &STI, unsigned CallLatency,
+                              bool IsCall) {
+  if (IsCall) {
     // We cannot estimate how long this call will take.
     // Artificially set an arbitrarily high latency.
     ID.MaxLatency = CallLatency;
@@ -599,7 +598,8 @@ InstrBuilder::createInstrDescImpl(const MCInst &MCI,
   ID->NumMicroOps = SCDesc.NumMicroOps;
   ID->SchedClassID = SchedClassID;
 
-  if (MCDesc.isCall() && FirstCallInst) {
+  bool IsCall = MCIA->isCall(MCI);
+  if (IsCall && FirstCallInst) {
     // We don't correctly model calls.
     WithColor::warning() << "found a call in the input assembly sequence.\n";
     WithColor::note() << "call instructions are not correctly modeled. "
@@ -607,7 +607,7 @@ InstrBuilder::createInstrDescImpl(const MCInst &MCI,
     FirstCallInst = false;
   }
 
-  if (MCDesc.isReturn() && FirstReturnInst) {
+  if (MCIA->isReturn(MCI) && FirstReturnInst) {
     WithColor::warning() << "found a return instruction in the input"
                          << " assembly sequence.\n";
     WithColor::note() << "program counter updates are ignored.\n";
@@ -615,7 +615,7 @@ InstrBuilder::createInstrDescImpl(const MCInst &MCI,
   }
 
   initializeUsedResources(*ID, SCDesc, STI, ProcResourceMasks);
-  computeMaxLatency(*ID, MCDesc, SCDesc, STI, CallLatency);
+  computeMaxLatency(*ID, SCDesc, STI, CallLatency, IsCall);
 
   if (Error Err = verifyOperands(MCDesc, MCI))
     return std::move(Err);

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.cpp
@@ -15,6 +15,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCStreamer.h"
@@ -243,6 +244,10 @@ createNullTargetStreamer(MCStreamer &S) {
   return new SystemZTargetStreamer(S);
 }
 
+static MCInstrAnalysis *createSystemZMCInstrAnalysis(const MCInstrInfo *Info) {
+  return new MCInstrAnalysis(Info);
+}
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZTargetMC() {
   // Register the MCAsmInfo.
   TargetRegistry::RegisterMCAsmInfo(getTheSystemZTarget(),
@@ -283,4 +288,8 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZTargetMC() {
   // Register the null streamer
   TargetRegistry::RegisterNullTargetStreamer(getTheSystemZTarget(),
                                              createNullTargetStreamer);
+
+  // Register the MCInstrAnalysis.
+  TargetRegistry::RegisterMCInstrAnalysis(getTheSystemZTarget(),
+                                          createSystemZMCInstrAnalysis);
 }

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/jump.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/jump.s
@@ -12,12 +12,12 @@ ret
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      5
-# CHECK-NEXT: Total Cycles:      10
+# CHECK-NEXT: Total Cycles:      200
 # CHECK-NEXT: Total uOps:        5
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.50
-# CHECK-NEXT: IPC:               0.50
+# CHECK-NEXT: uOps Per Cycle:    0.03
+# CHECK-NEXT: IPC:               0.03
 # CHECK-NEXT: Block RThroughput: 5.0
 
 # CHECK:      Instruction Info:
@@ -58,13 +58,10 @@ ret
 # CHECK-NEXT:  -      -      -     1.00    -      -      -      -     ret
 
 # CHECK:      Timeline view:
-# CHECK-NEXT: Index     0123456789
+# CHECK-NEXT: Index     0123
 
-# CHECK:      [0,0]     DeeE .   .   j	.Ltmp0
-# CHECK-NEXT: [0,1]     .DeeE.   .   jal	a0, .Ltmp1
-# CHECK-NEXT: [0,2]     .   DeeE .   jr	a0
-# CHECK-NEXT: [0,3]     .    DeeE.   jalr	t0, a0
-# CHECK-NEXT: [0,4]     .    .DeeE   ret
+# CHECK:      [0,0]     DeeE   j	.Ltmp0
+# CHECK-NEXT: Truncated display due to cycle limit
 
 # CHECK:      Average Wait times (based on the timeline view):
 # CHECK-NEXT: [0]: Executions


### PR DESCRIPTION
The flag set in `MCInstrDesc` is not accurate and we should use
the result of `MCInstrAnalysis`.
