### PR TITLE
[libc] Include size_t type header in strings.h

### DIFF
--- a/libc/include/strings.yaml
+++ b/libc/include/strings.yaml
@@ -1,7 +1,8 @@
 header: strings.h
 header_template: strings.h.def
 macros: []
-types: []
+types:
+  - type_name: size_t
 enums: []
 objects: []
 functions:


### PR DESCRIPTION
A number of functions in strings.h take size_t as an argument.