### PR TITLE
[lldb] add required for lldb RISCV relocations in MCJIT

### DIFF
--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -277,6 +277,9 @@ public:
 
 } // end namespace detail
 
+using ulittle8_t =
+    detail::packed_endian_specific_integral<uint8_t, llvm::endianness::little,
+                                            unaligned>;
 using ulittle16_t =
     detail::packed_endian_specific_integral<uint16_t, llvm::endianness::little,
                                             unaligned>;

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
@@ -1306,6 +1306,11 @@ void RuntimeDyldELF::resolveRISCVRelocation(const SectionEntry &Section,
     Ref = Value + Addend;
     break;
   }
+  case ELF::R_RISCV_ADD8: {
+    auto Ref = support::ulittle8_t::ref(Section.getAddressWithOffset(Offset));
+    Ref = Ref + Value + Addend;
+    break;
+  }
   case ELF::R_RISCV_ADD16: {
     auto Ref = support::ulittle16_t::ref(Section.getAddressWithOffset(Offset));
     Ref = Ref + Value + Addend;
@@ -1321,6 +1326,11 @@ void RuntimeDyldELF::resolveRISCVRelocation(const SectionEntry &Section,
     Ref = Ref + Value + Addend;
     break;
   }
+  case ELF::R_RISCV_SUB8: {
+    auto Ref = support::ulittle8_t::ref(Section.getAddressWithOffset(Offset));
+    Ref = Ref - Value - Addend;
+    break;
+  }
   case ELF::R_RISCV_SUB16: {
     auto Ref = support::ulittle16_t::ref(Section.getAddressWithOffset(Offset));
     Ref = Ref - Value - Addend;
@@ -1334,6 +1344,21 @@ void RuntimeDyldELF::resolveRISCVRelocation(const SectionEntry &Section,
   case ELF::R_RISCV_SUB64: {
     auto Ref = support::ulittle64_t::ref(Section.getAddressWithOffset(Offset));
     Ref = Ref - Value - Addend;
+    break;
+  }
+  case ELF::R_RISCV_SET8: {
+    auto Ref = support::ulittle8_t::ref(Section.getAddressWithOffset(Offset));
+    Ref = Value + Addend;
+    break;
+  }
+  case ELF::R_RISCV_SET16: {
+    auto Ref = support::ulittle16_t::ref(Section.getAddressWithOffset(Offset));
+    Ref = Value + Addend;
+    break;
+  }
+  case ELF::R_RISCV_SET32: {
+    auto Ref = support::ulittle32_t::ref(Section.getAddressWithOffset(Offset));
+    Ref = Value + Addend;
     break;
   }
   }


### PR DESCRIPTION
After implementing CFI instructions in the function prologue, LLDB testing for RISC-V started failing due to insufficient relocations (e.g., R_RISCV_SET8, R_RISCV_SET16).

This patch adds support for the necessary RISC-V relocations in MCJIT.