### PR TITLE
[TySan] Added tests for methods of ignoring instrumentation

### DIFF
--- a/compiler-rt/test/tysan/ignorelist.c
+++ b/compiler-rt/test/tysan/ignorelist.c
@@ -1,0 +1,35 @@
+// RUN: %clang_tysan %s -o %t && %run %t 10 >%t.out.0 2>&1
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-BOTH %s < %t.out.0
+// RUN: echo "fun:typeViolationignored" > %tmp
+// RUN: echo "src:*ignorelist.h" > %tmp
+// RUN: %clang_tysan -fsanitize-ignorelist=%tmp %s -o %t && %run %t 10 >%t.out 2>&1
+// RUN: FileCheck --check-prefixes=CHECK-IGNORELIST,CHECK-BOTH %s < %t.out
+
+#include "ignorelist.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+void typeViolationIgnored(float *fPtr) { printf("As int: %d\n", *(int *)fPtr); }
+
+void typeViolation(int *fPtr) { printf("As float: %f\n", *(float *)fPtr); }
+
+int main() {
+  float *f = (float *)malloc(sizeof(float));
+  *f = 413.0f;
+  typeViolationIgnored(f);
+  // CHECK: TypeSanitizer: type-aliasing-violation on address 0x{{.*}}
+  // CHECK-NEXT: READ of size 4 at 0x{{.*}} with type int accesses an existing object of type float
+  // CHECK-IGNORELIST-NOT: TypeSanitizer: type-aliasing-violation on address 0x{{.*}}
+
+  int *i = (int *)malloc(sizeof(int));
+  *i = 612;
+  typeViolation(i);
+  // CHECK-BOTH: TypeSanitizer: type-aliasing-violation on address 0x{{.*}}
+  // CHECK-BOTH: READ of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+
+  typeViolationMultiFile((void *)i);
+  // CHECK: TypeSanitizer: type-aliasing-violation on address 0x{{.*}}
+  // CHECK-IGNORELIST-NOT: TypeSanitizer: type-aliasing-violation on address 0x{{.*}}
+
+  return 0;
+}

--- a/compiler-rt/test/tysan/ignorelist.h
+++ b/compiler-rt/test/tysan/ignorelist.h
@@ -1,0 +1,7 @@
+// Used as part of the ignorelist.c test
+// tests if the "src:" ignorelist directive works
+#include <stdio.h>
+
+void typeViolationMultiFile(void *value) {
+  printf("As long: %ld\n", *(long *)value);
+}

--- a/compiler-rt/test/tysan/preprocessor.c
+++ b/compiler-rt/test/tysan/preprocessor.c
@@ -1,0 +1,30 @@
+// RUN: %clang_tysan -O0 %s -o %t && %run %t >%t.out 2>&1 && FileCheck --check-prefix=CHECK-SANITIZED %s < %t.out
+// RUN: %clang_tysan -DNOSAN -O0 %s -o %t && %run %t >%t.out 2>&1 && FileCheck --check-prefix=CHECK-NOSAN %s < %t.out
+// RUN: %clang -O0 %s -o %t && %run %t >%t.out 2>&1 && FileCheck --check-prefix=CHECK-SIMPLE %s < %t.out
+
+#include <stdio.h>
+
+#if __has_feature(type_sanitizer)
+
+#  ifdef NOSAN
+__attribute__((no_sanitize("type")))
+#  endif
+int main(){
+
+  int value = 42;
+  printf("As float: %f\n", *(float *)&value);
+  // CHECK-SANITIZED: ERROR: TypeSanitizer
+  // CHECK-NOSAN-NOT: ERROR: TypeSanitizer
+
+  return 0;
+}
+
+#else
+
+int main() {
+  printf("Nothing interesting here\n");
+  return 0;
+}
+// CHECK-SIMPLE: Nothing interesting here
+
+#endif


### PR DESCRIPTION
TySan supports some preprocessor checks and ignorelists, but they are currently untested. This PR adds some tests to make sure they all work.

@fhahn @AaronBallman, this is based off the discussion in the documentation PR [#123595]