### PR TITLE
[mlir] ArithToLLVM: fix memref bitcast lowering

### DIFF
--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -54,7 +54,8 @@ struct ConstrainedVectorConvertToLLVMPattern
   }
 };
 
-/// No-op bitcast.
+/// No-op bitcast. Propagate type input arg if converted source and dest types
+/// are the same.
 struct IdentityBitcastLowering final
     : public OpConversionPattern<arith::BitcastOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -63,7 +64,8 @@ struct IdentityBitcastLowering final
   matchAndRewrite(arith::BitcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Value src = adaptor.getIn();
-    if (src.getType() != getTypeConverter()->convertType(op.getType()))
+    Type resultType = getTypeConverter()->convertType(op.getType());
+    if (src.getType() != resultType)
       return rewriter.notifyMatchFailure(op, "Types are different");
 
     rewriter.replaceOp(op, src);

--- a/mlir/lib/Conversion/LLVMCommon/VectorPattern.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/VectorPattern.cpp
@@ -103,6 +103,11 @@ LogicalResult LLVM::detail::handleMultidimensionalVectors(
   return success();
 }
 
+static bool isVectorCompatibleType(Type type) {
+  return isa<LLVM::LLVMArrayType, VectorType, IntegerType, FloatType>(type) &&
+         LLVM::isCompatibleType(type);
+}
+
 LogicalResult LLVM::detail::vectorOneToOneRewrite(
     Operation *op, StringRef targetOp, ValueRange operands,
     ArrayRef<NamedAttribute> targetAttrs,
@@ -111,7 +116,7 @@ LogicalResult LLVM::detail::vectorOneToOneRewrite(
   assert(!operands.empty());
 
   // Cannot convert ops if their operands are not of LLVM type.
-  if (!llvm::all_of(operands.getTypes(), isCompatibleType))
+  if (!llvm::all_of(operands.getTypes(), isVectorCompatibleType))
     return failure();
 
   auto llvmNDVectorTy = operands[0].getType();

--- a/mlir/lib/Conversion/LLVMCommon/VectorPattern.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/VectorPattern.cpp
@@ -104,6 +104,8 @@ LogicalResult LLVM::detail::handleMultidimensionalVectors(
 }
 
 static bool isVectorCompatibleType(Type type) {
+  // Limit `vectorOneToOneRewrite` to scalar and vector types (and to
+  // `LLVM::LLVMArrayType` which have a special handling).
   return isa<LLVM::LLVMArrayType, VectorType, IntegerType, FloatType>(type) &&
          LLVM::isCompatibleType(type);
 }

--- a/mlir/lib/Conversion/LLVMCommon/VectorPattern.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/VectorPattern.cpp
@@ -106,7 +106,8 @@ LogicalResult LLVM::detail::handleMultidimensionalVectors(
 static bool isVectorCompatibleType(Type type) {
   // Limit `vectorOneToOneRewrite` to scalar and vector types (and to
   // `LLVM::LLVMArrayType` which have a special handling).
-  return isa<LLVM::LLVMArrayType, VectorType, IntegerType, FloatType>(type) &&
+  return isa<LLVM::LLVMArrayType, LLVM::LLVMPointerType, VectorType,
+             IntegerType, FloatType>(type) &&
          LLVM::isCompatibleType(type);
 }
 

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -727,3 +727,15 @@ func.func @ops_supporting_overflow(%arg0: i64, %arg1: i64) {
   %3 = arith.shli %arg0, %arg1 overflow<nsw, nuw> : i64
   return
 }
+
+// -----
+
+// CHECK-LABEL: func @memref_bitcast
+//  CHECK-SAME:   (%[[ARG:.*]]: memref<?xi16>)
+//       CHECK:   %[[V1:.*]] = builtin.unrealized_conversion_cast %[[ARG]] : memref<?xi16> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+//       CHECK:   %[[V2:.*]] = builtin.unrealized_conversion_cast %[[V1]] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)> to memref<?xbf16>
+//       CHECK:   return %[[V2]]
+func.func @memref_bitcast(%1: memref<?xi16>) -> memref<?xbf16> {
+  %2 = arith.bitcast %1 : memref<?xi16> to memref<?xbf16>
+  func.return %2 : memref<?xbf16>
+}


### PR DESCRIPTION
`arith.bitcast` is allowed on memrefs and such code can actually be generated by IREE `ConvertBf16ArithToF32Pass`. `LLVM::detail::vectorOneToOneRewrite` doesn't properly check its types and will generate bitcast between structs which is illegal. 

With the opaque pointers this is a no-op operation for memref so we can just add type check in `LLVM::detail::vectorOneToOneRewrite` and add a separate pattern which removes op if converted types are the same.