### PR TITLE
[clang-linker-wrapper][lit] Temporarily disable OpenMP SPIR-V ELF test

### DIFF
--- a/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
+++ b/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
@@ -1,4 +1,6 @@
 // Verify the ELF packaging of OpenMP SPIR-V device images.
+// FIXME: Re-enable when spirv-tools feature detection fixed
+// UNSUPPORTED: system-linux
 // REQUIRES: system-linux
 // REQUIRES: spirv-tools
 // RUN: mkdir -p %t_tmp


### PR DESCRIPTION
The fix requires more investigation, and it's a test issue so reverting the product changes should not be necessary. 