### PR TITLE
[CodeGen][NewPM] Preserve all MF analyses in MFPM

### DIFF
--- a/llvm/lib/CodeGen/MachinePassManager.cpp
+++ b/llvm/lib/CodeGen/MachinePassManager.cpp
@@ -152,6 +152,7 @@ PassManager<MachineFunction>::run(MachineFunction &MF,
     PI.runAfterPass(*Pass, MF, PassPA);
     PA.intersect(std::move(PassPA));
   }
+  PA.preserveSet<AllAnalysesOn<MachineFunction>>();
   return PA;
 }
 


### PR DESCRIPTION
Invalidation is already handled in the passes loop for MFAM, so all of the rest analyses are preserved. (See `PassManager::run`)

This won't change the number of invalidations, but will prevent needless `MFAM::Invalidator::invalidate()` invocations made by results depending on other results (since the invalidate shorts if `<AllAnalysesOn<MF>>` is preserved)