### PR TITLE
[MLIR] Remove unnecessary include from MathToEmitC.h to fix build issue

### DIFF
--- a/mlir/include/mlir/Conversion/MathToEmitC/MathToEmitC.h
+++ b/mlir/include/mlir/Conversion/MathToEmitC/MathToEmitC.h
@@ -8,7 +8,6 @@
 
 #ifndef MLIR_CONVERSION_MATHTOEMITC_MATHTOEMITC_H
 #define MLIR_CONVERSION_MATHTOEMITC_MATHTOEMITC_H
-#include "mlir/Dialect/EmitC/IR/EmitC.h"
 namespace mlir {
 class RewritePatternSet;
 namespace emitc {


### PR DESCRIPTION
This removes the unnecessary inclusion of mlir/Dialect/EmitC/IR/EmitC.h from MathToEmitC.h, which caused a build failure due to a missing EmitCEnums.h.inc. The include was not needed, and removing it resolves the issue without requiring additional dependencies.