### PR TITLE
[Nomination] Add HighTec representatives to the Security Group

### DIFF
--- a/llvm/docs/Security.rst
+++ b/llvm/docs/Security.rst
@@ -37,6 +37,7 @@ username for an individual isn't available, the brackets will be empty.
 
 * Abhay Kanhere (Apple) [@AbhayKanhere]
 * Ahmed Bougacha (Apple) [@ahmedbougacha]
+* Andras Gemes (HighTec EDV Systeme) [@gemesa]
 * Artur Pilipenko (Azul Systems Inc) []
 * Boovaragavan Dasarathan (Nvidia) [@mrragava]
 * Dimitry Andric (individual; FreeBSD) [@DimitryAndric]
@@ -44,6 +45,7 @@ username for an individual isn't available, the brackets will be empty.
 * George Burgess IV (Google) [@gburgessiv]
 * Josh Stone (Red Hat; Rust) [@cuviper]
 * Kristof Beyls (ARM) [@kbeyls]
+* Mario Cupelli (HighTec EDV Systeme) [@mariocup]
 * Matthew Riley (Google) [@mmdriley]
 * Matthew Voss (Sony) [@ormris]
 * Nikhil Gupta (Nvidia) []


### PR DESCRIPTION
I would like to nominate Mario Cupelli (@mariocup) and myself to join the LLVM Security Group as representatives (vendor contacts) of [HighTec EDV Systeme](https://github.com/hightec-rt).

Mario is the CTO of HighTec and has a strong background in compiler safety qualification. I am a SW engineer with a focus on cybersecurity and a goal to contribute to the LLVM Security Group.

HighTec collaborates with major silicon vendors and offers safety-qualified C/C++ and Rust compilers based on LLVM. Our active contributions to LLVM include work on the linker and various patches and we are committed to further improving LLVM’s security.

Our motivation for joining the LLVM Security Group is to collaborate with LLVM security experts, stay informed about the latest CVEs in LLVM and meet the cybersecurity requirements of the automotive industry.