### PR TITLE
[ValueTracking] Pass changed predicate `SignedLPred` to `isImpliedByMatchingCmp`

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -9494,7 +9494,7 @@ isImpliedCondICmps(const ICmpInst *LHS, CmpPredicate RPred, const Value *R0,
        SignedLPred == ICmpInst::ICMP_SGE) &&
       match(R0, m_NSWSub(m_Specific(L0), m_Specific(L1)))) {
     if (match(R1, m_NonPositive()) &&
-        ICmpInst::isImpliedByMatchingCmp(LPred, RPred) == false)
+        ICmpInst::isImpliedByMatchingCmp(SignedLPred, RPred) == false)
       return false;
   }
 
@@ -9504,7 +9504,7 @@ isImpliedCondICmps(const ICmpInst *LHS, CmpPredicate RPred, const Value *R0,
        SignedLPred == ICmpInst::ICMP_SLE) &&
       match(R0, m_NSWSub(m_Specific(L0), m_Specific(L1)))) {
     if (match(R1, m_NonNegative()) &&
-        ICmpInst::isImpliedByMatchingCmp(LPred, RPred) == true)
+        ICmpInst::isImpliedByMatchingCmp(SignedLPred, RPred) == true)
       return true;
   }
 

--- a/llvm/test/Analysis/ValueTracking/implied-condition-samesign.ll
+++ b/llvm/test/Analysis/ValueTracking/implied-condition-samesign.ll
@@ -292,3 +292,47 @@ taken:
 end:
   ret i32 0
 }
+
+define i1 @gt_sub_nsw_ult(i8 %L0, i8 %L1, i1 %V) {
+; CHECK-LABEL: define i1 @gt_sub_nsw_ult(
+; CHECK-SAME: i8 [[L0:%.*]], i8 [[L1:%.*]], i1 [[V:%.*]]) {
+; CHECK-NEXT:    [[LHS:%.*]] = icmp samesign ugt i8 [[L0]], [[L1]]
+; CHECK-NEXT:    br i1 [[LHS]], label %[[LHS_TRUE:.*]], label %[[LHS_FALSE:.*]]
+; CHECK:       [[LHS_TRUE]]:
+; CHECK-NEXT:    ret i1 false
+; CHECK:       [[LHS_FALSE]]:
+; CHECK-NEXT:    ret i1 [[V]]
+;
+  %LHS = icmp samesign ugt i8 %L0, %L1
+  br i1 %LHS, label %LHS_true, label %LHS_false
+
+LHS_true:
+  %R0 = sub nsw i8 %L0, %L1
+  %RHS = icmp ult i8 %R0, -1
+  ret i1 %RHS
+
+LHS_false:
+  ret i1 %V
+}
+
+define i1 @ul_sub_nsw_ult(i8 %L0, i8 %L1, i1 %V) {
+; CHECK-LABEL: define i1 @ul_sub_nsw_ult(
+; CHECK-SAME: i8 [[L0:%.*]], i8 [[L1:%.*]], i1 [[V:%.*]]) {
+; CHECK-NEXT:    [[LHS:%.*]] = icmp samesign ult i8 [[L0]], [[L1]]
+; CHECK-NEXT:    br i1 [[LHS]], label %[[LHS_TRUE:.*]], label %[[LHS_FALSE:.*]]
+; CHECK:       [[LHS_TRUE]]:
+; CHECK-NEXT:    ret i1 true
+; CHECK:       [[LHS_FALSE]]:
+; CHECK-NEXT:    ret i1 [[V]]
+;
+  %LHS = icmp samesign ult i8 %L0, %L1
+  br i1 %LHS, label %LHS_true, label %LHS_false
+
+LHS_true:
+  %R0 = sub nsw i8 %L0, %L1
+  %RHS = icmp ult i8 %R0, 1
+  ret i1 %RHS
+
+LHS_false:
+  ret i1 %V
+}

--- a/llvm/test/Analysis/ValueTracking/implied-condition-samesign.ll
+++ b/llvm/test/Analysis/ValueTracking/implied-condition-samesign.ll
@@ -299,7 +299,9 @@ define i1 @gt_sub_nsw_ult(i8 %L0, i8 %L1, i1 %V) {
 ; CHECK-NEXT:    [[LHS:%.*]] = icmp samesign ugt i8 [[L0]], [[L1]]
 ; CHECK-NEXT:    br i1 [[LHS]], label %[[LHS_TRUE:.*]], label %[[LHS_FALSE:.*]]
 ; CHECK:       [[LHS_TRUE]]:
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    [[R0:%.*]] = sub nsw i8 [[L0]], [[L1]]
+; CHECK-NEXT:    [[RHS:%.*]] = icmp ult i8 [[R0]], -1
+; CHECK-NEXT:    ret i1 [[RHS]]
 ; CHECK:       [[LHS_FALSE]]:
 ; CHECK-NEXT:    ret i1 [[V]]
 ;
@@ -321,7 +323,9 @@ define i1 @ul_sub_nsw_ult(i8 %L0, i8 %L1, i1 %V) {
 ; CHECK-NEXT:    [[LHS:%.*]] = icmp samesign ult i8 [[L0]], [[L1]]
 ; CHECK-NEXT:    br i1 [[LHS]], label %[[LHS_TRUE:.*]], label %[[LHS_FALSE:.*]]
 ; CHECK:       [[LHS_TRUE]]:
-; CHECK-NEXT:    ret i1 true
+; CHECK-NEXT:    [[R0:%.*]] = sub nsw i8 [[L0]], [[L1]]
+; CHECK-NEXT:    [[RHS:%.*]] = icmp ult i8 [[R0]], 1
+; CHECK-NEXT:    ret i1 [[RHS]]
 ; CHECK:       [[LHS_FALSE]]:
 ; CHECK-NEXT:    ret i1 [[V]]
 ;

--- a/llvm/test/Analysis/ValueTracking/implied-condition-samesign.ll
+++ b/llvm/test/Analysis/ValueTracking/implied-condition-samesign.ll
@@ -317,8 +317,8 @@ LHS_false:
   ret i1 %V
 }
 
-define i1 @ul_sub_nsw_ult(i8 %L0, i8 %L1, i1 %V) {
-; CHECK-LABEL: define i1 @ul_sub_nsw_ult(
+define i1 @lt_sub_nsw_ult(i8 %L0, i8 %L1, i1 %V) {
+; CHECK-LABEL: define i1 @lt_sub_nsw_ult(
 ; CHECK-SAME: i8 [[L0:%.*]], i8 [[L1:%.*]], i1 [[V:%.*]]) {
 ; CHECK-NEXT:    [[LHS:%.*]] = icmp samesign ult i8 [[L0]], [[L1]]
 ; CHECK-NEXT:    br i1 [[LHS]], label %[[LHS_TRUE:.*]], label %[[LHS_FALSE:.*]]


### PR DESCRIPTION
Fixes #124267.

Since we are using the new predicate, we should also update the parameters of `isImpliedByMatchingCmp`.