### PR TITLE
[AMDGPU] Remove dead function metadata after amdgpu-lower-kernel-arguments

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
@@ -132,6 +132,7 @@ private:
     NF->setAttributes(AL);
     F.replaceAllUsesWith(NF);
     F.setCallingConv(CallingConv::C);
+    F.clearMetadata();
 
     return NF;
   }

--- a/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-debug-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-debug-info.ll
@@ -1,7 +1,7 @@
-; RUN: not --crash opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -passes='amdgpu-attributor,function(amdgpu-lower-kernel-arguments)' -amdgpu-kernarg-preload-count=16 -S < %s 2>&1 | FileCheck %s
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -passes='amdgpu-attributor,function(amdgpu-lower-kernel-arguments)' -amdgpu-kernarg-preload-count=16 -S < %s 2>&1 | FileCheck %s
 
-; CHECK: function declaration may only have a unique !dbg attachment
-; CHECK-NEXT: ptr @0
+; CHECK: define amdgpu_kernel void @preload_block_count_x{{.*}} !dbg ![[#]]
+; CHECK-NOT: declare void @0{{.*}} !dbg ![[#]]
 
 define amdgpu_kernel void @preload_block_count_x(ptr addrspace(1) %out) !dbg !4 !max_work_group_size !7 {
   %imp_arg_ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()

--- a/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-debug-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-debug-info.ll
@@ -1,7 +1,10 @@
-; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -passes='amdgpu-attributor,function(amdgpu-lower-kernel-arguments)' -amdgpu-kernarg-preload-count=16 -S < %s 2>&1 | FileCheck %s
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -passes='amdgpu-attributor,function(amdgpu-lower-kernel-arguments)' -amdgpu-kernarg-preload-count=16 -S < %s 2>&1 \
+; RUN: | FileCheck -implicit-check-not='declare {{.*}} !dbg' %s
+
+; The real test is via the -implicit-check-not, which confirms we do not
+; leave behind a declaration which references the same DISubprogram metadata.
 
 ; CHECK: define amdgpu_kernel void @preload_block_count_x{{.*}} !dbg ![[#]]
-; CHECK-NOT: declare void @0{{.*}} !dbg ![[#]]
 
 define amdgpu_kernel void @preload_block_count_x(ptr addrspace(1) %out) !dbg !4 !max_work_group_size !7 {
   %imp_arg_ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()

--- a/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-debug-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/preload-implicit-kernargs-debug-info.ll
@@ -1,10 +1,13 @@
 ; RUN: opt -mtriple=amdgcn-amd-amdhsa -mcpu=gfx940 -passes='amdgpu-attributor,function(amdgpu-lower-kernel-arguments)' -amdgpu-kernarg-preload-count=16 -S < %s 2>&1 \
-; RUN: | FileCheck -implicit-check-not='declare {{.*}} !dbg' %s
+; RUN: | FileCheck --match-full-lines --implicit-check-not='declare' %s
 
-; The real test is via the -implicit-check-not, which confirms we do not
-; leave behind a declaration which references the same DISubprogram metadata.
+; Confirms we do not leave behind a declaration which references the same
+; DISubprogram metadata.
 
-; CHECK: define amdgpu_kernel void @preload_block_count_x{{.*}} !dbg ![[#]]
+; CHECK: define amdgpu_kernel void @preload_block_count_x{{.*}} !dbg ![[#]] !max_work_group_size ![[#]] {
+; CHECK: declare void @0{{.*}} #[[#]]
+; CHECK: declare noundef align 4 ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr() #[[#]]
+; CHECK: declare noundef align 4 ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr() #[[#]]
 
 define amdgpu_kernel void @preload_block_count_x(ptr addrspace(1) %out) !dbg !4 !max_work_group_size !7 {
   %imp_arg_ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()


### PR DESCRIPTION
The verifier ensures function !dbg metadata is unique across the module,
so ensure the old nameless function we leave behind doesn't violate
this invariant.

Removing the function via e.g. eraseFromParent seems like a better
option, but doesn't seem to be legal from a FunctionPass.