### PR TITLE
[clang][ASTImporter] Import explicit object parameter location

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -4756,6 +4756,15 @@ ExpectedDecl ASTNodeImporter::VisitParmVarDecl(ParmVarDecl *D) {
                               /*DefaultArg*/ nullptr))
     return ToParm;
 
+  if (D->isExplicitObjectParameter()) {
+    auto ToExplicitObjectParameterLoc =
+        importChecked(Err, D->getExplicitObjectParamThisLoc());
+    if (Err)
+      return std::move(Err);
+
+    ToParm->setExplicitObjectParameterLoc(ToExplicitObjectParameterLoc);
+  }
+
   // Set the default argument. It should be no problem if it was already done.
   // Do not import the default expression before GetImportedOrCreateDecl call
   // to avoid possible infinite import loop because circular dependency.

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -4762,7 +4762,7 @@ ExpectedDecl ASTNodeImporter::VisitParmVarDecl(ParmVarDecl *D) {
     if (Err)
       return std::move(Err);
 
-    ToParm->setExplicitObjectParameterLoc(ToExplicitObjectParameterLoc);
+    //ToParm->setExplicitObjectParameterLoc(ToExplicitObjectParameterLoc);
   }
 
   // Set the default argument. It should be no problem if it was already done.

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -3441,6 +3441,7 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportParmVarDecl) {
   ASSERT_TRUE(FromVar);
   ASSERT_TRUE(FromVar->hasUninstantiatedDefaultArg());
   ASSERT_TRUE(FromVar->getUninstantiatedDefaultArg());
+  ASSERT_FALSE(FromVar->isExplicitObjectParameter());
 
   const auto *ToVar = Import(FromVar, Lang_CXX11);
   EXPECT_TRUE(ToVar);
@@ -3448,6 +3449,23 @@ TEST_P(ASTImporterOptionSpecificTestBase, ImportParmVarDecl) {
   EXPECT_TRUE(ToVar->getUninstantiatedDefaultArg());
   EXPECT_NE(FromVar->getUninstantiatedDefaultArg(),
             ToVar->getUninstantiatedDefaultArg());
+  EXPECT_FALSE(ToVar->isExplicitObjectParameter());
+}
+
+TEST_P(ASTImporterOptionSpecificTestBase, ImportParmVarDecl_Explicit) {
+  const auto *Code = R"(
+    struct Wrapper {
+      Wrapper(this Wrapper) {}
+    };
+    )";
+  Decl *FromTU = getTuDecl(Code, Lang_CXX23);
+  auto *FromVar = FirstDeclMatcher<ParmVarDecl>().match(FromTU, parmVarDecl());
+  ASSERT_TRUE(FromVar);
+  ASSERT_TRUE(FromVar->isExplicitObjectParameter());
+
+  const auto *ToVar = Import(FromVar, Lang_CXX23);
+  EXPECT_TRUE(ToVar);
+  EXPECT_TRUE(ToVar->isExplicitObjectParameter());
 }
 
 TEST_P(ASTImporterOptionSpecificTestBase, ImportOfNonEquivalentField) {


### PR DESCRIPTION
Make sure to import the explicit object parameter location for `ParmVarDecl`s. This is how Clang determines whether a parameter `isExplicitObjectParamater`. This will be needed to enable expression evaluation of explicit member functions from LLDB.