### PR TITLE
[flang] Fix building on aarch64 *BSD and musl libc after 9d8dc45d17088300e9e2086594ca581b119193c8

### DIFF
--- a/flang/runtime/exceptions.cpp
+++ b/flang/runtime/exceptions.cpp
@@ -11,7 +11,7 @@
 #include "flang/Runtime/exceptions.h"
 #include "terminator.h"
 #include <cfenv>
-#if defined(__aarch64__) && !defined(_WIN32)
+#if defined(__aarch64__) && defined(__GLIBC__)
 #include <fpu_control.h>
 #elif defined(__x86_64__) && !defined(_WIN32)
 #include <xmmintrin.h>


### PR DESCRIPTION
The fpu_control.h header appears to be GLIBC specific.