### PR TITLE
[flang][cuda] Detect illegal data transfer in semantic

### DIFF
--- a/flang/lib/Semantics/assignment.cpp
+++ b/flang/lib/Semantics/assignment.cpp
@@ -90,6 +90,17 @@ void AssignmentContext::Analyze(const parser::AssignmentStmt &stmt) {
     if (whereDepth_ > 0) {
       CheckShape(lhsLoc, &lhs);
     }
+    if (context_.foldingContext().languageFeatures().IsEnabled(
+            common::LanguageFeature::CUDA)) {
+      const auto &scope{context_.FindScope(lhsLoc)};
+      const Scope &progUnit{GetProgramUnitContaining(scope)};
+      if (!IsCUDADeviceContext(&progUnit)) {
+        if (Fortran::evaluate::HasCUDADeviceAttrs(lhs) &&
+            Fortran::evaluate::HasCUDAImplicitTransfer(rhs)) {
+          context_.Say(lhsLoc, "Unsupported CUDA data transfer"_err_en_US);
+        }
+      }
+    }
   }
 }
 

--- a/flang/test/Semantics/cuf18.cuf
+++ b/flang/test/Semantics/cuf18.cuf
@@ -1,0 +1,11 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+
+subroutine sub1()
+  real, allocatable, device :: a(:)
+
+!ERROR: Unsupported CUDA data transfer
+  a = a + 10 ! Illegal expression according to 3.4.2
+end subroutine
+
+
+


### PR DESCRIPTION
When the LHS is a device variable and the RHS has implicit transfer, this is considered as an illegal transfer according to https://docs.nvidia.com/hpc-sdk/compilers/cuda-fortran-prog-guide/index.html#implicit-data-transfer-in-expressions. 

Detect this is semantic . 