### PR TITLE
[gn] Add libcxx_enable_explicit_modules arg

### DIFF
--- a/llvm/utils/gn/build/toolchain/BUILD.gn
+++ b/llvm/utils/gn/build/toolchain/BUILD.gn
@@ -34,10 +34,18 @@ template("unix_toolchain") {
 
     tool("cxx") {
       depfile = "{{output}}.d"
-      command = "$cxx -MMD -MF $depfile -o {{output}} -c {{source}} {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}}"
+      command = "$cxx -MMD -MF $depfile -o {{output}} -c {{source}} {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} {{module_deps_no_self}}"
       depsformat = "gcc"
       description = "CXX {{output}}"
       outputs = [ "{{source_out_dir}}/{{label_name}}.{{source_name_part}}.o" ]
+    }
+
+    tool("cxx_module") {
+      depfile = "{{output}}.d"
+      command = "$cxx -MMD -MF $depfile -o {{output}} {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} {{module_deps_no_self}} -fmodule-name={{label_name}} -x c++ -Xclang -emit-module -c {{source}}"
+      depsformat = "gcc"
+      description = "CXX_MODULE {{output}}"
+      outputs = [ "{{source_out_dir}}/{{label_name}}.{{source_name_part}}.pcm" ]
     }
 
     tool("objcxx") {

--- a/llvm/utils/gn/secondary/clang/lib/Headers/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/lib/Headers/BUILD.gn
@@ -1,5 +1,6 @@
 import("//clang/resource_dir.gni")
 import("//clang/utils/TableGen/clang_tablegen.gni")
+import("//libcxx/config.gni")
 
 # Generate arm_neon.h
 clang_tablegen("arm_neon") {
@@ -350,4 +351,39 @@ copy("Headers") {
     "zos_wrappers/builtins.h",
   ]
   outputs = [ "$clang_resource_dir/include/{{source_target_relative}}" ]
+}
+
+config("module_config") {
+  cflags_cc = [
+    "-fno-implicit-modules",
+    "-fno-implicit-module-maps",
+    "-fmodules",
+    "-fmodule-map-file=" +
+        rebase_path("$clang_resource_dir/include/module.modulemap",
+                    root_build_dir),
+    "-std=c++23",
+  ]
+}
+
+template("builtin_module") {
+  source_set(target_name) {
+    if (libcxx_enable_explicit_modules) {
+      sources = [ "$clang_resource_dir/include/module.modulemap" ]
+    }
+    deps = [ ":Headers($default_toolchain)" ]
+
+    if (defined(invoker.deps)) {
+      deps += invoker.deps
+    } else {
+      not_needed(invoker, "*")
+    }
+
+    public_configs = [ ":module_config" ]
+  }
+}
+
+builtin_module("_Builtin_stddef") {
+}
+
+builtin_module("_Builtin_stdint") {
 }

--- a/llvm/utils/gn/secondary/libcxx/config.gni
+++ b/llvm/utils/gn/secondary/libcxx/config.gni
@@ -7,4 +7,9 @@ declare_args() {
 
   # Build timezone database as part of libc++experimental.
   libcxx_enable_time_zone_database = target_os == "linux"
+
+  # Whether to enable explicit Clang modules build for libc++.
+  # See https://clang.llvm.org/docs/Modules.html for more details about Clang
+  # Modules.
+  libcxx_enable_explicit_modules = false
 }

--- a/llvm/utils/gn/secondary/libcxx/include/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxx/include/BUILD.gn
@@ -1,3 +1,4 @@
+import("//clang/resource_dir.gni")
 import("//libcxx/config.gni")
 import("//llvm/utils/gn/build/write_cmake_config.gni")
 
@@ -1949,6 +1950,7 @@ if (current_toolchain == default_toolchain) {
       "ext/hash_set",
       "fenv.h",
       "filesystem",
+      "flat_map",
       "float.h",
       "format",
       "forward_list",
@@ -2047,7 +2049,107 @@ config("include_config") {
   include_dirs = [ libcxx_generated_include_dir ]
 }
 
+config("module_config") {
+  cflags_cc = [
+    "-fmodules",
+    "-fmodule-map-file=include/c++/v1/module.modulemap",
+    "-fno-implicit-modules",
+    "-fno-implicit-module-maps",
+    "-nostdinc++",
+    "-std=c++23",
+
+    # Disable build config mismatch warning.
+    # e.g. exception handling.
+    "-Wno-module-file-config-mismatch",
+  ]
+}
+
+template("libcxx_module") {
+  source_set(target_name) {
+    if (libcxx_enable_explicit_modules) {
+      sources = [ "$root_build_dir/include/c++/v1/module.modulemap" ]
+    }
+
+    deps = [ ":copy_headers($default_toolchain)" ]
+    if (defined(invoker.deps)) {
+      deps += invoker.deps
+    } else {
+      not_needed(invoker, "*")
+    }
+
+    configs += [
+      ":include_config",
+      ":module_config",
+    ]
+  }
+}
+
+libcxx_module("std_config") {
+}
+
+libcxx_module("std_core") {
+  deps = [
+    ":std_config",
+    "//clang/lib/Headers:_Builtin_stddef",
+    "//clang/lib/Headers:_Builtin_stdint",
+  ]
+}
+
+libcxx_module("std_ctype_h") {
+}
+
+libcxx_module("std_errno_h") {
+}
+
+libcxx_module("std_fenv_h") {
+}
+
+libcxx_module("std_float_h") {
+}
+
+libcxx_module("std_inttypes_h") {
+}
+
+libcxx_module("std_uchar_h") {
+}
+
+libcxx_module("std_private_mbstate_t") {
+}
+
+libcxx_module("std_math_h") {
+  deps = [ ":std_core" ]
+}
+
+libcxx_module("std_string_h") {
+}
+
+libcxx_module("std") {
+  deps = [
+    ":std_core",
+    ":std_ctype_h",
+    ":std_errno_h",
+    ":std_fenv_h",
+    ":std_float_h",
+    ":std_inttypes_h",
+    ":std_math_h",
+    ":std_private_mbstate_t",
+    ":std_string_h",
+    ":std_uchar_h",
+    ":std_wctype_h",
+  ]
+}
+
+libcxx_module("std_wctype_h") {
+  deps = [
+    ":std_core",
+    ":std_ctype_h",
+  ]
+}
+
 group("include") {
   deps = [ ":copy_headers($default_toolchain)" ]
-  public_configs = [ ":include_config" ]
+  public_configs = [
+    ":include_config",
+    ":module_config",
+  ]
 }

--- a/llvm/utils/gn/secondary/libcxx/include/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxx/include/BUILD.gn
@@ -2148,8 +2148,8 @@ libcxx_module("std_wctype_h") {
 
 group("include") {
   deps = [ ":copy_headers($default_toolchain)" ]
-  public_configs = [
-    ":include_config",
-    ":module_config",
-  ]
+  public_configs = [ ":include_config" ]
+  if (libcxx_enable_explicit_modules) {
+    public_configs += [ ":module_config" ]
+  }
 }

--- a/llvm/utils/gn/secondary/libcxx/src/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxx/src/BUILD.gn
@@ -249,6 +249,7 @@ if (libcxx_enable_shared) {
       "//compiler-rt/lib/builtins",
       "//libc:common_utils",
       "//libcxx/include",
+      "//libcxx/include:std",
       "//libcxxabi/src:cxxabi_shared",
       "//libunwind/src:unwind_shared",
     ]
@@ -301,6 +302,7 @@ if (libcxx_enable_static) {
       "//compiler-rt/lib/builtins",
       "//libc:common_utils",
       "//libcxx/include",
+      "//libcxx/include:std",
       "//libcxxabi/src:cxxabi_static",
       "//libunwind/src:unwind_static",
     ]
@@ -331,7 +333,10 @@ if (libcxx_enable_experimental) {
         "experimental/tzdb_list.cpp",
       ]
     }
-    deps = [ "//libcxx/include" ]
+    deps = [
+      "//libcxx/include",
+      "//libcxx/include:std",
+    ]
     configs += [ ":cxx_config" ]
     configs -= [
       "//llvm/utils/gn/build:no_exceptions",

--- a/llvm/utils/gn/secondary/libcxxabi/src/BUILD.gn
+++ b/llvm/utils/gn/secondary/libcxxabi/src/BUILD.gn
@@ -95,6 +95,7 @@ if (libcxxabi_enable_shared) {
     deps = [
       "//compiler-rt/lib/builtins",
       "//libcxx/include",
+      "//libcxx/include:std",
       "//libunwind/src:unwind_shared",
     ]
     configs += [ ":cxxabi_config" ]
@@ -126,6 +127,7 @@ if (libcxxabi_enable_static) {
     deps = [
       "//compiler-rt/lib/builtins",
       "//libcxx/include",
+      "//libcxx/include:std",
       "//libunwind/src:unwind_static",
     ]
     configs += [ ":cxxabi_config" ]


### PR DESCRIPTION
This is to enable Clang's header modules build for libc++ instead of C++20's modules.

Currently, there are many errors due to missing includes when chromium tries to use explicit Clang modules build. e.g.
https://ci.chromium.org/ui/p/chromium/builders/ci/linux-modules-compile-fyi-rel/5368/overview

To find and fix them easily, I'd like to have GN args enabling explicit Clang modules build for libc++ in this repository too.

Some more context is in https://crbug.com/40263312.