### PR TITLE
[NFC][GlobalISel] Minor cleanup in LegalityQuery constructors

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/LegalizerInfo.h
@@ -119,20 +119,17 @@ struct LegalityQuery {
     MemDesc(LLT MemoryTy, uint64_t AlignInBits, AtomicOrdering Ordering)
         : MemoryTy(MemoryTy), AlignInBits(AlignInBits), Ordering(Ordering) {}
     MemDesc(const MachineMemOperand &MMO)
-        : MemoryTy(MMO.getMemoryType()),
-          AlignInBits(MMO.getAlign().value() * 8),
-          Ordering(MMO.getSuccessOrdering()) {}
+        : MemDesc(MMO.getMemoryType(), MMO.getAlign().value() * 8,
+                  MMO.getSuccessOrdering()) {}
   };
 
   /// Operations which require memory can use this to place requirements on the
   /// memory type for each MMO.
   ArrayRef<MemDesc> MMODescrs;
 
-  constexpr LegalityQuery(unsigned Opcode, const ArrayRef<LLT> Types,
-                          const ArrayRef<MemDesc> MMODescrs)
+  constexpr LegalityQuery(unsigned Opcode, ArrayRef<LLT> Types,
+                          ArrayRef<MemDesc> MMODescrs = {})
       : Opcode(Opcode), Types(Types), MMODescrs(MMODescrs) {}
-  constexpr LegalityQuery(unsigned Opcode, const ArrayRef<LLT> Types)
-      : LegalityQuery(Opcode, Types, {}) {}
 
   raw_ostream &print(raw_ostream &OS) const;
 };


### PR DESCRIPTION
- Remove a redundant LegalityQuery constructor by using a default value for `MMODescrs` and remove const for ArrayRef arguments.
- Use a delegating constructor for `MemDesc` constructor that takes `MachineMemOperand`.