### PR TITLE
[clang][bytecode] Remove unnecessary if statement

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6234,9 +6234,6 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
 
       return this->emitGetPtrParam(It->second.Offset, E);
     }
-
-    if (D->getType()->isReferenceType())
-      return this->emitDummyPtr(D, E);
   }
 
   // In case we need to re-visit a declaration.


### PR DESCRIPTION
This doesn't seem to do any good and breaks a few libc++ tests. Remove the special case.