### PR TITLE
[Clang] Distro: Recognize newer Debian/Ubuntu releases and LinuxMint

### DIFF
--- a/clang/include/clang/Driver/Distro.h
+++ b/clang/include/clang/Driver/Distro.h
@@ -39,6 +39,8 @@ public:
     DebianBullseye,
     DebianBookworm,
     DebianTrixie,
+    DebianUnknown, // Unknown (likely newer) release of Debian
+    LMDE, // Just treat LMDE as Debian
     Exherbo,
     RHEL5,
     RHEL6,
@@ -81,6 +83,8 @@ public:
     UbuntuNoble,
     UbuntuOracular,
     UbuntuPlucky,
+    UbuntuUnknown, // Unknown (likely newer) release of Ubuntu
+    LinuxMint, // Just treat LinuxMint as Ubuntu
     UnknownDistro
   };
 
@@ -128,11 +132,11 @@ public:
   bool IsOpenSUSE() const { return DistroVal == OpenSUSE; }
 
   bool IsDebian() const {
-    return DistroVal >= DebianLenny && DistroVal <= DebianTrixie;
+    return DistroVal >= DebianLenny && DistroVal <= LMDE;
   }
 
   bool IsUbuntu() const {
-    return DistroVal >= UbuntuHardy && DistroVal <= UbuntuPlucky;
+    return DistroVal >= UbuntuHardy && DistroVal <= LinuxMint;
   }
 
   bool IsAlpineLinux() const { return DistroVal == AlpineLinux; }


### PR DESCRIPTION
Currently the `Distro` class detects Debian/Ubuntu based on hardcoded _known_ versions/codenames, as a result newer versions are unknown and detected as `UnknownDistro`. This could cause some issues on such newer distros, for example cuda not searching `/usr/lib/cuda` or missing `-z relro`.

Also, LinuxMint and LMDE are reported as `UnknownDistro`, whereas the expected behavior IMHO they should be treated as Ubuntu and Debian respectively.

Currently the new distro issue is handled by extending the hardcoded list manually as new Debian/Ubuntu codenames/versions are out, also distro maintainers are adding a patch when they build llvm from source - but this could still makes some difference if an average user decides to build llvm/clang from vanilla source.

So this patch adds `DebianUnknown` and `UbuntuUnknown` enum values to address this issue in case it looks like a Ubuntu/Debian distro but the version is unknown - which in most cases means the distro is more recent than llvm.

One thing up to discuss:
I added also `LMDE` and `LinuxMint` enum values because this way the code change is minimal and easy to review. An alternate way to do so is just use `DebianUnknown` and `UbuntuUnknown` enum values for LMDE/LinuxMint, but requires more code change and using flags to make the code harder to read.  
I don't have any preference and I can change the code if you think the latter is more preferable.