### PR TITLE
[libc][poll] remove entrypoint for riscv

### DIFF
--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -33,7 +33,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.fcntl.openat
 
     # poll.h entrypoints
-    libc.src.poll.poll
+    # TODO: https://github.com/llvm/llvm-project/issues/125940
+    # libc.src.poll.poll
 
     # sched.h entrypoints
     libc.src.sched.sched_get_priority_max

--- a/libc/src/poll/linux/poll.cpp
+++ b/libc/src/poll/linux/poll.cpp
@@ -21,9 +21,10 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, poll, (pollfd * fds, nfds_t nfds, int timeout)) {
+  int ret = 0;
 
 #ifdef SYS_poll
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_poll, fds, nfds, timeout);
+  ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_poll, fds, nfds, timeout);
 #elif defined(SYS_ppoll)
   timespec ts, *tsp;
   if (timeout >= 0) {
@@ -33,9 +34,10 @@ LLVM_LIBC_FUNCTION(int, poll, (pollfd * fds, nfds_t nfds, int timeout)) {
   } else {
     tsp = nullptr;
   }
-  int ret =
+  ret =
       LIBC_NAMESPACE::syscall_impl<int>(SYS_ppoll, fds, nfds, tsp, nullptr, 0);
 #else
+// TODO: https://github.com/llvm/llvm-project/issues/125940
 #error "SYS_ppoll_time64?"
 #endif
 


### PR DESCRIPTION
riscv32 specifically doesn't provide EITHER SYS_poll or SYS_ppoll. We may be
able to reimplement poll in terms of syscalls to SYS_ppoll_time64, but will
leave that as a TODO for the future. (Such as when we want to be able to cross
compile for riscv32).

Link: #125940
Fixes: #125118
