### PR TITLE
[LegalizeDAG] Use Base+Offset instead of Offset+Base for jump tables

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3981,7 +3981,8 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
       // For PIC, the sequence is:
       // BRIND(RelocBase + load(Jumptable + index))
       // RelocBase can be JumpTable, GOT or some sort of global base.
-      Addr = DAG.getMemBasePlusOffset(TLI.getPICJumpTableRelocBase(Table, DAG),                                      Addr, dl);
+      Addr = DAG.getMemBasePlusOffset(TLI.getPICJumpTableRelocBase(Table, DAG),
+                                      Addr, dl);
     }
 
     Tmp1 = TLI.expandIndirectJTBranch(dl, LD.getValue(1), Addr, JTI, DAG);

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp
@@ -3970,8 +3970,7 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
     else
       Index = DAG.getNode(ISD::MUL, dl, Index.getValueType(), Index,
                           DAG.getConstant(EntrySize, dl, Index.getValueType()));
-    SDValue Addr = DAG.getNode(ISD::ADD, dl, Index.getValueType(),
-                               Index, Table);
+    SDValue Addr = DAG.getMemBasePlusOffset(Table, Index, dl);
 
     EVT MemVT = EVT::getIntegerVT(*DAG.getContext(), EntrySize * 8);
     SDValue LD = DAG.getExtLoad(
@@ -3980,10 +3979,9 @@ bool SelectionDAGLegalize::ExpandNode(SDNode *Node) {
     Addr = LD;
     if (TLI.isJumpTableRelative()) {
       // For PIC, the sequence is:
-      // BRIND(load(Jumptable + index) + RelocBase)
+      // BRIND(RelocBase + load(Jumptable + index))
       // RelocBase can be JumpTable, GOT or some sort of global base.
-      Addr = DAG.getNode(ISD::ADD, dl, PTy, Addr,
-                          TLI.getPICJumpTableRelocBase(Table, DAG));
+      Addr = DAG.getMemBasePlusOffset(TLI.getPICJumpTableRelocBase(Table, DAG),                                      Addr, dl);
     }
 
     Tmp1 = TLI.expandIndirectJTBranch(dl, LD.getValue(1), Addr, JTI, DAG);

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -1138,13 +1138,22 @@ static SDValue performADDCombine(SDNode *N, SelectionDAG &DAG,
     return SDValue();
   }
 
+  // When loading from a jump table, push the Lo node to the position that
+  // allows folding it into a load immediate.
   // (add v0, (add v1, abs_lo(tjt))) => (add (add v0, v1), abs_lo(tjt))
-  SDValue Add = N->getOperand(1);
-
-  if (Add.getOpcode() != ISD::ADD)
+  // (add (add abs_lo(tjt), v1), v0) => (add (add v0, v1), abs_lo(tjt))
+  SDValue InnerAdd = N->getOperand(1);
+  SDValue Index = N->getOperand(0);
+  if (InnerAdd.getOpcode() != ISD::ADD)
+    std::swap(InnerAdd, Index);
+  if (InnerAdd.getOpcode() != ISD::ADD)
     return SDValue();
 
-  SDValue Lo = Add.getOperand(1);
+
+  SDValue Lo = InnerAdd.getOperand(0);
+  SDValue Other = InnerAdd.getOperand(1);
+  if (Lo.getOpcode() != MipsISD::Lo)
+    std::swap(Lo, Other);
 
   if ((Lo.getOpcode() != MipsISD::Lo) ||
       (Lo.getOperand(0).getOpcode() != ISD::TargetJumpTable))
@@ -1153,8 +1162,7 @@ static SDValue performADDCombine(SDNode *N, SelectionDAG &DAG,
   EVT ValTy = N->getValueType(0);
   SDLoc DL(N);
 
-  SDValue Add1 = DAG.getNode(ISD::ADD, DL, ValTy, N->getOperand(0),
-                             Add.getOperand(0));
+  SDValue Add1 = DAG.getNode(ISD::ADD, DL, ValTy, Index, Other);
   return DAG.getNode(ISD::ADD, DL, ValTy, Add1, Lo);
 }
 

--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
@@ -1149,7 +1149,6 @@ static SDValue performADDCombine(SDNode *N, SelectionDAG &DAG,
   if (InnerAdd.getOpcode() != ISD::ADD)
     return SDValue();
 
-
   SDValue Lo = InnerAdd.getOperand(0);
   SDValue Other = InnerAdd.getOperand(1);
   if (Lo.getOpcode() != MipsISD::Lo)

--- a/llvm/test/CodeGen/LoongArch/annotate-tablejump.ll
+++ b/llvm/test/CodeGen/LoongArch/annotate-tablejump.ll
@@ -57,7 +57,7 @@ define void @switch_4_arms(i32 %in, ptr %out) nounwind {
 ; LA64-JT-NEXT:    slli.d $a3, $a3, 3
 ; LA64-JT-NEXT:    pcalau12i $a4, %pc_hi20(.LJTI0_0)
 ; LA64-JT-NEXT:    addi.d $a4, $a4, %pc_lo12(.LJTI0_0)
-; LA64-JT-NEXT:    ldx.d $a3, $a3, $a4
+; LA64-JT-NEXT:    ldx.d $a3, $a4, $a3
 ; LA64-JT-NEXT:  .Ljrtb_0:
 ; LA64-JT-NEXT:    jr $a3
 ; LA64-JT-NEXT:  .LBB0_2: # %bb1
@@ -80,7 +80,7 @@ define void @switch_4_arms(i32 %in, ptr %out) nounwind {
 ; LA64-JT-NEXT:    slli.d $a3, $a3, 3
 ; LA64-JT-NEXT:    pcalau12i $a4, %pc_hi20(.LJTI0_1)
 ; LA64-JT-NEXT:    addi.d $a4, $a4, %pc_lo12(.LJTI0_1)
-; LA64-JT-NEXT:    ldx.d $a3, $a3, $a4
+; LA64-JT-NEXT:    ldx.d $a3, $a4, $a3
 ; LA64-JT-NEXT:  .Ljrtb_1:
 ; LA64-JT-NEXT:    jr $a3
 ; LA64-JT-NEXT:  .LBB0_9: # %exit2

--- a/llvm/test/CodeGen/LoongArch/jr-without-ra.ll
+++ b/llvm/test/CodeGen/LoongArch/jr-without-ra.ll
@@ -78,7 +78,7 @@ define void @jr_without_ra(ptr %rtwdev, ptr %chan, ptr %h2c, i8 %.pre, i1 %cmp.i
 ; CHECK-NEXT:  # %bb.6: # %calc_6g.i
 ; CHECK-NEXT:    # in Loop: Header=BB0_4 Depth=1
 ; CHECK-NEXT:    slli.d $s8, $zero, 3
-; CHECK-NEXT:    ldx.d $s8, $s8, $s1
+; CHECK-NEXT:    ldx.d $s8, $s1, $s8
 ; CHECK-NEXT:    jr $s8
 ; CHECK-NEXT:  .LBB0_7: # %sw.bb12.i.i
 ; CHECK-NEXT:    # in Loop: Header=BB0_4 Depth=1
@@ -113,7 +113,7 @@ define void @jr_without_ra(ptr %rtwdev, ptr %chan, ptr %h2c, i8 %.pre, i1 %cmp.i
 ; CHECK-NEXT:    # in Loop: Header=BB0_4 Depth=1
 ; CHECK-NEXT:    pcalau12i $ra, %pc_hi20(.LJTI0_1)
 ; CHECK-NEXT:    addi.d $ra, $ra, %pc_lo12(.LJTI0_1)
-; CHECK-NEXT:    ldx.d $s5, $s4, $ra
+; CHECK-NEXT:    ldx.d $s5, $ra, $s4
 ; CHECK-NEXT:    jr $s5
 ; CHECK-NEXT:  .LBB0_13: # %phy_tssi_get_ofdm_trim_de.exit
 ; CHECK-NEXT:    # in Loop: Header=BB0_4 Depth=1

--- a/llvm/test/CodeGen/LoongArch/jump-table.ll
+++ b/llvm/test/CodeGen/LoongArch/jump-table.ll
@@ -116,7 +116,7 @@ define void @switch_4_arms(i32 %in, ptr %out) nounwind {
 ; LA64-JT-NEXT:    slli.d $a0, $a0, 3
 ; LA64-JT-NEXT:    pcalau12i $a2, %pc_hi20(.LJTI0_0)
 ; LA64-JT-NEXT:    addi.d $a2, $a2, %pc_lo12(.LJTI0_0)
-; LA64-JT-NEXT:    ldx.d $a0, $a0, $a2
+; LA64-JT-NEXT:    ldx.d $a0, $a2, $a0
 ; LA64-JT-NEXT:    jr $a0
 ; LA64-JT-NEXT:  .LBB0_2: # %bb1
 ; LA64-JT-NEXT:    ori $a0, $zero, 4

--- a/llvm/test/CodeGen/Mips/2010-07-20-Switch.ll
+++ b/llvm/test/CodeGen/Mips/2010-07-20-Switch.ll
@@ -66,7 +66,7 @@ define i32 @main() nounwind readnone {
 ; PIC-O32-NEXT:    lw $3, %got($JTI0_0)($2)
 ; PIC-O32-NEXT:    addu $1, $1, $3
 ; PIC-O32-NEXT:    lw $1, %lo($JTI0_0)($1)
-; PIC-O32-NEXT:    addu $1, $1, $2
+; PIC-O32-NEXT:    addu $1, $2, $1
 ; PIC-O32-NEXT:    jr $1
 ; PIC-O32-NEXT:    nop
 ; PIC-O32-NEXT:  $BB0_2: # %bb5
@@ -109,7 +109,7 @@ define i32 @main() nounwind readnone {
 ; PIC-N64-NEXT:    ld $3, %got_page(.LJTI0_0)($1)
 ; PIC-N64-NEXT:    daddu $2, $2, $3
 ; PIC-N64-NEXT:    ld $2, %got_ofst(.LJTI0_0)($2)
-; PIC-N64-NEXT:    daddu $1, $2, $1
+; PIC-N64-NEXT:    daddu $1, $1, $2
 ; PIC-N64-NEXT:    jr $1
 ; PIC-N64-NEXT:    nop
 ; PIC-N64-NEXT:  .LBB0_2: # %bb5

--- a/llvm/test/CodeGen/Mips/indirect-jump-hazard/jumptables.ll
+++ b/llvm/test/CodeGen/Mips/indirect-jump-hazard/jumptables.ll
@@ -356,7 +356,7 @@ define ptr @_Z3fooi(i32 signext %Letter) {
 ; PIC-MIPS32R2-NEXT:    lw $3, %got($JTI0_0)($2)
 ; PIC-MIPS32R2-NEXT:    addu $1, $1, $3
 ; PIC-MIPS32R2-NEXT:    lw $1, %lo($JTI0_0)($1)
-; PIC-MIPS32R2-NEXT:    addu $1, $1, $2
+; PIC-MIPS32R2-NEXT:    addu $1, $2, $1
 ; PIC-MIPS32R2-NEXT:    jr.hb $1
 ; PIC-MIPS32R2-NEXT:    nop
 ; PIC-MIPS32R2-NEXT:  $BB0_2: # %sw.bb
@@ -418,7 +418,7 @@ define ptr @_Z3fooi(i32 signext %Letter) {
 ; PIC-MIPS32R6-NEXT:    lw $3, %got($JTI0_0)($2)
 ; PIC-MIPS32R6-NEXT:    addu $1, $1, $3
 ; PIC-MIPS32R6-NEXT:    lw $1, %lo($JTI0_0)($1)
-; PIC-MIPS32R6-NEXT:    addu $1, $1, $2
+; PIC-MIPS32R6-NEXT:    addu $1, $2, $1
 ; PIC-MIPS32R6-NEXT:    jr.hb $1
 ; PIC-MIPS32R6-NEXT:    nop
 ; PIC-MIPS32R6-NEXT:  $BB0_2: # %sw.bb
@@ -481,7 +481,7 @@ define ptr @_Z3fooi(i32 signext %Letter) {
 ; PIC-MIPS64R2-NEXT:    ld $3, %got_page(.LJTI0_0)($2)
 ; PIC-MIPS64R2-NEXT:    daddu $1, $1, $3
 ; PIC-MIPS64R2-NEXT:    ld $1, %got_ofst(.LJTI0_0)($1)
-; PIC-MIPS64R2-NEXT:    daddu $1, $1, $2
+; PIC-MIPS64R2-NEXT:    daddu $1, $2, $1
 ; PIC-MIPS64R2-NEXT:    jr.hb $1
 ; PIC-MIPS64R2-NEXT:    nop
 ; PIC-MIPS64R2-NEXT:  .LBB0_2: # %sw.bb
@@ -544,7 +544,7 @@ define ptr @_Z3fooi(i32 signext %Letter) {
 ; PIC-MIPS64R6-NEXT:    ld $3, %got_page(.LJTI0_0)($2)
 ; PIC-MIPS64R6-NEXT:    daddu $1, $1, $3
 ; PIC-MIPS64R6-NEXT:    ld $1, %got_ofst(.LJTI0_0)($1)
-; PIC-MIPS64R6-NEXT:    daddu $1, $1, $2
+; PIC-MIPS64R6-NEXT:    daddu $1, $2, $1
 ; PIC-MIPS64R6-NEXT:    jr.hb $1
 ; PIC-MIPS64R6-NEXT:    nop
 ; PIC-MIPS64R6-NEXT:  .LBB0_2: # %sw.bb

--- a/llvm/test/CodeGen/Mips/jump-table-mul.ll
+++ b/llvm/test/CodeGen/Mips/jump-table-mul.ll
@@ -16,7 +16,7 @@ define i64 @test(i64 %arg) {
 ; CHECK-NEXT:    ld $3, %got_page(.LJTI0_0)($1)
 ; CHECK-NEXT:    daddu $2, $2, $3
 ; CHECK-NEXT:    ld $2, %got_ofst(.LJTI0_0)($2)
-; CHECK-NEXT:    daddu $1, $2, $1
+; CHECK-NEXT:    daddu $1, $1, $2
 ; CHECK-NEXT:    jr $1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:  .LBB0_2: # %sw.bb

--- a/llvm/test/CodeGen/Mips/pseudo-jump-fill.ll
+++ b/llvm/test/CodeGen/Mips/pseudo-jump-fill.ll
@@ -20,7 +20,7 @@ define i32 @test(i32 signext %x, i32 signext %c) {
 ; CHECK-NEXT:    lw $6, %got($JTI0_0)($3)
 ; CHECK-NEXT:    addu16 $5, $5, $6
 ; CHECK-NEXT:    lw $5, %lo($JTI0_0)($5)
-; CHECK-NEXT:    addu16 $3, $5, $3
+; CHECK-NEXT:    addu16 $3, $3, $5
 ; CHECK-NEXT:    jr $3
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:  $BB0_2: # %sw.bb2

--- a/llvm/test/CodeGen/PowerPC/absol-jump-table-enabled.ll
+++ b/llvm/test/CodeGen/PowerPC/absol-jump-table-enabled.ll
@@ -48,7 +48,7 @@ define zeroext i32 @jumpTableTest(ptr readonly %list) {
 ; CHECK-LE-LABEL: jumpTableTest:
 ; CHECK-LE:       # %bb.0: # %entry
 ; CHECK-LE:       rldic r[[REG:[0-9]+]], r[[REG]], 3, 29
-; CHECK-LE:       ldx r[[REG]], r[[REG]], r[[REG1:[0-9]+]]
+; CHECK-LE:       ldx r[[REG]], r[[REG1:[0-9]+]], r[[REG]]
 ; CHECK-LE:       mtctr r[[REG]]
 ; CHECK-LE:       bctr
 ; CHECK-LE:       blr
@@ -56,7 +56,7 @@ define zeroext i32 @jumpTableTest(ptr readonly %list) {
 ; CHECK-BE-LABEL: jumpTableTest:
 ; CHECK-BE:       # %bb.0: # %entry
 ; CHECK-BE:       rldic r[[REG:[0-9]+]], r[[REG]], 2, 30
-; CHECK-BE:       lwax r[[REG]], r[[REG]], r[[REG1:[0-9]+]]
+; CHECK-BE:       lwax r[[REG]], r[[REG1:[0-9]+]], r[[REG]]
 ; CHECK-BE:       mtctr r[[REG]]
 ; CHECK-BE:       bctr
 ; CHECK-BE:       blr
@@ -64,7 +64,7 @@ define zeroext i32 @jumpTableTest(ptr readonly %list) {
 ; CHECK-AIX-LABEL: jumpTableTest:
 ; CHECK-AIX:       # %bb.0: # %entry
 ; CHECK-AIX:       rldic r[[REG:[0-9]+]], r[[REG]], 2, 30
-; CHECK-AIX:       lwax r[[REG]], r[[REG]], r[[REG1:[0-9]+]]
+; CHECK-AIX:       lwax r[[REG]], r[[REG1:[0-9]+]], r[[REG]]
 ; CHECK-AIX:       mtctr r[[REG]]
 ; CHECK-AIX:       bctr
 ; CHECK-AIX:       blr

--- a/llvm/test/CodeGen/PowerPC/aix-lower-jump-table-mir.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-lower-jump-table-mir.ll
@@ -31,8 +31,8 @@ define i32 @jump_table(i32 %a) {
   ; 32SMALL-MIR-NEXT: {{  $}}
   ; 32SMALL-MIR-NEXT:   renamable $r3 = RLWINM killed renamable $r3, 2, 0, 29
   ; 32SMALL-MIR-NEXT:   renamable $r4 = LWZtoc %jump-table.0, $r2 :: (load (s32) from got)
-  ; 32SMALL-MIR-NEXT:   renamable $r3 = LWZX killed renamable $r3, renamable $r4 :: (load (s32) from jump-table)
-  ; 32SMALL-MIR-NEXT:   renamable $r3 = ADD4 killed renamable $r3, killed renamable $r4
+  ; 32SMALL-MIR-NEXT:   renamable $r3 = LWZX renamable $r4, killed renamable $r3 :: (load (s32) from jump-table)
+  ; 32SMALL-MIR-NEXT:   renamable $r3 = ADD4 killed renamable $r4, killed renamable $r3
   ; 32SMALL-MIR-NEXT:   MTCTR killed renamable $r3, implicit-def $ctr
   ; 32SMALL-MIR-NEXT:   BCTR implicit $ctr
   ; 32SMALL-MIR-NEXT: {{  $}}
@@ -79,8 +79,8 @@ define i32 @jump_table(i32 %a) {
   ; 32LARGE-MIR-NEXT:   renamable $r3 = RLWINM killed renamable $r3, 2, 0, 29
   ; 32LARGE-MIR-NEXT:   renamable $r4 = ADDIStocHA $r2, %jump-table.0
   ; 32LARGE-MIR-NEXT:   renamable $r4 = LWZtocL %jump-table.0, killed renamable $r4, implicit $r2 :: (load (s32) from got)
-  ; 32LARGE-MIR-NEXT:   renamable $r3 = LWZX killed renamable $r3, renamable $r4 :: (load (s32) from jump-table)
-  ; 32LARGE-MIR-NEXT:   renamable $r3 = ADD4 killed renamable $r3, killed renamable $r4
+  ; 32LARGE-MIR-NEXT:   renamable $r3 = LWZX renamable $r4, killed renamable $r3 :: (load (s32) from jump-table)
+  ; 32LARGE-MIR-NEXT:   renamable $r3 = ADD4 killed renamable $r4, killed renamable $r3
   ; 32LARGE-MIR-NEXT:   MTCTR killed renamable $r3, implicit-def $ctr
   ; 32LARGE-MIR-NEXT:   BCTR implicit $ctr
   ; 32LARGE-MIR-NEXT: {{  $}}
@@ -126,8 +126,8 @@ define i32 @jump_table(i32 %a) {
   ; 64SMALL-MIR-NEXT: {{  $}}
   ; 64SMALL-MIR-NEXT:   renamable $x3 = RLDIC killed renamable $x3, 2, 30
   ; 64SMALL-MIR-NEXT:   renamable $x4 = LDtocJTI %jump-table.0, $x2 :: (load (s64) from got)
-  ; 64SMALL-MIR-NEXT:   renamable $x3 = LWAX killed renamable $x3, renamable $x4 :: (load (s32) from jump-table)
-  ; 64SMALL-MIR-NEXT:   renamable $x3 = ADD8 killed renamable $x3, killed renamable $x4
+  ; 64SMALL-MIR-NEXT:   renamable $x3 = LWAX renamable $x4, killed renamable $x3 :: (load (s32) from jump-table)
+  ; 64SMALL-MIR-NEXT:   renamable $x3 = ADD8 killed renamable $x4, killed renamable $x3
   ; 64SMALL-MIR-NEXT:   MTCTR8 killed renamable $x3, implicit-def $ctr8
   ; 64SMALL-MIR-NEXT:   BCTR8 implicit $ctr8
   ; 64SMALL-MIR-NEXT: {{  $}}
@@ -174,8 +174,8 @@ define i32 @jump_table(i32 %a) {
   ; 64LARGE-MIR-NEXT:   renamable $x3 = RLDIC killed renamable $x3, 2, 30
   ; 64LARGE-MIR-NEXT:   renamable $x4 = ADDIStocHA8 $x2, %jump-table.0
   ; 64LARGE-MIR-NEXT:   renamable $x4 = LDtocL %jump-table.0, killed renamable $x4, implicit $x2 :: (load (s64) from got)
-  ; 64LARGE-MIR-NEXT:   renamable $x3 = LWAX killed renamable $x3, renamable $x4 :: (load (s32) from jump-table)
-  ; 64LARGE-MIR-NEXT:   renamable $x3 = ADD8 killed renamable $x3, killed renamable $x4
+  ; 64LARGE-MIR-NEXT:   renamable $x3 = LWAX renamable $x4, killed renamable $x3 :: (load (s32) from jump-table)
+  ; 64LARGE-MIR-NEXT:   renamable $x3 = ADD8 killed renamable $x4, killed renamable $x3
   ; 64LARGE-MIR-NEXT:   MTCTR8 killed renamable $x3, implicit-def $ctr8
   ; 64LARGE-MIR-NEXT:   BCTR8 implicit $ctr8
   ; 64LARGE-MIR-NEXT: {{  $}}

--- a/llvm/test/CodeGen/PowerPC/aix-lower-jump-table.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-lower-jump-table.ll
@@ -51,8 +51,8 @@ sw.epilog:
 ; 32SMALL-ASM: 	    bgt	0, L..BB0_3
 ; 32SMALL-ASM: 	    lwz 4, L..C0(2)
 ; 32SMALL-ASM: 	    slwi 3, 3, 2
-; 32SMALL-ASM: 	    lwzx 3, 3, 4
-; 32SMALL-ASM: 	    add 3, 3, 4
+; 32SMALL-ASM: 	    lwzx 3, 4, 3
+; 32SMALL-ASM: 	    add 3, 4, 3
 ; 32SMALL-ASM: 	    mtctr 3
 ; 32SMALL-ASM: 	    bctr
 ; 32SMALL-ASM: L..BB0_2:
@@ -78,8 +78,8 @@ sw.epilog:
 ; 32LARGE-ASM: 	    addis 4, L..C0@u(2)
 ; 32LARGE-ASM: 	    slwi 3, 3, 2
 ; 32LARGE-ASM:      lwz 4, L..C0@l(4)
-; 32LARGE-ASM:      lwzx 3, 3, 4
-; 32LARGE-ASM:      add 3, 3, 4
+; 32LARGE-ASM:      lwzx 3, 4, 3
+; 32LARGE-ASM:      add 3, 4, 3
 ; 32LARGE-ASM:      mtctr 3
 ; 32LARGE-ASM:      bctr
 ; 32LARGE-ASM: L..BB0_2:
@@ -104,8 +104,8 @@ sw.epilog:
 ; 64SMALL-ASM:      bgt     0, L..BB0_3
 ; 64SMALL-ASM:      ld 4, L..C0(2)
 ; 64SMALL-ASM:      rldic 3, 3, 2, 30
-; 64SMALL-ASM:      lwax 3, 3, 4
-; 64SMALL-ASM:      add 3, 3, 4
+; 64SMALL-ASM:      lwax 3, 4, 3
+; 64SMALL-ASM:      add 3, 4, 3
 ; 64SMALL-ASM:      mtctr 3
 ; 64SMALL-ASM:      bctr
 ; 64SMALL-ASM: L..BB0_2:
@@ -131,8 +131,8 @@ sw.epilog:
 ; 64LARGE-ASM:      addis 4, L..C0@u(2)
 ; 64LARGE-ASM:      rldic 3, 3, 2, 30
 ; 64LARGE-ASM:      ld 4, L..C0@l(4)
-; 64LARGE-ASM:      lwax 3, 3, 4
-; 64LARGE-ASM:      add 3, 3, 4
+; 64LARGE-ASM:      lwax 3, 4, 3
+; 64LARGE-ASM:      add 3, 4, 3
 ; 64LARGE-ASM:      mtctr 3
 ; 64LARGE-ASM:      bctr
 ; 64LARGE-ASM: L..BB0_2:

--- a/llvm/test/CodeGen/PowerPC/jump-tables-collapse-rotate.ll
+++ b/llvm/test/CodeGen/PowerPC/jump-tables-collapse-rotate.ll
@@ -16,8 +16,8 @@ define dso_local zeroext i32 @test(i32 signext %l) nounwind {
 ; CHECK-NEXT:    addis r4, r2, .LC0@toc@ha
 ; CHECK-NEXT:    rldic r3, r3, 2, 30
 ; CHECK-NEXT:    ld r4, .LC0@toc@l(r4)
-; CHECK-NEXT:    lwax r3, r3, r4
-; CHECK-NEXT:    add r3, r3, r4
+; CHECK-NEXT:    lwax r3, r4, r3
+; CHECK-NEXT:    add r3, r4, r3
 ; CHECK-NEXT:    mtctr r3
 ; CHECK-NEXT:    bctr
 ; CHECK-NEXT:  .LBB0_2: # %sw.bb

--- a/llvm/test/CodeGen/PowerPC/mcm-5.ll
+++ b/llvm/test/CodeGen/PowerPC/mcm-5.ll
@@ -55,8 +55,8 @@ sw.epilog:                                        ; preds = %sw.bb3, %sw.default
 
 ; CHECK:       addis [[REG1:[0-9]+]], 2, .LC[[TOCNUM:[0-9]+]]@toc@ha
 ; CHECK:       ld [[REG2:[0-9]+]], .LC[[TOCNUM]]@toc@l([[REG1]])
-; CHECK:       lwax [[REG3:[0-9]+]], {{[0-9]+}}, [[REG2]]
-; CHECK-NEXT:  add  [[REG4:[0-9]+]], [[REG3]], [[REG2]]
+; CHECK:       lwax [[REG3:[0-9]+]], [[REG2]], {{[0-9]+}}
+; CHECK-NEXT:  add  [[REG4:[0-9]+]], [[REG2]], [[REG3]]
 ; CHECK-NEXT:  mtctr [[REG4]]
 ; CHECK-NEXT:  bctr
 
@@ -70,8 +70,8 @@ sw.epilog:                                        ; preds = %sw.bb3, %sw.default
 
 ; LARGE:       addis [[REG1:[0-9]+]], 2, .LC[[TOCNUM:[0-9]+]]@toc@ha
 ; LARGE:       ld [[REG2:[0-9]+]], .LC[[TOCNUM]]@toc@l([[REG1]])
-; LARGE:       lwax [[REG3:[0-9]+]], {{[0-9]+}}, [[REG2]]
-; LARGE-NEXT:  add  [[REG4:[0-9]+]], [[REG3]], [[REGBASE]]
+; LARGE:       lwax [[REG3:[0-9]+]], [[REG2]], {{[0-9]+}}
+; LARGE-NEXT:  add  [[REG4:[0-9]+]], [[REGBASE]], [[REG3]]
 ; LARGE-NEXT:  mtctr [[REG4]]
 ; LARGE-NEXT:  bctr
 

--- a/llvm/test/CodeGen/PowerPC/p10-spill-crgt.ll
+++ b/llvm/test/CodeGen/PowerPC/p10-spill-crgt.ll
@@ -65,8 +65,8 @@ define dso_local fastcc void @P10_Spill_CR_GT() unnamed_addr {
 ; CHECK-NEXT:    lwz r5, 0(r3)
 ; CHECK-NEXT:    rlwinm r4, r5, 0, 21, 22
 ; CHECK-NEXT:    cmpwi cr3, r4, 512
-; CHECK-NEXT:    lwax r4, r30, r29
-; CHECK-NEXT:    add r4, r4, r29
+; CHECK-NEXT:    lwax r4, r29, r30
+; CHECK-NEXT:    add r4, r29, r4
 ; CHECK-NEXT:    mtctr r4
 ; CHECK-NEXT:    li r4, 0
 ; CHECK-NEXT:    bctr
@@ -258,8 +258,8 @@ define dso_local fastcc void @P10_Spill_CR_GT() unnamed_addr {
 ; CHECK-BE-NEXT:    lwz r5, 0(r3)
 ; CHECK-BE-NEXT:    rlwinm r4, r5, 0, 21, 22
 ; CHECK-BE-NEXT:    cmpwi cr3, r4, 512
-; CHECK-BE-NEXT:    lwax r4, r30, r29
-; CHECK-BE-NEXT:    add r4, r4, r29
+; CHECK-BE-NEXT:    lwax r4, r29, r30
+; CHECK-BE-NEXT:    add r4, r29, r4
 ; CHECK-BE-NEXT:    mtctr r4
 ; CHECK-BE-NEXT:    li r4, 0
 ; CHECK-BE-NEXT:    bctr

--- a/llvm/test/CodeGen/PowerPC/pcrel-jump-table.ll
+++ b/llvm/test/CodeGen/PowerPC/pcrel-jump-table.ll
@@ -27,8 +27,8 @@ define dso_local signext i32 @jumptable(i32 signext %param) {
 ; CHECK-R-NEXT:  # %bb.1: # %entry
 ; CHECK-R-NEXT:    rldic r4, r4, 2, 30
 ; CHECK-R-NEXT:    paddi r5, 0, .LJTI0_0@PCREL, 1
-; CHECK-R-NEXT:    lwax r4, r4, r5
-; CHECK-R-NEXT:    add r4, r4, r5
+; CHECK-R-NEXT:    lwax r4, r5, r4
+; CHECK-R-NEXT:    add r4, r5, r4
 ; CHECK-R-NEXT:    mtctr r4
 ; CHECK-R-NEXT:    bctr
 ; CHECK-R-NEXT:  .LBB0_2: # %sw.bb1
@@ -56,7 +56,7 @@ define dso_local signext i32 @jumptable(i32 signext %param) {
 ; CHECK-A-LE-NEXT:  # %bb.1: # %entry
 ; CHECK-A-LE-NEXT:    rldic r4, r4, 3, 29
 ; CHECK-A-LE-NEXT:    paddi r5, 0, .LJTI0_0@PCREL, 1
-; CHECK-A-LE-NEXT:    ldx r4, r4, r5
+; CHECK-A-LE-NEXT:    ldx r4, r5, r4
 ; CHECK-A-LE-NEXT:    mtctr r4
 ; CHECK-A-LE-NEXT:    bctr
 ; CHECK-A-LE-NEXT:  .LBB0_2: # %sw.bb1
@@ -84,7 +84,7 @@ define dso_local signext i32 @jumptable(i32 signext %param) {
 ; CHECK-A-BE-NEXT:  # %bb.1: # %entry
 ; CHECK-A-BE-NEXT:    rldic r4, r4, 2, 30
 ; CHECK-A-BE-NEXT:    paddi r5, 0, .LJTI0_0@PCREL, 1
-; CHECK-A-BE-NEXT:    lwax r4, r4, r5
+; CHECK-A-BE-NEXT:    lwax r4, r5, r4
 ; CHECK-A-BE-NEXT:    mtctr r4
 ; CHECK-A-BE-NEXT:    bctr
 ; CHECK-A-BE-NEXT:  .LBB0_2: # %sw.bb1

--- a/llvm/test/CodeGen/RISCV/jumptable-swguarded.ll
+++ b/llvm/test/CodeGen/RISCV/jumptable-swguarded.ll
@@ -16,7 +16,7 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; CHECK-NEXT:    slli a0, a0, 2
 ; CHECK-NEXT:    lui a2, %hi(.LJTI0_0)
 ; CHECK-NEXT:    addi a2, a2, %lo(.LJTI0_0)
-; CHECK-NEXT:    add a0, a0, a2
+; CHECK-NEXT:    add a0, a2, a0
 ; CHECK-NEXT:    lw t2, 0(a0)
 ; CHECK-NEXT:    jr t2
 ; CHECK-NEXT:  .LBB0_2: # %bb1
@@ -50,7 +50,7 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; NO-ZICFILP-NEXT:    slli a0, a0, 2
 ; NO-ZICFILP-NEXT:    lui a2, %hi(.LJTI0_0)
 ; NO-ZICFILP-NEXT:    addi a2, a2, %lo(.LJTI0_0)
-; NO-ZICFILP-NEXT:    add a0, a0, a2
+; NO-ZICFILP-NEXT:    add a0, a2, a0
 ; NO-ZICFILP-NEXT:    lw a0, 0(a0)
 ; NO-ZICFILP-NEXT:    jr a0
 ; NO-ZICFILP-NEXT:  .LBB0_2: # %bb1

--- a/llvm/test/CodeGen/RISCV/jumptable.ll
+++ b/llvm/test/CodeGen/RISCV/jumptable.ll
@@ -89,7 +89,7 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; RV32I-SMALL-NEXT:    slli a0, a0, 2
 ; RV32I-SMALL-NEXT:    lui a2, %hi(.LJTI1_0)
 ; RV32I-SMALL-NEXT:    addi a2, a2, %lo(.LJTI1_0)
-; RV32I-SMALL-NEXT:    add a0, a0, a2
+; RV32I-SMALL-NEXT:    add a0, a2, a0
 ; RV32I-SMALL-NEXT:    lw a0, 0(a0)
 ; RV32I-SMALL-NEXT:    jr a0
 ; RV32I-SMALL-NEXT:  .LBB1_2: # %bb1
@@ -124,7 +124,7 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; RV32I-MEDIUM-NEXT:  .Lpcrel_hi0:
 ; RV32I-MEDIUM-NEXT:    auipc a2, %pcrel_hi(.LJTI1_0)
 ; RV32I-MEDIUM-NEXT:    addi a2, a2, %pcrel_lo(.Lpcrel_hi0)
-; RV32I-MEDIUM-NEXT:    add a0, a0, a2
+; RV32I-MEDIUM-NEXT:    add a0, a2, a0
 ; RV32I-MEDIUM-NEXT:    lw a0, 0(a0)
 ; RV32I-MEDIUM-NEXT:    jr a0
 ; RV32I-MEDIUM-NEXT:  .LBB1_2: # %bb1
@@ -159,9 +159,9 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; RV32I-PIC-NEXT:  .Lpcrel_hi0:
 ; RV32I-PIC-NEXT:    auipc a2, %pcrel_hi(.LJTI1_0)
 ; RV32I-PIC-NEXT:    addi a2, a2, %pcrel_lo(.Lpcrel_hi0)
-; RV32I-PIC-NEXT:    add a0, a0, a2
+; RV32I-PIC-NEXT:    add a0, a2, a0
 ; RV32I-PIC-NEXT:    lw a0, 0(a0)
-; RV32I-PIC-NEXT:    add a0, a0, a2
+; RV32I-PIC-NEXT:    add a0, a2, a0
 ; RV32I-PIC-NEXT:    jr a0
 ; RV32I-PIC-NEXT:  .LBB1_2: # %bb1
 ; RV32I-PIC-NEXT:    li a0, 4
@@ -194,7 +194,7 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; RV64I-SMALL-NEXT:    slli a0, a0, 2
 ; RV64I-SMALL-NEXT:    lui a2, %hi(.LJTI1_0)
 ; RV64I-SMALL-NEXT:    addi a2, a2, %lo(.LJTI1_0)
-; RV64I-SMALL-NEXT:    add a0, a0, a2
+; RV64I-SMALL-NEXT:    add a0, a2, a0
 ; RV64I-SMALL-NEXT:    lw a0, 0(a0)
 ; RV64I-SMALL-NEXT:    jr a0
 ; RV64I-SMALL-NEXT:  .LBB1_2: # %bb1
@@ -229,7 +229,7 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; RV64I-MEDIUM-NEXT:  .Lpcrel_hi0:
 ; RV64I-MEDIUM-NEXT:    auipc a2, %pcrel_hi(.LJTI1_0)
 ; RV64I-MEDIUM-NEXT:    addi a2, a2, %pcrel_lo(.Lpcrel_hi0)
-; RV64I-MEDIUM-NEXT:    add a0, a0, a2
+; RV64I-MEDIUM-NEXT:    add a0, a2, a0
 ; RV64I-MEDIUM-NEXT:    ld a0, 0(a0)
 ; RV64I-MEDIUM-NEXT:    jr a0
 ; RV64I-MEDIUM-NEXT:  .LBB1_2: # %bb1
@@ -264,9 +264,9 @@ define void @above_threshold(i32 signext %in, ptr %out) nounwind {
 ; RV64I-PIC-NEXT:  .Lpcrel_hi0:
 ; RV64I-PIC-NEXT:    auipc a2, %pcrel_hi(.LJTI1_0)
 ; RV64I-PIC-NEXT:    addi a2, a2, %pcrel_lo(.Lpcrel_hi0)
-; RV64I-PIC-NEXT:    add a0, a0, a2
+; RV64I-PIC-NEXT:    add a0, a2, a0
 ; RV64I-PIC-NEXT:    lw a0, 0(a0)
-; RV64I-PIC-NEXT:    add a0, a0, a2
+; RV64I-PIC-NEXT:    add a0, a2, a0
 ; RV64I-PIC-NEXT:    jr a0
 ; RV64I-PIC-NEXT:  .LBB1_2: # %bb1
 ; RV64I-PIC-NEXT:    li a0, 4

--- a/llvm/test/CodeGen/RISCV/shrinkwrap-jump-table.ll
+++ b/llvm/test/CodeGen/RISCV/shrinkwrap-jump-table.ll
@@ -19,7 +19,7 @@ define dso_local signext i32 @test_shrinkwrap_jump_table(ptr noundef %m) local_u
 ; CHECK-NEXT:    slli a1, a1, 2
 ; CHECK-NEXT:    lui a2, %hi(.LJTI0_0)
 ; CHECK-NEXT:    addi a2, a2, %lo(.LJTI0_0)
-; CHECK-NEXT:    add a1, a1, a2
+; CHECK-NEXT:    add a1, a2, a1
 ; CHECK-NEXT:    lw a1, 0(a1)
 ; CHECK-NEXT:    jr a1
 ; CHECK-NEXT:  .LBB0_2: # %sw.bb

--- a/llvm/test/CodeGen/SystemZ/branch-05.ll
+++ b/llvm/test/CodeGen/SystemZ/branch-05.ll
@@ -9,7 +9,7 @@ define i32 @f1(i32 %x, i32 %y, i32 %op) {
 ; CHECK: llgfr [[OP64:%r[0-5]]], %r4
 ; CHECK: sllg [[INDEX:%r[1-5]]], [[OP64]], 3
 ; CHECK: larl [[BASE:%r[1-5]]]
-; CHECK: lg [[TARGET:%r[1-5]]], 0([[BASE]],[[INDEX]])
+; CHECK: lg [[TARGET:%r[1-5]]], 0([[INDEX]],[[BASE]])
 ; CHECK: br [[TARGET]]
 entry:
   switch i32 %op, label %exit [

--- a/llvm/test/CodeGen/SystemZ/branch-11.ll
+++ b/llvm/test/CodeGen/SystemZ/branch-11.ll
@@ -9,7 +9,7 @@ define i32 @f1(i32 %x, i32 %y, i32 %op) {
 ; CHECK: llgfr [[OP64:%r[0-5]]], %r4
 ; CHECK: sllg [[INDEX:%r[1-5]]], [[OP64]], 3
 ; CHECK: larl [[BASE:%r[1-5]]]
-; CHECK: bi 0([[BASE]],[[INDEX]])
+; CHECK: bi 0([[INDEX]],[[BASE]])
 entry:
   switch i32 %op, label %exit [
     i32 1, label %b.add

--- a/llvm/test/CodeGen/VE/Scalar/br_jt.ll
+++ b/llvm/test/CodeGen/VE/Scalar/br_jt.ll
@@ -376,7 +376,7 @@ define signext i32 @br_jt4_m(i32 signext %0, i32 signext %1) {
 ; CHECK-NEXT:    lea %s2, .LJTI5_0@lo
 ; CHECK-NEXT:    and %s2, %s2, (32)0
 ; CHECK-NEXT:    lea.sl %s2, .LJTI5_0@hi(, %s2)
-; CHECK-NEXT:    ld %s2, (%s2, %s0)
+; CHECK-NEXT:    ld %s2, (%s0, %s2)
 ; CHECK-NEXT:    or %s0, 3, (0)1
 ; CHECK-NEXT:    b.l.t (, %s2)
 ; CHECK-NEXT:  .LBB5_2:
@@ -463,7 +463,7 @@ define signext i32 @br_jt7_m(i32 signext %0, i32 signext %1) {
 ; CHECK-NEXT:    lea %s3, .LJTI6_0@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
 ; CHECK-NEXT:    lea.sl %s3, .LJTI6_0@hi(, %s3)
-; CHECK-NEXT:    ld %s3, (%s3, %s0)
+; CHECK-NEXT:    ld %s3, (%s0, %s3)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    or %s0, 3, (0)1
 ; CHECK-NEXT:    b.l.t (, %s3)
@@ -599,7 +599,7 @@ define signext i32 @br_jt8_m(i32 signext %0, i32 signext %1) {
 ; CHECK-NEXT:    lea %s3, .LJTI7_0@lo
 ; CHECK-NEXT:    and %s3, %s3, (32)0
 ; CHECK-NEXT:    lea.sl %s3, .LJTI7_0@hi(, %s3)
-; CHECK-NEXT:    ld %s3, (%s3, %s0)
+; CHECK-NEXT:    ld %s3, (%s0, %s3)
 ; CHECK-NEXT:    and %s1, %s1, (32)0
 ; CHECK-NEXT:    or %s0, 3, (0)1
 ; CHECK-NEXT:    b.l.t (, %s3)
@@ -656,11 +656,11 @@ define signext i32 @br_jt8_m(i32 signext %0, i32 signext %1) {
 ; PIC-NEXT:    lea %s3, .LJTI7_0@gotoff_lo
 ; PIC-NEXT:    and %s3, %s3, (32)0
 ; PIC-NEXT:    lea.sl %s3, .LJTI7_0@gotoff_hi(%s3, %s15)
-; PIC-NEXT:    ldl.sx %s0, (%s3, %s0)
+; PIC-NEXT:    ldl.sx %s0, (%s0, %s3)
 ; PIC-NEXT:    lea %s3, br_jt8_m@gotoff_lo
 ; PIC-NEXT:    and %s3, %s3, (32)0
 ; PIC-NEXT:    lea.sl %s3, br_jt8_m@gotoff_hi(%s3, %s15)
-; PIC-NEXT:    adds.l %s3, %s0, %s3
+; PIC-NEXT:    adds.l %s3, %s3, %s0
 ; PIC-NEXT:    or %s0, 3, (0)1
 ; PIC-NEXT:    b.l.t (, %s3)
 ; PIC-NEXT:  .LBB7_2:


### PR DESCRIPTION
This is needed for architectures that actually use strict pointer
arithmetic instead of integers such as AArch64 with FEAT_CPA (see
https://github.com/llvm/llvm-project/pull/105669) or CHERI. Using an
index as the first operand of pointer arithmetic may result in an
invalid output.

While there are quite a few codegen changes here, these only change the
order of registers in add instructions. One MIPS combine had to be
updated to handle the new node order.
