### PR TITLE
[clang] CTAD alias: Respect explicit deduction guides defined after the first use of the alias template.

### DIFF
--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -237,8 +237,17 @@ static_assert(__is_same(decltype(s.t), int));
 // explicit deduction guide.
 Foo(int) -> Foo<X>;
 AFoo s2{i};
-// FIXME: the type should be X because of the above explicit deduction guide.
-static_assert(__is_same(decltype(s2.t), int));
+static_assert(__is_same(decltype(s2.t), X));
+
+
+template<class T>
+using BFoo = AFoo<T>;
+static_assert(__is_same(decltype(BFoo(i).t), X));
+
+
+Foo(double) -> Foo<int>;
+static_assert(__is_same(decltype(AFoo(1.0).t), int));
+static_assert(__is_same(decltype(BFoo(1.0).t), int));
 } // namespace test16
 
 namespace test17 {

--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -234,16 +234,19 @@ int i = 0;
 AFoo s{i};
 static_assert(__is_same(decltype(s.t), int));
 
-// explicit deduction guide.
-Foo(int) -> Foo<X>;
-AFoo s2{i};
-static_assert(__is_same(decltype(s2.t), X));
-
-
 template<class T>
 using BFoo = AFoo<T>;
-static_assert(__is_same(decltype(BFoo(i).t), X));
 
+// template explicit deduction guide.
+template<class T>
+Foo(T) -> Foo<float>;
+static_assert(__is_same(decltype(AFoo(i).t), float));
+static_assert(__is_same(decltype(BFoo(i).t), float));
+
+// explicit deduction guide.
+Foo(int) -> Foo<X>;
+static_assert(__is_same(decltype(AFoo(i).t), X));
+static_assert(__is_same(decltype(BFoo(i).t), X));
 
 Foo(double) -> Foo<int>;
 static_assert(__is_same(decltype(AFoo(1.0).t), int));


### PR DESCRIPTION
Fixes #103016

This is the last missing piece for the C++20 CTAD alias feature. No release note being added in this PR yet, I will send out a follow-up patch to mark this feature done. 

(Since the release 20 branch is cut, I think we should target on clang21). 