### PR TITLE
[libc++abi] Make once_flag constinit in cxa_exception_storage

### DIFF
--- a/libcxxabi/src/cxa_exception_storage.cpp
+++ b/libcxxabi/src/cxa_exception_storage.cpp
@@ -56,7 +56,7 @@ extern "C" {
 namespace __cxxabiv1 {
 namespace {
     std::__libcpp_tls_key key_;
-    std::__libcpp_exec_once_flag flag_ = _LIBCPP_EXEC_ONCE_INITIALIZER;
+    constinit std::__libcpp_exec_once_flag flag_ = _LIBCPP_EXEC_ONCE_INITIALIZER;
 
     void _LIBCPP_TLS_DESTRUCTOR_CC destruct_(void *p) {
         __free_with_fallback(p);


### PR DESCRIPTION
This makes it clearer that initialization of this global variable is taking place at compile-time, reducing the likelihood of static initialization order fiasco.