### PR TITLE
Remove incorrect CUDA defines

### DIFF
--- a/clang/include/clang/Basic/Cuda.h
+++ b/clang/include/clang/Basic/Cuda.h
@@ -44,12 +44,10 @@ enum class CudaVersion {
   CUDA_124,
   CUDA_125,
   CUDA_126,
-  CUDA_127,
   CUDA_128,
-  CUDA_129,
   FULLY_SUPPORTED = CUDA_123,
   PARTIALLY_SUPPORTED =
-      CUDA_129, // Partially supported. Proceed with a warning.
+      CUDA_128, // Partially supported. Proceed with a warning.
   NEW = 10000,  // Too new. Issue a warning, but allow using it.
 };
 const char *CudaVersionToString(CudaVersion V);

--- a/clang/lib/Basic/Cuda.cpp
+++ b/clang/lib/Basic/Cuda.cpp
@@ -44,9 +44,7 @@ static const CudaVersionMapEntry CudaNameVersionMap[] = {
     CUDA_ENTRY(12, 4),
     CUDA_ENTRY(12, 5),
     CUDA_ENTRY(12, 6),
-    CUDA_ENTRY(12, 7),
     CUDA_ENTRY(12, 8),
-    CUDA_ENTRY(12, 9),
     {"", CudaVersion::NEW, llvm::VersionTuple(std::numeric_limits<int>::max())},
     {"unknown", CudaVersion::UNKNOWN, {}} // End of list tombstone.
 };
@@ -232,7 +230,7 @@ CudaVersion MinVersionForOffloadArch(OffloadArch A) {
     return CudaVersion::CUDA_120;
   case OffloadArch::SM_100:
   case OffloadArch::SM_100a:
-    return CudaVersion::CUDA_127;
+    return CudaVersion::CUDA_128;
   default:
     llvm_unreachable("invalid enum");
   }

--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -89,12 +89,8 @@ CudaVersion getCudaVersion(uint32_t raw_version) {
     return CudaVersion::CUDA_125;
   if (raw_version < 12070)
     return CudaVersion::CUDA_126;
-  if (raw_version < 12080)
-    return CudaVersion::CUDA_127;
   if (raw_version < 12090)
     return CudaVersion::CUDA_128;
-  if (raw_version < 12100)
-    return CudaVersion::CUDA_129;
   return CudaVersion::NEW;
 }
 
@@ -688,9 +684,7 @@ void NVPTX::getNVPTXTargetFeatures(const Driver &D, const llvm::Triple &Triple,
   case CudaVersion::CUDA_##CUDA_VER:                                           \
     PtxFeature = "+ptx" #PTX_VER;                                              \
     break;
-    CASE_CUDA_VERSION(129, 87);
     CASE_CUDA_VERSION(128, 87);
-    CASE_CUDA_VERSION(127, 86);
     CASE_CUDA_VERSION(126, 85);
     CASE_CUDA_VERSION(125, 85);
     CASE_CUDA_VERSION(124, 84);


### PR DESCRIPTION
Remove CUDA_127 and CUDA_129 defines incorrectly added in https://github.com/llvm/llvm-project/pull/123398