### PR TITLE
[LLDB-DAP] SBDebugger don't prefix title on progress updates

### DIFF
--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -11,7 +11,15 @@ The Progress class helps make sure that progress is correctly reported
 and will always send an initial progress update, updates when
 Progress::Increment() is called, and also will make sure that a progress
 completed update is reported even if the user doesn't explicitly cause one
-to be sent.") lldb::SBProgress;
+to be sent.
+
+Progress can either be deterministic, incrementing up to a known total or non-deterministic
+with an unbounded total. Deterministic is better if you know the items of work in advance, but non-deterministic
+exposes a way to update a user during a long running process that work is taking place.
+
+For non-deterministic 
+
+") lldb::SBProgress;
 
 %feature("docstring",
 "Finalize the SBProgress, which will cause a progress end event to be emitted. This 

--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -22,7 +22,20 @@ is provided. This detail will also continue to be broadcasted on any subsequent 
 specify a new detail. Some implementations differ on throttling updates and this behavior differs primarily
 if the progress is deterministic or non-deterministic. For DAP, non-deterministic update messages have a higher
 throttling rate than deterministic ones.
-") lldb::SBProgress;
+
+Below are examples in Python for deterministic and non-deterministic progresses.
+
+    deterministic_progress = lldb.SBProgress('Deterministic Progress', 'Detail', 3, lldb.SBDebugger)
+    for i in range(3):
+        deterministic_progress.Increment(1, f'Update {i}')
+
+    non_deterministic_progress = lldb.SBProgress('Non deterministic progress, 'Detail', lldb.SBDebugger)
+    for i in range(10):
+        non_deterministic_progress.Increment(1)
+
+    # Explicitly send a progressEnd from Python.
+    non_deterministic_progress.Finalize()
+") lldb::SBProgress;    
 
 %feature("docstring",
 "Finalize the SBProgress, which will cause a progress end event to be emitted. This 

--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -17,8 +17,11 @@ Progress can either be deterministic, incrementing up to a known total or non-de
 with an unbounded total. Deterministic is better if you know the items of work in advance, but non-deterministic
 exposes a way to update a user during a long running process that work is taking place.
 
-For non-deterministic 
-
+For all progresses the details provided in the constructor will be sent until an increment detail
+is provided. This detail will also continue to be broadcasted on any subsequent update that doesn't
+specify a new detail. Some implementations differ on throttling updates and this behavior differs primarily
+if the progress is deterministic or non-deterministic. For DAP, non-deterministic update messages have a higher
+throttling rate than deterministic ones.
 ") lldb::SBProgress;
 
 %feature("docstring",

--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -25,15 +25,33 @@ throttling rate than deterministic ones.
 
 Below are examples in Python for deterministic and non-deterministic progresses.
 
-    deterministic_progress = lldb.SBProgress('Deterministic Progress', 'Detail', 3, lldb.SBDebugger)
-    for i in range(3):
-        deterministic_progress.Increment(1, f'Update {i}')
+    deterministic_progress1 = lldb.SBProgress('Deterministic Progress', 'Detail', 3, lldb.SBDebugger) 
+    for i in range(3): 
+        deterministic_progress1.Increment(1, f'Update {i}') 
+        
+    # The call to Finalize() is a no-op as we already incremented the right amount of 
+    # times and caused the end event to be sent. 
+    deterministic_progress1.Finalize() 
+    deterministic_progress2 = lldb.SBProgress('Deterministic Progress', 'Detail', 10, lldb.SBDebugger) 
+    for i in range(3): 
+        deterministic_progress2.Increment(1, f'Update {i}') 
+        
+    # Cause the progress end event to be sent even if we didn't increment the right 
+    # number of times. Real world examples would be in a try-finally block to ensure
+    # progress clean-up.
+
+    deterministic_progress2.Finalize() 
+If you don't call Finalize() when the progress is not done, the progress object will eventually get
+garbage collected by the Python runtime, the end event will eventually get sent, but it is best not to 
+rely on the garbage collection when using lldb.SBProgress.
+
+Non-deterministic progresses behave the same, but omit the total in the constructor.
 
     non_deterministic_progress = lldb.SBProgress('Non deterministic progress, 'Detail', lldb.SBDebugger)
     for i in range(10):
         non_deterministic_progress.Increment(1)
-
-    # Explicitly send a progressEnd from Python.
+    # Explicitly send a progressEnd, otherwise this will be sent
+    # when the python runtime cleans up this object.
     non_deterministic_progress.Finalize()
 ") lldb::SBProgress;    
 

--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -28,19 +28,18 @@ Below are examples in Python for deterministic and non-deterministic progresses.
     deterministic_progress1 = lldb.SBProgress('Deterministic Progress', 'Detail', 3, lldb.SBDebugger) 
     for i in range(3): 
         deterministic_progress1.Increment(1, f'Update {i}') 
-        
     # The call to Finalize() is a no-op as we already incremented the right amount of 
     # times and caused the end event to be sent. 
-    deterministic_progress1.Finalize() 
+    deterministic_progress1.Finalize()
+
     deterministic_progress2 = lldb.SBProgress('Deterministic Progress', 'Detail', 10, lldb.SBDebugger) 
     for i in range(3): 
-        deterministic_progress2.Increment(1, f'Update {i}') 
-        
+        deterministic_progress2.Increment(1, f'Update {i}')      
     # Cause the progress end event to be sent even if we didn't increment the right 
     # number of times. Real world examples would be in a try-finally block to ensure
     # progress clean-up.
-
     deterministic_progress2.Finalize() 
+
 If you don't call Finalize() when the progress is not done, the progress object will eventually get
 garbage collected by the Python runtime, the end event will eventually get sent, but it is best not to 
 rely on the garbage collection when using lldb.SBProgress.

--- a/lldb/include/lldb/Core/DebuggerEvents.h
+++ b/lldb/include/lldb/Core/DebuggerEvents.h
@@ -44,16 +44,12 @@ public:
   uint64_t GetCompleted() const { return m_completed; }
   uint64_t GetTotal() const { return m_total; }
   std::string GetMessage() const {
-    // Only put the title in the message of the progress create event.
-    if (m_completed == 0) {
-      std::string message = m_title;
-      if (!m_details.empty()) {
-        message.append(": ");
-        message.append(m_details);
-      }
-      return message;
-    } else
-      return !m_details.empty() ? m_details : std::string();
+    std::string message = m_title;
+    if (!m_details.empty()) {
+      message.append(": ");
+      message.append(m_details);
+    }
+    return message;
   }
   const std::string &GetTitle() const { return m_title; }
   const std::string &GetDetails() const { return m_details; }

--- a/lldb/include/lldb/Core/DebuggerEvents.h
+++ b/lldb/include/lldb/Core/DebuggerEvents.h
@@ -44,12 +44,15 @@ public:
   uint64_t GetCompleted() const { return m_completed; }
   uint64_t GetTotal() const { return m_total; }
   std::string GetMessage() const {
-    std::string message = m_title;
-    if (!m_details.empty()) {
-      message.append(": ");
-      message.append(m_details);
-    }
-    return message;
+    if (m_completed == 0) {
+      std::string message = m_title;
+      if (!m_details.empty()) {
+        message.append(": ");
+        message.append(m_details);
+      }
+      return message;
+    } else
+      return !m_details.empty() ? m_details : std::string();
   }
   const std::string &GetTitle() const { return m_title; }
   const std::string &GetDetails() const { return m_details; }

--- a/lldb/include/lldb/Core/DebuggerEvents.h
+++ b/lldb/include/lldb/Core/DebuggerEvents.h
@@ -44,6 +44,7 @@ public:
   uint64_t GetCompleted() const { return m_completed; }
   uint64_t GetTotal() const { return m_total; }
   std::string GetMessage() const {
+    // Only put the title in the message of the progress create event.
     if (m_completed == 0) {
       std::string message = m_title;
       if (!m_details.empty()) {

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -37,7 +37,10 @@ class ProgressTesterCommand:
         )
 
         parser.add_option(
-            "--total", dest="total", help="Total to count up.", type="int"
+            "--total",
+            dest="total",
+            help="Total to count up, use -1 to identify as indeterminate",
+            type="int",
         )
 
         parser.add_option(
@@ -45,6 +48,13 @@ class ProgressTesterCommand:
             dest="seconds",
             help="Total number of seconds to wait between increments",
             type="int",
+        )
+
+        parser.add_option(
+            "--no-details",
+            dest="no_details",
+            help="Do not display details",
+            action="store_true",
         )
 
         return parser
@@ -68,10 +78,23 @@ class ProgressTesterCommand:
             return
 
         total = cmd_options.total
-        progress = lldb.SBProgress("Progress tester", "Detail", total, debugger)
+        if total == -1:
+            progress = lldb.SBProgress(
+                "Progress tester", "Indeterminate Detail", debugger
+            )
+        else:
+            progress = lldb.SBProgress("Progress tester", "Detail", total, debugger)
+
+        # Check to see if total is set to -1 to indicate an indeterminate progress
+        # then default to 10 steps.
+        if total == -1:
+            total = 10
 
         for i in range(1, total):
-            progress.Increment(1, f"Step {i}")
+            if cmd_options.no_details:
+                progress.Increment(1)
+            else:
+                progress.Increment(1, f"Step {i}")
             time.sleep(cmd_options.seconds)
 
 

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -85,7 +85,9 @@ class ProgressTesterCommand:
                 "Progress tester", "Initial Indeterminate Detail", debugger
             )
         else:
-            progress = lldb.SBProgress("Progress tester", "Initial Detail", total, debugger)
+            progress = lldb.SBProgress(
+                "Progress tester", "Initial Detail", total, debugger
+            )
 
         # Check to see if total is set to None to indicate an indeterminate progress
         # then default to 10 steps.

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -39,8 +39,9 @@ class ProgressTesterCommand:
         parser.add_option(
             "--total",
             dest="total",
-            help="Total to count up, use -1 to identify as indeterminate",
+            help="Total to count up, use None to identify as indeterminate",
             type="int",
+            default=None,
         )
 
         parser.add_option(
@@ -78,16 +79,16 @@ class ProgressTesterCommand:
             return
 
         total = cmd_options.total
-        if total == -1:
+        if total is None:
             progress = lldb.SBProgress(
                 "Progress tester", "Indeterminate Detail", debugger
             )
         else:
             progress = lldb.SBProgress("Progress tester", "Detail", total, debugger)
 
-        # Check to see if total is set to -1 to indicate an indeterminate progress
+        # Check to see if total is set to None to indicate an indeterminate progress
         # then default to 10 steps.
-        if total == -1:
+        if total is None:
             total = 10
 
         for i in range(1, total):

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -56,6 +56,7 @@ class ProgressTesterCommand:
             dest="no_details",
             help="Do not display details",
             action="store_true",
+            default=False,
         )
 
         return parser
@@ -81,10 +82,10 @@ class ProgressTesterCommand:
         total = cmd_options.total
         if total is None:
             progress = lldb.SBProgress(
-                "Progress tester", "Indeterminate Detail", debugger
+                "Progress tester", "Initial Indeterminate Detail", debugger
             )
         else:
-            progress = lldb.SBProgress("Progress tester", "Detail", total, debugger)
+            progress = lldb.SBProgress("Progress tester", "Initial Detail", total, debugger)
 
         # Check to see if total is set to None to indicate an indeterminate progress
         # then default to 10 steps.

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -39,7 +39,7 @@ class ProgressTesterCommand:
         parser.add_option(
             "--total",
             dest="total",
-            help="Total to count up, use None to identify as indeterminate",
+            help="Total items in this progress object. When this option is not specified, this will be an indeterminate progress.",
             type="int",
             default=None,
         )
@@ -100,6 +100,9 @@ class ProgressTesterCommand:
             else:
                 progress.Increment(1, f"Step {i}")
             time.sleep(cmd_options.seconds)
+
+        # Not required for deterministic progress, but required for indeterminate progress.
+        progress.Finalize()
 
 
 def __lldb_init_module(debugger, dict):

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -19,7 +19,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         expected_not_in_message=None,
         only_verify_first_update=False,
     ):
-        self.dap_server.wait_for_event("progressEnd", 15)
+        self.dap_server.wait_for_event("progressEnd", 5)
         self.assertTrue(len(self.dap_server.progress_events) > 0)
         start_found = False
         update_found = False

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -87,9 +87,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
                 start_found = True
             if "progressUpdate" in event_type:
                 message = event["body"]["message"]
-                # We send an update on first message to set the details, so ignore the first update
-                if not update_found:
-                    self.assertTrue(message == "", message)
+                self.assertEqual("Initial Detail", message)
                 update_found = True
 
         self.assertTrue(start_found)
@@ -128,7 +126,9 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             if "progressUpdate" in event_type:
                 message = event["body"]["message"]
                 print(f"Progress update: {message}")
-                self.assertNotIn("Progres tester", message)
+                # Check on the first update we set the initial detail.
+                if not update_found:
+                    self.assertEqual("Step 1", message)
                 update_found = True
 
         self.assertTrue(start_found)
@@ -168,9 +168,9 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
                 start_found = True
             if "progressUpdate" in event_type:
                 message = event["body"]["message"]
-                # We send an update on first message to set the details, so ignore the first update
+                # Check on the first update we set the initial detail.
                 if not update_found:
-                    self.assertTrue(message == "", message)
+                    self.assertEqual("Initial Indeterminate Detail", message)
                 update_found = True
 
         self.assertTrue(start_found)

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -109,9 +109,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         self.dap_server.request_evaluate(
             f"`command script import {progress_emitter}", context="repl"
         )
-        self.dap_server.request_evaluate(
-            "`test-progress --total -1 --seconds 1", context="repl"
-        )
+        self.dap_server.request_evaluate("`test-progress --seconds 1", context="repl")
 
         self.dap_server.wait_for_event("progressEnd", 15)
         # Expect at least a start, an update, and end event
@@ -151,7 +149,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         )
 
         self.dap_server.request_evaluate(
-            "`test-progress --total -1 --seconds 1 --no-details", context="repl"
+            "`test-progress --seconds 1 --no-details", context="repl"
         )
 
         self.dap_server.wait_for_event("progressEnd", 15)

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -41,8 +41,13 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         for event in self.dap_server.progress_events:
             event_type = event["event"]
             if "progressStart" in event_type:
+                title = event["body"]["title"]
+                self.assertIn("Progress tester", title)
                 start_found = True
             if "progressUpdate" in event_type:
+                message = event["body"]["message"]
+                print(f"Progress update: {message}")
+                self.assertNotIn("Progres tester", message)
                 update_found = True
 
         self.assertTrue(start_found)

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -51,7 +51,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        print(f"Progress emitter path: {progress_emitter}")
         source = "main.cpp"
         breakpoint_ids = self.set_source_breakpoints(
             source, [line_number(source, "// break here")]
@@ -74,7 +73,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        print(f"Progress emitter path: {progress_emitter}")
         source = "main.cpp"
         breakpoint_ids = self.set_source_breakpoints(
             source, [line_number(source, "// break here")]
@@ -97,7 +95,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        print(f"Progress emitter path: {progress_emitter}")
         source = "main.cpp"
         breakpoint_ids = self.set_source_breakpoints(
             source, [line_number(source, "// break here")]
@@ -109,7 +106,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         self.dap_server.request_evaluate("`test-progress --seconds 1", context="repl")
 
         self.verify_progress_events(
-            expected_title="Progress tester",
+            expected_title="Progress tester: Initial Indeterminate Detail",
             expected_message="Step 1",
             only_verify_first_update=True,
         )
@@ -119,7 +116,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        print(f"Progress emitter path: {progress_emitter}")
         source = "main.cpp"
         breakpoint_ids = self.set_source_breakpoints(
             source, [line_number(source, "// break here")]
@@ -133,7 +129,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         )
 
         self.verify_progress_events(
-            expected_title="Progress tester",
+            expected_title="Progress tester: Initial Indeterminate Detail",
             expected_message="Initial Indeterminate Detail",
             only_verify_first_update=True,
         )

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -19,7 +19,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         expected_not_in_message=None,
         only_verify_first_update=False,
     ):
-        self.dap_server.wait_for_event("progressEnd", 5)
+        self.dap_server.wait_for_event("progressEnd", 15)
         self.assertTrue(len(self.dap_server.progress_events) > 0)
         start_found = False
         update_found = False

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -4,6 +4,7 @@ Test lldb-dap output events
 
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
+import json
 import os
 import time
 
@@ -18,7 +19,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
         print(f"Progress emitter path: {progress_emitter}")
         source = "main.cpp"
-        # Set breakpoint in the thread function so we can step the threads
         breakpoint_ids = self.set_source_breakpoints(
             source, [line_number(source, "// break here")]
         )
@@ -48,6 +48,131 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
                 message = event["body"]["message"]
                 print(f"Progress update: {message}")
                 self.assertNotIn("Progres tester", message)
+                update_found = True
+
+        self.assertTrue(start_found)
+        self.assertTrue(update_found)
+
+    @skipIfWindows
+    def test_output_nodetails(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
+        print(f"Progress emitter path: {progress_emitter}")
+        source = "main.cpp"
+        breakpoint_ids = self.set_source_breakpoints(
+            source, [line_number(source, "// break here")]
+        )
+        self.continue_to_breakpoints(breakpoint_ids)
+        self.dap_server.request_evaluate(
+            f"`command script import {progress_emitter}", context="repl"
+        )
+        self.dap_server.request_evaluate(
+            "`test-progress --total 3 --seconds 1 --no-details", context="repl"
+        )
+
+        self.dap_server.wait_for_event("progressEnd", 15)
+        # Expect at least a start, an update, and end event
+        # However because the underlying Progress instance is an RAII object and we can't guaruntee
+        # it's deterministic destruction in the python API, we verify just start and update
+        # otherwise this test could be flakey.
+        self.assertTrue(len(self.dap_server.progress_events) > 0)
+        start_found = False
+        update_found = False
+        for event in self.dap_server.progress_events:
+            event_type = event["event"]
+            if "progressStart" in event_type:
+                title = event["body"]["title"]
+                self.assertIn("Progress tester", title)
+                start_found = True
+            if "progressUpdate" in event_type:
+                message = event["body"]["message"]
+                # We send an update on first message to set the details, so ignore the first update
+                if not update_found:
+                    self.assertTrue(message == "", message)
+                update_found = True
+
+        self.assertTrue(start_found)
+        self.assertTrue(update_found)
+
+    @skipIfWindows
+    def test_output_indeterminate(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
+        print(f"Progress emitter path: {progress_emitter}")
+        source = "main.cpp"
+        breakpoint_ids = self.set_source_breakpoints(
+            source, [line_number(source, "// break here")]
+        )
+        self.continue_to_breakpoints(breakpoint_ids)
+        self.dap_server.request_evaluate(
+            f"`command script import {progress_emitter}", context="repl"
+        )
+        self.dap_server.request_evaluate(
+            "`test-progress --total -1 --seconds 1", context="repl"
+        )
+
+        self.dap_server.wait_for_event("progressEnd", 15)
+        # Expect at least a start, an update, and end event
+        # However because the underlying Progress instance is an RAII object and we can't guaruntee
+        # it's deterministic destruction in the python API, we verify just start and update
+        # otherwise this test could be flakey.
+        self.assertTrue(len(self.dap_server.progress_events) > 0)
+        start_found = False
+        update_found = False
+        for event in self.dap_server.progress_events:
+            event_type = event["event"]
+            if "progressStart" in event_type:
+                title = event["body"]["title"]
+                self.assertIn("Progress tester", title)
+                start_found = True
+            if "progressUpdate" in event_type:
+                message = event["body"]["message"]
+                print(f"Progress update: {message}")
+                self.assertNotIn("Progres tester", message)
+                update_found = True
+
+        self.assertTrue(start_found)
+        self.assertTrue(update_found)
+
+    @skipIfWindows
+    def test_output_nodetails_indeterminate(self):
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
+        print(f"Progress emitter path: {progress_emitter}")
+        source = "main.cpp"
+        breakpoint_ids = self.set_source_breakpoints(
+            source, [line_number(source, "// break here")]
+        )
+        self.dap_server.request_evaluate(
+            f"`command script import {progress_emitter}", context="repl"
+        )
+
+        self.dap_server.request_evaluate(
+            "`test-progress --total -1 --seconds 1 --no-details", context="repl"
+        )
+
+        self.dap_server.wait_for_event("progressEnd", 15)
+        # Expect at least a start, an update, and end event
+        # However because the underlying Progress instance is an RAII object and we can't guaruntee
+        # it's deterministic destruction in the python API, we verify just start and update
+        # otherwise this test could be flakey.
+        self.assertTrue(len(self.dap_server.progress_events) > 0)
+        start_found = False
+        update_found = False
+        for event in self.dap_server.progress_events:
+            event_type = event["event"]
+            if "progressStart" in event_type:
+                title = event["body"]["title"]
+                self.assertIn("Progress tester", title)
+                start_found = True
+            if "progressUpdate" in event_type:
+                message = event["body"]["message"]
+                # We send an update on first message to set the details, so ignore the first update
+                if not update_found:
+                    self.assertTrue(message == "", message)
                 update_found = True
 
         self.assertTrue(start_found)

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -12,6 +12,41 @@ import lldbdap_testcase
 
 
 class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
+    def verify_progress_events(
+        self,
+        expected_title,
+        expected_message=None,
+        expected_not_in_message=None,
+        only_verify_first_update=False,
+    ):
+        self.dap_server.wait_for_event("progressEnd", 15)
+        self.assertTrue(len(self.dap_server.progress_events) > 0)
+        start_found = False
+        update_found = False
+        end_found = False
+        for event in self.dap_server.progress_events:
+            event_type = event["event"]
+            if "progressStart" in event_type:
+                title = event["body"]["title"]
+                self.assertIn(expected_title, title)
+                start_found = True
+            if "progressUpdate" in event_type:
+                message = event["body"]["message"]
+                print(f"Progress update: {message}")
+                if only_verify_first_update and update_found:
+                    continue
+                if expected_message is not None:
+                    self.assertIn(expected_message, message)
+                if expected_not_in_message is not None:
+                    self.assertNotIn(expected_not_in_message, message)
+                update_found = True
+            if "progressEnd" in event_type:
+                end_found = True
+
+        self.assertTrue(start_found)
+        self.assertTrue(update_found)
+        self.assertTrue(end_found)
+
     @skipIfWindows
     def test_output(self):
         program = self.getBuildArtifact("a.out")
@@ -30,28 +65,10 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             "`test-progress --total 3 --seconds 1", context="repl"
         )
 
-        self.dap_server.wait_for_event("progressEnd", 15)
-        # Expect at least a start, an update, and end event
-        # However because the underlying Progress instance is an RAII object and we can't guaruntee
-        # it's deterministic destruction in the python API, we verify just start and update
-        # otherwise this test could be flakey.
-        self.assertTrue(len(self.dap_server.progress_events) > 0)
-        start_found = False
-        update_found = False
-        for event in self.dap_server.progress_events:
-            event_type = event["event"]
-            if "progressStart" in event_type:
-                title = event["body"]["title"]
-                self.assertIn("Progress tester", title)
-                start_found = True
-            if "progressUpdate" in event_type:
-                message = event["body"]["message"]
-                print(f"Progress update: {message}")
-                self.assertNotIn("Progres tester", message)
-                update_found = True
-
-        self.assertTrue(start_found)
-        self.assertTrue(update_found)
+        self.verify_progress_events(
+            expected_title="Progress tester",
+            expected_not_in_message="Progress tester",
+        )
 
     @skipIfWindows
     def test_output_nodetails(self):
@@ -71,27 +88,10 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             "`test-progress --total 3 --seconds 1 --no-details", context="repl"
         )
 
-        self.dap_server.wait_for_event("progressEnd", 15)
-        # Expect at least a start, an update, and end event
-        # However because the underlying Progress instance is an RAII object and we can't guaruntee
-        # it's deterministic destruction in the python API, we verify just start and update
-        # otherwise this test could be flakey.
-        self.assertTrue(len(self.dap_server.progress_events) > 0)
-        start_found = False
-        update_found = False
-        for event in self.dap_server.progress_events:
-            event_type = event["event"]
-            if "progressStart" in event_type:
-                title = event["body"]["title"]
-                self.assertIn("Progress tester", title)
-                start_found = True
-            if "progressUpdate" in event_type:
-                message = event["body"]["message"]
-                self.assertEqual("Initial Detail", message)
-                update_found = True
-
-        self.assertTrue(start_found)
-        self.assertTrue(update_found)
+        self.verify_progress_events(
+            expected_title="Progress tester",
+            expected_message="Initial Detail",
+        )
 
     @skipIfWindows
     def test_output_indeterminate(self):
@@ -109,30 +109,11 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         )
         self.dap_server.request_evaluate("`test-progress --seconds 1", context="repl")
 
-        self.dap_server.wait_for_event("progressEnd", 15)
-        # Expect at least a start, an update, and end event
-        # However because the underlying Progress instance is an RAII object and we can't guaruntee
-        # it's deterministic destruction in the python API, we verify just start and update
-        # otherwise this test could be flakey.
-        self.assertTrue(len(self.dap_server.progress_events) > 0)
-        start_found = False
-        update_found = False
-        for event in self.dap_server.progress_events:
-            event_type = event["event"]
-            if "progressStart" in event_type:
-                title = event["body"]["title"]
-                self.assertIn("Progress tester", title)
-                start_found = True
-            if "progressUpdate" in event_type:
-                message = event["body"]["message"]
-                print(f"Progress update: {message}")
-                # Check on the first update we set the initial detail.
-                if not update_found:
-                    self.assertEqual("Step 1", message)
-                update_found = True
-
-        self.assertTrue(start_found)
-        self.assertTrue(update_found)
+        self.verify_progress_events(
+            expected_title="Progress tester",
+            expected_message="Step 1",
+            only_verify_first_update=True,
+        )
 
     @skipIfWindows
     def test_output_nodetails_indeterminate(self):
@@ -152,26 +133,8 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             "`test-progress --seconds 1 --no-details", context="repl"
         )
 
-        self.dap_server.wait_for_event("progressEnd", 15)
-        # Expect at least a start, an update, and end event
-        # However because the underlying Progress instance is an RAII object and we can't guaruntee
-        # it's deterministic destruction in the python API, we verify just start and update
-        # otherwise this test could be flakey.
-        self.assertTrue(len(self.dap_server.progress_events) > 0)
-        start_found = False
-        update_found = False
-        for event in self.dap_server.progress_events:
-            event_type = event["event"]
-            if "progressStart" in event_type:
-                title = event["body"]["title"]
-                self.assertIn("Progress tester", title)
-                start_found = True
-            if "progressUpdate" in event_type:
-                message = event["body"]["message"]
-                # Check on the first update we set the initial detail.
-                if not update_found:
-                    self.assertEqual("Initial Indeterminate Detail", message)
-                update_found = True
-
-        self.assertTrue(start_found)
-        self.assertTrue(update_found)
+        self.verify_progress_events(
+            expected_title="Progress tester",
+            expected_message="Initial Indeterminate Detail",
+            only_verify_first_update=True,
+        )

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -32,7 +32,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
                 start_found = True
             if "progressUpdate" in event_type:
                 message = event["body"]["message"]
-                print(f"Progress update: {message}")
                 if only_verify_first_update and update_found:
                     continue
                 if expected_message is not None:

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -18,8 +18,32 @@ using namespace lldb;
 
 namespace lldb_dap {
 
-static void ProgressEventThreadFunction(DAP &dap) {
-  llvm::set_thread_name(dap.name + ".progress_handler");
+static std::string GetStringFromStructuredData(lldb::SBStructuredData &data,
+                                               const char *key) {
+  lldb::SBStructuredData keyValue = data.GetValueForKey(key);
+  if (!keyValue)
+    return std::string();
+
+  const size_t length = keyValue.GetStringValue(nullptr, 0);
+
+  if (length == 0)
+    return std::string();
+
+  std::string str(length + 1, 0);
+  keyValue.GetStringValue(&str[0], length + 1);
+  return str;
+}
+
+static uint64_t GetUintFromStructuredData(lldb::SBStructuredData &data,
+                                          const char *key) {
+  lldb::SBStructuredData keyValue = data.GetValueForKey(key);
+
+  if (!keyValue.IsValid())
+    return 0;
+  return keyValue.GetUnsignedIntegerValue();
+}
+
+void ProgressEventThreadFunction(DAP &dap) {
   lldb::SBListener listener("lldb-dap.progress.listener");
   dap.debugger.GetBroadcaster().AddListener(
       listener, lldb::SBDebugger::eBroadcastBitProgress |
@@ -35,14 +59,47 @@ static void ProgressEventThreadFunction(DAP &dap) {
           done = true;
         }
       } else {
-        uint64_t progress_id = 0;
-        uint64_t completed = 0;
-        uint64_t total = 0;
-        bool is_debugger_specific = false;
-        const char *message = lldb::SBDebugger::GetProgressFromEvent(
-            event, progress_id, completed, total, is_debugger_specific);
-        if (message)
-          dap.SendProgressEvent(progress_id, message, completed, total);
+        lldb::SBStructuredData data =
+            lldb::SBDebugger::GetProgressDataFromEvent(event);
+
+        const uint64_t progress_id =
+            GetUintFromStructuredData(data, "progress_id");
+        const uint64_t completed = GetUintFromStructuredData(data, "completed");
+        const uint64_t total = GetUintFromStructuredData(data, "total");
+        const std::string details =
+            GetStringFromStructuredData(data, "details");
+
+        if (completed == 0) {
+          if (total == 1) {
+            // This progress is non deterministic and won't get updated until it
+            // is completed. Send the "message" which will be the combined title
+            // and detail. The only other progress event for thus
+            // non-deterministic progress will be the completed event So there
+            // will be no need to update the detail.
+            const std::string message =
+                GetStringFromStructuredData(data, "message");
+            dap.SendProgressEvent(progress_id, message.c_str(), completed,
+                                  total);
+          } else {
+            // This progress is deterministic and will receive updates,
+            // on the progress creation event VSCode will save the message in
+            // the create packet and use that as the title, so we send just the
+            // title in the progressCreate packet followed immediately by a
+            // detail packet, if there is any detail.
+            const std::string title =
+                GetStringFromStructuredData(data, "title");
+            dap.SendProgressEvent(progress_id, title.c_str(), completed, total);
+            if (!details.empty())
+              dap.SendProgressEvent(progress_id, details.c_str(), completed,
+                                    total);
+          }
+        } else {
+          // This progress event is either the end of the progress dialog, or an
+          // update with possible detail. The "detail" string we send to VS Code
+          // will be appended to the progress dialog's initial text from when it
+          // was created.
+          dap.SendProgressEvent(progress_id, details.c_str(), completed, total);
+        }
       }
     }
   }

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -25,12 +25,8 @@ static std::string GetStringFromStructuredData(lldb::SBStructuredData &data,
     return std::string();
 
   const size_t length = keyValue.GetStringValue(nullptr, 0);
-
-  if (length == 0)
-    return std::string();
-
   std::string str(length + 1, 0);
-  keyValue.GetStringValue(&str[0], length + 1);
+  keyValue.GetStringValue(&str[0], length);
   return str;
 }
 
@@ -68,38 +64,19 @@ void ProgressEventThreadFunction(DAP &dap) {
         const uint64_t total = GetUintFromStructuredData(data, "total");
         const std::string details =
             GetStringFromStructuredData(data, "details");
-
+        std::string message;
+        // Include the title on the first event.
         if (completed == 0) {
-          if (total == 1) {
-            // This progress is non deterministic and won't get updated until it
-            // is completed. Send the "message" which will be the combined title
-            // and detail. The only other progress event for thus
-            // non-deterministic progress will be the completed event So there
-            // will be no need to update the detail.
-            const std::string message =
-                GetStringFromStructuredData(data, "message");
-            dap.SendProgressEvent(progress_id, message.c_str(), completed,
-                                  total);
-          } else {
-            // This progress is deterministic and will receive updates,
-            // on the progress creation event VSCode will save the message in
-            // the create packet and use that as the title, so we send just the
-            // title in the progressCreate packet followed immediately by a
-            // detail packet, if there is any detail.
-            const std::string title =
-                GetStringFromStructuredData(data, "title");
-            dap.SendProgressEvent(progress_id, title.c_str(), completed, total);
-            if (!details.empty())
-              dap.SendProgressEvent(progress_id, details.c_str(), completed,
-                                    total);
-          }
-        } else {
-          // This progress event is either the end of the progress dialog, or an
-          // update with possible detail. The "detail" string we send to VS Code
-          // will be appended to the progress dialog's initial text from when it
-          // was created.
-          dap.SendProgressEvent(progress_id, details.c_str(), completed, total);
+          const std::string title = GetStringFromStructuredData(data, "title");
+          message += title;
+          message += ": ";
         }
+
+        message += details;
+        // Verbose check, but we get -1 for the uint64 on failure to read
+        // so we check everything before broadcasting an event.
+        if (message.length() > 0)
+          dap.SendProgressEvent(progress_id, message.c_str(), completed, total);
       }
     }
   }

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -70,7 +70,7 @@ void ProgressEventThreadFunction(DAP &dap) {
             GetStringFromStructuredData(data, "details");
 
         if (completed == 0) {
-          if (total == 1) {
+          if (total == UINT64_MAX) {
             // This progress is non deterministic and won't get updated until it
             // is completed. Send the "message" which will be the combined title
             // and detail. The only other progress event for thus


### PR DESCRIPTION
In my last DAP patch (#123837), we piped the DAP update message into the update event. However, we had the title embedded into the update message. This makes sense for progress Start, but makes the update message look pretty wonky.

![image](https://github.com/user-attachments/assets/9f6083d1-fc50-455c-a1a7-a2f9bdaba22e)

Instead, we only use the title when it's the first message, removing the duplicate title problem.
![image](https://github.com/user-attachments/assets/ee7aefd1-1852-46f7-94bc-84b8faef6dac)
