### PR TITLE
Only include necessary files in the lldb-dap VSIX

### DIFF
--- a/lldb/tools/lldb-dap/.vscodeignore
+++ b/lldb/tools/lldb-dap/.vscodeignore
@@ -1,0 +1,9 @@
+// Ignore everything by default
+**/*
+
+// Only include specific files and directories
+!LICENSE.TXT
+!package.json
+!README.md
+!out/**
+!syntaxes/**


### PR DESCRIPTION
The published VSIX for the LLDB DAP extension contains a bunch of unnecessary files:
```
❯ tar tf llvm-vs-code-extensions.lldb-dap-0.2.8.vsix

extension.vsixmanifest
[Content_Types].xml
extension/.github/workflows/auto_publish.yml
extension/.github/workflows/integrate_llvmproject.yml
extension/.gitignore
extension/.vscode/launch.json
extension/.vscode/tasks.json
extension/LICENSE.TXT
extension/out/debug-adapter-factory.js
extension/out/debug-adapter-factory.js.map
extension/out/disposable-context.js
extension/out/disposable-context.js.map
extension/out/extension.js
extension/out/extension.js.map
extension/out/types.js
extension/out/types.js.map
extension/package.json
extension/README.md
extension/src-ts/debug-adapter-factory.ts
extension/src-ts/disposable-context.ts
extension/src-ts/extension.ts
extension/src-ts/types.ts
extension/syntaxes/arm.disasm
extension/syntaxes/arm64.disasm
extension/syntaxes/disassembly.json
extension/syntaxes/x86.disasm
extension/tsconfig.json
```

All that's really needed is the package.json, license, README, syntaxes folder, and compiled sources. This PR adds a `.vscodeignore` file that requires files and directories to be explicitly added to the VSIX.

Contents of the VSIX after applying this change and running `npm run package`:

```
❯ tar tf out/lldb-dap.vsix

extension.vsixmanifest
[Content_Types].xml
extension/LICENSE.TXT
extension/out/debug-adapter-factory.js
extension/out/debug-adapter-factory.js.map
extension/out/disposable-context.js
extension/out/disposable-context.js.map
extension/out/extension.js
extension/out/extension.js.map
extension/package.json
extension/README.md
extension/syntaxes/arm.disasm
extension/syntaxes/arm64.disasm
extension/syntaxes/disassembly.json
extension/syntaxes/x86.disasm
```

I did a very basic sanity check of installing the packaged extension and debugging a simple swift application in VS Code to make sure the extension was still functional.