### PR TITLE
[ViewOpGraph] Improve GraphViz output

### DIFF
--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -355,7 +355,14 @@ private:
 
   /// Generate a label for a block argument.
   std::string getLabel(BlockArgument arg) {
-    return "arg" + std::to_string(arg.getArgNumber());
+    return strFromOs([&](raw_ostream &os) {
+      os << "<" << getValuePortName(arg) << "> ";
+      arg.printAsOperand(os, OpPrintingFlags());
+      if (printResultTypes)
+        os << " "
+           << truncateString(escapeLabelString(
+                  strFromOs([&](raw_ostream &os) { os << arg.getType(); })));
+    });
   }
 
   /// Process a block. Emit a cluster and one node per block argument and

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -29,7 +29,7 @@ using namespace mlir;
 
 static const StringRef kLineStyleControlFlow = "dashed";
 static const StringRef kLineStyleDataFlow = "solid";
-static const StringRef kShapeNode = "ellipse";
+static const StringRef kShapeNode = "record";
 static const StringRef kShapeNone = "plain";
 
 /// Return the size limits for eliding large attributes.
@@ -57,6 +57,21 @@ static std::string escapeString(std::string str) {
 /// Put quotation marks around a given string.
 static std::string quoteString(const std::string &str) {
   return "\"" + str + "\"";
+}
+
+/// For Graphviz record nodes:
+/// " Braces, vertical bars and angle brackets must be escaped with a backslash
+/// character if you wish them to appear as a literal character "
+static std::string escapeLabelString(const std::string &str) {
+  std::string buf;
+  llvm::raw_string_ostream os(buf);
+  for (char c : str) {
+    if (c == '{' || c == '|' || c == '<' || c == '}' || c == '>') {
+      os << "\\\\";
+    }
+    os << c;
+  }
+  return buf;
 }
 
 using AttributeMap = std::map<std::string, std::string>;
@@ -240,7 +255,8 @@ private:
                     StringRef background = "") {
     int nodeId = ++counter;
     AttributeMap attrs;
-    attrs["label"] = quoteString(escapeString(std::move(label)));
+    attrs["label"] =
+        quoteString(escapeString(escapeLabelString(std::move(label))));
     attrs["shape"] = shape.str();
     if (!background.empty()) {
       attrs["style"] = "filled";

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -66,7 +66,7 @@ std::string escapeLabelString(const std::string &str) {
   std::string buf;
   llvm::raw_string_ostream os(buf);
   for (char c : str) {
-    if (c == '{' || c == '|' || c == '<' || c == '}' || c == '>') {
+    if (c == '{' || c == '|' || c == '<' || c == '}' || c == '>' || c == '\n') {
       os << '\\';
     }
     os << c;
@@ -222,7 +222,7 @@ private:
     std::string buf;
     llvm::raw_string_ostream ss(buf);
     attr.print(ss);
-    os << truncateString(buf);
+    os << escapeLabelString(truncateString(buf));
   }
 
   /// Append an edge to the list of edges.
@@ -306,6 +306,16 @@ private:
       }
       // Print operation name and type.
       os << op->getName();
+
+      // Print attributes.
+      if (printAttrs && !op->getAttrs().empty()) {
+        os << "\\n";
+        for (const NamedAttribute &attr : op->getAttrs()) {
+          os << "\\n" << attr.getName().getValue() << ": ";
+          emitMlirAttr(os, attr.getValue());
+        }
+      }
+
       if (printResultTypes && op->getNumResults() > 0) {
         os << "|{";
         std::string buf;
@@ -321,14 +331,6 @@ private:
         os << buf << "}";
       }
 
-      // Print attributes.
-      if (printAttrs) {
-        os << "\n";
-        for (const NamedAttribute &attr : op->getAttrs()) {
-          os << '\n' << attr.getName().getValue() << ": ";
-          emitMlirAttr(os, attr.getValue());
-        }
-      }
       os << "}";
     });
   }

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -124,7 +124,7 @@ public:
 private:
   /// Generate a color mapping that will color every operation with the same
   /// name the same way. It'll interpolate the hue in the HSV color-space,
-  /// attempting to keep the contrast suitable for black text.
+  /// using muted colors that provide good contrast for black text.
   template <typename T>
   void initColorMapping(T &irEntity) {
     backgroundColors.clear();
@@ -137,8 +137,10 @@ private:
     });
     for (auto indexedOps : llvm::enumerate(ops)) {
       double hue = ((double)indexedOps.index()) / ops.size();
+      // Use lower saturation (0.3) and higher value (0.95) for better
+      // readability
       backgroundColors[indexedOps.value()->getName()].second =
-          std::to_string(hue) + " 1.0 1.0";
+          std::to_string(hue) + " 0.3 0.95";
     }
   }
 
