### PR TITLE
MachineVerifier: Fix check for range type

### DIFF
--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1285,8 +1285,12 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
         if (MMO.getRanges()) {
           ConstantInt *i =
               mdconst::extract<ConstantInt>(MMO.getRanges()->getOperand(0));
-          if (i->getIntegerType()->getBitWidth() !=
-              ValTy.getScalarType().getSizeInBits()) {
+          const LLT RangeTy = LLT::scalar(i->getIntegerType()->getBitWidth());
+          const LLT MemTy = MMO.getMemoryType();
+          if (MemTy.getScalarType() != RangeTy ||
+              ValTy.isScalar() != MemTy.isScalar() ||
+              (ValTy.isVector() &&
+               ValTy.getNumElements() != MemTy.getNumElements())) {
             report("range is incompatible with the result type", MI);
           }
         }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-load-memory-metadata.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-load-memory-metadata.mir
@@ -30,7 +30,7 @@
   !0 = !{i24 0, i24 1048575}
   !1 = !{!"omnipotent char", !2}
   !2 = !{!"Simple C/C++ TBAA"}
-  !3 = !{i32 0, i32 1048575}
+  !3 = !{i24 0, i24 1048575}
 ...
 
 # Make sure range metadata is not preserved when widening loads, but

--- a/llvm/test/MachineVerifier/AMDGPU/test_g_incompatible_range.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/test_g_incompatible_range.mir
@@ -1,4 +1,4 @@
-# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -run-pass=none -filetype=null %s 2>&1 | FileCheck %s
+# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -run-pass=none -filetype=null %s 2>&1 | FileCheck -implicit-check-not="Bad machine code" %s
 --- |
   define void @mismatched_range_type() {
     ret void
@@ -21,9 +21,17 @@ body:             |
     ; CHECK: Bad machine code: range is incompatible with the result type
     %3:_(<2 x s32>) = G_LOAD %0(p1) :: (volatile load (s64), align 4, !range !0, addrspace 1)
 
+    ; CHECK: Bad machine code: range is incompatible with the result type
     %4:_(p0) = G_LOAD %0(p1) :: (volatile load (s64), align 4, !range !0, addrspace 1)
 
+    ; CHECK: Bad machine code: range is incompatible with the result type
     %5:_(<2 x p0>) = G_LOAD %0(p1) :: (volatile load (s64), align 4, !range !0, addrspace 1)
+
+    ; CHECK: Bad machine code: range is incompatible with the result type
+    %6:_(<3 x s64>) = G_LOAD %0(p1) :: (volatile load (s64), align 4, !range !0, addrspace 1)
+
+    ; CHECK: Bad machine code: range is incompatible with the result type
+    %7:_(<3 x s64>) = G_LOAD %0(p1) :: (volatile load (<2 x s64>), align 4, !range !0, addrspace 1)
 
     $vgpr0_vgpr1 = COPY %3
     SI_RETURN implicit $vgpr0_vgpr1


### PR DESCRIPTION
We need to permit scalar extending loads with range annotations.

Fix expensive_checks failures after 11db7fb09b36e656a801117d6a2492133e9c2e46