### PR TITLE
[LoopInterchange] Hoist isComputableLoopNest() in the control flow

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1766,9 +1766,9 @@ PreservedAnalyses LoopInterchangePass::run(LoopNest &LN,
   }
 
   ORE.emit([&]() {
-    return OptimizationRemark(DEBUG_TYPE, "Dependence",
-                              LN.getOutermostLoop().getStartLoc(),
-                              LN.getOutermostLoop().getHeader())
+    return OptimizationRemarkAnalysis(DEBUG_TYPE, "Dependence",
+                                      LN.getOutermostLoop().getStartLoc(),
+                                      LN.getOutermostLoop().getHeader())
            << "Computed dependence info, invoking the transform.";
   });
 

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -1759,16 +1759,16 @@ PreservedAnalyses LoopInterchangePass::run(LoopNest &LN,
   // Ensure minimum depth of the loop nest to do the interchange.
   if (!hasSupportedLoopDepth(LoopList, ORE))
     return PreservedAnalyses::all();
-  
   // Ensure computable loop nest.
   if (!isComputableLoopNest(&AR.SE, LoopList)) {
-      LLVM_DEBUG(dbgs() << "Not valid loop candidate for interchange\n");
-      return PreservedAnalyses::all();
+    LLVM_DEBUG(dbgs() << "Not valid loop candidate for interchange\n");
+    return PreservedAnalyses::all();
   }
 
   ORE.emit([&]() {
     return OptimizationRemark(DEBUG_TYPE, "Dependence",
-                              LN.getOutermostLoop().getStartLoc(), LN.getOutermostLoop().getHeader())
+                              LN.getOutermostLoop().getStartLoc(),
+                              LN.getOutermostLoop().getHeader())
            << "Computed dependence info, invoking the transform.";
   });
 

--- a/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopInterchange.cpp
@@ -277,7 +277,8 @@ static bool hasSupportedLoopDepth(SmallVectorImpl<Loop *> &LoopList,
   return true;
 }
 
