### PR TITLE
[lldb] Implement bidirectional access for backing<->backed thread relationship

### DIFF
--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -472,7 +472,7 @@ public:
 
   /// Sets the thread that is backed by this thread.
   /// If backed_thread.GetBackedThread() is null, this method also calls
-  /// backed_thread.SetBackedThread(this).
+  /// backed_thread.SetBackingThread(this).
   /// If backed_thread.GetBackedThread() is non-null, asserts that it is equal
   /// to `this`.
   void SetBackedThread(Thread &backed_thread) {

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -470,6 +470,18 @@ public:
 
   virtual void ClearStackFrames();
 
+  /// Derived classes implementing SetBackingThread should use this to provide
+  /// bidirectional access to the Backing-Backed relationship.
+  void SetBackedThread(Thread &backed_thread) {
+    assert(backed_thread.GetBackingThread().get() == this);
+    m_backed_thread = backed_thread.shared_from_this();
+  }
+
+  void ClearBackedThread() { m_backed_thread.reset(); }
+
+  /// Returns the thread that is backed by this thread, if any.
+  lldb::ThreadSP GetBackedThread() const { return m_backed_thread; }
+
   virtual bool SetBackingThread(const lldb::ThreadSP &thread_sp) {
     return false;
   }
@@ -1348,6 +1360,9 @@ protected:
                          // classes call DestroyThread.
   LazyBool m_override_should_notify;
   mutable std::unique_ptr<ThreadPlanStack> m_null_plan_stack_up;
+
+  /// The Thread backed by this thread, if any.
+  lldb::ThreadSP m_backed_thread;
 
 private:
   bool m_extended_info_fetched; // Have we tried to retrieve the m_extended_info

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -470,11 +470,19 @@ public:
 
   virtual void ClearStackFrames();
 
-  /// Derived classes implementing SetBackingThread should use this to provide
-  /// bidirectional access to the Backing-Backed relationship.
+  /// Sets the thread that is backed by this thread.
+  /// If backed_thread.GetBackedThread() is null, this method also calls
+  /// backed_thread.SetBackedThread(this).
+  /// If backed_thread.GetBackedThread() is non-null, asserts that it is equal
+  /// to `this`.
   void SetBackedThread(Thread &backed_thread) {
-    assert(backed_thread.GetBackingThread().get() == this);
     m_backed_thread = backed_thread.shared_from_this();
+
+    // Ensure the bidrectional relationship is preserved.
+    Thread *backing_thread = backed_thread.GetBackingThread().get();
+    assert(backing_thread == nullptr || backing_thread == this);
+    if (backing_thread == nullptr)
+      backed_thread.SetBackingThread(shared_from_this());
   }
 
   void ClearBackedThread() { m_backed_thread.reset(); }

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -488,7 +488,7 @@ public:
   void ClearBackedThread() { m_backed_thread.reset(); }
 
   /// Returns the thread that is backed by this thread, if any.
-  lldb::ThreadSP GetBackedThread() const { return m_backed_thread; }
+  lldb::ThreadSP GetBackedThread() const { return m_backed_thread.lock(); }
 
   virtual bool SetBackingThread(const lldb::ThreadSP &thread_sp) {
     return false;
@@ -1370,7 +1370,7 @@ protected:
   mutable std::unique_ptr<ThreadPlanStack> m_null_plan_stack_up;
 
   /// The Thread backed by this thread, if any.
-  lldb::ThreadSP m_backed_thread;
+  lldb::ThreadWP m_backed_thread;
 
 private:
   bool m_extended_info_fetched; // Have we tried to retrieve the m_extended_info

--- a/lldb/include/lldb/Target/ThreadList.h
+++ b/lldb/include/lldb/Target/ThreadList.h
@@ -101,8 +101,6 @@ public:
 
   lldb::ThreadSP GetThreadSPForThreadPtr(Thread *thread_ptr);
 
-  lldb::ThreadSP GetBackingThread(const lldb::ThreadSP &real_thread);
-
   bool ShouldStop(Event *event_ptr);
 
   Vote ShouldReportStop(Event *event_ptr);

--- a/lldb/source/Plugins/Process/Utility/ThreadMemory.h
+++ b/lldb/source/Plugins/Process/Utility/ThreadMemory.h
@@ -72,12 +72,17 @@ public:
 
   void ClearStackFrames() override;
 
-  void ClearBackingThread() override { m_backing_thread_sp.reset(); }
+  void ClearBackingThread() override {
+    if (m_backing_thread_sp)
+      m_backing_thread_sp->ClearBackedThread();
+    m_backing_thread_sp.reset();
+  }
 
   bool SetBackingThread(const lldb::ThreadSP &thread_sp) override {
     // printf ("Thread 0x%llx is being backed by thread 0x%llx\n", GetID(),
     // thread_sp->GetID());
     m_backing_thread_sp = thread_sp;
+    thread_sp->SetBackedThread(*this);
     return (bool)thread_sp;
   }
 

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -1728,7 +1728,7 @@ ThreadSP ProcessGDBRemote::SetThreadStopInfo(
     thread_sp->SetStopInfo(StopInfoSP());
     // If there's a memory thread backed by this thread, we need to use it to
     // calculate StopInfo.
-    if (ThreadSP memory_thread_sp = m_thread_list.GetBackingThread(thread_sp))
+    if (ThreadSP memory_thread_sp = thread_sp->GetBackedThread())
       thread_sp = memory_thread_sp;
 
     if (exc_type != 0) {

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -191,20 +191,6 @@ ThreadSP ThreadList::GetThreadSPForThreadPtr(Thread *thread_ptr) {
   return thread_sp;
 }
 
-ThreadSP ThreadList::GetBackingThread(const ThreadSP &real_thread) {
-  std::lock_guard<std::recursive_mutex> guard(GetMutex());
-
-  ThreadSP thread_sp;
-  const uint32_t num_threads = m_threads.size();
-  for (uint32_t idx = 0; idx < num_threads; ++idx) {
-    if (m_threads[idx]->GetBackingThread() == real_thread) {
-      thread_sp = m_threads[idx];
-      break;
-    }
-  }
-  return thread_sp;
-}
-
 ThreadSP ThreadList::FindThreadByIndexID(uint32_t index_id, bool can_update) {
   std::lock_guard<std::recursive_mutex> guard(GetMutex());
 


### PR DESCRIPTION
This enables finding the backed thread from the backing thread without going through the thread list, and it will be useful for subsequent commits.