### PR TITLE
[lldb] Use Function::GetAddress in Module::FindFunctions

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -919,9 +919,8 @@ void Module::FindFunctions(const RegularExpression &regex,
               const SymbolContext &sc = sc_list[i];
               if (sc.block)
                 continue;
-              file_addr_to_index[sc.function->GetAddressRange()
-                                     .GetBaseAddress()
-                                     .GetFileAddress()] = i;
+              file_addr_to_index[sc.function->GetAddress().GetFileAddress()] =
+                  i;
             }
 
             FileAddrToIndexMap::const_iterator end = file_addr_to_index.end();


### PR DESCRIPTION
The original code resulted in a misfire in the symtab vs. debug info deduplication code, which caused us to return the same function twice when searching via a regex (for functions whose entry point is also not the lowest address).