### PR TITLE
[NFC][StructurizeCFG] Add a test that can crash StructurizeCFG pass

### DIFF
--- a/llvm/test/Transforms/StructurizeCFG/simple-structurizecfg-crash.ll
+++ b/llvm/test/Transforms/StructurizeCFG/simple-structurizecfg-crash.ll
@@ -1,0 +1,19 @@
+; RUN: opt -S -passes=structurizecfg %s -o -
+; XFAIL: *
+
+; Issue tracking: https://github.com/llvm/llvm-project/issues/126534.
+; FIXME: This test is expected to crash. Generate checklines after the crash is fixed.
+
+define void @foo() {
+entry:
+  br i1 false, label %cond.true, label %cond.false
+
+cond.true:                                        ; preds = %entry
+  br label %cond.end
+
+cond.false:                                       ; preds = %entry
+  br label %cond.end
+
+cond.end:                                         ; preds = %cond.false, %cond.true
+  ret void
+}


### PR DESCRIPTION
I tried to fix it in #124051 but failed to do so. This PR adds the test and
marks it as xfail.