### PR TITLE
[bazel] Remove more references to ARCMigrate

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -2204,7 +2204,6 @@ cc_library(
     hdrs = glob(["include/clang/FrontendTool/*.h"]),
     includes = ["include"],
     deps = [
-        ":arc_migrate",
         ":codegen",
         ":config",
         ":driver",
@@ -2226,7 +2225,6 @@ cc_library(
     hdrs = glob(["include/clang-c/*.h"]),
     defines = ["CINDEX_NO_EXPORTS"],
     deps = [
-        ":arc_migrate",
         ":ast",
         ":basic",
         ":codegen",
@@ -2259,7 +2257,6 @@ cc_plugin_library(
     }),
     strip_include_prefix = "include",
     deps = [
-        ":arc_migrate",
         ":ast",
         ":basic",
         ":codegen",


### PR DESCRIPTION
c4a019747c98ad9326a675d3cb5a70311ba170a2 removed arc_migrate targets but accidentally left a few references to the now deleted target. Remove those.