### PR TITLE
[AST] Migrate away from PointerUnion::dyn_cast (NFC)

### DIFF
--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -5040,7 +5040,7 @@ public:
   }
 
   const FieldDecl *getInitializedFieldInUnion() const {
-    return ArrayFillerOrUnionFieldInit.dyn_cast<FieldDecl *>();
+    return dyn_cast_if_present<FieldDecl *>(ArrayFillerOrUnionFieldInit);
   }
 
   child_range children() {


### PR DESCRIPTION
Note that PointerUnion::dyn_cast has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

This patch migrates the use of PointerUnion::dyn_cast to
dyn_cast_if_present because the non-const variant of
getInitializedFieldInUnion is known to encounter null in
ArrayFillerOrUnionFieldInit.  See:

  commit 563c7c5539f05e7f8cbb42565c1f24466019f38b
  Author: Kazu Hirata <kazu@google.com>
  Date:   Sat Jan 25 14:05:01 2025 -0800

FWIW, I am not aware of any test case in check-clang that triggers
null here.
