### PR TITLE
[flang][Semantics] Fix ICE when compiling a mod file with parameter w…

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -955,7 +955,13 @@ void ModFileWriter::PutObjectEntity(
     }
   }
   PutEntity(
-      os, symbol, [&]() { PutType(os, DEREF(symbol.GetType())); },
+      os, symbol,
+      [&]() {
+        // Need to check if there is a TYPE on this symbol to avoid any ICE
+        if (details.type()) {
+          PutType(os, DEREF(symbol.GetType()));
+        }
+      },
       getSymbolAttrsToWrite(symbol));
   PutShape(os, details.shape(), '(', ')');
   PutShape(os, details.coshape(), '[', ']');

--- a/flang/test/Semantics/modfile_missing_type.f90
+++ b/flang/test/Semantics/modfile_missing_type.f90
@@ -1,0 +1,14 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Test to check that this module can be compiled when an argument has no specified type
+module inform
+  implicit none
+  interface normp
+     module subroutine normt( array,n,val,p )
+     integer siz
+     integer,optional::p
+     real*8 array(*)
+     real*8 val
+     end subroutine
+  end interface
+end
+


### PR DESCRIPTION
…ithout type specified

Fatal internal error occurred when compiling a mod file with a subroutine which contain a parameter with no 
explicit type. 

Ex: 
```fortran
   module inform
      implicit none
      interface normp
         module subroutine normt( array, n, val,p )
         integer siz
         integer,optional::p
         real*8 array(*)
         real*8 val
         end subroutine
      end interface
   end
```