### PR TITLE
[libc][sys/wait][linux] add missing and clean up existing macros

### DIFF
--- a/libc/include/llvm-libc-macros/linux/sys-wait-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-wait-macros.h
@@ -9,12 +9,7 @@
 #ifndef LLVM_LIBC_MACROS_LINUX_SYS_WAIT_MACROS_H
 #define LLVM_LIBC_MACROS_LINUX_SYS_WAIT_MACROS_H
 
-// Wait flags
-#define WNOHANG 1    // Do not block
-#define WUNTRACED 2  // Report is a child has stopped even if untraced
-#define WEXITED 4    // Report dead child
-#define WCONTINUED 8 // Report if a stopped child has been resumed by SIGCONT
-#define WSTOPPED WUNTRACED
+#include <linux/wait.h>
 
 // Wait status info macros
 #define __WEXITSTATUS(status) (((status)&0xff00) >> 8)
@@ -34,11 +29,5 @@
 #define WCOREFLAG __WCOREFLAG
 #define W_EXITCODE(ret, sig) __W_EXITCODE(ret, sig)
 #define W_STOPCODE(sig) __W_STOPCODE(sig)
-
-// First argument to waitid:
-#define P_ALL 0
-#define P_PID 1
-#define P_PGID 2
-#define P_PIDFD 3
 
 #endif // LLVM_LIBC_MACROS_LINUX_SYS_WAIT_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/sys-wait-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-wait-macros.h
@@ -12,9 +12,13 @@
 #include <linux/wait.h>
 
 // Wait status info macros
-#define __WEXITSTATUS(status) (((status)&0xff00) >> 8)
-#define __WTERMSIG(status) ((status)&0x7f)
+#define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
+#define __WTERMSIG(status) ((status) & 0x7f)
 #define __WIFEXITED(status) (__WTERMSIG(status) == 0)
+#define __WIFSIGNALED(status) ((__WTERMSIG(status) + 1) >= 2)
+#define __WIFSTOPPED(status) (__WTERMSIG(status) == 0x7f)
+#define __WIFCONTINUED(status) ((status) == __W_CONTINUED)
+#define __WCOREDUMP(status) ((status) & __WCOREFLAG)
 
 // Macros for constructing status values.
 #define __W_EXITCODE(ret, sig) ((ret) << 8 | (sig))
@@ -22,9 +26,14 @@
 #define __W_CONTINUED 0xffff
 #define __WCOREFLAG 0x80
 
+#define WCOREDUMP(status) ((status) & __WCOREFLAG)
 #define WEXITSTATUS(status) __WEXITSTATUS(status)
-#define WTERMSIG(status) __WTERMSIG(status)
+#define WIFCONTINUED(status) __WIFCONTINUED(status)
 #define WIFEXITED(status) __WIFEXITED(status)
+#define WIFSIGNALED(status) __WIFSIGNALED(status)
+#define WIFSTOPPED(status) __WIFSTOPPED(status)
+#define WSTOPSIG(status) WEXITSTATUS(status)
+#define WTERMSIG(status) __WTERMSIG(status)
 
 #define WCOREFLAG __WCOREFLAG
 #define W_EXITCODE(ret, sig) __W_EXITCODE(ret, sig)

--- a/libc/include/llvm-libc-macros/linux/sys-wait-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sys-wait-macros.h
@@ -11,32 +11,17 @@
 
 #include <linux/wait.h>
 
-// Wait status info macros
-#define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
-#define __WTERMSIG(status) ((status) & 0x7f)
-#define __WIFEXITED(status) (__WTERMSIG(status) == 0)
-#define __WIFSIGNALED(status) ((__WTERMSIG(status) + 1) >= 2)
-#define __WIFSTOPPED(status) (__WTERMSIG(status) == 0x7f)
-#define __WIFCONTINUED(status) ((status) == __W_CONTINUED)
-#define __WCOREDUMP(status) ((status) & __WCOREFLAG)
-
-// Macros for constructing status values.
-#define __W_EXITCODE(ret, sig) ((ret) << 8 | (sig))
-#define __W_STOPCODE(sig) ((sig) << 8 | 0x7f)
-#define __W_CONTINUED 0xffff
-#define __WCOREFLAG 0x80
-
-#define WCOREDUMP(status) ((status) & __WCOREFLAG)
-#define WEXITSTATUS(status) __WEXITSTATUS(status)
-#define WIFCONTINUED(status) __WIFCONTINUED(status)
-#define WIFEXITED(status) __WIFEXITED(status)
-#define WIFSIGNALED(status) __WIFSIGNALED(status)
-#define WIFSTOPPED(status) __WIFSTOPPED(status)
+#define WCOREDUMP(status) ((status) & WCOREFLAG)
+#define WEXITSTATUS(status) (((status) & 0xff00) >> 8)
+#define WIFCONTINUED(status) ((status) == 0xffff)
+#define WIFEXITED(status) (WTERMSIG(status) == 0)
+#define WIFSIGNALED(status) ((WTERMSIG(status) + 1) >= 2)
+#define WIFSTOPPED(status) (WTERMSIG(status) == 0x7f)
 #define WSTOPSIG(status) WEXITSTATUS(status)
-#define WTERMSIG(status) __WTERMSIG(status)
+#define WTERMSIG(status) ((status) & 0x7f)
 
-#define WCOREFLAG __WCOREFLAG
-#define W_EXITCODE(ret, sig) __W_EXITCODE(ret, sig)
-#define W_STOPCODE(sig) __W_STOPCODE(sig)
+#define WCOREFLAG 0x80
+#define W_EXITCODE(ret, sig) ((ret) << 8 | (sig))
+#define W_STOPCODE(sig) ((sig) << 8 | 0x7f)
 
 #endif // LLVM_LIBC_MACROS_LINUX_SYS_WAIT_MACROS_H


### PR DESCRIPTION
This patch does a few things:
- replace macro definitions with an inclusion of the linux/wait.h kernel
  header.
  - WNOHANG
  - WUNTRACED
  - WEXITED
  - WCONTINUED
  - WSTOPPED
  - P_ALL
  - P_PID
  - P_PGID
  - P_PIDFD
- Add missing macro definitions mandated by POSIX. Some are needed to build
  LLVM.
  - WCOREDUMP
  - WIFCONTINUED
  - WIFSIGNALELD
  - WIFSTOPPED
  - WSTOPSIG
- Remove glibc style __W* macros.  Users should stick with the POSIX macros. We
  can re-add them if necessary.
  - __WEXITSTATUS
  - __WTERMSIG
  - __WIFEXITED
  - __WIFSIGNALED
  - __WIFSTOPPED
  - __WIFCONTINUED
  - __WCOREDUMP
  - __W_EXITCODE
  - __W_STOPCODE
  - __W_CONTINUED
  - __WCOREFLAG

Fixes: #124944
