### PR TITLE
workflows/release-binaries: Build less projects on macos-13 runner

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -149,7 +149,6 @@ jobs:
           target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_LTO=OFF"
         fi
 
-        echo "target-cmake-flags=$target_cmake_flags" >> $GITHUB_OUTPUT
         echo "build-flang=$build_flang" >> $GITHUB_OUTPUT
         case "${{ inputs.runs-on }}" in
           ubuntu-22.04*)
@@ -180,6 +179,7 @@ jobs:
             build_runs_on=$test_runs_on
             ;;
         esac
+        echo "target-cmake-flags=$target_cmake_flags" >> $GITHUB_OUTPUT
         echo "build-runs-on=$build_runs_on" >> $GITHUB_OUTPUT
         echo "test-runs-on=$test_runs_on" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -163,6 +163,9 @@ jobs:
               build_runs_on="macos-13-large"
             fi
             test_runs_on="${{ inputs.runs-on }}"
+            # These runners hit timeouts building all of LLVM, so we need to
+            # limit the projects that we build.
+            target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS=clang;lld;lldb;clang-tools-extra;mlir"
             ;;
           macos-14)
             if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -164,7 +164,7 @@ jobs:
             test_runs_on="${{ inputs.runs-on }}"
             # These runners hit timeouts building all of LLVM, so we need to
             # limit the projects that we build.
-            target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS=clang;lld;lldb;clang-tools-extra;mlir"
+            target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS='clang;lld;lldb;clang-tools-extra;mlir'"
             ;;
           macos-14)
             if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then


### PR DESCRIPTION
We are currently hitting timeouts when using the GitHub hosted runners, so disable the flang, polly, and bolt projects to reduce build times.