### PR TITLE
[flang] Catch more semantic errors with coarrays

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -630,6 +630,8 @@ using PotentialAndPointerComponentIterator =
 // dereferenced.
 PotentialComponentIterator::const_iterator FindEventOrLockPotentialComponent(
     const DerivedTypeSpec &, bool ignoreCoarrays = false);
+PotentialComponentIterator::const_iterator FindCoarrayPotentialComponent(
+    const DerivedTypeSpec &);
 UltimateComponentIterator::const_iterator FindCoarrayUltimateComponent(
     const DerivedTypeSpec &);
 UltimateComponentIterator::const_iterator FindPointerUltimateComponent(

--- a/flang/lib/Evaluate/tools.cpp
+++ b/flang/lib/Evaluate/tools.cpp
@@ -1812,7 +1812,11 @@ bool IsSaved(const Symbol &original) {
   } else if (scopeKind == Scope::Kind::DerivedType) {
     return false; // this is a component
   } else if (symbol.attrs().test(Attr::SAVE)) {
-    return true; // explicit SAVE attribute
+    // explicit or implied SAVE attribute
+    // N.B.: semantics sets implied SAVE for main program
+    // local variables whose derived types have coarray
+    // potential subobject components.
+    return true;
   } else if (IsDummy(symbol) || IsFunctionResult(symbol) ||
       IsAutomatic(symbol) || IsNamedConstant(symbol)) {
     return false;

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -6043,32 +6043,6 @@ void DeclarationVisitor::Post(const parser::ComponentDecl &x) {
               "POINTER or ALLOCATABLE"_err_en_US);
         }
       }
-      // TODO: This would be more appropriate in CheckDerivedType()
-      if (auto it{FindCoarrayUltimateComponent(*derived)}) { // C748
-        std::string ultimateName{it.BuildResultDesignatorName()};
-        // Strip off the leading "%"
-        if (ultimateName.length() > 1) {
-          ultimateName.erase(0, 1);
-          if (attrs.HasAny({Attr::POINTER, Attr::ALLOCATABLE})) {
-            evaluate::AttachDeclaration(
-                Say(name.source,
-                    "A component with a POINTER or ALLOCATABLE attribute may "
-                    "not "
-                    "be of a type with a coarray ultimate component (named "
-                    "'%s')"_err_en_US,
-                    ultimateName),
-                derived->typeSymbol());
-          }
-          if (!arraySpec().empty() || !coarraySpec().empty()) {
-            evaluate::AttachDeclaration(
-                Say(name.source,
-                    "An array or coarray component may not be of a type with a "
-                    "coarray ultimate component (named '%s')"_err_en_US,
-                    ultimateName),
-                derived->typeSymbol());
-          }
-        }
-      }
     }
   }
   if (OkToAddComponent(name)) {
@@ -9802,6 +9776,21 @@ void ResolveNamesVisitor::ResolveSpecificationParts(ProgramTree &node) {
           (IsDummy(symbol) || object->IsArray())) {
         // Implicitly set device attribute if none is set in device context.
         object->set_cudaDataAttr(common::CUDADataAttr::Device);
+      }
+    }
+    // Main program local objects usually don't have an implied SAVE attribute,
+    // as one might think, but in the exceptional case of a derived type
+    // local object that contains a coarray, we have to mark it as an
+    // implied SAVE so that evaluate::IsSaved() will return true.
+    if (node.scope()->kind() == Scope::Kind::MainProgram) {
+      if (const auto *object{symbol.detailsIf<ObjectEntityDetails>()}) {
+        if (const DeclTypeSpec * type{object->type()}) {
+          if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+            if (!IsSaved(symbol) && FindCoarrayPotentialComponent(*derived)) {
+              SetImplicitAttr(symbol, Attr::SAVE);
+            }
+          }
+        }
       }
     }
   }

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -1386,6 +1386,13 @@ template class ComponentIterator<ComponentKind::Potential>;
 template class ComponentIterator<ComponentKind::Scope>;
 template class ComponentIterator<ComponentKind::PotentialAndPointer>;
 
