### PR TITLE
[SPIR-V] Fix parsing of command line options for the SPIR-V Backend API call

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -31,8 +31,8 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/SubtargetFeature.h"
 #include "llvm/TargetParser/Triple.h"
-#include <optional>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
+++ b/llvm/unittests/Target/SPIRV/SPIRVAPITest.cpp
@@ -92,18 +92,29 @@ TEST_F(SPIRVAPITest, checkTranslateOk) {
 }
 
 TEST_F(SPIRVAPITest, checkTranslateError) {
-  std::string Result, Error;
-  bool Status = toSpirv(OkAssembly, Result, Error, {},
-                        {"-mtriple=spirv32-unknown-unknown"});
-  EXPECT_FALSE(Status);
-  EXPECT_TRUE(Result.empty());
-  EXPECT_THAT(Error,
-              StartsWith("SPIRVTranslateModule: Unknown command line argument "
-                         "'-mtriple=spirv32-unknown-unknown'"));
-  Status = toSpirv(OkAssembly, Result, Error, {}, {"--spirv-O 5"});
-  EXPECT_FALSE(Status);
-  EXPECT_TRUE(Result.empty());
-  EXPECT_EQ(Error, "Invalid optimization level!");
+  {
+    std::string Result, Error;
+    bool Status = toSpirv(OkAssembly, Result, Error, {},
+                          {"-mtriple=spirv32-unknown-unknown"});
+    EXPECT_FALSE(Status);
+    EXPECT_TRUE(Result.empty());
+    EXPECT_THAT(
+        Error, StartsWith("SPIRVTranslateModule: Unknown command line argument "
+                          "'-mtriple=spirv32-unknown-unknown'"));
+  }
+  {
+    std::string Result, Error;
+    bool Status = toSpirv(OkAssembly, Result, Error, {}, {"--spirv-O 5"});
+    EXPECT_FALSE(Status);
+    EXPECT_TRUE(Result.empty());
+    EXPECT_EQ(Error, "Invalid optimization level!");
+  }
+  {
+    std::string Result, Error;
+    bool Status = toSpirv(OkAssembly, Result, Error, {}, {});
+    EXPECT_TRUE(Status && Error.empty() && !Result.empty());
+    EXPECT_EQ(identify_magic(Result), file_magic::spirv_object);
+  }
 }
 
 TEST_F(SPIRVAPITest, checkTranslateSupportExtensionByOpts) {


### PR DESCRIPTION
This PR fixes parsing of command line options for the SPIR-V Backend API call. The issue was discovered in https://github.com/llvm/llvm-project/pull/123733 (see https://github.com/llvm/llvm-project/pull/123733#issuecomment-2615563201).