### PR TITLE
[MLIR][doc] Fix docs for IRDL using -gen-dialect-doc

### DIFF
--- a/mlir/include/mlir/Dialect/IRDL/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/IRDL/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(IRDL irdl)
-add_mlir_doc(IRDLOps IRDL Dialects/ -gen-dialect-doc)
+add_mlir_doc(IRDLOps IRDL Dialects/ -gen-dialect-doc -dialect=irdl)
 
 # Add IRDL interfaces
 set(LLVM_TARGET_DEFINITIONS IRDLInterfaces.td)


### PR DESCRIPTION
mlir-tblgen fails to generate doc for IRDL because while parsing IRDL.td
it also finds the definition of the builtin dialect and cannot determine
what dialect to generate documentation for. This is because IRDL.td
includes IRDLOps.td which includes BuiltinAttributes.td which in turns
includes BuiltinDialect.td.
