### PR TITLE
[lld] Remove usage of `%T` in `lld/test`

### DIFF
--- a/lld/test/COFF/delayimporttables.yaml
+++ b/lld/test/COFF/delayimporttables.yaml
@@ -1,8 +1,9 @@
 # RUN: yaml2obj %p/Inputs/delayimporttables-dll1.yaml -o %t1.obj
 # RUN: yaml2obj %p/Inputs/delayimporttables-dll2.yaml -o %t2.obj
 # RUN: yaml2obj %s -o %t.obj
-# RUN: lld-link /nodefaultlib /entry:DllMain /out:%T/delayimporttables-dll1.dll /dll /implib:%t-dll1.lib %t1.obj
-# RUN: lld-link /nodefaultlib /entry:DllMain /out:%T/delayimporttables-dll2.dll /dll /implib:%t-dll2.lib %t2.obj
+# RUN: mkdir -p %t.dir
+# RUN: lld-link /nodefaultlib /entry:DllMain /out:%t.dir/delayimporttables-dll1.dll /dll /implib:%t-dll1.lib %t1.obj
+# RUN: lld-link /nodefaultlib /entry:DllMain /out:%t.dir/delayimporttables-dll2.dll /dll /implib:%t-dll2.lib %t2.obj
 # RUN: lld-link /nodefaultlib /entry:main /out:%t.exe /delayload:delayimporttables-dll1.dll /delayload:delayimporttables-dll2.dll %t.obj %t-dll1.lib %t-dll2.lib
 # RUN: llvm-readobj --coff-imports %t.exe |FileCheck %s
 

--- a/lld/test/COFF/export-all.s
+++ b/lld/test/COFF/export-all.s
@@ -81,14 +81,14 @@ __imp__unexported:
 
 # RUN: echo -e ".global foobar\n.global DllMainCRTStartup\n.text\nDllMainCRTStartup:\nret\nfoobar:\ncall mingwfunc\ncall crtfunc\nret\n" > %t.main.s
 # RUN: llvm-mc -triple=x86_64-windows-gnu %t.main.s -filetype=obj -o %t.main.obj
-# RUN: mkdir -p %T/libs
-# RUN: echo -e ".global mingwfunc\n.text\nmingwfunc:\nret\n" > %T/libs/mingwfunc.s
-# RUN: llvm-mc -triple=x86_64-windows-gnu %T/libs/mingwfunc.s -filetype=obj -o %T/libs/mingwfunc.o
-# RUN: rm -f %T/libs/libmingwex.a
-# RUN: llvm-ar rcs %T/libs/libmingwex.a %T/libs/mingwfunc.o
-# RUN: echo -e ".global crtfunc\n.text\ncrtfunc:\nret\n" > %T/libs/crtfunc.s
-# RUN: llvm-mc -triple=x86_64-windows-gnu %T/libs/crtfunc.s -filetype=obj -o %T/libs/crt2.o
-# RUN: lld-link -safeseh:no -out:%t.dll -dll -entry:DllMainCRTStartup %t.main.obj -lldmingw %T/libs/crt2.o %T/libs/libmingwex.a -output-def:%t.def
+# RUN: mkdir -p %t.dir/libs
+# RUN: echo -e ".global mingwfunc\n.text\nmingwfunc:\nret\n" > %t.dir/libs/mingwfunc.s
+# RUN: llvm-mc -triple=x86_64-windows-gnu %t.dir/libs/mingwfunc.s -filetype=obj -o %t.dir/libs/mingwfunc.o
+# RUN: rm -f %t.dir/libs/libmingwex.a
+# RUN: llvm-ar rcs %t.dir/libs/libmingwex.a %t.dir/libs/mingwfunc.o
+# RUN: echo -e ".global crtfunc\n.text\ncrtfunc:\nret\n" > %t.dir/libs/crtfunc.s
+# RUN: llvm-mc -triple=x86_64-windows-gnu %t.dir/libs/crtfunc.s -filetype=obj -o %t.dir/libs/crt2.o
+# RUN: lld-link -safeseh:no -out:%t.dll -dll -entry:DllMainCRTStartup %t.main.obj -lldmingw %t.dir/libs/crt2.o %t.dir/libs/libmingwex.a -output-def:%t.def
 # RUN: echo "EOF" >> %t.def
 # RUN: cat %t.def | FileCheck -check-prefix=CHECK-EXCLUDE %s
 
@@ -99,7 +99,7 @@ __imp__unexported:
 # Test that libraries included with -wholearchive: are autoexported, even if
 # they are in a library that otherwise normally would be excluded.
 
-# RUN: lld-link -safeseh:no -out:%t.dll -dll -entry:DllMainCRTStartup %t.main.obj -lldmingw %T/libs/crt2.o -wholearchive:%T/libs/libmingwex.a -output-def:%t.def
+# RUN: lld-link -safeseh:no -out:%t.dll -dll -entry:DllMainCRTStartup %t.main.obj -lldmingw %t.dir/libs/crt2.o -wholearchive:%t.dir/libs/libmingwex.a -output-def:%t.def
 # RUN: echo "EOF" >> %t.def
 # RUN: cat %t.def | FileCheck -check-prefix=CHECK-WHOLEARCHIVE %s
 

--- a/lld/test/COFF/filename-casing.s
+++ b/lld/test/COFF/filename-casing.s
@@ -1,10 +1,11 @@
 # REQUIRES: x86
 
-# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %T/MixedCase.obj %s
-# RUN: not lld-link /entry:main %T/MixedCase.obj 2>&1 | FileCheck -check-prefix=OBJECT %s
+# RUN: mkdir -p %t.dir
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %t.dir/MixedCase.obj %s
+# RUN: not lld-link /entry:main %t.dir/MixedCase.obj 2>&1 | FileCheck -check-prefix=OBJECT %s
 
-# RUN: llvm-lib /out:%T/MixedCase.lib %T/MixedCase.obj
-# RUN: not lld-link /machine:x64 /entry:main %T/MixedCase.lib 2>&1 | FileCheck -check-prefix=ARCHIVE %s
+# RUN: llvm-lib /out:%t.dir/MixedCase.lib %t.dir/MixedCase.obj
+# RUN: not lld-link /machine:x64 /entry:main %t.dir/MixedCase.lib 2>&1 | FileCheck -check-prefix=ARCHIVE %s
 
 # OBJECT: undefined symbol: f
 # OBJECT-NEXT: >>> referenced by {{.*}}MixedCase.obj:(main)

--- a/lld/test/COFF/guardcf-align.s
+++ b/lld/test/COFF/guardcf-align.s
@@ -1,10 +1,11 @@
 # REQUIRES: x86
+# RUN: mkdir -p %t.dir
 # RUN: llvm-mc -triple x86_64-windows-msvc -filetype=obj -o %t.obj %s
 # RUN: yaml2obj %p/Inputs/guardcf-align-foobar.yaml \
-# RUN:     > %T/guardcf-align-foobar.obj
-# RUN: lld-link -out:%T/guardcf-align.exe -entry:main -guard:cf \
-# RUN:     %t.obj %T/guardcf-align-foobar.obj
-# RUN: llvm-readobj --coff-load-config %T/guardcf-align.exe | FileCheck %s
+# RUN:     > %t.dir/guardcf-align-foobar.obj
+# RUN: lld-link -out:%t.dir/guardcf-align.exe -entry:main -guard:cf \
+# RUN:     %t.obj %t.dir/guardcf-align-foobar.obj
+# RUN: llvm-readobj --coff-load-config %t.dir/guardcf-align.exe | FileCheck %s
 
 # Check that the gfids table contains at least one entry that ends in 0
 # and no entries that end in something other than 0.

