### PR TITLE
[LVI] Handle nonnull attributes at callsite

### DIFF
--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -644,6 +644,13 @@ static void AddNonNullPointersByInstruction(
     AddNonNullPointer(MI->getRawDest(), PtrSet);
     if (MemTransferInst *MTI = dyn_cast<MemTransferInst>(MI))
       AddNonNullPointer(MTI->getRawSource(), PtrSet);
+  } else if (auto *CB = dyn_cast<CallBase>(I)) {
+    for (auto &U : CB->args()) {
+      if (U->getType()->isPointerTy() &&
+          CB->paramHasNonNullAttr(CB->getArgOperandNo(&U),
+                                  /*AllowUndefOrPoison=*/false))
+        AddNonNullPointer(U.get(), PtrSet);
+    }
   }
 }
 
@@ -780,25 +787,12 @@ void LazyValueInfoImpl::intersectAssumeOrGuardBlockValueConstantRange(
   }
 
   if (BBLV.isOverdefined()) {
-    if (PointerType *PTy = dyn_cast<PointerType>(Val->getType())) {
-      // Check whether we're checking at the terminator, and the pointer has
-      // been dereferenced in this block.
-      if (BB->getTerminator() == BBI && isNonNullAtEndOfBlock(Val, BB))
-        BBLV = ValueLatticeElement::getNot(ConstantPointerNull::get(PTy));
-      else {
-        for (Use &U : Val->uses()) {
-          if (auto *CB = dyn_cast<CallBase>(U.getUser())) {
-            if (CB->isArgOperand(&U) &&
-                CB->paramHasNonNullAttr(CB->getArgOperandNo(&U),
-                                        /*AllowUndefOrPoison=*/false) &&
-                isValidAssumeForContext(CB, BBI)) {
-              BBLV = ValueLatticeElement::getNot(ConstantPointerNull::get(PTy));
-              break;
-            }
-          }
-        }
-      }
-    }
+    // Check whether we're checking at the terminator, and the pointer has
+    // been dereferenced in this block.
+    PointerType *PTy = dyn_cast<PointerType>(Val->getType());
+    if (PTy && BB->getTerminator() == BBI &&
+        isNonNullAtEndOfBlock(Val, BB))
+      BBLV = ValueLatticeElement::getNot(ConstantPointerNull::get(PTy));
   }
 }
 

--- a/llvm/lib/Analysis/LazyValueInfo.cpp
+++ b/llvm/lib/Analysis/LazyValueInfo.cpp
@@ -622,10 +622,12 @@ LazyValueInfoImpl::solveBlockValueImpl(Value *Val, BasicBlock *BB) {
   return getFromRangeMetadata(BBI);
 }
 
-static void AddNonNullPointer(Value *Ptr, NonNullPointerSet &PtrSet) {
+static void AddNonNullPointer(Value *Ptr, NonNullPointerSet &PtrSet,
+                              bool IsDereferenced = true) {
   // TODO: Use NullPointerIsDefined instead.
   if (Ptr->getType()->getPointerAddressSpace() == 0)
-    PtrSet.insert(getUnderlyingObject(Ptr));
+    PtrSet.insert(IsDereferenced ? getUnderlyingObject(Ptr)
+                                 : Ptr->stripInBoundsOffsets());
 }
 
 static void AddNonNullPointersByInstruction(
@@ -649,7 +651,7 @@ static void AddNonNullPointersByInstruction(
       if (U->getType()->isPointerTy() &&
           CB->paramHasNonNullAttr(CB->getArgOperandNo(&U),
                                   /*AllowUndefOrPoison=*/false))
-        AddNonNullPointer(U.get(), PtrSet);
+        AddNonNullPointer(U.get(), PtrSet, /*IsDereferenced=*/false);
     }
   }
 }

--- a/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
@@ -433,7 +433,7 @@ define i1 @test_known_nonnull_at_callsite_gep_without_inbounds(ptr %src, i64 %x)
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[SRC:%.*]], i64 [[X:%.*]]
 ; CHECK-NEXT:    call void @callee(ptr noundef nonnull [[GEP]])
 ; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
-; CHECK-NEXT:    ret i1 false
+; CHECK-NEXT:    ret i1 [[NONNULL]]
 ;
 entry:
   %gep = getelementptr i8, ptr %src, i64 %x

--- a/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
@@ -344,4 +344,75 @@ define i1 @test_store_same_block(ptr %arg) {
   ret i1 %cmp
 }
 
