### PR TITLE
[Flang] [AIX] Mark real10 testcase as unsupported on AIX NFC

### DIFF
--- a/flang/test/Semantics/kinds04_q10.f90
+++ b/flang/test/Semantics/kinds04_q10.f90
@@ -5,6 +5,8 @@
 ! C717 The value of kind-param shall specify an approximation method that
 ! exists on the processor.
 
+! UNSUPPORTED: system-aix
+
 subroutine s(var)
   real :: realvar1 = 4.0E6_4
   real :: realvar2 = 4.0D6


### PR DESCRIPTION
Readd the unsupported flag for this testcase on AIX after https://github.com/llvm/llvm-project/pull/124158 as it breaks the flang on AIX buildbot.