### PR TITLE
[flang][NFC] do not hard code KIND 10 and 16 in lowering tests

### DIFF
--- a/flang/test/Lower/Intrinsics/aint.f90
+++ b/flang/test/Lower/Intrinsics/aint.f90
@@ -22,7 +22,7 @@ subroutine aint_test_real8(a, b)
 end subroutine
 
 ! CHECK-KIND10-LABEL: func.func @_QPaint_test_real10(
-! CHECK-KIND10:   fir.call @llvm.trunc.f64({{.*}}) {{.*}}: (f80) -> f80
+! CHECK-KIND10:   fir.call @llvm.trunc.f80({{.*}}) {{.*}}: (f80) -> f80
 subroutine aint_test_real10(a, b)
   integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
   real(kind10) :: a, b

--- a/flang/test/Lower/Intrinsics/aint.f90
+++ b/flang/test/Lower/Intrinsics/aint.f90
@@ -1,41 +1,31 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}
 
 ! CHECK-LABEL: func @_QPaint_test(
-! CHECK-SAME: %[[VAL_0:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<f32>{{.*}}) {
+! CHECK-SAME: %[[VAL_0_b:.*]]: !fir.ref<f32>{{.*}}, %[[VAL_1_b:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine aint_test(a, b)
-! CHECK: %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f32>
+! CHECK: %[[VAL_0:.*]]:2 = hlfir.declare %[[VAL_0_b]]
+! CHECK: %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_1_b]]
+! CHECK: %[[VAL_2:.*]] = fir.load %[[VAL_0]]#0 : !fir.ref<f32>
 ! CHECK: %[[VAL_3:.*]] = fir.call @llvm.trunc.f32(%[[VAL_2]]) {{.*}}: (f32) -> f32
-! CHECK: fir.store %[[VAL_3]] to %[[VAL_1]] : !fir.ref<f32>
+! CHECK: hlfir.assign %[[VAL_3]] to %[[VAL_1]]#0 : f32, !fir.ref<f32>
 ! CHECK: return
   real :: a, b
   b = aint(a)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPaint_test_real8(
-! CHECK-SAME:                                %[[VAL_0:.*]]: !fir.ref<f64> {fir.bindc_name = "a"},
-! CHECK-SAME:                                %[[VAL_1:.*]]: !fir.ref<f64> {fir.bindc_name = "b"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f64>
-! CHECK:         %[[VAL_3:.*]] = fir.call @llvm.trunc.f64(%[[VAL_2]]) {{.*}}: (f64) -> f64
-! CHECK:         fir.store %[[VAL_3]] to %[[VAL_1]] : !fir.ref<f64>
-! CHECK:         return
-! CHECK:       }
+! CHECK:   fir.call @llvm.trunc.f64({{.*}}) {{.*}}: (f64) -> f64
 
 subroutine aint_test_real8(a, b)
   real(8) :: a, b
   b = aint(a)
 end subroutine
 
-! CHECK-LABEL: func.func @_QPaint_test_real10(
-! CHECK-SAME:                                 %[[VAL_0:.*]]: !fir.ref<f80> {fir.bindc_name = "a"},
-! CHECK-SAME:                                 %[[VAL_1:.*]]: !fir.ref<f80> {fir.bindc_name = "b"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f80>
-! CHECK:         %[[VAL_3:.*]] = fir.call @llvm.trunc.f80(%[[VAL_2]]) {{.*}}: (f80) -> f80
-! CHECK:         fir.store %[[VAL_3]] to %[[VAL_1]] : !fir.ref<f80>
-! CHECK:         return
-! CHECK:       }
-
+! CHECK-KIND10-LABEL: func.func @_QPaint_test_real10(
+! CHECK-KIND10:   fir.call @llvm.trunc.f64({{.*}}) {{.*}}: (f80) -> f80
 subroutine aint_test_real10(a, b)
-  real(10) :: a, b
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: a, b
   b = aint(a)
 end subroutine
 

--- a/flang/test/Lower/Intrinsics/anint.f90
+++ b/flang/test/Lower/Intrinsics/anint.f90
@@ -1,11 +1,13 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}
 
 ! CHECK-LABEL: func.func @_QPanint_test(
-! CHECK-SAME:                           %[[VAL_0:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
-! CHECK-SAME:                           %[[VAL_1:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f32>
+! CHECK-SAME:                           %[[VAL_0_b:.*]]: !fir.ref<f32> {fir.bindc_name = "a"},
+! CHECK-SAME:                           %[[VAL_1_b:.*]]: !fir.ref<f32> {fir.bindc_name = "b"}) {
+! CHECK:         %[[VAL_0:.*]]:2 = hlfir.declare %[[VAL_0_b]]
+! CHECK:         %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_1_b]]
+! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]]#0 : !fir.ref<f32>
 ! CHECK:         %[[VAL_3:.*]] = llvm.intr.round(%[[VAL_2]]) : (f32) -> f32
-! CHECK:         fir.store %[[VAL_3]] to %[[VAL_1]] : !fir.ref<f32>
+! CHECK:         hlfir.assign %[[VAL_3]] to %[[VAL_1]]#0 : f32, !fir.ref<f32>
 ! CHECK:         return
 ! CHECK:       }
 
@@ -15,30 +17,19 @@ subroutine anint_test(a, b)
 end subroutine
 
 ! CHECK-LABEL: func.func @_QPanint_test_real8(
-! CHECK-SAME:                                 %[[VAL_0:.*]]: !fir.ref<f64> {fir.bindc_name = "a"},
-! CHECK-SAME:                                 %[[VAL_1:.*]]: !fir.ref<f64> {fir.bindc_name = "b"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f64>
-! CHECK:         %[[VAL_3:.*]] = llvm.intr.round(%[[VAL_2]]) : (f64) -> f64
-! CHECK:         fir.store %[[VAL_3]] to %[[VAL_1]] : !fir.ref<f64>
-! CHECK:         return
-! CHECK:       }
+! CHECK:    llvm.intr.round(%{{.*}}) : (f64) -> f64
 
 subroutine anint_test_real8(a, b)
   real(8) :: a, b
   b = anint(a)
 end subroutine
 
-! CHECK-LABEL: func.func @_QPanint_test_real10(
-! CHECK-SAME:                                  %[[VAL_0:.*]]: !fir.ref<f80> {fir.bindc_name = "a"},
-! CHECK-SAME:                                  %[[VAL_1:.*]]: !fir.ref<f80> {fir.bindc_name = "b"}) {
-! CHECK:         %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<f80>
-! CHECK:         %[[VAL_3:.*]] = llvm.intr.round(%[[VAL_2]]) : (f80) -> f80
-! CHECK:         fir.store %[[VAL_3]] to %[[VAL_1]] : !fir.ref<f80>
-! CHECK:         return
-! CHECK:       }
+! CHECK-KIND10-LABEL: func.func @_QPanint_test_real10(
+! CHECK-KIND10:    llvm.intr.round(%{{.*}}) : (f80) -> f80
 
 subroutine anint_test_real10(a, b)
-  real(10) :: a, b
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: a, b
   b = anint(a)
 end subroutine
 

--- a/flang/test/Lower/Intrinsics/dot_product.f90
+++ b/flang/test/Lower/Intrinsics/dot_product.f90
@@ -1,14 +1,16 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-fir -O0 %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! DOT_PROD
 ! CHECK-LABEL: dot_prod_int_default
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi32>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi32>>
 subroutine dot_prod_int_default (x, y, z)
   integer, dimension(1:) :: x,y
   integer, dimension(1:) :: z
+  ! CHECK: %[[x1:.*]] = fir.declare{{.*}}x"
+  ! CHECK: %[[x:.*]] = fir.rebox %[[x1]]{{.*}}
+  ! CHECK: %[[y1:.*]] = fir.declare{{.*}}y"
+  ! CHECK: %[[y:.*]] = fir.rebox %[[y1]]{{.*}}
+  ! CHECK: %[[z1:.*]] = fir.declare{{.*}}z"
+  ! CHECK: %[[z:.*]] = fir.rebox %[[z1]]{{.*}}
   ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
   ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
   ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32
@@ -16,268 +18,172 @@ subroutine dot_prod_int_default (x, y, z)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_int_kind_1
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi8>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi8>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi8>>
 subroutine dot_prod_int_kind_1 (x, y, z)
   integer(kind=1), dimension(1:) :: x,y
   integer(kind=1), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi8>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger1(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i8
+  ! CHECK: fir.call @_FortranADotProductInteger1(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i8
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_int_kind_2
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi16>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi16>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi16>>
 subroutine dot_prod_int_kind_2 (x, y, z)
   integer(kind=2), dimension(1:) :: x,y
   integer(kind=2), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi16>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger2(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i16
+  ! CHECK: fir.call @_FortranADotProductInteger2(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i16
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_int_kind_4
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi32>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi32>>
 subroutine dot_prod_int_kind_4 (x, y, z)
   integer(kind=4), dimension(1:) :: x,y
   integer(kind=4), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+  ! CHECK: fir.call @_FortranADotProductInteger4(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i32
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_int_kind_8
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi64>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi64>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi64>>
 subroutine dot_prod_int_kind_8 (x, y, z)
   integer(kind=8), dimension(1:) :: x,y
   integer(kind=8), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger8(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i64
+  ! CHECK: fir.call @_FortranADotProductInteger8(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i64
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_int_kind_16
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi128>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xi128>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xi128>>
 subroutine dot_prod_int_kind_16 (x, y, z)
   integer(kind=16), dimension(1:) :: x,y
   integer(kind=16), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi128>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xi128>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductInteger16(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i128
+  ! CHECK: fir.call @_FortranADotProductInteger16(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i128
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_real_kind_default
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf32>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf32>>
 subroutine dot_prod_real_kind_default (x, y, z)
   real, dimension(1:) :: x,y
   real, dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
+  ! CHECK: fir.call @_FortranADotProductReal4(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_real_kind_4
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf32>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf32>>
 subroutine dot_prod_real_kind_4 (x, y, z)
   real(kind=4), dimension(1:) :: x,y
   real(kind=4), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
+  ! CHECK: fir.call @_FortranADotProductReal4(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_real_kind_8
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf64>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf64>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf64>>
 subroutine dot_prod_real_kind_8 (x, y, z)
   real(kind=8), dimension(1:) :: x,y
   real(kind=8), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal8(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64
+  ! CHECK: fir.call @_FortranADotProductReal8(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64
   z = dot_product(x,y)
 end subroutine
 
-! CHECK-LABEL: dot_prod_real_kind_10
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf80>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf80>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf80>>
+! CHECK-KIND10-LABEL: dot_prod_real_kind_10
 subroutine dot_prod_real_kind_10 (x, y, z)
-  real(kind=10), dimension(1:) :: x,y
-  real(kind=10), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf80>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal10(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f80
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind=kind10), dimension(1:) :: x,y
+  real(kind=kind10), dimension(1:) :: z
+  ! CHECK-KIND10: fir.call @_FortranADotProductReal10(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f80
   z = dot_product(x,y)
 end subroutine
 
-! CHECK-LABEL: dot_prod_real_kind_16
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf128>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf128>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf128>>
+! CHECK-KIND16-LABEL: dot_prod_real_kind_16
 subroutine dot_prod_real_kind_16 (x, y, z)
-  real(kind=16), dimension(1:) :: x,y
-  real(kind=16), dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf128>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal16(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f128
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind=kind16), dimension(1:) :: x,y
+  real(kind=kind16), dimension(1:) :: z
+  ! CHECK-KIND16: fir.call @_FortranADotProductReal16(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f128
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_double_default
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf64>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf64>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf64>>
 subroutine dot_prod_double_default (x, y, z)
   double precision, dimension(1:) :: x,y
   double precision, dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal8(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64
+  ! CHECK: fir.call @_FortranADotProductReal8(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f64
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_complex_default
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xcomplex<f32>>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f32>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f32>>>
 subroutine dot_prod_complex_default (x, y, z)
   complex, dimension(1:) :: x,y
   complex, dimension(1:) :: z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f32>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xcomplex<f32>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f32>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex4(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  ! CHECK: %[[res:.*]] = fir.alloca complex<f32>
+  ! CHECK: fir.call @_FortranACppDotProductComplex4(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_complex_kind_4
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xcomplex<f32>>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f32>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f32>>>
 subroutine dot_prod_complex_kind_4 (x, y, z)
   complex(kind=4), dimension(1:) :: x,y
   complex(kind=4), dimension(1:) :: z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f32>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xcomplex<f32>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f32>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex4(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  ! CHECK: %[[res:.*]] = fir.alloca complex<f32>
+  ! CHECK: fir.call @_FortranACppDotProductComplex4(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_complex_kind_8
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xcomplex<f64>>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f64>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f64>>>
 subroutine dot_prod_complex_kind_8 (x, y, z)
   complex(kind=8), dimension(1:) :: x,y
   complex(kind=8), dimension(1:) :: z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f64>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xcomplex<f64>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f64>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex8(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f64>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  ! CHECK: %[[res:.*]] = fir.alloca complex<f64>
+  ! CHECK: fir.call @_FortranACppDotProductComplex8(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f64>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine
 
-! CHECK-LABEL: dot_prod_complex_kind_10
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xcomplex<f80>>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f80>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f80>>>
+! CHECK-KIND10-LABEL: dot_prod_complex_kind_10
 subroutine dot_prod_complex_kind_10 (x, y, z)
-  complex(kind=10), dimension(1:) :: x,y
-  complex(kind=10), dimension(1:) :: z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f80>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xcomplex<f80>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f80>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex10(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f80>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  complex(kind=kind10), dimension(1:) :: x,y
+  complex(kind=kind10), dimension(1:) :: z
+  ! CHECK-KIND10: %[[res:.*]] = fir.alloca complex<f80>
+  ! CHECK-KIND10: fir.call @_FortranACppDotProductComplex10(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f80>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine
 
-! CHECK-LABEL: dot_prod_complex_kind_16
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xcomplex<f128>>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f128>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f128>>>
+! CHECK-KIND16-LABEL: dot_prod_complex_kind_16
 subroutine dot_prod_complex_kind_16 (x, y, z)
-  complex(kind=16), dimension(1:) :: x,y
-  complex(kind=16), dimension(1:) :: z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f128>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xcomplex<f128>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f128>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex16(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f128>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  complex(kind=kind16), dimension(1:) :: x,y
+  complex(kind=kind16), dimension(1:) :: z
+  ! CHECK-KIND16: %[[res:.*]] = fir.alloca complex<f128>
+  ! CHECK-KIND16: fir.call @_FortranACppDotProductComplex16(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f128>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_prod_logical
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?x!fir.logical<4>>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?x!fir.logical<4>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?x!fir.logical<4>>>
 subroutine dot_prod_logical (x, y, z)
   logical, dimension(1:) :: x,y
   logical, dimension(1:) :: z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?x!fir.logical<4>>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductLogical(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i1
+  ! CHECK: fir.call @_FortranADotProductLogical(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> i1
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_product_mixed_int_real
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xf32>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xf32>>
 subroutine dot_product_mixed_int_real(x, y, z)
   integer, dimension(1:) :: x
   real, dimension(1:) :: y, z
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[res:.*]] = fir.call @_FortranADotProductReal4(%[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
+  ! CHECK: fir.call @_FortranADotProductReal4(%{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> f32
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_product_mixed_int_complex
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xi32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f32>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f32>>>
 subroutine dot_product_mixed_int_complex(x, y, z)
   integer, dimension(1:) :: x
   complex, dimension(1:) :: y, z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f32>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xi32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f32>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex4(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  ! CHECK: %[[res:.*]] = fir.alloca complex<f32>
+  ! CHECK: fir.call @_FortranACppDotProductComplex4(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine
 
 ! CHECK-LABEL: dot_product_mixed_real_complex
-! CHECK-SAME: %[[x:arg0]]: !fir.box<!fir.array<?xf32>>
-! CHECK-SAME: %[[y:arg1]]: !fir.box<!fir.array<?xcomplex<f32>>>
-! CHECK-SAME: %[[z:arg2]]: !fir.box<!fir.array<?xcomplex<f32>>>
 subroutine dot_product_mixed_real_complex(x, y, z)
   real, dimension(1:) :: x
   complex, dimension(1:) :: y, z
-  ! CHECK-DAG: %[[res:.*]] = fir.alloca complex<f32>
-  ! CHECK-DAG: %[[x_conv:.*]] = fir.convert %[[x]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[y_conv:.*]] = fir.convert %[[y]] : (!fir.box<!fir.array<?xcomplex<f32>>>) -> !fir.box<none>
-  ! CHECK-DAG: fir.call @_FortranACppDotProductComplex4(%[[res]], %[[x_conv]], %[[y_conv]], %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
+  ! CHECK: %[[res:.*]] = fir.alloca complex<f32>
+  ! CHECK: fir.call @_FortranACppDotProductComplex4(%[[res]], %{{.*}}, %{{.*}}, %{{[0-9]+}}, %{{.*}}) {{.*}}: (!fir.ref<complex<f32>>, !fir.box<none>, !fir.box<none>, !fir.ref<i8>, i32) -> ()
   z = dot_product(x,y)
 end subroutine

--- a/flang/test/Lower/Intrinsics/exponent.f90
+++ b/flang/test/Lower/Intrinsics/exponent.f90
@@ -1,41 +1,39 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! EXPONENT
-! CHECK-LABEL: exponent_test
-subroutine exponent_test
 
-    integer :: i1, i2, i3, i4
-  ! CHECK: %[[i0:.*]] = fir.alloca i32 {bindc_name = "i1", uniq_name = "_QFexponent_testEi1"}
-  ! CHECK: %[[i1:.*]] = fir.alloca i32 {bindc_name = "i2", uniq_name = "_QFexponent_testEi2"}
-  ! CHECK: %[[i2:.*]] = fir.alloca i32 {bindc_name = "i3", uniq_name = "_QFexponent_testEi3"}
-  ! CHECK: %[[i3:.*]] = fir.alloca i32 {bindc_name = "i4", uniq_name = "_QFexponent_testEi4"}
-  
-    real(kind = 4) :: x1
-    real(kind = 8) :: x2
-    real(kind = 10) :: x3
-    real(kind = 16) :: x4
-  ! CHECK: %[[x0:.*]] = fir.alloca f32 {bindc_name = "x1", uniq_name = "_QFexponent_testEx1"}
-  ! CHECK: %[[x1:.*]] = fir.alloca f64 {bindc_name = "x2", uniq_name = "_QFexponent_testEx2"}
-  ! CHECK: %[[x2:.*]] = fir.alloca f80 {bindc_name = "x3", uniq_name = "_QFexponent_testEx3"}
-  ! CHECK: %[[x3:.*]] = fir.alloca f128 {bindc_name = "x4", uniq_name = "_QFexponent_testEx4"}
-  
-    i1 = exponent(x1)
-  ! CHECK: %[[temp0:.*]] = fir.load %[[x0:.*]] : !fir.ref<f32>
-  ! CHECK: %[[result0:.*]] = fir.call @_FortranAExponent4_4(%[[temp0:.*]]) {{.*}}: (f32) -> i32
-  ! CHECK: fir.store %[[result0:.*]] to %[[i0:.*]] : !fir.ref<i32>
-  
-    i2 = exponent(x2)
-  ! CHECK: %[[temp1:.*]] = fir.load %[[x1:.*]] : !fir.ref<f64>
-  ! CHECK: %[[result1:.*]] = fir.call @_FortranAExponent8_4(%[[temp1:.*]]) {{.*}}: (f64) -> i32
-  ! CHECK: fir.store %[[result1:.*]] to %[[i1:.*]] : !fir.ref<i32>
-  
-    i3 = exponent(x3)
-  ! CHECK: %[[temp2:.*]] = fir.load %[[x2:.*]] : !fir.ref<f80>
-  ! CHECK: %[[result2:.*]] = fir.call @_FortranAExponent10_4(%[[temp2:.*]]) {{.*}}: (f80) -> i32
-  ! CHECK: fir.store %[[result2:.*]] to %[[i2:.*]] : !fir.ref<i32>
-  
-    i4 = exponent(x4)
-  ! CHECK: %[[temp3:.*]] = fir.load %[[x3:.*]] : !fir.ref<f128>
-  ! CHECK: %[[result3:.*]] = fir.call @_FortranAExponent16_4(%[[temp3:.*]]) {{.*}}: (f128) -> i32
-  ! CHECK: fir.store %[[result3:.*]] to %[[i3:.*]] : !fir.ref<i32>
-  end subroutine exponent_test
+! CHECK-LABEL: exponent_test(
+subroutine exponent_test(i1, i2, x4, x8)
+    integer :: i1, i2, i3
+    real(kind = 4) :: x4
+    real(kind = 8) :: x8
+    real(kind = 16) :: x16
+
+    i1 = exponent(x4)
+  ! CHECK: %[[temp0:.*]] = fir.load %{{.*}} : !fir.ref<f32>
+  ! CHECK: fir.call @_FortranAExponent4_4(%[[temp0:.*]]) {{.*}}: (f32) -> i32
+
+    i2 = exponent(x8)
+  ! CHECK: %[[temp1:.*]] = fir.load %{{.*}} : !fir.ref<f64>
+  ! CHECK: fir.call @_FortranAExponent8_4(%[[temp1:.*]]) {{.*}}: (f64) -> i32
+end subroutine exponent_test
+
+! CHECK-KIND10-LABEL: exponent_10(
+subroutine exponent_10(i, x10)
+    integer :: i
+    integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+    real(kind = kind10) :: x10
+    i = exponent(x10)
+  ! CHECK-KIND10: %[[temp2:.*]] = fir.load %{{.*}} : !fir.ref<f80>
+  ! CHECK-KIND10: fir.call @_FortranAExponent10_4(%[[temp2:.*]]) {{.*}}: (f80) -> i32
+end subroutine
+
+! CHECK-KIND16-LABEL: exponent_16(
+subroutine exponent_16(i, x16)
+    integer :: i
+    integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+    real(kind = kind16) :: x16
+    i = exponent(x16)
+  ! CHECK-KIND16: %[[temp2:.*]] = fir.load %{{.*}} : !fir.ref<f128>
+  ! CHECK-KIND16: fir.call @_FortranAExponent16_4(%[[temp2:.*]]) {{.*}}: (f128) -> i32
+end subroutine

--- a/flang/test/Lower/Intrinsics/fraction.f90
+++ b/flang/test/Lower/Intrinsics/fraction.f90
@@ -1,35 +1,35 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
- 
-! FRACTION
-! CHECK-LABE: fraction_test
-subroutine fraction_test
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
-    real(kind=4) :: x1 = 178.1387e-4
-    real(kind=8) :: x2 = 178.1387e-4
-    real(kind=10) :: x3 = 178.1387e-4
-    real(kind=16) :: x4 = 178.1387e-4
-  ! CHECK: %[[r0:.*]] = fir.address_of(@_QFfraction_testEx1) : !fir.ref<f32>
-  ! CHECK: %[[r1:.*]] = fir.address_of(@_QFfraction_testEx2) : !fir.ref<f64>
-  ! CHECK: %[[r2:.*]] = fir.address_of(@_QFfraction_testEx3) : !fir.ref<f80>
-  ! CHECK: %[[r3:.*]] = fir.address_of(@_QFfraction_testEx4) : !fir.ref<f128>
-  
-    x1 = fraction(x1)
-  ! CHECK: %[[temp0:.*]] = fir.load %[[r0:.*]] : !fir.ref<f32>
-  ! CHECK: %[[result0:.*]] = fir.call @_FortranAFraction4(%[[temp0:.*]]) {{.*}}: (f32) -> f32
-  ! CHECK: fir.store %[[result0:.*]] to %[[r0:.*]] : !fir.ref<f32>
-  
-    x2 = fraction(x2)
-  ! CHECK: %[[temp1:.*]] = fir.load %[[r1:.*]] : !fir.ref<f64>
-  ! CHECK: %[[result1:.*]] = fir.call @_FortranAFraction8(%[[temp1:.*]]) {{.*}}: (f64) -> f64
-  ! CHECK: fir.store %[[result1:.*]] to %[[r1:.*]] : !fir.ref<f64>
-  
-    x3 = fraction(x3)
-  ! CHECK: %[[temp2:.*]] = fir.load %[[r2:.*]] : !fir.ref<f80>
-  ! CHECK: %[[result2:.*]] = fir.call @_FortranAFraction10(%[[temp2:.*]]) {{.*}}: (f80) -> f80
-  ! CHECK: fir.store %[[result2:.*]] to %[[r2:.*]] : !fir.ref<f80>
-  
-    x4 = fraction(x4)
-  ! CHECK: %[[temp3:.*]] = fir.load %[[r3:.*]] : !fir.ref<f128>
-  ! CHECK: %[[result3:.*]] = fir.call @_FortranAFraction16(%[[temp3:.*]]) {{.*}}: (f128) -> f128
-  ! CHECK: fir.store %[[result3:.*]] to %[[r3:.*]] : !fir.ref<f128>
-  end subroutine fraction_test
+! FRACTION
+
+! CHECK-LABEL: fraction_test(
+subroutine fraction_test(res4, res8, x4, x8)
+    real(kind = 4) :: x4, res4
+    real(kind = 8) :: x8, res8
+
+    res4 = fraction(x4)
+  ! CHECK: %[[temp0:.*]] = fir.load %{{.*}} : !fir.ref<f32>
+  ! CHECK: fir.call @_FortranAFraction4(%[[temp0:.*]]) {{.*}}: (f32) -> f32
+
+    res8 = fraction(x8)
+  ! CHECK: %[[temp1:.*]] = fir.load %{{.*}} : !fir.ref<f64>
+  ! CHECK: fir.call @_FortranAFraction8(%[[temp1:.*]]) {{.*}}: (f64) -> f64
+end subroutine fraction_test
+
+! CHECK-KIND10-LABEL: fraction_10(
+subroutine fraction_10(res10, x10)
+    integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+    real(kind = kind10) :: x10, res10
+    res10 = fraction(x10)
+  ! CHECK-KIND10: %[[temp2:.*]] = fir.load %{{.*}} : !fir.ref<f80>
+  ! CHECK-KIND10: fir.call @_FortranAFraction10(%[[temp2:.*]]) {{.*}}: (f80) -> f80
+end subroutine
+
+! CHECK-KIND16-LABEL: fraction_16(
+subroutine fraction_16(res16, x16)
+    integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+    real(kind = kind16) :: x16, res16
+    res16 = fraction(x16)
+  ! CHECK-KIND16: %[[temp2:.*]] = fir.load %{{.*}} : !fir.ref<128>
+  ! CHECK-KIND16: fir.call @_FortranAFraction16(%[[temp2:.*]]) {{.*}}: (128) -> 128
+end subroutine

--- a/flang/test/Lower/Intrinsics/fraction.f90
+++ b/flang/test/Lower/Intrinsics/fraction.f90
@@ -30,6 +30,6 @@ subroutine fraction_16(res16, x16)
     integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
     real(kind = kind16) :: x16, res16
     res16 = fraction(x16)
-  ! CHECK-KIND16: %[[temp2:.*]] = fir.load %{{.*}} : !fir.ref<128>
-  ! CHECK-KIND16: fir.call @_FortranAFraction16(%[[temp2:.*]]) {{.*}}: (128) -> 128
+  ! CHECK-KIND16: %[[temp2:.*]] = fir.load %{{.*}} : !fir.ref<f128>
+  ! CHECK-KIND16: fir.call @_FortranAFraction16(%[[temp2:.*]]) {{.*}}: (f128) -> f128
 end subroutine

--- a/flang/test/Lower/Intrinsics/ieee_class_queries.f90
+++ b/flang/test/Lower/Intrinsics/ieee_class_queries.f90
@@ -8,7 +8,6 @@
   real(3) :: x3 = -3.0
   real(4) :: x4 = -4.0
   real(8) :: x8 = -8.0
-  real(10) :: x10 = -10.0
   real(16) :: x16 = -16.0
 
   ! CHECK:     "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 504 : i32}> : (f16) -> i1

--- a/flang/test/Lower/Intrinsics/ieee_is_normal.f90
+++ b/flang/test/Lower/Intrinsics/ieee_is_normal.f90
@@ -1,5 +1,4 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! RUN: flang -fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: ieee_is_normal_f16
 subroutine ieee_is_normal_f16(r)
@@ -39,20 +38,22 @@ subroutine ieee_is_normal_f64(r)
   ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine ieee_is_normal_f64
 
-! CHECK-LABEL: ieee_is_normal_f80
+! CHECK-KIND10-LABEL: ieee_is_normal_f80
 subroutine ieee_is_normal_f80(r)
   use ieee_arithmetic
-  real(KIND=10) :: r
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(KIND=kind10) :: r
   i = ieee_is_normal(r)
-  ! CHECK: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 360 : i32}> : (f80) -> i1
-  ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
+  ! CHECK-KIND10: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 360 : i32}> : (f80) -> i1
+  ! CHECK-KIND10: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine ieee_is_normal_f80
 
-! CHECK-LABEL: ieee_is_normal_f128
+! CHECK-KIND16-LABEL: ieee_is_normal_f128
 subroutine ieee_is_normal_f128(r)
   use ieee_arithmetic
-  real(KIND=16) :: r
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(KIND=kind16) :: r
   i = ieee_is_normal(r)
-  ! CHECK: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 360 : i32}> : (f128) -> i1
-  ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
+  ! CHECK-KIND16: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 360 : i32}> : (f128) -> i1
+  ! CHECK-KIND16: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine ieee_is_normal_f128

--- a/flang/test/Lower/Intrinsics/ieee_next.f90
+++ b/flang/test/Lower/Intrinsics/ieee_next.f90
@@ -1,14 +1,14 @@
-! RUN: bbc -emit-fir -o - %s | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: c.func @_QQmain
 program p
   use ieee_arithmetic, only: ieee_value, ieee_negative_inf, ieee_positive_inf
   use ieee_arithmetic, only: ieee_next_after, ieee_next_down, ieee_next_up
   implicit none
-  ! CHECK-DAG: %[[V_4:[0-9]+]] = fir.alloca f80 {bindc_name = "r10", uniq_name = "_QFEr10"}
-  ! CHECK-DAG: %[[V_5:[0-9]+]] = fir.declare %[[V_4]] {uniq_name = "_QFEr10"} : (!fir.ref<f80>) -> !fir.ref<f80>
-  ! CHECK-DAG: %[[V_6:[0-9]+]] = fir.alloca f128 {bindc_name = "r16", uniq_name = "_QFEr16"}
-  ! CHECK-DAG: %[[V_7:[0-9]+]] = fir.declare %[[V_6]] {uniq_name = "_QFEr16"} : (!fir.ref<f128>) -> !fir.ref<f128>
+  ! CHECK-KIND10-DAG: %[[V_4:[0-9]+]] = fir.alloca f80 {bindc_name = "r10", uniq_name = "_QFEr10"}
+  ! CHECK-KIND10-DAG: %[[V_5:[0-9]+]] = fir.declare %[[V_4]] {uniq_name = "_QFEr10"} : (!fir.ref<f80>) -> !fir.ref<f80>
+  ! CHECK-KIND16-DAG: %[[V_6:[0-9]+]] = fir.alloca f128 {bindc_name = "r16", uniq_name = "_QFEr16"}
+  ! CHECK-KIND16-DAG: %[[V_7:[0-9]+]] = fir.declare %[[V_6]] {uniq_name = "_QFEr16"} : (!fir.ref<f128>) -> !fir.ref<f128>
   ! CHECK-DAG: %[[V_8:[0-9]+]] = fir.alloca f16 {bindc_name = "r2", uniq_name = "_QFEr2"}
   ! CHECK-DAG: %[[V_9:[0-9]+]] = fir.declare %[[V_8]] {uniq_name = "_QFEr2"} : (!fir.ref<f16>) -> !fir.ref<f16>
   ! CHECK-DAG: %[[V_10:[0-9]+]] = fir.alloca bf16 {bindc_name = "r3", uniq_name = "_QFEr3"}
@@ -17,10 +17,10 @@ program p
   ! CHECK-DAG: %[[V_13:[0-9]+]] = fir.declare %[[V_12]] {uniq_name = "_QFEr4"} : (!fir.ref<f32>) -> !fir.ref<f32>
   ! CHECK-DAG: %[[V_14:[0-9]+]] = fir.alloca f64 {bindc_name = "r8", uniq_name = "_QFEr8"}
   ! CHECK-DAG: %[[V_15:[0-9]+]] = fir.declare %[[V_14]] {uniq_name = "_QFEr8"} : (!fir.ref<f64>) -> !fir.ref<f64>
-  ! CHECK-DAG: %[[V_16:[0-9]+]] = fir.address_of(@_QFEx10) : !fir.ref<f80>
-  ! CHECK-DAG: %[[V_17:[0-9]+]] = fir.declare %[[V_16]] {uniq_name = "_QFEx10"} : (!fir.ref<f80>) -> !fir.ref<f80>
-  ! CHECK-DAG: %[[V_18:[0-9]+]] = fir.alloca f128 {bindc_name = "x16", uniq_name = "_QFEx16"}
-  ! CHECK-DAG: %[[V_19:[0-9]+]] = fir.declare %[[V_18]] {uniq_name = "_QFEx16"} : (!fir.ref<f128>) -> !fir.ref<f128>
+  ! CHECK-KIND10-DAG: %[[V_16:[0-9]+]] = fir.address_of(@_QFEx10) : !fir.ref<f80>
+  ! CHECK-KIND10-DAG: %[[V_17:[0-9]+]] = fir.declare %[[V_16]] {uniq_name = "_QFEx10"} : (!fir.ref<f80>) -> !fir.ref<f80>
+  ! CHECK-KIND16-DAG: %[[V_18:[0-9]+]] = fir.alloca f128 {bindc_name = "x16", uniq_name = "_QFEx16"}
+  ! CHECK-KIND16-DAG: %[[V_19:[0-9]+]] = fir.declare %[[V_18]] {uniq_name = "_QFEx16"} : (!fir.ref<f128>) -> !fir.ref<f128>
   ! CHECK-DAG: %[[V_20:[0-9]+]] = fir.alloca f16 {bindc_name = "x2", uniq_name = "_QFEx2"}
   ! CHECK-DAG: %[[V_21:[0-9]+]] = fir.declare %[[V_20]] {uniq_name = "_QFEx2"} : (!fir.ref<f16>) -> !fir.ref<f16>
   ! CHECK-DAG: %[[V_22:[0-9]+]] = fir.address_of(@_QFEx3) : !fir.ref<bf16>
@@ -29,12 +29,14 @@ program p
   ! CHECK-DAG: %[[V_25:[0-9]+]] = fir.declare %[[V_24]] {uniq_name = "_QFEx4"} : (!fir.ref<f32>) -> !fir.ref<f32>
   ! CHECK-DAG: %[[V_26:[0-9]+]] = fir.address_of(@_QFEx8) : !fir.ref<f64>
   ! CHECK-DAG: %[[V_27:[0-9]+]] = fir.declare %[[V_26]] {uniq_name = "_QFEx8"} : (!fir.ref<f64>) -> !fir.ref<f64>
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
   real(2)  ::  r2,  x2
   real(3)  ::  r3,  x3 = -huge(x3)
   real(4)  ::  r4,  x4 = -0.
   real(8)  ::  r8,  x8 =  0.
-  real(10) :: r10, x10 =  huge(x10)
-  real(16) :: r16, x16
+  real(kind10) :: r10, x10 =  huge(x10)
+  real(kind16) :: r16, x16
 
   x2  = ieee_value(x2, ieee_negative_inf)
   x16 = ieee_value(x2, ieee_positive_inf)
@@ -211,71 +213,71 @@ program p
   r8 = ieee_next_after(x8, x2)
   print "('after:  ', z16.16, ' -> ', z16.16, ' = ', g0)", x8, r8, r8
 
-  ! CHECK:     %[[V_158:[0-9]+]] = fir.load %[[V_17]] : !fir.ref<f80>
-  ! CHECK:     %[[V_159:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 3 : i32}> : (f80) -> i1
-  ! CHECK:     %[[V_160:[0-9]+]] = arith.bitcast %[[V_158]] : f80 to i80
-  ! CHECK:     %[[V_161:[0-9]+]] = arith.shrui %[[V_160]], %c79{{.*}} : i80
-  ! CHECK:     %[[V_162:[0-9]+]] = fir.convert %[[V_161]] : (i80) -> i1
-  ! CHECK:     %[[V_163:[0-9]+]] = arith.cmpi ne, %[[V_162]], %true{{[_0-9]*}} : i1
-  ! CHECK:     %[[V_164:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 516 : i32}> : (f80) -> i1
-  ! CHECK:     %[[V_165:[0-9]+]] = arith.andi %[[V_164]], %[[V_163]] : i1
-  ! CHECK:     %[[V_166:[0-9]+]] = arith.ori %[[V_159]], %[[V_165]] : i1
-  ! CHECK:     %[[V_167:[0-9]+]] = fir.if %[[V_166]] -> (f80) {
-  ! CHECK:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 1 : i32}> : (f80) -> i1
-  ! CHECK:       fir.if %[[V_202]] {
-  ! CHECK:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_158]] : f80
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_158]], %cst{{[_0-9]*}} fastmath<contract> : f80
-  ! CHECK:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f80) {
-  ! CHECK:         fir.result %cst{{[_0-9]*}} : f80
-  ! CHECK:       } else {
-  ! CHECK:         %[[V_204:[0-9]+]] = fir.call @_FortranAMapException(%c63{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:         %[[V_205:[0-9]+]] = fir.call @fetestexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         %[[V_206:[0-9]+]] = fir.call @fedisableexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         %[[V_207:[0-9]+]] = fir.call @_FortranANearest10(%[[V_158]], %true{{[_0-9]*}}) fastmath<contract> : (f80, i1) -> f80
-  ! CHECK:         %[[V_208:[0-9]+]] = fir.call @feclearexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         %[[V_209:[0-9]+]] = fir.call @feraiseexcept(%[[V_205]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         %[[V_210:[0-9]+]] = fir.call @feenableexcept(%[[V_206]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         fir.result %[[V_207]] : f80
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_203]] : f80
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_167]] to %[[V_5]] : !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_158:[0-9]+]] = fir.load %[[V_17]] : !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_159:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 3 : i32}> : (f80) -> i1
+  ! CHECK-KIND10:     %[[V_160:[0-9]+]] = arith.bitcast %[[V_158]] : f80 to i80
+  ! CHECK-KIND10:     %[[V_161:[0-9]+]] = arith.shrui %[[V_160]], %c79{{.*}} : i80
+  ! CHECK-KIND10:     %[[V_162:[0-9]+]] = fir.convert %[[V_161]] : (i80) -> i1
+  ! CHECK-KIND10:     %[[V_163:[0-9]+]] = arith.cmpi ne, %[[V_162]], %true{{[_0-9]*}} : i1
+  ! CHECK-KIND10:     %[[V_164:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 516 : i32}> : (f80) -> i1
+  ! CHECK-KIND10:     %[[V_165:[0-9]+]] = arith.andi %[[V_164]], %[[V_163]] : i1
+  ! CHECK-KIND10:     %[[V_166:[0-9]+]] = arith.ori %[[V_159]], %[[V_165]] : i1
+  ! CHECK-KIND10:     %[[V_167:[0-9]+]] = fir.if %[[V_166]] -> (f80) {
+  ! CHECK-KIND10:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 1 : i32}> : (f80) -> i1
+  ! CHECK-KIND10:       fir.if %[[V_202]] {
+  ! CHECK-KIND10:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:       }
+  ! CHECK-KIND10:       fir.result %[[V_158]] : f80
+  ! CHECK-KIND10:     } else {
+  ! CHECK-KIND10:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_158]], %cst{{[_0-9]*}} fastmath<contract> : f80
+  ! CHECK-KIND10:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f80) {
+  ! CHECK-KIND10:         fir.result %cst{{[_0-9]*}} : f80
+  ! CHECK-KIND10:       } else {
+  ! CHECK-KIND10:         %[[V_204:[0-9]+]] = fir.call @_FortranAMapException(%c63{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         %[[V_205:[0-9]+]] = fir.call @fetestexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         %[[V_206:[0-9]+]] = fir.call @fedisableexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         %[[V_207:[0-9]+]] = fir.call @_FortranANearest10(%[[V_158]], %true{{[_0-9]*}}) fastmath<contract> : (f80, i1) -> f80
+  ! CHECK-KIND10:         %[[V_208:[0-9]+]] = fir.call @feclearexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         %[[V_209:[0-9]+]] = fir.call @feraiseexcept(%[[V_205]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         %[[V_210:[0-9]+]] = fir.call @feenableexcept(%[[V_206]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         fir.result %[[V_207]] : f80
+  ! CHECK-KIND10:       }
+  ! CHECK-KIND10:       fir.result %[[V_203]] : f80
+  ! CHECK-KIND10:     }
+  ! CHECK-KIND10:     fir.store %[[V_167]] to %[[V_5]] : !fir.ref<f80>
   r10 = ieee_next_up(x10)
   print "('up:     ', z20.20, ' -> ', z20.20, ' = ', g0)", x10, r10, r10
 
-  ! CHECK:     %[[V_180:[0-9]+]] = fir.load %[[V_19]] : !fir.ref<f128>
-  ! CHECK:     %[[V_181:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 3 : i32}> : (f128) -> i1
-  ! CHECK:     %[[V_182:[0-9]+]] = arith.bitcast %[[V_180]] : f128 to i128
-  ! CHECK:     %[[V_183:[0-9]+]] = arith.shrui %[[V_182]], %c127{{.*}} : i128
-  ! CHECK:     %[[V_184:[0-9]+]] = fir.convert %[[V_183]] : (i128) -> i1
-  ! CHECK:     %[[V_186:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 516 : i32}> : (f128) -> i1
-  ! CHECK:     %[[V_187:[0-9]+]] = arith.andi %[[V_186]], %[[V_184]] : i1
-  ! CHECK:     %[[V_188:[0-9]+]] = arith.ori %[[V_181]], %[[V_187]] : i1
-  ! CHECK:     %[[V_189:[0-9]+]] = fir.if %[[V_188]] -> (f128) {
-  ! CHECK:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 1 : i32}> : (f128) -> i1
-  ! CHECK:       fir.if %[[V_202]] {
-  ! CHECK:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_180]] : f128
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_180]], %cst{{[_0-9]*}} fastmath<contract> : f128
-  ! CHECK:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f128) {
-  ! CHECK:         fir.result %cst{{[_0-9]*}} : f128
-  ! CHECK:       } else {
-  ! CHECK-DAG:     %[[V_204:[0-9]+]] = arith.subi %[[V_182]], %c1{{.*}} : i128
-  ! CHECK-DAG:     %[[V_205:[0-9]+]] = arith.addi %[[V_182]], %c1{{.*}} : i128
-  ! CHECK:         %[[V_206:[0-9]+]] = arith.select %[[V_184]], %[[V_205]], %[[V_204]] : i128
-  ! CHECK:         %[[V_207:[0-9]+]] = arith.bitcast %[[V_206]] : i128 to f128
-  ! CHECK:         fir.result %[[V_207]] : f128
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_203]] : f128
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_189]] to %[[V_7]] : !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_180:[0-9]+]] = fir.load %[[V_19]] : !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_181:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 3 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     %[[V_182:[0-9]+]] = arith.bitcast %[[V_180]] : f128 to i128
+  ! CHECK-KIND16:     %[[V_183:[0-9]+]] = arith.shrui %[[V_182]], %c127{{.*}} : i128
+  ! CHECK-KIND16:     %[[V_184:[0-9]+]] = fir.convert %[[V_183]] : (i128) -> i1
+  ! CHECK-KIND16:     %[[V_186:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 516 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     %[[V_187:[0-9]+]] = arith.andi %[[V_186]], %[[V_184]] : i1
+  ! CHECK-KIND16:     %[[V_188:[0-9]+]] = arith.ori %[[V_181]], %[[V_187]] : i1
+  ! CHECK-KIND16:     %[[V_189:[0-9]+]] = fir.if %[[V_188]] -> (f128) {
+  ! CHECK-KIND16:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 1 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:       fir.if %[[V_202]] {
+  ! CHECK-KIND16:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:       }
+  ! CHECK-KIND16:       fir.result %[[V_180]] : f128
+  ! CHECK-KIND16:     } else {
+  ! CHECK-KIND16:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_180]], %cst{{[_0-9]*}} fastmath<contract> : f128
+  ! CHECK-KIND16:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f128) {
+  ! CHECK-KIND16:         fir.result %cst{{[_0-9]*}} : f128
+  ! CHECK-KIND16:       } else {
+  ! CHECK-KIND16-DAG:     %[[V_204:[0-9]+]] = arith.subi %[[V_182]], %c1{{.*}} : i128
+  ! CHECK-KIND16-DAG:     %[[V_205:[0-9]+]] = arith.addi %[[V_182]], %c1{{.*}} : i128
+  ! CHECK-KIND16:         %[[V_206:[0-9]+]] = arith.select %[[V_184]], %[[V_205]], %[[V_204]] : i128
+  ! CHECK-KIND16:         %[[V_207:[0-9]+]] = arith.bitcast %[[V_206]] : i128 to f128
+  ! CHECK-KIND16:         fir.result %[[V_207]] : f128
+  ! CHECK-KIND16:       }
+  ! CHECK-KIND16:       fir.result %[[V_203]] : f128
+  ! CHECK-KIND16:     }
+  ! CHECK-KIND16:     fir.store %[[V_189]] to %[[V_7]] : !fir.ref<f128>
 
   r16 = ieee_next_down(x16)
   print "('down:   ', z32.32, ' -> ', z32.32, ' = ', g0)", x16, r16, r16

--- a/flang/test/Lower/Intrinsics/ieee_next.f90
+++ b/flang/test/Lower/Intrinsics/ieee_next.f90
@@ -19,12 +19,12 @@ end subroutine
 !CHECK-KIND10:           %[[VAL_14:.*]]:2 = hlfir.declare {{.*}}x2"
 !CHECK-KIND10:           %[[VAL_15:.*]] = fir.load %[[VAL_14]]#0 : !fir.ref<f16>
 !CHECK-KIND10:           %[[VAL_16:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<f80>
-!CHECK-KIND10:           %[[VAL_17:.*]] = "llvm.intr.is.fpclass"(%[[VAL_16]]) <{bit = 3 : i32}> : (f80) -> i1
-!CHECK-KIND10:           %[[VAL_18:.*]] = arith.constant 2 : i8
-!CHECK-KIND10:           %[[VAL_19:.*]] = fir.address_of(@_FortranAIeeeValueTable_2) : !fir.ref<!fir.array<12xi16>>
-!CHECK-KIND10:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_18]] : (!fir.ref<!fir.array<12xi16>>, i8) -> !fir.ref<i16>
-!CHECK-KIND10:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i16>
-!CHECK-KIND10:           %[[VAL_22:.*]] = arith.bitcast %[[VAL_21]] : i16 to f16
+!CHECK-KIND10-DAG:       %[[VAL_17:.*]] = "llvm.intr.is.fpclass"(%[[VAL_16]]) <{bit = 3 : i32}> : (f80) -> i1
+!CHECK-KIND10-DAG:       %[[VAL_18:.*]] = arith.constant 2 : i8
+!CHECK-KIND10-DAG:       %[[VAL_19:.*]] = fir.address_of(@_FortranAIeeeValueTable_2) : !fir.ref<!fir.array<12xi16>>
+!CHECK-KIND10-DAG:       %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_18]] : (!fir.ref<!fir.array<12xi16>>, i8) -> !fir.ref<i16>
+!CHECK-KIND10-DAG:       %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i16>
+!CHECK-KIND10-DAG:       %[[VAL_22:.*]] = arith.bitcast %[[VAL_21]] : i16 to f16
 !CHECK-KIND10:           %[[VAL_23:.*]] = arith.select %[[VAL_17]], %[[VAL_22]], %[[VAL_15]] : f16
 !CHECK-KIND10:           %[[VAL_24:.*]] = "llvm.intr.is.fpclass"(%[[VAL_23]]) <{bit = 3 : i32}> : (f16) -> i1
 !CHECK-KIND10:           %[[VAL_25:.*]] = arith.constant 1 : i16
@@ -193,12 +193,12 @@ end subroutine
 !CHECK:           %[[VAL_14:.*]]:2 = hlfir.declare {{.*}}x8"
 !CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_14]]#0 : !fir.ref<f64>
 !CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<f16>
-!CHECK:           %[[VAL_17:.*]] = "llvm.intr.is.fpclass"(%[[VAL_16]]) <{bit = 3 : i32}> : (f16) -> i1
-!CHECK:           %[[VAL_18:.*]] = arith.constant 2 : i8
-!CHECK:           %[[VAL_19:.*]] = fir.address_of(@_FortranAIeeeValueTable_8) : !fir.ref<!fir.array<12xi64>>
-!CHECK:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_18]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>
-!CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i64>
-!CHECK:           %[[VAL_22:.*]] = arith.bitcast %[[VAL_21]] : i64 to f64
+!CHECK-DAG:       %[[VAL_17:.*]] = "llvm.intr.is.fpclass"(%[[VAL_16]]) <{bit = 3 : i32}> : (f16) -> i1
+!CHECK-DAG:       %[[VAL_18:.*]] = arith.constant 2 : i8
+!CHECK-DAG:       %[[VAL_19:.*]] = fir.address_of(@_FortranAIeeeValueTable_8) : !fir.ref<!fir.array<12xi64>>
+!CHECK-DAG:       %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_18]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>
+!CHECK-DAG:       %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i64>
+!CHECK-DAG:       %[[VAL_22:.*]] = arith.bitcast %[[VAL_21]] : i64 to f64
 !CHECK:           %[[VAL_23:.*]] = arith.select %[[VAL_17]], %[[VAL_22]], %[[VAL_15]] : f64
 !CHECK:           %[[VAL_24:.*]] = "llvm.intr.is.fpclass"(%[[VAL_23]]) <{bit = 3 : i32}> : (f64) -> i1
 !CHECK:           %[[VAL_25:.*]] = arith.constant 1 : i64

--- a/flang/test/Lower/Intrinsics/ieee_next.f90
+++ b/flang/test/Lower/Intrinsics/ieee_next.f90
@@ -1,36 +1,375 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
-! CHECK-LABEL: c.func @_QQmain
-program p
+module ieee_next_tests
   use ieee_arithmetic, only: ieee_value, ieee_negative_inf, ieee_positive_inf
   use ieee_arithmetic, only: ieee_next_after, ieee_next_down, ieee_next_up
   implicit none
-  ! CHECK-KIND10-DAG: %[[V_4:[0-9]+]] = fir.alloca f80 {bindc_name = "r10", uniq_name = "_QFEr10"}
-  ! CHECK-KIND10-DAG: %[[V_5:[0-9]+]] = fir.declare %[[V_4]] {uniq_name = "_QFEr10"} : (!fir.ref<f80>) -> !fir.ref<f80>
-  ! CHECK-KIND16-DAG: %[[V_6:[0-9]+]] = fir.alloca f128 {bindc_name = "r16", uniq_name = "_QFEr16"}
-  ! CHECK-KIND16-DAG: %[[V_7:[0-9]+]] = fir.declare %[[V_6]] {uniq_name = "_QFEr16"} : (!fir.ref<f128>) -> !fir.ref<f128>
-  ! CHECK-DAG: %[[V_8:[0-9]+]] = fir.alloca f16 {bindc_name = "r2", uniq_name = "_QFEr2"}
-  ! CHECK-DAG: %[[V_9:[0-9]+]] = fir.declare %[[V_8]] {uniq_name = "_QFEr2"} : (!fir.ref<f16>) -> !fir.ref<f16>
-  ! CHECK-DAG: %[[V_10:[0-9]+]] = fir.alloca bf16 {bindc_name = "r3", uniq_name = "_QFEr3"}
-  ! CHECK-DAG: %[[V_11:[0-9]+]] = fir.declare %[[V_10]] {uniq_name = "_QFEr3"} : (!fir.ref<bf16>) -> !fir.ref<bf16>
-  ! CHECK-DAG: %[[V_12:[0-9]+]] = fir.alloca f32 {bindc_name = "r4", uniq_name = "_QFEr4"}
-  ! CHECK-DAG: %[[V_13:[0-9]+]] = fir.declare %[[V_12]] {uniq_name = "_QFEr4"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  ! CHECK-DAG: %[[V_14:[0-9]+]] = fir.alloca f64 {bindc_name = "r8", uniq_name = "_QFEr8"}
-  ! CHECK-DAG: %[[V_15:[0-9]+]] = fir.declare %[[V_14]] {uniq_name = "_QFEr8"} : (!fir.ref<f64>) -> !fir.ref<f64>
-  ! CHECK-KIND10-DAG: %[[V_16:[0-9]+]] = fir.address_of(@_QFEx10) : !fir.ref<f80>
-  ! CHECK-KIND10-DAG: %[[V_17:[0-9]+]] = fir.declare %[[V_16]] {uniq_name = "_QFEx10"} : (!fir.ref<f80>) -> !fir.ref<f80>
-  ! CHECK-KIND16-DAG: %[[V_18:[0-9]+]] = fir.alloca f128 {bindc_name = "x16", uniq_name = "_QFEx16"}
-  ! CHECK-KIND16-DAG: %[[V_19:[0-9]+]] = fir.declare %[[V_18]] {uniq_name = "_QFEx16"} : (!fir.ref<f128>) -> !fir.ref<f128>
-  ! CHECK-DAG: %[[V_20:[0-9]+]] = fir.alloca f16 {bindc_name = "x2", uniq_name = "_QFEx2"}
-  ! CHECK-DAG: %[[V_21:[0-9]+]] = fir.declare %[[V_20]] {uniq_name = "_QFEx2"} : (!fir.ref<f16>) -> !fir.ref<f16>
-  ! CHECK-DAG: %[[V_22:[0-9]+]] = fir.address_of(@_QFEx3) : !fir.ref<bf16>
-  ! CHECK-DAG: %[[V_23:[0-9]+]] = fir.declare %[[V_22]] {uniq_name = "_QFEx3"} : (!fir.ref<bf16>) -> !fir.ref<bf16>
-  ! CHECK-DAG: %[[V_24:[0-9]+]] = fir.address_of(@_QFEx4) : !fir.ref<f32>
-  ! CHECK-DAG: %[[V_25:[0-9]+]] = fir.declare %[[V_24]] {uniq_name = "_QFEx4"} : (!fir.ref<f32>) -> !fir.ref<f32>
-  ! CHECK-DAG: %[[V_26:[0-9]+]] = fir.address_of(@_QFEx8) : !fir.ref<f64>
-  ! CHECK-DAG: %[[V_27:[0-9]+]] = fir.declare %[[V_26]] {uniq_name = "_QFEx8"} : (!fir.ref<f64>) -> !fir.ref<f64>
   integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
   integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+contains
+
+subroutine test1(r2, x2, x10)
+  real(2)  ::  r2,  x2
+  real(kind10) :: x10
+  r2 = ieee_next_after(x2, x10)
+end subroutine
+!CHECK-KIND10-LABEL:   func.func @_QMieee_next_testsPtest1(
+!CHECK-KIND10:           %[[VAL_12:.*]]:2 = hlfir.declare {{.*}}r2"
+!CHECK-KIND10:           %[[VAL_13:.*]]:2 = hlfir.declare {{.*}}x10"
+!CHECK-KIND10:           %[[VAL_14:.*]]:2 = hlfir.declare {{.*}}x2"
+!CHECK-KIND10:           %[[VAL_15:.*]] = fir.load %[[VAL_14]]#0 : !fir.ref<f16>
+!CHECK-KIND10:           %[[VAL_16:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<f80>
+!CHECK-KIND10:           %[[VAL_17:.*]] = "llvm.intr.is.fpclass"(%[[VAL_16]]) <{bit = 3 : i32}> : (f80) -> i1
+!CHECK-KIND10:           %[[VAL_18:.*]] = arith.constant 2 : i8
+!CHECK-KIND10:           %[[VAL_19:.*]] = fir.address_of(@_FortranAIeeeValueTable_2) : !fir.ref<!fir.array<12xi16>>
+!CHECK-KIND10:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_18]] : (!fir.ref<!fir.array<12xi16>>, i8) -> !fir.ref<i16>
+!CHECK-KIND10:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i16>
+!CHECK-KIND10:           %[[VAL_22:.*]] = arith.bitcast %[[VAL_21]] : i16 to f16
+!CHECK-KIND10:           %[[VAL_23:.*]] = arith.select %[[VAL_17]], %[[VAL_22]], %[[VAL_15]] : f16
+!CHECK-KIND10:           %[[VAL_24:.*]] = "llvm.intr.is.fpclass"(%[[VAL_23]]) <{bit = 3 : i32}> : (f16) -> i1
+!CHECK-KIND10:           %[[VAL_25:.*]] = arith.constant 1 : i16
+!CHECK-KIND10:           %[[VAL_26:.*]] = fir.convert %[[VAL_23]] : (f16) -> f32
+!CHECK-KIND10:           %[[VAL_27:.*]] = fir.convert %[[VAL_26]] : (f32) -> f80
+!CHECK-KIND10:           %[[VAL_28:.*]] = arith.cmpf oeq, %[[VAL_27]], %[[VAL_16]] fastmath<contract> : f80
+!CHECK-KIND10:           %[[VAL_29:.*]] = arith.ori %[[VAL_24]], %[[VAL_28]] : i1
+!CHECK-KIND10:           %[[VAL_30:.*]] = arith.cmpf olt, %[[VAL_27]], %[[VAL_16]] fastmath<contract> : f80
+!CHECK-KIND10:           %[[VAL_31:.*]] = arith.bitcast %[[VAL_15]] : f16 to i16
+!CHECK-KIND10:           %[[VAL_32:.*]] = arith.constant 15 : i16
+!CHECK-KIND10:           %[[VAL_33:.*]] = arith.shrui %[[VAL_31]], %[[VAL_32]] : i16
+!CHECK-KIND10:           %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i16) -> i1
+!CHECK-KIND10:           %[[VAL_35:.*]] = arith.cmpi ne, %[[VAL_30]], %[[VAL_34]] : i1
+!CHECK-KIND10:           %[[VAL_36:.*]] = "llvm.intr.is.fpclass"(%[[VAL_23]]) <{bit = 516 : i32}> : (f16) -> i1
+!CHECK-KIND10:           %[[VAL_37:.*]] = arith.andi %[[VAL_36]], %[[VAL_35]] : i1
+!CHECK-KIND10:           %[[VAL_38:.*]] = arith.ori %[[VAL_29]], %[[VAL_37]] : i1
+!CHECK-KIND10:           %[[VAL_39:.*]] = fir.if %[[VAL_38]] -> (f16) {
+!CHECK-KIND10:             fir.result %[[VAL_23]] : f16
+!CHECK-KIND10:           } else {
+!CHECK-KIND10:             %[[VAL_40:.*]] = arith.constant 0.000000e+00 : f16
+!CHECK-KIND10:             %[[VAL_41:.*]] = arith.cmpf oeq, %[[VAL_23]], %[[VAL_40]] fastmath<contract> : f16
+!CHECK-KIND10:             %[[VAL_42:.*]] = fir.if %[[VAL_41]] -> (f16) {
+!CHECK-KIND10:               %[[VAL_43:.*]] = arith.bitcast %[[VAL_25]] : i16 to f16
+!CHECK-KIND10:               %[[VAL_44:.*]] = arith.constant -32767 : i16
+!CHECK-KIND10:               %[[VAL_45:.*]] = arith.bitcast %[[VAL_44]] : i16 to f16
+!CHECK-KIND10:               %[[VAL_46:.*]] = arith.select %[[VAL_30]], %[[VAL_43]], %[[VAL_45]] : f16
+!CHECK-KIND10:               %[[VAL_47:.*]] = arith.constant 48 : i32
+!CHECK-KIND10:               %[[VAL_48:.*]] = fir.call @_FortranAMapException(%[[VAL_47]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_49:.*]] = fir.call @feraiseexcept(%[[VAL_48]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               fir.result %[[VAL_46]] : f16
+!CHECK-KIND10:             } else {
+!CHECK-KIND10:               %[[VAL_50:.*]] = arith.bitcast %[[VAL_23]] : f16 to i16
+!CHECK-KIND10-DAG:           %[[VAL_51:.*]] = arith.addi %[[VAL_50]], %[[VAL_25]] : i16
+!CHECK-KIND10-DAG:           %[[VAL_52:.*]] = arith.subi %[[VAL_50]], %[[VAL_25]] : i16
+!CHECK-KIND10:               %[[VAL_53:.*]] = arith.select %[[VAL_35]], %[[VAL_51]], %[[VAL_52]] : i16
+!CHECK-KIND10:               %[[VAL_54:.*]] = arith.bitcast %[[VAL_53]] : i16 to f16
+!CHECK-KIND10:               %[[VAL_55:.*]] = "llvm.intr.is.fpclass"(%[[VAL_54]]) <{bit = 516 : i32}> : (f16) -> i1
+!CHECK-KIND10:               fir.if %[[VAL_55]] {
+!CHECK-KIND10:                 %[[VAL_56:.*]] = arith.constant 40 : i32
+!CHECK-KIND10:                 %[[VAL_57:.*]] = fir.call @_FortranAMapException(%[[VAL_56]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:                 %[[VAL_58:.*]] = fir.call @feraiseexcept(%[[VAL_57]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               }
+!CHECK-KIND10:               %[[VAL_59:.*]] = "llvm.intr.is.fpclass"(%[[VAL_54]]) <{bit = 144 : i32}> : (f16) -> i1
+!CHECK-KIND10:               fir.if %[[VAL_59]] {
+!CHECK-KIND10:                 %[[VAL_60:.*]] = arith.constant 48 : i32
+!CHECK-KIND10:                 %[[VAL_61:.*]] = fir.call @_FortranAMapException(%[[VAL_60]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:                 %[[VAL_62:.*]] = fir.call @feraiseexcept(%[[VAL_61]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               }
+!CHECK-KIND10:               fir.result %[[VAL_54]] : f16
+!CHECK-KIND10:             }
+!CHECK-KIND10:             fir.result %[[VAL_42]] : f16
+!CHECK-KIND10:           }
+!CHECK-KIND10:           hlfir.assign %[[VAL_39]] to %[[VAL_12]]#0 : f16, !fir.ref<f16>
+!CHECK-KIND10:           return
+!CHECK-KIND10:         }
+
+subroutine test2(r3, x3)
+  real(3)  ::  r3,  x3
+  r3 = ieee_next_up(x3)
+end subroutine
+!CHECK-LABEL:   func.func @_QMieee_next_testsPtest2(
+!CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare {{.*}}r3"
+!CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare {{.*}}x3"
+!CHECK:           %[[VAL_13:.*]] = fir.load %[[VAL_12]]#0 : !fir.ref<bf16>
+!CHECK:           %[[VAL_14:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 3 : i32}> : (bf16) -> i1
+!CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i16
+!CHECK:           %[[VAL_16:.*]] = arith.constant true
+!CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_13]] : (bf16) -> f32
+!CHECK:           %[[VAL_18:.*]] = arith.bitcast %[[VAL_17]] : f32 to i32
+!CHECK:           %[[VAL_19:.*]] = arith.constant 31 : i32
+!CHECK:           %[[VAL_20:.*]] = arith.shrui %[[VAL_18]], %[[VAL_19]] : i32
+!CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (i32) -> i1
+!CHECK:           %[[VAL_22:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_21]] : i1
+!CHECK:           %[[VAL_23:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 516 : i32}> : (bf16) -> i1
+!CHECK:           %[[VAL_24:.*]] = arith.andi %[[VAL_23]], %[[VAL_22]] : i1
+!CHECK:           %[[VAL_25:.*]] = arith.ori %[[VAL_14]], %[[VAL_24]] : i1
+!CHECK:           %[[VAL_26:.*]] = fir.if %[[VAL_25]] -> (bf16) {
+!CHECK:             %[[VAL_27:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 1 : i32}> : (bf16) -> i1
+!CHECK:             fir.if %[[VAL_27]] {
+!CHECK:               %[[VAL_28:.*]] = arith.constant 1 : i32
+!CHECK:               %[[VAL_29:.*]] = fir.call @_FortranAMapException(%[[VAL_28]]) fastmath<contract> : (i32) -> i32
+!CHECK:               %[[VAL_30:.*]] = fir.call @feraiseexcept(%[[VAL_29]]) fastmath<contract> : (i32) -> i32
+!CHECK:             }
+!CHECK:             fir.result %[[VAL_13]] : bf16
+!CHECK:           } else {
+!CHECK:             %[[VAL_31:.*]] = arith.constant 0.000000e+00 : bf16
+!CHECK:             %[[VAL_32:.*]] = arith.cmpf oeq, %[[VAL_13]], %[[VAL_31]] fastmath<contract> : bf16
+!CHECK:             %[[VAL_33:.*]] = fir.if %[[VAL_32]] -> (bf16) {
+!CHECK:               %[[VAL_34:.*]] = arith.bitcast %[[VAL_15]] : i16 to bf16
+!CHECK:               %[[VAL_35:.*]] = arith.constant -32767 : i16
+!CHECK:               %[[VAL_36:.*]] = arith.bitcast %[[VAL_35]] : i16 to bf16
+!CHECK:               %[[VAL_37:.*]] = arith.select %[[VAL_16]], %[[VAL_34]], %[[VAL_36]] : bf16
+!CHECK:               fir.result %[[VAL_37]] : bf16
+!CHECK:             } else {
+!CHECK:               %[[VAL_38:.*]] = arith.bitcast %[[VAL_13]] : bf16 to i16
+!CHECK-DAG:           %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_15]] : i16
+!CHECK-DAG:           %[[VAL_40:.*]] = arith.subi %[[VAL_38]], %[[VAL_15]] : i16
+!CHECK:               %[[VAL_41:.*]] = arith.select %[[VAL_22]], %[[VAL_39]], %[[VAL_40]] : i16
+!CHECK:               %[[VAL_42:.*]] = arith.bitcast %[[VAL_41]] : i16 to bf16
+!CHECK:               fir.result %[[VAL_42]] : bf16
+!CHECK:             }
+!CHECK:             fir.result %[[VAL_33]] : bf16
+!CHECK:           }
+!CHECK:           hlfir.assign %[[VAL_26]] to %[[VAL_11]]#0 : bf16, !fir.ref<bf16>
+!CHECK:           return
+!CHECK:         }
+
+subroutine test3(r4, x4)
+  real(4)  ::  r4,  x4
+  r4 = ieee_next_down(x4)
+end subroutine
+!CHECK-LABEL:   func.func @_QMieee_next_testsPtest3(
+!CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare {{.*}}r4"
+!CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare {{.*}}x4"
+!CHECK:           %[[VAL_13:.*]] = fir.load %[[VAL_12]]#0 : !fir.ref<f32>
+!CHECK:           %[[VAL_14:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 3 : i32}> : (f32) -> i1
+!CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i32
+!CHECK:           %[[VAL_16:.*]] = arith.constant false
+!CHECK:           %[[VAL_17:.*]] = arith.bitcast %[[VAL_13]] : f32 to i32
+!CHECK:           %[[VAL_18:.*]] = arith.constant 31 : i32
+!CHECK:           %[[VAL_19:.*]] = arith.shrui %[[VAL_17]], %[[VAL_18]] : i32
+!CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i32) -> i1
+!CHECK:           %[[VAL_21:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_20]] : i1
+!CHECK:           %[[VAL_22:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 516 : i32}> : (f32) -> i1
+!CHECK:           %[[VAL_23:.*]] = arith.andi %[[VAL_22]], %[[VAL_21]] : i1
+!CHECK:           %[[VAL_24:.*]] = arith.ori %[[VAL_14]], %[[VAL_23]] : i1
+!CHECK:           %[[VAL_25:.*]] = fir.if %[[VAL_24]] -> (f32) {
+!CHECK:             %[[VAL_26:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 1 : i32}> : (f32) -> i1
+!CHECK:             fir.if %[[VAL_26]] {
+!CHECK:               %[[VAL_27:.*]] = arith.constant 1 : i32
+!CHECK:               %[[VAL_28:.*]] = fir.call @_FortranAMapException(%[[VAL_27]]) fastmath<contract> : (i32) -> i32
+!CHECK:               %[[VAL_29:.*]] = fir.call @feraiseexcept(%[[VAL_28]]) fastmath<contract> : (i32) -> i32
+!CHECK:             }
+!CHECK:             fir.result %[[VAL_13]] : f32
+!CHECK:           } else {
+!CHECK:             %[[VAL_30:.*]] = arith.constant 0.000000e+00 : f32
+!CHECK:             %[[VAL_31:.*]] = arith.cmpf oeq, %[[VAL_13]], %[[VAL_30]] fastmath<contract> : f32
+!CHECK:             %[[VAL_32:.*]] = fir.if %[[VAL_31]] -> (f32) {
+!CHECK:               %[[VAL_33:.*]] = arith.bitcast %[[VAL_15]] : i32 to f32
+!CHECK:               %[[VAL_34:.*]] = arith.constant -2147483647 : i32
+!CHECK:               %[[VAL_35:.*]] = arith.bitcast %[[VAL_34]] : i32 to f32
+!CHECK:               %[[VAL_36:.*]] = arith.select %[[VAL_16]], %[[VAL_33]], %[[VAL_35]] : f32
+!CHECK:               fir.result %[[VAL_36]] : f32
+!CHECK:             } else {
+!CHECK:               %[[VAL_37:.*]] = arith.bitcast %[[VAL_13]] : f32 to i32
+!CHECK-DAG:           %[[VAL_38:.*]] = arith.addi %[[VAL_37]], %[[VAL_15]] : i32
+!CHECK-DAG:           %[[VAL_39:.*]] = arith.subi %[[VAL_37]], %[[VAL_15]] : i32
+!CHECK:               %[[VAL_40:.*]] = arith.select %[[VAL_21]], %[[VAL_38]], %[[VAL_39]] : i32
+!CHECK:               %[[VAL_41:.*]] = arith.bitcast %[[VAL_40]] : i32 to f32
+!CHECK:               fir.result %[[VAL_41]] : f32
+!CHECK:             }
+!CHECK:             fir.result %[[VAL_32]] : f32
+!CHECK:           }
+!CHECK:           hlfir.assign %[[VAL_25]] to %[[VAL_11]]#0 : f32, !fir.ref<f32>
+!CHECK:           return
+!CHECK:         }
+
+subroutine test4(r8, x8, x2)
+  real(2)  ::  x2
+  real(8)  ::  r8,  x8
+  r8 = ieee_next_after(x8, x2)
+end subroutine
+!CHECK-LABEL:   func.func @_QMieee_next_testsPtest4(
+!CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare {{.*}}r8"
+!CHECK:           %[[VAL_13:.*]]:2 = hlfir.declare {{.*}}x2"
+!CHECK:           %[[VAL_14:.*]]:2 = hlfir.declare {{.*}}x8"
+!CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_14]]#0 : !fir.ref<f64>
+!CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<f16>
+!CHECK:           %[[VAL_17:.*]] = "llvm.intr.is.fpclass"(%[[VAL_16]]) <{bit = 3 : i32}> : (f16) -> i1
+!CHECK:           %[[VAL_18:.*]] = arith.constant 2 : i8
+!CHECK:           %[[VAL_19:.*]] = fir.address_of(@_FortranAIeeeValueTable_8) : !fir.ref<!fir.array<12xi64>>
+!CHECK:           %[[VAL_20:.*]] = fir.coordinate_of %[[VAL_19]], %[[VAL_18]] : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>
+!CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.ref<i64>
+!CHECK:           %[[VAL_22:.*]] = arith.bitcast %[[VAL_21]] : i64 to f64
+!CHECK:           %[[VAL_23:.*]] = arith.select %[[VAL_17]], %[[VAL_22]], %[[VAL_15]] : f64
+!CHECK:           %[[VAL_24:.*]] = "llvm.intr.is.fpclass"(%[[VAL_23]]) <{bit = 3 : i32}> : (f64) -> i1
+!CHECK:           %[[VAL_25:.*]] = arith.constant 1 : i64
+!CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_16]] : (f16) -> f32
+!CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_26]] : (f32) -> f64
+!CHECK:           %[[VAL_28:.*]] = arith.cmpf oeq, %[[VAL_23]], %[[VAL_27]] fastmath<contract> : f64
+!CHECK:           %[[VAL_29:.*]] = arith.ori %[[VAL_24]], %[[VAL_28]] : i1
+!CHECK:           %[[VAL_30:.*]] = arith.cmpf olt, %[[VAL_23]], %[[VAL_27]] fastmath<contract> : f64
+!CHECK:           %[[VAL_31:.*]] = arith.bitcast %[[VAL_15]] : f64 to i64
+!CHECK:           %[[VAL_32:.*]] = arith.constant 63 : i64
+!CHECK:           %[[VAL_33:.*]] = arith.shrui %[[VAL_31]], %[[VAL_32]] : i64
+!CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_33]] : (i64) -> i1
+!CHECK:           %[[VAL_35:.*]] = arith.cmpi ne, %[[VAL_30]], %[[VAL_34]] : i1
+!CHECK:           %[[VAL_36:.*]] = "llvm.intr.is.fpclass"(%[[VAL_23]]) <{bit = 516 : i32}> : (f64) -> i1
+!CHECK:           %[[VAL_37:.*]] = arith.andi %[[VAL_36]], %[[VAL_35]] : i1
+!CHECK:           %[[VAL_38:.*]] = arith.ori %[[VAL_29]], %[[VAL_37]] : i1
+!CHECK:           %[[VAL_39:.*]] = fir.if %[[VAL_38]] -> (f64) {
+!CHECK:             fir.result %[[VAL_23]] : f64
+!CHECK:           } else {
+!CHECK:             %[[VAL_40:.*]] = arith.constant 0.000000e+00 : f64
+!CHECK:             %[[VAL_41:.*]] = arith.cmpf oeq, %[[VAL_23]], %[[VAL_40]] fastmath<contract> : f64
+!CHECK:             %[[VAL_42:.*]] = fir.if %[[VAL_41]] -> (f64) {
+!CHECK:               %[[VAL_43:.*]] = arith.bitcast %[[VAL_25]] : i64 to f64
+!CHECK:               %[[VAL_44:.*]] = arith.constant -9223372036854775807 : i64
+!CHECK:               %[[VAL_45:.*]] = arith.bitcast %[[VAL_44]] : i64 to f64
+!CHECK:               %[[VAL_46:.*]] = arith.select %[[VAL_30]], %[[VAL_43]], %[[VAL_45]] : f64
+!CHECK:               %[[VAL_47:.*]] = arith.constant 48 : i32
+!CHECK:               %[[VAL_48:.*]] = fir.call @_FortranAMapException(%[[VAL_47]]) fastmath<contract> : (i32) -> i32
+!CHECK:               %[[VAL_49:.*]] = fir.call @feraiseexcept(%[[VAL_48]]) fastmath<contract> : (i32) -> i32
+!CHECK:               fir.result %[[VAL_46]] : f64
+!CHECK:             } else {
+!CHECK:               %[[VAL_50:.*]] = arith.bitcast %[[VAL_23]] : f64 to i64
+!CHECK-DAG:           %[[VAL_51:.*]] = arith.addi %[[VAL_50]], %[[VAL_25]] : i64
+!CHECK-DAG:           %[[VAL_52:.*]] = arith.subi %[[VAL_50]], %[[VAL_25]] : i64
+!CHECK:               %[[VAL_53:.*]] = arith.select %[[VAL_35]], %[[VAL_51]], %[[VAL_52]] : i64
+!CHECK:               %[[VAL_54:.*]] = arith.bitcast %[[VAL_53]] : i64 to f64
+!CHECK:               %[[VAL_55:.*]] = "llvm.intr.is.fpclass"(%[[VAL_54]]) <{bit = 516 : i32}> : (f64) -> i1
+!CHECK:               fir.if %[[VAL_55]] {
+!CHECK:                 %[[VAL_56:.*]] = arith.constant 40 : i32
+!CHECK:                 %[[VAL_57:.*]] = fir.call @_FortranAMapException(%[[VAL_56]]) fastmath<contract> : (i32) -> i32
+!CHECK:                 %[[VAL_58:.*]] = fir.call @feraiseexcept(%[[VAL_57]]) fastmath<contract> : (i32) -> i32
+!CHECK:               }
+!CHECK:               %[[VAL_59:.*]] = "llvm.intr.is.fpclass"(%[[VAL_54]]) <{bit = 144 : i32}> : (f64) -> i1
+!CHECK:               fir.if %[[VAL_59]] {
+!CHECK:                 %[[VAL_60:.*]] = arith.constant 48 : i32
+!CHECK:                 %[[VAL_61:.*]] = fir.call @_FortranAMapException(%[[VAL_60]]) fastmath<contract> : (i32) -> i32
+!CHECK:                 %[[VAL_62:.*]] = fir.call @feraiseexcept(%[[VAL_61]]) fastmath<contract> : (i32) -> i32
+!CHECK:               }
+!CHECK:               fir.result %[[VAL_54]] : f64
+!CHECK:             }
+!CHECK:             fir.result %[[VAL_42]] : f64
+!CHECK:           }
+!CHECK:           hlfir.assign %[[VAL_39]] to %[[VAL_12]]#0 : f64, !fir.ref<f64>
+!CHECK:           return
+!CHECK:         }
+
+subroutine test5(r10, x10)
+  real(kind10) :: x10, r10
+  r10 = ieee_next_up(x10)
+end subroutine
+!CHECK-KIND10-LABEL:   func.func @_QMieee_next_testsPtest5(
+!CHECK-KIND10:           %[[VAL_11:.*]]:2 = hlfir.declare {{.*}}r10"
+!CHECK-KIND10:           %[[VAL_12:.*]]:2 = hlfir.declare {{.*}}x10"
+!CHECK-KIND10:           %[[VAL_13:.*]] = fir.load %[[VAL_12]]#0 : !fir.ref<f80>
+!CHECK-KIND10:           %[[VAL_14:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 3 : i32}> : (f80) -> i1
+!CHECK-KIND10:           %[[VAL_15:.*]] = arith.constant 1 : i80
+!CHECK-KIND10:           %[[VAL_16:.*]] = arith.constant true
+!CHECK-KIND10:           %[[VAL_17:.*]] = arith.bitcast %[[VAL_13]] : f80 to i80
+!CHECK-KIND10:           %[[VAL_18:.*]] = arith.constant 79 : i80
+!CHECK-KIND10:           %[[VAL_19:.*]] = arith.shrui %[[VAL_17]], %[[VAL_18]] : i80
+!CHECK-KIND10:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i80) -> i1
+!CHECK-KIND10:           %[[VAL_21:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_20]] : i1
+!CHECK-KIND10:           %[[VAL_22:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 516 : i32}> : (f80) -> i1
+!CHECK-KIND10:           %[[VAL_23:.*]] = arith.andi %[[VAL_22]], %[[VAL_21]] : i1
+!CHECK-KIND10:           %[[VAL_24:.*]] = arith.ori %[[VAL_14]], %[[VAL_23]] : i1
+!CHECK-KIND10:           %[[VAL_25:.*]] = fir.if %[[VAL_24]] -> (f80) {
+!CHECK-KIND10:             %[[VAL_26:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 1 : i32}> : (f80) -> i1
+!CHECK-KIND10:             fir.if %[[VAL_26]] {
+!CHECK-KIND10:               %[[VAL_27:.*]] = arith.constant 1 : i32
+!CHECK-KIND10:               %[[VAL_28:.*]] = fir.call @_FortranAMapException(%[[VAL_27]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_29:.*]] = fir.call @feraiseexcept(%[[VAL_28]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:             }
+!CHECK-KIND10:             fir.result %[[VAL_13]] : f80
+!CHECK-KIND10:           } else {
+!CHECK-KIND10:             %[[VAL_30:.*]] = arith.constant 0.000000e+00 : f80
+!CHECK-KIND10:             %[[VAL_31:.*]] = arith.cmpf oeq, %[[VAL_13]], %[[VAL_30]] fastmath<contract> : f80
+!CHECK-KIND10:             %[[VAL_32:.*]] = fir.if %[[VAL_31]] -> (f80) {
+!CHECK-KIND10:               %[[VAL_33:.*]] = arith.bitcast %[[VAL_15]] : i80 to f80
+!CHECK-KIND10:               %[[VAL_34:.*]] = arith.constant -604462909807314587353087 : i80
+!CHECK-KIND10:               %[[VAL_35:.*]] = arith.bitcast %[[VAL_34]] : i80 to f80
+!CHECK-KIND10:               %[[VAL_36:.*]] = arith.select %[[VAL_16]], %[[VAL_33]], %[[VAL_35]] : f80
+!CHECK-KIND10:               fir.result %[[VAL_36]] : f80
+!CHECK-KIND10:             } else {
+!CHECK-KIND10:               %[[VAL_37:.*]] = arith.constant 63 : i32
+!CHECK-KIND10:               %[[VAL_38:.*]] = fir.call @_FortranAMapException(%[[VAL_37]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_39:.*]] = fir.call @fetestexcept(%[[VAL_38]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_40:.*]] = fir.call @fedisableexcept(%[[VAL_38]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_41:.*]] = fir.call @_FortranANearest10(%[[VAL_13]], %[[VAL_16]]) fastmath<contract> : (f80, i1) -> f80
+!CHECK-KIND10:               %[[VAL_42:.*]] = fir.call @feclearexcept(%[[VAL_38]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_43:.*]] = fir.call @feraiseexcept(%[[VAL_39]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               %[[VAL_44:.*]] = fir.call @feenableexcept(%[[VAL_40]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND10:               fir.result %[[VAL_41]] : f80
+!CHECK-KIND10:             }
+!CHECK-KIND10:             fir.result %[[VAL_32]] : f80
+!CHECK-KIND10:           }
+!CHECK-KIND10:           hlfir.assign %[[VAL_25]] to %[[VAL_11]]#0 : f80, !fir.ref<f80>
+!CHECK-KIND10:           return
+!CHECK-KIND10:         }
+
+subroutine test6(r16, x16)
+  real(kind16) :: r16, x16
+  r16 = ieee_next_down(x16)
+end subroutine
+!CHECK-KIND16-LABEL:   func.func @_QMieee_next_testsPtest6(
+!CHECK-KIND16:           %[[VAL_11:.*]]:2 = hlfir.declare {{.*}}r16"
+!CHECK-KIND16:           %[[VAL_12:.*]]:2 = hlfir.declare {{.*}}x16"
+!CHECK-KIND16:           %[[VAL_13:.*]] = fir.load %[[VAL_12]]#0 : !fir.ref<f128>
+!CHECK-KIND16:           %[[VAL_14:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 3 : i32}> : (f128) -> i1
+!CHECK-KIND16:           %[[VAL_15:.*]] = arith.constant 1 : i128
+!CHECK-KIND16:           %[[VAL_16:.*]] = arith.constant false
+!CHECK-KIND16:           %[[VAL_17:.*]] = arith.bitcast %[[VAL_13]] : f128 to i128
+!CHECK-KIND16:           %[[VAL_18:.*]] = arith.constant 127 : i128
+!CHECK-KIND16:           %[[VAL_19:.*]] = arith.shrui %[[VAL_17]], %[[VAL_18]] : i128
+!CHECK-KIND16:           %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (i128) -> i1
+!CHECK-KIND16:           %[[VAL_21:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_20]] : i1
+!CHECK-KIND16:           %[[VAL_22:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 516 : i32}> : (f128) -> i1
+!CHECK-KIND16:           %[[VAL_23:.*]] = arith.andi %[[VAL_22]], %[[VAL_21]] : i1
+!CHECK-KIND16:           %[[VAL_24:.*]] = arith.ori %[[VAL_14]], %[[VAL_23]] : i1
+!CHECK-KIND16:           %[[VAL_25:.*]] = fir.if %[[VAL_24]] -> (f128) {
+!CHECK-KIND16:             %[[VAL_26:.*]] = "llvm.intr.is.fpclass"(%[[VAL_13]]) <{bit = 1 : i32}> : (f128) -> i1
+!CHECK-KIND16:             fir.if %[[VAL_26]] {
+!CHECK-KIND16:               %[[VAL_27:.*]] = arith.constant 1 : i32
+!CHECK-KIND16:               %[[VAL_28:.*]] = fir.call @_FortranAMapException(%[[VAL_27]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND16:               %[[VAL_29:.*]] = fir.call @feraiseexcept(%[[VAL_28]]) fastmath<contract> : (i32) -> i32
+!CHECK-KIND16:             }
+!CHECK-KIND16:             fir.result %[[VAL_13]] : f128
+!CHECK-KIND16:           } else {
+!CHECK-KIND16:             %[[VAL_30:.*]] = arith.constant 0.000000e+00 : f128
+!CHECK-KIND16:             %[[VAL_31:.*]] = arith.cmpf oeq, %[[VAL_13]], %[[VAL_30]] fastmath<contract> : f128
+!CHECK-KIND16:             %[[VAL_32:.*]] = fir.if %[[VAL_31]] -> (f128) {
+!CHECK-KIND16:               %[[VAL_33:.*]] = arith.bitcast %[[VAL_15]] : i128 to f128
+!CHECK-KIND16:               %[[VAL_34:.*]] = arith.constant -170141183460469231731687303715884105727 : i128
+!CHECK-KIND16:               %[[VAL_35:.*]] = arith.bitcast %[[VAL_34]] : i128 to f128
+!CHECK-KIND16:               %[[VAL_36:.*]] = arith.select %[[VAL_16]], %[[VAL_33]], %[[VAL_35]] : f128
+!CHECK-KIND16:               fir.result %[[VAL_36]] : f128
+!CHECK-KIND16:             } else {
+!CHECK-KIND16:               %[[VAL_37:.*]] = arith.bitcast %[[VAL_13]] : f128 to i128
+!CHECK-KIND16-DAG:           %[[VAL_38:.*]] = arith.addi %[[VAL_37]], %[[VAL_15]] : i128
+!CHECK-KIND16-DAG:           %[[VAL_39:.*]] = arith.subi %[[VAL_37]], %[[VAL_15]] : i128
+!CHECK-KIND16:               %[[VAL_40:.*]] = arith.select %[[VAL_21]], %[[VAL_38]], %[[VAL_39]] : i128
+!CHECK-KIND16:               %[[VAL_41:.*]] = arith.bitcast %[[VAL_40]] : i128 to f128
+!CHECK-KIND16:               fir.result %[[VAL_41]] : f128
+!CHECK-KIND16:             }
+!CHECK-KIND16:             fir.result %[[VAL_32]] : f128
+!CHECK-KIND16:           }
+!CHECK-KIND16:           hlfir.assign %[[VAL_25]] to %[[VAL_11]]#0 : f128, !fir.ref<f128>
+!CHECK-KIND16:           return
+!CHECK-KIND16:         }
+end module
+
+! Expected end-to-end output when both kind10 and kind16 enabled (not part of lit
+! test, only provided for debug help):
+!
+! after:  FC00 -> FBFF = -.655E+5
+! up:     FF7F -> FF7E = -.337E+39
+! down:   80000000 -> 80000001 = -.1E-44
+! after:  0000000000000000 -> 8000000000000001 = -.5E-323
+! up:     7FFEFFFFFFFFFFFFFFFF -> 7FFF8000000000000000 = Inf
+! down:   7FFF0000000000000000000000000000 -> 7FFEFFFFFFFFFFFFFFFFFFFFFFFFFFFF = .1189731495357231765085759326628007E+4933
+program p
+  use ieee_next_tests
   real(2)  ::  r2,  x2
   real(3)  ::  r3,  x3 = -huge(x3)
   real(4)  ::  r4,  x4 = -0.
@@ -40,245 +379,16 @@ program p
 
   x2  = ieee_value(x2, ieee_negative_inf)
   x16 = ieee_value(x2, ieee_positive_inf)
-
-  ! CHECK:     %[[V_45:[0-9]+]] = fir.load %[[V_21]] : !fir.ref<f16>
-  ! CHECK:     %[[V_46:[0-9]+]] = fir.load %[[V_17]] : !fir.ref<f80>
-  ! CHECK-DAG: %[[V_47:[0-9]+]] = fir.coordinate_of %{{.*}}, %c2{{.*}} : (!fir.ref<!fir.array<12xi16>>, i8) -> !fir.ref<i16>
-  ! CHECK-DAG: %[[V_48:[0-9]+]] = fir.load %[[V_47]] : !fir.ref<i16>
-  ! CHECK-DAG: %[[V_49:[0-9]+]] = arith.bitcast %[[V_48]] : i16 to f16
-  ! CHECK-DAG: %[[V_50:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_46]]) <{bit = 3 : i32}> : (f80) -> i1
-  ! CHECK:     %[[V_51:[0-9]+]] = arith.select %[[V_50]], %[[V_49]], %[[V_45]] : f16
-  ! CHECK:     %[[V_52:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_51]]) <{bit = 3 : i32}> : (f16) -> i1
-  ! CHECK:     %[[V_53:[0-9]+]] = fir.convert %[[V_51]] : (f16) -> f80
-  ! CHECK:     %[[V_54:[0-9]+]] = arith.cmpf oeq, %[[V_53]], %[[V_46]] fastmath<contract> : f80
-  ! CHECK:     %[[V_55:[0-9]+]] = arith.ori %[[V_52]], %[[V_54]] : i1
-  ! CHECK:     %[[V_56:[0-9]+]] = arith.cmpf olt, %[[V_53]], %[[V_46]] fastmath<contract> : f80
-  ! CHECK:     %[[V_57:[0-9]+]] = arith.bitcast %[[V_45]] : f16 to i16
-  ! CHECK:     %[[V_58:[0-9]+]] = arith.shrui %[[V_57]], %c15{{.*}} : i16
-  ! CHECK:     %[[V_59:[0-9]+]] = fir.convert %[[V_58]] : (i16) -> i1
-  ! CHECK:     %[[V_60:[0-9]+]] = arith.cmpi ne, %[[V_56]], %[[V_59]] : i1
-  ! CHECK:     %[[V_61:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_51]]) <{bit = 516 : i32}> : (f16) -> i1
-  ! CHECK:     %[[V_62:[0-9]+]] = arith.andi %[[V_61]], %[[V_60]] : i1
-  ! CHECK:     %[[V_63:[0-9]+]] = arith.ori %[[V_55]], %[[V_62]] : i1
-  ! CHECK:     %[[V_64:[0-9]+]] = fir.if %[[V_63]] -> (f16) {
-  ! CHECK:       fir.result %[[V_51]] : f16
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_51]], %cst{{[_0-9]*}} fastmath<contract> : f16
-  ! CHECK:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f16) {
-  ! CHECK:         %[[V_204:[0-9]+]] = arith.select %[[V_56]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f16
-  ! CHECK:         %[[V_205:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                             fir.call @feraiseexcept(%[[V_205]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         fir.result %[[V_204]] : f16
-  ! CHECK:       } else {
-  ! CHECK:         %[[V_204:[0-9]+]] = arith.bitcast %[[V_51]] : f16 to i16
-  ! CHECK-DAG:     %[[V_205:[0-9]+]] = arith.subi %[[V_204]], %c1{{.*}} : i16
-  ! CHECK-DAG:     %[[V_206:[0-9]+]] = arith.addi %[[V_204]], %c1{{.*}} : i16
-  ! CHECK:         %[[V_207:[0-9]+]] = arith.select %[[V_60]], %[[V_206]], %[[V_205]] : i16
-  ! CHECK:         %[[V_208:[0-9]+]] = arith.bitcast %[[V_207]] : i16 to f16
-  ! CHECK:         %[[V_209:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_208]]) <{bit = 516 : i32}> : (f16) -> i1
-  ! CHECK:         fir.if %[[V_209]] {
-  ! CHECK:           %[[V_211:[0-9]+]] = fir.call @_FortranAMapException(%c40{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                               fir.call @feraiseexcept(%[[V_211]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         %[[V_210:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_208]]) <{bit = 144 : i32}> : (f16) -> i1
-  ! CHECK:         fir.if %[[V_210]] {
-  ! CHECK:           %[[V_211:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                               fir.call @feraiseexcept(%[[V_211]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         fir.result %[[V_208]] : f16
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_203]] : f16
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_64]] to %[[V_9]] : !fir.ref<f16>
-  r2 = ieee_next_after(x2, x10)
+  call test1(r2, x2, x10)
   print "('after:  ', z4.4, ' -> ', z4.4, ' = ', g0)", x2, r2, r2
-
-  ! CHECK:     %[[V_81:[0-9]+]] = fir.load %[[V_23]] : !fir.ref<bf16>
-  ! CHECK:     %[[V_82:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_81]]) <{bit = 3 : i32}> : (bf16) -> i1
-  ! CHECK:     %[[V_83:[0-9]+]] = fir.convert %[[V_81]] : (bf16) -> f32
-  ! CHECK:     %[[V_84:[0-9]+]] = arith.bitcast %[[V_83]] : f32 to i32
-  ! CHECK:     %[[V_85:[0-9]+]] = arith.shrui %[[V_84]], %c31{{.*}} : i32
-  ! CHECK:     %[[V_86:[0-9]+]] = fir.convert %[[V_85]] : (i32) -> i1
-  ! CHECK:     %[[V_87:[0-9]+]] = arith.cmpi ne, %[[V_86]], %true{{[_0-9]*}} : i1
-  ! CHECK:     %[[V_88:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_81]]) <{bit = 516 : i32}> : (bf16) -> i1
-  ! CHECK:     %[[V_89:[0-9]+]] = arith.andi %[[V_88]], %[[V_87]] : i1
-  ! CHECK:     %[[V_90:[0-9]+]] = arith.ori %[[V_82]], %[[V_89]] : i1
-  ! CHECK:     %[[V_91:[0-9]+]] = fir.if %[[V_90]] -> (bf16) {
-  ! CHECK:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_81]]) <{bit = 1 : i32}> : (bf16) -> i1
-  ! CHECK:       fir.if %[[V_202]] {
-  ! CHECK:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_81]] : bf16
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_81]], %cst{{[_0-9]*}} fastmath<contract> : bf16
-  ! CHECK:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (bf16) {
-  ! CHECK:         fir.result %cst{{[_0-9]*}} : bf16
-  ! CHECK:       } else {
-  ! CHECK:         %[[V_204:[0-9]+]] = arith.bitcast %[[V_81]] : bf16 to i16
-  ! CHECK-DAG:     %[[V_205:[0-9]+]] = arith.subi %[[V_204]], %c1{{.*}} : i16
-  ! CHECK-DAG:     %[[V_206:[0-9]+]] = arith.addi %[[V_204]], %c1{{.*}} : i16
-  ! CHECK:         %[[V_207:[0-9]+]] = arith.select %[[V_87]], %[[V_206]], %[[V_205]] : i16
-  ! CHECK:         %[[V_208:[0-9]+]] = arith.bitcast %[[V_207]] : i16 to bf16
-  ! CHECK:         fir.result %[[V_208]] : bf16
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_203]] : bf16
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_91]] to %[[V_11]] : !fir.ref<bf16>
-  r3 = ieee_next_up(x3)
+  call test2(r3, x3)
   print "('up:     ', z4.4, ' -> ', z4.4, ' = ', g0)", x3, r3, r3
-
-  ! CHECK:     %[[V_104:[0-9]+]] = fir.load %[[V_25]] : !fir.ref<f32>
-  ! CHECK:     %[[V_105:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_104]]) <{bit = 3 : i32}> : (f32) -> i1
-  ! CHECK:     %[[V_106:[0-9]+]] = arith.bitcast %[[V_104]] : f32 to i32
-  ! CHECK:     %[[V_107:[0-9]+]] = arith.shrui %[[V_106]], %c31{{.*}} : i32
-  ! CHECK:     %[[V_108:[0-9]+]] = fir.convert %[[V_107]] : (i32) -> i1
-  ! CHECK:     %[[V_110:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_104]]) <{bit = 516 : i32}> : (f32) -> i1
-  ! CHECK:     %[[V_111:[0-9]+]] = arith.andi %[[V_110]], %[[V_108]] : i1
-  ! CHECK:     %[[V_112:[0-9]+]] = arith.ori %[[V_105]], %[[V_111]] : i1
-  ! CHECK:     %[[V_113:[0-9]+]] = fir.if %[[V_112]] -> (f32) {
-  ! CHECK:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_104]]) <{bit = 1 : i32}> : (f32) -> i1
-  ! CHECK:       fir.if %[[V_202]] {
-  ! CHECK:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_104]] : f32
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_104]], %cst{{[_0-9]*}} fastmath<contract> : f32
-  ! CHECK:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f32) {
-  ! CHECK:         fir.result %cst{{[_0-9]*}} : f32
-  ! CHECK:       } else {
-  ! CHECK-DAG:     %[[V_204:[0-9]+]] = arith.subi %[[V_106]], %c1{{.*}} : i32
-  ! CHECK-DAG:     %[[V_205:[0-9]+]] = arith.addi %[[V_106]], %c1{{.*}} : i32
-  ! CHECK:         %[[V_206:[0-9]+]] = arith.select %[[V_108]], %[[V_205]], %[[V_204]] : i32
-  ! CHECK:         %[[V_207:[0-9]+]] = arith.bitcast %[[V_206]] : i32 to f32
-  ! CHECK:         fir.result %[[V_207]] : f32
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_203]] : f32
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_113]] to %[[V_13]] : !fir.ref<f32>
-  r4 = ieee_next_down(x4)
+  call test3(r4, x4)
   print "('down:   ', z8.8, ' -> ', z8.8, ' = ', g0)", x4, r4, r4
-
-  ! CHECK:     %[[V_125:[0-9]+]] = fir.load %[[V_27]] : !fir.ref<f64>
-  ! CHECK:     %[[V_126:[0-9]+]] = fir.load %[[V_21]] : !fir.ref<f16>
-  ! CHECK-DAG: %[[V_127:[0-9]+]] = fir.address_of(@_FortranAIeeeValueTable_8) : !fir.ref<!fir.array<12xi64>>
-  ! CHECK-DAG: %[[V_128:[0-9]+]] = fir.coordinate_of %[[V_127]], %c2{{.*}} : (!fir.ref<!fir.array<12xi64>>, i8) -> !fir.ref<i64>
-  ! CHECK-DAG: %[[V_129:[0-9]+]] = fir.load %[[V_128]] : !fir.ref<i64>
-  ! CHECK-DAG: %[[V_130:[0-9]+]] = arith.bitcast %[[V_129]] : i64 to f64
-  ! CHECK-DAG: %[[V_131:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_126]]) <{bit = 3 : i32}> : (f16) -> i1
-  ! CHECK:     %[[V_132:[0-9]+]] = arith.select %[[V_131]], %[[V_130]], %[[V_125]] : f64
-  ! CHECK:     %[[V_133:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_132]]) <{bit = 3 : i32}> : (f64) -> i1
-  ! CHECK:     %[[V_134:[0-9]+]] = fir.convert %[[V_126]] : (f16) -> f64
-  ! CHECK:     %[[V_135:[0-9]+]] = arith.cmpf oeq, %[[V_132]], %[[V_134]] fastmath<contract> : f64
-  ! CHECK:     %[[V_136:[0-9]+]] = arith.ori %[[V_133]], %[[V_135]] : i1
-  ! CHECK:     %[[V_137:[0-9]+]] = arith.cmpf olt, %[[V_132]], %[[V_134]] fastmath<contract> : f64
-  ! CHECK:     %[[V_138:[0-9]+]] = arith.bitcast %[[V_125]] : f64 to i64
-  ! CHECK:     %[[V_139:[0-9]+]] = arith.shrui %[[V_138]], %c63{{.*}} : i64
-  ! CHECK:     %[[V_140:[0-9]+]] = fir.convert %[[V_139]] : (i64) -> i1
-  ! CHECK:     %[[V_141:[0-9]+]] = arith.cmpi ne, %[[V_137]], %[[V_140]] : i1
-  ! CHECK:     %[[V_142:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_132]]) <{bit = 516 : i32}> : (f64) -> i1
-  ! CHECK:     %[[V_143:[0-9]+]] = arith.andi %[[V_142]], %[[V_141]] : i1
-  ! CHECK:     %[[V_144:[0-9]+]] = arith.ori %[[V_136]], %[[V_143]] : i1
-  ! CHECK:     %[[V_145:[0-9]+]] = fir.if %[[V_144]] -> (f64) {
-  ! CHECK:       fir.result %[[V_132]] : f64
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_132]], %cst{{[_0-9]*}} fastmath<contract> : f64
-  ! CHECK:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f64) {
-  ! CHECK:         %[[V_204:[0-9]+]] = arith.select %[[V_137]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f64
-  ! CHECK:         %[[V_205:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                             fir.call @feraiseexcept(%[[V_205]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         fir.result %[[V_204]] : f64
-  ! CHECK:       } else {
-  ! CHECK:         %[[V_204:[0-9]+]] = arith.bitcast %[[V_132]] : f64 to i64
-  ! CHECK-DAG:     %[[V_205:[0-9]+]] = arith.subi %[[V_204]], %c1{{.*}} : i64
-  ! CHECK-DAG:     %[[V_206:[0-9]+]] = arith.addi %[[V_204]], %c1{{.*}} : i64
-  ! CHECK:         %[[V_207:[0-9]+]] = arith.select %[[V_141]], %[[V_206]], %[[V_205]] : i64
-  ! CHECK:         %[[V_208:[0-9]+]] = arith.bitcast %[[V_207]] : i64 to f64
-  ! CHECK:         %[[V_209:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_208]]) <{bit = 516 : i32}> : (f64) -> i1
-  ! CHECK:         fir.if %[[V_209]] {
-  ! CHECK:           %[[V_211:[0-9]+]] = fir.call @_FortranAMapException(%c40{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                               fir.call @feraiseexcept(%[[V_211]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         %[[V_210:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_208]]) <{bit = 144 : i32}> : (f64) -> i1
-  ! CHECK:         fir.if %[[V_210]] {
-  ! CHECK:           %[[V_211:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                               fir.call @feraiseexcept(%[[V_211]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         fir.result %[[V_208]] : f64
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_203]] : f64
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_145]] to %[[V_15]] : !fir.ref<f64>
-  r8 = ieee_next_after(x8, x2)
+  call test4(r8, x8, x2)
   print "('after:  ', z16.16, ' -> ', z16.16, ' = ', g0)", x8, r8, r8
-
-  ! CHECK-KIND10:     %[[V_158:[0-9]+]] = fir.load %[[V_17]] : !fir.ref<f80>
-  ! CHECK-KIND10:     %[[V_159:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 3 : i32}> : (f80) -> i1
-  ! CHECK-KIND10:     %[[V_160:[0-9]+]] = arith.bitcast %[[V_158]] : f80 to i80
-  ! CHECK-KIND10:     %[[V_161:[0-9]+]] = arith.shrui %[[V_160]], %c79{{.*}} : i80
-  ! CHECK-KIND10:     %[[V_162:[0-9]+]] = fir.convert %[[V_161]] : (i80) -> i1
-  ! CHECK-KIND10:     %[[V_163:[0-9]+]] = arith.cmpi ne, %[[V_162]], %true{{[_0-9]*}} : i1
-  ! CHECK-KIND10:     %[[V_164:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 516 : i32}> : (f80) -> i1
-  ! CHECK-KIND10:     %[[V_165:[0-9]+]] = arith.andi %[[V_164]], %[[V_163]] : i1
-  ! CHECK-KIND10:     %[[V_166:[0-9]+]] = arith.ori %[[V_159]], %[[V_165]] : i1
-  ! CHECK-KIND10:     %[[V_167:[0-9]+]] = fir.if %[[V_166]] -> (f80) {
-  ! CHECK-KIND10:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_158]]) <{bit = 1 : i32}> : (f80) -> i1
-  ! CHECK-KIND10:       fir.if %[[V_202]] {
-  ! CHECK-KIND10:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:       }
-  ! CHECK-KIND10:       fir.result %[[V_158]] : f80
-  ! CHECK-KIND10:     } else {
-  ! CHECK-KIND10:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_158]], %cst{{[_0-9]*}} fastmath<contract> : f80
-  ! CHECK-KIND10:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f80) {
-  ! CHECK-KIND10:         fir.result %cst{{[_0-9]*}} : f80
-  ! CHECK-KIND10:       } else {
-  ! CHECK-KIND10:         %[[V_204:[0-9]+]] = fir.call @_FortranAMapException(%c63{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:         %[[V_205:[0-9]+]] = fir.call @fetestexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:         %[[V_206:[0-9]+]] = fir.call @fedisableexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:         %[[V_207:[0-9]+]] = fir.call @_FortranANearest10(%[[V_158]], %true{{[_0-9]*}}) fastmath<contract> : (f80, i1) -> f80
-  ! CHECK-KIND10:         %[[V_208:[0-9]+]] = fir.call @feclearexcept(%[[V_204]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:         %[[V_209:[0-9]+]] = fir.call @feraiseexcept(%[[V_205]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:         %[[V_210:[0-9]+]] = fir.call @feenableexcept(%[[V_206]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND10:         fir.result %[[V_207]] : f80
-  ! CHECK-KIND10:       }
-  ! CHECK-KIND10:       fir.result %[[V_203]] : f80
-  ! CHECK-KIND10:     }
-  ! CHECK-KIND10:     fir.store %[[V_167]] to %[[V_5]] : !fir.ref<f80>
-  r10 = ieee_next_up(x10)
+  call test5(r10, x10)
   print "('up:     ', z20.20, ' -> ', z20.20, ' = ', g0)", x10, r10, r10
-
-  ! CHECK-KIND16:     %[[V_180:[0-9]+]] = fir.load %[[V_19]] : !fir.ref<f128>
-  ! CHECK-KIND16:     %[[V_181:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 3 : i32}> : (f128) -> i1
-  ! CHECK-KIND16:     %[[V_182:[0-9]+]] = arith.bitcast %[[V_180]] : f128 to i128
-  ! CHECK-KIND16:     %[[V_183:[0-9]+]] = arith.shrui %[[V_182]], %c127{{.*}} : i128
-  ! CHECK-KIND16:     %[[V_184:[0-9]+]] = fir.convert %[[V_183]] : (i128) -> i1
-  ! CHECK-KIND16:     %[[V_186:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 516 : i32}> : (f128) -> i1
-  ! CHECK-KIND16:     %[[V_187:[0-9]+]] = arith.andi %[[V_186]], %[[V_184]] : i1
-  ! CHECK-KIND16:     %[[V_188:[0-9]+]] = arith.ori %[[V_181]], %[[V_187]] : i1
-  ! CHECK-KIND16:     %[[V_189:[0-9]+]] = fir.if %[[V_188]] -> (f128) {
-  ! CHECK-KIND16:       %[[V_202:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_180]]) <{bit = 1 : i32}> : (f128) -> i1
-  ! CHECK-KIND16:       fir.if %[[V_202]] {
-  ! CHECK-KIND16:         %[[V_203:[0-9]+]] = fir.call @_FortranAMapException(%c1{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND16:                             fir.call @feraiseexcept(%[[V_203]]) fastmath<contract> : (i32) -> i32
-  ! CHECK-KIND16:       }
-  ! CHECK-KIND16:       fir.result %[[V_180]] : f128
-  ! CHECK-KIND16:     } else {
-  ! CHECK-KIND16:       %[[V_202:[0-9]+]] = arith.cmpf oeq, %[[V_180]], %cst{{[_0-9]*}} fastmath<contract> : f128
-  ! CHECK-KIND16:       %[[V_203:[0-9]+]] = fir.if %[[V_202]] -> (f128) {
-  ! CHECK-KIND16:         fir.result %cst{{[_0-9]*}} : f128
-  ! CHECK-KIND16:       } else {
-  ! CHECK-KIND16-DAG:     %[[V_204:[0-9]+]] = arith.subi %[[V_182]], %c1{{.*}} : i128
-  ! CHECK-KIND16-DAG:     %[[V_205:[0-9]+]] = arith.addi %[[V_182]], %c1{{.*}} : i128
-  ! CHECK-KIND16:         %[[V_206:[0-9]+]] = arith.select %[[V_184]], %[[V_205]], %[[V_204]] : i128
-  ! CHECK-KIND16:         %[[V_207:[0-9]+]] = arith.bitcast %[[V_206]] : i128 to f128
-  ! CHECK-KIND16:         fir.result %[[V_207]] : f128
-  ! CHECK-KIND16:       }
-  ! CHECK-KIND16:       fir.result %[[V_203]] : f128
-  ! CHECK-KIND16:     }
-  ! CHECK-KIND16:     fir.store %[[V_189]] to %[[V_7]] : !fir.ref<f128>
-
-  r16 = ieee_next_down(x16)
+  call test6(r16, x16)
   print "('down:   ', z32.32, ' -> ', z32.32, ' = ', g0)", x16, r16, r16
 end

--- a/flang/test/Lower/Intrinsics/isnan.f90
+++ b/flang/test/Lower/Intrinsics/isnan.f90
@@ -1,5 +1,4 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! RUN: flang -fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: isnan_f32
 subroutine isnan_f32(r)
@@ -35,36 +34,40 @@ subroutine ieee_is_nan_f64(r)
   ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine ieee_is_nan_f64
 
-! CHECK-LABEL: isnan_f80
+! CHECK-KIND10-LABEL: isnan_f80
 subroutine isnan_f80(r)
-  real(KIND=10) :: r
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(KIND=kind10) :: r
   i = isnan(r)
-  ! CHECK: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f80) -> i1
-  ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
+  ! CHECK-KIND10: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f80) -> i1
+  ! CHECK-KIND10: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine isnan_f80
 
-! CHECK-LABEL: ieee_is_nan_f80
+! CHECK-KIND10-LABEL: ieee_is_nan_f80
 subroutine ieee_is_nan_f80(r)
   use ieee_arithmetic
-  real(KIND=10) :: r
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(KIND=kind10) :: r
   i = ieee_is_nan(r)
-  ! CHECK: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f80) -> i1
-  ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
+  ! CHECK-KIND10: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f80) -> i1
+  ! CHECK-KIND10: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine ieee_is_nan_f80
 
-! CHECK-LABEL: isnan_f128
+! CHECK-KIND16-LABEL: isnan_f128
 subroutine isnan_f128(r)
-  real(KIND=16) :: r
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(KIND=kind16) :: r
   i = isnan(r)
-  ! CHECK: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f128) -> i1
-  ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
+  ! CHECK-KIND16: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f128) -> i1
+  ! CHECK-KIND16: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine isnan_f128
 
-! CHECK-LABEL: ieee_is_nan_f128
+! CHECK-KIND16-LABEL: ieee_is_nan_f128
 subroutine ieee_is_nan_f128(r)
   use ieee_arithmetic
-  real(KIND=16) :: r
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(KIND=kind16) :: r
   i = ieee_is_nan(r)
-  ! CHECK: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f128) -> i1
-  ! CHECK: fir.convert %[[l]] : (i1) -> !fir.logical<4>
+  ! CHECK-KIND16: %[[l:.*]] = "llvm.intr.is.fpclass"(%{{.*}}) <{bit = 3 : i32}> : (f128) -> i1
+  ! CHECK-KIND16: fir.convert %[[l]] : (i1) -> !fir.logical<4>
 end subroutine ieee_is_nan_f128

--- a/flang/test/Lower/Intrinsics/mod.f90
+++ b/flang/test/Lower/Intrinsics/mod.f90
@@ -1,54 +1,38 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: func @_QPmod_testr4(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f32>{{.*}}, %[[arg1:.*]]: !fir.ref<f32>{{.*}}, %[[arg2:.*]]: !fir.ref<f32>{{.*}}) {
 subroutine mod_testr4(r, a, p)
   real(4) :: r, a, p
-! CHECK: %[[V1:.*]] = fir.load %[[arg1]] : !fir.ref<f32>
-! CHECK: %[[V2:.*]] = fir.load %[[arg2]] : !fir.ref<f32>
-! CHECK: %[[FILE:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK: %[[LINE:.*]] = arith.constant {{[0-9]*}} : i32
+! CHECK: %[[A:.*]] = fir.declare{{.*}}a"
+! CHECK: %[[P:.*]] = fir.declare{{.*}}p"
+! CHECK: %[[A_LOAD:.*]] = fir.load %[[A]]
+! CHECK: %[[P_LOAD:.*]] = fir.load %[[P]]
+! CHECK: %[[FILE:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
 ! CHECK: %[[FILEARG:.*]] = fir.convert %[[FILE]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK: fir.call @_FortranAModReal4(%[[V1]], %[[V2]], %[[FILEARG]], %[[LINE]]) {{.*}}: (f32, f32, !fir.ref<i8>, i32) -> f32
+! CHECK: fir.call @_FortranAModReal4(%[[A_LOAD]], %[[P_LOAD]], %[[FILEARG]], %[[LINE]]) {{.*}}: (f32, f32, !fir.ref<i8>, i32) -> f32
   r = mod(a, p)
 end subroutine
 
 ! CHECK-LABEL: func @_QPmod_testr8(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f64>{{.*}}, %[[arg1:.*]]: !fir.ref<f64>{{.*}}, %[[arg2:.*]]: !fir.ref<f64>{{.*}}) {
 subroutine mod_testr8(r, a, p)
   real(8) :: r, a, p
-! CHECK: %[[V1:.*]] = fir.load %[[arg1]] : !fir.ref<f64>
-! CHECK: %[[V2:.*]] = fir.load %[[arg2]] : !fir.ref<f64>
-! CHECK: %[[FILE:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
-! CHECK: %[[LINE:.*]] = arith.constant {{[0-9]*}} : i32
-! CHECK: %[[FILEARG:.*]] = fir.convert %[[FILE]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK: fir.call @_FortranAModReal8(%[[V1]], %[[V2]], %[[FILEARG]], %[[LINE]]) {{.*}}: (f64, f64, !fir.ref<i8>, i32) -> f64
+! CHECK: fir.call @_FortranAModReal8(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f64, f64, !fir.ref<i8>, i32) -> f64
   r = mod(a, p)
 end subroutine
 
-! CHECK-LABEL: func @_QPmod_testr10(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f80>{{.*}}, %[[arg1:.*]]: !fir.ref<f80>{{.*}}, %[[arg2:.*]]: !fir.ref<f80>{{.*}}) {
+! CHECK-KIND10-LABEL: func @_QPmod_testr10(
 subroutine mod_testr10(r, a, p)
-  real(10) :: r, a, p
-! CHECK: %[[V1:.*]] = fir.load %[[arg1]] : !fir.ref<f80>
-! CHECK: %[[V2:.*]] = fir.load %[[arg2]] : !fir.ref<f80>
-! CHECK: %[[FILE:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
-! CHECK: %[[LINE:.*]] = arith.constant {{[0-9]*}} : i32
-! CHECK: %[[FILEARG:.*]] = fir.convert %[[FILE]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK: fir.call @_FortranAModReal10(%[[V1]], %[[V2]], %[[FILEARG]], %[[LINE]]) {{.*}}: (f80, f80, !fir.ref<i8>, i32) -> f80
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: r, a, p
+! CHECK-KIND10: fir.call @_FortranAModReal10(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f80, f80, !fir.ref<i8>, i32) -> f80
   r = mod(a, p)
 end subroutine
 
-! CHECK-LABEL: func @_QPmod_testr16(
-! CHECK-SAME: %[[arg0:.*]]: !fir.ref<f128>{{.*}}, %[[arg1:.*]]: !fir.ref<f128>{{.*}}, %[[arg2:.*]]: !fir.ref<f128>{{.*}}) {
+! CHECK-KIND16-LABEL: func @_QPmod_testr16(
 subroutine mod_testr16(r, a, p)
-  real(16) :: r, a, p
-! CHECK: %[[V1:.*]] = fir.load %[[arg1]] : !fir.ref<f128>
-! CHECK: %[[V2:.*]] = fir.load %[[arg2]] : !fir.ref<f128>
-! CHECK: %[[FILE:.*]] = fir.address_of(@{{.*}}) : !fir.ref<!fir.char<1,{{.*}}>>
-! CHECK: %[[LINE:.*]] = arith.constant {{[0-9]*}} : i32
-! CHECK: %[[FILEARG:.*]] = fir.convert %[[FILE]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK: fir.call @_FortranAModReal16(%[[V1]], %[[V2]], %[[FILEARG]], %[[LINE]]) {{.*}}: (f128, f128, !fir.ref<i8>, i32) -> f128
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind16) :: r, a, p
+! CHECK-KIND16: fir.call @_FortranAModReal16(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}}: (f128, f128, !fir.ref<i8>, i32) -> f128
   r = mod(a, p)
 end subroutine

--- a/flang/test/Lower/Intrinsics/nearest.f90
+++ b/flang/test/Lower/Intrinsics/nearest.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: c.func @_QPnearest_test1
   ! CHECK:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
@@ -240,168 +240,171 @@ subroutine nearest_test4(x, s)
   res = nearest(x, s)
 end
 
-! CHECK-LABEL: c.func @_QPnearest_test5
-  ! CHECK:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
-  ! CHECK:     %[[V_1:[0-9]+]] = fir.alloca f80 {bindc_name = "res", uniq_name = "_QFnearest_test5Eres"}
-  ! CHECK:     %[[V_2:[0-9]+]] = fir.declare %[[V_1]] {uniq_name = "_QFnearest_test5Eres"} : (!fir.ref<f80>) -> !fir.ref<f80>
-  ! CHECK:     %[[V_3:[0-9]+]] = fir.declare %arg1 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test5Es"} : (!fir.ref<f80>, !fir.dscope) -> !fir.ref<f80>
-  ! CHECK:     %[[V_4:[0-9]+]] = fir.declare %arg0 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test5Ex"} : (!fir.ref<f80>, !fir.dscope) -> !fir.ref<f80>
-  ! CHECK:     %[[V_5:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<f80>
-  ! CHECK:     %[[V_6:[0-9]+]] = fir.load %[[V_3]] : !fir.ref<f80>
-  ! CHECK:     %[[V_7:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 3 : i32}> : (f80) -> i1
-  ! CHECK:     %[[V_8:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_6]]) <{bit = 96 : i32}> : (f80) -> i1
-  ! CHECK:     fir.if %[[V_8]] {
-  ! CHECK:       fir.call @_FortranAReportFatalUserError
-  ! CHECK:     }
-  ! CHECK:     %[[V_9:[0-9]+]] = arith.bitcast %[[V_6]] : f80 to i80
-  ! CHECK:     %[[V_10:[0-9]+]] = arith.shrui %[[V_9]], %c79{{.*}} : i80
-  ! CHECK:     %[[V_11:[0-9]+]] = arith.cmpi ne, %[[V_10]], %c1{{.*}} : i80
-  ! CHECK:     %[[V_12:[0-9]+]] = arith.bitcast %[[V_5]] : f80 to i80
-  ! CHECK:     %[[V_13:[0-9]+]] = arith.shrui %[[V_12]], %c79{{.*}} : i80
-  ! CHECK:     %[[V_14:[0-9]+]] = fir.convert %[[V_13]] : (i80) -> i1
-  ! CHECK:     %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_11]], %[[V_14]] : i1
-  ! CHECK:     %[[V_16:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 516 : i32}> : (f80) -> i1
-  ! CHECK:     %[[V_17:[0-9]+]] = arith.andi %[[V_16]], %[[V_15]] : i1
-  ! CHECK:     %[[V_18:[0-9]+]] = arith.ori %[[V_7]], %[[V_17]] : i1
-  ! CHECK:     %[[V_19:[0-9]+]] = fir.if %[[V_18]] -> (f80) {
-  ! CHECK:       fir.result %[[V_5]] : f80
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_20:[0-9]+]] = arith.cmpf oeq, %[[V_5]], %cst{{[_0-9]*}} fastmath<contract> : f80
-  ! CHECK:       %[[V_21:[0-9]+]] = fir.if %[[V_20]] -> (f80) {
-  ! CHECK:         %[[V_22:[0-9]+]] = arith.select %[[V_11]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f80
-  ! CHECK:         %[[V_23:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                            fir.call @feraiseexcept(%[[V_23]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         fir.result %[[V_22]] : f80
-  ! CHECK:       } else {
-  ! CHECK:         %[[V_22:[0-9]+]] = fir.call @_FortranANearest10(%[[V_5]], %[[V_11]]) fastmath<contract> : (f80, i1) -> f80
-  ! CHECK:         fir.result %[[V_22]] : f80
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_21]] : f80
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_19]] to %[[V_2]] : !fir.ref<f80>
-  ! CHECK:     return
-  ! CHECK:   }
+! CHECK-KIND10-LABEL: c.func @_QPnearest_test5
+  ! CHECK-KIND10:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
+  ! CHECK-KIND10:     %[[V_1:[0-9]+]] = fir.alloca f80 {bindc_name = "res", uniq_name = "_QFnearest_test5Eres"}
+  ! CHECK-KIND10:     %[[V_2:[0-9]+]] = fir.declare %[[V_1]] {uniq_name = "_QFnearest_test5Eres"} : (!fir.ref<f80>) -> !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_3:[0-9]+]] = fir.declare %arg1 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test5Es"} : (!fir.ref<f80>, !fir.dscope) -> !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_4:[0-9]+]] = fir.declare %arg0 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test5Ex"} : (!fir.ref<f80>, !fir.dscope) -> !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_5:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_6:[0-9]+]] = fir.load %[[V_3]] : !fir.ref<f80>
+  ! CHECK-KIND10:     %[[V_7:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 3 : i32}> : (f80) -> i1
+  ! CHECK-KIND10:     %[[V_8:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_6]]) <{bit = 96 : i32}> : (f80) -> i1
+  ! CHECK-KIND10:     fir.if %[[V_8]] {
+  ! CHECK-KIND10:       fir.call @_FortranAReportFatalUserError
+  ! CHECK-KIND10:     }
+  ! CHECK-KIND10:     %[[V_9:[0-9]+]] = arith.bitcast %[[V_6]] : f80 to i80
+  ! CHECK-KIND10:     %[[V_10:[0-9]+]] = arith.shrui %[[V_9]], %c79{{.*}} : i80
+  ! CHECK-KIND10:     %[[V_11:[0-9]+]] = arith.cmpi ne, %[[V_10]], %c1{{.*}} : i80
+  ! CHECK-KIND10:     %[[V_12:[0-9]+]] = arith.bitcast %[[V_5]] : f80 to i80
+  ! CHECK-KIND10:     %[[V_13:[0-9]+]] = arith.shrui %[[V_12]], %c79{{.*}} : i80
+  ! CHECK-KIND10:     %[[V_14:[0-9]+]] = fir.convert %[[V_13]] : (i80) -> i1
+  ! CHECK-KIND10:     %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_11]], %[[V_14]] : i1
+  ! CHECK-KIND10:     %[[V_16:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 516 : i32}> : (f80) -> i1
+  ! CHECK-KIND10:     %[[V_17:[0-9]+]] = arith.andi %[[V_16]], %[[V_15]] : i1
+  ! CHECK-KIND10:     %[[V_18:[0-9]+]] = arith.ori %[[V_7]], %[[V_17]] : i1
+  ! CHECK-KIND10:     %[[V_19:[0-9]+]] = fir.if %[[V_18]] -> (f80) {
+  ! CHECK-KIND10:       fir.result %[[V_5]] : f80
+  ! CHECK-KIND10:     } else {
+  ! CHECK-KIND10:       %[[V_20:[0-9]+]] = arith.cmpf oeq, %[[V_5]], %cst{{[_0-9]*}} fastmath<contract> : f80
+  ! CHECK-KIND10:       %[[V_21:[0-9]+]] = fir.if %[[V_20]] -> (f80) {
+  ! CHECK-KIND10:         %[[V_22:[0-9]+]] = arith.select %[[V_11]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f80
+  ! CHECK-KIND10:         %[[V_23:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:                            fir.call @feraiseexcept(%[[V_23]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND10:         fir.result %[[V_22]] : f80
+  ! CHECK-KIND10:       } else {
+  ! CHECK-KIND10:         %[[V_22:[0-9]+]] = fir.call @_FortranANearest10(%[[V_5]], %[[V_11]]) fastmath<contract> : (f80, i1) -> f80
+  ! CHECK-KIND10:         fir.result %[[V_22]] : f80
+  ! CHECK-KIND10:       }
+  ! CHECK-KIND10:       fir.result %[[V_21]] : f80
+  ! CHECK-KIND10:     }
+  ! CHECK-KIND10:     fir.store %[[V_19]] to %[[V_2]] : !fir.ref<f80>
+  ! CHECK-KIND10:     return
+  ! CHECK-KIND10:   }
 subroutine nearest_test5(x, s)
-  real(kind=10) :: x, s, res
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind=kind10) :: x, s, res
   res = nearest(x, s)
 end
 
-! CHECK-LABEL: c.func @_QPnearest_test6
-  ! CHECK:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
-  ! CHECK:     %[[V_1:[0-9]+]] = fir.alloca f128 {bindc_name = "res", uniq_name = "_QFnearest_test6Eres"}
-  ! CHECK:     %[[V_2:[0-9]+]] = fir.declare %[[V_1]] {uniq_name = "_QFnearest_test6Eres"} : (!fir.ref<f128>) -> !fir.ref<f128>
-  ! CHECK:     %[[V_3:[0-9]+]] = fir.declare %arg1 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test6Es"} : (!fir.ref<f128>, !fir.dscope) -> !fir.ref<f128>
-  ! CHECK:     %[[V_4:[0-9]+]] = fir.declare %arg0 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test6Ex"} : (!fir.ref<f128>, !fir.dscope) -> !fir.ref<f128>
-  ! CHECK:     %[[V_5:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<f128>
-  ! CHECK:     %[[V_6:[0-9]+]] = fir.load %[[V_3]] : !fir.ref<f128>
-  ! CHECK:     %[[V_7:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 3 : i32}> : (f128) -> i1
-  ! CHECK:     %[[V_8:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_6]]) <{bit = 96 : i32}> : (f128) -> i1
-  ! CHECK:     fir.if %[[V_8]] {
-  ! CHECK:       fir.call @_FortranAReportFatalUserError
-  ! CHECK:     }
-  ! CHECK:     %[[V_9:[0-9]+]] = arith.bitcast %[[V_6]] : f128 to i128
-  ! CHECK:     %[[V_10:[0-9]+]] = arith.shrui %[[V_9]], %c127{{.*}} : i128
-  ! CHECK:     %[[V_11:[0-9]+]] = arith.cmpi ne, %[[V_10]], %c1{{.*}} : i128
-  ! CHECK:     %[[V_12:[0-9]+]] = arith.bitcast %[[V_5]] : f128 to i128
-  ! CHECK:     %[[V_13:[0-9]+]] = arith.shrui %[[V_12]], %c127{{.*}} : i128
-  ! CHECK:     %[[V_14:[0-9]+]] = fir.convert %[[V_13]] : (i128) -> i1
-  ! CHECK:     %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_11]], %[[V_14]] : i1
-  ! CHECK:     %[[V_16:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 516 : i32}> : (f128) -> i1
-  ! CHECK:     %[[V_17:[0-9]+]] = arith.andi %[[V_16]], %[[V_15]] : i1
-  ! CHECK:     %[[V_18:[0-9]+]] = arith.ori %[[V_7]], %[[V_17]] : i1
-  ! CHECK:     %[[V_19:[0-9]+]] = fir.if %[[V_18]] -> (f128) {
-  ! CHECK:       fir.result %[[V_5]] : f128
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_20:[0-9]+]] = arith.cmpf oeq, %[[V_5]], %cst{{[_0-9]*}} fastmath<contract> : f128
-  ! CHECK:       %[[V_21:[0-9]+]] = fir.if %[[V_20]] -> (f128) {
-  ! CHECK:         %[[V_22:[0-9]+]] = arith.select %[[V_11]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f128
-  ! CHECK:         %[[V_23:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                            fir.call @feraiseexcept(%[[V_23]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         fir.result %[[V_22]] : f128
-  ! CHECK:       } else {
-  ! CHECK-DAG:     %[[V_22:[0-9]+]] = arith.subi %[[V_12]], %c1{{.*}} : i128
-  ! CHECK-DAG:     %[[V_23:[0-9]+]] = arith.addi %[[V_12]], %c1{{.*}} : i128
-  ! CHECK:         %[[V_24:[0-9]+]] = arith.select %[[V_15]], %[[V_23]], %[[V_22]] : i128
-  ! CHECK:         %[[V_25:[0-9]+]] = arith.bitcast %[[V_24]] : i128 to f128
-  ! CHECK:         %[[V_26:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_25]]) <{bit = 516 : i32}> : (f128) -> i1
-  ! CHECK:         fir.if %[[V_26]] {
-  ! CHECK:           %[[V_28:[0-9]+]] = fir.call @_FortranAMapException(%c40{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                              fir.call @feraiseexcept(%[[V_28]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         %[[V_27:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_25]]) <{bit = 144 : i32}> : (f128) -> i1
-  ! CHECK:         fir.if %[[V_27]] {
-  ! CHECK:           %[[V_28:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                              fir.call @feraiseexcept(%[[V_28]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         fir.result %[[V_25]] : f128
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_21]] : f128
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_19]] to %[[V_2]] : !fir.ref<f128>
-  ! CHECK:     return
-  ! CHECK:   }
+! CHECK-KIND16-LABEL: c.func @_QPnearest_test6
+  ! CHECK-KIND16:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
+  ! CHECK-KIND16:     %[[V_1:[0-9]+]] = fir.alloca f128 {bindc_name = "res", uniq_name = "_QFnearest_test6Eres"}
+  ! CHECK-KIND16:     %[[V_2:[0-9]+]] = fir.declare %[[V_1]] {uniq_name = "_QFnearest_test6Eres"} : (!fir.ref<f128>) -> !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_3:[0-9]+]] = fir.declare %arg1 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test6Es"} : (!fir.ref<f128>, !fir.dscope) -> !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_4:[0-9]+]] = fir.declare %arg0 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test6Ex"} : (!fir.ref<f128>, !fir.dscope) -> !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_5:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_6:[0-9]+]] = fir.load %[[V_3]] : !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_7:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 3 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     %[[V_8:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_6]]) <{bit = 96 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     fir.if %[[V_8]] {
+  ! CHECK-KIND16:       fir.call @_FortranAReportFatalUserError
+  ! CHECK-KIND16:     }
+  ! CHECK-KIND16:     %[[V_9:[0-9]+]] = arith.bitcast %[[V_6]] : f128 to i128
+  ! CHECK-KIND16:     %[[V_10:[0-9]+]] = arith.shrui %[[V_9]], %c127{{.*}} : i128
+  ! CHECK-KIND16:     %[[V_11:[0-9]+]] = arith.cmpi ne, %[[V_10]], %c1{{.*}} : i128
+  ! CHECK-KIND16:     %[[V_12:[0-9]+]] = arith.bitcast %[[V_5]] : f128 to i128
+  ! CHECK-KIND16:     %[[V_13:[0-9]+]] = arith.shrui %[[V_12]], %c127{{.*}} : i128
+  ! CHECK-KIND16:     %[[V_14:[0-9]+]] = fir.convert %[[V_13]] : (i128) -> i1
+  ! CHECK-KIND16:     %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_11]], %[[V_14]] : i1
+  ! CHECK-KIND16:     %[[V_16:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 516 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     %[[V_17:[0-9]+]] = arith.andi %[[V_16]], %[[V_15]] : i1
+  ! CHECK-KIND16:     %[[V_18:[0-9]+]] = arith.ori %[[V_7]], %[[V_17]] : i1
+  ! CHECK-KIND16:     %[[V_19:[0-9]+]] = fir.if %[[V_18]] -> (f128) {
+  ! CHECK-KIND16:       fir.result %[[V_5]] : f128
+  ! CHECK-KIND16:     } else {
+  ! CHECK-KIND16:       %[[V_20:[0-9]+]] = arith.cmpf oeq, %[[V_5]], %cst{{[_0-9]*}} fastmath<contract> : f128
+  ! CHECK-KIND16:       %[[V_21:[0-9]+]] = fir.if %[[V_20]] -> (f128) {
+  ! CHECK-KIND16:         %[[V_22:[0-9]+]] = arith.select %[[V_11]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f128
+  ! CHECK-KIND16:         %[[V_23:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                            fir.call @feraiseexcept(%[[V_23]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:         fir.result %[[V_22]] : f128
+  ! CHECK-KIND16:       } else {
+  ! CHECK-KIND16-DAG:     %[[V_22:[0-9]+]] = arith.subi %[[V_12]], %c1{{.*}} : i128
+  ! CHECK-KIND16-DAG:     %[[V_23:[0-9]+]] = arith.addi %[[V_12]], %c1{{.*}} : i128
+  ! CHECK-KIND16:         %[[V_24:[0-9]+]] = arith.select %[[V_15]], %[[V_23]], %[[V_22]] : i128
+  ! CHECK-KIND16:         %[[V_25:[0-9]+]] = arith.bitcast %[[V_24]] : i128 to f128
+  ! CHECK-KIND16:         %[[V_26:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_25]]) <{bit = 516 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:         fir.if %[[V_26]] {
+  ! CHECK-KIND16:           %[[V_28:[0-9]+]] = fir.call @_FortranAMapException(%c40{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                              fir.call @feraiseexcept(%[[V_28]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:         }
+  ! CHECK-KIND16:         %[[V_27:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_25]]) <{bit = 144 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:         fir.if %[[V_27]] {
+  ! CHECK-KIND16:           %[[V_28:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                              fir.call @feraiseexcept(%[[V_28]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:         }
+  ! CHECK-KIND16:         fir.result %[[V_25]] : f128
+  ! CHECK-KIND16:       }
+  ! CHECK-KIND16:       fir.result %[[V_21]] : f128
+  ! CHECK-KIND16:     }
+  ! CHECK-KIND16:     fir.store %[[V_19]] to %[[V_2]] : !fir.ref<f128>
+  ! CHECK-KIND16:     return
+  ! CHECK-KIND16:   }
 subroutine nearest_test6(x, s)
-  real(kind=16) :: x, s, res
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind=kind16) :: x, s, res
   res = nearest(x, s)
 end
 
-! CHECK-LABEL: c.func @_QPnearest_test7
-  ! CHECK:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
-  ! CHECK:     %[[V_1:[0-9]+]] = fir.alloca f128 {bindc_name = "res", uniq_name = "_QFnearest_test7Eres"}
-  ! CHECK:     %[[V_2:[0-9]+]] = fir.declare %[[V_1]] {uniq_name = "_QFnearest_test7Eres"} : (!fir.ref<f128>) -> !fir.ref<f128>
-  ! CHECK:     %[[V_3:[0-9]+]] = fir.declare %arg1 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test7Es"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
-  ! CHECK:     %[[V_4:[0-9]+]] = fir.declare %arg0 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test7Ex"} : (!fir.ref<f128>, !fir.dscope) -> !fir.ref<f128>
-  ! CHECK:     %[[V_5:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<f128>
-  ! CHECK:     %[[V_6:[0-9]+]] = fir.load %[[V_3]] : !fir.ref<f32>
-  ! CHECK:     %[[V_7:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 3 : i32}> : (f128) -> i1
-  ! CHECK:     %[[V_8:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_6]]) <{bit = 96 : i32}> : (f32) -> i1
-  ! CHECK:     fir.if %[[V_8]] {
-  ! CHECK:       fir.call @_FortranAReportFatalUserError
-  ! CHECK:     }
-  ! CHECK:     %[[V_9:[0-9]+]] = arith.bitcast %[[V_6]] : f32 to i32
-  ! CHECK:     %[[V_10:[0-9]+]] = arith.shrui %[[V_9]], %c31{{.*}} : i32
-  ! CHECK:     %[[V_11:[0-9]+]] = fir.convert %[[V_10]] : (i32) -> i128
-  ! CHECK:     %[[V_12:[0-9]+]] = arith.cmpi ne, %[[V_11]], %c1{{.*}} : i128
-  ! CHECK:     %[[V_13:[0-9]+]] = arith.bitcast %[[V_5]] : f128 to i128
-  ! CHECK:     %[[V_14:[0-9]+]] = arith.shrui %[[V_13]], %c127{{.*}} : i128
-  ! CHECK:     %[[V_15:[0-9]+]] = fir.convert %[[V_14]] : (i128) -> i1
-  ! CHECK:     %[[V_16:[0-9]+]] = arith.cmpi ne, %[[V_12]], %[[V_15]] : i1
-  ! CHECK:     %[[V_17:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 516 : i32}> : (f128) -> i1
-  ! CHECK:     %[[V_18:[0-9]+]] = arith.andi %[[V_17]], %[[V_16]] : i1
-  ! CHECK:     %[[V_19:[0-9]+]] = arith.ori %[[V_7]], %[[V_18]] : i1
-  ! CHECK:     %[[V_20:[0-9]+]] = fir.if %[[V_19]] -> (f128) {
-  ! CHECK:       fir.result %[[V_5]] : f128
-  ! CHECK:     } else {
-  ! CHECK:       %[[V_21:[0-9]+]] = arith.cmpf oeq, %[[V_5]], %cst{{[_0-9]*}} fastmath<contract> : f128
-  ! CHECK:       %[[V_22:[0-9]+]] = fir.if %[[V_21]] -> (f128) {
-  ! CHECK:         %[[V_23:[0-9]+]] = arith.select %[[V_12]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f128
-  ! CHECK:         %[[V_24:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                            fir.call @feraiseexcept(%[[V_24]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         fir.result %[[V_23]] : f128
-  ! CHECK:       } else {
-  ! CHECK-DAG:     %[[V_23:[0-9]+]] = arith.subi %[[V_13]], %c1{{.*}} : i128
-  ! CHECK-DAG:     %[[V_24:[0-9]+]] = arith.addi %[[V_13]], %c1{{.*}} : i128
-  ! CHECK:         %[[V_25:[0-9]+]] = arith.select %[[V_16]], %[[V_24]], %[[V_23]] : i128
-  ! CHECK:         %[[V_26:[0-9]+]] = arith.bitcast %[[V_25]] : i128 to f128
-  ! CHECK:         %[[V_27:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_26]]) <{bit = 516 : i32}> : (f128) -> i1
-  ! CHECK:         fir.if %[[V_27]] {
-  ! CHECK:           %[[V_29:[0-9]+]] = fir.call @_FortranAMapException(%c40{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                              fir.call @feraiseexcept(%[[V_29]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         %[[V_28:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_26]]) <{bit = 144 : i32}> : (f128) -> i1
-  ! CHECK:         fir.if %[[V_28]] {
-  ! CHECK:           %[[V_29:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
-  ! CHECK:                              fir.call @feraiseexcept(%[[V_29]]) fastmath<contract> : (i32) -> i32
-  ! CHECK:         }
-  ! CHECK:         fir.result %[[V_26]] : f128
-  ! CHECK:       }
-  ! CHECK:       fir.result %[[V_22]] : f128
-  ! CHECK:     }
-  ! CHECK:     fir.store %[[V_20]] to %[[V_2]] : !fir.ref<f128>
-  ! CHECK:     return
-  ! CHECK:   }
+! CHECK-KIND16-LABEL: c.func @_QPnearest_test7
+  ! CHECK-KIND16:     %[[V_0:[0-9]+]] = fir.dummy_scope : !fir.dscope
+  ! CHECK-KIND16:     %[[V_1:[0-9]+]] = fir.alloca f128 {bindc_name = "res", uniq_name = "_QFnearest_test7Eres"}
+  ! CHECK-KIND16:     %[[V_2:[0-9]+]] = fir.declare %[[V_1]] {uniq_name = "_QFnearest_test7Eres"} : (!fir.ref<f128>) -> !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_3:[0-9]+]] = fir.declare %arg1 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test7Es"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
+  ! CHECK-KIND16:     %[[V_4:[0-9]+]] = fir.declare %arg0 dummy_scope %[[V_0]] {uniq_name = "_QFnearest_test7Ex"} : (!fir.ref<f128>, !fir.dscope) -> !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_5:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<f128>
+  ! CHECK-KIND16:     %[[V_6:[0-9]+]] = fir.load %[[V_3]] : !fir.ref<f32>
+  ! CHECK-KIND16:     %[[V_7:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 3 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     %[[V_8:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_6]]) <{bit = 96 : i32}> : (f32) -> i1
+  ! CHECK-KIND16:     fir.if %[[V_8]] {
+  ! CHECK-KIND16:       fir.call @_FortranAReportFatalUserError
+  ! CHECK-KIND16:     }
+  ! CHECK-KIND16:     %[[V_9:[0-9]+]] = arith.bitcast %[[V_6]] : f32 to i32
+  ! CHECK-KIND16:     %[[V_10:[0-9]+]] = arith.shrui %[[V_9]], %c31{{.*}} : i32
+  ! CHECK-KIND16:     %[[V_11:[0-9]+]] = fir.convert %[[V_10]] : (i32) -> i128
+  ! CHECK-KIND16:     %[[V_12:[0-9]+]] = arith.cmpi ne, %[[V_11]], %c1{{.*}} : i128
+  ! CHECK-KIND16:     %[[V_13:[0-9]+]] = arith.bitcast %[[V_5]] : f128 to i128
+  ! CHECK-KIND16:     %[[V_14:[0-9]+]] = arith.shrui %[[V_13]], %c127{{.*}} : i128
+  ! CHECK-KIND16:     %[[V_15:[0-9]+]] = fir.convert %[[V_14]] : (i128) -> i1
+  ! CHECK-KIND16:     %[[V_16:[0-9]+]] = arith.cmpi ne, %[[V_12]], %[[V_15]] : i1
+  ! CHECK-KIND16:     %[[V_17:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_5]]) <{bit = 516 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:     %[[V_18:[0-9]+]] = arith.andi %[[V_17]], %[[V_16]] : i1
+  ! CHECK-KIND16:     %[[V_19:[0-9]+]] = arith.ori %[[V_7]], %[[V_18]] : i1
+  ! CHECK-KIND16:     %[[V_20:[0-9]+]] = fir.if %[[V_19]] -> (f128) {
+  ! CHECK-KIND16:       fir.result %[[V_5]] : f128
+  ! CHECK-KIND16:     } else {
+  ! CHECK-KIND16:       %[[V_21:[0-9]+]] = arith.cmpf oeq, %[[V_5]], %cst{{[_0-9]*}} fastmath<contract> : f128
+  ! CHECK-KIND16:       %[[V_22:[0-9]+]] = fir.if %[[V_21]] -> (f128) {
+  ! CHECK-KIND16:         %[[V_23:[0-9]+]] = arith.select %[[V_12]], %cst{{[_0-9]*}}, %cst{{[_0-9]*}} : f128
+  ! CHECK-KIND16:         %[[V_24:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                            fir.call @feraiseexcept(%[[V_24]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:         fir.result %[[V_23]] : f128
+  ! CHECK-KIND16:       } else {
+  ! CHECK-KIND16-DAG:     %[[V_23:[0-9]+]] = arith.subi %[[V_13]], %c1{{.*}} : i128
+  ! CHECK-KIND16-DAG:     %[[V_24:[0-9]+]] = arith.addi %[[V_13]], %c1{{.*}} : i128
+  ! CHECK-KIND16:         %[[V_25:[0-9]+]] = arith.select %[[V_16]], %[[V_24]], %[[V_23]] : i128
+  ! CHECK-KIND16:         %[[V_26:[0-9]+]] = arith.bitcast %[[V_25]] : i128 to f128
+  ! CHECK-KIND16:         %[[V_27:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_26]]) <{bit = 516 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:         fir.if %[[V_27]] {
+  ! CHECK-KIND16:           %[[V_29:[0-9]+]] = fir.call @_FortranAMapException(%c40{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                              fir.call @feraiseexcept(%[[V_29]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:         }
+  ! CHECK-KIND16:         %[[V_28:[0-9]+]] = "llvm.intr.is.fpclass"(%[[V_26]]) <{bit = 144 : i32}> : (f128) -> i1
+  ! CHECK-KIND16:         fir.if %[[V_28]] {
+  ! CHECK-KIND16:           %[[V_29:[0-9]+]] = fir.call @_FortranAMapException(%c48{{.*}}) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:                              fir.call @feraiseexcept(%[[V_29]]) fastmath<contract> : (i32) -> i32
+  ! CHECK-KIND16:         }
+  ! CHECK-KIND16:         fir.result %[[V_26]] : f128
+  ! CHECK-KIND16:       }
+  ! CHECK-KIND16:       fir.result %[[V_22]] : f128
+  ! CHECK-KIND16:     }
+  ! CHECK-KIND16:     fir.store %[[V_20]] to %[[V_2]] : !fir.ref<f128>
+  ! CHECK-KIND16:     return
+  ! CHECK-KIND16:   }
 subroutine nearest_test7(x, s)
-  real(kind=16) :: x, res
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind=kind16) :: x, res
   real :: s
   res = nearest(x, s)
 end

--- a/flang/test/Lower/Intrinsics/norm2.f90
+++ b/flang/test/Lower/Intrinsics/norm2.f90
@@ -1,94 +1,70 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
+! RUN: bbc -emit-fir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: func @_QPnorm2_test_4(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?xf32>>{{.*}}) -> f32
 real(4) function norm2_test_4(a)
   real(4) :: a(:)
-  ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+  ! CHECK:  %[[c0:.*]] = arith.constant 0 : index
+  ! CHECK: %[[a1:.*]] = fir.declare{{.*}}a"
+  ! CHECK: %[[a:.*]] = fir.rebox %[[a1]]{{.*}}
+  ! CHECK-DAG:  %[[arr:.*]] = fir.convert %[[a]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
   ! CHECK:  %[[dim:.*]] = fir.convert %[[c0]] : (index) -> i32
   norm2_test_4 = norm2(a)
   ! CHECK:  %{{.*}} = fir.call @_FortranANorm2_4(%[[arr]], %{{.*}}, %{{.*}}, %[[dim]]) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f32
 end function norm2_test_4
 
 ! CHECK-LABEL: func @_QPnorm2_test_8(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xf64>>{{.*}}) -> f64
 real(8) function norm2_test_8(a)
   real(8) :: a(:,:)
-  ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?x?xf64>>) -> !fir.box<none>
-  ! CHECK:  %[[dim:.*]] = fir.convert %[[c0]] : (index) -> i32
   norm2_test_8 = norm2(a)
-  ! CHECK:  %{{.*}} = fir.call @_FortranANorm2_8(%[[arr]], %{{.*}}, %{{.*}}, %[[dim]]) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f64
+  ! CHECK: fir.call @_FortranANorm2_8(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f64
 end function norm2_test_8
 
-! CHECK-LABEL: func @_QPnorm2_test_10(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x?xf80>>{{.*}}) -> f80
-real(10) function norm2_test_10(a)
-  real(10) :: a(:,:,:)
-  ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?x?x?xf80>>) -> !fir.box<none>
-  ! CHECK:  %[[dim:.*]] = fir.convert %[[c0]] : (index) -> i32
+! CHECK-KIND10-LABEL: func @_QPnorm2_test_10(
+function norm2_test_10(a)
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: a(:,:,:), norm2_test_10
   norm2_test_10 = norm2(a)
-  ! CHECK:  %{{.*}} = fir.call @_FortranANorm2_10(%[[arr]], %{{.*}}, %{{.*}}, %[[dim]]) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f80
+  ! CHECK-KIND10: fir.call @_FortranANorm2_10(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f80
 end function norm2_test_10
 
-! CHECK-LABEL: func @_QPnorm2_test_16(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x?xf128>>{{.*}}) -> f128
-real(16) function norm2_test_16(a)
-  real(16) :: a(:,:,:)
-  ! CHECK-DAG:  %[[c0:.*]] = arith.constant 0 : index
-  ! CHECK-DAG:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?x?x?xf128>>) -> !fir.box<none>
-  ! CHECK:  %[[dim:.*]] = fir.convert %[[c0]] : (index) -> i32
+! CHECK-KIND16-LABEL: func @_QPnorm2_test_16(
+function norm2_test_16(a)
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind16) :: a(:,:,:), norm2_test_16
   norm2_test_16 = norm2(a)
-  ! CHECK:  %{{.*}} = fir.call @_FortranANorm2_16(%[[arr]], %{{.*}}, %{{.*}}, %[[dim]]) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f128
+  ! CHECK-KIND16:  %{{.*}} = fir.call @_FortranANorm2_16(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (!fir.box<none>, !fir.ref<i8>, i32, i32) -> f128
 end function norm2_test_16
 
 ! CHECK-LABEL: func @_QPnorm2_test_dim_2(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?xf32>>{{.*}})
 subroutine norm2_test_dim_2(a,r)
   real :: a(:,:)
   real :: r(:)
   ! CHECK-DAG:  %[[dim:.*]] = arith.constant 1 : i32
+  ! CHECK-DAG: %[[a1:.*]] = fir.declare{{.*}}a"
+  ! CHECK-DAG: %[[a:.*]] = fir.rebox %[[a1]]{{.*}}
   ! CHECK-DAG:  %[[r:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>>
   ! CHECK-DAG:  %[[res:.*]] = fir.convert %[[r]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+  ! CHECK:  %[[arr:.*]] = fir.convert %[[a]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
   r = norm2(a,dim=1)
   ! CHECK:  fir.call @_FortranANorm2Dim(%[[res]], %[[arr]], %[[dim]], %{{.*}}, %{{.*}}) {{.*}} : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
-  ! CHECK:  %[[box:.*]] = fir.load %[[r]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-  ! CHECK-DAG:  %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
-  ! CHECK-DAG:  fir.freemem %[[addr]]
+  ! CHECK-DAG:  fir.freemem
 end subroutine norm2_test_dim_2
 
 ! CHECK-LABEL: func @_QPnorm2_test_dim_3(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x?xf32>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x?xf32>>{{.*}})
 subroutine norm2_test_dim_3(a,r)
   real :: a(:,:,:)
   real :: r(:,:)
   ! CHECK-DAG:  %[[dim:.*]] = arith.constant 3 : i32
-  ! CHECK-DAG:  %[[r:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf32>>>
-  ! CHECK-DAG:  %[[res:.*]] = fir.convert %[[r]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?x?x?xf32>>) -> !fir.box<none>
   r = norm2(a,dim=3)
-  ! CHECK:  fir.call @_FortranANorm2Dim(%[[res]], %[[arr]], %[[dim]], %{{.*}}, %{{.*}}) {{.*}} : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
-  ! CHECK:  %[[box:.*]] = fir.load %[[r]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf32>>>>
-  ! CHECK-DAG:  %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x?xf32>>>) -> !fir.heap<!fir.array<?x?xf32>>
-  ! CHECK-DAG:  fir.freemem %[[addr]]
+  ! CHECK:  fir.call @_FortranANorm2Dim(%{{.*}}, %{{.*}}, %[[dim]], %{{.*}}, %{{.*}}) {{.*}} : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
 end subroutine norm2_test_dim_3
 
 ! CHECK-LABEL: func @_QPnorm2_test_real16(
-! CHECK-SAME: %[[arg0:.*]]: !fir.box<!fir.array<?x?x?xf128>>{{.*}}, %[[arg1:.*]]: !fir.box<!fir.array<?x?xf128>>{{.*}})
 subroutine norm2_test_real16(a,r)
-  real(16) :: a(:,:,:)
-  real(16) :: r(:,:)
-  ! CHECK-DAG:  %[[dim:.*]] = arith.constant 3 : i32
-  ! CHECK-DAG:  %[[r:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x?xf128>>>
-  ! CHECK-DAG:  %[[res:.*]] = fir.convert %[[r]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf128>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK:  %[[arr:.*]] = fir.convert %[[arg0]] : (!fir.box<!fir.array<?x?x?xf128>>) -> !fir.box<none>
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind16) :: a(:,:,:)
+  real(kind16) :: r(:,:)
   r = norm2(a,dim=3)
-  ! CHECK:  fir.call @_FortranANorm2DimReal16(%[[res]], %[[arr]], %[[dim]], %{{.*}}, %{{.*}}) {{.*}} : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
-  ! CHECK:  %[[box:.*]] = fir.load %[[r]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?xf128>>>>
-  ! CHECK-DAG:  %[[addr:.*]] = fir.box_addr %[[box]] : (!fir.box<!fir.heap<!fir.array<?x?xf128>>>) -> !fir.heap<!fir.array<?x?xf128>>
-  ! CHECK-DAG:  fir.freemem %[[addr]]
+  ! CHECK-KIND16:  fir.call @_FortranANorm2DimReal16(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) {{.*}} : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, !fir.ref<i8>, i32) -> ()
+  ! CHECK-KIND16:  fir.freemem
 end subroutine norm2_test_real16

--- a/flang/test/Lower/Intrinsics/reduce.f90
+++ b/flang/test/Lower/Intrinsics/reduce.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 module reduce_mod
 
@@ -16,6 +16,10 @@ end type
       integer(1) :: red_int1_interface_value
     end function
   end interface
+
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  
 
 contains
 
@@ -270,48 +274,48 @@ end subroutine
 ! CHECK: fir.call @_FortranAReduceReal8Value
 
 pure function red_real10(a,b)
-  real(10), intent(in) :: a, b
-  real(10) :: red_real10
+  real(kind10), intent(in) :: a, b
+  real(kind10) :: red_real10
   red_real10 = a + b
 end function
 
 pure function red_real10_value(a,b)
-  real(10), value, intent(in) :: a, b
-  real(10) :: red_real10_value
+  real(kind10), value, intent(in) :: a, b
+  real(kind10) :: red_real10_value
   red_real10_value = a + b
 end function
 
 subroutine real10(a)
-  real(10), intent(in) :: a(:)
-  real(10) :: res
+  real(kind10), intent(in) :: a(:)
+  real(kind10) :: res
   res = reduce(a, red_real10)
   res = reduce(a, red_real10_value)
 end subroutine
 
-! CHECK: fir.call @_FortranAReduceReal10Ref
-! CHECK: fir.call @_FortranAReduceReal10Value
+! CHECK-KIND10: fir.call @_FortranAReduceReal10Ref
+! CHECK-KIND10: fir.call @_FortranAReduceReal10Value
 
 pure function red_real16(a,b)
-  real(16), intent(in) :: a, b
-  real(16) :: red_real16
+  real(kind16), intent(in) :: a, b
+  real(kind16) :: red_real16
   red_real16 = a + b
 end function
 
 pure function red_real16_value(a,b)
-  real(16), value, intent(in) :: a, b
-  real(16) :: red_real16_value
+  real(kind16), value, intent(in) :: a, b
+  real(kind16) :: red_real16_value
   red_real16_value = a + b
 end function
 
 subroutine real16(a)
-  real(16), intent(in) :: a(:)
-  real(16) :: res
+  real(kind16), intent(in) :: a(:)
+  real(kind16) :: res
   res = reduce(a, red_real16)
   res = reduce(a, red_real16_value)
 end subroutine
 
-! CHECK: fir.call @_FortranAReduceReal16Ref
-! CHECK: fir.call @_FortranAReduceReal16Value
+! CHECK-KIND16: fir.call @_FortranAReduceReal16Ref
+! CHECK-KIND16: fir.call @_FortranAReduceReal16Value
 
 pure function red_complex2(a,b)
   complex(2), intent(in) :: a, b
@@ -402,48 +406,48 @@ end subroutine
 ! CHECK: fir.call @_FortranACppReduceComplex8Value
 
 pure function red_complex10(a,b)
-  complex(10), intent(in) :: a, b
-  complex(10) :: red_complex10
+  complex(kind10), intent(in) :: a, b
+  complex(kind10) :: red_complex10
   red_complex10 = a + b
 end function
 
 pure function red_complex10_value(a,b)
-  complex(10), value, intent(in) :: a, b
-  complex(10) :: red_complex10_value
+  complex(kind10), value, intent(in) :: a, b
+  complex(kind10) :: red_complex10_value
   red_complex10_value = a + b
 end function
 
 subroutine complex10(a)
-  complex(10), intent(in) :: a(:)
-  complex(10) :: res
+  complex(kind10), intent(in) :: a(:)
+  complex(kind10) :: res
   res = reduce(a, red_complex10)
   res = reduce(a, red_complex10_value)
 end subroutine
 
-! CHECK: fir.call @_FortranACppReduceComplex10Ref
-! CHECK: fir.call @_FortranACppReduceComplex10Value
+! CHECK-KIND10: fir.call @_FortranACppReduceComplex10Ref
+! CHECK-KIND10: fir.call @_FortranACppReduceComplex10Value
 
 pure function red_complex16(a,b)
-  complex(16), intent(in) :: a, b
-  complex(16) :: red_complex16
+  complex(kind16), intent(in) :: a, b
+  complex(kind16) :: red_complex16
   red_complex16 = a + b
 end function
 
 pure function red_complex16_value(a,b)
-  complex(16), value, intent(in) :: a, b
-  complex(16) :: red_complex16_value
+  complex(kind16), value, intent(in) :: a, b
+  complex(kind16) :: red_complex16_value
   red_complex16_value = a + b
 end function
 
 subroutine complex16(a)
-  complex(16), intent(in) :: a(:)
-  complex(16) :: res
+  complex(kind16), intent(in) :: a(:)
+  complex(kind16) :: res
   res = reduce(a, red_complex16)
   res = reduce(a, red_complex16_value)
 end subroutine
 
-! CHECK: fir.call @_FortranACppReduceComplex16Ref
-! CHECK: fir.call @_FortranACppReduceComplex16Value
+! CHECK-KIND16: fir.call @_FortranACppReduceComplex16Ref
+! CHECK-KIND16: fir.call @_FortranACppReduceComplex16Value
 
 pure function red_log1(a,b)
   logical(1), intent(in) :: a, b
@@ -693,26 +697,26 @@ end subroutine
 ! CHECK: fir.call @_FortranAReduceReal8DimValue
 
 subroutine real10dim(a, id)
-  real(10), intent(in) :: a(:,:)
-  real(10), allocatable :: res(:)
+  real(kind10), intent(in) :: a(:,:)
+  real(kind10), allocatable :: res(:)
 
   res = reduce(a, red_real10, 2)
   res = reduce(a, red_real10_value, 2)
 end subroutine
 
-! CHECK: fir.call @_FortranAReduceReal10DimRef
-! CHECK: fir.call @_FortranAReduceReal10DimValue
+! CHECK-KIND10: fir.call @_FortranAReduceReal10DimRef
+! CHECK-KIND10: fir.call @_FortranAReduceReal10DimValue
 
 subroutine real16dim(a, id)
-  real(16), intent(in) :: a(:,:)
-  real(16), allocatable :: res(:)
+  real(kind16), intent(in) :: a(:,:)
+  real(kind16), allocatable :: res(:)
 
   res = reduce(a, red_real16, 2)
   res = reduce(a, red_real16_value, 2)
 end subroutine
 
-! CHECK: fir.call @_FortranAReduceReal16DimRef
-! CHECK: fir.call @_FortranAReduceReal16DimValue
+! CHECK-KIND16: fir.call @_FortranAReduceReal16DimRef
+! CHECK-KIND16: fir.call @_FortranAReduceReal16DimValue
 
 subroutine complex2dim(a, id)
   complex(2), intent(in) :: a(:,:)
@@ -759,26 +763,26 @@ end subroutine
 ! CHECK: fir.call @_FortranACppReduceComplex8DimValue
 
 subroutine complex10dim(a, id)
-  complex(10), intent(in) :: a(:,:)
-  complex(10), allocatable :: res(:)
+  complex(kind10), intent(in) :: a(:,:)
+  complex(kind10), allocatable :: res(:)
 
   res = reduce(a, red_complex10, 2)
   res = reduce(a, red_complex10_value, 2)
 end subroutine
 
-! CHECK: fir.call @_FortranACppReduceComplex10DimRef
-! CHECK: fir.call @_FortranACppReduceComplex10DimValue
+! CHECK-KIND10: fir.call @_FortranACppReduceComplex10DimRef
+! CHECK-KIND10: fir.call @_FortranACppReduceComplex10DimValue
 
 subroutine complex16dim(a, id)
-  complex(16), intent(in) :: a(:,:)
-  complex(16), allocatable :: res(:)
+  complex(kind16), intent(in) :: a(:,:)
+  complex(kind16), allocatable :: res(:)
 
   res = reduce(a, red_complex16, 2)
   res = reduce(a, red_complex16_value, 2)
 end subroutine
 
-! CHECK: fir.call @_FortranACppReduceComplex16DimRef
-! CHECK: fir.call @_FortranACppReduceComplex16DimValue
+! CHECK-KIND16: fir.call @_FortranACppReduceComplex16DimRef
+! CHECK-KIND16: fir.call @_FortranACppReduceComplex16DimValue
 
 subroutine logical1dim(a, id)
   logical(1), intent(in) :: a(:,:)

--- a/flang/test/Lower/Intrinsics/scale.f90
+++ b/flang/test/Lower/Intrinsics/scale.f90
@@ -1,53 +1,42 @@
-! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! CHECK-LABEL: scale_test1
 subroutine scale_test1(x, i)
     real :: x, res
-  ! CHECK: %[[res:.*]] = fir.alloca f32 {bindc_name = "res", uniq_name = "_QFscale_test1Eres"}
-  ! CHECK: %[[x:.*]] = fir.load %arg0 : !fir.ref<f32>
+  ! CHECK: %[[i:.*]]:2 = hlfir.declare{{.*}}i"
+  ! CHECK: %[[res:.*]]:2 = hlfir.declare{{.*}}res"
+  ! CHECK: %[[x:.*]]:2 = hlfir.declare{{.*}}x"
+  ! CHECK: %[[x_val:.*]] = fir.load %[[x]]#0 : !fir.ref<f32>
     integer :: i
-  ! CHECK: %[[i0:.*]] = fir.load %arg1 : !fir.ref<i32>
+  ! CHECK: %[[i_val:.*]] = fir.load %[[i]]#0 : !fir.ref<i32>
     res = scale(x, i)
-  ! CHECK: %[[i1:.*]] = fir.convert %[[i0]] : (i32) -> i64
-  ! CHECK: %[[tmp:.*]] = fir.call @_FortranAScale4(%[[x]], %[[i1]]) {{.*}}: (f32, i64) -> f32
-  ! CHECK: fir.store %[[tmp]] to %[[res]] : !fir.ref<f32>
-  end subroutine scale_test1
+  ! CHECK: %[[i_cast:.*]] = fir.convert %[[i_val]] : (i32) -> i64
+  ! CHECK: %[[tmp:.*]] = fir.call @_FortranAScale4(%[[x_val]], %[[i_cast]]) {{.*}}: (f32, i64) -> f32
+  ! CHECK: hlfir.assign %[[tmp]] to %[[res]]#0 : f32, !fir.ref<f32>
+end subroutine scale_test1
   
-  ! CHECK-LABEL: scale_test2
-  subroutine scale_test2(x, i)
-    real(kind=8) :: x, res
-  ! CHECK: %[[res:.*]] = fir.alloca f64 {bindc_name = "res", uniq_name = "_QFscale_test2Eres"}
-  ! CHECK: %[[x:.*]] = fir.load %arg0 : !fir.ref<f64>
-    integer :: i
-  ! CHECK: %[[i0:.*]] = fir.load %arg1 : !fir.ref<i32>
-    res = scale(x, i)
-  ! CHECK: %[[i1:.*]] = fir.convert %[[i0]] : (i32) -> i64
-  ! CHECK: %[[tmp:.*]] = fir.call @_FortranAScale8(%[[x]], %[[i1]]) {{.*}}: (f64, i64) -> f64
-  ! CHECK: fir.store %[[tmp]] to %[[res]] : !fir.ref<f64>
-  end subroutine scale_test2
-  
-  ! CHECK-LABEL: scale_test3
-  subroutine scale_test3(x, i)
-    real(kind=10) :: x, res
-  ! CHECK: %[[res:.*]] = fir.alloca f80 {bindc_name = "res", uniq_name = "_QFscale_test3Eres"}
-  ! CHECK: %[[x:.*]] = fir.load %arg0 : !fir.ref<f80>
-    integer :: i
-  ! CHECK: %[[i0:.*]] = fir.load %arg1 : !fir.ref<i32>
-    res = scale(x, i)
-  ! CHECK: %[[i1:.*]] = fir.convert %[[i0]] : (i32) -> i64
-  ! CHECK: %[[tmp:.*]] = fir.call @_FortranAScale10(%[[x]], %[[i1]]) {{.*}}: (f80, i64) -> f80
-  ! CHECK: fir.store %[[tmp]] to %[[res]] : !fir.ref<f80>
-  end subroutine scale_test3
-  
-  ! CHECK-LABEL: scale_test4
-  subroutine scale_test4(x, i)
-    real(kind=16) :: x, res
-  ! CHECK: %[[res:.*]] = fir.alloca f128 {bindc_name = "res", uniq_name = "_QFscale_test4Eres"}
-  ! CHECK: %[[x:.*]] = fir.load %arg0 : !fir.ref<f128>
-    integer :: i
-  ! CHECK: %[[i0:.*]] = fir.load %arg1 : !fir.ref<i32>
-    res = scale(x, i)
-  ! CHECK: %[[i1:.*]] = fir.convert %[[i0]] : (i32) -> i64
-  ! CHECK: %[[tmp:.*]] = fir.call @_FortranAScale16(%[[x]], %[[i1]]) {{.*}}: (f128, i64) -> f128
-  ! CHECK: fir.store %[[tmp]] to %[[res]] : !fir.ref<f128>
-  end subroutine scale_test4
+! CHECK-LABEL: scale_test2
+subroutine scale_test2(x, i)
+  real(kind=8) :: x, res
+  integer :: i
+  res = scale(x, i)
+! CHECK: fir.call @_FortranAScale8(%{{.*}}, %{{.*}}) {{.*}}: (f64, i64) -> f64
+end subroutine scale_test2
+
+! CHECK-KIND10-LABEL: scale_test3
+subroutine scale_test3(x, i)
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind=kind10) :: x, res
+  integer :: i
+  res = scale(x, i)
+! CHECK-KIND10: fir.call @_FortranAScale10(%{{.*}}, %{{.*}}) {{.*}}: (f80, i64) -> f80
+end subroutine scale_test3
+
+! CHECK-KIND16-LABEL: scale_test4
+subroutine scale_test4(x, i)
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind=kind16) :: x, res
+  integer :: i
+  res = scale(x, i)
+! CHECK-KIND16: fir.call @_FortranAScale16(%{{.*}}, %{{.*}}) {{.*}}: (f128, i64) -> f128
+end subroutine scale_test4

--- a/flang/test/Lower/Intrinsics/spacing.f90
+++ b/flang/test/Lower/Intrinsics/spacing.f90
@@ -1,5 +1,4 @@
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
-! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}
 
 ! CHECK-LABEL: func @_QPspacing_test(
 real*4 function spacing_test(x)
@@ -9,12 +8,13 @@ real*4 function spacing_test(x)
 ! CHECK: %{{.*}} = fir.call @_FortranASpacing4(%[[a1]]) {{.*}}: (f32) -> f32
 end function
 
-! CHECK-LABEL: func @_QPspacing_test2(
-real*10 function spacing_test2(x)
-  real*10 :: x
+! CHECK-KIND10-LABEL: func @_QPspacing_test2(
+function spacing_test2(x)
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: x, spacing_test2
   spacing_test2 = spacing(x)
-! CHECK: %[[a1:.*]] = fir.load %{{.*}} : !fir.ref<f80>
-! CHECK: %{{.*}} = fir.call @_FortranASpacing10(%[[a1]]) {{.*}}: (f80) -> f80
+! CHECK-KIND10: %[[a1:.*]] = fir.load %{{.*}} : !fir.ref<f80>
+! CHECK-KIND10: %{{.*}} = fir.call @_FortranASpacing10(%[[a1]]) {{.*}}: (f80) -> f80
 end function
 
 ! CHECK-LABEL: test_real2

--- a/flang/test/Lower/OpenMP/parallel-firstprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-firstprivate-clause-scalar.f90
@@ -2,7 +2,7 @@
 
 ! REQUIRES: shell
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - \
-! RUN: | FileCheck %s --check-prefix=CHECK
+! RUN: | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 !CHECK:  omp.private {type = firstprivate} @[[ARG2_LOGICAL_PRIVATIZER:_QFfirstprivate_logicalEarg2_firstprivate_ref_l8]] : !fir.ref<!fir.logical<1>> alloc
 
@@ -114,36 +114,62 @@ subroutine firstprivate_logical(arg1, arg2, arg3, arg4, arg5)
 
 end subroutine
 
-!CHECK-DAG: func @_QPfirstprivate_real(%[[ARG1:.*]]: !fir.ref<f32>{{.*}}, %[[ARG2:.*]]: !fir.ref<f16>{{.*}}, %[[ARG3:.*]]: !fir.ref<f32>{{.*}}, %[[ARG4:.*]]: !fir.ref<f64>{{.*}}, %[[ARG5:.*]]: !fir.ref<f80>{{.*}}, %[[ARG6:.*]]: !fir.ref<f128>{{.*}}) {
+!CHECK-LABEL: func @_QPfirstprivate_real(
+!CHECK-SAME: %[[ARG1:.*]]: !fir.ref<f32>{{.*}}, %[[ARG2:.*]]: !fir.ref<f16>{{.*}}, %[[ARG3:.*]]: !fir.ref<f32>{{.*}}, %[[ARG4:.*]]: !fir.ref<f64>{{.*}}) {
 !CHECK:   %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_realEarg1"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
 !CHECK:   %[[ARG2_DECL:.*]]:2 = hlfir.declare %[[ARG2]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_realEarg2"} : (!fir.ref<f16>, !fir.dscope) -> (!fir.ref<f16>, !fir.ref<f16>)
 !CHECK:   %[[ARG3_DECL:.*]]:2 = hlfir.declare %[[ARG3]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_realEarg3"} : (!fir.ref<f32>, !fir.dscope) -> (!fir.ref<f32>, !fir.ref<f32>)
 !CHECK:   %[[ARG4_DECL:.*]]:2 = hlfir.declare %[[ARG4]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_realEarg4"} : (!fir.ref<f64>, !fir.dscope) -> (!fir.ref<f64>, !fir.ref<f64>)
-!CHECK:   %[[ARG5_DECL:.*]]:2 = hlfir.declare %[[ARG5]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_realEarg5"} : (!fir.ref<f80>, !fir.dscope) -> (!fir.ref<f80>, !fir.ref<f80>)
-!CHECK:   %[[ARG6_DECL:.*]]:2 = hlfir.declare %[[ARG6]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_realEarg6"} : (!fir.ref<f128>, !fir.dscope) -> (!fir.ref<f128>, !fir.ref<f128>)
-!CHECK:  omp.parallel private({{.*firstprivate.*}} {{.*}}#0 -> %[[ARG1_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG2_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG3_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG4_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG5_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG6_PVT:.*]] : {{.*}}) {
+!CHECK:  omp.parallel private({{.*firstprivate.*}} {{.*}}#0 -> %[[ARG1_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG2_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG3_PVT:.*]], {{.*firstprivate.*}} {{.*}}#0 -> %[[ARG4_PVT:.*]] : {{.*}}) {
 !CHECK:     %[[ARG1_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG1_PVT]] {uniq_name = "_QFfirstprivate_realEarg1"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
 !CHECK:     %[[ARG2_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG2_PVT]] {uniq_name = "_QFfirstprivate_realEarg2"} : (!fir.ref<f16>) -> (!fir.ref<f16>, !fir.ref<f16>)
 !CHECK:     %[[ARG3_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG3_PVT]] {uniq_name = "_QFfirstprivate_realEarg3"} : (!fir.ref<f32>) -> (!fir.ref<f32>, !fir.ref<f32>)
 !CHECK:     %[[ARG4_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG4_PVT]] {uniq_name = "_QFfirstprivate_realEarg4"} : (!fir.ref<f64>) -> (!fir.ref<f64>, !fir.ref<f64>)
-!CHECK:     %[[ARG5_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG5_PVT]] {uniq_name = "_QFfirstprivate_realEarg5"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
-!CHECK:     %[[ARG6_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG6_PVT]] {uniq_name = "_QFfirstprivate_realEarg6"} : (!fir.ref<f128>) -> (!fir.ref<f128>, !fir.ref<f128>)
-!CHECK:     fir.call @_QPqux(%[[ARG1_PVT_DECL]]#1, %[[ARG2_PVT_DECL]]#1, %[[ARG3_PVT_DECL]]#1, %[[ARG4_PVT_DECL]]#1, %[[ARG5_PVT_DECL]]#1, %[[ARG6_PVT_DECL]]#1) {{.*}}: (!fir.ref<f32>, !fir.ref<f16>, !fir.ref<f32>, !fir.ref<f64>, !fir.ref<f80>, !fir.ref<f128>) -> ()
+!CHECK:     fir.call @_QPqux(%[[ARG1_PVT_DECL]]#1, %[[ARG2_PVT_DECL]]#1, %[[ARG3_PVT_DECL]]#1, %[[ARG4_PVT_DECL]]#1) {{.*}}: (!fir.ref<f32>, !fir.ref<f16>, !fir.ref<f32>, !fir.ref<f64>) -> ()
 !CHECK:     omp.terminator
 !CHECK:   }
-
 subroutine firstprivate_real(arg1, arg2, arg3, arg4, arg5, arg6)
         real :: arg1
         real(kind=2) :: arg2
         real(kind=4) :: arg3
         real(kind=8) :: arg4
-        real(kind=10) :: arg5
-        real(kind=16) :: arg6
 
-!$OMP PARALLEL FIRSTPRIVATE(arg1, arg2, arg3, arg4, arg5, arg6)
-        call qux(arg1, arg2, arg3, arg4, arg5, arg6)
+!$OMP PARALLEL FIRSTPRIVATE(arg1, arg2, arg3, arg4)
+        call qux(arg1, arg2, arg3, arg4)
 !$OMP END PARALLEL
 
+end subroutine
+
+!CHECK-KIND10-LABEL: func @_QPfirstprivate_real10(
+!CHECK-KIND10-SAME: %[[ARG1:.*]]: !fir.ref<f80>{{.*}}) {
+!CHECK-KIND10:   %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_real10Earg1"} : (!fir.ref<f80>, !fir.dscope) -> (!fir.ref<f80>, !fir.ref<f80>)
+!CHECK-KIND10:  omp.parallel private({{.*firstprivate.*}} {{.*}}#0 -> %[[ARG1_PVT:.*]] : {{.*}}) {
+!CHECK-KIND10:     %[[ARG1_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG1_PVT]] {uniq_name = "_QFfirstprivate_real10Earg1"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
+!CHECK-KIND10:     fir.call @_QPqux10(%[[ARG1_PVT_DECL]]#1) {{.*}} : (!fir.ref<f80>) -> ()
+!CHECK-KIND10:     omp.terminator
+!CHECK-KIND10:   }
+subroutine firstprivate_real10(arg1)
+        integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+        real(kind=kind10) :: arg1
+!$OMP PARALLEL FIRSTPRIVATE(arg1)
+        call qux10(arg1)
+!$OMP END PARALLEL
+end subroutine
+
+!CHECK-KIND16-LABEL: func @_QPfirstprivate_real16(
+!CHECK-KIND16-SAME: %[[ARG1:.*]]: !fir.ref<f80>{{.*}}) {
+!CHECK-KIND16:   %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_real16Earg1"} : (!fir.ref<f80>, !fir.dscope) -> (!fir.ref<f80>, !fir.ref<f80>)
+!CHECK-KIND16:  omp.parallel private({{.*firstprivate.*}} {{.*}}#0 -> %[[ARG1_PVT:.*]] : {{.*}}) {
+!CHECK-KIND16:     %[[ARG1_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG1_PVT]] {uniq_name = "_QFfirstprivate_real16Earg1"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
+!CHECK-KIND16:     fir.call @_QPqux16(%[[ARG1_PVT_DECL]]#1) {{.*}} : (!fir.ref<f80>) -> ()
+!CHECK-KIND16:     omp.terminator
+!CHECK-KIND16:   }
+subroutine firstprivate_real16(arg1)
+        integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+        real(kind=kind16) :: arg1
+!$OMP PARALLEL FIRSTPRIVATE(arg1)
+        call qux16(arg1)
+!$OMP END PARALLEL
 end subroutine
 
 !CHECK-LABEL:   func.func @_QPmultiple_firstprivate(

--- a/flang/test/Lower/OpenMP/parallel-firstprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-firstprivate-clause-scalar.f90
@@ -157,11 +157,11 @@ subroutine firstprivate_real10(arg1)
 end subroutine
 
 !CHECK-KIND16-LABEL: func @_QPfirstprivate_real16(
-!CHECK-KIND16-SAME: %[[ARG1:.*]]: !fir.ref<f80>{{.*}}) {
-!CHECK-KIND16:   %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_real16Earg1"} : (!fir.ref<f80>, !fir.dscope) -> (!fir.ref<f80>, !fir.ref<f80>)
+!CHECK-KIND16-SAME: %[[ARG1:.*]]: !fir.ref<f128>{{.*}}) {
+!CHECK-KIND16:   %[[ARG1_DECL:.*]]:2 = hlfir.declare %[[ARG1]] dummy_scope %{{[0-9]+}} {uniq_name = "_QFfirstprivate_real16Earg1"} : (!fir.ref<f128>, !fir.dscope) -> (!fir.ref<f128>, !fir.ref<f128>)
 !CHECK-KIND16:  omp.parallel private({{.*firstprivate.*}} {{.*}}#0 -> %[[ARG1_PVT:.*]] : {{.*}}) {
-!CHECK-KIND16:     %[[ARG1_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG1_PVT]] {uniq_name = "_QFfirstprivate_real16Earg1"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
-!CHECK-KIND16:     fir.call @_QPqux16(%[[ARG1_PVT_DECL]]#1) {{.*}} : (!fir.ref<f80>) -> ()
+!CHECK-KIND16:     %[[ARG1_PVT_DECL:.*]]:2 = hlfir.declare %[[ARG1_PVT]] {uniq_name = "_QFfirstprivate_real16Earg1"} : (!fir.ref<f128>) -> (!fir.ref<f128>, !fir.ref<f128>)
+!CHECK-KIND16:     fir.call @_QPqux16(%[[ARG1_PVT_DECL]]#1) {{.*}} : (!fir.ref<f128>) -> ()
 !CHECK-KIND16:     omp.terminator
 !CHECK-KIND16:   }
 subroutine firstprivate_real16(arg1)

--- a/flang/test/Lower/basic-function.f90
+++ b/flang/test/Lower/basic-function.f90
@@ -1,4 +1,4 @@
-! RUN: bbc %s -o "-" -emit-fir -hlfir=false | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 integer(1) function fct1()
 end
@@ -102,15 +102,19 @@ end
 ! CHECK-LABEL: func @_QPrfct4() -> f64
 ! CHECK:         return %{{.*}} : f64
 
-real(10) function rfct5()
+function rfct5()
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: rfct5
 end
-! CHECK-LABEL: func @_QPrfct5() -> f80
-! CHECK:         return %{{.*}} : f80
+! CHECK-KIND10-LABEL: func @_QPrfct5() -> f80
+! CHECK-KIND10:         return %{{.*}} : f80
 
-real(16) function rfct6()
+function rfct6()
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind16) :: rfct6
 end
-! CHECK-LABEL: func @_QPrfct6() -> f128
-! CHECK:         return %{{.*}} : f128
+! CHECK-KIND16-LABEL: func @_QPrfct6() -> f128
+! CHECK-KIND16:         return %{{.*}} : f128
 
 complex(2) function cplxfct1()
 end
@@ -132,15 +136,19 @@ end
 ! CHECK-LABEL: func @_QPcplxfct4() -> complex<f64>
 ! CHECK:         return %{{.*}} : complex<f64>
 
-complex(10) function cplxfct5()
+function cplxfct5()
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  complex(kind10) :: cplxfct5
 end
-! CHECK-LABEL: func @_QPcplxfct5() -> complex<f80>
-! CHECK:         return %{{.*}} : complex<f80>
+! CHECK-KIND10-LABEL: func @_QPcplxfct5() -> complex<f80>
+! CHECK-KIND10:         return %{{.*}} : complex<f80>
 
-complex(16) function cplxfct6()
+function cplxfct6()
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  complex(kind16) :: cplxfct5
 end
-! CHECK-LABEL: func @_QPcplxfct6() -> complex<f128>
-! CHECK:         return %{{.*}} : complex<f128>
+! CHECK-KIND16-LABEL: func @_QPcplxfct6() -> complex<f128>
+! CHECK-KIND16:         return %{{.*}} : complex<f128>
 
 function fct_with_character_return(i)
   character(10) :: fct_with_character_return

--- a/flang/test/Lower/basic-function.f90
+++ b/flang/test/Lower/basic-function.f90
@@ -145,7 +145,7 @@ end
 
 function cplxfct6()
   integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
-  complex(kind16) :: cplxfct5
+  complex(kind16) :: cplxfct6
 end
 ! CHECK-KIND16-LABEL: func @_QPcplxfct6() -> complex<f128>
 ! CHECK-KIND16:         return %{{.*}} : complex<f128>

--- a/flang/test/Lower/math-lowering/aint.f90
+++ b/flang/test/Lower/math-lowering/aint.f90
@@ -21,14 +21,6 @@ end function
 ! ALL-LABEL: @_QPtest_real8
 ! ALL: {{%[A-Za-z0-9._]+}} = fir.call @llvm.trunc.f64({{%[A-Za-z0-9._]+}}) {{.*}}: (f64) -> f64
 
-function test_real10(x)
-  real(10) :: x, test_real10
-  test_real10 = aint(x)
-end function
-
-! ALL-LABEL: @_QPtest_real10
-! ALL: {{%[A-Za-z0-9._]+}} = fir.call @llvm.trunc.f80({{%[A-Za-z0-9._]+}}) {{.*}}: (f80) -> f80
-
 ! TODO: wait until fp128 is supported well in llvm.trunc
 !function test_real16(x)
 !  real(16) :: x, test_real16
@@ -37,4 +29,3 @@ end function
 
 ! ALL-DAG: func.func private @llvm.trunc.f32(f32) -> f32 attributes {fir.bindc_name = "llvm.trunc.f32", fir.runtime}
 ! ALL-DAG: func.func private @llvm.trunc.f64(f64) -> f64 attributes {fir.bindc_name = "llvm.trunc.f64", fir.runtime}
-! ALL-DAG: func.func private @llvm.trunc.f80(f80) -> f80 attributes {fir.bindc_name = "llvm.trunc.f80", fir.runtime}

--- a/flang/test/Lower/math-lowering/sign.f90
+++ b/flang/test/Lower/math-lowering/sign.f90
@@ -1,9 +1,11 @@
-! RUN: bbc -emit-fir %s -o - --math-runtime=fast | FileCheck --check-prefixes=ALL,FAST %s
-! RUN: %flang_fc1 -emit-fir -mllvm -math-runtime=fast %s -o - | FileCheck --check-prefixes=ALL,FAST %s
-! RUN: bbc -emit-fir %s -o - --math-runtime=relaxed | FileCheck --check-prefixes=ALL,RELAXED %s
-! RUN: %flang_fc1 -emit-fir -mllvm -math-runtime=relaxed %s -o - | FileCheck --check-prefixes=ALL,RELAXED %s
-! RUN: bbc -emit-fir %s -o - --math-runtime=precise | FileCheck --check-prefixes=ALL,PRECISE %s
-! RUN: %flang_fc1 -emit-fir -mllvm -math-runtime=precise %s -o - | FileCheck --check-prefixes=ALL,PRECISE %s
+! RUN: %flang_fc1 -emit-hlfir -o - -mllvm -math-runtime=fast %s \
+! RUN: | FileCheck %s --check-prefixes=ALL,FAST%if target=x86_64{{.*}} %{,ALL-KIND10,FAST-KIND10%}%if flang-supports-f128-math %{ALL-KIND16,FAST-KIND16%}
+
+! RUN: %flang_fc1 -emit-hlfir -o - -mllvm -math-runtime=relaxed %s \
+! RUN: | FileCheck %s --check-prefixes=ALL,RELAXED%if target=x86_64{{.*}} %{,ALL-KIND10,RELAXED-KIND10%}%if flang-supports-f128-math %{ALL-KIND16,RELAXED-KIND16%}
+
+! RUN: %flang_fc1 -emit-hlfir -o - -mllvm -math-runtime=precise %s \
+! RUN: | FileCheck %s --check-prefixes=ALL,PRECISE%if target=x86_64{{.*}} %{,ALL-KIND10,PRECISE-KIND10%}%if flang-supports-f128-math %{ALL-KIND16,PRECISE-KIND16%}
 
 function test_real4(x, y)
   real :: x, y, test_real4
@@ -26,26 +28,28 @@ end function
 ! PRECISE: {{%[A-Za-z0-9._]+}} = fir.call @copysign({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) {{.*}}: (f64, f64) -> f64
 
 function test_real10(x, y)
-  real(10) :: x, y, test_real10
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  real(kind10) :: x, y, test_real10
   test_real10 = sign(x, y)
 end function
 
-! ALL-LABEL: @_QPtest_real10
-! FAST: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f80
-! RELAXED: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f80
-! PRECISE: {{%[A-Za-z0-9._]+}} = fir.call @copysignl({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) {{.*}}: (f80, f80) -> f80
+! ALL-KIND10-LABEL: @_QPtest_real10
+! FAST-KIND10: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f80
+! RELAXED-KIND10: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f80
+! PRECISE-KIND10: {{%[A-Za-z0-9._]+}} = fir.call @copysignl({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) {{.*}}: (f80, f80) -> f80
 
 function test_real16(x, y)
-  real(16) :: x, y, test_real16
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  real(kind16) :: x, y, test_real16
   test_real16 = sign(x, y)
 end function
 
-! ALL-LABEL: @_QPtest_real16
-! FAST: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f128
-! RELAXED: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f128
-! PRECISE: {{%[A-Za-z0-9._]+}} = fir.call @llvm.copysign.f128({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) {{.*}}: (f128, f128) -> f128
+! ALL-KIND16-LABEL: @_QPtest_real16
+! FAST-KIND16: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f128
+! RELAXED-KIND16: {{%[A-Za-z0-9._]+}} = math.copysign {{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}} {{.*}}: f128
+! PRECISE-KIND16: {{%[A-Za-z0-9._]+}} = fir.call @llvm.copysign.f128({{%[A-Za-z0-9._]+}}, {{%[A-Za-z0-9._]+}}) {{.*}}: (f128, f128) -> f128
 
 ! PRECISE-DAG: func.func private @copysignf(f32, f32) -> f32 attributes {fir.bindc_name = "copysignf", fir.runtime}
 ! PRECISE-DAG: func.func private @copysign(f64, f64) -> f64 attributes {fir.bindc_name = "copysign", fir.runtime}
-! PRECISE-DAG: func.func private @copysignl(f80, f80) -> f80 attributes {fir.bindc_name = "copysignl", fir.runtime}
-! PRECISE-DAG: func.func private @llvm.copysign.f128(f128, f128) -> f128 attributes {fir.bindc_name = "llvm.copysign.f128", fir.runtime}
+! PRECISE-KIND10-DAG: func.func private @copysignl(f80, f80) -> f80 attributes {fir.bindc_name = "copysignl", fir.runtime}
+! PRECISE-KIND16-DAG: func.func private @llvm.copysign.f128(f128, f128) -> f128 attributes {fir.bindc_name = "llvm.copysign.f128", fir.runtime}

--- a/flang/test/Lower/math-lowering/sign.f90
+++ b/flang/test/Lower/math-lowering/sign.f90
@@ -1,11 +1,11 @@
 ! RUN: %flang_fc1 -emit-hlfir -o - -mllvm -math-runtime=fast %s \
-! RUN: | FileCheck %s --check-prefixes=ALL,FAST%if target=x86_64{{.*}} %{,ALL-KIND10,FAST-KIND10%}%if flang-supports-f128-math %{ALL-KIND16,FAST-KIND16%}
+! RUN: | FileCheck %s --check-prefixes=ALL,FAST%if target=x86_64{{.*}} %{,ALL-KIND10,FAST-KIND10%}%if flang-supports-f128-math %{,ALL-KIND16,FAST-KIND16%}
 
 ! RUN: %flang_fc1 -emit-hlfir -o - -mllvm -math-runtime=relaxed %s \
-! RUN: | FileCheck %s --check-prefixes=ALL,RELAXED%if target=x86_64{{.*}} %{,ALL-KIND10,RELAXED-KIND10%}%if flang-supports-f128-math %{ALL-KIND16,RELAXED-KIND16%}
+! RUN: | FileCheck %s --check-prefixes=ALL,RELAXED%if target=x86_64{{.*}} %{,ALL-KIND10,RELAXED-KIND10%}%if flang-supports-f128-math %{,ALL-KIND16,RELAXED-KIND16%}
 
 ! RUN: %flang_fc1 -emit-hlfir -o - -mllvm -math-runtime=precise %s \
-! RUN: | FileCheck %s --check-prefixes=ALL,PRECISE%if target=x86_64{{.*}} %{,ALL-KIND10,PRECISE-KIND10%}%if flang-supports-f128-math %{ALL-KIND16,PRECISE-KIND16%}
+! RUN: | FileCheck %s --check-prefixes=ALL,PRECISE%if target=x86_64{{.*}} %{,ALL-KIND10,PRECISE-KIND10%}%if flang-supports-f128-math %{,ALL-KIND16,PRECISE-KIND16%}
 
 function test_real4(x, y)
   real :: x, y, test_real4

--- a/flang/test/Lower/real-descriptors.f90
+++ b/flang/test/Lower/real-descriptors.f90
@@ -1,43 +1,18 @@
-! RUN: bbc %s -o - | tco | FileCheck %s
+! RUN: bbc %s -o - | tco | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
-! CHECK-LABEL: define void @_QQmain()
-program p
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { ptr, i64, i32, i8, i8, i8, i8 }, align 8
-  ! CHECK-DAG:  alloca { x86_fp80, x86_fp80 }, i64 1, align 16
-  ! CHECK-DAG:  alloca { fp128, fp128 }, i64 1, align 16
-  ! CHECK-DAG:  alloca { half, half }, i64 1, align 8
-  ! CHECK-DAG:  alloca { bfloat, bfloat }, i64 1, align 8
-  ! CHECK-DAG:  alloca { float, float }, i64 1, align 8
-  ! CHECK-DAG:  alloca { double, double }, i64 1, align 8
-  ! CHECK-DAG:  alloca x86_fp80, i64 1, align 16
-  ! CHECK-DAG:  alloca fp128, i64 1, align 16
-  ! CHECK-DAG:  alloca half, i64 1, align 2
-  ! CHECK-DAG:  alloca bfloat, i64 1, align 2
-  ! CHECK-DAG:  alloca float, i64 1, align 4
-  ! CHECK-DAG:  alloca double, i64 1, align 8
-
+! CHECK-LABEL: test_reals
+subroutine test_reals(x2, x3, x4, x8, c2, c3, c4, c8)
   character(10) :: in = 'NaN NaN'
 
   real(kind=2)  :: x2
   real(kind=3)  :: x3
   real(kind=4)  :: x4
   real(kind=8)  :: x8
-  real(kind=10) :: x10
-  real(kind=16) :: x16
 
   complex(kind=2)  :: c2
   complex(kind=3)  :: c3
   complex(kind=4)  :: c4
   complex(kind=8)  :: c8
-  complex(kind=10) :: c10
-  complex(kind=16) :: c16
 
   read(in,*) x2
   ! CHECK:      insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr (half, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 25, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
@@ -57,17 +32,6 @@ program p
   ! CHECK:      call i1 @_FortranAioOutputReal64(ptr %{{[0-9]*}}, double %{{[0-9]*}})
   print "(z16)", x8
 
-  read(in,*) x10
-  ! CHECK:      insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr (x86_fp80, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 29, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
-  ! CHECK:      call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
-  print "(z20)", x10
-
-  read(in,*) x16
-  ! CHECK:      insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr (fp128, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 31, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
-  ! CHECK:      call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
-  print "(z32)", x16
-
-  print*
   read(in,*) c2
   ! CHECK:      insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr ({ half, half }, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 32, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
   ! CHECK:      call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
@@ -86,13 +50,40 @@ program p
   ! CHECK:      call i1 @_FortranAioOutputComplex64(ptr %{{[0-9]*}}, double %{{[0-9]*}}, double %{{[0-9]*}})
   print "(z16,' ',z16)", c8
 
+end
+
+! CHECK-KIND16-LABEL: test_kind10
+subroutine test_kind10(x10, c10)
+  integer, parameter :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  character(10) :: in = 'NaN NaN'
+  real(kind=kind10) :: x10
+  complex(kind=kind10) :: c10
+
+  read(in,*) x10
+  ! CHECK-KIND10:  insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr (x86_fp80, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 29, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
+  ! CHECK-KIND10:  call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
+  print "(z20)", x10
+
   read(in,*) c10
-  ! CHECK:      insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr ({ x86_fp80, x86_fp80 }, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 36, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
-  ! CHECK:      call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
+  ! CHECK-KIND10:  insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr ({ x86_fp80, x86_fp80 }, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 36, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
+  ! CHECK-KIND10:  call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
   print "(z20,' ',z20)", c10
+end subroutine
+
+! CHECK-KIND16-LABEL: test_kind16
+subroutine test_kind16(x16, c16)
+  integer, parameter :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  character(10) :: in = 'NaN NaN'
+  real(kind=kind16) :: x16
+  complex(kind=kind16) :: c16
+
+  read(in,*) x16
+  ! CHECK-KIND16:  insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr (fp128, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 31, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
+  ! CHECK-KIND16:  call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
+  print "(z32)", x16
 
   read(in,*) c16
-  ! CHECK:      insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr ({ fp128, fp128 }, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 38, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
-  ! CHECK:      call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
+  ! CHECK-KIND16:  insertvalue { ptr, i64, i32, i8, i8, i8, i8 } { ptr undef, i64 ptrtoint (ptr getelementptr ({ fp128, fp128 }, ptr null, i32 1) to i64), i32 {{[0-9]*}}, i8 0, i8 38, i8 0, i8 0 }, ptr %{{[0-9]*}}, 0
+  ! CHECK-KIND16:  call i1 @_FortranAioOutputDescriptor(ptr %{{[0-9]*}}, ptr %{{[0-9]*}})
   print "(z32,' ',z32)", c16
-end
+end subroutine

--- a/flang/test/Lower/real-descriptors.f90
+++ b/flang/test/Lower/real-descriptors.f90
@@ -1,6 +1,6 @@
 ! RUN: bbc %s -o - | tco | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
-! CHECK-LABEL: test_reals
+! CHECK-LABEL: define void {{.*}}test_reals
 subroutine test_reals(x2, x3, x4, x8, c2, c3, c4, c8)
   character(10) :: in = 'NaN NaN'
 

--- a/flang/test/Lower/real-operations-1.f90
+++ b/flang/test/Lower/real-operations-1.f90
@@ -1,4 +1,4 @@
-! RUN: bbc -hlfir=false %s -o - | FileCheck %s
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 
 ! Test real add on real kinds.
 
@@ -6,8 +6,10 @@
 REAL(2) FUNCTION real2(x0, x1)
   REAL(2) :: x0
   REAL(2) :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f16>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f16>
+  ! CHECK: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f16>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f16>
   ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f16
   real2 = x0 + x1
   ! CHECK: return %{{.*}} : f16
@@ -17,8 +19,10 @@ END FUNCTION real2
 REAL(3) FUNCTION real3(x0, x1)
   REAL(3) :: x0
   REAL(3) :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<bf16>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<bf16>
+  ! CHECK: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<bf16>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<bf16>
   ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: bf16
   real3 = x0 + x1
   ! CHECK: return %{{.*}} : bf16
@@ -28,8 +32,10 @@ END FUNCTION real3
 REAL(4) FUNCTION real4(x0, x1)
   REAL(4) :: x0
   REAL(4) :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f32>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f32>
+  ! CHECK: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f32>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f32>
   ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f32
   real4 = x0 + x1
   ! CHECK: return %{{.*}} : f32
@@ -39,8 +45,10 @@ END FUNCTION real4
 REAL FUNCTION defreal(x0, x1)
   REAL :: x0
   REAL :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f32>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f32>
+  ! CHECK: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f32>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f32>
   ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f32
   defreal = x0 + x1
   ! CHECK: return %{{.*}} : f32
@@ -50,8 +58,10 @@ END FUNCTION defreal
 REAL(8) FUNCTION real8(x0, x1)
   REAL(8) :: x0
   REAL(8) :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f64>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f64>
+  ! CHECK: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f64>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f64>
   ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f64
   real8 = x0 + x1
   ! CHECK: return %{{.*}} : f64
@@ -61,44 +71,58 @@ END FUNCTION real8
 DOUBLE PRECISION FUNCTION doubleprec(x0, x1)
   DOUBLE PRECISION :: x0
   DOUBLE PRECISION :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f64>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f64>
+  ! CHECK: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f64>
+  ! CHECK-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f64>
   ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f64
   doubleprec = x0 + x1
   ! CHECK: return %{{.*}} : f64
 END FUNCTION doubleprec
 
-! CHECK-LABEL: real10
-REAL(10) FUNCTION real10(x0, x1)
-  REAL(10) :: x0
-  REAL(10) :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f80>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f80>
-  ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f80
+! CHECK-KIND10-LABEL: real10
+FUNCTION real10(x0, x1)
+  INTEGER, PARAMETER :: kind10 = merge(10, 4, selected_real_kind(p=18).eq.10)
+  REAL(kind10) :: real10
+  REAL(kind10) :: x0
+  REAL(kind10) :: x1
+  ! CHECK-KIND10: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK-KIND10: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-KIND10-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f80>
+  ! CHECK-KIND10-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f80>
+  ! CHECK-KIND10: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f80
   real10 = x0 + x1
-  ! CHECK: return %{{.*}} : f80
+  ! CHECK-KIND10: return %{{.*}} : f80
 END FUNCTION real10
 
-! CHECK-LABEL: real16
-REAL(16) FUNCTION real16(x0, x1)
-  REAL(16) :: x0
-  REAL(16) :: x1
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f128>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f128>
-  ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f128
+! CHECK-KIND16-LABEL: real16(
+FUNCTION real16(x0, x1)
+  INTEGER, PARAMETER :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  REAL(kind16) :: real16
+  REAL(kind16) :: x0
+  REAL(kind16) :: x1
+  ! CHECK-KIND16: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK-KIND16: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-KIND16-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f128>
+  ! CHECK-KIND16-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f128>
+  ! CHECK-KIND16: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f128
   real16 = x0 + x1
-  ! CHECK: return %{{.*}} : f128
+  ! CHECK-KIND16: return %{{.*}} : f128
 END FUNCTION real16
 
-! CHECK-LABEL: real16b
-REAL(16) FUNCTION real16b(x0, x1)
-  REAL(16) :: x0
-  REAL(16) :: x1
-  ! CHECK-DAG: %[[v0:.+]] = arith.constant 4.0{{.*}} : f128
-  ! CHECK-DAG: %[[v1:.+]] = fir.load %arg0 : !fir.ref<f128>
-  ! CHECK-DAG: %[[v2:.+]] = fir.load %arg1 : !fir.ref<f128>
-  ! CHECK: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f128
-  ! CHECK: %[[v4:.+]] = arith.subf %[[v3]], %[[v0]] {{.*}}: f128
+! CHECK-KIND16-LABEL: real16b
+FUNCTION real16b(x0, x1)
+  INTEGER, PARAMETER :: kind16 = merge(16, 4, selected_real_kind(p=33).eq.16)
+  REAL(kind16) :: real16b
+  REAL(kind16) :: x0
+  REAL(kind16) :: x1
+  ! CHECK-KIND16: %[[x0:.*]]:2 = hlfir.declare{{.*}}x0"
+  ! CHECK-KIND16: %[[x1:.*]]:2 = hlfir.declare{{.*}}x1"
+  ! CHECK-KIND16-DAG: %[[v1:.+]] = fir.load %[[x0]]#0 : !fir.ref<f128>
+  ! CHECK-KIND16-DAG: %[[v2:.+]] = fir.load %[[x1]]#0 : !fir.ref<f128>
+  ! CHECK-KIND16-DAG: %[[v3:.+]] = arith.addf %[[v1]], %[[v2]] {{.*}}: f128
+  ! CHECK-KIND16-DAG: %[[v0:.+]] = arith.constant 4.0{{.*}} : f128
+  ! CHECK-KIND16: %[[v4:.+]] = arith.subf %[[v3]], %[[v0]] {{.*}}: f128
   real16b = x0 + x1 - 4.0_16
-  ! CHECK: return %{{.*}} : f128
+  ! CHECK-KIND16: return %{{.*}} : f128
 END FUNCTION real16b


### PR DESCRIPTION
KIND 10 and 16 are platform dependent and it will soon be a hard error to use them when not available (https://github.com/llvm/llvm-project/pull/124655)

Update some tests that used them to use SELECTED_REAL_KIND + lit conditional checks to make the tests usable on all platform.

Also update all those tests to use HFLIR lowering while modifying them since the goal is to remove the legacy lowering at some point.
