### PR TITLE
[SandboxIR] Remove sandboxir::PointerType::get(Type)

### DIFF
--- a/llvm/include/llvm/SandboxIR/Type.h
+++ b/llvm/include/llvm/SandboxIR/Type.h
@@ -292,8 +292,6 @@ class PointerType : public Type {
 public:
   // TODO: add missing functions
 
-  // TODO: Remove non-opaque variant of sandboxir::PointerType::get
-  static PointerType *get(Type *ElementType, unsigned AddressSpace);
   static PointerType *get(Context &Ctx, unsigned AddressSpace);
 
   static bool classof(const Type *From) {

--- a/llvm/lib/SandboxIR/Type.cpp
+++ b/llvm/lib/SandboxIR/Type.cpp
@@ -45,10 +45,6 @@ void Type::dump() {
 }
 #endif
 
-PointerType *PointerType::get(Type *ElementType, unsigned AddressSpace) {
-  return get(ElementType->getContext(), AddressSpace);
-}
-
 PointerType *PointerType::get(Context &Ctx, unsigned AddressSpace) {
   return cast<PointerType>(
       Ctx.getType(llvm::PointerType::get(Ctx.LLVMCtx, AddressSpace)));

--- a/llvm/unittests/SandboxIR/SandboxIRTest.cpp
+++ b/llvm/unittests/SandboxIR/SandboxIRTest.cpp
@@ -5150,8 +5150,8 @@ define void @foo(i32 %arg, float %farg, double %darg, ptr %ptr) {
   auto *Ti16 = sandboxir::Type::getInt16Ty(Ctx);
   auto *Tdouble = sandboxir::Type::getDoubleTy(Ctx);
   auto *Tfloat = sandboxir::Type::getFloatTy(Ctx);
-  auto *Tptr = sandboxir::PointerType::get(Tfloat, 0);
-  auto *Tptr1 = sandboxir::PointerType::get(Tfloat, 1);
+  auto *Tptr = sandboxir::PointerType::get(Ctx, 0);
+  auto *Tptr1 = sandboxir::PointerType::get(Ctx, 1);
 
   // Check classof(), getOpcode(), getSrcTy(), getDstTy()
   auto *ZExt = cast<sandboxir::CastInst>(&*It++);

--- a/llvm/unittests/SandboxIR/TypesTest.cpp
+++ b/llvm/unittests/SandboxIR/TypesTest.cpp
@@ -217,10 +217,6 @@ define void @foo(ptr %ptr) {
   auto *F = Ctx.createFunction(LLVMF);
   // Check classof(), creation.
   auto *PtrTy = cast<sandboxir::PointerType>(F->getArg(0)->getType());
-  // Check get(ElementType, AddressSpace).
-  auto *NewPtrTy =
-      sandboxir::PointerType::get(sandboxir::Type::getInt32Ty(Ctx), 0u);
-  EXPECT_EQ(NewPtrTy, PtrTy);
   // Check get(Ctx, AddressSpace).
   auto *NewPtrTy2 = sandboxir::PointerType::get(Ctx, 0u);
   EXPECT_EQ(NewPtrTy2, PtrTy);


### PR DESCRIPTION
This was just an alias for getting the LLVM Context from the type.

We are in the process of removing the same function for the regular LLVM type in https://github.com/llvm/llvm-project/issues/123569