### PR TITLE
[CFIFixup] Add a default constructor to BlockFlags (NFC)

### DIFF
--- a/llvm/lib/CodeGen/CFIFixup.cpp
+++ b/llvm/lib/CodeGen/CFIFixup.cpp
@@ -131,6 +131,9 @@ struct BlockFlags {
   bool StrongNoFrameOnEntry : 1;
   bool HasFrameOnEntry : 1;
   bool HasFrameOnExit : 1;
+  BlockFlags()
+      : Reachable(false), StrongNoFrameOnEntry(false), HasFrameOnEntry(false),
+        HasFrameOnExit(false) {}
 };
 
 // Most functions will have <= 32 basic blocks.
@@ -141,7 +144,7 @@ using BlockFlagsVector = SmallVector<BlockFlags, 32>;
 static BlockFlagsVector
 computeBlockInfo(const MachineFunction &MF,
                  const MachineBasicBlock *PrologueBlock) {
-  BlockFlagsVector BlockInfo(MF.getNumBlockIDs(), {false, false, false, false});
+  BlockFlagsVector BlockInfo(MF.getNumBlockIDs());
   BlockInfo[0].Reachable = true;
   BlockInfo[0].StrongNoFrameOnEntry = true;
 


### PR DESCRIPTION
This patch adds a default constructor to BlockFlags to initialize its
members to false, placing initializers close to the member
declarations.

Note that once C++20 is available in our codebase, we can replace
the explicit default constructor with:

  bool Reachable : 1 = true;
  :
