### PR TITLE
[libc] Workaround for gcc complaining about implicit conversions with the ternary ?: operator.

### DIFF
--- a/libc/src/__support/FPUtil/except_value_utils.h
+++ b/libc/src/__support/FPUtil/except_value_utils.h
@@ -81,12 +81,16 @@ template <typename T, size_t N> struct ExceptValues {
         StorageType out_bits = values[i].rnd_towardzero_result;
         switch (fputil::quick_get_round()) {
         case FE_UPWARD:
-          out_bits += sign ? values[i].rnd_downward_offset
-                           : values[i].rnd_upward_offset;
+          if (sign)
+            out_bits += values[i].rnd_downward_offset;
+          else
+            out_bits += values[i].rnd_upward_offset;
           break;
         case FE_DOWNWARD:
-          out_bits += sign ? values[i].rnd_upward_offset
-                           : values[i].rnd_downward_offset;
+          if (sign)
+            out_bits += values[i].rnd_upward_offset;
+          else
+            out_bits += values[i].rnd_downward_offset;
           break;
         case FE_TONEAREST:
           out_bits += values[i].rnd_tonearest_offset;

--- a/libc/src/__support/FPUtil/except_value_utils.h
+++ b/libc/src/__support/FPUtil/except_value_utils.h
@@ -87,6 +87,9 @@ template <typename T, size_t N> struct ExceptValues {
             out_bits += values[i].rnd_upward_offset;
           break;
         case FE_DOWNWARD:
+          // Use conditionals instead of ternary operator to work around gcc's
+          // -Wconversion false positive bug:
+          // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101537
           if (sign)
             out_bits += values[i].rnd_upward_offset;
           else


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/120427, https://github.com/llvm/llvm-project/issues/122745

This is caused by a -Wconversion false-positive bug in gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101537