### PR TITLE
[lldb][Breakpoint] Allow whitespace in breakpoint address expression

### DIFF
--- a/lldb/source/Interpreter/OptionArgParser.cpp
+++ b/lldb/source/Interpreter/OptionArgParser.cpp
@@ -262,8 +262,10 @@ OptionArgParser::DoToAddress(const ExecutionContext *exe_ctx, llvm::StringRef s,
   // 3: The symbol/reg name if there is an offset
   // 4: +/-
   // 5: The offset value.
+  // clang-format off
   static RegularExpression g_symbol_plus_offset_regex(
-      "^(\\$[^ +-]+)|(([^ +-]+)([-\\+])[[:space:]]*(0x[0-9A-Fa-f]+|[0-9]+)[[:space:]]*)$");
+      "^(\\$[^ +-]+)|(([^ +-]+)[[:space:]]*([-\\+])[[:space:]]*(0x[0-9A-Fa-f]+|[0-9]+)[[:space:]]*)$");
+  // clang-format on
 
   llvm::SmallVector<llvm::StringRef, 4> matches;
   if (g_symbol_plus_offset_regex.Execute(sref, &matches)) {

--- a/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
+++ b/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
@@ -1,3 +1,12 @@
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
+# RUN: %lldb -b -o 'breakpoint set -a "main+26"' %t.out | FileCheck %s --check-prefix CHECK
+# RUN: %lldb -b -o 'breakpoint set -a "main+ 26"' %t.out | FileCheck %s --check-prefix CHECK
+# RUN: %lldb -b -o 'breakpoint set -a "main +26"' %t.out | FileCheck %s --check-prefix CHECK
+# RUN: %lldb -b -o 'breakpoint set -a "main + 26"' %t.out | FileCheck %s --check-prefix CHECK
 # RUN: %lldb -b -o 'breakpoint set -a "main  +    26"' %t.out | FileCheck %s --check-prefix CHECK
+
 # CHECK: Breakpoint 1: address = 
+# CHECK: Breakpoint 2: address = 
+# CHECK: Breakpoint 3: address = 
+# CHECK: Breakpoint 4: address = 
+# CHECK: Breakpoint 5: address = 

--- a/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
+++ b/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
@@ -1,9 +1,9 @@
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
-# RUN: %lldb -b -o 'breakpoint set -a "main+26"' %t.out | FileCheck %s --check-prefix CHECK
-# RUN: %lldb -b -o 'breakpoint set -a "main+ 26"' %t.out | FileCheck %s --check-prefix CHECK
-# RUN: %lldb -b -o 'breakpoint set -a "main +26"' %t.out | FileCheck %s --check-prefix CHECK
-# RUN: %lldb -b -o 'breakpoint set -a "main + 26"' %t.out | FileCheck %s --check-prefix CHECK
-# RUN: %lldb -b -o 'breakpoint set -a "main  +    26"' %t.out | FileCheck %s --check-prefix CHECK
+# RUN: %lldb -b -o 'breakpoint set -a "main+26"' \
+# RUN:          -o 'breakpoint set -a "main+ 26"' \
+# RUN:          -o 'breakpoint set -a "main +26"' \
+# RUN:          -o 'breakpoint set -a "main + 26"' \
+# RUN:          -o 'breakpoint set -a "main  +    26"' %t.out | FileCheck %s
 
 # CHECK: Breakpoint 1: address = 
 # CHECK: Breakpoint 2: address = 

--- a/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
+++ b/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
@@ -1,9 +1,11 @@
 # RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
-# RUN: %lldb -b -o 'breakpoint set -a "main+26"' \
-# RUN:          -o 'breakpoint set -a "main+ 26"' \
-# RUN:          -o 'breakpoint set -a "main +26"' \
-# RUN:          -o 'breakpoint set -a "main + 26"' \
-# RUN:          -o 'breakpoint set -a "main  +    26"' %t.out | FileCheck %s
+# RUN: %lldb %t.out -b -s %s | FileCheck %s
+
+breakpoint set -a "main+26"
+breakpoint set -a "main+ 26"
+breakpoint set -a "main +26"
+breakpoint set -a "main + 26"
+breakpoint set -a "main  +    26"
 
 # CHECK: Breakpoint 1: address = 
 # CHECK: Breakpoint 2: address = 

--- a/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
+++ b/lldb/test/Shell/Commands/command-breakpoint-by-addr.test
@@ -1,0 +1,3 @@
+# RUN: %clang_host -g -O0 %S/Inputs/main.c -o %t.out
+# RUN: %lldb -b -o 'breakpoint set -a "main  +    26"' %t.out | FileCheck %s --check-prefix CHECK
+# CHECK: Breakpoint 1: address = 


### PR DESCRIPTION
Setting a breakpoint on `<symbol> + <offset>` used to work until `2c76e88e9eb284d17cf409851fb01f1d583bb22a`, where this regex was reworked. Now we only accept `<symbol>+ <offset>` or `<symbol>+<offset>`.

This patch fixes the regression by adding yet another `[[:space:]]*` component to the regex.

One could probably simplify the regex (or even replace the regex by just calling the relevent `consumeXXX` APIs on `llvm::StringRef`). Though I left that for the future.

rdar://130780342