### PR TITLE
[CIR] Fix some clang-tidy problems in CIR

### DIFF
--- a/clang/include/clang/CIR/FrontendAction/.clang-tidy
+++ b/clang/include/clang/CIR/FrontendAction/.clang-tidy
@@ -51,3 +51,18 @@ Checks: >
         readability-simplify-boolean-expr,
         readability-simplify-subscript-expr,
         readability-use-anyofallof
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase

--- a/clang/include/clang/CIR/LowerToLLVM.h
+++ b/clang/include/clang/CIR/LowerToLLVM.h
@@ -29,7 +29,8 @@ namespace cir {
 
 namespace direct {
 std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp M, llvm::LLVMContext &Ctx);
+lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule,
+                             llvm::LLVMContext &llvmCtx);
 } // namespace direct
 } // namespace cir
 

--- a/clang/lib/CIR/FrontendAction/.clang-tidy
+++ b/clang/lib/CIR/FrontendAction/.clang-tidy
@@ -1,0 +1,16 @@
+InheritParentConfig: true
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -23,17 +23,17 @@ namespace cir {
 namespace direct {
 
 std::unique_ptr<llvm::Module>
-lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp MOp, LLVMContext &LLVMCtx) {
+lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule, LLVMContext &llvmCtx) {
   llvm::TimeTraceScope scope("lower from CIR to LLVM directly");
 
-  std::optional<StringRef> ModuleName = MOp.getName();
-  auto M = std::make_unique<llvm::Module>(
-      ModuleName ? *ModuleName : "CIRToLLVMModule", LLVMCtx);
+  std::optional<StringRef> moduleName = mlirModule.getName();
+  auto llvmModule = std::make_unique<llvm::Module>(
+      moduleName ? *moduleName : "CIRToLLVMModule", llvmCtx);
 
-  if (!M)
+  if (!llvmModule)
     report_fatal_error("Lowering from LLVMIR dialect to llvm IR failed!");
 
-  return M;
+  return llvmModule;
 }
 } // namespace direct
 } // namespace cir


### PR DESCRIPTION
This adds a .clang-tidy file to the clang/lib/CIR/FrontendAction directory, moves and updates the incorrectly located include/clang/CIR/FrontendAction .clang-tidy file, and updates two files from a recent commit to bring them into conformance with previously agreed upon rules for where to use LLVM naming conventions and where to use MLIR naming conventions.