### PR TITLE
[libc] Fix conversion warnings for float16 tests.

### DIFF
--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -45,6 +45,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.errno.errno
     libc.src.math.cospif16
+    libc.src.__support.FPUtil.cast
 )
 
 add_fp_unittest(
@@ -69,6 +70,7 @@ add_fp_unittest(
   DEPENDS
     libc.src.errno.errno
     libc.src.math.sinf16
+    libc.src.__support.FPUtil.cast
 )
 
 add_fp_unittest(
@@ -1251,6 +1253,7 @@ add_fp_unittest(
     libc.hdr.fenv_macros
     libc.src.errno.errno
     libc.src.math.exp2m1f16
+    libc.src.__support.FPUtil.cast
 )
 
 add_fp_unittest(

--- a/libc/test/src/math/smoke/cospif16_test.cpp
+++ b/libc/test/src/math/smoke/cospif16_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/FPUtil/cast.h"
 #include "src/errno/libc_errno.h"
 #include "src/math/cospif16.h"
 #include "test/UnitTest/FPMatcher.h"
@@ -19,10 +20,10 @@ TEST_F(LlvmLibcCospif16Test, SpecialNumbers) {
   EXPECT_FP_EQ(aNaN, LIBC_NAMESPACE::cospif16(aNaN));
   EXPECT_MATH_ERRNO(0);
 
-  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::cospif16(zero));
+  EXPECT_FP_EQ(FPBits::one().get_val(), LIBC_NAMESPACE::cospif16(zero));
   EXPECT_MATH_ERRNO(0);
 
-  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::cospif16(neg_zero));
+  EXPECT_FP_EQ(FPBits::one().get_val(), LIBC_NAMESPACE::cospif16(neg_zero));
   EXPECT_MATH_ERRNO(0);
 
   EXPECT_FP_EQ(aNaN, LIBC_NAMESPACE::cospif16(inf));
@@ -33,12 +34,24 @@ TEST_F(LlvmLibcCospif16Test, SpecialNumbers) {
 }
 
 TEST_F(LlvmLibcCospif16Test, Integers) {
-  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::cospif16(-0x420));
-  EXPECT_FP_EQ(1.0f, LIBC_NAMESPACE::cospif16(-0x1.4p+14));
-  EXPECT_FP_EQ(-1.0f, LIBC_NAMESPACE::cospif16(0x421));
-  EXPECT_FP_EQ(-1.0f, LIBC_NAMESPACE::cospif16(0x333));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(-0x1.28p4));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(-0x1.ffcp9));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(0x1.01p7));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(0x1.f6cp9));
+  EXPECT_FP_EQ(FPBits::one().get_val(),
+               LIBC_NAMESPACE::cospif16(
+                   LIBC_NAMESPACE::fputil::cast<float16>(-0x420.0p0)));
+  EXPECT_FP_EQ(FPBits::one().get_val(),
+               LIBC_NAMESPACE::cospif16(
+                   LIBC_NAMESPACE::fputil::cast<float16>(-0x1.4p+14)));
+  EXPECT_FP_EQ(FPBits::one(Sign::NEG).get_val(),
+               LIBC_NAMESPACE::cospif16(
+                   LIBC_NAMESPACE::fputil::cast<float16>(0x421.0p0)));
+  EXPECT_FP_EQ(FPBits::one(Sign::NEG).get_val(),
+               LIBC_NAMESPACE::cospif16(
+                   LIBC_NAMESPACE::fputil::cast<float16>(0x333.0p0)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(-0x1.28p4)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(-0x1.ffcp9)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(0x1.01p7)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::cospif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(0x1.f6cp9)));
 }

--- a/libc/test/src/math/smoke/exp2m1f16_test.cpp
+++ b/libc/test/src/math/smoke/exp2m1f16_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/fenv_macros.h"
+#include "src/__support/FPUtil/cast.h"
 #include "src/errno/libc_errno.h"
 #include "src/math/exp2m1f16.h"
 #include "test/UnitTest/FPMatcher.h"
@@ -44,7 +45,7 @@ TEST_F(LlvmLibcExp2m1f16Test, Overflow) {
                               FE_OVERFLOW | FE_INEXACT);
   EXPECT_MATH_ERRNO(ERANGE);
 
-  float16 x = 16.0;
+  float16 x = LIBC_NAMESPACE::fputil::cast<float16>(16.0);
 
   EXPECT_FP_EQ_WITH_EXCEPTION_ROUNDING_NEAREST(
       inf, LIBC_NAMESPACE::exp2m1f16(x), FE_OVERFLOW | FE_INEXACT);
@@ -69,9 +70,11 @@ TEST_F(LlvmLibcExp2m1f16Test, ResultNearNegOne) {
   EXPECT_FP_EQ_WITH_EXCEPTION(-1.0, LIBC_NAMESPACE::exp2m1f16(neg_max_normal),
                               FE_INEXACT);
 
-  EXPECT_FP_EQ_ALL_ROUNDING(-0x1.ffcp-1, LIBC_NAMESPACE::exp2m1f16(-11.0));
+  EXPECT_FP_EQ_ALL_ROUNDING(
+      -0x1.ffcp-1,
+      LIBC_NAMESPACE::exp2m1f16(LIBC_NAMESPACE::fputil::cast<float16>(-11.0)));
 
-  float16 x = -12.0;
+  float16 x = LIBC_NAMESPACE::fputil::cast<float16>(-12.0);
 
   EXPECT_FP_EQ_WITH_EXCEPTION_ROUNDING_NEAREST(
       -1.0, LIBC_NAMESPACE::exp2m1f16(x), FE_INEXACT);

--- a/libc/test/src/math/smoke/sinpif16_test.cpp
+++ b/libc/test/src/math/smoke/sinpif16_test.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "src/__support/FPUtil/cast.h"
 #include "src/errno/libc_errno.h"
 #include "src/math/sinpif16.h"
 #include "test/UnitTest/FPMatcher.h"
@@ -33,10 +34,18 @@ TEST_F(LlvmLibcSinpif16Test, SpecialNumbers) {
 }
 
 TEST_F(LlvmLibcSinpif16Test, Integers) {
-  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinpif16(-0x420));
-  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinpif16(-0x1p+10));
-  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinpif16(-0x1.4p+14));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::sinpif16(0x420));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::sinpif16(0x1.cp+15));
-  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::sinpif16(0x1.cp+7));
+  EXPECT_FP_EQ(neg_zero,
+               LIBC_NAMESPACE::sinpif16(
+                   LIBC_NAMESPACE::fputil::cast<float16>(-0x420.0p0)));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinpif16(
+                             LIBC_NAMESPACE::fputil::cast<float16>(-0x1p+10)));
+  EXPECT_FP_EQ(neg_zero,
+               LIBC_NAMESPACE::sinpif16(
+                   LIBC_NAMESPACE::fputil::cast<float16>(-0x1.4p+14)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::sinpif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(0x420.0p0)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::sinpif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(0x1.cp+15)));
+  EXPECT_FP_EQ(zero, LIBC_NAMESPACE::sinpif16(
+                         LIBC_NAMESPACE::fputil::cast<float16>(0x1.cp+7)));
 }


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/124801.