+
+define i1 @test_known_nonnull_at_callsite(ptr %src) {
+; CHECK-LABEL: @test_known_nonnull_at_callsite(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @callee(ptr noundef nonnull [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 [[NONNULL]]
+;
+entry:
+  call void @callee(ptr noundef nonnull %src)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
+define i1 @test_known_nonnull_mixed(ptr %src) {
+; CHECK-LABEL: @test_known_nonnull_mixed(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @callee2(ptr nonnull [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 [[NONNULL]]
+;
+entry:
+  call void @callee2(ptr nonnull %src)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
+define i1 @test_known_nonnull_at_callsite_dereferenceable(ptr %src) {
+; CHECK-LABEL: @test_known_nonnull_at_callsite_dereferenceable(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @callee(ptr dereferenceable(1) [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 [[NONNULL]]
+;
+entry:
+  call void @callee(ptr dereferenceable(1) %src)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
+; Negative tests
+
+define i1 @test_known_nonnull_at_callsite_without_noundef(ptr %src) {
+; CHECK-LABEL: @test_known_nonnull_at_callsite_without_noundef(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @callee(ptr nonnull [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 [[NONNULL]]
+;
+entry:
+  call void @callee(ptr nonnull %src)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
+define i1 @test_known_nonnull_at_callsite_dereferenceable_null_is_defined(ptr %src) #0 {
+; CHECK-LABEL: @test_known_nonnull_at_callsite_dereferenceable_null_is_defined(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    call void @callee(ptr dereferenceable(1) [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 [[NONNULL]]
+;
+entry:
+  call void @callee(ptr dereferenceable(1) %src)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
+declare void @callee(ptr)
+declare void @callee2(ptr noundef)
+
 attributes #0 = { null_pointer_is_valid }

--- a/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
@@ -349,6 +349,7 @@ define i1 @test_known_nonnull_at_callsite(ptr %src) {
 ; CHECK-LABEL: @test_known_nonnull_at_callsite(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @callee(ptr noundef nonnull [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
 ; CHECK-NEXT:    ret i1 false
 ;
 entry:
@@ -361,6 +362,7 @@ define i1 @test_known_nonnull_mixed(ptr %src) {
 ; CHECK-LABEL: @test_known_nonnull_mixed(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @callee2(ptr nonnull [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
 ; CHECK-NEXT:    ret i1 false
 ;
 entry:
@@ -373,6 +375,7 @@ define i1 @test_known_nonnull_at_callsite_dereferenceable(ptr %src) {
 ; CHECK-LABEL: @test_known_nonnull_at_callsite_dereferenceable(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @callee(ptr dereferenceable(1) [[SRC:%.*]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
 ; CHECK-NEXT:    ret i1 false
 ;
 entry:

--- a/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
@@ -349,8 +349,7 @@ define i1 @test_known_nonnull_at_callsite(ptr %src) {
 ; CHECK-LABEL: @test_known_nonnull_at_callsite(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @callee(ptr noundef nonnull [[SRC:%.*]])
-; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
-; CHECK-NEXT:    ret i1 [[NONNULL]]
+; CHECK-NEXT:    ret i1 false
 ;
 entry:
   call void @callee(ptr noundef nonnull %src)
@@ -362,8 +361,7 @@ define i1 @test_known_nonnull_mixed(ptr %src) {
 ; CHECK-LABEL: @test_known_nonnull_mixed(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @callee2(ptr nonnull [[SRC:%.*]])
-; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
-; CHECK-NEXT:    ret i1 [[NONNULL]]
+; CHECK-NEXT:    ret i1 false
 ;
 entry:
   call void @callee2(ptr nonnull %src)
@@ -375,8 +373,7 @@ define i1 @test_known_nonnull_at_callsite_dereferenceable(ptr %src) {
 ; CHECK-LABEL: @test_known_nonnull_at_callsite_dereferenceable(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    call void @callee(ptr dereferenceable(1) [[SRC:%.*]])
-; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
-; CHECK-NEXT:    ret i1 [[NONNULL]]
+; CHECK-NEXT:    ret i1 false
 ;
 entry:
   call void @callee(ptr dereferenceable(1) %src)

--- a/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/non-null.ll
@@ -384,6 +384,21 @@ entry:
   ret i1 %nonnull
 }
 
+define i1 @test_known_nonnull_at_callsite_gep_inbounds(ptr %src, i64 %x) {
+; CHECK-LABEL: @test_known_nonnull_at_callsite_gep_inbounds(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds i8, ptr [[SRC:%.*]], i64 [[X:%.*]]
+; CHECK-NEXT:    call void @callee(ptr noundef nonnull [[GEP]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %gep = getelementptr inbounds i8, ptr %src, i64 %x
+  call void @callee(ptr noundef nonnull %gep)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
 ; Negative tests
 
 define i1 @test_known_nonnull_at_callsite_without_noundef(ptr %src) {
@@ -408,6 +423,21 @@ define i1 @test_known_nonnull_at_callsite_dereferenceable_null_is_defined(ptr %s
 ;
 entry:
   call void @callee(ptr dereferenceable(1) %src)
+  %nonnull = icmp eq ptr %src, null
+  ret i1 %nonnull
+}
+
+define i1 @test_known_nonnull_at_callsite_gep_without_inbounds(ptr %src, i64 %x) {
+; CHECK-LABEL: @test_known_nonnull_at_callsite_gep_without_inbounds(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i8, ptr [[SRC:%.*]], i64 [[X:%.*]]
+; CHECK-NEXT:    call void @callee(ptr noundef nonnull [[GEP]])
+; CHECK-NEXT:    [[NONNULL:%.*]] = icmp eq ptr [[SRC]], null
+; CHECK-NEXT:    ret i1 false
+;
+entry:
+  %gep = getelementptr i8, ptr %src, i64 %x
+  call void @callee(ptr noundef nonnull %gep)
   %nonnull = icmp eq ptr %src, null
   ret i1 %nonnull
 }


### PR DESCRIPTION
This patch is the followup of https://github.com/llvm/llvm-project/pull/124908.
