### PR TITLE
[clang-cl]: generate debug info when `novtable` is specified

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -2815,7 +2815,7 @@ static bool shouldOmitDefinition(llvm::codegenoptions::DebugInfoKind DebugKind,
   // without any dllimport methods can be used in one DLL and constructed in
   // another, but it is the current behavior of LimitedDebugInfo.
   if (CXXDecl->hasDefinition() && CXXDecl->isDynamicClass() &&
-      !isClassOrMethodDLLImport(CXXDecl))
+      !isClassOrMethodDLLImport(CXXDecl) && !CXXDecl->hasAttr<MSNoVTableAttr>())
     return true;
 
   TemplateSpecializationKind Spec = TSK_Undeclared;

--- a/clang/test/CodeGenCXX/debug-info-ms-novtable.cpp
+++ b/clang/test/CodeGenCXX/debug-info-ms-novtable.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang -g -S -emit-llvm -fms-extensions -fms-compatibility -target x86_64-pc-windows-msvc -o - %s | FileCheck %s
+
+// CHECK-DAG: ![[FOO:[0-9]+]] = distinct !DICompositeType(tag: DW_TAG_class_type, name: "Foo", file: !{{[0-9]+}}, line: {{[0-9]+}}, size: 128, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: ![[FOO_ELEMENTS:[0-9]+]], vtableHolder: ![[FOO]], identifier: ".?AVFoo@@")
+// CHECK-DAG: ![[FOO_ELEMENTS]] = !{![[FOO_VTBL_TY:[0-9]+]], ![[FOO_VTBL_MEMBER:[0-9]+]], ![[FOO_MEMBER:[0-9]+]], ![[FOO_DUMMY:[0-9]+]]}
+// CHECK-DAG: ![[FOO_VTBL_TY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "__vtbl_ptr_type", baseType: null, size: 64)
+// CHECK-DAG: ![[FOO_VTBL_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, name: "_vptr$Foo", scope: !10, file: !{{[0-9]+}}, baseType: ![[FOO_VTBL_PTR_TY:[0-9]+]], size: 64, flags: DIFlagArtificial)
+// CHECK-DAG: ![[FOO_VTBL_PTR_TY]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: ![[FOO_VTBL_TY]], size: 64)
+// CHECK-DAG: ![[FOO_MEMBER]] = !DIDerivedType(tag: DW_TAG_member, name: "member", scope: ![[FOO]], file: !{{[0-9]+}}, line: {{[0-9]+}}, baseType: !{{[0-9]+}}, size: 32, offset: 64)
+// CHECK-DAG: ![[FOO_DUMMY]] = !DISubprogram(name: "dummy", linkageName: "?dummy@Foo@@EEAAXXZ", scope: ![[FOO]], file: !{{[0-9]+}}, line: {{[0-9]+}}, type: !{{[0-9]+}}, scopeLine: {{[0-9]+}}, containingType: ![[FOO]], virtualIndex: 0, flags: DIFlagPrototyped | DIFlagIntroducedVirtual, spFlags: DISPFlagVirtual)
+class __declspec(novtable) Foo {
+    virtual void dummy() noexcept {};
+
+    int member = 1;
+};
+
+void foo(Foo) {}


### PR DESCRIPTION
When no vtable is emitted in the debug info because a record was marked `__declspec(novtable)`, only a forward declaration of that type will be emitted. This PR fixes that by not omitting the definition for the `RecordDecl` in this case.

Fixes #124638.