### PR TITLE
[GlobalOpt] Look through non-PointerType constant expressions.

### DIFF
--- a/llvm/test/Transforms/GlobalOpt/cleanup-pointer-root-users-ptrtoint-add-constexpr.ll
+++ b/llvm/test/Transforms/GlobalOpt/cleanup-pointer-root-users-ptrtoint-add-constexpr.ll
@@ -12,8 +12,6 @@ declare i32 @fn1()
 define void @stores_single_use_gep_constexpr() {
 ; CHECK-LABEL: @stores_single_use_gep_constexpr(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store ptr @fn0, ptr @global.20ptr, align 8
-; CHECK-NEXT:    store ptr @fn1, ptr getelementptr inbounds ([[STRUCT_GLOBAL_20PTR:%.*]], ptr @global.20ptr, i64 0, i32 1), align 8
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/Transforms/GlobalOpt/read-with-constexpr-users.ll
+++ b/llvm/test/Transforms/GlobalOpt/read-with-constexpr-users.ll
@@ -5,15 +5,14 @@
 @H = internal global [2 x i64 ] zeroinitializer
 
 ;.
-; CHECK: @G = internal global [2 x i64] zeroinitializer
+; CHECK: @G = internal constant [2 x i64] zeroinitializer
 ; CHECK: @H = internal global [2 x i64] zeroinitializer
 ;.
 define i64 @G_used_by_gep_inttoptr_exprs() {
 ; CHECK-LABEL: define i64 @G_used_by_gep_inttoptr_exprs() local_unnamed_addr {
-; CHECK-NEXT:    [[L:%.*]] = load i64, ptr @G, align 8
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr inttoptr (i64 add (i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @G, i64 16) to i64), i64 8) to ptr), i64 1
 ; CHECK-NEXT:    [[C:%.*]] = icmp eq ptr [[GEP]], @G
-; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C]], i64 [[L]], i64 9
+; CHECK-NEXT:    [[SEL:%.*]] = select i1 [[C]], i64 0, i64 9
 ; CHECK-NEXT:    ret i64 [[SEL]]
 ;
   %l = load i64, ptr @G, align 8


### PR DESCRIPTION
Allow looking through constant expressions. Constant expressions cannot read, modify or leak the global themselves.

I might be missing something, but using analyzeGlobalAux should ensure all (instruction) users that may read, modify or leak the global are checked.

This fixes another regression exposed by
https://github.com/llvm/llvm-project/pull/123518.