### PR TITLE
[offload] [test] Use test compiler ID rather than host

### DIFF
--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt file for unit testing OpenMP offloading runtime library.
-if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
-   CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0.0)
+if(NOT OPENMP_TEST_COMPILER_ID STREQUAL "Clang" OR
+   OPENMP_TEST_COMPILER_VERSION VERSION_LESS 6.0.0)
   message(STATUS "Can only test with Clang compiler in version 6.0.0 or later.")
   message(WARNING "The check-offload target will not be available!")
   return()


### PR DESCRIPTION
Use the test compiler ID to verify whether tests can be run rather than the host compiler.  This makes it possible to run tests (with Clang) while the library itself was built with GCC.