### PR TITLE
[mlir] Fix MLIRTestDialect dependency in MLIRTestIR

### DIFF
--- a/mlir/test/lib/IR/CMakeLists.txt
+++ b/mlir/test/lib/IR/CMakeLists.txt
@@ -28,7 +28,7 @@ add_mlir_library(MLIRTestIR
 
   EXCLUDE_FROM_LIBMLIR
 
-  DEPENDS
+  LINK_LIBS PUBLIC
   MLIRTestDialect
   )
 
@@ -37,7 +37,6 @@ mlir_target_link_libraries(MLIRTestIR PUBLIC
   MLIRBytecodeReader
   MLIRBytecodeWriter
   MLIRFunctionInterfaces
-  MLIRTestDialect
   )
 
 target_include_directories(MLIRTestIR


### PR DESCRIPTION
This is a test library which is not part of libMLIR, so it should use normal LINK_LIBS instead of mlir_target_link_libraries.

This fixes an issue introduced in #123910 and follows up on the fix in #125004, which added the library to DEPENDS, which is not sufficient.