### PR TITLE
[PS5][Driver] Don't link with --build-id when -static

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -262,7 +262,10 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     // index the symbols. `uuid` is the cheapest fool-proof method.
     // (The non-determinism and alternative methods are noted in the downstream
     // PlayStation docs).
-    CmdArgs.push_back("--build-id=uuid");
+    // Static executables are only used for a handful of specialized components,
+    // where the extra section is not wanted.
+    if (!Static)
+      CmdArgs.push_back("--build-id=uuid");
 
     // All references are expected to be resolved at static link time for both
     // executables and dynamic libraries. This has been the default linking

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -49,7 +49,6 @@
 // CHECK-EXE: {{ld(\.exe)?}}"
 // CHECK-EXE-SAME: "--eh-frame-hdr"
 // CHECK-EXE-SAME: "--hash-style=sysv"
-// CHECK-EXE-SAME: "--build-id=uuid"
 // CHECK-EXE-SAME: "--unresolved-symbols=report-all"
 // CHECK-EXE-SAME: "-z" "now"
 // CHECK-EXE-SAME: "-z" "start-stop-visibility=hidden"
@@ -63,9 +62,22 @@
 // CHECK-NO-EXE: {{ld(\.exe)?}}"
 // CHECK-NO-EXE-NOT: "--eh-frame-hdr"
 // CHECK-NO-EXE-NOT: "--hash-style
-// CHECK-NO-EXE-NOT: "--build-id
 // CHECK-NO-EXE-NOT: "--unresolved-symbols
 // CHECK-NO-EXE-NOT: "-z"
+
+// Test that --build-id is supplied to the linker for non-static executables
+// and -shared.
+
+// RUN: %clang --target=x86_64-sie-ps5 %s -### 2>&1 | FileCheck --check-prefixes=CHECK-BUILD-ID %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -shared -### 2>&1 | FileCheck --check-prefixes=CHECK-BUILD-ID %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -static -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-BUILD-ID %s
+// RUN: %clang --target=x86_64-sie-ps5 %s -r -### 2>&1 | FileCheck --check-prefixes=CHECK-NO-BUILD-ID %s
+
+// CHECK-BUILD-ID: {{ld(\.exe)?}}"
+// CHECK-BUILD-ID-SAME: "--build-id=uuid"
+
+// CHECK-NO-BUILD-ID: {{ld(\.exe)?}}"
+// CHECK-NO-BUILD-ID-NOT: "--build-id
 
 // Test that an appropriate linker script is supplied by the driver, but can
 // be overridden with -T.


### PR DESCRIPTION
Users of the PlayStation SDK aren't given the means to create or run static executables. Uses of `-static` are limited a few specialized cases within SIE. A `--build-id` isn't wanted in those cases.

SIE tracker: TOOLCHAIN-16704