### PR TITLE
[LLVM][SelectionDAGBuilder] Add initial DAG for target("aarch64.svcount") constants to the node cache.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1893,8 +1893,9 @@ SDValue SelectionDAGBuilder::getValueImpl(const Value *V) {
 
     if (VT == MVT::aarch64svcount) {
       assert(C->isNullValue() && "Can only zero this target type!");
-      return DAG.getNode(ISD::BITCAST, getCurSDLoc(), VT,
-                         DAG.getConstant(0, getCurSDLoc(), MVT::nxv16i1));
+      return NodeMap[V] =
+                 DAG.getNode(ISD::BITCAST, getCurSDLoc(), VT,
+                             DAG.getConstant(0, getCurSDLoc(), MVT::nxv16i1));
     }
 
     if (VT.isRISCVVectorTuple()) {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/126089 forgot to update `NodeMap` when building the initial DAG, which could result in duplicate identical nodes.