### PR TITLE
[lldb-dap] Partially reverting OutputRedirector changes.

### DIFF
--- a/lldb/tools/lldb-dap/OutputRedirector.h
+++ b/lldb/tools/lldb-dap/OutputRedirector.h
@@ -20,6 +20,8 @@ namespace lldb_dap {
 
 class OutputRedirector {
 public:
+  static int kInvalidDescriptor;
+
   /// Creates writable file descriptor that will invoke the given callback on
   /// each write in a background thread.
   ///
@@ -33,13 +35,13 @@ public:
 
   ~OutputRedirector() { Stop(); }
 
-  OutputRedirector() = default;
+  OutputRedirector();
   OutputRedirector(const OutputRedirector &) = delete;
   OutputRedirector &operator=(const OutputRedirector &) = delete;
 
 private:
   std::atomic<bool> m_stopped = false;
-  lldb_private::Pipe m_pipe;
+  int m_fd;
   std::thread m_forwarder;
 };
 


### PR DESCRIPTION
I just noticed with these changes lldb-dap was using 200% of my CPU and root causing the issue it seems that lldb_private::Pipe::Read() (without a timeout) is using a timeout of `std::chrono::microseconds::zero()` which ends up setting the SelectHelper  timeout to `now + 0` (see https://github.com/llvm/llvm-project/blob/7ceef1b1824073fcfd4724539f5942442da1a9c2/lldb/source/Host/posix/PipePosix.cpp#L314 and https://github.com/llvm/llvm-project/blob/7ceef1b1824073fcfd4724539f5942442da1a9c2/lldb/source/Utility/SelectHelper.cpp#L46) which causes SelectHelper to return immediately with a timeout error. As a result the `lldb_dap::OutputRedirector::RedirectTo()` to turn into a busy loop.

Additionally, the 'read' call is waiting until the output buffer is full before returning, which prevents any partial output (see https://github.com/llvm/llvm-project/blob/7ceef1b1824073fcfd4724539f5942442da1a9c2/lldb/source/Host/posix/PipePosix.cpp#L325C9-L326C17).

This is not the desired behavior for lldb-dap. Instead we want a write to the FD to result in a callback to send the DAP Output event, which mean we want partial output.

To mitigate this, I'm reverting the reading operation to the previous behavior before 873426bea3dd67d80dd10650e64e91c69796614f but keeping the refactored structure and thread management.