### PR TITLE
[MLIR] Fix mlirExecutionEngineLookup throwing assert on lookup fail

### DIFF
--- a/mlir/lib/CAPI/ExecutionEngine/ExecutionEngine.cpp
+++ b/mlir/lib/CAPI/ExecutionEngine/ExecutionEngine.cpp
@@ -85,18 +85,20 @@ mlirExecutionEngineInvokePacked(MlirExecutionEngine jit, MlirStringRef name,
 
 extern "C" void *mlirExecutionEngineLookupPacked(MlirExecutionEngine jit,
                                                  MlirStringRef name) {
-  auto expectedFPtr = unwrap(jit)->lookupPacked(unwrap(name));
-  if (!expectedFPtr)
+  auto optionalFPtr =
+      llvm::expectedToOptional(unwrap(jit)->lookupPacked(unwrap(name)));
+  if (!optionalFPtr)
     return nullptr;
-  return reinterpret_cast<void *>(*expectedFPtr);
+  return reinterpret_cast<void *>(*optionalFPtr);
 }
 
 extern "C" void *mlirExecutionEngineLookup(MlirExecutionEngine jit,
                                            MlirStringRef name) {
-  auto expectedFPtr = unwrap(jit)->lookup(unwrap(name));
-  if (!expectedFPtr)
+  auto optionalFPtr =
+      llvm::expectedToOptional(unwrap(jit)->lookup(unwrap(name)));
+  if (!optionalFPtr)
     return nullptr;
-  return reinterpret_cast<void *>(*expectedFPtr);
+  return *optionalFPtr;
 }
 
 extern "C" void mlirExecutionEngineRegisterSymbol(MlirExecutionEngine jit,


### PR DESCRIPTION
Apparently trying to lookup a function pointer using the C api `mlirExecutionEngineLookup` will throw an assert instead of just returning a nullptr on builds with asserts.

The docs itself says it returns a nullptr when no function is found so it should be sensible to not throw an assert in this case.