### PR TITLE
[libc++][NFC] Remove __default_allocator_type aliases

### DIFF
--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -84,9 +84,6 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Allocator /* = allocator<_Tp> */>
 class _LIBCPP_TEMPLATE_VIS vector {
-private:
-  typedef allocator<_Tp> __default_allocator_type;
-
 public:
   //
   // Types

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -763,9 +763,6 @@ struct __padding<0> {};
 
 template <class _CharT, class _Traits, class _Allocator>
 class basic_string {
-private:
-  using __default_allocator_type _LIBCPP_NODEBUG = allocator<_CharT>;
-
 public:
   typedef basic_string __self;
   typedef basic_string_view<_CharT, _Traits> __self_view;


### PR DESCRIPTION
These aliases are never used, so we can ditch them.