-static bool isComputableLoopNest(ScalarEvolution *SE, ArrayRef<Loop *> LoopList) {
+static bool isComputableLoopNest(ScalarEvolution *SE,
+                                 ArrayRef<Loop *> LoopList) {
   for (Loop *L : LoopList) {
     const SCEV *ExitCountOuter = SE->getBackedgeTakenCount(L);
     if (isa<SCEVCouldNotCompute>(ExitCountOuter)) {
@@ -1764,6 +1765,12 @@ PreservedAnalyses LoopInterchangePass::run(LoopNest &LN,
       LLVM_DEBUG(dbgs() << "Not valid loop candidate for interchange\n");
       return PreservedAnalyses::all();
   }
+
+  ORE.emit([&]() {
+    return OptimizationRemark(DEBUG_TYPE, "Dependence",
+                              LN.getOutermostLoop().getStartLoc(), LN.getOutermostLoop().getHeader())
+           << "Computed dependence info, invoking the transform.";
+  });
 
   DependenceInfo DI(&F, &AR.AA, &AR.SE, &AR.LI);
   std::unique_ptr<CacheCost> CC =

--- a/llvm/test/Transforms/LoopInterchange/loop-interchange-optimization-remarks.ll
+++ b/llvm/test/Transforms/LoopInterchange/loop-interchange-optimization-remarks.ll
@@ -58,6 +58,14 @@ for.end19:
   ret void
 }
 
+; CHECK: --- !Passed
+; CHECK-NEXT: Pass:            loop-interchange
+; CHECK-NEXT: Name:            Dependence
+; CHECK-NEXT: Function:        test01
+; CHECK-NEXT: Args:
+; CHECK-NEXT:   - String:          Computed dependence info, invoking the transform.
+; CHECK-NEXT: ...
+
 ; CHECK: --- !Missed
 ; CHECK-NEXT: Pass:            loop-interchange
 ; CHECK-NEXT: Name:            Dependence
@@ -65,6 +73,14 @@ for.end19:
 ; CHECK-NEXT: Args:
 ; CHECK-NEXT:   - String:          Cannot interchange loops due to dependences.
 ; CHECK-NEXT: ...
+
+; DELIN: --- !Passed
+; DELIN-NEXT: Pass:            loop-interchange
+; DELIN-NEXT: Name:            Dependence
+; DELIN-NEXT: Function:        test01
+; DELIN-NEXT: Args:
+; DELIN-NEXT:   - String:          Computed dependence info, invoking the transform.
+; DELIN-NEXT: ...
 
 ; DELIN: --- !Missed
 ; DELIN-NEXT: Pass:            loop-interchange
@@ -118,6 +134,14 @@ define void @test02(i32 %k, i32 %N) {
    ret void
 }
 
+; CHECK: --- !Passed
+; CHECK-NEXT: Pass:            loop-interchange
+; CHECK-NEXT: Name:            Dependence
+; CHECK-NEXT: Function:        test02
+; CHECK-NEXT: Args:
+; CHECK-NEXT:   - String:          Computed dependence info, invoking the transform.
+; CHECK-NEXT: ...
+
 ; CHECK: --- !Missed
 ; CHECK-NEXT: Pass:            loop-interchange
 ; CHECK-NEXT: Name:            Dependence
@@ -125,6 +149,14 @@ define void @test02(i32 %k, i32 %N) {
 ; CHECK-NEXT: Args:
 ; CHECK-NEXT:   - String:          Cannot interchange loops due to dependences.
 ; CHECK-NEXT: ...
+
+; DELIN: --- !Passed
+; DELIN-NEXT: Pass:            loop-interchange
+; DELIN-NEXT: Name:            Dependence
+; DELIN-NEXT: Function:        test02
+; DELIN-NEXT: Args:
+; DELIN-NEXT:   - String:          Computed dependence info, invoking the transform.
+; DELIN-NEXT: ...
 
 ; DELIN: --- !Passed
 ; DELIN-NEXT: Pass:            loop-interchange
@@ -176,11 +208,27 @@ for.body4:                                        ; preds = %for.body4, %for.con
 
 ; CHECK: --- !Passed
 ; CHECK-NEXT: Pass:            loop-interchange
+; CHECK-NEXT: Name:            Dependence
+; CHECK-NEXT: Function:        test03
+; CHECK-NEXT: Args:
+; CHECK-NEXT:   - String:          Computed dependence info, invoking the transform.
+; CHECK-NEXT: ...
+
+; CHECK: --- !Passed
+; CHECK-NEXT: Pass:            loop-interchange
 ; CHECK-NEXT: Name:            Interchanged
 ; CHECK-NEXT: Function:        test03
 ; CHECK-NEXT: Args:
 ; CHECK-NEXT:   - String:          Loop interchanged with enclosing loop.
 ; CHECK-NEXT: ...
+
+; DELIN: --- !Passed
+; DELIN-NEXT: Pass:            loop-interchange
+; DELIN-NEXT: Name:            Dependence
+; DELIN-NEXT: Function:        test03
+; DELIN-NEXT: Args:
+; DELIN-NEXT:   - String:          Computed dependence info, invoking the transform.
+; DELIN-NEXT: ...
 
 ; DELIN: --- !Passed
 ; DELIN-NEXT: Pass:            loop-interchange

--- a/llvm/test/Transforms/LoopInterchange/loop-interchange-optimization-remarks.ll
+++ b/llvm/test/Transforms/LoopInterchange/loop-interchange-optimization-remarks.ll
@@ -58,7 +58,7 @@ for.end19:
   ret void
 }
 
-; CHECK: --- !Passed
+; CHECK: --- !Analysis
 ; CHECK-NEXT: Pass:            loop-interchange
 ; CHECK-NEXT: Name:            Dependence
 ; CHECK-NEXT: Function:        test01
@@ -74,7 +74,7 @@ for.end19:
 ; CHECK-NEXT:   - String:          Cannot interchange loops due to dependences.
 ; CHECK-NEXT: ...
 
-; DELIN: --- !Passed
+; DELIN: --- !Analysis
 ; DELIN-NEXT: Pass:            loop-interchange
 ; DELIN-NEXT: Name:            Dependence
 ; DELIN-NEXT: Function:        test01
@@ -134,7 +134,7 @@ define void @test02(i32 %k, i32 %N) {
    ret void
 }
 
-; CHECK: --- !Passed
+; CHECK: --- !Analysis
 ; CHECK-NEXT: Pass:            loop-interchange
 ; CHECK-NEXT: Name:            Dependence
 ; CHECK-NEXT: Function:        test02
@@ -150,7 +150,7 @@ define void @test02(i32 %k, i32 %N) {
 ; CHECK-NEXT:   - String:          Cannot interchange loops due to dependences.
 ; CHECK-NEXT: ...
 
-; DELIN: --- !Passed
+; DELIN: --- !Analysis
 ; DELIN-NEXT: Pass:            loop-interchange
 ; DELIN-NEXT: Name:            Dependence
 ; DELIN-NEXT: Function:        test02
@@ -206,7 +206,7 @@ for.body4:                                        ; preds = %for.body4, %for.con
   br i1 %exitcond, label %for.body4, label %for.cond.loopexit
 }
 
-; CHECK: --- !Passed
+; CHECK: --- !Analysis
 ; CHECK-NEXT: Pass:            loop-interchange
 ; CHECK-NEXT: Name:            Dependence
 ; CHECK-NEXT: Function:        test03
@@ -222,7 +222,7 @@ for.body4:                                        ; preds = %for.body4, %for.con
 ; CHECK-NEXT:   - String:          Loop interchanged with enclosing loop.
 ; CHECK-NEXT: ...
 
-; DELIN: --- !Passed
+; DELIN: --- !Analysis
 ; DELIN-NEXT: Pass:            loop-interchange
 ; DELIN-NEXT: Name:            Dependence
 ; DELIN-NEXT: Function:        test03

--- a/llvm/test/Transforms/LoopInterchange/no-dependence-info.ll
+++ b/llvm/test/Transforms/LoopInterchange/no-dependence-info.ll
@@ -1,0 +1,107 @@
+; RUN: opt %s -passes='loop-interchange' -pass-remarks=loop-interchange -disable-output 2>&1 | FileCheck --allow-empty %s
+
+target triple = "aarch64-unknown-linux-gnu"
+
+; CHECK-NOT: Computed dependence info, invoking the transform.
+
+define dso_local void @_foo(ptr noundef %a, ptr noundef %neg, ptr noundef %pos) {
+entry:
+  %a.addr = alloca ptr, align 8
+  %neg.addr = alloca ptr, align 8
+  %pos.addr = alloca ptr, align 8
+  %p = alloca i32, align 4
+  %q = alloca i32, align 4
+  %i = alloca i32, align 4
+  %cleanup.dest.slot = alloca i32, align 4
+  %j = alloca i32, align 4
+  store ptr %a, ptr %a.addr, align 8
+  store ptr %neg, ptr %neg.addr, align 8
+  store ptr %pos, ptr %pos.addr, align 8
+  store i32 0, ptr %p, align 4
+  store i32 0, ptr %q, align 4
+  store i32 0, ptr %i, align 4
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.inc16, %entry
+  %0 = load i32, ptr %i, align 4
+  %cmp = icmp slt i32 %0, 32
+  br i1 %cmp, label %for.body, label %for.cond.cleanup
+
+for.cond.cleanup:                                 ; preds = %for.cond
+  store i32 2, ptr %cleanup.dest.slot, align 4
+  br label %for.end18
+
+for.body:                                         ; preds = %for.cond
+  store i32 0, ptr %j, align 4
+  br label %for.cond1
+
+for.cond1:                                        ; preds = %for.inc, %for.body
+  %1 = load i32, ptr %j, align 4
+  %cmp2 = icmp slt i32 %1, 32
+  br i1 %cmp2, label %for.body4, label %for.cond.cleanup3
+
+for.cond.cleanup3:                                ; preds = %for.cond1
+  store i32 5, ptr %cleanup.dest.slot, align 4
+  br label %for.end
+
+for.body4:                                        ; preds = %for.cond1
+  %2 = load ptr, ptr %a.addr, align 8
+  %3 = load i32, ptr %i, align 4
+  %idxprom = sext i32 %3 to i64
+  %arrayidx = getelementptr inbounds i32, ptr %2, i64 %idxprom
+  %4 = load i32, ptr %arrayidx, align 4
+  %cmp5 = icmp slt i32 %4, 0
+  br i1 %cmp5, label %if.then, label %if.else
+
+if.then:                                          ; preds = %for.body4
+  %5 = load ptr, ptr %a.addr, align 8
+  %6 = load i32, ptr %i, align 4
+  %idxprom6 = sext i32 %6 to i64
+  %arrayidx7 = getelementptr inbounds i32, ptr %5, i64 %idxprom6
+  %7 = load i32, ptr %arrayidx7, align 4
+  %8 = load ptr, ptr %neg.addr, align 8
+  %9 = load i32, ptr %p, align 4
+  %inc = add nsw i32 %9, 1
+  store i32 %inc, ptr %p, align 4
+  %idxprom8 = sext i32 %9 to i64
+  %arrayidx9 = getelementptr inbounds i32, ptr %8, i64 %idxprom8
+  store i32 %7, ptr %arrayidx9, align 4
+  br label %if.end
+
+if.else:                                          ; preds = %for.body4
+  %10 = load ptr, ptr %a.addr, align 8
+  %11 = load i32, ptr %i, align 4
+  %idxprom10 = sext i32 %11 to i64
+  %arrayidx11 = getelementptr inbounds i32, ptr %10, i64 %idxprom10
+  %12 = load i32, ptr %arrayidx11, align 4
+  %13 = load ptr, ptr %pos.addr, align 8
+  %14 = load i32, ptr %q, align 4
+  %inc12 = add nsw i32 %14, 1
+  store i32 %inc12, ptr %q, align 4
+  %idxprom13 = sext i32 %14 to i64
+  %arrayidx14 = getelementptr inbounds i32, ptr %13, i64 %idxprom13
+  store i32 %12, ptr %arrayidx14, align 4
+  br label %if.end
+
+if.end:                                           ; preds = %if.else, %if.then
+  br label %for.inc
+
+for.inc:                                          ; preds = %if.end
+  %15 = load i32, ptr %j, align 4
+  %inc15 = add nsw i32 %15, 1
+  store i32 %inc15, ptr %j, align 4
+  br label %for.cond1
+
+for.end:                                          ; preds = %for.cond.cleanup3
+  br label %for.inc16
+
+for.inc16:                                        ; preds = %for.end
+  %16 = load i32, ptr %i, align 4
+  %inc17 = add nsw i32 %16, 1
+  store i32 %inc17, ptr %i, align 4
+  br label %for.cond
+
+for.end18:                                        ; preds = %for.cond.cleanup
+  ret void
+}
+

--- a/llvm/test/Transforms/LoopInterchange/no-dependence-info.ll
+++ b/llvm/test/Transforms/LoopInterchange/no-dependence-info.ll
@@ -2,6 +2,24 @@
 
 target triple = "aarch64-unknown-linux-gnu"
 
+; For the below test, backedge count cannot be computed. 
+; Computing backedge count requires only SCEV and should
+; not require dependence info. 
+;
+; void foo(int *a, int *neg, int *pos) {
+; int p = 0, q = 0;
+; for (unsigned int i = 0; i < 32; ++i) {
+;    for (unsigned int j = 0; j < 32; ++j) {
+;      if (a[i] < 0){
+;        neg[p++] = a[i];
+;      }
+;      else {
+;        pos[q++] = a[i];
+;      }
+;    }
+;  }
+;}
+
 ; CHECK-NOT: Computed dependence info, invoking the transform.
 
 define dso_local void @_foo(ptr noundef %a, ptr noundef %neg, ptr noundef %pos) {

--- a/llvm/test/Transforms/LoopInterchange/no-dependence-info.ll
+++ b/llvm/test/Transforms/LoopInterchange/no-dependence-info.ll
@@ -2,124 +2,51 @@
 
 target triple = "aarch64-unknown-linux-gnu"
 
+; CHECK-NOT: Computed dependence info, invoking the transform.
+
 ; For the below test, backedge count cannot be computed. 
 ; Computing backedge count requires only SCEV and should
 ; not require dependence info. 
 ;
-; void foo(int *a, int *neg, int *pos) {
-; int p = 0, q = 0;
-; for (unsigned int i = 0; i < 32; ++i) {
-;    for (unsigned int j = 0; j < 32; ++j) {
-;      if (a[i] < 0){
-;        neg[p++] = a[i];
-;      }
-;      else {
-;        pos[q++] = a[i];
-;      }
+; void bar(int m, int n) {
+; for (unsigned int i = 0; i < m; ++i) {
+;    for (unsigned int j = 0; j < m; ++j) {
+;     // dummy code
 ;    }
 ;  }
 ;}
 
-; CHECK-NOT: Computed dependence info, invoking the transform.
-
-define dso_local void @_foo(ptr noundef %a, ptr noundef %neg, ptr noundef %pos) {
+define void @bar(i32 %m, i32 %n)
+{
 entry:
-  %a.addr = alloca ptr, align 8
-  %neg.addr = alloca ptr, align 8
-  %pos.addr = alloca ptr, align 8
-  %p = alloca i32, align 4
-  %q = alloca i32, align 4
-  %i = alloca i32, align 4
-  %cleanup.dest.slot = alloca i32, align 4
-  %j = alloca i32, align 4
-  store ptr %a, ptr %a.addr, align 8
-  store ptr %neg, ptr %neg.addr, align 8
-  store ptr %pos, ptr %pos.addr, align 8
-  store i32 0, ptr %p, align 4
-  store i32 0, ptr %q, align 4
-  store i32 0, ptr %i, align 4
-  br label %for.cond
+  br label %outer.header
 
-for.cond:                                         ; preds = %for.inc16, %entry
-  %0 = load i32, ptr %i, align 4
-  %cmp = icmp slt i32 %0, 32
-  br i1 %cmp, label %for.body, label %for.cond.cleanup
+outer.header:
+ %m_temp1 = phi i32 [%m, %entry], [%m_temp, %outer.latch]
+ br label %inner.header
 
-for.cond.cleanup:                                 ; preds = %for.cond
-  store i32 2, ptr %cleanup.dest.slot, align 4
-  br label %for.end18
 
-for.body:                                         ; preds = %for.cond
-  store i32 0, ptr %j, align 4
-  br label %for.cond1
+inner.header:
+ %n_temp1 = phi i32 [%n, %outer.header], [%n_temp, %inner.latch]
 
-for.cond1:                                        ; preds = %for.inc, %for.body
-  %1 = load i32, ptr %j, align 4
-  %cmp2 = icmp slt i32 %1, 32
-  br i1 %cmp2, label %for.body4, label %for.cond.cleanup3
+ br label %body
 
-for.cond.cleanup3:                                ; preds = %for.cond1
-  store i32 5, ptr %cleanup.dest.slot, align 4
-  br label %for.end
+body:
+ ; dummy code
 
-for.body4:                                        ; preds = %for.cond1
-  %2 = load ptr, ptr %a.addr, align 8
-  %3 = load i32, ptr %i, align 4
-  %idxprom = sext i32 %3 to i64
-  %arrayidx = getelementptr inbounds i32, ptr %2, i64 %idxprom
-  %4 = load i32, ptr %arrayidx, align 4
-  %cmp5 = icmp slt i32 %4, 0
-  br i1 %cmp5, label %if.then, label %if.else
+br label %inner.latch 
 
-if.then:                                          ; preds = %for.body4
-  %5 = load ptr, ptr %a.addr, align 8
-  %6 = load i32, ptr %i, align 4
-  %idxprom6 = sext i32 %6 to i64
-  %arrayidx7 = getelementptr inbounds i32, ptr %5, i64 %idxprom6
-  %7 = load i32, ptr %arrayidx7, align 4
-  %8 = load ptr, ptr %neg.addr, align 8
-  %9 = load i32, ptr %p, align 4
-  %inc = add nsw i32 %9, 1
-  store i32 %inc, ptr %p, align 4
-  %idxprom8 = sext i32 %9 to i64
-  %arrayidx9 = getelementptr inbounds i32, ptr %8, i64 %idxprom8
-  store i32 %7, ptr %arrayidx9, align 4
-  br label %if.end
+inner.latch:
+%n_temp = add i32 %n_temp1, 1
+%cmp2 = icmp eq i32 %n_temp, 1 
+br i1 %cmp2, label %outer.latch, label %inner.header
 
-if.else:                                          ; preds = %for.body4
-  %10 = load ptr, ptr %a.addr, align 8
-  %11 = load i32, ptr %i, align 4
-  %idxprom10 = sext i32 %11 to i64
-  %arrayidx11 = getelementptr inbounds i32, ptr %10, i64 %idxprom10
-  %12 = load i32, ptr %arrayidx11, align 4
-  %13 = load ptr, ptr %pos.addr, align 8
-  %14 = load i32, ptr %q, align 4
-  %inc12 = add nsw i32 %14, 1
-  store i32 %inc12, ptr %q, align 4
-  %idxprom13 = sext i32 %14 to i64
-  %arrayidx14 = getelementptr inbounds i32, ptr %13, i64 %idxprom13
-  store i32 %12, ptr %arrayidx14, align 4
-  br label %if.end
+outer.latch:
+%m_temp = add i32 %n, 1
+%cmp3 = icmp eq i32 %m_temp, 1 
+br i1 %cmp3, label %exit, label %outer.header
 
-if.end:                                           ; preds = %if.else, %if.then
-  br label %for.inc
-
-for.inc:                                          ; preds = %if.end
-  %15 = load i32, ptr %j, align 4
-  %inc15 = add nsw i32 %15, 1
-  store i32 %inc15, ptr %j, align 4
-  br label %for.cond1
-
-for.end:                                          ; preds = %for.cond.cleanup3
-  br label %for.inc16
-
-for.inc16:                                        ; preds = %for.end
-  %16 = load i32, ptr %i, align 4
-  %inc17 = add nsw i32 %16, 1
-  store i32 %inc17, ptr %i, align 4
-  br label %for.cond
-
-for.end18:                                        ; preds = %for.cond.cleanup
-  ret void
+exit:
+ret void
 }
 

--- a/llvm/test/Transforms/LoopInterchange/pr43326-ideal-access-pattern.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43326-ideal-access-pattern.ll
@@ -14,7 +14,7 @@
 ;   }
 ; }
 
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        pr43326-triply-nested

--- a/llvm/test/Transforms/LoopInterchange/pr43326-ideal-access-pattern.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43326-ideal-access-pattern.ll
@@ -16,6 +16,14 @@
 
 ; REMARKS: --- !Passed
 ; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        pr43326-triply-nested
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Interchanged
 ; REMARKS-NEXT: Function:        pr43326-triply-nested
 ; REMARKS: --- !Passed

--- a/llvm/test/Transforms/LoopInterchange/pr43326.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43326.ll
@@ -8,7 +8,7 @@
 @d = global i32 0
 @e = global [1 x [1 x i32]] zeroinitializer
 
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        pr43326

--- a/llvm/test/Transforms/LoopInterchange/pr43326.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr43326.ll
@@ -10,6 +10,14 @@
 
 ; REMARKS: --- !Passed
 ; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        pr43326
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Interchanged
 ; REMARKS-NEXT: Function:        pr43326
 

--- a/llvm/test/Transforms/LoopInterchange/pr48212.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr48212.ll
@@ -2,7 +2,7 @@
 ; RUN:     -verify-dom-info -verify-loop-info -verify-loop-lcssa 2>&1
 ; RUN: FileCheck --input-file=%t --check-prefix=REMARKS %s
 
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        pr48212

--- a/llvm/test/Transforms/LoopInterchange/pr48212.ll
+++ b/llvm/test/Transforms/LoopInterchange/pr48212.ll
@@ -4,6 +4,14 @@
 
 ; REMARKS: --- !Passed
 ; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        pr48212
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Interchanged
 ; REMARKS-NEXT: Function:        pr48212
 

--- a/llvm/test/Transforms/LoopInterchange/reductions-across-inner-and-outer-loop.ll
+++ b/llvm/test/Transforms/LoopInterchange/reductions-across-inner-and-outer-loop.ll
@@ -5,7 +5,7 @@
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test1
@@ -85,7 +85,7 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; In this test case, the inner reduction PHI %inner does not involve the outer
 ; reduction PHI %sum.outer, do not interchange.
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test2
@@ -130,7 +130,7 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; Check that we do not interchange if there is an additional instruction
 ; between the outer and inner reduction PHIs.
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test3
@@ -175,7 +175,7 @@ for1.loopexit:                                 ; preds = %for1.inc
 }
 
 ; Check that we do not interchange if reduction is stored in an invariant address inside inner loop
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test4
@@ -222,7 +222,7 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; Check that we do not interchange or crash if the PHI in the outer loop gets a
 ; constant from the inner loop.
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test_constant_inner_loop_res
@@ -269,7 +269,7 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; Floating point reductions are interchanged if all the fp instructions
 ; involved allow reassociation.
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test5
@@ -317,7 +317,7 @@ for.exit:                                         ; preds = %outer.inc
 
 ; Floating point reductions are not interchanged if not all the fp instructions
 ; involved allow reassociation.
-; REMARKS: --- !Passed
+; REMARKS: --- !Analysis
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
 ; REMARKS-NEXT: Function:        test6

--- a/llvm/test/Transforms/LoopInterchange/reductions-across-inner-and-outer-loop.ll
+++ b/llvm/test/Transforms/LoopInterchange/reductions-across-inner-and-outer-loop.ll
@@ -7,6 +7,14 @@ target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
 ; REMARKS: --- !Passed
 ; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test1
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Interchanged
 ; REMARKS-NEXT: Function:        test1
 
@@ -77,6 +85,14 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; In this test case, the inner reduction PHI %inner does not involve the outer
 ; reduction PHI %sum.outer, do not interchange.
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test2
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
 ; REMARKS: --- !Missed
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            UnsupportedPHIOuter
@@ -114,6 +130,14 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; Check that we do not interchange if there is an additional instruction
 ; between the outer and inner reduction PHIs.
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test3
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
 ; REMARKS: --- !Missed
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            UnsupportedPHIOuter
@@ -151,6 +175,14 @@ for1.loopexit:                                 ; preds = %for1.inc
 }
 
 ; Check that we do not interchange if reduction is stored in an invariant address inside inner loop
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test4
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
 ; REMARKS: --- !Missed
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Dependence
@@ -190,6 +222,14 @@ for1.loopexit:                                 ; preds = %for1.inc
 
 ; Check that we do not interchange or crash if the PHI in the outer loop gets a
 ; constant from the inner loop.
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test_constant_inner_loop_res
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
 ; REMARKS: --- !Missed
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            UnsupportedPHIOuter
@@ -231,6 +271,14 @@ for1.loopexit:                                 ; preds = %for1.inc
 ; involved allow reassociation.
 ; REMARKS: --- !Passed
 ; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test5
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            Interchanged
 ; REMARKS-NEXT: Function:        test5
 
@@ -269,6 +317,14 @@ for.exit:                                         ; preds = %outer.inc
 
 ; Floating point reductions are not interchanged if not all the fp instructions
 ; involved allow reassociation.
+; REMARKS: --- !Passed
+; REMARKS-NEXT: Pass:            loop-interchange
+; REMARKS-NEXT: Name:            Dependence
+; REMARKS-NEXT: Function:        test6
+; REMARKS-NEXT: Args:
+; REMARKS-NEXT:   - String:          Computed dependence info, invoking the transform.
+; REMARKS-NEXT: ...
+
 ; REMARKS: --- !Missed
 ; REMARKS-NEXT: Pass:            loop-interchange
 ; REMARKS-NEXT: Name:            UnsupportedPHIOuter


### PR DESCRIPTION
The profiling of the LLVM Test-suite reveals that a significant portion, specifically 14,090 out of 139,323, loop nests were identified as non-viable candidates for transformation, leading to the transform exiting from isComputableLoopNest() without any action.

More importantly, dependence information was computed for these loop nests before reaching the function isComputableLoopNest(), which does not require DI and relies solely on scalar evolution (SE).

To enhance compile-time efficiency, this patch moves the call to isComputableLoopNest() earlier in the control-flow, thereby avoiding unnecessary dependence calculations.

The impact of this change is evident on the compile-time-tracker, with the overall geometric mean improvement recorded at 0.11%, while the lencode benchmark gets a more substantial benefit of 0.44%.
This improvement can be tracked in the isc-ln-exp-2 branch under my repo.