### PR TITLE
[OpenMP] Make `omp.h` work when compiled with `-ffreestanding`

### DIFF
--- a/openmp/runtime/src/include/omp.h.var
+++ b/openmp/runtime/src/include/omp.h.var
@@ -15,8 +15,14 @@
 #ifndef __OMP_H
 #   define __OMP_H
 
+#   ifndef __has_include
+#   define __has_include(x) 0
+#   endif
+
 #   include <stddef.h>
-#   include <stdlib.h>
+#   if (__has_include(<stdlib.h>))
+#     include <stdlib.h>
+#   endif
 #   include <stdint.h>
 
 #   define KMP_VERSION_MAJOR    @LIBOMP_VERSION_MAJOR@


### PR DESCRIPTION
Summary:
Freestanding builds have `stddef.h` and `stdint.h` but not `stdlib.h`.
We don't actually use any `stdlib.h` definitions in the OpenMP headers,
and some definitions from this header are usable without the OpenMP
runtime (allocators) so we should be able to do this. This ignores the
include if possible, removing the implicit include would possibly break
some applications so it stays here.
