### PR TITLE
[offload] Extend LIT infrastructure to allow using more tools

### DIFF
--- a/offload/cmake/OpenMPTesting.cmake
+++ b/offload/cmake/OpenMPTesting.cmake
@@ -47,6 +47,19 @@ function(find_standalone_test_dependencies)
     set(ENABLE_CHECK_TARGETS FALSE PARENT_SCOPE)
     return()
   endif()
+
+  find_program(OPENMP_LLVM_CONFIG_EXECUTABLE
+   NAMES llvm-config
+   PATHS ${OPENMP_LLVM_TOOLS_DIR})
+  if (LLVM_CONFIG OPENMP_LLVM_CONFIG_EXECUTABLE)
+    message(STATUS "Cannot find 'llvm-config'.")
+    message(STATUS "Please put 'llvm-config' in your PATH, set OPENMP_LLVM_CONFIG_EXECUTABLE to its full path, or point OPENMP_LLVM_TOOLS_DIR to its directory.")
+    message(WARNING "The check targets will not be available!")
+    set(ENABLE_CHECK_TARGETS FALSE PARENT_SCOPE)
+    return()
+  else()
+    set(OPENMP_LLVM_CONFIG_EXECUTABLE ${OPENMP_LLVM_CONFIG_EXECUTABLE} PARENT_SCOPE)
+  endif()
 endfunction()
 
 if (${OPENMP_STANDALONE_BUILD})
@@ -71,6 +84,7 @@ else()
     set(OPENMP_FILECHECK_EXECUTABLE ${LLVM_RUNTIME_OUTPUT_INTDIR}/FileCheck)
   endif()
   set(OPENMP_NOT_EXECUTABLE ${LLVM_RUNTIME_OUTPUT_INTDIR}/not)
+  set(OPENMP_LLVM_CONFIG_EXECUTABLE ${LLVM_RUNTIME_OUTPUT_INTDIR}/llvm-config)
 endif()
 set(OFFLOAD_DEVICE_INFO_EXECUTABLE ${LLVM_RUNTIME_OUTPUT_INTDIR}/llvm-offload-device-info)
 set(OFFLOAD_TBLGEN_EXECUTABLE ${LLVM_RUNTIME_OUTPUT_INTDIR}/offload-tblgen)
@@ -163,6 +177,8 @@ else()
   set(OPENMP_TEST_COMPILER_HAS_OMP_H 1)
   set(OPENMP_TEST_COMPILER_OPENMP_FLAGS "-fopenmp ${OPENMP_TEST_COMPILER_THREAD_FLAGS}")
   set(OPENMP_TEST_COMPILER_HAS_OMIT_FRAME_POINTER_FLAGS 1)
+  execute_process(COMMAND "${OPENMP_LLVM_CONFIG_EXECUTABLE}" "--targets-built"
+    OUTPUT_VARIABLE LLVM_TARGETS_BUILT OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 
 # Function to set compiler features for use in lit.

--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -101,6 +101,9 @@ config.target_triple = [ ]
 for feature in config.test_compiler_features:
     config.available_features.add(feature)
 
+for target in config.llvm_targets_built:
+    config.available_features.add(target.lower() + '-registered-target')
+
 if config.libomptarget_debug:
   config.available_features.add('libomptarget-debug')
 
@@ -419,3 +422,5 @@ config.substitutions.append(("%not", config.libomptarget_not))
 config.substitutions.append(("%offload-device-info",
                              config.offload_device_info))
 config.substitutions.append(("%offload-tblgen", config.offload_tblgen))
+config.substitutions.append(("%offload-packager", config.offload_packager))
+config.substitutions.append(("%offload-readelf", config.offload_readelf))

--- a/offload/test/lit.site.cfg.in
+++ b/offload/test/lit.site.cfg.in
@@ -15,6 +15,7 @@ config.libomptarget_obj_root = "@CMAKE_CURRENT_BINARY_DIR@/@CURRENT_TARGET@"
 config.library_dir = "@LIBOMPTARGET_LIBRARY_DIR@"
 config.llvm_library_dir = "@LIBOMPTARGET_LLVM_LIBRARY_DIR@"
 config.llvm_library_intdir = "@LIBOMPTARGET_LLVM_LIBRARY_INTDIR@"
+config.llvm_targets_built = "@LLVM_TARGETS_BUILT@".split()
 config.omp_header_directory = "@LIBOMPTARGET_OPENMP_HEADER_FOLDER@"
 config.omp_host_rtl_directory = "@LIBOMPTARGET_OPENMP_HOST_RTL_FOLDER@"
 config.llvm_lib_directory = "@LIBOMPTARGET_LLVM_LIBRARY_DIR@"
@@ -29,5 +30,7 @@ config.has_libomptarget_ompt = @LIBOMPTARGET_OMPT_SUPPORT@
 config.libomptarget_has_libc = @LIBOMPTARGET_GPU_LIBC_SUPPORT@
 config.libomptarget_test_pgo = @LIBOMPTARGET_TEST_GPU_PGO@
 config.offload_tblgen = "@OFFLOAD_TBLGEN_EXECUTABLE@"
+config.offload_packager = "@PACKAGER_TOOL@"
+config.offload_readelf = "@CMAKE_READELF@"
 # Let the main config do the real work.
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg")


### PR DESCRIPTION
This is kind of an RFC since I'm not sure if this change is the best way to do what I want.

In a future PR I will be adding ELF packaging of `spirv64-intel` OpenMP device images, as there is no ELF linker for SPIR-V today. I want to test the image is packaged correctly in the test by doing something like:

```
clang++ -nogpulib -fopenmp -fopenmp-targets=spirv64-intel %s -o %t.out
clang-offload-packager --image=kind=openmp,triple=spirv64-intel,file=%t.elf %t.out
llvm-readelf --notes %t.elf | FileCheck %s
// CHECK: ...
```

We don't build the DeviceRTL for SPIR-V yet, so this test will be a little bit different than the existing offload LIT tests.

I did some basic testing locally and this seems to work, but the offload project build seems complicated so I might have not handled a case.


