### PR TITLE
[ARM] Reject fixed-point VCVT with different registers

### DIFF
--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -8652,6 +8652,37 @@ bool ARMAsmParser::validateInstruction(MCInst &Inst,
                    "coprocessor must be configured as GCP");
     break;
   }
+
+  case ARM::VTOSHH:
+  case ARM::VTOUHH:
+  case ARM::VTOSLH:
+  case ARM::VTOULH:
+  case ARM::VTOSHS:
+  case ARM::VTOUHS:
+  case ARM::VTOSLS:
+  case ARM::VTOULS:
+  case ARM::VTOSHD:
+  case ARM::VTOUHD:
+  case ARM::VTOSLD:
+  case ARM::VTOULD:
+  case ARM::VSHTOH:
+  case ARM::VUHTOH:
+  case ARM::VSLTOH:
+  case ARM::VULTOH:
+  case ARM::VSHTOS:
+  case ARM::VUHTOS:
+  case ARM::VSLTOS:
+  case ARM::VULTOS:
+  case ARM::VSHTOD:
+  case ARM::VUHTOD:
+  case ARM::VSLTOD:
+  case ARM::VULTOD: {
+    if (Operands[MnemonicOpsEndInd]->getReg() !=
+        Operands[MnemonicOpsEndInd + 1]->getReg())
+      return Error(Operands[MnemonicOpsEndInd]->getStartLoc(),
+                   "source and destination registers must be the same");
+    break;
+  }
   }
 
   return false;

--- a/llvm/test/MC/ARM/vcvt-fixed-point-errors.s
+++ b/llvm/test/MC/ARM/vcvt-fixed-point-errors.s
@@ -1,0 +1,51 @@
+// RUN: not llvm-mc -triple=armv8a-none-eabi -mattr=+fullfp16 < %s 2>&1 | FileCheck %s
+
+  vcvt.u16.f16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.s16.f16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.u32.f16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.s32.f16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.u16.f32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.s16.f32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.u32.f32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.s32.f32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.u16.f64 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.s16.f64 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.u32.f64 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.s32.f64 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f16.u16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f16.s16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f16.u32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f16.s32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f32.u16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f32.s16 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f32.u32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f32.s32 s0, s1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f64.u16 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f64.s16 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f64.u32 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+  vcvt.f64.s32 d0, d1, #1
+// CHECK: [[@LINE-1]]{{.*}}error: source and destination registers must be the same
+

--- a/llvm/test/tools/llvm-mca/ARM/m55-fp.s
+++ b/llvm/test/tools/llvm-mca/ARM/m55-fp.s
@@ -21,30 +21,30 @@ vcmpe.f32 s1, #0.0
 vcmpe.f64 d1, #0.0
 vcvt.f32.f64 s1, d2
 vcvt.f64.f32 d1, s1
-vcvt.f16.u16 s1, s2, #8
-vcvt.f16.s16 s1, s2, #8
-vcvt.f16.u32 s1, s2, #8
-vcvt.f16.s32 s1, s2, #8
-vcvt.u16.f16 s1, s2, #8
-vcvt.s16.f16 s1, s2, #8
-vcvt.u32.f16 s1, s2, #8
-vcvt.s32.f16 s1, s2, #8
-vcvt.f32.u16 s1, s2, #8
-vcvt.f32.s16 s1, s2, #8
-vcvt.f32.u32 s1, s2, #8
-vcvt.f32.s32 s1, s2, #8
-vcvt.u16.f32 s1, s2, #8
-vcvt.s16.f32 s1, s2, #8
-vcvt.u32.f32 s1, s2, #8
-vcvt.s32.f32 s1, s2, #8
-vcvt.f64.u16 d1, d2, #8
-vcvt.f64.s16 d1, d2, #8
-vcvt.f64.u32 d1, d2, #8
-vcvt.f64.s32 d1, d2, #8
-vcvt.u16.f64 d1, d2, #8
-vcvt.s16.f64 d1, d2, #8
-vcvt.u32.f64 d1, d2, #8
-vcvt.s32.f64 d1, d2, #8
+vcvt.f16.u16 s1, s1, #8
+vcvt.f16.s16 s1, s1, #8
+vcvt.f16.u32 s1, s1, #8
+vcvt.f16.s32 s1, s1, #8
+vcvt.u16.f16 s1, s1, #8
+vcvt.s16.f16 s1, s1, #8
+vcvt.u32.f16 s1, s1, #8
+vcvt.s32.f16 s1, s1, #8
+vcvt.f32.u16 s1, s1, #8
+vcvt.f32.s16 s1, s1, #8
+vcvt.f32.u32 s1, s1, #8
+vcvt.f32.s32 s1, s1, #8
+vcvt.u16.f32 s1, s1, #8
+vcvt.s16.f32 s1, s1, #8
+vcvt.u32.f32 s1, s1, #8
+vcvt.s32.f32 s1, s1, #8
+vcvt.f64.u16 d1, d1, #8
+vcvt.f64.s16 d1, d1, #8
+vcvt.f64.u32 d1, d1, #8
+vcvt.f64.s32 d1, d1, #8
+vcvt.u16.f64 d1, d1, #8
+vcvt.s16.f64 d1, d1, #8
+vcvt.u32.f64 d1, d1, #8
+vcvt.s32.f64 d1, d1, #8
 vcvt.u32.f16 s1, s2
 vcvt.s32.f16 s1, s2
 vcvt.u32.f32 s1, s2

