### PR TITLE
[TableGen][Docs] Fix production for ValueList

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -390,8 +390,8 @@ statements, etc. When parsed, these literals are converted to integers.
 A question mark represents an uninitialized value.
 
 .. productionlist::
-   SimpleValue4: "{" [`ValueList`] "}"
-   ValueList: `ValueListNE`
+   SimpleValue4: "{" `ValueList` "}"
+   ValueList: [`ValueListNE`]
    ValueListNE: `Value` ("," `Value`)*
 
 This value represents a sequence of bits, which can be used to initialize a


### PR DESCRIPTION
ValueList (which can be empty) is an optional ValueListNE (which must be
Non Empty).
