### PR TITLE
[mlir][Vector] Add `vector.shuffle` fold for poison inputs

### DIFF
--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -2023,6 +2023,45 @@ func.func @shuffle_1d_poison_idx() -> vector<4xi32> {
 
 // -----
 
+// CHECK-LABEL: func @shuffle_1d_rhs_lhs_poison
+//   CHECK-NOT:   vector.shuffle
+//       CHECK:   %[[V:.+]] = ub.poison : vector<4xi32>
+//       CHECK:   return %[[V]]
+func.func @shuffle_1d_rhs_lhs_poison() -> vector<4xi32> {
+  %v0 = ub.poison : vector<3xi32>
+  %v1 = ub.poison : vector<3xi32>
+  %shuffle = vector.shuffle %v0, %v1 [3, 1, 5, 4] : vector<3xi32>, vector<3xi32>
+  return %shuffle : vector<4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @shuffle_1d_lhs_poison
+//   CHECK-NOT:   vector.shuffle
+//       CHECK:   %[[V:.+]] = arith.constant dense<[5, 4, 5, 5]> : vector<4xi32>
+//       CHECK:   return %[[V]]
+func.func @shuffle_1d_lhs_poison() -> vector<4xi32> {
+  %v0 = arith.constant dense<[5, 4, 3]> : vector<3xi32>
+  %v1 = ub.poison : vector<3xi32>
+  %shuffle = vector.shuffle %v0, %v1 [3, 1, 5, 4] : vector<3xi32>, vector<3xi32>
+  return %shuffle : vector<4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @shuffle_1d_rhs_poison
+//   CHECK-NOT:   vector.shuffle
+//       CHECK:   %[[V:.+]] = arith.constant dense<[2, 2, 0, 1]> : vector<4xi32>
+//       CHECK:   return %[[V]]
+func.func @shuffle_1d_rhs_poison() -> vector<4xi32> {
+  %v0 = ub.poison : vector<3xi32>
+  %v1 = arith.constant dense<[2, 1, 0]> : vector<3xi32>
+  %shuffle = vector.shuffle %v0, %v1 [3, 1, 5, 4] : vector<3xi32>, vector<3xi32>
+  return %shuffle : vector<4xi32>
+}
+
+// -----
+
 // CHECK-LABEL: func @shuffle_canonicalize_0d
 func.func @shuffle_canonicalize_0d(%v0 : vector<i32>, %v1 : vector<i32>) -> vector<1xi32> {
   // CHECK: vector.broadcast %{{.*}} : vector<i32> to vector<1xi32>

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -2012,11 +2012,11 @@ func.func @shuffle_1d() -> vector<4xi32> {
 // input vector. That is, %v[0] (i.e., 5) in this test.
 
 // CHECK-LABEL: func @shuffle_1d_poison_idx
-//       CHECK:   %[[V:.+]] = arith.constant dense<[2, 5, 0, 5]> : vector<4xi32>
+//       CHECK:   %[[V:.+]] = arith.constant dense<[13, 10, 15, 10]> : vector<4xi32>
 //       CHECK:   return %[[V]]
 func.func @shuffle_1d_poison_idx() -> vector<4xi32> {
-  %v0 = arith.constant dense<[5, 4, 3]> : vector<3xi32>
-  %v1 = arith.constant dense<[2, 1, 0]> : vector<3xi32>
+  %v0 = arith.constant dense<[10, 11, 12]> : vector<3xi32>
+  %v1 = arith.constant dense<[13, 14, 15]> : vector<3xi32>
   %shuffle = vector.shuffle %v0, %v1 [3, -1, 5, -1] : vector<3xi32>, vector<3xi32>
   return %shuffle : vector<4xi32>
 }
@@ -2038,10 +2038,10 @@ func.func @shuffle_1d_rhs_lhs_poison() -> vector<4xi32> {
 
 // CHECK-LABEL: func @shuffle_1d_lhs_poison
 //   CHECK-NOT:   vector.shuffle
-//       CHECK:   %[[V:.+]] = arith.constant dense<[5, 4, 5, 5]> : vector<4xi32>
+//       CHECK:   %[[V:.+]] = arith.constant dense<[11, 12, 11, 11]> : vector<4xi32>
 //       CHECK:   return %[[V]]
 func.func @shuffle_1d_lhs_poison() -> vector<4xi32> {
-  %v0 = arith.constant dense<[5, 4, 3]> : vector<3xi32>
+  %v0 = arith.constant dense<[11, 12, 13]> : vector<3xi32>
   %v1 = ub.poison : vector<3xi32>
   %shuffle = vector.shuffle %v0, %v1 [3, 1, 5, 4] : vector<3xi32>, vector<3xi32>
   return %shuffle : vector<4xi32>
@@ -2051,11 +2051,11 @@ func.func @shuffle_1d_lhs_poison() -> vector<4xi32> {
 
 // CHECK-LABEL: func @shuffle_1d_rhs_poison
 //   CHECK-NOT:   vector.shuffle
-//       CHECK:   %[[V:.+]] = arith.constant dense<[2, 2, 0, 1]> : vector<4xi32>
+//       CHECK:   %[[V:.+]] = arith.constant dense<[11, 11, 13, 12]> : vector<4xi32>
 //       CHECK:   return %[[V]]
 func.func @shuffle_1d_rhs_poison() -> vector<4xi32> {
   %v0 = ub.poison : vector<3xi32>
-  %v1 = arith.constant dense<[2, 1, 0]> : vector<3xi32>
+  %v1 = arith.constant dense<[11, 12, 13]> : vector<3xi32>
   %shuffle = vector.shuffle %v0, %v1 [3, 1, 5, 4] : vector<3xi32>, vector<3xi32>
   return %shuffle : vector<4xi32>
 }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/124863 added folding support for poison indices to `vector.shuffle`. This PR adds support for folding `vector.shuffle` ops with one or two poison input vectors.