### PR TITLE
[GitHub] Add tablegen label for llvm/docs/TableGen/**

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -1035,6 +1035,4 @@ offload:
   - offload/**
 
 tablegen:
-  - llvm/include/TableGen/**
-  - llvm/lib/TableGen/**
-  - llvm/utils/TableGen/**
+  - llvm/**/TableGen/**


### PR DESCRIPTION
The pattern I used will also match:

llvm/test/TableGen/**
llvm/unittests/TableGen/**

ans some directories inside llvm/utils/gn/.
