### PR TITLE
[flang] Fold character array constructor with unknown length

### DIFF
--- a/flang/test/Evaluate/bug123766.f90
+++ b/flang/test/Evaluate/bug123766.f90
@@ -1,0 +1,5 @@
+! RUN: %python %S/test_folding.py %s %flang_fc1
+character(10), parameter :: a = '0123456789'
+character(3), parameter :: arr(3) = [(a(1:i), i=1,3)]
+logical, parameter :: test1 = all(arr == ["0", "01", "012"])
+end


### PR DESCRIPTION
When a character array constructor does not have an explicit type with a constant length, the compiler can still fold it if all of its elements are constants.  These array constructors will have been wrapped up in the internal %SET_LENGTH operation, which will determine the final length of the folded value, so use the maximum length of the constant elements as the length of the folded array constructor.

Fixes https://github.com/llvm/llvm-project/issues/123766.