### PR TITLE
[AArch64] Fix movk parsing with an .equ operand

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -5017,7 +5017,9 @@ bool AArch64AsmParser::parseOperand(OperandVector &Operands, bool isCondCode,
       return true;
     E = SMLoc::getFromPointer(getLoc().getPointer() - 1);
     Operands.push_back(AArch64Operand::CreateImm(IdVal, S, E, getContext()));
-    return false;
+
+    // Parse an optional shift/extend modifier.
+    return parseOptionalShiftExtend(getTok());
   }
   case AsmToken::Integer:
   case AsmToken::Real:

--- a/llvm/test/MC/AArch64/arm64-basic-a64-instructions.s
+++ b/llvm/test/MC/AArch64/arm64-basic-a64-instructions.s
@@ -16,3 +16,6 @@
 // CHECK: crc32ch  w13, w17, w25           // encoding: [0x2d,0x56,0xd9,0x1a]
 // CHECK: crc32cw  wzr, w3, w5             // encoding: [0x7f,0x58,0xc5,0x1a]
 // CHECK: crc32cx  w18, w16, xzr           // encoding: [0x12,0x5e,0xdf,0x9a]
+
+        .equ	p4_low_b0, 0x0000
+        movk x1, p4_low_b0, lsl 16

--- a/llvm/test/MC/AArch64/arm64-basic-a64-instructions.s
+++ b/llvm/test/MC/AArch64/arm64-basic-a64-instructions.s
@@ -16,6 +16,3 @@
 // CHECK: crc32ch  w13, w17, w25           // encoding: [0x2d,0x56,0xd9,0x1a]
 // CHECK: crc32cw  wzr, w3, w5             // encoding: [0x7f,0x58,0xc5,0x1a]
 // CHECK: crc32cx  w18, w16, xzr           // encoding: [0x12,0x5e,0xdf,0x9a]
-
-        .equ	p4_low_b0, 0x0000
-        movk x1, p4_low_b0, lsl 16

--- a/llvm/test/MC/AArch64/basic-a64-instructions.s
+++ b/llvm/test/MC/AArch64/basic-a64-instructions.s
@@ -3347,6 +3347,11 @@ _func:
 // CHECK: mov      x2, #5299989643264             // encoding: [0x42,0x9a,0xc0,0xd2]
 // CHECK: movk     xzr, #{{4321|0x10e1}}, lsl #48 // encoding: [0x3f,0x1c,0xe2,0xf2]
 
+	.equ equvalue, 0x0001
+        movk x1, equvalue, lsl 16
+// CHECK: .set equvalue, 1
+// CHECK-NEXT: movk x1, #1, lsl #16 // encoding: [0x21,0x00,0xa0,0xf2]
+
         movz x2, #:abs_g0:sym
         movk w3, #:abs_g0_nc:sym
 


### PR DESCRIPTION
Prior to 5da801386c2b820a4596fc6d8da6b5f4a6da94b4, this code worked:

    .equ    p4_low_b0, 0x0000
    movk    x1, p4_low_b0, lsl 16

(The code above is from the isa-l project - I discovered this issue while trying to compile it with clang 19 on MacOS on aarch64)

That commit fixed a different bug, but accidentally broke the case where the second operand to movk is not a literal.

In 442f066fc464e953b7783230e95ccf2a67ebfb38, a fix was applied to handle the case where the second operand is a value like "(Val) >> 16". However, that didn't appear to fix the test case in this commit. In this commit, we extend the change to handle the case where the second operand is a identifier defined by .equ.

Fixes #124427

I do not understand the code super well - I extended the existing fix and it appears to work / passes all tests that I ran.

I'm not 100% sure where to add a test case. I added it to the best file that seemed to make sense to me, but it could be the wrong place. Even if its the wrong place, it does appear to test the fix - it fails without the fix and passes with it.