### PR TITLE
[CodeGen][NewPM] MachineCopyPropagation Remove dead ID

### DIFF
--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -459,8 +459,6 @@ class MachineCopyPropagation {
   bool UseCopyInstr;
 
 public:
-  static char ID; // Pass identification, replacement for typeid
-
   MachineCopyPropagation(bool CopyInstr = false)
       : UseCopyInstr(CopyInstr || MCPUseCopyInstr) {}
 


### PR DESCRIPTION
Fix for #125202 (4313345f2eeeb1e2ea7127a056ec4e1aaaa7fefb)
(supposed to be "unused ID")