### PR TITLE
[Reassociate] Conserve nsw/nuw flags when factoring out

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/Reassociate.h
+++ b/llvm/include/llvm/Transforms/Scalar/Reassociate.h
@@ -119,9 +119,11 @@ private:
                        SmallVectorImpl<reassociate::ValueEntry> &Ops,
                        reassociate::OverflowTracking Flags);
   Value *OptimizeExpression(BinaryOperator *I,
-                            SmallVectorImpl<reassociate::ValueEntry> &Ops);
+                            SmallVectorImpl<reassociate::ValueEntry> &Ops,
+                            reassociate::OverflowTracking Flags);
   Value *OptimizeAdd(Instruction *I,
-                     SmallVectorImpl<reassociate::ValueEntry> &Ops);
+                     SmallVectorImpl<reassociate::ValueEntry> &Ops,
+                     reassociate::OverflowTracking Flags);
   Value *OptimizeXor(Instruction *I,
                      SmallVectorImpl<reassociate::ValueEntry> &Ops);
   bool CombineXorOpnd(BasicBlock::iterator It, reassociate::XorOpnd *Opnd1,

--- a/llvm/test/Transforms/Reassociate/basictest.ll
+++ b/llvm/test/Transforms/Reassociate/basictest.ll
@@ -293,3 +293,40 @@ define i32 @test17(i32 %X1, i32 %X2, i32 %X3, i32 %X4) {
   ret i32 %E
 }
 
+define i32 @test18(i32 %X1, i32 %X2) {
+; CHECK-LABEL: @test18(
+; CHECK-NEXT:    [[REASS_ADD:%.*]] = add i32 [[X2:%.*]], [[X1:%.*]]
+; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul i32 [[REASS_ADD]], 47
+; CHECK-NEXT:    ret i32 [[REASS_MUL]]
+;
+  %B = mul nsw i32 %X1, 47
+  %C = mul nsw i32 %X2, 47
+  %D = add nsw i32 %B, %C
+  ret i32 %D
+}
+
+define i32 @test19(i32 %X1, i32 %X2) {
+; CHECK-LABEL: @test19(
+; CHECK-NEXT:    [[REASS_ADD:%.*]] = add i32 [[X1:%.*]], 67
+; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul i32 [[REASS_ADD]], [[X2:%.*]]
+; CHECK-NEXT:    ret i32 [[REASS_MUL]]
+;
+  %A = add i32 %X1, 20
+  %B = mul nsw i32 %X2, 47
+  %C = mul nsw i32 %X2, %A
+  %D = add nsw i32 %B, %C
+  ret i32 %D
+}
+
+define i32 @test20(i32 %X1, i32 %X2) {
+; CHECK-LABEL: @test20(
+; CHECK-NEXT:    [[REASS_ADD:%.*]] = add i32 [[X1:%.*]], 67
+; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul i32 [[REASS_ADD]], [[X2:%.*]]
+; CHECK-NEXT:    ret i32 [[REASS_MUL]]
+;
+  %A = add i32 %X1, 20
+  %B = mul nuw i32 %X2, 47
+  %C = mul nsw i32 %X2, %A
+  %D = add nsw i32 %B, %C
+  ret i32 %D
+}

--- a/llvm/test/Transforms/Reassociate/basictest.ll
+++ b/llvm/test/Transforms/Reassociate/basictest.ll
@@ -295,8 +295,8 @@ define i32 @test17(i32 %X1, i32 %X2, i32 %X3, i32 %X4) {
 
 define i32 @test18(i32 %X1, i32 %X2) {
 ; CHECK-LABEL: @test18(
-; CHECK-NEXT:    [[REASS_ADD:%.*]] = add i32 [[X2:%.*]], [[X1:%.*]]
-; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul i32 [[REASS_ADD]], 47
+; CHECK-NEXT:    [[REASS_ADD:%.*]] = add nsw i32 [[X2:%.*]], [[X1:%.*]]
+; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul nsw i32 [[REASS_ADD]], 47
 ; CHECK-NEXT:    ret i32 [[REASS_MUL]]
 ;
   %B = mul nsw i32 %X1, 47
@@ -308,7 +308,7 @@ define i32 @test18(i32 %X1, i32 %X2) {
 define i32 @test19(i32 %X1, i32 %X2) {
 ; CHECK-LABEL: @test19(
 ; CHECK-NEXT:    [[REASS_ADD:%.*]] = add i32 [[X1:%.*]], 67
-; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul i32 [[REASS_ADD]], [[X2:%.*]]
+; CHECK-NEXT:    [[REASS_MUL:%.*]] = mul nsw i32 [[REASS_ADD]], [[X2:%.*]]
 ; CHECK-NEXT:    ret i32 [[REASS_MUL]]
 ;
   %A = add i32 %X1, 20


### PR DESCRIPTION
When transforming, e.g, A*A+A*B*C+D into A*(A+B*C)+D, we can set the
factored out mul to have nuw/nsw iff all of the adds and muls had this
flag set.

Proof: https://alive2.llvm.org/ce/z/BNb5wS