### PR TITLE
[clang][CodeComplete] Add code completion for if constexpr and consteval

### DIFF
--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -152,6 +152,7 @@ public:
   void CodeCompleteDesignator(const QualType BaseType,
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
+  void CodeCompleteIfConstExpr(Scope *S) const;
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -152,7 +152,7 @@ public:
   void CodeCompleteDesignator(const QualType BaseType,
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
-  void CodeCompleteIfConstexpr(Scope *S) const;
+  void CodeCompleteIfConst(Scope *S) const;
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -152,7 +152,7 @@ public:
   void CodeCompleteDesignator(const QualType BaseType,
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
-  void CodeCompleteIfConst(Scope *S) const;
+  void CodeCompleteIfConst(Scope *S, bool AfterExclaim) const;
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -152,7 +152,7 @@ public:
   void CodeCompleteDesignator(const QualType BaseType,
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
-  void CodeCompleteIfConst(bool AfterExclaim) const;
+  void CodeCompleteKeywordAfterIf(bool AfterExclaim) const;
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -152,7 +152,7 @@ public:
   void CodeCompleteDesignator(const QualType BaseType,
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
-  void CodeCompleteIfConst(Scope *S, bool AfterExclaim) const;
+  void CodeCompleteIfConst(bool AfterExclaim) const;
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -152,7 +152,7 @@ public:
   void CodeCompleteDesignator(const QualType BaseType,
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
-  void CodeCompleteIfConstExpr(Scope *S) const;
+  void CodeCompleteIfConstexpr(Scope *S) const;
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1553,6 +1553,14 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
       IsConsteval = true;
       ConstevalLoc = ConsumeToken();
     }
+
+    if (Tok.is(tok::code_completion)) {
+      if (getLangOpts().CPlusPlus17) {
+        cutOffParsing();
+        Actions.CodeCompletion().CodeCompleteIfConstExpr(getCurScope());
+        return StmtError();
+      }
+    }
   }
   if (!IsConsteval && (NotLocation.isValid() || Tok.isNot(tok::l_paren))) {
     Diag(Tok, diag::err_expected_lparen_after) << "if";

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1557,7 +1557,7 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
     if (Tok.is(tok::code_completion)) {
       if (getLangOpts().CPlusPlus17) {
         cutOffParsing();
-        Actions.CodeCompletion().CodeCompleteIfConstExpr(getCurScope());
+        Actions.CodeCompletion().CodeCompleteIfConstexpr(getCurScope());
         return StmtError();
       }
     }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1555,11 +1555,9 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
     }
 
     if (Tok.is(tok::code_completion)) {
-      if (getLangOpts().CPlusPlus17) {
-        cutOffParsing();
-        Actions.CodeCompletion().CodeCompleteIfConstexpr(getCurScope());
-        return StmtError();
-      }
+      cutOffParsing();
+      Actions.CodeCompletion().CodeCompleteIfConst(getCurScope());
+      return StmtError();
     }
   }
   if (!IsConsteval && (NotLocation.isValid() || Tok.isNot(tok::l_paren))) {

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1556,7 +1556,7 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
 
     if (Tok.is(tok::code_completion)) {
       cutOffParsing();
-      Actions.CodeCompletion().CodeCompleteIfConst(getCurScope());
+      Actions.CodeCompletion().CodeCompleteIfConst(getCurScope(), NotLocation.isValid());
       return StmtError();
     }
   }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1556,8 +1556,7 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
 
     if (Tok.is(tok::code_completion)) {
       cutOffParsing();
-      Actions.CodeCompletion().CodeCompleteIfConst(getCurScope(),
-                                                   NotLocation.isValid());
+      Actions.CodeCompletion().CodeCompleteIfConst(NotLocation.isValid());
       return StmtError();
     }
   }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1556,7 +1556,7 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
 
     if (Tok.is(tok::code_completion)) {
       cutOffParsing();
-      Actions.CodeCompletion().CodeCompleteIfConst(NotLocation.isValid());
+      Actions.CodeCompletion().CodeCompleteKeywordAfterIf(NotLocation.isValid());
       return StmtError();
     }
   }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1554,7 +1554,8 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
       ConstevalLoc = ConsumeToken();
     } else if (Tok.is(tok::code_completion)) {
       cutOffParsing();
-      Actions.CodeCompletion().CodeCompleteKeywordAfterIf(NotLocation.isValid());
+      Actions.CodeCompletion().CodeCompleteKeywordAfterIf(
+          NotLocation.isValid());
       return StmtError();
     }
   }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1556,7 +1556,8 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
 
     if (Tok.is(tok::code_completion)) {
       cutOffParsing();
-      Actions.CodeCompletion().CodeCompleteIfConst(getCurScope(), NotLocation.isValid());
+      Actions.CodeCompletion().CodeCompleteIfConst(getCurScope(),
+                                                   NotLocation.isValid());
       return StmtError();
     }
   }

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1552,9 +1552,7 @@ StmtResult Parser::ParseIfStatement(SourceLocation *TrailingElseLoc) {
                                           : diag::ext_consteval_if);
       IsConsteval = true;
       ConstevalLoc = ConsumeToken();
