### PR TITLE
[SPIR-V] Add SPIR-V Linker

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -232,6 +232,7 @@ if (LLVM_INCLUDE_SPIRV_TOOLS_TESTS)
   list(APPEND LLVM_TEST_DEPENDS spirv-dis)
   list(APPEND LLVM_TEST_DEPENDS spirv-val)
   list(APPEND LLVM_TEST_DEPENDS spirv-as)
+  list(APPEND LLVM_TEST_DEPENDS spirv-link)
 endif()
 
 add_custom_target(llvm-test-depends DEPENDS ${LLVM_TEST_DEPENDS})

--- a/llvm/test/CodeGen/SPIRV/lit.local.cfg
+++ b/llvm/test/CodeGen/SPIRV/lit.local.cfg
@@ -16,3 +16,4 @@ if config.spirv_tools_tests:
     config.substitutions.append(("spirv-dis", os.path.join(config.llvm_tools_dir, "spirv-dis")))
     config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
     config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
+    config.substitutions.append(("spirv-link", os.path.join(config.llvm_tools_dir, "spirv-link")))

--- a/llvm/tools/spirv-tools/CMakeLists.txt
+++ b/llvm/tools/spirv-tools/CMakeLists.txt
@@ -9,10 +9,10 @@ if (NOT "SPIRV" IN_LIST LLVM_TARGETS_TO_BUILD)
   message(FATAL_ERROR "Building SPIRV-Tools tests is unsupported without the SPIR-V target")
 endif ()
 
-# SPIRV_DIS and SPIRV_VAL variables can be used to provide paths to existing
-# spirv-dis and spirv-val binaries, respectively. Otherwise, build them from
+# SPIRV_DIS, SPIRV_VAL, SPIRV_AS and SPIRV_LINK variables can be used to provide paths to existing
+# spirv-dis, spirv-val, spirv-as, and spirv-link binaries, respectively. Otherwise, build them from
 # SPIRV-Tools source.
-if (NOT SPIRV_DIS OR NOT SPIRV_VAL OR NOT SPIRV_AS)
+if (NOT SPIRV_DIS OR NOT SPIRV_VAL OR NOT SPIRV_AS OR NOT SPIRV_LINK)
   include(ExternalProject)
 
   set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/SPIRVTools-bin)
@@ -21,8 +21,8 @@ if (NOT SPIRV_DIS OR NOT SPIRV_VAL OR NOT SPIRV_AS)
     GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Tools.git
     GIT_TAG main
     BINARY_DIR ${BINARY_DIR}
-    BUILD_COMMAND ${CMAKE_COMMAND} --build ${BINARY_DIR} --target spirv-dis spirv-val spirv-as
-    BUILD_BYPRODUCTS ${BINARY_DIR}/tools/spirv-dis ${BINARY_DIR}/tools/spirv-val ${BINARY_DIR}/tools/spirv-as
+    BUILD_COMMAND ${CMAKE_COMMAND} --build ${BINARY_DIR} --target spirv-dis spirv-val spirv-as spirv-link
+    BUILD_BYPRODUCTS ${BINARY_DIR}/tools/spirv-dis ${BINARY_DIR}/tools/spirv-val ${BINARY_DIR}/tools/spirv-as ${BINARY_DIR}/tools/spirv-link
     DOWNLOAD_COMMAND git clone https://github.com/KhronosGroup/SPIRV-Tools.git SPIRVTools &&
       cd SPIRVTools &&
       ${Python3_EXECUTABLE} utils/git-sync-deps
@@ -43,7 +43,7 @@ else ()
   set(LLVM_LINK_OR_COPY copy)
 endif ()
 
-# Link the provided or just built spirv-dis and spirv-val binaries.
+# Link the provided or just built binaries.
 if (SPIRV_DIS)
   add_custom_target(spirv-dis
     COMMAND ${CMAKE_COMMAND} -E ${LLVM_LINK_OR_COPY} "${SPIRV_DIS}" "${LLVM_RUNTIME_OUTPUT_INTDIR}/spirv-dis")
@@ -70,6 +70,16 @@ if (SPIRV_AS)
 else ()
   add_custom_target(spirv-as
     COMMAND ${CMAKE_COMMAND} -E ${LLVM_LINK_OR_COPY} "${BINARY_DIR}/tools/spirv-as${CMAKE_EXECUTABLE_SUFFIX}" "${LLVM_RUNTIME_OUTPUT_INTDIR}/spirv-as${CMAKE_EXECUTABLE_SUFFIX}"
+    DEPENDS SPIRVTools
+    )
+endif ()
+
+if (SPIRV_LINK)
+  add_custom_target(spirv-link
+    COMMAND ${CMAKE_COMMAND} -E ${LLVM_LINK_OR_COPY} "${SPIRV_LINK}" "${LLVM_RUNTIME_OUTPUT_INTDIR}/spirv-link")
+else ()
+  add_custom_target(spirv-link
+    COMMAND ${CMAKE_COMMAND} -E ${LLVM_LINK_OR_COPY} "${BINARY_DIR}/tools/spirv-link${CMAKE_EXECUTABLE_SUFFIX}" "${LLVM_RUNTIME_OUTPUT_INTDIR}/spirv-link${CMAKE_EXECUTABLE_SUFFIX}"
     DEPENDS SPIRVTools
     )
 endif ()


### PR DESCRIPTION
I want to use `spirv-link` from `SPIR-V-Tools` in a test, so let's build it if `LLVM_INCLUDE_SPIRV_TOOLS_TESTS` is set, as we do with the other tools.