### PR TITLE
[mlir][gpu] GPUToROCDL/NVVM: use generic llvm conversion interface instead of hardcoded conversions.

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -578,20 +578,24 @@ def ConvertGpuOpsToROCDLOps : Pass<"convert-gpu-to-rocdl", "gpu::GPUModuleOp"> {
            /*default=*/"\"gfx000\"",
            "Chipset that these operations will run on">,
     Option<"indexBitwidth", "index-bitwidth", "unsigned",
-           /*default=kDeriveIndexBitwidthFromDataLayout*/"0",
+           /*default=kDeriveIndexBitwidthFromDataLayout*/ "0",
            "Bitwidth of the index type, 0 to use size of machine word">,
     Option<"useBarePtrCallConv", "use-bare-ptr-memref-call-conv", "bool",
            /*default=*/"false",
            "Replace memref arguments in GPU functions with bare pointers."
            "All memrefs must have static shape">,
     Option<"runtime", "runtime", "::mlir::gpu::amd::Runtime",
-          "::mlir::gpu::amd::Runtime::Unknown",
-          "Runtime code will be run on (default is Unknown, can also use HIP or OpenCl)",
-          [{::llvm::cl::values(
-            clEnumValN(::mlir::gpu::amd::Runtime::Unknown, "unknown", "Unknown (default)"),
-            clEnumValN(::mlir::gpu::amd::Runtime::HIP, "HIP", "HIP"),
-            clEnumValN(::mlir::gpu::amd::Runtime::OpenCL, "OpenCL", "OpenCL")
-          )}]>
+           "::mlir::gpu::amd::Runtime::Unknown",
+           "Runtime code will be run on (default is Unknown, can also use HIP "
+           "or OpenCl)",
+           [{::llvm::cl::values(
+               clEnumValN(::mlir::gpu::amd::Runtime::Unknown, "unknown",
+                          "Unknown (default)"),
+               clEnumValN(::mlir::gpu::amd::Runtime::HIP, "HIP", "HIP"),
+               clEnumValN(::mlir::gpu::amd::Runtime::OpenCL, "OpenCL",
+                          "OpenCL"))}]>,
+    ListOption<"filterDialects", "filter-dialects", "std::string",
+               "Run conversion patterns of only the specified dialects">,
   ];
 }
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -550,14 +550,16 @@ def ConvertGpuOpsToNVVMOps : Pass<"convert-gpu-to-nvvm", "gpu::GPUModuleOp"> {
   ];
   let options = [
     Option<"indexBitwidth", "index-bitwidth", "unsigned",
-           /*default=kDeriveIndexBitwidthFromDataLayout*/"0",
+           /*default=kDeriveIndexBitwidthFromDataLayout*/ "0",
            "Bitwidth of the index type, 0 to use size of machine word">,
     Option<"hasRedux", "has-redux", "bool", /*default=*/"false",
            "Target gpu supports redux">,
     Option<"useBarePtrCallConv", "use-bare-ptr-memref-call-conv", "bool",
            /*default=*/"false",
            "Replace memref arguments in GPU functions with bare pointers. "
-           "All memrefs must have static shape.">
+           "All memrefs must have static shape.">,
+    ListOption<"filterDialects", "filter-dialects", "std::string",
+               "Run conversion patterns of only the specified dialects">,
   ];
 }
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -558,7 +558,7 @@ def ConvertGpuOpsToNVVMOps : Pass<"convert-gpu-to-nvvm", "gpu::GPUModuleOp"> {
            /*default=*/"false",
            "Replace memref arguments in GPU functions with bare pointers. "
            "All memrefs must have static shape.">,
-    ListOption<"filterDialects", "filter-dialects", "std::string",
+    ListOption<"allowedDialects", "allowed-dialects", "std::string",
                "Run conversion patterns of only the specified dialects">,
   ];
 }
@@ -589,14 +589,14 @@ def ConvertGpuOpsToROCDLOps : Pass<"convert-gpu-to-rocdl", "gpu::GPUModuleOp"> {
     Option<"runtime", "runtime", "::mlir::gpu::amd::Runtime",
            "::mlir::gpu::amd::Runtime::Unknown",
            "Runtime code will be run on (default is Unknown, can also use HIP "
-           "or OpenCl)",
+           "or OpenCL)",
            [{::llvm::cl::values(
                clEnumValN(::mlir::gpu::amd::Runtime::Unknown, "unknown",
                           "Unknown (default)"),
                clEnumValN(::mlir::gpu::amd::Runtime::HIP, "HIP", "HIP"),
                clEnumValN(::mlir::gpu::amd::Runtime::OpenCL, "OpenCL",
                           "OpenCL"))}]>,
-    ListOption<"filterDialects", "filter-dialects", "std::string",
+    ListOption<"allowedDialects", "allowed-dialects", "std::string",
                "Run conversion patterns of only the specified dialects">,
   ];
 }

