### PR TITLE
[libc][bit_test] fix -Wimplicit-int-conversion

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -232,7 +232,7 @@ rotl(T value, int rotate) {
     return value;
   if (rotate < 0)
     return cpp::rotr<T>(value, -rotate);
-  return (value << rotate) | (value >> (N - rotate));
+  return static_cast<T>((value << rotate) | (value >> (N - rotate)));
 }
 
 template <typename T>
@@ -244,7 +244,7 @@ rotr(T value, int rotate) {
     return value;
   if (rotate < 0)
     return cpp::rotl<T>(value, -rotate);
-  return (value >> rotate) | (value << (N - rotate));
+  return static_cast<T>((value >> rotate) | (value << (N - rotate)));
 }
 
 // TODO: Do we need this function at all? How is it different from

--- a/libc/test/src/__support/CPP/bit_test.cpp
+++ b/libc/test/src/__support/CPP/bit_test.cpp
@@ -41,7 +41,8 @@ TYPED_TEST(LlvmLibcBitTest, HasSingleBit, UnsignedTypes) {
   constexpr auto LSB = T(1);
   constexpr auto MSB = T(~(ALL_ONES >> 1));
   for (T value = 1; value; value <<= 1) {
-    auto two_bits_value = value | ((value <= MIDPOINT) ? MSB : LSB);
+    T two_bits_value =
+        static_cast<T>(value | ((value <= MIDPOINT) ? MSB : LSB));
     EXPECT_FALSE(has_single_bit<T>(two_bits_value));
   }
 }


### PR DESCRIPTION
Fixes:

    llvm-project/libc/src/__support/CPP/bit.h:235:28: error: implicit
    conversion loses integer precision: 'int' to
    'cpp::enable_if_t<cpp::is_unsigned_v<unsigned short>, unsigned short>' (aka
    'unsigned short') [-Werror,-Wimplicit-int-conversion]
      235 |   return (value << rotate) | (value >> (N - rotate));
          |   ~~~~~~ ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    llvm-project/libc/src/__support/CPP/bit.h:247:28: error: implicit
    conversion loses integer precision: 'int' to
    'cpp::enable_if_t<cpp::is_unsigned_v<unsigned short>, unsigned short>' (aka
    'unsigned short') [-Werror,-Wimplicit-int-conversion]
      247 |   return (value >> rotate) | (value << (N - rotate));
          |   ~~~~~~ ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
    llvm-project/libc/test/src/__support/CPP/bit_test.cpp:45:36: error:
    implicit conversion loses integer precision: 'int' to 'unsigned char'
    [-Werror,-Wimplicit-int-conversion]
       45 |     EXPECT_FALSE(has_single_bit<T>(two_bits_value));
          |                  ~~~~~~~~~~~~~~    ^~~~~~~~~~~~~~

Via the libc-cpp-utils-tests ninja target.
