### PR TITLE
[WPD]Provide branch weight for checking mode.

### DIFF
--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -1225,8 +1225,9 @@ void DevirtModule::applySingleImplDevirt(VTableSlotInfo &SlotInfo,
       // perform a debug trap.
       if (DevirtCheckMode == WPDCheckMode::Trap) {
         auto *Cond = Builder.CreateICmpNE(CB.getCalledOperand(), Callee);
-        Instruction *ThenTerm =
-            SplitBlockAndInsertIfThen(Cond, &CB, /*Unreachable=*/false);
+        Instruction *ThenTerm = SplitBlockAndInsertIfThen(
+            Cond, &CB, /*Unreachable=*/false,
+            MDBuilder(M.getContext()).createUnlikelyBranchWeights());
         Builder.SetInsertPoint(ThenTerm);
         Function *TrapFn =
             Intrinsic::getOrInsertDeclaration(&M, Intrinsic::debugtrap);

--- a/llvm/test/ThinLTO/X86/devirt_check.ll
+++ b/llvm/test/ThinLTO/X86/devirt_check.ll
@@ -58,7 +58,7 @@ entry:
   ; Ensure !prof and !callees metadata for indirect call promotion removed.
   ; TRAP-NOT: prof
   ; TRAP-NOT: callees
-  ; TRAP:   br i1 %.not, label %1, label %0, !prof ![[UNLIKELY:[0-9]+]]
+  ; TRAP:   br i1 %.not, label %1, label %0, !prof ![[PROF:[0-9]+]]
   ; TRAP: 0:
   ; TRAP:   tail call void @llvm.debugtrap()
   ; TRAP:   br label %1
@@ -89,7 +89,7 @@ entry:
 ; CHECK-LABEL:   ret i32
 ; CHECK-LABEL: }
 
-; TRAP: ![[UNLIKELY]] = !{!"branch_weights", i32 1, i32 1048575}
+; TRAP: ![[PROF]] = !{!"branch_weights", i32 1048575, i32 1}
 
 declare i1 @llvm.type.test(i8*, metadata)
 declare void @llvm.assume(i1)

--- a/llvm/test/ThinLTO/X86/devirt_check.ll
+++ b/llvm/test/ThinLTO/X86/devirt_check.ll
@@ -58,7 +58,7 @@ entry:
   ; Ensure !prof and !callees metadata for indirect call promotion removed.
   ; TRAP-NOT: prof
   ; TRAP-NOT: callees
-  ; TRAP:   br i1 %.not, label %1, label %0
+  ; TRAP:   br i1 %.not, label %1, label %0, !prof ![[UNLIKELY:[0-9]+]]
   ; TRAP: 0:
   ; TRAP:   tail call void @llvm.debugtrap()
   ; TRAP:   br label %1
@@ -88,6 +88,8 @@ entry:
 }
 ; CHECK-LABEL:   ret i32
 ; CHECK-LABEL: }
+
+; TRAP: ![[UNLIKELY]] = !{!"branch_weights", i32 1, i32 1048575}
 
 declare i1 @llvm.type.test(i8*, metadata)
 declare void @llvm.assume(i1)


### PR DESCRIPTION
Checking mode aims to help diagnose and confirm undefined behavior. In most cases, source code don't cast pointers between unrelated types for virtual calls, so we expect direct calls in the frequent branch and debug trap in the unlikely branch.

This way, the overhead of checking mode is not higher than an indirect call promotion as long as the callsite doesn't run the debug trap branch.