### PR TITLE
[tblgen] Add command line flag for using fallback TypeIDs in generation

### DIFF
--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AttrOrTypeFormatGen.h"
+#include "SharedCL.h"
 #include "mlir/TableGen/AttrOrTypeDef.h"
 #include "mlir/TableGen/Class.h"
 #include "mlir/TableGen/CodeGenHelpers.h"
@@ -24,18 +25,6 @@ using namespace mlir;
 using namespace mlir::tblgen;
 using llvm::Record;
 using llvm::RecordKeeper;
-
-//===----------------------------------------------------------------------===//
-// CL Options
-//===----------------------------------------------------------------------===//
-
-static llvm::cl::OptionCategory clAttrOrTypeDefs("Options for -gen-*def-*");
-
-static llvm::cl::opt<bool> clUseFallbackTypeIDs(
-    "gen-attr-or-type-use-fallback-type-ids",
-    llvm::cl::desc(
-        "Don't generate static TypeID decls; fall back to string comparison."),
-    llvm::cl::init(false), llvm::cl::cat(clAttrOrTypeDefs));
 
 //===----------------------------------------------------------------------===//
 // Utility Functions

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//
 //===----------------------------------------------------------------------===//
 
 #include "AttrOrTypeFormatGen.h"
@@ -24,6 +25,16 @@ using namespace mlir;
 using namespace mlir::tblgen;
 using llvm::Record;
 using llvm::RecordKeeper;
+
+//===----------------------------------------------------------------------===//
+// Utility structs and functions
+//===----------------------------------------------------------------------===//
+
+static llvm::cl::OptionCategory clAttrOrTypeDefs("Options for -gen-*def-*");
+
+static llvm::cl::opt<bool> clUseFallbackTypeIDs(
+    "gen-attr-or-type-use-fallback-type-ids", llvm::cl::desc("Don't generate static TypeID decls; fall back to string comparison."),
+    llvm::cl::init(false), llvm::cl::cat(clAttrOrTypeDefs));
 
 //===----------------------------------------------------------------------===//
 // Utility Functions
