### PR TITLE
[HLSL] Define the HLSLRootSignature Attr

### DIFF
--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -26,6 +26,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Support/Compiler.h"
 #include "llvm/Frontend/HLSL/HLSLResource.h"
+#include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/VersionTuple.h"

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4643,6 +4643,26 @@ def Error : InheritableAttr {
   let Documentation = [ErrorAttrDocs];
 }
 
+/// HLSL Root Signature Attribute
+def HLSLRootSignature : Attr {
+  /// [RootSignature(Signature)]
+  let Spellings = [Microsoft<"RootSignature">];
+  let Args = [StringArgument<"Signature">];
+  let Subjects = SubjectList<[Function],
+                             ErrorDiag, "'function'">;
+  let LangOpts = [HLSL];
+  let Documentation = [HLSLRootSignatureDocs];
+  let AdditionalMembers = [{
+private:
+  ArrayRef<llvm::hlsl::root_signature::RootElement> RootElements;
+public:
+  void setElements(ArrayRef<llvm::hlsl::root_signature::RootElement> Elements) {
+    RootElements = Elements;
+  }
+  auto getElements() const { return RootElements; }
+}];
+}
+
 def HLSLNumThreads: InheritableAttr {
   let Spellings = [Microsoft<"numthreads">];
   let Args = [IntArgument<"X">, IntArgument<"Y">, IntArgument<"Z">];

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4654,9 +4654,9 @@ def HLSLRootSignature : Attr {
   let Documentation = [HLSLRootSignatureDocs];
   let AdditionalMembers = [{
 private:
-  ArrayRef<llvm::hlsl::root_signature::RootElement> RootElements;
+  ArrayRef<llvm::hlsl::rootsig::RootElement> RootElements;
 public:
-  void setElements(ArrayRef<llvm::hlsl::root_signature::RootElement> Elements) {
+  void setElements(ArrayRef<llvm::hlsl::rootsig::RootElement> Elements) {
     RootElements = Elements;
   }
   auto getElements() const { return RootElements; }

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7783,6 +7783,10 @@ and https://microsoft.github.io/hlsl-specs/proposals/0013-wave-size-range.html
   }];
 }
 
+def HLSLRootSignatureDocs : Documentation {
+  let Category = DocCatUndocumented;
+}
+
 def NumThreadsDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -7784,7 +7784,14 @@ and https://microsoft.github.io/hlsl-specs/proposals/0013-wave-size-range.html
 }
 
 def HLSLRootSignatureDocs : Documentation {
-  let Category = DocCatUndocumented;
+  let Category = DocCatFunction;
+  let Content = [{
+The ``RootSignature`` attribute applies to HLSL entry functions to define what
+types of resources are bound to the graphics pipeline.
+
+For details about the use and specification of Root Signatures please see here:
+https://learn.microsoft.com/en-us/windows/win32/direct3d12/root-signatures
+  }];
 }
 
 def NumThreadsDocs : Documentation {

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -116,6 +116,7 @@ public:
                                        bool IsCompAssign);
   void emitLogicalOperatorFixIt(Expr *LHS, Expr *RHS, BinaryOperatorKind Opc);
 
+  void handleRootSignatureAttr(Decl *D, const ParsedAttr &AL);
   void handleNumThreadsAttr(Decl *D, const ParsedAttr &AL);
   void handleWaveSizeAttr(Decl *D, const ParsedAttr &AL);
   void handleSV_DispatchThreadIDAttr(Decl *D, const ParsedAttr &AL);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7149,6 +7149,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     break;
 
   // HLSL attributes:
+  case ParsedAttr::AT_HLSLRootSignature:
+    S.HLSL().handleRootSignatureAttr(D, AL);
+    break;
   case ParsedAttr::AT_HLSLNumThreads:
     S.HLSL().handleNumThreadsAttr(D, AL);
     break;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -664,21 +664,21 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
   if (Lexer.Lex(Tokens))
     return;
 
-  SmallVector<llvm::hlsl::root_signature::RootElement> Elements;
+  SmallVector<llvm::hlsl::rootsig::RootElement> Elements;
   hlsl::RootSignatureParser Parser(Elements, Tokens,
-                             SemaRef.getPreprocessor().getDiagnostics());
+                                   SemaRef.getPreprocessor().getDiagnostics());
   if (Parser.Parse())
     return;
 
   unsigned N = Elements.size();
