### PR TITLE
[libc++] Speed-up input_range based operations in vector<bool> 

### DIFF
--- a/libcxx/test/benchmarks/containers/vector_bool_operations.bench.cpp
+++ b/libcxx/test/benchmarks/containers/vector_bool_operations.bench.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "ContainerBenchmarks.h"
+#include "../GenerateInput.h"
+
+using namespace ContainerBenchmarks;
+
+BENCHMARK_CAPTURE(BM_ConstructInputIterIter<std::vector<bool>>, vb, getRandomIntegerInputs<bool>)->Arg(514048);
+BENCHMARK_CAPTURE(BM_ConstructFromInputRange<std::vector<bool>>, vb, getRandomIntegerInputs<bool>)->Arg(514048);
+
+BENCHMARK_CAPTURE(BM_AssignInputIterIter<std::vector<bool>>, vb, getRandomIntegerInputs<bool>)->Arg(514048);
+BENCHMARK_CAPTURE(BM_AssignInputRange<std::vector<bool>>, vb, getRandomIntegerInputs<bool>)->Arg(514048);
+
+BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/containers/vector_operations.bench.cpp
+++ b/libcxx/test/benchmarks/containers/vector_operations.bench.cpp
@@ -78,18 +78,11 @@ BENCHMARK(bm_grow<std::string>);
 BENCHMARK(bm_grow<std::unique_ptr<int>>);
 BENCHMARK(bm_grow<std::deque<int>>);
 
-BENCHMARK_CAPTURE(BM_AssignInputIterIter, vector_int, std::vector<int>{}, getRandomIntegerInputs<int>)
-    ->Args({TestNumInputs, TestNumInputs});
+BENCHMARK_CAPTURE(BM_AssignInputIterIter<std::vector<int>>, vector_int, getRandomIntegerInputs<int>)
+    ->Arg(TestNumInputs);
 
-BENCHMARK_CAPTURE(
-    BM_AssignInputIterIter<32>, vector_string, std::vector<std::string>{}, getRandomStringInputsWithLength)
-    ->Args({TestNumInputs, TestNumInputs});
-
-BENCHMARK_CAPTURE(BM_AssignInputIterIter<100>,
-                  vector_vector_int,
-                  std::vector<std::vector<int>>{},
-                  getRandomIntegerInputsWithLength<int>)
-    ->Args({TestNumInputs, TestNumInputs});
+BENCHMARK_CAPTURE(BM_AssignInputIterIter<std::vector<std::string>>, vector_string, getRandomStringInputs)
+    ->Arg(TestNumInputs);
 
 BENCHMARK_CAPTURE(BM_Insert_InputIterIter_NoRealloc, vector_int, std::vector<int>(100, 1), getRandomIntegerInputs<int>)
     ->Arg(514048);

--- a/libcxx/test/std/containers/from_range_helpers.h
+++ b/libcxx/test/std/containers/from_range_helpers.h
@@ -50,6 +50,24 @@ constexpr auto wrap_input(std::vector<T>& input) {
   return std::ranges::subrange(std::move(b), std::move(e));
 }
 
+template <class It>
+class input_only_range {
+public:
+  using Iter = cpp20_input_iterator<It>;
+  using Sent = sentinel_wrapper<Iter>;
+
+  input_only_range(It begin, It end) : begin_(std::move(begin)), end_(std::move(end)) {}
+  Iter begin() { return Iter(std::move(begin_)); }
+  Sent end() { return Sent(Iter(std::move(end_))); }
+
+private:
+  It begin_;
+  It end_;
+};
+
+template <class It>
+input_only_range(It, It) -> input_only_range<It>;
+
 struct KeyValue {
   int key; // Only the key is considered for equality comparison.
   char value; // Allows distinguishing equivalent instances.


### PR DESCRIPTION
This PR complements the optimizations for forward (or higher) range in #120134 by extending the improvements to  **input-only** and **unsized** range for range-based operations in `vector<bool>`. The improvement is based on the same optimization techniques as in #120134: Instead of processing individual bits as in the previous implementation, the new implementation first collects bits into full storage words and then processes entire words. 

The optimizations result in performance improvements of up to 5.5x for assignment functions with `input_{range, iterator}` inputs and up to 1.9x for constructors with `input_{range, iterator}` inputs.

| Operation                          |  Signature                                          | Improvement |
|----------------------------------------|-----------------------------------------------------------|-------------|
| input_range assignment | `assign_range(R&& rg)`                                   | **5.5x**    |
| input_iterator-pair assignment  | `assign(InputIt first, InputIt last)`                   | **5.1x**    |
| input_range constructors                | `vector(std::from_range_t, R&& rg, const Allocator& alloc)` | **1.9x**    |
| input_iterator-pair constructors        | `vector(InputIt first, InputIt last, const Allocator& alloc)` | **1.9x**    |



#### Before:
```
--------------------------------------------------------------------------------------------------
Benchmark                                                        Time             CPU   Iterations
--------------------------------------------------------------------------------------------------
BM_ConstructInputIterIter<std::vector<bool>>/vb/514048     4726350 ns      4433882 ns          160
BM_ConstructFromInputRange<std::vector<bool>>/vb/514048    4824221 ns      4453109 ns          161
BM_AssignInputIterIter<std::vector<bool>>/vb/514048        2509647 ns      2316606 ns          302
BM_AssignInputRange<std::vector<bool>>/vb/514048           2604604 ns      2445725 ns          257
```

#### After:
```
--------------------------------------------------------------------------------------------------
Benchmark                                                        Time             CPU   Iterations
--------------------------------------------------------------------------------------------------
BM_ConstructInputIterIter<std::vector<bool>>/vb/514048     2533024 ns      2522681 ns          281
BM_ConstructFromInputRange<std::vector<bool>>/vb/514048    2551838 ns      2551748 ns          269
BM_AssignInputIterIter<std::vector<bool>>/vb/514048         490259 ns       485889 ns         1177
BM_AssignInputRange<std::vector<bool>>/vb/514048            475265 ns       469883 ns         1514
```

Note: The constructors exhibit less performance improvement compared to the assignment functions due to slow reallocation operations with unsized `input_range`s or `input_iterator-pair` inputs, which slightly offset the optimization benefits.