### PR TITLE
[llvm-profdata] Fix detailed summary format on Windows

### DIFF
--- a/llvm/lib/IR/ProfileSummary.cpp
+++ b/llvm/lib/IR/ProfileSummary.cpp
@@ -259,10 +259,11 @@ void ProfileSummary::printSummary(raw_ostream &OS) const {
 void ProfileSummary::printDetailedSummary(raw_ostream &OS) const {
   OS << "Detailed summary:\n";
   for (const auto &Entry : DetailedSummary) {
-    OS << format("%lu blocks (%.2f%%) with count >= %lu account for %0.6g%% of "
-                 "the total counts.\n",
-                 Entry.NumCounts,
-                 NumCounts ? (100.f * Entry.NumCounts / NumCounts) : 0,
-                 Entry.MinCount, 100.f * Entry.Cutoff / Scale);
+    OS << Entry.NumCounts << " blocks "
+       << format("(%.2f%%)",
+                 NumCounts ? (100.f * Entry.NumCounts / NumCounts) : 0)
+       << " with count >= " << Entry.MinCount << " account for "
+       << format("%0.6g", 100.f * Entry.Cutoff / Scale)
+       << "% of the total counts.\n";
   }
 }

--- a/llvm/test/tools/llvm-profdata/general.proftext
+++ b/llvm/test/tools/llvm-profdata/general.proftext
@@ -1,5 +1,3 @@
-# FIXME: Somehow this is failing on windows after https://github.com/llvm/llvm-project/pull/105915
-# XFAIL: system-windows
 # RUN: llvm-profdata merge -sparse=true %s -o %t.profdata
 
 # RUN: llvm-profdata merge -sparse=false %s -o %t.profdata.dense


### PR DESCRIPTION
The detailed summary format was changed in https://github.com/llvm/llvm-project/pull/105915 which broke `llvm/test/tools/llvm-profdata/general.proftext` (XFAILed in https://github.com/llvm/llvm-project/pull/124165). Apparently the behavior of `%lu` is different between Linux and Windows, so I reverted back to using `<<` style formats.