### PR TITLE
[LV]: Add costs to VPInstruction

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1315,6 +1315,9 @@ public:
   InstructionCost computeCost(ElementCount VF,
                               VPCostContext &Ctx) const override {
     // TODO: Compute accurate cost after retiring the legacy cost model.
+    // Use legacy cost model for now.
+    if (auto *I = dyn_cast_or_null<Instruction>(getUnderlyingValue()))
+      return Ctx.getLegacyCost(I, VF);
     return 0;
   }
 


### PR DESCRIPTION
- In some cases VPlanTransforms pass replaces some instructions by VPInstructions.
- Right now VPInstruction returns 0 cost, and that causes inaccurate VPlan-based cost 
  calculations which may cause choosing VF different than chosen one by legacy cost model. 