### PR TITLE
[bazel][NFC] Add td_library for downstream use

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -1267,6 +1267,12 @@ filegroup(
     ]),
 )
 
+td_library(
+    name = "CommonTargetTdFiles",
+    srcs = [":common_target_td_sources"],
+    includes = ["include"],
+)
+
 gentbl(
     name = "ARMTargetParserDefGen",
     tbl_outs = [("-gen-arm-target-def", "include/llvm/TargetParser/ARMTargetParserDef.inc")],


### PR DESCRIPTION
This will allow td_library/gentbl_cc_library in other packages to use these td files.