### PR TITLE
[LLD][COFF] Keep hasData true in NullChunk constructor

### DIFF
--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -132,7 +132,6 @@ public:
 class NullChunk : public NonSectionChunk {
 public:
   explicit NullChunk(size_t n, uint32_t align) : size(n) {
-    hasData = false;
     setAlignment(align);
   }
   explicit NullChunk(COFFLinkerContext &ctx)

--- a/lld/test/COFF/arm64ec-import.test
+++ b/lld/test/COFF/arm64ec-import.test
@@ -160,6 +160,19 @@ BASERELOC-NEXT:     Type: DIR64
 BASERELOC-NEXT:     Address: 0x5020
 BASERELOC-NEXT:   }
 
+
+Build with -filealign:8 to enable precise size checking.
+
+RUN: lld-link -machine:arm64ec -dll -noentry -out:out-size.dll loadconfig-arm64ec.obj icall.obj hybmp.obj \
+RUN:          test.obj test-arm64ec.lib test2-arm64ec.lib -filealign:8
+
+RUN: llvm-readobj --headers out-size.dll | FileCheck --check-prefix=RDATA-HEADER %s
+
+RDATA-HEADER:      Name: .rdata (2E 72 64 61 74 61 00 00)
+RDATA-HEADER-NEXT: VirtualSize: 0x2030
+RDATA-HEADER-NEXT: VirtualAddress: 0x3000
+RDATA-HEADER-NEXT: RawDataSize: 8240
+
 #--- test.s
     .section .test, "r"
     .globl arm64ec_data_sym


### PR DESCRIPTION
`NullChunk` instances do write data, even if it's always zero. Setting `hasData` to false
causes `Writer::assignAddresses` to ignore them when calculating `rawSize`. This typically
isn't an issue, as null chunks are usually positioned within a section, and later
chunks adjust the size accordingly.

However, on ARM64EC, the auxiliary IAT is placed at the end of the `.rdata` section and
terminates with a null chunk. As a result, `rawSize` is never updated to account for it,
and space for the null chunk is not allocated. Consequently, when `NullChunk::writeTo`
is called, it receives an invalid pointer - either pointing to the next section or
beyond the allocated buffer.