### PR TITLE
[compiler-rt][Mips] Fix mips SP register definition

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -37,8 +37,11 @@
 # include <asm/ptrace.h>
 #endif
 #include <sys/user.h>  // for user_regs_struct
-#if SANITIZER_ANDROID && SANITIZER_MIPS
-# include <asm/reg.h>  // for mips SP register in sys/user.h
+#if SANITIZER_MIPS
+// clang-format off
+# include <asm/sgidefs.h>  // <asm/sgidefs.h> must be included before <asm/reg.h>
+# include <asm/reg.h>      // for mips SP register
+// clang-format on
 #endif
 #include <sys/wait.h> // for signal-related stuff
 
@@ -510,11 +513,7 @@ typedef pt_regs regs_struct;
 
 #elif defined(__mips__)
 typedef struct user regs_struct;
-# if SANITIZER_ANDROID
 #  define REG_SP regs[EF_R29]
-# else
-#  define REG_SP regs[EF_REG29]
-# endif
 
 #elif defined(__aarch64__)
 typedef struct user_pt_regs regs_struct;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -37,28 +37,28 @@
 # include <asm/ptrace.h>
 #endif
 #include <sys/user.h>  // for user_regs_struct
-#if SANITIZER_MIPS
+#  if SANITIZER_MIPS
 // clang-format off
 # include <asm/sgidefs.h>  // <asm/sgidefs.h> must be included before <asm/reg.h>
 # include <asm/reg.h>      // for mips SP register
 // clang-format on
-#endif
-#include <sys/wait.h> // for signal-related stuff
+#  endif
+#  include <sys/wait.h>  // for signal-related stuff
 
-#ifdef sa_handler
-# undef sa_handler
-#endif
+#  ifdef sa_handler
+#    undef sa_handler
+#  endif
 
-#ifdef sa_sigaction
-# undef sa_sigaction
-#endif
+#  ifdef sa_sigaction
+#    undef sa_sigaction
+#  endif
 
-#include "sanitizer_common.h"
-#include "sanitizer_flags.h"
-#include "sanitizer_libc.h"
-#include "sanitizer_linux.h"
-#include "sanitizer_mutex.h"
-#include "sanitizer_placement_new.h"
+#  include "sanitizer_common.h"
+#  include "sanitizer_flags.h"
+#  include "sanitizer_libc.h"
+#  include "sanitizer_linux.h"
+#  include "sanitizer_mutex.h"
+#  include "sanitizer_placement_new.h"
 
 // Sufficiently old kernel headers don't provide this value, but we can still
 // call prctl with it. If the runtime kernel is new enough, the prctl call will
@@ -513,7 +513,7 @@ typedef pt_regs regs_struct;
 
 #elif defined(__mips__)
 typedef struct user regs_struct;
-#  define REG_SP regs[EF_R29]
+#    define REG_SP regs[EF_R29]
 
 #elif defined(__aarch64__)
 typedef struct user_pt_regs regs_struct;


### PR DESCRIPTION
The mainline Linux kernel defines EF_R29, not EF_REG29 [1]. Further, the asm/reg.h header requires `_MIPS_SIM_*` to be defined, which reside in asm/sgidefs.h [2].

[1]: https://github.com/torvalds/linux/blob/v6.13/arch/mips/include/uapi/asm/reg.h#L151
[2]: https://github.com/torvalds/linux/blob/v6.13/arch/mips/include/uapi/asm/sgidefs.h#L33-L35