### PR TITLE
[pstl] Fix typos discovered by codespell

### DIFF
--- a/pstl/include/pstl/internal/omp/util.h
+++ b/pstl/include/pstl/internal/omp/util.h
@@ -44,7 +44,7 @@ namespace __omp_backend
 inline void
 __cancel_execution()
 {
-    // TODO: Figure out how to make cancelation work.
+    // TODO: Figure out how to make cancellation work.
 }
 
 //------------------------------------------------------------------------

--- a/pstl/include/pstl/internal/parallel_backend_tbb.h
+++ b/pstl/include/pstl/internal/parallel_backend_tbb.h
@@ -198,7 +198,7 @@ __parallel_transform_reduce(__pstl::__internal::__tbb_backend_tag, _ExecutionPol
                             _Up __u, _Tp __init, _Cp __combine, _Rp __brick_reduce)
 {
     __tbb_backend::__par_trans_red_body<_Index, _Up, _Tp, _Cp, _Rp> __body(__u, __init, __combine, __brick_reduce);
-    // The grain size of 3 is used in order to provide mininum 2 elements for each body
+    // The grain size of 3 is used in order to provide minimum 2 elements for each body
     tbb::this_task_arena::isolate(
         [__first, __last, &__body]() { tbb::parallel_reduce(tbb::blocked_range<_Index>(__first, __last, 3), __body); });
     return __body.sum();
@@ -727,7 +727,7 @@ class __merge_func
     _SizeType _M_zs;
     _Compare _M_comp;
     _LeafMerge _M_leaf_merge;
-    _SizeType _M_nsort; //number of elements to be sorted for partial_sort alforithm
+    _SizeType _M_nsort; //number of elements to be sorted for partial_sort algorithm
 
     static const _SizeType __merge_cut_off = _PSTL_MERGE_CUT_OFF;
 
@@ -1101,7 +1101,7 @@ class __stable_sort_func
     _Compare _M_comp;
     _LeafSort _M_leaf_sort;
     bool _M_root;
-    _SizeType _M_nsort; //zero or number of elements to be sorted for partial_sort alforithm
+    _SizeType _M_nsort; //zero or number of elements to be sorted for partial_sort algorithm
 
   public:
     __stable_sort_func(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __zs,
@@ -1166,7 +1166,7 @@ __parallel_stable_sort(__pstl::__internal::__tbb_backend_tag, _ExecutionPolicy&&
         typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
         const _DifferenceType __n = __xe - __xs;
         if (__nsort == __n)
-            __nsort = 0; // 'partial_sort' becames 'sort'
+            __nsort = 0; // 'partial_sort' becomes 'sort'
 
         const _DifferenceType __sort_cut_off = _PSTL_STABLE_SORT_CUT_OFF;
         if (__n > __sort_cut_off)

--- a/pstl/test/std/algorithms/alg.nonmodifying/equal.pass.cpp
+++ b/pstl/test/std/algorithms/alg.nonmodifying/equal.pass.cpp
@@ -108,7 +108,7 @@ struct test_one_policy
         // testing bool
         EXPECT_TRUE(is_true_equal == actual, "result for equal for random-access iterator, bool");
 
-//add C++14 equal symantics tests
+//add C++14 equal semantics tests
 //add more cases for inCopy size less than in
 #if CPP14_ENABLED
         auto actualr14 = std::equal(in.cbegin(), in.cend(), inCopy.cbegin(), inCopy.cend());

--- a/pstl/test/std/algorithms/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/pstl/test/std/algorithms/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -92,7 +92,7 @@ struct sequence_wrapper
             return;
         seq[at] = value;
 
-        //Producing serveral red herrings
+        //Producing several red herrings
         for (std::size_t i = at + 1; i < seq.size(); i += 1 + TestUtils::HashBits(i, 5))
             seq[i] = value;
     }

--- a/pstl/test/std/numerics/numeric.ops/scan.pass.cpp
+++ b/pstl/test/std/numerics/numeric.ops/scan.pass.cpp
@@ -191,7 +191,7 @@ main()
                                                             Matrix2x2<int32_t>(-666, 666));
 #endif
 
-        // Since the implict "+" forms of the scan delegate to the generic forms,
+        // Since the implicit "+" forms of the scan delegate to the generic forms,
         // there's little point in using a highly restricted type, so just use double.
         test_with_plus<float64_t>(inclusive ? 0.0 : -1.0, -666.0,
                                   [](uint32_t k) { return float64_t((k % 991 + 1) ^ (k % 997 + 2)); });

--- a/pstl/test/support/utils.h
+++ b/pstl/test/support/utils.h
@@ -133,7 +133,7 @@ expect_equal(Iterator1 expected_first, Iterator2 actual_first, Size n, const cha
 
 // ForwardIterator is like type Iterator, but restricted to be a forward iterator.
 // Only the forward iterator signatures that are necessary for tests are present.
-// Post-increment in particular is deliberatly omitted since our templates should avoid using it
+// Post-increment in particular is deliberately omitted since our templates should avoid using it
 // because of efficiency considerations.
 template <typename Iterator, typename IteratorTag>
 class ForwardIterator
@@ -252,7 +252,7 @@ struct MemoryChecker {
     MemoryChecker(MemoryChecker&& other) : _value(other.value()) {
         // check for EXPECT_TRUE(state() != alive_state, ...) has not been done since
         // compiler can optimize out the move ctor call that results in false positive failure
-        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker(MemoryChecker&&): attemp to construct an object from non-existing object");
+        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker(MemoryChecker&&): attempt to construct an object from non-existing object");
         // set constructed state and increment counter for living object
         inc_alive_objects();
         _state = alive_state;
@@ -260,15 +260,15 @@ struct MemoryChecker {
     MemoryChecker(const MemoryChecker& other) : _value(other.value()) {
         // check for EXPECT_TRUE(state() != alive_state, ...) has not been done since
         // compiler can optimize out the copy ctor call that results in false positive failure
-        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker(const MemoryChecker&): attemp to construct an object from non-existing object");
+        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker(const MemoryChecker&): attempt to construct an object from non-existing object");
         // set constructed state and increment counter for living object
         inc_alive_objects();
         _state = alive_state;
     }
     MemoryChecker& operator=(MemoryChecker&& other) {
         // check if we do not assign over uninitialized memory
-        EXPECT_TRUE(state() == alive_state, "wrong effect from MemoryChecker::operator=(MemoryChecker&& other): attemp to assign to non-existing object");
-        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker::operator=(MemoryChecker&& other): attemp to assign from non-existing object");
+        EXPECT_TRUE(state() == alive_state, "wrong effect from MemoryChecker::operator=(MemoryChecker&& other): attempt to assign to non-existing object");
+        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker::operator=(MemoryChecker&& other): attempt to assign from non-existing object");
         // just assign new value, counter is the same, state is the same
         _value = other.value();
 
@@ -276,8 +276,8 @@ struct MemoryChecker {
     }
     MemoryChecker& operator=(const MemoryChecker& other) {
         // check if we do not assign over uninitialized memory
-        EXPECT_TRUE(state() == alive_state, "wrong effect from MemoryChecker::operator=(const MemoryChecker& other): attemp to assign to non-existing object");
-        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker::operator=(const MemoryChecker& other): attemp to assign from non-existing object");
+        EXPECT_TRUE(state() == alive_state, "wrong effect from MemoryChecker::operator=(const MemoryChecker& other): attempt to assign to non-existing object");
+        EXPECT_TRUE(other.state() == alive_state, "wrong effect from MemoryChecker::operator=(const MemoryChecker& other): attempt to assign from non-existing object");
         // just assign new value, counter is the same, state is the same
         _value = other.value();
 
@@ -285,7 +285,7 @@ struct MemoryChecker {
     }
     ~MemoryChecker() {
         // check if we do not double destruct the object
-        EXPECT_TRUE(state() == alive_state, "wrong effect from ~MemoryChecker(): attemp to destroy non-existing object");
+        EXPECT_TRUE(state() == alive_state, "wrong effect from ~MemoryChecker(): attempt to destroy non-existing object");
         // set destructed state and decrement counter for living object
         static_cast<volatile std::int64_t&>(_state) = dead_state;
         dec_alive_objects();
@@ -685,7 +685,7 @@ multiply_matrix(const Matrix2x2<T>& left, const Matrix2x2<T>& right)
 //============================================================================
 // Adapters for creating different types of iterators.
 //
-// In this block we implemented some adapters for creating differnet types of iterators.
+// In this block we implemented some adapters for creating different types of iterators.
 // It's needed for extending the unit testing of Parallel STL algorithms.
 // We have adapters for iterators with different tags (forward_iterator_tag, bidirectional_iterator_tag), reverse iterators.
 // The input iterator should be const or non-const, non-reverse random access iterator.


### PR DESCRIPTION
https://github.com/codespell-project/codespell
```bash
codespell pstl --ignore-words-list=inout
```