### PR TITLE
[clang] Stop parsing warning suppression mappings in driver

### DIFF
--- a/clang/test/Driver/warning-suppression-mappings-not-parsed.cpp
+++ b/clang/test/Driver/warning-suppression-mappings-not-parsed.cpp
@@ -1,0 +1,5 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: echo '[unknown-warning]' > %t/foo.txt
+// RUN: %clang -fdriver-only --warning-suppression-mappings=%t/foo.txt %s | FileCheck -allow-empty %s
+// CHECK-NOT: unknown warning option 'unknown-warning'

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -318,6 +318,10 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
 
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts =
       CreateAndPopulateDiagOpts(Args);
+  // Driver's diagnostics don't use suppression mappings, so don't bother
+  // parsing them. CC1 still receives full args, so this doesn't impact other
+  // actions.
+  DiagOpts->DiagnosticSuppressionMappingsFile.clear();
 
   TextDiagnosticPrinter *DiagClient
     = new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);


### PR DESCRIPTION
This gets rid of some extra IO from driver startup, and possiblity of
emitting warnings twice.
