### PR TITLE
[lldb] Show value for libcxx and libstdcxx summary and remove pointer value in libcxx container summary

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -641,7 +641,7 @@ static void LoadLibCxxFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       .SetSkipPointers(false)
       .SetSkipReferences(false)
       .SetDontShowChildren(true)
-      .SetDontShowValue(true)
+      .SetDontShowValue(false)
       .SetShowMembersOneLiner(false)
       .SetHideItemNames(false);
 
@@ -1204,7 +1204,7 @@ static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
       .SetSkipPointers(false)
       .SetSkipReferences(false)
       .SetDontShowChildren(true)
-      .SetDontShowValue(true)
+      .SetDontShowValue(false)
       .SetShowMembersOneLiner(false)
       .SetHideItemNames(false);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -430,12 +430,6 @@ size_t lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::
 
 bool lldb_private::formatters::LibcxxContainerSummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  if (valobj.IsPointerType()) {
-    uint64_t value = valobj.GetValueAsUnsigned(0);
-    if (!value)
-      return false;
-    stream.Printf("0x%016" PRIx64 " ", value);
-  }
   return FormatEntity::FormatStringRef("size=${svar%#}", stream, nullptr,
                                        nullptr, nullptr, &valobj, false, false);
 }

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/deque/TestDataFormatterLibcxxDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/deque/TestDataFormatterLibcxxDeque.py
@@ -9,7 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class LibcxxDequeDataFormatterTestCase(TestBase):
-    def check_numbers(self, var_name, show_ptr = False):
+    def check_numbers(self, var_name, show_ptr=False):
         if show_ptr:
             self.expect(
                 "frame variable " + var_name,

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/deque/TestDataFormatterLibcxxDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/deque/TestDataFormatterLibcxxDeque.py
@@ -9,22 +9,37 @@ from lldbsuite.test import lldbutil
 
 
 class LibcxxDequeDataFormatterTestCase(TestBase):
-    def check_numbers(self, var_name):
-        self.expect(
-            "frame variable " + var_name,
-            substrs=[
-                var_name + " = size=7",
-                "[0] = 1",
-                "[1] = 12",
-                "[2] = 123",
-                "[3] = 1234",
-                "[4] = 12345",
-                "[5] = 123456",
-                "[6] = 1234567",
-                "}",
-            ],
-        )
-
+    def check_numbers(self, var_name, show_ptr = False):
+        if show_ptr:
+            self.expect(
+                "frame variable " + var_name,
+                patterns=[var_name + " = 0x.* size=7"],
+                substrs=[
+                    "[0] = 1",
+                    "[1] = 12",
+                    "[2] = 123",
+                    "[3] = 1234",
+                    "[4] = 12345",
+                    "[5] = 123456",
+                    "[6] = 1234567",
+                    "}",
+                ],
+            )
+        else:
+            self.expect(
+                "frame variable " + var_name,
+                substrs=[
+                    var_name + " = size=7",
+                    "[0] = 1",
+                    "[1] = 12",
+                    "[2] = 123",
+                    "[3] = 1234",
+                    "[4] = 12345",
+                    "[5] = 123456",
+                    "[6] = 1234567",
+                    "}",
+                ],
+            )
         self.expect_expr(
             var_name,
             result_summary="size=7",
@@ -75,7 +90,7 @@ class LibcxxDequeDataFormatterTestCase(TestBase):
         )
 
         # The reference should display the same was as the value did
-        self.check_numbers("ref")
+        self.check_numbers("ref", True)
 
         # The pointer should just show the right number of elements:
         self.expect("frame variable ptr", substrs=["ptr =", " size=7"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/deque/TestDataFormatterLibcxxDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/deque/TestDataFormatterLibcxxDeque.py
@@ -10,36 +10,26 @@ from lldbsuite.test import lldbutil
 
 class LibcxxDequeDataFormatterTestCase(TestBase):
     def check_numbers(self, var_name, show_ptr=False):
+        patterns = []
+        substrs = [
+            "[0] = 1",
+            "[1] = 12",
+            "[2] = 123",
+            "[3] = 1234",
+            "[4] = 12345",
+            "[5] = 123456",
+            "[6] = 1234567",
+            "}",
+        ]
         if show_ptr:
-            self.expect(
-                "frame variable " + var_name,
-                patterns=[var_name + " = 0x.* size=7"],
-                substrs=[
-                    "[0] = 1",
-                    "[1] = 12",
-                    "[2] = 123",
-                    "[3] = 1234",
-                    "[4] = 12345",
-                    "[5] = 123456",
-                    "[6] = 1234567",
-                    "}",
-                ],
-            )
+            patterns = [var_name + " = 0x.* size=7"]
         else:
-            self.expect(
-                "frame variable " + var_name,
-                substrs=[
-                    var_name + " = size=7",
-                    "[0] = 1",
-                    "[1] = 12",
-                    "[2] = 123",
-                    "[3] = 1234",
-                    "[4] = 12345",
-                    "[5] = 123456",
-                    "[6] = 1234567",
-                    "}",
-                ],
-            )
+            substrs.insert(0, var_name + " = size=7")
+        self.expect(
+            "frame variable " + var_name,
+            patterns=patterns,
+            substrs=substrs,
+        )
         self.expect_expr(
             var_name,
             result_summary="size=7",

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/span/TestDataFormatterLibcxxSpan.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/span/TestDataFormatterLibcxxSpan.py
@@ -172,7 +172,4 @@ class LibcxxSpanDataFormatterTestCase(TestBase):
 
         # The pointer should just show the right number of elements:
 
-        ptrAddr = self.findVariable("ptr").GetValue()
-        self.expect_expr(
-            "ptr", result_type="std::span<int, 5> *", result_summary=f"{ptrAddr} size=5"
-        )
+        self.expect("frame variable ptr", patterns=["ptr = 0x.*", " size=5"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/variant/TestDataFormatterLibcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/variant/TestDataFormatterLibcxxVariant.py
@@ -47,7 +47,7 @@ class LibcxxVariantDataFormatterTestCase(TestBase):
 
         self.expect(
             "frame variable v1_ref",
-            substrs=["v1_ref =  Active Type = int : {", "Value = 12", "}"],
+            patterns=["v1_ref = 0x.* Active Type = int : {", "Value = 12", "}"],
         )
 
         self.expect(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -10,7 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class LibcxxVectorDataFormatterTestCase(TestBase):
-    def check_numbers(self, var_name, show_ptr = False):
+    def check_numbers(self, var_name, show_ptr=False):
         if show_ptr:           
             self.expect(
                 "frame variable " + var_name,

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -10,22 +10,37 @@ from lldbsuite.test import lldbutil
 
 
 class LibcxxVectorDataFormatterTestCase(TestBase):
-    def check_numbers(self, var_name):
-        self.expect(
-            "frame variable " + var_name,
-            substrs=[
-                var_name + " = size=7",
-                "[0] = 1",
-                "[1] = 12",
-                "[2] = 123",
-                "[3] = 1234",
-                "[4] = 12345",
-                "[5] = 123456",
-                "[6] = 1234567",
-                "}",
-            ],
-        )
-
+    def check_numbers(self, var_name, show_ptr = False):
+        if show_ptr:           
+            self.expect(
+                "frame variable " + var_name,
+                patterns=[var_name + " = 0x.* size=7"],
+                substrs=[
+                    "[0] = 1",
+                    "[1] = 12",
+                    "[2] = 123",
+                    "[3] = 1234",
+                    "[4] = 12345",
+                    "[5] = 123456",
+                    "[6] = 1234567",
+                    "}",
+                ],
+            )
+        else:
+            self.expect(
+                "frame variable " + var_name,
+                substrs=[
+                    var_name + " = size=7",
+                    "[0] = 1",
+                    "[1] = 12",
+                    "[2] = 123",
+                    "[3] = 1234",
+                    "[4] = 12345",
+                    "[5] = 123456",
+                    "[6] = 1234567",
+                    "}",
+                ],
+            )
         self.expect_expr(
             var_name,
             result_summary="size=7",
@@ -174,7 +189,7 @@ class LibcxxVectorDataFormatterTestCase(TestBase):
         )
 
         # The reference should display the same was as the value did
-        self.check_numbers("ref")
+        self.check_numbers("ref", True)
 
         # The pointer should just show the right number of elements:
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -11,36 +11,27 @@ from lldbsuite.test import lldbutil
 
 class LibcxxVectorDataFormatterTestCase(TestBase):
     def check_numbers(self, var_name, show_ptr=False):
+        patterns = []
+        substrs = [
+            "[0] = 1",
+            "[1] = 12",
+            "[2] = 123",
+            "[3] = 1234",
+            "[4] = 12345",
+            "[5] = 123456",
+            "[6] = 1234567",
+            "}",
+        ]
         if show_ptr:
-            self.expect(
-                "frame variable " + var_name,
-                patterns=[var_name + " = 0x.* size=7"],
-                substrs=[
-                    "[0] = 1",
-                    "[1] = 12",
-                    "[2] = 123",
-                    "[3] = 1234",
-                    "[4] = 12345",
-                    "[5] = 123456",
-                    "[6] = 1234567",
-                    "}",
-                ],
-            )
+            patterns = [var_name + " = 0x.* size=7"]
         else:
-            self.expect(
-                "frame variable " + var_name,
-                substrs=[
-                    var_name + " = size=7",
-                    "[0] = 1",
-                    "[1] = 12",
-                    "[2] = 123",
-                    "[3] = 1234",
-                    "[4] = 12345",
-                    "[5] = 123456",
-                    "[6] = 1234567",
-                    "}",
-                ],
-            )
+            substrs.insert(0, var_name + " = size=7")
+
+        self.expect(
+            "frame variable " + var_name,
+            patterns=patterns,
+            substrs=substrs,
+        )
         self.expect_expr(
             var_name,
             result_summary="size=7",

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/vector/TestDataFormatterLibcxxVector.py
@@ -11,7 +11,7 @@ from lldbsuite.test import lldbutil
 
 class LibcxxVectorDataFormatterTestCase(TestBase):
     def check_numbers(self, var_name, show_ptr=False):
-        if show_ptr:           
+        if show_ptr:
             self.expect(
                 "frame variable " + var_name,
                 patterns=[var_name + " = 0x.* size=7"],

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -30,7 +30,7 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
         for name in ["v1_ref", "v1_typedef_ref"]:
             self.expect(
                 "frame variable " + name,
-                substrs=[name + " =  Active Type = int : {", "Value = 12", "}"],
+                patterns=[name + " = 0x.*  Active Type = int : {", "Value = 12", "}"],
             )
 
         self.expect(


### PR DESCRIPTION
This has two changes:
1. Set show value for libcxx and libstdcxx summary provider. This will print the pointer value for both pointer type and reference type.
2. Remove pointer value printing in libcxx container summary.

Discussion:
https://discourse.llvm.org/t/lldb-hides-raw-pointer-value-for-libcxx-and-libstdcxx-pointer-types-in-summary-string/84226