@@ -263,7 +265,7 @@ private:
     attrs["shape"] = shape.str();
     if (!background.empty()) {
       attrs["style"] = "filled";
-      attrs["fillcolor"] = ("\"" + background + "\"").str();
+      attrs["fillcolor"] = quoteString(background.str());
     }
     os << llvm::format("v%i ", nodeId);
     emitAttrList(os, attrs);

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -29,7 +29,7 @@ using namespace mlir;
 
 static const StringRef kLineStyleControlFlow = "dashed";
 static const StringRef kLineStyleDataFlow = "solid";
-static const StringRef kShapeNode = "record";
+static const StringRef kShapeNode = "Mrecord";
 static const StringRef kShapeNone = "plain";
 
 /// Return the size limits for eliding large attributes.

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -320,19 +320,19 @@ private:
         }
       }
 
-      if (printResultTypes && op->getNumResults() > 0) {
+      if (op->getNumResults() > 0) {
         os << "|{";
-        std::string buf;
-        llvm::raw_string_ostream ss(buf);
         interleave(
-            op->getResultTypes(), ss,
-            [&](Type type) {
-              ss << escapeLabelString(
-                  strFromOs([&](raw_ostream &os) { os << type; }));
+            op->getResults(), os,
+            [&](Value result) {
+              os << "<" << getOperandPortName(result) << "> ";
+              if (printResultTypes)
+                os << truncateString(escapeLabelString(strFromOs(
+                    [&](raw_ostream &os) { os << result.getType(); })));
             },
             "|");
         // TODO: how to truncate string without breaking the layout?
-        os << buf << "}";
+        os << "}";
       }
 
       os << "}";
@@ -385,7 +385,7 @@ private:
       for (unsigned i = 0; i < numOperands; i++) {
         auto operand = op->getOperand(i);
         auto inPort = getOperandPortName(operand);
-        dataFlowEdges.push_back({operand, "", node, inPort});
+        dataFlowEdges.push_back({operand, inPort, node, inPort});
       }
     }
 

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -241,11 +241,11 @@ private:
     edges.push_back(strFromOs([&](raw_ostream &os) {
       os << "v" << n1.id;
       if (!outPort.empty())
-        os << ":" << outPort;
+        os << ":" << outPort << ":s";
       os << " -> ";
       os << "v" << n2.id;
       if (!inPort.empty())
-        os << ":" << inPort;
+        os << ":" << inPort << ":n";
       emitAttrList(os, attrs);
     }));
   }

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -322,11 +322,11 @@ private:
         os << "|{";
         auto resultToPort = [&](Value result) {
           os << "<" << getValuePortName(result) << "> ";
+          result.printAsOperand(os, OpPrintingFlags());
           if (printResultTypes)
-            os << truncateString(escapeLabelString(
-                strFromOs([&](raw_ostream &os) { os << result.getType(); })));
-          else
-            result.printAsOperand(os, OpPrintingFlags());
+            os << " "
+               << truncateString(escapeLabelString(strFromOs(
+                      [&](raw_ostream &os) { os << result.getType(); })));
         };
         interleave(op->getResults(), os, resultToPort, "|");
         os << "}";

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -305,14 +305,16 @@ private:
         os << "}|";
       }
       // Print operation name and type.
-      os << op->getName();
+      os << op->getName() << "\\l";
 
       // Print attributes.
       if (printAttrs && !op->getAttrs().empty()) {
-        os << "\\n";
+        // Extra line break to separate attributes from the operation name.
+        os << "\\l";
         for (const NamedAttribute &attr : op->getAttrs()) {
-          os << "\\n" << attr.getName().getValue() << ": ";
+          os << attr.getName().getValue() << ": ";
           emitMlirAttr(os, attr.getValue());
+          os << "\\l";
         }
       }
 

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -247,12 +247,12 @@ private:
 
     edges.push_back(strFromOs([&](raw_ostream &os) {
       os << "v" << n1.id;
-      if (!port.empty())
+      if (!port.empty() && !n1.clusterId)
         // Attach edge to south compass point of the result
         os << ":res" << port << ":s";
       os << " -> ";
       os << "v" << n2.id;
-      if (!port.empty())
+      if (!port.empty() && !n2.clusterId)
         // Attach edge to north compass point of the operand
         os << ":arg" << port << ":n";
       emitAttrList(os, attrs);

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -248,12 +248,12 @@ private:
       os << "v" << n1.id;
       if (!port.empty())
         // Attach edge to south compass point of the result
-        os << ":" << port << ":s";
+        os << ":res" << port << ":s";
       os << " -> ";
       os << "v" << n2.id;
       if (!port.empty())
         // Attach edge to north compass point of the operand
-        os << ":" << port << ":n";
+        os << ":arg" << port << ":n";
       emitAttrList(os, attrs);
     }));
   }
