### PR TITLE
[flang] Handle indirect USE of ancestor module into submodule

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -3354,6 +3354,15 @@ void ModuleVisitor::DoAddUse(SourceName location, SourceName localName,
     // use-associating the same symbol again -- ok
     return;
   }
+  if (useUltimate.owner().IsModule() && localUltimate.owner().IsSubmodule() &&
+      DoesScopeContain(&useUltimate.owner(), localUltimate)) {
+    // Within a submodule, USE'ing a symbol that comes indirectly
+    // from the ancestor module, e.g. foo in:
+    //  MODULE m1; INTERFACE; MODULE SUBROUTINE foo; END INTERFACE; END
+    //  MODULE m2; USE m1; END
+    //  SUBMODULE m1(sm); USE m2; CONTAINS; MODULE PROCEDURE foo; END; END
+    return; // ok, ignore it
+  }
 
   if (localUltimate.name() == useUltimate.name() &&
       localUltimate.owner().IsModule() && useUltimate.owner().IsModule() &&

--- a/flang/test/Semantics/bug124731.f90
+++ b/flang/test/Semantics/bug124731.f90
@@ -1,0 +1,24 @@
+!RUN: %flang_fc1 -fsyntax-only %s  2>&1 | FileCheck %s --allow-empty
+!CHECK-NOT: error:
+module m1
+  interface
+    module subroutine foo
+    end
+  end interface
+  real x
+end
+module m2
+  use m1
+end
+submodule(m1) sm1
+  use m2 ! ok
+ contains
+  module procedure foo
+  end
+end
+submodule(m1) sm2
+ contains
+  subroutine bar
+    use m2 ! ok
+  end
+end

--- a/flang/test/Semantics/self-use.f90
+++ b/flang/test/Semantics/self-use.f90
@@ -15,7 +15,6 @@ submodule(m) submod1
  contains
   module subroutine separate
     !ERROR: Module 'm' cannot USE itself from its own submodule 'submod1'
-    !ERROR: Cannot use-associate 'separate'; it is already declared in this scope
     use m
   end
 end


### PR DESCRIPTION
A USE statement within a submodule (possibly in a nested scope) is not allowed to USE the submodule's ancestor module directly, but it is permissible to USE that ancestor module indirectly via another unrelated module.  Don't emit "already present in scope" errors for this case.

Fixes https://github.com/llvm/llvm-project/issues/124731.