--- a/lld/test/COFF/implib-name.test
+++ b/lld/test/COFF/implib-name.test
@@ -1,73 +1,73 @@
 # REQUIRES: x86
-# RUN: mkdir -p %T
-# RUN: llvm-mc -triple x86_64-unknown-windows-msvc -filetype obj -o %T/object.obj %S/Inputs/object.s
+# RUN: mkdir -p %t.dir
+# RUN: llvm-mc -triple x86_64-unknown-windows-msvc -filetype obj -o %t.dir/object.obj %S/Inputs/object.s
 
-# RUN: lld-link /dll /machine:x64 /def:%S/Inputs/named.def /out:%T/library.dll %T/object.obj /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/library.lib | FileCheck %s -check-prefix CHECK-DEFAULT-DLL-EXT
+# RUN: lld-link /dll /machine:x64 /def:%S/Inputs/named.def /out:%t.dir/library.dll %t.dir/object.obj /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/library.lib | FileCheck %s -check-prefix CHECK-DEFAULT-DLL-EXT
 
-# RUN: lld-link /machine:x64 /def:%S/Inputs/named.def /out:%T/library.lib
-# RUN: llvm-ar t %T/library.lib | FileCheck %s -check-prefix CHECK-DEFAULT-DLL-EXT
+# RUN: lld-link /machine:x64 /def:%S/Inputs/named.def /out:%t.dir/library.lib
+# RUN: llvm-ar t %t.dir/library.lib | FileCheck %s -check-prefix CHECK-DEFAULT-DLL-EXT
 
 CHECK-DEFAULT-DLL-EXT: library.dll
 CHECK-DEFAULT-DLL-EXT: library.dll
 CHECK-DEFAULT-DLL-EXT: library.dll
 CHECK-DEFAULT-DLL-EXT: library.dll
 
-# RUN: lld-link /machine:x64 /def:%S/Inputs/named.def /out:%T/library.exe %T/object.obj /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/library.lib | FileCheck %s -check-prefix CHECK-DEFAULT-EXE-EXT
+# RUN: lld-link /machine:x64 /def:%S/Inputs/named.def /out:%t.dir/library.exe %t.dir/object.obj /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/library.lib | FileCheck %s -check-prefix CHECK-DEFAULT-EXE-EXT
 
 CHECK-DEFAULT-EXE-EXT: library.exe
 CHECK-DEFAULT-EXE-EXT: library.exe
 CHECK-DEFAULT-EXE-EXT: library.exe
 CHECK-DEFAULT-EXE-EXT: library.exe
 
-# RUN: lld-link /dll /machine:x64 /def:%S/Inputs/extension.def /out:%T/extension.dll /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/extension.lib | FileCheck %s -check-prefix CHECK-EXTENSION
+# RUN: lld-link /dll /machine:x64 /def:%S/Inputs/extension.def /out:%t.dir/extension.dll /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/extension.lib | FileCheck %s -check-prefix CHECK-EXTENSION
 
-# RUN: lld-link /machine:x64 /def:%S/Inputs/extension.def /out:%T/extension.exe /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/extension.lib | FileCheck %s -check-prefix CHECK-EXTENSION
+# RUN: lld-link /machine:x64 /def:%S/Inputs/extension.def /out:%t.dir/extension.exe /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/extension.lib | FileCheck %s -check-prefix CHECK-EXTENSION
 
-# RUN: lld-link /machine:x64 /def:%S/Inputs/extension.def /out:%T/extension.lib
-# RUN: llvm-ar t %T/extension.lib | FileCheck %s -check-prefix CHECK-EXTENSION
+# RUN: lld-link /machine:x64 /def:%S/Inputs/extension.def /out:%t.dir/extension.lib
+# RUN: llvm-ar t %t.dir/extension.lib | FileCheck %s -check-prefix CHECK-EXTENSION
 
 CHECK-EXTENSION: library.ext
 CHECK-EXTENSION: library.ext
 CHECK-EXTENSION: library.ext
 CHECK-EXTENSION: library.ext
 
-# RUN: lld-link /dll /machine:x64 /def:%S/Inputs/default.def /out:%T/default.dll /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/default.lib | FileCheck %s -check-prefix CHECK-OUTPUT-NAME-DLL
+# RUN: lld-link /dll /machine:x64 /def:%S/Inputs/default.def /out:%t.dir/default.dll /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/default.lib | FileCheck %s -check-prefix CHECK-OUTPUT-NAME-DLL
 
-# RUN: lld-link /machine:x64 /def:%S/Inputs/default.def /out:%T/default.lib
-# RUN: llvm-ar t %T/default.lib | FileCheck %s -check-prefix CHECK-OUTPUT-NAME-DLL
+# RUN: lld-link /machine:x64 /def:%S/Inputs/default.def /out:%t.dir/default.lib
+# RUN: llvm-ar t %t.dir/default.lib | FileCheck %s -check-prefix CHECK-OUTPUT-NAME-DLL
 
 CHECK-OUTPUT-NAME-DLL: default.dll
 CHECK-OUTPUT-NAME-DLL: default.dll
 CHECK-OUTPUT-NAME-DLL: default.dll
 CHECK-OUTPUT-NAME-DLL: default.dll
 
-# RUN: lld-link /machine:x64 /def:%S/Inputs/default.def /out:%T/default.exe %T/object.obj /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/default.lib | FileCheck %s -check-prefix CHECK-OUTPUT-NAME-EXE
+# RUN: lld-link /machine:x64 /def:%S/Inputs/default.def /out:%t.dir/default.exe %t.dir/object.obj /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/default.lib | FileCheck %s -check-prefix CHECK-OUTPUT-NAME-EXE
 
 CHECK-OUTPUT-NAME-EXE: default.exe
 CHECK-OUTPUT-NAME-EXE: default.exe
 CHECK-OUTPUT-NAME-EXE: default.exe
 CHECK-OUTPUT-NAME-EXE: default.exe
 
-# RUN: lld-link /machine:x64 /out:%T/default.exe %T/object.obj /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/default.lib | FileCheck %s -check-prefix CHECK-NODEF-EXE
+# RUN: lld-link /machine:x64 /out:%t.dir/default.exe %t.dir/object.obj /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/default.lib | FileCheck %s -check-prefix CHECK-NODEF-EXE
 
 CHECK-NODEF-EXE: default.exe
 CHECK-NODEF-EXE: default.exe
 CHECK-NODEF-EXE: default.exe
 CHECK-NODEF-EXE: default.exe
 
-# RUN: lld-link /machine:x64 /dll /out:%T/default.dll %T/object.obj /entry:f /subsystem:CONSOLE
-# RUN: llvm-ar t %T/default.lib | FileCheck %s -check-prefix CHECK-NODEF-DLL
+# RUN: lld-link /machine:x64 /dll /out:%t.dir/default.dll %t.dir/object.obj /entry:f /subsystem:CONSOLE
+# RUN: llvm-ar t %t.dir/default.lib | FileCheck %s -check-prefix CHECK-NODEF-DLL
 
 CHECK-NODEF-DLL: default.dll
 CHECK-NODEF-DLL: default.dll
 CHECK-NODEF-DLL: default.dll
 CHECK-NODEF-DLL: default.dll
 
-# RUN: lld-link /nologo /machine:x64 /out:%T/exe %T/object.obj /entry:f /subsystem:CONSOLE
+# RUN: lld-link /nologo /machine:x64 /out:%t.dir/exe %t.dir/object.obj /entry:f /subsystem:CONSOLE

