### PR TITLE
[SPIR-V] Rename internal command line flags for optimization level and mtriple used when passing options into the translate API call

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -42,8 +42,9 @@ namespace {
 
 // Mimic limited number of command line flags from llc to provide a better
 // user experience when passing options into the translate API call.
-static cl::opt<char> SpvOptLevel(" O", cl::Hidden, cl::Prefix, cl::init('0'));
-static cl::opt<std::string> SpvTargetTriple(" mtriple", cl::Hidden,
+static cl::opt<char> SpvOptLevel("spv_O", cl::Hidden, cl::Prefix,
+                                 cl::init('0'));
+static cl::opt<std::string> SpvTargetTriple("spv_mtriple", cl::Hidden,
                                             cl::init(""));
 
 // Utility to accept options in a command line style.

--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -53,10 +53,8 @@ void parseSPIRVCommandLineOptions(const std::vector<std::string> &Options,
   static constexpr const char *Origin = "SPIRVTranslateModule";
   if (!Options.empty()) {
     std::vector<const char *> Argv(1, Origin);
-    for (const auto &Arg : Options) {
+    for (const auto &Arg : Options)
       Argv.push_back(Arg.c_str());
-      dbgs() << Arg << " ...\n";
-    }
     cl::ParseCommandLineOptions(Argv.size(), Argv.data(), Origin, Errs);
   }
 }

--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -42,10 +42,10 @@ namespace {
 
 // Mimic limited number of command line flags from llc to provide a better
 // user experience when passing options into the translate API call.
-static cl::opt<char> SpvOptLevel("spv_O", cl::Hidden, cl::Prefix,
-                                 cl::init('0'));
-static cl::opt<std::string> SpvTargetTriple("spv_mtriple", cl::Hidden,
-                                            cl::init(""));
+static cl::opt<char> SpirvOptLevel("spirv-O", cl::Hidden, cl::Prefix,
+                                   cl::init('0'));
+static cl::opt<std::string> SpirvTargetTriple("spirv-mtriple", cl::Hidden,
+                                              cl::init(""));
 
 // Utility to accept options in a command line style.
 void parseSPIRVCommandLineOptions(const std::vector<std::string> &Options,
@@ -53,8 +53,10 @@ void parseSPIRVCommandLineOptions(const std::vector<std::string> &Options,
   static constexpr const char *Origin = "SPIRVTranslateModule";
   if (!Options.empty()) {
     std::vector<const char *> Argv(1, Origin);
-    for (const auto &Arg : Options)
+    for (const auto &Arg : Options) {
       Argv.push_back(Arg.c_str());
+      dbgs() << Arg << " ...\n";
+    }
     cl::ParseCommandLineOptions(Argv.size(), Argv.data(), Origin, Errs);
   }
 }
@@ -95,7 +97,7 @@ SPIRVTranslateModule(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   }
 
   llvm::CodeGenOptLevel OLevel;
-  if (auto Level = CodeGenOpt::parseLevel(SpvOptLevel)) {
+  if (auto Level = CodeGenOpt::parseLevel(SpirvOptLevel)) {
     OLevel = *Level;
   } else {
     ErrMsg = "Invalid optimization level!";
@@ -116,9 +118,9 @@ SPIRVTranslateModule(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   // SPIR-V-specific target initialization.
   InitializeSPIRVTarget();
 
-  Triple TargetTriple(SpvTargetTriple.empty()
+  Triple TargetTriple(SpirvTargetTriple.empty()
                           ? M->getTargetTriple()
-                          : Triple::normalize(SpvTargetTriple));
+                          : Triple::normalize(SpirvTargetTriple));
   if (TargetTriple.getTriple().empty()) {
     TargetTriple.setTriple(DefaultTriple);
     M->setTargetTriple(DefaultTriple);

--- a/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
+++ b/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
@@ -80,7 +80,7 @@ TEST_F(SPIRVAPITest, checkTranslateOk) {
   // Those command line arguments that overlap with registered by llc/codegen
   // are to be started with the ' ' symbol.
   std::vector<std::string> SetOfOpts[] = {
-      {}, {"-spv_mtriple=spirv32-unknown-unknown"}};
+      {}, {"--spirv-mtriple=spirv32-unknown-unknown"}};
   for (const auto &Opts : SetOfOpts) {
     for (StringRef &Assembly : Assemblies) {
       std::string Result, Error;
@@ -100,7 +100,7 @@ TEST_F(SPIRVAPITest, checkTranslateError) {
   EXPECT_THAT(Error,
               StartsWith("SPIRVTranslateModule: Unknown command line argument "
                          "'-mtriple=spirv32-unknown-unknown'"));
-  Status = toSpirv(OkAssembly, Result, Error, {}, {"-spv_O 5"});
+  Status = toSpirv(OkAssembly, Result, Error, {}, {"--spirv-O 5"});
   EXPECT_FALSE(Status);
   EXPECT_TRUE(Result.empty());
   EXPECT_EQ(Error, "Invalid optimization level!");

--- a/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
+++ b/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
@@ -80,7 +80,7 @@ TEST_F(SPIRVAPITest, checkTranslateOk) {
   // Those command line arguments that overlap with registered by llc/codegen
   // are to be started with the ' ' symbol.
   std::vector<std::string> SetOfOpts[] = {
-      {}, {"- mtriple=spirv32-unknown-unknown"}};
+      {}, {"-spv_mtriple=spirv32-unknown-unknown"}};
   for (const auto &Opts : SetOfOpts) {
     for (StringRef &Assembly : Assemblies) {
       std::string Result, Error;
@@ -100,7 +100,7 @@ TEST_F(SPIRVAPITest, checkTranslateError) {
   EXPECT_THAT(Error,
               StartsWith("SPIRVTranslateModule: Unknown command line argument "
                          "'-mtriple=spirv32-unknown-unknown'"));
-  Status = toSpirv(OkAssembly, Result, Error, {}, {"- O 5"});
+  Status = toSpirv(OkAssembly, Result, Error, {}, {"-spv_O 5"});
   EXPECT_FALSE(Status);
   EXPECT_TRUE(Result.empty());
   EXPECT_EQ(Error, "Invalid optimization level!");


### PR DESCRIPTION
Rename internal command line flags for optimization level and mtriple used when passing options into the translate API call.