--- a/llvm/test/tools/llvm-mca/ARM/m7-fp.s
+++ b/llvm/test/tools/llvm-mca/ARM/m7-fp.s
@@ -9,22 +9,22 @@ vcmp.f32 s1, s2
 vcmp.f64 d1, d2
 vcvt.f32.f64 s1, d2
 vcvt.f64.f32 d1, s1
-vcvt.f32.u16 s1, s2, #8
-vcvt.f32.s16 s1, s2, #8
-vcvt.f32.u32 s1, s2, #8
-vcvt.f32.s32 s1, s2, #8
-vcvt.u16.f32 s1, s2, #8
-vcvt.s16.f32 s1, s2, #8
-vcvt.u32.f32 s1, s2, #8
-vcvt.s32.f32 s1, s2, #8
-vcvt.f64.u16 d1, d2, #8
-vcvt.f64.s16 d1, d2, #8
-vcvt.f64.u32 d1, d2, #8
-vcvt.f64.s32 d1, d2, #8
-vcvt.u16.f64 d1, d2, #8
-vcvt.s16.f64 d1, d2, #8
-vcvt.u32.f64 d1, d2, #8
-vcvt.s32.f64 d1, d2, #8
+vcvt.f32.u16 s1, s1, #8
+vcvt.f32.s16 s1, s1, #8
+vcvt.f32.u32 s1, s1, #8
+vcvt.f32.s32 s1, s1, #8
+vcvt.u16.f32 s1, s1, #8
+vcvt.s16.f32 s1, s1, #8
+vcvt.u32.f32 s1, s1, #8
+vcvt.s32.f32 s1, s1, #8
+vcvt.f64.u16 d1, d1, #8
+vcvt.f64.s16 d1, d1, #8
+vcvt.f64.u32 d1, d1, #8
+vcvt.f64.s32 d1, d1, #8
+vcvt.u16.f64 d1, d1, #8
+vcvt.s16.f64 d1, d1, #8
+vcvt.u32.f64 d1, d1, #8
+vcvt.s32.f64 d1, d1, #8
 vcvt.u32.f32 s1, s2
 vcvt.s32.f32 s1, s2
 vcvt.u32.f64 s1, d2

--- a/llvm/test/tools/llvm-mca/ARM/m85-fp.s
+++ b/llvm/test/tools/llvm-mca/ARM/m85-fp.s
@@ -21,30 +21,30 @@ vcmpe.f32 s1, #0.0
 vcmpe.f64 d1, #0.0
 vcvt.f32.f64 s1, d2
 vcvt.f64.f32 d1, s1
-vcvt.f16.u16 s1, s2, #8
-vcvt.f16.s16 s1, s2, #8
-vcvt.f16.u32 s1, s2, #8
-vcvt.f16.s32 s1, s2, #8
-vcvt.u16.f16 s1, s2, #8
-vcvt.s16.f16 s1, s2, #8
-vcvt.u32.f16 s1, s2, #8
-vcvt.s32.f16 s1, s2, #8
-vcvt.f32.u16 s1, s2, #8
-vcvt.f32.s16 s1, s2, #8
-vcvt.f32.u32 s1, s2, #8
-vcvt.f32.s32 s1, s2, #8
-vcvt.u16.f32 s1, s2, #8
-vcvt.s16.f32 s1, s2, #8
-vcvt.u32.f32 s1, s2, #8
-vcvt.s32.f32 s1, s2, #8
-vcvt.f64.u16 d1, d2, #8
-vcvt.f64.s16 d1, d2, #8
-vcvt.f64.u32 d1, d2, #8
-vcvt.f64.s32 d1, d2, #8
-vcvt.u16.f64 d1, d2, #8
-vcvt.s16.f64 d1, d2, #8
-vcvt.u32.f64 d1, d2, #8
-vcvt.s32.f64 d1, d2, #8
+vcvt.f16.u16 s1, s1, #8
+vcvt.f16.s16 s1, s1, #8
+vcvt.f16.u32 s1, s1, #8
+vcvt.f16.s32 s1, s1, #8
+vcvt.u16.f16 s1, s1, #8
+vcvt.s16.f16 s1, s1, #8
+vcvt.u32.f16 s1, s1, #8
+vcvt.s32.f16 s1, s1, #8
+vcvt.f32.u16 s1, s1, #8
+vcvt.f32.s16 s1, s1, #8
+vcvt.f32.u32 s1, s1, #8
+vcvt.f32.s32 s1, s1, #8
+vcvt.u16.f32 s1, s1, #8
+vcvt.s16.f32 s1, s1, #8
+vcvt.u32.f32 s1, s1, #8
+vcvt.s32.f32 s1, s1, #8
+vcvt.f64.u16 d1, d1, #8
+vcvt.f64.s16 d1, d1, #8
+vcvt.f64.u32 d1, d1, #8
+vcvt.f64.s32 d1, d1, #8
+vcvt.u16.f64 d1, d1, #8
+vcvt.s16.f64 d1, d1, #8
+vcvt.u32.f64 d1, d1, #8
+vcvt.s32.f64 d1, d1, #8
 vcvt.u32.f16 s1, s2
 vcvt.s32.f16 s1, s2
 vcvt.u32.f32 s1, s2


### PR DESCRIPTION
These instructions only have one register field in their encoding, so both registers in the assembly must be the same.

Previously, we were accepting these instructions, but ignoring the second register operand.

Fixes #126227