### PR TITLE
[asan][test][MSVC] Disabling test on MSVC x86 because of optimized builds

### DIFF
--- a/compiler-rt/test/asan/TestCases/suppressions-alloc-dealloc-mismatch.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-alloc-dealloc-mismatch.cpp
@@ -10,7 +10,7 @@
 // XFAIL: android
 
 // FIXME: atos does not work for inlined functions, yet llvm-symbolizer
-// does not always work with debug info on Darwin.
+// does not always work with debug info on Darwin. Behavior is similar on MSVC x86 outside of /Od.
 // UNSUPPORTED: darwin
 // UNSUPPORTED: target={{.*windows-msvc.*}} && asan-32-bits
 

--- a/compiler-rt/test/asan/TestCases/suppressions-alloc-dealloc-mismatch.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-alloc-dealloc-mismatch.cpp
@@ -12,6 +12,7 @@
 // FIXME: atos does not work for inlined functions, yet llvm-symbolizer
 // does not always work with debug info on Darwin.
 // UNSUPPORTED: darwin
+// UNSUPPORTED: target={{.*windows-msvc.*}} && asan-32-bits
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/asan/TestCases/suppressions-function.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-function.cpp
@@ -11,8 +11,9 @@
 // UNSUPPORTED: ios
 
 // FIXME: atos does not work for inlined functions, yet llvm-symbolizer
-// does not always work with debug info on Darwin.
+// does not always work with debug info on Darwin. Behavior is similar on MSVC x86 outside of /Od.
 // UNSUPPORTED: darwin
+// UNSUPPORTED: target={{.*windows-msvc.*}} && asan-32-bits
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Including #124987, we have failures on Windows on x86 with `/O2` builds, similar to Darwin. This disables the test for MSVC-x86.