### PR TITLE
libclc: clspv: add missing clc_isnan.cl dependency

### DIFF
--- a/libclc/clc/lib/clspv/SOURCES
+++ b/libclc/clc/lib/clspv/SOURCES
@@ -5,5 +5,6 @@
 ../generic/math/clc_nextafter.cl
 ../generic/math/clc_rint.cl
 ../generic/math/clc_trunc.cl
+../generic/relational/clc_isnan.cl
 ../generic/relational/clc_select.cl
 ../generic/shared/clc_clamp.cl


### PR DESCRIPTION
clc_isnan.cl is needed since https://github.com/llvm/llvm-project/pull/124097