### PR TITLE
[mlir][x86vector] Restrict BF16 dot test to x86

### DIFF
--- a/mlir/test/Dialect/X86Vector/dot-bf16.mlir
+++ b/mlir/test/Dialect/X86Vector/dot-bf16.mlir
@@ -1,3 +1,5 @@
+// REQUIRES: target=x86{{.*}}
+
 // RUN: mlir-opt %s \
 // RUN:   -convert-vector-to-llvm="enable-x86vector" -convert-to-llvm \
 // RUN:   -reconcile-unrealized-casts | \


### PR DESCRIPTION
Requires x86 target for the lit test to ensure required instructions are available.