### PR TITLE
[OpenMP] Fix misspelled symbol name

### DIFF
--- a/llvm/lib/Transforms/IPO/Internalize.cpp
+++ b/llvm/lib/Transforms/IPO/Internalize.cpp
@@ -235,7 +235,7 @@ bool InternalizePass::internalizeModule(Module &M) {
 
   // Preserve the RPC interface for GPU host callbacks when internalizing.
   if (Triple(M.getTargetTriple()).isNVPTX())
-    AlwaysPreserved.insert("__llvm_rpc_server");
+    AlwaysPreserved.insert("__llvm_rpc_client");
 
   // Mark all functions not in the api as internal.
   IsWasm = Triple(M.getTargetTriple()).isOSBinFormatWasm();


### PR DESCRIPTION
Summary:
This is supposed to be `__llvm_rpc_client` but I screwed it up and
didn't notice at the time. Will need to be backported.
