### PR TITLE
[Clang] Only allow `clang` arguments to `-Xarch`

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1651,7 +1651,8 @@ void ToolChain::TranslateXarchArgs(
   const InputArgList &BaseArgs = Args.getBaseArgs();
   unsigned Index = BaseArgs.MakeIndex(A->getValue(ValuePos));
   unsigned Prev = Index;
-  std::unique_ptr<llvm::opt::Arg> XarchArg(Opts.ParseOneArg(Args, Index));
+  std::unique_ptr<llvm::opt::Arg> XarchArg(Opts.ParseOneArg(
+      Args, Index, llvm::opt::Visibility(clang::driver::options::ClangOption)));
 
   // If the argument parsing failed or more than one argument was
   // consumed, the -Xarch_ argument's parameter tried to consume

--- a/clang/test/Driver/Xarch.c
+++ b/clang/test/Driver/Xarch.c
@@ -18,3 +18,7 @@
 
 // RUN: %clang -target x86_64-unknown-linux-gnu -Xarch_x86_64 -Wl,foo %s -### 2>&1 | FileCheck -check-prefix=LINKER %s
 // LINKER: "foo"
+
+// RUN: %clang -target x86_64-unknown-linux-gnu -Xarch_x86_64 -O1 %s -S -### 2>&1 | FileCheck -check-prefix=O1ONCE %s
+// O1ONCE: "-O1"
+// O1ONCE-NOT: "-O1"


### PR DESCRIPTION
Summary:
Currently the `-Xarch` argument needs to re-parse the option, which goes
through every single registered argument. This causes errors when trying
to pass `-O1` through it because it thinks it's a DXC option. This patch
changes the behavior to only allow `clang` options. Concievably we could
detect the driver mode to make this more robust, but I don't know if
there are other users for this.

Fixes: https://github.com/llvm/llvm-project/issues/110325
