### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Fix a regression that [[noescape]] on a member function no longer works.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -109,9 +109,7 @@ public:
       bool VisitCallExpr(CallExpr *CE) override {
         checkCalleeLambda(CE);
         if (auto *Callee = CE->getDirectCallee()) {
-          unsigned ArgIndex = 0;
-          if (auto *CXXCallee = dyn_cast<CXXMethodDecl>(Callee))
-            ArgIndex = CXXCallee->isInstance();
+          unsigned ArgIndex = isa<CXXOperatorCallExpr>(CE);
           bool TreatAllArgsAsNoEscape = shouldTreatAllArgAsNoEscape(Callee);
           for (auto *Param : Callee->parameters()) {
             if (ArgIndex >= CE->getNumArgs())

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -70,6 +70,7 @@ public:
   HashMap([[clang::noescape]] const Function<ValueType()>&);
   void ensure(const KeyType&, [[clang::noescape]] const Function<ValueType()>&);
   bool operator+([[clang::noescape]] const Function<ValueType()>&) const;
+  static void ifAny(HashMap, [[clang::noescape]] const Function<bool(ValueType)>&);
 
 private:
   ValueType* m_table { nullptr };
@@ -281,6 +282,7 @@ struct RefCountableWithLambdaCapturingThis {
     });
   }
 
+  static void callLambda([[clang::noescape]] const WTF::Function<RefPtr<RefCountable>()>&);
   void method_captures_this_in_template_method() {
     RefCountable* obj = make_obj();
     WTF::HashMap<int, RefPtr<RefCountable>> nextMap;
@@ -290,6 +292,12 @@ struct RefCountableWithLambdaCapturingThis {
     nextMap+[&] {
       return obj->next();
     };
+    WTF::HashMap<int, RefPtr<RefCountable>>::ifAny(nextMap, [&](auto& item) -> bool {
+      return item->next() && obj->next();
+    });
+    callLambda([&]() -> RefPtr<RefCountable> {
+      return obj->next();
+    });
   }
 };
 

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -63,6 +63,18 @@ template<typename Out, typename... In> Function<Out(In...)> adopt(Detail::Callab
     return Function<Out(In...)>(impl, Function<Out(In...)>::Adopt);
 }
 
+template <typename KeyType, typename ValueType>
+class HashMap {
+public:
+  HashMap();
+  HashMap([[clang::noescape]] const Function<ValueType()>&);
+  void ensure(const KeyType&, [[clang::noescape]] const Function<ValueType()>&);
+  bool operator+([[clang::noescape]] const Function<ValueType()>&) const;
+
+private:
+  ValueType* m_table { nullptr };
+};
+
 } // namespace WTF
 
 struct A {
@@ -267,6 +279,17 @@ struct RefCountableWithLambdaCapturingThis {
     run([&](RefCountable&) {
       nonTrivial();
     });
+  }
+
+  void method_captures_this_in_template_method() {
+    RefCountable* obj = make_obj();
+    WTF::HashMap<int, RefPtr<RefCountable>> nextMap;
+    nextMap.ensure(3, [&] {
+      return obj->next();
+    });
+    nextMap+[&] {
+      return obj->next();
+    };
   }
 };
 


### PR DESCRIPTION
We should skip the first argument for CXXOperatorCallExpr, not other kinds of calls.