### PR TITLE
[clang-linker-wrapper][lit] Fix OpenMP SPIR-V ELF test again

### DIFF
--- a/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
+++ b/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
@@ -1,6 +1,4 @@
 // Verify the ELF packaging of OpenMP SPIR-V device images.
-// FIXME: Re-enable when spirv-tools feature detection fixed
-// UNSUPPORTED: system-linux
 // REQUIRES: system-linux
 // REQUIRES: spirv-tools
 // RUN: mkdir -p %t_tmp

--- a/clang/test/lit.site.cfg.py.in
+++ b/clang/test/lit.site.cfg.py.in
@@ -43,7 +43,7 @@ config.llvm_external_lit = path(r"@LLVM_EXTERNAL_LIT@")
 config.standalone_build = @CLANG_BUILT_STANDALONE@
 config.ppc_linux_default_ieeelongdouble = @PPC_LINUX_DEFAULT_IEEELONGDOUBLE@
 config.have_llvm_driver = @LLVM_TOOL_LLVM_DRIVER_BUILD@
-config.spirv_tools_tests = "@LLVM_INCLUDE_SPIRV_TOOLS_TESTS@"
+config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
 config.substitutions.append(("%llvm-version-major", "@LLVM_VERSION_MAJOR@"))
 
 import lit.llvm

--- a/llvm/utils/gn/secondary/clang/test/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/test/BUILD.gn
@@ -74,6 +74,7 @@ write_lit_config("lit_site_cfg") {
     "Python3_EXECUTABLE=$python_path",
     "USE_Z3_SOLVER=",
     "PPC_LINUX_DEFAULT_IEEELONGDOUBLE=0",
+    "LLVM_INCLUDE_SPIRV_TOOLS_TESTS=0",
   ]
 
   if (clang_enable_static_analyzer) {


### PR DESCRIPTION
I was able to reproduce the issue with the sanitizer buildbot scripts and confirmed this fixes it. 

The issue was the quotes, `"0"` is true in Python so we incorrectly added the `spirv-tools` feature even when the CMake variable was false.  I don't know why it didn't always fail.

Also add the var to clang's `BUILD.gn` which matches what we do for other similar variables, however I don't think it has any effect on CI here.