### PR TITLE
[NFC] Remove redundant `sys/file.h` header.

### DIFF
--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -29,7 +29,6 @@
 
 #include <dirent.h>
 #include <pwd.h>
-#include <sys/file.h>
 
 #ifdef __APPLE__
 #include <copyfile.h>


### PR DESCRIPTION
Closes #124652.

This header was introduced in https://github.com/llvm/llvm-project/commit/536736995bf5d073853c7e884968c9847b4ae64d, but it appears that including only `fnctl.h` should be enough. Hopefully, this patch will not cause build issues on other Unix platforms.