### PR TITLE
[CVP] Simplify minmax at use

### DIFF
--- a/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
+++ b/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp
@@ -610,7 +610,42 @@ static bool processMinMaxIntrinsic(MinMaxIntrinsic *MM, LazyValueInfo *LVI) {
     return true;
   }
 
-  return false;
+  bool Changed = false;
+  for (Use &U : make_early_inc_range(MM->uses())) {
+    ConstantRange LHS_CR =
+        ConstantRange::getEmpty(MM->getType()->getScalarSizeInBits());
+    ConstantRange RHS_CR = LHS_CR;
+    auto *CxtI = cast<Instruction>(U.getUser());
+    if (auto *PN = dyn_cast<PHINode>(CxtI)) {
+      BasicBlock *FromBB = PN->getIncomingBlock(U);
+      LHS_CR = LVI->getConstantRangeOnEdge(MM->getOperand(0), FromBB,
+                                           CxtI->getParent(), CxtI);
+      RHS_CR = LVI->getConstantRangeOnEdge(MM->getOperand(1), FromBB,
+                                           CxtI->getParent(), CxtI);
+    } else {
+      LHS_CR = LVI->getConstantRange(MM->getOperand(0), CxtI,
+                                     /*UndefAllowed=*/false);
+      RHS_CR = LVI->getConstantRange(MM->getOperand(1), CxtI,
+                                     /*UndefAllowed=*/false);
+    }
+    if (LHS_CR.icmp(Pred, RHS_CR)) {
+      Changed = true;
+      ++NumMinMax;
+      U.set(MM->getLHS());
+      continue;
+    }
+    if (RHS_CR.icmp(Pred, LHS_CR)) {
+      Changed = true;
+      ++NumMinMax;
+      U.set(MM->getRHS());
+      continue;
+    }
+  }
+
+  if (MM->use_empty())
+    MM->eraseFromParent();
+
+  return Changed;
 }
 
 // Rewrite this with.overflow intrinsic as non-overflowing.

--- a/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
@@ -355,3 +355,28 @@ define i8 @test_umax_nneg(i8 %a, i8 %b) {
   %ret = call i8 @llvm.umax.i8(i8 %nneg_a, i8 %nneg_b)
   ret i8 %ret
 }
+
+define i64 @test_at_use2(i32 %x) {
+; CHECK-LABEL: @test_at_use2(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[COND:%.*]] = icmp slt i32 [[X:%.*]], 0
+; CHECK-NEXT:    [[SMAX:%.*]] = call i32 @llvm.smax.i32(i32 [[X]], i32 -1)
+; CHECK-NEXT:    br i1 [[COND]], label [[IF_END:%.*]], label [[IF_THEN:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[SMAX]] to i64
+; CHECK-NEXT:    ret i64 [[EXT]]
+; CHECK:       if.end:
+; CHECK-NEXT:    ret i64 0
+;
+entry:
+  %cond = icmp slt i32 %x, 0
+  %smax = call i32 @llvm.smax.i32(i32 %x, i32 -1)
+  br i1 %cond, label %if.end, label %if.then
+
+if.then:
+  %ext = zext nneg i32 %smax to i64
+  ret i64 %ext
+
+if.end:
+  ret i64 0
+}

--- a/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/min-max.ll
@@ -360,10 +360,9 @@ define i64 @test_at_use2(i32 %x) {
 ; CHECK-LABEL: @test_at_use2(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[COND:%.*]] = icmp slt i32 [[X:%.*]], 0
-; CHECK-NEXT:    [[SMAX:%.*]] = call i32 @llvm.smax.i32(i32 [[X]], i32 -1)
 ; CHECK-NEXT:    br i1 [[COND]], label [[IF_END:%.*]], label [[IF_THEN:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[SMAX]] to i64
+; CHECK-NEXT:    [[EXT:%.*]] = zext nneg i32 [[X]] to i64
 ; CHECK-NEXT:    ret i64 [[EXT]]
 ; CHECK:       if.end:
 ; CHECK-NEXT:    ret i64 0


### PR DESCRIPTION
Address a regression caused by https://github.com/llvm/llvm-project/pull/121958.
Compile-time overhead: https://llvm-compile-time-tracker.com/compare.php?from=fc520e86cc87b2bd7fbf05d8b47ba3a7bb0e01bb&to=1cd00ec0795f2b2381496fa6bceaf2693ef425fd&stat=instructions:u