### PR TITLE
[mlir][scf] scf.for support inline which contains affine map op.

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -133,8 +133,9 @@ def ExecuteRegionOp : SCF_Op<"execute_region", [
 // ForOp
 //===----------------------------------------------------------------------===//
 
-def ForOp : SCF_Op<"for",
-      [AutomaticAllocationScope, DeclareOpInterfaceMethods<LoopLikeOpInterface,
+def ForOp : SCF_Op<"for", [
+  AffineScope, AutomaticAllocationScope,
+  DeclareOpInterfaceMethods<LoopLikeOpInterface,
        ["getInitsMutable", "getLoopResults", "getRegionIterArgs",
         "getLoopInductionVars", "getLoopLowerBounds", "getLoopSteps",
         "getLoopUpperBounds", "getYieldedValuesMutable",


### PR DESCRIPTION
I want inline a call op in a scf.for region.
But there is a affine map in the function.
The inliner don't work because of the affine map.
