### PR TITLE
[NFC][Index] Disable LSAN on crash recovery tests

### DIFF
--- a/clang/test/Index/crash-recovery-modules.m
+++ b/clang/test/Index/crash-recovery-modules.m
@@ -1,10 +1,12 @@
+// RUN: export LSAN_OPTIONS=detect_leaks=0
+
 // Clear out the module cache entirely, so we start from nothing.
 // RUN: rm -rf %t
 
 // Parse the file, such that building the module will cause Clang to crash.
 // RUN: env CINDEXTEST_FAILONERROR=1 not c-index-test -test-load-source all -fmodules -fmodules-cache-path=%t -Xclang -fdisable-module-hash -I %S/Inputs/Headers -DCRASH %s > /dev/null 2> %t.err
 // RUN: FileCheck < %t.err -check-prefix=CHECK-CRASH %s
-// CHECK-CRASH: crash-recovery-modules.m:16:9:{16:2-16:14}: fatal error: could not build module 'Crash'
+// CHECK-CRASH: crash-recovery-modules.m:[[@LINE+9]]:9:{[[@LINE+9]]:2-[[@LINE+9]]:14}: fatal error: could not build module 'Crash'
 
 // Parse the file again, without crashing, to make sure that
 // subsequent parses do the right thing.


### PR DESCRIPTION
Avoiding leaks in such cases is very hard.

There are similar suppression in other Index tests.
