### PR TITLE
[MLIR][LLVM] LLVM import should use is isDSOLocal instead of hasLocalLinkage to set dso_local attribute

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -2128,7 +2128,7 @@ LogicalResult ModuleImport::processFunction(llvm::Function *func) {
       iface.isConvertibleIntrinsic(func->getIntrinsicID()))
     return success();
 
-  bool dsoLocal = func->hasLocalLinkage();
+  bool dsoLocal = func->isDSOLocal();
   CConv cconv = convertCConvFromLLVM(func->getCallingConv());
 
   // Insert the function at the end of the module.

--- a/mlir/test/Target/LLVMIR/Import/function-attributes.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-attributes.ll
@@ -10,6 +10,12 @@ define internal spir_func void @spir_func_internal() {
   ret void
 }
 
+; Ensure that we have dso_local;
+; CHECK : llvm.func @dsolocal_func() attributes{dso_local}
+define dso_local void @dsolocal_func() {
+  ret void
+}
+
 ; // -----
 
 ; CHECK-LABEL: @func_readnone

--- a/mlir/test/Target/LLVMIR/Import/function-attributes.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-attributes.ll
@@ -10,8 +10,9 @@ define internal spir_func void @spir_func_internal() {
   ret void
 }
 
-; Ensure that we have dso_local;
-; CHECK : llvm.func @dsolocal_func() attributes{dso_local}
+; Ensure that we have dso_local.
+; CHECK: llvm.func @dsolocal_func()
+; CHECK-SAME: attributes{dso_local}
 define dso_local void @dsolocal_func() {
   ret void
 }

--- a/mlir/test/Target/LLVMIR/Import/function-attributes.ll
+++ b/mlir/test/Target/LLVMIR/Import/function-attributes.ll
@@ -10,9 +10,11 @@ define internal spir_func void @spir_func_internal() {
   ret void
 }
 
+; // -----
+
 ; Ensure that we have dso_local.
 ; CHECK: llvm.func @dsolocal_func()
-; CHECK-SAME: attributes{dso_local}
+; CHECK-SAME: attributes {dso_local}
 define dso_local void @dsolocal_func() {
   ret void
 }


### PR DESCRIPTION
Without this change, function definitions that mostly have external linkage would be missing dso_local attribute during translation.