### PR TITLE
[libc] Disable fixed point printing for baremetal

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -5,6 +5,9 @@
     }
   },
   "printf": {
+    "LIBC_CONF_PRINTF_DISABLE_FIXED_POINT": {
+      "value": true
+    },
     "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
       "value": true
     },


### PR DESCRIPTION
This follows suite with disabling float printing.