### PR TITLE
[Driver][HIP] Do not pass -dependency-file flag for HIP Device offloading

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -1013,21 +1013,23 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     ArgM = ArgMD;
 
   if (ArgM) {
-    // Determine the output location.
-    const char *DepFile;
-    if (Arg *MF = Args.getLastArg(options::OPT_MF)) {
-      DepFile = MF->getValue();
-      C.addFailureResultFile(DepFile, &JA);
-    } else if (Output.getType() == types::TY_Dependencies) {
-      DepFile = Output.getFilename();
-    } else if (!ArgMD) {
-      DepFile = "-";
-    } else {
-      DepFile = getDependencyFileName(Args, Inputs);
-      C.addFailureResultFile(DepFile, &JA);
+    if (!JA.isDeviceOffloading(Action::OFK_HIP)) {
+      // Determine the output location.
+      const char *DepFile;
+      if (Arg *MF = Args.getLastArg(options::OPT_MF)) {
+        DepFile = MF->getValue();
+        C.addFailureResultFile(DepFile, &JA);
+      } else if (Output.getType() == types::TY_Dependencies) {
+        DepFile = Output.getFilename();
+      } else if (!ArgMD) {
+        DepFile = "-";
+      } else {
+        DepFile = getDependencyFileName(Args, Inputs);
+        C.addFailureResultFile(DepFile, &JA);
+      }
+      CmdArgs.push_back("-dependency-file");
+      CmdArgs.push_back(DepFile);
     }
-    CmdArgs.push_back("-dependency-file");
-    CmdArgs.push_back(DepFile);
 
     bool HasTarget = false;
     for (const Arg *A : Args.filtered(options::OPT_MT, options::OPT_MQ)) {

--- a/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
+++ b/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
@@ -1,0 +1,13 @@
+// RUN: %clang -### -x hip --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 -MD -MF tmp.d -v %s 2>&1 | FileCheck %s
+
+// CHECK: Build config:
+// CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1030"{{.*}}"-dependency-file" "tmp.d"
+// CHECK: {{.*}}lld{{.*}}"-plugin-opt=mcpu=gfx1030"
+// CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1100"{{.*}}"-dependency-file" "tmp.d"
+// CHECK: {{.*}}lld{{.*}}"-plugin-opt=mcpu=gfx1100"
+// CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1101"{{.*}}"-dependency-file" "tmp.d"
+// CHECK: {{.*}}lld{{.*}}"-plugin-opt=mcpu=gfx1101"
+// CHECK: {{.*}}clang-offload-bundler
+// CHECK: {{.*}}clang{{.*}}"-target-cpu" "x86-64"{{.*}}"-dependency-file" "tmp.d"
+
+void main(){}

--- a/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
+++ b/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
@@ -1,4 +1,4 @@
-// RUN: %clang -### -x hip --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 -MD -MF tmp.d -v %s 2>&1 | FileCheck %s
+// RUN: %clang -### -nogpuinc -nogpulib --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 -MD -MF tmp.d %s 2>&1 | FileCheck %s
 
 // CHECK: Build config:
 // CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1030"{{.*}}"-dependency-file" "tmp.d"


### PR DESCRIPTION
When we launch hipcc with multiple offload architectures along with -MF dep_file flag, the clang compilation invocations for host and device offloads write to the same dep_file, and can lead to collision during file IO operations. This can typically happen during large workloads. This commit provides a fix to generate dep_file only in host compilation.