### PR TITLE
[Clang] Cleanup docs and comments relating to -fextend-variable-liveness

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -524,7 +524,7 @@ New Compiler Flags
   Clang to generate code that tries to preserve the liveness of source variables
   through optimizations, meaning that variables will typically be visible in a
   debugger more often. The flag has two levels: ``-fextend-variable-liveness``,
-  or ``-fextend-variable-liveness=all``, extendes the liveness of all user
+  or ``-fextend-variable-liveness=all``, extends the liveness of all user
   variables and the ``this`` pointer. Alternatively
   ``-fextend-variable-liveness=this`` has the same behaviour but applies only to
   the ``this`` variable in C++ class member functions, meaning its effect is a

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -525,14 +525,14 @@ New Compiler Flags
   through optimizations, meaning that variables will typically be visible in a
   debugger more often. The flag has two levels: ``-fextend-variable-liveness``,
   or ``-fextend-variable-liveness=all``, extendes the liveness of all user
-  variables and the ``this`` pointer. Alternatively ``-fextend-this-ptr``, or
-  ``-fextend-variable-liveness=this``, has the same behaviour but applies only
-  to the ``this`` variable in C++ class member functions, meaning its effect is
-  a strict subset of ``-fextend-variable-liveness``. Note that this flag
-  modifies the results of optimizations that Clang performs, which will result
-  in reduced performance in generated code; however, this feature will not
-  extend the liveness of some variables in cases where doing so would likely
-  have a severe impact on generated code performance.
+  variables and the ``this`` pointer. Alternatively
+  ``-fextend-variable-liveness=this`` has the same behaviour but applies only to
+  the ``this`` variable in C++ class member functions, meaning its effect is a
+  strict subset of ``-fextend-variable-liveness``. Note that this flag modifies
+  the results of optimizations that Clang performs, which will result in reduced
+  performance in generated code; however, this feature will not extend the
+  liveness of some variables in cases where doing so would likely have a severe
+  impact on generated code performance.
 
 - The ``-Warray-compare`` warning has been added to warn about array comparison
   on versions older than C++20.

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4352,19 +4352,11 @@ def stack_usage_file : Separate<["-"], "stack-usage-file">,
 def fextend_variable_liveness_EQ : Joined<["-"], "fextend-variable-liveness=">,
   Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Extend the liveness of user variables through optimizations to "
-           "prevent stale or optimized-out variable values when debugging. Can "
-           "be applied to all user variables, or just to the C++ 'this' ptr. "
-           "May choose not to extend the liveness of some variables, such as "
-           "non-scalars larger than 4 unsigned ints, or variables in any "
-           "inlined functions.">,
+           "prevent stale or optimized-out variable values when debugging."
   Values<"all,this,none">,
   NormalizedValues<["All", "This", "None"]>,
   NormalizedValuesScope<"CodeGenOptions::ExtendVariableLivenessKind">,
   MarshallingInfoEnum<CodeGenOpts<"ExtendVariableLiveness">, "None">;
-def fextend_this_ptr_liveness : Flag<["-"], "fextend-this-ptr-liveness">,
-  Visibility<[ClangOption, CC1Option]>,
-  Alias<fextend_variable_liveness_EQ>, AliasArgs<["this"]>,
-  HelpText<"Alias for -fextend-variable-liveness=this.">;
 def fextend_variable_liveness : Flag<["-"], "fextend-variable-liveness">,
   Visibility<[ClangOption, CC1Option]>,
   Alias<fextend_variable_liveness_EQ>, AliasArgs<["all"]>,

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1423,7 +1423,7 @@ void CodeGenFunction::EmitAndRegisterVariableArrayDimensions(
 }
 
 /// Return the maximum size of an aggregate for which we generate a fake use
-/// intrinsic when -fextend-lifetimes is in effect.
+/// intrinsic when -fextend-variable-liveness is in effect.
 static uint64_t maxFakeUseAggregateSize(const ASTContext &C) {
   return 4 * C.getTypeSize(C.UnsignedIntTy);
 }

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -724,8 +724,8 @@ public:
   };
 
   // We are using objects of this 'cleanup' class to emit fake.use calls