--- a/lld/test/COFF/locally-imported-warn-multiple.s
+++ b/lld/test/COFF/locally-imported-warn-multiple.s
@@ -1,10 +1,11 @@
 # REQUIRES: x86
 
-# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %T/locally-imported-def.obj %S/Inputs/locally-imported-def.s
-# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %T/locally-imported-imp1.obj %S/Inputs/locally-imported-imp.s
-# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %T/locally-imported-imp2.obj %S/Inputs/locally-imported-imp.s
+# RUN: mkdir -p %t.dir
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %t.dir/locally-imported-def.obj %S/Inputs/locally-imported-def.s
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %t.dir/locally-imported-imp1.obj %S/Inputs/locally-imported-imp.s
+# RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %t.dir/locally-imported-imp2.obj %S/Inputs/locally-imported-imp.s
 # RUN: llvm-mc -filetype=obj -triple=x86_64-windows-msvc -o %t.obj %s
-# RUN: lld-link /entry:main %T/locally-imported-def.obj %T/locally-imported-imp1.obj %T/locally-imported-imp2.obj %t.obj 2>&1 | FileCheck %s
+# RUN: lld-link /entry:main %t.dir/locally-imported-def.obj %t.dir/locally-imported-imp1.obj %t.dir/locally-imported-imp2.obj %t.obj 2>&1 | FileCheck %s
 
 # CHECK: warning: [[TESTDIR:.+]]locally-imported-imp1.obj: locally defined symbol imported: f (defined in [[TESTDIR]]locally-imported-def.obj)
 # CHECK-NEXT: warning: [[TESTDIR:.+]]locally-imported-imp2.obj: locally defined symbol imported: f (defined in [[TESTDIR]]locally-imported-def.obj)

--- a/lld/test/COFF/lto-chkstk.ll
+++ b/lld/test/COFF/lto-chkstk.ll
@@ -1,10 +1,11 @@
 ; REQUIRES: x86
+; RUN: mkdir -p %t.dir
 ; RUN: llvm-as -o %t.obj %s
-; RUN: llvm-mc -triple=x86_64-pc-windows-msvc -filetype=obj -o %T/lto-chkstk-foo.obj %S/Inputs/lto-chkstk-foo.s
-; RUN: llvm-mc -triple=x86_64-pc-windows-msvc -filetype=obj -o %T/lto-chkstk-chkstk.obj %S/Inputs/lto-chkstk-chkstk.s
+; RUN: llvm-mc -triple=x86_64-pc-windows-msvc -filetype=obj -o %t.dir/lto-chkstk-foo.obj %S/Inputs/lto-chkstk-foo.s
+; RUN: llvm-mc -triple=x86_64-pc-windows-msvc -filetype=obj -o %t.dir/lto-chkstk-chkstk.obj %S/Inputs/lto-chkstk-chkstk.s
 ; RUN: rm -f %t.lib
-; RUN: llvm-ar cru %t.lib %T/lto-chkstk-chkstk.obj
-; RUN: lld-link /out:%t.exe /entry:main /subsystem:console %t.obj %T/lto-chkstk-foo.obj %t.lib
+; RUN: llvm-ar cru %t.lib %t.dir/lto-chkstk-chkstk.obj
+; RUN: lld-link /out:%t.exe /entry:main /subsystem:console %t.obj %t.dir/lto-chkstk-foo.obj %t.lib
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc"

--- a/lld/test/COFF/lto-comdat.ll
+++ b/lld/test/COFF/lto-comdat.ll
@@ -1,44 +1,45 @@
 ; REQUIRES: x86
-; RUN: llvm-as -o %T/comdat-main.lto.obj %s
-; RUN: llvm-as -o %T/comdat1.lto.obj %S/Inputs/lto-comdat1.ll
-; RUN: llvm-as -o %T/comdat2.lto.obj %S/Inputs/lto-comdat2.ll
-; RUN: rm -f %T/comdat.lto.lib
-; RUN: llvm-ar cru %T/comdat.lto.lib %T/comdat1.lto.obj %T/comdat2.lto.obj
+; RUN: mkdir -p %t.dir
+; RUN: llvm-as -o %t.dir/comdat-main.lto.obj %s
+; RUN: llvm-as -o %t.dir/comdat1.lto.obj %S/Inputs/lto-comdat1.ll
+; RUN: llvm-as -o %t.dir/comdat2.lto.obj %S/Inputs/lto-comdat2.ll
+; RUN: rm -f %t.dir/comdat.lto.lib
+; RUN: llvm-ar cru %t.dir/comdat.lto.lib %t.dir/comdat1.lto.obj %t.dir/comdat2.lto.obj
 
-; RUN: llc -filetype=obj -o %T/comdat-main.obj %s
-; RUN: llc -filetype=obj -o %T/comdat1.obj %S/Inputs/lto-comdat1.ll
-; RUN: llc -filetype=obj -o %T/comdat2.obj %S/Inputs/lto-comdat2.ll
-; RUN: rm -f %T/comdat.lib
-; RUN: llvm-ar cru %T/comdat.lib %T/comdat1.obj %T/comdat2.obj
+; RUN: llc -filetype=obj -o %t.dir/comdat-main.obj %s
+; RUN: llc -filetype=obj -o %t.dir/comdat1.obj %S/Inputs/lto-comdat1.ll
+; RUN: llc -filetype=obj -o %t.dir/comdat2.obj %S/Inputs/lto-comdat2.ll
+; RUN: rm -f %t.dir/comdat.lib
+; RUN: llvm-ar cru %t.dir/comdat.lib %t.dir/comdat1.obj %t.dir/comdat2.obj
 
 ; Check that, when we use an LTO main with LTO objects, we optimize away all
 ; of f1, f2, and comdat.
-; RUN: lld-link /out:%T/comdat-main.exe /entry:main /subsystem:console %T/comdat-main.lto.obj %T/comdat1.lto.obj %T/comdat2.lto.obj
-; RUN: llvm-readobj --file-headers %T/comdat-main.exe | FileCheck -check-prefix=HEADERS-11 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/comdat-main.exe | FileCheck --check-prefix=TEXT-11 %s
-; RUN: lld-link /out:%T/comdat-main.exe /entry:main /subsystem:console %T/comdat-main.lto.obj %T/comdat.lto.lib
-; RUN: llvm-readobj --file-headers %T/comdat-main.exe | FileCheck -check-prefix=HEADERS-11 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/comdat-main.exe | FileCheck --check-prefix=TEXT-11 %s
+; RUN: lld-link /out:%t.dir/comdat-main.exe /entry:main /subsystem:console %t.dir/comdat-main.lto.obj %t.dir/comdat1.lto.obj %t.dir/comdat2.lto.obj
+; RUN: llvm-readobj --file-headers %t.dir/comdat-main.exe | FileCheck -check-prefix=HEADERS-11 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/comdat-main.exe | FileCheck --check-prefix=TEXT-11 %s
+; RUN: lld-link /out:%t.dir/comdat-main.exe /entry:main /subsystem:console %t.dir/comdat-main.lto.obj %t.dir/comdat.lto.lib
+; RUN: llvm-readobj --file-headers %t.dir/comdat-main.exe | FileCheck -check-prefix=HEADERS-11 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/comdat-main.exe | FileCheck --check-prefix=TEXT-11 %s
 
 ; Check that, when we use a non-LTO main with LTO objects, we pick the comdat
 ; implementation in LTO, elide calls to it from inside LTO, and retain the
 ; call to comdat from main.
