### PR TITLE
[lldb] Make SBProgress move-only

### DIFF
--- a/lldb/include/lldb/API/SBProgress.h
+++ b/lldb/include/lldb/API/SBProgress.h
@@ -51,6 +51,10 @@ public:
   SBProgress(const char *title, const char *details, uint64_t total_units,
              SBDebugger &debugger);
 
+#ifndef SWIG
+  SBProgress(SBProgress &&rhs);
+#endif
+
   ~SBProgress();
 
   void Increment(uint64_t amount, const char *description = nullptr);
@@ -59,6 +63,9 @@ protected:
   lldb_private::Progress &ref() const;
 
 private:
+  SBProgress(const SBProgress &rhs) = delete;
+  const SBProgress &operator=(const SBProgress &rhs) = delete;
+
   std::unique_ptr<lldb_private::Progress> m_opaque_up;
 }; // SBProgress
 } // namespace lldb

--- a/lldb/source/API/SBProgress.cpp
+++ b/lldb/source/API/SBProgress.cpp
@@ -32,6 +32,9 @@ SBProgress::SBProgress(const char *title, const char *details,
       lldb_private::Progress::Origin::eExternal);
 }
 
+SBProgress::SBProgress(SBProgress &&rhs)
+    : m_opaque_up(std::move(rhs.m_opaque_up)) {}
+
 SBProgress::~SBProgress() = default;
 
 void SBProgress::Increment(uint64_t amount, const char *description) {


### PR DESCRIPTION
I wanted to clarify the semantics around SBProgress. Given the nature of Progress events, copying seems like the wrong idea. Making SBProgress move-only (like SBStream) seems like the better choice here.