### PR TITLE
[Flang] Implicitly add clang if flang enabled.

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -146,7 +146,8 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
   endif()
 
   if (NOT "clang" IN_LIST LLVM_ENABLE_PROJECTS)
-    message(FATAL_ERROR "Clang is not enabled, but is required for the Flang driver")
+    message(STATUS "Enabling clang as a dependency to flang")
+    list(APPEND LLVM_ENABLE_PROJECTS "clang")
   endif()
 endif()
 


### PR DESCRIPTION
Clang is required to compile Flang. Instead of erroring-out if Clang is enabled, for convinience implicitly add it to `LLVM_ENABLE_PROJECTS`, consistent with how the MLIR dependency is handled.

This is mainly intended as a discussion about whether `LLVM_ENABLE_RUNTIMES=flang-rt` (#110217) is to be enabled implicitly as well (https://discourse.llvm.org/t/buildbot-changes-with-llvm-enable-runtimes-flang-rt/83571/2). If yes, not implicitly enabling Clang would be inconsistent with how the MLIR and flang-rt dependency are enforced.

I'd prefer to not do so implicitly:

 * LLVM_ENABLE_PROJECTS and LLVM_ENABLE_RUNTIMES are user-controlled. Overwriting them takes away from their decision. I  would expect to have only those projects/runtimes to be built that I have specified.

 * The global variable LLVM_ENABLE_PROJECTS and the CMakeCache.txt entry for LLVM_ENABLE_PROJECTS are different entities. How it is implemented, the global LLVM_ENABLE_PROJECTS shadows the cache entry, so they have two different values. This adds to confusion. Overwriting the cache value with `FORCE` option would cause CMake to re-run a second time. Better get it right the first time.

 * The buildbots use the settings `depends_on_projects=[..]` (which the values of `LLVM_ENABLE_PROJECTS` and `LLVM_ENABLE_RUNTIMES` is derived from). If `clang`, `mlir`, or `flang-rt` is not specified there, the buildbot will not trigger a rebuild if files in those directories have been changed. 

 * For `LLVM_ENABLE_RUNTIMES`, including flang-rt, it is possible to build the runtime separately/out-of-tree/standalone, or not for the default target for whatever reason, in which case the implicit addition of `LLVM_ENABLE_RUNTIMES=flang-rt` must be again disabled somehow. This adds to the complexity to the build system.

 * `LLVM_ENABLE_PROJECTS=clang` also does not implicitly add any project/runtime that is technically required for a complete toolchain, such as `lld`, `compiler-rt`, `libc`, `libcxx`, `libcxxabi`, `unwind`.