-; RUN: lld-link /out:%T/comdat-main.exe /entry:main /subsystem:console %T/comdat-main.obj %T/comdat1.lto.obj %T/comdat2.lto.obj
-; RUN: llvm-readobj --file-headers %T/comdat-main.exe | FileCheck -check-prefix=HEADERS-01 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/comdat-main.exe | FileCheck --check-prefix=TEXT-01 %s
-; RUN: lld-link /out:%T/comdat-main.exe /entry:main /subsystem:console %T/comdat-main.obj %T/comdat.lto.lib
-; RUN: llvm-readobj --file-headers %T/comdat-main.exe | FileCheck -check-prefix=HEADERS-01 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/comdat-main.exe | FileCheck --check-prefix=TEXT-01 %s
+; RUN: lld-link /out:%t.dir/comdat-main.exe /entry:main /subsystem:console %t.dir/comdat-main.obj %t.dir/comdat1.lto.obj %t.dir/comdat2.lto.obj
+; RUN: llvm-readobj --file-headers %t.dir/comdat-main.exe | FileCheck -check-prefix=HEADERS-01 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/comdat-main.exe | FileCheck --check-prefix=TEXT-01 %s
+; RUN: lld-link /out:%t.dir/comdat-main.exe /entry:main /subsystem:console %t.dir/comdat-main.obj %t.dir/comdat.lto.lib
+; RUN: llvm-readobj --file-headers %t.dir/comdat-main.exe | FileCheck -check-prefix=HEADERS-01 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/comdat-main.exe | FileCheck --check-prefix=TEXT-01 %s
 
 ; Check that, when we use an LTO main with non-LTO objects, we pick the comdat
 ; implementation in LTO, elide the call to it from inside LTO, and keep the
 ; calls to comdat from the non-LTO objects.
-; RUN: lld-link /out:%T/comdat-main.exe /entry:main /subsystem:console %T/comdat-main.lto.obj %T/comdat1.obj %T/comdat2.obj
-; RUN: llvm-readobj --file-headers %T/comdat-main.exe | FileCheck -check-prefix=HEADERS-10 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/comdat-main.exe | FileCheck --check-prefix=TEXT-10 %s
-; RUN: lld-link /out:%T/comdat-main.exe /entry:main /subsystem:console %T/comdat-main.lto.obj %T/comdat.lib
-; RUN: llvm-readobj --file-headers %T/comdat-main.exe | FileCheck -check-prefix=HEADERS-10 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/comdat-main.exe | FileCheck --check-prefix=TEXT-10 %s
+; RUN: lld-link /out:%t.dir/comdat-main.exe /entry:main /subsystem:console %t.dir/comdat-main.lto.obj %t.dir/comdat1.obj %t.dir/comdat2.obj
+; RUN: llvm-readobj --file-headers %t.dir/comdat-main.exe | FileCheck -check-prefix=HEADERS-10 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/comdat-main.exe | FileCheck --check-prefix=TEXT-10 %s
+; RUN: lld-link /out:%t.dir/comdat-main.exe /entry:main /subsystem:console %t.dir/comdat-main.lto.obj %t.dir/comdat.lib
+; RUN: llvm-readobj --file-headers %t.dir/comdat-main.exe | FileCheck -check-prefix=HEADERS-10 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/comdat-main.exe | FileCheck --check-prefix=TEXT-10 %s
 
 ; HEADERS-11: AddressOfEntryPoint: 0x1000
 ; TEXT-11: Disassembly of section .text:

--- a/lld/test/COFF/lto-lazy-reference.ll
+++ b/lld/test/COFF/lto-lazy-reference.ll
@@ -1,8 +1,9 @@
 ; REQUIRES: x86
-; RUN: llc -mtriple=i686-pc-windows-msvc -filetype=obj -o %T/lto-lazy-reference-quadruple.obj %S/Inputs/lto-lazy-reference-quadruple.ll
-; RUN: llvm-as -o %T/lto-lazy-reference-dummy.bc %S/Inputs/lto-lazy-reference-dummy.ll
+; RUN: mkdir -p %t.dir
+; RUN: llc -mtriple=i686-pc-windows-msvc -filetype=obj -o %t.dir/lto-lazy-reference-quadruple.obj %S/Inputs/lto-lazy-reference-quadruple.ll
+; RUN: llvm-as -o %t.dir/lto-lazy-reference-dummy.bc %S/Inputs/lto-lazy-reference-dummy.ll
 ; RUN: rm -f %t.lib
-; RUN: llvm-ar cru %t.lib %T/lto-lazy-reference-quadruple.obj %T/lto-lazy-reference-dummy.bc
+; RUN: llvm-ar cru %t.lib %t.dir/lto-lazy-reference-quadruple.obj %t.dir/lto-lazy-reference-dummy.bc
 ; RUN: llvm-as -o %t.obj %s
 ; RUN: lld-link /out:%t.exe /entry:main /subsystem:console %t.obj %t.lib
 

--- a/lld/test/COFF/lto-linker-opts.ll
+++ b/lld/test/COFF/lto-linker-opts.ll
@@ -1,6 +1,7 @@
 ; REQUIRES: x86
-; RUN: llvm-as -o %T/lto-linker-opts.obj %s
-; RUN: env LIB=%S/Inputs lld-link /out:%T/lto-linker-opts.exe /entry:main /subsystem:console %T/lto-linker-opts.obj
+; RUN: mkdir -p %t.dir
+; RUN: llvm-as -o %t.dir/lto-linker-opts.obj %s
+; RUN: env LIB=%S/Inputs lld-link /out:%t.dir/lto-linker-opts.exe /entry:main /subsystem:console %t.dir/lto-linker-opts.obj
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc"

--- a/lld/test/COFF/lto.ll
+++ b/lld/test/COFF/lto.ll
@@ -1,34 +1,35 @@
 ; REQUIRES: x86
-; RUN: llvm-as -o %T/main.lto.obj %s
-; RUN: llvm-as -o %T/foo.lto.obj %S/Inputs/lto-dep.ll
-; RUN: rm -f %T/foo.lto.lib
-; RUN: llvm-ar cru %T/foo.lto.lib %T/foo.lto.obj
+; RUN: mkdir -p %t.dir
+; RUN: llvm-as -o %t.dir/main.lto.obj %s
+; RUN: llvm-as -o %t.dir/foo.lto.obj %S/Inputs/lto-dep.ll
+; RUN: rm -f %t.dir/foo.lto.lib
+; RUN: llvm-ar cru %t.dir/foo.lto.lib %t.dir/foo.lto.obj
 
-; RUN: llc -filetype=obj -o %T/main.obj %s
-; RUN: llc -filetype=obj -o %T/foo.obj %S/Inputs/lto-dep.ll
-; RUN: rm -f %T/foo.lib
-; RUN: llvm-ar cru %T/foo.lib %T/foo.obj
+; RUN: llc -filetype=obj -o %t.dir/main.obj %s
+; RUN: llc -filetype=obj -o %t.dir/foo.obj %S/Inputs/lto-dep.ll
+; RUN: rm -f %t.dir/foo.lib
+; RUN: llvm-ar cru %t.dir/foo.lib %t.dir/foo.obj
 
