### PR TITLE
[XRay][SystemZ] Use stckf for non-clang compilers

### DIFF
--- a/compiler-rt/lib/xray/xray_tsc.h
+++ b/compiler-rt/lib/xray/xray_tsc.h
@@ -96,11 +96,11 @@ namespace __xray {
 inline bool probeRequiredCPUFeatures() XRAY_NEVER_INSTRUMENT { return true; }
 
 ALWAYS_INLINE uint64_t readTSC(uint8_t &CPU) XRAY_NEVER_INSTRUMENT {
-#if defined(__clang__)
+#if __has_builtin(__builtin_readcyclecounter)
   return __builtin_readcyclecounter();
 #else
   uint64_t Cycles;
-  asm volatile("stckf %0" : /* No output. */ : "Q"(Cycles) : "cc");
+  asm volatile("stckf %0" : : "Q"(Cycles) : "cc");
   return Cycles;
 #endif
 }

--- a/compiler-rt/lib/xray/xray_tsc.h
+++ b/compiler-rt/lib/xray/xray_tsc.h
@@ -96,7 +96,13 @@ namespace __xray {
 inline bool probeRequiredCPUFeatures() XRAY_NEVER_INSTRUMENT { return true; }
 
 ALWAYS_INLINE uint64_t readTSC(uint8_t &CPU) XRAY_NEVER_INSTRUMENT {
+#if defined(__clang__)
   return __builtin_readcyclecounter();
+#else
+  uint64_t Cycles;
+  asm volatile("stckf %0" : /* No output. */ : "Q"(Cycles) : "cc");
+  return Cycles;
+#endif
 }
 
 inline uint64_t getTSCFrequency() XRAY_NEVER_INSTRUMENT {


### PR DESCRIPTION
Turns out there are users who use gcc to compile compiler-rt. Using the clang-specific builtin function `__builtin_readcyclecounter()` does not work in this case.
Solution is to use inline assembly using the stckf instruction in case the compiler is not clang.