### PR TITLE
[flang][cuda] Remove the need of special compile definition for CUFInit

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -475,7 +475,6 @@ option(FLANG_CUF_RUNTIME
   "Compile CUDA Fortran runtime sources" OFF)
 if (FLANG_CUF_RUNTIME)
   find_package(CUDAToolkit REQUIRED)
-  add_compile_definitions(FLANG_CUDA_SUPPORT=1)
 endif()
 
 add_subdirectory(include)

--- a/flang/include/flang/Runtime/CUDA/init.h
+++ b/flang/include/flang/Runtime/CUDA/init.h
@@ -9,7 +9,6 @@
 #ifndef FORTRAN_RUNTIME_CUDA_INIT_H_
 #define FORTRAN_RUNTIME_CUDA_INIT_H_
 
-#include "common.h"
 #include "flang/Runtime/entry-names.h"
 
 extern "C" {

--- a/flang/lib/Optimizer/Builder/Runtime/Main.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Main.cpp
@@ -14,11 +14,9 @@
 #include "flang/Optimizer/Builder/Runtime/RTBuilder.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
+#include "flang/Runtime/CUDA/init.h"
 #include "flang/Runtime/main.h"
 #include "flang/Runtime/stop.h"
-#ifdef FLANG_CUDA_SUPPORT
-#include "flang/Runtime/CUDA/init.h"
-#endif
 
 using namespace Fortran::runtime;
 
@@ -66,13 +64,11 @@ void fir::runtime::genMain(
 
   builder.create<fir::CallOp>(loc, startFn, args);
 
-#ifdef FLANG_CUDA_SUPPORT
   if (initCuda) {
     auto initFn = builder.createFunction(
         loc, RTNAME_STRING(CUFInit), mlir::FunctionType::get(context, {}, {}));
     builder.create<fir::CallOp>(loc, initFn);
   }
-#endif
 
   builder.create<fir::CallOp>(loc, qqMainFn);
   builder.create<fir::CallOp>(loc, stopFn);

--- a/flang/test/Lower/CUDA/cuda-init.cuf
+++ b/flang/test/Lower/CUDA/cuda-init.cuf
@@ -1,0 +1,11 @@
+! RUN: bbc -emit-fir -hlfir -fcuda %s -o - | FileCheck %s --check-prefixes=ALL,CUDA
+! RUN: bbc -emit-fir -hlfir %s -o - | FileCheck %s --check-prefixes=ALL,NOCUDA
+
+program test_init
+
+end 
+
+! ALL-LABEL: func.func @main
+! ALL: fir.call @_FortranAProgramStart
+! CUDA: fir.call @_FortranACUFInit() fastmath<contract> : () -> ()
+! NOCUDA-NOT: fir.call @_FortranACUFInit() fastmath<contract> : () -> ()


### PR DESCRIPTION
This patch addresses post commit review comments from #124859. 

The extra compile definition is not necessary and goes against the effort to separate the runtimes from the flang compiler itself. The function declaration for `CUFInit` can be accessed anyway since the header are always present. The insertion of the call is only based on the language feature options from the folding context. 

A program compiled with cuda enabled but no cufruntime would just fail at link time as expected. 