### PR TITLE
[WebKit checkers] Treat an implicit value initialization as trivial

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -636,6 +636,11 @@ public:
     return true;
   }
 
+  bool VisitImplicitValueInitExpr(const ImplicitValueInitExpr *IVIE) {
+    // An implicit value initialization is trvial.
+    return true;
+  }
+
 private:
   CacheTy &Cache;
   CacheTy RecursiveFn;

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -368,6 +368,11 @@ public:
   }
   RefPtr<RefCounted> trivial66() { return children[0]; }
   Ref<RefCounted> trivial67() { return *children[0]; }
+  struct point {
+    double x;
+    double y;
+  };
+  void trivial68() { point pt = { 1.0 }; }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -554,6 +559,7 @@ public:
     getFieldTrivial().trivial65(); // no-warning
     getFieldTrivial().trivial66()->trivial6(); // no-warning
     getFieldTrivial().trivial67()->trivial6(); // no-warning
+    getFieldTrivial().trivial68(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning


### PR DESCRIPTION
Implicit value initialization is trivial for our purposes.