### PR TITLE
[flang] Use clang_target_link_libraries() for clang dependency

### DIFF
--- a/flang/unittests/Frontend/CMakeLists.txt
+++ b/flang/unittests/Frontend/CMakeLists.txt
@@ -12,7 +12,6 @@ add_flang_unittest(FlangFrontendTests
 
 target_link_libraries(FlangFrontendTests
   PRIVATE
-  clangBasic
   flangFrontend
   flangFrontendTool
   FortranLower
@@ -20,6 +19,11 @@ target_link_libraries(FlangFrontendTests
   FortranSemantics
   FortranCommon
   FortranEvaluate
+)
+
+clang_target_link_libraries(FlangFrontendTests
+  PRIVATE
+  clangBasic
 )
 
 mlir_target_link_libraries(FlangFrontendTests


### PR DESCRIPTION
This dependency is part of libclang-cpp, so it should use clang_target_link_libraries.