-; RUN: lld-link /out:%T/main.exe /entry:main /include:f2 /subsystem:console %T/main.lto.obj %T/foo.lto.obj
-; RUN: llvm-readobj --file-headers %T/main.exe | FileCheck -check-prefix=HEADERS-11 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/main.exe | FileCheck --check-prefix=TEXT-11 %s
-; RUN: lld-link /out:%T/main.exe /entry:main /include:f2 /subsystem:console %T/main.lto.obj %T/foo.lto.lib /verbose 2>&1 | FileCheck -check-prefix=VERBOSE %s
-; RUN: llvm-readobj --file-headers %T/main.exe | FileCheck -check-prefix=HEADERS-11 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/main.exe | FileCheck --check-prefix=TEXT-11 %s
+; RUN: lld-link /out:%t.dir/main.exe /entry:main /include:f2 /subsystem:console %t.dir/main.lto.obj %t.dir/foo.lto.obj
+; RUN: llvm-readobj --file-headers %t.dir/main.exe | FileCheck -check-prefix=HEADERS-11 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/main.exe | FileCheck --check-prefix=TEXT-11 %s
+; RUN: lld-link /out:%t.dir/main.exe /entry:main /include:f2 /subsystem:console %t.dir/main.lto.obj %t.dir/foo.lto.lib /verbose 2>&1 | FileCheck -check-prefix=VERBOSE %s
+; RUN: llvm-readobj --file-headers %t.dir/main.exe | FileCheck -check-prefix=HEADERS-11 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/main.exe | FileCheck --check-prefix=TEXT-11 %s
 
-; RUN: lld-link /out:%T/main.exe /entry:main /subsystem:console %T/main.obj %T/foo.lto.obj
-; RUN: llvm-readobj --file-headers %T/main.exe | FileCheck -check-prefix=HEADERS-01 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/main.exe | FileCheck --check-prefix=TEXT-01 %s
-; RUN: lld-link /out:%T/main.exe /entry:main /subsystem:console %T/main.obj %T/foo.lto.lib
-; RUN: llvm-readobj --file-headers %T/main.exe | FileCheck -check-prefix=HEADERS-01 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/main.exe | FileCheck --check-prefix=TEXT-01 %s
+; RUN: lld-link /out:%t.dir/main.exe /entry:main /subsystem:console %t.dir/main.obj %t.dir/foo.lto.obj
+; RUN: llvm-readobj --file-headers %t.dir/main.exe | FileCheck -check-prefix=HEADERS-01 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/main.exe | FileCheck --check-prefix=TEXT-01 %s
+; RUN: lld-link /out:%t.dir/main.exe /entry:main /subsystem:console %t.dir/main.obj %t.dir/foo.lto.lib
+; RUN: llvm-readobj --file-headers %t.dir/main.exe | FileCheck -check-prefix=HEADERS-01 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/main.exe | FileCheck --check-prefix=TEXT-01 %s
 
-; RUN: lld-link /out:%T/main.exe /entry:main /subsystem:console %T/main.lto.obj %T/foo.obj
-; RUN: llvm-readobj --file-headers %T/main.exe | FileCheck -check-prefix=HEADERS-10 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/main.exe | FileCheck --check-prefix=TEXT-10 %s
-; RUN: lld-link /out:%T/main.exe /entry:main /subsystem:console %T/main.lto.obj %T/foo.lib
-; RUN: llvm-readobj --file-headers %T/main.exe | FileCheck -check-prefix=HEADERS-10 %s
-; RUN: llvm-objdump --no-print-imm-hex -d %T/main.exe | FileCheck --check-prefix=TEXT-10 %s
+; RUN: lld-link /out:%t.dir/main.exe /entry:main /subsystem:console %t.dir/main.lto.obj %t.dir/foo.obj
+; RUN: llvm-readobj --file-headers %t.dir/main.exe | FileCheck -check-prefix=HEADERS-10 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/main.exe | FileCheck --check-prefix=TEXT-10 %s
+; RUN: lld-link /out:%t.dir/main.exe /entry:main /subsystem:console %t.dir/main.lto.obj %t.dir/foo.lib
+; RUN: llvm-readobj --file-headers %t.dir/main.exe | FileCheck -check-prefix=HEADERS-10 %s
+; RUN: llvm-objdump --no-print-imm-hex -d %t.dir/main.exe | FileCheck --check-prefix=TEXT-10 %s
 
 ; VERBOSE: foo.lto.lib({{.*}}foo.lto.obj)
 

--- a/lld/test/COFF/map.test
+++ b/lld/test/COFF/map.test
@@ -1,13 +1,14 @@
+# RUN: mkdir -p %t.dir
 # RUN: yaml2obj %p/Inputs/export.yaml -o %t-dll.obj
 # RUN: lld-link /out:%t.dll /dll %t-dll.obj /implib:%t-dll.lib \
 # RUN:   /export:exportfn1 /export:exportfn2
 # RUN: yaml2obj %p/Inputs/map.yaml -o %t.obj
-# RUN: lld-link /out:%t.exe /entry:main %t.obj %t-dll.lib /map:%T/foo.map  /lldmap
-# RUN: FileCheck -check-prefix=MAP -strict-whitespace %s < %T/foo.map
+# RUN: lld-link /out:%t.exe /entry:main %t.obj %t-dll.lib /map:%t.dir/foo.map  /lldmap
+# RUN: FileCheck -check-prefix=MAP -strict-whitespace %s < %t.dir/foo.map
 # RUN: FileCheck -check-prefix=LLDMAP -strict-whitespace %s < %t.map
-# RUN: lld-link /out:%t.exe /entry:main %t.obj %t-dll.lib /map /lldmap:%T/foo-lld.map
+# RUN: lld-link /out:%t.exe /entry:main %t.obj %t-dll.lib /map /lldmap:%t.dir/foo-lld.map
 # RUN: FileCheck -check-prefix=MAP -strict-whitespace %s < %t.map
-# RUN: FileCheck -check-prefix=LLDMAP -strict-whitespace %s < %T/foo-lld.map
+# RUN: FileCheck -check-prefix=LLDMAP -strict-whitespace %s < %t.dir/foo-lld.map
 # RUN: lld-link /out:%t.dll /dll %t-dll.obj /export:exportfn1 \
 # RUN:   /export:foo=exportfn2 /map /mapinfo:exports
 # RUN: FileCheck -check-prefix=MAPINFO -strict-whitespace %s < %t.map

--- a/lld/test/COFF/out.test
+++ b/lld/test/COFF/out.test
@@ -1,16 +1,16 @@
 # RUN: yaml2obj %p/Inputs/ret42.yaml -o %t.obj
 
-# RUN: mkdir -p %T/out/tmp
-# RUN: cp %t.obj %T/out/out1.obj
-# RUN: cp %t.obj %T/out/tmp/out2
-# RUN: cp %t.obj %T/out/tmp/out3.xyz
-# RUN: lld-link /lib %t.obj /out:%T/out/out4.lib
+# RUN: mkdir -p %t.dir/out/tmp
+# RUN: cp %t.obj %t.dir/out/out1.obj
+# RUN: cp %t.obj %t.dir/out/tmp/out2
+# RUN: cp %t.obj %t.dir/out/tmp/out3.xyz
+# RUN: lld-link /lib %t.obj /out:%t.dir/out/out4.lib
 
 # RUN: rm -f out1.exe out2.exe out3.exe out3.dll out4.exe
-# RUN: lld-link /entry:main %T/out/out1.obj
-# RUN: lld-link /entry:main %T/out/tmp/out2
-# RUN: lld-link /dll /entry:main %T/out/tmp/out3.xyz
-# RUN: lld-link /entry:main -wholearchive:%T/out/out4.lib
+# RUN: lld-link /entry:main %t.dir/out/out1.obj
+# RUN: lld-link /entry:main %t.dir/out/tmp/out2
+# RUN: lld-link /dll /entry:main %t.dir/out/tmp/out3.xyz
+# RUN: lld-link /entry:main -wholearchive:%t.dir/out/out4.lib
 
 # RUN: llvm-readobj out1.exe | FileCheck %s
 # RUN: llvm-readobj out2.exe | FileCheck %s

