### PR TITLE
added option `google-readability-namespace-comments.AllowNoNamespaceComments`

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/NamespaceCommentCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/NamespaceCommentCheck.h
@@ -34,6 +34,7 @@ private:
   llvm::Regex NamespaceCommentPattern;
   const unsigned ShortNamespaceLines;
   const unsigned SpacesBeforeComments;
+  const bool AllowOmittingNamespaceComments;
   llvm::SmallVector<SourceLocation, 4> Ends;
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -187,6 +187,16 @@ Changes in existing checks
   <clang-tidy/checks/concurrency/mt-unsafe>` check by fixing a false positive
   where ``strerror`` was flagged as MT-unsafe.
 
+- Improved :doc:`google-readability-namespace-comments
+  <clang-tidy/checks/google/readability-namespace-comments>` check by adding
+  the option `AllowOmittingNamespaceComments` to accept if a namespace comment
+  is omitted entirely.
+
+- Improved :doc:`llvm-namespace-comment
+  <clang-tidy/checks/llvm/namespace-comment>` check by adding the option
+  `AllowOmittingNamespaceComments` to accept if a namespace comment is omitted
+  entirely.
+
 - Improved :doc:`misc-const-correctness
   <clang-tidy/checks/misc/const-correctness>` check by adding the option
   `AllowedTypes`, that excludes specified types from const-correctness

--- a/clang-tools-extra/docs/clang-tidy/checks/llvm/namespace-comment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/llvm/namespace-comment.rst
@@ -39,3 +39,9 @@ Options
 
    An unsigned integer specifying the number of spaces before the comment
    closing a namespace definition. Default is `1U`.
+
+.. option:: AllowOmittingNamespaceComments
+
+   When `true`, the check will accept if no namespace comment is present.
+   The check will only fail if the specified namespace comment is different
+   than expected. Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-namespace-comments-missing-nested-namespaces.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-namespace-comments-missing-nested-namespaces.cpp
@@ -1,0 +1,32 @@
+// RUN: %check_clang_tidy %s google-readability-namespace-comments %t -std=c++20 \
+// RUN:   '-config={CheckOptions: { \
+// RUN:     google-readability-namespace-comments.AllowOmittingNamespaceComments: true, \
+// RUN:     google-readability-namespace-comments.ShortNamespaceLines: 0, \
+// RUN:   }}'
+
+// accept if namespace comments are fully omitted
+namespace n1::n2 {
+namespace /*comment1*/n3/*comment2*/::/*comment3*/inline/*comment4*/n4/*comment5*/ {
+void f();
+}}
+
+namespace n5::inline n6 {
+void f();
+}
+
+namespace n7::inline n8 {
+void f();
+}
+
+// accept if namespace comments are partly omitted (e.g. only for nested namespace)
+namespace n1::n2 {
+namespace n3::n4 {
+void f();
+}
+} // namespace n1::n2
+
+// fail if namespace comment is different than expected
+namespace n9::inline n10 {
+void f();
+} // namespace n9::n10
+// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: namespace 'n9::inline n10' ends with a comment that refers to a wrong namespace 'n9::n10' [google-readability-namespace-comments]

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-namespace-comments-missing.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-namespace-comments-missing.cpp
@@ -1,0 +1,40 @@
+// RUN: %check_clang_tidy %s google-readability-namespace-comments %t \
+// RUN:   -config='{CheckOptions: { \
+// RUN:     google-readability-namespace-comments.AllowOmittingNamespaceComments: true, \
+// RUN:     google-readability-namespace-comments.ShortNamespaceLines: 0, \
+// RUN:   }}'
+
+// accept if namespace comments are fully omitted
+namespace n1 {
+namespace /* a comment */ n2 /* another comment */ {
+void f();
+}}
+
+#define MACRO macro_expansion
+namespace MACRO {
+void f();
+}
+
+namespace [[deprecated("foo")]] namespace_with_attr {
+inline namespace inline_namespace {
+void f();
+}
+}
+
+namespace [[]] {
+void f();
+}
+
+// accept if namespace comments are partly omitted (e.g. only for nested namespace)
+namespace n3 {
+namespace n4 {
+void f();
+} // n4
+}
+
+// fail if namespace comment is different than expected
+namespace n1 {
+void f();
+} // namespace n2
+// CHECK-MESSAGES: :[[@LINE-1]]:2: warning: namespace 'n1' ends with a comment that refers to a wrong namespace 'n2' [google-readability-namespace-comments]
+


### PR DESCRIPTION
new option AllowNoNamespaceComments for `google-readability-namespace-comments.AllowNoNamespaceComments` is added.

Fixes #124264

When true, the check will allow that no namespace comment is present. If a namespace comment is added but it is not matching, the check will fail. Default is `false`