### PR TITLE
[TableGen] Destroy parser before writing output file

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1928,7 +1928,7 @@ class RecordKeeper {
   using GlobalMap = std::map<std::string, const Init *, std::less<>>;
 
 public:
-  RecordKeeper();
+  RecordKeeper(TGTimer &Timer);
   ~RecordKeeper();
 
   /// Return the internal implementation of the RecordKeeper.
@@ -1992,7 +1992,7 @@ public:
 
   const Init *getNewAnonymousName();
 
-  TGTimer &getTimer() const { return *Timer; }
+  TGTimer &getTimer() const { return Timer; }
 
   //===--------------------------------------------------------------------===//
   // High-level helper methods, useful for tablegen backends.
@@ -2028,7 +2028,7 @@ private:
 
   /// The internal uniquer implementation of the RecordKeeper.
   std::unique_ptr<detail::RecordKeeperImpl> Impl;
-  std::unique_ptr<TGTimer> Timer;
+  TGTimer &Timer;
 };
 
 /// Sorting predicate to sort record pointers by name.

--- a/llvm/include/llvm/TableGen/TableGenBackend.h
+++ b/llvm/include/llvm/TableGen/TableGenBackend.h
@@ -53,7 +53,7 @@ bool ApplyCallback(const RecordKeeper &Records, raw_ostream &OS);
 /// emitSourceFileHeader - Output an LLVM style file header to the specified
 /// raw_ostream.
 void emitSourceFileHeader(StringRef Desc, raw_ostream &OS,
-                          const RecordKeeper &Record = RecordKeeper());
+                          const RecordKeeper *Record = nullptr);
 
 } // namespace llvm
 

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -3261,9 +3261,8 @@ void Record::checkUnusedTemplateArgs() {
   }
 }
 
-RecordKeeper::RecordKeeper()
-    : Impl(std::make_unique<detail::RecordKeeperImpl>(*this)),
-      Timer(std::make_unique<TGTimer>()) {}
+RecordKeeper::RecordKeeper(TGTimer &Timer)
+    : Impl(std::make_unique<detail::RecordKeeperImpl>(*this)), Timer(Timer) {}
 
 RecordKeeper::~RecordKeeper() = default;
 

--- a/llvm/lib/TableGen/TableGenBackend.cpp
+++ b/llvm/lib/TableGen/TableGenBackend.cpp
@@ -82,7 +82,7 @@ static void printLine(raw_ostream &OS, const Twine &Prefix, char Fill,
 }
 
 void llvm::emitSourceFileHeader(StringRef Desc, raw_ostream &OS,
-                                const RecordKeeper &Record) {
+                                const RecordKeeper *Record) {
   printLine(OS, "/*===- TableGen'erated file ", '-', "*- C++ -*-===*\\");
   StringRef Prefix("|* ");
   StringRef Suffix(" *|");
@@ -100,9 +100,9 @@ void llvm::emitSourceFileHeader(StringRef Desc, raw_ostream &OS,
             Suffix);
 
   // Print the filename of source file.
-  if (!Record.getInputFilename().empty())
+  if (Record)
     printLine(
-        OS, Prefix + "From: " + sys::path::filename(Record.getInputFilename()),
+        OS, Prefix + "From: " + sys::path::filename(Record->getInputFilename()),
         ' ', Suffix);
   printLine(OS, Prefix, ' ', Suffix);
   printLine(OS, "\\*===", '-', "===*/");

--- a/llvm/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/AsmMatcherEmitter.cpp
@@ -3243,7 +3243,7 @@ void AsmMatcherEmitter::run(raw_ostream &OS) {
   const Record *AsmParser = Target.getAsmParser();
   StringRef ClassName = AsmParser->getValueAsString("AsmParserClassName");
 
-  emitSourceFileHeader("Assembly Matcher Source Fragment", OS, Records);
+  emitSourceFileHeader("Assembly Matcher Source Fragment", OS, &Records);
 
   // Compute the information on the instructions to match.
   AsmMatcherInfo Info(AsmParser, Target, Records);

--- a/llvm/utils/TableGen/AsmWriterEmitter.cpp
+++ b/llvm/utils/TableGen/AsmWriterEmitter.cpp
@@ -1331,7 +1331,7 @@ void AsmWriterEmitter::run(raw_ostream &O) {
   std::vector<std::vector<std::string>> TableDrivenOperandPrinters;
   unsigned BitsLeft = 0;
   unsigned AsmStrBits = 0;
-  emitSourceFileHeader("Assembly Writer Source Fragment", O, Records);
+  emitSourceFileHeader("Assembly Writer Source Fragment", O, &Records);
   EmitGetMnemonic(O, TableDrivenOperandPrinters, BitsLeft, AsmStrBits);
   EmitPrintInstruction(O, TableDrivenOperandPrinters, BitsLeft, AsmStrBits);
   EmitGetRegisterName(O);

--- a/llvm/utils/TableGen/Basic/VTEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/VTEmitter.cpp
@@ -87,7 +87,7 @@ static void vTtoGetLlvmTyString(raw_ostream &OS, const Record *VT) {
 }
 
 void VTEmitter::run(raw_ostream &OS) {
-  emitSourceFileHeader("ValueTypes Source Fragment", OS, Records);
+  emitSourceFileHeader("ValueTypes Source Fragment", OS, &Records);
 
   std::vector<const Record *> VTsByNumber{512};
   for (auto *VT : Records.getAllDerivedDefinitions("ValueType")) {

--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -906,7 +906,7 @@ void CompressInstEmitter::run(raw_ostream &OS) {
     evaluateCompressPat(Pat);
 
   // Emit file header.
-  emitSourceFileHeader("Compress instruction Source Fragment", OS, Records);
+  emitSourceFileHeader("Compress instruction Source Fragment", OS, &Records);
   // Generate compressInst() function.
   emitCompressInstEmitter(OS, EmitterType::Compress);
   // Generate uncompressInst() function.

--- a/llvm/utils/TableGen/SDNodeInfoEmitter.cpp
+++ b/llvm/utils/TableGen/SDNodeInfoEmitter.cpp
@@ -352,7 +352,7 @@ void SDNodeInfoEmitter::emitDescs(raw_ostream &OS) const {
 }
 
 void SDNodeInfoEmitter::run(raw_ostream &OS) const {
-  emitSourceFileHeader("Target SDNode descriptions", OS, RK);
+  emitSourceFileHeader("Target SDNode descriptions", OS, &RK);
   emitEnum(OS);
   emitDescs(OS);
 }


### PR DESCRIPTION
When -write-if-changed is being used, this frees all data used by the
parser and RecordKeeper before reading any existing output file into a
memory buffer. This can reduce peak memory usage for the process.

I ran TableGen on `AMDGPU.td` and measured the peak memory usage with
`/usr/bin/time -v`. This patch reduced it from 1740 MiB to 1720 MiB.
