### PR TITLE
[TableGen] Add a SmallPtrSet to track WriteRes that are referenced by some ReadAdvance. NFC

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -2129,13 +2129,15 @@ void CodeGenSchedModels::addWriteRes(const Record *ProcWriteResDef,
 void CodeGenSchedModels::addReadAdvance(const Record *ProcReadAdvanceDef,
                                         CodeGenProcModel &PM) {
   for (const Record *ValidWrite :
-       ProcReadAdvanceDef->getValueAsListOfDefs("ValidWrites"))
+       ProcReadAdvanceDef->getValueAsListOfDefs("ValidWrites")) {
     if (getSchedRWIdx(ValidWrite, /*IsRead=*/false) == 0)
       PrintFatalError(
           ProcReadAdvanceDef->getLoc(),
           "ReadAdvance referencing a ValidWrite that is not used by "
           "any instruction (" +
               ValidWrite->getName() + ")");
+    PM.ReadOfWriteSet.insert(ValidWrite);
+  }
 
   ConstRecVec &RADefs = PM.ReadAdvanceDefs;
   if (is_contained(RADefs, ProcReadAdvanceDef))
@@ -2173,12 +2175,7 @@ bool CodeGenProcModel::isUnsupported(const CodeGenInstruction &Inst) const {
 }
 
 bool CodeGenProcModel::hasReadOfWrite(const Record *WriteDef) const {
-  for (auto &RADef : ReadAdvanceDefs) {
-    ConstRecVec ValidWrites = RADef->getValueAsListOfDefs("ValidWrites");
-    if (is_contained(ValidWrites, WriteDef))
-      return true;
-  }
-  return false;
+  return ReadOfWriteSet.count(WriteDef) != 0;
 }
 
 #ifndef NDEBUG

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.cpp
@@ -2175,7 +2175,7 @@ bool CodeGenProcModel::isUnsupported(const CodeGenInstruction &Inst) const {
 }
 
 bool CodeGenProcModel::hasReadOfWrite(const Record *WriteDef) const {
-  return ReadOfWriteSet.count(WriteDef) != 0;
+  return ReadOfWriteSet.count(WriteDef);
 }
 
 #ifndef NDEBUG

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/SetTheory.h"
@@ -251,7 +252,7 @@ struct CodeGenProcModel {
   DenseMap<const Record *, const Record *> ReadAdvanceMap;
 
   // Set of WriteRes that are referenced by a ReadAdvance.
-  DenseSet<const Record *> ReadOfWriteSet;
+  SmallPtrSet<const Record *, 8> ReadOfWriteSet;
 
   // Per-operand machine model resources associated with this processor.
   ConstRecVec ProcResourceDefs;

--- a/llvm/utils/TableGen/Common/CodeGenSchedule.h
+++ b/llvm/utils/TableGen/Common/CodeGenSchedule.h
@@ -250,6 +250,9 @@ struct CodeGenProcModel {
   // Map from the ReadType field to the parent ReadAdvance record.
   DenseMap<const Record *, const Record *> ReadAdvanceMap;
 
+  // Set of WriteRes that are referenced by a ReadAdvance.
+  DenseSet<const Record *> ReadOfWriteSet;
+
   // Per-operand machine model resources associated with this processor.
   ConstRecVec ProcResourceDefs;
 


### PR DESCRIPTION
Use this to remove a linear scan from CodeGenProcModel::hasReadOfWrite.

This reduces build time of RISCVGenSubtargetInfo.inc on by machine from ~6 seconds to ~3 seconds.