### PR TITLE
[llvm] Remove undef in `llvm/test/Transforms` tests

### DIFF
--- a/llvm/test/CodeGen/AArch64/aarch64-address-type-promotion-assertion.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-address-type-promotion-assertion.ll
@@ -2,7 +2,7 @@
 ; PR20188: don't crash when merging sexts.
 
 ; CHECK: foo:
-define void @foo() unnamed_addr align 2 {
+define void @foo(i1 %arg) unnamed_addr align 2 {
 entry:
   br label %invoke.cont145
 
@@ -12,7 +12,7 @@ invoke.cont145:
 
 if.then274:
   %0 = load i32, ptr null, align 4
-  br i1 undef, label %invoke.cont291, label %if.else313
+  br i1 %arg, label %invoke.cont291, label %if.else313
 
 invoke.cont291:
   %idxprom.i.i.i605 = sext i32 %0 to i64
@@ -26,7 +26,7 @@ if.else313:
   br i1 %cmp314, label %invoke.cont317, label %invoke.cont353
 
 invoke.cont317:
-  br i1 undef, label %invoke.cont326, label %invoke.cont334
+  br i1 %arg, label %invoke.cont326, label %invoke.cont334
 
 invoke.cont326:
   %idxprom.i.i.i587 = sext i32 %0 to i64
@@ -36,7 +36,7 @@ invoke.cont326:
 
 invoke.cont334:
   %lo.1 = phi double [ %sub329, %invoke.cont326 ], [ undef, %invoke.cont317 ]
-  br i1 undef, label %invoke.cont342, label %if.end356
+  br i1 %arg, label %invoke.cont342, label %if.end356
 
 invoke.cont342:
   %idxprom.i.i.i578 = sext i32 %0 to i64

--- a/llvm/test/CodeGen/AArch64/arm64-2011-03-09-CPSRSpill.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2011-03-09-CPSRSpill.ll
@@ -3,15 +3,15 @@
 ; Can't copy or spill / restore CPSR.
 ; rdar://9105206
 
-define fastcc void @t() ssp align 2 {
+define fastcc void @t(i1 %arg) ssp align 2 {
 entry:
-  br i1 undef, label %bb3.i, label %bb2.i
+  br i1 %arg, label %bb3.i, label %bb2.i
 
 bb2.i:                                            ; preds = %entry
   br label %bb3.i
 
 bb3.i:                                            ; preds = %bb2.i, %entry
-  br i1 undef, label %_ZN12gjkepa2_impl3EPA6appendERNS0_5sListEPNS0_5sFaceE.exit71, label %bb.i69
+  br i1 %arg, label %_ZN12gjkepa2_impl3EPA6appendERNS0_5sListEPNS0_5sFaceE.exit71, label %bb.i69
 
 bb.i69:                                           ; preds = %bb3.i
   br label %_ZN12gjkepa2_impl3EPA6appendERNS0_5sListEPNS0_5sFaceE.exit71
@@ -22,10 +22,10 @@ _ZN12gjkepa2_impl3EPA6appendERNS0_5sListEPNS0_5sFaceE.exit71: ; preds = %bb.i69,
   %2 = fcmp ult float %1, 0xBF847AE140000000
   %storemerge9 = select i1 %2, float %1, float 0.000000e+00
   store float %storemerge9, ptr undef, align 4
-  br i1 undef, label %bb42, label %bb47
+  br i1 %arg, label %bb42, label %bb47
 
 bb42:                                             ; preds = %_ZN12gjkepa2_impl3EPA6appendERNS0_5sListEPNS0_5sFaceE.exit71
-  br i1 undef, label %bb46, label %bb53
+  br i1 %arg, label %bb46, label %bb53
 
 bb46:                                             ; preds = %bb42
   br label %bb48
@@ -34,7 +34,7 @@ bb47:                                             ; preds = %_ZN12gjkepa2_impl3E
   br label %bb48
 
 bb48:                                             ; preds = %bb47, %bb46
-  br i1 undef, label %bb1.i14, label %bb.i13
+  br i1 %arg, label %bb1.i14, label %bb.i13
 
 bb.i13:                                           ; preds = %bb48
   br label %bb1.i14

--- a/llvm/test/CodeGen/AArch64/arm64-2011-03-17-AsmPrinterCrash.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2011-03-17-AsmPrinterCrash.ll
@@ -5,10 +5,10 @@
 source_filename = "test/CodeGen/AArch64/arm64-2011-03-17-AsmPrinterCrash.ll"
 
 ; Function Attrs: nounwind ssp
-define void @drt_vsprintf() #0 {
+define void @drt_vsprintf(i1 %arg) #0 {
 entry:
   %do_tab_convert = alloca i32, align 4
-  br i1 undef, label %if.then24, label %if.else295, !dbg !11
+  br i1 %arg, label %if.then24, label %if.else295, !dbg !11
 
 if.then24:                                        ; preds = %entry
   unreachable

--- a/llvm/test/CodeGen/AArch64/arm64-2011-04-21-CPSRBug.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2011-04-21-CPSRBug.ll
@@ -3,7 +3,7 @@
 ; CPSR is not allocatable so fast allocatable wouldn't mark them killed.
 ; rdar://9313272
 
-define hidden void @t() nounwind {
+define hidden void @t(i1 %arg) nounwind {
 entry:
   %cmp = icmp eq ptr null, undef
   %frombool = zext i1 %cmp to i8
@@ -16,7 +16,7 @@ land.lhs.true:                                    ; preds = %entry
   unreachable
 
 if.end:                                           ; preds = %entry
-  br i1 undef, label %land.lhs.true14, label %if.end33
+  br i1 %arg, label %land.lhs.true14, label %if.end33
 
 land.lhs.true14:                                  ; preds = %if.end
   unreachable

--- a/llvm/test/CodeGen/AArch64/arm64-2012-01-11-ComparisonDAGCrash.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2012-01-11-ComparisonDAGCrash.ll
@@ -5,12 +5,12 @@
 ; cycles in DAGs, and eventually crashes.  This is the testcase for
 ; one of those crashes. (rdar://10653656)
 
-define void @test(i1 zeroext %IsArrow) nounwind ssp align 2 {
+define void @test(i1 zeroext %IsArrow, i1 %arg) nounwind ssp align 2 {
 entry:
-  br i1 undef, label %return, label %lor.lhs.false
+  br i1  %arg, label %return, label %lor.lhs.false
 
 lor.lhs.false:
-  br i1 undef, label %return, label %if.end
+  br i1  %arg, label %return, label %if.end
 
 if.end:
   %tmp.i = load i64, ptr undef, align 8
@@ -18,7 +18,7 @@ if.end:
   br i1 %IsArrow, label %if.else_crit_edge, label %if.end32
 
 if.else_crit_edge:
-  br i1 undef, label %if.end32, label %return
+  br i1  %arg, label %if.end32, label %return
 
 if.end32:
   %0 = icmp ult i32 undef, 3
@@ -27,7 +27,7 @@ if.end32:
   %.pn = shl i320 %1, %.pn.v
   %ins346392 = or i320 %.pn, 0
   store i320 %ins346392, ptr undef, align 8
-  br i1 undef, label %sw.bb.i.i, label %exit
+  br i1  %arg, label %sw.bb.i.i, label %exit
 
 sw.bb.i.i:
   unreachable

--- a/llvm/test/CodeGen/AArch64/arm64-2012-07-11-InstrEmitterBug.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2012-07-11-InstrEmitterBug.ll
@@ -15,18 +15,18 @@ declare ptr @__strcat_chk(ptr, ptr, i64) nounwind optsize
 
 declare noalias ptr @xstrdup(ptr) optsize
 
-define ptr @dyld_fix_path(ptr %path) nounwind optsize ssp {
+define ptr @dyld_fix_path(ptr %path, i1 %arg) nounwind optsize ssp {
 entry:
-  br i1 undef, label %if.end56, label %for.cond
+  br i1  %arg, label %if.end56, label %for.cond
 
 for.cond:                                         ; preds = %entry
-  br i1 undef, label %for.cond10, label %for.body
+  br i1  %arg, label %for.cond10, label %for.body
 
 for.body:                                         ; preds = %for.cond
   unreachable
 
 for.cond10:                                       ; preds = %for.cond
-  br i1 undef, label %if.end56, label %for.body14
+  br i1  %arg, label %if.end56, label %for.body14
 
 for.body14:                                       ; preds = %for.cond10
   %call22 = tail call i64 @strlen(ptr undef) nounwind optsize
@@ -38,7 +38,7 @@ for.body14:                                       ; preds = %for.cond10
   %sext59 = add i64 %add31, 4294967296
   %conv33 = ashr exact i64 %sext59, 32
   %call34 = tail call noalias ptr @xmalloc(i64 %conv33) nounwind optsize
-  br i1 undef, label %cond.false45, label %cond.true43
+  br i1  %arg, label %cond.false45, label %cond.true43
 
 cond.true43:                                      ; preds = %for.body14
   unreachable

--- a/llvm/test/CodeGen/AArch64/arm64-2013-01-23-frem-crash.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2013-01-23-frem-crash.ll
@@ -1,14 +1,14 @@
 ; RUN: llc < %s -mtriple=arm64-eabi
 ; Make sure we are not crashing on this test.
 
-define void @autogen_SD13158() {
+define void @autogen_SD13158(i1 %arg) {
 entry:
-  %B26 = frem float 0.000000e+00, undef
-  br i1 undef, label %CF, label %CF77
+  %B26 = frem float 0.000000e+00, poison
+  br i1 %arg, label %CF, label %CF77
 
 CF:                                               ; preds = %CF, %CF76
-  store float %B26, ptr undef
-  br i1 undef, label %CF, label %CF77
+  store float %B26, ptr poison
+  br i1 %arg, label %CF, label %CF77
 
 CF77:                                             ; preds = %CF
   ret void

--- a/llvm/test/CodeGen/AArch64/arm64-2013-01-23-sext-crash.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-2013-01-23-sext-crash.ll
@@ -2,13 +2,13 @@
 
 ; Make sure we are not crashing on this test.
 
-define void @autogen_SD12881() {
+define void @autogen_SD12881(i1 %arg) {
 BB:
   %B17 = ashr <4 x i32> zeroinitializer, zeroinitializer
   br label %CF
 
 CF:                                               ; preds = %CF83, %CF, %BB
-  br i1 undef, label %CF, label %CF83
+  br i1 %arg, label %CF, label %CF83
 
 CF83:                                             ; preds = %CF
   %FC70 = sitofp <4 x i32> %B17 to <4 x double>
@@ -16,13 +16,13 @@ CF83:                                             ; preds = %CF
 }
 
 
-define void @autogen_SD12881_2() {
+define void @autogen_SD12881_2(i1 %arg) {
 BB:
   %B17 = ashr <4 x i32> zeroinitializer, zeroinitializer
   br label %CF
 
 CF:                                               ; preds = %CF83, %CF, %BB
-  br i1 undef, label %CF, label %CF83
+  br i1 %arg, label %CF, label %CF83
 
 CF83:                                             ; preds = %CF
   %FC70 = uitofp <4 x i32> %B17 to <4 x double>

--- a/llvm/test/CodeGen/AArch64/arm64-bitfield-extract.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-bitfield-extract.ll
@@ -1032,7 +1032,7 @@ define void @sameOperandBFI(i64 %src, i64 %src2, ptr %ptr) {
 ; OPT-NEXT:  entry:
 ; OPT-NEXT:    [[SHR47:%.*]] = lshr i64 [[SRC:%.*]], 47
 ; OPT-NEXT:    [[SRC2_TRUNC:%.*]] = trunc i64 [[SRC2:%.*]] to i32
-; OPT-NEXT:    br i1 undef, label [[END:%.*]], label [[IF_ELSE:%.*]]
+; OPT-NEXT:    br i1 poison, label [[END:%.*]], label [[IF_ELSE:%.*]]
 ; OPT:       if.else:
 ; OPT-NEXT:    [[AND3:%.*]] = and i32 [[SRC2_TRUNC]], 3
 ; OPT-NEXT:    [[SHL2:%.*]] = shl nuw nsw i64 [[SHR47]], 2
@@ -1050,7 +1050,7 @@ define void @sameOperandBFI(i64 %src, i64 %src2, ptr %ptr) {
 entry:
   %shr47 = lshr i64 %src, 47
   %src2.trunc = trunc i64 %src2 to i32
-  br i1 undef, label %end, label %if.else
+  br i1 poison, label %end, label %if.else
 
 if.else:
   %and3 = and i32 %src2.trunc, 3

--- a/llvm/test/CodeGen/AArch64/arm64-call-tailcalls.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-call-tailcalls.ll
@@ -36,12 +36,12 @@ define float @t5(float %a) nounwind readonly ssp {
   ret float %tmp
 }
 
-define void @t7() nounwind {
+define void @t7(i1 %arg) nounwind {
 ; CHECK-LABEL: t7:
 ; CHECK: b	_foo
 ; CHECK: b	_bar
 
-  br i1 undef, label %bb, label %bb1.lr.ph
+  br i1 %arg, label %bb, label %bb1.lr.ph
 
 bb1.lr.ph:                                        ; preds = %entry
   tail call void @bar() nounwind

--- a/llvm/test/CodeGen/AArch64/arm64-collect-loh.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-collect-loh.ll
@@ -662,9 +662,9 @@ define void @uninterestingSub(ptr nocapture %row) #0 {
 @.str.89 = external unnamed_addr constant [12 x i8], align 1
 @.str.90 = external unnamed_addr constant [5 x i8], align 1
 ; CHECK-LABEL: test_r274582
-define void @test_r274582(double %x) {
+define void @test_r274582(double %x, i1 %arg) {
 entry:
-  br i1 undef, label %if.then.i, label %if.end.i
+  br i1 %arg, label %if.then.i, label %if.end.i
 if.then.i:
   ret void
 if.end.i:

--- a/llvm/test/CodeGen/AArch64/arm64-dead-register-def-bug.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-dead-register-def-bug.ll
@@ -8,14 +8,14 @@
 ;
 ; <rdar://problem/16492408>
 
-define void @testcase() {
+define void @testcase(i1 %arg) {
 ; CHECK: testcase:
 ; CHECK-NOT: orr xzr, xzr, #0x2
 
 bb1:
   %tmp1 = tail call float @ceilf(float 2.000000e+00)
   %tmp2 = fptoui float %tmp1 to i64
-  br i1 undef, label %bb2, label %bb3
+  br i1 %arg, label %bb2, label %bb3
 
 bb2:
   tail call void @foo()

--- a/llvm/test/CodeGen/AArch64/arm64-fast-isel.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-fast-isel.ll
@@ -118,14 +118,14 @@ entry:
 
 declare { i64, i1 } @llvm.umul.with.overflow.i64(i64, i64)
 
-define void @logicalReg() {
+define void @logicalReg(i1 %arg) {
 ; Make sure we generate a logical reg = reg, reg instruction without any
 ; machine verifier errors.
 ; CHECK-LABEL: logicalReg:
 ; CHECK: orr w{{[0-9]+}}, w{{[0-9]+}}, w{{[0-9]+}}
 ; CHECK: ret
 entry:
-  br i1 undef, label %cond.end, label %cond.false
+  br i1 %arg, label %cond.end, label %cond.false
 
 cond.false:
   %cond = select i1 undef, i1 true, i1 false

--- a/llvm/test/Transforms/AlignmentFromAssumptions/start-unk.ll
+++ b/llvm/test/Transforms/AlignmentFromAssumptions/start-unk.ll
@@ -74,17 +74,17 @@ if.end123:                                        ; preds = %for.end
   br i1 %arg, label %if.end150, label %if.then126
 
 if.then126:                                       ; preds = %if.end123
-  %ptrint.i.i185 = ptrtoint ptr undef to i64
+  %ptrint.i.i185 = ptrtoint ptr poison to i64
   %maskedptr.i.i186 = and i64 %ptrint.i.i185, 1
   %maskcond.i.i187 = icmp eq i64 %maskedptr.i.i186, 0
   tail call void @llvm.assume(i1 %maskcond.i.i187) #0
-  %ret.0.copyload.i.i189 = load i32, ptr undef, align 2
+  %ret.0.copyload.i.i189 = load i32, ptr poison, align 2
 
 ; CHECK: load {{.*}} align 2
 
   %0 = tail call i32 @llvm.bswap.i32(i32 %ret.0.copyload.i.i189) #0
   %conv131 = zext i32 %0 to i64
-  %add.ptr132 = getelementptr inbounds i8, ptr undef, i64 %conv131
+  %add.ptr132 = getelementptr inbounds i8, ptr poison, i64 %conv131
   br i1 %arg, label %if.end150, label %if.end.i173
 
 if.end.i173:                                      ; preds = %if.then126

--- a/llvm/test/Transforms/ArgumentPromotion/fp80.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/fp80.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 %union.u = type { x86_fp80 }
 %struct.s = type { double, i16, i8, [5 x i8] }
 
-@b = internal global %struct.s { double 3.14, i16 9439, i8 25, [5 x i8] undef }, align 16
+@b = internal global %struct.s { double 3.14, i16 9439, i8 25, [5 x i8] poison }, align 16
 
 %struct.Foo = type { i32, i64 }
 @a = internal global %struct.Foo { i32 1, i64 2 }, align 8

--- a/llvm/test/Transforms/ArgumentPromotion/musttail.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/musttail.ll
@@ -52,7 +52,7 @@ define internal i32 @test2(ptr %p, i32 %p2) {
 ; CHECK-NEXT:    [[A:%.*]] = load i32, ptr [[A_GEP]], align 4
 ; CHECK-NEXT:    [[B:%.*]] = load i32, ptr [[B_GEP]], align 4
 ; CHECK-NEXT:    [[V:%.*]] = add i32 [[A]], [[B]]
-; CHECK-NEXT:    [[CA:%.*]] = musttail call i32 @foo(ptr undef, i32 [[V]])
+; CHECK-NEXT:    [[CA:%.*]] = musttail call i32 @foo(ptr poison, i32 [[V]])
 ; CHECK-NEXT:    ret i32 [[CA]]
 ;
   %a.gep = getelementptr %T, ptr %p, i64 0, i32 3
@@ -60,7 +60,7 @@ define internal i32 @test2(ptr %p, i32 %p2) {
   %a = load i32, ptr %a.gep
   %b = load i32, ptr %b.gep
   %v = add i32 %a, %b
-  %ca = musttail call i32 @foo(ptr undef, i32 %v)
+  %ca = musttail call i32 @foo(ptr poison, i32 %v)
   ret i32 %ca
 }
 

--- a/llvm/test/Transforms/ArgumentPromotion/variadic.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/variadic.ll
@@ -18,11 +18,11 @@ define i32 @main(i32 %argc, ptr nocapture readnone %argv) #0 {
 ; CHECK-LABEL: define {{[^@]+}}@main
 ; CHECK-SAME: (i32 [[ARGC:%.*]], ptr readnone captures(none) [[ARGV:%.*]]) {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    tail call void (ptr, ptr, ptr, ptr, ptr, ...) @callee_t0f(ptr undef, ptr undef, ptr undef, ptr undef, ptr undef, ptr byval([[STRUCT_TT0:%.*]]) align 8 @t45)
+; CHECK-NEXT:    tail call void (ptr, ptr, ptr, ptr, ptr, ...) @callee_t0f(ptr poison, ptr poison, ptr poison, ptr poison, ptr poison, ptr byval([[STRUCT_TT0:%.*]]) align 8 @t45)
 ; CHECK-NEXT:    ret i32 0
 ;
 entry:
-  tail call void (ptr, ptr, ptr, ptr, ptr, ...) @callee_t0f(ptr undef, ptr undef, ptr undef, ptr undef, ptr undef, ptr byval(%struct.tt0) align 8 @t45)
+  tail call void (ptr, ptr, ptr, ptr, ptr, ...) @callee_t0f(ptr poison, ptr poison, ptr poison, ptr poison, ptr poison, ptr byval(%struct.tt0) align 8 @t45)
   ret i32 0
 }
 

--- a/llvm/test/Transforms/Attributor/nonnull.ll
+++ b/llvm/test/Transforms/Attributor/nonnull.ll
@@ -212,7 +212,7 @@ entry:
   br label %loop
 loop:
   %phi = phi ptr [%ret, %entry], [%phi, %loop]
-  br i1 undef, label %loop, label %exit
+  br i1 poison, label %loop, label %exit
 exit:
   ret ptr %phi
 }


### PR DESCRIPTION
This PR replaces some instances of `undef` with function argument value or poison or concrete values in several tests under `llvm/test/Transforms/` directory. This PR is a continuation of PR #123889

@nunoplopes 