### PR TITLE
workflows/build-ci-container: Fix container push

### DIFF
--- a/.github/workflows/build-ci-container.yml
+++ b/.github/workflows/build-ci-container.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           function push_container {
             image_name=$1
-            latest_name=$(echo $image_name | sed 's/:[.0-9]\+$/:latest/g')
+            latest_name=$(echo $image_name | sed 's/:[a-f0-9]\+$/:latest/g')
             podman tag $image_name $latest_name
             echo "Pushing $image_name ..."
             podman push $image_name


### PR DESCRIPTION
After the changes in 89001d1de8ecf03c8820594ea03345b99560272a, the container pushes failed, because it was attempting to push the same container twice.  This fixes the sed expression used to push the :latest alias for each container.