### PR TITLE
[flang][OpenMP] Skip invalid conditional compilation sentinels

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -1432,6 +1432,21 @@ Prescanner::IsFixedFormCompilerDirectiveLine(const char *start) const {
     }
     *sp++ = ToLowerCaseLetter(*p);
   }
+  // A fixed form OpenMP conditional compilation sentinel must satisfy the
+  // following criteria, for initial lines:
+  // - Columns 3 through 5 must have only white space or numbers.
+  // - Column 6 must be space or zero.
+  if (column == 3 && sentinel[0] == '$') {
+    const char *q{p};
+    for (int col{3}; col < 6; ++col, ++q) {
+      if (!IsSpaceOrTab(q) && !IsDecimalDigit(*q)) {
+        return std::nullopt;
+      }
+    }
+    if (*q != ' ' && *q != '0') {
+      return std::nullopt;
+    }
+  }
   if (column == 6) {
     if (*p == '0') {
       ++p;

--- a/flang/test/Parser/OpenMP/sentinels.f
+++ b/flang/test/Parser/OpenMP/sentinels.f
@@ -39,4 +39,34 @@ c    $This is a comment line
 C $   This is a comment line
 c $   his is a comment line
 * $   This is a comment line
+
+! Test non-space/non-number char in columns 3-5, for initial lines.
+! CHECK-NOT:  "comment"
+c$x   PRINT *, "comment"
+c$ +  PRINT *, "comment"
+c$  * PRINT *, "comment"
+
+! Test non-space/non-number char in columns 3-5, for continuation lines.
+! CHECK:      "msg1"
+! CHECK-NOT:  "comment"
+c$ x  PRINT *, "comment"
+c$1  &         , "comment"
+c$ x &         , "comment"
+c$  +&         , "comment"
+
+c$    PRINT *, "msg1"
+c$1  &         , "comment"
+c$ x &         , "comment"
+c$  +&         , "comment"
+
+! Test valid chars in initial and continuation lines.
+! CHECK:      "msg2"
+! CHECK-SAME: "msg3"
+c$ 20 PRINT *, "msg2"
+c$   &         , "msg3"
+
+! CHECK:      "msg4"
+! CHECK-SAME: "msg5"
+c$   0PRINT *, "msg4",
+c$   +         "msg5"
       end


### PR DESCRIPTION
In fixed form, an initial line can have an OpenMP conditional
compilation sentinel only if columns 3 through 5 have only
white space or numbers.

Fixes https://github.com/llvm/llvm-project/issues/89560
