### PR TITLE
add me to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -38,6 +38,8 @@ Jianjian GUAN <jacquesguan@me.com> <Jianjian.Guan@streamcomputing.com>
 Jon Roelofs <jonathan_roelofs@apple.com> <jonathan@codesourcery.com>
 Jon Roelofs <jonathan_roelofs@apple.com> <jroelofs@jroelofs.com>
 Jonathan Thackray <jonathan.thackray@arm.com> <jthackray@users.noreply.github.com>
+klensy <nightouser@gmail.com>
+klensy <nightouser@gmail.com> <klensy@users.noreply.github.com>
 LLVM GN Syncbot <llvmgnsyncbot@gmail.com>
 Martin Storsjö <martin@martin.st>
 Med Ismail Bennani <ismail@bennani.ma> <m.i.b@apple.com>


### PR DESCRIPTION
 Should add ability for buildbot to find proper mail.

https://github.com/buildbot/buildbot/blob/f1a84bbe5555a40b3fb4f04707fe6398aed4c092/master/buildbot/changes/gitpoller.py#L418

At least buildbot parses user names and mails with respect to mailmap.