### PR TITLE
[RISCV] Rename Mips instruction records to start with MIPS_. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXMips.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXMips.td
@@ -109,61 +109,52 @@ class SWPFormat<dag outs, dag ins, string opcodestr, string argstr>
 
 let Predicates = [HasVendorXMIPSCMove], hasSideEffects = 0, mayLoad = 0, mayStore = 0,
                  DecoderNamespace = "Xmipscmove" in {
-def CCMOV : RVInstR4<0b11, 0b011, OPC_CUSTOM_0, (outs GPR:$rd),
-                     (ins GPR:$rs1, GPR:$rs2, GPR:$rs3),
-                    "mips.ccmov", "$rd, $rs2, $rs1, $rs3">,
-           Sched<[]>;
+def MIPS_CCMOV : RVInstR4<0b11, 0b011, OPC_CUSTOM_0, (outs GPR:$rd),
+                          (ins GPR:$rs1, GPR:$rs2, GPR:$rs3),
+                          "mips.ccmov", "$rd, $rs2, $rs1, $rs3">,
+                 Sched<[]>;
 }
 
 let Predicates = [UseCCMovInsn] in {
 def : Pat<(select (XLenVT (setne (XLenVT GPR:$rs2), (XLenVT 0))),
                   (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
-          (CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
 def : Pat<(select (XLenVT (setne (XLenVT GPR:$x), (XLenVT simm12_plus1:$y))),
                   (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
-          (CCMOV GPR:$rs1, (ADDI GPR:$x, (NegImm simm12_plus1:$y)), GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, (ADDI GPR:$x, (NegImm simm12_plus1:$y)), GPR:$rs3)>;
 def : Pat<(select (XLenVT (setne (XLenVT GPR:$x), (XLenVT GPR:$y))),
                   (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
-          (CCMOV GPR:$rs1, (XOR GPR:$x, GPR:$y), GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, (XOR GPR:$x, GPR:$y), GPR:$rs3)>;
 def : Pat<(select (XLenVT (seteq (XLenVT GPR:$rs2), (XLenVT 0))),
                   (XLenVT GPR:$rs3), (XLenVT GPR:$rs1)),
-          (CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
 def : Pat<(select (XLenVT (seteq (XLenVT GPR:$x), (XLenVT simm12_plus1:$y))),
                   (XLenVT GPR:$rs3), (XLenVT GPR:$rs1)),
-          (CCMOV GPR:$rs1, (ADDI GPR:$x, (NegImm simm12_plus1:$y)), GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, (ADDI GPR:$x, (NegImm simm12_plus1:$y)), GPR:$rs3)>;
 def : Pat<(select (XLenVT (seteq (XLenVT GPR:$x), (XLenVT GPR:$y))),
                   (XLenVT GPR:$rs3), (XLenVT GPR:$rs1)),
-          (CCMOV GPR:$rs1, (XOR GPR:$x, GPR:$y), GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, (XOR GPR:$x, GPR:$y), GPR:$rs3)>;
 def : Pat<(select (XLenVT GPR:$rs2), (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
-          (CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
+          (MIPS_CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
 }
 
 let Predicates = [HasVendorXMIPSLSP], hasSideEffects = 0,
                  DecoderNamespace = "Xmipslsp" in {
+let mayLoad = 1, mayStore = 0 in {
+def MIPS_LWP : LWPFormat<(outs GPR:$rd1, GPR:$rd2), (ins GPR:$rs1, uimm7_lsb00:$imm7),
+                         "mips.lwp", "$rd1, $rd2, ${imm7}(${rs1})">,
+               Sched<[WriteLDW, WriteLDW, ReadMemBase]>;
+def MIPS_LDP : LDPFormat<(outs GPR:$rd1, GPR:$rd2), (ins GPR:$rs1, uimm7_lsb000:$imm7),
+                         "mips.ldp", "$rd1, $rd2, ${imm7}(${rs1})">,
+               Sched<[WriteLDD, WriteLDD, ReadMemBase]>;
+} // mayLoad = 1, mayStore = 0
 
-def LWP : LWPFormat<(outs GPR:$rd1, GPR:$rd2), (ins GPR:$rs1, uimm7_lsb00:$imm7),
-                    "mips.lwp", "$rd1, $rd2, ${imm7}(${rs1})">,
-          Sched<[WriteLDW, WriteLDW, ReadMemBase]> {
-  let mayLoad = 1;
-  let mayStore = 0;
-}
-def LDP : LDPFormat<(outs GPR:$rd1, GPR:$rd2), (ins GPR:$rs1, uimm7_lsb000:$imm7),
-                    "mips.ldp", "$rd1, $rd2, ${imm7}(${rs1})">,
-          Sched<[WriteLDD, WriteLDD, ReadMemBase]> {
-  let mayLoad = 1;
-  let mayStore = 0;
-}
-def SWP : SWPFormat<(outs), (ins GPR:$rs2, GPR:$rs3, GPR:$rs1, uimm7_lsb00:$imm7),
-                    "mips.swp", "$rs2, $rs3, ${imm7}(${rs1})">,
-          Sched<[WriteSTW, ReadStoreData, ReadStoreData, ReadMemBase]> {
-  let mayLoad = 0;
-  let mayStore = 1;
-}
-def SDP : SDPFormat<(outs), (ins GPR:$rs2, GPR:$rs3, GPR:$rs1, uimm7_lsb000:$imm7),
-                    "mips.sdp", "$rs2, $rs3, ${imm7}(${rs1})">,
-          Sched<[WriteSTD, ReadStoreData, ReadStoreData, ReadMemBase]> {
-  let mayLoad = 0;
-  let mayStore = 1;
-}
-
-}
+let mayLoad = 0, mayStore = 1 in {
+def MIPS_SWP : SWPFormat<(outs), (ins GPR:$rs2, GPR:$rs3, GPR:$rs1, uimm7_lsb00:$imm7),
+                         "mips.swp", "$rs2, $rs3, ${imm7}(${rs1})">,
+               Sched<[WriteSTW, ReadStoreData, ReadStoreData, ReadMemBase]>;
+def MIPS_SDP : SDPFormat<(outs), (ins GPR:$rs2, GPR:$rs3, GPR:$rs1, uimm7_lsb000:$imm7),
+                         "mips.sdp", "$rs2, $rs3, ${imm7}(${rs1})">,
+               Sched<[WriteSTD, ReadStoreData, ReadStoreData, ReadMemBase]>;
+} // mayLoad = 0, mayStore = 1
+} // Predicates = [HasVendorXMIPSLSP], hasSideEffects = 0, DecoderNamespace = "Xmipslsp"


### PR DESCRIPTION
This matches established conventions and avoids potential future conflicts with standard instructions.