### PR TITLE
[libc] Add `returns_twice` attribute to `setjmp(3)`

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -45,6 +45,9 @@
 #define __NOEXCEPT throw()
 #endif
 
+#undef _Returns_twice
+#define _Returns_twice [[gnu::returns_twice]]
+
 #else // not __cplusplus
 
 #undef __BEGIN_C_DECLS
@@ -79,6 +82,9 @@
 #else
 #define __NOEXCEPT
 #endif
+
+#undef _Returns_twice
+#define _Returns_twice __attribute__((returns_twice))
 
 #endif // __cplusplus
 

--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -45,9 +45,6 @@
 #define __NOEXCEPT throw()
 #endif
 
-#undef _Returns_twice
-#define _Returns_twice [[gnu::returns_twice]]
-
 #else // not __cplusplus
 
 #undef __BEGIN_C_DECLS

--- a/libc/include/setjmp.yaml
+++ b/libc/include/setjmp.yaml
@@ -17,5 +17,7 @@ functions:
     standards:
       - stdc
     return_type: int
+    attributes:
+      - _Returns_twice
     arguments:
       - type: jmp_buf

--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -29,7 +29,8 @@ namespace LIBC_NAMESPACE_DECL {
 #ifdef LIBC_COMPILER_IS_GCC
 [[gnu::nothrow]]
 #endif
-int setjmp(jmp_buf buf);
+[[gnu::returns_twice]] int
+setjmp(jmp_buf buf);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/setjmp/setjmp_impl.h
+++ b/libc/src/setjmp/setjmp_impl.h
@@ -29,8 +29,7 @@ namespace LIBC_NAMESPACE_DECL {
 #ifdef LIBC_COMPILER_IS_GCC
 [[gnu::nothrow]]
 #endif
-[[gnu::returns_twice]] int
-setjmp(jmp_buf buf);
+__attribute__((returns_twice)) int setjmp(jmp_buf buf);
 
 } // namespace LIBC_NAMESPACE_DECL
 


### PR DESCRIPTION
This is to ensure that calls to `setjmp(3)` result in correct code generation that respects `setjmp(3)`'s `returns_twice` behavior. Otherwise, we might run into bugs (for example, Clang may perform tail-call optimization on this function if `-fno-builtins` is set (#122840)).