### PR TITLE
[Hexagon] Fix -Wuninitialized warning

### DIFF
--- a/llvm/lib/Target/Hexagon/BitTracker.h
+++ b/llvm/lib/Target/Hexagon/BitTracker.h
@@ -100,9 +100,9 @@ private:
       bool operator()(const MachineInstr *MI, const MachineInstr *MJ) const;
       DenseMap<const MachineInstr*,unsigned> &Dist;
     };
-    std::priority_queue<MachineInstr*, std::vector<MachineInstr*>, Cmp> Uses;
     DenseSet<const MachineInstr*> Set; // Set to avoid adding duplicate entries.
     DenseMap<const MachineInstr*,unsigned> Dist;
+    std::priority_queue<MachineInstr *, std::vector<MachineInstr *>, Cmp> Uses;
   };
 
   void reset();


### PR DESCRIPTION
`gcc (GCC) 14.2.1 20240910` reports the warning below on the baseline, this change fixes the warning.

    In file included from /home/user/CLionProjects/llvm-project/llvm/lib/Target/Hexagon/BitTracker.cpp:55:
    /home/user/CLionProjects/llvm-project/llvm/lib/Target/Hexagon/BitTracker.h: In constructor ‘llvm::BitTracker::UseQueueType::UseQueueType()’:
    /home/user/CLionProjects/llvm-project/llvm/lib/Target/Hexagon/BitTracker.h:75:27: warning: member ‘llvm::BitTracker::UseQueueType::Dist’ is used uninitialized [-Wuninitialized]
       75 |     UseQueueType() : Uses(Dist) {}
          |                           ^~~~

Fixes #125545