### PR TITLE
workflows/premerge: Move concurrency definition to workflow level

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -21,15 +21,16 @@ on:
       - 'main'
       - 'release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   premerge-checks-linux:
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
     runs-on: llvm-premerge-linux-runners
-    concurrency:
-      group: ${{ github.workflow }}-linux-${{ github.event.pull_request.number || github.sha }}
-      cancel-in-progress: true
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@v4
@@ -88,9 +89,6 @@ jobs:
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
     runs-on: llvm-premerge-windows-runners
-    concurrency:
-      group: ${{ github.workflow }}-windows-${{ github.event.pull_request.number || github.sha }}
-      cancel-in-progress: true
     defaults:
       run:
         shell: bash
@@ -148,9 +146,6 @@ jobs:
 
   permerge-check-macos:
     runs-on: macos-14
-    concurrency:
-      group: ${{ github.workflow }}-macos-${{ github.event.pull_request.number || github.sha }}
-      cancel-in-progress: true
     if: >-
       github.repository_owner == 'llvm' &&
       (startswith(github.ref_name, 'release/') ||


### PR DESCRIPTION
Prior workflow runs were not being cancelled when the pull request was closed, and I think this was why.  Also, there is no advantage to having the definitions at the job level.