### PR TITLE
[libc] Add `FILENO` related macros to `unistd.h`.

### DIFF
--- a/libc/include/llvm-libc-macros/unistd-macros.h
+++ b/libc/include/llvm-libc-macros/unistd-macros.h
@@ -5,4 +5,8 @@
 #include "linux/unistd-macros.h"
 #endif
 
+#define STDIN_FILENO 0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
 #endif // LLVM_LIBC_MACROS_UNISTD_MACROS_H


### PR DESCRIPTION
Closes #124637.

This is necessary to build LLVM with LLVM-libc and align the behavior with other libc implementations.
ref: https://man7.org/linux/man-pages/man3/stdin.3.html