### PR TITLE
[flang] Fix crash on SMP with dummy procedure

### DIFF
--- a/flang/lib/Semantics/resolve-names-utils.cpp
+++ b/flang/lib/Semantics/resolve-names-utils.cpp
@@ -762,7 +762,11 @@ void SymbolMapper::MapSymbolExprs(Symbol &symbol) {
               proc.set_procInterfaces(
                   *mappedSymbol, BypassGeneric(mappedSymbol->GetUltimate()));
             } else if (const DeclTypeSpec * mappedType{MapType(proc.type())}) {
-              proc.set_type(*mappedType);
+              if (proc.type()) {
+                CHECK(*proc.type() == *mappedType);
+              } else {
+                proc.set_type(*mappedType);
+              }
             }
             if (proc.init()) {
               if (const Symbol * mapped{MapSymbol(*proc.init())}) {

--- a/flang/test/Semantics/bug124487.f90
+++ b/flang/test/Semantics/bug124487.f90
@@ -1,0 +1,14 @@
+!RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck --allow-empty %s
+!CHECK-NOT: error:
+module m
+  interface
+    module subroutine smp(x)
+      character, external :: x
+    end
+  end interface
+end
+submodule (m) sm
+ contains
+  module procedure smp ! crashes here
+  end
+end


### PR DESCRIPTION
When a separate module procedure is defined with MODULE PROCEDURE, the compiler crashes if there is a dummy procedure in the interface defined with only a result type.  This is due to the type already having been defined on the ProcEntityDetails symbol as part of earlier wholesale symbol duplication.  Adjust the code to not define the result type of the ProcEntityDetails if it is already present, but to verify that it is the same type instead.

Fixes https://github.com/llvm/llvm-project/issues/124487.