### PR TITLE
[mlir] Add NamedAttribute ctor taking StringRef. NFC.

### DIFF
--- a/mlir/include/mlir/IR/Attributes.h
+++ b/mlir/include/mlir/IR/Attributes.h
@@ -207,6 +207,7 @@ inline ::llvm::hash_code hash_value(Attribute arg) {
 class NamedAttribute {
 public:
   NamedAttribute(StringAttr name, Attribute value);
+  NamedAttribute(StringRef name, Attribute value);
 
   /// Return the name of the attribute.
   StringAttr getName() const;

--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -819,7 +819,9 @@ public:
   }
 
   /// Add an attribute with the specified name.
-  void append(StringRef name, Attribute attr);
+  void append(StringRef name, Attribute attr) {
+    append(NamedAttribute(name, attr));
+  }
 
   /// Add an attribute with the specified name.
   void append(StringAttr name, Attribute attr) {

--- a/mlir/lib/IR/Attributes.cpp
+++ b/mlir/lib/IR/Attributes.cpp
@@ -46,6 +46,12 @@ NamedAttribute::NamedAttribute(StringAttr name, Attribute value)
   assert(!name.empty() && "expected valid attribute name");
 }
 
+NamedAttribute::NamedAttribute(StringRef name, Attribute value) : value(value) {
+  assert(value && "expected valid attribute value");
+  assert(!name.empty() && "expected valid attribute name");
+  this->name = StringAttr::get(value.getContext(), name);
+}
+
 StringAttr NamedAttribute::getName() const {
   return llvm::cast<StringAttr>(name);
 }

--- a/mlir/lib/IR/Builders.cpp
+++ b/mlir/lib/IR/Builders.cpp
@@ -88,7 +88,7 @@ NoneType Builder::getNoneType() { return NoneType::get(context); }
 //===----------------------------------------------------------------------===//
 
 NamedAttribute Builder::getNamedAttr(StringRef name, Attribute val) {
-  return NamedAttribute(getStringAttr(name), val);
+  return NamedAttribute(name, val);
 }
 
 UnitAttr Builder::getUnitAttr() { return UnitAttr::get(context); }

--- a/mlir/lib/IR/OperationSupport.cpp
+++ b/mlir/lib/IR/OperationSupport.cpp
@@ -62,11 +62,6 @@ DictionaryAttr NamedAttrList::getDictionary(MLIRContext *context) const {
   return llvm::cast<DictionaryAttr>(dictionarySorted.getPointer());
 }
 
-/// Add an attribute with the specified name.
-void NamedAttrList::append(StringRef name, Attribute attr) {
-  append(StringAttr::get(attr.getContext(), name), attr);
-}
-
 /// Replaces the attributes with new list of attributes.
 void NamedAttrList::assign(const_iterator inStart, const_iterator inEnd) {
   DictionaryAttr::sort(ArrayRef<NamedAttribute>{inStart, inEnd}, attrs);


### PR DESCRIPTION
This is a small QoL improvement so that we don't have to go through helpers when building `NamedAttribute`s.