### PR TITLE
[libc] Revise the definition of `posix_spawn`.

### DIFF
--- a/libc/include/spawn.yaml
+++ b/libc/include/spawn.yaml
@@ -18,8 +18,8 @@ functions:
       - type: const char *__restrict
       - type: posix_spawn_file_actions_t *
       - type: posix_spawnattr_t *__restrict
-      - type: const char *__restrict *
-      - type: const char *__restrict *
+      - type: char * const * __restrict
+      - type: char * const * __restrict
   - name: posix_spawn_file_actions_addclose
     standards:
       - POSIX


### PR DESCRIPTION
Closes #124635.

Some parameter types in the definition of `posix_spawn` currently do not match the standard. This patch resolves the issue.
ref: https://man7.org/linux/man-pages/man3/posix_spawn.3.html