### PR TITLE
[MLIR][DLTI] Add mangling style

### DIFF
--- a/mlir/include/mlir/Dialect/DLTI/DLTIAttrs.td
+++ b/mlir/include/mlir/Dialect/DLTI/DLTIAttrs.td
@@ -77,8 +77,8 @@ def DLTI_DataLayoutSpecAttr :
     /// Returns the alloca memory space identifier.
     StringAttr getAllocaMemorySpaceIdentifier(MLIRContext *context) const;
 
-    /// Returns the mangling style identifier.
-    StringAttr getManglingStyleIdentifier(MLIRContext *context) const;
+    /// Returns the mangling mode identifier.
+    StringAttr getManglingModeIdentifier(MLIRContext *context) const;
 
     /// Returns the program memory space identifier.
     StringAttr getProgramMemorySpaceIdentifier(MLIRContext *context) const;

--- a/mlir/include/mlir/Dialect/DLTI/DLTIAttrs.td
+++ b/mlir/include/mlir/Dialect/DLTI/DLTIAttrs.td
@@ -77,6 +77,9 @@ def DLTI_DataLayoutSpecAttr :
     /// Returns the alloca memory space identifier.
     StringAttr getAllocaMemorySpaceIdentifier(MLIRContext *context) const;
 
+    /// Returns the mangling style identifier.
+    StringAttr getManglingStyleIdentifier(MLIRContext *context) const;
+
     /// Returns the program memory space identifier.
     StringAttr getProgramMemorySpaceIdentifier(MLIRContext *context) const;
 

