### PR TITLE
[ObjC][ARC] Initialize member of ObjCARCContract

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCContract.cpp
@@ -64,7 +64,7 @@ namespace {
 
 class ObjCARCContract {
   bool Changed;
-  bool CFGChanged;
+  bool CFGChanged = false;
   AAResults *AA;
   DominatorTree *DT;
   ProvenanceAnalysis PA;


### PR DESCRIPTION
This fixes a bug where hasCFGChanged was called before CFGChanged had been initialized.

rdar://142842745