### PR TITLE
[TableGen] Fix OperandMap table size

### DIFF
--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -300,8 +300,8 @@ void InstrInfoEmitter::emitOperandNameMappings(
     assert(MaxOperandNo <= INT16_MAX &&
            "Too many operands for the operand name -> index table");
     StringRef Type = MaxOperandNo <= INT8_MAX ? "int8_t" : "int16_t";
-    OS << "  static constexpr " << Type << " OperandMap[][" << NumOperandNames
-       << "] = {\n";
+    OS << "  static constexpr " << Type << " OperandMap[]["
+       << NumOperandNames + 1 << "] = {\n";
     for (const auto &Entry : OperandMap) {
       const std::map<unsigned, unsigned> &OpList = Entry.first;
 
@@ -311,7 +311,8 @@ void InstrInfoEmitter::emitOperandNameMappings(
         auto Iter = OpList.find(ID);
         OS << (Iter != OpList.end() ? (int)Iter->second : -1) << ", ";
       }
-      OS << "},\n";
+      // value for OPERAND_LAST
+      OS << "-1 },\n";
     }
     OS << "  };\n";
 


### PR DESCRIPTION
- add missing value for OPERAND_LAST type. If function 'getNamedOperandIdx' is called with NamedIdx=OPERAND_LAST then we are accessing first element of next row in 2dim table.
- in most cases this will work unnoticed because 2dim OperandMap is sparse with most elements set to '-1'.