### PR TITLE
[TableGen] Don't use inline storage for ReferenceLocs (NFC)

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1523,7 +1523,7 @@ private:
   bool IsUsed = false;
 
   /// Reference locations to this record value.
-  SmallVector<SMRange> ReferenceLocs;
+  SmallVector<SMRange, 0> ReferenceLocs;
 
 public:
   RecordVal(const Init *N, const RecTy *T, FieldKind K);


### PR DESCRIPTION
The ReferenceLocs are not enabled by default (they are used by the tablegen lsp server), and as such always empty, but still allocate inline storage for the SmallVector. Disabling it saves about 200MB on RISCVGenGlobalISel.inc.

(The equivalent field in Record already disables inline storage.)