### PR TITLE
[NFC] Suppress spurious deprecation warning with MSVC

### DIFF
--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -287,10 +287,7 @@ public:
   const Instruction *getFirstNonPHI() const;
   LLVM_DEPRECATED("Use iterators as instruction positions instead",
                   "getFirstNonPHIIt")
-  Instruction *getFirstNonPHI() {
-    return const_cast<Instruction *>(
-        static_cast<const BasicBlock *>(this)->getFirstNonPHI());
-  }
+  Instruction *getFirstNonPHI();
 
   /// Returns an iterator to the first instruction in this block that is not a
   /// PHINode instruction.

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -371,6 +371,13 @@ const Instruction* BasicBlock::getFirstNonPHI() const {
   return nullptr;
 }
 
+Instruction* BasicBlock::getFirstNonPHI() {
+  for (Instruction &I : *this)
+    if (!isa<PHINode>(I))
+      return &I;
+  return nullptr;
+}
+
 BasicBlock::const_iterator BasicBlock::getFirstNonPHIIt() const {
   for (const Instruction &I : *this) {
     if (isa<PHINode>(I))

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -371,7 +371,7 @@ const Instruction* BasicBlock::getFirstNonPHI() const {
   return nullptr;
 }
 
-Instruction* BasicBlock::getFirstNonPHI() {
+Instruction *BasicBlock::getFirstNonPHI() {
   for (Instruction &I : *this)
     if (!isa<PHINode>(I))
       return &I;


### PR DESCRIPTION
gcc and clang won't complain about calls to deprecated functions, if you're calling from a function that is deprecated too. However, MSVC does care, and expands into maaany deprecation warnings for getFirstNonPHI.

Suppress this by converting the inlineable copy of getFirstNonPHI into a non-inline copy.