### PR TITLE
[clang][test] Add .cuh as a recognized extension for lit test files

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -33,6 +33,7 @@ config.suffixes = [
     ".m",
     ".mm",
     ".cu",
+    ".cuh",
     ".hip",
     ".hlsl",
     ".ll",


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/124079