### PR TITLE
[clang] Improve diagnostics for vector builtins

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12521,11 +12521,11 @@ def err_builtin_is_within_lifetime_invalid_arg : Error<
 
 def err_builtin_invalid_arg_type: Error<
   "%ordinal0 argument must be a"
-  "%select{| scalar| vector| vector,| vector of| scalar or vector of}1"
+  "%select{| scalar| vector| matrix| vector,| vector of| scalar or vector of}1"
   "%select{| integer| signed integer| unsigned integer| 'int'|"
-  " matrix| pointer to a valid matrix element}2"
+  " pointer to a valid matrix element}2"
   "%plural{0:|:%plural{0:|: or}2}3"
-  "%select{| floating-point}3 %plural{[0,3]:type|:types}1 (was %4)">;
+  "%select{| floating-point}3 %plural{[0,4]:type|:types}1 (was %4)">;
 
 def err_builtin_matrix_disabled: Error<
   "matrix types extension is disabled. Pass -fenable-matrix to enable it">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12519,13 +12519,31 @@ def err_builtin_is_within_lifetime_invalid_arg : Error<
   "%select{non-|function }0pointer argument to '__builtin_is_within_lifetime' "
   "is not allowed">;
 
+// A multi-component builtin type diagnostic. The first component broadly
+// selects a scalar or container type (scalar, vector or matrix). The second
+// component selects integer types and the third component selects
+// floating-point types. Any component can be left empty.
 def err_builtin_invalid_arg_type: Error<
-  "%ordinal0 argument must be a"
-  "%select{| scalar| vector| matrix| vector,| vector of| scalar or vector of}1"
-  "%select{| integer| signed integer| unsigned integer| 'int'|"
-  " pointer to a valid matrix element}2"
-  "%plural{0:|:%plural{0:|: or}2}3"
-  "%select{| floating-point}3 %plural{[0,4]:type|:types}1 (was %4)">;
+  "%ordinal0 argument must be a "
+  // First component: scalar or container types
+  "%select{|scalar|vector|matrix|vector of|scalar or vector of}1"
+  // A comma after generic vector/matrix types if there are non-empty second
+  // and third components, to initiate a list.
+  "%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1"
+  // A space after a non-empty first component
+  "%plural{0:|: }1"
+  // Second component: integer-like types
+  "%select{|integer|signed integer|unsigned integer|'int'|"
+  "pointer to a valid matrix element}2"
+  // A space after a non-empty second component
+  "%plural{0:|: }2"
+  // An 'or' if non-empty second and third components are combined
+  "%plural{0:|:%plural{0:|:or }2}3"
+  // Third component: floating-point types
+  "%select{|floating-point}3"
+  // A space after a non-empty third component
+  "%plural{0:|: }3"
+  "%plural{[0,3]:type|:types}1 (was %4)">;
 
 def err_builtin_matrix_disabled: Error<
   "matrix types extension is disabled. Pass -fenable-matrix to enable it">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12519,17 +12519,13 @@ def err_builtin_is_within_lifetime_invalid_arg : Error<
   "%select{non-|function }0pointer argument to '__builtin_is_within_lifetime' "
   "is not allowed">;
 
-def err_builtin_invalid_arg_type: Error <
-  "%ordinal0 argument must be "
-  "%select{a vector, integer or floating point type|a matrix|"
-  "a pointer to a valid matrix element type|"
-  "a signed integer or floating point type|a vector type|"
-  "a floating point type|"
-  "a vector of integers|"
-  "an unsigned integer|"
-  "an 'int'|"
-  "a vector of floating points|"
-  "an integer or vector of integers}1 (was %2)">;
+def err_builtin_invalid_arg_type: Error<
+  "%ordinal0 argument must be a"
+  "%select{| scalar| vector| vector,| vector of| scalar or vector of}1"
+  "%select{| integer| signed integer| unsigned integer| 'int'|"
+  " matrix| pointer to a valid matrix element}2"
+  "%plural{0:|:%plural{0:|: or}2}3"
+  "%select{| floating-point}3 %plural{[0,3]:type|:types}1 (was %4)">;
 
 def err_builtin_matrix_disabled: Error<
   "matrix types extension is disabled. Pass -fenable-matrix to enable it">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12528,7 +12528,8 @@ def err_builtin_invalid_arg_type: Error <
   "a vector of integers|"
   "an unsigned integer|"
   "an 'int'|"
-  "a vector of floating points}1 (was %2)">;
+  "a vector of floating points|"
+  "an integer or vector of integers}1 (was %2)">;
 
 def err_builtin_matrix_disabled: Error<
   "matrix types extension is disabled. Pass -fenable-matrix to enable it">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2353,9 +2353,18 @@ public:
   bool CheckFunctionCall(FunctionDecl *FDecl, CallExpr *TheCall,
                          const FunctionProtoType *Proto);
 
+  enum class EltwiseBuiltinArgTyRestriction {
+    None,
+    FloatTy,
+    IntegerTy,
+    SignedIntOrFloatTy,
+  };
+
   /// \param FPOnly restricts the arguments to floating-point types.
-  std::optional<QualType> BuiltinVectorMath(CallExpr *TheCall,
-                                            bool FPOnly = false);
+  std::optional<QualType>
+  BuiltinVectorMath(CallExpr *TheCall,
+                    EltwiseBuiltinArgTyRestriction ArgTyRestr =
+                        EltwiseBuiltinArgTyRestriction::None);
   bool BuiltinVectorToScalarMath(CallExpr *TheCall);
 
   void checkLifetimeCaptureBy(FunctionDecl *FDecl, bool IsMemberFunction,
@@ -2459,9 +2468,13 @@ public:
                                bool *ICContext = nullptr,
                                bool IsListInit = false);
 
-  bool BuiltinElementwiseTernaryMath(CallExpr *TheCall,
-                                     bool CheckForFloatArgs = true);
-  bool PrepareBuiltinElementwiseMathOneArgCall(CallExpr *TheCall);
+  bool
+  BuiltinElementwiseTernaryMath(CallExpr *TheCall,
+                                EltwiseBuiltinArgTyRestriction ArgTyRestr =
+                                    EltwiseBuiltinArgTyRestriction::FloatTy);
+  bool PrepareBuiltinElementwiseMathOneArgCall(
+      CallExpr *TheCall, EltwiseBuiltinArgTyRestriction ArgTyRestr =
+                             EltwiseBuiltinArgTyRestriction::None);
 
 private:
   void CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
@@ -2570,7 +2583,9 @@ private:
                                  AtomicExpr::AtomicOp Op);
 
   /// \param FPOnly restricts the arguments to floating-point types.
