### PR TITLE
[clang][bytecode][NFC] Add a FunctionKind enum

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -135,11 +135,9 @@ Function *ByteCodeEmitter::compileFunc(const FunctionDecl *FuncDecl) {
   // Create a handle over the emitted code.
   Function *Func = P.getFunction(FuncDecl);
   if (!Func) {
-    unsigned BuiltinID = FuncDecl->getBuiltinID();
-    Func =
-        P.createFunction(FuncDecl, ParamOffset, std::move(ParamTypes),
-                         std::move(ParamDescriptors), std::move(ParamOffsets),
-                         HasThisPointer, HasRVO, BuiltinID);
+    Func = P.createFunction(FuncDecl, ParamOffset, std::move(ParamTypes),
+                            std::move(ParamDescriptors),
+                            std::move(ParamOffsets), HasThisPointer, HasRVO);
   }
 
   assert(Func);
@@ -212,8 +210,7 @@ Function *ByteCodeEmitter::compileObjCBlock(const BlockExpr *BE) {
   Function *Func =
       P.createFunction(BE, ParamOffset, std::move(ParamTypes),
                        std::move(ParamDescriptors), std::move(ParamOffsets),
-                       /*HasThisPointer=*/false, /*HasRVO=*/false,
-                       /*IsUnevaluatedBuiltin=*/false);
+                       /*HasThisPointer=*/false, /*HasRVO=*/false);
 
   assert(Func);
   Func->setDefined(true);

--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -19,12 +19,28 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
                    llvm::SmallVectorImpl<PrimType> &&ParamTypes,
                    llvm::DenseMap<unsigned, ParamDescriptor> &&Params,
                    llvm::SmallVectorImpl<unsigned> &&ParamOffsets,
-                   bool HasThisPointer, bool HasRVO, unsigned BuiltinID)
-    : P(P), Source(Source), ArgSize(ArgSize), ParamTypes(std::move(ParamTypes)),
-      Params(std::move(Params)), ParamOffsets(std::move(ParamOffsets)),
-      HasThisPointer(HasThisPointer), HasRVO(HasRVO), BuiltinID(BuiltinID) {
-  if (const auto *F = Source.dyn_cast<const FunctionDecl *>())
+                   bool HasThisPointer, bool HasRVO)
+    : P(P), Kind(FunctionKind::Normal), Source(Source), ArgSize(ArgSize),
+      ParamTypes(std::move(ParamTypes)), Params(std::move(Params)),
+      ParamOffsets(std::move(ParamOffsets)), HasThisPointer(HasThisPointer),
+      HasRVO(HasRVO) {
+  if (const auto *F = dyn_cast<const FunctionDecl *>(Source)) {
     Variadic = F->isVariadic();
+    BuiltinID = F->getBuiltinID();
+    if (const auto *CD = dyn_cast<CXXConstructorDecl>(F)) {
+      Virtual = CD->isVirtual();
+      Kind = FunctionKind::Ctor;
+    } else if (const auto *CD = dyn_cast<CXXDestructorDecl>(F)) {
+      Virtual = CD->isVirtual();
+      Kind = FunctionKind::Dtor;
+    } else if (const auto *MD = dyn_cast<CXXMethodDecl>(F)) {
+      Virtual = MD->isVirtual();
+      if (MD->isLambdaStaticInvoker())
+        Kind = FunctionKind::LambdaStaticInvoker;
+      else if (clang::isLambdaCallOperator(F))
+        Kind = FunctionKind::LambdaCallOperator;
+    }
+  }
 }
 
 Function::ParamDescriptor Function::getParamDescriptor(unsigned Offset) const {
@@ -43,13 +59,6 @@ SourceInfo Function::getSource(CodePtr PC) const {
   if (It == SrcMap.end())
     return SrcMap.back().second;
   return It->second;
-}
-
-bool Function::isVirtual() const {
-  if (const auto *M = dyn_cast_if_present<CXXMethodDecl>(
-          Source.dyn_cast<const FunctionDecl *>()))
-    return M->isVirtual();
-  return false;
 }
 
 /// Unevaluated builtins don't get their arguments put on the stack

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -80,6 +80,13 @@ using FunctionDeclTy =
 ///
 class Function final {
 public:
+  enum class FunctionKind {
+    Normal,
+    Ctor,
+    Dtor,
+    LambdaStaticInvoker,
+    LambdaCallOperator,
+  };
   using ParamDescriptor = std::pair<PrimType, Descriptor *>;
 
   /// Returns the size of the function's local stack.
@@ -141,17 +148,23 @@ public:
   bool isConstexpr() const { return IsValid || isLambdaStaticInvoker(); }
 
   /// Checks if the function is virtual.
-  bool isVirtual() const;
+  bool isVirtual() const { return Virtual; };
 
   /// Checks if the function is a constructor.
-  bool isConstructor() const {
-    return isa_and_nonnull<CXXConstructorDecl>(
-        dyn_cast<const FunctionDecl *>(Source));
-  }
+  bool isConstructor() const { return Kind == FunctionKind::Ctor; }
   /// Checks if the function is a destructor.
-  bool isDestructor() const {
-    return isa_and_nonnull<CXXDestructorDecl>(
-        dyn_cast<const FunctionDecl *>(Source));
+  bool isDestructor() const { return Kind == FunctionKind::Dtor; }
+
+  /// Returns whether this function is a lambda static invoker,
+  /// which we generate custom byte code for.
+  bool isLambdaStaticInvoker() const {
+    return Kind == FunctionKind::LambdaStaticInvoker;
+  }
+
+  /// Returns whether this function is the call operator
+  /// of a lambda record decl.
+  bool isLambdaCallOperator() const {
+    return Kind == FunctionKind::LambdaCallOperator;
   }
 
   /// Returns the parent record decl, if any.
@@ -160,24 +173,6 @@ public:
             dyn_cast<const FunctionDecl *>(Source)))
       return MD->getParent();
     return nullptr;
-  }
-
-  /// Returns whether this function is a lambda static invoker,
-  /// which we generate custom byte code for.
-  bool isLambdaStaticInvoker() const {
-    if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            dyn_cast<const FunctionDecl *>(Source)))
-      return MD->isLambdaStaticInvoker();
-    return false;
-  }
-
-  /// Returns whether this function is the call operator
-  /// of a lambda record decl.
-  bool isLambdaCallOperator() const {
-    if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            dyn_cast<const FunctionDecl *>(Source)))
-      return clang::isLambdaCallOperator(MD);
-    return false;
   }
 
   /// Checks if the function is fully done compiling.
