### PR TITLE
[Clang] Silently ignore unknown warnings in `--warning-suppression-mappings`

### DIFF
--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -547,11 +547,9 @@ void WarningsSpecialCaseList::processSections(DiagnosticsEngine &Diags) {
     StringRef DiagGroup = SectionEntry->getKey();
     if (Diags.getDiagnosticIDs()->getDiagnosticsInGroup(
             WarningFlavor, DiagGroup, GroupDiags)) {
-      StringRef Suggestion =
-          DiagnosticIDs::getNearestOption(WarningFlavor, DiagGroup);
-      Diags.Report(diag::warn_unknown_diag_option)
-          << static_cast<unsigned>(WarningFlavor) << DiagGroup
-          << !Suggestion.empty() << Suggestion;
+      // If a diagnostic group name is unknown, simply ignore the
+      // suppressions. This allows use of a single suppression file on multiple
+      // versions of clang.
       continue;
     }
     for (diag::kind Diag : GroupDiags)

--- a/clang/test/Misc/Inputs/suppression-mapping.txt
+++ b/clang/test/Misc/Inputs/suppression-mapping.txt
@@ -11,3 +11,7 @@ src:*foo/*=emit
 [format=2]
 src:*
 src:*foo/*=emit
+
+# A warning group that clang doesn't know about should be silently ignored.
+[barglegunk]
+src:*

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -319,6 +319,9 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts =
       CreateAndPopulateDiagOpts(Args);
 
+  // The _driver_ (vs cc1) diagnostics engine shouldn't bother to load a suppression file.
+  DiagOpts->DiagnosticSuppressionMappingsFile = "";
+
   TextDiagnosticPrinter *DiagClient
     = new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);
   FixupDiagPrefixExeName(DiagClient, ProgName);

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -319,7 +319,8 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts =
       CreateAndPopulateDiagOpts(Args);
 
-  // The _driver_ (vs cc1) diagnostics engine shouldn't bother to load a suppression file.
+  // The _driver_ (vs cc1) diagnostics engine shouldn't bother to load a
+  // suppression file.
   DiagOpts->DiagnosticSuppressionMappingsFile = "";
 
   TextDiagnosticPrinter *DiagClient

--- a/clang/unittests/Basic/DiagnosticTest.cpp
+++ b/clang/unittests/Basic/DiagnosticTest.cpp
@@ -253,8 +253,7 @@ TEST_F(SuppressionMappingTest, UnknownDiagName) {
   FS->addFile("foo.txt", /*ModificationTime=*/{},
               llvm::MemoryBuffer::getMemBuffer("[non-existing-warning]"));
   clang::ProcessWarningOptions(Diags, Diags.getDiagnosticOptions(), *FS);
-  EXPECT_THAT(diags(), ElementsAre(WithMessage(
-                           "unknown warning option 'non-existing-warning'")));
+  EXPECT_THAT(diags(), IsEmpty());
 }
 
 TEST_F(SuppressionMappingTest, SuppressesGroup) {


### PR DESCRIPTION
This allows the same file to be used on multiple Clang versions, without generating output spam.

Also disable parsing of the suppressions file in the Driver, where it's not needed. This was previously causing the diagnostics to be emitted twice, as the file was being parsed twice.

I'll also note that if we do ever wish to emit non-fatal diagnostics from parsing this file, it'll need more: the code deleted here emitted warnings which were not possible for a user to disable, since the suppression file is parsed _before_ the diagnostic state has been setup.