### PR TITLE
[sanitizer] [clang] Introduce fsanitize-undefined-strict-flex-arrays

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -481,8 +481,8 @@ LANGOPT(RawStringLiterals, 1, 1, "Enable or disable raw string literals")
 ENUM_LANGOPT(StrictFlexArraysLevel, StrictFlexArraysLevelKind, 2,
              StrictFlexArraysLevelKind::Default,
              "Rely on strict definition of flexible arrays")
-ENUM_LANGOPT(ArrayBoundsStrictFlexArraysLevel, ArrayBoundsStrictFlexArraysLevelKind, 3,
-             ArrayBoundsStrictFlexArraysLevelKind::None,
+ENUM_LANGOPT(UbsanStrictFlexArraysLevel, UbsanStrictFlexArraysLevelKind, 3,
+             UbsanStrictFlexArraysLevelKind::None,
              "Definition of flexible arrays for bounds checks")
 
 COMPATIBLE_VALUE_LANGOPT(MaxTokens, 32, 0, "Max number of tokens per TU or 0")

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -481,6 +481,9 @@ LANGOPT(RawStringLiterals, 1, 1, "Enable or disable raw string literals")
 ENUM_LANGOPT(StrictFlexArraysLevel, StrictFlexArraysLevelKind, 2,
              StrictFlexArraysLevelKind::Default,
              "Rely on strict definition of flexible arrays")
+ENUM_LANGOPT(ArrayBoundsStrictFlexArraysLevel, ArrayBoundsStrictFlexArraysLevelKind, 3,
+             ArrayBoundsStrictFlexArraysLevelKind::None,
+             "Definition of flexible arrays for bounds checks")
 
 COMPATIBLE_VALUE_LANGOPT(MaxTokens, 32, 0, "Max number of tokens per TU or 0")
 

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -444,7 +444,7 @@ public:
     IncompleteOnly = 3,
   };
 
