### PR TITLE
[MLGO] Count LR Evictions Rather than Relying on Cascade

### DIFF
--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
@@ -673,7 +673,7 @@ bool MLEvictAdvisor::loadInterferenceFeatures(
       // large amount of compile time being spent in regalloc. If we hit the
       // threshold, prevent the range from being evicted. We still let the
       // range through if it is urgent as we are required to produce an
-      // eviction if the candidate is not spillable. 
+      // eviction if the candidate is not spillable.
       if (getEvictionCount(Intf->reg()) > MaxEvictionCount && !Urgent)
         return false;
 

--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
@@ -376,9 +376,8 @@ private:
 
   unsigned getEvictionCount(Register Reg) const {
     auto EvictionCountIt = VirtRegEvictionCounts.find(Reg.id());
-    if (EvictionCountIt != VirtRegEvictionCounts.end()) {
+    if (EvictionCountIt != VirtRegEvictionCounts.end())
       return EvictionCountIt->second;
-    }
     return 0;
   }
 };


### PR DESCRIPTION
This patch adjusts the mlregalloc-max-cascade flag (renaming it to mlregalloc-max-eviction-count) to actually count evictions rather than just looking at the cascade number. The cascade number is not very representative of how many times a LR has been evicted, which can lead to some problems in certain cases, where we might end up with many eviction problems where we have now masked off all the interferences and are forced to evict the candidate.

This is probably what I should've done in the first place. No test case as this only shows up in quite large functions post ThinLTO and it would be hard to construct something that would serve as a nice regression test without being super brittle. I've tested this on the pathological cases that we have come across so far and it works.

Fixes #122829