--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -378,8 +378,8 @@ struct LowerGpuOpsToNVVMOpsPass
     RewritePatternSet llvmPatterns(m.getContext());
     LLVMConversionTarget target(getContext());
 
-    if (!filterDialects.empty()) {
-      for (StringRef dialectName : filterDialects) {
+    if (!allowedDialects.empty()) {
+      for (StringRef dialectName : allowedDialects) {
         Dialect *dialect = getContext().getLoadedDialect(dialectName);
         // Dialect may not be loaded if it wasn't used in source module, ignore.
         if (!dialect)

--- a/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
+++ b/mlir/lib/Conversion/GPUToNVVM/LowerGpuOpsToNVVMOps.cpp
@@ -337,11 +337,11 @@ struct AssertOpToAssertfailLowering
 ///
 /// This pass only handles device code and is not meant to be run on GPU host
 /// code.
-struct LowerGpuOpsToNVVMOpsPass
+struct LowerGpuOpsToNVVMOpsPass final
     : public impl::ConvertGpuOpsToNVVMOpsBase<LowerGpuOpsToNVVMOpsPass> {
   using Base::Base;
 
-  void getDependentDialects(DialectRegistry &registry) const override final {
+  void getDependentDialects(DialectRegistry &registry) const override {
     Base::getDependentDialects(registry);
     registerConvertToLLVMDependentDialectLoading(registry);
   }
@@ -389,7 +389,7 @@ struct LowerGpuOpsToNVVMOpsPass
         if (!iface) {
           m.emitError()
               << "dialect does not implement ConvertToLLVMPatternInterface: "
-              << dialectName << "\n";
+              << dialectName;
           return signalPassFailure();
         }
 
@@ -398,7 +398,8 @@ struct LowerGpuOpsToNVVMOpsPass
       }
     } else {
       for (Dialect *dialect : getContext().getLoadedDialects()) {
-        if (isa<math::MathDialect>(dialect)) // Need custom math lowering
+        // Skip math patterns as nvvm needs custom math lowering.
+        if (isa<math::MathDialect>(dialect))
           continue;
 
         auto iface = dyn_cast<ConvertToLLVMPatternInterface>(dialect);

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -293,8 +293,8 @@ struct LowerGpuOpsToROCDLOpsPass
     RewritePatternSet llvmPatterns(ctx);
     LLVMConversionTarget target(getContext());
 
-    if (!filterDialects.empty()) {
-      for (StringRef dialectName : filterDialects) {
+    if (!allowedDialects.empty()) {
+      for (StringRef dialectName : allowedDialects) {
         Dialect *dialect = ctx->getLoadedDialect(dialectName);
         // Dialect may not be loaded if it wasn't used in source module, ignore.
         if (!dialect)

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -293,33 +293,29 @@ struct LowerGpuOpsToROCDLOpsPass final
     RewritePatternSet llvmPatterns(ctx);
     LLVMConversionTarget target(getContext());
 
-    if (!allowedDialects.empty()) {
-      for (StringRef dialectName : allowedDialects) {
-        Dialect *dialect = ctx->getLoadedDialect(dialectName);
-        // Dialect may not be loaded if it wasn't used in source module, ignore.
-        if (!dialect)
-          continue;
+    llvm::SmallDenseSet<StringRef> allowedDialectsSet(allowedDialects.begin(),
+                                                      allowedDialects.end());
+    for (Dialect *dialect : ctx->getLoadedDialects()) {
+      bool allowed = allowedDialectsSet.contains(dialect->getNamespace());
+      // Empty `allowedDialectsSet` means all dialects are allowed.
+      if (!allowedDialectsSet.empty() && !allowed)
+        continue;
 
-        auto *iface = dyn_cast<ConvertToLLVMPatternInterface>(dialect);
-        if (!iface) {
+      auto iface = dyn_cast<ConvertToLLVMPatternInterface>(dialect);
+      if (!iface) {
+        // Error out if dialect was explicily specified but doesn't implement
+        // conversion interface.
+        if (allowed) {
           m.emitError()
               << "dialect does not implement ConvertToLLVMPatternInterface: "
-              << dialectName;
+              << dialect->getNamespace();
           return signalPassFailure();
         }
-
-        iface->populateConvertToLLVMConversionPatterns(target, converter,
-                                                       llvmPatterns);
+        continue;
       }
-    } else {
-      for (Dialect *dialect : ctx->getLoadedDialects()) {
-        auto iface = dyn_cast<ConvertToLLVMPatternInterface>(dialect);
-        if (!iface)
-          continue;
 
-        iface->populateConvertToLLVMConversionPatterns(target, converter,
-                                                       llvmPatterns);
-      }
+      iface->populateConvertToLLVMConversionPatterns(target, converter,
+                                                     llvmPatterns);
     }
 
     populateAMDGPUToROCDLConversionPatterns(converter, llvmPatterns,

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -199,7 +199,7 @@ struct GPUShuffleOpLowering : public ConvertOpToLLVMPattern<gpu::ShuffleOp> {
 //
 // This pass only handles device code and is not meant to be run on GPU host
 // code.
-struct LowerGpuOpsToROCDLOpsPass
+struct LowerGpuOpsToROCDLOpsPass final
     : public impl::ConvertGpuOpsToROCDLOpsBase<LowerGpuOpsToROCDLOpsPass> {
   LowerGpuOpsToROCDLOpsPass() = default;
   LowerGpuOpsToROCDLOpsPass(const std::string &chipset, unsigned indexBitwidth,
@@ -215,7 +215,7 @@ struct LowerGpuOpsToROCDLOpsPass
       this->runtime = runtime;
   }
 
-  void getDependentDialects(DialectRegistry &registry) const override final {
+  void getDependentDialects(DialectRegistry &registry) const override {
     Base::getDependentDialects(registry);
     registerConvertToLLVMDependentDialectLoading(registry);
   }
@@ -304,7 +304,7 @@ struct LowerGpuOpsToROCDLOpsPass
         if (!iface) {
           m.emitError()
               << "dialect does not implement ConvertToLLVMPatternInterface: "
-              << dialectName << "\n";
+              << dialectName;
           return signalPassFailure();
         }
 

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-invalid-dialect.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm-invalid-dialect.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt %s -convert-gpu-to-nvvm='allowed-dialects=test' -verify-diagnostics
+
+// expected-error @+1 {{dialect does not implement ConvertToLLVMPatternInterface: test}}
+gpu.module @test_module_1 {
+  func.func @test(%0 : index) -> index {
+    %1 = test.increment %0 : index
+    func.return %1 : index
+  }
+}
+

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1' -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1 filter-dialects=func,arith,cf' -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1 use-bare-ptr-memref-call-conv=1' -split-input-file | FileCheck %s --check-prefix=CHECK-BARE
 // RUN: mlir-opt %s -transform-interpreter | FileCheck %s
 

--- a/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
+++ b/mlir/test/Conversion/GPUToNVVM/gpu-to-nvvm.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1' -split-input-file | FileCheck %s
-// RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1 filter-dialects=func,arith,cf' -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1 allowed-dialects=func,arith,cf' -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -convert-gpu-to-nvvm='has-redux=1 use-bare-ptr-memref-call-conv=1' -split-input-file | FileCheck %s --check-prefix=CHECK-BARE
 // RUN: mlir-opt %s -transform-interpreter | FileCheck %s
 

--- a/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl-invalid-dialect.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl-invalid-dialect.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt %s -convert-gpu-to-rocdl='allowed-dialects=test' -verify-diagnostics
+
+// expected-error @+1 {{dialect does not implement ConvertToLLVMPatternInterface: test}}
+gpu.module @test_module_1 {
+  func.func @test(%0 : index) -> index {
+    %1 = test.increment %0 : index
+    func.return %1 : index
+  }
+}
+

--- a/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s -convert-gpu-to-rocdl -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -convert-gpu-to-rocdl='filter-dialects=func,arith,math' -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -convert-gpu-to-rocdl='index-bitwidth=32' -split-input-file | FileCheck --check-prefix=CHECK32 %s
 
 // CHECK-LABEL: @test_module

--- a/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
+++ b/mlir/test/Conversion/GPUToROCDL/gpu-to-rocdl.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s -convert-gpu-to-rocdl -split-input-file | FileCheck %s
-// RUN: mlir-opt %s -convert-gpu-to-rocdl='filter-dialects=func,arith,math' -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -convert-gpu-to-rocdl='allowed-dialects=func,arith,math' -split-input-file | FileCheck %s
 // RUN: mlir-opt %s -convert-gpu-to-rocdl='index-bitwidth=32' -split-input-file | FileCheck --check-prefix=CHECK32 %s
 
 // CHECK-LABEL: @test_module


### PR DESCRIPTION
Using `ConvertToLLVMPatternInterface` allows to unhardcode specific dialect conversions from passes and, more importantly, allows downstream projects to inject their ops/types translation here by registering corresponding interface.

Add `allowed-dialects` option so user can control which dialects can be used to populate conversions.