### PR TITLE
[GlobalISel] Prefix MatchTable Lines with their Index

### DIFF
--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -291,18 +291,20 @@ void MatchTable::emitDeclaration(raw_ostream &OS) const {
   OS << "  constexpr static uint8_t MatchTable" << ID << "[] = {";
   LineBreak.emit(OS, true, *this);
 
+  // We want to display the table index of each line in a consistent
+  // manner. It has to appear as a column on the left side of the table.
+  // To determine how wide the column needs to be, check how many characters
+  // we need to fit the largest possible index in the current table.
   const unsigned NumColsForIdx = llvm::to_string(CurrentSize).size();
 
   unsigned CurIndex = 0;
   const auto BeginLine = [&]() {
-    OS << std::string(BaseIndent, ' ');
-    // To keep the /* index */ column consistent, pad
-    // the string at the start so we can always fit the
-    // exact number of characters to print the largest possible index.
+    OS.indent(BaseIndent);
     std::string IdxStr = llvm::to_string(CurIndex);
+    // Pad the string with spaces to keep the size of the prefix consistent.
     OS << " /* " << std::string(NumColsForIdx - IdxStr.size(), ' ') << IdxStr
        << " */ ";
-    OS << std::string(Indentation, ' ');
+    OS.indent(Indentation);
   };
 
   BeginLine();

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -302,8 +302,8 @@ void MatchTable::emitDeclaration(raw_ostream &OS) const {
     OS.indent(BaseIndent);
     std::string IdxStr = llvm::to_string(CurIndex);
     // Pad the string with spaces to keep the size of the prefix consistent.
-    OS << " /* " << std::string(NumColsForIdx - IdxStr.size(), ' ') << IdxStr
-       << " */ ";
+    OS << " /* ";
+    OS.indent(NumColsForIdx - IdxStr.size()) << IdxStr << " */ ";
     OS.indent(Indentation);
   };
 

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -294,13 +294,14 @@ void MatchTable::emitDeclaration(raw_ostream &OS) const {
   const unsigned NumColsForIdx = llvm::to_string(CurrentSize).size();
 
   unsigned CurIndex = 0;
-  const auto BeginLine = [&](){
+  const auto BeginLine = [&]() {
     OS << std::string(BaseIndent, ' ');
     // To keep the /* index */ column consistent, pad
     // the string at the start so we can always fit the
     // exact number of characters to print the largest possible index.
     std::string IdxStr = llvm::to_string(CurIndex);
-    OS << " /* " << std::string(NumColsForIdx - IdxStr.size(), ' ') << IdxStr << " */ ";
+    OS << " /* " << std::string(NumColsForIdx - IdxStr.size(), ' ') << IdxStr
+       << " */ ";
     OS << std::string(Indentation, ' ');
   };
 

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -286,11 +286,25 @@ MatchTableRecord MatchTable::JumpTarget(unsigned LabelID) {
 void MatchTable::emitUse(raw_ostream &OS) const { OS << "MatchTable" << ID; }
 
 void MatchTable::emitDeclaration(raw_ostream &OS) const {
-  unsigned Indentation = 4;
+  static constexpr unsigned BaseIndent = 4;
+  unsigned Indentation = 0;
   OS << "  constexpr static uint8_t MatchTable" << ID << "[] = {";
   LineBreak.emit(OS, true, *this);
-  OS << std::string(Indentation, ' ');
 
+  const unsigned NumColsForIdx = llvm::to_string(CurrentSize).size();
+
+  unsigned CurIndex = 0;
+  const auto BeginLine = [&](){
+    OS << std::string(BaseIndent, ' ');
+    // To keep the /* index */ column consistent, pad
+    // the string at the start so we can always fit the
+    // exact number of characters to print the largest possible index.
+    std::string IdxStr = llvm::to_string(CurIndex);
+    OS << " /* " << std::string(NumColsForIdx - IdxStr.size(), ' ') << IdxStr << " */ ";
+    OS << std::string(Indentation, ' ');
+  };
+
+  BeginLine();
   for (auto I = Contents.begin(), E = Contents.end(); I != E; ++I) {
     bool LineBreakIsNext = false;
     const auto &NextI = std::next(I);
@@ -306,11 +320,14 @@ void MatchTable::emitDeclaration(raw_ostream &OS) const {
 
     I->emit(OS, LineBreakIsNext, *this);
     if (I->Flags & MatchTableRecord::MTRF_LineBreakFollows)
-      OS << std::string(Indentation, ' ');
+      BeginLine();
 
     if (I->Flags & MatchTableRecord::MTRF_Outdent)
       Indentation -= 2;
+
+    CurIndex += I->size();
   }
+  assert(CurIndex == CurrentSize);
   OS << "}; // Size: " << CurrentSize << " bytes\n";
 }
 


### PR DESCRIPTION
I tried to keep it readable by making the width of the column with the index always enough to contain the largest number.
That way things don't shift to the right every time a new digit appears, it remains consistent.

Tests don't break because this only affects the beginning of the line and FileCheck doesn't care about what comes before for the most part.

Example of the new output:
```
     /* 758359 */   // Label 9988: @758359
     /* 758359 */   GIM_Try, /*On fail goto*//*Label 9989*/ GIMT_Encode4(758435), // Rule ID 6715 //
     /* 758364 */     GIM_CheckConstantInt8, /*MI*/0, /*Op*/2, 0,
     /* 758368 */     // MIs[0] offset
```

Fixes #119177