+PotentialComponentIterator::const_iterator FindCoarrayPotentialComponent(
+    const DerivedTypeSpec &derived) {
+  PotentialComponentIterator potentials{derived};
+  return std::find_if(potentials.begin(), potentials.end(),
+      [](const Symbol &symbol) { return evaluate::IsCoarray(symbol); });
+}
+
 UltimateComponentIterator::const_iterator FindCoarrayUltimateComponent(
     const DerivedTypeSpec &derived) {
   UltimateComponentIterator ultimates{derived};

--- a/flang/test/Lower/pre-fir-tree04.f90
+++ b/flang/test/Lower/pre-fir-tree04.f90
@@ -5,6 +5,7 @@
 ! CHECK: Subroutine test_coarray
 Subroutine test_coarray
   use iso_fortran_env, only: team_type, event_type, lock_type
+  save
   type(team_type) :: t
   type(event_type) :: done[*]
   type(lock_type) :: alock[*]

--- a/flang/test/Semantics/allocate11.f90
+++ b/flang/test/Semantics/allocate11.f90
@@ -38,7 +38,14 @@ subroutine C937(var)
 
   type B
     type(A) y
-    !ERROR: A component with a POINTER or ALLOCATABLE attribute may not be of a type with a coarray ultimate component (named 'y%x')
+    !ERROR: Allocatable or array component 'forward' may not have a coarray ultimate component '%y%x'
+    type(B), allocatable :: forward
+    real :: u
+  end type
+
+  type B2
+    type(A) y
+    !ERROR: Pointer 'forward' may not have a coarray potential component '%y%x'
     type(B), pointer :: forward
     real :: u
   end type
@@ -48,11 +55,14 @@ subroutine C937(var)
   end type
 
   type D
-    !ERROR: A component with a POINTER or ALLOCATABLE attribute may not be of a type with a coarray ultimate component (named 'x')
-    type(A), pointer :: potential
+    !ERROR: Allocatable or array component 'potential' may not have a coarray ultimate component '%x'
+    type(A), allocatable :: potential
   end type
 
-
+  type D2
+    !ERROR: Pointer 'potential' may not have a coarray potential component '%x'
+    type(A), pointer :: potential
+  end type
 
   class(*), allocatable :: var
   ! unlimited polymorphic is the ONLY way to get an allocatable/pointer 'var' that can be

--- a/flang/test/Semantics/assign02.f90
+++ b/flang/test/Semantics/assign02.f90
@@ -74,8 +74,8 @@ contains
 
   ! C1020
   subroutine s5
-    real, target :: x[*]
-    real, target, volatile :: y[*]
+    real, target, save :: x[*]
+    real, target, volatile, save :: y[*]
     real, pointer :: p
     real, pointer, volatile :: q
     p => x
@@ -148,7 +148,7 @@ contains
 
   ! C1026 (R1037) A data-target shall not be a coindexed object.
   subroutine s10
-    real, target :: a[*]
+    real, target, save :: a[*]
     real, pointer :: b
     !ERROR: A coindexed object may not be a pointer target
     b => a[1]

--- a/flang/test/Semantics/associated.f90
+++ b/flang/test/Semantics/associated.f90
@@ -90,7 +90,7 @@ subroutine assoc()
     type(t2) :: t2x
     type(t2), target :: t2xtarget
     integer, target :: targetIntArr(2)
-    integer, target :: targetIntCoarray[*]
+    integer, target, save :: targetIntCoarray[*]
     integer, pointer :: intPointerArr(:)
     procedure(objPtrFunc), pointer :: objPtrFuncPointer
 

--- a/flang/test/Semantics/bind-c09.f90
+++ b/flang/test/Semantics/bind-c09.f90
@@ -44,6 +44,6 @@ function func8() result(res) bind(c)
 end
 
 function func9() result(res) bind(c)
-  ! ERROR: Interoperable function result may not be a coarray
+  ! ERROR: Function result may not be a coarray
   integer :: res[10, *]
 end

--- a/flang/test/Semantics/call10.f90
+++ b/flang/test/Semantics/call10.f90
@@ -200,8 +200,9 @@ module m
     !ERROR: An image control statement may not appear in a pure subprogram
     sync all ! C1599
   end subroutine
-  pure subroutine s14
-    integer :: img, nimgs, i[*], tmp
+  pure subroutine s14(i)
+    integer :: img, nimgs, tmp
+    integer, intent(in out) :: i[*]
                                    ! implicit sync all
     img = this_image()
     nimgs = num_images()

--- a/flang/test/Semantics/call12.f90
+++ b/flang/test/Semantics/call12.f90
@@ -40,7 +40,9 @@ module m
     type(hasHiddenPtr), intent(in) :: hhpd
     type(hasPtr), allocatable :: alloc
     type(hasHiddenPtr), allocatable :: hpAlloc
+    !ERROR: Pointer 'hcp' may not have a coarray potential component '%co'
     type(hasCoarray), pointer :: hcp
+    type(hasCoarray), allocatable :: hca
     integer :: n
     common /block/ y
     external :: extfunc
@@ -60,8 +62,8 @@ module m
     !BECAUSE: 'in' is an INTENT(IN) dummy argument
     in%a = 0. ! C1594(1)
     !ERROR: Left-hand side of assignment is not definable
-    !BECAUSE: A pure subprogram may not define the coindexed object 'hcp%co[1_8]'
-    hcp%co[1] = 0. ! C1594(1)
+    !BECAUSE: A pure subprogram may not define the coindexed object 'hca%co[1_8]'
+    hca%co[1] = 0. ! C1594(1)
     !ERROR: The left-hand side of a pointer assignment is not definable
     !BECAUSE: 'ptr' may not be defined in pure subprogram 'test' because it is a POINTER dummy argument of a pure function
     ptr => z ! C1594(2)

--- a/flang/test/Semantics/change_team01.f90
+++ b/flang/test/Semantics/change_team01.f90
@@ -4,6 +4,7 @@
 
 subroutine test
   use, intrinsic :: iso_fortran_env, only: team_type
+  save
   type(team_type) :: team
   integer, codimension[*] :: selector
   integer, codimension[2,*] :: selector2d

--- a/flang/test/Semantics/coarrays01.f90
+++ b/flang/test/Semantics/coarrays01.f90
@@ -2,7 +2,7 @@
 ! Test selector and team-value in CHANGE TEAM statement
 
 ! OK
-subroutine s1
+subroutine s1(y)
   use iso_fortran_env, only: team_type
   type(team_type) :: t
   real :: y[10,*]
@@ -11,7 +11,7 @@ subroutine s1
   form team(1, t)
 end
 
-subroutine s2
+subroutine s2(y,y2,x)
   use iso_fortran_env
   type(team_type) :: t
   real :: y[10,*], y2[*], x[*]
@@ -27,7 +27,7 @@ subroutine s2
   end team
 end
 
-subroutine s3
+subroutine s3(y)
   type :: team_type
   end type
   type :: foo

--- a/flang/test/Semantics/coarrays02.f90
+++ b/flang/test/Semantics/coarrays02.f90
@@ -1,0 +1,50 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! More coarray error tests.
+module m
+  integer :: local[*] ! ok in module
+end
+program main
+  use iso_fortran_env
+  !ERROR: Coarray 'namedconst' may not be a named constant
+  !ERROR: Local coarray must have the SAVE attribute
+  integer, parameter :: namedConst = 123
+  codimension namedConst[*]
+  !ERROR: Coarray 'coarr1' may not be in COMMON block '//'
+  real :: coarr1[*]
+  common//coarr1
+  !ERROR: Variable 'event' with EVENT_TYPE or LOCK_TYPE must be a coarray
+  type(event_type) event
+  !ERROR: Variable 'lock' with EVENT_TYPE or LOCK_TYPE must be a coarray
+  type(lock_type) lock
+  integer :: local[*] ! ok in main
+end
+
+function func1()
+  !ERROR: Function result may not be a coarray
+  integer :: func1[*]
+  !ERROR: Local coarray must have the SAVE attribute
+  integer :: local[*]
+  integer, save :: saved[*] ! ok
+  integer :: inited[*] = 1 ! ok
+  func = 1
+end
+
+function func2()
+  type t
+    real, allocatable :: comp[:]
+  end type
+  type t2
+    !ERROR: Allocatable or array component 'allo' may not have a coarray ultimate component '%comp'
+    type(t), allocatable :: allo
+    !ERROR: Allocatable or array component 'arr' may not have a coarray ultimate component '%comp'
+    type(t) :: arr(1)
+  end type
+  !ERROR: Function result 'func2' may not have a coarray potential component '%comp'
+  type(t) func2
+  !ERROR: Pointer 'ptr' may not have a coarray potential component '%comp'
+  type(t), pointer :: ptr
+  !ERROR: Coarray 'coarr' may not have a coarray potential component '%comp'
+  type(t), save :: coarr[*]
+  !ERROR: Local variable 'local' without the SAVE attribute may not have a coarray potential subobject component '%comp'
+  type(t) :: local
+end

--- a/flang/test/Semantics/critical02.f90
+++ b/flang/test/Semantics/critical02.f90
@@ -61,7 +61,7 @@ end subroutine test6
 
 subroutine test7()
   use iso_fortran_env
-  type(event_type) :: x[*], y[*]
+  type(event_type), save :: x[*], y[*]
   critical
     !ERROR: An image control statement is not allowed in a CRITICAL construct
     event post (x)

--- a/flang/test/Semantics/doconcurrent01.f90
+++ b/flang/test/Semantics/doconcurrent01.f90
@@ -69,7 +69,7 @@ end subroutine do_concurrent_test2
 
 subroutine s1()
   use iso_fortran_env
-  type(event_type) :: x[*]
+  type(event_type), save :: x[*]
   do concurrent (i = 1:n)
 !ERROR: An image control statement is not allowed in DO CONCURRENT
     event post (x)
@@ -78,7 +78,7 @@ end subroutine s1
 
 subroutine s2()
   use iso_fortran_env
-  type(event_type) :: x[*]
+  type(event_type), save :: x[*]
   do concurrent (i = 1:n)
 !ERROR: An image control statement is not allowed in DO CONCURRENT
     event wait (x)
@@ -124,8 +124,7 @@ subroutine s6()
     type(type0) :: type1_field
   end type
 
-  type(type1) :: pvar;
-  type(type1) :: qvar;
+  type(type1), save :: pvar, qvar
   integer, allocatable, dimension(:) :: array1
   integer, allocatable, dimension(:) :: array2
   integer, allocatable, codimension[:] :: ca, cb

--- a/flang/test/Semantics/doconcurrent08.f90
+++ b/flang/test/Semantics/doconcurrent08.f90
@@ -85,13 +85,13 @@ subroutine s1()
         type(HasAllocPolyType) :: nonAllocatableWithAllocPoly
 
         ! OK because the declared variable is not allocatable
-        type(HasAllocPolyCoarrayType) :: nonAllocatableWithAllocPolyCoarray
+        type(HasAllocPolyCoarrayType), save :: nonAllocatableWithAllocPolyCoarray
 
         ! Bad because even though the declared the allocatable component is a coarray
         type(HasAllocPolyCoarrayType), allocatable :: allocWithAllocPolyCoarray
 
         ! OK since it has no polymorphic component
-        type(HasAllocCoarrayType) :: nonAllocWithAllocCoarray
+        type(HasAllocCoarrayType), save :: nonAllocWithAllocCoarray
 
         ! OK since it has no component that's polymorphic, oops
         type(HasPointerPolyType), allocatable :: allocatableWithPointerPoly

--- a/flang/test/Semantics/form_team01.f90
+++ b/flang/test/Semantics/form_team01.f90
@@ -8,8 +8,7 @@ subroutine test
   integer :: team_index
   integer :: statvar
   character(len=50) :: errvar
-  integer, codimension[*] :: co_team_number
-  integer, codimension[*] :: co_team_index
+  integer, codimension[*], save :: co_team_number, co_team_index
   type(team_type), dimension(1) :: array_team
   integer, dimension(1) :: array_team_number
   integer, dimension(1) :: array_team_index

--- a/flang/test/Semantics/init01.f90
+++ b/flang/test/Semantics/init01.f90
@@ -18,6 +18,7 @@ subroutine objectpointers(j)
   end type
   type(t1), target, save :: o1
   type(t1), save :: o2
+!ERROR: Local variable 'o3' without the SAVE attribute may not have a coarray potential subobject component '%c2'
   type(t1), target :: o3
 !ERROR: An initial data target may not be a reference to an ALLOCATABLE 'x1'
   real, pointer :: p1 => x1

--- a/flang/test/Semantics/resolve07.f90
+++ b/flang/test/Semantics/resolve07.f90
@@ -18,6 +18,7 @@ subroutine s2
 end
 
 subroutine s3
+  save
   dimension :: x(4), x2(8)
   !ERROR: The dimensions of 'x' have already been declared
   allocatable :: x(:)

--- a/flang/test/Semantics/resolve50.f90
+++ b/flang/test/Semantics/resolve50.f90
@@ -3,6 +3,7 @@
 
 subroutine s1
   use iso_fortran_env
+  save
   type(team_type) :: t
   complex :: x[*]
   real :: y[*]
@@ -22,7 +23,7 @@ end
 subroutine s2
   use iso_fortran_env
   type(team_type) :: t
-  real :: y[10,*], y2[*], x[*]
+  real, save :: y[10,*], y2[*], x[*]
   ! C1113
   !ERROR: The codimensions of 'x' have already been declared
   change team(t, x[10,*] => y, x[*] => y2)

--- a/flang/test/Semantics/resolve55.f90
+++ b/flang/test/Semantics/resolve55.f90
@@ -81,7 +81,7 @@ end subroutine s6
 
 subroutine s7()
 ! Cannot have a coarray
-  integer, codimension[*] :: coarray_var
+  integer, codimension[*], save :: coarray_var
 !ERROR: Coarray 'coarray_var' not allowed in a LOCAL locality-spec
   do concurrent(i=1:5) local(coarray_var)
   end do

--- a/flang/test/Semantics/resolve88.f90
+++ b/flang/test/Semantics/resolve88.f90
@@ -64,11 +64,11 @@ module m
 
   type testType
     type(coarrayType) :: goodField
-    !ERROR: A component with a POINTER or ALLOCATABLE attribute may not be of a type with a coarray ultimate component (named 'goodcoarrayfield')
+    !ERROR: Pointer 'pointerfield' may not have a coarray potential component '%goodcoarrayfield'
     type(coarrayType), pointer :: pointerField
-    !ERROR: A component with a POINTER or ALLOCATABLE attribute may not be of a type with a coarray ultimate component (named 'goodcoarrayfield')
+    !ERROR: Allocatable or array component 'allocatablefield' may not have a coarray ultimate component '%goodcoarrayfield'
     type(coarrayType), allocatable :: allocatableField
-    !ERROR: An array or coarray component may not be of a type with a coarray ultimate component (named 'goodcoarrayfield')
+    !ERROR: Allocatable or array component 'arrayfield' may not have a coarray ultimate component '%goodcoarrayfield'
     type(coarrayType), dimension(3) :: arrayField
   end type testType
 

--- a/flang/test/Semantics/resolve94.f90
+++ b/flang/test/Semantics/resolve94.f90
@@ -6,6 +6,7 @@
 ! C931 A stat-variable in an image-selector shall not be a coindexed object.
 subroutine s1()
   use ISO_FORTRAN_ENV
+  save
   type(team_type) :: team1, team2
   real :: rCoarray[10,20,*]
   real :: rVar1, rVar2

--- a/flang/test/Semantics/this_image01.f90
+++ b/flang/test/Semantics/this_image01.f90
@@ -8,7 +8,7 @@ subroutine test
   type(team_type) :: coteam[*]
   integer :: coscalar[*], coarray(3)[*]
   save :: coteam, coscalar, coarray
-  real coarray1[*], coarray2[2,*], coarray3[2,3,*]
+  real, save :: coarray1[*], coarray2[2,*], coarray3[2,3,*]
   integer indices(3)
 
   ! correct calls, should produce no errors


### PR DESCRIPTION
Detect and report a bunch of uncaught semantic errors with coarray declarations.  Add more tests, and clean up bad usage in existing tests.