### PR TITLE
[flang][OpenMP][NFC] test the current private dealloc runtime calls

### DIFF
--- a/flang/test/Lower/OpenMP/derived-type-allocatable.f90
+++ b/flang/test/Lower/OpenMP/derived-type-allocatable.f90
@@ -24,6 +24,9 @@ contains
 !CHECK-LABEL: omp.private {type = private} @_QMm1Ftest_array_of_allocs
 !CHECK:       fir.call @_FortranAInitializeClone
 !CHECK-NEXT:  omp.yield
+!CHECK:       } dealloc {
+!CHECK:       fir.call @_FortranAAllocatableDeallocate
+!CHECK:       omp.yield
 
 !CHECK-LABEL: omp.private {type = firstprivate} @_QMm1Ftest_array
 !CHECK-NOT:   fir.call @_FortranAInitializeClone


### PR DESCRIPTION
It looks like in most cases we still don't make calls to deallocate allocatable members of derived types which have been privatized.

This is just intended to add a test for the one case where we do, to make sure this doesn't regress with my upcoming changes.