### PR TITLE
[RISCV] Simplify MIPS CCMov patterns. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXMips.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXMips.td
@@ -116,24 +116,13 @@ def MIPS_CCMOV : RVInstR4<0b11, 0b011, OPC_CUSTOM_0, (outs GPR:$rd),
 }
 
 let Predicates = [UseCCMovInsn] in {
-def : Pat<(select (XLenVT (setne (XLenVT GPR:$rs2), (XLenVT 0))),
+def : Pat<(select (riscv_setne (XLenVT GPR:$rs2)),
                   (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
           (MIPS_CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
-def : Pat<(select (XLenVT (setne (XLenVT GPR:$x), (XLenVT simm12_plus1:$y))),
-                  (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
-          (MIPS_CCMOV GPR:$rs1, (ADDI GPR:$x, (NegImm simm12_plus1:$y)), GPR:$rs3)>;
-def : Pat<(select (XLenVT (setne (XLenVT GPR:$x), (XLenVT GPR:$y))),
-                  (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
-          (MIPS_CCMOV GPR:$rs1, (XOR GPR:$x, GPR:$y), GPR:$rs3)>;
-def : Pat<(select (XLenVT (seteq (XLenVT GPR:$rs2), (XLenVT 0))),
+def : Pat<(select (riscv_seteq (XLenVT GPR:$rs2)),
                   (XLenVT GPR:$rs3), (XLenVT GPR:$rs1)),
           (MIPS_CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
-def : Pat<(select (XLenVT (seteq (XLenVT GPR:$x), (XLenVT simm12_plus1:$y))),
-                  (XLenVT GPR:$rs3), (XLenVT GPR:$rs1)),
-          (MIPS_CCMOV GPR:$rs1, (ADDI GPR:$x, (NegImm simm12_plus1:$y)), GPR:$rs3)>;
-def : Pat<(select (XLenVT (seteq (XLenVT GPR:$x), (XLenVT GPR:$y))),
-                  (XLenVT GPR:$rs3), (XLenVT GPR:$rs1)),
-          (MIPS_CCMOV GPR:$rs1, (XOR GPR:$x, GPR:$y), GPR:$rs3)>;
+
 def : Pat<(select (XLenVT GPR:$rs2), (XLenVT GPR:$rs1), (XLenVT GPR:$rs3)),
           (MIPS_CCMOV GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
 }


### PR DESCRIPTION
We have ComplexPatterns that reduce 3 patterns to 1, by handling the ==/!= 0, imm, and register cases. These are used for XTHeadCondMove, Zicond, XVentanaCondOps, and our basic seteq/setne patterns.