--- a/lld/test/COFF/precomp-link.test
+++ b/lld/test/COFF/precomp-link.test
@@ -40,10 +40,11 @@ WARNING-NOT: warning
 
 Check that a PCH with wrong signature, but with right LF_PRECOMP records count, works.
 
+RUN: mkdir -p %t.dir
 RUN: sed '16,19s/Signature: *545589255/Signature: 123456789/' < %t.precomp.yaml > precomp-wrong-sig.yaml
-RUN: yaml2obj precomp-wrong-sig.yaml -o %T/precomp.obj
-RUN: env LLD_IN_TEST=1 lld-link %T/precomp.obj %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj /nodefaultlib /entry:main /debug:noghash /pdb:%t.pdb /out:%t.exe 2>&1 | FileCheck %s -check-prefix WARNING --allow-empty
-RUN: env LLD_IN_TEST=1 lld-link %T/precomp.obj %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj /nodefaultlib /entry:main /debug:ghash /pdb:%t.pdb /out:%t.exe 2>&1 | FileCheck %s -check-prefix WARNING --allow-empty
+RUN: yaml2obj precomp-wrong-sig.yaml -o %t.dir/precomp.obj
+RUN: env LLD_IN_TEST=1 lld-link %t.dir/precomp.obj %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj /nodefaultlib /entry:main /debug:noghash /pdb:%t.pdb /out:%t.exe 2>&1 | FileCheck %s -check-prefix WARNING --allow-empty
+RUN: env LLD_IN_TEST=1 lld-link %t.dir/precomp.obj %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj /nodefaultlib /entry:main /debug:ghash /pdb:%t.pdb /out:%t.exe 2>&1 | FileCheck %s -check-prefix WARNING --allow-empty
 
 Check that two PCH objs with duplicate signatures are an error.
 

--- a/lld/test/COFF/savetemps-colon.ll
+++ b/lld/test/COFF/savetemps-colon.ll
@@ -1,55 +1,55 @@
 ; REQUIRES: x86
-; RUN: rm -fr %T/savetemps-colon
-; RUN: mkdir %T/savetemps-colon
-; RUN: opt -thinlto-bc -o %T/savetemps-colon/savetemps.obj %s
-; RUN: opt -thinlto-bc -o %T/savetemps-colon/thin1.obj %S/Inputs/thinlto.ll
+; RUN: rm -fr %t.dir/savetemps-colon
+; RUN: mkdir -p %t.dir/savetemps-colon
+; RUN: opt -thinlto-bc -o %t.dir/savetemps-colon/savetemps.obj %s
+; RUN: opt -thinlto-bc -o %t.dir/savetemps-colon/thin1.obj %S/Inputs/thinlto.ll
 
 ;; Check preopt
-; RUN: lld-link /lldsavetemps:preopt /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.obj.*.preopt.bc | count 2
+; RUN: lld-link /lldsavetemps:preopt /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.obj.*.preopt.bc | count 2
 
 ;; Check promote
-; RUN: lld-link /lldsavetemps:promote /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.obj.*.promote.bc | count 2
+; RUN: lld-link /lldsavetemps:promote /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.obj.*.promote.bc | count 2
 
 ;; Check internalize
-; RUN: lld-link /lldsavetemps:internalize /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.obj.*.internalize.bc | count 2
+; RUN: lld-link /lldsavetemps:internalize /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.obj.*.internalize.bc | count 2
 
 ;; Check import
-; RUN: lld-link /lldsavetemps:import /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.obj.*.import.bc | count 2
+; RUN: lld-link /lldsavetemps:import /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.obj.*.import.bc | count 2
 
 ;; Check opt
 ;; Not supported on Windows due to difficulty with escaping "opt" across platforms.
 
 ;; Check precodegen
-; RUN: lld-link /lldsavetemps:precodegen /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.obj.*.precodegen.bc | count 2
+; RUN: lld-link /lldsavetemps:precodegen /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.obj.*.precodegen.bc | count 2
 
 ;; Check combinedindex
-; RUN: lld-link /lldsavetemps:combinedindex /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.exe.index.bc | count 1
+; RUN: lld-link /lldsavetemps:combinedindex /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.exe.index.bc | count 1
 
 ;; Check prelink
-; RUN: lld-link /lldsavetemps:prelink /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.exe.lto.*.obj | count 2
+; RUN: lld-link /lldsavetemps:prelink /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.exe.lto.*.obj | count 2
 
 ;; Check resolution
