### PR TITLE
[TableGen][Docs] Allow trailing commas

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -392,7 +392,7 @@ A question mark represents an uninitialized value.
 .. productionlist::
    SimpleValue4: "{" [`ValueList`] "}"
    ValueList: `ValueListNE`
-   ValueListNE: `Value` ("," `Value`)*
+   ValueListNE: `Value` ("," `Value`)* [","]
 
 This value represents a sequence of bits, which can be used to initialize a
 ``bits<``\ *n*\ ``>`` field (note the braces). When doing so, the values

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -488,7 +488,7 @@ See `Using Classes as Subroutines`_ for more information.
 
 .. productionlist::
    SimpleValue9: `BangOperator` ["<" `Type` ">"] "(" `ValueListNE` ")"
-              :| `CondOperator` "(" `CondClause` ("," `CondClause`)* ")"
+              :| `CondOperator` "(" `CondClause` ("," `CondClause`)* [","] ")"
    CondClause: `Value` ":" `Value`
 
 The bang operators provide functions that are not available with the other


### PR DESCRIPTION
TableGen accepts trailing commas in a ValueList like `[1,2,]` and `{1,2,}` and in CondOperator like `!cond(a:b,c:d,)`.
