### PR TITLE
[TySan] Fix false positives with derived classes

### DIFF
--- a/compiler-rt/test/tysan/derrived_default_constructor.cpp
+++ b/compiler-rt/test/tysan/derrived_default_constructor.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx_tysan %s -o %t && %run %t 2>&1 | FileCheck --implicit-check-not ERROR %s
+
+#include <stdio.h>
+
+class Inner {
+public:
+  void *ptr = nullptr;
+};
+
+class Base {
+public:
+  void *buffer1;
+  Inner inside;
+  void *buffer2;
+};
+
+class Derrived : public Base {};
+
+Derrived derr;
+
+int main() {
+  printf("%p", derr.inside.ptr);
+
+  return 0;
+}

--- a/compiler-rt/test/tysan/inherited_member.cpp
+++ b/compiler-rt/test/tysan/inherited_member.cpp
@@ -1,0 +1,21 @@
+// RUN: %clangxx_tysan %s -o %t && %run %t 2>&1 | FileCheck --implicit-check-not ERROR %s
+
+#include <stdio.h>
+
+class Base {
+public:
+  void *first;
+  void *second;
+  void *third;
+};
+
+class Derrived : public Base {};
+
+Derrived derr;
+
+int main() {
+  derr.second = nullptr;
+  printf("%p", derr.second);
+
+  return 0;
+}


### PR DESCRIPTION
Fixes issue #125079 as well as another case I discovered while trying to build LLVM with TySan.
The case when the access has an offset needs some slightly different legwork to the average check.