@@ -773,7 +784,7 @@ bool DefGenerator::emitDecls(StringRef selectedDialect) {
   // Emit the TypeID explicit specializations to have a single definition for
   // each of these.
   for (const AttrOrTypeDef &def : defs)
-    if (!def.getDialect().getCppNamespace().empty())
+    if (!clUseFallbackTypeIDs && !def.getDialect().getCppNamespace().empty())
       os << "MLIR_DECLARE_EXPLICIT_TYPE_ID("
          << def.getDialect().getCppNamespace() << "::" << def.getCppClassName()
          << ")\n";
@@ -986,7 +997,7 @@ bool DefGenerator::emitDefs(StringRef selectedDialect) {
       gen.emitDef(os);
     }
     // Emit the TypeID explicit specializations to have a single symbol def.
-    if (!def.getDialect().getCppNamespace().empty())
+    if (!clUseFallbackTypeIDs && !def.getDialect().getCppNamespace().empty())
       os << "MLIR_DEFINE_EXPLICIT_TYPE_ID("
          << def.getDialect().getCppNamespace() << "::" << def.getCppClassName()
          << ")\n";

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -32,7 +32,9 @@ using llvm::RecordKeeper;
 static llvm::cl::OptionCategory clAttrOrTypeDefs("Options for -gen-*def-*");
 
 static llvm::cl::opt<bool> clUseFallbackTypeIDs(
-    "gen-attr-or-type-use-fallback-type-ids", llvm::cl::desc("Don't generate static TypeID decls; fall back to string comparison."),
+    "gen-attr-or-type-use-fallback-type-ids",
+    llvm::cl::desc(
+        "Don't generate static TypeID decls; fall back to string comparison."),
     llvm::cl::init(false), llvm::cl::cat(clAttrOrTypeDefs));
 
 //===----------------------------------------------------------------------===//

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//
 //===----------------------------------------------------------------------===//
 
 #include "AttrOrTypeFormatGen.h"

--- a/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
+++ b/mlir/tools/mlir-tblgen/AttrOrTypeDefGen.cpp
@@ -27,7 +27,7 @@ using llvm::Record;
 using llvm::RecordKeeper;
 
 //===----------------------------------------------------------------------===//
-// Utility structs and functions
+// CL Options
 //===----------------------------------------------------------------------===//
 
 static llvm::cl::OptionCategory clAttrOrTypeDefs("Options for -gen-*def-*");

--- a/mlir/tools/mlir-tblgen/CMakeLists.txt
+++ b/mlir/tools/mlir-tblgen/CMakeLists.txt
@@ -31,6 +31,7 @@ add_tablegen(mlir-tblgen MLIR
   PassDocGen.cpp
   PassGen.cpp
   RewriterGen.cpp
+  SharedCL.cpp
   SPIRVUtilsGen.cpp
   )
 

--- a/mlir/tools/mlir-tblgen/DialectGen.cpp
+++ b/mlir/tools/mlir-tblgen/DialectGen.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "SharedCL.h"
 #include "DialectGenUtilities.h"
 #include "mlir/TableGen/Class.h"
 #include "mlir/TableGen/CodeGenHelpers.h"
@@ -37,12 +38,6 @@ static llvm::cl::OptionCategory dialectGenCat("Options for -gen-dialect-*");
 llvm::cl::opt<std::string>
     selectedDialect("dialect", llvm::cl::desc("The dialect to gen for"),
                     llvm::cl::cat(dialectGenCat), llvm::cl::CommaSeparated);
-
-static llvm::cl::opt<bool> clUseFallbackTypeIDs(
-    "gen-dialect-use-fallback-type-ids",
-    llvm::cl::desc(
-        "Don't generate static TypeID decls; fall back to string comparison."),
-    llvm::cl::init(false), llvm::cl::cat(dialectGenCat));
 
 /// Utility iterator used for filtering records for a specific dialect.
 namespace {

--- a/mlir/tools/mlir-tblgen/DialectGen.cpp
+++ b/mlir/tools/mlir-tblgen/DialectGen.cpp
@@ -38,6 +38,12 @@ llvm::cl::opt<std::string>
     selectedDialect("dialect", llvm::cl::desc("The dialect to gen for"),
                     llvm::cl::cat(dialectGenCat), llvm::cl::CommaSeparated);
 
+static llvm::cl::opt<bool> clUseFallbackTypeIDs(
+    "gen-dialect-use-fallback-type-ids",
+    llvm::cl::desc(
+        "Don't generate static TypeID decls; fall back to string comparison."),
+    llvm::cl::init(false), llvm::cl::cat(dialectGenCat));
+
 /// Utility iterator used for filtering records for a specific dialect.
 namespace {
 using DialectFilterIterator =
@@ -293,7 +299,7 @@ static void emitDialectDecl(Dialect &dialect, raw_ostream &os) {
     // End the dialect decl.
     os << "};\n";
   }
-  if (!dialect.getCppNamespace().empty())
+  if (!clUseFallbackTypeIDs && !dialect.getCppNamespace().empty())
     os << "MLIR_DECLARE_EXPLICIT_TYPE_ID(" << dialect.getCppNamespace()
        << "::" << dialect.getCppClassName() << ")\n";
 }
@@ -347,7 +353,7 @@ static void emitDialectDef(Dialect &dialect, const RecordKeeper &records,
   std::string cppClassName = dialect.getCppClassName();
 
   // Emit the TypeID explicit specializations to have a single symbol def.
-  if (!dialect.getCppNamespace().empty())
+  if (!clUseFallbackTypeIDs && !dialect.getCppNamespace().empty())
     os << "MLIR_DEFINE_EXPLICIT_TYPE_ID(" << dialect.getCppNamespace()
        << "::" << cppClassName << ")\n";
 

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -14,6 +14,7 @@
 #include "OpClass.h"
 #include "OpFormatGen.h"
 #include "OpGenHelpers.h"
+#include "SharedCL.h"
 #include "mlir/TableGen/Argument.h"
 #include "mlir/TableGen/Attribute.h"
 #include "mlir/TableGen/Class.h"
@@ -229,18 +230,6 @@ static const char *const opCommentHeader = R"(
 //===----------------------------------------------------------------------===//
 
 )";
-
-//===----------------------------------------------------------------------===//
-// CL Options
-//===----------------------------------------------------------------------===//
-
-static llvm::cl::OptionCategory clOpDefs("Options for op definitions");
-
-static llvm::cl::opt<bool> clUseFallbackTypeIDs(
-    "gen-op-use-fallback-type-ids",
-    llvm::cl::desc(
-        "Don't generate static TypeID decls; fall back to string comparison."),
-    llvm::cl::init(false), llvm::cl::cat(clOpDefs));
 
 //===----------------------------------------------------------------------===//
 // Utility structs and functions

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -237,7 +237,9 @@ static const char *const opCommentHeader = R"(
 static llvm::cl::OptionCategory clOpDefs("Options for op definitions");
 
 static llvm::cl::opt<bool> clUseFallbackTypeIDs(
-    "gen-op-use-fallback-type-ids", llvm::cl::desc("Don't generate static TypeID decls; fall back to string comparison."),
+    "gen-op-use-fallback-type-ids",
+    llvm::cl::desc(
+        "Don't generate static TypeID decls; fall back to string comparison."),
     llvm::cl::init(false), llvm::cl::cat(clOpDefs));
 
 //===----------------------------------------------------------------------===//

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -231,7 +231,7 @@ static const char *const opCommentHeader = R"(
 )";
 
 //===----------------------------------------------------------------------===//
-// Utility structs and functions
+// CL Options
 //===----------------------------------------------------------------------===//
 
 static llvm::cl::OptionCategory clOpDefs("Options for op definitions");

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -31,6 +31,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Signals.h"
@@ -228,6 +229,16 @@ static const char *const opCommentHeader = R"(
 //===----------------------------------------------------------------------===//
 
 )";
