### PR TITLE
[clang][docs] Clarify the tail padding considered by `__datasizeof`

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -432,7 +432,7 @@ __datasizeof
 ------------
 
 ``__datasizeof`` behaves like ``sizeof``, except that it returns the size of the
-type ignoring tail padding.
+type ignoring reusable tail padding according to the ABI.
 
 _BitInt, _ExtInt
 ----------------


### PR DESCRIPTION
Some tail padding are not reusable due to the ABI specification, and `__datasizeof` intentionally doesn't consider them.

Closes #125863.