-  auto RootElements =
-      MutableArrayRef<llvm::hlsl::root_signature::RootElement>(::new (getASTContext()) llvm::hlsl::root_signature::RootElement[N], N);
+  auto RootElements = MutableArrayRef<llvm::hlsl::rootsig::RootElement>(
+      ::new (getASTContext()) llvm::hlsl::rootsig::RootElement[N], N);
   for (unsigned I = 0; I < N; ++I)
     RootElements[I] = Elements[I];
 
   auto *Result = ::new (getASTContext())
       HLSLRootSignatureAttr(getASTContext(), AL, Signature);
-  Result->setElements(ArrayRef<llvm::hlsl::root_signature::RootElement>(RootElements));
+  Result->setElements(ArrayRef<llvm::hlsl::rootsig::RootElement>(RootElements));
   D->addAttr(Result);
 }
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -650,6 +650,7 @@ void SemaHLSL::emitLogicalOperatorFixIt(Expr *LHS, Expr *RHS,
 
 void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
   using namespace llvm::hlsl::root_signature;
+  using namespace clang::hlsl;
 
   if (AL.getNumArgs() != 1)
     return;
@@ -667,7 +668,8 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
     return;
 
   SmallVector<RootElement> Elements;
-  RootSignatureParser Parser(Elements, Tokens);
+  RootSignatureParser Parser(Elements, Tokens,
+                             SemaRef.getPreprocessor().getDiagnostics());
   if (Parser.Parse())
     return;
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -649,9 +649,6 @@ void SemaHLSL::emitLogicalOperatorFixIt(Expr *LHS, Expr *RHS,
 }
 
 void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
-  using namespace llvm::hlsl::root_signature;
-  using namespace clang::hlsl;
-
   if (AL.getNumArgs() != 1)
     return;
 
@@ -662,26 +659,26 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
   SourceLocation Loc = AL.getArgAsExpr(0)->getExprLoc();
   // FIXME: pass down below to lexer when fp is supported
   // llvm::RoundingMode RM = SemaRef.CurFPFeatures.getRoundingMode();
-  SmallVector<RootSignatureToken> Tokens;
-  RootSignatureLexer Lexer(Signature, Loc, SemaRef.getPreprocessor());
+  SmallVector<hlsl::RootSignatureToken> Tokens;
+  hlsl::RootSignatureLexer Lexer(Signature, Loc, SemaRef.getPreprocessor());
   if (Lexer.Lex(Tokens))
     return;
 
-  SmallVector<RootElement> Elements;
-  RootSignatureParser Parser(Elements, Tokens,
+  SmallVector<llvm::hlsl::root_signature::RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Tokens,
                              SemaRef.getPreprocessor().getDiagnostics());
   if (Parser.Parse())
     return;
 
   unsigned N = Elements.size();
   auto RootElements =
-      MutableArrayRef<RootElement>(::new (getASTContext()) RootElement[N], N);
+      MutableArrayRef<llvm::hlsl::root_signature::RootElement>(::new (getASTContext()) llvm::hlsl::root_signature::RootElement[N], N);
   for (unsigned I = 0; I < N; ++I)
     RootElements[I] = Elements[I];
 
   auto *Result = ::new (getASTContext())
       HLSLRootSignatureAttr(getASTContext(), AL, Signature);
-  Result->setElements(ArrayRef<RootElement>(RootElements));
+  Result->setElements(ArrayRef<llvm::hlsl::root_signature::RootElement>(RootElements));
   D->addAttr(Result);
 }
 

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -649,8 +649,10 @@ void SemaHLSL::emitLogicalOperatorFixIt(Expr *LHS, Expr *RHS,
 }
 
 void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
-  if (AL.getNumArgs() != 1)
+  if (AL.getNumArgs() != 1) {
+    Diag(AL.getLoc(), diag::err_attribute_wrong_number_arguments) << AL << 1;
     return;
+  }
 
   StringRef Signature;
   if (!SemaRef.checkStringLiteralArgumentAttr(AL, 0, Signature))

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -659,13 +659,9 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
   SourceLocation Loc = AL.getArgAsExpr(0)->getExprLoc();
   // FIXME: pass down below to lexer when fp is supported
   // llvm::RoundingMode RM = SemaRef.CurFPFeatures.getRoundingMode();
