### PR TITLE
[llvm] Fix potential Out-of-order Evaluation in DebugInfo

### DIFF
--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -798,7 +798,8 @@ private:
 
       return getReplacementMDNode(N);
     };
-    Replacements[N] = doRemap(N);
+    auto value = doRemap(N);
+    Replacements[N] = value;
   }
 
   /// Do the remapping traversal.

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -798,6 +798,9 @@ private:
 
       return getReplacementMDNode(N);
     };
+
+    // Intentionally separate rvalue and lvalue that may access the same memory
+    // location to guarantee the evaluation order.
     auto value = doRemap(N);
     Replacements[N] = value;
   }


### PR DESCRIPTION
In DebugTypeInfoRemoval, DenseMap Replacements's assignment's rvalue is a recursive function that may access Replacements itself. Since C++17 such an "right to left" order cannot get guaranteed. This change is to separate 1 line into 2, avoid such a case.