### PR TITLE
[RISCV] Add RVVConstraint to SiFive custom matrix multiply instructions.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
@@ -210,7 +210,7 @@ let Predicates = [HasVendorXSfvqmaccdod], DecoderNamespace = "XSfvqmaccdod",
 }
 
 let Predicates = [HasVendorXSfvqmaccqoq], DecoderNamespace = "XSfvqmaccqoq",
-    DestEEW = EEWSEWx4, RVVConstraint=VS2Constraint in {
+    DestEEW = EEWSEWx4, RVVConstraint=WidenV in {
   def VQMACCU_4x8x4  : CustomSiFiveVMACC<0b111100, OPMVV, "sf.vqmaccu.4x8x4">;
   def VQMACC_4x8x4   : CustomSiFiveVMACC<0b111101, OPMVV, "sf.vqmacc.4x8x4">;
   def VQMACCUS_4x8x4 : CustomSiFiveVMACC<0b111110, OPMVV, "sf.vqmaccus.4x8x4">;
@@ -218,7 +218,7 @@ let Predicates = [HasVendorXSfvqmaccqoq], DecoderNamespace = "XSfvqmaccqoq",
 }
 
 let Predicates = [HasVendorXSfvfwmaccqqq], DecoderNamespace = "XSfvfwmaccqqq",
-    DestEEW = EEWSEWx2, RVVConstraint=VS2Constraint in {
+    DestEEW = EEWSEWx2, RVVConstraint=WidenV in {
   def VFWMACC_4x4x4 : CustomSiFiveVMACC<0b111100, OPFVV, "sf.vfwmacc.4x4x4">;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
@@ -202,7 +202,7 @@ let Predicates = [HasVendorXSfvcp], mayLoad = 0, mayStore = 0,
 }
 
 let Predicates = [HasVendorXSfvqmaccdod], DecoderNamespace = "XSfvqmaccdod",
-    DestEEW = EEWSEWx4 in {
+    DestEEW = EEWSEWx4, RVVConstraint=VS2Constraint in {
   def VQMACCU_2x8x2  : CustomSiFiveVMACC<0b101100, OPMVV, "sf.vqmaccu.2x8x2">;
   def VQMACC_2x8x2   : CustomSiFiveVMACC<0b101101, OPMVV, "sf.vqmacc.2x8x2">;
   def VQMACCUS_2x8x2 : CustomSiFiveVMACC<0b101110, OPMVV, "sf.vqmaccus.2x8x2">;
@@ -210,7 +210,7 @@ let Predicates = [HasVendorXSfvqmaccdod], DecoderNamespace = "XSfvqmaccdod",
 }
 
 let Predicates = [HasVendorXSfvqmaccqoq], DecoderNamespace = "XSfvqmaccqoq",
-    DestEEW = EEWSEWx4 in {
+    DestEEW = EEWSEWx4, RVVConstraint=VS2Constraint in {
   def VQMACCU_4x8x4  : CustomSiFiveVMACC<0b111100, OPMVV, "sf.vqmaccu.4x8x4">;
   def VQMACC_4x8x4   : CustomSiFiveVMACC<0b111101, OPMVV, "sf.vqmacc.4x8x4">;
   def VQMACCUS_4x8x4 : CustomSiFiveVMACC<0b111110, OPMVV, "sf.vqmaccus.4x8x4">;
@@ -218,7 +218,7 @@ let Predicates = [HasVendorXSfvqmaccqoq], DecoderNamespace = "XSfvqmaccqoq",
 }
 
 let Predicates = [HasVendorXSfvfwmaccqqq], DecoderNamespace = "XSfvfwmaccqqq",
-    DestEEW = EEWSEWx2 in {
+    DestEEW = EEWSEWx2, RVVConstraint=VS2Constraint in {
   def VFWMACC_4x4x4 : CustomSiFiveVMACC<0b111100, OPFVV, "sf.vfwmacc.4x4x4">;
 }
 

--- a/llvm/test/MC/RISCV/rvv/xsfvfwmacc-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/xsfvfwmacc-invalid.s
@@ -4,3 +4,7 @@
 sf.vfwmacc.4x4x4 v8, v8, v20
 # CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
 # CHECK-ERROR-LABEL: sf.vfwmacc.4x4x4 v8, v8, v20{{$}}
+
+sf.vfwmacc.4x4x4 v8, v4, v8
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vfwmacc.4x4x4 v8, v4, v8{{$}}

--- a/llvm/test/MC/RISCV/rvv/xsfvfwmacc-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/xsfvfwmacc-invalid.s
@@ -1,0 +1,6 @@
+# RUN: not llvm-mc -triple=riscv64 -show-encoding -mattr=+v,+xsfvfwmaccqqq %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
+
+sf.vfwmacc.4x4x4 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vfwmacc.4x4x4 v8, v8, v20{{$}}

--- a/llvm/test/MC/RISCV/rvv/xsfvqmacc-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/xsfvqmacc-invalid.s
@@ -32,3 +32,19 @@ sf.vqmaccus.4x8x4 v8, v8, v20
 sf.vqmaccsu.4x8x4 v8, v8, v20
 # CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
 # CHECK-ERROR-LABEL: sf.vqmaccsu.4x8x4 v8, v8, v20
+
+sf.vqmaccu.4x8x4 v8, v4, v8
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccu.4x8x4 v8, v4, v8
+
+sf.vqmacc.4x8x4 v8, v4, v8
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmacc.4x8x4 v8, v4, v8
+
+sf.vqmaccus.4x8x4 v8, v4, v8
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccus.4x8x4 v8, v4, v8
+
+sf.vqmaccsu.4x8x4 v8, v4, v8
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccsu.4x8x4 v8, v4, v8

--- a/llvm/test/MC/RISCV/rvv/xsfvqmacc-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/xsfvqmacc-invalid.s
@@ -1,0 +1,34 @@
+# RUN: not llvm-mc -triple=riscv64 -show-encoding -mattr=+v,+xsfvqmaccqoq,+xsfvqmaccdod %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+sf.vqmaccu.2x8x2 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccu.2x8x2 v8, v8, v20
+
+sf.vqmacc.2x8x2 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmacc.2x8x2 v8, v8, v20
+
+sf.vqmaccus.2x8x2 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccus.2x8x2 v8, v8, v20
+
+sf.vqmaccsu.2x8x2 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccsu.2x8x2 v8, v8, v20
+
+sf.vqmaccu.4x8x4 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccu.4x8x4 v8, v8, v20
+
+sf.vqmacc.4x8x4 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmacc.4x8x4 v8, v8, v20
+
+sf.vqmaccus.4x8x4 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccus.4x8x4 v8, v8, v20
+
+sf.vqmaccsu.4x8x4 v8, v8, v20
+# CHECK-ERROR: the destination vector register group cannot overlap the source vector register group{{$}}
+# CHECK-ERROR-LABEL: sf.vqmaccsu.4x8x4 v8, v8, v20


### PR DESCRIPTION
The instructions don't allow the vs1 encoded register to overlap vd. Confusingly these instructions order their operands vd, vs1, vs2 while every other vector instruction is vd, vs2, vs1. So we need to use VS2Constraint for this since it checks the first operand after vd.

2 of the 3 extensions have instruction that produce result with EMUL=2*LMUL. This makes them subject to the widening constraints for vs2. So for these extensions we use WidenV which includes VS2Constraint.
