### PR TITLE
[SystemZ][XRay] Make xray work with gcc

### DIFF
--- a/compiler-rt/lib/xray/CMakeLists.txt
+++ b/compiler-rt/lib/xray/CMakeLists.txt
@@ -111,7 +111,7 @@ set(riscv64_SOURCES
   xray_trampoline_s390x.S
   )
 # Enable vector instructions in the assembly file.
-set_source_files_properties(xray_trampoline_s390x.S PROPERTIES COMPILE_FLAGS -mvx)
+set_source_files_properties(xray_trampoline_s390x.S PROPERTIES COMPILE_FLAGS -march=z13)
 
 set(XRAY_SOURCE_ARCHS
   arm

--- a/compiler-rt/lib/xray/xray_tsc.h
+++ b/compiler-rt/lib/xray/xray_tsc.h
@@ -96,6 +96,7 @@ namespace __xray {
 inline bool probeRequiredCPUFeatures() XRAY_NEVER_INSTRUMENT { return true; }
 
 ALWAYS_INLINE uint64_t readTSC(uint8_t &CPU) XRAY_NEVER_INSTRUMENT {
+  CPU = 0;
 #if __has_builtin(__builtin_readcyclecounter)
   return __builtin_readcyclecounter();
 #else


### PR DESCRIPTION
It seems that depending on the platform, gcc acceptts or does not accept `-mvx` without specifying an architecture actually having vector instructions. The solution which seems to work across different versions of gcc and clang is to specify the least architecture which has vector instructions.

In addition, initialization of the unused variable CPU prevents a compiler warning from gcc.