### PR TITLE
[bazel]Fix bazel build past 2e6cc79f816d942ab09d6a310cd925c1da148aa9

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -5545,10 +5545,22 @@ gentbl_cc_library(
 
 cc_library(
     name = "LLVMIRTransforms",
-    srcs = glob([
-        "lib/Dialect/LLVMIR/Transforms/*.cpp",
-    ]),
-    hdrs = glob(["include/mlir/Dialect/LLVMIR/Transforms/*.h"]),
+    srcs = glob(
+        [
+            "lib/Dialect/LLVMIR/Transforms/*.cpp",
+        ],
+        exclude = ["lib/Dialect/LLVMIR/Transforms/LegalizeForExport.cpp"],
+    ),
+    hdrs = glob(
+        [
+            "include/mlir/Dialect/LLVMIR/Transforms/*.h",
+        ],
+        exclude = [
+            "include/mlir/Dialect/LLVMIR/Transforms/DIExpressionLegalization.h",
+            "include/mlir/Dialect/LLVMIR/Transforms/DIExpressionRewriter.h",
+            "include/mlir/Dialect/LLVMIR/Transforms/LegalizeForExport.h",
+        ],
+    ),
     includes = ["include"],
     deps = [
         ":Analysis",
@@ -5557,6 +5569,7 @@ cc_library(
         ":IR",
         ":InliningUtils",
         ":LLVMDialect",
+        ":LLVMIRTransformsLegalizeForExport",
         ":LLVMPassIncGen",
         ":NVVMDialect",
         ":Pass",
@@ -5564,6 +5577,23 @@ cc_library(
         ":ViewLikeInterface",
         "//llvm:BinaryFormat",
         "//llvm:Support",
+    ],
+)
+
+cc_library(
+    name = "LLVMIRTransformsLegalizeForExport",
+    srcs = ["lib/Dialect/LLVMIR/Transforms/LegalizeForExport.cpp"],
+    hdrs = [
+        "include/mlir/Dialect/LLVMIR/Transforms/DIExpressionLegalization.h",
+        "include/mlir/Dialect/LLVMIR/Transforms/DIExpressionRewriter.h",
+        "include/mlir/Dialect/LLVMIR/Transforms/LegalizeForExport.h",
+    ],
+    includes = ["include"],
+    deps = [
+        ":IR",
+        ":LLVMPassIncGen",
+        ":LLVMDialect",
+        ":Pass",
     ],
 )
 
@@ -6459,6 +6489,7 @@ cc_library(
         ":NVVMOpsIncGen",
         ":SideEffectInterfaces",
         ":Support",
+        ":ToLLVMIRTranslation",
         "//llvm:AsmParser",
         "//llvm:Core",
         "//llvm:Support",
@@ -9212,8 +9243,8 @@ cc_library(
         ":IR",
         ":LLVMConversionIncGen",
         ":LLVMDialect",
-        ":LLVMIRTransforms",
         ":LLVMIntrinsicConversionIncGen",
+        ":LLVMIRTransformsLegalizeForExport",
         ":OpenMPDialect",
         ":Support",
         ":TransformUtils",


### PR DESCRIPTION
Split target under LLVMIR/Transforms to avoid deps loop.