### PR TITLE
[flang] Suppress USEs of non-USE'able names in module files

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -306,8 +306,10 @@ void ModFileWriter::PrepareRenamings(const Scope &scope) {
   // to their names in this scope, creating those new names when needed.
   auto &renamings{context_.moduleFileOutputRenamings()};
   for (SymbolRef s : symbolsNeeded) {
-    if (s->owner().kind() == Scope::Kind::DerivedType) {
-      continue; // component or binding: ok
+    if (s->owner().kind() != Scope::Kind::Module) {
+      // Not a USE'able name from a module's top scope;
+      // component, binding, dummy argument, &c.
+      continue;
     }
     const Scope *sMod{FindModuleContaining(s->owner())};
     if (!sMod || sMod == &scope) {

--- a/flang/test/Semantics/bug124716.f90
+++ b/flang/test/Semantics/bug124716.f90
@@ -1,0 +1,36 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+MODULE m1
+  INTERFACE
+    MODULE SUBROUTINE sub1(N, ARR)
+      INTEGER, INTENT(IN) :: N
+      INTEGER, DIMENSION(N) :: ARR
+    END SUBROUTINE
+  END INTERFACE
+END MODULE
+SUBMODULE (m1) m1sub
+ CONTAINS
+  MODULE SUBROUTINE sub1(N, ARR)
+    INTEGER, INTENT(IN) :: N
+    INTEGER, DIMENSION(N) :: ARR
+    PRINT *, "sub1", N, ARR
+  END SUBROUTINE
+END SUBMODULE
+
+!Expect: m1.mod
+!module m1
+!interface
+!module subroutine sub1(n,arr)
+!integer(4),intent(in)::n
+!integer(4)::arr(1_8:int(n,kind=8))
+!end
+!end interface
+!end
+
+!Expect: m1-m1sub.mod
+!submodule(m1) m1sub
+!contains
+!module subroutine sub1(n,arr)
+!integer(4),intent(in)::n
+!integer(4)::arr(1_8:int(n,kind=8))
+!end
+!end


### PR DESCRIPTION
When harvesting and formatting symbols USE'd from other modules, don't emit USE statements to module files for names unless they come from the topmost scope of the module.  There was a check to prevent names from derived type scopes from escaping in this way, but it must be made more general to prevent other cases like dummy arguments in interfaces.

Fixes https://github.com/llvm/llvm-project/issues/124716.