### PR TITLE
[lldb/windows] Make "anonymous" pipe names more unique

### DIFF
--- a/lldb/source/Host/windows/PipeWindows.cpp
+++ b/lldb/source/Host/windows/PipeWindows.cpp
@@ -71,9 +71,8 @@ Status PipeWindows::CreateNew(bool child_process_inherit) {
   // cannot get overlapped i/o on Windows without using a named pipe.  So we
   // synthesize a unique name.
   uint32_t serial = g_pipe_serial.fetch_add(1);
-  std::string pipe_name;
-  llvm::raw_string_ostream pipe_name_stream(pipe_name);
-  pipe_name_stream << "lldb.pipe." << ::GetCurrentProcessId() << "." << serial;
+  std::string pipe_name = llvm::formatv(
+      "lldb.pipe.{0}.{1}.{2}", GetCurrentProcessId(), &g_pipe_serial, serial);
 
   return CreateNew(pipe_name.c_str(), child_process_inherit);
 }


### PR DESCRIPTION
Using a "random" name for an "anonymous" pipe seems to be the state of the art on windows (according to stack overflow, new windows versions may have something better, but it involves calling kernel APIs directly and generally a lot of dark magic).

The problem with the current method was that is does not produce unique names if one has two copies of the pipe code in the same process, which is what happened with #120457 (because liblldb only exposes the public api, and we've started using the pipe code in lldb-dap as well).

This patch works around the problem by adding the address of the counter variable to the pipe name.

Replicating the multiple-copies setup in a test would be very difficult, which is why I'm not adding a test for this scenario.