### PR TITLE
[lldb][test] Add test for detecting CV-quals of explicit object member functions

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/explicit-member-function-quals.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/explicit-member-function-quals.cpp
@@ -1,0 +1,22 @@
+// XFAIL: *
+
+// Tests that we correctly deduce the CV-quals and storage
+// class of explicit object member functions.
+//
+// RUN: %clangxx_host %s -g -std=c++23 -c -o %t
+// RUN: %lldb %t -b -o "type lookup Foo" 2>&1 | FileCheck %s
+//
+// CHECK:      (lldb) type lookup Foo
+// CHECK-NEXT: struct Foo {
+// CHECK-NEXT:      void Method(Foo);
+// CHECK-NEXT:      void cMethod(Foo const&);
+// CHECK-NEXT:      void vMethod(Foo volatile&);
+// CHECK-NEXT:      void cvMethod(const Foo volatile&) const volatile;
+// CHECK-NEXT: }
+
+struct Foo {
+  void Method(this Foo) {}
+  void cMethod(this Foo const&) {}
+  void vMethod(this Foo volatile&) {}
+  void cvMethod(this Foo const volatile&) {}
+} f;

--- a/lldb/test/Shell/SymbolFile/DWARF/explicit-member-function-quals.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/explicit-member-function-quals.cpp
@@ -16,7 +16,7 @@
 
 struct Foo {
   void Method(this Foo) {}
-  void cMethod(this Foo const&) {}
-  void vMethod(this Foo volatile&) {}
-  void cvMethod(this Foo const volatile&) {}
+  void cMethod(this Foo const &) {}
+  void vMethod(this Foo volatile &) {}
+  void cvMethod(this Foo const volatile &) {}
 } f;

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/explicit-member-function-quals.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/explicit-member-function-quals.cpp
@@ -3,7 +3,7 @@
 // Tests that we correctly deduce the CV-quals and storage
 // class of explicit object member functions.
 //
-// RUN: %clangxx_host %s -g -std=c++23 -c -o %t
+// RUN: %clangxx_host %s -triple x86_64-pc-linux -g -std=c++23 -c -o %t
 // RUN: %lldb %t -b -o "type lookup Foo" 2>&1 | FileCheck %s
 //
 // CHECK:      (lldb) type lookup Foo


### PR DESCRIPTION
This is XFAILed for now until we find a good way to locate the DW_AT_object_pointer of function declarations (a possible solution being https://github.com/llvm/llvm-project/pull/124790).

Made it a shell test because I couldn't find any SBAPIs that i could query to find the CV-qualifiers/etc. of member functions.