### PR TITLE
[lldb][Darwin] Change DynamicLoaderDarwin to default to new SPI

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -1208,34 +1208,43 @@ DynamicLoaderDarwin::GetThreadLocalData(const lldb::ModuleSP module_sp,
 
 bool DynamicLoaderDarwin::UseDYLDSPI(Process *process) {
   Log *log = GetLog(LLDBLog::DynamicLoader);
-  bool use_new_spi_interface = false;
+  bool use_new_spi_interface = true;
 
   llvm::VersionTuple version = process->GetHostOSVersion();
   if (!version.empty()) {
     const llvm::Triple::OSType os_type =
         process->GetTarget().GetArchitecture().GetTriple().getOS();
 
-    // macOS 10.12 and newer
-    if (os_type == llvm::Triple::MacOSX &&
-        version >= llvm::VersionTuple(10, 12))
-      use_new_spi_interface = true;
+    // Older than macOS 10.12
+    if (os_type == llvm::Triple::MacOSX && version < llvm::VersionTuple(10, 12))
+      use_new_spi_interface = false;
 
-    // iOS 10 and newer
-    if (os_type == llvm::Triple::IOS && version >= llvm::VersionTuple(10))
-      use_new_spi_interface = true;
+    // Older than iOS 10
+    if (os_type == llvm::Triple::IOS && version < llvm::VersionTuple(10))
+      use_new_spi_interface = false;
 
-    // tvOS 10 and newer
-    if (os_type == llvm::Triple::TvOS && version >= llvm::VersionTuple(10))
-      use_new_spi_interface = true;
+    // Older than tvOS 10
+    if (os_type == llvm::Triple::TvOS && version < llvm::VersionTuple(10))
+      use_new_spi_interface = false;
 
-    // watchOS 3 and newer
-    if (os_type == llvm::Triple::WatchOS && version >= llvm::VersionTuple(3))
-      use_new_spi_interface = true;
+    // Older than watchOS 3
+    if (os_type == llvm::Triple::WatchOS && version < llvm::VersionTuple(3))
+      use_new_spi_interface = false;
 
-    // NEED_BRIDGEOS_TRIPLE // Any BridgeOS
-    // NEED_BRIDGEOS_TRIPLE if (os_type == llvm::Triple::BridgeOS)
-    // NEED_BRIDGEOS_TRIPLE   use_new_spi_interface = true;
+    // llvm::Triple::BridgeOS and llvm::Triple::XROS always use the new
+    // libdyld SPI interface.
+  } else {
+    // We could not get an OS version string, we are likely not
+    // connected to debugserver and the packets to call the libdyld SPI
+    // will not exist.
+    use_new_spi_interface = false;
   }
+
+  // Corefiles cannot use the dyld SPI to get the inferior's
+  // binaries, we must find it through metadata or a scan
+  // of the corefile memory.
+  if (!process->IsLiveDebugSession())
+    use_new_spi_interface = false;
 
   if (log) {
     if (use_new_spi_interface)

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -1240,7 +1240,7 @@ bool DynamicLoaderDarwin::UseDYLDSPI(Process *process) {
     use_new_spi_interface = false;
   }
 
-  // Corefiles cannot use the dyld SPI to get the inferior's
+  // Corefiles cannot use the libdyld SPI to get the inferior's
   // binaries, we must find it through metadata or a scan
   // of the corefile memory.
   if (!process->IsLiveDebugSession())


### PR DESCRIPTION
In Sep 2016 and newer Darwin releases, debugserver uses libdyld SPI to gather information about the binaries loaded in a process.  Before Sep 2016, lldb would inspect the dyld internal data structures directly itself to find this information.

DynamicLoaderDarwin::UseDYLDSPI currently defaults to the old inspect-dyld-internal-structures method for binaries (DynamicLoaderMacOSXDYLD).  If it detects that the Process' host OS version is new enough, it enables the newer libdyld SPI methods in debugserver (DynamicLoaderMacOS).

This patch changes the default to use the new libdyld SPI interfaces. If the Process has a HostOS and it is one of the four specific OSes that existed in 2015 (Mac OS X, iOS, tvOS, watchOS) with an old version number, then we will enable the old DynamicLoader plugin.

If this debug session is a corefile, we will always use the old DynamicLoader plugin -- the libdyld SPI cannot run against a corefile, lldb must read metadata or the dyld internal data structures in the corefile to find the loaded binaries.