### PR TITLE
[C-API] Preserve backwards compatability for LLVMDIBuilderCreateObjectPointerType

### DIFF
--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -870,6 +870,14 @@ LLVMDIBuilderCreateObjCProperty(LLVMDIBuilderRef Builder,
                                 LLVMMetadataRef Ty);
 
 /**
+ * Create a uniqued DIType* clone with FlagObjectPointer.
+ * \param Builder   The DIBuilder.
+ * \param Type      The underlying type to which this pointer points.
+ */
+LLVMMetadataRef LLVMDIBuilderCreateObjectPointerType(LLVMDIBuilderRef Builder,
+                                                     LLVMMetadataRef Type);
+
+/**
  * Create a uniqued DIType* clone with FlagObjectPointer. If \c Implicit
  * is true, then also set FlagArtificial.
  * \param Builder   The DIBuilder.
@@ -877,9 +885,9 @@ LLVMDIBuilderCreateObjCProperty(LLVMDIBuilderRef Builder,
  * \param Implicit  Indicates whether this pointer was implicitly generated
  *                  (i.e., not spelled out in source).
  */
-LLVMMetadataRef LLVMDIBuilderCreateObjectPointerType(LLVMDIBuilderRef Builder,
-                                                     LLVMMetadataRef Type,
-                                                     LLVMBool Implicit);
+LLVMMetadataRef
+LLVMDIBuilderCreateImplicitObjectPointerType(LLVMDIBuilderRef Builder,
+                                             LLVMMetadataRef Type);
 
 /**
  * Create debugging information entry for a qualified

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -1433,10 +1433,16 @@ LLVMDIBuilderCreateObjCProperty(LLVMDIBuilderRef Builder,
 }
 
 LLVMMetadataRef LLVMDIBuilderCreateObjectPointerType(LLVMDIBuilderRef Builder,
-                                                     LLVMMetadataRef Type,
-                                                     LLVMBool Implicit) {
+                                                     LLVMMetadataRef Type) {
   return wrap(unwrap(Builder)->createObjectPointerType(unwrapDI<DIType>(Type),
-                                                       Implicit));
+                                                       /*Implicit=*/false));
+}
+
+LLVMMetadataRef
+LLVMDIBuilderCreateImplicitObjectPointerType(LLVMDIBuilderRef Builder,
+                                             LLVMMetadataRef Type) {
+  return wrap(unwrap(Builder)->createObjectPointerType(unwrapDI<DIType>(Type),
+                                                       /*Implicit=*/true));
 }
 
 LLVMMetadataRef


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/122928 Introduces a change to the C DebugInfo API which breaks compatability with older versions. This patch proposes the same functionality through a new function instead. Another idea is maybe to expose more of the flags here instead of taking a single boolean?

I'm not that familiar with Clang development, but from how things are described in the original patch (and its parent) it seems like it should be an avoidable breakage.

I suppose the same could be said for the OCaml API.