### PR TITLE
Diagnose the code with trailing comma in the function call.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -703,8 +703,6 @@ def ext_consteval_if : ExtWarn<
 def warn_cxx20_compat_consteval_if : Warning<
   "consteval if is incompatible with C++ standards before C++23">,
   InGroup<CXXPre23Compat>, DefaultIgnore;
-def err_extraneous_trailing_comma : Error<
-  "extraneous trailing comma">;
 
 def ext_init_statement : ExtWarn<
   "'%select{if|switch}0' initialization statements are a C++17 extension">,

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -703,6 +703,8 @@ def ext_consteval_if : ExtWarn<
 def warn_cxx20_compat_consteval_if : Warning<
   "consteval if is incompatible with C++ standards before C++23">,
   InGroup<CXXPre23Compat>, DefaultIgnore;
+def err_extraneous_trailing_comma : Error<
+  "extraneous trailing comma">;
 
 def ext_init_statement : ExtWarn<
   "'%select{if|switch}0' initialization statements are a C++17 extension">,

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2237,6 +2237,9 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
             if (PP.isCodeCompletionReached() && !CalledSignatureHelp)
               RunSignatureHelp();
             LHS = ExprError();
+          } else if (!HasError && HasTrailingComma) {
+            // FIXME: add a FIXIT to remove the trailing comma.
+            Diag(Tok, diag::err_extraneous_trailing_comma);
           } else if (LHS.isInvalid()) {
             for (auto &E : ArgExprs)
               Actions.CorrectDelayedTyposInExpr(E);

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2238,8 +2238,7 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
               RunSignatureHelp();
             LHS = ExprError();
           } else if (!HasError && HasTrailingComma) {
-            // FIXME: add a FIXIT to remove the trailing comma.
-            Diag(Tok, diag::err_extraneous_trailing_comma);
+            Diag(Tok, diag::err_expected_expression);
           } else if (LHS.isInvalid()) {
             for (auto &E : ArgExprs)
               Actions.CorrectDelayedTyposInExpr(E);

--- a/clang/test/Parser/recovery.cpp
+++ b/clang/test/Parser/recovery.cpp
@@ -219,6 +219,6 @@ class :: : {} a;  // expected-error {{expected identifier}} expected-error {{exp
 namespace GH125225 {
 void func(int);
 void k() {
-  func(1, ); // expected-error {{extraneous trailing comma}}
+  func(1, ); // expected-error {{expected expression}}
 }
 }

--- a/clang/test/Parser/recovery.cpp
+++ b/clang/test/Parser/recovery.cpp
@@ -215,3 +215,10 @@ struct ::template foo, struct ::template bar; // expected-error 2 {{expected ide
 struct ::foo struct::; // expected-error {{no struct named 'foo' in the global namespace}} expected-error {{expected identifier}}
 class :: : {} a;  // expected-error {{expected identifier}} expected-error {{expected class name}}
 }
+
+namespace GH125225 {
+void func(int);
+void k() {
+  func(1, ); // expected-error {{extraneous trailing comma}}
+}
+}


### PR DESCRIPTION
This patch fixes a regression caused by https://github.com/llvm/llvm-project/pull/114684 where clang accepts trailing commas for function calls.

Fixes #125225 