### PR TITLE
[RISCV] Fix Enum for Custom Vendor CSR encodings

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -19,6 +19,9 @@ include "llvm/TableGen/SearchableTable.td"
 
 class SysReg<string name, bits<12> op> {
   string Name = name;
+  // Custom vendor CSRs have a "<vendor>." prefix. Convert these to "<vendor>_"
+  // before passing it to the SysRegEncodings GenericEnum below.
+  string EnumName = !subst(".", "_", name);
   bits<12> Encoding = op;
   // FIXME: add these additional fields when needed.
   // Privilege Access: Read and Write = 0, 1, 2; Read-Only = 3.
@@ -50,7 +53,7 @@ def SysRegsList : GenericTable {
 
 def SysRegEncodings : GenericEnum {
   let FilterClass = "SysReg";
-  let NameField = "Name";
+  let NameField = "EnumName";
   let ValueField = "Encoding";
 }
 


### PR DESCRIPTION
The enum added in 1401703fe42003745e6937efa13078b462a9d706 does not work for custom vendor CSRs due to the presence of a "." in the `<vendor>.<csr>` naming scheme required by the toolchain convention.

Fix this by adding a new EnumName to the SysReg class which replaces the "." with and "_" before passing it to tablegen.