### PR TITLE
[Hexagon] Fix typos discovered by codespell (NFC)

### DIFF
--- a/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
+++ b/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
@@ -74,7 +74,7 @@ static cl::opt<bool> WarnSignedMismatch(
     cl::init(false));
 static cl::opt<bool> WarnNoncontigiousRegister(
     "mwarn-noncontigious-register",
-    cl::desc("Warn for register names that arent contigious"), cl::init(true));
+    cl::desc("Warn for register names that aren't contigious"), cl::init(true));
 static cl::opt<bool> ErrorNoncontigiousRegister(
     "merror-noncontigious-register",
     cl::desc("Error for register names that aren't contigious"),
@@ -1330,7 +1330,7 @@ unsigned HexagonAsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp,
   return Match_InvalidOperand;
 }
 
-// FIXME: Calls to OutOfRange shoudl propagate failure up to parseStatement.
+// FIXME: Calls to OutOfRange should propagate failure up to parseStatement.
 bool HexagonAsmParser::OutOfRange(SMLoc IDLoc, long long Val, long long Max) {
   std::string errStr;
   raw_string_ostream ES(errStr);

--- a/llvm/lib/Target/Hexagon/HexagonBitSimplify.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonBitSimplify.cpp
@@ -2854,7 +2854,7 @@ bool HexagonBitSimplify::runOnMachineFunction(MachineFunction &MF) {
 // Recognize loops where the code at the end of the loop matches the code
 // before the entry of the loop, and the matching code is such that is can
 // be simplified. This pass relies on the bit simplification above and only
-// prepares code in a way that can be handled by the bit simplifcation.
+// prepares code in a way that can be handled by the bit simplification.
 //
 // This is the motivating testcase (and explanation):
 //

--- a/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
@@ -1040,7 +1040,7 @@ unsigned HCE::getDirectRegReplacement(unsigned ExtOpc) const {
 // extender. It may be possible for MI to be tweaked to work for a register
 // defined with a slightly different value. For example
 //   ... = L2_loadrub_io Rb, 1
-// can be modifed to be
+// can be modified to be
 //   ... = L2_loadrub_io Rb', 0
 // if Rb' = Rb+1.
 // The range for Rb would be [Min+1, Max+1], where [Min, Max] is a range

--- a/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
@@ -101,7 +101,7 @@ namespace {
 
   // Lattice cell, based on that was described in the W-Z paper on constant
   // propagation.
-  // Latice cell will be allowed to hold multiple constant values. While
+  // Lattice cell will be allowed to hold multiple constant values. While
   // multiple values would normally indicate "bottom", we can still derive
   // some useful information from them. For example, comparison X > 0
   // could be folded if all the values in the cell associated with X are
@@ -795,7 +795,7 @@ void MachineConstPropagator::visitUsesOf(unsigned Reg) {
   LLVM_DEBUG(dbgs() << "Visiting uses of " << printReg(Reg, &MCE.TRI)
                     << Cells.get(Reg) << '\n');
   for (MachineInstr &MI : MRI->use_nodbg_instructions(Reg)) {
-    // Do not process non-executable instructions. They can become exceutable
+    // Do not process non-executable instructions. They can become executable
     // later (via a flow-edge in the work queue). In such case, the instruc-
     // tion will be visited at that time.
     if (!InstrExec.count(&MI))

--- a/llvm/lib/Target/Hexagon/HexagonCopyToCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCopyToCombine.cpp
@@ -385,7 +385,7 @@ bool HexagonCopyToCombine::isSafeToMoveTogether(MachineInstr &I1,
   return true;
 }
 
-/// findPotentialNewifiableTFRs - Finds tranfers that feed stores that could be
+/// findPotentialNewifiableTFRs - Finds transfers that feed stores that could be
 /// newified. (A use of a 64 bit register define can not be newified)
 void
 HexagonCopyToCombine::findPotentialNewifiableTFRs(MachineBasicBlock &BB) {

--- a/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
@@ -720,7 +720,7 @@ bool HexagonExpandCondsets::split(MachineInstr &MI,
     }
   }
 
-  // First, create the two invididual conditional transfers, and add each
+  // First, create the two individual conditional transfers, and add each
   // of them to the live intervals information. Do that first and then remove
   // the old instruction from live intervals.
   MachineInstr *TfrT =

--- a/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
@@ -825,7 +825,7 @@ CountValue *HexagonHardwareLoops::computeCount(MachineLoop *Loop,
   // a computation of it into the preheader.
 
   // If the induction variable bump is not a power of 2, quit.
-  // Othwerise we'd need a general integer division.
+  // Otherwise we'd need a general integer division.
   if (!isPowerOf2_64(std::abs(IVBump)))
     return nullptr;
 
@@ -1398,10 +1398,10 @@ bool HexagonHardwareLoops::phiMayWrapOrUnderflow(
 /// counter if it is <= 1. We only need to perform this analysis if the
 /// initial value is a register.
 ///
-/// This function assumes the initial value may underfow unless proven
+/// This function assumes the initial value may underflow unless proven
 /// otherwise. If the type is signed, then we don't care because signed
 /// underflow is undefined. We attempt to prove the initial value is not
-/// zero by perfoming a crude analysis of the loop counter. This function
+/// zero by performing a crude analysis of the loop counter. This function
 /// checks if the initial value is used in any comparison prior to the loop
 /// and, if so, assumes the comparison is a range check. This is inexact,
 /// but will catch the simple cases.

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
@@ -1984,7 +1984,7 @@ SmallVector<uint32_t, 8> HvxSelector::getPerfectCompletions(ShuffleMask SM,
   // same as in P. This implies that P == Q.
 
   // There can be a situation where there are more entries with the same
-  // bits set than there are set bits (e.g. value 9 occuring more than 2
+  // bits set than there are set bits (e.g. value 9 occurring more than 2
   // times). In such cases it will be impossible to complete this to a
   // perfect shuffle.
   SmallVector<uint32_t, 8> Sorted(Worklist);
@@ -1995,7 +1995,7 @@ SmallVector<uint32_t, 8> HvxSelector::getPerfectCompletions(ShuffleMask SM,
     while (++I != E && P == Sorted[I])
       ++Count;
     if ((unsigned)llvm::popcount(P) < Count) {
-      // Reset all occurences of P, if there are more occurrences of P
+      // Reset all occurrences of P, if there are more occurrences of P
       // than there are bits in P.
       llvm::replace(Worklist, P, 0U);
     }
@@ -2223,7 +2223,7 @@ OpRef HvxSelector::perfect(ShuffleMask SM, OpRef Va, ResultStack &Results) {
   // V6_vdeal{b,h}
   // V6_vshuff{b,h}
 
-  // V6_vshufoe{b,h}  those are quivalent to vshuffvdd(..,{1,2})
+  // V6_vshufoe{b,h}  those are equivalent to vshuffvdd(..,{1,2})
   // V6_vshuffvdd (V6_vshuff)
   // V6_dealvdd (V6_vdeal)
 

--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -814,7 +814,7 @@ SDValue HexagonTargetLowering::LowerFormalArguments(
   // stack where the return value will be stored. For Hexagon, the location on
   // caller's stack is passed only when the struct size is smaller than (and
   // equal to) 8 bytes. If not, no address will be passed into callee and
-  // callee return the result direclty through R0/R1.
+  // callee return the result directly through R0/R1.
   auto NextSingleReg = [] (const TargetRegisterClass &RC, unsigned Reg) {
     switch (RC.getID()) {
     case Hexagon::IntRegsRegClassID:
@@ -979,7 +979,7 @@ HexagonTargetLowering::LowerVASTART(SDValue Op, SelectionDAG &DAG) const {
   // If first Vararg register is odd, add 4 bytes to start of
   // saved register area to point to the first register location.
   // This is because the saved register area has to be 8 byte aligned.
-  // Incase of an odd start register, there will be 4 bytes of padding in
+  // In case of an odd start register, there will be 4 bytes of padding in
   // the beginning of saved register area. If all registers area used up,
   // the following condition will handle it correctly.
   SDValue SavedRegAreaStartFrameIndex =
@@ -1321,7 +1321,7 @@ HexagonTargetLowering::GetDynamicTLSAddr(SelectionDAG &DAG, SDValue Chain,
 }
 
 //
-// Lower using the intial executable model for TLS addresses
+// Lower using the initial executable model for TLS addresses
 //
 SDValue
 HexagonTargetLowering::LowerToTLSInitialExecModel(GlobalAddressSDNode *GA,
@@ -3320,7 +3320,7 @@ HexagonTargetLowering::LowerEH_RETURN(SDValue Op, SelectionDAG &DAG) const {
   Chain = DAG.getStore(Chain, dl, Handler, StoreAddr, MachinePointerInfo());
   Chain = DAG.getCopyToReg(Chain, dl, OffsetReg, Offset);
 
-  // Not needed we already use it as explict input to EH_RETURN.
+  // Not needed we already use it as explicit input to EH_RETURN.
   // MF.getRegInfo().addLiveOut(OffsetReg);
 
   return DAG.getNode(HexagonISD::EH_RETURN, dl, MVT::Other, Chain);

--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -2400,7 +2400,7 @@ HexagonTargetLowering::VectorPair
 HexagonTargetLowering::emitHvxAddWithOverflow(SDValue A, SDValue B,
       const SDLoc &dl, bool Signed, SelectionDAG &DAG) const {
   // Compute A+B, return {A+B, O}, where O = vector predicate indicating
-  // whether an overflow has occured.
+  // whether an overflow has occurred.
   MVT ResTy = ty(A);
   assert(ResTy == ty(B));
   MVT PredTy = MVT::getVectorVT(MVT::i1, ResTy.getVectorNumElements());
@@ -2911,7 +2911,7 @@ HexagonTargetLowering::CreateTLWrapper(SDValue Op, SelectionDAG &DAG) const {
 #ifndef NDEBUG
     Op.dump(&DAG);
 #endif
-    llvm_unreachable("Unepected operator");
+    llvm_unreachable("Unexpected operator");
   }
 
   const SDLoc &dl(Op);

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.cpp
@@ -2240,7 +2240,7 @@ bool HexagonInstrInfo::isDependent(const MachineInstr &ProdMI,
   return false;
 }
 
-// Returns true if the instruction is alread a .cur.
+// Returns true if the instruction is already a .cur.
 bool HexagonInstrInfo::isDotCurInst(const MachineInstr &MI) const {
   switch (MI.getOpcode()) {
   case Hexagon::V6_vL32b_cur_pi:
@@ -3860,7 +3860,7 @@ int HexagonInstrInfo::getDotNewPredJumpOp(const MachineInstr &MI,
 int HexagonInstrInfo::getDotNewPredOp(const MachineInstr &MI,
       const MachineBranchProbabilityInfo *MBPI) const {
   switch (MI.getOpcode()) {
-  // Condtional Jumps
+  // Conditional Jumps
   case Hexagon::J2_jumpt:
   case Hexagon::J2_jumpf:
     return getDotNewPredJumpOp(MI, MBPI);
@@ -4325,7 +4325,7 @@ unsigned HexagonInstrInfo::getInstrTimingClassLatency(
 /// operand latency. But it may not be possible for instructions with variable
 /// number of defs / uses.
 ///
-/// This is a raw interface to the itinerary that may be directly overriden by
+/// This is a raw interface to the itinerary that may be directly overridden by
 /// a target. Use computeOperandLatency to get the best estimate of latency.
 std::optional<unsigned> HexagonInstrInfo::getOperandLatency(
     const InstrItineraryData *ItinData, const MachineInstr &DefMI,

--- a/llvm/lib/Target/Hexagon/HexagonInstrInfo.h
+++ b/llvm/lib/Target/Hexagon/HexagonInstrInfo.h
@@ -145,7 +145,7 @@ public:
 
   /// Second variant of isProfitableToIfCvt. This one
   /// checks for the case where two basic blocks from true and false path
-  /// of a if-then-else (diamond) are predicated on mutally exclusive
+  /// of a if-then-else (diamond) are predicated on mutually exclusive
   /// predicates, where the probability of the true path being taken is given
   /// by Probability, and Confidence is a measure of our confidence that it
   /// will be properly predicted.
@@ -307,8 +307,9 @@ public:
   /// operand latency. But it may not be possible for instructions with variable
   /// number of defs / uses.
   ///
-  /// This is a raw interface to the itinerary that may be directly overriden by
-  /// a target. Use computeOperandLatency to get the best estimate of latency.
+  /// This is a raw interface to the itinerary that may be directly overridden
+  /// by a target. Use computeOperandLatency to get the best estimate of
+  /// latency.
   std::optional<unsigned> getOperandLatency(const InstrItineraryData *ItinData,
                                             const MachineInstr &DefMI,
                                             unsigned DefIdx,

--- a/llvm/lib/Target/Hexagon/HexagonLoopAlign.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoopAlign.cpp
@@ -49,7 +49,7 @@ static cl::opt<uint32_t> TinyLoopBndlAlignLimit(
 
 static cl::opt<uint32_t>
     LoopEdgeThreshold("hexagon-loop-edge-threshold", cl::Hidden, cl::init(7500),
-                      cl::desc("Set hexagon loop align edge theshold"));
+                      cl::desc("Set hexagon loop align edge threshold"));
 
 namespace llvm {
 FunctionPass *createHexagonLoopAlign();

--- a/llvm/lib/Target/Hexagon/HexagonNewValueJump.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonNewValueJump.cpp
@@ -13,10 +13,10 @@
 // Having said that, we should re-attempt to pull this earlier at some point
 // in future.
 
-// The basic approach looks for sequence of predicated jump, compare instruciton
-// that genereates the predicate and, the feeder to the predicate. Once it finds
+// The basic approach looks for sequence of predicated jump, compare instruction
+// that generates the predicate and, the feeder to the predicate. Once it finds
 // all, it collapses compare and jump instruction into a new value jump
-// intstructions.
+// instructions.
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/Target/Hexagon/HexagonOptAddrMode.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonOptAddrMode.cpp
@@ -152,10 +152,10 @@ bool HexagonOptAddrMode::hasRepForm(MachineInstr &MI, unsigned TfrDefR) {
   }
 
   if (HII->getAddrMode(MI) == HexagonII::BaseRegOffset)
-    // Tranform to Absolute plus register offset.
+    // Transform to Absolute plus register offset.
     return (HII->changeAddrMode_rr_ur(MI) >= 0);
   else if (HII->getAddrMode(MI) == HexagonII::BaseImmOffset)
-    // Tranform to absolute addressing mode.
+    // Transform to absolute addressing mode.
     return (HII->changeAddrMode_io_abs(MI) >= 0);
 
   return false;
@@ -163,7 +163,7 @@ bool HexagonOptAddrMode::hasRepForm(MachineInstr &MI, unsigned TfrDefR) {
 
 // Check if addasl instruction can be removed. This is possible only
 // if it's feeding to only load/store instructions with base + register
-// offset as these instruction can be tranformed to use 'absolute plus
+// offset as these instruction can be transformed to use 'absolute plus
 // shifted register offset'.
 // ex:
 // Rs = ##foo
@@ -551,7 +551,7 @@ bool HexagonOptAddrMode::processAddBases(NodeAddr<StmtNode *> AddSN,
     return Changed;
   ProcessedAddiInsts.insert(AddMI);
 
-  // Get the base register that would be shared by other Addi Intructions
+  // Get the base register that would be shared by other Addi Instructions
   Register BaseReg = AddMI->getOperand(1).getReg();
 
   // Store a list of all Addi instructions that share the above common base
@@ -638,7 +638,7 @@ bool HexagonOptAddrMode::processAddBases(NodeAddr<StmtNode *> AddSN,
 
     NewOffset = CurrentMIImmOp.getImm() - FirstReachedMIImmOp.getImm();
 
-    // This is the first occuring Addi, so skip modifying this
+    // This is the first occurring Addi, so skip modifying this
     if (CurrentMI == FirstReachedMI) {
       continue;
     }
@@ -1084,7 +1084,7 @@ bool HexagonOptAddrMode::processBlock(NodeAddr<BlockNode *> BA) {
 
     // Analyze all uses of 'add'. If the output of 'add' is used as an address
     // in the base+immediate addressing mode load/store instructions, see if
-    // they can be updated to use the immediate value as an offet. Thus,
+    // they can be updated to use the immediate value as an offset. Thus,
     // providing us the opportunity to eliminate 'add'.
     // Ex: Rx= add(Rt,#12)
     //     memw(Rx+#0) = Rs

--- a/llvm/lib/Target/Hexagon/HexagonPeephole.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonPeephole.cpp
@@ -1,4 +1,4 @@
-//===-- HexagonPeephole.cpp - Hexagon Peephole Optimiztions ---------------===//
+//===-- HexagonPeephole.cpp - Hexagon Peephole Optimizations --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/Target/Hexagon/HexagonPseudo.td
+++ b/llvm/lib/Target/Hexagon/HexagonPseudo.td
@@ -185,7 +185,7 @@ def PS_call_stk : T_Call<"">;
 // This pseudo instruction is used to replace int_hexagon_instrprof_custom intrinsic
 // with a call to custom handler passed as the first argument to the intrinsic.
 
-// Pleae Note:
+// Please Note:
 // 1) The call to the custom handler is being treated as a special one as the
 //    callee is responsible for saving and restoring all the registers it needs
 //    to modify. This includes caller saved registers as well as r0-r5 argument

--- a/llvm/lib/Target/Hexagon/HexagonSubtarget.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSubtarget.cpp
@@ -686,7 +686,7 @@ bool HexagonSubtarget::isBestZeroLatency(SUnit *Src, SUnit *Dst,
       restoreLatency(Src, DstBest);
   }
 
-  // Attempt to find another opprotunity for zero latency in a different
+  // Attempt to find another opportunity for zero latency in a different
   // dependence.
   if (SrcBest && DstBest)
     // If there is an edge from SrcBest to DstBst, then try to change that

--- a/llvm/lib/Target/Hexagon/HexagonTfrCleanup.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTfrCleanup.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// This pass is to address a situation that appears after register allocaion
-// evey now and then, namely a register copy from a source that was defined
+// This pass is to address a situation that appears after register allocation
+// every now and then, namely a register copy from a source that was defined
 // as an immediate value in the same block (usually just before the copy).
 //
 // Here is an example of actual code emitted that shows this problem:

--- a/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
@@ -440,7 +440,7 @@ bool HexagonPacketizerList::canPromoteToDotCur(const MachineInstr &MI,
     return false;
 
   // Check for existing uses of a vector register within the packet which
-  // would be affected by converting a vector load into .cur formt.
+  // would be affected by converting a vector load into .cur format.
   for (auto *BI : CurrentPacketMIs) {
     LLVM_DEBUG(dbgs() << "packet has "; BI->dump(););
     if (BI->readsRegister(DepReg, MF.getSubtarget().getRegisterInfo()))
@@ -750,7 +750,7 @@ bool HexagonPacketizerList::canPromoteToNewValueStore(const MachineInstr &MI,
   // modified by they should not be modified between the producer and the store
   // instruction as it will make them both conditional on different values.
   // We already know this to be true for all the instructions before and
-  // including PacketMI. Howerver, we need to perform the check for the
+  // including PacketMI. However, we need to perform the check for the
   // remaining instructions in the packet.
 
   unsigned StartCheck = 0;
@@ -868,7 +868,7 @@ bool HexagonPacketizerList::canPromoteToDotNew(const MachineInstr &MI,
   if (PI.isImplicitDef())
     return false;
 
-  // If dependency is trough an implicitly defined register, we should not
+  // If dependency is through an implicitly defined register, we should not
   // newify the use.
   if (isImplicitDependency(PI, true, DepReg) ||
       isImplicitDependency(MI, false, DepReg))
@@ -989,7 +989,7 @@ bool HexagonPacketizerList::arePredicatesComplements(MachineInstr &MI1,
   // We attempt to detect it by analyzing existing dependencies in the packet.
 
   // Analyze relationships between all existing members of the packet.
-  // Look for Anti dependecy on the same predicate reg as used in the
+  // Look for Anti dependency on the same predicate reg as used in the
   // candidate.
   for (auto *I : CurrentPacketMIs) {
     // Scheduling Unit for current insn in the packet.
@@ -1276,7 +1276,7 @@ bool HexagonPacketizerList::hasRegMaskDependence(const MachineInstr &I,
   // occur on calls, and the problematic case is when we add an instruction
   // defining a register R to a packet that has a call that clobbers R via
   // a regmask. Those cannot be packetized together, because the call will
-  // be executed last. That's also a reson why it is ok to add a call
+  // be executed last. That's also a reason why it is ok to add a call
   // clobbering R to a packet that defines R.
 
   // Look for regmasks in J.
@@ -1450,7 +1450,7 @@ bool HexagonPacketizerList::isLegalToPacketizeTogether(SUnit *SUI, SUnit *SUJ) {
           continue;
     }
 
-    // Data dpendence ok if we have load.cur.
+    // Data dependence ok if we have load.cur.
     if (DepType == SDep::Data && HII->isDotCurInst(J)) {
       if (HII->isHVXVec(I))
         continue;
@@ -1843,7 +1843,7 @@ bool HexagonPacketizerList::shouldAddToPacket(const MachineInstr &MI) {
   // with any other instruction in the existing packet.
   auto &HST = MI.getParent()->getParent()->getSubtarget<HexagonSubtarget>();
   // Constraint 1: Only one duplex allowed per packet.
-  // Constraint 2: Consider duplex checks only if there is atleast one
+  // Constraint 2: Consider duplex checks only if there is at least one
   // instruction in a packet.
   // Constraint 3: If one of the existing instructions in the packet has a
   // SLOT0 only instruction that can not be duplexed, do not attempt to form

--- a/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.h
+++ b/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.h
@@ -97,7 +97,7 @@ public:
   // together.
   bool isLegalToPacketizeTogether(SUnit *SUI, SUnit *SUJ) override;
 
-  // isLegalToPruneDependencies - Is it legal to prune dependece between SUI
+  // isLegalToPruneDependencies - Is it legal to prune dependence between SUI
   // and SUJ.
   bool isLegalToPruneDependencies(SUnit *SUI, SUnit *SUJ) override;
 

--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -986,7 +986,7 @@ auto AlignVectors::createStoreGroups(const AddrList &Group) const -> MoveList {
     assert(!Move.Main.empty() && "Move group should have non-empty Main");
     if (Move.Main.size() >= SizeLimit)
       return false;
-    // For stores with return values we'd have to collect downward depenencies.
+    // For stores with return values we'd have to collect downward dependencies.
     // There are no such stores that we handle at the moment, so omit that.
     assert(Info.Inst->getType()->isVoidTy() &&
            "Not handling stores with return values");

--- a/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.cpp
@@ -323,7 +323,7 @@ bool HexagonVectorLoopCarriedReuse::isEquivalentOperation(Instruction *I1,
     return false;
   // This check is in place specifically for intrinsics. isSameOperationAs will
   // return two for any two hexagon intrinsics because they are essentially the
-  // same instruciton (CallInst). We need to scratch the surface to see if they
+  // same instruction (CallInst). We need to scratch the surface to see if they
   // are calls to the same function.
   if (CallInst *C1 = dyn_cast<CallInst>(I1)) {
     if (CallInst *C2 = dyn_cast<CallInst>(I2)) {

--- a/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.h
+++ b/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.h
@@ -55,7 +55,7 @@
 //  cond_branch <Loop>
 //
 // In this pass, we look for PHIs such as X2 whose incoming values come only
-// from the Loop Preheader and over the backedge and additionaly, both these
+// from the Loop Preheader and over the backedge and additionally, both these
 // values are the results of the same operation in terms of opcode. We call such
 // a PHI node a dependence chain or DepChain. In this case, the dependence of X2
 // over X1 is carried over only one iteration and so the DepChain is only one

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCompound.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCompound.cpp
@@ -395,7 +395,7 @@ static bool lookForCompound(MCInstrInfo const &MCII, MCContext &Context,
 }
 
 /// tryCompound - Given a bundle check for compound insns when one
-/// is found update the contents fo the bundle with the compound insn.
+/// is found update the contents of the bundle with the compound insn.
 /// If a compound instruction is found then the bundle will have one
 /// additional slot.
 void HexagonMCInstrInfo::tryCompound(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
@@ -435,7 +435,7 @@ unsigned HexagonMCInstrInfo::getCVIResources(MCInstrInfo const &MCII,
   int SchedClass = HexagonMCInstrInfo::getDesc(MCII, MCI).getSchedClass();
   int Size = II[SchedClass].LastStage - II[SchedClass].FirstStage;
 
-  // HVX resources used are currenty located at the second to last stage.
+  // HVX resources used are currently located at the second to last stage.
   // This could also be done with a linear search of the stages looking for:
   // CVI_ALL, CVI_MPY01, CVI_XLSHF, CVI_MPY0, CVI_MPY1, CVI_SHIFT, CVI_XLANE,
   // CVI_ZW

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
@@ -614,7 +614,7 @@ MCSubtargetInfo *Hexagon_MC::createHexagonMCSubtargetInfo(const Triple &TT,
   }
 
   // Add qfloat subtarget feature by default to v68 and above
-  // unless explicitely disabled
+  // unless explicitly disabled
   if (checkFeature(X, Hexagon::ExtensionHVXV68) &&
       !ArchFS.contains("-hvx-qfloat")) {
     llvm::FeatureBitset Features = X->getFeatureBits();


### PR DESCRIPTION
Found using https://github.com/codespell-project/codespell

```
codespell Hexagon --write-changes \
     --ignore-words-list=CarryIn,CreateOr,ORE,COPYs,ArchVer,predicable,UE,MIs,isNT,Vor,CountR,DUM,GEs,AddD,ToI, \
     CopyIn,TheI,TotalIn,vor,MOne,contigious,Contigious 
```