### PR TITLE
[LLDB][Documentation] Add a doc string to sbprocess to show MemoryRegions is iterable

### DIFF
--- a/lldb/bindings/interface/SBProcessDocstrings.i
+++ b/lldb/bindings/interface/SBProcessDocstrings.i
@@ -258,3 +258,14 @@ SBProcess supports thread iteration. For example (from test/lldbutil.py), ::
     Deallocates the block of memory (previously allocated using
     AllocateMemory) given in the argument."
 ) lldb::SBProcess::DeallocateMemory;
+
+%feature("docstring", "
+    Get a list of all the memory regions associated with this process.
+    ```
+        readable_regions = []
+        for region in process.GetMemoryRegions():
+            if region.IsReadable():
+                readable_regions.append(region)
+    ```
+"
+) lldb::SBProcess::GetMemoryRegions;


### PR DESCRIPTION
My colleague, @lukejriddle made the SBMemoryRegionList object iterable in #117358. This isn't documented anywhere and so I added a blurb about it to SBProcess.