--- a/mlir/include/mlir/Dialect/DLTI/DLTIBase.td
+++ b/mlir/include/mlir/Dialect/DLTI/DLTIBase.td
@@ -49,8 +49,9 @@ def DLTI_Dialect : Dialect {
     constexpr const static ::llvm::StringLiteral
     kDataLayoutEndiannessLittle = "little";
 
+    // Mangling mode, a.k.a mangling style used to mangle llvm names.
     constexpr const static ::llvm::StringLiteral
-    kDataLayoutManglingStyleKey = "dlti.mangling_style";
+    kDataLayoutManglingModeKey = "dlti.mangling_mode";
 
     constexpr const static ::llvm::StringLiteral
     kDataLayoutAllocaMemorySpaceKey = "dlti.alloca_memory_space";

--- a/mlir/include/mlir/Dialect/DLTI/DLTIBase.td
+++ b/mlir/include/mlir/Dialect/DLTI/DLTIBase.td
@@ -50,6 +50,9 @@ def DLTI_Dialect : Dialect {
     kDataLayoutEndiannessLittle = "little";
 
     constexpr const static ::llvm::StringLiteral
+    kDataLayoutManglingStyleKey = "dlti.mangling_style";
+
+    constexpr const static ::llvm::StringLiteral
     kDataLayoutAllocaMemorySpaceKey = "dlti.alloca_memory_space";
     
     constexpr const static ::llvm::StringLiteral

--- a/mlir/include/mlir/Interfaces/DataLayoutInterfaces.h
+++ b/mlir/include/mlir/Interfaces/DataLayoutInterfaces.h
@@ -78,6 +78,10 @@ Attribute getDefaultEndianness(DataLayoutEntryInterface entry);
 /// DataLayoutInterface if specified, otherwise returns the default.
 Attribute getDefaultAllocaMemorySpace(DataLayoutEntryInterface entry);
 
+/// Default handler for mangling style request. Dispatches to the
+/// DataLayoutInterface if specified, otherwise returns the default.
+Attribute getDefaultManglingStyle(DataLayoutEntryInterface entry);
+
 /// Default handler for program memory space request. Dispatches to the
 /// DataLayoutInterface if specified, otherwise returns the default.
 Attribute getDefaultProgramMemorySpace(DataLayoutEntryInterface entry);
@@ -230,6 +234,9 @@ public:
   /// Returns the memory space used for AllocaOps.
   Attribute getAllocaMemorySpace() const;
 
+  /// Returns the mangling style.
+  Attribute getManglingStyle() const;
+
   /// Returns the memory space used for program memory operations.
   Attribute getProgramMemorySpace() const;
 
@@ -276,6 +283,8 @@ private:
 
   /// Cache for the endianness.
   mutable std::optional<Attribute> endianness;
+  /// Cache for the mangling style.
+  mutable std::optional<Attribute> manglingStyle;
   /// Cache for alloca, global, and program memory spaces.
   mutable std::optional<Attribute> allocaMemorySpace;
   mutable std::optional<Attribute> programMemorySpace;

--- a/mlir/include/mlir/Interfaces/DataLayoutInterfaces.h
+++ b/mlir/include/mlir/Interfaces/DataLayoutInterfaces.h
@@ -78,9 +78,9 @@ Attribute getDefaultEndianness(DataLayoutEntryInterface entry);
 /// DataLayoutInterface if specified, otherwise returns the default.
 Attribute getDefaultAllocaMemorySpace(DataLayoutEntryInterface entry);
 
-/// Default handler for mangling style request. Dispatches to the
+/// Default handler for mangling mode request. Dispatches to the
 /// DataLayoutInterface if specified, otherwise returns the default.
-Attribute getDefaultManglingStyle(DataLayoutEntryInterface entry);
+Attribute getDefaultManglingMode(DataLayoutEntryInterface entry);
 
 /// Default handler for program memory space request. Dispatches to the
 /// DataLayoutInterface if specified, otherwise returns the default.
@@ -234,8 +234,8 @@ public:
   /// Returns the memory space used for AllocaOps.
   Attribute getAllocaMemorySpace() const;
 
-  /// Returns the mangling style.
-  Attribute getManglingStyle() const;
+  /// Returns the mangling mode.
+  Attribute getManglingMode() const;
 
   /// Returns the memory space used for program memory operations.
   Attribute getProgramMemorySpace() const;
@@ -283,8 +283,8 @@ private:
 
   /// Cache for the endianness.
   mutable std::optional<Attribute> endianness;
-  /// Cache for the mangling style.
-  mutable std::optional<Attribute> manglingStyle;
+  /// Cache for the mangling mode.
+  mutable std::optional<Attribute> manglingMode;
   /// Cache for alloca, global, and program memory spaces.
   mutable std::optional<Attribute> allocaMemorySpace;
   mutable std::optional<Attribute> programMemorySpace;

--- a/mlir/include/mlir/Interfaces/DataLayoutInterfaces.td
+++ b/mlir/include/mlir/Interfaces/DataLayoutInterfaces.td
@@ -154,9 +154,9 @@ def DataLayoutSpecInterface : AttrInterface<"DataLayoutSpecInterface", [DLTIQuer
       /*args=*/(ins "::mlir::MLIRContext *":$context)
     >,
     InterfaceMethod<
-      /*description=*/"Returns the mangling style identifier.",
+      /*description=*/"Returns the mangling mode identifier.",
       /*retTy=*/"::mlir::StringAttr",
-      /*methodName=*/"getManglingStyleIdentifier",
+      /*methodName=*/"getManglingModeIdentifier",
       /*args=*/(ins "::mlir::MLIRContext *":$context)
     >,
     InterfaceMethod<
@@ -488,15 +488,15 @@ def DataLayoutOpInterface : OpInterface<"DataLayoutOpInterface"> {
       }]
     >,
     StaticInterfaceMethod<
-      /*description=*/"Returns the mangling style computed "
+      /*description=*/"Returns the mangling mode computed "
                       "using the relevant entries. The data layout object "
                       "can be used for recursive queries.",
       /*retTy=*/"::mlir::Attribute",
-      /*methodName=*/"getManglingStyle",
+      /*methodName=*/"getManglingMode",
       /*args=*/(ins "::mlir::DataLayoutEntryInterface":$entry),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        return ::mlir::detail::getDefaultManglingStyle(entry);
+        return ::mlir::detail::getDefaultManglingMode(entry);
       }]
     >,
     StaticInterfaceMethod<

--- a/mlir/include/mlir/Interfaces/DataLayoutInterfaces.td
+++ b/mlir/include/mlir/Interfaces/DataLayoutInterfaces.td
@@ -154,6 +154,12 @@ def DataLayoutSpecInterface : AttrInterface<"DataLayoutSpecInterface", [DLTIQuer
       /*args=*/(ins "::mlir::MLIRContext *":$context)
     >,
     InterfaceMethod<
+      /*description=*/"Returns the mangling style identifier.",
+      /*retTy=*/"::mlir::StringAttr",
+      /*methodName=*/"getManglingStyleIdentifier",
+      /*args=*/(ins "::mlir::MLIRContext *":$context)
+    >,
+    InterfaceMethod<
       /*description=*/"Returns the stack alignment identifier.",
       /*retTy=*/"::mlir::StringAttr",
       /*methodName=*/"getStackAlignmentIdentifier",
@@ -479,6 +485,18 @@ def DataLayoutOpInterface : OpInterface<"DataLayoutOpInterface"> {
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return ::mlir::detail::getDefaultAllocaMemorySpace(entry);
+      }]
+    >,
+    StaticInterfaceMethod<
+      /*description=*/"Returns the mangling style computed "
+                      "using the relevant entries. The data layout object "
+                      "can be used for recursive queries.",
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getManglingStyle",
+      /*args=*/(ins "::mlir::DataLayoutEntryInterface":$entry),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return ::mlir::detail::getDefaultManglingStyle(entry);
       }]
     >,
     StaticInterfaceMethod<

