### PR TITLE
workflows/premerge: Generate a ccache artifact for each pull request

### DIFF
--- a/.github/workflows/pr-ccache-restore/action.yml
+++ b/.github/workflows/pr-ccache-restore/action.yml
@@ -18,7 +18,6 @@ runs:
       run: |
         # Is this the best way to clear the cache?
         rm -Rf .ccache/
-        unzip ${{ steps.download-artifact.outputs.filename }}
         rm ${{ steps.download-artifact.outputs.filename }}
         tar --zstd -xf ccache.tar.zst
         rm ccache.tar.zst

--- a/.github/workflows/pr-ccache-restore/action.yml
+++ b/.github/workflows/pr-ccache-restore/action.yml
@@ -1,0 +1,25 @@
+name: PR ccache restore
+
+inputs:
+  artifact-name-suffix:
+    desciption: The suffix to append to the artifict name (ccache-pr#)
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/workflows/unprivileged-download-artifact
+      id: download-artifact
+      with:
+        artifact-name: ccache-pr${{ github.event.pull_request.number }}-${{ inputs.artifact-name-suffix }}
+
+    - shell: bash
+      if: steps.download-artifact.outputs.filename != ''
+      run: |
+        # Is this the best way to clear the cache?
+        rm -Rf .ccache/
+        unzip ${{ steps.download-artifact.outputs.filename }}
+        rm ${{ steps.download-artifact.outputs.filename }}
+        tar --zstd -xf ccache.tar.zst
+        rm ccache.tar.zst
+        ls -altr

--- a/.github/workflows/pr-ccache-restore/action.yml
+++ b/.github/workflows/pr-ccache-restore/action.yml
@@ -21,4 +21,3 @@ runs:
         rm ${{ steps.download-artifact.outputs.filename }}
         tar --zstd -xf ccache.tar.zst
         rm ccache.tar.zst
-        ls -altr

--- a/.github/workflows/pr-ccache-save/action.yml
+++ b/.github/workflows/pr-ccache-save/action.yml
@@ -1,0 +1,25 @@
+name: PR ccache save
+inputs:
+  artifact-name-suffix:
+    desciption: The suffix to append to the artifict name (ccache-pr#)
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Package ccache Directory
+      shell: bash
+      run: |
+        # Dereference symlinks so that this works on Windows.
+        tar -h -c .ccache | zstd -T0 -c > ccache.tar.zst
+    - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0
+      with:
+        name: 'ccache-pr${{ github.event.number }}-${{ inputs.artifact-name-suffix }}'
+        path: ccache.tar.zst
+        retention-days: 7
+        overwrite: true
+
+    - shell: bash
+      run: |
+        rm ccache.tar.zst
+        ccache --show-stats

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -27,6 +27,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           max-size: "2000M"
+      - name: Install zstd
+        run: |
+          sudo apt-get install zstd
       - name: Restore ccache from previous PR run
         uses: ./.github/workflows/pr-ccache-restore
         with:

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -27,9 +27,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           max-size: "2000M"
-      - name: Install zstd
+      - name: Install dependencies for pr-ccache-restore
         run: |
-          sudo apt-get install zstd
+          sudo apt-get install zstd unzip
       - name: Restore ccache from previous PR run
         uses: ./.github/workflows/pr-ccache-restore
         with:

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -27,6 +27,10 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.14
         with:
           max-size: "2000M"
+      - name: Restore ccache from previous PR run
+        uses: ./.github/workflows/pr-ccache-restore
+        with:
+          artifact-name-suffix: Linux-x86
       - name: Build and Test
         # Mark the job as a success even if the step fails so that people do
         # not get notified while the new premerge pipeline is in an
@@ -70,3 +74,9 @@ jobs:
           export CXX=/opt/llvm/bin/clang++
 
           ./.ci/monolithic-linux.sh "$(echo ${linux_projects} | tr ' ' ';')" "$(echo ${linux_check_targets})" "$(echo ${linux_runtimes} | tr ' ' ';')" "$(echo ${linux_runtime_check_targets})"
+
+      - name: Save ccache for next PR run
+        if: always()
+        uses: ./.github/workflows/pr-ccache-save
+        with:
+          artifact-name-suffix: Linux-x86


### PR DESCRIPTION
This allows each update for a pull request to reuse the ccache data from the previous run for that pull request.  This will help improve build times since the ccache data used will be specific to the pull request and not polluted with builds of other PRs.