### PR TITLE
[LangRef] Correct documentation for `roundeven`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -17255,8 +17255,8 @@ Semantics:
 """"""""""
 
 This function implements IEEE-754 operation ``roundToIntegralTiesToEven``. It
-also behaves in the same way as C standard function ``roundeven``, except that
-it does not raise floating point exceptions.
+also behaves in the same way as C standard function ``roundeven``, including
+that it disregards rounding mode and does not raise floating point exceptions.
 
 
 '``llvm.lround.*``' Intrinsic


### PR DESCRIPTION
Langref for `roundeven` implies that the C standard function `roundeven` may raise floating point exceptions. However, this is not correct; C23 does not mention exceptions for `roundeven`, and per [1] `FE_INEXACT` is never raised.

Clarify that LLVM's `roundeven` behaves the same.

[1]: https://en.cppreference.com/w/c/numeric/math/roundeven