-; RUN: lld-link /lldsavetemps:resolution /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj
-; RUN: ls %T/savetemps-colon/*.resolution.txt | count 1
+; RUN: lld-link /lldsavetemps:resolution /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj
+; RUN: ls %t.dir/savetemps-colon/*.resolution.txt | count 1
 
 ;; Check error message
-; RUN: not lld-link /lldsavetemps:notastage /out:%T/savetemps-colon/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps-colon/savetemps.obj %T/savetemps-colon/thin1.obj 2>&1 \
+; RUN: not lld-link /lldsavetemps:notastage /out:%t.dir/savetemps-colon/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps-colon/savetemps.obj %t.dir/savetemps-colon/thin1.obj 2>&1 \
 ; RUN: | FileCheck %s
 ; CHECK: unknown /lldsavetemps value: notastage
 

--- a/lld/test/COFF/savetemps.ll
+++ b/lld/test/COFF/savetemps.ll
@@ -1,21 +1,21 @@
 ; REQUIRES: x86
-; RUN: rm -fr %T/savetemps
-; RUN: mkdir %T/savetemps
-; RUN: llvm-as -o %T/savetemps/savetemps.obj %s
-; RUN: lld-link /out:%T/savetemps/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps/savetemps.obj
-; RUN: not llvm-dis -o - %T/savetemps/savetemps.exe.0.0.preopt.bc
-; RUN: not llvm-dis -o - %T/savetemps/savetemps.exe.0.2.internalize.bc
-; RUN: not llvm-dis -o - %T/savetemps/savetemps.exe.0.4.opt.bc
-; RUN: not llvm-dis -o - %T/savetemps/savetemps.exe.0.5.precodegen.bc
-; RUN: not llvm-objdump -s %T/savetemps/savetemps.exe.lto.obj
-; RUN: lld-link /lldsavetemps /out:%T/savetemps/savetemps.exe /entry:main \
-; RUN:     /subsystem:console %T/savetemps/savetemps.obj
-; RUN: llvm-dis -o - %T/savetemps/savetemps.exe.0.0.preopt.bc | FileCheck %s
-; RUN: llvm-dis -o - %T/savetemps/savetemps.exe.0.2.internalize.bc | FileCheck %s
-; RUN: llvm-dis -o - %T/savetemps/savetemps.exe.0.4.opt.bc | FileCheck %s
-; RUN: llvm-dis -o - %T/savetemps/savetemps.exe.0.5.precodegen.bc | FileCheck %s
-; RUN: llvm-objdump -s %T/savetemps/savetemps.exe.lto.obj | \
+; RUN: rm -fr %t.dir/savetemps
+; RUN: mkdir -p %t.dir/savetemps
+; RUN: llvm-as -o %t.dir/savetemps/savetemps.obj %s
+; RUN: lld-link /out:%t.dir/savetemps/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps/savetemps.obj
+; RUN: not llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.0.preopt.bc
+; RUN: not llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.2.internalize.bc
+; RUN: not llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.4.opt.bc
+; RUN: not llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.5.precodegen.bc
+; RUN: not llvm-objdump -s %t.dir/savetemps/savetemps.exe.lto.obj
+; RUN: lld-link /lldsavetemps /out:%t.dir/savetemps/savetemps.exe /entry:main \
+; RUN:     /subsystem:console %t.dir/savetemps/savetemps.obj
+; RUN: llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.0.preopt.bc | FileCheck %s
+; RUN: llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.2.internalize.bc | FileCheck %s
+; RUN: llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.4.opt.bc | FileCheck %s
+; RUN: llvm-dis -o - %t.dir/savetemps/savetemps.exe.0.5.precodegen.bc | FileCheck %s
+; RUN: llvm-objdump -s %t.dir/savetemps/savetemps.exe.lto.obj | \
 ; RUN:     FileCheck --check-prefix=CHECK-OBJDUMP %s
 
 ; CHECK: define {{(noundef )?}}i32 @main()

--- a/lld/test/COFF/thinlto-archives.ll
+++ b/lld/test/COFF/thinlto-archives.ll
@@ -1,15 +1,15 @@
 ; REQUIRES: x86
-; RUN: rm -fr %T/thinlto-archives
-; RUN: mkdir %T/thinlto-archives %T/thinlto-archives/a %T/thinlto-archives/b
-; RUN: opt -thinlto-bc -o %T/thinlto-archives/main.obj %s
-; RUN: opt -thinlto-bc -o %T/thinlto-archives/a/bar.obj %S/Inputs/lto-dep.ll
-; RUN: opt -thinlto-bc -o %T/thinlto-archives/b/bar.obj %S/Inputs/bar.ll
-; RUN: llvm-ar crs %T/thinlto-archives/a.lib %T/thinlto-archives/a/bar.obj
-; RUN: llvm-ar crs %T/thinlto-archives/b.lib %T/thinlto-archives/b/bar.obj
-; RUN: lld-link -out:%T/thinlto-archives/main.exe -entry:main \
-; RUN:     -lldsavetemps -subsystem:console %T/thinlto-archives/main.obj \
-; RUN:     %T/thinlto-archives/a.lib %T/thinlto-archives/b.lib
-; RUN: FileCheck %s < %T/thinlto-archives/main.exe.resolution.txt
+; RUN: rm -fr %t.dir/thinlto-archives
+; RUN: mkdir -p %t.dir/thinlto-archives %t.dir/thinlto-archives/a %t.dir/thinlto-archives/b
+; RUN: opt -thinlto-bc -o %t.dir/thinlto-archives/main.obj %s
+; RUN: opt -thinlto-bc -o %t.dir/thinlto-archives/a/bar.obj %S/Inputs/lto-dep.ll
+; RUN: opt -thinlto-bc -o %t.dir/thinlto-archives/b/bar.obj %S/Inputs/bar.ll
+; RUN: llvm-ar crs %t.dir/thinlto-archives/a.lib %t.dir/thinlto-archives/a/bar.obj
+; RUN: llvm-ar crs %t.dir/thinlto-archives/b.lib %t.dir/thinlto-archives/b/bar.obj
+; RUN: lld-link -out:%t.dir/thinlto-archives/main.exe -entry:main \
+; RUN:     -lldsavetemps -subsystem:console %t.dir/thinlto-archives/main.obj \
+; RUN:     %t.dir/thinlto-archives/a.lib %t.dir/thinlto-archives/b.lib
+; RUN: FileCheck %s < %t.dir/thinlto-archives/main.exe.resolution.txt
 
 ; CHECK: {{/thinlto-archives/main.obj$}}
 ; CHECK: {{^-r=.*/thinlto-archives/main.obj,main,px$}}

--- a/lld/test/COFF/thinlto-mangled.ll
+++ b/lld/test/COFF/thinlto-mangled.ll
@@ -1,7 +1,8 @@
 ; REQUIRES: x86
+; RUN: mkdir -p %t.dir
 ; RUN: opt -thinlto-bc %s -o %t.obj
-; RUN: opt -thinlto-bc %S/Inputs/thinlto-mangled-qux.ll -o thinlto-mangled-qux.obj
-; RUN: lld-link -out:%t.exe -entry:main %t.obj thinlto-mangled-qux.obj
+; RUN: opt -thinlto-bc %S/Inputs/thinlto-mangled-qux.ll -o %t.dir/thinlto-mangled-qux.obj
+; RUN: lld-link -out:%t.exe -entry:main %t.obj %t.dir/thinlto-mangled-qux.obj
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc19.0.24215"

--- a/lld/test/COFF/thinlto-mangled.ll
+++ b/lld/test/COFF/thinlto-mangled.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: x86
 ; RUN: opt -thinlto-bc %s -o %t.obj
-; RUN: opt -thinlto-bc %S/Inputs/thinlto-mangled-qux.ll -o %T/thinlto-mangled-qux.obj
-; RUN: lld-link -out:%t.exe -entry:main %t.obj %T/thinlto-mangled-qux.obj
+; RUN: opt -thinlto-bc %S/Inputs/thinlto-mangled-qux.ll -o thinlto-mangled-qux.obj
+; RUN: lld-link -out:%t.exe -entry:main %t.obj thinlto-mangled-qux.obj
 
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-pc-windows-msvc19.0.24215"

--- a/lld/test/COFF/thinlto-whole-archives.ll
+++ b/lld/test/COFF/thinlto-whole-archives.ll
@@ -1,14 +1,14 @@
 ; REQUIRES: x86
-; RUN: rm -fr %T/thinlto-whole-archives
-; RUN: mkdir %T/thinlto-whole-archives %T/thinlto-whole-archives/a %T/thinlto-whole-archives/b
-; RUN: opt -thinlto-bc -o %T/thinlto-whole-archives/main.obj %s
-; RUN: opt -thinlto-bc -o %T/thinlto-whole-archives/a/bar.obj %S/Inputs/lto-dep.ll
-; RUN: opt -thinlto-bc -o %T/thinlto-whole-archives/b/bar.obj %S/Inputs/bar.ll
-; RUN: llvm-ar crs %T/thinlto-whole-archives/a.lib %T/thinlto-whole-archives/a/bar.obj %T/thinlto-whole-archives/b/bar.obj
-; RUN: lld-link -out:%T/thinlto-whole-archives/main.exe -entry:main \
-; RUN:     -wholearchive -lldsavetemps -subsystem:console %T/thinlto-whole-archives/main.obj \
-; RUN:     %T/thinlto-whole-archives/a.lib
-; RUN: FileCheck %s < %T/thinlto-whole-archives/main.exe.resolution.txt
+; RUN: rm -fr %t.dir/thinlto-whole-archives
+; RUN: mkdir -p %t.dir/thinlto-whole-archives %t.dir/thinlto-whole-archives/a %t.dir/thinlto-whole-archives/b
+; RUN: opt -thinlto-bc -o %t.dir/thinlto-whole-archives/main.obj %s
+; RUN: opt -thinlto-bc -o %t.dir/thinlto-whole-archives/a/bar.obj %S/Inputs/lto-dep.ll
+; RUN: opt -thinlto-bc -o %t.dir/thinlto-whole-archives/b/bar.obj %S/Inputs/bar.ll
+; RUN: llvm-ar crs %t.dir/thinlto-whole-archives/a.lib %t.dir/thinlto-whole-archives/a/bar.obj %t.dir/thinlto-whole-archives/b/bar.obj
+; RUN: lld-link -out:%t.dir/thinlto-whole-archives/main.exe -entry:main \
+; RUN:     -wholearchive -lldsavetemps -subsystem:console %t.dir/thinlto-whole-archives/main.obj \
+; RUN:     %t.dir/thinlto-whole-archives/a.lib
+; RUN: FileCheck %s < %t.dir/thinlto-whole-archives/main.exe.resolution.txt
 
 ; CHECK: {{[/\\]thinlto-whole-archives[/\\]main.obj$}}
 ; CHECK: {{^-r=.*[/\\]thinlto-whole-archives[/\\]main.obj,main,px$}}

