### PR TITLE
Revert "[flang][hlfir] get rid of box when translating scalars to extented value"

### DIFF
--- a/flang/include/flang/Optimizer/Builder/HLFIRTools.h
+++ b/flang/include/flang/Optimizer/Builder/HLFIRTools.h
@@ -125,7 +125,7 @@ public:
   bool isSimplyContiguous() const {
     // If this can be described without a fir.box in FIR, this must
     // be contiguous.
-    if (!hlfir::isBoxAddressOrValueType(getFirBase().getType()) || isScalar())
+    if (!hlfir::isBoxAddressOrValueType(getFirBase().getType()))
       return true;
     // Otherwise, if this entity has a visible declaration in FIR,
     // or is the dereference of an allocatable or contiguous pointer

--- a/flang/test/HLFIR/assign-codegen.fir
+++ b/flang/test/HLFIR/assign-codegen.fir
@@ -427,13 +427,3 @@ func.func @test_upoly_expr_assignment(%arg0: !fir.class<!fir.array<?xnone>> {fir
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
-
-func.func @test_scalar_box(%arg0: f32, %arg1: !fir.box<!fir.ptr<f32>>) {
-  hlfir.assign %arg0 to %arg1 : f32, !fir.box<!fir.ptr<f32>>
-  return
-}
-// CHECK-LABEL:   func.func @test_scalar_box(
-// CHECK-SAME:                               %[[VAL_0:.*]]: f32,
-// CHECK-SAME:                               %[[VAL_1:.*]]: !fir.box<!fir.ptr<f32>>) {
-// CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.ptr<f32>>) -> !fir.ptr<f32>
-// CHECK:           fir.store %[[VAL_0]] to %[[VAL_2]] : !fir.ptr<f32>


### PR DESCRIPTION
Reverts llvm/llvm-project#125059

Broke OPTIONAL lowering for some intrinsics.

I have a proper fix for review https://github.com/llvm/llvm-project/pull/125215, but I would like to better test it, so I am reverting in the meantime.