### PR TITLE
Revert "[llvm][DebugInfo] Attach object-pointer to DISubprogram declarations (#122742)"

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -849,9 +849,7 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DIDerivedType *DTy) {
   }
 }
 
-DIE *DwarfUnit::constructSubprogramArguments(DIE &Buffer, DITypeRefArray Args) {
-  // Args[0] is the return type.
-  DIE *ObjectPointer = nullptr;
+void DwarfUnit::constructSubprogramArguments(DIE &Buffer, DITypeRefArray Args) {
   for (unsigned i = 1, N = Args.size(); i < N; ++i) {
     const DIType *Ty = Args[i];
     if (!Ty) {
@@ -862,14 +860,8 @@ DIE *DwarfUnit::constructSubprogramArguments(DIE &Buffer, DITypeRefArray Args) {
       addType(Arg, Ty);
       if (Ty->isArtificial())
         addFlag(Arg, dwarf::DW_AT_artificial);
-      if (Ty->isObjectPointer()) {
-        assert(!ObjectPointer && "Can't have more than one object pointer");
-        ObjectPointer = &Arg;
-      }
     }
   }
-
-  return ObjectPointer;
 }
 
 void DwarfUnit::constructTypeDIE(DIE &Buffer, const DISubroutineType *CTy) {
@@ -1366,8 +1358,7 @@ void DwarfUnit::applySubprogramAttributes(const DISubprogram *SP, DIE &SPDie,
 
     // Add arguments. Do not add arguments for subprogram definition. They will
     // be handled while processing variables.
-    if (auto *ObjectPointer = constructSubprogramArguments(SPDie, Args))
-      addDIEEntry(SPDie, dwarf::DW_AT_object_pointer, *ObjectPointer);
+    constructSubprogramArguments(SPDie, Args);
   }
 
   addThrownTypes(SPDie, SP->getThrownTypes());

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -268,9 +268,7 @@ public:
   void constructContainingTypeDIEs();
 
   /// Construct function argument DIEs.
-  ///
-  /// \returns DIE of the object pointer if one exists. Nullptr otherwise.
-  DIE *constructSubprogramArguments(DIE &Buffer, DITypeRefArray Args);
+  void constructSubprogramArguments(DIE &Buffer, DITypeRefArray Args);
 
   /// Create a DIE with the given Tag, add the DIE to its parent, and
   /// call insertDIE if MD is not null.

--- a/llvm/test/DebugInfo/NVPTX/debug-info.ll
+++ b/llvm/test/DebugInfo/NVPTX/debug-info.ll
@@ -98,2584 +98,2554 @@ if.end:                                           ; preds = %if.then, %entry
 ; CHECK-DAG: .file {{[0-9]+}} "{{.*}}/usr/local/cuda/include{{/|\\\\}}vector_types.h"
 
 ; CHECK:	.section	.debug_loc
-; CHECK-NEXT:	{
-; CHECK-NEXT:$L__debug_loc0:
-; CHECK-NEXT:.b64 $L__tmp8
-; CHECK-NEXT:.b64 $L__tmp10
-; CHECK-NEXT:.b8 5                                   // Loc expr size
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 144                                 // DW_OP_regx
-; CHECK-NEXT:.b8 177                                 // 2450993
-; CHECK-NEXT:.b8 204                                 //
-; CHECK-NEXT:.b8 149                                 //
-; CHECK-NEXT:.b8 1                                   //
-; CHECK-NEXT:.b64 0
-; CHECK-NEXT:.b64 0
-; CHECK-NEXT:$L__debug_loc1:
-; CHECK-NEXT:.b64 $L__tmp5
-; CHECK-NEXT:.b64 $L__func_end0
-; CHECK-NEXT:.b8 5                                   // Loc expr size
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 144                                 // DW_OP_regx
-; CHECK-NEXT:.b8 177                                 // 2454065
-; CHECK-NEXT:.b8 228                                 //
-; CHECK-NEXT:.b8 149                                 //
-; CHECK-NEXT:.b8 1                                   //
-; CHECK-NEXT:.b64 0
-; CHECK-NEXT:.b64 0
-; CHECK-NEXT:	}
-; CHECK-NEXT:	.section	.debug_abbrev
-; CHECK-NEXT:	{
-; CHECK-NEXT:.b8 1                                   // Abbreviation Code
-; CHECK-NEXT:.b8 17                                  // DW_TAG_compile_unit
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 37                                  // DW_AT_producer
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 19                                  // DW_AT_language
-; CHECK-NEXT:.b8 5                                   // DW_FORM_data2
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 16                                  // DW_AT_stmt_list
-; CHECK-NEXT:.b8 6                                   // DW_FORM_data4
-; CHECK-NEXT:.b8 27                                  // DW_AT_comp_dir
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 2                                   // Abbreviation Code
-; CHECK-NEXT:.b8 19                                  // DW_TAG_structure_type
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 11                                  // DW_AT_byte_size
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 3                                   // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 4                                   // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 100                                 // DW_AT_object_pointer
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 5                                   // Abbreviation Code
-; CHECK-NEXT:.b8 5                                   // DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 52                                  // DW_AT_artificial
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 6                                   // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 100                                 // DW_AT_object_pointer
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 50                                  // DW_AT_accessibility
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 7                                   // Abbreviation Code
-; CHECK-NEXT:.b8 5                                   // DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 8                                   // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 100                                 // DW_AT_object_pointer
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 50                                  // DW_AT_accessibility
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 9                                   // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 100                                 // DW_AT_object_pointer
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 50                                  // DW_AT_accessibility
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 10                                  // Abbreviation Code
-; CHECK-NEXT:.b8 36                                  // DW_TAG_base_type
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 62                                  // DW_AT_encoding
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 11                                  // DW_AT_byte_size
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 11                                  // Abbreviation Code
-; CHECK-NEXT:.b8 13                                  // DW_TAG_member
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 56                                  // DW_AT_data_member_location
-; CHECK-NEXT:.b8 10                                  // DW_FORM_block1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 12                                  // Abbreviation Code
-; CHECK-NEXT:.b8 15                                  // DW_TAG_pointer_type
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 13                                  // Abbreviation Code
-; CHECK-NEXT:.b8 38                                  // DW_TAG_const_type
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 14                                  // Abbreviation Code
-; CHECK-NEXT:.b8 16                                  // DW_TAG_reference_type
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 15                                  // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 71                                  // DW_AT_specification
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 32                                  // DW_AT_inline
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 16                                  // Abbreviation Code
-; CHECK-NEXT:.b8 19                                  // DW_TAG_structure_type
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 11                                  // DW_AT_byte_size
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 5                                   // DW_FORM_data2
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 17                                  // Abbreviation Code
-; CHECK-NEXT:.b8 13                                  // DW_TAG_member
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 5                                   // DW_FORM_data2
-; CHECK-NEXT:.b8 56                                  // DW_AT_data_member_location
-; CHECK-NEXT:.b8 10                                  // DW_FORM_block1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 18                                  // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 5                                   // DW_FORM_data2
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 100                                 // DW_AT_object_pointer
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 19                                  // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 5                                   // DW_FORM_data2
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 100                                 // DW_AT_object_pointer
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 20                                  // Abbreviation Code
-; CHECK-NEXT:.b8 22                                  // DW_TAG_typedef
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 5                                   // DW_FORM_data2
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 21                                  // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 32                                  // DW_AT_inline
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 22                                  // Abbreviation Code
-; CHECK-NEXT:.b8 5                                   // DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 23                                  // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 17                                  // DW_AT_low_pc
-; CHECK-NEXT:.b8 1                                   // DW_FORM_addr
-; CHECK-NEXT:.b8 18                                  // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_FORM_addr
-; CHECK-NEXT:.b8 64                                  // DW_AT_frame_base
-; CHECK-NEXT:.b8 10                                  // DW_FORM_block1
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 63                                  // DW_AT_external
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 24                                  // Abbreviation Code
-; CHECK-NEXT:.b8 5                                   // DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 51                                  // DW_AT_address_class
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 2                                   // DW_AT_location
-; CHECK-NEXT:.b8 10                                  // DW_FORM_block1
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 25                                  // Abbreviation Code
-; CHECK-NEXT:.b8 5                                   // DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 2                                   // DW_AT_location
-; CHECK-NEXT:.b8 6                                   // DW_FORM_data4
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 26                                  // Abbreviation Code
-; CHECK-NEXT:.b8 52                                  // DW_TAG_variable
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 2                                   // DW_AT_location
-; CHECK-NEXT:.b8 6                                   // DW_FORM_data4
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 27                                  // Abbreviation Code
-; CHECK-NEXT:.b8 29                                  // DW_TAG_inlined_subroutine
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 49                                  // DW_AT_abstract_origin
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 17                                  // DW_AT_low_pc
-; CHECK-NEXT:.b8 1                                   // DW_FORM_addr
-; CHECK-NEXT:.b8 18                                  // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_FORM_addr
-; CHECK-NEXT:.b8 88                                  // DW_AT_call_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 89                                  // DW_AT_call_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 87                                  // DW_AT_call_column
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 28                                  // Abbreviation Code
-; CHECK-NEXT:.b8 29                                  // DW_TAG_inlined_subroutine
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 49                                  // DW_AT_abstract_origin
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 17                                  // DW_AT_low_pc
-; CHECK-NEXT:.b8 1                                   // DW_FORM_addr
-; CHECK-NEXT:.b8 18                                  // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_FORM_addr
-; CHECK-NEXT:.b8 88                                  // DW_AT_call_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 89                                  // DW_AT_call_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 87                                  // DW_AT_call_column
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 29                                  // Abbreviation Code
-; CHECK-NEXT:.b8 5                                   // DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 51                                  // DW_AT_address_class
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 2                                   // DW_AT_location
-; CHECK-NEXT:.b8 10                                  // DW_FORM_block1
-; CHECK-NEXT:.b8 49                                  // DW_AT_abstract_origin
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 30                                  // Abbreviation Code
-; CHECK-NEXT:.b8 57                                  // DW_TAG_namespace
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 31                                  // Abbreviation Code
-; CHECK-NEXT:.b8 8                                   // DW_TAG_imported_declaration
-; CHECK-NEXT:.b8 0                                   // DW_CHILDREN_no
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 24                                  // DW_AT_import
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 32                                  // Abbreviation Code
-; CHECK-NEXT:.b8 46                                  // DW_TAG_subprogram
-; CHECK-NEXT:.b8 1                                   // DW_CHILDREN_yes
-; CHECK-NEXT:.b8 135                                 // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 64
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 3                                   // DW_AT_name
-; CHECK-NEXT:.b8 8                                   // DW_FORM_string
-; CHECK-NEXT:.b8 58                                  // DW_AT_decl_file
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 59                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // DW_FORM_data1
-; CHECK-NEXT:.b8 73                                  // DW_AT_type
-; CHECK-NEXT:.b8 19                                  // DW_FORM_ref4
-; CHECK-NEXT:.b8 60                                  // DW_AT_declaration
-; CHECK-NEXT:.b8 12                                  // DW_FORM_flag
-; CHECK-NEXT:.b8 0                                   // EOM(1)
-; CHECK-NEXT:.b8 0                                   // EOM(2)
-; CHECK-NEXT:.b8 0                                   // EOM(3)
-; CHECK-NEXT:	}
-; CHECK-NEXT:	.section	.debug_info
-; CHECK-NEXT:	{
-; CHECK-NEXT:.b32 2460                               // Length of Unit
-; CHECK-NEXT:.b8 2                                   // DWARF version number
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 .debug_abbrev                      // Offset Into Abbrev. Section
-; CHECK-NEXT:.b8 8                                   // Address Size (in bytes)
-; CHECK-NEXT:.b8 1                                   // Abbrev [1] 0xb:0x995 DW_TAG_compile_unit
-; CHECK-NEXT:.b8 0                                   // DW_AT_producer
-; CHECK-NEXT:.b8 4                                   // DW_AT_language
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 100                                 // DW_AT_name
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 103
-; CHECK-NEXT:.b8 45
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 46
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 .debug_line                        // DW_AT_stmt_list
-; CHECK-NEXT:.b8 47                                  // DW_AT_comp_dir
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 47
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // Abbrev [2] 0x31:0x23e DW_TAG_structure_type
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 77                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x4f:0x4f DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 78                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x9e:0x4f DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 79                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0xed:0x4f DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 122
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 122
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 80                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 4                                   // Abbrev [4] 0x13c:0x4d DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 83                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 639                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 386                                // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x182:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 686                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 6                                   // Abbrev [6] 0x189:0x2b DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 85                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 429                                // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x1ad:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 696                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 6                                   // Abbrev [6] 0x1b4:0x30 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 85                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 472                                // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x1d8:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 696                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x1de:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 701                                // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 8                                   // Abbrev [8] 0x1e4:0x47 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 82
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 61
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 85                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 543                                // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x21f:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 686                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x225:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 701                                // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 9                                   // Abbrev [9] 0x22b:0x43 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 38
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 85                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 706                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 615                                // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x267:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 686                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 10                                  // Abbrev [10] 0x26f:0x10 DW_TAG_base_type
-; CHECK-NEXT:.b8 117                                 // DW_AT_name
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 103
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 7                                   // DW_AT_encoding
-; CHECK-NEXT:.b8 4                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 2                                   // Abbrev [2] 0x27f:0x2f DW_TAG_structure_type
-; CHECK-NEXT:.b8 117                                 // DW_AT_name
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 12                                  // DW_AT_byte_size
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 190                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 11                                  // Abbrev [11] 0x289:0xc DW_TAG_member
-; CHECK-NEXT:.b8 120                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 192                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 2                                   // DW_AT_data_member_location
-; CHECK-NEXT:.b8 35
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 11                                  // Abbrev [11] 0x295:0xc DW_TAG_member
-; CHECK-NEXT:.b8 121                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 192                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 2                                   // DW_AT_data_member_location
-; CHECK-NEXT:.b8 35
-; CHECK-NEXT:.b8 4
-; CHECK-NEXT:.b8 11                                  // Abbrev [11] 0x2a1:0xc DW_TAG_member
-; CHECK-NEXT:.b8 122                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 192                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 2                                   // DW_AT_data_member_location
-; CHECK-NEXT:.b8 35
-; CHECK-NEXT:.b8 8
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x2ae:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 691                                // DW_AT_type
-; CHECK-NEXT:.b8 13                                  // Abbrev [13] 0x2b3:0x5 DW_TAG_const_type
-; CHECK-NEXT:.b32 49                                 // DW_AT_type
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x2b8:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 49                                 // DW_AT_type
-; CHECK-NEXT:.b8 14                                  // Abbrev [14] 0x2bd:0x5 DW_TAG_reference_type
-; CHECK-NEXT:.b32 691                                // DW_AT_type
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x2c2:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 49                                 // DW_AT_type
-; CHECK-NEXT:.b8 15                                  // Abbrev [15] 0x2c7:0x6 DW_TAG_subprogram
-; CHECK-NEXT:.b32 79                                 // DW_AT_specification
-; CHECK-NEXT:.b8 1                                   // DW_AT_inline
-; CHECK-NEXT:.b8 2                                   // Abbrev [2] 0x2cd:0x23c DW_TAG_structure_type
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 88                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x2eb:0x4f DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 89                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x33a:0x4f DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 90                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x389:0x4f DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 122
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 122
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 91                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 4                                   // Abbrev [4] 0x3d8:0x4b DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 52
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 94                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 1289                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1052                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x41c:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1477                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 6                                   // Abbrev [6] 0x423:0x2b DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 96                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1095                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x447:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1487                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 6                                   // Abbrev [6] 0x44e:0x30 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 96                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1138                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x472:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1487                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x478:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1492                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 8                                   // Abbrev [8] 0x47e:0x47 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 82
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 61
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 96                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1209                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x4b9:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1477                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x4bf:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1492                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 9                                   // Abbrev [9] 0x4c5:0x43 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 107
-; CHECK-NEXT:.b8 68
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 38
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 96                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 1497                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1281                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x501:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1477                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 16                                  // Abbrev [16] 0x509:0xa9 DW_TAG_structure_type
-; CHECK-NEXT:.b8 100                                 // DW_AT_name
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 12                                  // DW_AT_byte_size
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 161                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 17                                  // Abbrev [17] 0x513:0xd DW_TAG_member
-; CHECK-NEXT:.b8 120                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 163                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 2                                   // DW_AT_data_member_location
-; CHECK-NEXT:.b8 35
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 17                                  // Abbrev [17] 0x520:0xd DW_TAG_member
-; CHECK-NEXT:.b8 121                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 163                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 2                                   // DW_AT_data_member_location
-; CHECK-NEXT:.b8 35
-; CHECK-NEXT:.b8 4
-; CHECK-NEXT:.b8 17                                  // Abbrev [17] 0x52d:0xd DW_TAG_member
-; CHECK-NEXT:.b8 122                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 163                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 2                                   // DW_AT_data_member_location
-; CHECK-NEXT:.b8 35
-; CHECK-NEXT:.b8 8
-; CHECK-NEXT:.b8 18                                  // Abbrev [18] 0x53a:0x25 DW_TAG_subprogram
-; CHECK-NEXT:.b8 100                                 // DW_AT_name
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 165                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1353                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x549:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1458                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x54f:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x554:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x559:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 18                                  // Abbrev [18] 0x55f:0x1b DW_TAG_subprogram
-; CHECK-NEXT:.b8 100                                 // DW_AT_name
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 166                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1390                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x56e:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1458                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x574:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1463                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 19                                  // Abbrev [19] 0x57a:0x37 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 52
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 109
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 167                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b32 1463                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1450                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x5aa:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 1458                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x5b2:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 1289                               // DW_AT_type
-; CHECK-NEXT:.b8 20                                  // Abbrev [20] 0x5b7:0xe DW_TAG_typedef
-; CHECK-NEXT:.b32 639                                // DW_AT_type
-; CHECK-NEXT:.b8 117                                 // DW_AT_name
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 127                                 // DW_AT_decl_line
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x5c5:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 1482                               // DW_AT_type
-; CHECK-NEXT:.b8 13                                  // Abbrev [13] 0x5ca:0x5 DW_TAG_const_type
-; CHECK-NEXT:.b32 717                                // DW_AT_type
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x5cf:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 717                                // DW_AT_type
-; CHECK-NEXT:.b8 14                                  // Abbrev [14] 0x5d4:0x5 DW_TAG_reference_type
-; CHECK-NEXT:.b32 1482                               // DW_AT_type
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x5d9:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 717                                // DW_AT_type
-; CHECK-NEXT:.b8 15                                  // Abbrev [15] 0x5de:0x6 DW_TAG_subprogram
-; CHECK-NEXT:.b32 747                                // DW_AT_specification
-; CHECK-NEXT:.b8 1                                   // DW_AT_inline
-; CHECK-NEXT:.b8 2                                   // Abbrev [2] 0x5e4:0x247 DW_TAG_structure_type
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 66                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x603:0x50 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 54
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 67                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x653:0x50 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 54
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 68                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // Abbrev [3] 0x6a3:0x50 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 54
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 49
-; CHECK-NEXT:.b8 55
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 122
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 122
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 69                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 623                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 4                                   // Abbrev [4] 0x6f3:0x4e DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 54
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 72                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 639                                // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1850                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x73a:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2091                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 6                                   // Abbrev [6] 0x741:0x2c DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 74                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1894                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x766:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2101                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 6                                   // Abbrev [6] 0x76d:0x31 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_name
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 74                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 1938                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x792:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2101                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x798:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2106                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 8                                   // Abbrev [8] 0x79e:0x48 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 54
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 82
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 61
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 74                                  // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 2010                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x7da:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2091                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x7e0:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2106                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 9                                   // Abbrev [9] 0x7e6:0x44 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 78
-; CHECK-NEXT:.b8 75
-; CHECK-NEXT:.b8 50
-; CHECK-NEXT:.b8 54
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 99
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 117
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 104
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 73
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 69
-; CHECK-NEXT:.b8 118
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 111                                 // DW_AT_name
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 38
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 2                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 74                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 2111                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b32 2083                               // DW_AT_object_pointer
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 3                                   // DW_AT_accessibility
-; CHECK-NEXT:                                        // DW_ACCESS_private
-; CHECK-NEXT:.b8 5                                   // Abbrev [5] 0x823:0x6 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2091                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_artificial
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x82b:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 2096                               // DW_AT_type
-; CHECK-NEXT:.b8 13                                  // Abbrev [13] 0x830:0x5 DW_TAG_const_type
-; CHECK-NEXT:.b32 1508                               // DW_AT_type
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x835:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 1508                               // DW_AT_type
-; CHECK-NEXT:.b8 14                                  // Abbrev [14] 0x83a:0x5 DW_TAG_reference_type
-; CHECK-NEXT:.b32 2096                               // DW_AT_type
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x83f:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 1508                               // DW_AT_type
-; CHECK-NEXT:.b8 15                                  // Abbrev [15] 0x844:0x6 DW_TAG_subprogram
-; CHECK-NEXT:.b32 1539                               // DW_AT_specification
-; CHECK-NEXT:.b8 1                                   // DW_AT_inline
-; CHECK-NEXT:.b8 21                                  // Abbrev [21] 0x84a:0x32 DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 114
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 80
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 114                                 // DW_AT_name
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 1                                   // DW_AT_inline
-; CHECK-NEXT:.b8 22                                  // Abbrev [22] 0x85e:0x9 DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 120                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2172                               // DW_AT_type
-; CHECK-NEXT:.b8 22                                  // Abbrev [22] 0x867:0x9 DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 121                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2172                               // DW_AT_type
-; CHECK-NEXT:.b8 22                                  // Abbrev [22] 0x870:0xb DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 114                                 // DW_AT_name
-; CHECK-NEXT:.b8 101
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 3                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2181                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 10                                  // Abbrev [10] 0x87c:0x9 DW_TAG_base_type
-; CHECK-NEXT:.b8 102                                 // DW_AT_name
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 4                                   // DW_AT_encoding
-; CHECK-NEXT:.b8 4                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 12                                  // Abbrev [12] 0x885:0x5 DW_TAG_pointer_type
-; CHECK-NEXT:.b32 2172                               // DW_AT_type
-; CHECK-NEXT:.b8 23                                  // Abbrev [23] 0x88a:0xd5 DW_TAG_subprogram
-; CHECK-NEXT:.b64 $L__func_begin0                    // DW_AT_low_pc
-; CHECK-NEXT:.b64 $L__func_end0                      // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_AT_frame_base
-; CHECK-NEXT:.b8 156
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 53
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 80
-; CHECK-NEXT:.b8 102
-; CHECK-NEXT:.b8 83
-; CHECK-NEXT:.b8 95
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 115                                 // DW_AT_name
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 112
-; CHECK-NEXT:.b8 121
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 5                                   // DW_AT_decl_line
-; CHECK-NEXT:.b8 1                                   // DW_AT_external
-; CHECK-NEXT:.b8 24                                  // Abbrev [24] 0x8b5:0x10 DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 2                                   // DW_AT_address_class
-; CHECK-NEXT:.b8 5                                   // DW_AT_location
-; CHECK-NEXT:.b8 144
-; CHECK-NEXT:.b8 178
-; CHECK-NEXT:.b8 228
-; CHECK-NEXT:.b8 149
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b8 110                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 5                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2456                               // DW_AT_type
-; CHECK-NEXT:.b8 25                                  // Abbrev [25] 0x8c5:0xd DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 $L__debug_loc0                     // DW_AT_location
-; CHECK-NEXT:.b8 97                                  // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 5                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2172                               // DW_AT_type
-; CHECK-NEXT:.b8 22                                  // Abbrev [22] 0x8d2:0x9 DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 120                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 5                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2181                               // DW_AT_type
-; CHECK-NEXT:.b8 22                                  // Abbrev [22] 0x8db:0x9 DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 121                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 5                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2181                               // DW_AT_type
-; CHECK-NEXT:.b8 26                                  // Abbrev [26] 0x8e4:0xd DW_TAG_variable
-; CHECK-NEXT:.b32 $L__debug_loc1                     // DW_AT_location
-; CHECK-NEXT:.b8 105                                 // DW_AT_name
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 1                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 6                                   // DW_AT_decl_line
-; CHECK-NEXT:.b32 2456                               // DW_AT_type
-; CHECK-NEXT:.b8 27                                  // Abbrev [27] 0x8f1:0x18 DW_TAG_inlined_subroutine
-; CHECK-NEXT:.b32 711                                // DW_AT_abstract_origin
-; CHECK-NEXT:.b64 $L__tmp1                           // DW_AT_low_pc
-; CHECK-NEXT:.b64 $L__tmp2                           // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_AT_call_file
-; CHECK-NEXT:.b8 6                                   // DW_AT_call_line
-; CHECK-NEXT:.b8 11                                  // DW_AT_call_column
-; CHECK-NEXT:.b8 27                                  // Abbrev [27] 0x909:0x18 DW_TAG_inlined_subroutine
-; CHECK-NEXT:.b32 1502                               // DW_AT_abstract_origin
-; CHECK-NEXT:.b64 $L__tmp2                           // DW_AT_low_pc
-; CHECK-NEXT:.b64 $L__tmp3                           // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_AT_call_file
-; CHECK-NEXT:.b8 6                                   // DW_AT_call_line
-; CHECK-NEXT:.b8 24                                  // DW_AT_call_column
-; CHECK-NEXT:.b8 27                                  // Abbrev [27] 0x921:0x18 DW_TAG_inlined_subroutine
-; CHECK-NEXT:.b32 2116                               // DW_AT_abstract_origin
-; CHECK-NEXT:.b64 $L__tmp3                           // DW_AT_low_pc
-; CHECK-NEXT:.b64 $L__tmp4                           // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_AT_call_file
-; CHECK-NEXT:.b8 6                                   // DW_AT_call_line
-; CHECK-NEXT:.b8 37                                  // DW_AT_call_column
-; CHECK-NEXT:.b8 28                                  // Abbrev [28] 0x939:0x25 DW_TAG_inlined_subroutine
-; CHECK-NEXT:.b32 2122                               // DW_AT_abstract_origin
-; CHECK-NEXT:.b64 $L__tmp9                           // DW_AT_low_pc
-; CHECK-NEXT:.b64 $L__tmp10                          // DW_AT_high_pc
-; CHECK-NEXT:.b8 1                                   // DW_AT_call_file
-; CHECK-NEXT:.b8 8                                   // DW_AT_call_line
-; CHECK-NEXT:.b8 5                                   // DW_AT_call_column
-; CHECK-NEXT:.b8 29                                  // Abbrev [29] 0x951:0xc DW_TAG_formal_parameter
-; CHECK-NEXT:.b8 2                                   // DW_AT_address_class
-; CHECK-NEXT:.b8 5                                   // DW_AT_location
-; CHECK-NEXT:.b8 144
-; CHECK-NEXT:.b8 179
-; CHECK-NEXT:.b8 204
-; CHECK-NEXT:.b8 149
-; CHECK-NEXT:.b8 1
-; CHECK-NEXT:.b32 2151                               // DW_AT_abstract_origin
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 30                                  // Abbrev [30] 0x95f:0xd DW_TAG_namespace
-; CHECK-NEXT:.b8 115                                 // DW_AT_name
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 100
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 31                                  // Abbrev [31] 0x964:0x7 DW_TAG_imported_declaration
-; CHECK-NEXT:.b8 4                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 202                                 // DW_AT_decl_line
-; CHECK-NEXT:.b32 2412                               // DW_AT_import
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 32                                  // Abbrev [32] 0x96c:0x1b DW_TAG_subprogram
-; CHECK-NEXT:.b8 95                                  // DW_AT_MIPS_linkage_name
-; CHECK-NEXT:.b8 90
-; CHECK-NEXT:.b8 76
-; CHECK-NEXT:.b8 51
-; CHECK-NEXT:.b8 97
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 120
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 97                                  // DW_AT_name
-; CHECK-NEXT:.b8 98
-; CHECK-NEXT:.b8 115
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 4                                   // DW_AT_decl_file
-; CHECK-NEXT:.b8 44                                  // DW_AT_decl_line
-; CHECK-NEXT:.b32 2439                               // DW_AT_type
-; CHECK-NEXT:.b8 1                                   // DW_AT_declaration
-; CHECK-NEXT:.b8 7                                   // Abbrev [7] 0x981:0x5 DW_TAG_formal_parameter
-; CHECK-NEXT:.b32 2439                               // DW_AT_type
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:.b8 10                                  // Abbrev [10] 0x987:0x11 DW_TAG_base_type
-; CHECK-NEXT:.b8 108                                 // DW_AT_name
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 103
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 108
-; CHECK-NEXT:.b8 111
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 103
-; CHECK-NEXT:.b8 32
-; CHECK-NEXT:.b8 105
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 5                                   // DW_AT_encoding
-; CHECK-NEXT:.b8 8                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 10                                  // Abbrev [10] 0x998:0x7 DW_TAG_base_type
-; CHECK-NEXT:.b8 105                                 // DW_AT_name
-; CHECK-NEXT:.b8 110
-; CHECK-NEXT:.b8 116
-; CHECK-NEXT:.b8 0
-; CHECK-NEXT:.b8 5                                   // DW_AT_encoding
-; CHECK-NEXT:.b8 4                                   // DW_AT_byte_size
-; CHECK-NEXT:.b8 0                                   // End Of Children Mark
-; CHECK-NEXT:	}
-; CHECK-NEXT:	.section	.debug_macinfo	{	}
+; CHECK-NEXT: 	{
+; CHECK-NEXT: $L__debug_loc0:
+; CHECK-NEXT: .b64 $L__tmp8
+; CHECK-NEXT: .b64 $L__tmp10
+; CHECK-NEXT: .b8 5                                   // Loc expr size
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 144                                 // DW_OP_regx
+; CHECK-NEXT: .b8 177                                 // 2450993
+; CHECK-NEXT: .b8 204                                 // 
+; CHECK-NEXT: .b8 149                                 // 
+; CHECK-NEXT: .b8 1                                   // 
+; CHECK-NEXT: .b64 0
+; CHECK-NEXT: .b64 0
+; CHECK-NEXT: $L__debug_loc1:
+; CHECK-NEXT: .b64 $L__tmp5
+; CHECK-NEXT: .b64 $L__func_end0
+; CHECK-NEXT: .b8 5                                   // Loc expr size
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 144                                 // DW_OP_regx
+; CHECK-NEXT: .b8 177                                 // 2454065
+; CHECK-NEXT: .b8 228                                 // 
+; CHECK-NEXT: .b8 149                                 // 
+; CHECK-NEXT: .b8 1                                   // 
+; CHECK-NEXT: .b64 0
+; CHECK-NEXT: .b64 0
+; CHECK-NEXT: 	}
+; CHECK-NEXT: 	.section	.debug_abbrev
+; CHECK-NEXT: 	{
+; CHECK-NEXT: .b8 1                                   // Abbreviation Code
+; CHECK-NEXT: .b8 17                                  // DW_TAG_compile_unit
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 37                                  // DW_AT_producer
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 19                                  // DW_AT_language
+; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 16                                  // DW_AT_stmt_list
+; CHECK-NEXT: .b8 6                                   // DW_FORM_data4
+; CHECK-NEXT: .b8 27                                  // DW_AT_comp_dir
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 2                                   // Abbreviation Code
+; CHECK-NEXT: .b8 19                                  // DW_TAG_structure_type
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 11                                  // DW_AT_byte_size
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 3                                   // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 4                                   // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 5                                   // Abbreviation Code
+; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 52                                  // DW_AT_artificial
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 6                                   // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 50                                  // DW_AT_accessibility
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 7                                   // Abbreviation Code
+; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 8                                   // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 50                                  // DW_AT_accessibility
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 9                                   // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 50                                  // DW_AT_accessibility
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 10                                  // Abbreviation Code
+; CHECK-NEXT: .b8 36                                  // DW_TAG_base_type
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 62                                  // DW_AT_encoding
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 11                                  // DW_AT_byte_size
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 11                                  // Abbreviation Code
+; CHECK-NEXT: .b8 13                                  // DW_TAG_member
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 56                                  // DW_AT_data_member_location
+; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 12                                  // Abbreviation Code
+; CHECK-NEXT: .b8 15                                  // DW_TAG_pointer_type
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 13                                  // Abbreviation Code
+; CHECK-NEXT: .b8 38                                  // DW_TAG_const_type
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 14                                  // Abbreviation Code
+; CHECK-NEXT: .b8 16                                  // DW_TAG_reference_type
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 15                                  // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 71                                  // DW_AT_specification
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 32                                  // DW_AT_inline
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 16                                  // Abbreviation Code
+; CHECK-NEXT: .b8 19                                  // DW_TAG_structure_type
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 11                                  // DW_AT_byte_size
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 17                                  // Abbreviation Code
+; CHECK-NEXT: .b8 13                                  // DW_TAG_member
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
+; CHECK-NEXT: .b8 56                                  // DW_AT_data_member_location
+; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 18                                  // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 19                                  // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 20                                  // Abbreviation Code
+; CHECK-NEXT: .b8 22                                  // DW_TAG_typedef
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 5                                   // DW_FORM_data2
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 21                                  // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 32                                  // DW_AT_inline
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 22                                  // Abbreviation Code
+; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 23                                  // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 17                                  // DW_AT_low_pc
+; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+; CHECK-NEXT: .b8 18                                  // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+; CHECK-NEXT: .b8 64                                  // DW_AT_frame_base
+; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 63                                  // DW_AT_external
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 24                                  // Abbreviation Code
+; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 51                                  // DW_AT_address_class
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 2                                   // DW_AT_location
+; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 25                                  // Abbreviation Code
+; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 2                                   // DW_AT_location
+; CHECK-NEXT: .b8 6                                   // DW_FORM_data4
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 26                                  // Abbreviation Code
+; CHECK-NEXT: .b8 52                                  // DW_TAG_variable
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 2                                   // DW_AT_location
+; CHECK-NEXT: .b8 6                                   // DW_FORM_data4
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 27                                  // Abbreviation Code
+; CHECK-NEXT: .b8 29                                  // DW_TAG_inlined_subroutine
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 49                                  // DW_AT_abstract_origin
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 17                                  // DW_AT_low_pc
+; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+; CHECK-NEXT: .b8 18                                  // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+; CHECK-NEXT: .b8 88                                  // DW_AT_call_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 89                                  // DW_AT_call_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 87                                  // DW_AT_call_column
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 28                                  // Abbreviation Code
+; CHECK-NEXT: .b8 29                                  // DW_TAG_inlined_subroutine
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 49                                  // DW_AT_abstract_origin
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 17                                  // DW_AT_low_pc
+; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+; CHECK-NEXT: .b8 18                                  // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_FORM_addr
+; CHECK-NEXT: .b8 88                                  // DW_AT_call_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 89                                  // DW_AT_call_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 87                                  // DW_AT_call_column
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 29                                  // Abbreviation Code
+; CHECK-NEXT: .b8 5                                   // DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 51                                  // DW_AT_address_class
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 2                                   // DW_AT_location
+; CHECK-NEXT: .b8 10                                  // DW_FORM_block1
+; CHECK-NEXT: .b8 49                                  // DW_AT_abstract_origin
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 30                                  // Abbreviation Code
+; CHECK-NEXT: .b8 57                                  // DW_TAG_namespace
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 31                                  // Abbreviation Code
+; CHECK-NEXT: .b8 8                                   // DW_TAG_imported_declaration
+; CHECK-NEXT: .b8 0                                   // DW_CHILDREN_no
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 24                                  // DW_AT_import
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 32                                  // Abbreviation Code
+; CHECK-NEXT: .b8 46                                  // DW_TAG_subprogram
+; CHECK-NEXT: .b8 1                                   // DW_CHILDREN_yes
+; CHECK-NEXT: .b8 135                                 // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 64
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 3                                   // DW_AT_name
+; CHECK-NEXT: .b8 8                                   // DW_FORM_string
+; CHECK-NEXT: .b8 58                                  // DW_AT_decl_file
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 59                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // DW_FORM_data1
+; CHECK-NEXT: .b8 73                                  // DW_AT_type
+; CHECK-NEXT: .b8 19                                  // DW_FORM_ref4
+; CHECK-NEXT: .b8 60                                  // DW_AT_declaration
+; CHECK-NEXT: .b8 12                                  // DW_FORM_flag
+; CHECK-NEXT: .b8 0                                   // EOM(1)
+; CHECK-NEXT: .b8 0                                   // EOM(2)
+; CHECK-NEXT: .b8 0                                   // EOM(3)
+; CHECK-NEXT: 	}
+; CHECK-NEXT: 	.section	.debug_info
+; CHECK-NEXT: 	{
+; CHECK-NEXT: .b32 2388                               // Length of Unit
+; CHECK-NEXT: .b8 2                                   // DWARF version number
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 .debug_abbrev                      // Offset Into Abbrev. Section
+; CHECK-NEXT: .b8 8                                   // Address Size (in bytes)
+; CHECK-NEXT: .b8 1                                   // Abbrev [1] 0xb:0x94d DW_TAG_compile_unit
+; CHECK-NEXT: .b8 0                                   // DW_AT_producer
+; CHECK-NEXT: .b8 4                                   // DW_AT_language
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 100                                 // DW_AT_name
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 103
+; CHECK-NEXT: .b8 45
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 46
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 .debug_line                        // DW_AT_stmt_list
+; CHECK-NEXT: .b8 47                                  // DW_AT_comp_dir
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 47
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x31:0x22a DW_TAG_structure_type
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 77                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x4f:0x4f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 78                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x9e:0x4f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 79                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0xed:0x4f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 122
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 122
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 80                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 4                                   // Abbrev [4] 0x13c:0x49 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 83                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 619                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x17e:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 666                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x185:0x27 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 85                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x1a5:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 676                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x1ac:0x2c DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 85                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x1cc:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 676                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x1d2:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 681                                // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 8                                   // Abbrev [8] 0x1d8:0x43 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 82
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 61
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 85                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x20f:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 666                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x215:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 681                                // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 9                                   // Abbrev [9] 0x21b:0x3f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 38
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 85                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 686                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x253:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 666                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 10                                  // Abbrev [10] 0x25b:0x10 DW_TAG_base_type
+; CHECK-NEXT: .b8 117                                 // DW_AT_name
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 103
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 7                                   // DW_AT_encoding
+; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x26b:0x2f DW_TAG_structure_type
+; CHECK-NEXT: .b8 117                                 // DW_AT_name
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 12                                  // DW_AT_byte_size
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 190                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 11                                  // Abbrev [11] 0x275:0xc DW_TAG_member
+; CHECK-NEXT: .b8 120                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 192                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 2                                   // DW_AT_data_member_location
+; CHECK-NEXT: .b8 35
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 11                                  // Abbrev [11] 0x281:0xc DW_TAG_member
+; CHECK-NEXT: .b8 121                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 192                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 2                                   // DW_AT_data_member_location
+; CHECK-NEXT: .b8 35
+; CHECK-NEXT: .b8 4
+; CHECK-NEXT: .b8 11                                  // Abbrev [11] 0x28d:0xc DW_TAG_member
+; CHECK-NEXT: .b8 122                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 192                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 2                                   // DW_AT_data_member_location
+; CHECK-NEXT: .b8 35
+; CHECK-NEXT: .b8 8
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x29a:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 671                                // DW_AT_type
+; CHECK-NEXT: .b8 13                                  // Abbrev [13] 0x29f:0x5 DW_TAG_const_type
+; CHECK-NEXT: .b32 49                                 // DW_AT_type
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x2a4:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 49                                 // DW_AT_type
+; CHECK-NEXT: .b8 14                                  // Abbrev [14] 0x2a9:0x5 DW_TAG_reference_type
+; CHECK-NEXT: .b32 671                                // DW_AT_type
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x2ae:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 49                                 // DW_AT_type
+; CHECK-NEXT: .b8 15                                  // Abbrev [15] 0x2b3:0x6 DW_TAG_subprogram
+; CHECK-NEXT: .b32 79                                 // DW_AT_specification
+; CHECK-NEXT: .b8 1                                   // DW_AT_inline
+; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x2b9:0x228 DW_TAG_structure_type
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 88                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x2d7:0x4f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 89                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x326:0x4f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 90                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x375:0x4f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 122
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 122
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 91                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 4                                   // Abbrev [4] 0x3c4:0x47 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 52
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 94                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 1249                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x404:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1425                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x40b:0x27 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 96                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x42b:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1435                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x432:0x2c DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 96                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x452:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1435                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x458:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1440                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 8                                   // Abbrev [8] 0x45e:0x43 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 82
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 61
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 96                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x495:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1425                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x49b:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1440                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 9                                   // Abbrev [9] 0x4a1:0x3f DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 107
+; CHECK-NEXT: .b8 68
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 38
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 96                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 1445                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x4d9:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1425                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 16                                  // Abbrev [16] 0x4e1:0x9d DW_TAG_structure_type
+; CHECK-NEXT: .b8 100                                 // DW_AT_name
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 12                                  // DW_AT_byte_size
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 161                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 17                                  // Abbrev [17] 0x4eb:0xd DW_TAG_member
+; CHECK-NEXT: .b8 120                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 163                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 2                                   // DW_AT_data_member_location
+; CHECK-NEXT: .b8 35
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 17                                  // Abbrev [17] 0x4f8:0xd DW_TAG_member
+; CHECK-NEXT: .b8 121                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 163                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 2                                   // DW_AT_data_member_location
+; CHECK-NEXT: .b8 35
+; CHECK-NEXT: .b8 4
+; CHECK-NEXT: .b8 17                                  // Abbrev [17] 0x505:0xd DW_TAG_member
+; CHECK-NEXT: .b8 122                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 163                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 2                                   // DW_AT_data_member_location
+; CHECK-NEXT: .b8 35
+; CHECK-NEXT: .b8 8
+; CHECK-NEXT: .b8 18                                  // Abbrev [18] 0x512:0x21 DW_TAG_subprogram
+; CHECK-NEXT: .b8 100                                 // DW_AT_name
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 165                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x51d:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1406                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x523:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x528:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x52d:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 18                                  // Abbrev [18] 0x533:0x17 DW_TAG_subprogram
+; CHECK-NEXT: .b8 100                                 // DW_AT_name
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 166                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x53e:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1406                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x544:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1411                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 19                                  // Abbrev [19] 0x54a:0x33 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 52
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 109
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 167                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b32 1411                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x576:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 1406                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x57e:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 1249                               // DW_AT_type
+; CHECK-NEXT: .b8 20                                  // Abbrev [20] 0x583:0xe DW_TAG_typedef
+; CHECK-NEXT: .b32 619                                // DW_AT_type
+; CHECK-NEXT: .b8 117                                 // DW_AT_name
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 127                                 // DW_AT_decl_line
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x591:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 1430                               // DW_AT_type
+; CHECK-NEXT: .b8 13                                  // Abbrev [13] 0x596:0x5 DW_TAG_const_type
+; CHECK-NEXT: .b32 697                                // DW_AT_type
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x59b:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 697                                // DW_AT_type
+; CHECK-NEXT: .b8 14                                  // Abbrev [14] 0x5a0:0x5 DW_TAG_reference_type
+; CHECK-NEXT: .b32 1430                               // DW_AT_type
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x5a5:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 697                                // DW_AT_type
+; CHECK-NEXT: .b8 15                                  // Abbrev [15] 0x5aa:0x6 DW_TAG_subprogram
+; CHECK-NEXT: .b32 727                                // DW_AT_specification
+; CHECK-NEXT: .b8 1                                   // DW_AT_inline
+; CHECK-NEXT: .b8 2                                   // Abbrev [2] 0x5b0:0x233 DW_TAG_structure_type
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 66                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x5cf:0x50 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 54
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 67                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x61f:0x50 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 54
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 68                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // Abbrev [3] 0x66f:0x50 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 54
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 49
+; CHECK-NEXT: .b8 55
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 122
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 122
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 69                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 603                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 4                                   // Abbrev [4] 0x6bf:0x4a DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 54
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 72                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 619                                // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x702:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2019                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x709:0x28 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 74                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x72a:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2029                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 6                                   // Abbrev [6] 0x731:0x2d DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_name
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 74                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x752:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2029                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x758:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2034                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 8                                   // Abbrev [8] 0x75e:0x44 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 54
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 82
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 61
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 74                                  // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x796:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2019                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x79c:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2034                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 9                                   // Abbrev [9] 0x7a2:0x40 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 78
+; CHECK-NEXT: .b8 75
+; CHECK-NEXT: .b8 50
+; CHECK-NEXT: .b8 54
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 99
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 117
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 104
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 73
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 69
+; CHECK-NEXT: .b8 118
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 111                                 // DW_AT_name
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 38
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 2                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 74                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 2039                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 3                                   // DW_AT_accessibility
+; CHECK-NEXT:                                         // DW_ACCESS_private
+; CHECK-NEXT: .b8 5                                   // Abbrev [5] 0x7db:0x6 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2019                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_artificial
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x7e3:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 2024                               // DW_AT_type
+; CHECK-NEXT: .b8 13                                  // Abbrev [13] 0x7e8:0x5 DW_TAG_const_type
+; CHECK-NEXT: .b32 1456                               // DW_AT_type
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x7ed:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 1456                               // DW_AT_type
+; CHECK-NEXT: .b8 14                                  // Abbrev [14] 0x7f2:0x5 DW_TAG_reference_type
+; CHECK-NEXT: .b32 2024                               // DW_AT_type
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x7f7:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 1456                               // DW_AT_type
+; CHECK-NEXT: .b8 15                                  // Abbrev [15] 0x7fc:0x6 DW_TAG_subprogram
+; CHECK-NEXT: .b32 1487                               // DW_AT_specification
+; CHECK-NEXT: .b8 1                                   // DW_AT_inline
+; CHECK-NEXT: .b8 21                                  // Abbrev [21] 0x802:0x32 DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 114
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 80
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 114                                 // DW_AT_name
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 1                                   // DW_AT_inline
+; CHECK-NEXT: .b8 22                                  // Abbrev [22] 0x816:0x9 DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 120                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2100                               // DW_AT_type
+; CHECK-NEXT: .b8 22                                  // Abbrev [22] 0x81f:0x9 DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 121                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2100                               // DW_AT_type
+; CHECK-NEXT: .b8 22                                  // Abbrev [22] 0x828:0xb DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 114                                 // DW_AT_name
+; CHECK-NEXT: .b8 101
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 3                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2109                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 10                                  // Abbrev [10] 0x834:0x9 DW_TAG_base_type
+; CHECK-NEXT: .b8 102                                 // DW_AT_name
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 4                                   // DW_AT_encoding
+; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 12                                  // Abbrev [12] 0x83d:0x5 DW_TAG_pointer_type
+; CHECK-NEXT: .b32 2100                               // DW_AT_type
+; CHECK-NEXT: .b8 23                                  // Abbrev [23] 0x842:0xd5 DW_TAG_subprogram
+; CHECK-NEXT: .b64 $L__func_begin0                    // DW_AT_low_pc
+; CHECK-NEXT: .b64 $L__func_end0                      // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_AT_frame_base
+; CHECK-NEXT: .b8 156
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 53
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 80
+; CHECK-NEXT: .b8 102
+; CHECK-NEXT: .b8 83
+; CHECK-NEXT: .b8 95
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 115                                 // DW_AT_name
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 112
+; CHECK-NEXT: .b8 121
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 5                                   // DW_AT_decl_line
+; CHECK-NEXT: .b8 1                                   // DW_AT_external
+; CHECK-NEXT: .b8 24                                  // Abbrev [24] 0x86d:0x10 DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 2                                   // DW_AT_address_class
+; CHECK-NEXT: .b8 5                                   // DW_AT_location
+; CHECK-NEXT: .b8 144
+; CHECK-NEXT: .b8 178
+; CHECK-NEXT: .b8 228
+; CHECK-NEXT: .b8 149
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b8 110                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 5                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2384                               // DW_AT_type
+; CHECK-NEXT: .b8 25                                  // Abbrev [25] 0x87d:0xd DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 $L__debug_loc0                     // DW_AT_location
+; CHECK-NEXT: .b8 97                                  // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 5                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2100                               // DW_AT_type
+; CHECK-NEXT: .b8 22                                  // Abbrev [22] 0x88a:0x9 DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 120                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 5                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2109                               // DW_AT_type
+; CHECK-NEXT: .b8 22                                  // Abbrev [22] 0x893:0x9 DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 121                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 5                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2109                               // DW_AT_type
+; CHECK-NEXT: .b8 26                                  // Abbrev [26] 0x89c:0xd DW_TAG_variable
+; CHECK-NEXT: .b32 $L__debug_loc1                     // DW_AT_location
+; CHECK-NEXT: .b8 105                                 // DW_AT_name
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 1                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 6                                   // DW_AT_decl_line
+; CHECK-NEXT: .b32 2384                               // DW_AT_type
+; CHECK-NEXT: .b8 27                                  // Abbrev [27] 0x8a9:0x18 DW_TAG_inlined_subroutine
+; CHECK-NEXT: .b32 691                                // DW_AT_abstract_origin
+; CHECK-NEXT: .b64 $L__tmp1                           // DW_AT_low_pc
+; CHECK-NEXT: .b64 $L__tmp2                           // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_AT_call_file
+; CHECK-NEXT: .b8 6                                   // DW_AT_call_line
+; CHECK-NEXT: .b8 11                                  // DW_AT_call_column
+; CHECK-NEXT: .b8 27                                  // Abbrev [27] 0x8c1:0x18 DW_TAG_inlined_subroutine
+; CHECK-NEXT: .b32 1450                               // DW_AT_abstract_origin
+; CHECK-NEXT: .b64 $L__tmp2                           // DW_AT_low_pc
+; CHECK-NEXT: .b64 $L__tmp3                           // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_AT_call_file
+; CHECK-NEXT: .b8 6                                   // DW_AT_call_line
+; CHECK-NEXT: .b8 24                                  // DW_AT_call_column
+; CHECK-NEXT: .b8 27                                  // Abbrev [27] 0x8d9:0x18 DW_TAG_inlined_subroutine
+; CHECK-NEXT: .b32 2044                               // DW_AT_abstract_origin
+; CHECK-NEXT: .b64 $L__tmp3                           // DW_AT_low_pc
+; CHECK-NEXT: .b64 $L__tmp4                           // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_AT_call_file
+; CHECK-NEXT: .b8 6                                   // DW_AT_call_line
+; CHECK-NEXT: .b8 37                                  // DW_AT_call_column
+; CHECK-NEXT: .b8 28                                  // Abbrev [28] 0x8f1:0x25 DW_TAG_inlined_subroutine
+; CHECK-NEXT: .b32 2050                               // DW_AT_abstract_origin
+; CHECK-NEXT: .b64 $L__tmp9                           // DW_AT_low_pc
+; CHECK-NEXT: .b64 $L__tmp10                          // DW_AT_high_pc
+; CHECK-NEXT: .b8 1                                   // DW_AT_call_file
+; CHECK-NEXT: .b8 8                                   // DW_AT_call_line
+; CHECK-NEXT: .b8 5                                   // DW_AT_call_column
+; CHECK-NEXT: .b8 29                                  // Abbrev [29] 0x909:0xc DW_TAG_formal_parameter
+; CHECK-NEXT: .b8 2                                   // DW_AT_address_class
+; CHECK-NEXT: .b8 5                                   // DW_AT_location
+; CHECK-NEXT: .b8 144
+; CHECK-NEXT: .b8 179
+; CHECK-NEXT: .b8 204
+; CHECK-NEXT: .b8 149
+; CHECK-NEXT: .b8 1
+; CHECK-NEXT: .b32 2079                               // DW_AT_abstract_origin
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 30                                  // Abbrev [30] 0x917:0xd DW_TAG_namespace
+; CHECK-NEXT: .b8 115                                 // DW_AT_name
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 100
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 31                                  // Abbrev [31] 0x91c:0x7 DW_TAG_imported_declaration
+; CHECK-NEXT: .b8 4                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 202                                 // DW_AT_decl_line
+; CHECK-NEXT: .b32 2340                               // DW_AT_import
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 32                                  // Abbrev [32] 0x924:0x1b DW_TAG_subprogram
+; CHECK-NEXT: .b8 95                                  // DW_AT_MIPS_linkage_name
+; CHECK-NEXT: .b8 90
+; CHECK-NEXT: .b8 76
+; CHECK-NEXT: .b8 51
+; CHECK-NEXT: .b8 97
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 120
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 97                                  // DW_AT_name
+; CHECK-NEXT: .b8 98
+; CHECK-NEXT: .b8 115
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 4                                   // DW_AT_decl_file
+; CHECK-NEXT: .b8 44                                  // DW_AT_decl_line
+; CHECK-NEXT: .b32 2367                               // DW_AT_type
+; CHECK-NEXT: .b8 1                                   // DW_AT_declaration
+; CHECK-NEXT: .b8 7                                   // Abbrev [7] 0x939:0x5 DW_TAG_formal_parameter
+; CHECK-NEXT: .b32 2367                               // DW_AT_type
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: .b8 10                                  // Abbrev [10] 0x93f:0x11 DW_TAG_base_type
+; CHECK-NEXT: .b8 108                                 // DW_AT_name
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 103
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 108
+; CHECK-NEXT: .b8 111
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 103
+; CHECK-NEXT: .b8 32
+; CHECK-NEXT: .b8 105
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 5                                   // DW_AT_encoding
+; CHECK-NEXT: .b8 8                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 10                                  // Abbrev [10] 0x950:0x7 DW_TAG_base_type
+; CHECK-NEXT: .b8 105                                 // DW_AT_name
+; CHECK-NEXT: .b8 110
+; CHECK-NEXT: .b8 116
+; CHECK-NEXT: .b8 0
+; CHECK-NEXT: .b8 5                                   // DW_AT_encoding
+; CHECK-NEXT: .b8 4                                   // DW_AT_byte_size
+; CHECK-NEXT: .b8 0                                   // End Of Children Mark
+; CHECK-NEXT: 	}
+; CHECK-NEXT: 	.section	.debug_macinfo	{	}
 ; CHECK-NOT: debug_
 
 ; Function Attrs: nounwind readnone

--- a/llvm/test/DebugInfo/X86/DW_AT_object_pointer.ll
+++ b/llvm/test/DebugInfo/X86/DW_AT_object_pointer.ll
@@ -5,15 +5,7 @@
 ; CHECK-NOT: ""
 ; CHECK: DW_TAG
 ; CHECK: DW_TAG_class_type
-; CHECK: [[DECL:0x[0-9a-f]+]]: DW_TAG_subprogram
-; CHECK:                         DW_AT_name {{.*}} "A"
-; CHECK:                         DW_AT_object_pointer [DW_FORM_ref4] 
-; CHECK-SAME:                    (cu + 0x{{[0-9a-f]*}} => {[[DECL_PARAM:0x[0-9a-f]*]]})
-; CHECK: [[DECL_PARAM]]:         DW_TAG_formal_parameter
-;
-; CHECK: DW_TAG_subprogram
-; CHECK:   DW_AT_specification [DW_FORM_ref4] (cu + {{.*}} => {[[DECL]]}
-; CHECK:   DW_AT_object_pointer [DW_FORM_ref4]     (cu + 0x{{[0-9a-f]*}} => {[[PARAM:0x[0-9a-f]*]]})
+; CHECK: DW_AT_object_pointer [DW_FORM_ref4]     (cu + 0x{{[0-9a-f]*}} => {[[PARAM:0x[0-9a-f]*]]})
 ; CHECK: [[PARAM]]:     DW_TAG_formal_parameter
 ; CHECK-NOT: DW_TAG
 ; CHECK: DW_AT_name [DW_FORM_strp]     ( .debug_str[0x{{[0-9a-f]*}}] = "this")

--- a/llvm/test/DebugInfo/X86/dwarf-public-names.ll
+++ b/llvm/test/DebugInfo/X86/dwarf-public-names.ll
@@ -61,7 +61,7 @@
 
 ; Skip the output to the header of the pubnames section.
 ; LINUX: debug_pubnames
-; LINUX-NEXT: unit_size =
+; LINUX-NEXT: unit_size = 0x00000128
 
 ; Check for each name in the output.
 ; LINUX-DAG: "ns"

--- a/llvm/test/tools/llvm-dwarfdump/X86/statistics.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/statistics.ll
@@ -55,8 +55,8 @@
 ; CHECK:      "#bytes within functions": [[FUNCSIZE:[0-9]+]]
 ; CHECK:      "#bytes within inlined functions": [[INLINESIZE:[0-9]+]]
 ; CHECK:      "#bytes in __debug_loc": 35,
-; CHECK-NEXT: "#bytes in __debug_abbrev": 386,
-; CHECK-NEXT: "#bytes in __debug_info": 463,
+; CHECK-NEXT: "#bytes in __debug_abbrev": 384,
+; CHECK-NEXT: "#bytes in __debug_info": 459,
 ; CHECK-NEXT: "#bytes in __debug_str": 231,
 ; CHECK-NEXT: "#bytes in __apple_names": 348,
 ; CHECK-NEXT: "#bytes in __apple_objc": 36,


### PR DESCRIPTION
This introduces a substantial (5-10%) regression in .debug_info size, so
we're discussing alternatives in #122742 and #124790.

This reverts commit 7c729418d721147bf1f2b257afd30f84721888ad.
