### PR TITLE
[MemProf] Use correct print_text value

### DIFF
--- a/compiler-rt/lib/memprof/memprof_allocator.cpp
+++ b/compiler-rt/lib/memprof/memprof_allocator.cpp
@@ -291,10 +291,9 @@ struct Allocator {
 
   atomic_uint8_t destructing;
   atomic_uint8_t constructed;
-  bool print_text;
 
   // ------------------- Initialization ------------------------
-  explicit Allocator(LinkerInitialized) : print_text(flags()->print_text) {
+  explicit Allocator(LinkerInitialized) {
     atomic_store_relaxed(&destructing, 0);
     atomic_store_relaxed(&constructed, 1);
   }
@@ -350,13 +349,13 @@ struct Allocator {
   }
 
   void FinishAndWrite() {
-    if (print_text && common_flags()->print_module_map)
+    if (flags()->print_text && common_flags()->print_module_map)
       DumpProcessMap();
 
     allocator.ForceLock();
 
     InsertLiveBlocks();
-    if (print_text) {
+    if (flags()->print_text) {
       if (!flags()->print_terse)
         Printf("Recorded MIBs (incl. live on exit):\n");
       MIBMap.ForEach(PrintCallback,


### PR DESCRIPTION
Use the correct value for `print_text` in `FinishAndWrite()`.

This value was initialized in the constructor of a global variable 
https://github.com/llvm/llvm-project/blob/65683b081fd049750e57d95a311575a3ba324344/compiler-rt/lib/memprof/memprof_allocator.cpp#L641

The flag values in `flags()` are populated in `InitializeFlags()`, which is also called in a constructor of a global variable
https://github.com/llvm/llvm-project/blob/65683b081fd049750e57d95a311575a3ba324344/compiler-rt/lib/memprof/memprof_rtl.cpp#L241-L255

I think the order that these two functions run is undefined, and the value of the field `print_text` depends on this order when the user overrides default values.