### PR TITLE
[analyzer][docs] CSA release notes for clang-20

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1382,8 +1382,7 @@ Crash and bug fixes
   assumptions caused false positive reports (e.g. 100+ out-of-bounds reports in
   the FFMPEG codebase) in loops where the programmer intended only two or three
   steps but the analyzer wasn't able to understand that the loop is limited.
-  Read the `RFC <https://discourse.llvm.org/t/loop-handling-improvement-plans/80417/17>`_
-  for details. (#GH119388)
+  (#GH119388)
 
 - In clang-19, the ``crosscheck-with-z3-timeout-threshold`` was set to 300ms,
   but it is now reset back to 15000, aka. 15 seconds. This is to reduce the


### PR DESCRIPTION
The commits were gathered using:
```sh
git log --reverse --oneline llvmorg-20-init..llvm/main \
  clang/{lib/StaticAnalyzer,include/clang/StaticAnalyzer} | grep -v NFC | grep -v OpenACC | grep -v -i revert
```

After this I categorized the changes and dropped the less user-facing commits.

FYI, I also ignored Webkit changes because I assue it's fairly specific for them, and they likely already know what they ship xD.

I used the `LLVM_ENABLE_SPHINX=ON` and `LLVM_ENABLE_DOXYGEN=ON` cmake options to enable the `docs-clang-html` build target, which generates the html into `build/tools/clang/docs/html/ReleaseNotes.html` of which I attach the screenshots to let you judge if it looks all good or not.

I also used Grammarly this time to check for blatant typos.