### PR TITLE
[llvm][AsmWriter] Don't skip zero-valued DwarfEnum MDField when ShouldSkipZero is not set

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2004,7 +2004,7 @@ void MDFieldPrinter::printNameTableKind(StringRef Name,
 template <class IntTy, class Stringifier>
 void MDFieldPrinter::printDwarfEnum(StringRef Name, IntTy Value,
                                     Stringifier toString, bool ShouldSkipZero) {
-  if (!Value)
+  if (ShouldSkipZero && !Value)
     return;
 
   Out << FS << Name << ": ";


### PR DESCRIPTION
I ran into this while working on a different patch where I'm emitting a zero-valued DWARF enum field which shouldn't be skipped.

This patch checks the (currently unused) `ShouldSkipZero` before deciding to skip printing this field. Based on git history this seems like an oversight from the initial refactor that introduced this. We have a similar check in `printInt`.

Wasn't sure how to best test this, but tests in an upcoming patch rely on this functionality (see https://github.com/llvm/llvm-project/pull/126045).

Currently the only place `ShouldSkipZero` is set to `false` is when emitting the `DW_LANG_` enum. But the language codes start at `0x1`. So it never exercised this codepath (and we should probably just make it not pass this parameter).