### PR TITLE
Added const reference for params wth size >= 16 bytes

### DIFF
--- a/llvm/include/llvm/Analysis/AliasSetTracker.h
+++ b/llvm/include/llvm/Analysis/AliasSetTracker.h
@@ -249,7 +249,7 @@ private:
     }
   }
 
-  AliasSet &addMemoryLocation(MemoryLocation Loc, AliasSet::AccessLattice E);
+  AliasSet &addMemoryLocation(const MemoryLocation &Loc, AliasSet::AccessLattice E);
   AliasSet *mergeAliasSetsForMemoryLocation(const MemoryLocation &MemLoc,
                                             AliasSet *PtrAS,
                                             bool &MustAliasAll);

--- a/llvm/include/llvm/Analysis/AssumeBundleQueries.h
+++ b/llvm/include/llvm/Analysis/AssumeBundleQueries.h
@@ -100,14 +100,14 @@ struct RetainedKnowledge {
   Attribute::AttrKind AttrKind = Attribute::None;
   uint64_t ArgValue = 0;
   Value *WasOn = nullptr;
-  bool operator==(RetainedKnowledge Other) const {
+  bool operator==(const RetainedKnowledge &Other) const {
     return AttrKind == Other.AttrKind && WasOn == Other.WasOn &&
            ArgValue == Other.ArgValue;
   }
-  bool operator!=(RetainedKnowledge Other) const { return !(*this == Other); }
+  bool operator!=(const RetainedKnowledge &Other) const { return !(*this == Other); }
   /// This is only intended for use in std::min/std::max between attribute that
   /// only differ in ArgValue.
-  bool operator<(RetainedKnowledge Other) const {
+  bool operator<(const RetainedKnowledge &Other) const {
     assert(((AttrKind == Other.AttrKind && WasOn == Other.WasOn) ||
             AttrKind == Attribute::None || Other.AttrKind == Attribute::None) &&
            "This is only intend for use in min/max to select the best for "

--- a/llvm/include/llvm/Analysis/SparsePropagation.h
+++ b/llvm/include/llvm/Analysis/SparsePropagation.h
@@ -92,7 +92,7 @@ public:
       SparseSolver<LatticeKey, LatticeVal> &SS) = 0;
 
   /// PrintLatticeVal - Render the given LatticeVal to the specified stream.
-  virtual void PrintLatticeVal(LatticeVal LV, raw_ostream &OS);
+  virtual void PrintLatticeVal(const LatticeVal &LV, raw_ostream &OS);
 
   /// PrintLatticeKey - Render the given LatticeKey to the specified stream.
   virtual void PrintLatticeKey(LatticeKey Key, raw_ostream &OS);
@@ -203,7 +203,7 @@ private:
 
 template <class LatticeKey, class LatticeVal>
 void AbstractLatticeFunction<LatticeKey, LatticeVal>::PrintLatticeVal(
-    LatticeVal V, raw_ostream &OS) {
+    const LatticeVal &V, raw_ostream &OS) {
   if (V == UndefVal)
     OS << "undefined";
   else if (V == OverdefinedVal)

--- a/llvm/include/llvm/Bitcode/BitcodeReader.h
+++ b/llvm/include/llvm/Bitcode/BitcodeReader.h
@@ -119,12 +119,12 @@ struct ParserCallbacks {
 
     // Calls the ctor.
     friend Expected<BitcodeFileContents>
-    getBitcodeFileContents(MemoryBufferRef Buffer);
+    getBitcodeFileContents(const MemoryBufferRef &Buffer);
 
     Expected<std::unique_ptr<Module>>
     getModuleImpl(LLVMContext &Context, bool MaterializeAll,
                   bool ShouldLazyLoadMetadata, bool IsImporting,
-                  ParserCallbacks Callbacks = {});
+                  const ParserCallbacks &Callbacks = {});
 
   public:
     StringRef getBuffer() const {
@@ -141,11 +141,11 @@ struct ParserCallbacks {
     /// importing into another module.
     Expected<std::unique_ptr<Module>>
     getLazyModule(LLVMContext &Context, bool ShouldLazyLoadMetadata,
-                  bool IsImporting, ParserCallbacks Callbacks = {});
+                  bool IsImporting, const ParserCallbacks &Callbacks = {});
 
     /// Read the entire bitcode module and return it.
     Expected<std::unique_ptr<Module>>
-    parseModule(LLVMContext &Context, ParserCallbacks Callbacks = {});
+    parseModule(LLVMContext &Context, const ParserCallbacks &Callbacks = {});
 
     /// Returns information about the module to be used for LTO: whether to
     /// compile with ThinLTO, and whether it has a summary.
@@ -171,21 +171,21 @@ struct ParserCallbacks {
   /// symbol table should prefer to use irsymtab::read instead of this function
   /// because it creates a reader for the irsymtab and handles upgrading bitcode
   /// files without a symbol table or with an old symbol table.
-  Expected<BitcodeFileContents> getBitcodeFileContents(MemoryBufferRef Buffer);
+  Expected<BitcodeFileContents> getBitcodeFileContents(const MemoryBufferRef &Buffer);
 
   /// Returns a list of modules in the specified bitcode buffer.
   Expected<std::vector<BitcodeModule>>
-  getBitcodeModuleList(MemoryBufferRef Buffer);
+  getBitcodeModuleList(const MemoryBufferRef &Buffer);
 
   /// Read the header of the specified bitcode buffer and prepare for lazy
   /// deserialization of function bodies. If ShouldLazyLoadMetadata is true,
   /// lazily load metadata as well. If IsImporting is true, this module is
   /// being parsed for ThinLTO importing into another module.
   Expected<std::unique_ptr<Module>>
-  getLazyBitcodeModule(MemoryBufferRef Buffer, LLVMContext &Context,
+  getLazyBitcodeModule(const MemoryBufferRef &Buffer, LLVMContext &Context,
                        bool ShouldLazyLoadMetadata = false,
                        bool IsImporting = false,
-                       ParserCallbacks Callbacks = {});
+                       const ParserCallbacks &Callbacks = {});
 
   /// Like getLazyBitcodeModule, except that the module takes ownership of
   /// the memory buffer if successful. If successful, this moves Buffer. On
@@ -194,36 +194,36 @@ struct ParserCallbacks {
   Expected<std::unique_ptr<Module>> getOwningLazyBitcodeModule(
       std::unique_ptr<MemoryBuffer> &&Buffer, LLVMContext &Context,
       bool ShouldLazyLoadMetadata = false, bool IsImporting = false,
-      ParserCallbacks Callbacks = {});
+      const ParserCallbacks &Callbacks = {});
 
   /// Read the header of the specified bitcode buffer and extract just the
   /// triple information. If successful, this returns a string. On error, this
   /// returns "".
-  Expected<std::string> getBitcodeTargetTriple(MemoryBufferRef Buffer);
+  Expected<std::string> getBitcodeTargetTriple(const MemoryBufferRef &Buffer);
 
   /// Return true if \p Buffer contains a bitcode file with ObjC code (category
   /// or class) in it.
-  Expected<bool> isBitcodeContainingObjCCategory(MemoryBufferRef Buffer);
+  Expected<bool> isBitcodeContainingObjCCategory(const MemoryBufferRef &Buffer);
 
   /// Read the header of the specified bitcode buffer and extract just the
   /// producer string information. If successful, this returns a string. On
   /// error, this returns "".
-  Expected<std::string> getBitcodeProducerString(MemoryBufferRef Buffer);
+  Expected<std::string> getBitcodeProducerString(const MemoryBufferRef &Buffer);
 
   /// Read the specified bitcode file, returning the module.
   Expected<std::unique_ptr<Module>>
-  parseBitcodeFile(MemoryBufferRef Buffer, LLVMContext &Context,
-                   ParserCallbacks Callbacks = {});
+  parseBitcodeFile(const MemoryBufferRef &Buffer, LLVMContext &Context,
+                   const ParserCallbacks &Callbacks = {});
 
   /// Returns LTO information for the specified bitcode file.
-  Expected<BitcodeLTOInfo> getBitcodeLTOInfo(MemoryBufferRef Buffer);
+  Expected<BitcodeLTOInfo> getBitcodeLTOInfo(const MemoryBufferRef &Buffer);
 
   /// Parse the specified bitcode buffer, returning the module summary index.
   Expected<std::unique_ptr<ModuleSummaryIndex>>
-  getModuleSummaryIndex(MemoryBufferRef Buffer);
+  getModuleSummaryIndex(const MemoryBufferRef &Buffer);
 
   /// Parse the specified bitcode buffer and merge the index into CombinedIndex.
-  Error readModuleSummaryIndex(MemoryBufferRef Buffer,
+  Error readModuleSummaryIndex(const MemoryBufferRef &Buffer,
                                ModuleSummaryIndex &CombinedIndex);
 
   /// Parse the module summary index out of an IR file and return the module

--- a/llvm/include/llvm/Bitcode/BitcodeWriter.h
+++ b/llvm/include/llvm/Bitcode/BitcodeWriter.h
@@ -163,7 +163,7 @@ void writeIndexToFile(
 /// If EmbedCmdline is set, the command line is also exported in
 /// the corresponding section (__LLVM,_cmdline / .llvmcmd) - even if CmdArgs
 /// were empty.
-void embedBitcodeInModule(Module &M, MemoryBufferRef Buf, bool EmbedBitcode,
+void embedBitcodeInModule(Module &M, const MemoryBufferRef &Buf, bool EmbedBitcode,
                           bool EmbedCmdline,
                           const std::vector<uint8_t> &CmdArgs);
 

--- a/llvm/include/llvm/CGData/CodeGenData.h
+++ b/llvm/include/llvm/CGData/CodeGenData.h
@@ -265,7 +265,7 @@ std::unique_ptr<Module> loadModuleForTwoRounds(BitcodeModule &OrigModule,
 Expected<stable_hash> mergeCodeGenData(ArrayRef<StringRef> ObjectFiles);
 
 void warn(Error E, StringRef Whence = "");
-void warn(Twine Message, std::string Whence = "", std::string Hint = "");
+void warn(const Twine &Message, const std::string &Whence = "", const std::string &Hint = "");
 
 } // end namespace cgdata
 

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -632,7 +632,7 @@ public:
                                          StringRef Suffix) const;
 
   /// Return the MCSymbol for the specified ExternalSymbol.
-  MCSymbol *GetExternalSymbolSymbol(Twine Sym) const;
+  MCSymbol *GetExternalSymbolSymbol(const Twine &Sym) const;
 
   /// Return the symbol for the specified jump table entry.
   MCSymbol *GetJTISymbol(unsigned JTID, bool isLinkerPrivate = false) const;
@@ -723,10 +723,10 @@ public:
   /// emitDwarfSymbolReference().
   ///
   /// The length of the emitted value depends on the DWARF format.
-  void emitDwarfStringOffset(DwarfStringPoolEntry S) const;
+  void emitDwarfStringOffset(const DwarfStringPoolEntry &S) const;
 
   /// Emit the 4-or 8-byte offset of a string from the start of its section.
-  void emitDwarfStringOffset(DwarfStringPoolEntryRef S) const {
+  void emitDwarfStringOffset(const DwarfStringPoolEntryRef &S) const {
     emitDwarfStringOffset(S.getEntry());
   }
 

--- a/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
+++ b/llvm/include/llvm/CodeGen/BasicBlockSectionsProfileReader.h
@@ -105,7 +105,7 @@ private:
   }
 
   // Returns a profile parsing error for the current line.
-  Error createProfileParseError(Twine Message) const {
+  Error createProfileParseError(const Twine &Message) const {
     return make_error<StringError>(
         Twine("invalid profile " + MBuf->getBufferIdentifier() + " at line " +
               Twine(LineIt.line_number()) + ": " + Message),

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -1059,7 +1059,7 @@ public:
       AtomicOrdering Ordering = AtomicOrdering::NotAtomic,
       AtomicOrdering FailureOrdering = AtomicOrdering::NotAtomic);
   MachineMemOperand *getMachineMemOperand(
-      MachinePointerInfo PtrInfo, MachineMemOperand::Flags F, LocationSize Size,
+      const MachinePointerInfo &PtrInfo, MachineMemOperand::Flags F, LocationSize Size,
       Align BaseAlignment, const AAMDNodes &AAInfo = AAMDNodes(),
       const MDNode *Ranges = nullptr, SyncScope::ID SSID = SyncScope::System,
       AtomicOrdering Ordering = AtomicOrdering::NotAtomic,

--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -1408,7 +1408,7 @@ public:
                   const MDNode *Ranges = nullptr);
   inline SDValue getLoad(
       ISD::MemIndexedMode AM, ISD::LoadExtType ExtType, EVT VT, const SDLoc &dl,
-      SDValue Chain, SDValue Ptr, SDValue Offset, MachinePointerInfo PtrInfo,
+      SDValue Chain, SDValue Ptr, SDValue Offset, const MachinePointerInfo &PtrInfo,
       EVT MemVT, MaybeAlign Alignment = MaybeAlign(),
       MachineMemOperand::Flags MMOFlags = MachineMemOperand::MONone,
       const AAMDNodes &AAInfo = AAMDNodes(), const MDNode *Ranges = nullptr) {

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFLinker.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFLinker.h
@@ -665,7 +665,7 @@ private:
                                         CompileUnit &Unit);
 
     /// Clone a DWARF expression that may be referencing another DIE.
-    void cloneExpression(DataExtractor &Data, DWARFExpression Expression,
+    void cloneExpression(DataExtractor &Data, const DWARFExpression &Expression,
                          const DWARFFile &File, CompileUnit &Unit,
                          SmallVectorImpl<uint8_t> &OutputBuffer,
                          int64_t AddrRelocAdjustment, bool IsLittleEndian);
@@ -709,7 +709,7 @@ private:
 
     /// Helper for cloneDIE.
     void addObjCAccelerator(CompileUnit &Unit, const DIE *Die,
-                            DwarfStringPoolEntryRef Name,
+                            const DwarfStringPoolEntryRef &Name,
                             OffsetsStringPool &StringPool, bool SkipPubSection);
 
     void rememberUnitForMacroOffset(CompileUnit &Unit);

--- a/llvm/include/llvm/DWARFLinker/Classic/DWARFStreamer.h
+++ b/llvm/include/llvm/DWARFLinker/Classic/DWARFStreamer.h
@@ -227,25 +227,25 @@ private:
   /// Emit piece of .debug_ranges for \p LinkedRanges.
   void emitDwarfDebugRangesTableFragment(const CompileUnit &Unit,
                                          const AddressRanges &LinkedRanges,
-                                         PatchLocation Patch);
+                                         const PatchLocation &Patch);
 
   /// Emit piece of .debug_rnglists for \p LinkedRanges.
   void emitDwarfDebugRngListsTableFragment(const CompileUnit &Unit,
                                            const AddressRanges &LinkedRanges,
-                                           PatchLocation Patch,
+                                           const PatchLocation &Patch,
                                            DebugDieValuePool &AddrPool);
 
   /// Emit piece of .debug_loc for \p LinkedRanges.
   void emitDwarfDebugLocTableFragment(
       const CompileUnit &Unit,
       const DWARFLocationExpressionsVector &LinkedLocationExpression,
-      PatchLocation Patch);
+      const PatchLocation &Patch);
 
   /// Emit piece of .debug_loclists for \p LinkedRanges.
   void emitDwarfDebugLocListsTableFragment(
       const CompileUnit &Unit,
       const DWARFLocationExpressionsVector &LinkedLocationExpression,
-      PatchLocation Patch, DebugDieValuePool &AddrPool);
+      const PatchLocation &Patch, DebugDieValuePool &AddrPool);
 
   /// \defgroup Line table emission
   /// @{

--- a/llvm/include/llvm/DebugInfo/CodeView/CVTypeVisitor.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/CVTypeVisitor.h
@@ -30,13 +30,13 @@ enum VisitorDataSource {
                     // supply the bytes.
 };
 
-Error visitTypeRecord(CVType &Record, TypeIndex Index,
+Error visitTypeRecord(CVType &Record, const TypeIndex &Index,
                       TypeVisitorCallbacks &Callbacks,
                       VisitorDataSource Source = VDS_BytesPresent);
 Error visitTypeRecord(CVType &Record, TypeVisitorCallbacks &Callbacks,
                       VisitorDataSource Source = VDS_BytesPresent);
 
-Error visitMemberRecord(CVMemberRecord Record, TypeVisitorCallbacks &Callbacks,
+Error visitMemberRecord(const CVMemberRecord &Record, TypeVisitorCallbacks &Callbacks,
                         VisitorDataSource Source = VDS_BytesPresent);
 Error visitMemberRecord(TypeLeafKind Kind, ArrayRef<uint8_t> Record,
                         TypeVisitorCallbacks &Callbacks);

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h
@@ -69,7 +69,7 @@ public:
   }
 
   Error initialize(BinaryStreamReader Reader);
-  Error initialize(BinaryStreamRef Section) {
+  Error initialize(const BinaryStreamRef &Section) {
     return initialize(BinaryStreamReader(Section));
   }
 
@@ -101,7 +101,7 @@ public:
   Error commit(BinaryStreamWriter &Writer) const override;
   uint32_t calculateSerializedSize() const override;
 
-  void addInlineSite(TypeIndex FuncId, StringRef FileName, uint32_t SourceLine);
+  void addInlineSite(const TypeIndex &FuncId, StringRef FileName, uint32_t SourceLine);
   void addExtraFile(StringRef FileName);
 
   bool hasExtraFiles() const { return HasExtraFiles; }

--- a/llvm/include/llvm/DebugInfo/CodeView/DebugStringTableSubsection.h
+++ b/llvm/include/llvm/DebugInfo/CodeView/DebugStringTableSubsection.h
@@ -36,7 +36,7 @@ public:
     return S->kind() == DebugSubsectionKind::StringTable;
   }
 
-  Error initialize(BinaryStreamRef Contents);
+  Error initialize(const BinaryStreamRef &Contents);
   Error initialize(BinaryStreamReader &Reader);
 
   Expected<StringRef> getString(uint32_t Offset) const;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAbbreviationDeclaration.h
@@ -173,7 +173,7 @@ public:
   getAttributeValueFromOffset(uint32_t AttrIndex, uint64_t Offset,
                               const DWARFUnit &U) const;
 
-  llvm::Expected<ExtractState> extract(DataExtractor Data, uint64_t *OffsetPtr);
+  llvm::Expected<ExtractState> extract(const DataExtractor &Data, uint64_t *OffsetPtr);
   void dump(raw_ostream &OS) const;
 
   // Return an optional byte size of all attribute data in this abbreviation

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAddressRange.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAddressRange.h
@@ -68,7 +68,7 @@ struct DWARFAddressRange {
     return true;
   }
 
-  void dump(raw_ostream &OS, uint32_t AddressSize, DIDumpOptions DumpOpts = {},
+  void dump(raw_ostream &OS, uint32_t AddressSize, const DIDumpOptions &DumpOpts = {},
             const DWARFObject *Obj = nullptr) const;
 };
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h
@@ -34,7 +34,7 @@ public:
 
   uint64_t getOffset() const { return Offset; }
   void dump(raw_ostream &OS) const;
-  Error extract(DataExtractor Data, uint64_t *OffsetPtr);
+  Error extract(const DataExtractor &Data, uint64_t *OffsetPtr);
 
   const DWARFAbbreviationDeclaration *
   getAbbreviationDeclaration(uint32_t AbbrCode) const;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAddr.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAddr.h
@@ -63,7 +63,7 @@ public:
   Error extractPreStandard(const DWARFDataExtractor &Data, uint64_t *OffsetPtr,
                            uint16_t CUVersion, uint8_t CUAddrSize);
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts = {}) const;
+  void dump(raw_ostream &OS, const DIDumpOptions &DumpOpts = {}) const;
 
   /// Return the address based on a given index.
   Expected<uint64_t> getAddrEntry(uint32_t Index) const;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugArangeSet.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugArangeSet.h
@@ -61,7 +61,7 @@ public:
   DWARFDebugArangeSet() { clear(); }
 
   void clear();
-  Error extract(DWARFDataExtractor data, uint64_t *offset_ptr,
+  Error extract(const DWARFDataExtractor &data, uint64_t *offset_ptr,
                 function_ref<void(Error)> WarningHandler = nullptr);
   void dump(raw_ostream &OS) const;
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
@@ -27,7 +27,7 @@ public:
 
 private:
   void clear();
-  void extract(DWARFDataExtractor DebugArangesData,
+  void extract(const DWARFDataExtractor &DebugArangesData,
                function_ref<void(Error)> RecoverableErrorHandler,
                function_ref<void(Error)> WarningHandler);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugFrame.h
@@ -124,8 +124,8 @@ public:
   /// Create a location whose value is the result of evaluating a DWARF
   /// expression. This allows complex expressions to be evaluated in order to
   /// unwind a register or CFA value.
-  static UnwindLocation createIsDWARFExpression(DWARFExpression Expr);
-  static UnwindLocation createAtDWARFExpression(DWARFExpression Expr);
+  static UnwindLocation createIsDWARFExpression(const DWARFExpression &Expr);
+  static UnwindLocation createAtDWARFExpression(const DWARFExpression &Expr);
   static UnwindLocation createIsConstant(int32_t Value);
 
   Location getLocation() const { return Kind; }
@@ -164,7 +164,7 @@ public:
   /// instead of from .debug_frame. This is needed for register number
   /// conversion because some register numbers differ between the two sections
   /// for certain architectures like x86.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts) const;
+  void dump(raw_ostream &OS, const DIDumpOptions &DumpOpts) const;
 
   bool operator==(const UnwindLocation &RHS) const;
 };
@@ -303,7 +303,7 @@ public:
   ///
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+  void dump(raw_ostream &OS, const DIDumpOptions &DumpOpts,
             unsigned IndentLevel = 0) const;
 };
 
@@ -348,7 +348,7 @@ public:
   ///
   /// \param IndentLevel specify the indent level as an integer. The UnwindRow
   /// will be output to the stream preceded by 2 * IndentLevel number of spaces.
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+  void dump(raw_ostream &OS, const DIDumpOptions &DumpOpts,
             unsigned IndentLevel = 0) const;
 
   /// Create an UnwindTable from a Common Information Entry (CIE).
@@ -454,7 +454,7 @@ public:
   /// where a problem occurred in case an error is returned.
   Error parse(DWARFDataExtractor Data, uint64_t *Offset, uint64_t EndOffset);
 
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts, unsigned IndentLevel,
+  void dump(raw_ostream &OS, const DIDumpOptions &DumpOpts, unsigned IndentLevel,
             std::optional<uint64_t> InitialLocation) const;
 
   void addInstruction(const Instruction &I) { Instructions.push_back(I); }
@@ -522,7 +522,7 @@ private:
   static ArrayRef<OperandType[MaxOperands]> getOperandTypes();
 
   /// Print \p Opcode's operand number \p OperandIdx which has value \p Operand.
-  void printOperand(raw_ostream &OS, DIDumpOptions DumpOpts,
+  void printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                     const Instruction &Instr, unsigned OperandIdx,
                     uint64_t Operand, std::optional<uint64_t> &Address) const;
 };

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h
@@ -122,7 +122,7 @@ public:
                        sys::path::Style Style = sys::path::Style::native) const;
 
     void clear();
-    void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
+    void dump(raw_ostream &OS, const DIDumpOptions &DumpOptions) const;
     Error parse(DWARFDataExtractor Data, uint64_t *OffsetPtr,
                 function_ref<void(Error)> RecoverableErrorHandler,
                 const DWARFContext &Ctx, const DWARFUnit *U = nullptr);
@@ -277,7 +277,7 @@ public:
     bool getDirectoryForEntry(const FileNameEntry &Entry,
                               std::string &Directory) const;
 
-    void dump(raw_ostream &OS, DIDumpOptions DumpOptions) const;
+    void dump(raw_ostream &OS, const DIDumpOptions &DumpOptions) const;
     void clear();
 
     /// Parse prologue and all rows.

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLoc.h
@@ -108,7 +108,7 @@ public:
       : DWARFLocationTable(std::move(Data)) {}
 
   /// Print the location lists found within the debug_loc section.
-  void dump(raw_ostream &OS, const DWARFObject &Obj, DIDumpOptions DumpOpts,
+  void dump(raw_ostream &OS, const DWARFObject &Obj, const DIDumpOptions &DumpOpts,
             std::optional<uint64_t> Offset) const;
 
   Error visitLocationList(
@@ -132,7 +132,7 @@ public:
 
   /// Dump all location lists within the given range.
   void dumpRange(uint64_t StartOffset, uint64_t Size, raw_ostream &OS,
-                 const DWARFObject &Obj, DIDumpOptions DumpOpts);
+                 const DWARFObject &Obj, const DIDumpOptions &DumpOpts);
 
 protected:
   void dumpRawEntry(const DWARFLocationEntry &Entry, raw_ostream &OS,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugMacro.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugMacro.h
@@ -65,7 +65,7 @@ class DWARFDebugMacro {
     void dumpMacroHeader(raw_ostream &OS) const;
 
     /// Parse the debug_macro header.
-    Error parseMacroHeader(DWARFDataExtractor Data, uint64_t *Offset);
+    Error parseMacroHeader(const DWARFDataExtractor &Data, uint64_t *Offset);
 
     /// Get the DWARF format according to the flags.
     dwarf::DwarfFormat getDwarfFormat() const;
@@ -119,12 +119,12 @@ public:
   void dump(raw_ostream &OS) const;
 
   Error parseMacro(DWARFUnitVector::compile_unit_range Units,
-                   DataExtractor StringExtractor,
-                   DWARFDataExtractor MacroData) {
+                   const DataExtractor &StringExtractor,
+                   const DWARFDataExtractor &MacroData) {
     return parseImpl(Units, StringExtractor, MacroData, /*IsMacro=*/true);
   }
 
-  Error parseMacinfo(DWARFDataExtractor MacroData) {
+  Error parseMacinfo(const DWARFDataExtractor &MacroData) {
     return parseImpl(std::nullopt, std::nullopt, MacroData, /*IsMacro=*/false);
   }
 
@@ -144,7 +144,7 @@ private:
   /// parameter.
   Error parseImpl(std::optional<DWARFUnitVector::compile_unit_range> Units,
                   std::optional<DataExtractor> StringExtractor,
-                  DWARFDataExtractor Data, bool IsMacro);
+                  const DWARFDataExtractor &Data, bool IsMacro);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugPubTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugPubTable.h
@@ -74,7 +74,7 @@ private:
 public:
   DWARFDebugPubTable() = default;
 
-  void extract(DWARFDataExtractor Data, bool GnuStyle,
+  void extract(const DWARFDataExtractor &Data, bool GnuStyle,
                function_ref<void(Error)> RecoverableErrorHandler);
 
   void dump(raw_ostream &OS) const;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRnglists.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugRnglists.h
@@ -35,7 +35,7 @@ struct RangeListEntry : public DWARFListEntryBase {
   uint64_t Value0;
   uint64_t Value1;
 
-  Error extract(DWARFDataExtractor Data, uint64_t *OffsetPtr);
+  Error extract(const DWARFDataExtractor &Data, uint64_t *OffsetPtr);
   void
   dump(raw_ostream &OS, uint8_t AddrSize, uint8_t MaxEncodingStringLength,
        uint64_t &CurrentBase, DIDumpOptions DumpOpts,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFExpression.h
@@ -98,14 +98,14 @@ public:
     }
     uint64_t getEndOffset() const { return EndOffset; }
     bool isError() const { return Error; }
-    bool print(raw_ostream &OS, DIDumpOptions DumpOpts,
+    bool print(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                const DWARFExpression *Expr, DWARFUnit *U) const;
 
     /// Verify \p Op. Does not affect the return of \a isError().
     static bool verify(const Operation &Op, DWARFUnit *U);
 
   private:
-    bool extract(DataExtractor Data, uint8_t AddressSize, uint64_t Offset,
+    bool extract(const DataExtractor &Data, uint8_t AddressSize, uint64_t Offset,
                  std::optional<dwarf::DwarfFormat> Format);
   };
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
@@ -82,14 +82,14 @@ public:
 
   bool isFormClass(FormClass FC) const;
   const DWARFUnit *getUnit() const { return U; }
-  void dump(raw_ostream &OS, DIDumpOptions DumpOpts = DIDumpOptions()) const;
-  void dumpSectionedAddress(raw_ostream &OS, DIDumpOptions DumpOpts,
+  void dump(raw_ostream &OS, const DIDumpOptions &DumpOpts = DIDumpOptions()) const;
+  void dumpSectionedAddress(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                             object::SectionedAddress SA) const;
   void dumpAddress(raw_ostream &OS, uint64_t Address) const;
   static void dumpAddress(raw_ostream &OS, uint8_t AddressSize,
                           uint64_t Address);
   static void dumpAddressSection(const DWARFObject &Obj, raw_ostream &OS,
-                                 DIDumpOptions DumpOpts, uint64_t SectionIndex);
+                                 const DIDumpOptions &DumpOpts, uint64_t SectionIndex);
 
   /// Extracts a value in \p Data at offset \p *OffsetPtr. The information
   /// in \p FormParams is needed to interpret some forms. The optional
@@ -143,7 +143,7 @@ public:
   /// \param OffsetPtr A reference to the offset that will be updated.
   /// \param Params DWARF parameters to help interpret forms.
   /// \returns true on success, false if the form was not skipped.
-  bool skipValue(DataExtractor DebugInfoData, uint64_t *OffsetPtr,
+  bool skipValue(const DataExtractor &DebugInfoData, uint64_t *OffsetPtr,
                  const dwarf::FormParams Params) const {
     return DWARFFormValue::skipValue(Form, DebugInfoData, OffsetPtr, Params);
   }
@@ -158,7 +158,7 @@ public:
   /// \param OffsetPtr A reference to the offset that will be updated.
   /// \param FormParams DWARF parameters to help interpret forms.
   /// \returns true on success, false if the form was not skipped.
-  static bool skipValue(dwarf::Form Form, DataExtractor DebugInfoData,
+  static bool skipValue(dwarf::Form Form, const DataExtractor &DebugInfoData,
                         uint64_t *OffsetPtr,
                         const dwarf::FormParams FormParams);
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFGdbIndex.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFGdbIndex.h
@@ -67,11 +67,11 @@ class DWARFGdbIndex {
   void dumpSymbolTable(raw_ostream &OS) const;
   void dumpConstantPool(raw_ostream &OS) const;
 
-  bool parseImpl(DataExtractor Data);
+  bool parseImpl(const DataExtractor &Data);
 
 public:
   void dump(raw_ostream &OS);
-  void parse(DataExtractor Data);
+  void parse(const DataExtractor &Data);
 
   bool HasContent = false;
   bool HasError = false;

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFListTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFListTable.h
@@ -110,9 +110,9 @@ public:
     llvm_unreachable("Invalid DWARF format (expected DWARF32 or DWARF64");
   }
 
-  void dump(DataExtractor Data, raw_ostream &OS,
-            DIDumpOptions DumpOpts = {}) const;
-  std::optional<uint64_t> getOffsetEntry(DataExtractor Data,
+  void dump(const DataExtractor &Data, raw_ostream &OS,
+            const DIDumpOptions &DumpOpts = {}) const;
+  std::optional<uint64_t> getOffsetEntry(const DataExtractor &Data,
                                          uint32_t Index) const {
     if (Index >= HeaderData.OffsetEntryCount)
       return std::nullopt;
@@ -120,7 +120,7 @@ public:
     return getOffsetEntry(Data, getHeaderOffset() + getHeaderSize(Format), Format, Index);
   }
 
-  static std::optional<uint64_t> getOffsetEntry(DataExtractor Data,
+  static std::optional<uint64_t> getOffsetEntry(const DataExtractor &Data,
                                                 uint64_t OffsetTableOffset,
                                                 dwarf::DwarfFormat Format,
                                                 uint32_t Index) {

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFUnitIndex.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFUnitIndex.h
@@ -103,7 +103,7 @@ class DWARFUnitIndex {
     uint32_t NumUnits;
     uint32_t NumBuckets = 0;
 
-    bool parse(DataExtractor IndexData, uint64_t *OffsetPtr);
+    bool parse(const DataExtractor &IndexData, uint64_t *OffsetPtr);
     void dump(raw_ostream &OS) const;
   };
 
@@ -162,7 +162,7 @@ private:
 
   static StringRef getColumnHeader(DWARFSectionKind DS);
 
-  bool parseImpl(DataExtractor IndexData);
+  bool parseImpl(const DataExtractor &IndexData);
 
 public:
   DWARFUnitIndex(DWARFSectionKind InfoColumnKind)
@@ -170,7 +170,7 @@ public:
 
   explicit operator bool() const { return Header.NumBuckets; }
 
-  bool parse(DataExtractor IndexData);
+  bool parse(const DataExtractor &IndexData);
   void dump(raw_ostream &OS) const;
 
   uint32_t getVersion() const { return Header.Version; }

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.h
@@ -126,7 +126,7 @@ public:
   /// in parallel on different DbiModuleDescriptorBuilder objects. Only modifies
   /// the pre-allocated stream in question.
   Error commitSymbolStream(const msf::MSFLayout &MsfLayout,
-                           WritableBinaryStreamRef MsfBuffer);
+                           const WritableBinaryStreamRef &MsfBuffer);
 
 private:
   uint32_t calculateC13DebugInfoSize() const;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleList.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiModuleList.h
@@ -68,7 +68,7 @@ class DbiModuleList {
   friend DbiModuleSourceFilesIterator;
 
 public:
-  Error initialize(BinaryStreamRef ModInfo, BinaryStreamRef FileInfo);
+  Error initialize(const BinaryStreamRef &ModInfo, const BinaryStreamRef &FileInfo);
 
   Expected<StringRef> getFileName(uint32_t Index) const;
   uint32_t getModuleCount() const;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/DbiStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/DbiStreamBuilder.h
@@ -74,7 +74,7 @@ public:
 
   Error finalizeMsfLayout();
 
-  Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef MsfBuffer);
+  Error commit(const msf::MSFLayout &Layout, const WritableBinaryStreamRef &MsfBuffer);
 
   void addSectionContrib(const SectionContrib &SC) {
     SectionContribs.emplace_back(SC);

--- a/llvm/include/llvm/DebugInfo/PDB/Native/GSIStreamBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/GSIStreamBuilder.h
@@ -54,7 +54,7 @@ public:
 
   Error finalizeMsfLayout();
 
-  Error commit(const msf::MSFLayout &Layout, WritableBinaryStreamRef Buffer);
+  Error commit(const msf::MSFLayout &Layout, const WritableBinaryStreamRef &Buffer);
 
   uint32_t getPublicsStreamIndex() const { return PublicsStreamIndex; }
   uint32_t getGlobalsStreamIndex() const { return GlobalsStreamIndex; }

--- a/llvm/include/llvm/Debuginfod/Debuginfod.h
+++ b/llvm/include/llvm/Debuginfod/Debuginfod.h
@@ -112,7 +112,7 @@ class DebuginfodLog {
 
 public:
   // Adds a log entry to end of the queue.
-  void push(DebuginfodLogEntry Entry);
+  void push(const DebuginfodLogEntry &Entry);
   // Adds a log entry to end of the queue.
   void push(const Twine &Message);
   // Blocks until there are log entries in the queue, then pops and returns the

--- a/llvm/include/llvm/ExecutionEngine/JITLink/COFF.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/COFF.h
@@ -24,7 +24,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromCOFFObject(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromCOFFObject(const MemoryBufferRef &ObjectBuffer,
                               std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// Link the given graph.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/COFF_x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/COFF_x86_64.h
@@ -24,7 +24,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromCOFFObject_x86_64(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a COFF x86-64 object file.
 void link_COFF_x86_64(std::unique_ptr<LinkGraph> G,

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF.h
@@ -24,7 +24,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject(const MemoryBufferRef &ObjectBuffer,
                              std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// Link the given graph.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch32.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch32.h
@@ -25,7 +25,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_aarch32(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be an ELF arm/thumb object
 /// file.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_aarch64.h
@@ -26,7 +26,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_aarch64(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF aarch64 relocatable
 /// object file.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_i386.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_i386.h
@@ -26,7 +26,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject_i386(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject_i386(const MemoryBufferRef &ObjectBuffer,
                                   std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF i386 relocatable

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_loongarch.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_loongarch.h
@@ -26,7 +26,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_loongarch(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be an ELF loongarch object
 /// file.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_riscv.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_riscv.h
@@ -26,7 +26,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject_riscv(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject_riscv(const MemoryBufferRef &ObjectBuffer,
                                    std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF riscv object file.

--- a/llvm/include/llvm/ExecutionEngine/JITLink/ELF_x86_64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/ELF_x86_64.h
@@ -24,7 +24,7 @@ namespace jitlink {
 /// its contents. The caller is responsible for ensuring that the object buffer
 /// outlives the graph.
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject_x86_64(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject_x86_64(const MemoryBufferRef &ObjectBuffer,
                                     std::shared_ptr<orc::SymbolStringPool> SSP);
 
 /// jit-link the given object buffer, which must be a ELF x86-64 object file.

--- a/llvm/include/llvm/ExecutionEngine/Orc/Core.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Core.h
@@ -1437,7 +1437,7 @@ public:
   /// If a Platform is attached then Platform::setupJITDylib will be called to
   /// install standard platform symbols (e.g. standard library interposes).
   /// If no Platform is attached this call is equivalent to createBareJITDylib.
-  Expected<JITDylib &> createJITDylib(std::string Name);
+  Expected<JITDylib &> createJITDylib(const std::string &Name);
 
   /// Removes the given JITDylibs from the ExecutionSession.
   ///

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -59,7 +59,7 @@ class UnaryInstruction : public Instruction {
 
 protected:
   UnaryInstruction(Type *Ty, unsigned iType, Value *V,
-                   InsertPosition InsertBefore = nullptr)
+                   const InsertPosition &InsertBefore = nullptr)
       : Instruction(Ty, iType, AllocMarker, InsertBefore) {
     Op<0>() = V;
   }
@@ -102,7 +102,7 @@ class UnaryOperator : public UnaryInstruction {
 
 protected:
   UnaryOperator(UnaryOps iType, Value *S, Type *Ty, const Twine &Name,
-                InsertPosition InsertBefore);
+                const InsertPosition &InsertBefore);
 
   // Note: Instruction needs to be a friend here to call cloneImpl.
   friend class Instruction;
@@ -117,7 +117,7 @@ public:
   ///
   static UnaryOperator *Create(UnaryOps Op, Value *S,
                                const Twine &Name = Twine(),
-                               InsertPosition InsertBefore = nullptr);
+                               const InsertPosition &InsertBefore = nullptr);
 
   /// These methods just forward to Create, and are useful when you
   /// statically know what type of instruction you're going to create.  These
@@ -129,7 +129,7 @@ public:
 #include "llvm/IR/Instruction.def"
 #define HANDLE_UNARY_INST(N, OPC, CLASS)                                       \
   static UnaryOperator *Create##OPC(Value *V, const Twine &Name,               \
-                                    InsertPosition InsertBefore = nullptr) {   \
+                                    const InsertPosition &InsertBefore = nullptr) {   \
     return Create(Instruction::OPC, V, Name, InsertBefore);                    \
   }
 #include "llvm/IR/Instruction.def"
@@ -137,7 +137,7 @@ public:
   static UnaryOperator *
   CreateWithCopiedFlags(UnaryOps Opc, Value *V, Instruction *CopyO,
                         const Twine &Name = "",
-                        InsertPosition InsertBefore = nullptr) {
+                        const InsertPosition &InsertBefore = nullptr) {
     UnaryOperator *UO = Create(Opc, V, Name, InsertBefore);
     UO->copyIRFlags(CopyO);
     return UO;
@@ -145,7 +145,7 @@ public:
 
   static UnaryOperator *CreateFNegFMF(Value *Op, Instruction *FMFSource,
                                       const Twine &Name = "",
-                                      InsertPosition InsertBefore = nullptr) {
+                                      const InsertPosition &InsertBefore = nullptr) {
     return CreateWithCopiedFlags(Instruction::FNeg, Op, FMFSource, Name,
                                  InsertBefore);
   }
@@ -174,7 +174,7 @@ class BinaryOperator : public Instruction {
 
 protected:
   BinaryOperator(BinaryOps iType, Value *S1, Value *S2, Type *Ty,
-                 const Twine &Name, InsertPosition InsertBefore);
+                 const Twine &Name, const InsertPosition &InsertBefore);
 
   // Note: Instruction needs to be a friend here to call cloneImpl.
   friend class Instruction;
@@ -196,7 +196,7 @@ public:
   ///
   static BinaryOperator *Create(BinaryOps Op, Value *S1, Value *S2,
                                 const Twine &Name = Twine(),
-                                InsertPosition InsertBefore = nullptr);
+                                const InsertPosition &InsertBefore = nullptr);
 
   /// These methods just forward to Create, and are useful when you
   /// statically know what type of instruction you're going to create.  These
@@ -209,7 +209,7 @@ public:
 #include "llvm/IR/Instruction.def"
 #define HANDLE_BINARY_INST(N, OPC, CLASS)                                      \
   static BinaryOperator *Create##OPC(Value *V1, Value *V2, const Twine &Name,  \
-                                     InsertPosition InsertBefore) {            \
+                                     const InsertPosition &InsertBefore) {            \
     return Create(Instruction::OPC, V1, V2, Name, InsertBefore);               \
   }
 #include "llvm/IR/Instruction.def"
@@ -217,7 +217,7 @@ public:
   static BinaryOperator *
   CreateWithCopiedFlags(BinaryOps Opc, Value *V1, Value *V2, Value *CopyO,
                         const Twine &Name = "",
-                        InsertPosition InsertBefore = nullptr) {
+                        const InsertPosition &InsertBefore = nullptr) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
     BO->copyIRFlags(CopyO);
     return BO;
@@ -226,7 +226,7 @@ public:
   static BinaryOperator *CreateWithFMF(BinaryOps Opc, Value *V1, Value *V2,
                                        FastMathFlags FMF,
                                        const Twine &Name = "",
-                                       InsertPosition InsertBefore = nullptr) {
+                                       const InsertPosition &InsertBefore = nullptr) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
     BO->setFastMathFlags(FMF);
     return BO;
@@ -284,7 +284,7 @@ public:
 
   static BinaryOperator *CreateNSW(BinaryOps Opc, Value *V1, Value *V2,
                                    const Twine &Name,
-                                   InsertPosition InsertBefore) {
+                                   const InsertPosition &InsertBefore) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
     BO->setHasNoSignedWrap(true);
     return BO;
@@ -299,7 +299,7 @@ public:
 
   static BinaryOperator *CreateNUW(BinaryOps Opc, Value *V1, Value *V2,
                                    const Twine &Name,
-                                   InsertPosition InsertBefore) {
+                                   const InsertPosition &InsertBefore) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
     BO->setHasNoUnsignedWrap(true);
     return BO;
@@ -314,7 +314,7 @@ public:
 
   static BinaryOperator *CreateExact(BinaryOps Opc, Value *V1, Value *V2,
                                      const Twine &Name,
-                                     InsertPosition InsertBefore) {
+                                     const InsertPosition &InsertBefore) {
     BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
     BO->setIsExact(true);
     return BO;
@@ -324,7 +324,7 @@ public:
   CreateDisjoint(BinaryOps Opc, Value *V1, Value *V2, const Twine &Name = "");
   static inline BinaryOperator *CreateDisjoint(BinaryOps Opc, Value *V1,
                                                Value *V2, const Twine &Name,
-                                               InsertPosition InsertBefore);
+                                               const InsertPosition &InsertBefore);
 
 #define DEFINE_HELPERS(OPC, NUWNSWEXACT)                                       \
   static BinaryOperator *Create##NUWNSWEXACT##OPC(Value *V1, Value *V2,        \
@@ -333,7 +333,7 @@ public:
   }                                                                            \
   static BinaryOperator *Create##NUWNSWEXACT##OPC(                             \
       Value *V1, Value *V2, const Twine &Name,                                 \
-      InsertPosition InsertBefore = nullptr) {                                 \
+      const InsertPosition &InsertBefore = nullptr) {                          \
     return Create##NUWNSWEXACT(Instruction::OPC, V1, V2, Name, InsertBefore);  \
   }
 
@@ -361,11 +361,11 @@ public:
   /// Create the NEG and NOT instructions out of SUB and XOR instructions.
   ///
   static BinaryOperator *CreateNeg(Value *Op, const Twine &Name = "",
-                                   InsertPosition InsertBefore = nullptr);
+                                   const InsertPosition &InsertBefore = nullptr);
   static BinaryOperator *CreateNSWNeg(Value *Op, const Twine &Name = "",
-                                      InsertPosition InsertBefore = nullptr);
+                                      const InsertPosition &InsertBefore = nullptr);
   static BinaryOperator *CreateNot(Value *Op, const Twine &Name = "",
-                                   InsertPosition InsertBefore = nullptr);
+                                   const InsertPosition &InsertBefore = nullptr);
 
   BinaryOps getOpcode() const {
     return static_cast<BinaryOps>(Instruction::getOpcode());
@@ -425,7 +425,7 @@ BinaryOperator *BinaryOperator::CreateDisjoint(BinaryOps Opc, Value *V1,
 }
 BinaryOperator *BinaryOperator::CreateDisjoint(BinaryOps Opc, Value *V1,
                                                Value *V2, const Twine &Name,
-                                               InsertPosition InsertBefore) {
+                                               const InsertPosition &InsertBefore) {
   BinaryOperator *BO = Create(Opc, V1, V2, Name, InsertBefore);
   cast<PossiblyDisjointInst>(BO)->setIsDisjoint(true);
   return BO;
@@ -445,7 +445,7 @@ class CastInst : public UnaryInstruction {
 protected:
   /// Constructor with insert-before-instruction semantics for subclasses
   CastInst(Type *Ty, unsigned iType, Value *S, const Twine &NameStr = "",
-           InsertPosition InsertBefore = nullptr)
+           const InsertPosition &InsertBefore = nullptr)
       : UnaryInstruction(Ty, iType, S, InsertBefore) {
     setName(NameStr);
   }
@@ -462,7 +462,7 @@ public:
       Value *S,               ///< The value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a ZExt or BitCast cast instruction
@@ -470,7 +470,7 @@ public:
       Value *S,               ///< The value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a SExt or BitCast cast instruction
@@ -478,7 +478,7 @@ public:
       Value *S,               ///< The value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a BitCast, AddrSpaceCast or a PtrToInt cast instruction.
@@ -486,7 +486,7 @@ public:
       Value *S,               ///< The pointer value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a BitCast or an AddrSpaceCast cast instruction.
@@ -494,7 +494,7 @@ public:
       Value *S,               ///< The pointer value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a BitCast, a PtrToInt, or an IntToPTr cast instruction.
@@ -507,7 +507,7 @@ public:
       Value *S,               ///< The pointer value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a ZExt, BitCast, or Trunc for int -> int casts.
@@ -516,7 +516,7 @@ public:
       Type *Ty,               ///< The type to which cast should be made
       bool isSigned,          ///< Whether to regard S as signed or not
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create an FPExt, BitCast, or FPTrunc for fp -> fp casts
@@ -524,7 +524,7 @@ public:
       Value *S,               ///< The floating point value to be casted
       Type *Ty,               ///< The floating point type to cast to
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Create a Trunc or BitCast cast instruction
@@ -532,7 +532,7 @@ public:
       Value *S,               ///< The value to be casted (operand 0)
       Type *Ty,               ///< The type to which cast should be made
       const Twine &Name = "", ///< Name for the instruction
-      InsertPosition InsertBefore = nullptr ///< Place to insert the instruction
+      const InsertPosition &InsertBefore = nullptr ///< Place to insert the instruction
   );
 
   /// Check whether a bitcast between these types is valid
@@ -725,7 +725,7 @@ public:
 protected:
   CmpInst(Type *ty, Instruction::OtherOps op, Predicate pred, Value *LHS,
           Value *RHS, const Twine &Name = "",
-          InsertPosition InsertBefore = nullptr,
+          const InsertPosition &InsertBefore = nullptr,
           Instruction *FlagsSource = nullptr);
 
 public:
@@ -740,7 +740,7 @@ public:
   /// Create a CmpInst
   static CmpInst *Create(OtherOps Op, Predicate Pred, Value *S1, Value *S2,
                          const Twine &Name = "",
-                         InsertPosition InsertBefore = nullptr);
+                         const InsertPosition &InsertBefore = nullptr);
 
   /// Construct a compare instruction, given the opcode, the predicate,
   /// the two operands and the instruction to copy the flags from. Optionally
@@ -752,7 +752,7 @@ public:
                                         Value *S2,
                                         const Instruction *FlagsSource,
                                         const Twine &Name = "",
-                                        InsertPosition InsertBefore = nullptr);
+                                        const InsertPosition &InsertBefore = nullptr);
 
   /// Get the opcode casted to the right type
   OtherOps getOpcode() const {
@@ -1160,7 +1160,7 @@ public:
   /// the operand bundles for the new instruction are set to the operand bundles
   /// in \p Bundles.
   static CallBase *Create(CallBase *CB, ArrayRef<OperandBundleDef> Bundles,
-                          InsertPosition InsertPt = nullptr);
+                          const InsertPosition &InsertBefore = nullptr);
 
   /// Create a clone of \p CB with the operand bundle with the tag matching
   /// \p Bundle's tag replaced with Bundle, and insert it before \p InsertPt.
@@ -1168,16 +1168,16 @@ public:
   /// The returned call instruction is identical \p CI in every way except that
   /// the specified operand bundle has been replaced.
   static CallBase *Create(CallBase *CB, OperandBundleDef Bundle,
-                          InsertPosition InsertPt = nullptr);
+                          const InsertPosition &InsertBefore = nullptr);
 
   /// Create a clone of \p CB with operand bundle \p OB added.
   static CallBase *addOperandBundle(CallBase *CB, uint32_t ID,
-                                    OperandBundleDef OB,
-                                    InsertPosition InsertPt = nullptr);
+                                    const OperandBundleDef &OB,
+                                    const InsertPosition &InsertBefore = nullptr);
 
   /// Create a clone of \p CB with operand bundle \p ID removed.
   static CallBase *removeOperandBundle(CallBase *CB, uint32_t ID,
-                                       InsertPosition InsertPt = nullptr);
+                                       const InsertPosition &InsertBefore = nullptr);
 
   /// Return the convergence control token for this call, if it exists.
   Value *getConvergenceControlToken() const {
@@ -2330,7 +2330,7 @@ private:
 
   explicit FuncletPadInst(Instruction::FuncletPadOps Op, Value *ParentPad,
                           ArrayRef<Value *> Args, AllocInfo AllocInfo,
-                          const Twine &NameStr, InsertPosition InsertBefore);
+                          const Twine &NameStr, const InsertPosition &InsertBefore);
 
   void init(Value *ParentPad, ArrayRef<Value *> Args, const Twine &NameStr);
 

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -78,13 +78,13 @@ protected:
 
 public:
   explicit AllocaInst(Type *Ty, unsigned AddrSpace, Value *ArraySize,
-                      const Twine &Name, InsertPosition InsertBefore);
+                      const Twine &Name, const InsertPosition &InsertBefore);
 
   AllocaInst(Type *Ty, unsigned AddrSpace, const Twine &Name,
-             InsertPosition InsertBefore);
+             const InsertPosition &InsertBefore);
 
   AllocaInst(Type *Ty, unsigned AddrSpace, Value *ArraySize, Align Align,
-             const Twine &Name = "", InsertPosition InsertBefore = nullptr);
+             const Twine &Name = "", const InsertPosition &InsertBefore = nullptr);
 
   /// Return true if there is an allocation size parameter to the allocation
   /// instruction that is not 1.
@@ -191,15 +191,15 @@ protected:
 
 public:
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr,
-           InsertPosition InsertBefore);
+           const InsertPosition &InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           InsertPosition InsertBefore);
+           const InsertPosition &InsertBefore);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
-           Align Align, InsertPosition InsertBefore = nullptr);
+           Align Align, const InsertPosition &InsertBefore = nullptr);
   LoadInst(Type *Ty, Value *Ptr, const Twine &NameStr, bool isVolatile,
            Align Align, AtomicOrdering Order,
            SyncScope::ID SSID = SyncScope::System,
-           InsertPosition InsertBefore = nullptr);
+           const InsertPosition &InsertBefore = nullptr);
 
   /// Return true if this is a load from a volatile memory location.
   bool isVolatile() const { return getSubclassData<VolatileField>(); }
@@ -308,14 +308,14 @@ protected:
   StoreInst *cloneImpl() const;
 
 public:
-  StoreInst(Value *Val, Value *Ptr, InsertPosition InsertBefore);
+  StoreInst(Value *Val, Value *Ptr, const InsertPosition &InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile,
-            InsertPosition InsertBefore);
+            const InsertPosition &InsertBefore);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
-            InsertPosition InsertBefore = nullptr);
+            const InsertPosition &InsertBefore = nullptr);
   StoreInst(Value *Val, Value *Ptr, bool isVolatile, Align Align,
             AtomicOrdering Order, SyncScope::ID SSID = SyncScope::System,
-            InsertPosition InsertBefore = nullptr);
+            const InsertPosition &InsertBefore = nullptr);
 
   // allocate space for exactly two operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -439,7 +439,7 @@ public:
   // SequentiallyConsistent.
   FenceInst(LLVMContext &C, AtomicOrdering Ordering,
             SyncScope::ID SSID = SyncScope::System,
-            InsertPosition InsertBefore = nullptr);
+            const InsertPosition &InsertBefore = nullptr);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -520,7 +520,7 @@ public:
   AtomicCmpXchgInst(Value *Ptr, Value *Cmp, Value *NewVal, Align Alignment,
                     AtomicOrdering SuccessOrdering,
                     AtomicOrdering FailureOrdering, SyncScope::ID SSID,
-                    InsertPosition InsertBefore = nullptr);
+                    const InsertPosition &InsertBefore = nullptr);
 
   // allocate space for exactly three operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -787,7 +787,7 @@ private:
 public:
   AtomicRMWInst(BinOp Operation, Value *Ptr, Value *Val, Align Alignment,
                 AtomicOrdering Ordering, SyncScope::ID SSID,
-                InsertPosition InsertBefore = nullptr);
+                const InsertPosition &InsertBefore = nullptr);
 
   // allocate space for exactly two operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -942,7 +942,7 @@ class GetElementPtrInst : public Instruction {
   /// specified BasicBlock.
   inline GetElementPtrInst(Type *PointeeType, Value *Ptr,
                            ArrayRef<Value *> IdxList, AllocInfo AllocInfo,
-                           const Twine &NameStr, InsertPosition InsertBefore);
+                           const Twine &NameStr, const InsertPosition &InsertBefore);
 
   void init(Value *Ptr, ArrayRef<Value *> IdxList, const Twine &NameStr);
 
@@ -956,7 +956,7 @@ public:
   static GetElementPtrInst *Create(Type *PointeeType, Value *Ptr,
                                    ArrayRef<Value *> IdxList,
                                    const Twine &NameStr = "",
-                                   InsertPosition InsertBefore = nullptr) {
+                                   const InsertPosition &InsertBefore = nullptr) {
     unsigned Values = 1 + unsigned(IdxList.size());
     assert(PointeeType && "Must specify element type");
     IntrusiveOperandsAllocMarker AllocMarker{Values};
@@ -967,7 +967,7 @@ public:
   static GetElementPtrInst *Create(Type *PointeeType, Value *Ptr,
                                    ArrayRef<Value *> IdxList, GEPNoWrapFlags NW,
                                    const Twine &NameStr = "",
-                                   InsertPosition InsertBefore = nullptr) {
+                                   const InsertPosition &InsertBefore = nullptr) {
     GetElementPtrInst *GEP =
         Create(PointeeType, Ptr, IdxList, NameStr, InsertBefore);
     GEP->setNoWrapFlags(NW);
@@ -979,7 +979,7 @@ public:
   static GetElementPtrInst *
   CreateInBounds(Type *PointeeType, Value *Ptr, ArrayRef<Value *> IdxList,
                  const Twine &NameStr = "",
-                 InsertPosition InsertBefore = nullptr) {
+                 const InsertPosition &InsertBefore = nullptr) {
     return Create(PointeeType, Ptr, IdxList, GEPNoWrapFlags::inBounds(),
                   NameStr, InsertBefore);
   }
@@ -1137,7 +1137,7 @@ struct OperandTraits<GetElementPtrInst>
 GetElementPtrInst::GetElementPtrInst(Type *PointeeType, Value *Ptr,
                                      ArrayRef<Value *> IdxList,
                                      AllocInfo AllocInfo, const Twine &NameStr,
-                                     InsertPosition InsertBefore)
+                                     const InsertPosition &InsertBefore)
     : Instruction(getGEPReturnType(Ptr, IdxList), GetElementPtr, AllocInfo,
                   InsertBefore),
       SourceElementType(PointeeType),
@@ -1178,7 +1178,7 @@ protected:
 
 public:
   /// Constructor with insertion semantics.
-  ICmpInst(InsertPosition InsertBefore, ///< Where to insert
+  ICmpInst(const InsertPosition &InsertBefore, ///< Where to insert
            Predicate pred, ///< The predicate to use for the comparison
            Value *LHS,     ///< The left-hand-side of the expression
            Value *RHS,     ///< The right-hand-side of the expression
@@ -1395,7 +1395,7 @@ protected:
 
 public:
   /// Constructor with insertion semantics.
-  FCmpInst(InsertPosition InsertBefore, ///< Where to insert
+  FCmpInst(const InsertPosition &InsertBefore, ///< Where to insert
            Predicate pred, ///< The predicate to use for the comparison
            Value *LHS,     ///< The left-hand-side of the expression
            Value *RHS,     ///< The right-hand-side of the expression
@@ -1482,15 +1482,15 @@ class CallInst : public CallBase {
   /// Construct a CallInst from a range of arguments
   inline CallInst(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                   ArrayRef<OperandBundleDef> Bundles, const Twine &NameStr,
-                  AllocInfo AllocInfo, InsertPosition InsertBefore);
+                  AllocInfo AllocInfo, const InsertPosition &InsertBefore);
 
   inline CallInst(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                   const Twine &NameStr, AllocInfo AllocInfo,
-                  InsertPosition InsertBefore)
+                  const InsertPosition &InsertBefore)
       : CallInst(Ty, Func, Args, {}, NameStr, AllocInfo, InsertBefore) {}
 
   explicit CallInst(FunctionType *Ty, Value *F, const Twine &NameStr,
-                    AllocInfo AllocInfo, InsertPosition InsertBefore);
+                    AllocInfo AllocInfo, const InsertPosition &InsertBefore);
 
   void init(FunctionType *FTy, Value *Func, ArrayRef<Value *> Args,
             ArrayRef<OperandBundleDef> Bundles, const Twine &NameStr);
@@ -1512,7 +1512,7 @@ protected:
 
 public:
   static CallInst *Create(FunctionType *Ty, Value *F, const Twine &NameStr = "",
-                          InsertPosition InsertBefore = nullptr) {
+                          const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{ComputeNumOperands(0)};
     return new (AllocMarker)
         CallInst(Ty, F, NameStr, AllocMarker, InsertBefore);
@@ -1520,7 +1520,7 @@ public:
 
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                           const Twine &NameStr,
-                          InsertPosition InsertBefore = nullptr) {
+                          const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{ComputeNumOperands(Args.size())};
     return new (AllocMarker)
         CallInst(Ty, Func, Args, {}, NameStr, AllocMarker, InsertBefore);
@@ -1529,7 +1529,7 @@ public:
   static CallInst *Create(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles = {},
                           const Twine &NameStr = "",
-                          InsertPosition InsertBefore = nullptr) {
+                          const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAndDescriptorAllocMarker AllocMarker{
         ComputeNumOperands(unsigned(Args.size()), CountBundleInputs(Bundles)),
         unsigned(Bundles.size() * sizeof(BundleOpInfo))};
@@ -1539,7 +1539,7 @@ public:
   }
 
   static CallInst *Create(FunctionCallee Func, const Twine &NameStr = "",
-                          InsertPosition InsertBefore = nullptr) {
+                          const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), NameStr,
                   InsertBefore);
   }
@@ -1547,14 +1547,14 @@ public:
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
                           ArrayRef<OperandBundleDef> Bundles = {},
                           const Twine &NameStr = "",
-                          InsertPosition InsertBefore = nullptr) {
+                          const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, Bundles,
                   NameStr, InsertBefore);
   }
 
   static CallInst *Create(FunctionCallee Func, ArrayRef<Value *> Args,
                           const Twine &NameStr,
-                          InsertPosition InsertBefore = nullptr) {
+                          const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), Args, NameStr,
                   InsertBefore);
   }
@@ -1566,7 +1566,7 @@ public:
   /// the operand bundles for the new instruction are set to the operand bundles
   /// in \p Bundles.
   static CallInst *Create(CallInst *CI, ArrayRef<OperandBundleDef> Bundles,
-                          InsertPosition InsertPt = nullptr);
+                          const InsertPosition &InsertBefore = nullptr);
 
   // Note that 'musttail' implies 'tail'.
   enum TailCallKind : unsigned {
@@ -1640,7 +1640,7 @@ private:
 
 CallInst::CallInst(FunctionType *Ty, Value *Func, ArrayRef<Value *> Args,
                    ArrayRef<OperandBundleDef> Bundles, const Twine &NameStr,
-                   AllocInfo AllocInfo, InsertPosition InsertBefore)
+                   AllocInfo AllocInfo, const InsertPosition &InsertBefore)
     : CallBase(Ty->getReturnType(), Instruction::Call, AllocInfo,
                InsertBefore) {
   assert(AllocInfo.NumOps ==
@@ -1658,7 +1658,7 @@ class SelectInst : public Instruction {
   constexpr static IntrusiveOperandsAllocMarker AllocMarker{3};
 
   SelectInst(Value *C, Value *S1, Value *S2, const Twine &NameStr,
-             InsertPosition InsertBefore)
+             const InsertPosition &InsertBefore)
       : Instruction(S1->getType(), Instruction::Select, AllocMarker,
                     InsertBefore) {
     init(C, S1, S2);
@@ -1681,7 +1681,7 @@ protected:
 public:
   static SelectInst *Create(Value *C, Value *S1, Value *S2,
                             const Twine &NameStr = "",
-                            InsertPosition InsertBefore = nullptr,
+                            const InsertPosition &InsertBefore = nullptr,
                             Instruction *MDFrom = nullptr) {
     SelectInst *Sel =
         new (AllocMarker) SelectInst(C, S1, S2, NameStr, InsertBefore);
@@ -1747,7 +1747,7 @@ protected:
 
 public:
   VAArgInst(Value *List, Type *Ty, const Twine &NameStr = "",
-            InsertPosition InsertBefore = nullptr)
+            const InsertPosition &InsertBefore = nullptr)
       : UnaryInstruction(Ty, VAArg, List, InsertBefore) {
     setName(NameStr);
   }
@@ -1776,7 +1776,7 @@ class ExtractElementInst : public Instruction {
   constexpr static IntrusiveOperandsAllocMarker AllocMarker{2};
 
   ExtractElementInst(Value *Vec, Value *Idx, const Twine &NameStr = "",
-                     InsertPosition InsertBefore = nullptr);
+                     const InsertPosition &InsertBefore = nullptr);
 
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
@@ -1787,7 +1787,7 @@ protected:
 public:
   static ExtractElementInst *Create(Value *Vec, Value *Idx,
                                     const Twine &NameStr = "",
-                                    InsertPosition InsertBefore = nullptr) {
+                                    const InsertPosition &InsertBefore = nullptr) {
     return new (AllocMarker)
         ExtractElementInst(Vec, Idx, NameStr, InsertBefore);
   }
@@ -1836,7 +1836,7 @@ class InsertElementInst : public Instruction {
 
   InsertElementInst(Value *Vec, Value *NewElt, Value *Idx,
                     const Twine &NameStr = "",
-                    InsertPosition InsertBefore = nullptr);
+                    const InsertPosition &InsertBefore = nullptr);
 
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
@@ -1847,7 +1847,7 @@ protected:
 public:
   static InsertElementInst *Create(Value *Vec, Value *NewElt, Value *Idx,
                                    const Twine &NameStr = "",
-                                   InsertPosition InsertBefore = nullptr) {
+                                   const InsertPosition &InsertBefore = nullptr) {
     return new (AllocMarker)
         InsertElementInst(Vec, NewElt, Idx, NameStr, InsertBefore);
   }
@@ -1912,15 +1912,15 @@ protected:
 
 public:
   ShuffleVectorInst(Value *V1, Value *Mask, const Twine &NameStr = "",
-                    InsertPosition InsertBefore = nullptr);
+                    const InsertPosition &InsertBefore = nullptr);
   ShuffleVectorInst(Value *V1, ArrayRef<int> Mask, const Twine &NameStr = "",
-                    InsertPosition InsertBefore = nullptr);
+                    const InsertPosition &InsertBefore = nullptr);
   ShuffleVectorInst(Value *V1, Value *V2, Value *Mask,
                     const Twine &NameStr = "",
-                    InsertPosition InsertBefore = nullptr);
+                    const InsertPosition &InsertBefore = nullptr);
   ShuffleVectorInst(Value *V1, Value *V2, ArrayRef<int> Mask,
                     const Twine &NameStr = "",
-                    InsertPosition InsertBefore = nullptr);
+                    const InsertPosition &InsertBefore = nullptr);
 
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
   void operator delete(void *Ptr) { return User::operator delete(Ptr); }
