### PR TITLE
[flang] Fold KIND= arguments in intrinsic function references

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -2357,7 +2357,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       if (kindArg) {
         if (auto *expr{kindArg->UnwrapExpr()}) {
           CHECK(expr->Rank() == 0);
-          if (auto code{ToInt64(*expr)}) {
+          if (auto code{ToInt64(Fold(context, common::Clone(*expr)))}) {
             if (context.targetCharacteristics().IsTypeEnabled(
                     *category, *code)) {
               if (*category == TypeCategory::Character) { // ACHAR & CHAR
@@ -2369,9 +2369,8 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
             }
           }
         }
-        messages.Say("'kind=' argument must be a constant scalar integer "
-                     "whose value is a supported kind for the "
-                     "intrinsic result type"_err_en_US);
+        messages.Say(
+            "'kind=' argument must be a constant scalar integer whose value is a supported kind for the intrinsic result type"_err_en_US);
         // use default kind below for error recovery
       } else if (kindDummyArg->flags.test(ArgFlag::defaultsToSameKind)) {
         CHECK(sameArg);

--- a/flang/test/Evaluate/bug124618.f90
+++ b/flang/test/Evaluate/bug124618.f90
@@ -1,0 +1,5 @@
+! RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck --allow-empty %s
+!CHECK-NOT: error:
+real x
+print *, char(48, kind=size([x])) ! folds down to 1
+end


### PR DESCRIPTION
KIND= arguments in e.g. ACHAR(..., KIND=...) intrinsic function references must be compilation-time constant expressions.  The compiler was failing to evaluate those expressions if they were not actually literaly constant values.

Fixes https://github.com/llvm/llvm-project/issues/124618.