### PR TITLE
[lldb] Remove unused posix_openpt function definition for Android

### DIFF
--- a/lldb/source/Host/common/PseudoTerminal.cpp
+++ b/lldb/source/Host/common/PseudoTerminal.cpp
@@ -27,10 +27,6 @@
 #include <Availability.h>
 #endif
 
-#if defined(__ANDROID__)
-int posix_openpt(int flags);
-#endif
-
 using namespace lldb_private;
 
 // PseudoTerminal constructor


### PR DESCRIPTION
This was for the wrapper function that was in
source/Host/android/LibcGlue.cpp. Android added
support 10+ years ago.