### PR TITLE
[flang][cmake] Fix bcc dependencies

### DIFF
--- a/flang/tools/bbc/CMakeLists.txt
+++ b/flang/tools/bbc/CMakeLists.txt
@@ -29,6 +29,11 @@ target_link_libraries(bbc PRIVATE
   flangFrontend
   flangPasses
   FlangOpenMPTransforms
+  FortranCommon
+  FortranParser
+  FortranEvaluate
+  FortranSemantics
+  FortranLower
 )
 
 mlir_target_link_libraries(bbc PRIVATE
@@ -36,9 +41,4 @@ mlir_target_link_libraries(bbc PRIVATE
   ${extension_libs}
   MLIRAffineToStandard
   MLIRSCFToControlFlow
-  FortranCommon
-  FortranParser
-  FortranEvaluate
-  FortranSemantics
-  FortranLower
 )


### PR DESCRIPTION
The Fortran libraries are not part of MLIR, so they should use target_link_libraries() rather than mlir_target_link_libraries().

This fixes an issue introduced in https://github.com/llvm/llvm-project/pull/120966. (This is the last one, I was able to build flang now \o/)