@@ -330,7 +330,7 @@ private:
       if (op->getNumOperands() > 0) {
         os << "{";
         auto operandToPort = [&](Value operand) {
-          os << "<" << getValuePortName(operand) << "> ";
+          os << "<arg" << getValuePortName(operand) << "> ";
           emitMlirOperand(os, operand);
         };
         interleave(op->getOperands(), os, operandToPort, "|");
@@ -353,7 +353,7 @@ private:
       if (op->getNumResults() > 0) {
         os << "|{";
         auto resultToPort = [&](Value result) {
-          os << "<" << getValuePortName(result) << "> ";
+          os << "<res" << getValuePortName(result) << "> ";
           emitMlirOperand(os, result);
           if (printResultTypes) {
             os << " ";
@@ -371,7 +371,7 @@ private:
   /// Generate a label for a block argument.
   std::string getLabel(BlockArgument arg) {
     return strFromOs([&](raw_ostream &os) {
-      os << "<" << getValuePortName(arg) << "> ";
+      os << "<res" << getValuePortName(arg) << "> ";
       arg.printAsOperand(os, OpPrintingFlags());
       if (printResultTypes) {
         os << " ";

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -194,7 +194,8 @@ private:
 
     // Always emit splat attributes.
     if (isa<SplatElementsAttr>(attr)) {
-      attr.print(os);
+      os << escapeLabelString(
+          strFromOs([&](raw_ostream &os) { attr.print(os); }));
       return;
     }
 
@@ -202,8 +203,8 @@ private:
     auto elements = dyn_cast<ElementsAttr>(attr);
     if (elements && elements.getNumElements() > largeAttrLimit) {
       os << std::string(elements.getShapedType().getRank(), '[') << "..."
-         << std::string(elements.getShapedType().getRank(), ']') << " : "
-         << elements.getType();
+         << std::string(elements.getShapedType().getRank(), ']') << " : ";
+      emitMlirType(os, elements.getType());
       return;
     }
 
@@ -313,7 +314,7 @@ private:
       if (printAttrs) {
         os << "\\l";
         for (const NamedAttribute &attr : op->getAttrs()) {
-          os << attr.getName().getValue() << ": ";
+          os << escapeLabelString(attr.getName().getValue().str()) << ": ";
           emitMlirAttr(os, attr.getValue());
           os << "\\l";
         }

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -385,9 +385,8 @@ private:
   /// operation inside the cluster.
   void processBlock(Block &block) {
     emitClusterStmt([&]() {
-      for (BlockArgument &blockArg : block.getArguments()) {
+      for (BlockArgument &blockArg : block.getArguments())
         valueToNode[blockArg] = emitNodeStmt(getLabel(blockArg));
-      }
       // Emit a node for each operation.
       std::optional<Node> prevNode;
       for (Operation &op : block) {

--- a/mlir/lib/Transforms/ViewOpGraph.cpp
+++ b/mlir/lib/Transforms/ViewOpGraph.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/IndentedOstream.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/GraphWriter.h"
 #include <map>
@@ -60,11 +61,9 @@ static std::string quoteString(const std::string &str) {
 std::string escapeLabelString(const std::string &str) {
   std::string buf;
   llvm::raw_string_ostream os(buf);
-  llvm::DenseSet<char> shouldEscape = {'{', '|', '<', '}', '>', '\n', '"'};
   for (char c : str) {
-    if (shouldEscape.contains(c)) {
+    if (llvm::is_contained({'{', '|', '<', '}', '>', '\n', '"'}, c))
       os << '\\';
-    }
     os << c;
   }
   return buf;

--- a/mlir/test/Transforms/print-op-graph-back-edges.mlir
+++ b/mlir/test/Transforms/print-op-graph-back-edges.mlir
@@ -1,21 +1,21 @@
 // RUN: mlir-opt -view-op-graph %s -o %t 2>&1 | FileCheck -check-prefix=DFG %s
 
 // DFG-LABEL: digraph G {
-//       DFG:   compound = true;
-//       DFG:   subgraph cluster_1 {
-//       DFG:     v2 [label = " ", shape = plain];
-//       DFG:     label = "builtin.module : ()\l";
-//       DFG:     subgraph cluster_3 {
-//       DFG:       v4 [label = " ", shape = plain];
-//       DFG:       label = "";
-//       DFG:       v5 [fillcolor = "0.000000 0.3 0.95", label = "{{\{\{}}<arg_c0> %c0|<arg_c1> %c1}|arith.addi\l\loverflowFlags: #arith.overflow\<none...\l|{<res_0> %0 index}}", shape = Mrecord, style = filled];
-//       DFG:       v6 [fillcolor = "0.333333 0.3 0.95", label = "{arith.constant\l\lvalue: 0 : index\l|{<res_c0> %c0 index}}", shape = Mrecord, style = filled];
-//       DFG:       v7 [fillcolor = "0.333333 0.3 0.95", label = "{arith.constant\l\lvalue: 1 : index\l|{<res_c1> %c1 index}}", shape = Mrecord, style = filled];
-//       DFG:     }
-//       DFG:   }
-//       DFG:   v6:res_c0:s -> v5:arg_c0:n[style = solid];
-//       DFG:   v7:res_c1:s -> v5:arg_c1:n[style = solid];
-//       DFG: }
+//  DFG-NEXT:   compound = true;
+//  DFG-NEXT:   subgraph cluster_1 {
+//  DFG-NEXT:     v2 [label = " ", shape = plain];
+//  DFG-NEXT:     label = "builtin.module : ()\l";
+//  DFG-NEXT:     subgraph cluster_3 {
+//  DFG-NEXT:       v4 [label = " ", shape = plain];
+//  DFG-NEXT:       label = "";
+//  DFG-NEXT:       v5 [fillcolor = "0.000000 0.3 0.95", label = "{{\{\{}}<arg_c0> %c0|<arg_c1> %c1}|arith.addi\l\loverflowFlags: #arith.overflow\<none...\l|{<res_0> %0 index}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:       v6 [fillcolor = "0.333333 0.3 0.95", label = "{arith.constant\l\lvalue: 0 : index\l|{<res_c0> %c0 index}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:       v7 [fillcolor = "0.333333 0.3 0.95", label = "{arith.constant\l\lvalue: 1 : index\l|{<res_c1> %c1 index}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:     }
+//  DFG-NEXT:   }
+//  DFG-NEXT:   v6:res_c0:s -> v5:arg_c0:n[style = solid];
+//  DFG-NEXT:   v7:res_c1:s -> v5:arg_c1:n[style = solid];
+//  DFG-NEXT: }
 
 module {
   %add = arith.addi %c0, %c1 : index

--- a/mlir/test/Transforms/print-op-graph-back-edges.mlir
+++ b/mlir/test/Transforms/print-op-graph-back-edges.mlir
@@ -4,17 +4,17 @@
 //       DFG:   compound = true;
 //       DFG:   subgraph cluster_1 {
 //       DFG:     v2 [label = " ", shape = plain];
-//       DFG:     label = "builtin.module : ()\n";
+//       DFG:     label = "builtin.module : ()\l";
 //       DFG:     subgraph cluster_3 {
 //       DFG:       v4 [label = " ", shape = plain];
 //       DFG:       label = "";
-//       DFG:       v5 [fillcolor = "0.000000 1.0 1.0", label = "arith.addi : (index)\n\noverflowFlags: #arith.overflow<none...", shape = ellipse, style = filled];
-//       DFG:       v6 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 0 : index", shape = ellipse, style = filled];
-//       DFG:       v7 [fillcolor = "0.333333 1.0 1.0", label = "arith.constant : (index)\n\nvalue: 1 : index", shape = ellipse, style = filled];
+//       DFG:       v5 [fillcolor = "0.000000 0.3 0.95", label = "{{\{\{}}<arg_c0> %c0|<arg_c1> %c1}|arith.addi\l\loverflowFlags: #arith.overflow\<none...\l|{<res_0> %0 index}}", shape = Mrecord, style = filled];
+//       DFG:       v6 [fillcolor = "0.333333 0.3 0.95", label = "{arith.constant\l\lvalue: 0 : index\l|{<res_c0> %c0 index}}", shape = Mrecord, style = filled];
+//       DFG:       v7 [fillcolor = "0.333333 0.3 0.95", label = "{arith.constant\l\lvalue: 1 : index\l|{<res_c1> %c1 index}}", shape = Mrecord, style = filled];
 //       DFG:     }
 //       DFG:   }
-//       DFG:   v6 -> v5 [label = "0", style = solid];
-//       DFG:   v7 -> v5 [label = "1", style = solid];
+//       DFG:   v6:res_c0:s -> v5:arg_c0:n[style = solid];
+//       DFG:   v7:res_c1:s -> v5:arg_c1:n[style = solid];
 //       DFG: }
 
 module {

--- a/mlir/test/Transforms/print-op-graph-cycles.mlir
+++ b/mlir/test/Transforms/print-op-graph-cycles.mlir
@@ -1,45 +1,45 @@
 // RUN: mlir-opt -view-op-graph -allow-unregistered-dialect %s -o %t 2>&1 | FileCheck -check-prefix=DFG %s
 
 // DFG-LABEL: digraph G {
-//       DFG:   compound = true;
-//       DFG:   subgraph cluster_1 {
-//       DFG:     v2 [label = " ", shape = plain];
-//       DFG:     label = "builtin.module : ()\l";
-//       DFG:     subgraph cluster_3 {
-//       DFG:       v4 [label = " ", shape = plain];
-//       DFG:       label = "";
-//       DFG:       subgraph cluster_5 {
-//       DFG:         v6 [label = " ", shape = plain];
-//       DFG:         label = "test.graph_region : ()\l";
-//       DFG:         subgraph cluster_7 {
-//       DFG:           v8 [label = " ", shape = plain];
-//       DFG:           label = "";
-//       DFG:           v9 [fillcolor = "0.000000 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_2> %2}|op1\l|{<res_0> %0 i32}}", shape = Mrecord, style = filled];
-//       DFG:           subgraph cluster_10 {
-//       DFG:             v11 [label = " ", shape = plain];
-//       DFG:             label = "test.ssacfg_region : (i32)\l";
-//       DFG:             subgraph cluster_12 {
-//       DFG:               v13 [label = " ", shape = plain];
-//       DFG:               label = "";
-//       DFG:               v14 [fillcolor = "0.166667 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_1> %1|<arg_2> %2|<arg_3> %3}|op2\l|{<res_4> %4 i32}}", shape = Mrecord, style = filled];
-//       DFG:             }
-//       DFG:           }
-//       DFG:           v15 [fillcolor = "0.166667 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_3> %3}|op2\l|{<res_2> %2 i32}}", shape = Mrecord, style = filled];
-//       DFG:           v16 [fillcolor = "0.500000 0.3 0.95", label = "{{\{\{}}<arg_0> %0}|op3\l|{<res_3> %3 i32}}", shape = Mrecord, style = filled];
-//       DFG:         }
-//       DFG:       }
-//       DFG:     }
-//       DFG:   }
-//       DFG:   v9:res_0:s -> v9:arg_0:n[style = solid];
-//       DFG:   v15:res_2:s -> v9:arg_2:n[style = solid];
-//       DFG:   v9:res_0:s -> v14:arg_0:n[style = solid];
-//       DFG:   v11 -> v14:arg_1:n[ltail = cluster_10, style = solid];
-//       DFG:   v15:res_2:s -> v14:arg_2:n[style = solid];
-//       DFG:   v16:res_3:s -> v14:arg_3:n[style = solid];
-//       DFG:   v9:res_0:s -> v15:arg_0:n[style = solid];
-//       DFG:   v16:res_3:s -> v15:arg_3:n[style = solid];
-//       DFG:   v9:res_0:s -> v16:arg_0:n[style = solid];
-//       DFG: }
+//  DFG-NEXT:   compound = true;
+//  DFG-NEXT:   subgraph cluster_1 {
+//  DFG-NEXT:     v2 [label = " ", shape = plain];
+//  DFG-NEXT:     label = "builtin.module : ()\l";
+//  DFG-NEXT:     subgraph cluster_3 {
+//  DFG-NEXT:       v4 [label = " ", shape = plain];
+//  DFG-NEXT:       label = "";
+//  DFG-NEXT:       subgraph cluster_5 {
+//  DFG-NEXT:         v6 [label = " ", shape = plain];
+//  DFG-NEXT:         label = "test.graph_region : ()\l";
+//  DFG-NEXT:         subgraph cluster_7 {
+//  DFG-NEXT:           v8 [label = " ", shape = plain];
+//  DFG-NEXT:           label = "";
+//  DFG-NEXT:           v9 [fillcolor = "0.000000 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_2> %2}|op1\l|{<res_0> %0 i32}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:           subgraph cluster_10 {
+//  DFG-NEXT:             v11 [label = " ", shape = plain];
+//  DFG-NEXT:             label = "test.ssacfg_region : (i32)\l";
+//  DFG-NEXT:             subgraph cluster_12 {
+//  DFG-NEXT:               v13 [label = " ", shape = plain];
+//  DFG-NEXT:               label = "";
+//  DFG-NEXT:               v14 [fillcolor = "0.166667 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_1> %1|<arg_2> %2|<arg_3> %3}|op2\l|{<res_4> %4 i32}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:             }
+//  DFG-NEXT:           }
+//  DFG-NEXT:           v15 [fillcolor = "0.166667 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_3> %3}|op2\l|{<res_2> %2 i32}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:           v16 [fillcolor = "0.500000 0.3 0.95", label = "{{\{\{}}<arg_0> %0}|op3\l|{<res_3> %3 i32}}", shape = Mrecord, style = filled];
+//  DFG-NEXT:         }
+//  DFG-NEXT:       }
+//  DFG-NEXT:     }
+//  DFG-NEXT:   }
+//  DFG-NEXT:   v9:res_0:s -> v9:arg_0:n[style = solid];
+//  DFG-NEXT:   v15:res_2:s -> v9:arg_2:n[style = solid];
+//  DFG-NEXT:   v9:res_0:s -> v14:arg_0:n[style = solid];
+//  DFG-NEXT:   v11 -> v14:arg_1:n[ltail = cluster_10, style = solid];
+//  DFG-NEXT:   v15:res_2:s -> v14:arg_2:n[style = solid];
+//  DFG-NEXT:   v16:res_3:s -> v14:arg_3:n[style = solid];
+//  DFG-NEXT:   v9:res_0:s -> v15:arg_0:n[style = solid];
+//  DFG-NEXT:   v16:res_3:s -> v15:arg_3:n[style = solid];
+//  DFG-NEXT:   v9:res_0:s -> v16:arg_0:n[style = solid];
+//  DFG-NEXT: }
 
 "test.graph_region"() ({ // A Graph region
   %1 = "op1"(%1, %3) : (i32, i32) -> (i32)  // OK: %1, %3 allowed here

--- a/mlir/test/Transforms/print-op-graph-cycles.mlir
+++ b/mlir/test/Transforms/print-op-graph-cycles.mlir
@@ -4,41 +4,41 @@
 //       DFG:   compound = true;
 //       DFG:   subgraph cluster_1 {
 //       DFG:     v2 [label = " ", shape = plain];
-//       DFG:     label = "builtin.module : ()\n";
+//       DFG:     label = "builtin.module : ()\l";
 //       DFG:     subgraph cluster_3 {
 //       DFG:       v4 [label = " ", shape = plain];
 //       DFG:       label = "";
 //       DFG:       subgraph cluster_5 {
 //       DFG:         v6 [label = " ", shape = plain];
-//       DFG:         label = "test.graph_region : ()\n";
+//       DFG:         label = "test.graph_region : ()\l";
 //       DFG:         subgraph cluster_7 {
 //       DFG:           v8 [label = " ", shape = plain];
 //       DFG:           label = "";
-//       DFG:           v9 [fillcolor = "0.000000 1.0 1.0", label = "op1 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:           v9 [fillcolor = "0.000000 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_2> %2}|op1\l|{<res_0> %0 i32}}", shape = Mrecord, style = filled];
 //       DFG:           subgraph cluster_10 {
 //       DFG:             v11 [label = " ", shape = plain];
-//       DFG:             label = "test.ssacfg_region : (i32)\n";
+//       DFG:             label = "test.ssacfg_region : (i32)\l";
 //       DFG:             subgraph cluster_12 {
 //       DFG:               v13 [label = " ", shape = plain];
 //       DFG:               label = "";
-//       DFG:               v14 [fillcolor = "0.166667 1.0 1.0", label = "op2 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:               v14 [fillcolor = "0.166667 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_1> %1|<arg_2> %2|<arg_3> %3}|op2\l|{<res_4> %4 i32}}", shape = Mrecord, style = filled];
 //       DFG:             }
 //       DFG:           }
-//       DFG:           v15 [fillcolor = "0.166667 1.0 1.0", label = "op2 : (i32)\n", shape = ellipse, style = filled];
-//       DFG:           v16 [fillcolor = "0.500000 1.0 1.0", label = "op3 : (i32)\n", shape = ellipse, style = filled];
+//       DFG:           v15 [fillcolor = "0.166667 0.3 0.95", label = "{{\{\{}}<arg_0> %0|<arg_3> %3}|op2\l|{<res_2> %2 i32}}", shape = Mrecord, style = filled];
+//       DFG:           v16 [fillcolor = "0.500000 0.3 0.95", label = "{{\{\{}}<arg_0> %0}|op3\l|{<res_3> %3 i32}}", shape = Mrecord, style = filled];
 //       DFG:         }
 //       DFG:       }
 //       DFG:     }
 //       DFG:   }
-//       DFG:   v9 -> v9 [label = "0", style = solid];
-//       DFG:   v15 -> v9 [label = "1", style = solid];
-//       DFG:   v9 -> v14 [label = "0", style = solid];
-//       DFG:   v11 -> v14 [ltail = cluster_10, style = solid];
-//       DFG:   v15 -> v14 [label = "2", style = solid];
-//       DFG:   v16 -> v14 [label = "3", style = solid];
-//       DFG:   v9 -> v15 [label = "0", style = solid];
-//       DFG:   v16 -> v15 [label = "1", style = solid];
-//       DFG:   v9 -> v16 [label = "", style = solid];
+//       DFG:   v9:res_0:s -> v9:arg_0:n[style = solid];
+//       DFG:   v15:res_2:s -> v9:arg_2:n[style = solid];
+//       DFG:   v9:res_0:s -> v14:arg_0:n[style = solid];
+//       DFG:   v11:res_1:s -> v14:arg_1:n[ltail = cluster_10, style = solid];
+//       DFG:   v15:res_2:s -> v14:arg_2:n[style = solid];
+//       DFG:   v16:res_3:s -> v14:arg_3:n[style = solid];
+//       DFG:   v9:res_0:s -> v15:arg_0:n[style = solid];
+//       DFG:   v16:res_3:s -> v15:arg_3:n[style = solid];
+//       DFG:   v9:res_0:s -> v16:arg_0:n[style = solid];
 //       DFG: }
 
 "test.graph_region"() ({ // A Graph region

--- a/mlir/test/Transforms/print-op-graph-cycles.mlir
+++ b/mlir/test/Transforms/print-op-graph-cycles.mlir
@@ -33,7 +33,7 @@
 //       DFG:   v9:res_0:s -> v9:arg_0:n[style = solid];
 //       DFG:   v15:res_2:s -> v9:arg_2:n[style = solid];
 //       DFG:   v9:res_0:s -> v14:arg_0:n[style = solid];
-//       DFG:   v11:res_1:s -> v14:arg_1:n[ltail = cluster_10, style = solid];
+//       DFG:   v11 -> v14:arg_1:n[ltail = cluster_10, style = solid];
 //       DFG:   v15:res_2:s -> v14:arg_2:n[style = solid];
 //       DFG:   v16:res_3:s -> v14:arg_3:n[style = solid];
 //       DFG:   v9:res_0:s -> v15:arg_0:n[style = solid];

--- a/mlir/test/Transforms/print-op-graph.mlir
+++ b/mlir/test/Transforms/print-op-graph.mlir
@@ -20,8 +20,8 @@
 //       DFG:         v[[TEST_RET:.*]] [{{.*}}label = "{{.*}}test.return
 //       DFG:   v[[ARG0]]:res_arg0:s -> v[[TEST_BR]]:arg_arg0:n
 //       DFG:   v[[CONST10]]:res_c10_i32:s -> v[[TEST_BR]]
-//       DFG:   v[[ANCHOR]]:res_1_0:s -> v[[TEST_RET]]:arg_1_0:n[ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
-//       DFG:   v[[ANCHOR]]:res_1_1:s -> v[[TEST_RET]]:arg_1_1:n[ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
+//       DFG:   v[[ANCHOR]] -> v[[TEST_RET]]:arg_1_0:n[ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
+//       DFG:   v[[ANCHOR]] -> v[[TEST_RET]]:arg_1_1:n[ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
 
 // CFG-LABEL: digraph G {
 //       CFG:   subgraph {{.*}} {

--- a/mlir/test/Transforms/print-op-graph.mlir
+++ b/mlir/test/Transforms/print-op-graph.mlir
@@ -6,49 +6,49 @@
 //       DFG:     subgraph {{.*}}
 //       DFG:       label = "func.func{{.*}}merge_blocks
 //       DFG:       subgraph {{.*}} {
-//       DFG:         v[[ARG0:.*]] [label = "arg0"
+//       DFG:         v[[ARG0:.*]] [label = "<res_arg0> %arg0 i32"
 //       DFG:         v[[CONST10:.*]] [{{.*}}label ={{.*}}10 : i32
 //       DFG:         subgraph [[CLUSTER_MERGE_BLOCKS:.*]] {
 //       DFG:           v[[ANCHOR:.*]] [label = " ", shape = plain]
 //       DFG:           label = "test.merge_blocks
 //       DFG:           subgraph {{.*}} {
-//       DFG:             v[[TEST_BR:.*]] [{{.*}}label = "test.br
+//       DFG:             v[[TEST_BR:.*]] [{{.*}}label = "{{.*}}test.br
 //       DFG:           }
 //       DFG:           subgraph {{.*}} {
 //       DFG:           }
 //       DFG:         }
-//       DFG:         v[[TEST_RET:.*]] [{{.*}}label = "test.return
-//       DFG:   v[[ARG0]] -> v[[TEST_BR]]
-//       DFG:   v[[CONST10]] -> v[[TEST_BR]]
-//       DFG:   v[[ANCHOR]] -> v[[TEST_RET]] [ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
-//       DFG:   v[[ANCHOR]] -> v[[TEST_RET]] [ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
+//       DFG:         v[[TEST_RET:.*]] [{{.*}}label = "{{.*}}test.return
+//       DFG:   v[[ARG0]]:res_arg0:s -> v[[TEST_BR]]:arg_arg0:n
+//       DFG:   v[[CONST10]]:res_c10_i32:s -> v[[TEST_BR]]
+//       DFG:   v[[ANCHOR]]:res_1_0:s -> v[[TEST_RET]]:arg_1_0:n[ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
+//       DFG:   v[[ANCHOR]]:res_1_1:s -> v[[TEST_RET]]:arg_1_1:n[ltail = [[CLUSTER_MERGE_BLOCKS]], style = solid];
 
 // CFG-LABEL: digraph G {
 //       CFG:   subgraph {{.*}} {
 //       CFG:     subgraph {{.*}}
 //       CFG:       label = "func.func{{.*}}merge_blocks
 //       CFG:       subgraph {{.*}} {
-//       CFG:         v[[C1:.*]] [{{.*}}label = "arith.constant
-//       CFG:         v[[C2:.*]] [{{.*}}label = "arith.constant
-//       CFG:         v[[C3:.*]] [{{.*}}label = "arith.constant
-//       CFG:         v[[C4:.*]] [{{.*}}label = "arith.constant
-//       CFG:         v[[TEST_FUNC:.*]] [{{.*}}label = "test.func
+//       CFG:         v[[C1:.*]] [{{.*}}label = "{arith.constant
+//       CFG:         v[[C2:.*]] [{{.*}}label = "{arith.constant
+//       CFG:         v[[C3:.*]] [{{.*}}label = "{arith.constant
+//       CFG:         v[[C4:.*]] [{{.*}}label = "{arith.constant
+//       CFG:         v[[TEST_FUNC:.*]] [{{.*}}label = "{test.func
 //       CFG:         subgraph [[CLUSTER_MERGE_BLOCKS:.*]] {
 //       CFG:           v[[ANCHOR:.*]] [label = " ", shape = plain]
 //       CFG:           label = "test.merge_blocks
 //       CFG:           subgraph {{.*}} {
-//       CFG:             v[[TEST_BR:.*]] [{{.*}}label = "test.br
+//       CFG:             v[[TEST_BR:.*]] [{{.*}}label = "{{.*}}test.br
 //       CFG:           }
 //       CFG:           subgraph {{.*}} {
 //       CFG:           }
 //       CFG:         }
-//       CFG:         v[[TEST_RET:.*]] [{{.*}}label = "test.return
+//       CFG:         v[[TEST_RET:.*]] [{{.*}}label = "{{.*}}test.return
 //       CFG:   v[[C1]] -> v[[C2]]
 //       CFG:   v[[C2]] -> v[[C3]]
 //       CFG:   v[[C3]] -> v[[C4]]
 //       CFG:   v[[C4]] -> v[[TEST_FUNC]]
-//       CFG:   v[[TEST_FUNC]] -> v[[ANCHOR]] [lhead = [[CLUSTER_MERGE_BLOCKS]], style = dashed];
-//       CFG:   v[[ANCHOR]] -> v[[TEST_RET]] [ltail = [[CLUSTER_MERGE_BLOCKS]], style = dashed];
+//       CFG:   v[[TEST_FUNC]] -> v[[ANCHOR]][lhead = [[CLUSTER_MERGE_BLOCKS]], style = dashed];
+//       CFG:   v[[ANCHOR]] -> v[[TEST_RET]][ltail = [[CLUSTER_MERGE_BLOCKS]], style = dashed];
 
 func.func @merge_blocks(%arg0: i32, %arg1 : i32) -> () {
   %0 = arith.constant dense<[[0, 1], [2, 3]]> : tensor<2x2xi32>


### PR DESCRIPTION
This patch improves the GraphViz output of ViewOpGraph (--view-op-graph).

- Switch to rectangular record-based nodes, inspired by a similar visualization in [Glow](https://github.com/pytorch/glow). Rectangles make more efficient use of space when printing text. 
- Add input and output ports for each operand and result, and remove edge labels.
- Switch to a muted color palette to reduce eye strain. 

Before:
![print-op-graph-back-edges](https://github.com/user-attachments/assets/4212d1d8-98d2-4352-aae6-528d38ebb387)
After:
![print-op-graph-back-edges](https://github.com/user-attachments/assets/a6f30871-828c-48a2-93e7-660515244882)
More comparisons here: [compare.tar.gz](https://github.com/user-attachments/files/18660636/compare.tar.gz)

This visualization displays the short name of each operand along the top edge of each node.
Result types are displayed along the bottom edge of each node. This differs somewhat from
reading the mlir source code, where the name of the result comes before the operation name.

But in my opinion this style works better in the visualization for the following reasons:

1. Most ops have many operands but few results. So we need a short
representation for the operands, but we can use a longer representation for the results.
2. Since a value has only one producer, we only need to print the full type in one place for each value.
3. The dataflow dependencies flow from top to bottom, so it makes sense to put the
operands on top and the results on the bottom.
4. The viewer's eye can naturally follow the edge upwards to match the value number to its type.

The graphviz documentation notes some limitations with record-based nodes, and
recommends switching to the HTML-like syntax. I'm sticking with record-based
nodes for now since it's less verbose and I don't need any of the newer features,
but it might be worth switching to the HTML-like syntax in the future.