### PR TITLE
[llvm] Remove `undef` from `llvm/test/Transforms` tests

### DIFF
--- a/llvm/test/Transforms/ADCE/2017-08-21-DomTree-deletions.ll
+++ b/llvm/test/Transforms/ADCE/2017-08-21-DomTree-deletions.ll
@@ -1,11 +1,11 @@
 ; RUN: opt < %s -passes=adce | llvm-dis
 ; RUN: opt < %s -passes=adce -verify-dom-info | llvm-dis
 
-define void @foo() {
+define void @foo(i32 %arg) {
 entry:
   br label %switch
 switch:                    ; preds = %entry
-  switch i32 undef, label %default [
+  switch i32 %arg, label %default [
     i32 2, label %two
     i32 5, label %five
     i32 4, label %four

--- a/llvm/test/Transforms/ADCE/preserve-memoryssa-if-only-remove-debug.ll
+++ b/llvm/test/Transforms/ADCE/preserve-memoryssa-if-only-remove-debug.ll
@@ -33,7 +33,7 @@
 
 define i16 @test1() {
 entry:
-  call void @llvm.dbg.declare(metadata ptr undef, metadata !4, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.declare(metadata ptr null, metadata !4, metadata !DIExpression()), !dbg !16
   ret i16 0
 }
 

--- a/llvm/test/Transforms/ADCE/preserve-memoryssa-if-only-remove-debug.ll
+++ b/llvm/test/Transforms/ADCE/preserve-memoryssa-if-only-remove-debug.ll
@@ -33,7 +33,7 @@
 
 define i16 @test1() {
 entry:
-  call void @llvm.dbg.declare(metadata ptr null, metadata !4, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.declare(metadata ptr poison, metadata !4, metadata !DIExpression()), !dbg !16
   ret i16 0
 }
 

--- a/llvm/test/Transforms/AddDiscriminators/inlined.ll
+++ b/llvm/test/Transforms/AddDiscriminators/inlined.ll
@@ -24,11 +24,11 @@ for.cond:                                         ; preds = %for.cond, %entry
 }
 
 ; Function Attrs: nounwind ssp
-define i32 @g() local_unnamed_addr #1 !dbg !12 {
+define i32 @g(i32 %arg) local_unnamed_addr #1 !dbg !12 {
 entry:
   %0 = tail call i64 @llvm.objectsize.i64.p0(ptr inttoptr (i64 1 to ptr), i1 false), !dbg !22
   %call = tail call ptr @__memset_chk(ptr null, i32 0, i64 0, i64 %0) #2, !dbg !23
-  ret i32 undef, !dbg !24
+  ret i32 %arg, !dbg !24
 }
 
 ; Function Attrs: nounwind

--- a/llvm/test/Transforms/AddDiscriminators/invoke.ll
+++ b/llvm/test/Transforms/AddDiscriminators/invoke.ll
@@ -54,7 +54,7 @@ try.cont:                                         ; preds = %invoke.cont
 eh.resume:                                        ; preds = %invoke.cont2
   %exn3 = load ptr, ptr %exn.slot, align 8, !dbg !20
   %sel = load i32, ptr %ehselector.slot, align 4, !dbg !20
-  %lpad.val = insertvalue { ptr, i32 } undef, ptr %exn3, 0, !dbg !20
+  %lpad.val = insertvalue { ptr, i32 } poison, ptr %exn3, 0, !dbg !20
   %lpad.val4 = insertvalue { ptr, i32 } %lpad.val, i32 %sel, 1, !dbg !20
   resume { ptr, i32 } %lpad.val4, !dbg !20
 

--- a/llvm/test/Transforms/AggressiveInstCombine/AArch64/combine_ignore_debug.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/AArch64/combine_ignore_debug.ll
@@ -16,7 +16,7 @@ define void @test() {
 ; DBG-LABEL: define void @test() {
 ; DBG-NEXT:  entry:
 ; DBG-NEXT:    [[L1:%.*]] = load i32, ptr @e, align 1
-; DBG-NEXT:      #dbg_value(i32 undef, [[META3:![0-9]+]], !DIExpression(), [[META5:![0-9]+]])
+; DBG-NEXT:      #dbg_value(i32 poison, [[META3:![0-9]+]], !DIExpression(), [[META5:![0-9]+]])
 ; DBG-NEXT:    store i32 [[L1]], ptr @l, align 1
 ; DBG-NEXT:    ret void
 ;
@@ -28,7 +28,7 @@ define void @test() {
 ;
 entry:
   %l1 = load i16, ptr @e, align 1
-  call void @llvm.dbg.value(metadata i32 undef, metadata !3, metadata !DIExpression()), !dbg !5
+  call void @llvm.dbg.value(metadata i32 poison, metadata !3, metadata !DIExpression()), !dbg !5
   %l2 = load i16, ptr getelementptr inbounds (%s, ptr @e, i16 0, i32 1), align 1
   %e2 = zext i16 %l2 to i32
   %e1 = zext i16 %l1 to i32

--- a/llvm/test/Transforms/AggressiveInstCombine/trunc_unreachable_bb.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/trunc_unreachable_bb.ll
@@ -4,12 +4,12 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 
 ; Aggressive Instcombine should be able ignore unreachable basic block.
 
-define void @func_20() {
+define void @func_20(i32 %arg) {
 ; CHECK-LABEL: @func_20(
 ; CHECK-NEXT:  for.body94:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       for.cond641:
-; CHECK-NEXT:    [[OR722:%.*]] = or i32 [[OR722]], undef
+; CHECK-NEXT:    [[OR722:%.*]] = or i32 [[OR722]], %arg
 ; CHECK-NEXT:    [[OR723:%.*]] = or i32 [[OR722]], 1
 ; CHECK-NEXT:    [[CONV724:%.*]] = trunc i32 [[OR723]] to i16
 ; CHECK-NEXT:    br label [[FOR_COND641:%.*]]
@@ -18,19 +18,19 @@ for.body94:
   unreachable
 
 for.cond641:
-  %or722 = or i32 %or722, undef
+  %or722 = or i32 %or722, %arg
   %or723 = or i32 %or722, 1
   %conv724 = trunc i32 %or723 to i16
   br label %for.cond641
 }
 
-define void @func_21() {
+define void @func_21(i32 %arg) {
 ; CHECK-LABEL: @func_21(
 ; CHECK-NEXT:  for.body94:
 ; CHECK-NEXT:    unreachable
 ; CHECK:       for.cond641:
-; CHECK-NEXT:    [[OR722:%.*]] = or i32 [[A:%.*]], undef
-; CHECK-NEXT:    [[A]] = or i32 [[OR722]], undef
+; CHECK-NEXT:    [[OR722:%.*]] = or i32 [[A:%.*]], %arg
+; CHECK-NEXT:    [[A]] = or i32 [[OR722]], %arg
 ; CHECK-NEXT:    [[OR723:%.*]] = or i32 [[OR722]], 1
 ; CHECK-NEXT:    [[CONV724:%.*]] = trunc i32 [[OR723]] to i16
 ; CHECK-NEXT:    br label [[FOR_COND641:%.*]]
@@ -39,8 +39,8 @@ for.body94:
   unreachable
 
 for.cond641:
-  %or722 = or i32 %a, undef
-  %a = or i32 %or722, undef
+  %or722 = or i32 %a, %arg
+  %a = or i32 %or722, %arg
   %or723 = or i32 %or722, 1
   %conv724 = trunc i32 %or723 to i16
   br label %for.cond641

--- a/llvm/test/Transforms/AggressiveInstCombine/trunc_vector_instrs.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/trunc_vector_instrs.ll
@@ -19,12 +19,12 @@ define <4 x i16> @shuffle(<2 x i8> %a, <2 x i8> %b) {
 define <2 x i16> @unary_shuffle(<2 x i8> %a) {
 ; CHECK-LABEL: @unary_shuffle(
 ; CHECK-NEXT:    [[ZEXTA:%.*]] = zext <2 x i8> [[A:%.*]] to <2 x i32>
-; CHECK-NEXT:    [[SHUF:%.*]] = shufflevector <2 x i32> [[ZEXTA]], <2 x i32> undef, <2 x i32> <i32 1, i32 0>
+; CHECK-NEXT:    [[SHUF:%.*]] = shufflevector <2 x i32> [[ZEXTA]], <2 x i32> poison, <2 x i32> <i32 1, i32 0>
 ; CHECK-NEXT:    [[TRUNC:%.*]] = trunc <2 x i32> [[SHUF]] to <2 x i16>
 ; CHECK-NEXT:    ret <2 x i16> [[TRUNC]]
 ;
   %zexta = zext <2 x i8> %a to <2 x i32>
-  %shuf = shufflevector <2 x i32> %zexta, <2 x i32> undef, <2 x i32> <i32 1, i32 0>
+  %shuf = shufflevector <2 x i32> %zexta, <2 x i32> poison, <2 x i32> <i32 1, i32 0>
   %trunc = trunc <2 x i32> %shuf to <2 x i16>
   ret <2 x i16> %trunc
 }

--- a/llvm/test/Transforms/AlignmentFromAssumptions/simple.ll
+++ b/llvm/test/Transforms/AlignmentFromAssumptions/simple.ll
@@ -327,12 +327,12 @@ define i32 @moo(ptr nocapture %a) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 true) [ "align"(ptr [[A]], i16 32) ]
 ; CHECK-NEXT:    tail call void @llvm.memset.p0.i64(ptr align 32 [[A]], i8 0, i64 64, i1 false)
-; CHECK-NEXT:    ret i32 undef
+; CHECK-NEXT:    ret i32 0
 ;
 entry:
   tail call void @llvm.assume(i1 true) ["align"(ptr %a, i16 32)]
   tail call void @llvm.memset.p0.i64(ptr align 4 %a, i8 0, i64 64, i1 false)
-  ret i32 undef
+  ret i32 0
 }
 
 define i32 @moo2(ptr nocapture %a, ptr nocapture %b) {
@@ -342,13 +342,13 @@ define i32 @moo2(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 true) [ "align"(ptr [[B]], i32 128) ]
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 true) [ "align"(ptr [[A]], i16 32) ]
 ; CHECK-NEXT:    tail call void @llvm.memcpy.p0.p0.i64(ptr align 32 [[A]], ptr align 128 [[B]], i64 64, i1 false)
-; CHECK-NEXT:    ret i32 undef
+; CHECK-NEXT:    ret i32 0
 ;
 entry:
   tail call void @llvm.assume(i1 true) ["align"(ptr %b, i32 128)]
   tail call void @llvm.assume(i1 true) ["align"(ptr %a, i16 32)]
   tail call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %b, i64 64, i1 false)
-  ret i32 undef
+  ret i32 0
 }
 
 define i32 @moo3(ptr nocapture %a, ptr nocapture %b) {
@@ -357,12 +357,12 @@ define i32 @moo3(ptr nocapture %a, ptr nocapture %b) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 true) [ "align"(ptr [[A]], i16 32), "align"(ptr [[B]], i32 128) ]
 ; CHECK-NEXT:    tail call void @llvm.memcpy.p0.p0.i64(ptr align 32 [[A]], ptr align 128 [[B]], i64 64, i1 false)
-; CHECK-NEXT:    ret i32 undef
+; CHECK-NEXT:    ret i32 0
 ;
 entry:
   tail call void @llvm.assume(i1 true) ["align"(ptr %a, i16 32), "align"(ptr %b, i32 128)]
   tail call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %b, i64 64, i1 false)
-  ret i32 undef
+  ret i32 0
 }
 
 

--- a/llvm/test/Transforms/AlignmentFromAssumptions/simple32.ll
+++ b/llvm/test/Transforms/AlignmentFromAssumptions/simple32.ll
@@ -254,12 +254,12 @@ define i32 @moo(ptr nocapture %a) nounwind uwtable {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[A]], i64 32) ]
 ; CHECK-NEXT:    tail call void @llvm.memset.p0.i64(ptr align 32 [[A]], i8 0, i64 64, i1 false)
-; CHECK-NEXT:    ret i32 undef
+; CHECK-NEXT:    ret i32 0
 ;
 entry:
   call void @llvm.assume(i1 true) ["align"(ptr %a, i64 32)]
   tail call void @llvm.memset.p0.i64(ptr align 4 %a, i8 0, i64 64, i1 false)
-  ret i32 undef
+  ret i32 0
 
 }
 
@@ -270,13 +270,13 @@ define i32 @moo2(ptr nocapture %a, ptr nocapture %b) nounwind uwtable {
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[A]], i64 32) ]
 ; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[B]], i64 128) ]
 ; CHECK-NEXT:    tail call void @llvm.memcpy.p0.p0.i64(ptr align 32 [[A]], ptr align 128 [[B]], i64 64, i1 false)
