### PR TITLE
[TableGen] Make sure BitWidth is set even if all instructions are Pseudo or TargetOpcode 

### DIFF
--- a/llvm/test/TableGen/OnlyPseudoInst.td
+++ b/llvm/test/TableGen/OnlyPseudoInst.td
@@ -1,0 +1,25 @@
+
+// RUN: llvm-tblgen -gen-emitter -I %p/../../include %s | \
+// RUN:     FileCheck %s --check-prefix=ENCODER
+
+include "llvm/Target/Target.td"
+
+def archInstrInfo : InstrInfo { }
+
+def arch : Target {
+  let InstructionSet = archInstrInfo;
+}
+
+class PseudoInst<bits<16> Opcode> : Instruction {
+  field bits<16> Inst;
+  let Inst = Opcode;
+  dag OutOperandList = (outs);
+  dag InOperandList =  (ins);
+  let Pattern = [];
+  let isPseudo = 1;
+}
+
+def DummyInst : PseudoInst<0>;
+
+// ENCODER-LABEL:   static const uint64_t InstBits[] = {
+// ENCODER:         UINT64_C(0),

--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -484,7 +484,7 @@ void CodeEmitterGen::run(raw_ostream &O) {
     const CodeGenHwModes &HWM = Target.getHwModes();
     // The set of HwModes used by instruction encodings.
     std::set<unsigned> HwModes;
-    BitWidth = 0;
+    BitWidth = 1;
     for (const CodeGenInstruction *CGI : NumberedInstructions) {
       const Record *R = CGI->TheDef;
       if (R->getValueAsString("Namespace") == "TargetOpcode" ||


### PR DESCRIPTION
## Bug
If all instruction records are TargetOpcode or isPseudo we never grows BitWidth above zero.

## Why
The reason why it is like this is because TargetOpcode do not have an Inst field.

## The problem
That causes a compile error because InstBits is just full of commas with no data in the array.

## Fix
On line 487 Set BitWidth to 1.

fixes #124067