### PR TITLE
[libc] generate sys/wait.h for aarch64

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -27,6 +27,7 @@ set(TARGET_PUBLIC_HEADERS
     libc.include.sys_socket
     libc.include.sys_syscall
     libc.include.sys_time
+    libc.include.sys_wait
     libc.include.threads
     libc.include.time
     libc.include.unistd


### PR DESCRIPTION
Fixes: #125102 