-; CHECK-NEXT:    ret i32 undef
+; CHECK-NEXT:    ret i32 0
 ;
 entry:
   call void @llvm.assume(i1 true) ["align"(ptr %a, i64 32)]
   call void @llvm.assume(i1 true) ["align"(ptr %b, i64 128)]
   tail call void @llvm.memcpy.p0.p0.i64(ptr align 4 %a, ptr align 4 %b, i64 64, i1 false)
-  ret i32 undef
+  ret i32 0
 
 }
 

--- a/llvm/test/Transforms/ArgumentPromotion/crash.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/crash.ll
@@ -55,7 +55,7 @@ bb:
 
 define internal i1 @barney(ptr %arg) {
 bb:
-  ret i1 undef
+  ret i1 poison
 }
 
 define i32 @test_inf_promote_caller(i32 %arg) {

--- a/llvm/test/Transforms/ArgumentPromotion/min-legal-vector-width.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/min-legal-vector-width.ll
@@ -1,7 +1,7 @@
 ; RUN: opt < %s -passes=argpromotion -S | FileCheck %s
 
 ; CHECK-LABEL: define i32 @foo() #0 {
-; CHECK-NEXT:      %.val = load <32 x half>, ptr undef, align 4
+; CHECK-NEXT:      %.val = load <32 x half>, ptr poison, align 4
 ; CHECK-NEXT:      call void @bar(<32 x half> %.val)
 ; CHECK-NEXT:      ret i32 0
 ; CHECK-NEXT:    }