@@ -2404,7 +2404,7 @@ class ExtractValueInst : public UnaryInstruction {
   /// insert before an existing instruction, the third appends the new
   /// instruction to the specified BasicBlock.
   inline ExtractValueInst(Value *Agg, ArrayRef<unsigned> Idxs,
-                          const Twine &NameStr, InsertPosition InsertBefore);
+                          const Twine &NameStr, const InsertPosition &InsertBefore);
 
   void init(ArrayRef<unsigned> Idxs, const Twine &NameStr);
 
@@ -2417,7 +2417,7 @@ protected:
 public:
   static ExtractValueInst *Create(Value *Agg, ArrayRef<unsigned> Idxs,
                                   const Twine &NameStr = "",
-                                  InsertPosition InsertBefore = nullptr) {
+                                  const InsertPosition &InsertBefore = nullptr) {
     return new
       ExtractValueInst(Agg, Idxs, NameStr, InsertBefore);
   }
@@ -2469,7 +2469,7 @@ public:
 
 ExtractValueInst::ExtractValueInst(Value *Agg, ArrayRef<unsigned> Idxs,
                                    const Twine &NameStr,
-                                   InsertPosition InsertBefore)
+                                   const InsertPosition &InsertBefore)
     : UnaryInstruction(checkGEPType(getIndexedType(Agg->getType(), Idxs)),
                        ExtractValue, Agg, InsertBefore) {
   init(Idxs, NameStr);
@@ -2494,13 +2494,13 @@ class InsertValueInst : public Instruction {
   /// can optionally insert before an existing instruction, the third appends
   /// the new instruction to the specified BasicBlock.
   inline InsertValueInst(Value *Agg, Value *Val, ArrayRef<unsigned> Idxs,
-                         const Twine &NameStr, InsertPosition InsertBefore);
+                         const Twine &NameStr, const InsertPosition &InsertBefore);
 
   /// Constructors - These three constructors are convenience methods because
   /// one and two index insertvalue instructions are so common.
   InsertValueInst(Value *Agg, Value *Val, unsigned Idx,
                   const Twine &NameStr = "",
-                  InsertPosition InsertBefore = nullptr);
+                  const InsertPosition &InsertBefore = nullptr);
 
   void init(Value *Agg, Value *Val, ArrayRef<unsigned> Idxs,
             const Twine &NameStr);
