### PR TITLE
Revert "[libc] Make LlvmLibcStackChkFail.Smash test compatible with asan, hwasan"

### DIFF
--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -12,24 +12,19 @@
 #include "src/string/memset.h"
 #include "test/UnitTest/Test.h"
 
-namespace {
-
 TEST(LlvmLibcStackChkFail, Death) {
   EXPECT_DEATH([] { __stack_chk_fail(); }, WITH_SIGNAL(SIGABRT));
 }
 
-// Disable sanitizers such as asan and hwasan that would catch the buffer
-// overrun before it clobbered the stack canary word.  Function attributes
-// can't be applied to lambdas before C++23, so this has to be separate.  When
-// https://github.com/llvm/llvm-project/issues/125760 is fixed, this can use
-// the modern spelling [[gnu::no_sanitize(...)]] without conditionalization.
-__attribute__((no_sanitize("all"))) void smash_stack() {
-  int arr[20];
-  LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
-}
-
+// Disable the test when asan is enabled so that it doesn't immediately fail
+// after the memset, but before the stack canary is re-checked.
+#ifndef LIBC_HAS_ADDRESS_SANITIZER
 TEST(LlvmLibcStackChkFail, Smash) {
-  EXPECT_DEATH(smash_stack, WITH_SIGNAL(SIGABRT));
+  EXPECT_DEATH(
+      [] {
+        int arr[20];
+        LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
+      },
+      WITH_SIGNAL(SIGABRT));
 }
-
-} // namespace
+#endif // LIBC_HAS_ADDRESS_SANITIZER


### PR DESCRIPTION
Reverts llvm/llvm-project#125763

This causes failures in asan. More thought is needed.