### PR TITLE
[NaryReassociate] Fix crash from pointer width / index width confusion

### DIFF
--- a/llvm/lib/Transforms/Scalar/NaryReassociate.cpp
+++ b/llvm/lib/Transforms/Scalar/NaryReassociate.cpp
@@ -402,13 +402,10 @@ NaryReassociatePass::tryReassociateGEPAtIndex(GetElementPtrInst *GEP,
     IndexExprs.push_back(SE->getSCEV(Index));
   // Replace the I-th index with LHS.
   IndexExprs[I] = SE->getSCEV(LHS);
-  Type *GEPArgType = GEP->getOperand(I)->getType();
-  Type *LHSType = LHS->getType();
+  Type *GEPArgType = SE->getEffectiveSCEVType(GEP->getOperand(I)->getType());
+  Type *LHSType = SE->getEffectiveSCEVType(LHS->getType());
   size_t LHSSize = DL->getTypeSizeInBits(LHSType).getFixedValue();
   size_t GEPArgSize = DL->getTypeSizeInBits(GEPArgType).getFixedValue();
-  // For pointers, we need to look at the index size, not the total type size.
-  if (isa<PointerType>(GEPArgType))
-    GEPArgSize = DL->getIndexTypeSizeInBits(GEPArgType);
   if (isKnownNonNegative(LHS, SimplifyQuery(*DL, DT, AC, GEP)) &&
       LHSSize < GEPArgSize) {
     // Zero-extend LHS if it is non-negative. InstCombine canonicalizes sext to

--- a/llvm/test/Transforms/NaryReassociate/nary-gep.ll
+++ b/llvm/test/Transforms/NaryReassociate/nary-gep.ll
@@ -21,14 +21,14 @@ define void @no_sext_fat_pointer(ptr addrspace(2) %a, i32 %i, i32 %j) {
   ret void
 }
 
-define ptr addrspace(2) @zext_fat_pointer_crash() {
+define ptr addrspace(2) @zext_fat_pointer_crash(ptr addrspace(2) %p, i32 %a) {
 ; CHECK-LABEL: @zext_fat_pointer_crash(
-; CHECK-NEXT:    [[C:%.*]] = add i32 0, 0
-; CHECK-NEXT:    [[Q:%.*]] = getelementptr double, ptr addrspace(2) null, i32 [[C]]
+; CHECK-NEXT:    [[C:%.*]] = add i32 [[A:%.*]], 1
+; CHECK-NEXT:    [[Q:%.*]] = getelementptr double, ptr addrspace(2) [[P:%.*]], i32 [[C]]
 ; CHECK-NEXT:    ret ptr addrspace(2) [[Q]]
 ;
-  %c = add i32 0, 0
-  %q = getelementptr double, ptr addrspace(2) null, i32 %c
+  %c = add i32 %a, 1
+  %q = getelementptr double, ptr addrspace(2) %p, i32 %c
   ret ptr addrspace(2) %q
 }
 

--- a/llvm/test/Transforms/NaryReassociate/nary-gep.ll
+++ b/llvm/test/Transforms/NaryReassociate/nary-gep.ll
@@ -21,6 +21,17 @@ define void @no_sext_fat_pointer(ptr addrspace(2) %a, i32 %i, i32 %j) {
   ret void
 }
 
+define ptr addrspace(2) @zext_fat_pointer_crash() {
+; CHECK-LABEL: @zext_fat_pointer_crash(
+; CHECK-NEXT:    [[C:%.*]] = add i32 0, 0
+; CHECK-NEXT:    [[Q:%.*]] = getelementptr double, ptr addrspace(2) null, i32 [[C]]
+; CHECK-NEXT:    ret ptr addrspace(2) [[Q]]
+;
+  %c = add i32 0, 0
+  %q = getelementptr double, ptr addrspace(2) null, i32 %c
+  ret ptr addrspace(2) %q
+}
+
 define void @or_disjoint(ptr addrspace(2) %a, i32 %i, i32 %j, i32 %k) {
 ; CHECK-LABEL: @or_disjoint(
 ; CHECK-NEXT:    [[OR:%.*]] = or disjoint i32 [[I:%.*]], [[J:%.*]]


### PR DESCRIPTION
NaryReassociate would crash on expressions like the one in the added test that involved pointers where the size of the type was greater than the index width of the pointer, causing calls to SCEV's zext expression on types that didn't need to be zero-extended.

This commit fixes the issue.