### PR TITLE
[libc++][test] Fix `size_type` issues with `MinSequenceContainer` and `min_allocator`

### DIFF
--- a/libcxx/test/support/MinSequenceContainer.h
+++ b/libcxx/test/support/MinSequenceContainer.h
@@ -31,7 +31,7 @@ struct MinSequenceContainer {
   const_iterator cbegin() const { return const_iterator(data_.data()); }
   iterator end() { return begin() + size(); }
   const_iterator end() const { return begin() + size(); }
-  size_type size() const { return data_.size(); }
+  size_type size() const { return static_cast<size_type>(data_.size()); }
   bool empty() const { return data_.empty(); }
 
   void clear() { data_.clear(); }

--- a/libcxx/test/support/min_allocator.h
+++ b/libcxx/test/support/min_allocator.h
@@ -394,15 +394,9 @@ public:
     template <class U>
     TEST_CONSTEXPR_CXX20 min_allocator(min_allocator<U>) {}
 
-    TEST_CONSTEXPR_CXX20 pointer allocate(std::ptrdiff_t n)
-    {
-        return pointer(std::allocator<T>().allocate(n));
-    }
+    TEST_CONSTEXPR_CXX20 pointer allocate(std::size_t n) { return pointer(std::allocator<T>().allocate(n)); }
 
-    TEST_CONSTEXPR_CXX20 void deallocate(pointer p, std::ptrdiff_t n)
-    {
-        std::allocator<T>().deallocate(p.ptr_, n);
-    }
+    TEST_CONSTEXPR_CXX20 void deallocate(pointer p, std::size_t n) { std::allocator<T>().deallocate(p.ptr_, n); }
 
     TEST_CONSTEXPR_CXX20 friend bool operator==(min_allocator, min_allocator) {return true;}
     TEST_CONSTEXPR_CXX20 friend bool operator!=(min_allocator x, min_allocator y) {return !(x == y);}


### PR DESCRIPTION
`MinSequenceContainer::size` can be narrowing on 64-bit platforms, and MSVC complains about such implicit conversion. This PR changes the implicit conversion to explicit `static_cast`.

`min_allocator::allocate` and `min_allocator::deallocate` have `ptrdiff_t` as the parameter type, which seems weird, because the underlying `std::allocator`'s member functions take `size_t`. It seems better to use `size_t` consistently.