### PR TITLE
[HLSL][RootSignature] Add Metadata generation of Root Signatures for Attr

### DIFF
--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -124,20 +124,14 @@ void addRootSignature(
     llvm::Function *Fn, llvm::Module &M) {
   auto &Ctx = M.getContext();
 
-  SmallVector<Metadata *> GeneratedMetadata;
-  for (auto Element : Elements) {
-    MDNode *ExampleRootElement = MDNode::get(Ctx, {});
-    GeneratedMetadata.push_back(ExampleRootElement);
-  }
-
-  MDNode *ExampleRootSignature = MDNode::get(Ctx, GeneratedMetadata);
-
-  MDNode *ExamplePairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
-                                             ExampleRootSignature});
+  llvm::hlsl::root_signature::MetadataBuilder Builder(Ctx, Elements);
+  MDNode *RootSignature = Builder.BuildRootSignature();
+  MDNode *FnPairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
+                                        RootSignature});
 
   StringRef RootSignatureValKey = "dx.rootsignatures";
   auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);
-  RootSignatureValMD->addOperand(ExamplePairing);
+  RootSignatureValMD->addOperand(FnPairing);
 }
 
 } // namespace

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -119,6 +119,20 @@ GlobalVariable *replaceBuffer(CGHLSLRuntime::Buffer &Buf) {
   return CBGV;
 }
 
