### PR TITLE
[ExecutionEngine] Include <map>

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
@@ -13,6 +13,7 @@
 #include "llvm/ExecutionEngine/Orc/Shared/VTuneSharedStructs.h"
 
 #if LLVM_USE_INTEL_JITEVENTS
+#include <map>
 #include "IntelJITEventsWrapper.h"
 #include "ittnotify.h"
 

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/JITLoaderVTune.cpp
@@ -13,9 +13,9 @@
 #include "llvm/ExecutionEngine/Orc/Shared/VTuneSharedStructs.h"
 
 #if LLVM_USE_INTEL_JITEVENTS
-#include <map>
 #include "IntelJITEventsWrapper.h"
 #include "ittnotify.h"
+#include <map>
 
 using namespace llvm;
 using namespace llvm::orc;


### PR DESCRIPTION
This patch reinstates an include of <map>, fixing a build failure
caused by:

  commit 1f4d91ecb8529678a3d3919d7523743bd21942ca
  Author: Kazu Hirata <kazu@google.com>
  Date:   Tue Nov 19 19:41:59 2024 -0800

  [ExecutionEngine] Remove unused includes (NFC) (#116749)
