### PR TITLE
[libc] Add the `<endian.h>` header.

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -4,6 +4,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.ctype
     libc.include.dlfcn
     libc.include.elf
+    libc.include.endian
     libc.include.errno
     libc.include.features
     libc.include.fenv

--- a/libc/config/linux/x86_64/headers.txt
+++ b/libc/config/linux/x86_64/headers.txt
@@ -5,6 +5,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.dirent
     libc.include.dlfcn
     libc.include.elf
+    libc.include.endian
     libc.include.errno
     libc.include.fcntl
     libc.include.features

--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -39,6 +39,7 @@ if (SPHINX_FOUND)
       assert
       cpio
       ctype
+      endian
       errno
       fenv
       float

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -10,6 +10,7 @@ Implementation Status
    complex
    cpio
    ctype
+   endian
    errno
    fenv
    float

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -74,6 +74,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  endian
+  ../libc/include/endian.yaml
+  endian.h
+  DEPENDS
+    .llvm-libc-macros.endian_macros
+    .llvm_libc_common_h
+)
+
+add_header_macro(
   features
   ../libc/include/features.yaml
   features.h

--- a/libc/include/endian.h.def
+++ b/libc/include/endian.h.def
@@ -1,4 +1,4 @@
-//===-- System V header endian.h ------------------------------------------===//
+//===-- POSIX header endian.h ---------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/libc/include/endian.h.def
+++ b/libc/include/endian.h.def
@@ -1,0 +1,17 @@
+//===-- System V header endian.h ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_ENDIAN_H
+#define LLVM_LIBC_ENDIAN_H
+
+#include "__llvm-libc-common.h"
+#include "llvm-libc-macros/endian-macros.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_ENDIAN_H

--- a/libc/include/endian.yaml
+++ b/libc/include/endian.yaml
@@ -1,0 +1,9 @@
+header: endian.h
+header_template: endian.h.def
+standards:
+  - POSIX
+macros: []
+types: []
+enums: []
+objects: []
+functions: []

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -311,6 +311,12 @@ add_macro_header(
 )
 
 add_macro_header(
+  endian_macros
+  HDR
+    endian-macros.h
+)
+
+add_macro_header(
   locale_macros
   HDR
     locale-macros.h

--- a/libc/include/llvm-libc-macros/endian-macros.h
+++ b/libc/include/llvm-libc-macros/endian-macros.h
@@ -1,0 +1,16 @@
+//===-- Definition of macros from endian.h --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_ENDIAN_MACROS_H
+#define LLVM_LIBC_MACROS_ENDIAN_MACROS_H
+
+#define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#define BYTE_ORDER __BYTE_ORDER__
+
+#endif // LLVM_LIBC_MACROS_ENDIAN_MACROS_H

--- a/libc/utils/docgen/endian.yaml
+++ b/libc/utils/docgen/endian.yaml
@@ -5,4 +5,28 @@ macros:
     in-latest-posix: ''
   BYTE_ORDER:
     in-latest-posix: ''
+  be16toh:
+    in-latest-posix: ''
+  be32toh:
+    in-latest-posix: ''
+  be64toh:
+    in-latest-posix: ''
+  htobe16:
+    in-latest-posix: ''
+  htobe32:
+    in-latest-posix: ''
+  htobe64:
+    in-latest-posix: ''
+  htole16:
+    in-latest-posix: ''
+  htole32:
+    in-latest-posix: ''
+  htole64:
+    in-latest-posix: ''
+  le16toh:
+    in-latest-posix: ''
+  le32toh:
+    in-latest-posix: ''
+  le64toh:
+    in-latest-posix: ''
 

--- a/libc/utils/docgen/endian.yaml
+++ b/libc/utils/docgen/endian.yaml
@@ -1,0 +1,8 @@
+macros:
+  LITTLE_ENDIAN:
+    in-latest-posix: ''
+  BIG_ENDIAN:
+    in-latest-posix: ''
+  BYTE_ORDER:
+    in-latest-posix: ''
+


### PR DESCRIPTION
Closes [#124631](https://github.com/llvm/llvm-project/issues/124631).
ref: https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/endian.h.html

This patch adds the implementation of `endian.h`, which includes the header itself and three related macros. These macros in the header rely on the compiler preprocessor, similar to how https://github.com/llvm/llvm-project/blob/main/libc/src/__support/endian_internal.h does. Hopefully this will meet the requirements for compiling llvm with llvm-libc.