### PR TITLE
[lldb][NFC] Remove old skipIfOutOfTreeDebugserver's

### DIFF
--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -111,7 +111,6 @@ class RegisterCommandsTestCase(TestBase):
     # "register read fstat" always return 0xffff
     @expectedFailureAndroid(archs=["i386"])
     @skipIf(archs=no_match(["amd64", "i386", "x86_64"]))
-    @skipIfOutOfTreeDebugserver
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr37995")
     def test_fp_special_purpose_register_read(self):
         """Test commands that read fpu special purpose registers."""

--- a/lldb/test/API/commands/watchpoints/unaligned-watchpoint/TestUnalignedWatchpoint.py
+++ b/lldb/test/API/commands/watchpoints/unaligned-watchpoint/TestUnalignedWatchpoint.py
@@ -16,7 +16,6 @@ from lldbsuite.test import lldbutil
 class UnalignedWatchpointTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfOutOfTreeDebugserver
     def test_unaligned_watchpoint(self):
         """Test an unaligned watchpoint triggered by a larger aligned write."""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
@@ -15,14 +15,12 @@ class HardwareBreakpointMultiThreadTestCase(HardwareBreakpointTestBase):
     def does_not_support_hw_breakpoints(self):
         return not super().supports_hw_breakpoints()
 
-    @skipIfOutOfTreeDebugserver
     @skipTestIfFn(does_not_support_hw_breakpoints)
     def test_hw_break_set_delete_multi_thread_macos(self):
         self.build()
         self.setTearDownCleanup()
         self.break_multi_thread("delete")
 
-    @skipIfOutOfTreeDebugserver
     @skipTestIfFn(does_not_support_hw_breakpoints)
     def test_hw_break_set_disable_multi_thread_macos(self):
         self.build()

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -32,7 +32,6 @@ class StackCoreScriptedProcesTestCase(TestBase):
         return None
 
     @skipUnlessDarwin
-    @skipIfOutOfTreeDebugserver
     @skipIfRemote
     @skipIfAsan  # On ASAN builds, this test times-out (rdar://98678134)
     @skipIfDarwin

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyBreakpoints.py
@@ -7,7 +7,6 @@ from lldbsuite.test.lldbtest import TestBase
 class ConcurrentManyBreakpoints(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.
     @skipIf(triple="^mips")
-    @skipIfOutOfTreeDebugserver
     @expectedFailureAll(
         archs=["aarch64"], oslist=["freebsd"], bugnumber="llvm.org/pr49433"
     )

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyCrash.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyCrash.py
@@ -7,7 +7,6 @@ from lldbsuite.test.lldbtest import TestBase
 class ConcurrentManyCrash(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.
     @skipIf(triple="^mips")
-    @skipIfOutOfTreeDebugserver
     def test(self):
         """Test 100 threads that cause a segfault."""
         self.build()

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManySignals.py
@@ -10,7 +10,6 @@ class ConcurrentManySignals(ConcurrentEventsBase):
     # This test is flaky on Darwin.
     @skipIfDarwin
     @expectedFailureNetBSD
-    @skipIfOutOfTreeDebugserver
     def test(self):
         """Test 100 signals from 100 threads."""
         self.build()

--- a/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
+++ b/lldb/test/API/functionalities/thread/concurrent_events/TestConcurrentManyWatchpoints.py
@@ -8,7 +8,6 @@ class ConcurrentManyWatchpoints(ConcurrentEventsBase):
     # Atomic sequences are not supported yet for MIPS in LLDB.
     @skipIf(triple="^mips")
     @add_test_categories(["watchpoint"])
-    @skipIfOutOfTreeDebugserver
     def test(self):
         """Test 100 watchpoints from 100 threads."""
         self.build()

--- a/lldb/test/API/functionalities/watchpoint/large-watchpoint/TestLargeWatchpoint.py
+++ b/lldb/test/API/functionalities/watchpoint/large-watchpoint/TestLargeWatchpoint.py
@@ -27,7 +27,6 @@ class UnalignedWatchpointTestCase(TestBase):
 
     # debugserver only gained the ability to watch larger regions
     # with this patch.
-    @skipIfOutOfTreeDebugserver
     def test_large_watchpoint(self):
         """Test watchpoint that covers a large region of memory."""
         self.build()

--- a/lldb/test/API/functionalities/watchpoint/unaligned-spanning-two-dwords/TestUnalignedSpanningDwords.py
+++ b/lldb/test/API/functionalities/watchpoint/unaligned-spanning-two-dwords/TestUnalignedSpanningDwords.py
@@ -32,7 +32,6 @@ class UnalignedWatchpointTestCase(TestBase):
     # older debugservers will return the base address of the doubleword
     # which lldb doesn't understand, and will stop executing without a
     # proper stop reason.
-    @skipIfOutOfTreeDebugserver
     def test_unaligned_watchpoint(self):
         """Test a watchpoint that is handled by two hardware watchpoint registers."""
         self.build()

--- a/lldb/test/API/macosx/corefile-exception-reason/TestCorefileExceptionReason.py
+++ b/lldb/test/API/macosx/corefile-exception-reason/TestCorefileExceptionReason.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCorefileExceptionReason(TestBase):
-    @skipIfOutOfTreeDebugserver  # newer debugserver required for these qMemoryRegionInfo types
     @no_debug_info_test
     @skipUnlessDarwin
     @skipIf(archs=no_match(["arm64", "arm64e"]))

--- a/lldb/test/API/macosx/debugserver-exit-code/TestDebugServerExitCode.py
+++ b/lldb/test/API/macosx/debugserver-exit-code/TestDebugServerExitCode.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @no_debug_info_test
     @skipUnlessDarwin
-    @skipIfOutOfTreeDebugserver
     def test_abort(self):
         self.build()
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))

