### PR TITLE
[clang-format] Add null-terminated path option (#123921)

### DIFF
--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -274,7 +274,7 @@ def main():
                 print_filename(filename, opts.null)
 
     if not changed_lines:
-        if opts.verbose >= 0:
+        if opts.verbose >= 0 and not opts.null:
             print("no modified files to format")
         return 0
 
@@ -295,7 +295,7 @@ def main():
         print("new tree: %s" % new_tree)
 
     if old_tree == new_tree:
-        if opts.verbose >= 0:
+        if opts.verbose >= 0 and not opts.null:
             print("clang-format did not modify any files")
         return 0
 
@@ -308,7 +308,8 @@ def main():
         old_tree, new_tree, force=opts.force, patch_mode=opts.patch
     )
     if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
-        print("changed files:")
+        if not opts.null:
+            print("changed files:")
         for filename in changed_files:
             print_filename(filename, opts.null)
 

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -205,6 +205,12 @@ def main():
             "commits"
         ),
     )
+    p.add_argument(
+        "-0",
+        "--null",
+        action="store_true",
+        help="print the affected paths with null-terminated characters",
+    )
     # We gather all the remaining positional arguments into 'args' since we need
     # to use some heuristics to determine whether or not <commit> was present.
     # However, to print pretty messages, we make use of metavar and help.
@@ -261,11 +267,11 @@ def main():
                 "ignored by clang-format):"
             )
             for filename in ignored_files:
-                print("    %s" % filename)
+                print_filename(filename, opts.null)
         if changed_lines:
             print("Running clang-format on the following files:")
             for filename in changed_lines:
-                print("    %s" % filename)
+                print_filename(filename, opts.null)
 
     if not changed_lines:
         if opts.verbose >= 0:
@@ -304,7 +310,7 @@ def main():
     if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
         print("changed files:")
         for filename in changed_files:
-            print("    %s" % filename)
+            print_filename(filename, opts.null)
 
     return 1
 
@@ -867,6 +873,13 @@ def convert_string(bytes_input):
         return str(bytes_input)
     except UnicodeError:
         return str(bytes_input)
+
+
+def print_filename(filename, null=False):
+    if null:
+        print(filename + "\0", end="")
+    else:
+        print("    %s" % filename)
 
 
 if __name__ == "__main__":

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -206,8 +206,7 @@ def main():
         ),
     )
     p.add_argument(
-        "-0",
-        "--null",
+        "--print0",
         action="store_true",
         help="end each printed filename with a null character",
     )
@@ -267,14 +266,14 @@ def main():
                 "ignored by clang-format):"
             )
             for filename in ignored_files:
-                print_filename(filename, opts.null)
+                print_filename(filename, opts.print0)
         if changed_lines:
             print("Running clang-format on the following files:")
             for filename in changed_lines:
-                print_filename(filename, opts.null)
+                print_filename(filename, opts.print0)
 
     if not changed_lines:
-        if opts.verbose >= 0 and not opts.null:
+        if opts.verbose >= 0 and not opts.print0:
             print("no modified files to format")
         return 0
 
@@ -295,7 +294,7 @@ def main():
         print("new tree: %s" % new_tree)
 
     if old_tree == new_tree:
-        if opts.verbose >= 0 and not opts.null:
+        if opts.verbose >= 0 and not opts.print0:
             print("clang-format did not modify any files")
         return 0
 
@@ -308,10 +307,10 @@ def main():
         old_tree, new_tree, force=opts.force, patch_mode=opts.patch
     )
     if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
-        if not opts.null:
+        if not opts.print0:
             print("changed files:")
         for filename in changed_files:
-            print_filename(filename, opts.null)
+            print_filename(filename, opts.print0)
 
     return 1
 

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -150,6 +150,15 @@ def main():
         help="print a diff instead of applying the changes",
     )
     p.add_argument(
+        "--diff_from_common_commit",
+        action="store_true",
+        help=(
+            "diff from the last common commit for commits in "
+            "separate branches rather than the exact point of the "
+            "commits"
+        ),
+    )
+    p.add_argument(
         "--diffstat",
         action="store_true",
         help="print a diffstat instead of applying the changes",
@@ -170,6 +179,11 @@ def main():
     )
     p.add_argument(
         "-p", "--patch", action="store_true", help="select hunks interactively"
+    )
+    p.add_argument(
+        "--print0",
+        action="store_true",
+        help="end each printed filename with a null character",
     )
     p.add_argument(
         "-q",
@@ -195,20 +209,6 @@ def main():
         action="count",
         default=0,
         help="print extra information",
-    )
-    p.add_argument(
-        "--diff_from_common_commit",
-        action="store_true",
-        help=(
-            "diff from the last common commit for commits in "
-            "separate branches rather than the exact point of the "
-            "commits"
-        ),
-    )
-    p.add_argument(
-        "--print0",
-        action="store_true",
-        help="end each printed filename with a null character",
     )
     # We gather all the remaining positional arguments into 'args' since we need
     # to use some heuristics to determine whether or not <commit> was present.

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -872,7 +872,7 @@ def convert_string(bytes_input):
         return str(bytes_input)
 
 
-def print_filenames(filenames, print0=False):
+def print_filenames(filenames, print0):
     for filename in filenames:
         if print0:
             print(filename, end="\0")

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -265,12 +265,10 @@ def main():
                 "Ignoring the following files (wrong extension, symlink, or "
                 "ignored by clang-format):"
             )
-            for filename in ignored_files:
-                print_filename(filename, opts.print0)
+            print_filenames(ignored_files, opts.print0)
         if changed_lines:
             print("Running clang-format on the following files:")
-            for filename in changed_lines:
-                print_filename(filename, opts.print0)
+            print_filenames(changed_lines, opts.print0)
 
     if not changed_lines:
         if opts.verbose >= 0 and not opts.print0:
@@ -309,8 +307,7 @@ def main():
     if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
         if not opts.print0:
             print("changed files:")
-        for filename in changed_files:
-            print_filename(filename, opts.print0)
+        print_filenames(changed_files, opts.print0)
 
     return 1
 

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -876,11 +876,12 @@ def convert_string(bytes_input):
         return str(bytes_input)
 
 
-def print_filename(filename, null=False):
-    if null:
-        print(filename + "\0", end="")
-    else:
-        print("    %s" % filename)
+def print_filenames(filenames, print0=False):
+    for filename in filenames:
+        if print0:
+            print(filename, end="\0")
+        else:
+            print(" " * 4 + filename)
 
 
 if __name__ == "__main__":

--- a/clang/tools/clang-format/git-clang-format
+++ b/clang/tools/clang-format/git-clang-format
@@ -209,7 +209,7 @@ def main():
         "-0",
         "--null",
         action="store_true",
-        help="print the affected paths with null-terminated characters",
+        help="end each printed filename with a null character",
     )
     # We gather all the remaining positional arguments into 'args' since we need
     # to use some heuristics to determine whether or not <commit> was present.


### PR DESCRIPTION
This makes the `git clang-format` tool compose nicely with other shell utilities in case of maliciously (or innocently) crafted filenames.

Closes #123921.