### PR TITLE
[libc] Revise the definition of `{get, set}rlimit`.

### DIFF
--- a/libc/include/sys/resource.yaml
+++ b/libc/include/sys/resource.yaml
@@ -12,10 +12,12 @@ functions:
       - POSIX
     return_type: int
     arguments:
+      - type: int
       - type: struct rlimit *
   - name: setrlimit
     standards:
       - POSIX
     return_type: int
     arguments:
-      - type: const struct rlimit
+      - type: int
+      - type: const struct rlimit *


### PR DESCRIPTION
Closes #124633.

Some parameter types in the definition of `{get, set}rlimit` currently do not match the standard. This patch resolves the issue.
ref: https://man7.org/linux/man-pages/man2/getrlimit.2.html