### PR TITLE
[object][WebAssembly] Add support for RUNTIME_PATH to yaml2obj and obj2yaml

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -295,7 +295,7 @@ struct WasmDylinkInfo {
   std::vector<StringRef> Needed; // Shared library dependencies
   std::vector<WasmDylinkImportInfo> ImportInfo;
   std::vector<WasmDylinkExportInfo> ExportInfo;
-  StringRef RuntimePath;
+  std::vector<StringRef> RuntimePath;
 };
 
 struct WasmProducerInfo {

--- a/llvm/include/llvm/BinaryFormat/Wasm.h
+++ b/llvm/include/llvm/BinaryFormat/Wasm.h
@@ -201,6 +201,7 @@ enum : unsigned {
   WASM_DYLINK_NEEDED = 0x2,
   WASM_DYLINK_EXPORT_INFO = 0x3,
   WASM_DYLINK_IMPORT_INFO = 0x4,
+  WASM_DYLINK_RUNTIME_PATH = 0x5,
 };
 
 // Kind codes used in the custom "linking" section in the WASM_COMDAT_INFO
@@ -294,6 +295,7 @@ struct WasmDylinkInfo {
   std::vector<StringRef> Needed; // Shared library dependencies
   std::vector<WasmDylinkImportInfo> ImportInfo;
   std::vector<WasmDylinkExportInfo> ExportInfo;
+  StringRef RuntimePath;
 };
 
 struct WasmProducerInfo {

--- a/llvm/include/llvm/ObjectYAML/WasmYAML.h
+++ b/llvm/include/llvm/ObjectYAML/WasmYAML.h
@@ -230,7 +230,7 @@ struct DylinkSection : CustomSection {
   std::vector<StringRef> Needed;
   std::vector<DylinkImportInfo> ImportInfo;
   std::vector<DylinkExportInfo> ExportInfo;
-  StringRef RuntimePath;
+  std::vector<StringRef> RuntimePath;
 };
 
 struct NameSection : CustomSection {

--- a/llvm/include/llvm/ObjectYAML/WasmYAML.h
+++ b/llvm/include/llvm/ObjectYAML/WasmYAML.h
@@ -230,6 +230,7 @@ struct DylinkSection : CustomSection {
   std::vector<StringRef> Needed;
   std::vector<DylinkImportInfo> ImportInfo;
   std::vector<DylinkExportInfo> ExportInfo;
+  StringRef RuntimePath;
 };
 
 struct NameSection : CustomSection {

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -485,7 +485,10 @@ Error WasmObjectFile::parseDylink0Section(ReadContext &Ctx) {
       break;
     }
     case wasm::WASM_DYLINK_RUNTIME_PATH: {
-      DylinkInfo.RuntimePath = readString(Ctx);
+      Count = readVaruint32(Ctx);
+      while (Count--) {
+        DylinkInfo.RuntimePath.push_back(readString(Ctx));
+      }
       break;
     }
     default:

--- a/llvm/lib/Object/WasmObjectFile.cpp
+++ b/llvm/lib/Object/WasmObjectFile.cpp
@@ -484,6 +484,10 @@ Error WasmObjectFile::parseDylink0Section(ReadContext &Ctx) {
       }
       break;
     }
+    case wasm::WASM_DYLINK_RUNTIME_PATH: {
+      DylinkInfo.RuntimePath = readString(Ctx);
+      break;
+    }
     default:
       LLVM_DEBUG(dbgs() << "unknown dylink.0 sub-section: " << Type << "\n");
       Ctx.Ptr += Size;

--- a/llvm/lib/ObjectYAML/WasmEmitter.cpp
+++ b/llvm/lib/ObjectYAML/WasmEmitter.cpp
@@ -180,6 +180,12 @@ void WasmWriter::writeSectionContent(raw_ostream &OS,
       writeStringRef(Needed, SubOS);
     SubSection.done();
   }
+  if (Section.RuntimePath.size()) {
+    writeUint8(OS, wasm::WASM_DYLINK_RUNTIME_PATH);
+    raw_ostream &SubOS = SubSection.getStream();
+    writeStringRef(Section.RuntimePath, SubOS);
+    SubSection.done();
+  }
 }
 
 void WasmWriter::writeSectionContent(raw_ostream &OS,

--- a/llvm/lib/ObjectYAML/WasmEmitter.cpp
+++ b/llvm/lib/ObjectYAML/WasmEmitter.cpp
@@ -183,7 +183,9 @@ void WasmWriter::writeSectionContent(raw_ostream &OS,
   if (Section.RuntimePath.size()) {
     writeUint8(OS, wasm::WASM_DYLINK_RUNTIME_PATH);
     raw_ostream &SubOS = SubSection.getStream();
-    writeStringRef(Section.RuntimePath, SubOS);
+    encodeULEB128(Section.RuntimePath.size(), SubOS);
+    for (StringRef Path : Section.RuntimePath)
+      writeStringRef(Path, SubOS);
     SubSection.done();
   }
 }

--- a/llvm/lib/ObjectYAML/WasmYAML.cpp
+++ b/llvm/lib/ObjectYAML/WasmYAML.cpp
@@ -59,6 +59,7 @@ static void sectionMapping(IO &IO, WasmYAML::DylinkSection &Section) {
   IO.mapRequired("Needed", Section.Needed);
   IO.mapOptional("ImportInfo", Section.ImportInfo);
   IO.mapOptional("ExportInfo", Section.ExportInfo);
+  IO.mapOptional("RuntimePath", Section.RuntimePath);
 }
 
 static void sectionMapping(IO &IO, WasmYAML::NameSection &Section) {

--- a/llvm/test/ObjectYAML/wasm/dylink_section.yaml
+++ b/llvm/test/ObjectYAML/wasm/dylink_section.yaml
@@ -11,7 +11,7 @@ Sections:
     TableSize:       1
     TableAlignment:  0
     Needed:          [ libfoo.so, libbar.so ]
-    RuntimePath: $ORIGIN/../lib:$ORIGIN/../../.libs
+    RuntimePath: [ $ORIGIN/../lib, $ORIGIN/../../.libs]
 ...
 # CHECK: --- !WASM
 # CHECK: FileHeader:
@@ -26,5 +26,7 @@ Sections:
 # CHECK:     Needed:
 # CHECK:       - libfoo.so
 # CHECK:       - libbar.so
-# CHECK:     RuntimePath: '$ORIGIN/../lib:$ORIGIN/../../.libs'
+# CHECK:     RuntimePath:
+# CHECK:      - '$ORIGIN/../lib'
+# CHECK:      - '$ORIGIN/../../.libs'
 # CHECK: ...

--- a/llvm/test/ObjectYAML/wasm/dylink_section.yaml
+++ b/llvm/test/ObjectYAML/wasm/dylink_section.yaml
@@ -11,6 +11,7 @@ Sections:
     TableSize:       1
     TableAlignment:  0
     Needed:          [ libfoo.so, libbar.so ]
+    RuntimePath: $ORIGIN/../lib:$ORIGIN/../../.libs
 ...
 # CHECK: --- !WASM
 # CHECK: FileHeader:
@@ -25,4 +26,5 @@ Sections:
 # CHECK:     Needed:
 # CHECK:       - libfoo.so
 # CHECK:       - libbar.so
+# CHECK:     RuntimePath: '$ORIGIN/../lib:$ORIGIN/../../.libs'
 # CHECK: ...

--- a/llvm/tools/obj2yaml/wasm2yaml.cpp
+++ b/llvm/tools/obj2yaml/wasm2yaml.cpp
@@ -61,6 +61,7 @@ WasmDumper::dumpCustomSection(const WasmSection &WasmSec) {
     DylinkSec->TableSize = Info.TableSize;
     DylinkSec->TableAlignment = Info.TableAlignment;
     DylinkSec->Needed = Info.Needed;
+    DylinkSec->RuntimePath = Info.RuntimePath;
     for (const auto &Imp : Info.ImportInfo)
       DylinkSec->ImportInfo.push_back({Imp.Module, Imp.Field, Imp.Flags});
     for (const auto &Exp : Info.ExportInfo)


### PR DESCRIPTION
This is the first step of adding RPATH support for wasm. See corresponding update to the WebAssembly/tool-conventions repo on dynamic linking:
https://github.com/WebAssembly/tool-conventions/pull/246

cc @sbc100 @ryanking13