### PR TITLE
[flang] Move FIRSupport dependency to correct place

### DIFF
--- a/flang/lib/Optimizer/Analysis/CMakeLists.txt
+++ b/flang/lib/Optimizer/Analysis/CMakeLists.txt
@@ -12,6 +12,7 @@ add_flang_library(FIRAnalysis
   LINK_LIBS
   FIRBuilder
   FIRDialect
+  FIRSupport
   HLFIRDialect
 
   MLIR_LIBS
@@ -19,5 +20,4 @@ add_flang_library(FIRAnalysis
   MLIRLLVMDialect
   MLIRMathTransforms
   MLIROpenMPDialect
-  FIRSupport
 )


### PR DESCRIPTION
This library is provided by flang, not MLIR, so it should not be part of MLIR_LIBS.

Fixes an issue introduced in https://github.com/llvm/llvm-project/pull/120966.