### PR TITLE
[Offload] Fix assumptions on symbols after #124846

### DIFF
--- a/offload/test/sanitizer/kernel_crash_many.c
+++ b/offload/test/sanitizer/kernel_crash_many.c
@@ -37,36 +37,36 @@ int main(void) {
 // CHECK: Kernel 1: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 2: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 3: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 4: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 5: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 6: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 7: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK-NOT: Kernel {{[[0-9]]+}}:

--- a/offload/test/sanitizer/kernel_trap.c
+++ b/offload/test/sanitizer/kernel_trap.c
@@ -39,5 +39,4 @@ int main(void) {
 // CHECK: OFFLOAD ERROR: Kernel 'omp target in main @ 30 (__omp_offloading_{{.*}}_main_l30)'
 // CHECK: OFFLOAD ERROR: execution interrupted by hardware trap instruction
 // TRACE:     launchKernel
-// CHECK:     main
 // clang-format on

--- a/offload/test/sanitizer/kernel_trap.cpp
+++ b/offload/test/sanitizer/kernel_trap.cpp
@@ -47,6 +47,6 @@ int main(void) {
 // TRACE:     launchKernel
 // NDEBG:     cxx_function_name<S>(int, S*)
 // NDEBG:     main
-// DEBUG:     cxx_function_name<S>(int, S*) {{.*}}kernel_trap.cpp:
-// DEBUG:     main {{.*}}kernel_trap.cpp:
+// DEBUG:     cxx_function_name<S>(int, S*) {{.*}}kernel_trap.cpp
+// DEBUG:     main {{.*}}kernel_trap.cpp
 // clang-format on

--- a/offload/test/sanitizer/kernel_trap_many.c
+++ b/offload/test/sanitizer/kernel_trap_many.c
@@ -32,4 +32,4 @@ int main(void) {
 // TRACE: OFFLOAD ERROR: execution interrupted by hardware trap instruction
 // TRACE:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_trap_many.c:
+// DEBUG:     main {{.*}}kernel_trap_many.c


### PR DESCRIPTION
In #124846 the symbolizer was changed to ignore 0-column entries, which lead to a slightly different representation in the stack traces. This patch addresses these differences.

Not sure if the difference in kernel_trap.c is also a result of this change or not.
Can be tracked separate from this, after the bots are back to green.