### PR TITLE
[libc++] Provide sized deallocation declarations even when the compiler doesn't support sized deallocation

### DIFF
--- a/libcxx/include/__new/global_new_delete.h
+++ b/libcxx/include/__new/global_new_delete.h
@@ -25,7 +25,7 @@
 #  define _THROW_BAD_ALLOC
 #endif
 
-#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
+#if _LIBCPP_STD_VER >= 14
 #  define _LIBCPP_HAS_SIZED_DEALLOCATION 1
 #else
 #  define _LIBCPP_HAS_SIZED_DEALLOCATION 0

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.fno-sized-deallocation.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.fno-sized-deallocation.pass.cpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Ensure that libc++ still provides the declaration of sized operator delete even
+// when sized deallocation support is disabled at the language level, since it should
+// still be valid to call these operators explicitly (as opposed to via a compiler
+// rewrite of a delete expression).
+
+// UNSUPPORTED: c++03, c++11
+
+// ADDITIONAL_COMPILE_FLAGS: -fno-sized-deallocation
+
+// Sized deallocation support was introduced in LLVM 11
+// XFAIL: using-built-library-before-llvm-11
+
+#include <new>
+
+int main(int, char**) {
+    void* p = ::operator new(10);
+    ::operator delete(p, 10);
+    return 0;
+}

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.fno-sized-deallocation.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.fno-sized-deallocation.pass.cpp
@@ -21,7 +21,7 @@
 #include <new>
 
 int main(int, char**) {
-    void* p = ::operator new(10);
-    ::operator delete(p, 10);
-    return 0;
+  void* p = ::operator new(10);
+  ::operator delete(p, 10);
+  return 0;
 }


### PR DESCRIPTION
After ef804d8f9b4, we stopped providing the declaration of sized deallocation functions unless the compiler provides support for the language feature. In reality, we can still provide the declarations of global operator delete for users who want to call these operators directly without going through the compiler rewrite.