### PR TITLE
[GitHub] Remove rovka from release uploaders

### DIFF
--- a/.github/workflows/release-asset-audit.py
+++ b/.github/workflows/release-asset-audit.py
@@ -34,7 +34,6 @@ def main():
             "zmodem",
             "androm3da",
             "tru",
-            "rovka",
             "rorth",
             "quinnlp",
             "kamaub",


### PR DESCRIPTION
As they are no longer doing releases for Linaro and I assume not for their current employer.