@@ -13,7 +13,7 @@
 ; CHECK:    attributes #0 = { uwtable "min-legal-vector-width"="512" }
 
 define i32 @foo() #0 {
-  call void @bar(ptr undef)
+  call void @bar(ptr poison)
   ret i32 0
 }
 

--- a/llvm/test/Transforms/ArgumentPromotion/pr32917.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/pr32917.ll
@@ -13,13 +13,13 @@ define i32 @fn2() local_unnamed_addr {
 ; CHECK-NEXT:    [[TMP4:%.*]] = getelementptr i8, ptr [[TMP3]], i64 -4
 ; CHECK-NEXT:    [[DOTVAL:%.*]] = load i32, ptr [[TMP4]], align 4
 ; CHECK-NEXT:    call fastcc void @fn1(i32 [[DOTVAL]])
-; CHECK-NEXT:    ret i32 undef
+; CHECK-NEXT:    ret i32 0
 ;
   %1 = load i32, ptr @b, align 4
   %2 = sext i32 %1 to i64
   %3 = inttoptr i64 %2 to ptr
   call fastcc void @fn1(ptr %3)
-  ret i32 undef
+  ret i32 0
 }
 
 define internal fastcc void @fn1(ptr nocapture readonly) unnamed_addr {


### PR DESCRIPTION
This PR replaces some instances of `undef` with `function argument value` or `poison` or `concrete values` in several tests under `llvm/test/Transforms/` directory. These changes align with modern LLVM standards for better-defined behavior and test determinism. If this small PR is okay and gets merged, I will work on the rest.

This is inspired by [this project](https://discourse.llvm.org/t/gsoc-2024-remove-undefined-behavior-from-tests/77236/29), work done on this by @leewei05  

This is my first PR here. Any suggestions are welcome. 

@nunoplopes @regehr 