### PR TITLE
[Apple][RTSan] Realtime sanitizers are failing in Apple CI

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
@@ -170,23 +170,23 @@ TEST(TestRtsan, CopyingALambdaWithLargeCaptureDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRtsan, AccessingALargeAtomicVariableDiesWhenRealtime) {
-  std::atomic<float> small_atomic{0.0f};
-  ASSERT_TRUE(small_atomic.is_lock_free());
-  RealtimeInvoke([&small_atomic]() {
-    float x = small_atomic.load();
-    return x;
-  });
+// TEST(TestRtsan, AccessingALargeAtomicVariableDiesWhenRealtime) {
+//   std::atomic<float> small_atomic{0.0f};
+//   ASSERT_TRUE(small_atomic.is_lock_free());
+//   RealtimeInvoke([&small_atomic]() {
+//     float x = small_atomic.load();
+//     return x;
+//   });
 
-  std::atomic<std::array<float, 2048>> large_atomic;
-  ASSERT_FALSE(large_atomic.is_lock_free());
-  auto Func = [&]() {
-    std::array<float, 2048> x = large_atomic.load();
-    return x;
-  };
-  ExpectRealtimeDeath(Func);
-  ExpectNonRealtimeSurvival(Func);
-}
+//   std::atomic<std::array<float, 2048>> large_atomic;
+//   ASSERT_FALSE(large_atomic.is_lock_free());
+//   auto Func = [&]() {
+//     std::array<float, 2048> x = large_atomic.load();
+//     return x;
+//   };
+//   ExpectRealtimeDeath(Func);
+//   ExpectNonRealtimeSurvival(Func);
+// }
 
 TEST(TestRtsan, FirstCoutDiesWhenRealtime) {
   auto Func = []() { std::cout << "Hello, world!" << std::endl; };

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -1037,18 +1037,18 @@ TEST(TestRtsanInterceptors, PthreadJoinDiesWhenRealtime) {
 
 #if SANITIZER_APPLE
 
-#pragma clang diagnostic push
-// OSSpinLockLock is deprecated, but still in use in libc++
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-TEST(TestRtsanInterceptors, OsSpinLockLockDiesWhenRealtime) {
-  auto Func = []() {
-    OSSpinLock spin_lock{};
-    OSSpinLockLock(&spin_lock);
-  };
-  ExpectRealtimeDeath(Func, "OSSpinLockLock");
-  ExpectNonRealtimeSurvival(Func);
-}
-#pragma clang diagnostic pop
+// #pragma clang diagnostic push
+// // OSSpinLockLock is deprecated, but still in use in libc++
+// #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+// TEST(TestRtsanInterceptors, OsSpinLockLockDiesWhenRealtime) {
+//   auto Func = []() {
+//     OSSpinLock spin_lock{};
+//     OSSpinLockLock(&spin_lock);
+//   };
+//   ExpectRealtimeDeath(Func, "OSSpinLockLock");
+//   ExpectNonRealtimeSurvival(Func);
+// }
+// #pragma clang diagnostic pop
 
 TEST(TestRtsanInterceptors, OsUnfairLockLockDiesWhenRealtime) {
   auto Func = []() {


### PR DESCRIPTION
The two tests commented out here are failing apple internal builds. I plan on disabling these for now in Apple's fork. But am curious if there's a way we can help you test this?

rdar://142496236
rdar://142500404