### PR TITLE
[libc] Use __builtin_elementwise_fma instead of __builtin_fma

### DIFF
--- a/libc/src/__support/FPUtil/FMA.h
+++ b/libc/src/__support/FPUtil/FMA.h
@@ -25,11 +25,20 @@ LIBC_INLINE OutType fma(InType x, InType y, InType z) {
 
 #ifdef LIBC_TARGET_CPU_HAS_FMA
 template <> LIBC_INLINE float fma(float x, float y, float z) {
+#if __has_builtin(__builtin_elementwise_fma)
   return __builtin_elementwise_fma(x, y, z);
+#else
+  return __builtin_fmaf(x, y, z);
+#endif
 }
 
 template <> LIBC_INLINE double fma(double x, double y, double z) {
+#if __has_builtin(__builtin_elementwise_fma)
   return __builtin_elementwise_fma(x, y, z);
+#else
+  return __builtin_fma(x, y, z);
+#endif
+
 }
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/__support/FPUtil/FMA.h
+++ b/libc/src/__support/FPUtil/FMA.h
@@ -38,7 +38,6 @@ template <> LIBC_INLINE double fma(double x, double y, double z) {
 #else
   return __builtin_fma(x, y, z);
 #endif
-
 }
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/__support/FPUtil/FMA.h
+++ b/libc/src/__support/FPUtil/FMA.h
@@ -25,11 +25,11 @@ LIBC_INLINE OutType fma(InType x, InType y, InType z) {
 
 #ifdef LIBC_TARGET_CPU_HAS_FMA
 template <> LIBC_INLINE float fma(float x, float y, float z) {
-  return __builtin_fmaf(x, y, z);
+  return __builtin_elementwise_fma(x, y, z);
 }
 
 template <> LIBC_INLINE double fma(double x, double y, double z) {
-  return __builtin_fma(x, y, z);
+  return __builtin_elementwise_fma(x, y, z);
 }
 #endif // LIBC_TARGET_CPU_HAS_FMA
 

--- a/libc/src/__support/FPUtil/multiply_add.h
+++ b/libc/src/__support/FPUtil/multiply_add.h
@@ -47,11 +47,11 @@ namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 
 LIBC_INLINE float multiply_add(float x, float y, float z) {
-  return __builtin_fmaf(x, y, z);
+  return __builtin_elementwise_fma(x, y, z);
 }
 
 LIBC_INLINE double multiply_add(double x, double y, double z) {
-  return __builtin_fma(x, y, z);
+  return __builtin_elementwise_fma(x, y, z);
 }
 
 } // namespace fputil

--- a/libc/src/__support/FPUtil/multiply_add.h
+++ b/libc/src/__support/FPUtil/multiply_add.h
@@ -58,7 +58,7 @@ LIBC_INLINE double multiply_add(double x, double y, double z) {
 #if __has_builtin(__builtin_elementwise_fma)
   return __builtin_elementwise_fma(x, y, z);
 #else
-  return __builtin_fmaf(x, y, z);
+  return __builtin_fma(x, y, z);
 #endif
 }
 

--- a/libc/src/__support/FPUtil/multiply_add.h
+++ b/libc/src/__support/FPUtil/multiply_add.h
@@ -47,11 +47,19 @@ namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 
 LIBC_INLINE float multiply_add(float x, float y, float z) {
+#if __has_builtin(__builtin_elementwise_fma)
   return __builtin_elementwise_fma(x, y, z);
+#else
+  return __builtin_fmaf(x, y, z);
+#endif
 }
 
 LIBC_INLINE double multiply_add(double x, double y, double z) {
+#if __has_builtin(__builtin_elementwise_fma)
   return __builtin_elementwise_fma(x, y, z);
+#else
+  return __builtin_fmaf(x, y, z);
+#endif
 }
 
 } // namespace fputil


### PR DESCRIPTION
__builtin_elementwise_fma doesn't consider errno and is thus more suitable for libc fma implementation.