### PR TITLE
workflows/premerge: Enable macos builds

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -5,8 +5,6 @@ permissions:
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/premerge.yaml
   push:
     branches:
       - 'main'
@@ -14,7 +12,7 @@ on:
 
 jobs:
   premerge-checks-linux:
-    if: github.repository_owner == 'llvm'
+    if: false && github.repository_owner == 'llvm'
     runs-on: llvm-premerge-linux-runners
     concurrency:
       group: ${{ github.workflow }}-linux-${{ github.event.pull_request.number || github.sha }}
@@ -73,7 +71,7 @@ jobs:
           ./.ci/monolithic-linux.sh "$(echo ${linux_projects} | tr ' ' ';')" "$(echo ${linux_check_targets})" "$(echo ${linux_runtimes} | tr ' ' ';')" "$(echo ${linux_runtime_check_targets})"
 
   premerge-checks-windows:
-    if: github.repository_owner == 'llvm'
+    if: false && github.repository_owner == 'llvm'
     runs-on: llvm-premerge-windows-runners
     concurrency:
       group: ${{ github.workflow }}-windows-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -136,8 +136,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-macos-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
-    if: >- 
-      github.repository_owner == 'llvm'
+    if: >-
+      github.repository_owner == 'llvm' &&
+      (startswith(github.ref_name, 'release/') ||
+       startswith(github.base_ref, 'release/'))
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@v4

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -136,9 +136,8 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-macos-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
-    if: >-
-      (startswith(github.ref_name, 'release/') ||
-       startswith(github.base_ref, 'refs/heads/release/'))
+    if: >- 
+      github.repository_owner == 'llvm'
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@v4
@@ -152,6 +151,8 @@ jobs:
         uses: llvm/actions/install-ninja@main
       - name: Build and Test
         run: |
+          echo $GITHUB_REF_NAME
+          echo $GITHUB_BASE_REF
           modified_files=$(git diff --name-only HEAD~1...HEAD)
           modified_dirs=$(echo "$modified_files" | cut -d'/' -f1 | sort -u)
 

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -153,8 +153,6 @@ jobs:
         uses: llvm/actions/install-ninja@main
       - name: Build and Test
         run: |
-          echo $GITHUB_REF_NAME
-          echo $GITHUB_BASE_REF
           modified_files=$(git diff --name-only HEAD~1...HEAD)
           modified_dirs=$(echo "$modified_files" | cut -d'/' -f1 | sort -u)
 


### PR DESCRIPTION
We still have buildkite for testing Linux and Windows, so we don't need to enable those builds yet.