### PR TITLE
[Modules] Fix missing module dependency introduced by 7347870

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -112,6 +112,8 @@ module Clang_Diagnostics {
   module Parse { header "clang/Basic/DiagnosticParse.h" export * }
   module Serialization { header "clang/Serialization/SerializationDiagnostic.h" export * }
   module Refactoring { header "clang/Tooling/Refactoring/RefactoringDiagnostic.h" export * }
+
+  textual header "clang/Basic/AllDiagnosticKinds.inc"
 }
 
 module Clang_Driver {


### PR DESCRIPTION
73478708839fad8b02b3cfc84959d64a15ba93ca introduced a textual header but did not update clang's module map. This PR adds the header to the module map. 