### PR TITLE
Fix use of `MLIR_SRC_SHARDER_TABLEGEN` when cross compiling

### DIFF
--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -201,7 +201,8 @@ macro(add_tablegen target project)
       STRING "Native TableGen executable. Saves building one when cross-compiling.")
   else()
     # Internal tablegen
-    set(${project}_TABLEGEN "${${project}_TABLEGEN_DEFAULT}")
+    set(${project}_TABLEGEN "${${project}_TABLEGEN_DEFAULT}" CACHE
+      STRING "Native TableGen executable. Saves building one when cross-compiling.")
     set_target_properties(${target} PROPERTIES EXCLUDE_FROM_ALL ON)
   endif()
 


### PR DESCRIPTION
Makes it so that setting `MLIR_SRC_SHARDER_TABLEGEN` works. @chapuni could you please review, see #106918 for further details.

Fixes #106918