### PR TITLE
Add test for dwarf verification JSON output

### DIFF
--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify--completeness-json-output.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify--completeness-json-output.s
@@ -1,15 +1,8 @@
-# RUN: llvm-mc -triple x86_64-pc-linux %s -filetype=obj -o - | not llvm-dwarfdump -verify - | FileCheck %s
+# RUN: llvm-mc -triple x86_64-pc-linux %s -filetype=obj -o - | not llvm-dwarfdump -verify --verify-json=%t.json -
+# RUN: FileCheck %s --input-file %t.json
 
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_namespace) with name namesp missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_variable) with name var_block_addr missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_namespace) with name (anonymous namespace) missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_variable) with name var_loc_addr missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_variable) with name var_loc_tls missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_variable) with name var_loc_gnu_tls missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_subprogram) with name fun_name missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_subprogram) with name _Z8fun_name missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_inlined_subroutine) with name fun_inline missing.
-# CHECK: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_label) with name label missing.
+# CHECK: {"error-categories":{"Name Index DIE entry missing name":{"count":10}},"error-count":10}
+# CHECK-NOT: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_variable) with name var_block_addr missing.
 
         .section        .debug_loc,"",@progbits
 .Ldebug_loc0:

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness.s
@@ -177,3 +177,4 @@
 .Lnames_abbrev_end0:
 .Lnames_entries0:
 .Lnames_end0:
+

--- a/llvm/test/tools/llvm-dwarfdump/X86/dwarf-verify-good-json-output.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/dwarf-verify-good-json-output.s
@@ -1,0 +1,32 @@
+# RUN: llvm-mc %s -filetype obj -triple x86_64-apple-darwin -o - | llvm-dwarfdump -verify --verify-json=%t.json -
+# RUN: FileCheck %s --input-file %t.json
+
+# CHECK: {"error-categories":{},"error-count":0}
+
+# This test is meant to verify that the -verify option
+# in llvm-dwarfdump doesn't produce any .apple_names related
+# output when there's no such section in the object.
+# The test was manually modified to exclude the
+# .apple_names section from the apple_names_verify_num_atoms.s
+# test file in the same directory.
+
+  .section  __TEXT,__text,regular,pure_instructions
+  .file 1 "basic.c"
+  .comm _i,4,2                  ## @i
+  .comm _j,4,2                  ## @j
+  .section  __DWARF,__debug_str,regular,debug
+Linfo_string:
+  .asciz  "Apple LLVM version 8.1.0 (clang-802.0.35)" ## string offset=0
+  .asciz  "basic.c"               ## string offset=42
+  .asciz  "/Users/sgravani/Development/tests" ## string offset=50
+  .asciz  "i"                     ## string offset=84
+  .asciz  "int"                   ## string offset=86
+  .asciz  "j"                     ## string offset=90
+
+  .section  __DWARF,__debug_info,regular,debug
+Lsection_info:
+
+.subsections_via_symbols
+  .section  __DWARF,__debug_line,regular,debug
+Lsection_line:
+Lline_table_start0:


### PR DESCRIPTION
Summary:
    6244dfef5cd45f1395c66abbe061c6a7eb002676 LLVM commit added the ability
for llvm-dwarfdump to specify --verify-json and get a JSON aggregation of the DWARF errors in a file.  This diff improves the testing by ensuring we validate the expected JSON shape.
    A follow up diff will modify the JSON and this ensures we can verify.

  Test Plan:
     ninja check-llvm-tools-llvm-dwarfdump