### PR TITLE
[TableGen] Add declarations to silence gcc warning. NFC

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.h
@@ -393,6 +393,9 @@ struct SDTypeConstraint {
                         const SDTypeConstraint &RHS);
 };
 
+bool operator==(const SDTypeConstraint &LHS, const SDTypeConstraint &RHS);
+bool operator<(const SDTypeConstraint &LHS, const SDTypeConstraint &RHS);
+
 /// ScopedName - A name of a node associated with a "scope" that indicates
 /// the context (e.g. instance of Pattern or PatFrag) in which the name was
 /// used. This enables substitution of pattern fragments while keeping track


### PR DESCRIPTION
Add declarations of SDTypeConstraint's operator== and operator< to the llvm namespace. These are declared as friends inside the class which makes them part of the enclosing namespace, but gcc wants it to be more explicit.

Fixes #125537.