### PR TITLE
[LLDB][LoongArch] Fix build errors about NT_LOONGARCH_HW_{BREAK,WATCH}

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp
@@ -27,13 +27,24 @@
 // struct iovec definition
 #include <sys/uio.h>
 
+// LoongArch SIMD eXtension registers
 #ifndef NT_LOONGARCH_LSX
-#define NT_LOONGARCH_LSX 0xa02 /* LoongArch SIMD eXtension registers */
+#define NT_LOONGARCH_LSX 0xa02
 #endif
 
+// LoongArch Advanced SIMD eXtension registers
 #ifndef NT_LOONGARCH_LASX
-#define NT_LOONGARCH_LASX                                                      \
-  0xa03 /* LoongArch Advanced SIMD eXtension registers */
+#define NT_LOONGARCH_LASX 0xa03
+#endif
+
+// LoongArch hardware breakpoint registers
+#ifndef NT_LOONGARCH_HW_BREAK
+#define NT_LOONGARCH_HW_BREAK 0xa05
+#endif
+
+// LoongArch hardware watchpoint registers
+#ifndef NT_LOONGARCH_HW_WATCH
+#define NT_LOONGARCH_HW_WATCH 0xa06
 #endif
 
 #define REG_CONTEXT_SIZE                                                       \


### PR DESCRIPTION
On some OS distros such as LoongArch Fedora 38 mate-5 [1], there are
no macro definitions NT_LOONGARCH_HW_BREAK and NT_LOONGARCH_HW_WATCH
in the system header, then there exist some errors when building LLDB
on LoongArch.

(1) Description of Problem:

```
llvm-project/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp:529:16:
error: 'NT_LOONGARCH_HW_WATCH' was not declared in this scope; did you mean 'NT_LOONGARCH_LBT'?
  529 |   int regset = NT_LOONGARCH_HW_WATCH;
      |                ^~~~~~~~~~~~~~~~~~~~~
      |                NT_LOONGARCH_LBT
llvm-project/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_loongarch64.cpp:543:12:
error: 'NT_LOONGARCH_HW_BREAK' was not declared in this scope; did you mean 'NT_LOONGARCH_CSR'?
  543 |   regset = NT_LOONGARCH_HW_BREAK;
      |            ^~~~~~~~~~~~~~~~~~~~~
      |            NT_LOONGARCH_CSR
```

(2) Steps to Reproduce:

```
git clone https://github.com/llvm/llvm-project.git
mkdir -p llvm-project/llvm/build && cd llvm-project/llvm/build
cmake .. -G "Ninja" \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_BUILD_RUNTIME=OFF \
         -DLLVM_ENABLE_PROJECTS="clang;lldb" \
         -DCMAKE_INSTALL_PREFIX=/usr/local/llvm \
         -DLLVM_TARGETS_TO_BUILD="LoongArch" \
         -DLLVM_HOST_TRIPLE=loongarch64-redhat-linux
ninja
```

(3) Additional Info:

Maybe there are no problems on the OS distros with newer glibc devel
library, so this issue is related with OS distros.

(4) Root Cause Analysis:

This is because the related Linux kernel commit [2] was merged in
2023-02-25 and the glibc devel library has some delay with kernel,
the glibc version of specified OS distros is not updated in time.

(5) Final Solution:

One way is to ask the maintainer of OS distros to update glibc devel
library, but it is better to not depend on the glibc version.

In order to avoid the build errors, just define NT_LOONGARCH_HW_BREAK
and NT_LOONGARCH_HW_WATCH in LLDB if there are no these definitions in
the system header.

By the way, in order to fit within 80 columns, use C++-style comments
for the new added NT_LOONGARCH_HW_BREAK and NT_LOONGARCH_HW_WATCH.

While at it, for consistency, just modify the current NT_LOONGARCH_LSX
and NT_LOONGARCH_LASX to C++-style comments too.

[1] https://mirrors.wsyu.edu.cn/fedora/linux/development/rawhide/Everything/loongarch64/iso/livecd-fedora-mate-5.loongarch64.iso
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1a69f7a161a7

Signed-off-by: Tiezhu Yang \<yangtiezhu@loongson.cn\>