### PR TITLE
[InstCombine] Fold xor of bittests into bittest of xor'd value

### DIFF
--- a/llvm/test/Transforms/InstCombine/xor-icmps.ll
+++ b/llvm/test/Transforms/InstCombine/xor-icmps.ll
@@ -319,3 +319,166 @@ define i1 @xor_icmp_to_icmp_add_multiuse2(i32 %a) {
   %cmp3 = xor i1 %cmp, %cmp1
   ret i1 %cmp3
 }
+
+define i1 @test_xor_of_bittest_ne_ne(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_ne(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  %cmp1 = icmp ne i8 %mask1, 0
+  %mask2 = and i8 %y, 2
+  %cmp2 = icmp ne i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_eq_eq(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_eq_eq(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp eq i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp eq i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  %cmp1 = icmp eq i8 %mask1, 0
+  %mask2 = and i8 %y, 2
+  %cmp2 = icmp eq i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_ne_eq(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_eq(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp eq i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  %cmp1 = icmp ne i8 %mask1, 0
+  %mask2 = and i8 %y, 2
+  %cmp2 = icmp eq i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_eq_ne(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_eq_ne(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp eq i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  %cmp1 = icmp eq i8 %mask1, 0
+  %mask2 = and i8 %y, 2
+  %cmp2 = icmp ne i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_ne_ne_multiuse1(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_ne_multiuse1(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    call void @usei8(i8 [[MASK1]])
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    call void @usei8(i8 [[MASK2]])
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  call void @usei8(i8 %mask1)
+  %cmp1 = icmp ne i8 %mask1, 0
+  %mask2 = and i8 %y, 2
+  call void @usei8(i8 %mask2)
+  %cmp2 = icmp ne i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+; Negative tests
+
+define i1 @test_xor_of_bittest_ne_ne_type_mismatch(i8 %x, i16 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_ne_type_mismatch(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i16 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i16 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  %cmp1 = icmp ne i8 %mask1, 0
+  %mask2 = and i16 %y, 2
+  %cmp2 = icmp ne i16 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_ne_ne_mask_mismatch(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_ne_mask_mismatch(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 4
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 4
+  %cmp1 = icmp ne i8 %mask1, 0
+  %mask2 = and i8 %y, 2
+  %cmp2 = icmp ne i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_ne_ne_nonpower2(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_ne_nonpower2(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 3
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 3
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 3
+  %cmp1 = icmp ne i8 %mask1, 0
+  %mask2 = and i8 %y, 3
+  %cmp2 = icmp ne i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+define i1 @test_xor_of_bittest_ne_ne_multiuse2(i8 %x, i8 %y) {
+; CHECK-LABEL: @test_xor_of_bittest_ne_ne_multiuse2(
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
+; CHECK-NEXT:    call void @use(i1 [[CMP1]])
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
+; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    ret i1 [[XOR]]
+;
+  %mask1 = and i8 %x, 2
+  %cmp1 = icmp ne i8 %mask1, 0
+  call void @use(i1 %cmp1)
+  %mask2 = and i8 %y, 2
+  %cmp2 = icmp ne i8 %mask2, 0
+  %xor = xor i1 %cmp1, %cmp2
+  ret i1 %xor
+}
+
+declare void @usei8(i8)

--- a/llvm/test/Transforms/InstCombine/xor-icmps.ll
+++ b/llvm/test/Transforms/InstCombine/xor-icmps.ll
@@ -322,12 +322,10 @@ define i1 @xor_icmp_to_icmp_add_multiuse2(i32 %a) {
 
 define i1 @test_xor_of_bittest_ne_ne(i8 %x, i8 %y) {
 ; CHECK-LABEL: @test_xor_of_bittest_ne_ne(
-; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
-; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[Y:%.*]] = xor i8 [[X:%.*]], [[Y1:%.*]]
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y]], 2
 ; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
-; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
-; CHECK-NEXT:    ret i1 [[XOR]]
+; CHECK-NEXT:    ret i1 [[CMP2]]
 ;
   %mask1 = and i8 %x, 2
   %cmp1 = icmp ne i8 %mask1, 0
@@ -339,11 +337,9 @@ define i1 @test_xor_of_bittest_ne_ne(i8 %x, i8 %y) {
 
 define i1 @test_xor_of_bittest_eq_eq(i8 %x, i8 %y) {
 ; CHECK-LABEL: @test_xor_of_bittest_eq_eq(
-; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[CMP1:%.*]] = icmp eq i8 [[MASK1]], 0
-; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
-; CHECK-NEXT:    [[CMP2:%.*]] = icmp eq i8 [[MASK2]], 0
-; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    [[Y:%.*]] = xor i8 [[X:%.*]], [[Y1:%.*]]
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y]], 2
+; CHECK-NEXT:    [[XOR:%.*]] = icmp ne i8 [[MASK2]], 0
 ; CHECK-NEXT:    ret i1 [[XOR]]
 ;
   %mask1 = and i8 %x, 2
@@ -356,12 +352,10 @@ define i1 @test_xor_of_bittest_eq_eq(i8 %x, i8 %y) {
 
 define i1 @test_xor_of_bittest_ne_eq(i8 %x, i8 %y) {
 ; CHECK-LABEL: @test_xor_of_bittest_ne_eq(
-; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
-; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
-; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
+; CHECK-NEXT:    [[Y:%.*]] = xor i8 [[X:%.*]], [[Y1:%.*]]
+; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y]], 2
 ; CHECK-NEXT:    [[CMP2:%.*]] = icmp eq i8 [[MASK2]], 0
-; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
-; CHECK-NEXT:    ret i1 [[XOR]]
+; CHECK-NEXT:    ret i1 [[CMP2]]
 ;
   %mask1 = and i8 %x, 2
   %cmp1 = icmp ne i8 %mask1, 0
@@ -373,12 +367,10 @@ define i1 @test_xor_of_bittest_ne_eq(i8 %x, i8 %y) {
 
 define i1 @test_xor_of_bittest_eq_ne(i8 %x, i8 %y) {
 ; CHECK-LABEL: @test_xor_of_bittest_eq_ne(
-; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
+; CHECK-NEXT:    [[X:%.*]] = xor i8 [[X1:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X]], 2
 ; CHECK-NEXT:    [[CMP1:%.*]] = icmp eq i8 [[MASK1]], 0
-; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
-; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
-; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
-; CHECK-NEXT:    ret i1 [[XOR]]
+; CHECK-NEXT:    ret i1 [[CMP1]]
 ;
   %mask1 = and i8 %x, 2
   %cmp1 = icmp eq i8 %mask1, 0
@@ -392,11 +384,11 @@ define i1 @test_xor_of_bittest_ne_ne_multiuse1(i8 %x, i8 %y) {
 ; CHECK-LABEL: @test_xor_of_bittest_ne_ne_multiuse1(
 ; CHECK-NEXT:    [[MASK1:%.*]] = and i8 [[X:%.*]], 2
 ; CHECK-NEXT:    call void @usei8(i8 [[MASK1]])
-; CHECK-NEXT:    [[CMP1:%.*]] = icmp ne i8 [[MASK1]], 0
 ; CHECK-NEXT:    [[MASK2:%.*]] = and i8 [[Y:%.*]], 2
 ; CHECK-NEXT:    call void @usei8(i8 [[MASK2]])
-; CHECK-NEXT:    [[CMP2:%.*]] = icmp ne i8 [[MASK2]], 0
-; CHECK-NEXT:    [[XOR:%.*]] = xor i1 [[CMP1]], [[CMP2]]
+; CHECK-NEXT:    [[TMP1:%.*]] = xor i8 [[X]], [[Y]]
+; CHECK-NEXT:    [[TMP2:%.*]] = and i8 [[TMP1]], 2
+; CHECK-NEXT:    [[XOR:%.*]] = icmp ne i8 [[TMP2]], 0
 ; CHECK-NEXT:    ret i1 [[XOR]]
 ;
   %mask1 = and i8 %x, 2


### PR DESCRIPTION
Motivating case: https://github.com/llvm/llvm-project/blob/64927af52a3bedf2b20d6cdd98bb47d9bba630f9/llvm/lib/Analysis/ValueTracking.cpp#L8600-L8602

It is translated into `xor (X & 2) != 0, (Y & 2) != 0`.
Alive2: https://alive2.llvm.org/ce/z/dJehZ8
