### PR TITLE
[libc++] Remove Android header no longer in use

### DIFF
--- a/libcxx/src/system_error.cpp
+++ b/libcxx/src/system_error.cpp
@@ -21,10 +21,6 @@
 
 #include "include/config_elast.h"
 
-#if defined(__ANDROID__)
-#  include <android/api-level.h>
-#endif
-
 #if defined(_LIBCPP_WIN32API)
 #  include <windows.h>
 #  include <winerror.h>


### PR DESCRIPTION
929f159777bec47c80a3b302f190261d426e1c3b removed the use of `__ANDROID_API__`