### PR TITLE
[clang] UEFI targets must use CodeView.

### DIFF
--- a/clang/lib/Driver/ToolChains/UEFI.h
+++ b/clang/lib/Driver/ToolChains/UEFI.h
@@ -55,6 +55,10 @@ public:
   void
   AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &CC1Args) const override;
+
+  llvm::codegenoptions::DebugInfoFormat getDefaultDebugFormat() const override {
+    return llvm::codegenoptions::DIF_CodeView;                                        
+  }
 };
 
 } // namespace toolchains

--- a/clang/lib/Driver/ToolChains/UEFI.h
+++ b/clang/lib/Driver/ToolChains/UEFI.h
@@ -57,7 +57,7 @@ public:
                             llvm::opt::ArgStringList &CC1Args) const override;
 
   llvm::codegenoptions::DebugInfoFormat getDefaultDebugFormat() const override {
-    return llvm::codegenoptions::DIF_CodeView;                                        
+    return llvm::codegenoptions::DIF_CodeView;
   }
 };
 

--- a/clang/unittests/Driver/ToolChainTest.cpp
+++ b/clang/unittests/Driver/ToolChainTest.cpp
@@ -21,6 +21,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Frontend/Debug/Options.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -593,6 +594,21 @@ TEST(ToolChainTest, UEFICallingConventionTest) {
 
   EXPECT_EQ(compiler.getTarget().getCallingConvKind(true),
             TargetInfo::CallingConvKind::CCK_MicrosoftWin64);
+}
+
+TEST(ToolChainTest, UEFIDefaultDebugFormatTest) {
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
+  IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
+  struct TestDiagnosticConsumer : public DiagnosticConsumer {};
+  DiagnosticsEngine Diags(DiagID, &*DiagOpts, new TestDiagnosticConsumer);
+  IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> InMemoryFileSystem(
+      new llvm::vfs::InMemoryFileSystem);
+  Driver CCDriver("/home/test/bin/clang", "x86_64-unknown-uefi", Diags,
+                  "clang LLVM compiler", InMemoryFileSystem);
+  CCDriver.setCheckInputsExist(false);
+  std::unique_ptr<Compilation> CC(
+      CCDriver.BuildCompilation({"/home/test/bin/clang", "foo.cpp"}));
+  EXPECT_EQ(CC->getDefaultToolChain().getDefaultDebugFormat(), llvm::codegenoptions::DIF_CodeView);
 }
 
 TEST(GetDriverMode, PrefersLastDriverMode) {

--- a/clang/unittests/Driver/ToolChainTest.cpp
+++ b/clang/unittests/Driver/ToolChainTest.cpp
@@ -608,7 +608,8 @@ TEST(ToolChainTest, UEFIDefaultDebugFormatTest) {
   CCDriver.setCheckInputsExist(false);
   std::unique_ptr<Compilation> CC(
       CCDriver.BuildCompilation({"/home/test/bin/clang", "foo.cpp"}));
-  EXPECT_EQ(CC->getDefaultToolChain().getDefaultDebugFormat(), llvm::codegenoptions::DIF_CodeView);
+  EXPECT_EQ(CC->getDefaultToolChain().getDefaultDebugFormat(),
+            llvm::codegenoptions::DIF_CodeView);
 }
 
 TEST(GetDriverMode, PrefersLastDriverMode) {


### PR DESCRIPTION
Default debug format for PE COFF binaries is CodeView. Marking the
default debug format for all UEFI targets to be CodeView.
