### PR TITLE
[libc] Remove LlvmLibcStackChkFail.Smash test

### DIFF
--- a/libc/test/src/compiler/stack_chk_guard_test.cpp
+++ b/libc/test/src/compiler/stack_chk_guard_test.cpp
@@ -7,24 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/signal_macros.h"
-#include "src/__support/macros/sanitizer.h"
 #include "src/compiler/__stack_chk_fail.h"
-#include "src/string/memset.h"
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcStackChkFail, Death) {
   EXPECT_DEATH([] { __stack_chk_fail(); }, WITH_SIGNAL(SIGABRT));
 }
-
-// Disable the test when asan is enabled so that it doesn't immediately fail
-// after the memset, but before the stack canary is re-checked.
-#ifndef LIBC_HAS_ADDRESS_SANITIZER
-TEST(LlvmLibcStackChkFail, Smash) {
-  EXPECT_DEATH(
-      [] {
-        int arr[20];
-        LIBC_NAMESPACE::memset(arr, 0xAA, 2001);
-      },
-      WITH_SIGNAL(SIGABRT));
-}
-#endif // LIBC_HAS_ADDRESS_SANITIZER


### PR DESCRIPTION
This test was problematic, and also unnecessary.  It's not really
a test of the libc functionality or ABI.  That's already covered
by the LlvmLibcStackChkFail.Death test.  The Smash test was in
fact just testing that the compiler produces the call in the
expected situation.  That's a compiler test, not a libc test.

It's not really feasible to make a test like this both reliable
and safe.  Since it's not something libc needs to test, it's not
worth trying.
