### PR TITLE
[ConstantMerge] Check local linkage while merging

### DIFF
--- a/llvm/lib/Transforms/IPO/ConstantMerge.cpp
+++ b/llvm/lib/Transforms/IPO/ConstantMerge.cpp
@@ -109,6 +109,8 @@ static CanMerge makeMergeable(GlobalVariable *Old, GlobalVariable *New) {
   assert(!hasMetadataOtherThanDebugLoc(New));
   if (!Old->hasGlobalUnnamedAddr())
     New->setUnnamedAddr(GlobalValue::UnnamedAddr::None);
+  if (Old->hasLocalLinkage() && !New->hasLocalLinkage())
+    return CanMerge::No;
   return CanMerge::Yes;
 }
 


### PR DESCRIPTION
Avoid merging a constant with a local linkage into a constant with a non-local linkage because it might be used in pointer arithmetics like in relative lookup tables, where it uses pointer arithmetics that is only valid with local linkage.