### PR TITLE
[analyzer][NFC] Remove "V2" from ArrayBoundCheckerV2.cpp

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
@@ -1,4 +1,4 @@
-//== ArrayBoundCheckerV2.cpp ------------------------------------*- C++ -*--==//
+//== ArrayBoundChecker.cpp --------------------------------------*- C++ -*--==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,12 +10,6 @@
 // that looks for out of bounds access of memory regions.
 //
 //===----------------------------------------------------------------------===//
-
-// NOTE: The name of this file ends with "V2" because previously
-// "ArrayBoundChecker.cpp" contained the implementation of another (older and
-// simpler) checker that was called `alpha.security.ArrayBound`.
-// TODO: Rename this file to "ArrayBoundChecker.cpp" when it won't be confused
-// with that older file.
 
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/ParentMapContext.h"

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
@@ -1,4 +1,4 @@
-//== ArrayBoundChecker.cpp --------------------------------------*- C++ -*--==//
+//== ArrayBoundChecker.cpp -------------------------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
@@ -291,7 +291,8 @@ static std::pair<ProgramStateRef, ProgramStateRef>
 compareValueToThreshold(ProgramStateRef State, NonLoc Value, NonLoc Threshold,
                         SValBuilder &SVB, bool CheckEquality = false) {
   if (auto ConcreteThreshold = Threshold.getAs<nonloc::ConcreteInt>()) {
-    std::tie(Value, Threshold) = getSimplifiedOffsets(Value, *ConcreteThreshold, SVB);
+    std::tie(Value, Threshold) =
+        getSimplifiedOffsets(Value, *ConcreteThreshold, SVB);
   }
 
   // We want to perform a _mathematical_ comparison between the numbers `Value`

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LLVM_LINK_COMPONENTS
 add_clang_library(clangStaticAnalyzerCheckers
   AnalysisOrderChecker.cpp
   AnalyzerStatsChecker.cpp
-  ArrayBoundCheckerV2.cpp
+  ArrayBoundChecker.cpp
   BasicObjCFoundationChecks.cpp
   BitwiseShiftChecker.cpp
   BlockInCriticalSectionChecker.cpp

--- a/llvm/utils/gn/secondary/clang/lib/StaticAnalyzer/Checkers/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/lib/StaticAnalyzer/Checkers/BUILD.gn
@@ -16,7 +16,7 @@ static_library("Checkers") {
   sources = [
     "AnalysisOrderChecker.cpp",
     "AnalyzerStatsChecker.cpp",
-    "ArrayBoundCheckerV2.cpp",
+    "ArrayBoundChecker.cpp",
     "BasicObjCFoundationChecks.cpp",
     "BitwiseShiftChecker.cpp",
     "BlockInCriticalSectionChecker.cpp",


### PR DESCRIPTION
Previously commit 6e17ed9b04e5523cc910bf171c3122dcc64b86db deleted the obsolete checker `alpha.security.ArrayBound` which was implemented in `ArrayBoundChecker.cpp` and renamed the checker `alpha.security.ArrayBoundV2` to `security.ArrayBound`.

This commit concludes that consolidation by renaming the source file `ArrayBoundCheckerV2.cpp` to `ArrayBoundChecker.cpp` (which was "freed up" by the previous commit).