### PR TITLE
[lldb] Add missing return statements in ThreadMemory

### DIFF
--- a/lldb/source/Plugins/Process/Utility/ThreadMemory.h
+++ b/lldb/source/Plugins/Process/Utility/ThreadMemory.h
@@ -33,7 +33,7 @@ public:
 
   const char *GetInfo() override {
     if (m_backing_thread_sp)
-      m_backing_thread_sp->GetInfo();
+      return m_backing_thread_sp->GetInfo();
     return nullptr;
   }
 
@@ -41,7 +41,7 @@ public:
     if (!m_name.empty())
       return m_name.c_str();
     if (m_backing_thread_sp)
-      m_backing_thread_sp->GetName();
+      return m_backing_thread_sp->GetName();
     return nullptr;
   }
 
@@ -49,7 +49,7 @@ public:
     if (!m_queue.empty())
       return m_queue.c_str();
     if (m_backing_thread_sp)
-      m_backing_thread_sp->GetQueueName();
+      return m_backing_thread_sp->GetQueueName();
     return nullptr;
   }
 

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -160,6 +160,8 @@ class PluginPythonOSPlugin(TestBase):
         )
         self.assertTrue(process, PROCESS_IS_VALID)
 
+        core_thread_zero = process.GetThreadAtIndex(0)
+
         # Make sure there are no OS plug-in created thread when we first stop
         # at our breakpoint in main
         thread = process.GetThreadByID(0x111111111)
@@ -183,6 +185,10 @@ class PluginPythonOSPlugin(TestBase):
             thread.IsValid(),
             "Make sure there is a thread 0x111111111 after we load the python OS plug-in",
         )
+        # This OS plugin does not set thread names / queue names, so it should
+        # inherit the core thread's name.
+        self.assertEqual(core_thread_zero.GetName(), thread.GetName())
+        self.assertEqual(core_thread_zero.GetQueueName(), thread.GetQueueName())
 
         frame = thread.GetFrameAtIndex(0)
         self.assertTrue(


### PR DESCRIPTION
These prevented ThreadMemory from correctly returning the Name/Queue/Info of the backing thread.

Note about testing: this test only finds regressions if the system sets a name or queue for the backing thread. While this may not be true everywhere, it still provides coverage in some systems, e.g. in Apple platforms.