--- a/lld/test/COFF/thinlto.ll
+++ b/lld/test/COFF/thinlto.ll
@@ -1,25 +1,25 @@
 ; REQUIRES: x86
-; RUN: rm -fr %T/thinlto
-; RUN: mkdir %T/thinlto
-; RUN: opt -thinlto-bc -o %T/thinlto/main.obj %s
-; RUN: opt -thinlto-bc -o %T/thinlto/foo.obj %S/Inputs/lto-dep.ll
-; RUN: lld-link /lldsavetemps /out:%T/thinlto/main.exe /entry:main /subsystem:console %T/thinlto/main.obj %T/thinlto/foo.obj
-; RUN: llvm-nm %T/thinlto/main.exe.lto.foo.obj | FileCheck %s
+; RUN: rm -fr %t.dir/thinlto
+; RUN: mkdir -p %t.dir/thinlto
+; RUN: opt -thinlto-bc -o %t.dir/thinlto/main.obj %s
+; RUN: opt -thinlto-bc -o %t.dir/thinlto/foo.obj %S/Inputs/lto-dep.ll
+; RUN: lld-link /lldsavetemps /out:%t.dir/thinlto/main.exe /entry:main /subsystem:console %t.dir/thinlto/main.obj %t.dir/thinlto/foo.obj
+; RUN: llvm-nm %t.dir/thinlto/main.exe.lto.foo.obj | FileCheck %s
 
 ; Test various possible options for /opt:lldltojobs
-; RUN: lld-link /lldsavetemps /out:%T/thinlto/main.exe /entry:main /subsystem:console %T/thinlto/main.obj %T/thinlto/foo.obj /opt:lldltojobs=1
-; RUN: llvm-nm %T/thinlto/main.exe.lto.foo.obj | FileCheck %s
-; RUN: lld-link /lldsavetemps /out:%T/thinlto/main.exe /entry:main /subsystem:console %T/thinlto/main.obj %T/thinlto/foo.obj /opt:lldltojobs=all
-; RUN: llvm-nm %T/thinlto/main.exe.lto.foo.obj | FileCheck %s
-; RUN: lld-link /lldsavetemps /out:%T/thinlto/main.exe /entry:main /subsystem:console %T/thinlto/main.obj %T/thinlto/foo.obj /opt:lldltojobs=100
-; RUN: llvm-nm %T/thinlto/main.exe.lto.foo.obj | FileCheck %s
-; RUN: not lld-link /lldsavetemps /out:%T/thinlto/main.exe /entry:main /subsystem:console %T/thinlto/main.obj %T/thinlto/foo.obj /opt:lldltojobs=foo 2>&1 | FileCheck %s --check-prefix=BAD-JOBS
+; RUN: lld-link /lldsavetemps /out:%t.dir/thinlto/main.exe /entry:main /subsystem:console %t.dir/thinlto/main.obj %t.dir/thinlto/foo.obj /opt:lldltojobs=1
+; RUN: llvm-nm %t.dir/thinlto/main.exe.lto.foo.obj | FileCheck %s
+; RUN: lld-link /lldsavetemps /out:%t.dir/thinlto/main.exe /entry:main /subsystem:console %t.dir/thinlto/main.obj %t.dir/thinlto/foo.obj /opt:lldltojobs=all
+; RUN: llvm-nm %t.dir/thinlto/main.exe.lto.foo.obj | FileCheck %s
+; RUN: lld-link /lldsavetemps /out:%t.dir/thinlto/main.exe /entry:main /subsystem:console %t.dir/thinlto/main.obj %t.dir/thinlto/foo.obj /opt:lldltojobs=100
+; RUN: llvm-nm %t.dir/thinlto/main.exe.lto.foo.obj | FileCheck %s
+; RUN: not lld-link /lldsavetemps /out:%t.dir/thinlto/main.exe /entry:main /subsystem:console %t.dir/thinlto/main.obj %t.dir/thinlto/foo.obj /opt:lldltojobs=foo 2>&1 | FileCheck %s --check-prefix=BAD-JOBS
 ; BAD-JOBS: error: /opt:lldltojobs: invalid job count: foo
 
 ; This command will store full path to foo.obj in the archive %t.lib
 ; Check that /lldsavetemps is still usable in such case.
-; RUN: lld-link /lib %T/thinlto/foo.obj /out:%t.lib
-; RUN: lld-link /lldsavetemps /out:%t.exe /entry:main /subsystem:console %T/thinlto/main.obj %t.lib
+; RUN: lld-link /lib %t.dir/thinlto/foo.obj /out:%t.lib
+; RUN: lld-link /lldsavetemps /out:%t.exe /entry:main /subsystem:console %t.dir/thinlto/main.obj %t.lib
 
 ; CHECK-NOT: U foo
 

--- a/lld/test/MachO/objc-category-merging-erase-objc-name-test.s
+++ b/lld/test/MachO/objc-category-merging-erase-objc-name-test.s
@@ -4,9 +4,11 @@
 ; then when merging the category into the base class (and deleting the category), we don't
 ; delete the 'MyTestProtocol' name
 
-; RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos -o %T/erase-objc-name.o %s
-; RUN: %lld -no_objc_relative_method_lists -arch arm64 -dylib -o %T/erase-objc-name.dylib %T/erase-objc-name.o -objc_category_merging
-; RUN: llvm-objdump --objc-meta-data --macho %T/erase-objc-name.dylib | FileCheck %s --check-prefixes=MERGE_CATS
+; RUN: mkdir -p %t.dir
+
+; RUN: llvm-mc -filetype=obj -triple=arm64-apple-macos -o %t.dir/erase-objc-name.o %s
+; RUN: %lld -no_objc_relative_method_lists -arch arm64 -dylib -o %t.dir/erase-objc-name.dylib %t.dir/erase-objc-name.o -objc_category_merging
+; RUN: llvm-objdump --objc-meta-data --macho %t.dir/erase-objc-name.dylib | FileCheck %s --check-prefixes=MERGE_CATS
 
 ; === Check merge categories enabled ===
 ; Check that the original categories are not there

--- a/lld/test/wasm/shared-weak-undefined.s
+++ b/lld/test/wasm/shared-weak-undefined.s
@@ -7,10 +7,11 @@
 # This verifies that LazySymbols (those found in library archives) are correctly
 # demoted to undefined symbols in the final link when they are only weakly
 # referenced.
+# RUN: mkdir -p %t.dir
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.ret32.o %p/Inputs/ret32.s
-# RUN: rm -f %T/libret32.a
-# RUN: llvm-ar cru %T/libret32.a %t.ret32.o
-# RUN: wasm-ld --experimental-pic -shared -o %t.ret32.wasm %t.o %T/libret32.a
+# RUN: rm -f %t.dir/libret32.a
+# RUN: llvm-ar cru %t.dir/libret32.a %t.ret32.o
+# RUN: wasm-ld --experimental-pic -shared -o %t.ret32.wasm %t.o %t.dir/libret32.a
 # RUN: obj2yaml %t.wasm | FileCheck %s
 # RUN: llvm-objdump -d %t.wasm | FileCheck %s -check-prefix=ASM
 


### PR DESCRIPTION
`%T` is not unique and deprecated [[1](https://llvm.org/docs/CommandGuide/lit.html#substitutions)].

This patch replaces all `%T` in `lld/test` with `%t.dir` (`mkdir` if necessary)