### PR TITLE
[ValueTracking] Handle `min/max` when breaking recursive PHI's

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -601,9 +601,9 @@ static void breakSelfRecursivePHI(const Use *U, const PHINode *PHI,
   Value *V;
   // If the Use is a select of this phi, compute analysis on other arm to break
   // recursion.
-  // TODO: Min/Max
   if (match(ValOut, m_Select(m_Value(), m_Specific(PHI), m_Value(V))) ||
-      match(ValOut, m_Select(m_Value(), m_Value(V), m_Specific(PHI))))
+      match(ValOut, m_Select(m_Value(), m_Value(V), m_Specific(PHI))) ||
+      match(ValOut, m_c_MaxOrMin(m_Value(V), m_Specific(PHI))))
     ValOut = V;
 
   // Same for select, if this phi is 2-operand phi, compute analysis on other

--- a/llvm/test/Transforms/InstCombine/known-phi-recurse.ll
+++ b/llvm/test/Transforms/InstCombine/known-phi-recurse.ll
@@ -261,14 +261,11 @@ define i8 @knownbits_umax_select_test() {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
 ; CHECK:       loop:
-; CHECK-NEXT:    [[INDVAR:%.*]] = phi i8 [ 0, [[ENTRY:%.*]] ], [ [[CONTAIN:%.*]], [[LOOP]] ]
 ; CHECK-NEXT:    [[COND0:%.*]] = call i1 @cond()
-; CHECK-NEXT:    [[CONTAIN]] = call i8 @llvm.umax.i8(i8 [[INDVAR]], i8 1)
 ; CHECK-NEXT:    [[COND1:%.*]] = call i1 @cond()
 ; CHECK-NEXT:    br i1 [[COND1]], label [[EXIT:%.*]], label [[LOOP]]
 ; CHECK:       exit:
-; CHECK-NEXT:    [[BOOL:%.*]] = and i8 [[CONTAIN]], 1
-; CHECK-NEXT:    ret i8 [[BOOL]]
+; CHECK-NEXT:    ret i8 1
 ;
 entry:
   br label %loop


### PR DESCRIPTION
Follows the same principal as `select`.
