### PR TITLE
[AMDGPU] - Fix non-deterministic compile issue

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.h
@@ -442,7 +442,7 @@ private:
 
   // Map a trivially rematerializable def to a list of regions at MinOccupancy
   // that has the defined reg as a live-in.
-  DenseMap<MachineInstr *, SmallVector<unsigned, 4>> RematDefToLiveInRegions;
+  MapVector<MachineInstr *, SmallVector<unsigned, 4>> RematDefToLiveInRegions;
 
   // Collect all trivially rematerializable VGPR instructions with a single def
   // and single use outside the defining block into RematerializableInsts.


### PR DESCRIPTION
4ce1f9079d4d3 [AMDGPU] Allow rematerialization of instructions with virtual register uses (#124327)
made changes that require an ordered traversal of a DenseMap. Changing it to MapVector which
respects insertion order.
