### PR TITLE
[libc] Use -fno-math-errno to for __builtin_fma* to generate fma instructions.

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -28,6 +28,13 @@ function(_get_compile_options_from_flags output_var)
       elseif(LIBC_TARGET_ARCHITECTURE_IS_RISCV64)
         list(APPEND compile_options "-D__LIBC_RISCV_USE_FMA")
       endif()
+      # For clang, we will build the math functions with `-fno-math-errno` so that
+      # __builtin_fma* will generate the fused-mutliply-add instructions.  We
+      # don't put the control flag to the public config yet, and see if it makes
+      # sense to just enable this flag by default.
+      if(LIBC_ADD_FNO_MATH_ERRNO)
+        list(APPEND compile_options "-fno-math-errno")
+      endif()
     endif()
     if(ADD_ROUND_OPT_FLAG)
       if(LIBC_TARGET_ARCHITECTURE_IS_X86_64)

--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -1,6 +1,11 @@
 function(_get_common_test_compile_options output_var c_test flags)
   _get_compile_options_from_flags(compile_flags ${flags})
 
+  # Remove -fno-math-errno if it was added.
+  if(LIBC_ADD_FNO_MATH_ERRNO)
+    list(REMOVE_ITEM compile_options "-fno-math-errno")
+  endif()
+
   set(compile_options
       ${LIBC_COMPILE_OPTIONS_DEFAULT}
       ${LIBC_TEST_COMPILE_OPTIONS_DEFAULT}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/123387