-  enum class ArrayBoundsStrictFlexArraysLevelKind {
+  enum class UbsanStrictFlexArraysLevelKind {
     // Use same StrictFlexArrayLevel as compiler.
     None = 0,
     /// Any trailing array member is a FAM.

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -444,6 +444,19 @@ public:
     IncompleteOnly = 3,
   };
 
+  enum class ArrayBoundsStrictFlexArraysLevelKind {
+    // Use same StrictFlexArrayLevel as compiler.
+    None = 0,
+    /// Any trailing array member is a FAM.
+    Default = 1,
+    /// Any trailing array member of undefined, 0, or 1 size is a FAM.
+    OneZeroOrIncomplete = 2,
+    /// Any trailing array member of undefined or 0 size is a FAM.
+    ZeroOrIncomplete = 3,
+    /// Any trailing array member of undefined size is a FAM.
+    IncompleteOnly = 4,
+  };
+
   /// Controls the various implementations for complex multiplication and
   // division.
   enum ComplexRangeKind {

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1535,19 +1535,19 @@ def fstrict_flex_arrays_EQ : Joined<["-"], "fstrict-flex-arrays=">, Group<f_Grou
   MarshallingInfoEnum<LangOpts<"StrictFlexArraysLevel">, "Default">;
 // We might want a different (generally stricter) definition of flexible arrays
 // for sanitization than for the codegen.
-def fsanitize_array_bounds_strict_flex_arrays_EQ
-    : Joined<["-"], "fsanitize-bounds-strict-flex-arrays=">,
+def fsanitize_undefined_strict_flex_arrays_EQ
+    : Joined<["-"], "fsanitize-undefined-strict-flex-arrays=">,
       Group<f_Group>,
       MetaVarName<"<n>">,
       Values<"none,0,1,2,3">,
-      LangOpts<"ArrayBoundsStrictFlexArraysLevel">,
+      LangOpts<"UbsanStrictFlexArraysLevel">,
       Visibility<[ClangOption, CC1Option]>,
       NormalizedValuesScope<
-          "LangOptions::ArrayBoundsStrictFlexArraysLevelKind">,
+          "LangOptions::UbsanStrictFlexArraysLevelKind">,
       NormalizedValues<["None", "Default", "OneZeroOrIncomplete",
                         "ZeroOrIncomplete", "IncompleteOnly"]>,
       HelpText<"Set definition of flexible arrays for bounds checks">,
-      MarshallingInfoEnum<LangOpts<"ArrayBoundsStrictFlexArraysLevel">, "None">;
+      MarshallingInfoEnum<LangOpts<"UbsanStrictFlexArraysLevel">, "None">;
 defm apple_pragma_pack : BoolFOption<"apple-pragma-pack",
   LangOpts<"ApplePragmaPack">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1533,6 +1533,21 @@ def fstrict_flex_arrays_EQ : Joined<["-"], "fstrict-flex-arrays=">, Group<f_Grou
   NormalizedValues<["Default", "OneZeroOrIncomplete", "ZeroOrIncomplete", "IncompleteOnly"]>,
   HelpText<"Enable optimizations based on the strict definition of flexible arrays">,
   MarshallingInfoEnum<LangOpts<"StrictFlexArraysLevel">, "Default">;
+// We might want a different (generally stricter) definition of flexible arrays
+// for sanitization than for the codegen.
+def fsanitize_array_bounds_strict_flex_arrays_EQ
+    : Joined<["-"], "fsanitize-bounds-strict-flex-arrays=">,
+      Group<f_Group>,
+      MetaVarName<"<n>">,
+      Values<"none,0,1,2,3">,
+      LangOpts<"ArrayBoundsStrictFlexArraysLevel">,
+      Visibility<[ClangOption, CC1Option]>,
+      NormalizedValuesScope<
+          "LangOptions::ArrayBoundsStrictFlexArraysLevelKind">,
+      NormalizedValues<["None", "Default", "OneZeroOrIncomplete",
+                        "ZeroOrIncomplete", "IncompleteOnly"]>,
+      HelpText<"Set definition of flexible arrays for bounds checks">,
+      MarshallingInfoEnum<LangOpts<"ArrayBoundsStrictFlexArraysLevel">, "None">;
 defm apple_pragma_pack : BoolFOption<"apple-pragma-pack",
   LangOpts<"ApplePragmaPack">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1198,25 +1198,18 @@ CodeGenFunction::effectiveArrayBoundsFlexArraysLevel() {
   using StrictFlexArraysLevelKind = LangOptions::StrictFlexArraysLevelKind;
   using ArrayBoundsStrictFlexArraysLevelKind =
       LangOptions::ArrayBoundsStrictFlexArraysLevelKind;
-  StrictFlexArraysLevelKind StrictFlexArraysLevel;
   switch (getLangOpts().getArrayBoundsStrictFlexArraysLevel()) {
   case ArrayBoundsStrictFlexArraysLevelKind::Default:
-    StrictFlexArraysLevel = StrictFlexArraysLevelKind::Default;
-    break;
+    return StrictFlexArraysLevelKind::Default;
   case ArrayBoundsStrictFlexArraysLevelKind::OneZeroOrIncomplete:
-    StrictFlexArraysLevel = StrictFlexArraysLevelKind::OneZeroOrIncomplete;
-    break;
+    return StrictFlexArraysLevelKind::OneZeroOrIncomplete;
   case ArrayBoundsStrictFlexArraysLevelKind::ZeroOrIncomplete:
-    StrictFlexArraysLevel = StrictFlexArraysLevelKind::ZeroOrIncomplete;
-    break;
+    return StrictFlexArraysLevelKind::ZeroOrIncomplete;
   case ArrayBoundsStrictFlexArraysLevelKind::IncompleteOnly:
-    StrictFlexArraysLevel = StrictFlexArraysLevelKind::IncompleteOnly;
-    break;
+    return StrictFlexArraysLevelKind::IncompleteOnly;
   case ArrayBoundsStrictFlexArraysLevelKind::None:
-    StrictFlexArraysLevel = getLangOpts().getStrictFlexArraysLevel();
-    break;
+    return getLangOpts().getStrictFlexArraysLevel();
   }
-  return StrictFlexArraysLevel;
 }
 
 void CodeGenFunction::EmitBoundsCheck(const Expr *E, const Expr *Base,

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1194,20 +1194,20 @@ llvm::Value *CodeGenFunction::EmitLoadOfCountedByField(
 }
 
 LangOptions::StrictFlexArraysLevelKind
-CodeGenFunction::effectiveArrayBoundsFlexArraysLevel() {
+CodeGenFunction::effectiveUbsanFlexArraysLevel() {
   using StrictFlexArraysLevelKind = LangOptions::StrictFlexArraysLevelKind;
-  using ArrayBoundsStrictFlexArraysLevelKind =
-      LangOptions::ArrayBoundsStrictFlexArraysLevelKind;
-  switch (getLangOpts().getArrayBoundsStrictFlexArraysLevel()) {
-  case ArrayBoundsStrictFlexArraysLevelKind::Default:
+  using UbsansStrictFlexArraysLevelKind =
+      LangOptions::UbsanStrictFlexArraysLevelKind;
+  switch (getLangOpts().getUbsanStrictFlexArraysLevel()) {
+  case UbsansStrictFlexArraysLevelKind::Default:
     return StrictFlexArraysLevelKind::Default;
-  case ArrayBoundsStrictFlexArraysLevelKind::OneZeroOrIncomplete:
+  case UbsansStrictFlexArraysLevelKind::OneZeroOrIncomplete:
     return StrictFlexArraysLevelKind::OneZeroOrIncomplete;
-  case ArrayBoundsStrictFlexArraysLevelKind::ZeroOrIncomplete:
+  case UbsansStrictFlexArraysLevelKind::ZeroOrIncomplete:
     return StrictFlexArraysLevelKind::ZeroOrIncomplete;
-  case ArrayBoundsStrictFlexArraysLevelKind::IncompleteOnly:
+  case UbsansStrictFlexArraysLevelKind::IncompleteOnly:
     return StrictFlexArraysLevelKind::IncompleteOnly;
-  case ArrayBoundsStrictFlexArraysLevelKind::None:
+  case UbsansStrictFlexArraysLevelKind::None:
     return getLangOpts().getStrictFlexArraysLevel();
   }
 }
@@ -1218,7 +1218,7 @@ void CodeGenFunction::EmitBoundsCheck(const Expr *E, const Expr *Base,
   assert(SanOpts.has(SanitizerKind::ArrayBounds) &&
          "should not be called unless adding bounds checks");
   LangOptions::StrictFlexArraysLevelKind StrictFlexArraysLevel =
-      effectiveArrayBoundsFlexArraysLevel();
+      effectiveUbsanFlexArraysLevel();
 
   QualType IndexedType;
   llvm::Value *Bound =
@@ -4404,7 +4404,7 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
       // i.e. "a.b.count", so we shouldn't need the full force of EmitLValue or
       // similar to emit the correct GEP.
       const LangOptions::StrictFlexArraysLevelKind StrictFlexArraysLevel =
-          effectiveArrayBoundsFlexArraysLevel();
+          effectiveUbsanFlexArraysLevel();
 
       if (const auto *ME = dyn_cast<MemberExpr>(Array);
           ME &&

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3315,6 +3315,7 @@ public:
                      SanitizerSet SkippedChecks = SanitizerSet(),
                      llvm::Value *ArraySize = nullptr);
 
+  LangOptions::StrictFlexArraysLevelKind effectiveArrayBoundsFlexArraysLevel();
   /// Emit a check that \p Base points into an array object, which
   /// we can access at index \p Index. \p Accessed should be \c false if we
   /// this expression is used as an lvalue, for instance in "&Arr[Idx]".

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3315,7 +3315,7 @@ public:
                      SanitizerSet SkippedChecks = SanitizerSet(),
                      llvm::Value *ArraySize = nullptr);
 
-  LangOptions::StrictFlexArraysLevelKind effectiveArrayBoundsFlexArraysLevel();
+  LangOptions::StrictFlexArraysLevelKind effectiveUbsanFlexArraysLevel();
   /// Emit a check that \p Base points into an array object, which
   /// we can access at index \p Index. \p Accessed should be \c false if we
   /// this expression is used as an lvalue, for instance in "&Arr[Idx]".

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6976,6 +6976,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                   options::OPT_fno_unroll_loops);
 
   Args.AddLastArg(CmdArgs, options::OPT_fstrict_flex_arrays_EQ);
+  Args.AddLastArg(CmdArgs,
+                  options::OPT_fsanitize_array_bounds_strict_flex_arrays_EQ);
 
   Args.AddLastArg(CmdArgs, options::OPT_pthread);
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6977,7 +6977,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_fstrict_flex_arrays_EQ);
   Args.AddLastArg(CmdArgs,
-                  options::OPT_fsanitize_array_bounds_strict_flex_arrays_EQ);
+                  options::OPT_fsanitize_undefined_strict_flex_arrays_EQ);
 
   Args.AddLastArg(CmdArgs, options::OPT_pthread);
 

--- a/clang/test/CodeGen/bounds-checking-fam.c
+++ b/clang/test/CodeGen/bounds-checking-fam.c
@@ -7,6 +7,16 @@
 // RUN: %clang_cc1 -emit-llvm -triple x86_64 -fstrict-flex-arrays=2 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2,CXX
 // RUN: %clang_cc1 -emit-llvm -triple x86_64 -fstrict-flex-arrays=3 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3
 // RUN: %clang_cc1 -emit-llvm -triple x86_64 -fstrict-flex-arrays=3 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3,CXX
+
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=0 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-0,CXX,CXX-STRICT-0
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=0 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-0
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=1 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-1
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=1 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-1,CXX
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=2 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=2 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2,CXX
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=3 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=3 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3,CXX
+
 // Before flexible array member was added to C99, many projects use a
 // one-element array as the last member of a structure as an alternative.
 // E.g. https://github.com/python/cpython/issues/84301

--- a/clang/test/CodeGen/bounds-checking-fam.c
+++ b/clang/test/CodeGen/bounds-checking-fam.c
@@ -8,14 +8,14 @@
 // RUN: %clang_cc1 -emit-llvm -triple x86_64 -fstrict-flex-arrays=3 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3
 // RUN: %clang_cc1 -emit-llvm -triple x86_64 -fstrict-flex-arrays=3 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3,CXX
 
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=0 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-0,CXX,CXX-STRICT-0
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=0 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-0
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=1 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-1
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=1 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-1,CXX
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=2 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=2 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2,CXX
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=3 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3
-// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-bounds-strict-flex-arrays=3 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3,CXX
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=0 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-0,CXX,CXX-STRICT-0
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=0 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-0
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=1 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-1
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=1 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-1,CXX
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=2 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=2 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-2,CXX
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=3 -fsanitize=array-bounds        %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3
+// RUN: %clang_cc1 -emit-llvm -triple x86_64 -fsanitize-undefined-strict-flex-arrays=3 -fsanitize=array-bounds -x c++ %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-STRICT-3,CXX
 
 // Before flexible array member was added to C99, many projects use a
 // one-element array as the last member of a structure as an alternative.


### PR DESCRIPTION
This is the control the definition of flex arrays separately for bounds
sanitizer than for the codegen.
