### PR TITLE
Add support for the intrinsic @llvm.fptosi.sat.* and @llvm.fptoui.sat.* lowering

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -603,6 +603,11 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
   case TargetOpcode::G_FPTOUI:
     return selectUnOp(ResVReg, ResType, I, SPIRV::OpConvertFToU);
 
+  case TargetOpcode::G_FPTOSI_SAT:
+    return selectUnOp(ResVReg, ResType, I, SPIRV::OpConvertFToS);
+  case TargetOpcode::G_FPTOUI_SAT:
+    return selectUnOp(ResVReg, ResType, I, SPIRV::OpConvertFToU);
+
   case TargetOpcode::G_SITOFP:
     return selectIToF(ResVReg, ResType, I, true, SPIRV::OpConvertSToF);
   case TargetOpcode::G_UITOFP:

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -236,6 +236,10 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       .legalForCartesianProduct(allIntScalarsAndVectors,
                                 allFloatScalarsAndVectors);
 
+  getActionDefinitionsBuilder({G_FPTOSI_SAT, G_FPTOUI_SAT})
+      .legalForCartesianProduct(allIntScalarsAndVectors,
+                                allFloatScalarsAndVectors);
+
   getActionDefinitionsBuilder({G_SITOFP, G_UITOFP})
       .legalForCartesianProduct(allFloatScalarsAndVectors,
                                 allScalarsAndVectors);

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp_to_int_intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp_to_int_intrinsics.ll
@@ -1,0 +1,210 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unkown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unkown-unknown %s -o - -filetype=obj | spirv-val %}
+ 
+; CHECK: OpDecorate %[[#SAT1:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT2:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT3:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT4:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT5:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT6:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT7:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT8:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT9:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT10:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT11:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT12:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT13:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT14:]] SaturatedConversion
+; CHECK: OpDecorate %[[#SAT15:]] SaturatedConversion
+ 
+
+; CHECK: %[[#SAT1:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_signed_i8(float %input) {
+entry:
+   %ptr = alloca i8
+   %0 = call i8 @llvm.fptosi.sat.i8.f32(float %input)
+   store i8 %0, i8* %ptr
+   ret void
+
+}
+declare i8 @llvm.fptosi.sat.i8.f32(float)
+ 
+ 
+; CHECK: %[[#SAT2:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_signed_i16(float %input) {
+entry:
+   %ptr = alloca i16
+   %0 = call i16 @llvm.fptosi.sat.i16.f32(float %input)
+   store i16 %0, i16* %ptr
+   ret void
+
+}
+declare i16 @llvm.fptosi.sat.i16.f32(float)
+ 
+; CHECK: %[[#SAT3:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_signed_i32(float %input) {
+entry:
+   %ptr = alloca i32
+   %0 = call i32 @llvm.fptosi.sat.i32.f32(float %input)
+   store i32 %0, i32* %ptr
+   ret void
+
+}
+declare i32 @llvm.fptosi.sat.i32.f32(float)
+ 
+
+; CHECK: %[[#SAT4:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_signed_i64(float %input) {
+entry:
+   %ptr = alloca i64
+   %0 = call i64 @llvm.fptosi.sat.i64.f32(float %input)
+   store i64 %0, i64* %ptr
+   ret void
+}
+declare i64 @llvm.fptosi.sat.i64.f32(float)
+ 
+
+; CHECK: %[[#SAT5:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_signed_i8(double %input) {
+entry:
+   %ptr = alloca i8
+   %0 = call i8 @llvm.fptosi.sat.i8.f64(double %input)
+   store i8 %0, i8* %ptr
+   ret void
+}
+declare i8 @llvm.fptosi.sat.i8.f64(double)
+ 
+
+; CHECK: %[[#SAT6:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_signed_i16(double %input) {
+entry:
+   %ptr = alloca i16
+   %0 = call i16 @llvm.fptosi.sat.i16.f64(double %input)
+   store i16 %0, i16* %ptr
+   ret void
+}
+declare i16 @llvm.fptosi.sat.i16.f64(double)
+ 
+ 
+; CHECK: %[[#SAT7:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_signed_i32(double %input) {
+entry:
+   %ptr = alloca i32
+   %0 = call i32 @llvm.fptosi.sat.i32.f64(double %input)
+   store i32 %0, i32* %ptr
+   ret void
+}
+declare i32 @llvm.fptosi.sat.i32.f64(double)
+ 
+ 
+; CHECK: %[[#SAT8:]] = OpConvertFToS %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_signed_i64(double %input) {
+entry:
+   %ptr = alloca i64
+   %0 = call i64 @llvm.fptosi.sat.i64.f64(double %input)
+   store i64 %0, i64* %ptr
+   ret void
+}
+declare i64 @llvm.fptosi.sat.i64.f64(double)
+ 
+ 
+ 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; unsigned output
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+; CHECK: %[[#SAT8:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_unsigned_i8(float %input) {
+entry:
+   %ptr = alloca i8
+   %0 = call i8 @llvm.fptoui.sat.i8.f32(float %input)
+   store i8 %0, i8* %ptr
+   ret void
+}
+declare i8 @llvm.fptoui.sat.i8.f32(float)
+ 
+
+; CHECK: %[[#SAT9:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_unsigned_i16(float %input) {
+entry:
+   %ptr = alloca i16
+   %0 = call i16 @llvm.fptoui.sat.i16.f32(float %input)
+   store i16 %0, i16* %ptr
+   ret void
+}
+declare i16 @llvm.fptoui.sat.i16.f32(float)
+
+
+; CHECK: %[[#SAT10:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_unsigned_i32(float %input) {
+entry:
+   %ptr = alloca i32
+   %0 = call i32 @llvm.fptoui.sat.i32.f32(float %input)
+   store i32 %0, i32* %ptr
+   ret void
+}
+declare i32 @llvm.fptoui.sat.i32.f32(float)
+ 
+
+; CHECK: %[[#SAT11:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_float_to_unsigned_i64(float %input) {
+entry:
+   %ptr = alloca i64
+   %0 = call i64 @llvm.fptoui.sat.i64.f32(float %input)
+   store i64 %0, i64* %ptr
+   ret void
+}
+declare i64 @llvm.fptoui.sat.i64.f32(float)
+ 
+
+; CHECK: %[[#SAT12:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_unsigned_i8(double %input) {
+entry:
+   %ptr = alloca i8
+   %0 = call i8 @llvm.fptoui.sat.i8.f64(double %input)
+   store i8 %0, i8* %ptr
+   ret void
+}
+declare i8 @llvm.fptoui.sat.i8.f64(double)
+ 
+
+; CHECK: %[[#SAT13:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_unsigned_i16(double %input) {
+entry:
+   %ptr = alloca i16
+   %0 = call i16 @llvm.fptoui.sat.i16.f64(double %input)
+   store i16 %0, i16* %ptr
+   ret void
+}
+declare i16 @llvm.fptoui.sat.i16.f64(double)
+ 
+
+; CHECK: %[[#SAT14:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_unsigned_i32(double %input) {
+entry:
+   %ptr = alloca i32
+   %0 = call i32 @llvm.fptoui.sat.i32.f64(double %input)
+   store i32 %0, i32* %ptr
+   ret void
+}
+declare i32 @llvm.fptoui.sat.i32.f64(double)
+ 
+
+; CHECK: %[[#SAT15:]] = OpConvertFToU %{{[0-9]+}} %[[#]]
+define spir_kernel void @testfunction_double_to_unsigned_i64(double %input) {
+entry:
+   %ptr = alloca i64
+   %0 = call i64 @llvm.fptoui.sat.i64.f64(double %input)
+   store i64 %0, i64* %ptr
+   ret void
+}
+declare i64 @llvm.fptoui.sat.i64.f64(double)
+ 
+ 
+ 
+ 
+


### PR DESCRIPTION
- add legalizer for G_FPTOSI_SAT and G_FPTOUI_SAT
- add instructionSelector for G_FPTOSI_SAT and G_FPTOUI_SAT
- add function to add saturatedConversion decoration to the intrinsic


currently does not support arbitrary size integer because of the constraints placed by the prelegalizer