### PR TITLE
[clang-format] Hanlde qualified type name for `QualifierAlignment`

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -415,8 +415,7 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeLeft(
   // The case `long volatile long int const` -> `const volatile long long int`
   if (TypeToken->isTypeName(LangOpts)) {
     for (const auto *Prev = TypeToken->Previous;
-         Prev && Prev->is(tok::coloncolon);
-         Prev = Prev->Previous) {
+         Prev && Prev->is(tok::coloncolon); Prev = Prev->Previous) {
       TypeToken = Prev;
       Prev = Prev->Previous;
       if (!(Prev && Prev->is(tok::identifier)))

--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -414,11 +414,11 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeLeft(
   // The case `const long long volatile int` -> `const volatile long long int`
   // The case `long volatile long int const` -> `const volatile long long int`
   if (TypeToken->isTypeName(LangOpts)) {
-    for (const auto *Prev = TypeToken->getPreviousNonComment();
+    for (const auto *Prev = TypeToken->Previous;
          Prev && Prev->is(tok::coloncolon);
-         Prev = Prev->getPreviousNonComment()) {
+         Prev = Prev->Previous) {
       TypeToken = Prev;
-      Prev = Prev->getPreviousNonComment();
+      Prev = Prev->Previous;
       if (!(Prev && Prev->is(tok::identifier)))
         break;
       TypeToken = Prev;

--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -132,8 +132,10 @@ static void rotateTokens(const SourceManager &SourceMgr,
   // Then move through the other tokens.
   auto *Tok = Begin;
   while (Tok != End) {
-    if (!NewText.empty() && !endsWithSpace(NewText))
+    if (!NewText.empty() && !endsWithSpace(NewText) &&
+        Tok->isNot(tok::coloncolon)) {
       NewText += " ";
+    }
 
     NewText += Tok->TokenText;
     Tok = Tok->Next;
@@ -412,6 +414,10 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeLeft(
   // The case `const long long volatile int` -> `const volatile long long int`
   // The case `long volatile long int const` -> `const volatile long long int`
   if (TypeToken->isTypeName(LangOpts)) {
+    if (const auto *Prev = TypeToken->getPreviousNonComment();
+        Prev && Prev->endsSequence(tok::coloncolon, tok::identifier)) {
+      TypeToken = Prev->getPreviousNonComment();
+    }
     const FormatToken *LastSimpleTypeSpecifier = TypeToken;
     while (isConfiguredQualifierOrType(
         LastSimpleTypeSpecifier->getPreviousNonComment(),

--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -414,9 +414,14 @@ const FormatToken *LeftRightQualifierAlignmentFixer::analyzeLeft(
   // The case `const long long volatile int` -> `const volatile long long int`
   // The case `long volatile long int const` -> `const volatile long long int`
   if (TypeToken->isTypeName(LangOpts)) {
-    if (const auto *Prev = TypeToken->getPreviousNonComment();
-        Prev && Prev->endsSequence(tok::coloncolon, tok::identifier)) {
-      TypeToken = Prev->getPreviousNonComment();
+    for (const auto *Prev = TypeToken->getPreviousNonComment();
+         Prev && Prev->is(tok::coloncolon);
+         Prev = Prev->getPreviousNonComment()) {
+      TypeToken = Prev;
+      Prev = Prev->getPreviousNonComment();
+      if (!(Prev && Prev->is(tok::identifier)))
+        break;
+      TypeToken = Prev;
     }
     const FormatToken *LastSimpleTypeSpecifier = TypeToken;
     while (isConfiguredQualifierOrType(

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -1291,6 +1291,18 @@ TEST_F(QualifierFixerTest, WithCpp11Attribute) {
                "[[maybe_unused]] constexpr static int A", Style);
 }
 
+TEST_F(QualifierFixerTest, WithQualifiedTypeName) {
+  auto Style = getLLVMStyle();
+  Style.QualifierAlignment = FormatStyle::QAS_Custom;
+  Style.QualifierOrder = {"constexpr", "type", "const"};
+
+  verifyFormat("constexpr std::int64_t x{123};",
+               "std::int64_t constexpr x{123};", Style);
+
+  Style.TypeNames.push_back("bar");
+  verifyFormat("constexpr foo::bar x{12};", "foo::bar constexpr x{12};", Style);
+}
+
 TEST_F(QualifierFixerTest, DisableRegions) {
   FormatStyle Style = getLLVMStyle();
   Style.QualifierAlignment = FormatStyle::QAS_Custom;

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -1296,8 +1296,11 @@ TEST_F(QualifierFixerTest, WithQualifiedTypeName) {
   Style.QualifierAlignment = FormatStyle::QAS_Custom;
   Style.QualifierOrder = {"constexpr", "type", "const"};
 
+  verifyFormat("constexpr ::int64_t x{1};", "::int64_t constexpr x{1};", Style);
   verifyFormat("constexpr std::int64_t x{123};",
                "std::int64_t constexpr x{123};", Style);
+  verifyFormat("constexpr ::std::int64_t x{123};",
+               "::std::int64_t constexpr x{123};", Style);
 
   Style.TypeNames.push_back("bar");
   verifyFormat("constexpr foo::bar x{12};", "foo::bar constexpr x{12};", Style);


### PR DESCRIPTION
Fixes #125178.