-    }
-
-    if (Tok.is(tok::code_completion)) {
+    } else if (Tok.is(tok::code_completion)) {
       cutOffParsing();
       Actions.CodeCompletion().CodeCompleteKeywordAfterIf(NotLocation.isValid());
       return StmtError();

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6753,7 +6753,8 @@ void SemaCodeCompletion::CodeCompleteIfConst(Scope *S) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);
-  CodeCompletionBuilder Builder(Results.getAllocator(), Results.getCodeCompletionTUInfo());
+  CodeCompletionBuilder Builder(Results.getAllocator(),
+                                Results.getCodeCompletionTUInfo());
   Results.EnterNewScope();
   if (getLangOpts().CPlusPlus17) {
     if (Results.includeCodePatterns()) {

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,7 +6749,8 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
-void SemaCodeCompletion::CodeCompleteIfConst(Scope *S, bool AfterExclaim) const {
+void SemaCodeCompletion::CodeCompleteIfConst(Scope *S,
+                                             bool AfterExclaim) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6752,11 +6752,9 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
 void SemaCodeCompletion::CodeCompleteIfConstexpr(Scope *S) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
-                        CodeCompletionContext::CCC_SymbolOrNewName);
+                        CodeCompletionContext::CCC_Other);
   Results.EnterNewScope();
-
   Results.AddResult(CodeCompletionResult("constexpr"));
-
   Results.ExitScope();
 
   HandleCodeCompleteResults(&SemaRef, CodeCompleter,

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,6 +6749,21 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
+void SemaCodeCompletion::CodeCompleteIfConstExpr(Scope *S) const {
+  ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
+                        CodeCompleter->getCodeCompletionTUInfo(),
+                        CodeCompletionContext::CCC_SymbolOrNewName);
+  Results.EnterNewScope();
+
+  Results.AddResult(CodeCompletionResult("constexpr"));
+
+  Results.ExitScope();
+
+  HandleCodeCompleteResults(&SemaRef, CodeCompleter,
+                            Results.getCompletionContext(), Results.data(),
+                            Results.size());
+}
+
 void SemaCodeCompletion::CodeCompleteAfterIf(Scope *S, bool IsBracedThen) {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6753,12 +6753,39 @@ void SemaCodeCompletion::CodeCompleteIfConst(Scope *S) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);
+  CodeCompletionBuilder Builder(Results.getAllocator(), Results.getCodeCompletionTUInfo());
   Results.EnterNewScope();
   if (getLangOpts().CPlusPlus17) {
-    Results.AddResult(CodeCompletionResult("constexpr"));
+    if (Results.includeCodePatterns()) {
+      Builder.AddTypedTextChunk("constexpr");
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_LeftParen);
+      Builder.AddPlaceholderChunk("condition");
+      Builder.AddChunk(CodeCompletionString::CK_RightParen);
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_LeftBrace);
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddPlaceholderChunk("statements");
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_RightBrace);
+      Results.AddResult({Builder.TakeString()});
+    } else {
+      Results.AddResult({"constexpr"});
+    }
   }
   if (getLangOpts().CPlusPlus23) {
-    Results.AddResult(CodeCompletionResult("consteval"));
+    if (Results.includeCodePatterns()) {
+      Builder.AddTypedTextChunk("consteval");
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_LeftBrace);
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddPlaceholderChunk("statements");
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_RightBrace);
+      Results.AddResult({Builder.TakeString()});
+    } else {
+      Results.AddResult({"consteval"});
+    }
   }
   Results.ExitScope();
 

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,7 +6749,7 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
-void SemaCodeCompletion::CodeCompleteIfConstExpr(Scope *S) const {
+void SemaCodeCompletion::CodeCompleteIfConstexpr(Scope *S) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_SymbolOrNewName);

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6755,7 +6755,6 @@ void SemaCodeCompletion::CodeCompleteKeywordAfterIf(bool AfterExclaim) const {
                         CodeCompletionContext::CCC_Other);
   CodeCompletionBuilder Builder(Results.getAllocator(),
                                 Results.getCodeCompletionTUInfo());
