### PR TITLE
[Index] Skip adding call relations to deduction guides

### DIFF
--- a/clang/lib/Index/IndexBody.cpp
+++ b/clang/lib/Index/IndexBody.cpp
@@ -130,6 +130,9 @@ public:
 
   void addCallRole(SymbolRoleSet &Roles,
                    SmallVectorImpl<SymbolRelation> &Relations) {
+    if (isa<CXXDeductionGuideDecl>(ParentDC))
+      return;
+
     Roles |= (unsigned)SymbolRole::Call;
     if (auto *FD = dyn_cast<FunctionDecl>(ParentDC))
       Relations.emplace_back((unsigned)SymbolRole::RelationCalledBy, FD);

--- a/clang/test/Index/index-deduction-guide.cpp
+++ b/clang/test/Index/index-deduction-guide.cpp
@@ -1,0 +1,10 @@
+// RUN: c-index-test core -print-source-symbols -- %s -std=gnu++17 | FileCheck %s
+
+template<typename T>
+typename T::type declval() {}
+template <typename T> struct Test;
+template <typename C, typename T = decltype(declval<C>().d())> Test(C &) -> Test<T>;
+// CHECK: [[@LINE-1]]:45 | function/C | declval
+// CHECK-NOT: RelCall
+// CHECK: [[@LINE-3]]:77 | struct(Gen)/C++ | Test
+// CHECK: [[@LINE-4]]:64 | struct(Gen)/C++ | Test


### PR DESCRIPTION
Deduction guides have no name and we already skip adding occurrences to them for that reason. Also skip adding any relations to them.