-  // for -fextend-lifetimes and -fextend-this-ptr. They are placed at the end of
-  // a variable's scope analogous to lifetime markers.
+  // for -fextend-variable-liveness. They are placed at the end of a variable's
+  // scope analogous to lifetime markers.
   class FakeUse final : public EHScopeStack::Cleanup {
     Address Addr;
 

--- a/clang/test/CodeGen/fake-use-sanitizer.cpp
+++ b/clang/test/CodeGen/fake-use-sanitizer.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 %s -triple x86_64-unknown-linux-gnu -emit-llvm -fextend-variable-liveness -fsanitize=null -fsanitize-trap=null -o - | FileCheck --check-prefixes=CHECK,NULL --implicit-check-not=ubsantrap %s
 // RUN: %clang_cc1 %s -triple x86_64-unknown-linux-gnu -emit-llvm -fextend-variable-liveness -o - | FileCheck %s
 
-// With -fextend-lifetimes, the compiler previously generated a fake.use of any
+// With -fextend-variable-liveness, the compiler previously generated a fake.use of any
 // reference variable at the end of the scope in which its alloca exists. This
 // caused two issues, where we would get fake uses for uninitialized variables
 // if that variable was declared after an early-return, and UBSan's null checks

--- a/clang/test/CodeGen/fake-use-this.cpp
+++ b/clang/test/CodeGen/fake-use-this.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -emit-llvm -fextend-this-ptr-liveness -o - | FileCheck %s --implicit-check-not=fake.use
+// RUN: %clang_cc1 %s -emit-llvm -fextend-variable-liveness=this -o - | FileCheck %s --implicit-check-not=fake.use
 // Check that we generate a fake_use call with the 'this' pointer as argument,
 // and no other fake uses.
 // The call should appear after the call to bar().

--- a/clang/test/Driver/extend-variable-liveness.c
+++ b/clang/test/Driver/extend-variable-liveness.c
@@ -4,7 +4,6 @@
 // RUN: %clang -### -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DEFAULT
 // RUN: %clang -fextend-variable-liveness=none -### -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK,NONE
 // RUN: %clang -fextend-variable-liveness=this -### -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK,THIS
-// RUN: %clang -fextend-this-ptr-liveness -### -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK,THIS
 // RUN: %clang -fextend-variable-liveness=all -### -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK,ALL
 // RUN: %clang -fextend-variable-liveness -### -c %s 2>&1 | FileCheck %s --check-prefixes=CHECK,ALL
 

--- a/llvm/test/CodeGen/MIR/X86/fake-use-tailcall.mir
+++ b/llvm/test/CodeGen/MIR/X86/fake-use-tailcall.mir
@@ -8,7 +8,7 @@
 # in the return block itself into the predecessor blocks. This test enures that we do so.
 #
 # Generated from the following source with
-# clang -fextend-lifetimes -S -emit-llvm -O2 -mllvm -stop-before=codegenprepare -o test.mir test.c
+# clang -fextend-variable-liveness -S -emit-llvm -O2 -mllvm -stop-before=codegenprepare -o test.mir test.c
 #
 # extern int f0();
 # extern int f1();

--- a/llvm/test/CodeGen/X86/fake-use-simple-tail-call.ll
+++ b/llvm/test/CodeGen/X86/fake-use-simple-tail-call.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s -mtriple=x86_64-unknown-unknown -O2 -o - \
 ; RUN:   | FileCheck %s --implicit-check-not=TAILCALL
-; Generated with: clang -emit-llvm -O2 -S -fextend-lifetimes test.cpp -o -
+; Generated with: clang -emit-llvm -O2 -S -fextend-variable-liveness test.cpp -o -
 ; =========== test.cpp ===============
 ; extern int bar(int);
 ; int foo1(int i)

--- a/llvm/test/CodeGen/X86/fake-use-zero-length.ll
+++ b/llvm/test/CodeGen/X86/fake-use-zero-length.ll
@@ -4,7 +4,7 @@
 ; and structs. Check also that they are not propagated.
 ;
 ; Generated from the following source with
-; clang -fextend-lifetimes -S -emit-llvm -O2 -mllvm -stop-after=safe-stack -o test.mir test.cpp
+; clang -fextend-variable-liveness -S -emit-llvm -O2 -mllvm -stop-after=safe-stack -o test.mir test.cpp
 ;
 ; int main ()
 ; { int array[0]; }

--- a/llvm/test/DebugInfo/AArch64/fake-use-global-isel.ll
+++ b/llvm/test/DebugInfo/AArch64/fake-use-global-isel.ll
@@ -12,7 +12,7 @@
 ; RUN: not %python %p/../Inputs/check-fake-use.py %t
 
 ; Generated with:
-; clang -O2 -g -S -emit-llvm -fextend-this-ptr fake-use.c
+; clang -O2 -g -S -emit-llvm -fextend-variable-liveness=this fake-use.c
 ;
 ; int glob[10];
 ; extern void bar();

--- a/llvm/test/DebugInfo/X86/fake-use.ll
+++ b/llvm/test/DebugInfo/X86/fake-use.ll
@@ -9,7 +9,7 @@
 ; RUN: not %python %p/../Inputs/check-fake-use.py %t
 
 ; Generated with:
-; clang -O2 -g -S -emit-llvm -fextend-this-ptr fake-use.c
+; clang -O2 -g -S -emit-llvm -fextend-variable-liveness=this fake-use.c
 ;
 ; int glob[10];
 ; extern void bar();

--- a/llvm/test/Transforms/CodeGenPrepare/X86/fake-use-split-ret.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/fake-use-split-ret.ll
@@ -2,7 +2,7 @@
 ;
 ; Ensure return instruction splitting ignores fake uses.
 ;
-; IR Generated with clang -O2 -S -emit-llvm -fextend-lifetimes test.cpp
+; IR Generated with clang -O2 -S -emit-llvm -fextend-variable-liveness test.cpp
 ;
 ;// test.cpp
 ;extern int bar(int);

--- a/llvm/test/Transforms/GVN/fake-use-constprop.ll
+++ b/llvm/test/Transforms/GVN/fake-use-constprop.ll
@@ -7,7 +7,7 @@
 ; with respect to keeping the variable live up until the fake.use.
 ; This test checks that we don't generate any fake.uses with constant 0.
 ;
-; Reduced from the following test case, generated with clang -O2 -S -emit-llvm -fextend-lifetimes test.c
+; Reduced from the following test case, generated with clang -O2 -S -emit-llvm -fextend-variable-liveness test.c
 ;
 ; extern void func1();
 ; extern int bar();


### PR DESCRIPTION
This patch contains a number of changes relating to the above flag; primarily it updates comment references to the old flag names, "-fextend-lifetimes" and "-fextend-this-ptr" to refer to the new names, "-fextend-variable-liveness[={all,this}]". These changes are all NFC.

This patch also removes the explicit -fextend-this-ptr-liveness flag alias, and shortens the help-text for the main flag; these are both changes that were meant to be applied in the initial PR (#110000), but due to some user-error on my part they were not included in the merged commit.