### PR TITLE
[mlir][cmake] Add missing MLIRTestDialect dependency

### DIFF
--- a/mlir/test/lib/IR/CMakeLists.txt
+++ b/mlir/test/lib/IR/CMakeLists.txt
@@ -27,7 +27,11 @@ add_mlir_library(MLIRTestIR
   TestVisitorsGeneric.cpp
 
   EXCLUDE_FROM_LIBMLIR
+
+  DEPENDS
+  MLIRTestDialect
   )
+
 mlir_target_link_libraries(MLIRTestIR PUBLIC
   MLIRPass
   MLIRBytecodeReader


### PR DESCRIPTION
Hopefully this will fix the flaky build issue that we have in one of the bots: https://lab.llvm.org/buildbot/#/builders/50/builds/9532