### PR TITLE
[ADT] Reduce copies and recursion in StringSwitch

### DIFF
--- a/llvm/unittests/ADT/StringSwitchTest.cpp
+++ b/llvm/unittests/ADT/StringSwitchTest.cpp
@@ -205,3 +205,28 @@ TEST(StringSwitchTest, CasesLower) {
   EXPECT_EQ(OSType::Unknown, Translate("wind"));
   EXPECT_EQ(OSType::Unknown, Translate(""));
 }
+
+TEST(StringSwitchTest, CasesCopies) {
+  struct Copyable {
+    unsigned &NumCopies;
+    Copyable(unsigned &Value) : NumCopies(Value) {}
+    Copyable(const Copyable &Other) : NumCopies(Other.NumCopies) {
+      ++NumCopies;
+    }
+    Copyable &operator=(const Copyable &Other) {
+      ++NumCopies;
+      return *this;
+    }
+  };
+
+  // Check that evaluating multiple cases does not cause unnecessary copies.
+  unsigned NumCopies = 0;
+  llvm::StringSwitch<Copyable, void>("baz").Cases("foo", "bar", "baz", "qux",
+                                                  Copyable{NumCopies});
+  EXPECT_EQ(NumCopies, 1u);
+
+  NumCopies = 0;
+  llvm::StringSwitch<Copyable, void>("baz").CasesLower(
+      "Foo", "Bar", "Baz", "Qux", Copyable{NumCopies});
+  EXPECT_EQ(NumCopies, 1u);
+}


### PR DESCRIPTION
Optimize the `.Cases` and `.CasesLower` functions to avoid needlessly recursing on each case and copying the associated values. We can instead take `Value` by reference and short-circuit by using the `||` operator.

Note that while the implementation uses variadic templates, we cannot simplify the public functions in the same way. This is because the current API forces the arguments to be converted to `StringLiterals` and places the `Value` parameter at the very end. Even if we did some tricks like split the parameter pack to separate out the `Value`, I do not see how we could force conversion to `StringLiteral`.