@@ -2519,7 +2519,7 @@ public:
   static InsertValueInst *Create(Value *Agg, Value *Val,
                                  ArrayRef<unsigned> Idxs,
                                  const Twine &NameStr = "",
-                                 InsertPosition InsertBefore = nullptr) {
+                                 const InsertPosition &InsertBefore = nullptr) {
     return new InsertValueInst(Agg, Val, Idxs, NameStr, InsertBefore);
   }
 
@@ -2582,7 +2582,7 @@ struct OperandTraits<InsertValueInst> :
 
 InsertValueInst::InsertValueInst(Value *Agg, Value *Val,
                                  ArrayRef<unsigned> Idxs, const Twine &NameStr,
-                                 InsertPosition InsertBefore)
+                                 const InsertPosition &InsertBefore)
     : Instruction(Agg->getType(), InsertValue, AllocMarker, InsertBefore) {
   init(Agg, Val, Idxs, NameStr);
 }
@@ -2608,7 +2608,7 @@ class PHINode : public Instruction {
 
   explicit PHINode(Type *Ty, unsigned NumReservedValues,
                    const Twine &NameStr = "",
-                   InsertPosition InsertBefore = nullptr)
+                   const InsertPosition &InsertBefore = nullptr)
       : Instruction(Ty, Instruction::PHI, AllocMarker, InsertBefore),
         ReservedSpace(NumReservedValues) {
     assert(!Ty->isTokenTy() && "PHI nodes cannot have token type!");
@@ -2634,7 +2634,7 @@ public:
   /// edges that this phi node will have (use 0 if you really have no idea).
   static PHINode *Create(Type *Ty, unsigned NumReservedValues,
                          const Twine &NameStr = "",
-                         InsertPosition InsertBefore = nullptr) {
+                         const InsertPosition &InsertBefore = nullptr) {
     return new (AllocMarker)
         PHINode(Ty, NumReservedValues, NameStr, InsertBefore);
   }
@@ -2853,7 +2853,7 @@ public:
 
 private:
   explicit LandingPadInst(Type *RetTy, unsigned NumReservedValues,
-                          const Twine &NameStr, InsertPosition InsertBefore);
+                          const Twine &NameStr, const InsertPosition &InsertBefore);
 
   // Allocate space for exactly zero operands.
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -2874,7 +2874,7 @@ public:
   /// clauses that this landingpad will have (use 0 if you really have no idea).
   static LandingPadInst *Create(Type *RetTy, unsigned NumReservedClauses,
                                 const Twine &NameStr = "",
-                                InsertPosition InsertBefore = nullptr);
+                                const InsertPosition &InsertBefore = nullptr);
 
   /// Provide fast operand accessors
   DECLARE_TRANSPARENT_OPERAND_ACCESSORS(Value);
@@ -2953,7 +2953,7 @@ private:
   // NOTE: If the Value* passed is of type void then the constructor behaves as
   // if it was passed NULL.
   explicit ReturnInst(LLVMContext &C, Value *retVal, AllocInfo AllocInfo,
-                      InsertPosition InsertBefore);
+                      const InsertPosition &InsertBefore);
 
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
@@ -2963,7 +2963,7 @@ protected:
 
 public:
   static ReturnInst *Create(LLVMContext &C, Value *retVal = nullptr,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{retVal ? 1U : 0U};
     return new (AllocMarker) ReturnInst(C, retVal, AllocMarker, InsertBefore);
   }
@@ -3029,9 +3029,9 @@ class BranchInst : public Instruction {
   // BranchInst(BB* B, BB *I)                    - 'br B'        insert at end
   // BranchInst(BB* T, BB *F, Value *C, BB *I)   - 'br C, T, F', insert at end
   explicit BranchInst(BasicBlock *IfTrue, AllocInfo AllocInfo,
-                      InsertPosition InsertBefore);
+                      const InsertPosition &InsertBefore);
   BranchInst(BasicBlock *IfTrue, BasicBlock *IfFalse, Value *Cond,
-             AllocInfo AllocInfo, InsertPosition InsertBefore);
+             AllocInfo AllocInfo, const InsertPosition &InsertBefore);
 
   void AssertOK();
 
@@ -3070,14 +3070,14 @@ public:
   };
 
   static BranchInst *Create(BasicBlock *IfTrue,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{1};
     return new (AllocMarker) BranchInst(IfTrue, AllocMarker, InsertBefore);
   }
 
   static BranchInst *Create(BasicBlock *IfTrue, BasicBlock *IfFalse,
                             Value *Cond,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{3};
     return new (AllocMarker)
         BranchInst(IfTrue, IfFalse, Cond, AllocMarker, InsertBefore);
@@ -3167,7 +3167,7 @@ class SwitchInst : public Instruction {
   /// to make memory allocation more efficient. This constructor can also
   /// auto-insert before another instruction.
   SwitchInst(Value *Value, BasicBlock *Default, unsigned NumCases,
-             InsertPosition InsertBefore);
+             const InsertPosition &InsertBefore);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -3337,7 +3337,7 @@ public:
 
   static SwitchInst *Create(Value *Value, BasicBlock *Default,
                             unsigned NumCases,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     return new SwitchInst(Value, Default, NumCases, InsertBefore);
   }
 
@@ -3555,7 +3555,7 @@ class IndirectBrInst : public Instruction {
   /// here to make memory allocation more efficient.  This constructor can also
   /// autoinsert before another instruction.
   IndirectBrInst(Value *Address, unsigned NumDests,
-                 InsertPosition InsertBefore);
+                 const InsertPosition &InsertBefore);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -3600,7 +3600,7 @@ public:
   };
 
   static IndirectBrInst *Create(Value *Address, unsigned NumDests,
-                                InsertPosition InsertBefore = nullptr) {
+                                const InsertPosition &InsertBefore = nullptr) {
     return new IndirectBrInst(Address, NumDests, InsertBefore);
   }
 
@@ -3686,7 +3686,7 @@ class InvokeInst : public CallBase {
   inline InvokeInst(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                     BasicBlock *IfException, ArrayRef<Value *> Args,
                     ArrayRef<OperandBundleDef> Bundles, AllocInfo AllocInfo,
-                    const Twine &NameStr, InsertPosition InsertBefore);
+                    const Twine &NameStr, const InsertPosition &InsertBefore);
 
   void init(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
             BasicBlock *IfException, ArrayRef<Value *> Args,
@@ -3710,7 +3710,7 @@ public:
   static InvokeInst *Create(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             const Twine &NameStr,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{
         ComputeNumOperands(unsigned(Args.size()))};
     return new (AllocMarker) InvokeInst(Ty, Func, IfNormal, IfException, Args,
@@ -3721,7 +3721,7 @@ public:
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles = {},
                             const Twine &NameStr = "",
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAndDescriptorAllocMarker AllocMarker{
         ComputeNumOperands(Args.size(), CountBundleInputs(Bundles)),
         unsigned(Bundles.size() * sizeof(BundleOpInfo))};
@@ -3734,7 +3734,7 @@ public:
   static InvokeInst *Create(FunctionCallee Func, BasicBlock *IfNormal,
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             const Twine &NameStr,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, {}, NameStr, InsertBefore);
   }
@@ -3743,7 +3743,7 @@ public:
                             BasicBlock *IfException, ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles = {},
                             const Twine &NameStr = "",
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), IfNormal,
                   IfException, Args, Bundles, NameStr, InsertBefore);
   }
@@ -3755,7 +3755,7 @@ public:
   /// that the operand bundles for the new instruction are set to the operand
   /// bundles in \p Bundles.
   static InvokeInst *Create(InvokeInst *II, ArrayRef<OperandBundleDef> Bundles,
-                            InsertPosition InsertPt = nullptr);
+                            const InsertPosition &InsertBefore = nullptr);
 
   // get*Dest - Return the destination basic blocks...
   BasicBlock *getNormalDest() const {
@@ -3813,7 +3813,7 @@ private:
 InvokeInst::InvokeInst(FunctionType *Ty, Value *Func, BasicBlock *IfNormal,
                        BasicBlock *IfException, ArrayRef<Value *> Args,
                        ArrayRef<OperandBundleDef> Bundles, AllocInfo AllocInfo,
-                       const Twine &NameStr, InsertPosition InsertBefore)
+                       const Twine &NameStr, const InsertPosition &InsertBefore)
     : CallBase(Ty->getReturnType(), Instruction::Invoke, AllocInfo,
                InsertBefore) {
   init(Ty, Func, IfNormal, IfException, Args, Bundles, NameStr);
@@ -3840,7 +3840,7 @@ class CallBrInst : public CallBase {
                     ArrayRef<BasicBlock *> IndirectDests,
                     ArrayRef<Value *> Args, ArrayRef<OperandBundleDef> Bundles,
                     AllocInfo AllocInfo, const Twine &NameStr,
-                    InsertPosition InsertBefore);
+                    const InsertPosition &InsertBefore);
 
   void init(FunctionType *FTy, Value *Func, BasicBlock *DefaultDest,
             ArrayRef<BasicBlock *> IndirectDests, ArrayRef<Value *> Args,
@@ -3865,7 +3865,7 @@ public:
                             BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args, const Twine &NameStr,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{
         ComputeNumOperands(Args.size(), IndirectDests.size())};
     return new (AllocMarker)
@@ -3877,7 +3877,7 @@ public:
   Create(FunctionType *Ty, Value *Func, BasicBlock *DefaultDest,
          ArrayRef<BasicBlock *> IndirectDests, ArrayRef<Value *> Args,
          ArrayRef<OperandBundleDef> Bundles = {}, const Twine &NameStr = "",
-         InsertPosition InsertBefore = nullptr) {
+         const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAndDescriptorAllocMarker AllocMarker{
         ComputeNumOperands(Args.size(), IndirectDests.size(),
                            CountBundleInputs(Bundles)),
@@ -3891,7 +3891,7 @@ public:
   static CallBrInst *Create(FunctionCallee Func, BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
                             ArrayRef<Value *> Args, const Twine &NameStr,
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, NameStr, InsertBefore);
   }
@@ -3901,7 +3901,7 @@ public:
                             ArrayRef<Value *> Args,
                             ArrayRef<OperandBundleDef> Bundles = {},
                             const Twine &NameStr = "",
-                            InsertPosition InsertBefore = nullptr) {
+                            const InsertPosition &InsertBefore = nullptr) {
     return Create(Func.getFunctionType(), Func.getCallee(), DefaultDest,
                   IndirectDests, Args, Bundles, NameStr, InsertBefore);
   }
@@ -3913,7 +3913,7 @@ public:
   /// except that the operand bundles for the new instruction are set to the
   /// operand bundles in \p Bundles.
   static CallBrInst *Create(CallBrInst *CBI, ArrayRef<OperandBundleDef> Bundles,
-                            InsertPosition InsertBefore = nullptr);
+                            const InsertPosition &InsertBefore = nullptr);
 
   /// Return the number of callbr indirect dest labels.
   ///