--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -398,9 +398,9 @@ DataLayoutSpecAttr::getGlobalMemorySpaceIdentifier(MLIRContext *context) const {
 }
 
 StringAttr
-DataLayoutSpecAttr::getManglingStyleIdentifier(MLIRContext *context) const {
+DataLayoutSpecAttr::getManglingModeIdentifier(MLIRContext *context) const {
   return Builder(context).getStringAttr(
-      DLTIDialect::kDataLayoutManglingStyleKey);
+      DLTIDialect::kDataLayoutManglingModeKey);
 }
 
 StringAttr
@@ -613,7 +613,7 @@ public:
         entryName == DLTIDialect::kDataLayoutProgramMemorySpaceKey ||
         entryName == DLTIDialect::kDataLayoutGlobalMemorySpaceKey ||
         entryName == DLTIDialect::kDataLayoutStackAlignmentKey ||
-        entryName == DLTIDialect::kDataLayoutManglingStyleKey)
+        entryName == DLTIDialect::kDataLayoutManglingModeKey)
       return success();
     return emitError(loc) << "unknown data layout entry name: " << entryName;
   }

--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -398,6 +398,12 @@ DataLayoutSpecAttr::getGlobalMemorySpaceIdentifier(MLIRContext *context) const {
 }
 
 StringAttr
+DataLayoutSpecAttr::getManglingStyleIdentifier(MLIRContext *context) const {
+  return Builder(context).getStringAttr(
+      DLTIDialect::kDataLayoutManglingStyleKey);
+}
+
+StringAttr
 DataLayoutSpecAttr::getStackAlignmentIdentifier(MLIRContext *context) const {
   return Builder(context).getStringAttr(
       DLTIDialect::kDataLayoutStackAlignmentKey);
@@ -606,7 +612,8 @@ public:
     if (entryName == DLTIDialect::kDataLayoutAllocaMemorySpaceKey ||
         entryName == DLTIDialect::kDataLayoutProgramMemorySpaceKey ||
         entryName == DLTIDialect::kDataLayoutGlobalMemorySpaceKey ||
-        entryName == DLTIDialect::kDataLayoutStackAlignmentKey)
+        entryName == DLTIDialect::kDataLayoutStackAlignmentKey ||
+        entryName == DLTIDialect::kDataLayoutManglingStyleKey)
       return success();
     return emitError(loc) << "unknown data layout entry name: " << entryName;
   }

--- a/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
+++ b/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
@@ -258,6 +258,17 @@ mlir::detail::getDefaultAllocaMemorySpace(DataLayoutEntryInterface entry) {
   return entry.getValue();
 }
 
+// Returns the mangling style if specified in the given entry.
+// If the entry is empty, an empty attribute is returned.
+Attribute
+mlir::detail::getDefaultManglingStyle(DataLayoutEntryInterface entry) {
+  if (entry == DataLayoutEntryInterface()) {
+    return Attribute();
+  }
+
+  return entry.getValue();
+}
+
 // Returns the memory space used for the program memory space.  if
 // specified in the given entry. If the entry is empty the default
 // memory space represented by an empty attribute is returned.
