### PR TITLE
[RISCV][VLOPT] Remove dead passthru check in getOperandLog2EEW. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -208,13 +208,6 @@ getOperandLog2EEW(const MachineOperand &MO, const MachineRegisterInfo *MRI) {
   const bool HasPassthru = RISCVII::isFirstDefTiedToFirstUse(MI.getDesc());
   const bool IsTied = RISCVII::isTiedPseudo(MI.getDesc().TSFlags);
 
-  // We bail out early for instructions that have passthru with non NoRegister,
-  // which means they are using TU policy. We are not interested in these
-  // since they must preserve the entire register content.
-  if (HasPassthru && MO.getOperandNo() == MI.getNumExplicitDefs() &&
-      (MO.getReg() != RISCV::NoRegister))
-    return std::nullopt;
-
   bool IsMODef = MO.getOperandNo() == 0;
 
   // All mask operands have EEW=1


### PR DESCRIPTION
We already bail if the user is tied in checkUsers, which is true for all passthrus. Remove the check in getOperandLog2EEW so that it only worries about computing the OperandInfo, and leaves the passthru correctness to checkUsers.
