### PR TITLE
[libc] change return type of pthread_setspecific to int in generated header

### DIFF
--- a/libc/include/pthread.yaml
+++ b/libc/include/pthread.yaml
@@ -402,7 +402,7 @@ functions:
   - name: pthread_setspecific
     standards:
       - POSIX
-    return_type: void *
+    return_type: int
     arguments:
       - type: pthread_key_t
       - type: const void *


### PR DESCRIPTION
Fixes: #124032 