### PR TITLE
[llvm][NFC] Remove CV-qualified base class in PassManagerInternal.h

### DIFF
--- a/llvm/include/llvm/IR/PassManagerInternal.h
+++ b/llvm/include/llvm/IR/PassManagerInternal.h
@@ -22,8 +22,8 @@
 #include "llvm/IR/Analysis.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
 namespace llvm {
 

--- a/llvm/include/llvm/IR/PassManagerInternal.h
+++ b/llvm/include/llvm/IR/PassManagerInternal.h
@@ -23,6 +23,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
 #include <utility>
+#include <type_traits>
 
 namespace llvm {
 
@@ -167,7 +168,7 @@ template <typename IRUnitT, typename ResultT> class ResultHasInvalidateMethod {
   // ambiguous if there were an invalidate member in the result type.
   template <typename T, typename U> static DisabledType NonceFunction(T U::*);
   struct CheckerBase { int invalidate; };
-  template <typename T> struct Checker : CheckerBase, T {};
+  template <typename T> struct Checker : CheckerBase, std::remove_cv_t<T> {};
   template <typename T>
   static decltype(NonceFunction(&Checker<T>::invalidate)) check(rank<1>);
 


### PR DESCRIPTION
This resolves the `-Wignored-qualifiers` warning introduced by the new warnign in https://github.com/llvm/llvm-project/pull/121419. First caught in buildbot `ppc64le-lld-multistage-test`

https://lab.llvm.org/buildbot/#/builders/168/builds/7756