### PR TITLE
[libc] Build with -Wdeprecated, fix some warnings

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -179,8 +179,9 @@ function(_get_common_compile_options output_var flags)
     endif()
     list(APPEND compile_options "-Wconversion")
     list(APPEND compile_options "-Wno-sign-conversion")
-    # Silence this warning because _Complex is a part of C99.
+    list(APPEND compile_options "-Wdeprecated")
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      # Silence this warning because _Complex is a part of C99.
       list(APPEND compile_options "-fext-numeric-literals")
     else()
       list(APPEND compile_options "-Wno-c99-extensions")

--- a/libc/src/__support/CPP/span.h
+++ b/libc/src/__support/CPP/span.h
@@ -52,6 +52,8 @@ public:
 
   LIBC_INLINE constexpr span() : span_data(nullptr), span_size(0) {}
 
+  LIBC_INLINE constexpr span(const span&) = default;
+
   LIBC_INLINE constexpr span(pointer first, size_type count)
       : span_data(first), span_size(count) {}
 

--- a/libc/src/__support/CPP/span.h
+++ b/libc/src/__support/CPP/span.h
@@ -10,7 +10,7 @@
 
 #include <stddef.h> // For size_t
 
-#include "array.h"       // For array
+#include "array.h" // For array
 #include "src/__support/macros/config.h"
 #include "type_traits.h" // For remove_cv_t, enable_if_t, is_same_v, is_const_v
 
@@ -52,7 +52,7 @@ public:
 
   LIBC_INLINE constexpr span() : span_data(nullptr), span_size(0) {}
 
-  LIBC_INLINE constexpr span(const span&) = default;
+  LIBC_INLINE constexpr span(const span &) = default;
 
   LIBC_INLINE constexpr span(pointer first, size_type count)
       : span_data(first), span_size(count) {}

--- a/libc/test/src/setjmp/CMakeLists.txt
+++ b/libc/test/src/setjmp/CMakeLists.txt
@@ -11,6 +11,8 @@ add_libc_unittest(
     libc_setjmp_unittests
   SRCS
     setjmp_test.cpp
+  CXX_STANDARD
+    20
   DEPENDS
     libc.src.setjmp.longjmp
     libc.src.setjmp.setjmp

--- a/libc/test/src/setjmp/setjmp_test.cpp
+++ b/libc/test/src/setjmp/setjmp_test.cpp
@@ -27,7 +27,7 @@ TEST(LlvmLibcSetJmpTest, SetAndJumpBack) {
   // The first time setjmp is called, it should return 0.
   // Subsequent calls will return the value passed to jump_back below.
   if (LIBC_NAMESPACE::setjmp(buf) <= MAX_LOOP) {
-    ++n;
+    n = n + 1;
     jump_back(buf, n);
   }
   ASSERT_EQ(longjmp_called, n);


### PR DESCRIPTION
While GCC's -Wdeprecated is on by default and doesn't do much,
Clang's -Wdeprecated enables many more things.  More apply in
C++20, so switch a test file that tickled one to using that.  In
future, C++20 should probably be made the baseline for compiling
all the libc code.
