### PR TITLE
[lldb] Use validation combination of options in TestAbbreviations

### DIFF
--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -45,10 +45,10 @@ class AbbreviationsTestCase(TestBase):
 
         # Make sure an unabbreviated command is not mangled.
         command_interpreter.ResolveCommand(
-            "breakpoint set --name main --line 123", result
+            "breakpoint set --name main --ignore-count 123", result
         )
         self.assertTrue(result.Succeeded())
-        self.assertEqual("breakpoint set --name main --line 123", result.GetOutput())
+        self.assertEqual("breakpoint set --name main --ignore-count 123", result.GetOutput())
 
         # Create some aliases.
         self.runCmd("com a alias com al")
@@ -72,10 +72,10 @@ class AbbreviationsTestCase(TestBase):
             "process launch -s -o /dev/tty0 -e /dev/tty0", result.GetOutput()
         )
 
-        self.runCmd("alias xyzzy breakpoint set -n %1 -l %2")
+        self.runCmd("alias xyzzy breakpoint set -n %1 -i %2")
         command_interpreter.ResolveCommand("xyzzy main 123", result)
         self.assertTrue(result.Succeeded())
-        self.assertEqual("breakpoint set -n main -l 123", result.GetOutput().strip())
+        self.assertEqual("breakpoint set -n main -i 123", result.GetOutput().strip())
 
         # And again, without enough parameters.
         command_interpreter.ResolveCommand("xyzzy main", result)

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -48,7 +48,9 @@ class AbbreviationsTestCase(TestBase):
             "breakpoint set --name main --ignore-count 123", result
         )
         self.assertTrue(result.Succeeded())
-        self.assertEqual("breakpoint set --name main --ignore-count 123", result.GetOutput())
+        self.assertEqual(
+            "breakpoint set --name main --ignore-count 123", result.GetOutput()
+        )
 
         # Create some aliases.
         self.runCmd("com a alias com al")


### PR DESCRIPTION
Name and line number are part of different option groups and are not compatible.

```
(lldb) breakpoint set -n foo -l 10
error: invalid combination of options for the given command
```

The help output for `breakpoint set` confirms this. This patch updates the test to use two compatible options. With the improved error reporting from #125125 this becomes an issue.