### PR TITLE
[Bazel] Set HAVE_MALLINFO2=1

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
+++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
@@ -48,6 +48,7 @@ posix_defines = [
 linux_defines = posix_defines + [
     "_GNU_SOURCE",
     "HAVE_MALLINFO=1",
+    "HAVE_MALLINFO2=1",
     "HAVE_SBRK=1",
     "HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=1",
 ]


### PR DESCRIPTION
This silences the annoying warning from `llvm/lib/Support/Process.cpp`.