### PR TITLE
[libc++] Add clang-21 to failing tests on Windows

### DIFF
--- a/libcxx/test/libcxx/fuzzing/random.pass.cpp
+++ b/libcxx/test/libcxx/fuzzing/random.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test fails because Clang no longer enables -fdelayed-template-parsing
 // by default on Windows with C++20 (#69431).
-// XFAIL: msvc && (clang-18 || clang-19 || clang-20)
+// XFAIL: msvc && (clang-18 || clang-19 || clang-20 || clang-21)
 
 // UNSUPPORTED: c++03, c++11
 

--- a/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test fails because Clang no longer enables -fdelayed-template-parsing
 // by default on Windows with C++20 (#69431).
-// XFAIL: msvc && (clang-18 || clang-19 || clang-20)
+// XFAIL: msvc && (clang-18 || clang-19 || clang-20 || clang-21)
 
 // <math.h>
 

--- a/libcxx/test/std/numerics/c.math/cmath.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/cmath.pass.cpp
@@ -8,7 +8,7 @@
 
 // This test fails because Clang no longer enables -fdelayed-template-parsing
 // by default on Windows with C++20 (#69431).
-// XFAIL: msvc && (clang-18 || clang-19 || clang-20)
+// XFAIL: msvc && (clang-18 || clang-19 || clang-20 || clang-21)
 
 // <cmath>
 


### PR DESCRIPTION
After we switched to LLVM version 21, some libc++ tests started failing on Windows. This patch adds the clang-21 condition to XFAIL to fix the issue.