### PR TITLE
[clang-format] Improve function pointer CastRParen detection.

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -2925,7 +2925,7 @@ private:
       Prev = Prev->Previous;
       if (!Prev || Prev->isNot(tok::r_paren))
         return false;
-      const auto* PrevMatchingParen = Prev->MatchingParen;
+      const auto *PrevMatchingParen = Prev->MatchingParen;
       if (!PrevMatchingParen)
         return false;
 

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -874,8 +874,8 @@ TEST_F(TokenAnnotatorTest, UnderstandsCasts) {
   EXPECT_TOKEN(Tokens[14], tok::r_paren, TT_CastRParen);
   EXPECT_TOKEN(Tokens[15], tok::amp, TT_UnaryOperator);
 
-  Tokens = annotate("func((foo(bar::*)(void))&a);");
-  ASSERT_EQ(Tokens.size(), 18u) << Tokens;
+  Tokens = annotate("func((foo(bar::*)(void))&bar::a);");
+  ASSERT_EQ(Tokens.size(), 20u) << Tokens;
   EXPECT_TOKEN(Tokens[12], tok::r_paren, TT_CastRParen);
   EXPECT_TOKEN(Tokens[13], tok::amp, TT_UnaryOperator);
 

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -874,6 +874,11 @@ TEST_F(TokenAnnotatorTest, UnderstandsCasts) {
   EXPECT_TOKEN(Tokens[14], tok::r_paren, TT_CastRParen);
   EXPECT_TOKEN(Tokens[15], tok::amp, TT_UnaryOperator);
 
+  Tokens = annotate("func((foo(bar::*)(void))&a);");
+  ASSERT_EQ(Tokens.size(), 18u) << Tokens;
+  EXPECT_TOKEN(Tokens[12], tok::r_paren, TT_CastRParen);
+  EXPECT_TOKEN(Tokens[13], tok::amp, TT_UnaryOperator);
+
   auto Style = getLLVMStyle();
   Style.TypeNames.push_back("Foo");
   Tokens = annotate("#define FOO(bar) foo((Foo)&bar)", Style);


### PR DESCRIPTION
Fixes #125012