### PR TITLE
[MLIR][LLVM] Import LLVM target triple into MLIR LLVM Dialect

### DIFF
--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -71,6 +71,10 @@ public:
   /// specification.
   LogicalResult convertDataLayout();
 
+  /// Converts target triple of the LLVM module to an MLIR target triple
+  /// specification.
+  void convertTargetTriple();
+
   /// Stores the mapping between an LLVM value and its MLIR counterpart.
   void mapValue(llvm::Value *llvm, Value mlir) { mapValue(llvm) = mlir; }
 

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -662,6 +662,11 @@ LogicalResult ModuleImport::convertDataLayout() {
   return success();
 }
 
+void ModuleImport::convertTargetTriple() {
+  mlirModule->setAttr(LLVM::LLVMDialect::getTargetTripleAttrName(),
+                      builder.getStringAttr(llvmModule->getTargetTriple()));
+}
+
 LogicalResult ModuleImport::convertFunctions() {
   for (llvm::Function &func : llvmModule->functions())
     if (failed(processFunction(&func)))
@@ -2451,6 +2456,6 @@ mlir::translateLLVMIRToModule(std::unique_ptr<llvm::Module> llvmModule,
     return {};
   if (failed(moduleImport.convertFunctions()))
     return {};
-
+  moduleImport.convertTargetTriple();
   return module;
 }

--- a/mlir/test/Target/LLVMIR/Import/target-triple.ll
+++ b/mlir/test/Target/LLVMIR/Import/target-triple.ll
@@ -1,0 +1,5 @@
+; RUN: mlir-translate -import-llvm %s | FileCheck %s
+; CHECK: module attributes {
+; CHECK-SAME: llvm.target_triple = "aarch64-none-linux-android21"
+target triple = "aarch64-none-linux-android21"
+


### PR DESCRIPTION
It would be essential and useful info to have it in MLIR when we are doing optimizations at MLIR level using LLVM IR as input. Thought about making it part of [`ModuleImport::convertMetadata()`](https://github.com/llvm/llvm-project/blob/242aa8c743fe4344844753d8faf59744235319df/mlir/lib/Target/LLVMIR/ModuleImport.cpp#L597), but decided not as this logic is its own simple thing. However, open to options like that.