### PR TITLE
[lldb-dap] Fix build failure on Windows.

### DIFF
--- a/lldb/tools/lldb-dap/IOStream.h
+++ b/lldb/tools/lldb-dap/IOStream.h
@@ -10,13 +10,8 @@
 #define LLDB_TOOLS_LLDB_DAP_IOSTREAM_H
 
 #if defined(_WIN32)
-// We need to #define NOMINMAX in order to skip `min()` and `max()` macro
-// definitions that conflict with other system headers.
-// We also need to #undef GetObject (which is defined to GetObjectW) because
-// the JSON code we use also has methods named `GetObject()` and we conflict
-// against these.
-#define NOMINMAX
-#include <windows.h>
+#include "lldb/Host/windows/windows.h"
+#include <winsock2.h>
 #else
 typedef int SOCKET;
 #endif


### PR DESCRIPTION
A previous change is triggering a failure due to SOCKET not being defined in IOStream.h. Adjusting the Windows includes to correct the imports and using a more narrow import (winsock2.h vs windows.h).

Also removed a stale comment.

Tested this on an x86_64 wins 11 vm.

This should fix https://lab.llvm.org/buildbot/#/builders/197/builds/1379 and https://lab.llvm.org/buildbot/#/builders/141/builds/5878