### PR TITLE
[TableGen] Restore OpName::OPERAND_LAST emission in InstrInfoEmitter

### DIFF
--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -286,6 +286,7 @@ void InstrInfoEmitter::emitOperandNameMappings(
   OS << "enum {\n";
   for (const auto &[I, Op] : enumerate(OperandNameToID))
     OS << "  " << Op.first << " = " << I << ",\n";
+  OS << "  OPERAND_LAST = " << NumOperandNames << ",\n";
   OS << "};\n";
   OS << "} // end namespace llvm::" << Namespace << "::OpName\n";
   OS << "#endif //GET_INSTRINFO_OPERAND_ENUM\n\n";


### PR DESCRIPTION
- Looks like this sentinel value is used in some downstream backends, so restore emitting it.
- It now also has the correct value (earlier code may have emitted an incorrect value for OPERAND_LAST and hence it was removed in https://github.com/llvm/llvm-project/pull/124960)