### PR TITLE
SCEV/test: re-org after tracing codepaths

### DIFF
--- a/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
+++ b/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
@@ -416,15 +416,15 @@ define void @swapped_predicate(i32 %n) {
 ; Prove that (n s>= 1) ===> (0 s>= -n / 2).
 ; CHECK-LABEL: 'swapped_predicate'
 ; CHECK-NEXT:  Determining loop execution counts for: @swapped_predicate
-; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nuw><nsw>
+; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nuw><nsw>
+; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: Trip multiple is 1
 ;
 entry:
   %cmp1 = icmp sge i32 %n, 1
   %n.div.2 = sdiv i32 %n, 2
-  call void @llvm.assume(i1 %cmp1)
+  call void(i1, ...) @llvm.experimental.guard(i1 %cmp1) [ "deopt"() ]
   br label %header
 
 header:
@@ -450,7 +450,7 @@ define void @swapped_predicate_neg(i32 %n) {
 entry:
   %cmp1 = icmp sge i32 %n, 1
   %n.div.2 = sdiv i32 %n, 2
-  call void @llvm.assume(i1 %cmp1)
+  call void(i1, ...) @llvm.experimental.guard(i1 %cmp1) [ "deopt"() ]
   br label %header
 
 header:


### PR DESCRIPTION
Follow up on e069518f (SCEV: cover a codepath in isImpliedCondBalancedTypes) to discover that, due to changing a call to llvm.experimental.guard to llvm.assume as requested in the review, the codepath that it promised to cover is no longer covered, as SCEV takes an alternate codepath. Hence, change it back to llvm.experimental.guard, and move the existing test to known-constrange.ll, as it actually covers isKnownPredicateViaConstantRanges. While at it, also notice that 0ab368c (SCEV/test: cover implied-via-addition) does not actually cover any implication-codepaths, and that the tests should be moved to the new known-constrange.ll.

-- 8< --
Sorry for the confusion and mess.