### PR TITLE
[WebAssembly] Enable Wasm EH features only once

### DIFF
--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -347,6 +347,9 @@ void WebAssembly::addClangTargetOptions(const ArgList &DriverArgs,
   // Bans incompatible options for Wasm EH / SjLj. We don't allow using
   // different modes for EH and SjLj.
   auto BanIncompatibleOptionsForWasmEHSjLj = [&](StringRef CurOption) {
+    static bool HasRun = false;
+    if (HasRun)
+      return;
     if (DriverArgs.hasFlag(options::OPT_mno_exception_handing,
                            options::OPT_mexception_handing, false))
       getDriver().Diag(diag::err_drv_argument_not_allowed_with)
@@ -370,10 +373,14 @@ void WebAssembly::addClangTargetOptions(const ArgList &DriverArgs,
               << CurOption << Option;
       }
     }
+    HasRun = true;
   };
 
   // Enable necessary features for Wasm EH / SjLj in the backend.
   auto EnableFeaturesForWasmEHSjLj = [&]() {
+    static bool HasRun = false;
+    if (HasRun)
+      return;
     CC1Args.push_back("-target-feature");
     CC1Args.push_back("+exception-handling");
     // The standardized Wasm EH spec requires multivalue and reference-types.
@@ -383,6 +390,7 @@ void WebAssembly::addClangTargetOptions(const ArgList &DriverArgs,
     CC1Args.push_back("+reference-types");
     // Backend needs '-exception-model=wasm' to use Wasm EH instructions
     CC1Args.push_back("-exception-model=wasm");
+    HasRun = true;
   };
 
   if (DriverArgs.getLastArg(options::OPT_fwasm_exceptions)) {


### PR DESCRIPTION
 #122466 had an unexpected side effect that, `EnableFeaturesForWasmEHSjLj` and `BanIncompatibleOptionsForWasmEHSjLj` can be called multiple times now, every time a Wasm EH flag (`-fwasm-exceptions`, `-wasm-enable-eh`, `-wasm-enable-sjlj`, ..) was checked and handled. This resulted in unnecessarily adding the same feature-enabling arguments multiple times to the command line, for example, `-target-feature +exception-handling` could be added as many as three times, which didn't cause any errors but unnecessary. Also we ran `BanIncompatibleOptionsForWasmEHSjLj` more than once, which was harmless but unnecessary.

This guards these functions with a static variable so that we only run them once.

This does not add any new tests because honestly I don't see any value of having a test that checks `-target-feature +exception-handling` is only added once...