### PR TITLE
Reapply 44c0719e77b37374c89b7fc1320664ebb404323d with fix; NFC

### DIFF
--- a/clang/include/clang/AST/DynamicRecursiveASTVisitor.h
+++ b/clang/include/clang/AST/DynamicRecursiveASTVisitor.h
@@ -251,11 +251,11 @@ public:
   // Decls.
 #define ABSTRACT_DECL(DECL)
 #define DECL(CLASS, BASE)                                                      \
+  bool WalkUpFrom##CLASS##Decl(MaybeConst<CLASS##Decl> *D);                    \
   virtual bool Traverse##CLASS##Decl(MaybeConst<CLASS##Decl> *D);
 #include "clang/AST/DeclNodes.inc"
 
 #define DECL(CLASS, BASE)                                                      \
-  bool WalkUpFrom##CLASS##Decl(MaybeConst<CLASS##Decl> *D);                    \
   virtual bool Visit##CLASS##Decl(MaybeConst<CLASS##Decl> *D) { return true; }
 #include "clang/AST/DeclNodes.inc"
 
@@ -272,11 +272,11 @@ public:
   // Types.
 #define ABSTRACT_TYPE(CLASS, BASE)
 #define TYPE(CLASS, BASE)                                                      \
+  bool WalkUpFrom##CLASS##Type(MaybeConst<CLASS##Type> *T);                    \
   virtual bool Traverse##CLASS##Type(MaybeConst<CLASS##Type> *T);
 #include "clang/AST/TypeNodes.inc"
 
 #define TYPE(CLASS, BASE)                                                      \
-  bool WalkUpFrom##CLASS##Type(MaybeConst<CLASS##Type> *T);                    \
   virtual bool Visit##CLASS##Type(MaybeConst<CLASS##Type> *T) { return true; }
 #include "clang/AST/TypeNodes.inc"
 


### PR DESCRIPTION
Silence MSVC warnings; NFC
After the changes to DynamicRecursiveASTVisitor, we started getting several warnings from MSVC like:

warning C4661: 'bool clang::DynamicRecursiveASTVisitorBase<false>::WalkUpFromNamedDecl(clang::NamedDecl *)': no suitable definition provided for explicit template instantiation request

These changes silence the warnings by providing a definition for those functions.