@@ -610,6 +621,22 @@ mlir::Attribute mlir::DataLayout::getAllocaMemorySpace() const {
   else
     allocaMemorySpace = detail::getDefaultAllocaMemorySpace(entry);
   return *allocaMemorySpace;
+}
+
+mlir::Attribute mlir::DataLayout::getManglingStyle() const {
+  checkValid();
+  if (manglingStyle)
+    return *manglingStyle;
+  DataLayoutEntryInterface entry;
+  if (originalLayout)
+    entry = originalLayout.getSpecForIdentifier(
+        originalLayout.getManglingStyleIdentifier(originalLayout.getContext()));
+
+  if (auto iface = dyn_cast_or_null<DataLayoutOpInterface>(scope))
+    manglingStyle = iface.getManglingStyle(entry);
+  else
+    manglingStyle = detail::getDefaultManglingStyle(entry);
+  return *manglingStyle;
 }
 
 mlir::Attribute mlir::DataLayout::getProgramMemorySpace() const {

--- a/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
+++ b/mlir/lib/Interfaces/DataLayoutInterfaces.cpp
@@ -258,13 +258,11 @@ mlir::detail::getDefaultAllocaMemorySpace(DataLayoutEntryInterface entry) {
   return entry.getValue();
 }
 
-// Returns the mangling style if specified in the given entry.
+// Returns the mangling mode if specified in the given entry.
 // If the entry is empty, an empty attribute is returned.
-Attribute
-mlir::detail::getDefaultManglingStyle(DataLayoutEntryInterface entry) {
-  if (entry == DataLayoutEntryInterface()) {
+Attribute mlir::detail::getDefaultManglingMode(DataLayoutEntryInterface entry) {
+  if (entry == DataLayoutEntryInterface())
     return Attribute();
-  }
 
   return entry.getValue();
 }
@@ -623,20 +621,20 @@ mlir::Attribute mlir::DataLayout::getAllocaMemorySpace() const {
   return *allocaMemorySpace;
 }
 
-mlir::Attribute mlir::DataLayout::getManglingStyle() const {
+mlir::Attribute mlir::DataLayout::getManglingMode() const {
   checkValid();
-  if (manglingStyle)
-    return *manglingStyle;
+  if (manglingMode)
+    return *manglingMode;
   DataLayoutEntryInterface entry;
   if (originalLayout)
     entry = originalLayout.getSpecForIdentifier(
-        originalLayout.getManglingStyleIdentifier(originalLayout.getContext()));
+        originalLayout.getManglingModeIdentifier(originalLayout.getContext()));
 
   if (auto iface = dyn_cast_or_null<DataLayoutOpInterface>(scope))
-    manglingStyle = iface.getManglingStyle(entry);
+    manglingMode = iface.getManglingMode(entry);
   else
-    manglingStyle = detail::getDefaultManglingStyle(entry);
-  return *manglingStyle;
+    manglingMode = detail::getDefaultManglingMode(entry);
+  return *manglingMode;
 }
 
 mlir::Attribute mlir::DataLayout::getProgramMemorySpace() const {

--- a/mlir/lib/Target/LLVMIR/DataLayoutImporter.cpp
+++ b/mlir/lib/Target/LLVMIR/DataLayoutImporter.cpp
@@ -163,7 +163,7 @@ DataLayoutImporter::tryToEmplaceEndiannessEntry(StringRef endianness,
   return success();
 }
 
-LogicalResult DataLayoutImporter::tryToEmplaceManglingStyleEntry(
+LogicalResult DataLayoutImporter::tryToEmplaceManglingModeEntry(
     StringRef token, llvm::StringLiteral manglingKey) {
   auto key = StringAttr::get(context, manglingKey);
   if (keyEntries.count(key))
@@ -269,10 +269,10 @@ void DataLayoutImporter::translateDataLayout(
         return;
       continue;
     }
-    // Parse the mangling style.
+    // Parse the mangling mode.
     if (*prefix == "m") {
-      if (failed(tryToEmplaceManglingStyleEntry(
-              token, DLTIDialect::kDataLayoutManglingStyleKey)))
+      if (failed(tryToEmplaceManglingModeEntry(
+              token, DLTIDialect::kDataLayoutManglingModeKey)))
         return;
       continue;
     }

--- a/mlir/lib/Target/LLVMIR/DataLayoutImporter.h
+++ b/mlir/lib/Target/LLVMIR/DataLayoutImporter.h
@@ -100,6 +100,10 @@ private:
   LogicalResult tryToEmplaceAddrSpaceEntry(StringRef token,
                                            llvm::StringLiteral spaceKey);
 
+  /// Adds an mangling style entry if there is none yet.
+  LogicalResult tryToEmplaceManglingStyleEntry(StringRef token,
+                                               llvm::StringLiteral manglingKey);
+
   /// Adds a stack alignment entry if there is none yet.
   LogicalResult tryToEmplaceStackAlignmentEntry(StringRef token);
 

--- a/mlir/lib/Target/LLVMIR/DataLayoutImporter.h
+++ b/mlir/lib/Target/LLVMIR/DataLayoutImporter.h
@@ -100,9 +100,9 @@ private:
   LogicalResult tryToEmplaceAddrSpaceEntry(StringRef token,
                                            llvm::StringLiteral spaceKey);
 
-  /// Adds an mangling style entry if there is none yet.
-  LogicalResult tryToEmplaceManglingStyleEntry(StringRef token,
-                                               llvm::StringLiteral manglingKey);
+  /// Adds an mangling mode entry if there is none yet.
+  LogicalResult tryToEmplaceManglingModeEntry(StringRef token,
+                                              llvm::StringLiteral manglingKey);
 
   /// Adds a stack alignment entry if there is none yet.
   LogicalResult tryToEmplaceStackAlignmentEntry(StringRef token);

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -199,7 +199,7 @@ translateDataLayout(DataLayoutSpecInterface attribute,
       layoutStream << "-" << (isLittleEndian ? "e" : "E");
       continue;
     }
-    if (key.getValue() == DLTIDialect::kDataLayoutManglingStyleKey) {
+    if (key.getValue() == DLTIDialect::kDataLayoutManglingModeKey) {
       auto value = cast<StringAttr>(entry.getValue());
       layoutStream << "-m:" << value.getValue();
       continue;

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -199,6 +199,11 @@ translateDataLayout(DataLayoutSpecInterface attribute,
       layoutStream << "-" << (isLittleEndian ? "e" : "E");
       continue;
     }
+    if (key.getValue() == DLTIDialect::kDataLayoutManglingStyleKey) {
+      auto value = cast<StringAttr>(entry.getValue());
+      layoutStream << "-m:" << value.getValue();
+      continue;
+    }
     if (key.getValue() == DLTIDialect::kDataLayoutProgramMemorySpaceKey) {
       auto value = cast<IntegerAttr>(entry.getValue());
       uint64_t space = value.getValue().getZExtValue();

--- a/mlir/test/Dialect/LLVMIR/layout.mlir
+++ b/mlir/test/Dialect/LLVMIR/layout.mlir
@@ -9,6 +9,7 @@ module {
     // CHECK: endianness = ""
     // CHECK: global_memory_space = 0
     // CHECK: index = 64
+    // CHECK: mangling_mode = ""
     // CHECK: preferred = 8
     // CHECK: program_memory_space = 0
     // CHECK: size = 8
@@ -20,6 +21,7 @@ module {
     // CHECK: endianness = ""
     // CHECK: global_memory_space = 0
     // CHECK: index = 64
+    // CHECK: mangling_mode = ""
     // CHECK: preferred = 8
     // CHECK: program_memory_space = 0
     // CHECK: size = 8
@@ -31,6 +33,7 @@ module {
     // CHECK: endianness = ""
     // CHECK: global_memory_space = 0
     // CHECK: index = 64
+    // CHECK: mangling_mode = ""
     // CHECK: preferred = 8
     // CHECK: program_memory_space = 0
     // CHECK: size = 8
@@ -50,7 +53,8 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
   #dlti.dl_entry<"dlti.alloca_memory_space", 5 : ui64>,
   #dlti.dl_entry<"dlti.global_memory_space", 2 : ui64>,
   #dlti.dl_entry<"dlti.program_memory_space", 3 : ui64>,
-  #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>
+  #dlti.dl_entry<"dlti.stack_alignment", 128 : i64>,
+  #dlti.dl_entry<"dlti.mangling_mode", "e">
 >} {
   // CHECK: @spec
   func.func @spec() {
@@ -60,6 +64,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
     // CHECK: endianness = "little"
     // CHECK: global_memory_space = 2
     // CHECK: index = 32
+    // CHECK: mangling_mode = "e"
     // CHECK: preferred = 8
     // CHECK: program_memory_space = 3
     // CHECK: size = 4
@@ -82,6 +87,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
     // CHECK: endianness = "little"
     // CHECK: global_memory_space = 2
     // CHECK: index = 64
+    // CHECK: mangling_mode = "e"
     // CHECK: preferred = 8
     // CHECK: program_memory_space = 3
     // CHECK: size = 8
@@ -93,6 +99,7 @@ module attributes { dlti.dl_spec = #dlti.dl_spec<
     // CHECK: endianness = "little"
     // CHECK: global_memory_space = 2
     // CHECK: index = 24
+    // CHECK: mangling_mode = "e"
     // CHECK: preferred = 8
     // CHECK: program_memory_space = 3
     // CHECK: size = 4

--- a/mlir/test/Target/LLVMIR/Import/data-layout.ll
+++ b/mlir/test/Target/LLVMIR/Import/data-layout.ll
@@ -29,7 +29,7 @@ target datalayout = ""
 ; CHECK-DAG:   !llvm.ptr<271> = dense<32> : vector<4xi64>
 ; CHECK-DAG:   !llvm.ptr<272> = dense<64> : vector<4xi64>
 ; CHECK-DAG:   "dlti.stack_alignment" = 128 : i64
-; CHECK-DAG:   "dlti.mangling_style" = "e"
+; CHECK-DAG:   "dlti.mangling_mode" = "e"
 target datalayout = "e-m:e-p270:32:64-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
 ; // -----

--- a/mlir/test/Target/LLVMIR/Import/data-layout.ll
+++ b/mlir/test/Target/LLVMIR/Import/data-layout.ll
@@ -29,6 +29,7 @@ target datalayout = ""
 ; CHECK-DAG:   !llvm.ptr<271> = dense<32> : vector<4xi64>
 ; CHECK-DAG:   !llvm.ptr<272> = dense<64> : vector<4xi64>
 ; CHECK-DAG:   "dlti.stack_alignment" = 128 : i64
+; CHECK-DAG:   "dlti.mangling_style" = "e"
 target datalayout = "e-m:e-p270:32:64-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
 ; // -----

--- a/mlir/test/Target/LLVMIR/Import/import-failure.ll
+++ b/mlir/test/Target/LLVMIR/Import/import-failure.ll
@@ -355,6 +355,11 @@ declare void @llvm.experimental.noalias.scope.decl(metadata)
 target datalayout = "e-ni:42-i64:64"
 
 ; // -----
+; CHECK:      import-failure.ll
+; CHECK-SAME: malformed specification, must be of the form "m:<mangling>"
+target datalayout = "e-m-i64:64"
+
+; // -----
 
 ; CHECK:      <unknown>
 ; CHECK-SAME: incompatible call and callee types: '!llvm.func<void (i64)>' and '!llvm.func<void (ptr)>'

--- a/mlir/test/Target/LLVMIR/Import/import-failure.ll
+++ b/mlir/test/Target/LLVMIR/Import/import-failure.ll
@@ -355,6 +355,7 @@ declare void @llvm.experimental.noalias.scope.decl(metadata)
 target datalayout = "e-ni:42-i64:64"
 
 ; // -----
+
 ; CHECK:      import-failure.ll
 ; CHECK-SAME: malformed specification, must be of the form "m:<mangling>"
 target datalayout = "e-m-i64:64"

--- a/mlir/test/Target/LLVMIR/data-layout.mlir
+++ b/mlir/test/Target/LLVMIR/data-layout.mlir
@@ -13,7 +13,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
 #dlti.dl_entry<"dlti.endianness", "big">,
 #dlti.dl_entry<"dlti.alloca_memory_space", 4 : ui32>,
 #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>,
-#dlti.dl_entry<"dlti.mangling_style", "e">,
+#dlti.dl_entry<"dlti.mangling_mode", "e">,
 #dlti.dl_entry<index, 64>,
 #dlti.dl_entry<i64, dense<[64,128]> : vector<2xi64>>,
 #dlti.dl_entry<f80, dense<[128,256]> : vector<2xi64>>,

--- a/mlir/test/Target/LLVMIR/data-layout.mlir
+++ b/mlir/test/Target/LLVMIR/data-layout.mlir
@@ -4,6 +4,7 @@
 // CHECK: E-
 // CHECK: A4-
 // CHECK: S128-
+// CHECK: m:e-
 // CHECK: i64:64:128
 // CHECK: f80:128:256
 // CHECK: p0:32:64:128:32
@@ -12,6 +13,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<
 #dlti.dl_entry<"dlti.endianness", "big">,
 #dlti.dl_entry<"dlti.alloca_memory_space", 4 : ui32>,
 #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>,
+#dlti.dl_entry<"dlti.mangling_style", "e">,
 #dlti.dl_entry<index, 64>,
 #dlti.dl_entry<i64, dense<[64,128]> : vector<2xi64>>,
 #dlti.dl_entry<f80, dense<[128,256]> : vector<2xi64>>,

--- a/mlir/test/lib/Dialect/DLTI/TestDataLayoutQuery.cpp
+++ b/mlir/test/lib/Dialect/DLTI/TestDataLayoutQuery.cpp
@@ -43,7 +43,7 @@ struct TestDataLayoutQuery
       uint64_t index = layout.getTypeIndexBitwidth(op.getType()).value_or(0);
       Attribute endianness = layout.getEndianness();
       Attribute allocaMemorySpace = layout.getAllocaMemorySpace();
-      Attribute manglingStyle = layout.getManglingStyle();
+      Attribute manglingMode = layout.getManglingMode();
       Attribute programMemorySpace = layout.getProgramMemorySpace();
       Attribute globalMemorySpace = layout.getGlobalMemorySpace();
       uint64_t stackAlignment = layout.getStackAlignment();
@@ -73,10 +73,9 @@ struct TestDataLayoutQuery
                                 allocaMemorySpace == Attribute()
                                     ? builder.getUI32IntegerAttr(0)
                                     : allocaMemorySpace),
-           builder.getNamedAttr("mangling_style",
-                                manglingStyle == Attribute()
-                                    ? builder.getStringAttr("")
-                                    : manglingStyle),
+           builder.getNamedAttr("mangling_mode", manglingMode == Attribute()
+                                                     ? builder.getStringAttr("")
+                                                     : manglingMode),
            builder.getNamedAttr("program_memory_space",
                                 programMemorySpace == Attribute()
                                     ? builder.getUI32IntegerAttr(0)

--- a/mlir/test/lib/Dialect/DLTI/TestDataLayoutQuery.cpp
+++ b/mlir/test/lib/Dialect/DLTI/TestDataLayoutQuery.cpp
@@ -43,6 +43,7 @@ struct TestDataLayoutQuery
       uint64_t index = layout.getTypeIndexBitwidth(op.getType()).value_or(0);
       Attribute endianness = layout.getEndianness();
       Attribute allocaMemorySpace = layout.getAllocaMemorySpace();
+      Attribute manglingStyle = layout.getManglingStyle();
       Attribute programMemorySpace = layout.getProgramMemorySpace();
       Attribute globalMemorySpace = layout.getGlobalMemorySpace();
       uint64_t stackAlignment = layout.getStackAlignment();
@@ -72,6 +73,10 @@ struct TestDataLayoutQuery
                                 allocaMemorySpace == Attribute()
                                     ? builder.getUI32IntegerAttr(0)
                                     : allocaMemorySpace),
+           builder.getNamedAttr("mangling_style",
+                                manglingStyle == Attribute()
+                                    ? builder.getStringAttr("")
+                                    : manglingStyle),
            builder.getNamedAttr("program_memory_space",
                                 programMemorySpace == Attribute()
                                     ? builder.getUI32IntegerAttr(0)

--- a/mlir/unittests/Interfaces/DataLayoutInterfacesTest.cpp
+++ b/mlir/unittests/Interfaces/DataLayoutInterfacesTest.cpp
@@ -25,6 +25,7 @@ constexpr static llvm::StringLiteral kAttrName = "dltest.layout";
 constexpr static llvm::StringLiteral kEndiannesKeyName = "dltest.endianness";
 constexpr static llvm::StringLiteral kAllocaKeyName =
     "dltest.alloca_memory_space";
+constexpr static llvm::StringLiteral kManglingStyleKeyName = "dltest.mangling";
 constexpr static llvm::StringLiteral kProgramKeyName =
     "dltest.program_memory_space";
 constexpr static llvm::StringLiteral kGlobalKeyName =
@@ -82,6 +83,9 @@ struct CustomDataLayoutSpec
   }
   StringAttr getAllocaMemorySpaceIdentifier(MLIRContext *context) const {
     return Builder(context).getStringAttr(kAllocaKeyName);
+  }
+  StringAttr getManglingStyleIdentifier(MLIRContext *context) const {
+    return Builder(context).getStringAttr(kManglingStyleKeyName);
   }
   StringAttr getProgramMemorySpaceIdentifier(MLIRContext *context) const {
     return Builder(context).getStringAttr(kProgramKeyName);

--- a/mlir/unittests/Interfaces/DataLayoutInterfacesTest.cpp
+++ b/mlir/unittests/Interfaces/DataLayoutInterfacesTest.cpp
@@ -25,7 +25,7 @@ constexpr static llvm::StringLiteral kAttrName = "dltest.layout";
 constexpr static llvm::StringLiteral kEndiannesKeyName = "dltest.endianness";
 constexpr static llvm::StringLiteral kAllocaKeyName =
     "dltest.alloca_memory_space";
-constexpr static llvm::StringLiteral kManglingStyleKeyName = "dltest.mangling";
+constexpr static llvm::StringLiteral kManglingModeKeyName = "dltest.mangling";
 constexpr static llvm::StringLiteral kProgramKeyName =
     "dltest.program_memory_space";
 constexpr static llvm::StringLiteral kGlobalKeyName =
@@ -84,8 +84,8 @@ struct CustomDataLayoutSpec
   StringAttr getAllocaMemorySpaceIdentifier(MLIRContext *context) const {
     return Builder(context).getStringAttr(kAllocaKeyName);
   }
-  StringAttr getManglingStyleIdentifier(MLIRContext *context) const {
-    return Builder(context).getStringAttr(kManglingStyleKeyName);
+  StringAttr getManglingModeIdentifier(MLIRContext *context) const {
+    return Builder(context).getStringAttr(kManglingModeKeyName);
   }
   StringAttr getProgramMemorySpaceIdentifier(MLIRContext *context) const {
     return Builder(context).getStringAttr(kProgramKeyName);
@@ -478,6 +478,7 @@ module {}
   EXPECT_EQ(layout.getProgramMemorySpace(), Attribute());
   EXPECT_EQ(layout.getGlobalMemorySpace(), Attribute());
   EXPECT_EQ(layout.getStackAlignment(), 0u);
+  EXPECT_EQ(layout.getManglingMode(), Attribute());
 }
 
 TEST(DataLayout, NullSpec) {
@@ -510,6 +511,7 @@ TEST(DataLayout, NullSpec) {
   EXPECT_EQ(layout.getProgramMemorySpace(), Attribute());
   EXPECT_EQ(layout.getGlobalMemorySpace(), Attribute());
   EXPECT_EQ(layout.getStackAlignment(), 0u);
+  EXPECT_EQ(layout.getManglingMode(), Attribute());
 
   EXPECT_EQ(layout.getDevicePropertyValue(
                 Builder(&ctx).getStringAttr("CPU" /* device ID*/),
@@ -550,6 +552,7 @@ TEST(DataLayout, EmptySpec) {
   EXPECT_EQ(layout.getProgramMemorySpace(), Attribute());
   EXPECT_EQ(layout.getGlobalMemorySpace(), Attribute());
   EXPECT_EQ(layout.getStackAlignment(), 0u);
+  EXPECT_EQ(layout.getManglingMode(), Attribute());
 
   EXPECT_EQ(layout.getDevicePropertyValue(
                 Builder(&ctx).getStringAttr("CPU" /* device ID*/),
@@ -571,7 +574,8 @@ TEST(DataLayout, SpecWithEntries) {
   #dlti.dl_entry<"dltest.alloca_memory_space", 5 : i32>,
   #dlti.dl_entry<"dltest.program_memory_space", 3 : i32>,
   #dlti.dl_entry<"dltest.global_memory_space", 2 : i32>,
-  #dlti.dl_entry<"dltest.stack_alignment", 128 : i32>
+  #dlti.dl_entry<"dltest.stack_alignment", 128 : i32>,
+  #dlti.dl_entry<"dltest.mangling_mode", "o">
 > } : () -> ()
   )MLIR";
 
@@ -608,6 +612,7 @@ TEST(DataLayout, SpecWithEntries) {
   EXPECT_EQ(layout.getProgramMemorySpace(), Builder(&ctx).getI32IntegerAttr(3));
   EXPECT_EQ(layout.getGlobalMemorySpace(), Builder(&ctx).getI32IntegerAttr(2));
   EXPECT_EQ(layout.getStackAlignment(), 128u);
+  EXPECT_EQ(layout.getManglingMode(), Builder(&ctx).getStringAttr("o"));
 }
 
 TEST(DataLayout, SpecWithTargetSystemDescEntries) {

--- a/mlir/unittests/Interfaces/DataLayoutInterfacesTest.cpp
+++ b/mlir/unittests/Interfaces/DataLayoutInterfacesTest.cpp
@@ -25,7 +25,8 @@ constexpr static llvm::StringLiteral kAttrName = "dltest.layout";
 constexpr static llvm::StringLiteral kEndiannesKeyName = "dltest.endianness";
 constexpr static llvm::StringLiteral kAllocaKeyName =
     "dltest.alloca_memory_space";
-constexpr static llvm::StringLiteral kManglingModeKeyName = "dltest.mangling";
+constexpr static llvm::StringLiteral kManglingModeKeyName =
+    "dltest.mangling_mode";
 constexpr static llvm::StringLiteral kProgramKeyName =
     "dltest.program_memory_space";
 constexpr static llvm::StringLiteral kGlobalKeyName =


### PR DESCRIPTION
Add mangling style as a spec entry to datalayout, and implemented importing and exporting LLVM IR to MLIR (LLVM dialect).
Its represented as string as the scope of this PR is to preserve info from LLVM IR, so client in MLIR still need to map deduce the meaning of the string, like "e" means ELF, "o" for Mach-O, etc.

it addresses one of issues mentioned in this [issue](https://github.com/llvm/llvm-project/issues/126046)