### PR TITLE
[Clang] Do not try to transform invalid bindings

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -12716,7 +12716,7 @@ TreeTransform<Derived>::TransformDeclRefExpr(DeclRefExpr *E) {
   ValueDecl *ND
     = cast_or_null<ValueDecl>(getDerived().TransformDecl(E->getLocation(),
                                                          E->getDecl()));
-  if (!ND)
+  if (!ND || ND->isInvalidDecl())
     return ExprError();
 
   NamedDecl *Found = ND;

--- a/clang/test/SemaCXX/cxx2c-binding-pack.cpp
+++ b/clang/test/SemaCXX/cxx2c-binding-pack.cpp
@@ -218,3 +218,18 @@ auto X = [] <typename = void> () {
     static_assert(sizeof...(pack3) == 5);
 };
 }  // namespace
+
+namespace GH125165 {
+
+template <typename = void>
+auto f(auto t) {
+    const auto& [...pack] = t;
+    // expected-error@-1 {{cannot decompose non-class, non-array type 'char const'}}
+    (pack, ...);
+};
+
+void g() {
+    f('x'); // expected-note {{in instantiation}}
+}
+
+}


### PR DESCRIPTION
In the presence of an invalid structured binding decomposition, some binding packs may be invalid and trying to transform them would produce a recovery expression that does not contains a pack, leading to assertions in places where we would expect a pack at that stage.

Fixes #125165