+
+//===----------------------------------------------------------------------===//
+// Utility structs and functions
+//===----------------------------------------------------------------------===//
+
+static llvm::cl::OptionCategory clOpDefs("Options for op definitions");
+
+static llvm::cl::opt<bool> clUseFallbackTypeIDs(
+    "gen-op-use-fallback-type-ids", llvm::cl::desc("Don't generate static TypeID decls; fall back to string comparison."),
+    llvm::cl::init(false), llvm::cl::cat(clOpDefs));
 
 //===----------------------------------------------------------------------===//
 // Utility structs and functions
@@ -4625,7 +4636,7 @@ emitOpClasses(const RecordKeeper &records,
         OpEmitter::emitDecl(op, os, staticVerifierEmitter);
       }
       // Emit the TypeID explicit specialization to have a single definition.
-      if (!op.getCppNamespace().empty())
+      if (!clUseFallbackTypeIDs && !op.getCppNamespace().empty())
         os << "MLIR_DECLARE_EXPLICIT_TYPE_ID(" << op.getCppNamespace()
            << "::" << op.getCppClassName() << ")\n\n";
     } else {
@@ -4636,7 +4647,7 @@ emitOpClasses(const RecordKeeper &records,
         OpEmitter::emitDef(op, os, staticVerifierEmitter);
       }
       // Emit the TypeID explicit specialization to have a single definition.
-      if (!op.getCppNamespace().empty())
+      if (!clUseFallbackTypeIDs && !op.getCppNamespace().empty())
         os << "MLIR_DEFINE_EXPLICIT_TYPE_ID(" << op.getCppNamespace()
            << "::" << op.getCppClassName() << ")\n\n";
     }

--- a/mlir/tools/mlir-tblgen/SharedCL.cpp
+++ b/mlir/tools/mlir-tblgen/SharedCL.cpp
@@ -1,0 +1,21 @@
+//===- SharedCL.cpp - tblgen command line arguments -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SharedCL.h"
+
+using namespace mlir;
+using namespace mlir::tblgen;
+namespace cl = llvm::cl;
+
+static llvm::cl::OptionCategory clShared("Options for all -gen-*");
+
+cl::opt<bool> mlir::tblgen::clUseFallbackTypeIDs = cl::opt<bool>(
+  "use-fallback-type-ids",
+  cl::desc(
+      "Don't generate static TypeID decls; fall back to string comparison."),
+  cl::init(false), cl::cat(clShared));

--- a/mlir/tools/mlir-tblgen/SharedCL.cpp
+++ b/mlir/tools/mlir-tblgen/SharedCL.cpp
@@ -15,7 +15,7 @@ namespace cl = llvm::cl;
 static llvm::cl::OptionCategory clShared("Options for all -gen-*");
 
 cl::opt<bool> mlir::tblgen::clUseFallbackTypeIDs = cl::opt<bool>(
-  "use-fallback-type-ids",
-  cl::desc(
-      "Don't generate static TypeID decls; fall back to string comparison."),
-  cl::init(false), cl::cat(clShared));
+    "use-fallback-type-ids",
+    cl::desc(
+        "Don't generate static TypeID decls; fall back to string comparison."),
+    cl::init(false), cl::cat(clShared));

--- a/mlir/tools/mlir-tblgen/SharedCL.h
+++ b/mlir/tools/mlir-tblgen/SharedCL.h
@@ -1,0 +1,22 @@
+//===- SharedCL.h - tblgen command line arguments -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_TOOLS_MLIRTBLGEN_SHARED_CL_H_
+#define MLIR_TOOLS_MLIRTBLGEN_SHARED_CL_H_
+
+#include "llvm/Support/CommandLine.h"
+
+namespace mlir {
+namespace tblgen {
+
+extern llvm::cl::opt<bool> clUseFallbackTypeIDs;
+
+} // namespace tblgen
+} // namespace mlir
+
+#endif // MLIR_TOOLS_MLIRTBLGEN_SHARED_CL_H_


### PR DESCRIPTION
Adds a new `-use-fallback-type-ids` flag to tblgen.

When specified, this flag causes type, attr, op, and dialect decl+definition generation to not emit `MLIR_*_EXPLICIT_TYPE_ID` macros. This falls back to string TypeIDs which use string comparison, and a potential avenue in avoiding complications related to https://discourse.llvm.org/t/more-work-needed-for-typeid-duplication-help-wanted/4041/14.