### PR TITLE
[libc] Make LlvmLibcStackChkFail.Smash test compatible with asan, hwasan

### DIFF
--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -18,18 +18,12 @@ TEST(LlvmLibcStackChkFail, Death) {
   EXPECT_DEATH([] { __stack_chk_fail(); }, WITH_SIGNAL(SIGABRT));
 }
 
-// When https://github.com/llvm/llvm-project/issues/125760 is fixed,
-// this can use the `gnu::` spelling unconditionally.
-#ifdef __clang__
-#define SANITIZER_ATTR_NS clang
-#else
-#define SANITIZER_ATTR_NS gnu
-#endif
-
 // Disable sanitizers such as asan and hwasan that would catch the buffer
 // overrun before it clobbered the stack canary word.  Function attributes
-// can't be applied to lambdas before C++23, so this has to be separate.
-[[SANITIZER_ATTR_NS::no_sanitize("all")]] void smash_stack() {
+// can't be applied to lambdas before C++23, so this has to be separate.  When
+// https://github.com/llvm/llvm-project/issues/125760 is fixed, this can use
+// the modern spelling [[gnu::no_sanitize(...)]] without conditionalization.
+__attribute__((no_sanitize("all"))) void smash_stack() {
   int arr[20];
   LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
 }

--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -12,19 +12,30 @@
 #include "src/string/memset.h"
 #include "test/UnitTest/Test.h"
 
+namespace {
+
 TEST(LlvmLibcStackChkFail, Death) {
   EXPECT_DEATH([] { __stack_chk_fail(); }, WITH_SIGNAL(SIGABRT));
 }
 
-// Disable the test when asan is enabled so that it doesn't immediately fail
-// after the memset, but before the stack canary is re-checked.
-#ifndef LIBC_HAS_ADDRESS_SANITIZER
-TEST(LlvmLibcStackChkFail, Smash) {
-  EXPECT_DEATH(
-      [] {
-        int arr[20];
-        LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
-      },
-      WITH_SIGNAL(SIGABRT));
+// When https://github.com/llvm/llvm-project/issues/125760 is fixed,
+// this can use the `gnu::` spelling unconditionally.
+#ifdef __clang__
+#define SANITIZER_ATTR_NS clang
+#else
+#define SANITIZER_ATTR_NS gnu
+#endif
+
+// Disable sanitizers such as asan and hwasan that would catch the buffer
+// overrun before it clobbered the stack canary word.  Function attributes
+// can't be applied to lambdas before C++23, so this has to be separate.
+[[SANITIZER_ATTR_NS::no_sanitize("all")]] void smash_stack() {
+  int arr[20];
+  LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
 }
-#endif // LIBC_HAS_ADDRESS_SANITIZER
+
+TEST(LlvmLibcStackChkFail, Smash) {
+  EXPECT_DEATH(smash_stack, WITH_SIGNAL(SIGABRT));
+}
+
+} // namespace


### PR DESCRIPTION
Previously this test was entirely disabled under asan, but not
hwasan.  Instead of disabling the test, make the test compatible
with both asan and hwasan by disabling sanitizers only on the
subroutine that does the stack-smashing.
