### PR TITLE
[libc][wait] hard code __W_CONTINUED for SYS_waitid fallback

### DIFF
--- a/libc/src/sys/wait/wait4Impl.h
+++ b/libc/src/sys/wait/wait4Impl.h
@@ -65,7 +65,7 @@ LIBC_INLINE ErrorOr<pid_t> wait4impl(pid_t pid, int *wait_status, int options,
       *wait_status = W_STOPCODE(info.si_status);
       break;
     case CLD_CONTINUED:
-      *wait_status = __W_CONTINUED;
+      *wait_status = 0xffff;
       break;
     default:
       *wait_status = 0;


### PR DESCRIPTION
riscv32 currently doesn't have SYS_wait4, so wait4 is implemented via fallback
to SYS_waitid. In #125572, I missed that we had one use of the removed
__W_CONTINUED value. Hard code it here.

Fixes: #125572
