### PR TITLE
[clang-format] Fix annotating attrs in class/struct

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2633,11 +2633,19 @@ private:
              PreviousNotConst->MatchingParen->Previous->isNot(tok::kw_template);
     }
 
-    if ((PreviousNotConst->is(tok::r_paren) &&
-         PreviousNotConst->is(TT_TypeDeclarationParen)) ||
-        PreviousNotConst->is(TT_AttributeRParen)) {
+    if (PreviousNotConst->is(tok::r_paren) &&
+        PreviousNotConst->is(TT_TypeDeclarationParen)) {
       return true;
     }
+
+    auto InTypeDecl = [&]() {
+      for (auto Next = Tok.Next; Next; Next = Next->Next)
+        if (Next->isOneOf(TT_ClassLBrace, TT_StructLBrace))
+          return true;
+      return false;
+    };
+    if (PreviousNotConst->is(TT_AttributeRParen) && (!IsCpp || !InTypeDecl()))
+      return true;
 
     // If is a preprocess keyword like #define.
     if (IsPPKeyword)

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12415,6 +12415,18 @@ TEST_F(FormatTest, UnderstandsAttributes) {
   verifyFormat("SomeType s __unused{InitValue};", CustomAttrs);
   verifyFormat("SomeType *__capability s(InitValue);", CustomAttrs);
   verifyFormat("SomeType *__capability s{InitValue};", CustomAttrs);
+
+  FormatStyle Style = getLLVMStyle(FormatStyle::LK_Cpp);
+  verifyFormat(
+      "template <>\n"
+      "struct __declspec(uuid(\"3895C200-8F26-4F5A-B29D-2B5D72E68F99\"))\n"
+      "IAsyncOperation<IUnknown *> : IAsyncOperation_impl<IUnknown *> {};",
+      Style);
+  verifyFormat(
+      "template <>\n"
+      "class __declspec(uuid(\"3895C200-8F26-4F5A-B29D-2B5D72E68F99\"))\n"
+      "IAsyncOperation<IUnknown *> : IAsyncOperation_impl<IUnknown *> {};",
+      Style);
 }
 
 TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12415,18 +12415,6 @@ TEST_F(FormatTest, UnderstandsAttributes) {
   verifyFormat("SomeType s __unused{InitValue};", CustomAttrs);
   verifyFormat("SomeType *__capability s(InitValue);", CustomAttrs);
   verifyFormat("SomeType *__capability s{InitValue};", CustomAttrs);
-
-  FormatStyle Style = getLLVMStyle(FormatStyle::LK_Cpp);
-  verifyFormat(
-      "template <>\n"
-      "struct __declspec(uuid(\"3895C200-8F26-4F5A-B29D-2B5D72E68F99\"))\n"
-      "IAsyncOperation<IUnknown *> : IAsyncOperation_impl<IUnknown *> {};",
-      Style);
-  verifyFormat(
-      "template <>\n"
-      "class __declspec(uuid(\"3895C200-8F26-4F5A-B29D-2B5D72E68F99\"))\n"
-      "IAsyncOperation<IUnknown *> : IAsyncOperation_impl<IUnknown *> {};",
-      Style);
 }
 
 TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -3123,6 +3123,15 @@ TEST_F(TokenAnnotatorTest, UnderstandsAttributes) {
   EXPECT_TOKEN(Tokens[7], tok::identifier, TT_FunctionDeclarationName);
   EXPECT_TOKEN(Tokens[8], tok::l_paren, TT_FunctionDeclarationLParen);
 
+  Tokens = annotate("struct __attribute__((x)) foo {};");
+  ASSERT_EQ(Tokens.size(), 12u) << Tokens;
+  EXPECT_TOKEN(Tokens[2], tok::l_paren, TT_AttributeLParen);
+  EXPECT_TOKEN(Tokens[3], tok::l_paren, TT_Unknown);
+  EXPECT_TOKEN(Tokens[5], tok::r_paren, TT_Unknown);
+  EXPECT_TOKEN(Tokens[6], tok::r_paren, TT_AttributeRParen);
+  EXPECT_TOKEN(Tokens[7], tok::identifier, TT_Unknown);
+  EXPECT_TOKEN(Tokens[8], tok::l_brace, TT_StructLBrace);
+
   FormatStyle Style = getLLVMStyle();
   Style.AttributeMacros.push_back("FOO");
   Tokens = annotate("bool foo FOO(unused);", Style);


### PR DESCRIPTION
An attribute in a class/struct declaration confuses the annotator to treat the identifier following the attribute as a function or variable name.

Fixes #124574