### PR TITLE
[LLVM] Automatically strip `-fno-lifetime-dse` from compile_commands.json

### DIFF
--- a/llvm/utils/merge-json.py
+++ b/llvm/utils/merge-json.py
@@ -35,6 +35,13 @@ def main():
         except (IOError, json.JSONDecodeError) as e:
             continue
 
+    # LLVM passes this argument by default but it is not supported by clang,
+    # causing annoying errors in the generated compile_commands.json file.
+    # Remove it here before we deduplicate the entries.
+    for entry in merged_data:
+        if isinstance(entry, dict) and "command" in entry:
+            entry["command"] = entry["command"].replace("-fno-lifetime-dse ", "")
+
     # Deduplicate by converting each entry to a tuple of sorted key-value pairs
     unique_data = list({json.dumps(entry, sort_keys=True) for entry in merged_data})
     unique_data = [json.loads(entry) for entry in unique_data]

--- a/llvm/utils/merge-json.py
+++ b/llvm/utils/merge-json.py
@@ -9,6 +9,7 @@ created by CMake when performing an LLVM runtime build.
 import argparse
 import json
 import sys
+import os
 
 
 def main():
@@ -40,7 +41,8 @@ def main():
     # Remove it here before we deduplicate the entries.
     for entry in merged_data:
         if isinstance(entry, dict) and "command" in entry:
-            entry["command"] = entry["command"].replace("-fno-lifetime-dse ", "")
+            if os.path.basename(entry["command"].partition(" ")[0]) != "g++":
+                entry["command"] = entry["command"].replace("-fno-lifetime-dse ", "")
 
     # Deduplicate by converting each entry to a tuple of sorted key-value pairs
     unique_data = list({json.dumps(entry, sort_keys=True) for entry in merged_data})


### PR DESCRIPTION
Summary:
This flag is always passed by LLVM to bypass some LTO related bug with
GCC. The problem is that this is not supported by clang and shows up in
the compile_commands.json file. That means it will always show at least
one error complaining about this file. Since I already have a script to
merge the runtimes stuff, just strip this out there for convenience.

There was a discussion a long time ago about not adding this as a no-op
flag to clang, so this is the next best thing.
