### PR TITLE
[llvm][Docs] Clarify the process for requesting a merge on your behalf

### DIFF
--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -107,11 +107,19 @@ way, in which case you can still get the attention of potential reviewers by CC'
 them in a comment -- just @name them.
 
 If you have received no comments on your patch for a week, you can request a
-review by 'ping'ing the GitHub PR with "Ping". The common courtesy 'ping' rate
+review by 'ping'ing the GitHub PR with "Ping" in a comment. The common courtesy 'ping' rate
 is once a week. Please remember that you are asking for valuable time from
-other professional developers. Finally, if you do not have commit access,
-please let people know during the review and someone should commit it on your
-behalf once it has been accepted.
+other professional developers.
+
+After your PR is approved, ensure that:
+
+  * The PR title and description describe the final changes. These will be used
+    as the title and message of the final squashed commit. The titles or
+    messages of any commits in the PR will **not** be used.
+  * You have set a valid email address in your GitHub account, see :ref:`github-email-address`.
+
+Now you can merge your PR. If you do not have the ability to merge the PR, ask your
+reviewers to merge it on your behalf.
 
 For more information on LLVM's code-review process, please see
 :doc:`CodeReview`.

--- a/llvm/docs/Contributing.rst
+++ b/llvm/docs/Contributing.rst
@@ -114,12 +114,13 @@ other professional developers.
 After your PR is approved, ensure that:
 
   * The PR title and description describe the final changes. These will be used
-    as the title and message of the final squashed commit. The titles or
-    messages of any commits in the PR will **not** be used.
+    as the title and message of the final squashed commit. The titles and
+    messages of commits in the PR will **not** be used.
   * You have set a valid email address in your GitHub account, see :ref:`github-email-address`.
 
 Now you can merge your PR. If you do not have the ability to merge the PR, ask your
-reviewers to merge it on your behalf.
+reviewers to merge it on your behalf. You must do this explicitly, as reviewers'
+default assumption is that you are able to merge your own PR.
 
 For more information on LLVM's code-review process, please see
 :doc:`CodeReview`.

--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -105,10 +105,17 @@ When submitting patches, please do not add confidentiality or non-disclosure
 notices to the patches themselves.  These notices conflict with the LLVM
 licensing terms and may result in your contribution being excluded.
 
+.. _github-email-address:
+
+Email Addresses
+---------------
+
 The LLVM project uses email to communicate to contributors outside of the
 GitHub platform about their past contributions. Primarily, our buildbot
 infrastructure uses emails to contact contributors about build and test
-failures. Therefore, the LLVM community requires contributors to have a public
+failures.
+
+Therefore, the LLVM community requires contributors to have a public
 email address associated with their GitHub commits, so please ensure that "Keep
 my email addresses private" is disabled in your
 `account settings <https://github.com/settings/emails>`_.


### PR DESCRIPTION
This makes it more clear what you the author must do, and what reviewers can expect you to do, before an approved PR can be merged. Spliting out the email bit into a section also means we can link directly to it in discussions.

This relies on one of those parties actually reading this, but I plan to tackle the case where they don't with some new automation.