### PR TITLE
[Lex] Migrate away from PointerUnion::dyn_cast (NFC)

### DIFF
--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -933,7 +933,7 @@ private:
     }
 
     ArrayRef<ModuleMacro*> getOverriddenMacros() const {
-      if (auto *Info = State.dyn_cast<ModuleMacroInfo*>())
+      if (auto *Info = dyn_cast_if_present<ModuleMacroInfo *>(State))
         return Info->OverriddenMacros;
       return {};
     }


### PR DESCRIPTION
Note that PointerUnion::dyn_cast has been soft deprecated in
PointerUnion.h:

  // FIXME: Replace the uses of is(), get() and dyn_cast() with
  //        isa<T>, cast<T> and the llvm::dyn_cast<T>

This patch migrates the use of PointerUnion::dyn_cast to
dyn_cast_if_present because State is not guaranteed to be nonnull
elsewhere in this class.  See:

  commit 563c7c5539f05e7f8cbb42565c1f24466019f38b
  Author: Kazu Hirata <kazu@google.com>
  Date:   Sat Jan 25 14:05:01 2025 -0800

FWIW, I am not aware of any test case in check-clang that triggers
null here.
