### PR TITLE
Add overload of DIBuilder::createArrayType

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -588,6 +588,35 @@ namespace llvm {
         PointerUnion<DIExpression *, DIVariable *> Allocated = nullptr,
         PointerUnion<DIExpression *, DIVariable *> Rank = nullptr);
 
+    /// Create debugging information entry for an array.
+    /// \param Scope          Scope in which this enumeration is defined.
+    /// \param Name           Union name.
+    /// \param File           File where this member is defined.
+    /// \param LineNumber     Line number.
+    /// \param Size           Array size.
+    /// \param AlignInBits    Alignment.
+    /// \param Ty             Element type.
+    /// \param Subscripts     Subscripts.
+    /// \param DataLocation   The location of the raw data of a descriptor-based
+    ///                       Fortran array, either a DIExpression* or
+    ///                       a DIVariable*.
+    /// \param Associated     The associated attribute of a descriptor-based
+    ///                       Fortran array, either a DIExpression* or
+    ///                       a DIVariable*.
+    /// \param Allocated      The allocated attribute of a descriptor-based
+    ///                       Fortran array, either a DIExpression* or
+    ///                       a DIVariable*.
+    /// \param Rank           The rank attribute of a descriptor-based
+    ///                       Fortran array, either a DIExpression* or
+    ///                       a DIVariable*.
+    DICompositeType *createArrayType(
+        DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
+        uint64_t Size, uint32_t AlignInBits, DIType *Ty, DINodeArray Subscripts,
+        PointerUnion<DIExpression *, DIVariable *> DataLocation = nullptr,
+        PointerUnion<DIExpression *, DIVariable *> Associated = nullptr,
+        PointerUnion<DIExpression *, DIVariable *> Allocated = nullptr,
+        PointerUnion<DIExpression *, DIVariable *> Rank = nullptr);
+
     /// Create debugging information entry for a vector type.
     /// \param Size         Array size.
     /// \param AlignInBits  Alignment.

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -601,10 +601,21 @@ DIBuilder::createArrayType(uint64_t Size, uint32_t AlignInBits, DIType *Ty,
                            PointerUnion<DIExpression *, DIVariable *> AS,
                            PointerUnion<DIExpression *, DIVariable *> AL,
                            PointerUnion<DIExpression *, DIVariable *> RK) {
+  return createArrayType(nullptr, StringRef(), nullptr, 0, Size, AlignInBits,
+                         Ty, Subscripts, DL, AS, AL, RK);
+}
+
+DICompositeType *DIBuilder::createArrayType(
+    DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
+    uint64_t Size, uint32_t AlignInBits, DIType *Ty, DINodeArray Subscripts,
+    PointerUnion<DIExpression *, DIVariable *> DL,
+    PointerUnion<DIExpression *, DIVariable *> AS,
+    PointerUnion<DIExpression *, DIVariable *> AL,
+    PointerUnion<DIExpression *, DIVariable *> RK) {
   auto *R = DICompositeType::get(
-      VMContext, dwarf::DW_TAG_array_type, "", nullptr, 0, nullptr, Ty, Size,
-      AlignInBits, 0, DINode::FlagZero, Subscripts, 0,
-      /*EnumKind=*/std::nullopt, nullptr, nullptr, "", nullptr,
+      VMContext, dwarf::DW_TAG_array_type, Name, File, LineNumber,
+      getNonCompileUnitScope(Scope), Ty, Size, AlignInBits, 0, DINode::FlagZero,
+      Subscripts, 0, /*EnumKind=*/std::nullopt, nullptr, nullptr, "", nullptr,
       isa<DIExpression *>(DL) ? (Metadata *)cast<DIExpression *>(DL)
                               : (Metadata *)cast<DIVariable *>(DL),
       isa<DIExpression *>(AS) ? (Metadata *)cast<DIExpression *>(AS)

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -1270,6 +1270,12 @@ TEST(DIBuilder, CompositeTypes) {
   DICompositeType *Array = DIB.createArrayType(8, 8, nullptr, {});
   EXPECT_EQ(Array->getTag(), dwarf::DW_TAG_array_type);
 
+  StringRef ArrayNameExp = "AnArray";
+  DICompositeType *NamedArray =
+      DIB.createArrayType(nullptr, ArrayNameExp, nullptr, 0, 8, 8, nullptr, {});
+  EXPECT_EQ(NamedArray->getTag(), dwarf::DW_TAG_array_type);
+  EXPECT_EQ(NamedArray->getName(), ArrayNameExp);
+
   DICompositeType *Vector = DIB.createVectorType(8, 8, nullptr, {});
   EXPECT_EQ(Vector->getTag(), dwarf::DW_TAG_array_type);
 


### PR DESCRIPTION
DICompositeType has an attribute representing the name of a type, but currently it isn't possible to set this for array types via the DIBuilder method.  This patch adds a new overload of DIBuilder::createArrayType that allows "full" construction of an array type.  This is useful for Ada, where arrays are a bit more first-class than C.