@@ -213,7 +208,7 @@ public:
 
   bool isThisPointerExplicit() const {
     if (const auto *MD = dyn_cast_if_present<CXXMethodDecl>(
-            Source.dyn_cast<const FunctionDecl *>()))
+            dyn_cast<const FunctionDecl *>(Source)))
       return MD->isExplicitObjectMemberFunction();
     return false;
   }
@@ -232,7 +227,7 @@ private:
            llvm::SmallVectorImpl<PrimType> &&ParamTypes,
            llvm::DenseMap<unsigned, ParamDescriptor> &&Params,
            llvm::SmallVectorImpl<unsigned> &&ParamOffsets, bool HasThisPointer,
-           bool HasRVO, unsigned BuiltinID);
+           bool HasRVO);
 
   /// Sets the code of a function.
   void setCode(unsigned NewFrameSize, std::vector<std::byte> &&NewCode,
@@ -255,6 +250,8 @@ private:
 
   /// Program reference.
   Program &P;
+  /// Function Kind.
+  FunctionKind Kind;
   /// Declaration this function was compiled from.
   FunctionDeclTy Source;
   /// Local area size: storage + metadata.
@@ -289,6 +286,7 @@ private:
   bool HasBody = false;
   bool Defined = false;
   bool Variadic = false;
+  bool Virtual = false;
   unsigned BuiltinID = 0;
 
 public:


### PR DESCRIPTION
Some function types are special to us, so add an enum and determinte the function kind once when creating the function, instead of looking at the Decl every time we need the information.