### PR TITLE
[XCOFF][llvm-readobj] Print symbol value kind when dumping symbols

### DIFF
--- a/llvm/test/tools/llvm-readobj/XCOFF/symbols.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/symbols.test
@@ -162,43 +162,68 @@ Symbols:
         SectionOrLength:        256
         StabInfoIndex:          44
         StabSectNum:            55
-  - Name:               .fun3
+
+  - Name:               bstat
     Value:              0x0
     Section:            N_DEBUG
-    Type:               0x20
-    StorageClass:       C_WEAKEXT
+    Type:               0x00
+    StorageClass:       C_BSTAT
 
-  - Name:              stsym
+  - Name:               cfun
+    Value:              0x0
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_FUN
+
+  - Name:               stsym
     Value:              0x05
-    Section:            .text
+    Section:            N_DEBUG
     Type:               0x00
     StorageClass:       C_STSYM
 
-  - Name:              bincl
+  - Name:               bincl
     Value:              0x06
     Section:            .text
     Type:               0x00
     StorageClass:       C_BINCL
 
-  - Name:              lsym
-    Value:              0x07
+  - Name:               eincl
+    Value:              0x06
     Section:            .text
+    Type:               0x00
+    StorageClass:       C_EINCL
+
+  - Name:               lsym
+    Value:              0x07
+    Section:            N_DEBUG
     Type:               0x00
     StorageClass:       C_LSYM
 
-  - Name:              rsym
+  - Name:               psym
+    Value:              0x07
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_PSYM
+
+  - Name:               rsym
     Value:              0x08
-    Section:            .text
+    Section:            N_DEBUG
     Type:               0x00
     StorageClass:       C_RSYM
 
-  - Name:              ecoml
+  - Name:               rpsym
+    Value:              0x08
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_RPSYM
+
+  - Name:               ecoml
     Value:              0x09
     Section:            .text
     Type:               0x00
     StorageClass:       C_ECOML
 
-  - Name:              cinfo
+  - Name:               cinfo
     Value:              0x02
     Section:            .text
     Type:               0x00
@@ -412,24 +437,33 @@ Symbols:
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
 # SYMBOL32-NEXT:     Index: 25
-# SYMBOL32-NEXT:     Name: .fun3
-# SYMBOL32-NEXT:     Value (RelocatableAddress): 0x0
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (SymbolTableIndex): 0x0
 # SYMBOL32-NEXT:     Section: N_DEBUG
-# SYMBOL32-NEXT:     Type: 0x20
-# SYMBOL32-NEXT:     StorageClass: C_WEAKEXT (0x6F)
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_BSTAT (0x8F)
 # SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
 # SYMBOL32-NEXT:     Index: 26
 # SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (OffsetInCSect): 0x0
+# SYMBOL32-NEXT:     Section: N_DEBUG
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_FUN (0x8E)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 27
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
 # SYMBOL32-NEXT:     Value (OffsetInCSect): 0x5
-# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Section: N_DEBUG
 # SYMBOL32-NEXT:     Type: 0x0
 # SYMBOL32-NEXT:     StorageClass: C_STSYM (0x85)
 # SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
-# SYMBOL32-NEXT:     Index: 27
+# SYMBOL32-NEXT:     Index: 28
 # SYMBOL32-NEXT:     Name: bincl
 # SYMBOL32-NEXT:     Value (OffsetInFile): 0x6
 # SYMBOL32-NEXT:     Section: .text
@@ -438,25 +472,52 @@ Symbols:
 # SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
-# SYMBOL32-NEXT:     Index: 28
+# SYMBOL32-NEXT:     Index: 29
+# SYMBOL32-NEXT:     Name: eincl
+# SYMBOL32-NEXT:     Value (OffsetInFile): 0x6
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_EINCL (0x6D)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 30
 # SYMBOL32-NEXT:     Name: Unimplemented Debug Name
 # SYMBOL32-NEXT:     Value (OffsetRelToStackFrame): 0x7
-# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Section: N_DEBUG
 # SYMBOL32-NEXT:     Type: 0x0
 # SYMBOL32-NEXT:     StorageClass: C_LSYM (0x81)
 # SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
-# SYMBOL32-NEXT:     Index: 29
+# SYMBOL32-NEXT:     Index: 31
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (OffsetRelToStackFrame): 0x7
+# SYMBOL32-NEXT:     Section: N_DEBUG
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_PSYM (0x82)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 32
 # SYMBOL32-NEXT:     Name: Unimplemented Debug Name
 # SYMBOL32-NEXT:     Value (RegisterNumber): 0x8
-# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Section: N_DEBUG
 # SYMBOL32-NEXT:     Type: 0x0
 # SYMBOL32-NEXT:     StorageClass: C_RSYM (0x83)
 # SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
-# SYMBOL32-NEXT:     Index: 30
+# SYMBOL32-NEXT:     Index: 33
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (RegisterNumber): 0x8
+# SYMBOL32-NEXT:     Section: N_DEBUG
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_RPSYM (0x84)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 34
 # SYMBOL32-NEXT:     Name: Unimplemented Debug Name
 # SYMBOL32-NEXT:     Value (OffsetInCommBlock): 0x9
 # SYMBOL32-NEXT:     Section: .text
@@ -465,7 +526,7 @@ Symbols:
 # SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT:   Symbol {
-# SYMBOL32-NEXT:     Index: 31
+# SYMBOL32-NEXT:     Index: 35
 # SYMBOL32-NEXT:     Name: cinfo
 # SYMBOL32-NEXT:     Value (OffsetInCommentSection): 0x2
 # SYMBOL32-NEXT:     Section: .text

--- a/llvm/test/tools/llvm-readobj/XCOFF/symbols.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/symbols.test
@@ -162,6 +162,48 @@ Symbols:
         SectionOrLength:        256
         StabInfoIndex:          44
         StabSectNum:            55
+  - Name:               .fun3
+    Value:              0x0
+    Section:            N_DEBUG
+    Type:               0x20
+    StorageClass:       C_WEAKEXT
+
+  - Name:              stsym
+    Value:              0x05
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_STSYM
+
+  - Name:              bincl
+    Value:              0x06
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_BINCL
+
+  - Name:              lsym
+    Value:              0x07
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_LSYM
+
+  - Name:              rsym
+    Value:              0x08
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_RSYM
+
+  - Name:              ecoml
+    Value:              0x09
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_ECOML
+
+  - Name:              cinfo
+    Value:              0x02
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_INFO
+
 
 # SYMBOL32:      Symbols [
 # SYMBOL32-NEXT:   Symbol {
@@ -367,5 +409,68 @@ Symbols:
 # SYMBOL32-NEXT:       StabInfoIndex: 0x2C
 # SYMBOL32-NEXT:       StabSectNum: 0x37
 # SYMBOL32-NEXT:     }
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 25
+# SYMBOL32-NEXT:     Name: .fun3
+# SYMBOL32-NEXT:     Value (RelocatableAddress): 0x0
+# SYMBOL32-NEXT:     Section: N_DEBUG
+# SYMBOL32-NEXT:     Type: 0x20
+# SYMBOL32-NEXT:     StorageClass: C_WEAKEXT (0x6F)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 26
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (OffsetInCSect): 0x5
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_STSYM (0x85)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 27
+# SYMBOL32-NEXT:     Name: bincl
+# SYMBOL32-NEXT:     Value (OffsetInFile): 0x6
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_BINCL (0x6C)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 28
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (OffsetRelToStackFrame): 0x7
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_LSYM (0x81)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 29
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (RegisterNumber): 0x8
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_RSYM (0x83)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 30
+# SYMBOL32-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL32-NEXT:     Value (OffsetInCommBlock): 0x9
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_ECOML (0x88)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL32-NEXT:   }
+# SYMBOL32-NEXT:   Symbol {
+# SYMBOL32-NEXT:     Index: 31
+# SYMBOL32-NEXT:     Name: cinfo
+# SYMBOL32-NEXT:     Value (OffsetInCommentSection): 0x2
+# SYMBOL32-NEXT:     Section: .text
+# SYMBOL32-NEXT:     Type: 0x0
+# SYMBOL32-NEXT:     StorageClass: C_INFO (0x6E)
+# SYMBOL32-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL32-NEXT:   }
 # SYMBOL32-NEXT: ]

--- a/llvm/test/tools/llvm-readobj/XCOFF/symbols64.test
+++ b/llvm/test/tools/llvm-readobj/XCOFF/symbols64.test
@@ -138,6 +138,73 @@ Symbols:
       - Type:    AUX_SYM
         LineNum: 3
 
