### PR TITLE
Suppress reference to free variable errors

### DIFF
--- a/clang/tools/clang-format/clang-format.el
+++ b/clang/tools/clang-format/clang-format.el
@@ -32,6 +32,7 @@
 
 (require 'cl-lib)
 (require 'xml)
+(require 'vc-git)
 
 (defgroup clang-format nil
   "Format code using clang-format."


### PR DESCRIPTION
vc-git-program is referenced but not defined -- vc-git provides the definition.