+void addRootSignature(llvm::Function *Fn, llvm::Module &M) {
+  auto &Ctx = M.getContext();
+  IRBuilder<> B(M.getContext());
+
+  MDNode *ExampleRootSignature = MDNode::get(Ctx, {});
+
+  MDNode *ExamplePairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
+                                             ExampleRootSignature});
+
+  StringRef RootSignatureValKey = "dx.rootsignatures";
+  auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);
+  RootSignatureValMD->addOperand(ExamplePairing);
+}
+
 } // namespace
 
 llvm::Type *CGHLSLRuntime::convertHLSLSpecificType(const Type *T) {
@@ -453,6 +467,13 @@ void CGHLSLRuntime::emitEntryFunction(const FunctionDecl *FD,
   // FIXME: Handle codegen for return type semantics.
   // See: https://github.com/llvm/llvm-project/issues/57875
   B.CreateRetVoid();
+
+  // Add and identify root signature to function, if applicable
+  const AttrVec &Attrs = FD->getAttrs();
+  for (const Attr *Attr : Attrs) {
+    if (isa<HLSLRootSignatureAttr>(Attr))
+      addRootSignature(EntryFn, M);
+  }
 }
 
 void CGHLSLRuntime::setHLSLFunctionAttributes(const FunctionDecl *FD,

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -119,15 +119,14 @@ GlobalVariable *replaceBuffer(CGHLSLRuntime::Buffer &Buf) {
   return CBGV;
 }
 
-void addRootSignature(
-    ArrayRef<llvm::hlsl::root_signature::RootElement> Elements,
-    llvm::Function *Fn, llvm::Module &M) {
+void addRootSignature(ArrayRef<llvm::hlsl::rootsig::RootElement> Elements,
+                      llvm::Function *Fn, llvm::Module &M) {
   auto &Ctx = M.getContext();
 
-  llvm::hlsl::root_signature::MetadataBuilder Builder(Ctx, Elements);
+  llvm::hlsl::rootsig::MetadataBuilder Builder(Ctx, Elements);
   MDNode *RootSignature = Builder.BuildRootSignature();
-  MDNode *FnPairing = MDNode::get(Ctx, {ValueAsMetadata::get(Fn),
-                                        RootSignature});
+  MDNode *FnPairing =
+      MDNode::get(Ctx, {ValueAsMetadata::get(Fn), RootSignature});
 
   StringRef RootSignatureValKey = "dx.rootsignatures";
   auto *RootSignatureValMD = M.getOrInsertNamedMetadata(RootSignatureValKey);
@@ -471,10 +470,9 @@ void CGHLSLRuntime::emitEntryFunction(const FunctionDecl *FD,
 
   // Add and identify root signature to function, if applicable
   const AttrVec &Attrs = FD->getAttrs();
-  for (const Attr *Attr : Attrs) {
+  for (const Attr *Attr : Attrs)
     if (const auto *RSAttr = dyn_cast<HLSLRootSignatureAttr>(Attr))
       addRootSignature(RSAttr->getElements(), EntryFn, M);
-  }
 }
 
 void CGHLSLRuntime::setHLSLFunctionAttributes(const FunctionDecl *FD,

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -19,7 +19,7 @@ void FirstEntry() {}
 [numthreads(1,1,1)]
 void SecondEntry() {}
 
-// Sanity test to ensure to root is added for this function
+// Sanity test to ensure no root is added for this function
 [shader("compute")]
 [numthreads(1,1,1)]
 void ThirdEntry() {}

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
+
+// CHECK: !dx.rootsignatures = !{![[#FIRST_ENTRY:]], ![[#SECOND_ENTRY:]]}
+// CHECK-DAG: ![[#FIRST_ENTRY]] = !{ptr @FirstEntry, ![[#RS:]]}
+// CHECK-DAG: ![[#SECOND_ENTRY]] = !{ptr @SecondEntry, ![[#RS:]]}
+// CHECK-DAG: ![[#RS]] = !{}
+
+[shader("compute"), RootSignature("")]
+[numthreads(1,1,1)]
+void FirstEntry() {}
+
+[shader("compute"), RootSignature("DescriptorTable()")]
+[numthreads(1,1,1)]
+void SecondEntry() {}
+
+// Sanity test to ensure to root is added for this function
+[shader("compute")]
+[numthreads(1,1,1)]
+void ThirdEntry() {}

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,9 +1,10 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
-// CHECK: !dx.rootsignatures = !{![[#FIRST_ENTRY:]], ![[#SECOND_ENTRY:]]}
-// CHECK-DAG: ![[#FIRST_ENTRY]] = !{ptr @FirstEntry, ![[#RS:]]}
-// CHECK-DAG: ![[#SECOND_ENTRY]] = !{ptr @SecondEntry, ![[#RS:]]}
-// CHECK-DAG: ![[#RS]] = !{}
+// CHECK-DAG: ![[#EMPTY:]] = !{}
+// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#EMPTY]]}
+// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
+// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
+// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}
 
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -5,11 +5,13 @@
 [numthreads(1,1,1)]
 void FirstEntry() {}
 
+// CHECK-DAG: ![[#CBV:]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
 // CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable"}
 // CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
 
 #define SampleDescriptorTable \
   "DescriptorTable( " \
+  "  CBV(b0) " \
   ")"
 [shader("compute"), RootSignature(SampleDescriptorTable)]
 [numthreads(1,1,1)]

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -6,12 +6,14 @@
 void FirstEntry() {}
 
 // CHECK-DAG: ![[#CBV:]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
-// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable"}
+// CHECK-DAG: ![[#SRV:]] = !{!"SRV", i32 4, i32 42, i32 3, i32 32, i32 0}
+// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable", i32 0, ![[#CBV]], ![[#SRV]]}
 // CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
 
 #define SampleDescriptorTable \
   "DescriptorTable( " \
-  "  CBV(b0) " \
+  "  CBV(b0), " \
+  "  SRV(t42, space = 3, offset = 32, numDescriptors = 4, flags = 0) " \
   ")"
 [shader("compute"), RootSignature(SampleDescriptorTable)]
 [numthreads(1,1,1)]

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,16 +1,17 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
 // CHECK-DAG: ![[#EMPTY:]] = !{}
-// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#EMPTY]]}
-// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
-// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
-// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}
-
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]
 void FirstEntry() {}
 
-[shader("compute"), RootSignature("DescriptorTable()")]
+// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable"}
+// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
+
+#define SampleDescriptorTable \
+  "DescriptorTable( " \
+  ")"
+[shader("compute"), RootSignature(SampleDescriptorTable)]
 [numthreads(1,1,1)]
 void SecondEntry() {}
 
@@ -18,3 +19,7 @@ void SecondEntry() {}
 [shader("compute")]
 [numthreads(1,1,1)]
 void ThirdEntry() {}
+
+// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
+// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
+// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,14 +1,19 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
-// CHECK-DAG: ![[#EMPTY:]] = !{}
+// CHECK: !dx.rootsignatures = !{![[#FIRST_ENTRY:]], ![[#SECOND_ENTRY:]]}
+
+// CHECK: ![[#FIRST_ENTRY]] = !{ptr @FirstEntry, ![[#EMPTY:]]}
+// CHECK: ![[#EMPTY]] = !{}
+
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]
 void FirstEntry() {}
 
-// CHECK-DAG: ![[#CBV:]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
-// CHECK-DAG: ![[#SRV:]] = !{!"SRV", i32 4, i32 42, i32 3, i32 32, i32 0}
-// CHECK-DAG: ![[#TABLE:]] = !{!"DescriptorTable", i32 0, ![[#CBV]], ![[#SRV]]}
-// CHECK-DAG: ![[#SECOND_RS:]] = !{![[#TABLE]]}
+// CHECK: ![[#SECOND_ENTRY]] = !{ptr @SecondEntry, ![[#SECOND_RS:]]}
+// CHECK: ![[#SECOND_RS]] = !{![[#TABLE:]]}
+// CHECK: ![[#TABLE]] = !{!"DescriptorTable", i32 0, ![[#CBV:]], ![[#SRV:]]}
+// CHECK: ![[#CBV]] = !{!"CBV", i32 1, i32 0, i32 0, i32 -1, i32 4}
+// CHECK: ![[#SRV]] = !{!"SRV", i32 4, i32 42, i32 3, i32 32, i32 0}
 
 #define SampleDescriptorTable \
   "DescriptorTable( " \
@@ -19,11 +24,8 @@ void FirstEntry() {}
 [numthreads(1,1,1)]
 void SecondEntry() {}
 
-// Sanity test to ensure no root is added for this function
+// Sanity test to ensure no root is added for this function as there is only
+// two entries in !dx.roosignatures
 [shader("compute")]
 [numthreads(1,1,1)]
 void ThirdEntry() {}
-
-// CHECK-DAG: ![[#FIRST_ENTRY:]] = !{ptr @FirstEntry, ![[#EMPTY]]}
-// CHECK-DAG: ![[#SECOND_ENTRY:]] = !{ptr @SecondEntry, ![[#SECOND_RS]]}
-// CHECK-DAG: !dx.rootsignatures = !{![[#FIRST_ENTRY]], ![[#SECOND_ENTRY]]}

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -129,15 +129,18 @@ using ParamType = std::variant<uint32_t *, DescriptorRangeOffset *,
                                DescriptorRangeFlags *, ShaderVisibility *>;
 
 class MetadataBuilder {
- public:
+public:
   MetadataBuilder(llvm::LLVMContext &Ctx, ArrayRef<RootElement> Elements)
-   : Ctx(Ctx), Elements(Elements) {}
+      : Ctx(Ctx), Elements(Elements) {}
 
-  // Iterates through the elements and builds the respective nodes
+  /// Iterates through the elements and dispatches onto the correct Build method
+  ///
+  /// Accumulates the root signature and returns the Metadata node that is just
+  /// a list of all the elements
   MDNode *BuildRootSignature();
 
- private:
-  // Define the various builders for the different metadata types
+private:
+  /// Define the various builders for the different metadata types
   MDNode *BuildDescriptorTable(const DescriptorTable &Table);
   MDNode *BuildDescriptorTableClause(const DescriptorTableClause &Clause);
 

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -14,10 +14,16 @@
 #ifndef LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 #define LLVM_FRONTEND_HLSL_HLSLROOTSIGNATURE_H
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/DXILABI.h"
 #include <variant>
 
 namespace llvm {
+class LLVMContext;
+class MDNode;
+class Metadata;
+
 namespace hlsl {
 namespace rootsig {
 
@@ -121,6 +127,24 @@ using RootElement = std::variant<DescriptorTable, DescriptorTableClause>;
 // may have. Things of the form: Keyword = Param
 using ParamType = std::variant<uint32_t *, DescriptorRangeOffset *,
                                DescriptorRangeFlags *, ShaderVisibility *>;
+
+class MetadataBuilder {
+ public:
+  MetadataBuilder(llvm::LLVMContext &Ctx, ArrayRef<RootElement> Elements)
+   : Ctx(Ctx), Elements(Elements) {}
+
+  // Iterates through the elements and builds the respective nodes
+  MDNode *BuildRootSignature();
+
+ private:
+  // Define the various builders for the different metadata types
+  MDNode *BuildDescriptorTable(const DescriptorTable &Table);
+  MDNode *BuildDescriptorTableClause(const DescriptorTableClause &Clause);
+
+  llvm::LLVMContext &Ctx;
+  ArrayRef<RootElement> Elements;
+  SmallVector<Metadata *> GeneratedMetadata;
+};
 
 } // namespace rootsig
 } // namespace hlsl

--- a/llvm/lib/Frontend/HLSL/CMakeLists.txt
+++ b/llvm/lib/Frontend/HLSL/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_llvm_component_library(LLVMFrontendHLSL
   HLSLResource.cpp
+  HLSLRootSignature.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -68,7 +68,15 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTableClause(const DescriptorTableClause &Clause) {
-  return MDNode::get(Ctx, {ClauseTypeToName(Ctx, Clause.Type)});
+  IRBuilder<> B(Ctx);
+  return MDNode::get(Ctx, {
+    ClauseTypeToName(Ctx, Clause.Type),
+    ConstantAsMetadata::get(B.getInt32(Clause.NumDescriptors)),
+    ConstantAsMetadata::get(B.getInt32(Clause.Register.Number)),
+    ConstantAsMetadata::get(B.getInt32(Clause.Space)),
+    ConstantAsMetadata::get(B.getInt32(llvm::to_underlying(Clause.Offset))),
+    ConstantAsMetadata::get(B.getInt32(llvm::to_underlying(Clause.Flags))),
+  });
 }
 
 } // namespace root_signature

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -64,7 +64,16 @@ MDNode *MetadataBuilder::BuildRootSignature() {
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
-  return MDNode::get(Ctx, {MDString::get(Ctx, "DescriptorTable")});
+  IRBuilder<> B(Ctx);
+  SmallVector<Metadata *> TableOperands;
+  TableOperands.push_back(MDString::get(Ctx, "DescriptorTable"));
+  TableOperands.push_back(ConstantAsMetadata::get(B.getInt32(llvm::to_underlying(Table.Visibility))));
+
+  assert(Table.NumClauses <= GeneratedMetadata.size() && "Table expected all owned clauses to be generated already");
+  TableOperands.append(GeneratedMetadata.end() - Table.NumClauses, GeneratedMetadata.end());
+  GeneratedMetadata.pop_back_n(Table.NumClauses);
+
+  return MDNode::get(Ctx, TableOperands);
 }
 
 MDNode *MetadataBuilder::BuildDescriptorTableClause(const DescriptorTableClause &Clause) {

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -1,0 +1,77 @@
+//===- HLSLRootSignature.cpp - HLSL Root Signature helper objects ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file This file contains helpers for working with HLSL Root Signatures.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Frontend/HLSL/HLSLRootSignature.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+namespace llvm {
+namespace hlsl {
+namespace root_signature {
+
+static MDString *ClauseTypeToName(LLVMContext &Ctx, ClauseType Type) {
+  StringRef Name;
+  switch (Type) {
+  case ClauseType::CBuffer:
+    Name = "CBV";
+    break;
+  case ClauseType::SRV:
+    Name = "SRV";
+    break;
+  case ClauseType::UAV:
+    Name = "UAV";
+    break;
+  case ClauseType::Sampler:
+    Name = "Sampler";
+    break;
+  }
+  return MDString::get(Ctx, Name);
+}
+
+// Helper struct so that we can use the overloaded notation of std::visit
+template <class... Ts> struct OverloadBuilds : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts> OverloadBuilds(Ts...) -> OverloadBuilds<Ts...>;
+
+MDNode *MetadataBuilder::BuildRootSignature() {
+  for (const RootElement &Element : Elements) {
+    MDNode *ElementMD =
+      std::visit(
+        OverloadBuilds{
+            [&](DescriptorTable Table) -> MDNode * {
+              return BuildDescriptorTable(Table);
+            },
+            [&](DescriptorTableClause Clause) -> MDNode * {
+              return BuildDescriptorTableClause(Clause);
+            },
+        },
+        Element);
+    GeneratedMetadata.push_back(ElementMD);
+  }
+
+  return MDNode::get(Ctx, GeneratedMetadata);
+}
+
+MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
+  return MDNode::get(Ctx, {MDString::get(Ctx, "DescriptorTable")});
+}
+
+MDNode *MetadataBuilder::BuildDescriptorTableClause(const DescriptorTableClause &Clause) {
+  return MDNode::get(Ctx, {ClauseTypeToName(Ctx, Clause.Type)});
+}
+
+} // namespace root_signature
+} // namespace hlsl
+} // namespace llvm
+


### PR DESCRIPTION
- Define and implement `MetadataBuilder` in `HLSLRootSignature`
- Integrate and invoke the builder in `CGHLSLRuntime.cpp` to generate the Root Signature for any associated entry functions
- Add tests to demonstrate functionality in `RootSignature.hlsl`

Resolves https://github.com/llvm/llvm-project/issues/126584