### PR TITLE
[TableGen] Reject "field" keyword in template argument declaration

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -670,7 +670,7 @@ arguments.
 
 .. productionlist::
    Body: ";" | "{" `BodyItem`* "}"
-   BodyItem: (`Type` | "code") `TokIdentifier` ["=" `Value`] ";"
+   BodyItem: ["field"] (`Type` | "code") `TokIdentifier` ["=" `Value`] ";"
            :| "let" `TokIdentifier` ["{" `RangeList` "}"] "=" `Value` ";"
            :| "defvar" `TokIdentifier` "=" `Value` ";"
            :| `Assert`

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -3286,7 +3286,7 @@ bool TGParser::ParseTemplateArgValueList(
 const Init *TGParser::ParseDeclaration(Record *CurRec,
                                        bool ParsingTemplateArgs) {
   // Read the field prefix if present.
-  bool HasField = consume(tgtok::Field);
+  bool HasField = !ParsingTemplateArgs && consume(tgtok::Field);
 
   const RecTy *Type = ParseType();
   if (!Type) return nullptr;

--- a/llvm/test/TableGen/field-keyword.td
+++ b/llvm/test/TableGen/field-keyword.td
@@ -1,0 +1,14 @@
+// RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
+// RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
+
+#ifdef ERROR1
+// ERROR1: [[@LINE+1]]:9: error: Unknown token when expecting a type
+class C<field int x = 0>;
+#endif
+
+#ifdef ERROR2
+// ERROR2: [[@LINE+1]]:14: error: Unknown token when expecting a type
+multiclass M<field string s> {
+  def D;
+}
+#endif


### PR DESCRIPTION
This seems like an obvious oversight in the parser.

Also document where the "field" keyword is allowed: only on the
declaration of a field in a class or def.
