### PR TITLE
[benchmark] Support Linux/sparc64 /proc/cpuinfo

### DIFF
--- a/third-party/benchmark/src/sysinfo.cc
+++ b/third-party/benchmark/src/sysinfo.cc
@@ -520,6 +520,8 @@ int GetNumCPUsImpl() {
   }
 #if defined(__alpha__)
   const std::string Key = "cpus detected";
+#elif defined(__sparc__)
+  const std::string Key = "ncpus active";
 #else
   const std::string Key = "processor";
 #endif


### PR DESCRIPTION
When running an LLVM 20.1.0 rc1 reltest on Linux/sparc64, all 75 of the new `libcxx/test/benchmarks` tests `FAIL`, all in the same way:

```
# .---command stderr------------
# | Unable to extract number of CPUs.  If your platform uses /proc/cpuinfo, custom support may need to be added.
```

And indeed the Linux/sparc64 `/proc/cpuinfo` format is completely different from the x86_64 one: the interesting line is
```
ncpus active	: 24
```
This patch adjusts `sysinfo.cc` to handle that.

Tested on `sparc64-unknown-linux-gnu`.

I hope this can go in without going via upstream which doesn't have the analogous alpha patch either.