### PR TITLE
[libc] Fix recently introduced integer-type warnings

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -604,7 +604,7 @@ approx_reciprocal(const DyadicFloat<Bits> &a) {
   // of correct bits in x' is double the number in x.
 
   // An initial approximation to the reciprocal
-  DyadicFloat<Bits> x(Sign::POS, -32 - a.exponent - Bits,
+  DyadicFloat<Bits> x(Sign::POS, -32 - a.exponent - int(Bits),
                       uint64_t(0xFFFFFFFFFFFFFFFF) /
                           static_cast<uint64_t>(a.mantissa >> (Bits - 32)));
 

--- a/libc/src/__support/integer_to_string.h
+++ b/libc/src/__support/integer_to_string.h
@@ -231,7 +231,7 @@ extract_decimal_digit(T &value) {
   // Having multiplied it by 6, add the lowest half-word, and then reduce mod
   // 10 by normal integer division to finish.
   acc_remainder += value.val[0] & HALFWORD_MASK;
-  uint8_t digit = acc_remainder % 10;
+  uint8_t digit = static_cast<uint8_t>(acc_remainder % 10);
 
   // Now we have the output digit. Subtract it from the input value, and shift
   // right to divide by 2.

--- a/libc/src/stdio/printf_core/float_dec_converter_limited.h
+++ b/libc/src/stdio/printf_core/float_dec_converter_limited.h
@@ -113,7 +113,7 @@ struct DigitsOutput {
 // enough that for any binary exponent in the range of float128 it will give
 // the correct value of floor(log10(2^n)).
 LIBC_INLINE int estimate_log10(int exponent_of_2) {
-  return (exponent_of_2 * 1292913986LL) >> 32;
+  return static_cast<int>((exponent_of_2 * 1292913986LL) >> 32);
 }
 
 // Calculate the actual digits of a decimal representation of an FP number.
@@ -189,7 +189,7 @@ DigitsOutput decimal_digits(DigitsInput input, int precision, bool e_mode) {
   // overflow _after_ the multiplication and retry. So if even the smaller
   // number of possible output digits is too many, we might as well change our
   // mind right now and switch into E mode.
-  if (log10_input_max - log10_low_digit + 1 > MAX_DIGITS) {
+  if (log10_input_max - log10_low_digit + 1 > int(MAX_DIGITS)) {
     precision = MAX_DIGITS;
     e_mode = true;
     log10_low_digit = log10_input_min + 1 - precision;
@@ -362,8 +362,8 @@ DigitsOutput decimal_digits(DigitsInput input, int precision, bool e_mode) {
       // we made it from and doing the decimal conversion all over again.)
       for (size_t i = output.ndigits; i-- > 0;) {
         if (output.digits[i] != '9') {
-          output.digits[i] = internal::int_to_b36_char(
-              internal::b36_char_to_int(output.digits[i]) + 1);
+          output.digits[i] = static_cast<char>(internal::int_to_b36_char(
+              internal::b36_char_to_int(output.digits[i]) + 1));
           break;
         } else {
           output.digits[i] = '0';


### PR DESCRIPTION
These warnings all come up in code modified by one of my two recent commits c06d0ff806b72b1 and b53da77c505a2d3, and all relate to implicit integer type conversion. In a build of ours with strict compile options two of them became errors. Even without that problem, it's worth fixing them to reduce noise that might hide a more serious warning.