@@ -3986,7 +3986,7 @@ CallBrInst::CallBrInst(FunctionType *Ty, Value *Func, BasicBlock *DefaultDest,
                        ArrayRef<BasicBlock *> IndirectDests,
                        ArrayRef<Value *> Args,
                        ArrayRef<OperandBundleDef> Bundles, AllocInfo AllocInfo,
-                       const Twine &NameStr, InsertPosition InsertBefore)
+                       const Twine &NameStr, const InsertPosition &InsertBefore)
     : CallBase(Ty->getReturnType(), Instruction::CallBr, AllocInfo,
                InsertBefore) {
   init(Ty, Func, DefaultDest, IndirectDests, Args, Bundles, NameStr);
@@ -4004,7 +4004,7 @@ class ResumeInst : public Instruction {
 
   ResumeInst(const ResumeInst &RI);
 
-  explicit ResumeInst(Value *Exn, InsertPosition InsertBefore = nullptr);
+  explicit ResumeInst(Value *Exn, const InsertPosition &InsertBefore = nullptr);
 
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
@@ -4013,7 +4013,7 @@ protected:
   ResumeInst *cloneImpl() const;
 
 public:
-  static ResumeInst *Create(Value *Exn, InsertPosition InsertBefore = nullptr) {
+  static ResumeInst *Create(Value *Exn, const InsertPosition &InsertBefore = nullptr) {
     return new (AllocMarker) ResumeInst(Exn, InsertBefore);
   }
 
@@ -4073,7 +4073,7 @@ class CatchSwitchInst : public Instruction {
   /// This constructor can also autoinsert before another instruction.
   CatchSwitchInst(Value *ParentPad, BasicBlock *UnwindDest,
                   unsigned NumHandlers, const Twine &NameStr,
-                  InsertPosition InsertBefore);
+                  const InsertPosition &InsertBefore);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -4093,7 +4093,7 @@ public:
   static CatchSwitchInst *Create(Value *ParentPad, BasicBlock *UnwindDest,
                                  unsigned NumHandlers,
                                  const Twine &NameStr = "",
-                                 InsertPosition InsertBefore = nullptr) {
+                                 const InsertPosition &InsertBefore = nullptr) {
     return new CatchSwitchInst(ParentPad, UnwindDest, NumHandlers, NameStr,
                                InsertBefore);
   }
@@ -4222,14 +4222,14 @@ class CleanupPadInst : public FuncletPadInst {
 private:
   explicit CleanupPadInst(Value *ParentPad, ArrayRef<Value *> Args,
                           AllocInfo AllocInfo, const Twine &NameStr,
-                          InsertPosition InsertBefore)
+                          const InsertPosition &InsertBefore)
       : FuncletPadInst(Instruction::CleanupPad, ParentPad, Args, AllocInfo,
                        NameStr, InsertBefore) {}
 
 public:
   static CleanupPadInst *Create(Value *ParentPad, ArrayRef<Value *> Args = {},
                                 const Twine &NameStr = "",
-                                InsertPosition InsertBefore = nullptr) {
+                                const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{unsigned(1 + Args.size())};
     return new (AllocMarker)
         CleanupPadInst(ParentPad, Args, AllocMarker, NameStr, InsertBefore);
@@ -4251,14 +4251,14 @@ class CatchPadInst : public FuncletPadInst {
 private:
   explicit CatchPadInst(Value *CatchSwitch, ArrayRef<Value *> Args,
                         AllocInfo AllocInfo, const Twine &NameStr,
-                        InsertPosition InsertBefore)
+                        const InsertPosition &InsertBefore)
       : FuncletPadInst(Instruction::CatchPad, CatchSwitch, Args, AllocInfo,
                        NameStr, InsertBefore) {}
 
 public:
   static CatchPadInst *Create(Value *CatchSwitch, ArrayRef<Value *> Args,
                               const Twine &NameStr = "",
-                              InsertPosition InsertBefore = nullptr) {
+                              const InsertPosition &InsertBefore = nullptr) {
     IntrusiveOperandsAllocMarker AllocMarker{unsigned(1 + Args.size())};
     return new (AllocMarker)
         CatchPadInst(CatchSwitch, Args, AllocMarker, NameStr, InsertBefore);
@@ -4290,7 +4290,7 @@ class CatchReturnInst : public Instruction {
   constexpr static IntrusiveOperandsAllocMarker AllocMarker{2};
 
   CatchReturnInst(const CatchReturnInst &RI);
-  CatchReturnInst(Value *CatchPad, BasicBlock *BB, InsertPosition InsertBefore);
+  CatchReturnInst(Value *CatchPad, BasicBlock *BB, const InsertPosition &InsertBefore);
 
   void init(Value *CatchPad, BasicBlock *BB);
 
@@ -4302,7 +4302,7 @@ protected:
 
 public:
   static CatchReturnInst *Create(Value *CatchPad, BasicBlock *BB,
-                                 InsertPosition InsertBefore = nullptr) {
+                                 const InsertPosition &InsertBefore = nullptr) {
     assert(CatchPad);
     assert(BB);
     return new (AllocMarker) CatchReturnInst(CatchPad, BB, InsertBefore);
@@ -4367,7 +4367,7 @@ class CleanupReturnInst : public Instruction {
 private:
   CleanupReturnInst(const CleanupReturnInst &RI, AllocInfo AllocInfo);
   CleanupReturnInst(Value *CleanupPad, BasicBlock *UnwindBB,
-                    AllocInfo AllocInfo, InsertPosition InsertBefore = nullptr);
+                    AllocInfo AllocInfo, const InsertPosition &InsertBefore = nullptr);
 
   void init(Value *CleanupPad, BasicBlock *UnwindBB);
 
@@ -4380,7 +4380,7 @@ protected:
 public:
   static CleanupReturnInst *Create(Value *CleanupPad,
                                    BasicBlock *UnwindBB = nullptr,
-                                   InsertPosition InsertBefore = nullptr) {
+                                   const InsertPosition &InsertBefore = nullptr) {
     assert(CleanupPad);
     unsigned Values = 1;
     if (UnwindBB)
@@ -4469,7 +4469,7 @@ protected:
 
 public:
   explicit UnreachableInst(LLVMContext &C,
-                           InsertPosition InsertBefore = nullptr);
+                           const InsertPosition &InsertBefore = nullptr);
 
   // allocate space for exactly zero operands
   void *operator new(size_t S) { return User::operator new(S, AllocMarker); }
@@ -4515,7 +4515,7 @@ public:
   TruncInst(Value *S,                  ///< The value to be truncated
             Type *Ty,                  ///< The (smaller) type to truncate to
             const Twine &NameStr = "", ///< A name for the new instruction
-            InsertPosition InsertBefore =
+            const InsertPosition &InsertBefore =
                 nullptr ///< Where to insert the new instruction
   );
 
@@ -4579,7 +4579,7 @@ public:
   ZExtInst(Value *S,                  ///< The value to be zero extended
            Type *Ty,                  ///< The type to zero extend to
            const Twine &NameStr = "", ///< A name for the new instruction
-           InsertPosition InsertBefore =
+           const InsertPosition &InsertBefore =
                nullptr ///< Where to insert the new instruction
   );
 
@@ -4610,7 +4610,7 @@ public:
   SExtInst(Value *S,                  ///< The value to be sign extended
            Type *Ty,                  ///< The type to sign extend to
            const Twine &NameStr = "", ///< A name for the new instruction
-           InsertPosition InsertBefore =
+           const InsertPosition &InsertBefore =
                nullptr ///< Where to insert the new instruction
   );
 
@@ -4640,7 +4640,7 @@ public:                 /// Constructor with insert-before-instruction semantics
   FPTruncInst(Value *S, ///< The value to be truncated
               Type *Ty, ///< The type to truncate to
               const Twine &NameStr = "", ///< A name for the new instruction
-              InsertPosition InsertBefore =
+              const InsertPosition &InsertBefore =
                   nullptr ///< Where to insert the new instruction
   );
 
@@ -4671,7 +4671,7 @@ public:
   FPExtInst(Value *S,                  ///< The value to be extended
             Type *Ty,                  ///< The type to extend to
             const Twine &NameStr = "", ///< A name for the new instruction
-            InsertPosition InsertBefore =
+            const InsertPosition &InsertBefore =
                 nullptr ///< Where to insert the new instruction
   );
 
@@ -4702,7 +4702,7 @@ public:
   UIToFPInst(Value *S,                  ///< The value to be converted
              Type *Ty,                  ///< The type to convert to
              const Twine &NameStr = "", ///< A name for the new instruction
-             InsertPosition InsertBefore =
+             const InsertPosition &InsertBefore =
                  nullptr ///< Where to insert the new instruction
   );
 
@@ -4733,7 +4733,7 @@ public:
   SIToFPInst(Value *S,                  ///< The value to be converted
              Type *Ty,                  ///< The type to convert to
              const Twine &NameStr = "", ///< A name for the new instruction
-             InsertPosition InsertBefore =
+             const InsertPosition &InsertBefore =
                  nullptr ///< Where to insert the new instruction
   );
 
@@ -4764,7 +4764,7 @@ public:
   FPToUIInst(Value *S,                  ///< The value to be converted
              Type *Ty,                  ///< The type to convert to
              const Twine &NameStr = "", ///< A name for the new instruction
-             InsertPosition InsertBefore =
+             const InsertPosition &InsertBefore =
                  nullptr ///< Where to insert the new instruction
   );
 
@@ -4795,7 +4795,7 @@ public:
   FPToSIInst(Value *S,                  ///< The value to be converted
              Type *Ty,                  ///< The type to convert to
              const Twine &NameStr = "", ///< A name for the new instruction
-             InsertPosition InsertBefore =
+             const InsertPosition &InsertBefore =
                  nullptr ///< Where to insert the new instruction
   );
 
@@ -4822,7 +4822,7 @@ public:
   IntToPtrInst(Value *S,                  ///< The value to be converted
                Type *Ty,                  ///< The type to convert to
                const Twine &NameStr = "", ///< A name for the new instruction
-               InsertPosition InsertBefore =
+               const InsertPosition &InsertBefore =
                    nullptr ///< Where to insert the new instruction
   );
 
@@ -4861,7 +4861,7 @@ public:
   PtrToIntInst(Value *S,                  ///< The value to be converted
                Type *Ty,                  ///< The type to convert to
                const Twine &NameStr = "", ///< A name for the new instruction
-               InsertPosition InsertBefore =
+               const InsertPosition &InsertBefore =
                    nullptr ///< Where to insert the new instruction
   );
 
@@ -4904,7 +4904,7 @@ public:
   BitCastInst(Value *S,                  ///< The value to be casted
               Type *Ty,                  ///< The type to casted to
               const Twine &NameStr = "", ///< A name for the new instruction
-              InsertPosition InsertBefore =
+              const InsertPosition &InsertBefore =
                   nullptr ///< Where to insert the new instruction
   );
 
@@ -4937,7 +4937,7 @@ public:
       Value *S,                  ///< The value to be casted
       Type *Ty,                  ///< The type to casted to
       const Twine &NameStr = "", ///< A name for the new instruction
-      InsertPosition InsertBefore =
+      const InsertPosition &InsertBefore =
           nullptr ///< Where to insert the new instruction
   );
 
@@ -5095,7 +5095,7 @@ protected:
 
 public:
   explicit FreezeInst(Value *S, const Twine &NameStr = "",
-                      InsertPosition InsertBefore = nullptr);
+                      const InsertPosition &InsertBefore = nullptr);
 
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static inline bool classof(const Instruction *I) {

--- a/llvm/include/llvm/InterfaceStub/ELFObjHandler.h
+++ b/llvm/include/llvm/InterfaceStub/ELFObjHandler.h
@@ -24,7 +24,7 @@ namespace ifs {
 struct IFSStub;
 
 /// Attempt to read a binary ELF file from a MemoryBuffer.
-Expected<std::unique_ptr<IFSStub>> readELFFile(MemoryBufferRef Buf);
+Expected<std::unique_ptr<IFSStub>> readELFFile(const MemoryBufferRef &Buf);
 
 /// Attempt to write a binary ELF stub.
 /// This function determines appropriate ELFType using the passed ELFTarget and

--- a/llvm/include/llvm/Object/Binary.h
+++ b/llvm/include/llvm/Object/Binary.h
@@ -189,7 +189,7 @@ DEFINE_ISA_CONVERSION_FUNCTIONS(Binary, LLVMBinaryRef)
 /// Create a Binary from Source, autodetecting the file type.
 ///
 /// @param Source The data to create the Binary from.
-Expected<std::unique_ptr<Binary>> createBinary(MemoryBufferRef Source,
+Expected<std::unique_ptr<Binary>> createBinary(const MemoryBufferRef &Source,
                                                LLVMContext *Context = nullptr,
                                                bool InitContent = true);
 

--- a/llvm/include/llvm/Object/COFFModuleDefinition.h
+++ b/llvm/include/llvm/Object/COFFModuleDefinition.h
@@ -40,7 +40,7 @@ struct COFFModuleDefinition {
 };
 
 Expected<COFFModuleDefinition>
-parseCOFFModuleDefinition(MemoryBufferRef MB, COFF::MachineTypes Machine,
+parseCOFFModuleDefinition(const MemoryBufferRef &MB, COFF::MachineTypes Machine,
                           bool MingwDef = false, bool AddUnderscores = true);
 
 } // End namespace object.

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -370,7 +370,7 @@ public:
   PartIterator end() const { return PartIterator(*this, PartOffsets.end()); }
 
   StringRef getData() const { return Data.getBuffer(); }
-  static Expected<DXContainer> create(MemoryBufferRef Object);
+  static Expected<DXContainer> create(const MemoryBufferRef &Object);
 
   const dxbc::Header &getHeader() const { return Header; }
 

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -382,7 +382,7 @@ public:
   }
 
   static Expected<std::unique_ptr<COFFObjectFile>>
-  createCOFFObjectFile(MemoryBufferRef Object);
+  createCOFFObjectFile(const MemoryBufferRef &Object);
 
   static Expected<std::unique_ptr<ObjectFile>>
   createXCOFFObjectFile(MemoryBufferRef Object, unsigned FileType);
@@ -396,7 +396,7 @@ public:
                         size_t MachOFilesetEntryOffset = 0);
 
   static Expected<std::unique_ptr<ObjectFile>>
-  createGOFFObjectFile(MemoryBufferRef Object);
+  createGOFFObjectFile(const MemoryBufferRef &Object);
 
   static Expected<std::unique_ptr<WasmObjectFile>>
   createWasmObjectFile(MemoryBufferRef Object);

--- a/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
+++ b/llvm/include/llvm/ProfileData/Coverage/CoverageMappingReader.h
@@ -212,7 +212,7 @@ public:
   BinaryCoverageReader &operator=(const BinaryCoverageReader &) = delete;
 
   static Expected<std::vector<std::unique_ptr<BinaryCoverageReader>>>
-  create(MemoryBufferRef ObjectBuffer, StringRef Arch,
+  create(const MemoryBufferRef &ObjectBuffer, StringRef Arch,
          SmallVectorImpl<std::unique_ptr<MemoryBuffer>> &ObjectFileBuffers,
          StringRef CompilationDir = "",
          SmallVectorImpl<object::BuildIDRef> *BinaryIDs = nullptr);

--- a/llvm/include/llvm/SandboxIR/Instruction.h
+++ b/llvm/include/llvm/SandboxIR/Instruction.h
@@ -414,7 +414,7 @@ class FenceInst : public SingleLLVMInstructionImpl<llvm::FenceInst> {
   friend Context; // For constructor;
 
 public:
-  static FenceInst *create(AtomicOrdering Ordering, InsertPosition Pos,
+  static FenceInst *create(AtomicOrdering Ordering, const InsertPosition &Pos,
                            Context &Ctx,
                            SyncScope::ID SSID = SyncScope::System);
   /// Returns the ordering constraint of this fence instruction.
@@ -444,7 +444,7 @@ class SelectInst : public SingleLLVMInstructionImpl<llvm::SelectInst> {
 
 public:
   static Value *create(Value *Cond, Value *True, Value *False,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
 
   const Value *getCondition() const { return getOperand(0); }
@@ -481,7 +481,7 @@ class InsertElementInst final
 
 public:
   static Value *create(Value *Vec, Value *NewElt, Value *Idx,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::InsertElement;
@@ -503,7 +503,7 @@ class ExtractElementInst final
                         // create*()
 
 public:
-  static Value *create(Value *Vec, Value *Idx, InsertPosition Pos, Context &Ctx,
+  static Value *create(Value *Vec, Value *Idx, const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::ExtractElement;
@@ -528,10 +528,10 @@ class ShuffleVectorInst final
   friend class Context; // For accessing the constructor in create*()
 
 public:
-  static Value *create(Value *V1, Value *V2, Value *Mask, InsertPosition Pos,
+  static Value *create(Value *V1, Value *V2, Value *Mask, const InsertPosition &Pos,
                        Context &Ctx, const Twine &Name = "");
   static Value *create(Value *V1, Value *V2, ArrayRef<int> Mask,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::ShuffleVector;
@@ -966,7 +966,7 @@ class InsertValueInst
 
 public:
   static Value *create(Value *Agg, Value *Val, ArrayRef<unsigned> Idxs,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
 
   static bool classof(const Value *From) {
@@ -1024,10 +1024,10 @@ class BranchInst : public SingleLLVMInstructionImpl<llvm::BranchInst> {
   friend Context; // for BranchInst()
 
 public:
-  static BranchInst *create(BasicBlock *IfTrue, InsertPosition Pos,
+  static BranchInst *create(BasicBlock *IfTrue, const InsertPosition &Pos,
                             Context &Ctx);
   static BranchInst *create(BasicBlock *IfTrue, BasicBlock *IfFalse,
-                            Value *Cond, InsertPosition Pos, Context &Ctx);
+                            Value *Cond, const InsertPosition &Pos, Context &Ctx);
   /// For isa/dyn_cast.
   static bool classof(const Value *From);
   bool isUnconditional() const {
@@ -1109,7 +1109,7 @@ class ExtractValueInst : public UnaryInstruction {
   friend Context; // for ExtractValueInst()
 
 public:
-  static Value *create(Value *Agg, ArrayRef<unsigned> Idxs, InsertPosition Pos,
+  static Value *create(Value *Agg, ArrayRef<unsigned> Idxs, const InsertPosition &Pos,
                        Context &Ctx, const Twine &Name = "");
 
   static bool classof(const Value *From) {
@@ -1163,7 +1163,7 @@ class VAArgInst : public UnaryInstruction {
   friend Context; // For constructor;
 
 public:
-  static VAArgInst *create(Value *List, Type *Ty, InsertPosition Pos,
+  static VAArgInst *create(Value *List, Type *Ty, const InsertPosition &Pos,
                            Context &Ctx, const Twine &Name = "");
   Value *getPointerOperand();
   const Value *getPointerOperand() const {
@@ -1183,7 +1183,7 @@ class FreezeInst : public UnaryInstruction {
   friend Context; // For constructor;
 
 public:
-  static FreezeInst *create(Value *V, InsertPosition Pos, Context &Ctx,
+  static FreezeInst *create(Value *V, const InsertPosition &Pos, Context &Ctx,
                             const Twine &Name = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::Freeze;
@@ -1203,10 +1203,10 @@ public:
   void setVolatile(bool V);
 
   static LoadInst *create(Type *Ty, Value *Ptr, MaybeAlign Align,
-                          InsertPosition Pos, bool IsVolatile, Context &Ctx,
+                          const InsertPosition &Pos, bool IsVolatile, Context &Ctx,
                           const Twine &Name = "");
   static LoadInst *create(Type *Ty, Value *Ptr, MaybeAlign Align,
-                          InsertPosition Pos, Context &Ctx,
+                          const InsertPosition &Pos, Context &Ctx,
                           const Twine &Name = "") {
     return create(Ty, Ptr, Align, Pos, /*IsVolatile=*/false, Ctx, Name);
   }
@@ -1232,9 +1232,9 @@ public:
   void setVolatile(bool V);
 
   static StoreInst *create(Value *V, Value *Ptr, MaybeAlign Align,
-                           InsertPosition Pos, bool IsVolatile, Context &Ctx);
+                           const InsertPosition &Pos, bool IsVolatile, Context &Ctx);
   static StoreInst *create(Value *V, Value *Ptr, MaybeAlign Align,
-                           InsertPosition Pos, Context &Ctx) {
+                           const InsertPosition &Pos, Context &Ctx) {
     return create(V, Ptr, Align, Pos, /*IsVolatile=*/false, Ctx);
   }
 
@@ -1260,7 +1260,7 @@ class UnreachableInst final : public Instruction {
   }
 
 public:
-  static UnreachableInst *create(InsertPosition Pos, Context &Ctx);
+  static UnreachableInst *create(const InsertPosition &Pos, Context &Ctx);
   static bool classof(const Value *From);
   unsigned getNumSuccessors() const { return 0; }
   unsigned getUseOperandNo(const Use &Use) const final {
@@ -1280,7 +1280,7 @@ class ReturnInst final : public SingleLLVMInstructionImpl<llvm::ReturnInst> {
                                   Context &Ctx);
 
 public:
-  static ReturnInst *create(Value *RetVal, InsertPosition Pos, Context &Ctx);
+  static ReturnInst *create(Value *RetVal, const InsertPosition &Pos, Context &Ctx);
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::Ret;
   }
@@ -1429,7 +1429,7 @@ class CallInst : public CallBase {
 
 public:
   static CallInst *create(FunctionType *FTy, Value *Func,
-                          ArrayRef<Value *> Args, InsertPosition Pos,
+                          ArrayRef<Value *> Args, const InsertPosition &Pos,
                           Context &Ctx, const Twine &NameStr = "");
 
   static bool classof(const Value *From) {
@@ -1448,7 +1448,7 @@ class InvokeInst final : public CallBase {
 public:
   static InvokeInst *create(FunctionType *FTy, Value *Func,
                             BasicBlock *IfNormal, BasicBlock *IfException,
-                            ArrayRef<Value *> Args, InsertPosition Pos,
+                            ArrayRef<Value *> Args, const InsertPosition &Pos,
                             Context &Ctx, const Twine &NameStr = "");
 
   static bool classof(const Value *From) {
@@ -1484,7 +1484,7 @@ public:
   static CallBrInst *create(FunctionType *FTy, Value *Func,
                             BasicBlock *DefaultDest,
                             ArrayRef<BasicBlock *> IndirectDests,
-                            ArrayRef<Value *> Args, InsertPosition Pos,
+                            ArrayRef<Value *> Args, const InsertPosition &Pos,
                             Context &Ctx, const Twine &NameStr = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::CallBr;
@@ -1513,7 +1513,7 @@ class LandingPadInst : public SingleLLVMInstructionImpl<llvm::LandingPadInst> {
 
 public:
   static LandingPadInst *create(Type *RetTy, unsigned NumReservedClauses,
-                                InsertPosition Pos, Context &Ctx,
+                                const InsertPosition &Pos, Context &Ctx,
                                 const Twine &Name = "");
   /// Return 'true' if this landingpad instruction is a
   /// cleanup. I.e., it should be run when unwinding even if its landing pad
@@ -1590,7 +1590,7 @@ public:
   // for now, as there is no CatchPadInst member function that can undo it.
 
   static CatchPadInst *create(Value *ParentPad, ArrayRef<Value *> Args,
-                              InsertPosition Pos, Context &Ctx,
+                              const InsertPosition &Pos, Context &Ctx,
                               const Twine &Name = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::CatchPad;
@@ -1604,7 +1604,7 @@ class CleanupPadInst : public FuncletPadInst {
 
 public:
   static CleanupPadInst *create(Value *ParentPad, ArrayRef<Value *> Args,
-                                InsertPosition Pos, Context &Ctx,
+                                const InsertPosition &Pos, Context &Ctx,
                                 const Twine &Name = "");
   static bool classof(const Value *From) {
     return From->getSubclassID() == ClassID::CleanupPad;
@@ -1620,7 +1620,7 @@ class CatchReturnInst
 
 public:
   static CatchReturnInst *create(CatchPadInst *CatchPad, BasicBlock *BB,
-                                 InsertPosition Pos, Context &Ctx);
+                                 const InsertPosition &Pos, Context &Ctx);
   CatchPadInst *getCatchPad() const;
   void setCatchPad(CatchPadInst *CatchPad);
   BasicBlock *getSuccessor() const;
@@ -1643,7 +1643,7 @@ class CleanupReturnInst
 
 public:
   static CleanupReturnInst *create(CleanupPadInst *CleanupPad,
-                                   BasicBlock *UnwindBB, InsertPosition Pos,
+                                   BasicBlock *UnwindBB, const InsertPosition &Pos,
                                    Context &Ctx);
   bool hasUnwindDest() const {
     return cast<llvm::CleanupReturnInst>(Val)->hasUnwindDest();
@@ -1678,7 +1678,7 @@ class GetElementPtrInst final
 
 public:
   static Value *create(Type *Ty, Value *Ptr, ArrayRef<Value *> IdxList,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &NameStr = "");
 
   static bool classof(const Value *From) {
@@ -1751,7 +1751,7 @@ class CatchSwitchInst
 
 public:
   static CatchSwitchInst *create(Value *ParentPad, BasicBlock *UnwindBB,
-                                 unsigned NumHandlers, InsertPosition Pos,
+                                 unsigned NumHandlers, const InsertPosition &Pos,
                                  Context &Ctx, const Twine &Name = "");
 
   Value *getParentPad() const;
@@ -1839,7 +1839,7 @@ class ResumeInst : public SingleLLVMInstructionImpl<llvm::ResumeInst> {
   friend class Context; // For accessing the constructor in create*()
 
 public:
-  static ResumeInst *create(Value *Exn, InsertPosition Pos, Context &Ctx);
+  static ResumeInst *create(Value *Exn, const InsertPosition &Pos, Context &Ctx);
   Value *getValue() const;
   unsigned getNumSuccessors() const {
     return cast<llvm::ResumeInst>(Val)->getNumSuccessors();
@@ -1859,7 +1859,7 @@ public:
       llvm::SwitchInst::DefaultPseudoIndex;
 
   static SwitchInst *create(Value *V, BasicBlock *Dest, unsigned NumCases,
-                            InsertPosition Pos, Context &Ctx,
+                            const InsertPosition &Pos, Context &Ctx,
                             const Twine &Name = "");
 
   Value *getCondition() const;
@@ -1950,10 +1950,10 @@ class UnaryOperator : public UnaryInstruction {
                          Ctx) {}
   friend Context; // for constructor.
 public:
-  static Value *create(Instruction::Opcode Op, Value *OpV, InsertPosition Pos,
+  static Value *create(Instruction::Opcode Op, Value *OpV, const InsertPosition &Pos,
                        Context &Ctx, const Twine &Name = "");
   static Value *createWithCopiedFlags(Instruction::Opcode Op, Value *OpV,
-                                      Value *CopyFrom, InsertPosition Pos,
+                                      Value *CopyFrom, const InsertPosition &Pos,
                                       Context &Ctx, const Twine &Name = "");
   /// For isa/dyn_cast.
   static bool classof(const Value *From) {
@@ -2014,12 +2014,12 @@ protected:
 
 public:
   static Value *create(Instruction::Opcode Op, Value *LHS, Value *RHS,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
 
   static Value *createWithCopiedFlags(Instruction::Opcode Op, Value *LHS,
                                       Value *RHS, Value *CopyFrom,
-                                      InsertPosition Pos, Context &Ctx,
+                                      const InsertPosition &Pos, Context &Ctx,
                                       const Twine &Name = "");
   /// For isa/dyn_cast.
   static bool classof(const Value *From) {
@@ -2099,7 +2099,7 @@ public:
 
   static AtomicRMWInst *create(BinOp Op, Value *Ptr, Value *Val,
                                MaybeAlign Align, AtomicOrdering Ordering,
-                               InsertPosition Pos, Context &Ctx,
+                               const InsertPosition &Pos, Context &Ctx,
                                SyncScope::ID SSID = SyncScope::System,
                                const Twine &Name = "");
 };
@@ -2175,7 +2175,7 @@ public:
   static AtomicCmpXchgInst *
   create(Value *Ptr, Value *Cmp, Value *New, MaybeAlign Align,
          AtomicOrdering SuccessOrdering, AtomicOrdering FailureOrdering,
-         InsertPosition Pos, Context &Ctx,
+         const InsertPosition &Pos, Context &Ctx,
          SyncScope::ID SSID = SyncScope::System, const Twine &Name = "");
 
   static bool classof(const Value *From) {
@@ -2190,7 +2190,7 @@ class AllocaInst final : public UnaryInstruction {
   friend class Context; // For constructor.
 
 public:
-  static AllocaInst *create(Type *Ty, unsigned AddrSpace, InsertPosition Pos,
+  static AllocaInst *create(Type *Ty, unsigned AddrSpace, const InsertPosition &Pos,
                             Context &Ctx, Value *ArraySize = nullptr,
                             const Twine &Name = "");
 
@@ -2294,7 +2294,7 @@ class CastInst : public UnaryInstruction {
 
 public:
   static Value *create(Type *DestTy, Opcode Op, Value *Operand,
-                       InsertPosition Pos, Context &Ctx,
+                       const InsertPosition &Pos, Context &Ctx,
                        const Twine &Name = "");
   /// For isa/dyn_cast.
   static bool classof(const Value *From);
@@ -2388,7 +2388,7 @@ class PHINode final : public SingleLLVMInstructionImpl<llvm::PHINode> {
 
 public:
   static PHINode *create(Type *Ty, unsigned NumReservedValues,
-                         InsertPosition Pos, Context &Ctx,
+                         const InsertPosition &Pos, Context &Ctx,
                          const Twine &Name = "");
   /// For isa/dyn_cast.
   static bool classof(const Value *From);
@@ -2478,11 +2478,11 @@ protected:
 public:
   using Predicate = llvm::CmpInst::Predicate;
 
-  static Value *create(Predicate Pred, Value *S1, Value *S2, InsertPosition Pos,
+  static Value *create(Predicate Pred, Value *S1, Value *S2, const InsertPosition &Pos,
                        Context &Ctx, const Twine &Name = "");
   static Value *createWithCopiedFlags(Predicate Pred, Value *S1, Value *S2,
                                       const Instruction *FlagsSource,
-                                      InsertPosition Pos, Context &Ctx,
+                                      const InsertPosition &Pos, Context &Ctx,
                                       const Twine &Name = "");
   void setPredicate(Predicate P);
   void swapOperands();

--- a/llvm/include/llvm/Support/BinaryStreamWriter.h
+++ b/llvm/include/llvm/Support/BinaryStreamWriter.h
@@ -109,7 +109,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeStreamRef(BinaryStreamRef Ref);
+  Error writeStreamRef(const BinaryStreamRef &Ref);
 
   /// Efficiently reads \p Size bytes from \p Ref, and writes it to this stream.
   /// This operation will not invoke any copies of the source data, regardless
@@ -117,7 +117,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeStreamRef(BinaryStreamRef Ref, uint64_t Size);
+  Error writeStreamRef(const BinaryStreamRef &Ref, uint64_t Size);
 
   /// Writes the object \p Obj to the underlying stream, as if by using memcpy.
   /// It is up to the caller to ensure that type of \p Obj can be safely copied

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -1049,7 +1049,7 @@ Expected<T> handleExpected(Expected<T> ValOrErr, RecoveryFtor &&RecoveryPath,
 /// This is useful in the base level of your program to allow clean termination
 /// (allowing clean deallocation of resources, etc.), while reporting error
 /// information to the user.
-void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner = {});
+void logAllUnhandledErrors(Error E, raw_ostream &OS, const Twine &ErrorBanner = {});
 
 /// Write all error messages (if any) in E to a string. The newline character
 /// is used to separate error messages.

--- a/llvm/include/llvm/TargetParser/ARMTargetParser.h
+++ b/llvm/include/llvm/TargetParser/ARMTargetParser.h
@@ -268,7 +268,7 @@ StringRef computeDefaultTargetABI(const Triple &TT, StringRef CPU);
 /// string then the triple's arch name is used.
 StringRef getARMCPUForArch(const llvm::Triple &Triple, StringRef MArch = {});
 
-void PrintSupportedExtensions(StringMap<StringRef> DescMap);
+void PrintSupportedExtensions(StringMap<StringRef> &DescMap);
 
 } // namespace ARM
 } // namespace llvm

--- a/llvm/include/llvm/TextAPI/DylibReader.h
+++ b/llvm/include/llvm/TextAPI/DylibReader.h
@@ -37,12 +37,12 @@ struct ParseOption {
 /// \param Buffer Data that points to dylib.
 /// \param Options Determines which attributes to extract.
 /// \return List of record slices.
-Expected<Records> readFile(MemoryBufferRef Buffer, const ParseOption &Opt);
+Expected<Records> readFile(const MemoryBufferRef &Buffer, const ParseOption &Opt);
 
 /// Get TAPI file representation of binary dylib.
 ///
 /// \param Buffer Data that points to dylib.
-Expected<std::unique_ptr<InterfaceFile>> get(MemoryBufferRef Buffer);
+Expected<std::unique_ptr<InterfaceFile>> get(const MemoryBufferRef &Buffer);
 
 using SymbolToSourceLocMap = llvm::StringMap<RecordLoc>;
 /// Get the source location for each symbol from dylib.

--- a/llvm/include/llvm/Transforms/Scalar/Float2Int.h
+++ b/llvm/include/llvm/Transforms/Scalar/Float2Int.h
@@ -40,7 +40,7 @@ private:
   void seen(Instruction *I, ConstantRange R);
   ConstantRange badRange();
   ConstantRange unknownRange();
-  ConstantRange validateRange(ConstantRange R);
+  ConstantRange validateRange(const ConstantRange &R);
   std::optional<ConstantRange> calcRange(Instruction *I);
   void walkBackwards();
   void walkForwards();

--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -337,7 +337,7 @@ private:
   /// Given a local dependency (Def or Clobber) determine if a value is
   /// available for the load.
   std::optional<gvn::AvailableValue>
-  AnalyzeLoadAvailability(LoadInst *Load, MemDepResult DepInfo, Value *Address);
+  AnalyzeLoadAvailability(LoadInst *Load, const MemDepResult &DepInfo, Value *Address);
 
   /// Given a list of non-local dependencies, determine if a value is
   /// available for the load in each specified block.  If it is, add it to

--- a/llvm/include/llvm/Transforms/Utils/FunctionImportUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/FunctionImportUtils.h
@@ -62,7 +62,7 @@ class FunctionImportGlobalProcessing {
   DenseMap<const Comdat *, Comdat *> RenamedComdats;
 
   /// Check if we should promote the given local value to global scope.
-  bool shouldPromoteLocalToGlobal(const GlobalValue *SGV, ValueInfo VI);
+  bool shouldPromoteLocalToGlobal(const GlobalValue *SGV, const ValueInfo &VI);
 
 #ifndef NDEBUG
   /// Check if the given value is a local that can't be renamed (promoted).

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -48,7 +48,7 @@ class DependencyGraph;
 /// While OpIt points to a Value that is not an Instruction keep incrementing
 /// it. \Returns the first iterator that points to an Instruction, or end.
 [[nodiscard]] static User::op_iterator skipNonInstr(User::op_iterator OpIt,
-                                                    User::op_iterator OpItE) {
+                                                    const User::op_iterator &OpItE) {
   while (OpIt != OpItE && !isa<Instruction>((*OpIt).get()))
     ++OpIt;
   return OpIt;

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -491,7 +491,7 @@ AliasSet &AliasSetTracker::mergeAllAliasSets() {
   return *AliasAnyAS;
 }
 
-AliasSet &AliasSetTracker::addMemoryLocation(MemoryLocation Loc,
+AliasSet &AliasSetTracker::addMemoryLocation(const MemoryLocation &Loc,
                                              AliasSet::AccessLattice E) {
   AliasSet &AS = getAliasSetFor(Loc);
   AS.Access |= E;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -254,7 +254,7 @@ private:
   }
 
   // Helper to get the valueId for the type of value recorded in VI.
-  unsigned getValueId(ValueInfo VI) {
+  unsigned getValueId(const ValueInfo &VI) {
     if (!VI.haveGVs() || !VI.getValue())
       return getValueId(VI.getGUID());
     return VE.getValueID(VI.getValue());
@@ -5644,7 +5644,7 @@ static const char *getSectionNameForCommandline(const Triple &T) {
   llvm_unreachable("Unimplemented ObjectFormatType");
 }
 
-void llvm::embedBitcodeInModule(llvm::Module &M, llvm::MemoryBufferRef Buf,
+void llvm::embedBitcodeInModule(llvm::Module &M, const llvm::MemoryBufferRef &Buf,
                                 bool EmbedBitcode, bool EmbedCmdline,
                                 const std::vector<uint8_t> &CmdArgs) {
   // Save llvm.compiler.used and remove it.

--- a/llvm/lib/CGData/CodeGenData.cpp
+++ b/llvm/lib/CGData/CodeGenData.cpp
@@ -204,7 +204,7 @@ Expected<Header> Header::readFromBuffer(const unsigned char *Curr) {
 
 namespace cgdata {
 
-void warn(Twine Message, std::string Whence, std::string Hint) {
+void warn(const Twine &Message, const std::string &Whence, const std::string &Hint) {
   WithColor::warning();
   if (!Whence.empty())
     errs() << Whence << ": ";

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3508,7 +3508,7 @@ static void emitGlobalConstantImpl(const DataLayout &DL, const Constant *C,
                                    AsmPrinter::AliasMapTy *AliasList = nullptr);
 
 static void emitGlobalConstantFP(const ConstantFP *CFP, AsmPrinter &AP);
-static void emitGlobalConstantFP(APFloat APF, Type *ET, AsmPrinter &AP);
+static void emitGlobalConstantFP(const APFloat &APF, Type *ET, AsmPrinter &AP);
 
 /// isRepeatedByteSequence - Determine whether the given value is
 /// composed of a repeated sequence of identical bytes and return the
@@ -3705,9 +3705,9 @@ static void emitGlobalConstantStruct(const DataLayout &DL,
          "Layout of constant struct may be incorrect!");
 }
 
-static void emitGlobalConstantFP(APFloat APF, Type *ET, AsmPrinter &AP) {
+static void emitGlobalConstantFP(const APFloat &APF, Type *ET, AsmPrinter &AP) {
   assert(ET && "Unknown float type");
-  APInt API = APF.bitcastToAPInt();
+  const APInt &API = APF.bitcastToAPInt();
 
   // First print a comment with what we think the original floating-point value
   // should have been.
@@ -4118,7 +4118,7 @@ MCSymbol *AsmPrinter::getSymbolWithGlobalValueBase(const GlobalValue *GV,
 }
 
 /// Return the MCSymbol for the specified ExternalSymbol.
-MCSymbol *AsmPrinter::GetExternalSymbolSymbol(Twine Sym) const {
+MCSymbol *AsmPrinter::GetExternalSymbolSymbol(const Twine &Sym) const {
   SmallString<60> NameStr;
   Mangler::getNameWithPrefix(NameStr, Sym, getDataLayout());
   return OutContext.getOrCreateSymbol(NameStr);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
@@ -151,7 +151,7 @@ void AsmPrinter::emitDwarfSymbolReference(const MCSymbol *Label,
                       getDwarfOffsetByteSize());
 }
 
-void AsmPrinter::emitDwarfStringOffset(DwarfStringPoolEntry S) const {
+void AsmPrinter::emitDwarfStringOffset(const DwarfStringPoolEntry &S) const {
   if (doesDwarfUseRelocationsAcrossSections()) {
     assert(S.Symbol && "No symbol available");
     emitDwarfSymbolReference(S.Symbol);

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -474,7 +474,7 @@ TypeIndex CodeViewDebug::getMemberFunctionType(const DISubprogram *SP,
 }
 
 TypeIndex CodeViewDebug::recordTypeIndexForDINode(const DINode *Node,
-                                                  TypeIndex TI,
+                                                  const TypeIndex &TI,
                                                   const DIType *ClassTy) {
   auto InsertResult = TypeIndices.insert({{Node, ClassTy}, TI});
   (void)InsertResult;
@@ -2208,7 +2208,7 @@ static ClassOptions getCommonClassOptions(const DICompositeType *Ty) {
   return CO;
 }
 
-void CodeViewDebug::addUDTSrcLine(const DIType *Ty, TypeIndex TI) {
+void CodeViewDebug::addUDTSrcLine(const DIType *Ty, const TypeIndex &TI) {
   switch (Ty->getTag()) {
   case dwarf::DW_TAG_class_type:
   case dwarf::DW_TAG_structure_type:

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -433,7 +433,7 @@ private:
 
   void addToUDTs(const DIType *Ty);
 
-  void addUDTSrcLine(const DIType *Ty, codeview::TypeIndex TI);
+  void addUDTSrcLine(const DIType *Ty, const codeview::TypeIndex &TI);
 
   codeview::TypeIndex lowerType(const DIType *Ty, const DIType *ClassTy);
   codeview::TypeIndex lowerTypeAlias(const DIDerivedType *Ty);
@@ -482,7 +482,7 @@ private:
 
   /// Inserts {{Node, ClassTy}, TI} into TypeIndices and checks for duplicates.
   codeview::TypeIndex recordTypeIndexForDINode(const DINode *Node,
-                                               codeview::TypeIndex TI,
+                                               const codeview::TypeIndex &TI,
                                                const DIType *ClassTy = nullptr);
 
   /// Collect the names of parent scopes, innermost to outermost. Return the

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -111,7 +111,7 @@ public:
   unsigned getNumVariables() const { return Variables.size(); }
 
   /// Find or insert \p V and return the ID.
-  VariableID insertVariable(DebugVariable V) {
+  VariableID insertVariable(const DebugVariable &V) {
     return static_cast<VariableID>(Variables.insert(V));
   }
 
@@ -135,7 +135,7 @@ public:
   }
 
   /// Add a def for a variable that is valid for its lifetime.
-  void addSingleLocVar(DebugVariable Var, DIExpression *Expr, DebugLoc DL,
+  void addSingleLocVar(const DebugVariable &Var, DIExpression *Expr, DebugLoc DL,
                        RawLocationWrapper R) {
     VarLocInfo VarLoc;
     VarLoc.VariableID = insertVariable(Var);
@@ -146,7 +146,7 @@ public:
   }
 
   /// Add a def to the wedge of defs just before /p Before.
-  void addVarLoc(VarLocInsertPt Before, DebugVariable Var, DIExpression *Expr,
+  void addVarLoc(VarLocInsertPt Before, const DebugVariable &Var, DIExpression *Expr,
                  DebugLoc DL, RawLocationWrapper R) {
     VarLocInfo VarLoc;
     VarLoc.VariableID = insertVariable(Var);

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -6593,7 +6593,7 @@ bool CombinerHelper::matchRedundantBinOpInEquality(MachineInstr &MI,
 /// Return the minimum useless shift amount that results in complete loss of the
 /// source value. Return std::nullopt when it cannot determine a value.
 static std::optional<unsigned>
-getMinUselessShift(KnownBits ValueKB, unsigned Opcode,
+getMinUselessShift(const KnownBits &ValueKB, unsigned Opcode,
                    std::optional<int64_t> &Result) {
   assert(Opcode == TargetOpcode::G_SHL || Opcode == TargetOpcode::G_LSHR ||
          Opcode == TargetOpcode::G_ASHR && "Expect G_SHL, G_LSHR or G_ASHR.");

--- a/llvm/lib/CodeGen/MachineFunction.cpp
+++ b/llvm/lib/CodeGen/MachineFunction.cpp
@@ -520,7 +520,7 @@ void MachineFunction::deleteMachineBasicBlock(MachineBasicBlock *MBB) {
 }
 
 MachineMemOperand *MachineFunction::getMachineMemOperand(
-    MachinePointerInfo PtrInfo, MachineMemOperand::Flags F, LocationSize Size,
+    const MachinePointerInfo &PtrInfo, MachineMemOperand::Flags F, LocationSize Size,
     Align BaseAlignment, const AAMDNodes &AAInfo, const MDNode *Ranges,
     SyncScope::ID SSID, AtomicOrdering Ordering,
     AtomicOrdering FailureOrdering) {

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -1154,7 +1154,7 @@ unsigned DWARFLinker::DIECloner::cloneDieReferenceAttribute(
 }
 
 void DWARFLinker::DIECloner::cloneExpression(
-    DataExtractor &Data, DWARFExpression Expression, const DWARFFile &File,
+    DataExtractor &Data, const DWARFExpression &Expression, const DWARFFile &File,
     CompileUnit &Unit, SmallVectorImpl<uint8_t> &OutputBuffer,
     int64_t AddrRelocAdjustment, bool IsLittleEndian) {
   using Encoding = DWARFExpression::Operation::Encoding;
@@ -1628,7 +1628,7 @@ unsigned DWARFLinker::DIECloner::cloneAttribute(
 
 void DWARFLinker::DIECloner::addObjCAccelerator(CompileUnit &Unit,
                                                 const DIE *Die,
-                                                DwarfStringPoolEntryRef Name,
+                                                const DwarfStringPoolEntryRef &Name,
                                                 OffsetsStringPool &StringPool,
                                                 bool SkipPubSection) {
   std::optional<ObjCSelectorNames> Names =

--- a/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
@@ -474,7 +474,7 @@ void DwarfStreamer::emitDwarfDebugArangesTable(
 
 void DwarfStreamer::emitDwarfDebugRangesTableFragment(
     const CompileUnit &Unit, const AddressRanges &LinkedRanges,
-    PatchLocation Patch) {
+    const PatchLocation &Patch) {
   Patch.set(RangesSectionSize);
 
   // Make .debug_ranges to be current section.
@@ -563,7 +563,7 @@ void DwarfStreamer::emitDwarfDebugRangeListFooter(const CompileUnit &Unit,
 
 void DwarfStreamer::emitDwarfDebugRngListsTableFragment(
     const CompileUnit &Unit, const AddressRanges &LinkedRanges,
-    PatchLocation Patch, DebugDieValuePool &AddrPool) {
+    const PatchLocation &Patch, DebugDieValuePool &AddrPool) {
   Patch.set(RngListsSectionSize);
 
   // Make .debug_rnglists to be current section.
@@ -666,7 +666,7 @@ void DwarfStreamer::emitDwarfDebugLocListFooter(const CompileUnit &Unit,
 void DwarfStreamer::emitDwarfDebugLocTableFragment(
     const CompileUnit &Unit,
     const DWARFLocationExpressionsVector &LinkedLocationExpression,
-    PatchLocation Patch) {
+    const PatchLocation &Patch) {
   Patch.set(LocSectionSize);
 
   // Make .debug_loc to be current section.
@@ -757,7 +757,7 @@ void DwarfStreamer::emitDwarfDebugAddrsFooter(const CompileUnit &Unit,
 void DwarfStreamer::emitDwarfDebugLocListsTableFragment(
     const CompileUnit &Unit,
     const DWARFLocationExpressionsVector &LinkedLocationExpression,
-    PatchLocation Patch, DebugDieValuePool &AddrPool) {
+    const PatchLocation &Patch, DebugDieValuePool &AddrPool) {
   Patch.set(LocListsSectionSize);
 
   // Make .debug_loclists the current section.

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -28,7 +28,7 @@ using namespace llvm::object;
 static mc::RegisterMCTargetOptionsFlags MCTargetOptionsFlags;
 
 // Returns the size of debug_str_offsets section headers in bytes.
-static uint64_t debugStrOffsetsHeaderSize(DataExtractor StrOffsetsData,
+static uint64_t debugStrOffsetsHeaderSize(const DataExtractor &StrOffsetsData,
                                           uint16_t DwarfVersion) {
   if (DwarfVersion <= 4)
     return 0; // There is no header before dwarf 5.
@@ -55,7 +55,7 @@ static uint64_t getCUAbbrev(StringRef Abbrev, uint64_t AbbrCode) {
 }
 
 static Expected<const char *>
-getIndexedString(dwarf::Form Form, DataExtractor InfoData, uint64_t &InfoOffset,
+getIndexedString(dwarf::Form Form, const DataExtractor &InfoData, uint64_t &InfoOffset,
                  StringRef StrOffsets, StringRef Str, uint16_t Version) {
   if (Form == dwarf::DW_FORM_string)
     return InfoData.getCStr(&InfoOffset);

--- a/llvm/lib/DebugInfo/CodeView/CVTypeVisitor.cpp
+++ b/llvm/lib/DebugInfo/CodeView/CVTypeVisitor.cpp
@@ -75,7 +75,7 @@ class CVTypeVisitor {
 public:
   explicit CVTypeVisitor(TypeVisitorCallbacks &Callbacks);
 
-  Error visitTypeRecord(CVType &Record, TypeIndex Index);
+  Error visitTypeRecord(CVType &Record, const TypeIndex &Index);
   Error visitTypeRecord(CVType &Record);
 
   /// Visits the type records in Data. Sets the error flag on parse failures.
@@ -121,7 +121,7 @@ Error CVTypeVisitor::finishVisitation(CVType &Record) {
   return Error::success();
 }
 
-Error CVTypeVisitor::visitTypeRecord(CVType &Record, TypeIndex Index) {
+Error CVTypeVisitor::visitTypeRecord(CVType &Record, const TypeIndex &Index) {
   if (auto EC = Callbacks.visitTypeBegin(Record, Index))
     return EC;
 
@@ -216,7 +216,7 @@ struct VisitHelper {
 };
 }
 
-Error llvm::codeview::visitTypeRecord(CVType &Record, TypeIndex Index,
+Error llvm::codeview::visitTypeRecord(CVType &Record, const TypeIndex &Index,
                                       TypeVisitorCallbacks &Callbacks,
                                       VisitorDataSource Source) {
   VisitHelper V(Callbacks, Source);
@@ -252,7 +252,7 @@ Error llvm::codeview::visitTypeStream(TypeCollection &Types,
   return V.Visitor.visitTypeStream(Types);
 }
 
-Error llvm::codeview::visitMemberRecord(CVMemberRecord Record,
+Error llvm::codeview::visitMemberRecord(const CVMemberRecord &Record,
                                         TypeVisitorCallbacks &Callbacks,
                                         VisitorDataSource Source) {
   FieldListVisitHelper V(Callbacks, Record.Data, Source);

--- a/llvm/lib/DebugInfo/CodeView/DebugInlineeLinesSubsection.cpp
+++ b/llvm/lib/DebugInfo/CodeView/DebugInlineeLinesSubsection.cpp
@@ -113,7 +113,7 @@ void DebugInlineeLinesSubsection::addExtraFile(StringRef FileName) {
   ++ExtraFileCount;
 }
 
-void DebugInlineeLinesSubsection::addInlineSite(TypeIndex FuncId,
+void DebugInlineeLinesSubsection::addInlineSite(const TypeIndex &FuncId,
                                                 StringRef FileName,
                                                 uint32_t SourceLine) {
   uint32_t Offset = Checksums.mapChecksumOffset(FileName);

--- a/llvm/lib/DebugInfo/CodeView/DebugStringTableSubsection.cpp
+++ b/llvm/lib/DebugInfo/CodeView/DebugStringTableSubsection.cpp
@@ -21,7 +21,7 @@ using namespace llvm::codeview;
 DebugStringTableSubsectionRef::DebugStringTableSubsectionRef()
     : DebugSubsectionRef(DebugSubsectionKind::StringTable) {}
 
-Error DebugStringTableSubsectionRef::initialize(BinaryStreamRef Contents) {
+Error DebugStringTableSubsectionRef::initialize(const BinaryStreamRef &Contents) {
   Stream = Contents;
   return Error::success();
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFAbbreviationDeclaration.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAbbreviationDeclaration.cpp
@@ -35,7 +35,7 @@ DWARFAbbreviationDeclaration::DWARFAbbreviationDeclaration() {
 }
 
 llvm::Expected<DWARFAbbreviationDeclaration::ExtractState>
-DWARFAbbreviationDeclaration::extract(DataExtractor Data, uint64_t *OffsetPtr) {
+DWARFAbbreviationDeclaration::extract(const DataExtractor &Data, uint64_t *OffsetPtr) {
   clear();
   const uint64_t Offset = *OffsetPtr;
   Error Err = Error::success();

--- a/llvm/lib/DebugInfo/DWARF/DWARFAddressRange.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAddressRange.cpp
@@ -14,7 +14,7 @@
 using namespace llvm;
 
 void DWARFAddressRange::dump(raw_ostream &OS, uint32_t AddressSize,
-                             DIDumpOptions DumpOpts,
+                             const DIDumpOptions &DumpOpts,
                              const DWARFObject *Obj) const {
 
   OS << (DumpOpts.DisplayRawContents ? " " : "[");

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -977,7 +977,7 @@ static void dumpLoclistsSection(raw_ostream &OS, DIDumpOptions DumpOpts,
   }
 }
 
-static void dumpPubTableSection(raw_ostream &OS, DIDumpOptions DumpOpts,
+static void dumpPubTableSection(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                                 DWARFDataExtractor Data, bool GnuStyle) {
   DWARFDebugPubTable Table;
   Table.extract(Data, GnuStyle, DumpOpts.RecoverableErrorHandler);

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
@@ -24,7 +24,7 @@ void DWARFAbbreviationDeclarationSet::clear() {
   Decls.clear();
 }
 
-Error DWARFAbbreviationDeclarationSet::extract(DataExtractor Data,
+Error DWARFAbbreviationDeclarationSet::extract(const DataExtractor &Data,
                                                uint64_t *OffsetPtr) {
   clear();
   const uint64_t BeginOffset = *OffsetPtr;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAddr.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAddr.cpp
@@ -133,7 +133,7 @@ Error DWARFDebugAddrTable::extract(const DWARFDataExtractor &Data,
   return extractV5(Data, OffsetPtr, CUAddrSize, WarnCallback);
 }
 
-void DWARFDebugAddrTable::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
+void DWARFDebugAddrTable::dump(raw_ostream &OS, const DIDumpOptions &DumpOpts) const {
   if (DumpOpts.Verbose)
     OS << format("0x%8.8" PRIx64 ": ", Offset);
   if (Length) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugArangeSet.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugArangeSet.cpp
@@ -35,7 +35,7 @@ void DWARFDebugArangeSet::clear() {
   ArangeDescriptors.clear();
 }
 
-Error DWARFDebugArangeSet::extract(DWARFDataExtractor data,
+Error DWARFDebugArangeSet::extract(const DWARFDataExtractor &data,
                                    uint64_t *offset_ptr,
                                    function_ref<void(Error)> WarningHandler) {
   assert(data.isValidOffset(*offset_ptr));

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAranges.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAranges.cpp
@@ -20,7 +20,7 @@
 using namespace llvm;
 
 void DWARFDebugAranges::extract(
-    DWARFDataExtractor DebugArangesData,
+    const DWARFDataExtractor &DebugArangesData,
     function_ref<void(Error)> RecoverableErrorHandler,
     function_ref<void(Error)> WarningHandler) {
   if (!DebugArangesData.isValidOffset(0))

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugFrame.cpp
@@ -69,15 +69,15 @@ UnwindLocation::createAtRegisterPlusOffset(uint32_t RegNum, int32_t Offset,
   return {RegPlusOffset, RegNum, Offset, AddrSpace, true};
 }
 
-UnwindLocation UnwindLocation::createIsDWARFExpression(DWARFExpression Expr) {
+UnwindLocation UnwindLocation::createIsDWARFExpression(const DWARFExpression &Expr) {
   return {Expr, false};
 }
 
-UnwindLocation UnwindLocation::createAtDWARFExpression(DWARFExpression Expr) {
+UnwindLocation UnwindLocation::createAtDWARFExpression(const DWARFExpression &Expr) {
   return {Expr, true};
 }
 
-void UnwindLocation::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
+void UnwindLocation::dump(raw_ostream &OS, const DIDumpOptions &DumpOpts) const {
   if (Dereference)
     OS << '[';
   switch (Kind) {
@@ -168,7 +168,7 @@ raw_ostream &llvm::dwarf::operator<<(raw_ostream &OS,
   return OS;
 }
 
-void UnwindRow::dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+void UnwindRow::dump(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                      unsigned IndentLevel) const {
   OS.indent(2 * IndentLevel);
   if (hasAddress())
@@ -188,7 +188,7 @@ raw_ostream &llvm::dwarf::operator<<(raw_ostream &OS, const UnwindRow &Row) {
   return OS;
 }
 
-void UnwindTable::dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+void UnwindTable::dump(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                        unsigned IndentLevel) const {
   for (const UnwindRow &Row : Rows)
     Row.dump(OS, DumpOpts, IndentLevel);
@@ -881,7 +881,7 @@ CFIProgram::getOperandTypes() {
 }
 
 /// Print \p Opcode's operand number \p OperandIdx which has value \p Operand.
-void CFIProgram::printOperand(raw_ostream &OS, DIDumpOptions DumpOpts,
+void CFIProgram::printOperand(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                               const Instruction &Instr, unsigned OperandIdx,
                               uint64_t Operand,
                               std::optional<uint64_t> &Address) const {
@@ -948,7 +948,7 @@ void CFIProgram::printOperand(raw_ostream &OS, DIDumpOptions DumpOpts,
   }
 }
 
-void CFIProgram::dump(raw_ostream &OS, DIDumpOptions DumpOpts,
+void CFIProgram::dump(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                       unsigned IndentLevel,
                       std::optional<uint64_t> Address) const {
   for (const auto &Instr : Instructions) {
@@ -1055,7 +1055,7 @@ DWARFDebugFrame::DWARFDebugFrame(Triple::ArchType Arch,
 
 DWARFDebugFrame::~DWARFDebugFrame() = default;
 
-static void LLVM_ATTRIBUTE_UNUSED dumpDataAux(DataExtractor Data,
+static void LLVM_ATTRIBUTE_UNUSED dumpDataAux(const DataExtractor &Data,
                                               uint64_t Offset, int Length) {
   errs() << "DUMP: ";
   for (int i = 0; i < Length; ++i) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -115,7 +115,7 @@ void DWARFDebugLine::Prologue::clear() {
 }
 
 void DWARFDebugLine::Prologue::dump(raw_ostream &OS,
-                                    DIDumpOptions DumpOptions) const {
+                                    const DIDumpOptions &DumpOptions) const {
   if (!totalLengthIsValid())
     return;
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(FormParams.Format);
@@ -536,7 +536,7 @@ void DWARFDebugLine::Sequence::reset() {
 DWARFDebugLine::LineTable::LineTable() { clear(); }
 
 void DWARFDebugLine::LineTable::dump(raw_ostream &OS,
-                                     DIDumpOptions DumpOptions) const {
+                                     const DIDumpOptions &DumpOptions) const {
   Prologue.dump(OS, DumpOptions);
 
   if (!Rows.empty()) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLoc.cpp
@@ -109,7 +109,7 @@ DWARFLocationInterpreter::Interpret(const DWARFLocationEntry &E) {
   }
 }
 
-static void dumpExpression(raw_ostream &OS, DIDumpOptions DumpOpts,
+static void dumpExpression(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                            ArrayRef<uint8_t> Data, bool IsLittleEndian,
                            unsigned AddressSize, DWARFUnit *U) {
   DWARFDataExtractor Extractor(Data, IsLittleEndian, AddressSize);
@@ -182,7 +182,7 @@ Error DWARFLocationTable::visitAbsoluteLocationList(
 }
 
 void DWARFDebugLoc::dump(raw_ostream &OS, const DWARFObject &Obj,
-                         DIDumpOptions DumpOpts,
+                         const DIDumpOptions &DumpOpts,
                          std::optional<uint64_t> DumpOffset) const {
   auto BaseAddr = std::nullopt;
   unsigned Indent = 12;
@@ -385,7 +385,7 @@ void DWARFDebugLoclists::dumpRawEntry(const DWARFLocationEntry &Entry,
 
 void DWARFDebugLoclists::dumpRange(uint64_t StartOffset, uint64_t Size,
                                    raw_ostream &OS, const DWARFObject &Obj,
-                                   DIDumpOptions DumpOpts) {
+                                   const DIDumpOptions &DumpOpts) {
   if (!Data.isValidOffsetForDataOfSize(StartOffset, Size))  {
     OS << "Invalid dump range\n";
     return;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugMacro.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugMacro.cpp
@@ -106,7 +106,7 @@ void DWARFDebugMacro::dump(raw_ostream &OS) const {
 
 Error DWARFDebugMacro::parseImpl(
     std::optional<DWARFUnitVector::compile_unit_range> Units,
-    std::optional<DataExtractor> StringExtractor, DWARFDataExtractor Data,
+    std::optional<DataExtractor> StringExtractor, const DWARFDataExtractor &Data,
     bool IsMacro) {
   uint64_t Offset = 0;
   MacroList *M = nullptr;
@@ -230,7 +230,7 @@ Error DWARFDebugMacro::parseImpl(
   return Error::success();
 }
 
-Error DWARFDebugMacro::MacroHeader::parseMacroHeader(DWARFDataExtractor Data,
+Error DWARFDebugMacro::MacroHeader::parseMacroHeader(const DWARFDataExtractor &Data,
                                                      uint64_t *Offset) {
   Version = Data.getU16(Offset);
   uint8_t FlagData = Data.getU8(Offset);

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugPubTable.cpp
@@ -20,7 +20,7 @@ using namespace llvm;
 using namespace dwarf;
 
 void DWARFDebugPubTable::extract(
-    DWARFDataExtractor Data, bool GnuStyle,
+    const DWARFDataExtractor &Data, bool GnuStyle,
     function_ref<void(Error)> RecoverableErrorHandler) {
   this->GnuStyle = GnuStyle;
   Sets.clear();

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugRnglists.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugRnglists.cpp
@@ -17,7 +17,7 @@
 
 using namespace llvm;
 
-Error RangeListEntry::extract(DWARFDataExtractor Data, uint64_t *OffsetPtr) {
+Error RangeListEntry::extract(const DWARFDataExtractor &Data, uint64_t *OffsetPtr) {
   Offset = *OffsetPtr;
   SectionIndex = -1ULL;
   // The caller should guarantee that we have at least 1 byte available, so

--- a/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDie.cpp
@@ -70,7 +70,7 @@ static void dumpRanges(const DWARFObject &Obj, raw_ostream &OS,
 
 static void dumpLocationList(raw_ostream &OS, const DWARFFormValue &FormValue,
                              DWARFUnit *U, unsigned Indent,
-                             DIDumpOptions DumpOpts) {
+                             const DIDumpOptions &DumpOpts) {
   assert(FormValue.isFormClass(DWARFFormValue::FC_SectionOffset) &&
          "bad FORM for location list");
   DWARFContext &Ctx = U->getContext();
@@ -90,7 +90,7 @@ static void dumpLocationList(raw_ostream &OS, const DWARFFormValue &FormValue,
 
 static void dumpLocationExpr(raw_ostream &OS, const DWARFFormValue &FormValue,
                              DWARFUnit *U, unsigned Indent,
-                             DIDumpOptions DumpOpts) {
+                             const DIDumpOptions &DumpOpts) {
   assert((FormValue.isFormClass(DWARFFormValue::FC_Block) ||
           FormValue.isFormClass(DWARFFormValue::FC_Exprloc)) &&
          "bad FORM for location expression");
@@ -102,7 +102,7 @@ static void dumpLocationExpr(raw_ostream &OS, const DWARFFormValue &FormValue,
       .print(OS, DumpOpts, U);
 }
 
-static DWARFDie resolveReferencedType(DWARFDie D, DWARFFormValue F) {
+static DWARFDie resolveReferencedType(DWARFDie D, const DWARFFormValue &F) {
   return D.getAttributeValueAsReferencedDie(F).resolveTypeUnitReference();
 }
 
@@ -581,7 +581,7 @@ std::optional<uint64_t> DWARFDie::getTypeSize(uint64_t PointerSize) {
 
 /// Helper to dump a DIE with all of its parents, but no siblings.
 static unsigned dumpParentChain(DWARFDie Die, raw_ostream &OS, unsigned Indent,
-                                DIDumpOptions DumpOpts, unsigned Depth = 0) {
+                                const DIDumpOptions &DumpOpts, unsigned Depth = 0) {
   if (!Die)
     return Indent;
   if (DumpOpts.ParentRecurseDepth > 0 && Depth >= DumpOpts.ParentRecurseDepth)

--- a/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFExpression.cpp
@@ -140,7 +140,7 @@ static Desc getSubOpDesc(unsigned Opcode, unsigned SubOpcode) {
   return getDescImpl(Descriptions, SubOpcode);
 }
 
-bool DWARFExpression::Operation::extract(DataExtractor Data,
+bool DWARFExpression::Operation::extract(const DataExtractor &Data,
                                          uint8_t AddressSize, uint64_t Offset,
                                          std::optional<DwarfFormat> Format) {
   EndOffset = Offset;
@@ -238,7 +238,7 @@ bool DWARFExpression::Operation::extract(DataExtractor Data,
 }
 
 static void prettyPrintBaseTypeRef(DWARFUnit *U, raw_ostream &OS,
-                                   DIDumpOptions DumpOpts,
+                                   const DIDumpOptions &DumpOpts,
                                    ArrayRef<uint64_t> Operands,
                                    unsigned Operand) {
   assert(Operand < Operands.size() && "operand out of bounds");
@@ -299,7 +299,7 @@ std::optional<unsigned> DWARFExpression::Operation::getSubCode() const {
   return Operands[0];
 }
 
-bool DWARFExpression::Operation::print(raw_ostream &OS, DIDumpOptions DumpOpts,
+bool DWARFExpression::Operation::print(raw_ostream &OS, const DIDumpOptions &DumpOpts,
                                        const DWARFExpression *Expr,
                                        DWARFUnit *U) const {
   if (Error) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFFormValue.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFFormValue.cpp
@@ -107,7 +107,7 @@ DWARFFormValue DWARFFormValue::createFromUnit(dwarf::Form F, const DWARFUnit *U,
   return FormValue;
 }
 
-bool DWARFFormValue::skipValue(dwarf::Form Form, DataExtractor DebugInfoData,
+bool DWARFFormValue::skipValue(dwarf::Form Form, const DataExtractor &DebugInfoData,
                                uint64_t *OffsetPtr,
                                const dwarf::FormParams Params) {
   bool Indirect = false;
@@ -357,7 +357,7 @@ void DWARFFormValue::dumpAddress(raw_ostream &OS, uint8_t AddressSize,
 }
 
 void DWARFFormValue::dumpSectionedAddress(raw_ostream &OS,
-                                          DIDumpOptions DumpOpts,
+                                          const DIDumpOptions &DumpOpts,
                                           object::SectionedAddress SA) const {
   dumpAddress(OS, U->getAddressByteSize(), SA.Address);
   dumpAddressSection(U->getContext().getDWARFObj(), OS, DumpOpts,
@@ -365,7 +365,7 @@ void DWARFFormValue::dumpSectionedAddress(raw_ostream &OS,
 }
 
 void DWARFFormValue::dumpAddressSection(const DWARFObject &Obj, raw_ostream &OS,
-                                        DIDumpOptions DumpOpts,
+                                        const DIDumpOptions &DumpOpts,
                                         uint64_t SectionIndex) {
   if (!DumpOpts.Verbose || SectionIndex == -1ULL)
     return;
@@ -379,7 +379,7 @@ void DWARFFormValue::dumpAddressSection(const DWARFObject &Obj, raw_ostream &OS,
     OS << format(" [%" PRIu64 "]", SectionIndex);
 }
 
-void DWARFFormValue::dump(raw_ostream &OS, DIDumpOptions DumpOpts) const {
+void DWARFFormValue::dump(raw_ostream &OS, const DIDumpOptions &DumpOpts) const {
   uint64_t UValue = Value.uval;
   bool CURelativeOffset = false;
   raw_ostream &AddrOS = DumpOpts.ShowAddresses

--- a/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFGdbIndex.cpp
@@ -112,7 +112,7 @@ void DWARFGdbIndex::dump(raw_ostream &OS) {
   }
 }
 
-bool DWARFGdbIndex::parseImpl(DataExtractor Data) {
+bool DWARFGdbIndex::parseImpl(const DataExtractor &Data) {
   uint64_t Offset = 0;
 
   // Only version 7 and 8 are supported at this moment.
@@ -195,7 +195,7 @@ bool DWARFGdbIndex::parseImpl(DataExtractor Data) {
   return true;
 }
 
-void DWARFGdbIndex::parse(DataExtractor Data) {
+void DWARFGdbIndex::parse(const DataExtractor &Data) {
   HasContent = !Data.getData().empty();
   HasError = HasContent && !parseImpl(Data);
 }

--- a/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFListTable.cpp
@@ -75,8 +75,8 @@ Error DWARFListTableHeader::extract(DWARFDataExtractor Data,
   return Error::success();
 }
 
-void DWARFListTableHeader::dump(DataExtractor Data, raw_ostream &OS,
-                                DIDumpOptions DumpOpts) const {
+void DWARFListTableHeader::dump(const DataExtractor &Data, raw_ostream &OS,
+                                const DIDumpOptions &DumpOpts) const {
   if (DumpOpts.Verbose)
     OS << format("0x%8.8" PRIx64 ": ", HeaderOffset);
   int OffsetDumpWidth = 2 * dwarf::getDwarfOffsetByteSize(Format);

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnitIndex.cpp
@@ -89,7 +89,7 @@ DWARFSectionKind llvm::deserializeSectionKind(uint32_t Value,
   return DW_SECT_EXT_unknown;
 }
 
-bool DWARFUnitIndex::Header::parse(DataExtractor IndexData,
+bool DWARFUnitIndex::Header::parse(const DataExtractor &IndexData,
                                    uint64_t *OffsetPtr) {
   const uint64_t BeginOffset = *OffsetPtr;
   if (!IndexData.isValidOffsetForDataOfSize(*OffsetPtr, 16))
@@ -116,7 +116,7 @@ void DWARFUnitIndex::Header::dump(raw_ostream &OS) const {
   OS << format("version = %u, units = %u, slots = %u\n\n", Version, NumUnits, NumBuckets);
 }
 
-bool DWARFUnitIndex::parse(DataExtractor IndexData) {
+bool DWARFUnitIndex::parse(const DataExtractor &IndexData) {
   bool b = parseImpl(IndexData);
   if (!b) {
     // Make sure we don't try to dump anything
@@ -128,7 +128,7 @@ bool DWARFUnitIndex::parse(DataExtractor IndexData) {
   return b;
 }
 
-bool DWARFUnitIndex::parseImpl(DataExtractor IndexData) {
+bool DWARFUnitIndex::parseImpl(const DataExtractor &IndexData) {
   uint64_t Offset = 0;
   if (!Header.parse(IndexData, &Offset))
     return false;

--- a/llvm/lib/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/DbiModuleDescriptorBuilder.cpp
@@ -162,7 +162,7 @@ Error DbiModuleDescriptorBuilder::commit(BinaryStreamWriter &ModiWriter) {
 }
 
 Error DbiModuleDescriptorBuilder::commitSymbolStream(
-    const msf::MSFLayout &MsfLayout, WritableBinaryStreamRef MsfBuffer) {
+    const msf::MSFLayout &MsfLayout, const WritableBinaryStreamRef &MsfBuffer) {
   if (Layout.ModDiStream == kInvalidStreamIndex)
     return Error::success();
 

--- a/llvm/lib/DebugInfo/PDB/Native/DbiModuleList.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/DbiModuleList.cpp
@@ -159,8 +159,8 @@ bool DbiModuleSourceFilesIterator::isCompatible(
   return Modi == R.Modi;
 }
 
-Error DbiModuleList::initialize(BinaryStreamRef ModInfo,
-                                BinaryStreamRef FileInfo) {
+Error DbiModuleList::initialize(const BinaryStreamRef &ModInfo,
+                                const BinaryStreamRef &FileInfo) {
   if (auto EC = initializeModInfo(ModInfo))
     return EC;
   if (auto EC = initializeFileInfo(FileInfo))

--- a/llvm/lib/DebugInfo/PDB/Native/DbiStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/DbiStreamBuilder.cpp
@@ -381,7 +381,7 @@ void DbiStreamBuilder::createSectionMap(
 }
 
 Error DbiStreamBuilder::commit(const msf::MSFLayout &Layout,
-                               WritableBinaryStreamRef MsfBuffer) {
+                               const WritableBinaryStreamRef &MsfBuffer) {
   llvm::TimeTraceScope timeScope("Commit DBI stream");
   if (auto EC = finalize())
     return EC;

--- a/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/GSIStreamBuilder.cpp
@@ -478,7 +478,7 @@ Error GSIStreamBuilder::commitGlobalsHashStream(
 }
 
 Error GSIStreamBuilder::commit(const msf::MSFLayout &Layout,
-                               WritableBinaryStreamRef Buffer) {
+                               const WritableBinaryStreamRef &Buffer) {
   llvm::TimeTraceScope timeScope("Commit GSI stream");
   auto GS = WritableMappedBlockStream::createIndexedStream(
       Layout, Buffer, getGlobalsStreamIndex(), Msf.getAllocator());

--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -324,7 +324,7 @@ void DebuginfodLog::push(const Twine &Message) {
   push(DebuginfodLogEntry(Message));
 }
 
-void DebuginfodLog::push(DebuginfodLogEntry Entry) {
+void DebuginfodLog::push(const DebuginfodLogEntry &Entry) {
   {
     std::lock_guard<std::mutex> Guard(QueueMutex);
     LogEntryQueue.push(Entry);

--- a/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
+++ b/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
@@ -38,7 +38,7 @@ static cl::opt<bool> PrintVolatile("interpreter-print-volatile", cl::Hidden,
 //                     Various Helper Functions
 //===----------------------------------------------------------------------===//
 
-static void SetValue(Value *V, GenericValue Val, ExecutionContext &SF) {
+static void SetValue(Value *V, const GenericValue &Val, ExecutionContext &SF) {
   SF.Values[V] = Val;
 }
 
@@ -46,7 +46,7 @@ static void SetValue(Value *V, GenericValue Val, ExecutionContext &SF) {
 //                    Unary Instruction Implementations
 //===----------------------------------------------------------------------===//
 
-static void executeFNegInst(GenericValue &Dest, GenericValue Src, Type *Ty) {
+static void executeFNegInst(GenericValue &Dest, const GenericValue &Src, Type *Ty) {
   switch (Ty->getTypeID()) {
   case Type::FloatTyID:
     Dest.FloatVal = -Src.FloatVal;
@@ -105,8 +105,8 @@ void Interpreter::visitUnaryOperator(UnaryOperator &I) {
      Dest.TY##Val = Src1.TY##Val OP Src2.TY##Val; \
      break
 
-static void executeFAddInst(GenericValue &Dest, GenericValue Src1,
-                            GenericValue Src2, Type *Ty) {
+static void executeFAddInst(GenericValue &Dest, const GenericValue &Src1,
+                            const GenericValue &Src2, Type *Ty) {
   switch (Ty->getTypeID()) {
     IMPLEMENT_BINARY_OPERATOR(+, Float);
     IMPLEMENT_BINARY_OPERATOR(+, Double);
@@ -116,8 +116,8 @@ static void executeFAddInst(GenericValue &Dest, GenericValue Src1,
   }
 }
 
-static void executeFSubInst(GenericValue &Dest, GenericValue Src1,
-                            GenericValue Src2, Type *Ty) {
+static void executeFSubInst(GenericValue &Dest, const GenericValue &Src1,
+                            const GenericValue &Src2, Type *Ty) {
   switch (Ty->getTypeID()) {
     IMPLEMENT_BINARY_OPERATOR(-, Float);
     IMPLEMENT_BINARY_OPERATOR(-, Double);
@@ -127,8 +127,8 @@ static void executeFSubInst(GenericValue &Dest, GenericValue Src1,
   }
 }
 
-static void executeFMulInst(GenericValue &Dest, GenericValue Src1,
-                            GenericValue Src2, Type *Ty) {
+static void executeFMulInst(GenericValue &Dest, const GenericValue &Src1,
+                            const GenericValue &Src2, Type *Ty) {
   switch (Ty->getTypeID()) {
     IMPLEMENT_BINARY_OPERATOR(*, Float);
     IMPLEMENT_BINARY_OPERATOR(*, Double);
@@ -138,8 +138,8 @@ static void executeFMulInst(GenericValue &Dest, GenericValue Src1,
   }
 }
 
-static void executeFDivInst(GenericValue &Dest, GenericValue Src1,
-                            GenericValue Src2, Type *Ty) {
+static void executeFDivInst(GenericValue &Dest, const GenericValue &Src1,
+                            const GenericValue &Src2, Type *Ty) {
   switch (Ty->getTypeID()) {
     IMPLEMENT_BINARY_OPERATOR(/, Float);
     IMPLEMENT_BINARY_OPERATOR(/, Double);
@@ -149,8 +149,8 @@ static void executeFDivInst(GenericValue &Dest, GenericValue Src1,
   }
 }
 
-static void executeFRemInst(GenericValue &Dest, GenericValue Src1,
-                            GenericValue Src2, Type *Ty) {
+static void executeFRemInst(GenericValue &Dest, const GenericValue &Src1,
+                            const GenericValue &Src2, Type *Ty) {
   switch (Ty->getTypeID()) {
   case Type::FloatTyID:
     Dest.FloatVal = fmod(Src1.FloatVal, Src2.FloatVal);
@@ -377,7 +377,7 @@ void Interpreter::visitICmpInst(ICmpInst &I) {
       IMPLEMENT_VECTOR_FCMP_T(OP, Double);                                     \
     }
 
-static GenericValue executeFCMP_OEQ(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_OEQ(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -427,7 +427,7 @@ static GenericValue executeFCMP_OEQ(GenericValue Src1, GenericValue Src2,
 
 
 
-static GenericValue executeFCMP_ONE(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_ONE(const GenericValue &Src1, const GenericValue &Src2,
                                     Type *Ty)
 {
   GenericValue Dest;
@@ -453,7 +453,7 @@ static GenericValue executeFCMP_ONE(GenericValue Src1, GenericValue Src2,
   return Dest;
 }
 
-static GenericValue executeFCMP_OLE(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_OLE(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -467,7 +467,7 @@ static GenericValue executeFCMP_OLE(GenericValue Src1, GenericValue Src2,
   return Dest;
 }
 
-static GenericValue executeFCMP_OGE(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_OGE(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -481,7 +481,7 @@ static GenericValue executeFCMP_OGE(GenericValue Src1, GenericValue Src2,
   return Dest;
 }
 
-static GenericValue executeFCMP_OLT(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_OLT(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -495,7 +495,7 @@ static GenericValue executeFCMP_OLT(GenericValue Src1, GenericValue Src2,
   return Dest;
 }
 
-static GenericValue executeFCMP_OGT(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_OGT(const GenericValue &Src1, const GenericValue &Src2,
                                      Type *Ty) {
   GenericValue Dest;
   switch (Ty->getTypeID()) {
@@ -530,7 +530,7 @@ static GenericValue executeFCMP_OGT(GenericValue Src1, GenericValue Src2,
     return Dest;                                                               \
   }
 
-static GenericValue executeFCMP_UEQ(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_UEQ(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -540,7 +540,7 @@ static GenericValue executeFCMP_UEQ(GenericValue Src1, GenericValue Src2,
 
 }
 
-static GenericValue executeFCMP_UNE(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_UNE(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -549,7 +549,7 @@ static GenericValue executeFCMP_UNE(GenericValue Src1, GenericValue Src2,
   return executeFCMP_ONE(Src1, Src2, Ty);
 }
 
-static GenericValue executeFCMP_ULE(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_ULE(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -558,7 +558,7 @@ static GenericValue executeFCMP_ULE(GenericValue Src1, GenericValue Src2,
   return executeFCMP_OLE(Src1, Src2, Ty);
 }
 
-static GenericValue executeFCMP_UGE(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_UGE(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -567,7 +567,7 @@ static GenericValue executeFCMP_UGE(GenericValue Src1, GenericValue Src2,
   return executeFCMP_OGE(Src1, Src2, Ty);
 }
 
-static GenericValue executeFCMP_ULT(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_ULT(const GenericValue &Src1, const GenericValue &Src2,
                                    Type *Ty) {
   GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -576,7 +576,7 @@ static GenericValue executeFCMP_ULT(GenericValue Src1, GenericValue Src2,
   return executeFCMP_OLT(Src1, Src2, Ty);
 }
 
-static GenericValue executeFCMP_UGT(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_UGT(const GenericValue &Src1, const GenericValue &Src2,
                                      Type *Ty) {
   GenericValue Dest;
   IMPLEMENT_UNORDERED(Ty, Src1, Src2)
@@ -585,7 +585,7 @@ static GenericValue executeFCMP_UGT(GenericValue Src1, GenericValue Src2,
   return executeFCMP_OGT(Src1, Src2, Ty);
 }
 
-static GenericValue executeFCMP_ORD(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_ORD(const GenericValue &Src1, const GenericValue &Src2,
                                      Type *Ty) {
   GenericValue Dest;
   if(Ty->isVectorTy()) {
@@ -616,7 +616,7 @@ static GenericValue executeFCMP_ORD(GenericValue Src1, GenericValue Src2,
   return Dest;
 }
 
-static GenericValue executeFCMP_UNO(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_UNO(const GenericValue &Src1, const GenericValue &Src2,
                                      Type *Ty) {
   GenericValue Dest;
   if(Ty->isVectorTy()) {
@@ -647,7 +647,7 @@ static GenericValue executeFCMP_UNO(GenericValue Src1, GenericValue Src2,
   return Dest;
 }
 
-static GenericValue executeFCMP_BOOL(GenericValue Src1, GenericValue Src2,
+static GenericValue executeFCMP_BOOL(const GenericValue &Src1, const GenericValue &Src2,
                                      Type *Ty, const bool val) {
   GenericValue Dest;
     if(Ty->isVectorTy()) {
@@ -806,8 +806,8 @@ void Interpreter::visitBinaryOperator(BinaryOperator &I) {
   SetValue(&I, R, SF);
 }
 
-static GenericValue executeSelectInst(GenericValue Src1, GenericValue Src2,
-                                      GenericValue Src3, Type *Ty) {
+static GenericValue executeSelectInst(const GenericValue &Src1, const GenericValue &Src2,
+                                      const GenericValue &Src3, Type *Ty) {
     GenericValue Dest;
     if(Ty->isVectorTy()) {
       assert(Src1.AggregateVal.size() == Src2.AggregateVal.size());
@@ -836,7 +836,7 @@ void Interpreter::visitSelectInst(SelectInst &I) {
 //                     Terminator Instruction Implementations
 //===----------------------------------------------------------------------===//
 
-void Interpreter::exitCalled(GenericValue GV) {
+void Interpreter::exitCalled(const GenericValue &GV) {
   // runAtExitHandlers() assumes there are no stack frames, but
   // if exit() was called, then it had a stack frame. Blow away
   // the stack before interpreting atexit handlers.
@@ -854,7 +854,7 @@ void Interpreter::exitCalled(GenericValue GV) {
 /// from an invoke.
 ///
 void Interpreter::popStackAndReturnValueToCaller(Type *RetTy,
-                                                 GenericValue Result) {
+                                                 const GenericValue &Result) {
   // Pop the current stack frame.
   ECStack.pop_back();
 

--- a/llvm/lib/ExecutionEngine/Interpreter/Interpreter.h
+++ b/llvm/lib/ExecutionEngine/Interpreter/Interpreter.h
@@ -174,7 +174,7 @@ public:
 
   GenericValue callExternalFunction(Function *F,
                                     ArrayRef<GenericValue> ArgVals);
-  void exitCalled(GenericValue GV);
+  void exitCalled(const GenericValue &GV);
 
   void addAtExitHandler(Function *F) {
     AtExitHandlers.push_back(F);
@@ -224,7 +224,7 @@ private:  // Helper functions
                                    ExecutionContext &SF);
   GenericValue executeBitCastInst(Value *SrcVal, Type *DstTy,
                                   ExecutionContext &SF);
-  void popStackAndReturnValueToCaller(Type *RetTy, GenericValue Result);
+  void popStackAndReturnValueToCaller(Type *RetTy, const GenericValue &Result);
 
 };
 

--- a/llvm/lib/ExecutionEngine/JITLink/COFF.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/COFF.cpp
@@ -40,7 +40,7 @@ static StringRef getMachineName(uint16_t Machine) {
 }
 
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromCOFFObject(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromCOFFObject(const MemoryBufferRef &ObjectBuffer,
                               std::shared_ptr<orc::SymbolStringPool> SSP) {
   StringRef Data = ObjectBuffer.getBuffer();
 

--- a/llvm/lib/ExecutionEngine/JITLink/COFF_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/COFF_x86_64.cpp
@@ -271,7 +271,7 @@ const char *getCOFFX86RelocationKindName(Edge::Kind R) {
 }
 
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromCOFFObject_x86_64(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "
            << ObjectBuffer.getBufferIdentifier() << "...\n";

--- a/llvm/lib/ExecutionEngine/JITLink/ELF.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF.cpp
@@ -69,7 +69,7 @@ Expected<uint16_t> readTargetMachineArch(StringRef Buffer) {
 }
 
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject(const MemoryBufferRef &ObjectBuffer,
                              std::shared_ptr<orc::SymbolStringPool> SSP) {
   StringRef Buffer = ObjectBuffer.getBuffer();
   if (Buffer.size() < ELF::EI_NIDENT)

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch32.cpp
@@ -242,7 +242,7 @@ Error buildTables_ELF_aarch32(LinkGraph &G) {
 }
 
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_aarch32(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "
            << ObjectBuffer.getBufferIdentifier() << "...\n";

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
@@ -673,7 +673,7 @@ namespace llvm {
 namespace jitlink {
 
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_aarch64(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "
            << ObjectBuffer.getBufferIdentifier() << "...\n";

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_i386.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_i386.cpp
@@ -233,7 +233,7 @@ public:
 };
 
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject_i386(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject_i386(const MemoryBufferRef &ObjectBuffer,
                                   std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_loongarch.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_loongarch.cpp
@@ -434,7 +434,7 @@ namespace llvm {
 namespace jitlink {
 
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_loongarch(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "
            << ObjectBuffer.getBufferIdentifier() << "...\n";

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
@@ -936,7 +936,7 @@ public:
 };
 
 Expected<std::unique_ptr<LinkGraph>>
-createLinkGraphFromELFObject_riscv(MemoryBufferRef ObjectBuffer,
+createLinkGraphFromELFObject_riscv(const MemoryBufferRef &ObjectBuffer,
                                    std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_x86_64.cpp
@@ -335,7 +335,7 @@ private:
 };
 
 Expected<std::unique_ptr<LinkGraph>> createLinkGraphFromELFObject_x86_64(
-    MemoryBufferRef ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
+    const MemoryBufferRef &ObjectBuffer, std::shared_ptr<orc::SymbolStringPool> SSP) {
   LLVM_DEBUG({
     dbgs() << "Building jitlink graph for new input "
            << ObjectBuffer.getBufferIdentifier() << "...\n";

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -1666,7 +1666,7 @@ JITDylib &ExecutionSession::createBareJITDylib(std::string Name) {
   });
 }
 
-Expected<JITDylib &> ExecutionSession::createJITDylib(std::string Name) {
+Expected<JITDylib &> ExecutionSession::createJITDylib(const std::string &Name) {
   auto &JD = createBareJITDylib(Name);
   if (P)
     if (auto Err = P->setupJITDylib(JD))

--- a/llvm/lib/ExecutionEngine/Orc/DebugObjectManagerPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/DebugObjectManagerPlugin.cpp
@@ -186,7 +186,7 @@ void DebugObject::finalizeAsync(FinalizeContinuation OnFinalize) {
 class ELFDebugObject : public DebugObject {
 public:
   static Expected<std::unique_ptr<DebugObject>>
-  Create(MemoryBufferRef Buffer, JITLinkContext &Ctx, ExecutionSession &ES);
+  Create(const MemoryBufferRef &Buffer, JITLinkContext &Ctx, ExecutionSession &ES);
 
   void reportSectionTargetMemoryRange(StringRef Name,
                                       SectionRange TargetMem) override;
@@ -208,7 +208,7 @@ private:
                  const JITLinkDylib *JD, ExecutionSession &ES);
 
   static std::unique_ptr<WritableMemoryBuffer>
-  CopyBuffer(MemoryBufferRef Buffer, Error &Err);
+  CopyBuffer(const MemoryBufferRef &Buffer, Error &Err);
 
   ELFDebugObject(std::unique_ptr<WritableMemoryBuffer> Buffer,
                  JITLinkMemoryManager &MemMgr, const JITLinkDylib *JD,
@@ -233,7 +233,7 @@ static bool isDwarfSection(StringRef SectionName) {
 }
 
 std::unique_ptr<WritableMemoryBuffer>
-ELFDebugObject::CopyBuffer(MemoryBufferRef Buffer, Error &Err) {
+ELFDebugObject::CopyBuffer(const MemoryBufferRef &Buffer, Error &Err) {
   ErrorAsOutParameter _(Err);
   size_t Size = Buffer.getBufferSize();
   StringRef Name = Buffer.getBufferIdentifier();
@@ -292,7 +292,7 @@ ELFDebugObject::CreateArchType(MemoryBufferRef Buffer,
 }
 
 Expected<std::unique_ptr<DebugObject>>
-ELFDebugObject::Create(MemoryBufferRef Buffer, JITLinkContext &Ctx,
+ELFDebugObject::Create(const MemoryBufferRef &Buffer, JITLinkContext &Ctx,
                        ExecutionSession &ES) {
   unsigned char Class, Endian;
   std::tie(Class, Endian) = getElfArchType(Buffer.getBuffer());
@@ -374,7 +374,7 @@ DebugObjectSection *ELFDebugObject::getSection(StringRef Name) {
 ///
 static Expected<std::unique_ptr<DebugObject>>
 createDebugObjectFromBuffer(ExecutionSession &ES, LinkGraph &G,
-                            JITLinkContext &Ctx, MemoryBufferRef ObjBuffer) {
+                            JITLinkContext &Ctx, const MemoryBufferRef &ObjBuffer) {
   switch (G.getTargetTriple().getObjectFormat()) {
   case Triple::ELF:
     return ELFDebugObject::Create(ObjBuffer, Ctx, ES);

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1502,7 +1502,7 @@ static void WriteAPFloatInternal(raw_ostream &Out, const APFloat &APF) {
   // These appear as a magic letter identifying the type, then a
   // fixed number of hex digits.
   Out << "0x";
-  APInt API = APF.bitcastToAPInt();
+  const APInt &API = APF.bitcastToAPInt();
   if (&APF.getSemantics() == &APFloat::x87DoubleExtended()) {
     Out << 'K';
     Out << format_hex_no_prefix(API.getHiBits(16).getZExtValue(), 4,

--- a/llvm/lib/IR/DataLayout.cpp
+++ b/llvm/lib/IR/DataLayout.cpp
@@ -268,7 +268,7 @@ Expected<DataLayout> DataLayout::parse(StringRef LayoutString) {
   return Layout;
 }
 
-static Error createSpecFormatError(Twine Format) {
+static Error createSpecFormatError(const Twine &Format) {
   return createStringError("malformed specification, must be of the form \"" +
                            Format + "\"");
 }

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -2050,7 +2050,7 @@ std::optional<AssignmentInfo> at::getAssignmentInfo(const DataLayout &DL,
 }
 
 /// Returns nullptr if the assignment shouldn't be attributed to this variable.
-static void emitDbgAssign(AssignmentInfo Info, Value *Val, Value *Dest,
+static void emitDbgAssign(const AssignmentInfo &Info, Value *Val, Value *Dest,
                           Instruction &StoreLikeInst, const VarRecord &VarRec,
                           DIBuilder &DIB) {
   auto *ID = StoreLikeInst.getMetadata(LLVMContext::MD_DIAssignID);

--- a/llvm/lib/InterfaceStub/ELFObjHandler.cpp
+++ b/llvm/lib/InterfaceStub/ELFObjHandler.cpp
@@ -688,7 +688,7 @@ static Error writeELFBinaryToFile(StringRef FilePath, const IFSStub &Stub,
   return FileBuf->commit();
 }
 
-Expected<std::unique_ptr<IFSStub>> readELFFile(MemoryBufferRef Buf) {
+Expected<std::unique_ptr<IFSStub>> readELFFile(const MemoryBufferRef &Buf) {
   Expected<std::unique_ptr<Binary>> BinOrErr = createBinary(Buf);
   if (!BinOrErr) {
     return BinOrErr.takeError();

--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -711,7 +711,7 @@ void SymbolTableSection::assignIndices() {
   }
 }
 
-void SymbolTableSection::addSymbol(Twine Name, uint8_t Bind, uint8_t Type,
+void SymbolTableSection::addSymbol(const Twine &Name, uint8_t Bind, uint8_t Type,
                                    SectionBase *DefinedIn, uint64_t Value,
                                    uint8_t Visibility, uint16_t Shndx,
                                    uint64_t SymbolSize) {
@@ -1680,7 +1680,7 @@ static Error initRelocations(RelocationSection *Relocs, T RelRange) {
 }
 
 Expected<SectionBase *> SectionTableRef::getSection(uint32_t Index,
-                                                    Twine ErrMsg) {
+                                                    const Twine &ErrMsg) {
   if (Index == SHN_UNDEF || Index > Sections.size())
     return createStringError(errc::invalid_argument, ErrMsg);
   return Sections[Index - 1].get();

--- a/llvm/lib/ObjCopy/ELF/ELFObject.h
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.h
@@ -61,7 +61,7 @@ public:
   iterator end() const { return iterator(Sections.data() + Sections.size()); }
   size_t size() const { return Sections.size(); }
 
-  Expected<SectionBase *> getSection(uint32_t Index, Twine ErrMsg);
+  Expected<SectionBase *> getSection(uint32_t Index, const Twine &ErrMsg);
 
   template <class T>
   Expected<T *> getSectionOfType(uint32_t Index, Twine IndexErrMsg,
@@ -825,7 +825,7 @@ protected:
 public:
   SymbolTableSection() { Type = OriginalType = ELF::SHT_SYMTAB; }
 
-  void addSymbol(Twine Name, uint8_t Bind, uint8_t Type, SectionBase *DefinedIn,
+  void addSymbol(const Twine &Name, uint8_t Bind, uint8_t Type, SectionBase *DefinedIn,
                  uint64_t Value, uint8_t Visibility, uint16_t Shndx,
                  uint64_t SymbolSize);
   void prepareForLayout();

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -40,7 +40,7 @@ using namespace llvm::support::endian;
 
 void Archive::anchor() {}
 
-static Error malformedError(Twine Msg) {
+static Error malformedError(const Twine &Msg) {
   std::string StringMsg = "truncated or malformed archive (" + Msg.str() + ")";
   return make_error<GenericBinaryError>(std::move(StringMsg),
                                         object_error::parse_failed);
@@ -177,7 +177,7 @@ Expected<StringRef> ArchiveMemberHeader::getRawName() const {
 }
 
 Expected<uint64_t>
-getArchiveMemberDecField(Twine FieldName, const StringRef RawField,
+getArchiveMemberDecField(const Twine &FieldName, const StringRef RawField,
                          const Archive *Parent,
                          const AbstractArchiveMemberHeader *MemHeader) {
   uint64_t Value;
@@ -195,7 +195,7 @@ getArchiveMemberDecField(Twine FieldName, const StringRef RawField,
 }
 
 Expected<uint64_t>
-getArchiveMemberOctField(Twine FieldName, const StringRef RawField,
+getArchiveMemberOctField(const Twine &FieldName, const StringRef RawField,
                          const Archive *Parent,
                          const AbstractArchiveMemberHeader *MemHeader) {
   uint64_t Value;

--- a/llvm/lib/Object/ArchiveWriter.cpp
+++ b/llvm/lib/Object/ArchiveWriter.cpp
@@ -482,7 +482,7 @@ static uint64_t computeHeadersSize(object::Archive::Kind Kind,
 }
 
 static Expected<std::unique_ptr<SymbolicFile>>
-getSymbolicFile(MemoryBufferRef Buf, LLVMContext &Context,
+getSymbolicFile(const MemoryBufferRef &Buf, LLVMContext &Context,
                 object::Archive::Kind Kind, function_ref<void(Error)> Warn) {
   const file_magic Type = identify_magic(Buf.getBuffer());
   // Don't attempt to read non-symbolic file types.

--- a/llvm/lib/Object/Binary.cpp
+++ b/llvm/lib/Object/Binary.cpp
@@ -42,7 +42,7 @@ StringRef Binary::getFileName() const { return Data.getBufferIdentifier(); }
 
 MemoryBufferRef Binary::getMemoryBufferRef() const { return Data; }
 
-Expected<std::unique_ptr<Binary>> object::createBinary(MemoryBufferRef Buffer,
+Expected<std::unique_ptr<Binary>> object::createBinary(const MemoryBufferRef &Buffer,
                                                        LLVMContext *Context,
                                                        bool InitContent) {
   file_magic Type = identify_magic(Buffer.getBuffer());

--- a/llvm/lib/Object/COFFModuleDefinition.cpp
+++ b/llvm/lib/Object/COFFModuleDefinition.cpp
@@ -362,7 +362,7 @@ private:
   bool AddUnderscores;
 };
 
-Expected<COFFModuleDefinition> parseCOFFModuleDefinition(MemoryBufferRef MB,
+Expected<COFFModuleDefinition> parseCOFFModuleDefinition(const MemoryBufferRef &MB,
                                                          MachineTypes Machine,
                                                          bool MingwDef,
                                                          bool AddUnderscores) {

--- a/llvm/lib/Object/COFFObjectFile.cpp
+++ b/llvm/lib/Object/COFFObjectFile.cpp
@@ -43,7 +43,7 @@ using support::ulittle64_t;
 using support::little16_t;
 
 // Returns false if size is greater than the buffer size. And sets ec.
-static bool checkSize(MemoryBufferRef M, std::error_code &EC, uint64_t Size) {
+static bool checkSize(const MemoryBufferRef &M, std::error_code &EC, uint64_t Size) {
   if (M.getBufferSize() < Size) {
     EC = object_error::unexpected_eof;
     return false;
@@ -353,7 +353,7 @@ bool COFFObjectFile::isSectionVirtual(DataRefImpl Ref) const {
 }
 
 static uint32_t getNumberOfRelocations(const coff_section *Sec,
-                                       MemoryBufferRef M, const uint8_t *base) {
+                                       const MemoryBufferRef &M, const uint8_t *base) {
   // The field for the number of relocations in COFF section table is only
   // 16-bit wide. If a section has more than 65535 relocations, 0xFFFF is set to
   // NumberOfRelocations field, and the actual relocation count is stored in the
@@ -373,7 +373,7 @@ static uint32_t getNumberOfRelocations(const coff_section *Sec,
 }
 
 static const coff_relocation *
-getFirstReloc(const coff_section *Sec, MemoryBufferRef M, const uint8_t *Base) {
+getFirstReloc(const coff_section *Sec, const MemoryBufferRef &M, const uint8_t *Base) {
   uint64_t NumRelocs = getNumberOfRelocations(Sec, M, Base);
   if (!NumRelocs)
     return nullptr;
@@ -1893,7 +1893,7 @@ Error ImportedSymbolRef::getOrdinal(uint16_t &Result) const {
 }
 
 Expected<std::unique_ptr<COFFObjectFile>>
-ObjectFile::createCOFFObjectFile(MemoryBufferRef Object) {
+ObjectFile::createCOFFObjectFile(const MemoryBufferRef &Object) {
   return COFFObjectFile::create(Object);
 }
 

--- a/llvm/lib/Object/DXContainer.cpp
+++ b/llvm/lib/Object/DXContainer.cpp
@@ -208,7 +208,7 @@ Error DXContainer::parsePartOffsets() {
   return Error::success();
 }
 
-Expected<DXContainer> DXContainer::create(MemoryBufferRef Object) {
+Expected<DXContainer> DXContainer::create(const MemoryBufferRef &Object) {
   DXContainer Container(Object);
   if (Error Err = Container.parseHeader())
     return std::move(Err);

--- a/llvm/lib/Object/GOFFObjectFile.cpp
+++ b/llvm/lib/Object/GOFFObjectFile.cpp
@@ -25,7 +25,7 @@ using namespace llvm::object;
 using namespace llvm;
 
 Expected<std::unique_ptr<ObjectFile>>
-ObjectFile::createGOFFObjectFile(MemoryBufferRef Object) {
+ObjectFile::createGOFFObjectFile(const MemoryBufferRef &Object) {
   Error Err = Error::success();
   std::unique_ptr<GOFFObjectFile> Ret(new GOFFObjectFile(Object, Err));
   if (Err)

--- a/llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp
+++ b/llvm/lib/ProfileData/Coverage/CoverageMappingReader.cpp
@@ -1268,7 +1268,7 @@ static bool isArchSpecifierInvalidOrMissing(Binary *Bin, StringRef Arch) {
 
 Expected<std::vector<std::unique_ptr<BinaryCoverageReader>>>
 BinaryCoverageReader::create(
-    MemoryBufferRef ObjectBuffer, StringRef Arch,
+    const MemoryBufferRef &ObjectBuffer, StringRef Arch,
     SmallVectorImpl<std::unique_ptr<MemoryBuffer>> &ObjectFileBuffers,
     StringRef CompilationDir, SmallVectorImpl<object::BuildIDRef> *BinaryIDs) {
   std::vector<std::unique_ptr<BinaryCoverageReader>> Readers;

--- a/llvm/lib/SandboxIR/Instruction.cpp
+++ b/llvm/lib/SandboxIR/Instruction.cpp
@@ -285,7 +285,7 @@ void Instruction::dumpOS(raw_ostream &OS) const {
 }
 #endif // NDEBUG
 
-VAArgInst *VAArgInst::create(Value *List, Type *Ty, InsertPosition Pos,
+VAArgInst *VAArgInst::create(Value *List, Type *Ty, const InsertPosition &Pos,
                              Context &Ctx, const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMI =
@@ -297,14 +297,14 @@ Value *VAArgInst::getPointerOperand() {
   return Ctx.getValue(cast<llvm::VAArgInst>(Val)->getPointerOperand());
 }
 
-FreezeInst *FreezeInst::create(Value *V, InsertPosition Pos, Context &Ctx,
+FreezeInst *FreezeInst::create(Value *V, const InsertPosition &Pos, Context &Ctx,
                                const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMI = cast<llvm::FreezeInst>(Builder.CreateFreeze(V->Val, Name));
   return Ctx.createFreezeInst(LLVMI);
 }
 
-FenceInst *FenceInst::create(AtomicOrdering Ordering, InsertPosition Pos,
+FenceInst *FenceInst::create(AtomicOrdering Ordering, const InsertPosition &Pos,
                              Context &Ctx, SyncScope::ID SSID) {
   auto &Builder = Instruction::setInsertPos(Pos);
   llvm::FenceInst *LLVMI = Builder.CreateFence(Ordering, SSID);
@@ -327,7 +327,7 @@ void FenceInst::setSyncScopeID(SyncScope::ID SSID) {
 }
 
 Value *SelectInst::create(Value *Cond, Value *True, Value *False,
-                          InsertPosition Pos, Context &Ctx, const Twine &Name) {
+                          const InsertPosition &Pos, Context &Ctx, const Twine &Name) {
   auto &Builder = Instruction::setInsertPos(Pos);
   llvm::Value *NewV =
       Builder.CreateSelect(Cond->Val, True->Val, False->Val, Name);
@@ -347,7 +347,7 @@ bool SelectInst::classof(const Value *From) {
   return From->getSubclassID() == ClassID::Select;
 }
 
-BranchInst *BranchInst::create(BasicBlock *IfTrue, InsertPosition Pos,
+BranchInst *BranchInst::create(BasicBlock *IfTrue, const InsertPosition &Pos,
                                Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   llvm::BranchInst *NewBr =
@@ -356,7 +356,7 @@ BranchInst *BranchInst::create(BasicBlock *IfTrue, InsertPosition Pos,
 }
 
 BranchInst *BranchInst::create(BasicBlock *IfTrue, BasicBlock *IfFalse,
-                               Value *Cond, InsertPosition Pos, Context &Ctx) {
+                               Value *Cond, const InsertPosition &Pos, Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   llvm::BranchInst *NewBr =
       Builder.CreateCondBr(Cond->Val, cast<llvm::BasicBlock>(IfTrue->Val),
@@ -401,7 +401,7 @@ void LoadInst::setVolatile(bool V) {
 }
 
 LoadInst *LoadInst::create(Type *Ty, Value *Ptr, MaybeAlign Align,
-                           InsertPosition Pos, bool IsVolatile, Context &Ctx,
+                           const InsertPosition &Pos, bool IsVolatile, Context &Ctx,
                            const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *NewLI =
@@ -426,7 +426,7 @@ void StoreInst::setVolatile(bool V) {
 }
 
 StoreInst *StoreInst::create(Value *V, Value *Ptr, MaybeAlign Align,
-                             InsertPosition Pos, bool IsVolatile,
+                             const InsertPosition &Pos, bool IsVolatile,
                              Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   auto *NewSI = Builder.CreateAlignedStore(V->Val, Ptr->Val, Align, IsVolatile);
@@ -446,7 +446,7 @@ Value *StoreInst::getPointerOperand() const {
   return Ctx.getValue(cast<llvm::StoreInst>(Val)->getPointerOperand());
 }
 
-UnreachableInst *UnreachableInst::create(InsertPosition Pos, Context &Ctx) {
+UnreachableInst *UnreachableInst::create(const InsertPosition &Pos, Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   llvm::UnreachableInst *NewUI = Builder.CreateUnreachable();
   return Ctx.createUnreachableInst(NewUI);
@@ -466,7 +466,7 @@ ReturnInst *ReturnInst::createCommon(Value *RetVal, IRBuilder<> &Builder,
   return Ctx.createReturnInst(NewRI);
 }
 
-ReturnInst *ReturnInst::create(Value *RetVal, InsertPosition Pos,
+ReturnInst *ReturnInst::create(Value *RetVal, const InsertPosition &Pos,
                                Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   return createCommon(RetVal, Builder, Ctx);
@@ -513,7 +513,7 @@ void CallBase::setCalledFunction(Function *F) {
 }
 
 CallInst *CallInst::create(FunctionType *FTy, Value *Func,
-                           ArrayRef<Value *> Args, InsertPosition Pos,
+                           ArrayRef<Value *> Args, const InsertPosition &Pos,
                            Context &Ctx, const Twine &NameStr) {
   auto &Builder = setInsertPos(Pos);
   SmallVector<llvm::Value *> LLVMArgs;
@@ -527,7 +527,7 @@ CallInst *CallInst::create(FunctionType *FTy, Value *Func,
 
 InvokeInst *InvokeInst::create(FunctionType *FTy, Value *Func,
                                BasicBlock *IfNormal, BasicBlock *IfException,
-                               ArrayRef<Value *> Args, InsertPosition Pos,
+                               ArrayRef<Value *> Args, const InsertPosition &Pos,
                                Context &Ctx, const Twine &NameStr) {
   auto &Builder = setInsertPos(Pos);
   SmallVector<llvm::Value *> LLVMArgs;
@@ -570,7 +570,7 @@ BasicBlock *InvokeInst::getSuccessor(unsigned SuccIdx) const {
 CallBrInst *CallBrInst::create(FunctionType *FTy, Value *Func,
                                BasicBlock *DefaultDest,
                                ArrayRef<BasicBlock *> IndirectDests,
-                               ArrayRef<Value *> Args, InsertPosition Pos,
+                               ArrayRef<Value *> Args, const InsertPosition &Pos,
                                Context &Ctx, const Twine &NameStr) {
   auto &Builder = setInsertPos(Pos);
   SmallVector<llvm::BasicBlock *> LLVMIndirectDests;
@@ -632,7 +632,7 @@ BasicBlock *CallBrInst::getSuccessor(unsigned Idx) const {
 }
 
 LandingPadInst *LandingPadInst::create(Type *RetTy, unsigned NumReservedClauses,
-                                       InsertPosition Pos, Context &Ctx,
+                                       const InsertPosition &Pos, Context &Ctx,
                                        const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::LandingPadInst *LLVMI =
@@ -681,7 +681,7 @@ CatchSwitchInst *CatchPadInst::getCatchSwitch() const {
 }
 
 CatchPadInst *CatchPadInst::create(Value *ParentPad, ArrayRef<Value *> Args,
-                                   InsertPosition Pos, Context &Ctx,
+                                   const InsertPosition &Pos, Context &Ctx,
                                    const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   SmallVector<llvm::Value *> LLVMArgs;
@@ -694,7 +694,7 @@ CatchPadInst *CatchPadInst::create(Value *ParentPad, ArrayRef<Value *> Args,
 }
 
 CleanupPadInst *CleanupPadInst::create(Value *ParentPad, ArrayRef<Value *> Args,
-                                       InsertPosition Pos, Context &Ctx,
+                                       const InsertPosition &Pos, Context &Ctx,
                                        const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   SmallVector<llvm::Value *> LLVMArgs;
@@ -707,7 +707,7 @@ CleanupPadInst *CleanupPadInst::create(Value *ParentPad, ArrayRef<Value *> Args,
 }
 
 CatchReturnInst *CatchReturnInst::create(CatchPadInst *CatchPad, BasicBlock *BB,
-                                         InsertPosition Pos, Context &Ctx) {
+                                         const InsertPosition &Pos, Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   llvm::CatchReturnInst *LLVMI = Builder.CreateCatchRet(
       cast<llvm::CatchPadInst>(CatchPad->Val), cast<llvm::BasicBlock>(BB->Val));
@@ -747,7 +747,7 @@ Value *CatchReturnInst::getCatchSwitchParentPad() const {
 
 CleanupReturnInst *CleanupReturnInst::create(CleanupPadInst *CleanupPad,
                                              BasicBlock *UnwindBB,
-                                             InsertPosition Pos, Context &Ctx) {
+                                             const InsertPosition &Pos, Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMUnwindBB =
       UnwindBB != nullptr ? cast<llvm::BasicBlock>(UnwindBB->Val) : nullptr;
@@ -785,7 +785,7 @@ void CleanupReturnInst::setUnwindDest(BasicBlock *NewDest) {
 }
 
 Value *GetElementPtrInst::create(Type *Ty, Value *Ptr,
-                                 ArrayRef<Value *> IdxList, InsertPosition Pos,
+                                 ArrayRef<Value *> IdxList, const InsertPosition &Pos,
                                  Context &Ctx, const Twine &NameStr) {
   auto &Builder = setInsertPos(Pos);
   SmallVector<llvm::Value *> LLVMIdxList;
@@ -824,7 +824,7 @@ BasicBlock *PHINode::LLVMBBToBB::operator()(llvm::BasicBlock *LLVMBB) const {
 }
 
 PHINode *PHINode::create(Type *Ty, unsigned NumReservedValues,
-                         InsertPosition Pos, Context &Ctx, const Twine &Name) {
+                         const InsertPosition &Pos, Context &Ctx, const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::PHINode *NewPHI =
       Builder.CreatePHI(Ty->LLVMTy, NumReservedValues, Name);
@@ -926,7 +926,7 @@ void PHINode::removeIncomingValueIf(function_ref<bool(unsigned)> Predicate) {
   }
 }
 
-Value *CmpInst::create(Predicate P, Value *S1, Value *S2, InsertPosition Pos,
+Value *CmpInst::create(Predicate P, Value *S1, Value *S2, const InsertPosition &Pos,
                        Context &Ctx, const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMV = Builder.CreateCmp(P, S1->Val, S2->Val, Name);
@@ -939,7 +939,7 @@ Value *CmpInst::create(Predicate P, Value *S1, Value *S2, InsertPosition Pos,
 }
 
 Value *CmpInst::createWithCopiedFlags(Predicate P, Value *S1, Value *S2,
-                                      const Instruction *F, InsertPosition Pos,
+                                      const Instruction *F, const InsertPosition &Pos,
                                       Context &Ctx, const Twine &Name) {
   Value *V = create(P, S1, S2, Pos, Ctx, Name);
   if (auto *C = dyn_cast<Constant>(V))
@@ -1041,7 +1041,7 @@ static llvm::Instruction::UnaryOps getLLVMUnaryOp(Instruction::Opcode Opc) {
 
 CatchSwitchInst *CatchSwitchInst::create(Value *ParentPad, BasicBlock *UnwindBB,
                                          unsigned NumHandlers,
-                                         InsertPosition Pos, Context &Ctx,
+                                         const InsertPosition &Pos, Context &Ctx,
                                          const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::CatchSwitchInst *LLVMCSI = Builder.CreateCatchSwitch(
@@ -1079,7 +1079,7 @@ void CatchSwitchInst::addHandler(BasicBlock *Dest) {
       cast<llvm::BasicBlock>(Dest->Val));
 }
 
-ResumeInst *ResumeInst::create(Value *Exn, InsertPosition Pos, Context &Ctx) {
+ResumeInst *ResumeInst::create(Value *Exn, const InsertPosition &Pos, Context &Ctx) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMI = cast<llvm::ResumeInst>(Builder.CreateResume(Exn->Val));
   return Ctx.createResumeInst(LLVMI);
@@ -1090,7 +1090,7 @@ Value *ResumeInst::getValue() const {
 }
 
 SwitchInst *SwitchInst::create(Value *V, BasicBlock *Dest, unsigned NumCases,
-                               InsertPosition Pos, Context &Ctx,
+                               const InsertPosition &Pos, Context &Ctx,
                                const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::SwitchInst *LLVMSwitch =
@@ -1161,7 +1161,7 @@ void SwitchInst::setSuccessor(unsigned Idx, BasicBlock *NewSucc) {
 }
 
 Value *UnaryOperator::create(Instruction::Opcode Op, Value *OpV,
-                             InsertPosition Pos, Context &Ctx,
+                             const InsertPosition &Pos, Context &Ctx,
                              const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *NewLLVMV = Builder.CreateUnOp(getLLVMUnaryOp(Op), OpV->Val, Name);
@@ -1173,7 +1173,7 @@ Value *UnaryOperator::create(Instruction::Opcode Op, Value *OpV,
 }
 
 Value *UnaryOperator::createWithCopiedFlags(Instruction::Opcode Op, Value *OpV,
-                                            Value *CopyFrom, InsertPosition Pos,
+                                            Value *CopyFrom, const InsertPosition &Pos,
                                             Context &Ctx, const Twine &Name) {
   auto *NewV = create(Op, OpV, Pos, Ctx, Name);
   if (auto *UnI = dyn_cast<llvm::UnaryOperator>(NewV->Val))
@@ -1225,7 +1225,7 @@ static llvm::Instruction::BinaryOps getLLVMBinaryOp(Instruction::Opcode Opc) {
   }
 }
 Value *BinaryOperator::create(Instruction::Opcode Op, Value *LHS, Value *RHS,
-                              InsertPosition Pos, Context &Ctx,
+                              const InsertPosition &Pos, Context &Ctx,
                               const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::Value *NewV =
@@ -1238,7 +1238,7 @@ Value *BinaryOperator::create(Instruction::Opcode Op, Value *LHS, Value *RHS,
 
 Value *BinaryOperator::createWithCopiedFlags(Instruction::Opcode Op, Value *LHS,
                                              Value *RHS, Value *CopyFrom,
-                                             InsertPosition Pos, Context &Ctx,
+                                             const InsertPosition &Pos, Context &Ctx,
                                              const Twine &Name) {
 
   Value *NewV = create(Op, LHS, RHS, Pos, Ctx, Name);
@@ -1293,7 +1293,7 @@ Value *AtomicRMWInst::getValOperand() {
 
 AtomicRMWInst *AtomicRMWInst::create(BinOp Op, Value *Ptr, Value *Val,
                                      MaybeAlign Align, AtomicOrdering Ordering,
-                                     InsertPosition Pos, Context &Ctx,
+                                     const InsertPosition &Pos, Context &Ctx,
                                      SyncScope::ID SSID, const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMAtomicRMW =
@@ -1325,7 +1325,7 @@ Value *AtomicCmpXchgInst::getNewValOperand() {
 AtomicCmpXchgInst *
 AtomicCmpXchgInst::create(Value *Ptr, Value *Cmp, Value *New, MaybeAlign Align,
                           AtomicOrdering SuccessOrdering,
-                          AtomicOrdering FailureOrdering, InsertPosition Pos,
+                          AtomicOrdering FailureOrdering, const InsertPosition &Pos,
                           Context &Ctx, SyncScope::ID SSID, const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   auto *LLVMAtomicCmpXchg =
@@ -1372,7 +1372,7 @@ void AtomicCmpXchgInst::setFailureOrdering(AtomicOrdering Ordering) {
   cast<llvm::AtomicCmpXchgInst>(Val)->setFailureOrdering(Ordering);
 }
 
-AllocaInst *AllocaInst::create(Type *Ty, unsigned AddrSpace, InsertPosition Pos,
+AllocaInst *AllocaInst::create(Type *Ty, unsigned AddrSpace, const InsertPosition &Pos,
                                Context &Ctx, Value *ArraySize,
                                const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
@@ -1416,7 +1416,7 @@ PointerType *AllocaInst::getType() const {
 }
 
 Value *CastInst::create(Type *DestTy, Opcode Op, Value *Operand,
-                        InsertPosition Pos, Context &Ctx, const Twine &Name) {
+                        const InsertPosition &Pos, Context &Ctx, const Twine &Name) {
   assert(getLLVMCastOp(Op) && "Opcode not suitable for CastInst!");
   auto &Builder = setInsertPos(Pos);
   auto *NewV =
@@ -1447,7 +1447,7 @@ void PossiblyNonNegInst::setNonNeg(bool B) {
 }
 
 Value *InsertElementInst::create(Value *Vec, Value *NewElt, Value *Idx,
-                                 InsertPosition Pos, Context &Ctx,
+                                 const InsertPosition &Pos, Context &Ctx,
                                  const Twine &Name) {
   auto &Builder = Instruction::setInsertPos(Pos);
   llvm::Value *NewV =
@@ -1458,7 +1458,7 @@ Value *InsertElementInst::create(Value *Vec, Value *NewElt, Value *Idx,
   return Ctx.getOrCreateConstant(cast<llvm::Constant>(NewV));
 }
 
-Value *ExtractElementInst::create(Value *Vec, Value *Idx, InsertPosition Pos,
+Value *ExtractElementInst::create(Value *Vec, Value *Idx, const InsertPosition &Pos,
                                   Context &Ctx, const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::Value *NewV = Builder.CreateExtractElement(Vec->Val, Idx->Val, Name);
@@ -1469,7 +1469,7 @@ Value *ExtractElementInst::create(Value *Vec, Value *Idx, InsertPosition Pos,
 }
 
 Value *ShuffleVectorInst::create(Value *V1, Value *V2, Value *Mask,
-                                 InsertPosition Pos, Context &Ctx,
+                                 const InsertPosition &Pos, Context &Ctx,
                                  const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::Value *NewV =
@@ -1481,7 +1481,7 @@ Value *ShuffleVectorInst::create(Value *V1, Value *V2, Value *Mask,
 }
 
 Value *ShuffleVectorInst::create(Value *V1, Value *V2, ArrayRef<int> Mask,
-                                 InsertPosition Pos, Context &Ctx,
+                                 const InsertPosition &Pos, Context &Ctx,
                                  const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::Value *NewV = Builder.CreateShuffleVector(V1->Val, V2->Val, Mask, Name);
@@ -1525,7 +1525,7 @@ VectorType *ExtractElementInst::getVectorOperandType() const {
 }
 
 Value *ExtractValueInst::create(Value *Agg, ArrayRef<unsigned> Idxs,
-                                InsertPosition Pos, Context &Ctx,
+                                const InsertPosition &Pos, Context &Ctx,
                                 const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::Value *NewV = Builder.CreateExtractValue(Agg->Val, Idxs, Name);
@@ -1541,7 +1541,7 @@ Type *ExtractValueInst::getIndexedType(Type *Agg, ArrayRef<unsigned> Idxs) {
 }
 
 Value *InsertValueInst::create(Value *Agg, Value *Val, ArrayRef<unsigned> Idxs,
-                               InsertPosition Pos, Context &Ctx,
+                               const InsertPosition &Pos, Context &Ctx,
                                const Twine &Name) {
   auto &Builder = setInsertPos(Pos);
   llvm::Value *NewV = Builder.CreateInsertValue(Agg->Val, Val->Val, Idxs, Name);

--- a/llvm/lib/Support/AMDGPUMetadata.cpp
+++ b/llvm/lib/Support/AMDGPUMetadata.cpp
@@ -217,7 +217,7 @@ std::error_code fromString(StringRef String, Metadata &HSAMetadata) {
   return YamlInput.error();
 }
 
-std::error_code toString(Metadata HSAMetadata, std::string &String) {
+std::error_code toString(Metadata &HSAMetadata, std::string &String) {
   raw_string_ostream YamlStream(String);
   yaml::Output YamlOutput(YamlStream, nullptr, std::numeric_limits<int>::max());
   YamlOutput << HSAMetadata;

--- a/llvm/lib/Support/BinaryStreamWriter.cpp
+++ b/llvm/lib/Support/BinaryStreamWriter.cpp
@@ -58,11 +58,11 @@ Error BinaryStreamWriter::writeFixedString(StringRef Str) {
   return writeBytes(arrayRefFromStringRef(Str));
 }
 
-Error BinaryStreamWriter::writeStreamRef(BinaryStreamRef Ref) {
+Error BinaryStreamWriter::writeStreamRef(const BinaryStreamRef &Ref) {
   return writeStreamRef(Ref, Ref.getLength());
 }
 
-Error BinaryStreamWriter::writeStreamRef(BinaryStreamRef Ref, uint64_t Length) {
+Error BinaryStreamWriter::writeStreamRef(const BinaryStreamRef &Ref, uint64_t Length) {
   BinaryStreamReader SrcReader(Ref.slice(0, Length));
   // This is a bit tricky.  If we just call readBytes, we are requiring that it
   // return us the entire stream as a contiguous buffer.  There is no guarantee

--- a/llvm/lib/Support/Error.cpp
+++ b/llvm/lib/Support/Error.cpp
@@ -62,7 +62,7 @@ char ECError::ID = 0;
 char StringError::ID = 0;
 char FileError::ID = 0;
 
-void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner) {
+void logAllUnhandledErrors(Error E, raw_ostream &OS, const Twine &ErrorBanner) {
   if (!E)
     return;
   OS << ErrorBanner;

--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -64,8 +64,8 @@ private:
                 MachineBasicBlock::iterator &NextMBBI);
   bool expandMultiVecPseudo(MachineBasicBlock &MBB,
                             MachineBasicBlock::iterator MBBI,
-                            TargetRegisterClass ContiguousClass,
-                            TargetRegisterClass StridedClass,
+                            const TargetRegisterClass &ContiguousClass,
+                            const TargetRegisterClass &StridedClass,
                             unsigned ContiguousOpc, unsigned StridedOpc);
   bool expandFormTuplePseudo(MachineBasicBlock &MBB,
                              MachineBasicBlock::iterator MBBI,
@@ -1121,7 +1121,8 @@ AArch64ExpandPseudo::expandCondSMToggle(MachineBasicBlock &MBB,
 
 bool AArch64ExpandPseudo::expandMultiVecPseudo(
     MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
-    TargetRegisterClass ContiguousClass, TargetRegisterClass StridedClass,
+    const TargetRegisterClass &ContiguousClass,
+    const TargetRegisterClass &StridedClass,
     unsigned ContiguousOp, unsigned StridedOpc) {
   MachineInstr &MI = *MBBI;
   Register Tuple = MI.getOperand(0).getReg();

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -4252,7 +4252,7 @@ public:
   }
   // Add an instruction to be replaced. Instructions must be added in the
   // ascending order of Offset, and have to be adjacent.
-  void addInstruction(TagStoreInstr I) {
+  void addInstruction(const TagStoreInstr &I) {
     assert((TagStores.empty() ||
             TagStores.back().Offset + TagStores.back().Size == I.Offset) &&
            "Non-adjacent tag store instructions.");

--- a/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.cpp
@@ -38,8 +38,8 @@ SDValue AArch64SelectionDAGInfo::EmitMOPS(unsigned Opcode, SelectionDAG &DAG,
                                           SDValue Dst, SDValue SrcOrValue,
                                           SDValue Size, Align Alignment,
                                           bool isVolatile,
-                                          MachinePointerInfo DstPtrInfo,
-                                          MachinePointerInfo SrcPtrInfo) const {
+                                          const MachinePointerInfo &DstPtrInfo,
+                                          const MachinePointerInfo &SrcPtrInfo) const {
 
   // Get the constant size of the copy/set.
   uint64_t ConstSize = 0;

--- a/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64SelectionDAGInfo.h
@@ -26,8 +26,8 @@ public:
   SDValue EmitMOPS(unsigned Opcode, SelectionDAG &DAG, const SDLoc &DL,
                    SDValue Chain, SDValue Dst, SDValue SrcOrValue, SDValue Size,
                    Align Alignment, bool isVolatile,
-                   MachinePointerInfo DstPtrInfo,
-                   MachinePointerInfo SrcPtrInfo) const;
+                   const MachinePointerInfo &DstPtrInfo,
+                   const MachinePointerInfo &SrcPtrInfo) const;
 
   SDValue EmitTargetCodeForMemcpy(SelectionDAG &DAG, const SDLoc &dl,
                                   SDValue Chain, SDValue Dst, SDValue Src,

--- a/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetTransformInfo.cpp
@@ -121,7 +121,7 @@ class TailFoldingOption {
     return Bits;
   }
 
-  void reportError(std::string Opt) {
+  void reportError(const std::string &Opt) {
     errs() << "invalid argument '" << Opt
            << "' to -sve-tail-folding=; the option should be of the form\n"
               "  (disabled|all|default|simple)[+(reductions|recurrences"

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -2455,7 +2455,7 @@ public:
   }
 
   static std::unique_ptr<AArch64Operand>
-  CreateFPImm(APFloat Val, bool IsExact, SMLoc S, MCContext &Ctx) {
+  CreateFPImm(const APFloat &Val, bool IsExact, SMLoc S, MCContext &Ctx) {
     auto Op = std::make_unique<AArch64Operand>(k_FPImm, Ctx);
     Op->FPImm.Val = Val.bitcastToAPInt().getSExtValue();
     Op->FPImm.IsExact = IsExact;
@@ -3837,7 +3837,7 @@ static const struct Extension {
     {"sme-tmop", {AArch64::FeatureSME_TMOP}},
 };
 
-static void setRequiredFeatureString(FeatureBitset FBS, std::string &Str) {
+static void setRequiredFeatureString(const FeatureBitset &FBS, std::string &Str) {
   if (FBS[AArch64::HasV8_0aOps])
     Str += "ARMv8a";
   if (FBS[AArch64::HasV8_1aOps])

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -373,7 +373,7 @@ struct SysAlias {
   constexpr SysAlias(const char *N, uint16_t E, FeatureBitset F)
       : Name(N), Encoding(E), FeaturesRequired(F) {}
 
-  bool haveFeatures(FeatureBitset ActiveFeatures) const {
+  bool haveFeatures(const FeatureBitset &ActiveFeatures) const {
     return ActiveFeatures[llvm::AArch64::FeatureAll] ||
            (FeaturesRequired & ActiveFeatures) == FeaturesRequired;
   }
@@ -634,7 +634,7 @@ struct PHint {
   unsigned Encoding;
   FeatureBitset FeaturesRequired;
 
-  bool haveFeatures(FeatureBitset ActiveFeatures) const {
+  bool haveFeatures(const FeatureBitset &ActiveFeatures) const {
     return ActiveFeatures[llvm::AArch64::FeatureAll] ||
            (FeaturesRequired & ActiveFeatures) == FeaturesRequired;
   }
@@ -753,7 +753,7 @@ namespace AArch64SysReg {
     bool Writeable;
     FeatureBitset FeaturesRequired;
 
-    bool haveFeatures(FeatureBitset ActiveFeatures) const {
+    bool haveFeatures(const FeatureBitset &ActiveFeatures) const {
       return ActiveFeatures[llvm::AArch64::FeatureAll] ||
              (FeaturesRequired & ActiveFeatures) == FeaturesRequired;
     }

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUDelayedMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUDelayedMCExpr.cpp
@@ -12,8 +12,8 @@
 
 using namespace llvm;
 
-static msgpack::DocNode getNode(msgpack::DocNode DN, msgpack::Type Type,
-                                MCValue Val) {
+static msgpack::DocNode getNode(const msgpack::DocNode &DN, msgpack::Type Type,
+                                const MCValue &Val) {
   msgpack::Document *Doc = DN.getDocument();
   switch (Type) {
   default:

--- a/llvm/lib/Target/ARM/ARMInstructionSelector.cpp
+++ b/llvm/lib/Target/ARM/ARMInstructionSelector.cpp
@@ -44,13 +44,13 @@ private:
   struct CmpConstants;
   struct InsertInfo;
 
-  bool selectCmp(CmpConstants Helper, MachineInstrBuilder &MIB,
+  bool selectCmp(const CmpConstants &Helper, MachineInstrBuilder &MIB,
                  MachineRegisterInfo &MRI) const;
 
   // Helper for inserting a comparison sequence that sets \p ResReg to either 1
   // if \p LHSReg and \p RHSReg are in the relationship defined by \p Cond, or
   // \p PrevRes otherwise. In essence, it computes PrevRes OR (LHS Cond RHS).
-  bool insertComparison(CmpConstants Helper, InsertInfo I, unsigned ResReg,
+  bool insertComparison(const CmpConstants &Helper, InsertInfo I, unsigned ResReg,
                         ARMCC::CondCodes Cond, unsigned LHSReg, unsigned RHSReg,
                         unsigned PrevRes) const;
 
@@ -525,7 +525,7 @@ bool ARMInstructionSelector::validReg(MachineRegisterInfo &MRI, unsigned Reg,
   return true;
 }
 
-bool ARMInstructionSelector::selectCmp(CmpConstants Helper,
+bool ARMInstructionSelector::selectCmp(const CmpConstants &Helper,
                                        MachineInstrBuilder &MIB,
                                        MachineRegisterInfo &MRI) const {
   const InsertInfo I(MIB);
@@ -572,7 +572,7 @@ bool ARMInstructionSelector::selectCmp(CmpConstants Helper,
   return true;
 }
 
-bool ARMInstructionSelector::insertComparison(CmpConstants Helper, InsertInfo I,
+bool ARMInstructionSelector::insertComparison(const CmpConstants &Helper, InsertInfo I,
                                               unsigned ResReg,
                                               ARMCC::CondCodes Cond,
                                               unsigned LHSReg, unsigned RHSReg,

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMachObjectWriter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMachObjectWriter.cpp
@@ -27,13 +27,15 @@ class ARMMachObjectWriter : public MCMachObjectTargetWriter {
   void recordARMScatteredRelocation(MachObjectWriter *Writer,
                                     const MCAssembler &Asm,
                                     const MCFragment *Fragment,
-                                    const MCFixup &Fixup, MCValue Target,
+                                    const MCFixup &Fixup,
+                                    const MCValue &Target,
                                     unsigned Type, unsigned Log2Size,
                                     uint64_t &FixedValue);
   void recordARMScatteredHalfRelocation(MachObjectWriter *Writer,
                                         const MCAssembler &Asm,
                                         const MCFragment *Fragment,
-                                        const MCFixup &Fixup, MCValue Target,
+                                        const MCFixup &Fixup,
+                                        const MCValue &Target,
                                         uint64_t &FixedValue);
 
   bool requiresExternRelocation(MachObjectWriter *Writer,
@@ -130,7 +132,7 @@ static bool getARMFixupKindMachOInfo(unsigned Kind, unsigned &RelocType,
 
 void ARMMachObjectWriter::recordARMScatteredHalfRelocation(
     MachObjectWriter *Writer, const MCAssembler &Asm,
-    const MCFragment *Fragment, const MCFixup &Fixup, MCValue Target,
+    const MCFragment *Fragment, const MCFixup &Fixup, const MCValue &Target,
     uint64_t &FixedValue) {
   uint32_t FixupOffset = Asm.getFragmentOffset(*Fragment) + Fixup.getOffset();
 
@@ -240,7 +242,7 @@ void ARMMachObjectWriter::recordARMScatteredHalfRelocation(
 
 void ARMMachObjectWriter::recordARMScatteredRelocation(
     MachObjectWriter *Writer, const MCAssembler &Asm,
-    const MCFragment *Fragment, const MCFixup &Fixup, MCValue Target,
+    const MCFragment *Fragment, const MCFixup &Fixup, const MCValue &Target,
     unsigned Type, unsigned Log2Size, uint64_t &FixedValue) {
   uint32_t FixupOffset = Asm.getFragmentOffset(*Fragment) + Fixup.getOffset();
 

--- a/llvm/lib/Target/ARM/Utils/ARMBaseInfo.h
+++ b/llvm/lib/Target/ARM/Utils/ARMBaseInfo.h
@@ -196,12 +196,12 @@ namespace ARMSysReg {
     FeatureBitset FeaturesRequired;
 
     // return true if FeaturesRequired are all present in ActiveFeatures
-    bool hasRequiredFeatures(FeatureBitset ActiveFeatures) const {
+    bool hasRequiredFeatures(const FeatureBitset &ActiveFeatures) const {
       return (FeaturesRequired & ActiveFeatures) == FeaturesRequired;
     }
 
     // returns true if TestFeatures are all present in FeaturesRequired
-    bool isInRequiredFeatures(FeatureBitset TestFeatures) const {
+    bool isInRequiredFeatures(const FeatureBitset &TestFeatures) const {
       return (FeaturesRequired & TestFeatures) == TestFeatures;
     }
   };

--- a/llvm/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
+++ b/llvm/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
@@ -32,7 +32,7 @@ namespace adjust {
 using namespace llvm;
 
 static void unsigned_width(unsigned Width, uint64_t Value,
-                           std::string Description, const MCFixup &Fixup,
+                           const std::string &Description, const MCFixup &Fixup,
                            MCContext *Ctx) {
   if (!isUIntN(Width, Value)) {
     std::string Diagnostic = "out of range " + Description;

--- a/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
@@ -202,7 +202,7 @@ namespace {
         Pos = std::distance(B->begin(), It);
       }
     }
-    bool operator<(Loc A) const {
+    bool operator<(const Loc &A) const {
       if (Block != A.Block)
         return Block->getNumber() < A.Block->getNumber();
       if (A.Pos == -1)

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
@@ -949,7 +949,7 @@ namespace llvm {
     void selectRor(SDNode *N);
     void selectVAlign(SDNode *N);
 
-    static SmallVector<uint32_t, 8> getPerfectCompletions(ShuffleMask SM,
+    static SmallVector<uint32_t, 8> getPerfectCompletions(const ShuffleMask &SM,
                                                           unsigned Width);
     static SmallVector<uint32_t, 8> completeToPerfect(
         ArrayRef<uint32_t> Completions, unsigned Width);
@@ -966,22 +966,22 @@ namespace llvm {
       None,
       PackMux,
     };
-    OpRef concats(OpRef Va, OpRef Vb, ResultStack &Results);
+    OpRef concats(const OpRef &Va, const OpRef &Vb, ResultStack &Results);
     OpRef funnels(OpRef Va, OpRef Vb, int Amount, ResultStack &Results);
 
     OpRef packs(ShuffleMask SM, OpRef Va, OpRef Vb, ResultStack &Results,
                 MutableArrayRef<int> NewMask, unsigned Options = None);
-    OpRef packp(ShuffleMask SM, OpRef Va, OpRef Vb, ResultStack &Results,
+    OpRef packp(const ShuffleMask &SM, const OpRef &Va, const OpRef &Vb, ResultStack &Results,
                 MutableArrayRef<int> NewMask);
-    OpRef vmuxs(ArrayRef<uint8_t> Bytes, OpRef Va, OpRef Vb,
+    OpRef vmuxs(ArrayRef<uint8_t> Bytes, const OpRef &Va, const OpRef &Vb,
                 ResultStack &Results);
-    OpRef vmuxp(ArrayRef<uint8_t> Bytes, OpRef Va, OpRef Vb,
+    OpRef vmuxp(ArrayRef<uint8_t> Bytes, const OpRef &Va, const OpRef &Vb,
                 ResultStack &Results);
 
-    OpRef shuffs1(ShuffleMask SM, OpRef Va, ResultStack &Results);
-    OpRef shuffs2(ShuffleMask SM, OpRef Va, OpRef Vb, ResultStack &Results);
-    OpRef shuffp1(ShuffleMask SM, OpRef Va, ResultStack &Results);
-    OpRef shuffp2(ShuffleMask SM, OpRef Va, OpRef Vb, ResultStack &Results);
+    OpRef shuffs1(ShuffleMask SM, const OpRef &Va, ResultStack &Results);
+    OpRef shuffs2(const ShuffleMask &SM, const OpRef &Va, const OpRef &Vb, ResultStack &Results);
+    OpRef shuffp1(const ShuffleMask &SM, const OpRef &Va, ResultStack &Results);
+    OpRef shuffp2(const ShuffleMask &SM, const OpRef &Va, const OpRef &Vb, ResultStack &Results);
 
     OpRef butterfly(ShuffleMask SM, OpRef Va, ResultStack &Results);
     OpRef contracting(ShuffleMask SM, OpRef Va, OpRef Vb, ResultStack &Results);
@@ -1048,7 +1048,7 @@ static bool isLowHalfOnly(ArrayRef<int> Mask) {
   return llvm::all_of(Mask.drop_front(L / 2), [](int M) { return M < 0; });
 }
 
-static SmallVector<unsigned, 4> getInputSegmentList(ShuffleMask SM,
+static SmallVector<unsigned, 4> getInputSegmentList(const ShuffleMask &SM,
                                                     unsigned SegLen) {
   assert(isPowerOf2_32(SegLen));
   SmallVector<unsigned, 4> SegList;
@@ -1068,7 +1068,7 @@ static SmallVector<unsigned, 4> getInputSegmentList(ShuffleMask SM,
   return SegList;
 }
 
-static SmallVector<unsigned, 4> getOutputSegmentMap(ShuffleMask SM,
+static SmallVector<unsigned, 4> getOutputSegmentMap(const ShuffleMask &SM,
                                                     unsigned SegLen) {
   // Calculate the layout of the output segments in terms of the input
   // segments.
@@ -1213,7 +1213,7 @@ void HvxSelector::materialize(const ResultStack &Results) {
   DAG.RemoveDeadNodes();
 }
 
-OpRef HvxSelector::concats(OpRef Lo, OpRef Hi, ResultStack &Results) {
+OpRef HvxSelector::concats(const OpRef &Lo, const OpRef &Hi, ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   const SDLoc &dl(Results.InpNode);
   Results.push(TargetOpcode::REG_SEQUENCE, getPairVT(MVT::i8), {
@@ -1496,7 +1496,7 @@ OpRef HvxSelector::packs(ShuffleMask SM, OpRef Va, OpRef Vb,
 // Va, Vb are vector pairs. If SM only uses two single vectors from Va/Vb,
 // pack these vectors into a pair, and remap SM into NewMask to use the
 // new pair instead.
-OpRef HvxSelector::packp(ShuffleMask SM, OpRef Va, OpRef Vb,
+OpRef HvxSelector::packp(const ShuffleMask &SM, const OpRef &Va, const OpRef &Vb,
                          ResultStack &Results, MutableArrayRef<int> NewMask) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   SmallVector<unsigned, 4> SegList = getInputSegmentList(SM.Mask, HwLen);
@@ -1533,7 +1533,7 @@ OpRef HvxSelector::packp(ShuffleMask SM, OpRef Va, OpRef Vb,
   return concats(Out[0], Out[1], Results);
 }
 
-OpRef HvxSelector::vmuxs(ArrayRef<uint8_t> Bytes, OpRef Va, OpRef Vb,
+OpRef HvxSelector::vmuxs(ArrayRef<uint8_t> Bytes, const OpRef &Va, const OpRef &Vb,
                          ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   MVT ByteTy = getSingleVT(MVT::i8);
@@ -1546,7 +1546,7 @@ OpRef HvxSelector::vmuxs(ArrayRef<uint8_t> Bytes, OpRef Va, OpRef Vb,
   return OpRef::res(Results.top());
 }
 
-OpRef HvxSelector::vmuxp(ArrayRef<uint8_t> Bytes, OpRef Va, OpRef Vb,
+OpRef HvxSelector::vmuxp(ArrayRef<uint8_t> Bytes, const OpRef &Va, const OpRef &Vb,
                          ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   size_t S = Bytes.size() / 2;
@@ -1555,7 +1555,7 @@ OpRef HvxSelector::vmuxp(ArrayRef<uint8_t> Bytes, OpRef Va, OpRef Vb,
   return concats(L, H, Results);
 }
 
-OpRef HvxSelector::shuffs1(ShuffleMask SM, OpRef Va, ResultStack &Results) {
+OpRef HvxSelector::shuffs1(ShuffleMask SM, const OpRef &Va, ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   unsigned VecLen = SM.Mask.size();
   assert(HwLen == VecLen);
@@ -1598,7 +1598,7 @@ OpRef HvxSelector::shuffs1(ShuffleMask SM, OpRef Va, ResultStack &Results) {
   return butterfly(SM, Va, Results);
 }
 
-OpRef HvxSelector::shuffs2(ShuffleMask SM, OpRef Va, OpRef Vb,
+OpRef HvxSelector::shuffs2(const ShuffleMask &SM, const OpRef &Va, const OpRef &Vb,
                            ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   if (isUndef(SM.Mask))
@@ -1633,7 +1633,7 @@ OpRef HvxSelector::shuffs2(ShuffleMask SM, OpRef Va, OpRef Vb,
   return vmuxs(Bytes, L, R, Results);
 }
 
-OpRef HvxSelector::shuffp1(ShuffleMask SM, OpRef Va, ResultStack &Results) {
+OpRef HvxSelector::shuffp1(const ShuffleMask &SM, const OpRef &Va, ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   int VecLen = SM.Mask.size();
 
@@ -1676,7 +1676,7 @@ OpRef HvxSelector::shuffp1(ShuffleMask SM, OpRef Va, ResultStack &Results) {
   return OpRef::fail();
 }
 
-OpRef HvxSelector::shuffp2(ShuffleMask SM, OpRef Va, OpRef Vb,
+OpRef HvxSelector::shuffp2(const ShuffleMask &SM, const OpRef &Va, const OpRef &Vb,
                            ResultStack &Results) {
   DEBUG_WITH_TYPE("isel", {dbgs() << __func__ << '\n';});
   if (isUndef(SM.Mask))
@@ -1917,7 +1917,7 @@ bool HvxSelector::scalarizeShuffle(ArrayRef<int> Mask, const SDLoc &dl,
   return true;
 }
 
-SmallVector<uint32_t, 8> HvxSelector::getPerfectCompletions(ShuffleMask SM,
+SmallVector<uint32_t, 8> HvxSelector::getPerfectCompletions(const ShuffleMask &SM,
                                                             unsigned Width) {
   auto possibilities = [](ArrayRef<uint8_t> Bs, unsigned Width) -> uint32_t {
     unsigned Impossible = ~(1u << Width) + 1;

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -1822,7 +1822,7 @@ void NVPTXAsmPrinter::printFPConstant(const ConstantFP *Fp, raw_ostream &O) {
   } else
     llvm_unreachable("unsupported fp type");
 
-  APInt API = APF.bitcastToAPInt();
+  const APInt &API = APF.bitcastToAPInt();
   O << lead << format_hex_no_prefix(API.getZExtValue(), numHex, /*Upper=*/true);
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTXMCExpr.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXMCExpr.cpp
@@ -51,7 +51,7 @@ void NVPTXFloatMCExpr::printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const {
     break;
   }
 
-  APInt API = APF.bitcastToAPInt();
+  const APInt &API = APF.bitcastToAPInt();
   OS << format_hex_no_prefix(API.getZExtValue(), NumHex, /*Upper=*/true);
 }
 

--- a/llvm/lib/TargetParser/ARMTargetParser.cpp
+++ b/llvm/lib/TargetParser/ARMTargetParser.cpp
@@ -650,7 +650,7 @@ StringRef ARM::getARMCPUForArch(const llvm::Triple &Triple, StringRef MArch) {
   llvm_unreachable("invalid arch name");
 }
 
-void ARM::PrintSupportedExtensions(StringMap<StringRef> DescMap) {
+void ARM::PrintSupportedExtensions(StringMap<StringRef> &DescMap) {
   outs() << "All available -march extensions for ARM\n\n"
          << "    " << left_justify("Name", 20)
          << (DescMap.empty() ? "\n" : "Description\n");

--- a/llvm/lib/TextAPI/BinaryReader/DylibReader.cpp
+++ b/llvm/lib/TextAPI/BinaryReader/DylibReader.cpp
@@ -350,7 +350,7 @@ static Error load(MachOObjectFile *Obj, RecordsSlice &Slice,
   return Error::success();
 }
 
-Expected<Records> DylibReader::readFile(MemoryBufferRef Buffer,
+Expected<Records> DylibReader::readFile(const MemoryBufferRef &Buffer,
                                         const ParseOption &Opt) {
   Records Results;
 
@@ -425,7 +425,7 @@ Expected<Records> DylibReader::readFile(MemoryBufferRef Buffer,
 }
 
 Expected<std::unique_ptr<InterfaceFile>>
-DylibReader::get(MemoryBufferRef Buffer) {
+DylibReader::get(const MemoryBufferRef &Buffer) {
   ParseOption Options;
   auto SlicesOrErr = readFile(Buffer, Options);
   if (!SlicesOrErr)

--- a/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
+++ b/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp
@@ -83,7 +83,7 @@ MachineTypes getEmulation(StringRef S) {
       .Default(IMAGE_FILE_MACHINE_UNKNOWN);
 }
 
-MachineTypes getMachine(Triple T) {
+MachineTypes getMachine(const Triple &T) {
   switch (T.getArch()) {
   case Triple::x86:
     return COFF::IMAGE_FILE_MACHINE_I386;

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -7536,7 +7536,7 @@ struct AAPrivatizablePtrArgument final : public AAPrivatizablePtrImpl {
   /// Extract values from \p Base according to the type \p PrivType at the
   /// call position \p ACS. The values are appended to \p ReplacementValues.
   void createReplacementValues(Align Alignment, Type *PrivType,
-                               AbstractCallSite ACS, Value *Base,
+                               const AbstractCallSite &ACS, Value *Base,
                                SmallVectorImpl<Value *> &ReplacementValues) {
     assert(Base && "Expected base value!");
     assert(PrivType && "Expected privatizable type!");
@@ -11156,7 +11156,7 @@ struct AAPotentialValuesFloating : AAPotentialValuesImpl {
     return true;
   }
 
-  bool handleLoadInst(Attributor &A, LoadInst &LI, ItemInfo II,
+  bool handleLoadInst(Attributor &A, LoadInst &LI, const ItemInfo &II,
                       SmallVectorImpl<ItemInfo> &Worklist) {
     SmallSetVector<Value *, 4> PotentialCopies;
     SmallSetVector<Instruction *, 4> PotentialValueOrigins;
@@ -11280,7 +11280,7 @@ struct AAPotentialValuesFloating : AAPotentialValuesImpl {
   /// Use the generic, non-optimistic InstSimplfy functionality if we managed to
   /// simplify any operand of the instruction \p I. Return true if successful,
   /// in that case Worklist will be updated.
-  bool handleGenericInst(Attributor &A, Instruction &I, ItemInfo II,
+  bool handleGenericInst(Attributor &A, Instruction &I, const ItemInfo &II,
                          SmallVectorImpl<ItemInfo> &Worklist) {
     bool SomeSimplified = false;
     bool UsedAssumedInformation = false;
@@ -11330,7 +11330,7 @@ struct AAPotentialValuesFloating : AAPotentialValuesImpl {
   }
 
   bool simplifyInstruction(
-      Attributor &A, Instruction &I, ItemInfo II,
+      Attributor &A, Instruction &I, const ItemInfo &II,
       SmallVectorImpl<ItemInfo> &Worklist,
       SmallMapVector<const Function *, LivenessInfo, 4> &LivenessAAs) {
     if (auto *CI = dyn_cast<CmpInst>(&I))

--- a/llvm/lib/Transforms/IPO/CalledValuePropagation.cpp
+++ b/llvm/lib/Transforms/IPO/CalledValuePropagation.cpp
@@ -190,7 +190,7 @@ public:
   }
 
   /// Print the given CVPLatticeVal to the specified stream.
-  void PrintLatticeVal(CVPLatticeVal LV, raw_ostream &OS) override {
+  void PrintLatticeVal(const CVPLatticeVal &LV, raw_ostream &OS) override {
     if (LV == getUndefVal())
       OS << "Undefined  ";
     else if (LV == getOverdefinedVal())

--- a/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -301,7 +301,7 @@ static void addMemoryAttrs(const SCCNodeSet &SCCNodes, AARGetterT &&AARGetter,
 // Compute definitive function attributes for a function taking into account
 // prevailing definitions and linkage types
 static FunctionSummary *calculatePrevailingSummary(
-    ValueInfo VI,
+    const ValueInfo &VI,
     DenseMap<ValueInfo, FunctionSummary *> &CachedPrevailingSummary,
     function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
         IsPrevailing) {
@@ -1714,7 +1714,7 @@ private:
   SmallVector<InferenceDescriptor, 4> InferenceDescriptors;
 
 public:
-  void registerAttrInference(InferenceDescriptor AttrInference) {
+  void registerAttrInference(const InferenceDescriptor &AttrInference) {
     InferenceDescriptors.push_back(AttrInference);
   }
 

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -1085,7 +1085,7 @@ void ModuleImportsManager::computeImportForModule(
 }
 
 #ifndef NDEBUG
-static bool isGlobalVarSummary(const ModuleSummaryIndex &Index, ValueInfo VI) {
+static bool isGlobalVarSummary(const ModuleSummaryIndex &Index, const ValueInfo &VI) {
   auto SL = VI.getSummaryList();
   return SL.empty()
              ? false

--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -141,7 +141,7 @@ struct FactOrCheck {
 
   static FactOrCheck getConditionFact(DomTreeNode *DTN, CmpPredicate Pred,
                                       Value *Op0, Value *Op1,
-                                      ConditionTy Precond = {}) {
+                                      const ConditionTy &Precond = {}) {
     return FactOrCheck(DTN, Pred, Op0, Op1, Precond);
   }
 

--- a/llvm/lib/Transforms/Scalar/Float2Int.cpp
+++ b/llvm/lib/Transforms/Scalar/Float2Int.cpp
@@ -125,7 +125,7 @@ ConstantRange Float2IntPass::badRange() {
 ConstantRange Float2IntPass::unknownRange() {
   return ConstantRange::getEmpty(MaxIntegerBW + 1);
 }
-ConstantRange Float2IntPass::validateRange(ConstantRange R) {
+ConstantRange Float2IntPass::validateRange(const ConstantRange &R) {
   if (R.getBitWidth() > MaxIntegerBW + 1)
     return badRange();
   return R;

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -1171,7 +1171,7 @@ static bool liesBetween(const Instruction *From, Instruction *Between,
 
 /// Try to locate the three instruction involved in a missed
 /// load-elimination case that is due to an intervening store.
-static void reportMayClobberedLoad(LoadInst *Load, MemDepResult DepInfo,
+static void reportMayClobberedLoad(LoadInst *Load, const MemDepResult &DepInfo,
                                    DominatorTree *DT,
                                    OptimizationRemarkEmitter *ORE) {
   using namespace ore;
@@ -1254,7 +1254,7 @@ static Value *findDominatingValue(const MemoryLocation &Loc, Type *LoadTy,
 }
 
 std::optional<AvailableValue>
-GVNPass::AnalyzeLoadAvailability(LoadInst *Load, MemDepResult DepInfo,
+GVNPass::AnalyzeLoadAvailability(LoadInst *Load, const MemDepResult &DepInfo,
                                  Value *Address) {
   assert(Load->isUnordered() && "rules below are incorrect for ordered access");
   assert(DepInfo.isLocal() && "expected a local dependence");

--- a/llvm/lib/Transforms/Utils/AssumeBundleBuilder.cpp
+++ b/llvm/lib/Transforms/Utils/AssumeBundleBuilder.cpp
@@ -113,7 +113,7 @@ struct AssumeBuilderState {
                      AssumptionCache *AC = nullptr, DominatorTree *DT = nullptr)
       : M(M), InstBeingModified(I), AC(AC), DT(DT) {}
 
-  bool tryToPreserveWithoutAddingAssume(RetainedKnowledge RK) {
+  bool tryToPreserveWithoutAddingAssume(const RetainedKnowledge &RK) const {
     if (!InstBeingModified || !RK.WasOn)
       return false;
     bool HasBeenPreserved = false;

--- a/llvm/lib/Transforms/Utils/CodeLayout.cpp
+++ b/llvm/lib/Transforms/Utils/CodeLayout.cpp
@@ -407,7 +407,7 @@ struct ChainEdge {
     return Src == SrcChain ? CachedGainForward : CachedGainBackward;
   }
 
-  void setCachedMergeGain(ChainT *Src, ChainT *Dst, MergeGainT MergeGain) {
+  void setCachedMergeGain(ChainT *Src, ChainT *Dst, const MergeGainT &MergeGain) {
     if (Src == SrcChain) {
       CachedGainForward = MergeGain;
       CacheValidForward = true;
@@ -422,7 +422,7 @@ struct ChainEdge {
     CacheValidBackward = false;
   }
 
-  void setMergeGain(MergeGainT Gain) { CachedGain = Gain; }
+  void setMergeGain(const MergeGainT &Gain) { CachedGain = Gain; }
 
   MergeGainT getMergeGain() const { return CachedGain; }
 

--- a/llvm/lib/Transforms/Utils/FunctionImportUtils.cpp
+++ b/llvm/lib/Transforms/Utils/FunctionImportUtils.cpp
@@ -43,7 +43,7 @@ bool FunctionImportGlobalProcessing::doImportAsDefinition(
 }
 
 bool FunctionImportGlobalProcessing::shouldPromoteLocalToGlobal(
-    const GlobalValue *SGV, ValueInfo VI) {
+    const GlobalValue *SGV, const ValueInfo &VI) {
   assert(SGV->hasLocalLinkage());
 
   // Ifuncs and ifunc alias does not have summary.

--- a/llvm/tools/bugpoint/BugDriver.h
+++ b/llvm/tools/bugpoint/BugDriver.h
@@ -183,7 +183,7 @@ public:
   /// MayModifySemantics argument is true, then the cleanups is allowed to
   /// modify how the code behaves.
   ///
-  std::unique_ptr<Module> performFinalCleanups(std::unique_ptr<Module> M,
+  std::unique_ptr<Module> performFinalCleanups(const std::unique_ptr<Module> &M,
                                                bool MayModifySemantics = false);
 
   /// Given a module, extract up to one loop from it into a new function. This

--- a/llvm/tools/bugpoint/ExtractFunction.cpp
+++ b/llvm/tools/bugpoint/ExtractFunction.cpp
@@ -126,7 +126,7 @@ BugDriver::deleteInstructionFromProgram(const Instruction *I,
 }
 
 std::unique_ptr<Module>
-BugDriver::performFinalCleanups(std::unique_ptr<Module> M,
+BugDriver::performFinalCleanups(const std::unique_ptr<Module> &M,
                                 bool MayModifySemantics) {
   // Make all functions external, so GlobalDCE doesn't delete them...
   for (Module::iterator I = M->begin(), E = M->end(); I != E; ++I)

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -119,7 +119,7 @@ static void dumpDIE(const DWARFDie *DIE, bool Verbose) {
 
 /// Report a warning to the user, optionally including information about a
 /// specific \p DIE related to the warning.
-void DwarfLinkerForBinary::reportWarning(Twine Warning, Twine Context,
+void DwarfLinkerForBinary::reportWarning(const Twine &Warning, const Twine &Context,
                                          const DWARFDie *DIE) const {
   // FIXME: implement warning logging which does not block other threads.
   if (ErrorHandlerMutex.try_lock()) {
@@ -129,7 +129,7 @@ void DwarfLinkerForBinary::reportWarning(Twine Warning, Twine Context,
   }
 }
 
-void DwarfLinkerForBinary::reportError(Twine Error, Twine Context,
+void DwarfLinkerForBinary::reportError(const Twine &Error, const Twine &Context,
                                        const DWARFDie *DIE) const {
   // FIXME: implement error logging which does not block other threads.
   if (ErrorHandlerMutex.try_lock()) {

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -80,9 +80,9 @@ public:
   /// Link the contents of the DebugMap.
   bool link(const DebugMap &);
 
-  void reportWarning(Twine Warning, Twine Context = {},
+  void reportWarning(const Twine &Warning, const Twine &Context = {},
                      const DWARFDie *DIE = nullptr) const;
-  void reportError(Twine Error, Twine Context = {},
+  void reportError(const Twine &Error, const Twine &Context = {},
                    const DWARFDie *DIE = nullptr) const;
 
   /// Returns true if input verification is enabled and verification errors were

--- a/llvm/tools/llvm-cov/CoverageExporterLcov.cpp
+++ b/llvm/tools/llvm-cov/CoverageExporterLcov.cpp
@@ -105,8 +105,8 @@ collectNestedBranches(const coverage::CoverageMapping &Coverage,
   return Branches;
 }
 
-bool sortLine(llvm::coverage::CountedRegion I,
-              llvm::coverage::CountedRegion J) {
+bool sortLine(const llvm::coverage::CountedRegion &I,
+              const llvm::coverage::CountedRegion &J) {
   return (I.LineStart < J.LineStart) ||
          ((I.LineStart == J.LineStart) && (I.ColumnStart < J.ColumnStart));
 }

--- a/llvm/tools/llvm-exegesis/lib/Assembler.cpp
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.cpp
@@ -240,7 +240,7 @@ BitVector getFunctionReservedRegs(const TargetMachine &TM) {
 }
 
 Error assembleToStream(const ExegesisTarget &ET,
-                       std::unique_ptr<TargetMachine> TM,
+                       const std::unique_ptr<TargetMachine> &TM,
                        ArrayRef<MCRegister> LiveIns, const FillFunction &Fill,
                        raw_pwrite_stream &AsmStream, const BenchmarkKey &Key,
                        bool GenerateMemoryInstructions) {

--- a/llvm/tools/llvm-exegesis/lib/Assembler.h
+++ b/llvm/tools/llvm-exegesis/lib/Assembler.h
@@ -89,7 +89,7 @@ using FillFunction = std::function<void(FunctionFiller &)>;
 // epilogue. Once the MachineFunction is ready, it is assembled for TM to
 // AsmStream, the temporary function is eventually discarded.
 Error assembleToStream(const ExegesisTarget &ET,
-                       std::unique_ptr<TargetMachine> TM,
+                       const std::unique_ptr<TargetMachine> &TM,
                        ArrayRef<MCRegister> LiveIns, const FillFunction &Fill,
                        raw_pwrite_stream &AsmStreamm, const BenchmarkKey &Key,
                        bool GenerateMemoryInstructions);

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.cpp
@@ -346,7 +346,7 @@ template <> struct MappingTraits<exegesis::Benchmark::TripleAndCpu> {
 namespace exegesis {
 
 Expected<std::set<Benchmark::TripleAndCpu>>
-Benchmark::readTriplesAndCpusFromYamls(MemoryBufferRef Buffer) {
+Benchmark::readTriplesAndCpusFromYamls(const MemoryBufferRef &Buffer) {
   // We're only mapping a field, drop other fields and silence the corresponding
   // warnings.
   yaml::Input Yin(Buffer, nullptr, +[](const SMDiagnostic &, void *Context) {});
@@ -365,7 +365,7 @@ Benchmark::readTriplesAndCpusFromYamls(MemoryBufferRef Buffer) {
 }
 
 Expected<Benchmark> Benchmark::readYaml(const LLVMState &State,
-                                        MemoryBufferRef Buffer) {
+                                        const MemoryBufferRef &Buffer) {
   yaml::Input Yin(Buffer);
   YamlContext Context(State);
   Benchmark Benchmark;
@@ -377,7 +377,7 @@ Expected<Benchmark> Benchmark::readYaml(const LLVMState &State,
 }
 
 Expected<std::vector<Benchmark>> Benchmark::readYamls(const LLVMState &State,
-                                                      MemoryBufferRef Buffer) {
+                                                      const MemoryBufferRef &Buffer) {
   yaml::Input Yin(Buffer);
   YamlContext Context(State);
   std::vector<Benchmark> Benchmarks;

--- a/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
+++ b/llvm/tools/llvm-exegesis/lib/BenchmarkResult.h
@@ -81,8 +81,8 @@ struct BenchmarkKey {
 struct BenchmarkMeasure {
   // A helper to create an unscaled BenchmarkMeasure.
   static BenchmarkMeasure
-  Create(std::string Key, double Value,
-         std::map<ValidationEvent, int64_t> ValCounters) {
+  Create(const std::string &Key, double Value,
+         const std::map<ValidationEvent, int64_t> &ValCounters) {
     return {Key, Value, Value, Value, ValCounters};
   }
   std::string Key;
@@ -134,10 +134,10 @@ struct Benchmark {
 
   // Read functions.
   static Expected<Benchmark> readYaml(const LLVMState &State,
-                                                 MemoryBufferRef Buffer);
+                                                 const MemoryBufferRef &Buffer);
 
   static Expected<std::vector<Benchmark>>
-  readYamls(const LLVMState &State, MemoryBufferRef Buffer);
+  readYamls(const LLVMState &State, const MemoryBufferRef &Buffer);
 
   // Given a set of serialized instruction benchmarks, returns the set of
   // triples and CPUs that appear in the list of benchmarks.
@@ -149,7 +149,7 @@ struct Benchmark {
     }
   };
   static Expected<std::set<TripleAndCpu>>
-  readTriplesAndCpusFromYamls(MemoryBufferRef Buffer);
+  readTriplesAndCpusFromYamls(const MemoryBufferRef &Buffer);
 
   class Error readYamlFrom(const LLVMState &State, StringRef InputContent);
 

--- a/llvm/tools/llvm-pdbutil/DumpOutputStyle.cpp
+++ b/llvm/tools/llvm-pdbutil/DumpOutputStyle.cpp
@@ -1201,7 +1201,7 @@ static void
 dumpFullTypeStream(LinePrinter &Printer, LazyRandomTypeCollection &Types,
                    TypeReferenceTracker *RefTracker, uint32_t NumTypeRecords,
                    uint32_t NumHashBuckets,
-                   FixedStreamArray<support::ulittle32_t> HashValues,
+                   const FixedStreamArray<support::ulittle32_t> &HashValues,
                    TpiStream *Stream, bool Bytes, bool Extras) {
 
   Printer.formatLine("Showing {0:N} records", NumTypeRecords);

--- a/llvm/tools/llvm-readobj/COFFDumper.cpp
+++ b/llvm/tools/llvm-readobj/COFFDumper.cpp
@@ -134,7 +134,7 @@ private:
   void printCodeViewTypeSection(StringRef SectionName, const SectionRef &Section);
   StringRef getFileNameForFileOffset(uint32_t FileOffset);
   void printFileNameForOffset(StringRef Label, uint32_t FileOffset);
-  void printTypeIndex(StringRef FieldName, TypeIndex TI) {
+  void printTypeIndex(StringRef FieldName, const TypeIndex &TI) {
     // Forward to CVTypeDumper for simplicity.
     codeview::printTypeIndex(Writer, FieldName, TI, Types);
   }

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -5840,7 +5840,7 @@ struct CoreNote {
   std::vector<CoreFileMapping> Mappings;
 };
 
-static Expected<CoreNote> readCoreNote(DataExtractor Desc) {
+static Expected<CoreNote> readCoreNote(const DataExtractor &Desc) {
   // Expected format of the NT_FILE note description:
   // 1. # of file mappings (call it N)
   // 2. Page size

--- a/llvm/tools/llvm-readtapi/DiffEngine.cpp
+++ b/llvm/tools/llvm-readtapi/DiffEngine.cpp
@@ -98,7 +98,7 @@ std::string SymScalar::getFlagString(const MachO::Symbol *Sym) {
   return std::string(Flags);
 }
 
-void SymScalar::print(raw_ostream &OS, std::string Indent, MachO::Target Targ) {
+void SymScalar::print(raw_ostream &OS, const std::string &Indent, const MachO::Target &Targ) {
   if (Val->getKind() == MachO::EncodeKind::ObjectiveCClass) {
     if (Targ.Arch == MachO::AK_i386 && Targ.Platform == MachO::PLATFORM_MACOS) {
       OS << Indent << "\t\t" << ((Order == lhs) ? "< " : "> ")
@@ -144,7 +144,7 @@ void addDiffForTargSlice(V Val, Target Targ, DiffOutput &Diff,
 }
 
 DiffOutput getSingleAttrDiff(const std::vector<InterfaceFileRef> &IRefVec,
-                             std::string Name, InterfaceInputOrder Order) {
+                             const std::string &Name, InterfaceInputOrder Order) {
   DiffOutput Diff(Name);
   Diff.Kind = AD_Str_Vec;
   for (const auto &IRef : IRefVec)
@@ -157,7 +157,7 @@ DiffOutput getSingleAttrDiff(const std::vector<InterfaceFileRef> &IRefVec,
 
 DiffOutput
 getSingleAttrDiff(const std::vector<std::pair<Target, std::string>> &PairVec,
-                  std::string Name, InterfaceInputOrder Order) {
+                  const std::string &Name, InterfaceInputOrder Order) {
   DiffOutput Diff(Name);
   Diff.Kind = AD_Str_Vec;
   for (const auto &Pair : PairVec)
@@ -168,7 +168,7 @@ getSingleAttrDiff(const std::vector<std::pair<Target, std::string>> &PairVec,
 }
 
 DiffOutput getSingleAttrDiff(InterfaceFile::const_symbol_range SymRange,
-                             std::string Name, InterfaceInputOrder Order) {
+                             const std::string &Name, InterfaceInputOrder Order) {
   DiffOutput Diff(Name);
   Diff.Kind = AD_Sym_Vec;
   for (const auto *Sym : SymRange)
@@ -305,7 +305,7 @@ DiffOutput recordDifferences(const std::vector<T> &LHS,
 
 DiffOutput recordDifferences(llvm::MachO::InterfaceFile::const_symbol_range LHS,
                              llvm::MachO::InterfaceFile::const_symbol_range RHS,
-                             std::string Attr) {
+                             const std::string &Attr) {
   DiffOutput Diff(Attr);
   Diff.Kind = AD_Sym_Vec;
   findAndAddDiff(LHS, RHS, Diff, lhs);

--- a/llvm/tools/llvm-readtapi/DiffEngine.h
+++ b/llvm/tools/llvm-readtapi/DiffEngine.h
@@ -85,7 +85,7 @@ public:
 
   std::string getFlagString(const MachO::Symbol *Sym);
 
-  void print(raw_ostream &OS, std::string Indent, MachO::Target Targ);
+  void print(raw_ostream &OS, const std::string &Indent, const MachO::Target &Targ);
 
   const MachO::Symbol *getVal() const { return Val; }
   InterfaceInputOrder getOrder() const { return Order; }

--- a/llvm/utils/FileCheck/FileCheck.cpp
+++ b/llvm/utils/FileCheck/FileCheck.cpp
@@ -343,7 +343,7 @@ struct InputAnnotation {
 };
 
 /// Get an abbreviation for the check type.
-static std::string GetCheckTypeAbbreviation(Check::FileCheckType Ty) {
+static std::string GetCheckTypeAbbreviation(const Check::FileCheckType &Ty) {
   switch (Ty) {
   case Check::CheckPlain:
     if (Ty.getCount() > 1)

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -85,7 +85,7 @@ public:
   // Emit code for a subset of itineraries.
   void emitForItineraries(raw_ostream &OS,
                           std::vector<const CodeGenProcModel *> &ProcItinList,
-                          std::string DFAName);
+                          const std::string &DFAName);
 
   void run(raw_ostream &OS);
 };
@@ -231,7 +231,7 @@ void DFAPacketizerEmitter::run(raw_ostream &OS) {
 
 void DFAPacketizerEmitter::emitForItineraries(
     raw_ostream &OS, std::vector<const CodeGenProcModel *> &ProcModels,
-    std::string DFAName) {
+    const std::string &DFAName) {
   OS << "} // end namespace llvm\n\n";
   OS << "namespace {\n";
   collectAllFuncUnits(ProcModels);

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -374,7 +374,7 @@ static void emitDXILAttributes(const RecordKeeper &Records, raw_ostream &OS) {
 
 // Helper function to determine if the given Attr is defined in the vector
 // Attrs, by comparing the names
-static bool attrIsDefined(std::vector<const Record *> Attrs,
+static bool attrIsDefined(const std::vector<const Record *> &Attrs,
                           const Record *Attr) {
   for (auto CurAttr : Attrs)
     if (CurAttr->getName() == Attr->getName())

--- a/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelCombinerEmitter.cpp
@@ -665,9 +665,9 @@ private:
   std::optional<LLTCodeGenOrTempType>
   getLLTCodeGenOrTempType(const PatternType &PT, RuleMatcher &RM);
 
-  void PrintError(Twine Msg) const { ::PrintError(&RuleDef, Msg); }
-  void PrintWarning(Twine Msg) const { ::PrintWarning(RuleDef.getLoc(), Msg); }
-  void PrintNote(Twine Msg) const { ::PrintNote(RuleDef.getLoc(), Msg); }
+  void PrintError(const Twine &Msg) const { ::PrintError(&RuleDef, Msg); }
+  void PrintWarning(const Twine &Msg) const { ::PrintWarning(RuleDef.getLoc(), Msg); }
+  void PrintNote(const Twine &Msg) const { ::PrintNote(RuleDef.getLoc(), Msg); }
 
   void print(raw_ostream &OS, const PatternAlternatives &Alts) const;
 
@@ -710,7 +710,7 @@ private:
   /// \param AdditionalComment Comment string to be added to the
   ///        `DebugCommentAction`.
   RuleMatcher &addRuleMatcher(const PatternAlternatives &Alts,
-                              Twine AdditionalComment = "");
+                              const Twine &AdditionalComment = "");
   bool addFeaturePredicates(RuleMatcher &M);
 
   bool findRoots();
@@ -1350,7 +1350,7 @@ bool CombineRuleBuilder::checkSemantics() {
 }
 
 RuleMatcher &CombineRuleBuilder::addRuleMatcher(const PatternAlternatives &Alts,
-                                                Twine AdditionalComment) {
+                                                const Twine &AdditionalComment) {
   auto &RM = OutRMs.emplace_back(RuleDef.getLoc());
   addFeaturePredicates(RM);
   RM.setPermanentGISelFlags(GISF_IgnoreCopies);


### PR DESCRIPTION
For better optimized code generation functions calls by compiler, objects sizes equal to or greater than 16 bytes must be pass by constant reference. A constant reference is also useful as refactoring technique that indicates that param is a constant.

Reference: https://stackoverflow.com/a/3314034