### PR TITLE
[LangRef] Fix some formatting issues (NFC)

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16162,8 +16162,10 @@ trapping or setting ``errno``.
 The first result is the fractional part of the operand and the second result is
 the integral part of the operand. Both results have the same sign as the operand.
 
-Not including exceptional inputs (listed below), `llvm.modf.*` is semantically
+Not including exceptional inputs (listed below), ``llvm.modf.*`` is semantically
 equivalent to:
+
+::
 
   %fp = frem <fptype> %x, 1.0  ; Fractional part
   %ip = fsub <fptype> %x, %fp  ; Integral part


### PR DESCRIPTION
Fixes codeblock and inline code formatting for the `llvm.modf.*` intrinsic.