### PR TITLE
[AMDGPU] Only run `AMDGPUPrintfRuntimeBindingPass` at non-prelink phase

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -791,7 +791,8 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
   PB.registerPipelineEarlySimplificationEPCallback(
       [](ModulePassManager &PM, OptimizationLevel Level,
          ThinOrFullLTOPhase Phase) {
-        PM.addPass(AMDGPUPrintfRuntimeBindingPass());
+        if (!isLTOPreLink(Phase))
+          PM.addPass(AMDGPUPrintfRuntimeBindingPass());
 
         if (Level == OptimizationLevel::O0)
           return;

--- a/llvm/test/CodeGen/AMDGPU/print-pipeline-passes.ll
+++ b/llvm/test/CodeGen/AMDGPU/print-pipeline-passes.ll
@@ -14,6 +14,7 @@
 
 ; PRE-NOT: internalize
 ; PRE-NOT: amdgpu-attributor
+; PRE-NOT: printfToRuntime
 
 define amdgpu_kernel void @kernel() {
 entry:


### PR DESCRIPTION
The pass is registered in a pipeline that will run at none LTO, LTO prelink, as
well as LTO postlink phase. It uses the _current_ number of metadata operands as
unique id for printf handling. However, if two TUs both have `printf`, their
unique id will be starting with 1. After they are linked together, the id is no
longer unique anymore. To resolve this issue, the pass should not run at LTO pre
link stage.