### PR TITLE
[LLD][COFF] Call setLocation on DelayAddressChunk when inserting into the addresses vector (NFC)

### DIFF
--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -927,6 +927,7 @@ void DelayLoadContents::create() {
       Chunk *t = newThunkChunk(s, tm);
       auto *a = make<DelayAddressChunk>(ctx, t);
       addresses.push_back(a);
+      s->setLocation(a);
       thunks.push_back(t);
       StringRef extName = s->getExternalName();
       if (extName.empty()) {
@@ -967,8 +968,6 @@ void DelayLoadContents::create() {
       auxIatCopy.push_back(make<NullChunk>(ctx, 8));
     }
 
-    for (int i = 0, e = syms.size(); i < e; ++i)
-      syms[i]->setLocation(addresses[base + i]);
     auto *mh = make<NullChunk>(8, 8);
     moduleHandles.push_back(mh);
 


### PR DESCRIPTION
This change prepares for ARM64X delay-load imports support (#124600). Delaying the `setLocation` call is problematic on ARM64X because the order of addresses may not align with the order of symbols.