### PR TITLE
[flang] Implement IERRNO intrinsic

### DIFF
--- a/flang/docs/Intrinsics.md
+++ b/flang/docs/Intrinsics.md
@@ -1095,3 +1095,14 @@ program chdir_func
   print *, "status: ", status
 end program chdir_func
 ```
+
+### Non-Standard Intrinsics: IERRNO
+
+#### Description
+`IERRNO()` returns the last system error number, as given by the C `errno` variable.
+
+#### Usage and Info
+
+- **Standard:** GNU extension
+- **Class:** function
+- **Syntax:** `RESULT = IERRNO()`

--- a/flang/include/flang/Runtime/extensions.h
+++ b/flang/include/flang/Runtime/extensions.h
@@ -72,5 +72,8 @@ std::int64_t FORTRAN_PROCEDURE_NAME(access)(const char *name,
 // GNU extension subroutine CHDIR(NAME, [STATUS])
 int RTNAME(Chdir)(const char *name);
 
+// GNU extension function IERRNO()
+int FORTRAN_PROCEDURE_NAME(ierrno)();
+
 } // extern "C"
 #endif // FORTRAN_RUNTIME_EXTENSIONS_H_

--- a/flang/runtime/extensions.cpp
+++ b/flang/runtime/extensions.cpp
@@ -260,5 +260,7 @@ int RTNAME(Chdir)(const char *name) {
 #endif
 }
 
+int FORTRAN_PROCEDURE_NAME(ierrno)() { return errno; }
+
 } // namespace Fortran::runtime
 } // extern "C"

--- a/flang/test/Lower/Intrinsics/ierrno.f90
+++ b/flang/test/Lower/Intrinsics/ierrno.f90
@@ -1,0 +1,13 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck --check-prefixes=CHECK %s
+! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck --check-prefixes=CHECK %s
+
+! CHECK-LABEL: func @_QPtest_ierrno(
+subroutine test_ierrno()
+    integer :: i
+    i = ierrno()
+! CHECK: %[[VAL_0:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFtest_ierrnoEi"}
+! CHECK: %[[VAL_1:.*]] = fir.declare %[[VAL_0]] {uniq_name = "_QFtest_ierrnoEi"} : (!fir.ref<i32>) -> !fir.ref<i32>
+! CHECK: %[[VAL_2:.*]] = fir.call @_QPierrno() fastmath<contract> : () -> i32
+! CHECK: fir.store %[[VAL_2]] to %[[VAL_1]] : !fir.ref<i32>
+! CHECK: return
+end subroutine test_ierrno


### PR DESCRIPTION
Add the implementation of the IERRNO intrinsic to get the last system error number, as given by the C errno variable.
This intrinsic is also used in RAMSES (https://github.com/ramses-organisation/ramses/).