### PR TITLE
[libc++] Use __detected_or_t to implement __has_iterator_{category,concept}_convertible_to

### DIFF
--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -24,6 +24,7 @@
 #include <__iterator/readable_traits.h>
 #include <__type_traits/common_reference.h>
 #include <__type_traits/conditional.h>
+#include <__type_traits/detected_or.h>
 #include <__type_traits/disjunction.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/integral_constant.h>
@@ -32,6 +33,7 @@
 #include <__type_traits/is_primary_template.h>
 #include <__type_traits/is_reference.h>
 #include <__type_traits/is_valid_expansion.h>
+#include <__type_traits/nat.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_cv.h>
 #include <__type_traits/remove_cvref.h>
@@ -124,30 +126,6 @@ private:
 
 public:
   static const bool value = decltype(__test<_Tp>(nullptr, nullptr, nullptr, nullptr, nullptr))::value;
-};
-
-template <class _Tp>
-struct __has_iterator_category {
-private:
-  template <class _Up>
-  static false_type __test(...);
-  template <class _Up>
-  static true_type __test(typename _Up::iterator_category* = nullptr);
-
-public:
-  static const bool value = decltype(__test<_Tp>(nullptr))::value;
-};
-
-template <class _Tp>
-struct __has_iterator_concept {
-private:
-  template <class _Up>
-  static false_type __test(...);
-  template <class _Up>
-  static true_type __test(typename _Up::iterator_concept* = nullptr);
-
-public:
-  static const bool value = decltype(__test<_Tp>(nullptr))::value;
 };
 
 #if _LIBCPP_STD_VER >= 20
@@ -417,18 +395,19 @@ struct _LIBCPP_TEMPLATE_VIS iterator_traits<_Tp*> {
 #endif
 };
 
-template <class _Tp, class _Up, bool = __has_iterator_category<iterator_traits<_Tp> >::value>
-struct __has_iterator_category_convertible_to : is_convertible<typename iterator_traits<_Tp>::iterator_category, _Up> {
-};
+template <class _Tp>
+using __iterator_category _LIBCPP_NODEBUG = typename _Tp::iterator_category;
+
+template <class _Tp>
+using __iterator_concept _LIBCPP_NODEBUG = typename _Tp::iterator_concept;
 
 template <class _Tp, class _Up>
-struct __has_iterator_category_convertible_to<_Tp, _Up, false> : false_type {};
-
-template <class _Tp, class _Up, bool = __has_iterator_concept<_Tp>::value>
-struct __has_iterator_concept_convertible_to : is_convertible<typename _Tp::iterator_concept, _Up> {};
+using __has_iterator_category_convertible_to _LIBCPP_NODEBUG =
+    is_convertible<__detected_or_t<__nat, __iterator_category, iterator_traits<_Tp> >, _Up>;
 
 template <class _Tp, class _Up>
-struct __has_iterator_concept_convertible_to<_Tp, _Up, false> : false_type {};
+using __has_iterator_concept_convertible_to _LIBCPP_NODEBUG =
+    is_convertible<__detected_or_t<__nat, __iterator_concept, _Tp>, _Up>;
 
 template <class _Tp>
 using __has_input_iterator_category _LIBCPP_NODEBUG = __has_iterator_category_convertible_to<_Tp, input_iterator_tag>;

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -418,7 +418,10 @@ module std [system] {
     module copy_backward                          { header "__algorithm/copy_backward.h" }
     module copy_if                                { header "__algorithm/copy_if.h" }
     module copy_move_common                       { header "__algorithm/copy_move_common.h" }
-    module copy_n                                 { header "__algorithm/copy_n.h" }
+    module copy_n                                 {
+      header "__algorithm/copy_n.h"
+      export std.iterator_traits
+    }
     module copy                                   { header "__algorithm/copy.h" }
     module count_if                               { header "__algorithm/count_if.h" }
     module count                                  { header "__algorithm/count.h" }
@@ -1471,6 +1474,7 @@ module std [system] {
     module iterator_traits {
       header "__iterator/iterator_traits.h"
       export std_core.type_traits.integral_constant
+      export std_core.type_traits.is_convertible
     }
     module iterator_with_data         { header "__iterator/iterator_with_data.h" }
     module iterator                   { header "__iterator/iterator.h" }


### PR DESCRIPTION
This simplifies the implementation a bit.
