### PR TITLE
[mlir] Translating task_reduction clause for pass-by-value vars to LLVMIR

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPClauses.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPClauses.td
@@ -1388,6 +1388,14 @@ class OpenMP_TaskReductionClauseSkip<
     OptionalAttr<SymbolRefArrayAttr>:$task_reduction_syms
   );
 
+  let extraClassDeclaration = [{
+        /// Returns the number of reduction variables.
+	unsigned getNumReductionVars() { return getTaskReductionVars().size(); }
+
+        /// Returns the reduction symbols
+	auto getReductionSyms() { return getTaskReductionSyms(); }
+  }];
+
   let description = [{
     The `task_reduction` clause specifies a reduction among tasks. For each list
     item, the number of copies is unspecified. Any copies associated with the

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPClauses.td
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPClauses.td
@@ -1389,11 +1389,11 @@ class OpenMP_TaskReductionClauseSkip<
   );
 
   let extraClassDeclaration = [{
-        /// Returns the number of reduction variables.
-	unsigned getNumReductionVars() { return getTaskReductionVars().size(); }
+    /// Returns the number of reduction variables.
+    unsigned getNumReductionVars() { return getTaskReductionVars().size(); }
 
-        /// Returns the reduction symbols
-	auto getReductionSyms() { return getTaskReductionSyms(); }
+    /// Returns the reduction symbols
+    auto getReductionSyms() { return getTaskReductionSyms(); }
   }];
 
   let description = [{

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2539,18 +2539,17 @@ static llvm::Value *createTaskReductionFunction(
   if (region.empty())
     bbBuilder.CreateRet(arg0); // Return from the function
   return function;
-}
 
-SmallVector<llvm::Value *, 1> phis;
-if (failed(inlineConvertOmpRegions(region, "", bbBuilder, moduleTranslation,
-                                   &phis)))
-  return nullptr;
-assert(
-    phis.size() == 1 &&
-    "expected one value to be yielded from the reduction declaration region");
-bbBuilder.CreateStore(phis[0], arg0);
-bbBuilder.CreateRet(arg0); // Return from the function
-return function;
+  SmallVector<llvm::Value *, 1> phis;
+  if (failed(inlineConvertOmpRegions(region, "", bbBuilder, moduleTranslation,
+                                     &phis)))
+    return nullptr;
+  assert(
+      phis.size() == 1 &&
+      "expected one value to be yielded from the reduction declaration region");
+  bbBuilder.CreateStore(phis[0], arg0);
+  bbBuilder.CreateRet(arg0); // Return from the function
+  return function;
 }
 
 void emitTaskRedInitCall(

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2538,19 +2538,19 @@ static llvm::Value *createTaskReductionFunction(
   // Emit an empty function body in case of empty region
   if (region.empty())
     bbBuilder.CreateRet(arg0); // Return from the function
-    return function;
+  return function;
 }
 
-  SmallVector<llvm::Value *, 1> phis;
-  if (failed(inlineConvertOmpRegions(region, "", bbBuilder, moduleTranslation,
-                                     &phis)))
-    return nullptr;
-  assert(
-      phis.size() == 1 &&
-      "expected one value to be yielded from the reduction declaration region");
-  bbBuilder.CreateStore(phis[0], arg0);
-  bbBuilder.CreateRet(arg0); // Return from the function
-  return function;
+SmallVector<llvm::Value *, 1> phis;
+if (failed(inlineConvertOmpRegions(region, "", bbBuilder, moduleTranslation,
+                                   &phis)))
+  return nullptr;
+assert(
+    phis.size() == 1 &&
+    "expected one value to be yielded from the reduction declaration region");
+bbBuilder.CreateStore(phis[0], arg0);
+bbBuilder.CreateRet(arg0); // Return from the function
+return function;
 }
 
 void emitTaskRedInitCall(

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2536,9 +2536,10 @@ static llvm::Value *createTaskReductionFunction(
   }
 
   // Emit an empty function body in case of empty region
-  if (region.empty())
+  if (region.empty()) {
     bbBuilder.CreateRet(arg0); // Return from the function
-  return function;
+    return function;
+  }
 
   SmallVector<llvm::Value *, 1> phis;
   if (failed(inlineConvertOmpRegions(region, "", bbBuilder, moduleTranslation,

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -2610,7 +2610,7 @@ static LogicalResult allocAndInitializeTaskReductionVars(
       llvm::PointerType::get(Context,
                              DL.getProgramAddressSpace()); // void*
   llvm::Type *SizeTy = DL.getIntPtrType(Context);          // size_t
-  llvm::Type *FlagsTy = llvm::Type::getInt32Ty(Context); // flags (i32)
+  llvm::Type *FlagsTy = llvm::Type::getInt32Ty(Context);   // flags (i32)
 
   // Structure members
   std::vector<llvm::Type *> structMembers = {

--- a/mlir/test/Target/LLVMIR/openmp-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-llvm.mlir
@@ -3093,7 +3093,7 @@ llvm.func @omp_taskgroup_task(%x: i32, %y: i32, %zaddr: !llvm.ptr) {
 // CHECK: %[[REDUCE_COMB:.*]] = getelementptr inbounds nuw %kmp_taskred_input_t, ptr %[[RED_ELEMENT]], i32 0, i32 5
 // CHECK: store ptr @red_comb, ptr %[[REDUCE_COMB]], align 8
 // CHECK: %[[FLAGS:.*]] = getelementptr inbounds nuw %kmp_taskred_input_t, ptr %[[RED_ELEMENT]], i32 0, i32 6
-// CHECK: store i64 0, ptr %[[FLAGS]], align 4
+// CHECK: store i32 0, ptr %[[FLAGS]], align 4
 // CHECK: %omp_global_thread_num1 = call i32 @__kmpc_global_thread_num(ptr @1)
 // CHECK: %[[INIT:.*]] = call ptr @__kmpc_taskred_init(i32 %omp_global_thread_num1, i32 1, ptr %kmp_taskred_array)
 
@@ -3152,7 +3152,7 @@ llvm.func @_QPtaskred_integer_arg() {
 // CHECK: %[[REDUCE_COMB:.*]] = getelementptr inbounds nuw %kmp_taskred_input_t, ptr %[[RED_ELEMENT]], i32 0, i32 5
 // CHECK: store ptr @red_comb, ptr %[[REDUCE_COMB]], align 8
 // CHECK: %[[FLAGS:.*]] = getelementptr inbounds nuw %kmp_taskred_input_t, ptr %[[RED_ELEMENT]], i32 0, i32 6
-// CHECK: store i64 0, ptr %[[FLAGS]], align 4
+// CHECK: store i32 0, ptr %[[FLAGS]], align 4
 // CHECK: %omp_global_thread_num1 = call i32 @__kmpc_global_thread_num(ptr @1)
 // CHECK: %[[INIT:.*]] = call ptr @__kmpc_taskred_init(i32 %omp_global_thread_num1, i32 1, ptr %kmp_taskred_array)
 
@@ -3214,7 +3214,7 @@ llvm.func @_QPfloat_arg() {
 // CHECK: %[[REDUCE_COMB:.*]] = getelementptr inbounds nuw %kmp_taskred_input_t, ptr %[[RED_ELEMENT]], i32 0, i32 5
 // CHECK: store ptr @red_comb, ptr %[[REDUCE_COMB]], align 8
 // CHECK: %[[FLAGS:.*]] = getelementptr inbounds nuw %kmp_taskred_input_t, ptr %[[RED_ELEMENT]], i32 0, i32 6
-// CHECK: store i64 0, ptr %[[FLAGS]], align 4
+// CHECK: store i32 0, ptr %[[FLAGS]], align 4
 // CHECK: %omp_global_thread_num1 = call i32 @__kmpc_global_thread_num(ptr @1)
 // CHECK: %[[INIT:.*]] = call ptr @__kmpc_taskred_init(i32 %omp_global_thread_num1, i32 1, ptr %kmp_taskred_array)
 


### PR DESCRIPTION
This PR adds support for translating task_reduction clause for pass-by-value vars to LLVMIR. A `kmp_taskred_input_t` structure is populated by task reduction specific information: `reduce_shar (void*), reduce_orig (void*), reduce_size (size_t), reduce_init (void*), reduce_fini (void*), reduce_comb (void*), flags (i32)`. Here, `reduce_init` and `reduce_comb` are translated from the clause's `red_init` and `red_comb` regions. `reduce_fini` is optional for task reduction clause.

A todo is added for pass-by-ref variables in task reduction. 