### PR TITLE
[clang-format] Fix mismatched break in BlockIndent

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -350,7 +350,7 @@ bool ContinuationIndenter::canBreak(const LineState &State) {
   }
 
   // Allow breaking before the right parens with block indentation if there was
-  // a break after the left parens, which is tracked by BreakBeforeClosingParen
+  // a break after the left parens, which is tracked by BreakBeforeClosingParen.
   if (Style.AlignAfterOpenBracket == FormatStyle::BAS_BlockIndent &&
       Current.is(tok::r_paren)) {
     return CurrentState.BreakBeforeClosingParen;

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -349,6 +349,13 @@ bool ContinuationIndenter::canBreak(const LineState &State) {
     }
   }
 
+  // Allow breaking before the right parens with block indentation if there was
+  // a break after the left parens, which is tracked by BreakBeforeClosingParen
+  if (Style.AlignAfterOpenBracket == FormatStyle::BAS_BlockIndent &&
+      Current.is(tok::r_paren)) {
+    return CurrentState.BreakBeforeClosingParen;
+  }
+
   // Don't allow breaking before a closing brace of a block-indented braced list
   // initializer if there isn't already a break.
   if (Current.is(tok::r_brace) && Current.MatchingParen &&

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -9608,15 +9608,15 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
       "    \"a aaaaaaa aaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaaaaaaa\"\n"
       ");",
       Style);
-  verifyFormat("aaaaaaaaaaaaaaaaaaaaaaa(\n"
-               "    &bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
-               ");",
-               Style);
   Style.ColumnLimit = 60;
   verifyFormat("auto lambda =\n"
                "    [&b](\n"
                "        auto aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
                "    ) {};",
+               Style);
+  verifyFormat("aaaaaaaaaaaaaaaaaaaaaaaa(\n"
+               "    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+               ");",
                Style);
 }
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -9608,6 +9608,10 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
       "    \"a aaaaaaa aaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaa aaaaaaaaaaaaa\"\n"
       ");",
       Style);
+  verifyFormat("aaaaaaaaaaaaaaaaaaaaaaa(\n"
+               "    &bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+               ");",
+               Style);
   Style.ColumnLimit = 60;
   verifyFormat("auto lambda =\n"
                "    [&b](\n"

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -9615,7 +9615,7 @@ TEST_F(FormatTest, AlignsAfterOpenBracket) {
                "    ) {};",
                Style);
   verifyFormat("aaaaaaaaaaaaaaaaaaaaaaaa(\n"
-               "    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+               "    &bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
                ");",
                Style);
 }


### PR DESCRIPTION
Near the ColumnLimit a break could be inserted before a right parens with BlockIndent without a break after the matching left parens. Avoid these hanging right parens by disallowing breaks before right parens unless there was a break after the left parens.

Fixes #103306