-  bool BuiltinElementwiseMath(CallExpr *TheCall, bool FPOnly = false);
+  bool BuiltinElementwiseMath(CallExpr *TheCall,
+                              EltwiseBuiltinArgTyRestriction ArgTyRestr =
+                                  EltwiseBuiltinArgTyRestriction::None);
   bool PrepareBuiltinReduceMathOneArgCall(CallExpr *TheCall);
 
   bool BuiltinNonDeterministicValue(CallExpr *TheCall);

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1983,28 +1983,28 @@ checkMathBuiltinElementType(Sema &S, SourceLocation Loc, QualType ArgTy,
     if (!ArgTy->getAs<VectorType>() &&
         !ConstantMatrixType::isValidElementType(ArgTy)) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* vector, */ 3 << /* integer */ 1 << /* fp */ 1
+             << ArgOrdinal << /* vector, */ 4 << /* integer */ 1 << /* fp */ 1
              << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::FloatTy:
     if (!EltTy->isRealFloatingType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* scalar or vector */ 5 << /* no int */ 0
+             << ArgOrdinal << /* scalar or vector */ 6 << /* no int */ 0
              << /* floating-point */ 1 << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::IntegerTy:
     if (!EltTy->isIntegerType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* scalar or vector */ 5 << /* integer */ 1
+             << ArgOrdinal << /* scalar or vector */ 6 << /* integer */ 1
              << /* no fp */ 0 << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::SignedIntOrFloatTy:
     if (EltTy->isUnsignedIntegerType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << 1 << /* scalar or vector */ 5 << /* signed int */ 2
+             << 1 << /* scalar or vector */ 6 << /* signed int */ 2
              << /* or fp */ 1 << ArgTy;
     }
     break;
@@ -2858,7 +2858,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
 
     if (ElTy.isNull() || !ElTy->isFloatingType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* vector of */ 4 << /* no int */ 0 << /* fp */ 1
+          << 1 << /* vector of */ 5 << /* no int */ 0 << /* fp */ 1
           << Arg->getType();
       return ExprError();
     }
@@ -2888,7 +2888,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
 
     if (ElTy.isNull() || !ElTy->isIntegerType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* vector of */ 4 << /* int */ 1 << /* no fp */ 0
+          << 1 << /* vector of */ 5 << /* int */ 1 << /* no fp */ 0
           << Arg->getType();
       return ExprError();
     }
@@ -15412,7 +15412,7 @@ bool Sema::BuiltinNonDeterministicValue(CallExpr *TheCall) {
   if (!TyArg->isBuiltinType() && !TyArg->isVectorType())
     return Diag(TheCall->getArg(0)->getBeginLoc(),
                 diag::err_builtin_invalid_arg_type)
-           << 1 << /* vector, */ 3 << /* integer */ 1 << /* fp */ 1 << TyArg;
+           << 1 << /* vector, */ 4 << /* integer */ 1 << /* fp */ 1 << TyArg;
 
   TheCall->setType(TyArg);
   return false;
@@ -15431,7 +15431,8 @@ ExprResult Sema::BuiltinMatrixTranspose(CallExpr *TheCall,
   auto *MType = Matrix->getType()->getAs<ConstantMatrixType>();
   if (!MType) {
     Diag(Matrix->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-        << 1 << 0 << /* matrix ty */ 5 << /* no fp */ 0 << Matrix->getType();
+        << 1 << /* matrix */ 3 << /* no int */ 0 << /* no fp */ 0
+        << Matrix->getType();
     return ExprError();
   }
 
@@ -15503,7 +15504,7 @@ ExprResult Sema::BuiltinMatrixColumnMajorLoad(CallExpr *TheCall,
   QualType ElementTy;
   if (!PtrTy) {
     Diag(PtrExpr->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-        << PtrArgIdx + 1 << 0 << /* pointer to element ty */ 6 << /* no fp */ 0
+        << PtrArgIdx + 1 << 0 << /* pointer to element ty */ 5 << /* no fp */ 0
         << PtrExpr->getType();
     ArgError = true;
   } else {
@@ -15511,7 +15512,7 @@ ExprResult Sema::BuiltinMatrixColumnMajorLoad(CallExpr *TheCall,
 
     if (!ConstantMatrixType::isValidElementType(ElementTy)) {
       Diag(PtrExpr->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << PtrArgIdx + 1 << 0 << /* pointer to element ty */ 6
+          << PtrArgIdx + 1 << 0 << /* pointer to element ty */ 5
           << /* no fp */ 0 << PtrExpr->getType();
       ArgError = true;
     }
@@ -15612,7 +15613,7 @@ ExprResult Sema::BuiltinMatrixColumnMajorStore(CallExpr *TheCall,
   auto *MatrixTy = MatrixExpr->getType()->getAs<ConstantMatrixType>();
   if (!MatrixTy) {
     Diag(MatrixExpr->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-        << 1 << 0 << /* matrix ty */ 5 << 0 << MatrixExpr->getType();
+        << 1 << /* matrix ty */ 3 << 0 << 0 << MatrixExpr->getType();
     ArgError = true;
   }
 
@@ -15632,7 +15633,7 @@ ExprResult Sema::BuiltinMatrixColumnMajorStore(CallExpr *TheCall,
   auto *PtrTy = PtrExpr->getType()->getAs<PointerType>();
   if (!PtrTy) {
     Diag(PtrExpr->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-        << PtrArgIdx + 1 << 0 << /* pointer to element ty */ 6 << 0
+        << PtrArgIdx + 1 << 0 << /* pointer to element ty */ 5 << 0
         << PtrExpr->getType();
     ArgError = true;
   } else {

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1983,28 +1983,28 @@ checkMathBuiltinElementType(Sema &S, SourceLocation Loc, QualType ArgTy,
     if (!ArgTy->getAs<VectorType>() &&
         !ConstantMatrixType::isValidElementType(ArgTy)) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* vector, */ 4 << /* integer */ 1 << /* fp */ 1
+             << ArgOrdinal << /* vector */ 2 << /* integer */ 1 << /* fp */ 1
              << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::FloatTy:
     if (!EltTy->isRealFloatingType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* scalar or vector */ 6 << /* no int */ 0
+             << ArgOrdinal << /* scalar or vector */ 5 << /* no int */ 0
              << /* floating-point */ 1 << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::IntegerTy:
     if (!EltTy->isIntegerType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << ArgOrdinal << /* scalar or vector */ 6 << /* integer */ 1
+             << ArgOrdinal << /* scalar or vector */ 5 << /* integer */ 1
              << /* no fp */ 0 << ArgTy;
     }
     break;
   case Sema::EltwiseBuiltinArgTyRestriction::SignedIntOrFloatTy:
     if (EltTy->isUnsignedIntegerType()) {
       return S.Diag(Loc, diag::err_builtin_invalid_arg_type)
-             << 1 << /* scalar or vector */ 6 << /* signed int */ 2
+             << 1 << /* scalar or vector */ 5 << /* signed int */ 2
              << /* or fp */ 1 << ArgTy;
     }
     break;
@@ -2858,7 +2858,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
 
     if (ElTy.isNull() || !ElTy->isFloatingType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* vector of */ 5 << /* no int */ 0 << /* fp */ 1
+          << 1 << /* vector of */ 4 << /* no int */ 0 << /* fp */ 1
           << Arg->getType();
       return ExprError();
     }
@@ -2888,7 +2888,7 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
 
     if (ElTy.isNull() || !ElTy->isIntegerType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* vector of */ 5 << /* int */ 1 << /* no fp */ 0
+          << 1 << /* vector of */ 4 << /* int */ 1 << /* no fp */ 0
           << Arg->getType();
       return ExprError();
     }
@@ -15412,7 +15412,7 @@ bool Sema::BuiltinNonDeterministicValue(CallExpr *TheCall) {
   if (!TyArg->isBuiltinType() && !TyArg->isVectorType())
     return Diag(TheCall->getArg(0)->getBeginLoc(),
                 diag::err_builtin_invalid_arg_type)
-           << 1 << /* vector, */ 4 << /* integer */ 1 << /* fp */ 1 << TyArg;
+           << 1 << /* vector */ 2 << /* integer */ 1 << /* fp */ 1 << TyArg;
 
   TheCall->setType(TyArg);
   return false;

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2421,8 +2421,10 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
         CheckAllArgsHaveSameType(&SemaRef, TheCall))
       return true;
     if (SemaRef.BuiltinElementwiseTernaryMath(
-            TheCall, /*CheckForFloatArgs*/
-            TheCall->getArg(0)->getType()->hasFloatingRepresentation()))
+            TheCall, /*ArgTyRestr*/
+            TheCall->getArg(0)->getType()->hasFloatingRepresentation()
+                ? Sema::EltwiseBuiltinArgTyRestriction::FloatTy
+                : Sema::EltwiseBuiltinArgTyRestriction::None))
       return true;
     break;
   }
@@ -2555,8 +2557,10 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     if (CheckVectorElementCallArgs(&SemaRef, TheCall))
       return true;
     if (SemaRef.BuiltinElementwiseTernaryMath(
-            TheCall, /*CheckForFloatArgs*/
-            TheCall->getArg(0)->getType()->hasFloatingRepresentation()))
+            TheCall, /*ArgTyRestr*/
+            TheCall->getArg(0)->getType()->hasFloatingRepresentation()
+                ? Sema::EltwiseBuiltinArgTyRestriction::FloatTy
+                : Sema::EltwiseBuiltinArgTyRestriction::None))
       return true;
     break;
   }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2493,7 +2493,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
 
     if (!EltTy->isIntegerType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* scalar or vector of */ 6 << /* integer ty */ 1
+          << 1 << /* scalar or vector of */ 5 << /* integer ty */ 1
           << /* no fp */ 0 << ArgTy;
       return true;
     }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2493,7 +2493,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
 
     if (!EltTy->isIntegerType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* scalar or vector of */ 5 << /* integer ty */ 1
+          << 1 << /* scalar or vector of */ 6 << /* integer ty */ 1
           << /* no fp */ 0 << ArgTy;
       return true;
     }

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2421,7 +2421,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
         CheckAllArgsHaveSameType(&SemaRef, TheCall))
       return true;
     if (SemaRef.BuiltinElementwiseTernaryMath(
-            TheCall, /*ArgTyRestr*/
+            TheCall, /*ArgTyRestr=*/
             TheCall->getArg(0)->getType()->hasFloatingRepresentation()
                 ? Sema::EltwiseBuiltinArgTyRestriction::FloatTy
                 : Sema::EltwiseBuiltinArgTyRestriction::None))
@@ -2558,7 +2558,7 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
     if (CheckVectorElementCallArgs(&SemaRef, TheCall))
       return true;
     if (SemaRef.BuiltinElementwiseTernaryMath(
-            TheCall, /*ArgTyRestr*/
+            TheCall, /*ArgTyRestr=*/
             TheCall->getArg(0)->getType()->hasFloatingRepresentation()
                 ? Sema::EltwiseBuiltinArgTyRestriction::FloatTy
                 : Sema::EltwiseBuiltinArgTyRestriction::None))

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -2493,7 +2493,8 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
 
     if (!EltTy->isIntegerType()) {
       Diag(Arg->getBeginLoc(), diag::err_builtin_invalid_arg_type)
-          << 1 << /* integer ty */ 6 << ArgTy;
+          << 1 << /* scalar or vector of */ 5 << /* integer ty */ 1
+          << /* no fp */ 0 << ArgTy;
       return true;
     }
 

--- a/clang/test/Sema/aarch64-sve-vector-exp-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-exp-ops.c
@@ -7,11 +7,11 @@
 svfloat32_t test_exp_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_exp(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_exp2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_exp2(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-exp-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-exp-ops.c
@@ -7,11 +7,11 @@
 svfloat32_t test_exp_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_exp(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_exp2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_exp2(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-log-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-log-ops.c
@@ -7,17 +7,17 @@
 svfloat32_t test_log_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_log10_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log10(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_log2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log2(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-log-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-log-ops.c
@@ -7,17 +7,17 @@
 svfloat32_t test_log_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_log10_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log10(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_log2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_log2(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-pow-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-pow-ops.c
@@ -7,5 +7,5 @@
 svfloat32_t test_pow_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_pow(v, v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-trig-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-trig-ops.c
@@ -7,19 +7,19 @@
 svfloat32_t test_asin_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_asin(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_acos_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_acos(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_atan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_atan(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_atan2_vv_i8mf8(svfloat32_t v) {
@@ -31,35 +31,35 @@ svfloat32_t test_atan2_vv_i8mf8(svfloat32_t v) {
 svfloat32_t test_sin_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_sin(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_cos_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_cos(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_tan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tan(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_sinh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_sinh(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_cosh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_cosh(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 svfloat32_t test_tanh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tanh(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }

--- a/clang/test/Sema/aarch64-sve-vector-trig-ops.c
+++ b/clang/test/Sema/aarch64-sve-vector-trig-ops.c
@@ -7,59 +7,59 @@
 svfloat32_t test_asin_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_asin(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_acos_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_acos(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_atan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_atan(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_atan2_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_atan2(v, v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_sin_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_sin(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_cos_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_cos(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_tan_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tan(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_sinh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_sinh(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_cosh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_cosh(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 svfloat32_t test_tanh_vv_i8mf8(svfloat32_t v) {
 
   return __builtin_elementwise_tanh(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -45,7 +45,7 @@ void test_builtin_elementwise_abs(int i, double d, float4 v, int3 iv, unsigned u
 
 void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_add_sat(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_add_sat(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -60,13 +60,16 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_add_sat(v, iv);
-  // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+
+  i = __builtin_elementwise_add_sat(iv, v);
+  // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_add_sat(uv, iv);
   // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
 
   v = __builtin_elementwise_add_sat(v, v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
 
   s = __builtin_elementwise_add_sat(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -95,7 +98,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   int A[10];
   A = __builtin_elementwise_add_sat(A, A);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
 
   int(ii);
   int j;
@@ -103,12 +106,12 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_add_sat(c1, c2);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_sub_sat(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_sub_sat(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -123,13 +126,16 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_sub_sat(v, iv);
-  // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+
+  i = __builtin_elementwise_sub_sat(iv, v);
+  // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_sub_sat(uv, iv);
   // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
 
   v = __builtin_elementwise_sub_sat(v, v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
 
   s = __builtin_elementwise_sub_sat(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -158,7 +164,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   int A[10];
   A = __builtin_elementwise_sub_sat(A, A);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
 
   int(ii);
   int j;
@@ -166,12 +172,12 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_sub_sat(c1, c2);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_max(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_max(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_max(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -231,7 +237,7 @@ void test_builtin_elementwise_max(int i, short s, double d, float4 v, int3 iv, u
 
 void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_min(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_min(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -291,7 +297,7 @@ void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, u
 
 void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_maximum(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_maximum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -309,7 +315,7 @@ void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximum(uv, iv);
-  // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_maximum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -336,7 +342,7 @@ void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 
 
 void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_minimum(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_minimum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -354,7 +360,7 @@ void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimum(uv, iv);
-  // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_minimum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -388,16 +394,16 @@ void test_builtin_elementwise_bitreverse(int i, float f, double d, float4 v, int
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_bitreverse(f);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float')}}
   
   i = __builtin_elementwise_bitreverse(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_bitreverse(d);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'double')}}
 
   v = __builtin_elementwise_bitreverse(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_elementwise_ceil(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -640,16 +646,16 @@ void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_popcount(f);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float')}}
 
   i = __builtin_elementwise_popcount(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_popcount(d);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double')}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'double')}}
 
   v = __builtin_elementwise_popcount(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
 
   int2 i2 = __builtin_elementwise_popcount(iv);
   // expected-error@-1 {{initializing 'int2' (vector of 2 'int' values) with an expression of incompatible type 'int3' (vector of 3 'int' values)}}
@@ -666,7 +672,7 @@ void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 
 
 void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_fmod(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_fmod(i, i);
   // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
@@ -684,7 +690,7 @@ void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_fmod(uv, iv);
-  // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   i = __builtin_elementwise_fmod(d, v);
   // expected-error@-1 {{arguments are of different types ('double' vs 'float4' (vector of 4 'float' values))}}
@@ -692,7 +698,7 @@ void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, 
 
 void test_builtin_elementwise_pow(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_pow(p, d);
-  // expected-error@-1 {{arguments are of different types ('int *' vs 'double')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_pow(i, i);
   // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
@@ -710,7 +716,7 @@ void test_builtin_elementwise_pow(int i, short s, double d, float4 v, int3 iv, u
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_pow(uv, iv);
-  // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
   
 }
 
@@ -754,10 +760,9 @@ void test_builtin_elementwise_round(int i, float f, double d, float4 v, int3 iv,
   uv = __builtin_elementwise_round(uv);
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
-  // FIXME: Error should not mention integer
   _Complex float c1, c2;
   c1 = __builtin_elementwise_round(c1);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_rint(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -779,10 +784,9 @@ void test_builtin_elementwise_rint(int i, float f, double d, float4 v, int3 iv, 
   uv = __builtin_elementwise_rint(uv);
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
-  // FIXME: Error should not mention integer
   _Complex float c1, c2;
   c1 = __builtin_elementwise_rint(c1);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -804,10 +808,9 @@ void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3
   uv = __builtin_elementwise_nearbyint(uv);
   // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
-  // FIXME: Error should not mention integer
   _Complex float c1, c2;
   c1 = __builtin_elementwise_nearbyint(c1);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_asin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -37,15 +37,15 @@ void test_builtin_elementwise_abs(int i, double d, float4 v, int3 iv, unsigned u
   // expected-error@-1 {{assigning to 'int' from incompatible type 'float4' (vector of 4 'float' values)}}
 
   u = __builtin_elementwise_abs(u);
-  // expected-error@-1 {{1st argument must be a signed integer or floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_abs(uv);
-  // expected-error@-1 {{1st argument must be a signed integer or floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of signed integer or floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_add_sat(p, d);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_add_sat(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -60,7 +60,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_add_sat(v, iv);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_add_sat(iv, v);
   // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'float4' (vector of 4 'float' values))}}
@@ -69,7 +69,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
 
   v = __builtin_elementwise_add_sat(v, v);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   s = __builtin_elementwise_add_sat(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -98,7 +98,7 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   int A[10];
   A = __builtin_elementwise_add_sat(A, A);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   int(ii);
   int j;
@@ -106,12 +106,12 @@ void test_builtin_elementwise_add_sat(int i, short s, double d, float4 v, int3 i
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_add_sat(c1, c2);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_sub_sat(p, d);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_sub_sat(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -126,7 +126,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_sub_sat(v, iv);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   i = __builtin_elementwise_sub_sat(iv, v);
   // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'float4' (vector of 4 'float' values))}}
@@ -135,7 +135,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
   // expected-error@-1 {{arguments are of different types ('unsigned3' (vector of 3 'unsigned int' values) vs 'int3' (vector of 3 'int' values))}}
 
   v = __builtin_elementwise_sub_sat(v, v);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   s = __builtin_elementwise_sub_sat(i, s);
   // expected-error@-1 {{arguments are of different types ('int' vs 'short')}}
@@ -164,7 +164,7 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   int A[10];
   A = __builtin_elementwise_sub_sat(A, A);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'int *')}}
 
   int(ii);
   int j;
@@ -172,12 +172,12 @@ void test_builtin_elementwise_sub_sat(int i, short s, double d, float4 v, int3 i
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_sub_sat(c1, c2);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_max(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_max(p, d);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_max(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -224,7 +224,7 @@ void test_builtin_elementwise_max(int i, short s, double d, float4 v, int3 iv, u
 
   int A[10];
   A = __builtin_elementwise_max(A, A);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'int *')}}
 
   int(ii);
   int j;
@@ -232,12 +232,12 @@ void test_builtin_elementwise_max(int i, short s, double d, float4 v, int3 iv, u
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_max(c1, c2);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_min(p, d);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_min(i, i);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'int'}}
@@ -284,7 +284,7 @@ void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, u
 
   int A[10];
   A = __builtin_elementwise_min(A, A);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'int *')}}
 
   int(ii);
   int j;
@@ -292,12 +292,12 @@ void test_builtin_elementwise_min(int i, short s, double d, float4 v, int3 iv, u
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_min(c1, c2);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_maximum(p, d);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_maximum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -315,7 +315,7 @@ void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximum(uv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_maximum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -326,23 +326,23 @@ void test_builtin_elementwise_maximum(int i, short s, float f, double d, float4 
   fv = __builtin_elementwise_maximum(fv, fv);
 
   i = __builtin_elementwise_maximum(iv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_maximum(i, i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   int A[10];
   A = __builtin_elementwise_maximum(A, A);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_maximum(c1, c2);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 fv, double4 dv, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_minimum(p, d);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_minimum(d, d);
   // expected-error@-1 {{initializing 'struct Foo' with an expression of incompatible type 'double'}}
@@ -360,7 +360,7 @@ void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimum(uv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   dv = __builtin_elementwise_minimum(fv, dv);
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'double4' (vector of 4 'double' values))}}
@@ -371,18 +371,18 @@ void test_builtin_elementwise_minimum(int i, short s, float f, double d, float4 
   fv = __builtin_elementwise_minimum(fv, fv);
 
   i = __builtin_elementwise_minimum(iv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_minimum(i, i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   int A[10];
   A = __builtin_elementwise_minimum(A, A);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_minimum(c1, c2);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_bitreverse(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -394,16 +394,16 @@ void test_builtin_elementwise_bitreverse(int i, float f, double d, float4 v, int
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_bitreverse(f);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float')}}
   
   i = __builtin_elementwise_bitreverse(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_bitreverse(d);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 
   v = __builtin_elementwise_bitreverse(v);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_elementwise_ceil(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -415,16 +415,16 @@ void test_builtin_elementwise_ceil(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_ceil(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_ceil(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_ceil(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_ceil(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_acos(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -436,16 +436,16 @@ void test_builtin_elementwise_acos(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_acos(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_acos(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_acos(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_acos(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_cos(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -457,16 +457,16 @@ void test_builtin_elementwise_cos(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_cos(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_cos(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_cos(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_cos(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_cosh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -478,16 +478,16 @@ void test_builtin_elementwise_cosh(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_cosh(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_cosh(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_cosh(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_cosh(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_exp(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -499,16 +499,16 @@ void test_builtin_elementwise_exp(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_exp(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_exp(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_exp(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_exp(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_exp2(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -520,16 +520,16 @@ void test_builtin_elementwise_exp2(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_exp2(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_exp2(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_exp2(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_exp2(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_exp10(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -541,16 +541,16 @@ void test_builtin_elementwise_exp10(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_exp10(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_exp10(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_exp10(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_exp10(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_floor(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -562,16 +562,16 @@ void test_builtin_elementwise_floor(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_floor(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_floor(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_floor(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_floor(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_log(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -583,16 +583,16 @@ void test_builtin_elementwise_log(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_log(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_log(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_log(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_log(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_log10(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -604,16 +604,16 @@ void test_builtin_elementwise_log10(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_log10(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_log10(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_log10(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_log10(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_log2(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -625,16 +625,16 @@ void test_builtin_elementwise_log2(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_log2(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_log2(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_log2(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_log2(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -646,16 +646,16 @@ void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_popcount(f);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float')}}
 
   i = __builtin_elementwise_popcount(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_popcount(d);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 
   v = __builtin_elementwise_popcount(v);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'float4' (vector of 4 'float' values))}}
 
   int2 i2 = __builtin_elementwise_popcount(iv);
   // expected-error@-1 {{initializing 'int2' (vector of 2 'int' values) with an expression of incompatible type 'int3' (vector of 3 'int' values)}}
@@ -672,10 +672,10 @@ void test_builtin_elementwise_popcount(int i, float f, double d, float4 v, int3 
 
 void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_fmod(p, d);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_fmod(i, i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_fmod(i);
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
@@ -690,7 +690,7 @@ void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, 
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_fmod(uv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   i = __builtin_elementwise_fmod(d, v);
   // expected-error@-1 {{arguments are of different types ('double' vs 'float4' (vector of 4 'float' values))}}
@@ -698,10 +698,10 @@ void test_builtin_elementwise_fmod(int i, short s, double d, float4 v, int3 iv, 
 
 void test_builtin_elementwise_pow(int i, short s, double d, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_pow(p, d);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   struct Foo foo = __builtin_elementwise_pow(i, i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_pow(i);
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
@@ -716,7 +716,7 @@ void test_builtin_elementwise_pow(int i, short s, double d, float4 v, int3 iv, u
   // expected-error@-1 {{arguments are of different types ('float4' (vector of 4 'float' values) vs 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_pow(uv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
   
 }
 
@@ -729,16 +729,16 @@ void test_builtin_elementwise_roundeven(int i, float f, double d, float4 v, int3
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_roundeven(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_roundeven(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_roundeven(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_roundeven(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_round(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -749,20 +749,20 @@ void test_builtin_elementwise_round(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_round(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_round(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_round(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_round(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_round(c1);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_rint(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -773,20 +773,20 @@ void test_builtin_elementwise_rint(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_rint(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_rint(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_rint(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_rint(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_rint(c1);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -797,20 +797,20 @@ void test_builtin_elementwise_nearbyint(int i, float f, double d, float4 v, int3
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_nearbyint(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_nearbyint(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_nearbyint(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_nearbyint(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_nearbyint(c1);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }
 
 void test_builtin_elementwise_asin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -822,16 +822,16 @@ void test_builtin_elementwise_asin(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_asin(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_asin(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_asin(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_asin(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_sin(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -843,16 +843,16 @@ void test_builtin_elementwise_sin(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_sin(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_sin(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_sin(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sin(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_sinh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -864,16 +864,16 @@ void test_builtin_elementwise_sinh(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_sinh(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_sinh(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_sinh(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sinh(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_sqrt(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -885,16 +885,16 @@ void test_builtin_elementwise_sqrt(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_sqrt(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_sqrt(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_sqrt(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_sqrt(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_atan(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -906,16 +906,16 @@ void test_builtin_elementwise_atan(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_atan(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_atan(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_atan(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_atan(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_atan2(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -930,16 +930,16 @@ void test_builtin_elementwise_atan2(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
 
   i = __builtin_elementwise_atan2(i, i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_atan2(f, f, f);
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   u = __builtin_elementwise_atan2(u, u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_atan2(uv, uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_tan(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -951,16 +951,16 @@ void test_builtin_elementwise_tan(int i, float f, double d, float4 v, int3 iv, u
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_tan(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_tan(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_tan(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_tan(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_tanh(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -972,16 +972,16 @@ void test_builtin_elementwise_tanh(int i, float f, double d, float4 v, int3 iv, 
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_tanh(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_tanh(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_tanh(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_tanh(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_trunc(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -993,16 +993,16 @@ void test_builtin_elementwise_trunc(int i, float f, double d, float4 v, int3 iv,
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_trunc(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_trunc(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_trunc(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_trunc(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_canonicalize(int i, float f, double d, float4 v, int3 iv, unsigned u, unsigned4 uv) {
@@ -1014,24 +1014,24 @@ void test_builtin_elementwise_canonicalize(int i, float f, double d, float4 v, i
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_elementwise_canonicalize(i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_canonicalize(f, f);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   u = __builtin_elementwise_canonicalize(u);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned int')}}
 
   uv = __builtin_elementwise_canonicalize(uv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned4' (vector of 4 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned4' (vector of 4 'unsigned int' values))}}
 }
 
 void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4 v, int3 iv, unsigned3 uv, int *p) {
   i = __builtin_elementwise_copysign(p, d);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int *')}}
 
   i = __builtin_elementwise_copysign(i, i);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   i = __builtin_elementwise_copysign(i);
   // expected-error@-1 {{too few arguments to function call, expected 2, have 1}}
@@ -1043,32 +1043,32 @@ void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4
   // expected-error@-1 {{too many arguments to function call, expected 2, have 3}}
 
   i = __builtin_elementwise_copysign(v, iv);
-  // expected-error@-1 {{2nd argument must be a floating point type (was 'int3' (vector of 3 'int' values))}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'int3' (vector of 3 'int' values))}}
 
   i = __builtin_elementwise_copysign(uv, iv);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'unsigned3' (vector of 3 'unsigned int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'unsigned3' (vector of 3 'unsigned int' values))}}
 
   s = __builtin_elementwise_copysign(i, s);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f = __builtin_elementwise_copysign(f, i);
-  // expected-error@-1 {{2nd argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f = __builtin_elementwise_copysign(i, f);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   enum e { one,
            two };
   i = __builtin_elementwise_copysign(one, two);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   enum f { three };
   enum f x = __builtin_elementwise_copysign(one, three);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   _BitInt(32) ext; // expected-warning {{'_BitInt' in C17 and earlier is a Clang extension}}
   ext = __builtin_elementwise_copysign(ext, ext);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_BitInt(32)')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_BitInt(32)')}}
 
   const float cf32;
   f = __builtin_elementwise_copysign(cf32, f);
@@ -1080,7 +1080,7 @@ void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4
 
   float A[10];
   A = __builtin_elementwise_copysign(A, A);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'float *')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'float *')}}
 
   float(ii);
   float j;
@@ -1088,7 +1088,7 @@ void test_builtin_elementwise_copysign(int i, short s, double d, float f, float4
 
   _Complex float c1, c2;
   c1 = __builtin_elementwise_copysign(c1, c2);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 
   double f64 = 0.0;
   double tmp0 = __builtin_elementwise_copysign(f64, f);
@@ -1177,28 +1177,28 @@ void test_builtin_elementwise_fma(int i32, int2 v2i32, short i16,
   // expected-error@-1 {{arguments are of different types ('double' vs 'double2' (vector of 2 'double' values)}}
 
   i32 = __builtin_elementwise_fma(i32, i32, i32);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 
   v2i32 = __builtin_elementwise_fma(v2i32, v2i32, v2i32);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (vector of 2 'int' values))}}
 
   f32 = __builtin_elementwise_fma(f32, f32, i32);
-  // expected-error@-1 {{3rd argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f32 = __builtin_elementwise_fma(f32, i32, f32);
-  // expected-error@-1 {{2nd argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'int')}}
 
   f32 = __builtin_elementwise_fma(f32, f32, i32);
-  // expected-error@-1 {{3rd argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'int')}}
 
 
   _Complex float c1, c2, c3;
   c1 = __builtin_elementwise_fma(c1, f32, f32);
-  // expected-error@-1 {{1st argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 
   c2 = __builtin_elementwise_fma(f32, c2, f32);
-  // expected-error@-1 {{2nd argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 
   c3 = __builtin_elementwise_fma(f32, f32, c3);
-  // expected-error@-1 {{3rd argument must be a floating point type (was '_Complex float')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was '_Complex float')}}
 }

--- a/clang/test/Sema/builtins-reduction-math.c
+++ b/clang/test/Sema/builtins-reduction-math.c
@@ -47,10 +47,10 @@ void test_builtin_reduce_add(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   i = __builtin_reduce_add(i);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'int')}}
 
   i = __builtin_reduce_add(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_reduce_mul(int i, float4 v, int3 iv) {
@@ -64,10 +64,10 @@ void test_builtin_reduce_mul(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   i = __builtin_reduce_mul(i);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'int')}}
 
   i = __builtin_reduce_mul(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_reduce_xor(int i, float4 v, int3 iv) {
@@ -81,10 +81,10 @@ void test_builtin_reduce_xor(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   i = __builtin_reduce_xor(i);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'int')}}
 
   i = __builtin_reduce_xor(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_reduce_or(int i, float4 v, int3 iv) {
@@ -98,10 +98,10 @@ void test_builtin_reduce_or(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   i = __builtin_reduce_or(i);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'int')}}
 
   i = __builtin_reduce_or(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_reduce_and(int i, float4 v, int3 iv) {
@@ -115,10 +115,10 @@ void test_builtin_reduce_and(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
 
   i = __builtin_reduce_and(i);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'int')}}
 
   i = __builtin_reduce_and(v);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'float4' (vector of 4 'float' values))}}
+  // expected-error@-1 {{1st argument must be a vector of integer types (was 'float4' (vector of 4 'float' values))}}
 }
 
 void test_builtin_reduce_maximum(int i, float4 v, int3 iv) {
@@ -132,7 +132,7 @@ void test_builtin_reduce_maximum(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_reduce_maximum(i);
-  // expected-error@-1 {{1st argument must be a vector of floating points (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of floating-point types (was 'int')}}
 }
 
 void test_builtin_reduce_minimum(int i, float4 v, int3 iv) {
@@ -146,5 +146,5 @@ void test_builtin_reduce_minimum(int i, float4 v, int3 iv) {
   // expected-error@-1 {{too few arguments to function call, expected 1, have 0}}
 
   i = __builtin_reduce_minimum(i);
-  // expected-error@-1 {{1st argument must be a vector of floating points (was 'int')}}
+  // expected-error@-1 {{1st argument must be a vector of floating-point types (was 'int')}}
 }

--- a/clang/test/Sema/count-builtins.c
+++ b/clang/test/Sema/count-builtins.c
@@ -9,17 +9,17 @@ void test_builtin_popcountg(short s, int i, __int128 i128, _BitInt(128) bi128,
   __builtin_popcountg(i, i);
   // expected-error@-1 {{too many arguments to function call, expected 1, have 2}}
   __builtin_popcountg(s);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'short')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'short')}}
   __builtin_popcountg(i);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int')}}
   __builtin_popcountg(i128);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was '__int128')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was '__int128')}}
   __builtin_popcountg(bi128);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was '_BitInt(128)')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was '_BitInt(128)')}}
   __builtin_popcountg(d);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'double')}}
   __builtin_popcountg(i2);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int2' (vector of 2 'int' values))}}
 }
 
 void test_builtin_clzg(short s, int i, unsigned int ui, __int128 i128,
@@ -29,29 +29,29 @@ void test_builtin_clzg(short s, int i, unsigned int ui, __int128 i128,
   __builtin_clzg(i, i, i);
   // expected-error@-1 {{too many arguments to function call, expected at most 2, have 3}}
   __builtin_clzg(s);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'short')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'short')}}
   __builtin_clzg(i);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int')}}
   __builtin_clzg(i128);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was '__int128')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was '__int128')}}
   __builtin_clzg(bi128);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was '_BitInt(128)')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was '_BitInt(128)')}}
   __builtin_clzg(d);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'double')}}
   __builtin_clzg(i2);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int2' (vector of 2 'int' values))}}
   __builtin_clzg(i2);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int2' (vector of 2 'int' values))}}
   __builtin_clzg(ui, ui);
-  // expected-error@-1 {{2nd argument must be an 'int' (was 'unsigned int')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was 'unsigned int')}}
   __builtin_clzg(ui, i128);
-  // expected-error@-1 {{2nd argument must be an 'int' (was '__int128')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was '__int128')}}
   __builtin_clzg(ui, bi128);
-  // expected-error@-1 {{2nd argument must be an 'int' (was '_BitInt(128)')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was '_BitInt(128)')}}
   __builtin_clzg(ui, d);
-  // expected-error@-1 {{2nd argument must be an 'int' (was 'double')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was 'double')}}
   __builtin_clzg(ui, i2);
-  // expected-error@-1 {{2nd argument must be an 'int' (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was 'int2' (vector of 2 'int' values))}}
 }
 
 void test_builtin_ctzg(short s, int i, unsigned int ui, __int128 i128,
@@ -61,27 +61,27 @@ void test_builtin_ctzg(short s, int i, unsigned int ui, __int128 i128,
   __builtin_ctzg(i, i, i);
   // expected-error@-1 {{too many arguments to function call, expected at most 2, have 3}}
   __builtin_ctzg(s);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'short')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'short')}}
   __builtin_ctzg(i);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int')}}
   __builtin_ctzg(i128);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was '__int128')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was '__int128')}}
   __builtin_ctzg(bi128);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was '_BitInt(128)')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was '_BitInt(128)')}}
   __builtin_ctzg(d);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'double')}}
   __builtin_ctzg(i2);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int2' (vector of 2 'int' values))}}
   __builtin_ctzg(i2);
-  // expected-error@-1 {{1st argument must be an unsigned integer (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{1st argument must be a scalar unsigned integer type (was 'int2' (vector of 2 'int' values))}}
   __builtin_ctzg(ui, ui);
-  // expected-error@-1 {{2nd argument must be an 'int' (was 'unsigned int')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was 'unsigned int')}}
   __builtin_ctzg(ui, i128);
-  // expected-error@-1 {{2nd argument must be an 'int' (was '__int128')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was '__int128')}}
   __builtin_ctzg(ui, bi128);
-  // expected-error@-1 {{2nd argument must be an 'int' (was '_BitInt(128)')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was '_BitInt(128)')}}
   __builtin_ctzg(ui, d);
-  // expected-error@-1 {{2nd argument must be an 'int' (was 'double')}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was 'double')}}
   __builtin_ctzg(ui, i2);
-  // expected-error@-1 {{2nd argument must be an 'int' (was 'int2' (vector of 2 'int' values))}}
+  // expected-error@-1 {{2nd argument must be a scalar 'int' type (was 'int2' (vector of 2 'int' values))}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-exp-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-exp-ops.c
@@ -9,11 +9,11 @@
 vfloat32mf2_t test_exp_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_exp(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 vfloat32mf2_t test_exp2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_exp2(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-exp-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-exp-ops.c
@@ -9,11 +9,11 @@
 vfloat32mf2_t test_exp_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_exp(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_exp2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_exp2(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-log-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-log-ops.c
@@ -9,17 +9,17 @@
 vfloat32mf2_t test_log_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 vfloat32mf2_t test_log10_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log10(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 vfloat32mf2_t test_log2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log2(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-log-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-log-ops.c
@@ -9,17 +9,17 @@
 vfloat32mf2_t test_log_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_log10_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log10(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_log2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_log2(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }

--- a/clang/test/Sema/riscv-rvv-vector-trig-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-trig-ops.c
@@ -8,19 +8,19 @@
 vfloat32mf2_t test_asin_vv_i8mf8(vfloat32mf2_t v) {
 
     return __builtin_elementwise_asin(v);
-    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+    // expected-error@-1 {{1st argument must be a floating point type}}
   }
   
   vfloat32mf2_t test_acos_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_acos(v);
-    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+    // expected-error@-1 {{1st argument must be a floating point type}}
   }
   
   vfloat32mf2_t test_atan_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_atan(v);
-    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+    // expected-error@-1 {{1st argument must be a floating point type}}
   }
 
 vfloat32mf2_t test_atan2_vv_i8mf8(vfloat32mf2_t v) {
@@ -32,36 +32,36 @@ vfloat32mf2_t test_atan2_vv_i8mf8(vfloat32mf2_t v) {
 vfloat32mf2_t test_sin_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_sin(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 vfloat32mf2_t test_cos_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_cos(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 vfloat32mf2_t test_tan_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_tan(v);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+  // expected-error@-1 {{1st argument must be a floating point type}}
 }
 
 vfloat32mf2_t test_sinh_vv_i8mf8(vfloat32mf2_t v) {
 
     return __builtin_elementwise_sinh(v);
-    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+    // expected-error@-1 {{1st argument must be a floating point type}}
   }
   
   vfloat32mf2_t test_cosh_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_cosh(v);
-    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+    // expected-error@-1 {{1st argument must be a floating point type}}
   }
   
   vfloat32mf2_t test_tanh_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_tanh(v);
-    // expected-error@-1 {{1st argument must be a vector, integer or floating point type}}
+    // expected-error@-1 {{1st argument must be a floating point type}}
   }
   

--- a/clang/test/Sema/riscv-rvv-vector-trig-ops.c
+++ b/clang/test/Sema/riscv-rvv-vector-trig-ops.c
@@ -8,60 +8,60 @@
 vfloat32mf2_t test_asin_vv_i8mf8(vfloat32mf2_t v) {
 
     return __builtin_elementwise_asin(v);
-    // expected-error@-1 {{1st argument must be a floating point type}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_acos_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_acos(v);
-    // expected-error@-1 {{1st argument must be a floating point type}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_atan_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_atan(v);
-    // expected-error@-1 {{1st argument must be a floating point type}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
 
 vfloat32mf2_t test_atan2_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_atan2(v, v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_sin_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_sin(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_cos_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_cos(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_tan_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_tan(v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
 }
 
 vfloat32mf2_t test_sinh_vv_i8mf8(vfloat32mf2_t v) {
 
     return __builtin_elementwise_sinh(v);
-    // expected-error@-1 {{1st argument must be a floating point type}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_cosh_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_cosh(v);
-    // expected-error@-1 {{1st argument must be a floating point type}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   
   vfloat32mf2_t test_tanh_vv_i8mf8(vfloat32mf2_t v) {
   
     return __builtin_elementwise_tanh(v);
-    // expected-error@-1 {{1st argument must be a floating point type}}
+    // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types}}
   }
   

--- a/clang/test/Sema/riscv-sve-vector-pow-ops.c
+++ b/clang/test/Sema/riscv-sve-vector-pow-ops.c
@@ -9,5 +9,5 @@
 vfloat32mf2_t test_pow_vv_i8mf8(vfloat32mf2_t v) {
 
   return __builtin_elementwise_pow(v, v);
-  // expected-error@-1 {{1st argument must be a floating point type}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point type}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/clamp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/clamp-errors.hlsl
@@ -103,7 +103,7 @@ float2 test_builtin_clamp_int_vect_to_float_vec_promotion(int2 p0, float p1) {
 
 float test_builtin_clamp_bool_type_promotion(bool p0) {
   return __builtin_hlsl_elementwise_clamp(p0, p0, p0);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'bool')}}
 }
 
 float builtin_bool_to_float_type_promotion(float p0, bool p1) {

--- a/clang/test/SemaHLSL/BuiltIns/dot-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/dot-errors.hlsl
@@ -106,7 +106,7 @@ float test_builtin_dot_int_vect_to_float_vec_promotion(int2 p0, float p1) {
 
 int test_builtin_dot_bool_type_promotion(bool p0, bool p1) {
   return __builtin_hlsl_dot(p0, p1);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'bool')}}
 }
 
 double test_dot_double(double2 p0, double2 p1) {

--- a/clang/test/SemaHLSL/BuiltIns/exp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/exp-errors.hlsl
@@ -14,7 +14,7 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'bool')}}
 }
 
 float builtin_exp_int_to_float_promotion(int p1) {

--- a/clang/test/SemaHLSL/BuiltIns/exp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/exp-errors.hlsl
@@ -14,15 +14,15 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_exp_int_to_float_promotion(int p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float2 builtin_exp_int2_to_float2_promotion(int2 p1) {
   return TEST_FUNC(p1);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/firstbithigh-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/firstbithigh-errors.hlsl
@@ -17,10 +17,10 @@ double test_int_builtin(double p0) {
 
 double2 test_int_builtin_2(double2 p0) {
   return __builtin_hlsl_elementwise_firstbithigh(p0);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 float test_int_builtin_3(float p0) {
   return __builtin_hlsl_elementwise_firstbithigh(p0);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/firstbitlow-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/firstbitlow-errors.hlsl
@@ -17,10 +17,10 @@ double test_int_builtin(double p0) {
 
 double2 test_int_builtin_2(double2 p0) {
   return __builtin_hlsl_elementwise_firstbitlow(p0);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 float test_int_builtin_3(float p0) {
   return __builtin_hlsl_elementwise_firstbitlow(p0);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
@@ -104,27 +104,27 @@ float2 test_builtin_lerp_int_vect_to_float_vec_promotion(int2 p0, float p1) {
 
 float test_builtin_lerp_bool_type_promotion(bool p0) {
   return __builtin_hlsl_lerp(p0, p0, p0);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_bool_to_float_type_promotion(float p0, bool p1) {
   return __builtin_hlsl_lerp(p0, p0, p1);
-  // expected-error@-1 {{3rd argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_bool_to_float_type_promotion2(bool p0, float p1) {
   return __builtin_hlsl_lerp(p1, p0, p1);
-  // expected-error@-1 {{2nd argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_lerp_int_to_float_promotion(float p0, int p1) {
   return __builtin_hlsl_lerp(p0, p0, p1);
-  // expected-error@-1 {{3rd argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float4 test_lerp_int4(int4 p0, int4 p1, int4 p2) {
   return __builtin_hlsl_lerp(p0, p1, p2);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int4' (aka 'vector<int, 4>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int4' (aka 'vector<int, 4>'))}}
 }
 
 // note: DefaultVariadicArgumentPromotion --> DefaultArgumentPromotion has already promoted to double

--- a/clang/test/SemaHLSL/BuiltIns/mad-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/mad-errors.hlsl
@@ -72,17 +72,17 @@ float2 test_builtin_mad_int_vect_to_float_vec_promotion(int2 p0, float p1) {
 
 float builtin_bool_to_float_type_promotion(float p0, bool p1) {
   return __builtin_hlsl_mad(p0, p0, p1);
-  // expected-error@-1 {{3rd argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_bool_to_float_type_promotion2(bool p0, float p1) {
   return __builtin_hlsl_mad(p1, p0, p1);
-  // expected-error@-1 {{2nd argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{2nd argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_mad_int_to_float_promotion(float p0, int p1) {
   return __builtin_hlsl_mad(p0, p0, p1);
-  // expected-error@-1 {{3rd argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{3rd argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 int builtin_mad_mixed_enums() {

--- a/clang/test/SemaHLSL/BuiltIns/reversebits-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/reversebits-errors.hlsl
@@ -3,7 +3,7 @@
 
 double2 test_int_builtin(double2 p0) {
     return __builtin_elementwise_bitreverse(p0);
-  // expected-error@-1 {{1st argument must be a vector of integers (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 int2 test_int_builtin(int2 p0) {

--- a/clang/test/SemaHLSL/BuiltIns/reversebits-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/reversebits-errors.hlsl
@@ -3,7 +3,7 @@
 
 double2 test_int_builtin(double2 p0) {
     return __builtin_elementwise_bitreverse(p0);
-  // expected-error@-1 {{1st argument must be an integer or vector of integers (was 'double2' (aka 'vector<double, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of integer types (was 'double2' (aka 'vector<double, 2>'))}}
 }
 
 int2 test_int_builtin(int2 p0) {

--- a/clang/test/SemaHLSL/BuiltIns/round-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/round-errors.hlsl
@@ -13,7 +13,7 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a vector, integer or floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a floating point type (was 'bool')}}
 }
 
 float builtin_round_int_to_float_promotion(int p1) {

--- a/clang/test/SemaHLSL/BuiltIns/round-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/round-errors.hlsl
@@ -13,15 +13,15 @@ float2 test_too_many_arg(float2 p0) {
 
 float builtin_bool_to_float_type_promotion(bool p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'bool')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'bool')}}
 }
 
 float builtin_round_int_to_float_promotion(int p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int')}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int')}}
 }
 
 float2 builtin_round_int2_to_float2_promotion(int2 p1) {
   return __builtin_elementwise_round(p1);
-  // expected-error@-1 {{1st argument must be a floating point type (was 'int2' (aka 'vector<int, 2>'))}}
+  // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int2' (aka 'vector<int, 2>'))}}
 }


### PR DESCRIPTION
This commit improves the diagnostics for vector (elementwise) builtins in a couple of ways.

It primarily provides more precise type-checking diagnostics for builtins with specific type requirements. Previously many builtins were receiving a catch-all diagnostic suggesting types which aren't valid.

It also makes consistent the type-checking behaviour between various binary and ternary builtins. The binary builtins would check for mismatched argument types before specific type requirements, whereas ternary builtins would perform the checks in the reverse order. The binary builtins now behave as the ternary ones do.