+  - Name:               bstat
+    Value:              0x0
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_BSTAT
+
+  - Name:               cfun
+    Value:              0x0
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_FUN
+
+  - Name:               stsym
+    Value:              0x05
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_STSYM
+
+  - Name:               bincl
+    Value:              0x06
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_BINCL
+
+  - Name:               eincl
+    Value:              0x06
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_EINCL
+
+  - Name:               lsym
+    Value:              0x07
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_LSYM
+
+  - Name:               psym
+    Value:              0x07
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_PSYM
+
+  - Name:               rsym
+    Value:              0x08
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_RSYM
+
+  - Name:               rpsym
+    Value:              0x08
+    Section:            N_DEBUG
+    Type:               0x00
+    StorageClass:       C_RPSYM
+
+  - Name:               ecoml
+    Value:              0x09
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_ECOML
+
+  - Name:               cinfo
+    Value:              0x02
+    Section:            .text
+    Type:               0x00
+    StorageClass:       C_INFO
+
+
 # SYMBOL64:      Symbols [
 # SYMBOL64-NEXT:   Symbol {
 # SYMBOL64-NEXT:     Index: 0
@@ -325,5 +392,104 @@ Symbols:
 # SYMBOL64-NEXT:       LineNumber: 0x3
 # SYMBOL64-NEXT:       Auxiliary Type: AUX_SYM (0xFD)
 # SYMBOL64-NEXT:     }
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 23
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (SymbolTableIndex): 0x0
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_BSTAT (0x8F)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 24
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (OffsetInCSect): 0x0
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_FUN (0x8E)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 25
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (OffsetInCSect): 0x5
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_STSYM (0x85)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 26
+# SYMBOL64-NEXT:     Name: bincl
+# SYMBOL64-NEXT:     Value (OffsetInFile): 0x6
+# SYMBOL64-NEXT:     Section: .text
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_BINCL (0x6C)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 27
+# SYMBOL64-NEXT:     Name: eincl
+# SYMBOL64-NEXT:     Value (OffsetInFile): 0x6
+# SYMBOL64-NEXT:     Section: .text
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_EINCL (0x6D)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 28
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (OffsetRelToStackFrame): 0x7
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_LSYM (0x81)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 29
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (OffsetRelToStackFrame): 0x7
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_PSYM (0x82)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 30
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (RegisterNumber): 0x8
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_RSYM (0x83)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 31
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (RegisterNumber): 0x8
+# SYMBOL64-NEXT:     Section: N_DEBUG
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_RPSYM (0x84)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 32
+# SYMBOL64-NEXT:     Name: Unimplemented Debug Name
+# SYMBOL64-NEXT:     Value (OffsetInCommBlock): 0x9
+# SYMBOL64-NEXT:     Section: .text
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_ECOML (0x88)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
+# SYMBOL64-NEXT:   }
+# SYMBOL64-NEXT:   Symbol {
+# SYMBOL64-NEXT:     Index: 33
+# SYMBOL64-NEXT:     Name: cinfo
+# SYMBOL64-NEXT:     Value (OffsetInCommentSection): 0x2
+# SYMBOL64-NEXT:     Section: .text
+# SYMBOL64-NEXT:     Type: 0x0
+# SYMBOL64-NEXT:     StorageClass: C_INFO (0x6E)
+# SYMBOL64-NEXT:     NumberOfAuxEntries: 0
 # SYMBOL64-NEXT:   }
 # SYMBOL64-NEXT: ]

--- a/llvm/tools/llvm-readobj/XCOFFDumper.cpp
+++ b/llvm/tools/llvm-readobj/XCOFFDumper.cpp
@@ -692,22 +692,26 @@ static StringRef GetSymbolValueName(XCOFF::StorageClass SC) {
   case XCOFF::C_BLOCK:
     return "Value (RelocatableAddress)";
   case XCOFF::C_FILE:
+  case XCOFF::C_BSTAT:
     return "Value (SymbolTableIndex)";
   case XCOFF::C_DWARF:
     return "Value (OffsetInDWARF)";
   case XCOFF::C_FUN:
   case XCOFF::C_STSYM:
+    return "Value (OffsetInCSect)";
   case XCOFF::C_BINCL:
   case XCOFF::C_EINCL:
+    return "Value (OffsetInFile)";
   case XCOFF::C_INFO:
-  case XCOFF::C_BSTAT:
+    return "Value (OffsetInCommentSection)";
   case XCOFF::C_LSYM:
   case XCOFF::C_PSYM:
+    return "Value (OffsetRelToStackFrame)";
   case XCOFF::C_RPSYM:
   case XCOFF::C_RSYM:
+    return "Value (RegisterNumber)";
   case XCOFF::C_ECOML:
-    assert(false && "This StorageClass for the symbol is not yet implemented.");
-    return "";
+    return "Value (OffsetInCommBlock)";
   default:
     return "Value";
   }


### PR DESCRIPTION
llvm-readobj print out symbol value name for xcoff symbol table.

reference doc: https://www.ibm.com/docs/en/aix/7.2?topic=formats-xcoff-object-file-format#XCOFF__yaa3i18fjbau