### PR TITLE
[SandboxVec][Scheduler] Fix clear() to clear all state

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -417,6 +417,13 @@ public:
     DAGInterval = {};
   }
 #ifndef NDEBUG
+  /// \Returns true if the DAG's state is clear. Used in assertions.
+  bool empty() const {
+    bool IsEmpty = InstrToNodeMap.empty();
+    assert(IsEmpty == DAGInterval.empty() &&
+           "Interval and InstrToNodeMap out of sync!");
+    return IsEmpty;
+  }
   void print(raw_ostream &OS) const;
   LLVM_DUMP_METHOD void dump() const;
 #endif // NDEBUG

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -164,7 +164,10 @@ public:
     Bndls.clear();
     // TODO: clear view once it lands.
     DAG.clear();
+    ReadyList.clear();
     ScheduleTopItOpt = std::nullopt;
+    assert(Bndls.empty() && DAG.empty() && ReadyList.empty() &&
+           !ScheduleTopItOpt && "Expected empty state!");
   }
 
 #ifndef NDEBUG


### PR DESCRIPTION
This patch fixes the scheduler's clear() function to also clear the ReadyList. Not doing so is a bug and results in crashes when the ReadyList contains stale instructions, because it was never clered.