### PR TITLE
[flang][RISCV] Add target-abi ModuleFlag.

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -261,6 +261,10 @@ void Flang::AddPPCTargetArgs(const ArgList &Args,
 void Flang::AddRISCVTargetArgs(const ArgList &Args,
                                ArgStringList &CmdArgs) const {
   const llvm::Triple &Triple = getToolChain().getTriple();
+
+  StringRef ABIName = riscv::getRISCVABI(Args, Triple);
+  CmdArgs.push_back(Args.MakeArgString("-mabi=" + ABIName));
+
   // Handle -mrvv-vector-bits=<bits>
   if (Arg *A = Args.getLastArg(options::OPT_mrvv_vector_bits_EQ)) {
     StringRef Val = A->getValue();

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -267,8 +267,7 @@ void Flang::AddRISCVTargetArgs(const ArgList &Args,
   if (ABIName == "lp64" || ABIName == "lp64f" || ABIName == "lp64d")
     CmdArgs.push_back(Args.MakeArgString("-mabi=" + ABIName));
   else
-    D.Diag(diag::err_drv_unsupported_option_argument)
-        << "-mabi=" << ABIName;
+    D.Diag(diag::err_drv_unsupported_option_argument) << "-mabi=" << ABIName;
 
   // Handle -mrvv-vector-bits=<bits>
   if (Arg *A = Args.getLastArg(options::OPT_mrvv_vector_bits_EQ)) {

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -260,15 +260,19 @@ void Flang::AddPPCTargetArgs(const ArgList &Args,
 
 void Flang::AddRISCVTargetArgs(const ArgList &Args,
                                ArgStringList &CmdArgs) const {
+  const Driver &D = getToolChain().getDriver();
   const llvm::Triple &Triple = getToolChain().getTriple();
 
   StringRef ABIName = riscv::getRISCVABI(Args, Triple);
-  CmdArgs.push_back(Args.MakeArgString("-mabi=" + ABIName));
+  if (ABIName == "lp64" || ABIName == "lp64f" || ABIName == "lp64d")
+    CmdArgs.push_back(Args.MakeArgString("-mabi=" + ABIName));
+  else
+    D.Diag(diag::err_drv_unsupported_option_argument)
+        << "-mabi=" << ABIName;
 
   // Handle -mrvv-vector-bits=<bits>
   if (Arg *A = Args.getLastArg(options::OPT_mrvv_vector_bits_EQ)) {
     StringRef Val = A->getValue();
-    const Driver &D = getToolChain().getDriver();
 
     // Get minimum VLen from march.
     unsigned MinVLen = 0;

--- a/flang/include/flang/Frontend/TargetOptions.h
+++ b/flang/include/flang/Frontend/TargetOptions.h
@@ -35,6 +35,9 @@ public:
   /// If given, the name of the target CPU to tune code for.
   std::string cpuToTuneFor;
 
+  /// If given, the name of the target ABI to use.
+  std::string abi;
+
   /// The list of target specific features to enable or disable, as written on
   /// the command line.
   std::vector<std::string> featuresAsWritten;

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -464,6 +464,7 @@ static void parseTargetArgs(TargetOptions &opts, llvm::opt::ArgList &args) {
 
   if (const llvm::opt::Arg *a =
           args.getLastArg(clang::driver::options::OPT_mabi_EQ)) {
+    opts.abi = a->getValue();
     llvm::StringRef V = a->getValue();
     if (V == "vec-extabi") {
       opts.EnableAIXExtendedAltivecABI = true;

--- a/flang/test/Driver/mabi-riscv.f90
+++ b/flang/test/Driver/mabi-riscv.f90
@@ -1,0 +1,14 @@
+! RUN: not %flang -c --target=riscv64-unknown-linux -mabi=ilp32 %s -### 2>&1 | FileCheck --check-prefix=INVALID1 %s
+! RUN: not %flang -c --target=riscv64-unknown-linux -mabi=lp64e %s -### 2>&1 | FileCheck --check-prefix=INVALID2 %s
+! RUN: %flang -c --target=riscv64-unknown-linux -mabi=lp64 %s -### 2>&1 | FileCheck --check-prefix=ABI1 %s
+! RUN: %flang -c --target=riscv64-unknown-linux -mabi=lp64f %s -### 2>&1 | FileCheck --check-prefix=ABI2 %s
+! RUN: %flang -c --target=riscv64-unknown-linux -mabi=lp64d %s -### 2>&1 | FileCheck --check-prefix=ABI3 %s
+! RUN: %flang -c --target=riscv64-unknown-linux %s -### 2>&1 | FileCheck --check-prefix=ABI3 %s
+
+! INVALID1: error: unsupported argument 'ilp32' to option '-mabi='
+! INVALID2: error: unsupported argument 'lp64e' to option '-mabi='
+
+! ABI1: "-mabi=lp64"
+! ABI2: "-mabi=lp64f"
+! ABI3: "-mabi=lp64d"
+

--- a/flang/test/Lower/RISCV/riscv-target-abi.f90
+++ b/flang/test/Lower/RISCV/riscv-target-abi.f90
@@ -1,0 +1,10 @@
+! REQUIRES: riscv-registered-target
+! RUN: %flang_fc1 -triple riscv64-none-linux-gnu -mabi=lp64  -emit-llvm -o - %s | FileCheck %s --check-prefix=LP64
+! RUN: %flang_fc1 -triple riscv64-none-linux-gnu -mabi=lp64f  -emit-llvm -o - %s | FileCheck %s --check-prefix=LP64F
+! RUN: %flang_fc1 -triple riscv64-none-linux-gnu -mabi=lp64d  -emit-llvm -o - %s | FileCheck %s --check-prefix=LP64D
+
+! LP64: !{{[0-9]+}} = !{i32 1, !"target-abi", !"lp64"}
+! LP64F: !{{[0-9]+}} = !{i32 1, !"target-abi", !"lp64f"}
+! LP64D: !{{[0-9]+}} = !{i32 1, !"target-abi", !"lp64d"}
+subroutine func
+end subroutine func


### PR DESCRIPTION
This is needed to generate proper ABI flags in the ELF header for LTO builds. If these flags aren't set correctly, we can't link with objects that were built with the correct flags.

For non-LTO builds the mcpu/mattr in the TargetMachine will cause the backend to infer an ABI. For LTO builds the mcpu/mattr aren't set.

I've only added lp64, lp64f, and lp64d ABIs. ilp32* requires riscv32 which is not yet supported in flang. lp64e requires a different DataLayout string and would need additional plumbing.

Fixes #115679