### PR TITLE
[BoundsChecking] Update ubsantrap to use GuardKind

### DIFF
--- a/clang/test/CodeGen/allow-ubsan-check.c
+++ b/clang/test/CodeGen/allow-ubsan-check.c
@@ -202,7 +202,7 @@ void use(double*);
 // TR-NEXT:    [[TMP5:%.*]] = load double, ptr [[ARRAYIDX]], align 8, !tbaa [[TBAA7:![0-9]+]]
 // TR-NEXT:    ret double [[TMP5]]
 // TR:       [[TRAP]]:
-// TR-NEXT:    call void @llvm.ubsantrap(i8 3) #[[ATTR5]], !nosanitize [[META2]]
+// TR-NEXT:    call void @llvm.ubsantrap(i8 71) #[[ATTR5]], !nosanitize [[META2]]
 // TR-NEXT:    unreachable, !nosanitize [[META2]]
 //
 // REC-LABEL: define dso_local double @lbounds(


### PR DESCRIPTION
This change makes it consistent with other uses of ubsantrap.

This also updates the BoundsChecking/runtimes.ll. Previously, the test had guard=3 which passed only because the method of calculating the parameter (IRB.GetInsertBlock()->getParent()->size()) happened to give the same answer.