### PR TITLE
[clang][Modules] Raise empty.modulemap expected size to <70KB to fix RISC-V failure

### DIFF
--- a/clang/test/Modules/empty.modulemap
+++ b/clang/test/Modules/empty.modulemap
@@ -13,8 +13,8 @@
 // The module file should be identical each time we produce it.
 // RUN: diff %t/base.pcm %t/check.pcm
 //
-// We expect an empty module to be less than 60KB (and at least 10K, for now).
+// We expect an empty module to be less than 70KB (and at least 10K, for now).
 // RUN: wc -c %t/base.pcm | FileCheck --check-prefix=CHECK-SIZE %s
-// CHECK-SIZE: {{(^|[^0-9])[1-5][0-9][0-9][0-9][0-9]($|[^0-9])}}
+// CHECK-SIZE: {{(^|[^0-9])[1-6][0-9][0-9][0-9][0-9]($|[^0-9])}}
 
 module empty { header "Inputs/empty.h" export * }


### PR DESCRIPTION
I'm not sure why the test is larger for RISC-V than other targets, but we saw this before with #111360.

The file is just over the current 60KB limit:

```
62772 /home/asb/llvm-project/build/stage2/tools/clang/test/Modules/Output/empty.modulemap.tmp/base.pcm
```