-  Results.EnterNewScope();
   if (getLangOpts().CPlusPlus17) {
     if (!AfterExclaim) {
       if (Results.includeCodePatterns()) {
@@ -6790,7 +6789,6 @@ void SemaCodeCompletion::CodeCompleteKeywordAfterIf(bool AfterExclaim) const {
       Results.AddResult({"consteval"});
     }
   }
-  Results.ExitScope();
 
   HandleCodeCompleteResults(&SemaRef, CodeCompleter,
                             Results.getCompletionContext(), Results.data(),

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,7 +6749,7 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
-void SemaCodeCompletion::CodeCompleteIfConst(bool AfterExclaim) const {
+void SemaCodeCompletion::CodeCompleteKeywordAfterIf(bool AfterExclaim) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,8 +6749,7 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
-void SemaCodeCompletion::CodeCompleteIfConst(Scope *S,
-                                             bool AfterExclaim) const {
+void SemaCodeCompletion::CodeCompleteIfConst(bool AfterExclaim) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,12 +6749,17 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
-void SemaCodeCompletion::CodeCompleteIfConstexpr(Scope *S) const {
+void SemaCodeCompletion::CodeCompleteIfConst(Scope *S) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);
   Results.EnterNewScope();
-  Results.AddResult(CodeCompletionResult("constexpr"));
+  if (getLangOpts().CPlusPlus17) {
+    Results.AddResult(CodeCompletionResult("constexpr"));
+  }
+  if (getLangOpts().CPlusPlus23) {
+    Results.AddResult(CodeCompletionResult("consteval"));
+  }
   Results.ExitScope();
 
   HandleCodeCompleteResults(&SemaRef, CodeCompleter,

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6749,7 +6749,7 @@ void SemaCodeCompletion::CodeCompleteInitializer(Scope *S, Decl *D) {
   CodeCompleteExpression(S, Data);
 }
 
-void SemaCodeCompletion::CodeCompleteIfConst(Scope *S) const {
+void SemaCodeCompletion::CodeCompleteIfConst(Scope *S, bool AfterExclaim) const {
   ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
                         CodeCompleter->getCodeCompletionTUInfo(),
                         CodeCompletionContext::CCC_Other);
@@ -6757,21 +6757,23 @@ void SemaCodeCompletion::CodeCompleteIfConst(Scope *S) const {
                                 Results.getCodeCompletionTUInfo());
   Results.EnterNewScope();
   if (getLangOpts().CPlusPlus17) {
-    if (Results.includeCodePatterns()) {
-      Builder.AddTypedTextChunk("constexpr");
-      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
-      Builder.AddChunk(CodeCompletionString::CK_LeftParen);
-      Builder.AddPlaceholderChunk("condition");
-      Builder.AddChunk(CodeCompletionString::CK_RightParen);
-      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
-      Builder.AddChunk(CodeCompletionString::CK_LeftBrace);
-      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
-      Builder.AddPlaceholderChunk("statements");
-      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
-      Builder.AddChunk(CodeCompletionString::CK_RightBrace);
-      Results.AddResult({Builder.TakeString()});
-    } else {
-      Results.AddResult({"constexpr"});
+    if (!AfterExclaim) {
+      if (Results.includeCodePatterns()) {
+        Builder.AddTypedTextChunk("constexpr");
+        Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+        Builder.AddChunk(CodeCompletionString::CK_LeftParen);
+        Builder.AddPlaceholderChunk("condition");
+        Builder.AddChunk(CodeCompletionString::CK_RightParen);
+        Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+        Builder.AddChunk(CodeCompletionString::CK_LeftBrace);
+        Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+        Builder.AddPlaceholderChunk("statements");
+        Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+        Builder.AddChunk(CodeCompletionString::CK_RightBrace);
+        Results.AddResult({Builder.TakeString()});
+      } else {
+        Results.AddResult({"constexpr"});
+      }
     }
   }
   if (getLangOpts().CPlusPlus23) {

--- a/clang/test/CodeCompletion/if-const.cpp
+++ b/clang/test/CodeCompletion/if-const.cpp
@@ -1,0 +1,6 @@
+void test() {
+  if c
+  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:2:7 %s -o - | FileCheck -check-prefix=CHECK-CXX17 %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:2:7 %s -o - | FileCheck -check-prefix=CHECK-CXX23 %s
+  // CHECK-CXX17: constexpr
+  // CHECK-CXX23: consteval

--- a/clang/test/CodeCompletion/if-const.cpp
+++ b/clang/test/CodeCompletion/if-const.cpp
@@ -1,6 +1,13 @@
+template <bool Flag>
 void test() {
-  if c
-  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:2:7 %s -o - | FileCheck -check-prefix=CHECK-CXX17 %s
-  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:2:7 %s -o - | FileCheck -check-prefix=CHECK-CXX23 %s
+  if constexpr (Flag) {
+    return;
+  }
+  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:3:7 %s -o - | FileCheck -check-prefix=CHECK-CXX17 %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:3:7 %s -o - | FileCheck -check-prefix=CHECK-CXX23 %s
   // CHECK-CXX17: constexpr
   // CHECK-CXX23: consteval
+  if !c
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:10:8 %s -o - | FileCheck -check-prefix=CHECK-CXX23-NOT %s
+  // CHECK-CXX23-NOT: consteval
+}

--- a/clang/test/CodeCompletion/if-const.cpp
+++ b/clang/test/CodeCompletion/if-const.cpp
@@ -3,11 +3,24 @@ void test() {
   if constexpr (Flag) {
     return;
   }
-  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:3:7 %s -o - | FileCheck -check-prefix=CHECK-CXX17 %s
-  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:3:7 %s -o - | FileCheck -check-prefix=CHECK-CXX23 %s
-  // CHECK-CXX17: constexpr
-  // CHECK-CXX23: consteval
+  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:3:7 %s | FileCheck -check-prefix=CHECK-CXX17 %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-patterns -code-completion-at=%s:3:7 %s | FileCheck -check-prefix=CHECK-PATTERN-CXX17 %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:3:7 %s | FileCheck -check-prefix=CHECK-CXX23 %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-patterns -code-completion-at=%s:3:7 %s | FileCheck -check-prefix=CHECK-PATTERN-CXX23 %s
+  // CHECK-CXX17: COMPLETION: constexpr
+  // CHECK-PATTERN-CXX17: COMPLETION: Pattern : constexpr (<#condition#>) {
+  // CHECK-PATTERN-CXX17: <#statements#>
+  // CHECK-PATTERN-CXX17: }
+  // CHECK-CXX23: COMPLETION: consteval
+  // CHECK-PATTERN-CXX23: COMPLETION: Pattern : consteval {
+  // CHECK-PATTERN-CXX23: <#statements#>
+  // CHECK-PATTERN-CXX23: }
   if !c
-  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:10:8 %s -o - | FileCheck -check-prefix=CHECK-CXX23-NOT %s
-  // CHECK-CXX23-NOT: consteval
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:18:8 %s -o - | FileCheck -check-prefix=CHECK-CXX23-EXCLAIM %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-patterns -code-completion-at=%s:18:8 %s -o - | FileCheck -check-prefix=CHECK-PATTERN-CXX23-EXCLAIM %s
+  // CHECK-CXX23-EXCLAIM: COMPLETION: consteval
+  // CHECK-CXX23-EXCLAIM-NOT: constexpr
+  // CHECK-PATTERN-CXX23-EXCLAIM: COMPLETION: Pattern : consteval {
+  // CHECK-PATTERN-CXX23-EXCLAIM: <#statements#>
+  // CHECK-PATTERN-CXX23-EXCLAIM: }
 }

--- a/clang/test/CodeCompletion/if-const.cpp
+++ b/clang/test/CodeCompletion/if-const.cpp
@@ -12,12 +12,16 @@ void test() {
   // CHECK-PATTERN-CXX17: <#statements#>
   // CHECK-PATTERN-CXX17: }
   // CHECK-CXX23: COMPLETION: consteval
+  // CHECK-CXX23: COMPLETION: constexpr
   // CHECK-PATTERN-CXX23: COMPLETION: Pattern : consteval {
   // CHECK-PATTERN-CXX23: <#statements#>
   // CHECK-PATTERN-CXX23: }
+  // CHECK-PATTERN-CXX23: COMPLETION: Pattern : constexpr (<#condition#>) {
+  // CHECK-PATTERN-CXX23: <#statements#>
+  // CHECK-PATTERN-CXX23: }
   if !c
-  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:18:8 %s -o - | FileCheck -check-prefix=CHECK-CXX23-EXCLAIM %s
-  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-patterns -code-completion-at=%s:18:8 %s -o - | FileCheck -check-prefix=CHECK-PATTERN-CXX23-EXCLAIM %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-at=%s:22:8 %s -o - | FileCheck -check-prefix=CHECK-CXX23-EXCLAIM %s
+  // RUN: %clang_cc1 -fsyntax-only -std=c++23 -code-completion-patterns -code-completion-at=%s:22:8 %s -o - | FileCheck -check-prefix=CHECK-PATTERN-CXX23-EXCLAIM %s
   // CHECK-CXX23-EXCLAIM: COMPLETION: consteval
   // CHECK-CXX23-EXCLAIM-NOT: constexpr
   // CHECK-PATTERN-CXX23-EXCLAIM: COMPLETION: Pattern : consteval {

--- a/clang/test/CodeCompletion/if-constexpr.cpp
+++ b/clang/test/CodeCompletion/if-constexpr.cpp
@@ -1,0 +1,4 @@
+void test() {
+  if c
+  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:%(line-1):7 %s -o - | FileCheck -check-prefix=CHECK-CC1 %s
+  // CHECK-CC1: constexpr

--- a/clang/test/CodeCompletion/if-constexpr.cpp
+++ b/clang/test/CodeCompletion/if-constexpr.cpp
@@ -1,4 +1,0 @@
-void test() {
-  if c
-  // RUN: %clang_cc1 -fsyntax-only -std=c++17 -code-completion-at=%s:%(line-1):7 %s -o - | FileCheck -check-prefix=CHECK-CC1 %s
-  // CHECK-CC1: constexpr


### PR DESCRIPTION
C++17 supports `if constexpr` statement. C++23 supports `if consteval` statement. This patch implements this in code completion.