### PR TITLE
[lldb] correct event when removing all watchpoints

### DIFF
--- a/lldb/source/Breakpoint/WatchpointList.cpp
+++ b/lldb/source/Breakpoint/WatchpointList.cpp
@@ -236,7 +236,7 @@ void WatchpointList::RemoveAll(bool notify) {
       wp_collection::iterator pos, end = m_watchpoints.end();
       for (pos = m_watchpoints.begin(); pos != end; ++pos) {
         if ((*pos)->GetTarget().EventTypeHasListeners(
-                Target::eBroadcastBitBreakpointChanged)) {
+                Target::eBroadcastBitWatchpointChanged)) {
           auto data_sp = std::make_shared<Watchpoint::WatchpointEventData>(
               eWatchpointEventTypeRemoved, *pos);
           (*pos)->GetTarget().BroadcastEvent(


### PR DESCRIPTION
    LLDB: correct event when removing all watchpoints
    
    Previously we incorrectly checked for a "breakpoint changed" event
    listener removing all watchpoints (e.g. via
    SBTarget::DeleteAllWatchpoints()), although we would emit a "watchpoint
    changed" event if there were a listener for 'breakpoint changed'.
    
    This meant that we might not emit a "watchpoint changed" event if there
    was a listener for this event.
    
    Correct it to check for the "watchpoint changed" event.


---


Updated regression tests which were also incorrectly peeking for the wrong event type. The 'remove' action actually triggers 2 events which the test didn't allow, so I updated it to allow specifically what was requested.

The test fails (expectedly) at the line following "DeleteAllWatchpoints" prior to this patch, and passes after.