### PR TITLE
[libc++] Avoid including <features.h> on arbitrary platforms

### DIFF
--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -30,12 +30,9 @@
 // ... add new file formats here ...
 #endif
 
-// To detect which libc we're using
-#if __has_include(<features.h>)
+// Need to detect which libc we're using if we're on Linux.
+#if defined(__linux__) || defined(__AMDGPU__) || defined(__NVPTX__)
 #  include <features.h>
-#endif
-
-#if defined(__linux__)
 #  if defined(__GLIBC_PREREQ)
 #    define _LIBCPP_GLIBC_PREREQ(a, b) __GLIBC_PREREQ(a, b)
 #  else


### PR DESCRIPTION
This partially reverts commit 5f2389d4. That commit started checking whether
<features.h> was a valid include unconditionally, however codebases are free
to have such a header on their search path, which breaks compilation. LLVM
libc should instead provide a more standard way of getting configuration
macros like __LLVM_LIBC__.

After this patch, we only include <features.h> when we're on Linux or
when we're compiling for GPUs.