--- a/lldb/test/API/macosx/early-process-launch/TestEarlyProcessLaunch.py
+++ b/lldb/test/API/macosx/early-process-launch/TestEarlyProcessLaunch.py
@@ -12,7 +12,6 @@ class TestEarlyProcessLaunch(TestBase):
 
     @skipUnlessDarwin
     @skipIfAsan  # rdar://103359354
-    @skipIfOutOfTreeDebugserver  # 2022-12-13 FIXME: skipping system debugserver
     # until this feature is included in the system
     # debugserver.
     @add_test_categories(["pyapi"])

--- a/lldb/test/API/macosx/ignore_exceptions/TestIgnoredExceptions.py
+++ b/lldb/test/API/macosx/ignore_exceptions/TestIgnoredExceptions.py
@@ -12,7 +12,6 @@ from lldbsuite.test.lldbtest import *
 class TestDarwinSignalHandlers(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @skipIfOutOfTreeDebugserver
     @skipUnlessDarwin
     def test_ignored_thread(self):
         """It isn't possible to convert an EXC_BAD_ACCESS to a signal when

--- a/lldb/test/API/macosx/profile_vrs_detach/TestDetachVrsProfile.py
+++ b/lldb/test/API/macosx/profile_vrs_detach/TestDetachVrsProfile.py
@@ -19,7 +19,6 @@ class TestDetachVrsProfile(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessDarwin
-    @skipIfOutOfTreeDebugserver
     @skipIfRemote
     def test_profile_and_detach(self):
         """There can be many tests in a test case - describe this test here."""

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -79,7 +79,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
-    @skipIfOutOfTreeDebugserver
     def test_ios(self):
         """Test running an iOS simulator binary"""
         self.run_with(
@@ -94,7 +93,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
-    @skipIfOutOfTreeDebugserver
     def test_tvos(self):
         """Test running an tvOS simulator binary"""
         self.run_with(
@@ -111,7 +109,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test("watch")
     @skipIfDarwin  # rdar://problem/64552748
     @skipIf(archs=["arm64", "arm64e"])
-    @skipIfOutOfTreeDebugserver
     def test_watchos_i386(self):
         """Test running a 32-bit watchOS simulator binary"""
         self.run_with(
@@ -128,7 +125,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test("watch")
     @skipIfDarwin  # rdar://problem/64552748
     @skipIf(archs=["i386", "x86_64"])
-    @skipIfOutOfTreeDebugserver
     def test_watchos_armv7k(self):
         """Test running a 32-bit watchOS simulator binary"""
         self.run_with(
@@ -150,7 +146,6 @@ class TestSimulatorPlatformLaunching(TestBase):
 
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
-    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_macosx(self):
         """Test running a back-deploying non-simulator MacOS X binary"""
         self.run_with(
@@ -166,7 +161,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
     @skipIf(archs=["arm64", "arm64e"])
-    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_iphoneos(self):
         """Test running a back-deploying iOS simulator binary
         with a legacy iOS load command"""
@@ -183,7 +177,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
     @skipIf(archs=["arm64", "arm64e"])
-    @skipIfOutOfTreeDebugserver
     def test_ios_backdeploy_x86(self):
         """Test running a back-deploying iOS simulator binary
         with a legacy iOS load command"""
@@ -200,7 +193,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("iphone")
     @skipIf(archs=["i386", "x86_64"])
-    @skipIfOutOfTreeDebugserver
     def test_ios_backdeploy_apple_silicon(self):
         """Test running a back-deploying iOS simulator binary"""
         self.run_with(
@@ -216,7 +208,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
     @skipIf(archs=["arm64", "arm64e"])
-    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_tvos(self):
         """Test running a back-deploying tvOS simulator binary
         with a legacy tvOS load command"""
@@ -233,7 +224,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @skipIfDarwinEmbedded
     @apple_simulator_test("appletv")
     @skipIf(archs=["i386", "x86_64"])
-    @skipIfOutOfTreeDebugserver
     def test_tvos_backdeploy_apple_silicon(self):
         """Test running a back-deploying tvOS simulator binary"""
         self.run_with(
@@ -250,7 +240,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test("watch")
     @skipIf(archs=["arm64", "arm64e"])
     @skipIfDarwin  # rdar://problem/64552748
-    @skipIfOutOfTreeDebugserver
     def test_lc_version_min_watchos(self):
         """Test running a back-deploying watchOS simulator binary
         with a legacy watchOS load command"""
@@ -268,7 +257,6 @@ class TestSimulatorPlatformLaunching(TestBase):
     @apple_simulator_test("watch")
     @skipIf(archs=["arm64", "arm64e"])
     @skipIfDarwin  # rdar://problem/64552748
-    @skipIfOutOfTreeDebugserver
     def test_watchos_backdeploy_apple_silicon(self):
         """Test running a back-deploying watchOS simulator binary"""
         self.run_with(

--- a/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
+++ b/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
@@ -12,7 +12,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestSkinnyCorefile(TestBase):
-    @skipIfOutOfTreeDebugserver  # newer debugserver required for these qMemoryRegionInfo types
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/macosx/stack-corefile/TestStackCorefile.py
+++ b/lldb/test/API/macosx/stack-corefile/TestStackCorefile.py
@@ -11,7 +11,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestStackCorefile(TestBase):
-    @skipIfOutOfTreeDebugserver  # newer debugserver required for these qMemoryRegionInfo types
     @no_debug_info_test
     @skipUnlessDarwin
     @skipIfRemote

--- a/lldb/test/API/macosx/unregistered-macho/TestUnregisteredMacho.py
+++ b/lldb/test/API/macosx/unregistered-macho/TestUnregisteredMacho.py
@@ -13,7 +13,6 @@ from lldbsuite.test import lldbutil
 class TestUnregisteredMacho(TestBase):
     # newer debugserver required for jGetLoadedDynamicLibrariesInfos
     # to support this
-    @skipIfOutOfTreeDebugserver
     @no_debug_info_test
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/tools/lldb-server/register-reading/TestGdbRemoteGPacket.py
+++ b/lldb/test/API/tools/lldb-server/register-reading/TestGdbRemoteGPacket.py
@@ -25,7 +25,6 @@ def _extract_register_value(reg_info, reg_bank, byte_order, bytes_per_entry=8):
 
 
 class TestGdbRemoteGPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
-    @skipIfOutOfTreeDebugserver
     @skipUnlessDarwin  # G packet not supported
     def test_g_packet(self):
         self.build()


### PR DESCRIPTION
When a test depends on a new debugserver feature/fix, the API test must be marked @skipIfOutOfTreeDebugserver because the macOS CI bots test using the latest Xcode release debugserver.  But over time all of these fixes & new features are picked up in the Xcode debugserver and these skips can be removed.

We may see unexpected test failures from removing all of these 1+ year old skips, but that's likely a separate reason the test is failing that is being papered over by this skip.