### PR TITLE
[Clang][TableGen] Use PointerType::get(Context) in MVE TableGen emitter (NFC)

### DIFF
--- a/clang/utils/TableGen/MveEmitter.cpp
+++ b/clang/utils/TableGen/MveEmitter.cpp
@@ -210,7 +210,7 @@ public:
     return Name + " *";
   }
   std::string llvmName() const override {
-    return "llvm::PointerType::getUnqual(CGM.getLLVMContext())";
+    return "llvm::PointerType::getUnqual(Builder.getPtrTy())";
   }
   const Type *getPointeeType() const { return Pointee; }
 

--- a/clang/utils/TableGen/MveEmitter.cpp
+++ b/clang/utils/TableGen/MveEmitter.cpp
@@ -209,9 +209,7 @@ public:
       Name = "const " + Name;
     return Name + " *";
   }
-  std::string llvmName() const override {
-    return "Builder.getPtrTy()";
-  }
+  std::string llvmName() const override { return "Builder.getPtrTy()"; }
   const Type *getPointeeType() const { return Pointee; }
 
   static bool classof(const Type *T) {

--- a/clang/utils/TableGen/MveEmitter.cpp
+++ b/clang/utils/TableGen/MveEmitter.cpp
@@ -210,7 +210,7 @@ public:
     return Name + " *";
   }
   std::string llvmName() const override {
-    return "llvm::PointerType::getUnqual(Builder.getPtrTy())";
+    return "Builder.getPtrTy()";
   }
   const Type *getPointeeType() const { return Pointee; }
 

--- a/clang/utils/TableGen/MveEmitter.cpp
+++ b/clang/utils/TableGen/MveEmitter.cpp
@@ -210,7 +210,7 @@ public:
     return Name + " *";
   }
   std::string llvmName() const override {
-    return "llvm::PointerType::getUnqual(" + Pointee->llvmName() + ")";
+    return "llvm::PointerType::getUnqual(CGM.getLLVMContext())";
   }
   const Type *getPointeeType() const { return Pointee; }
 


### PR DESCRIPTION
Follow-up to #123569

I don't know if directly using the CodeGenModule here is the best solution. Let me know if there's something better to use.