### PR TITLE
[mlir][PDLL] Allow (and ignore) `-D` tablegen macros.

### DIFF
--- a/mlir/tools/mlir-pdll/mlir-pdll.cpp
+++ b/mlir/tools/mlir-pdll/mlir-pdll.cpp
@@ -167,6 +167,15 @@ int main(int argc, char **argv) {
       "write-if-changed",
       llvm::cl::desc("Only write to the output file if it changed"));
 
+  // `ResetCommandLineParser` at the above unregistered the "D" option
+  // of `llvm-tblgen`, which causes tblgen usage to fail due to
+  // "Unknnown command line argument '-D...`" when a macros name is
+  // present. The following is a workaround to re-register it again.
+  llvm::cl::list<std::string> macroNames(
+      "D",
+      llvm::cl::desc("Name of the macro to be defined -- ignored by mlir-pdll"),
+      llvm::cl::value_desc("macro name"), llvm::cl::Prefix);
+
   llvm::InitLLVM y(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv, "PDLL Frontend");
 


### PR DESCRIPTION
Similar to #91329, `mlir-pdll` is a tool used in tablegen macros that unregisters from common flags, including `-D` macros. Because a macro may be used globally, e.g. configured via `LLVM_TABLEGEN_FLAGS`, we want this tool to just ignore the macro instead of a fatal failure due to the unrecognized flag.