-  SmallVector<hlsl::RootSignatureToken> Tokens;
   hlsl::RootSignatureLexer Lexer(Signature, Loc, SemaRef.getPreprocessor());
-  if (Lexer.Lex(Tokens))
-    return;
-
   SmallVector<llvm::hlsl::rootsig::RootElement> Elements;
-  hlsl::RootSignatureParser Parser(Elements, Tokens,
+  hlsl::RootSignatureParser Parser(Elements, Lexer,
                                    SemaRef.getPreprocessor().getDiagnostics());
   if (Parser.Parse())
     return;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -659,7 +659,7 @@ void SemaHLSL::handleRootSignatureAttr(Decl *D, const ParsedAttr &AL) {
     return;
 
   SourceLocation Loc = AL.getArgAsExpr(0)->getExprLoc();
-  // FIXME: pass down below to lexer when fp is supported
+  // TODO(#126565): pass down below to lexer when fp is supported
   // llvm::RoundingMode RM = SemaRef.CurFPFeatures.getRoundingMode();
   hlsl::RootSignatureLexer Lexer(Signature, Loc, SemaRef.getPreprocessor());
   SmallVector<llvm::hlsl::rootsig::RootElement> Elements;

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-library -ast-dump \
+// RUN:  -disable-llvm-passes -o - %s | FileCheck %s
+
+// This test ensures that the sample root signature is parsed without error and
+// the Attr AST Node is created succesfully. If an invalid root signature was
+// passed in then we would exit out of Sema before the Attr is created.
+
+#define SampleRS \
+  "DescriptorTable( " \
+  "  CBV(b1), " \
+  "  SRV(t1, numDescriptors = 8, " \
+  "          flags = DESCRIPTORS_VOLATILE), " \
+  "  UAV(u1, numDescriptors = 0, " \
+  "          flags = DESCRIPTORS_VOLATILE) " \
+  "), " \
+  "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+
+// CHECK:      HLSLRootSignatureAttr 0x{{[0-9A-Fa-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}>
+// CHECK-SAME: "DescriptorTable(
+// CHECK-SAME:   CBV(b1),
+// CHECK-SAME:   SRV(t1, numDescriptors = 8,
+// CHECK-SAME:           flags = DESCRIPTORS_VOLATILE),
+// CHECK-SAME:   UAV(u1, numDescriptors = 0,
+// CHECK-SAME:           flags = DESCRIPTORS_VOLATILE)
+// CHECK-SAME: ),
+// CHECK-SAME: DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
+[RootSignature(SampleRS)]
+void main() {}

--- a/clang/test/AST/HLSL/RootSignatures-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignatures-AST.hlsl
@@ -15,7 +15,7 @@
   "), " \
   "DescriptorTable(Sampler(s0, numDescriptors = 4, space = 1))"
 
-// CHECK:      HLSLRootSignatureAttr 0x{{[0-9A-Fa-f]+}} <line:{{[0-9]+}}:{{[0-9]+}}, col:{{[0-9]+}}>
+// CHECK:      HLSLRootSignatureAttr
 // CHECK-SAME: "DescriptorTable(
 // CHECK-SAME:   CBV(b1),
 // CHECK-SAME:   SRV(t1, numDescriptors = 8,

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -1,0 +1,54 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - %s -verify
+
+// This file mirrors the diagnostics testing in ParseHLSLRootSignatureTest.cpp
+// to verify that the correct diagnostics strings are output
+
+// Lexer related tests
+
+#define InvalidToken \
+  "DescriptorTable( " \
+  "  invalid " \
+  ")"
+
+[RootSignature(InvalidToken)] // expected-error {{unable to lex a valid Root Signature token}}
+void bad_root_signature_1() {}
+
+#define InvalidEmptyNumber \
+  "DescriptorTable( " \
+  "  CBV(t32, space = +) " \
+  ")"
+
+[RootSignature(InvalidEmptyNumber)] // expected-error {{expected number literal is not a supported number literal of unsigned integer or integer}}
+void bad_root_signature_2() {}
+
+#define InvalidOverflowNumber \
+  "DescriptorTable( " \
+  "  CBV(t32, space = 98273498327498273487) " \
+  ")"
+
+[RootSignature(InvalidOverflowNumber)] // expected-error {{provided unsigned integer literal '98273498327498273487' that overflows the maximum of 32 bits}}
+void bad_root_signature_3() {}
+
+#define InvalidEOS \
+  "DescriptorTable( "
+
+// Parser related tests
+
+[RootSignature(InvalidEOS)] // expected-error {{unexpected end to token stream}}
+void bad_root_signature_4() {}
+
+#define InvalidTokenKind \
+  "DescriptorTable( " \
+  "  DescriptorTable()" \
+  ")"
+
+[RootSignature(InvalidTokenKind)] // expected-error {{expected the one of the following token kinds 'CBV, SRV, UAV, Sampler'}}
+void bad_root_signature_5() {}
+
+#define InvalidRepeat \
+  "DescriptorTable( " \
+  "  CBV(t0, space = 1, space = 2)" \
+  ")"
+
+[RootSignature(InvalidRepeat)] // expected-error {{specified the same parameter 'space' multiple times}}
+void bad_root_signature_6() {}

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -10,7 +10,7 @@
   "  invalid " \
   ")"
 
-[RootSignature(InvalidToken)] // expected-error {{unable to lex a valid Root Signature token}}
+[RootSignature(InvalidToken)] // expected-error {{expected one of the following token kinds: CBV, SRV, UAV, Sampler}}
 void bad_root_signature_1() {}
 
 #define InvalidEmptyNumber \
@@ -18,7 +18,8 @@ void bad_root_signature_1() {}
   "  CBV(t32, space = +) " \
   ")"
 
-[RootSignature(InvalidEmptyNumber)] // expected-error {{expected number literal is not a supported number literal of unsigned integer or integer}}
+// expected-error@+1 {{expected the following token kind: integer literal}}
+[RootSignature(InvalidEmptyNumber)]
 void bad_root_signature_2() {}
 
 #define InvalidOverflowNumber \
@@ -26,23 +27,25 @@ void bad_root_signature_2() {}
   "  CBV(t32, space = 98273498327498273487) " \
   ")"
 
-[RootSignature(InvalidOverflowNumber)] // expected-error {{provided unsigned integer literal '98273498327498273487' that overflows the maximum of 32 bits}}
+// expected-error@+1 {{integer literal '98273498327498273487' is too large to be represented in a 32-bit integer type}}
+[RootSignature(InvalidOverflowNumber)]
 void bad_root_signature_3() {}
-
-#define InvalidEOS \
-  "DescriptorTable( "
 
 // Parser related tests
 
-[RootSignature(InvalidEOS)] // expected-error {{unexpected end to token stream}}
+#define InvalidEOS \
+  "DescriptorTable( " \
+  "  CBV("
+
+[RootSignature(InvalidEOS)] // expected-error {{expected one of the following token kinds: b register, t register, u register, s register}}
 void bad_root_signature_4() {}
 
 #define InvalidTokenKind \
   "DescriptorTable( " \
-  "  DescriptorTable()" \
+  "  SRV(s0, CBV())" \
   ")"
 
-[RootSignature(InvalidTokenKind)] // expected-error {{expected the one of the following token kinds 'CBV, SRV, UAV, Sampler'}}
+[RootSignature(InvalidTokenKind)] // expected-error {{expected one of the following token kinds: offset, numDescriptors, space, flags}}
 void bad_root_signature_5() {}
 
 #define InvalidRepeat \

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -3,6 +3,11 @@
 // This file mirrors the diagnostics testing in ParseHLSLRootSignatureTest.cpp
 // to verify that the correct diagnostics strings are output
 
+// Attr test
+
+[RootSignature()] // expected-error {{'RootSignature' attribute takes one argument}}
+void bad_root_signature_0() {}
+
 // Lexer related tests
 
 #define InvalidToken \


### PR DESCRIPTION
- Defines HLSLRootSignature Attr in `Attr.td`
- Define and implement handleHLSLRootSignature in `SemaHLSL`
- Adds sample test case to show AST Node is generated in `RootSignatures-AST.hlsl`

This commit will "hook-up" the seperately defined RootSignature parser and invoke it to create the RootElements, then store them on the ASTContext and finally store the reference to the Elements in RootSignatureAttr.

Resolves #119011, there is a follow-up issue to track adding the entire [sample root signature](https://learn.microsoft.com/en-us/windows/win32/direct3d12/specifying-root-signatures-in-hlsl#an-example-hlsl-root-signature) [here](https://github.com/llvm/llvm-project/issues/124595).