### PR TITLE
[DXIL] Add support for root signature Constants element Generation in DXContainer 

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -17,6 +17,7 @@
 #include "llvm/Support/SwapByteOrder.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <cstdint>
 #include <stdint.h>
 
 namespace llvm {
@@ -204,6 +205,50 @@ static_assert((uint64_t)FeatureFlags::NextUnusedBit <= 1ull << 63,
 #define ROOT_ELEMENT_FLAG(Num, Val, Str) Val = 1ull << Num,
 enum class RootElementFlag : uint32_t {
 #include "DXContainerConstants.def"
+};
+
+#define ROOT_PARAMETER(Val, Enum) Enum = Val,
+enum class RootParameterType : uint8_t {
+#include "DXContainerConstants.def"
+};
+
+#define SHADER_VISIBILITY(Val, Enum) Enum = Val,
+enum class ShaderVisibilityFlag : uint8_t {
+#include "DXContainerConstants.def"
+};
+
+struct RootConstants {
+  uint32_t ShaderRegister;
+  uint32_t RegisterSpace;
+  uint32_t Num32BitValues;
+
+  void swapBytes() {
+    sys::swapByteOrder(ShaderRegister);
+    sys::swapByteOrder(RegisterSpace);
+    sys::swapByteOrder(Num32BitValues);
+  }
+};
+
+struct RootParameter {
+  RootParameterType ParameterType;
+  union {
+    RootConstants Constants;
+  };
+  ShaderVisibilityFlag ShaderVisibility;
+
+  void swapBytes() {
+    switch (ParameterType) {
+
+    case RootParameterType::Constants32Bit:
+      Constants.swapBytes();
+      break;
+    case RootParameterType::DescriptorTable:
+    case RootParameterType::CBV:
+    case RootParameterType::SRV:
+    case RootParameterType::UAV:
+      break;
+    }
+  }
 };
 
 PartType parsePartType(StringRef S);
@@ -547,6 +592,8 @@ enum class SigComponentType : uint32_t {
 };
 
 ArrayRef<EnumEntry<SigComponentType>> getSigComponentTypes();
+ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
+ArrayRef<EnumEntry<ShaderVisibilityFlag>> getShaderVisibilityFlags();
 
 struct ProgramSignatureHeader {
   uint32_t ParamCount;

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -17,7 +17,6 @@
 #include "llvm/Support/SwapByteOrder.h"
 #include "llvm/TargetParser/Triple.h"
 
-#include <cstdint>
 #include <stdint.h>
 
 namespace llvm {
@@ -205,50 +204,6 @@ static_assert((uint64_t)FeatureFlags::NextUnusedBit <= 1ull << 63,
 #define ROOT_ELEMENT_FLAG(Num, Val, Str) Val = 1ull << Num,
 enum class RootElementFlag : uint32_t {
 #include "DXContainerConstants.def"
-};
-
-#define ROOT_PARAMETER(Val, Enum) Enum = Val,
-enum class RootParameterType : uint8_t {
-#include "DXContainerConstants.def"
-};
-
-#define SHADER_VISIBILITY(Val, Enum) Enum = Val,
-enum class ShaderVisibilityFlag : uint8_t {
-#include "DXContainerConstants.def"
-};
-
-struct RootConstants {
-  uint32_t ShaderRegister;
-  uint32_t RegisterSpace;
-  uint32_t Num32BitValues;
-
-  void swapBytes() {
-    sys::swapByteOrder(ShaderRegister);
-    sys::swapByteOrder(RegisterSpace);
-    sys::swapByteOrder(Num32BitValues);
-  }
-};
-
-struct RootParameter {
-  RootParameterType ParameterType;
-  union {
-    RootConstants Constants;
-  };
-  ShaderVisibilityFlag ShaderVisibility;
-
-  void swapBytes() {
-    switch (ParameterType) {
-
-    case RootParameterType::Constants32Bit:
-      Constants.swapBytes();
-      break;
-    case RootParameterType::DescriptorTable:
-    case RootParameterType::CBV:
-    case RootParameterType::SRV:
-    case RootParameterType::UAV:
-      break;
-    }
-  }
 };
 
 PartType parsePartType(StringRef S);

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -91,6 +91,13 @@ struct RootConstants {
 };
 
 struct RootParameter {
+  RootParameter() = default;
+  RootParameter(RootConstants RootConstant, ShaderVisibilityFlag Visibility) {
+    ParameterType = RootParameterType::Constants32Bit;
+    Constants = RootConstant;
+    ShaderVisibility = Visibility;
+  }
+  
   RootParameterType ParameterType;
   union {
     RootConstants Constants;

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -70,7 +70,6 @@ enum class RootParameterType : uint8_t {
 
 ArrayRef<EnumEntry<RootParameterType>> getRootParameterTypes();
 
-
 #define SHADER_VISIBILITY(Val, Enum) Enum = Val,
 enum class ShaderVisibilityFlag : uint8_t {
 #include "DXContainerConstants.def"

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -97,7 +97,7 @@ struct RootParameter {
     Constants = RootConstant;
     ShaderVisibility = Visibility;
   }
-  
+
   RootParameterType ParameterType;
   union {
     RootConstants Constants;

--- a/llvm/include/llvm/MC/DXContainerRootSignature.h
+++ b/llvm/include/llvm/MC/DXContainerRootSignature.h
@@ -8,7 +8,6 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/DXContainer.h"
-#include <cstdint>
 #include <limits>
 
 namespace llvm {
@@ -22,6 +21,8 @@ struct RootSignatureHeader {
 
   void swapBytes();
   void write(raw_ostream &OS);
+
+  void pushPart(dxbc::RootParameter Part);
 };
 } // namespace mcdxbc
 } // namespace llvm

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -22,7 +22,6 @@
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/TargetParser/Triple.h"
 #include <array>
-#include <cstdint>
 #include <variant>
 
 namespace llvm {

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -22,6 +22,7 @@
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/TargetParser/Triple.h"
 #include <array>
+#include <cstdint>
 #include <variant>
 
 namespace llvm {

--- a/llvm/lib/MC/DXContainerRootSignature.cpp
+++ b/llvm/lib/MC/DXContainerRootSignature.cpp
@@ -30,3 +30,7 @@ void RootSignatureHeader::write(raw_ostream &OS) {
       OS.write(reinterpret_cast<const char *>(&Param), BindingSize);
   }
 }
+
+void RootSignatureHeader::pushPart(dxbc::RootParameter Param){
+  Parameters.push_back(Param);
+}

--- a/llvm/lib/MC/DXContainerRootSignature.cpp
+++ b/llvm/lib/MC/DXContainerRootSignature.cpp
@@ -31,6 +31,6 @@ void RootSignatureHeader::write(raw_ostream &OS) {
   }
 }
 
-void RootSignatureHeader::pushPart(dxbc::RootParameter Param){
+void RootSignatureHeader::pushPart(dxbc::RootParameter Param) {
   Parameters.push_back(Param);
 }

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -222,7 +222,6 @@ void ScalarEnumerationTraits<dxbc::ShaderVisibilityFlag>::enumeration(
     IO.enumCase(Value, E.Name.str().c_str(), E.Value);
 }
 
-
 void MappingTraits<DXContainerYAML::RootSignatureDesc>::mapping(
     IO &IO, DXContainerYAML::RootSignatureDesc &S) {
   IO.mapRequired("Size", S.Size);

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -258,6 +258,33 @@ void MappingTraits<DXContainerYAML::RootSignatureDesc>::mapping(
 #include "llvm/BinaryFormat/DXContainerConstants.def"
 }
 
+void MappingTraits<dxbc::RootParameter>::mapping(IO &IO,
+                                                 dxbc::RootParameter &S) {
+
+  IO.mapRequired("Type", S.ParameterType);
+  IO.mapRequired("ShaderVisibility", S.ShaderVisibility);
+
+  switch (S.ParameterType) {
+
+  case dxbc::RootParameterType::Constants32Bit:
+    IO.mapRequired("Constants", S.Constants);
+    break;
+  case dxbc::RootParameterType::DescriptorTable:
+  case dxbc::RootParameterType::CBV:
+  case dxbc::RootParameterType::SRV:
+  case dxbc::RootParameterType::UAV:
+    break;
+  }
+}
+
+void MappingTraits<dxbc::RootConstants>::mapping(IO &IO,
+                                                 dxbc::RootConstants &S) {
+
+  IO.mapRequired("Num32BitValues", S.Num32BitValues);
+  IO.mapRequired("ShaderRegister", S.ShaderRegister);
+  IO.mapRequired("RegisterSpace", S.RegisterSpace);
+}
+
 void MappingTraits<DXContainerYAML::Part>::mapping(IO &IO,
                                                    DXContainerYAML::Part &P) {
   IO.mapRequired("Name", P.Name);
@@ -358,6 +385,18 @@ void ScalarEnumerationTraits<dxbc::SigMinPrecision>::enumeration(
 void ScalarEnumerationTraits<dxbc::SigComponentType>::enumeration(
     IO &IO, dxbc::SigComponentType &Value) {
   for (const auto &E : dxbc::getSigComponentTypes())
+    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+}
+
+void ScalarEnumerationTraits<dxbc::RootParameterType>::enumeration(
+    IO &IO, dxbc::RootParameterType &Value) {
+  for (const auto &E : dxbc::getRootParameterTypes())
+    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
+}
+
+void ScalarEnumerationTraits<dxbc::ShaderVisibilityFlag>::enumeration(
+    IO &IO, dxbc::ShaderVisibilityFlag &Value) {
+  for (const auto &E : dxbc::getShaderVisibilityFlags())
     IO.enumCase(Value, E.Name.str().c_str(), E.Value);
 }
 

--- a/llvm/lib/ObjectYAML/DXContainerYAML.cpp
+++ b/llvm/lib/ObjectYAML/DXContainerYAML.cpp
@@ -210,25 +210,6 @@ void MappingTraits<DXContainerYAML::Signature>::mapping(
   IO.mapRequired("Parameters", S.Parameters);
 }
 
-void MappingTraits<dxbc::RootParameter>::mapping(IO &IO,
-                                                 dxbc::RootParameter &S) {
-
-  IO.mapRequired("Type", S.ParameterType);
-  IO.mapRequired("ShaderVisibility", S.ShaderVisibility);
-
-  switch (S.ParameterType) {
-
-  case dxbc::RootParameterType::Constants32Bit:
-    IO.mapRequired("Constants", S.Constants);
-    break;
-  case dxbc::RootParameterType::DescriptorTable:
-  case dxbc::RootParameterType::CBV:
-  case dxbc::RootParameterType::SRV:
-  case dxbc::RootParameterType::UAV:
-    break;
-  }
-}
-
 void ScalarEnumerationTraits<dxbc::RootParameterType>::enumeration(
     IO &IO, dxbc::RootParameterType &Value) {
   for (const auto &E : dxbc::getRootParameterTypes())
@@ -241,13 +222,6 @@ void ScalarEnumerationTraits<dxbc::ShaderVisibilityFlag>::enumeration(
     IO.enumCase(Value, E.Name.str().c_str(), E.Value);
 }
 
-void MappingTraits<dxbc::RootConstants>::mapping(IO &IO,
-                                                 dxbc::RootConstants &S) {
-
-  IO.mapRequired("Num32BitValues", S.Num32BitValues);
-  IO.mapRequired("ShaderRegister", S.ShaderRegister);
-  IO.mapRequired("RegisterSpace", S.RegisterSpace);
-}
 
 void MappingTraits<DXContainerYAML::RootSignatureDesc>::mapping(
     IO &IO, DXContainerYAML::RootSignatureDesc &S) {
@@ -385,18 +359,6 @@ void ScalarEnumerationTraits<dxbc::SigMinPrecision>::enumeration(
 void ScalarEnumerationTraits<dxbc::SigComponentType>::enumeration(
     IO &IO, dxbc::SigComponentType &Value) {
   for (const auto &E : dxbc::getSigComponentTypes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
-}
-
-void ScalarEnumerationTraits<dxbc::RootParameterType>::enumeration(
-    IO &IO, dxbc::RootParameterType &Value) {
-  for (const auto &E : dxbc::getRootParameterTypes())
-    IO.enumCase(Value, E.Name.str().c_str(), E.Value);
-}
-
-void ScalarEnumerationTraits<dxbc::ShaderVisibilityFlag>::enumeration(
-    IO &IO, dxbc::ShaderVisibilityFlag &Value) {
-  for (const auto &E : dxbc::getShaderVisibilityFlags())
     IO.enumCase(Value, E.Name.str().c_str(), E.Value);
 }
 

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -73,18 +73,19 @@ public:
 } // namespace
 
 static dxbc::RootParameter constructHeaderPart(const RootSignaturePart &Part) {
-  
-  dxbc::ShaderVisibilityFlag Visibility = static_cast<dxbc::ShaderVisibilityFlag>(Part.Visibility);
 
-  switch(Part.Type){
+  dxbc::ShaderVisibilityFlag Visibility =
+      static_cast<dxbc::ShaderVisibilityFlag>(Part.Visibility);
 
-  case PartType::Constants:{
+  switch (Part.Type) {
 
-    return dxbc::RootParameter(dxbc::RootConstants {
-      Part.Constants.ShaderRegistry,
-      Part.Constants.RegistrySpace,
-      Part.Constants.Number32BitValues
-    }, Visibility);
+  case PartType::Constants: {
+
+    return dxbc::RootParameter(
+        dxbc::RootConstants{Part.Constants.ShaderRegistry,
+                            Part.Constants.RegistrySpace,
+                            Part.Constants.Number32BitValues},
+        Visibility);
   } break;
   }
 }

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -72,6 +72,23 @@ public:
 
 } // namespace
 
+static dxbc::RootParameter constructHeaderPart(const RootSignaturePart &Part) {
+  
+  dxbc::ShaderVisibilityFlag Visibility = static_cast<dxbc::ShaderVisibilityFlag>(Part.Visibility);
+
+  switch(Part.Type){
+
+  case PartType::Constants:{
+
+    return dxbc::RootParameter(dxbc::RootConstants {
+      Part.Constants.ShaderRegistry,
+      Part.Constants.RegistrySpace,
+      Part.Constants.Number32BitValues
+    }, Visibility);
+  } break;
+  }
+}
+
 bool DXContainerGlobals::runOnModule(Module &M) {
   llvm::SmallVector<GlobalValue *> Globals;
   Globals.push_back(getFeatureFlags(M));

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -181,6 +181,10 @@ void DXContainerGlobals::addRootSignature(Module &M,
   RootSignatureHeader RSH;
   RSH.Flags = MRS->Flags;
 
+  for (const auto &Part : MRS->Parts) {
+    RSH.pushPart(constructHeaderPart(Part));
+  }
+
   RSH.write(OS);
 
   Constant *Constant =

--- a/llvm/lib/Target/DirectX/DXILRootSignature.cpp
+++ b/llvm/lib/Target/DirectX/DXILRootSignature.cpp
@@ -26,17 +26,14 @@ static bool reportError(Twine Message) {
   return true;
 }
 
-
 static bool isValidShaderVisibility(uint32_t V) {
-    return V < static_cast<uint32_t>(ShaderVisibility::MAX_VALUE);
+  return V < static_cast<uint32_t>(ShaderVisibility::MAX_VALUE);
 }
-
 
 static uint64_t extractInt(MDNode *Node, unsigned int I) {
   assert(I > 0 && I < Node->getNumOperands() && "Invalid operand Index");
   return mdconst::extract<ConstantInt>(Node->getOperand(I))->getZExtValue();
 }
-
 
 static bool parseRootFlags(ModuleRootSignature *MRS, MDNode *RootFlagNode) {
 
@@ -56,27 +53,21 @@ static bool parseRootFlags(ModuleRootSignature *MRS, MDNode *RootFlagNode) {
 static bool parseRootConstants(ModuleRootSignature *MRS, MDNode *RootFlagNode) {
   assert(RootFlagNode->getNumOperands() == 5 &&
          "Invalid format for RootFlag Element");
-  
-  uint32_t MaybeShaderVisibility  = extractInt(RootFlagNode, 1);
-  assert(isValidShaderVisibility(MaybeShaderVisibility) && "Invalid shader visibility value");
 
-  ShaderVisibility Visibility = static_cast<ShaderVisibility>(MaybeShaderVisibility);
-  
-  uint32_t ShaderRegistry  = extractInt(RootFlagNode, 2);
-  uint32_t RegisterSpace  = extractInt(RootFlagNode, 3);
-  uint32_t Num32BitsValue  = extractInt(RootFlagNode, 4);
+  uint32_t MaybeShaderVisibility = extractInt(RootFlagNode, 1);
+  assert(isValidShaderVisibility(MaybeShaderVisibility) &&
+         "Invalid shader visibility value");
 
-  RootConstants Constant {
-    ShaderRegistry,
-    RegisterSpace,
-    Num32BitsValue
-  };
+  ShaderVisibility Visibility =
+      static_cast<ShaderVisibility>(MaybeShaderVisibility);
 
-  RootSignaturePart Part {
-    PartType::Constants,
-    {Constant},
-    Visibility
-  };
+  uint32_t ShaderRegistry = extractInt(RootFlagNode, 2);
+  uint32_t RegisterSpace = extractInt(RootFlagNode, 3);
+  uint32_t Num32BitsValue = extractInt(RootFlagNode, 4);
+
+  RootConstants Constant{ShaderRegistry, RegisterSpace, Num32BitsValue};
+
+  RootSignaturePart Part{PartType::Constants, {Constant}, Visibility};
 
   MRS->pushPart(Part);
 
@@ -108,7 +99,7 @@ static bool parseRootSignatureElement(ModuleRootSignature *MRS,
     break;
   }
 
-  case RootSignatureElementKind::RootConstants:{
+  case RootSignatureElementKind::RootConstants: {
     return parseRootConstants(MRS, Element);
     break;
   }

--- a/llvm/lib/Target/DirectX/DXILRootSignature.h
+++ b/llvm/lib/Target/DirectX/DXILRootSignature.h
@@ -16,7 +16,6 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
-#include <cstdint>
 #include <optional>
 
 namespace llvm {

--- a/llvm/lib/Target/DirectX/DXILRootSignature.h
+++ b/llvm/lib/Target/DirectX/DXILRootSignature.h
@@ -31,16 +31,14 @@ enum class RootSignatureElementKind {
   StaticSampler = 5
 };
 
-enum class PartType {
-  Constants = 0
-};
+enum class PartType { Constants = 0 };
 
 enum class ShaderVisibility : uint32_t {
   SHADER_VISIBILITY_ALL = 0,
   SHADER_VISIBILITY_VERTEX = 1,
   SHADER_VISIBILITY_HULL = 2,
   SHADER_VISIBILITY_DOMAIN = 3,
-  SHADER_VISIBILITY_GEOMETRY =4 ,
+  SHADER_VISIBILITY_GEOMETRY = 4,
   SHADER_VISIBILITY_PIXEL = 5,
   SHADER_VISIBILITY_AMPLIFICATION = 6,
   SHADER_VISIBILITY_MESH = 7,
@@ -55,11 +53,11 @@ struct RootConstants {
 };
 
 struct RootSignaturePart {
-    PartType Type;
-    union {
-      RootConstants Constants;
-    };
-    ShaderVisibility Visibility;
+  PartType Type;
+  union {
+    RootConstants Constants;
+  };
+  ShaderVisibility Visibility;
 };
 
 struct ModuleRootSignature {
@@ -72,9 +70,7 @@ struct ModuleRootSignature {
 
   static ModuleRootSignature analyzeModule(Module &M);
 
-  void pushPart(RootSignaturePart Part) {
-    Parts.push_back(Part);
-  }
+  void pushPart(RootSignaturePart Part) { Parts.push_back(Part); }
 };
 
 class RootSignatureAnalysis : public AnalysisInfoMixin<RootSignatureAnalysis> {

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
@@ -3,7 +3,7 @@
 
 target triple = "dxil-unknown-shadermodel6.0-compute"
 
-; CHECK: @dx.rts0 = private constant [12 x i8]  c"{{.*}}", section "RTS0", align 4
+; CHECK: @dx.rts0 = private constant [16 x i8]  c"{{.*}}", section "RTS0", align 4
 
 
 define void @main() #0 {

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
@@ -3,7 +3,7 @@
 
 target triple = "dxil-unknown-shadermodel6.0-compute"
 
-; CHECK: @dx.rts0 = private constant [40 x i8]  c"{{.*}}", section "RTS0", align 4
+; CHECK: @dx.rts0 = private constant [36 x i8]  c"{{.*}}", section "RTS0", align 4
 
 
 define void @main() #0 {
@@ -25,10 +25,9 @@ attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
 ; DXC:       - Name:            RTS0
-; DXC-NEXT:    Size:            40
+; DXC-NEXT:    Size:            36
 ; DXC-NEXT:    RootSignature:
 ; DXC-NEXT:      Size:            64
-; DXC-NEXT:      Version:         1
 ; DXC-NEXT:      NumParameters:   1
 ; DXC-NEXT:      Parameters:
 ; DXC-NEXT:        - Type:            Constants32Bit

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
@@ -3,7 +3,7 @@
 
 target triple = "dxil-unknown-shadermodel6.0-compute"
 
-; CHECK: @dx.rts0 = private constant [16 x i8]  c"{{.*}}", section "RTS0", align 4
+; CHECK: @dx.rts0 = private constant [40 x i8]  c"{{.*}}", section "RTS0", align 4
 
 
 define void @main() #0 {
@@ -19,14 +19,22 @@ attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 !dx.rootsignatures = !{!2} ; list of function/root signature pairs
 !2 = !{ ptr @main, !3 } ; function, root signature
-!3 = !{ !4 } ; list of root signature elements
+!3 = !{ !4, !5 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout
+!5 = !{ !"RootConstants", i32 0, i32 1, i32 2, i32 3 }
 
 
-; DXC:    - Name: RTS0
-; DXC-NEXT: Size: 12
-; DXC-NEXT: RootSignature:
-; DXC-NEXT:   Size: 64
-; DXC-NEXT:   NumParameters: 0 
-; DXC-NEXT:   Parameters: [] 
-; DXC-NEXT:   AllowInputAssemblerInputLayout: true
+; DXC:       - Name:            RTS0
+; DXC-NEXT:    Size:            40
+; DXC-NEXT:    RootSignature:
+; DXC-NEXT:      Size:            64
+; DXC-NEXT:      Version:         1
+; DXC-NEXT:      NumParameters:   1
+; DXC-NEXT:      Parameters:
+; DXC-NEXT:        - Type:            Constants32Bit
+; DXC-NEXT:          ShaderVisibility: All
+; DXC-NEXT:          Constants:
+; DXC-NEXT:            Num32BitValues:  3
+; DXC-NEXT:            ShaderRegister:  1
+; DXC-NEXT:            RegisterSpace:   2
+; DXC-NEXT:      AllowInputAssemblerInputLayout: true


### PR DESCRIPTION
Adding support for Root Signature Constant Element extraction and writing to DXContainer.

- Adding an analysis to deal with RootSignature metadata definition
- Adding validation for Constants
- 
This PR is related to task: https://github.com/llvm/llvm-project/issues/121487