### PR TITLE
[mlir][arith] EmulateWideInt only support `vector.print`

### DIFF
--- a/mlir/lib/Dialect/Arith/Transforms/EmulateWideInt.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/EmulateWideInt.cpp
@@ -1044,9 +1044,9 @@ struct EmulateWideIntPass final
       return typeConverter.isLegal(op);
     };
     target.addDynamicallyLegalOp<func::CallOp, func::ReturnOp>(opLegalCallback);
-    target
-        .addDynamicallyLegalDialect<arith::ArithDialect, vector::VectorDialect>(
-            opLegalCallback);
+    target.addDynamicallyLegalOp<vector::PrintOp>(opLegalCallback);
+    target.addDynamicallyLegalDialect<arith::ArithDialect>(opLegalCallback);
+    target.addLegalDialect<vector::VectorDialect>();
 
     RewritePatternSet patterns(ctx);
     arith::populateArithWideIntEmulationPatterns(typeConverter, patterns);

--- a/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
+++ b/mlir/test/Dialect/Arith/emulate-wide-int-unsupported.mlir
@@ -41,3 +41,13 @@ func.func @unsupported_argument_type(%arg0: vector<4xi128>) -> vector<4xi64> {
   return %0 : vector<4xi64>
 }
 
+// -----
+
+// Ensure this case not crash
+func.func @unsupported_vector(%arg0: vector<2xi1>) {
+  // expected-error@+1 {{failed to legalize unresolved materialization from ('vector<2x2xi32>') to ('vector<2xi64>') that remained live after conversion}}
+  %cst_0 = arith.constant dense<0> : vector<2xi64>
+  // expected-note@+1 {{see existing live user here}}
+  %0 = vector.mask %arg0 { vector.multi_reduction <xor>, %cst_0, %cst_0 [] : vector<2xi64> to vector<2xi64> } : vector<2xi1> -> vector<2xi64>
+  return
+}


### PR DESCRIPTION
This PR fixes a bug where dynamically legal operations were added for all vector operations, but only `vector.print` was supported, leading to a crash. Fixes #73381.