### PR TITLE
[libc] Don't manually override the optimization level for math

### DIFF
--- a/libc/src/complex/generic/CMakeLists.txt
+++ b/libc/src/complex/generic/CMakeLists.txt
@@ -196,8 +196,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
-    libc.src.__support.macros.properties.types
-    libc.src.__support.macros.properties.complex_types
 )
 
 add_entrypoint_object(

--- a/libc/src/complex/generic/CMakeLists.txt
+++ b/libc/src/complex/generic/CMakeLists.txt
@@ -4,8 +4,6 @@ add_entrypoint_object(
     cproj.cpp
   HDRS
     ../cproj.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
 )
@@ -16,8 +14,6 @@ add_entrypoint_object(
     cprojf.cpp
   HDRS
     ../cprojf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
 )
@@ -28,8 +24,6 @@ add_entrypoint_object(
     cprojl.cpp
   HDRS
     ../cprojl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
 )
@@ -40,8 +34,6 @@ add_entrypoint_object(
     cprojf16.cpp
   HDRS
     ../cprojf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
     libc.src.__support.macros.properties.types
@@ -54,8 +46,6 @@ add_entrypoint_object(
     cprojf128.cpp
   HDRS
     ../cprojf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
     libc.src.__support.macros.properties.types
@@ -68,8 +58,6 @@ add_entrypoint_object(
     conj.cpp
   HDRS
     ../conj.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
 )
@@ -80,8 +68,6 @@ add_entrypoint_object(
     conjf.cpp
   HDRS
     ../conjf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
 )
@@ -92,8 +78,6 @@ add_entrypoint_object(
     conjl.cpp
   HDRS
     ../conjl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
 )
@@ -104,8 +88,6 @@ add_entrypoint_object(
     conjf16.cpp
   HDRS
     ../conjf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
     libc.src.__support.macros.properties.types
@@ -118,8 +100,6 @@ add_entrypoint_object(
     conjf128.cpp
   HDRS
     ../conjf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.complex_basic_ops
     libc.src.__support.macros.properties.types
@@ -132,8 +112,6 @@ add_entrypoint_object(
     creal.cpp
   HDRS
     ../creal.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -145,8 +123,6 @@ add_entrypoint_object(
     crealf.cpp
   HDRS
     ../crealf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -158,8 +134,6 @@ add_entrypoint_object(
     creall.cpp
   HDRS
     ../creall.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -171,23 +145,6 @@ add_entrypoint_object(
     crealf16.cpp
   HDRS
     ../crealf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
-  DEPENDS
-    libc.src.__support.CPP.bit
-    libc.src.__support.complex_type
-    libc.src.__support.macros.properties.types
-    libc.src.__support.macros.properties.complex_types
-)
-
-add_entrypoint_object(
-  crealf128
-  SRCS
-    crealf128.cpp
-  HDRS
-    ../crealf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -201,8 +158,6 @@ add_entrypoint_object(
     cimag.cpp
   HDRS
     ../cimag.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -214,8 +169,6 @@ add_entrypoint_object(
     cimagf.cpp
   HDRS
     ../cimagf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -227,21 +180,6 @@ add_entrypoint_object(
     cimagl.cpp
   HDRS
     ../cimagl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
-  DEPENDS
-    libc.src.__support.CPP.bit
-    libc.src.__support.complex_type
-)
-
-add_entrypoint_object(
-  cimagf16
-  SRCS
-    cimagf16.cpp
-  HDRS
-    ../cimagf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type
@@ -255,8 +193,6 @@ add_entrypoint_object(
     cimagf128.cpp
   HDRS
     ../cimagf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type

--- a/libc/src/complex/generic/CMakeLists.txt
+++ b/libc/src/complex/generic/CMakeLists.txt
@@ -153,6 +153,19 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  crealf128
+  SRCS
+    crealf128.cpp
+  HDRS
+    ../crealf128.h
+  DEPENDS
+    libc.src.__support.CPP.bit
+    libc.src.__support.complex_type
+    libc.src.__support.macros.properties.types
+    libc.src.__support.macros.properties.complex_types
+)
+
+add_entrypoint_object(
   cimag
   SRCS
     cimag.cpp
@@ -180,6 +193,19 @@ add_entrypoint_object(
     cimagl.cpp
   HDRS
     ../cimagl.h
+  DEPENDS
+    libc.src.__support.CPP.bit
+    libc.src.__support.complex_type
+    libc.src.__support.macros.properties.types
+    libc.src.__support.macros.properties.complex_types
+)
+
+add_entrypoint_object(
+  cimagf16
+  SRCS
+    cimagf16.cpp
+  HDRS
+    ../cimagf16.h
   DEPENDS
     libc.src.__support.CPP.bit
     libc.src.__support.complex_type

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -6,8 +6,6 @@ add_entrypoint_object(
     canonicalize.cpp
   HDRS
     ../canonicalize.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
 )
@@ -18,8 +16,6 @@ add_entrypoint_object(
     canonicalizef.cpp
   HDRS
     ../canonicalizef.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
 )
@@ -30,8 +26,6 @@ add_entrypoint_object(
     canonicalizef16.cpp
   HDRS
     ../canonicalizef16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
@@ -43,8 +37,6 @@ add_entrypoint_object(
     canonicalizef128.cpp
   HDRS
     ../canonicalizef128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
@@ -56,8 +48,6 @@ add_entrypoint_object(
     canonicalizel.cpp
   HDRS
     ../canonicalizel.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
 )
@@ -68,8 +58,6 @@ add_entrypoint_object(
     iscanonical.cpp
   HDRS
     ../iscanonical.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -78,8 +66,6 @@ add_entrypoint_object(
     iscanonicalf.cpp
   HDRS
     ../iscanonicalf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -88,8 +74,6 @@ add_entrypoint_object(
     iscanonicall.cpp
   HDRS
     ../iscanonicall.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -98,8 +82,6 @@ add_entrypoint_object(
     iscanonicalf16.cpp
   HDRS
     ../iscanonicalf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
 )
@@ -110,8 +92,6 @@ add_entrypoint_object(
     iscanonicalf128.cpp
   HDRS
     ../iscanonicalf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
 )
@@ -122,8 +102,6 @@ add_entrypoint_object(
     ceil.cpp
   HDRS
     ../ceil.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -136,8 +114,6 @@ add_entrypoint_object(
     ceilf.cpp
   HDRS
     ../ceilf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -150,8 +126,6 @@ add_entrypoint_object(
     ceill.cpp
   HDRS
     ../ceill.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -162,8 +136,6 @@ add_entrypoint_object(
     ceilf16.cpp
   HDRS
     ../ceilf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -179,8 +151,6 @@ add_entrypoint_object(
     ceilf128.cpp
   HDRS
     ../ceilf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -192,8 +162,6 @@ add_entrypoint_object(
     daddl.cpp
   HDRS
     ../daddl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
 )
@@ -204,8 +172,6 @@ add_entrypoint_object(
     daddf128.cpp
   HDRS
     ../daddf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
  DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
@@ -217,8 +183,6 @@ add_entrypoint_object(
     ddivl.cpp
   HDRS
     ../ddivl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.generic.div
 )
@@ -229,8 +193,6 @@ add_entrypoint_object(
     ddivf128.cpp
   HDRS
     ../ddivf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.div
@@ -245,8 +207,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.FPUtil.fma
     libc.src.__support.macros.properties.types
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -257,8 +217,6 @@ add_entrypoint_object(
     ../dfmal.h
   DEPENDS
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -269,8 +227,6 @@ add_entrypoint_object(
     ../dsqrtl.h
   DEPENDS
     libc.src.__support.FPUtil.generic.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -282,8 +238,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 
@@ -296,8 +250,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
     libc.src.__support.macros.properties.types
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -308,8 +260,6 @@ add_entrypoint_object(
     ../dsubl.h
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_header_library(
@@ -392,8 +342,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -413,8 +361,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -449,8 +395,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fma
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -468,8 +412,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -490,8 +432,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -512,8 +452,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -555,8 +493,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -574,8 +510,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.common
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -595,8 +529,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -614,8 +546,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -635,8 +565,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -657,8 +585,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -696,8 +622,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.except_value_utils
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -708,8 +632,6 @@ add_entrypoint_object(
     ../fabs.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -722,8 +644,6 @@ add_entrypoint_object(
     ../fabsf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -736,8 +656,6 @@ add_entrypoint_object(
     ../fabsl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -751,8 +669,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.properties.architectures
     libc.src.__support.macros.properties.compiler
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -766,8 +682,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -778,8 +692,6 @@ add_entrypoint_object(
     ../fadd.h
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -790,8 +702,6 @@ add_entrypoint_object(
     ../faddl.h
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -803,8 +713,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
     libc.src.__support.macros.properties.types
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -813,8 +721,6 @@ add_entrypoint_object(
     trunc.cpp
   HDRS
     ../trunc.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -827,8 +733,6 @@ add_entrypoint_object(
     truncf.cpp
   HDRS
     ../truncf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -841,8 +745,6 @@ add_entrypoint_object(
     truncl.cpp
   HDRS
     ../truncl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -853,8 +755,6 @@ add_entrypoint_object(
     truncf16.cpp
   HDRS
     ../truncf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -870,8 +770,6 @@ add_entrypoint_object(
     truncf128.cpp
   HDRS
     ../truncf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -883,8 +781,6 @@ add_entrypoint_object(
     floor.cpp
   HDRS
     ../floor.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -897,8 +793,6 @@ add_entrypoint_object(
     floorf.cpp
   HDRS
     ../floorf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -911,8 +805,6 @@ add_entrypoint_object(
     floorl.cpp
   HDRS
     ../floorl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -923,8 +815,6 @@ add_entrypoint_object(
     floorf16.cpp
   HDRS
     ../floorf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -940,8 +830,6 @@ add_entrypoint_object(
     floorf128.cpp
   HDRS
     ../floorf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -953,8 +841,6 @@ add_entrypoint_object(
     round.cpp
   HDRS
     ../round.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -967,8 +853,6 @@ add_entrypoint_object(
     roundf.cpp
   HDRS
     ../roundf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -981,8 +865,6 @@ add_entrypoint_object(
     roundl.cpp
   HDRS
     ../roundl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -993,8 +875,6 @@ add_entrypoint_object(
     roundf16.cpp
   HDRS
     ../roundf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1010,8 +890,6 @@ add_entrypoint_object(
     roundf128.cpp
   HDRS
     ../roundf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1023,8 +901,6 @@ add_entrypoint_object(
     roundeven.cpp
   HDRS
     ../roundeven.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -1037,8 +913,6 @@ add_entrypoint_object(
     roundevenf.cpp
   HDRS
     ../roundevenf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -1051,20 +925,6 @@ add_entrypoint_object(
     roundevenl.cpp
   HDRS
     ../roundevenl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
-  DEPENDS
-    libc.src.__support.FPUtil.nearest_integer_operations
-)
-
-add_entrypoint_object(
-  roundevenf16
-  SRCS
-    roundevenf16.cpp
-  HDRS
-    ../roundevenf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1080,8 +940,6 @@ add_entrypoint_object(
     roundevenf128.cpp
   HDRS
     ../roundevenf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1093,8 +951,6 @@ add_entrypoint_object(
     lround.cpp
   HDRS
     ../lround.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1105,8 +961,6 @@ add_entrypoint_object(
     lroundf.cpp
   HDRS
     ../lroundf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1117,8 +971,6 @@ add_entrypoint_object(
     lroundl.cpp
   HDRS
     ../lroundl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1129,8 +981,6 @@ add_entrypoint_object(
     lroundf16.cpp
   HDRS
     ../lroundf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1142,8 +992,6 @@ add_entrypoint_object(
     lroundf128.cpp
   HDRS
     ../lroundf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1155,8 +1003,6 @@ add_entrypoint_object(
     llround.cpp
   HDRS
     ../llround.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1167,8 +1013,6 @@ add_entrypoint_object(
     llroundf.cpp
   HDRS
     ../llroundf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1179,8 +1023,6 @@ add_entrypoint_object(
     llroundl.cpp
   HDRS
     ../llroundl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1191,8 +1033,6 @@ add_entrypoint_object(
     llroundf16.cpp
   HDRS
     ../llroundf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1204,8 +1044,6 @@ add_entrypoint_object(
     llroundf128.cpp
   HDRS
     ../llroundf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1217,8 +1055,6 @@ add_entrypoint_object(
     rint.cpp
   HDRS
     ../rint.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -1231,8 +1067,6 @@ add_entrypoint_object(
     rintf.cpp
   HDRS
     ../rintf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
   FLAGS
@@ -1245,8 +1079,6 @@ add_entrypoint_object(
     rintl.cpp
   HDRS
     ../rintl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1257,8 +1089,6 @@ add_entrypoint_object(
     rintf16.cpp
   HDRS
     ../rintf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.cast
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1274,8 +1104,6 @@ add_entrypoint_object(
     rintf128.cpp
   HDRS
     ../rintf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1287,8 +1115,6 @@ add_entrypoint_object(
     lrint.cpp
   HDRS
     ../lrint.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1299,8 +1125,6 @@ add_entrypoint_object(
     lrintf.cpp
   HDRS
     ../lrintf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1311,8 +1135,6 @@ add_entrypoint_object(
     lrintl.cpp
   HDRS
     ../lrintl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1323,8 +1145,6 @@ add_entrypoint_object(
     lrintf16.cpp
   HDRS
     ../lrintf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1336,8 +1156,6 @@ add_entrypoint_object(
     lrintf128.cpp
   HDRS
     ../lrintf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1349,8 +1167,6 @@ add_entrypoint_object(
     llrint.cpp
   HDRS
     ../llrint.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1361,8 +1177,6 @@ add_entrypoint_object(
     llrintf.cpp
   HDRS
     ../llrintf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1373,8 +1187,6 @@ add_entrypoint_object(
     llrintl.cpp
   HDRS
     ../llrintl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
 )
@@ -1385,8 +1197,6 @@ add_entrypoint_object(
     llrintf16.cpp
   HDRS
     ../llrintf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1398,8 +1208,6 @@ add_entrypoint_object(
     llrintf128.cpp
   HDRS
     ../llrintf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
@@ -1413,8 +1221,6 @@ add_entrypoint_object(
     ../nearbyint.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1425,8 +1231,6 @@ add_entrypoint_object(
     ../nearbyintf.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1437,8 +1241,6 @@ add_entrypoint_object(
     ../nearbyintl.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1450,8 +1252,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1463,8 +1263,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_object_library(
@@ -1488,8 +1286,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1514,8 +1310,6 @@ add_entrypoint_object(
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1535,8 +1329,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1559,8 +1351,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1585,8 +1375,6 @@ add_entrypoint_object(
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_header_library(
@@ -1615,8 +1403,6 @@ add_entrypoint_object(
     ../exp2f.h
   DEPENDS
     .exp2f_impl
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1635,8 +1421,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1657,8 +1441,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1681,8 +1463,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1707,8 +1487,6 @@ add_entrypoint_object(
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_header_library(
@@ -1724,8 +1502,6 @@ add_header_library(
     libc.src.__support.macros.optimization
     libc.src.__support.common
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1736,8 +1512,6 @@ add_entrypoint_object(
     ../exp10f.h
   DEPENDS
     .exp10f_impl
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1761,8 +1535,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1782,8 +1554,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1805,8 +1575,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1831,8 +1599,6 @@ add_entrypoint_object(
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1852,8 +1618,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1874,8 +1638,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1901,8 +1663,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.triple_double
     libc.src.__support.macros.optimization
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1924,8 +1684,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1936,22 +1694,6 @@ add_entrypoint_object(
     ../copysign.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
-  FLAGS
-    MISC_MATH_BASIC_OPS_OPT
-)
-
-add_entrypoint_object(
-  copysignf
-  SRCS
-    copysignf.cpp
-  HDRS
-    ../copysignf.h
-  DEPENDS
-    libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -1964,8 +1706,6 @@ add_entrypoint_object(
     ../copysignl.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -1977,8 +1717,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -1992,8 +1730,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2002,8 +1738,6 @@ add_entrypoint_object(
     frexp.cpp
   HDRS
     ../frexp.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2014,8 +1748,6 @@ add_entrypoint_object(
     frexpf.cpp
   HDRS
     ../frexpf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2026,8 +1758,6 @@ add_entrypoint_object(
     frexpl.cpp
   HDRS
     ../frexpl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2038,8 +1768,6 @@ add_entrypoint_object(
     frexpf16.cpp
   HDRS
     ../frexpf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2051,8 +1779,6 @@ add_entrypoint_object(
     frexpf128.cpp
   HDRS
     ../frexpf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2064,8 +1790,6 @@ add_entrypoint_object(
     ilogb.cpp
   HDRS
     ../ilogb.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2076,8 +1800,6 @@ add_entrypoint_object(
     ilogbf.cpp
   HDRS
     ../ilogbf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2088,8 +1810,6 @@ add_entrypoint_object(
     ilogbl.cpp
   HDRS
     ../ilogbl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2100,8 +1820,6 @@ add_entrypoint_object(
     ilogbf16.cpp
   HDRS
     ../ilogbf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2113,8 +1831,6 @@ add_entrypoint_object(
     ilogbf128.cpp
   HDRS
     ../ilogbf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2126,8 +1842,6 @@ add_entrypoint_object(
     llogb.cpp
   HDRS
     ../llogb.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2138,8 +1852,6 @@ add_entrypoint_object(
     llogbf.cpp
   HDRS
     ../llogbf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2150,8 +1862,6 @@ add_entrypoint_object(
     llogbl.cpp
   HDRS
     ../llogbl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2162,8 +1872,6 @@ add_entrypoint_object(
     llogbf16.cpp
   HDRS
     ../llogbf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2175,8 +1883,6 @@ add_entrypoint_object(
     llogbf128.cpp
   HDRS
     ../llogbf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2188,8 +1894,6 @@ add_entrypoint_object(
     ldexp.cpp
   HDRS
     ../ldexp.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2200,8 +1904,6 @@ add_entrypoint_object(
     ldexpf.cpp
   HDRS
     ../ldexpf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2212,8 +1914,6 @@ add_entrypoint_object(
     ldexpl.cpp
   HDRS
     ../ldexpl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2224,8 +1924,6 @@ add_entrypoint_object(
     ldexpf16.cpp
   HDRS
     ../ldexpf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2237,8 +1935,6 @@ add_entrypoint_object(
     ldexpf128.cpp
   HDRS
     ../ldexpf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2282,8 +1978,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2299,8 +1993,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.fma
     libc.src.__support.FPUtil.polyeval
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2321,8 +2013,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2341,8 +2031,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2359,8 +2047,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fma
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2380,8 +2066,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2398,9 +2082,7 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fma
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-    COMPILE_OPTIONS
-    ${libc_opt_high_flag}
-)
+  )
 
 add_entrypoint_object(
   log2f16
@@ -2420,8 +2102,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2441,8 +2121,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2459,8 +2137,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2481,8 +2157,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2491,8 +2165,6 @@ add_entrypoint_object(
     logb.cpp
   HDRS
     ../logb.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2503,8 +2175,6 @@ add_entrypoint_object(
     logbf.cpp
   HDRS
     ../logbf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2515,8 +2185,6 @@ add_entrypoint_object(
     logbl.cpp
   HDRS
     ../logbl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
 )
@@ -2527,8 +2195,6 @@ add_entrypoint_object(
     logbf16.cpp
   HDRS
     ../logbf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2540,8 +2206,6 @@ add_entrypoint_object(
     logbf128.cpp
   HDRS
     ../logbf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
@@ -2555,8 +2219,6 @@ add_entrypoint_object(
     ../modf.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2567,8 +2229,6 @@ add_entrypoint_object(
     ../modff.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2579,8 +2239,6 @@ add_entrypoint_object(
     ../modfl.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2592,8 +2250,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2605,8 +2261,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2617,8 +2271,6 @@ add_entrypoint_object(
     ../fmin.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2631,8 +2283,6 @@ add_entrypoint_object(
     ../fminf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2645,8 +2295,6 @@ add_entrypoint_object(
     ../fminl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2658,8 +2306,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2671,8 +2317,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2686,8 +2330,6 @@ add_entrypoint_object(
     ../fmax.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2700,8 +2342,6 @@ add_entrypoint_object(
     ../fmaxf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2714,8 +2354,6 @@ add_entrypoint_object(
     ../fmaxl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2727,8 +2365,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2740,8 +2376,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2754,8 +2388,6 @@ add_entrypoint_object(
     ../fmaximum.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2768,8 +2400,6 @@ add_entrypoint_object(
     ../fmaximumf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2782,8 +2412,6 @@ add_entrypoint_object(
     ../fmaximuml.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2795,8 +2423,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2810,8 +2436,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2822,8 +2446,6 @@ add_entrypoint_object(
     ../fmaximum_num.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2836,8 +2458,6 @@ add_entrypoint_object(
     ../fmaximum_numf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2850,8 +2470,6 @@ add_entrypoint_object(
     ../fmaximum_numl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2863,8 +2481,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -2878,8 +2494,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2927,8 +2541,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2940,8 +2552,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -2989,8 +2599,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3002,8 +2610,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3014,8 +2620,6 @@ add_entrypoint_object(
     ../fminimum.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -3028,8 +2632,6 @@ add_entrypoint_object(
     ../fminimumf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -3042,8 +2644,6 @@ add_entrypoint_object(
     ../fminimuml.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3055,8 +2655,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -3070,8 +2668,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3082,8 +2678,6 @@ add_entrypoint_object(
     ../fminimum_num.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -3096,8 +2690,6 @@ add_entrypoint_object(
     ../fminimum_numf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -3110,8 +2702,6 @@ add_entrypoint_object(
     ../fminimum_numl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3123,8 +2713,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   FLAGS
     MISC_MATH_BASIC_OPS_OPT
 )
@@ -3138,8 +2726,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3187,8 +2773,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3200,8 +2784,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3249,8 +2831,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3262,8 +2842,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3276,8 +2854,6 @@ add_entrypoint_object(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.__support.FPUtil.double_double
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3288,8 +2864,6 @@ add_entrypoint_object(
     ../fmull.h
   DEPENDS
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3301,8 +2875,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3313,8 +2885,6 @@ add_entrypoint_object(
     ../fsub.h
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3325,8 +2895,6 @@ add_entrypoint_object(
     ../fsubl.h
   DEPENDS
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3338,8 +2906,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3350,8 +2916,6 @@ add_entrypoint_object(
     ../sqrt.h
   DEPENDS
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 
@@ -3363,8 +2927,6 @@ add_entrypoint_object(
     ../sqrtf.h
   DEPENDS
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3375,8 +2937,6 @@ add_entrypoint_object(
     ../sqrtl.h
   DEPENDS
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3387,8 +2947,6 @@ add_entrypoint_object(
     ../sqrtf16.h
   DEPENDS
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3400,8 +2958,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   )
 
 add_entrypoint_object(
@@ -3412,8 +2968,6 @@ add_entrypoint_object(
     ../remquof.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3424,8 +2978,6 @@ add_entrypoint_object(
     ../remquof128.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3436,8 +2988,6 @@ add_entrypoint_object(
     ../remquo.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3448,8 +2998,6 @@ add_entrypoint_object(
     ../remquol.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3461,8 +3009,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3473,8 +3019,6 @@ add_entrypoint_object(
     ../remainderf.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3485,8 +3029,6 @@ add_entrypoint_object(
     ../remainder.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3497,8 +3039,6 @@ add_entrypoint_object(
     ../remainderl.h
   DEPENDS
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3510,8 +3050,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3523,8 +3061,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.division_and_remainder_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3540,8 +3076,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3550,8 +3084,6 @@ add_entrypoint_object(
     fdim.cpp
   HDRS
     ../fdim.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
 )
@@ -3562,8 +3094,6 @@ add_entrypoint_object(
     fdimf.cpp
   HDRS
     ../fdimf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
 )
@@ -3574,8 +3104,6 @@ add_entrypoint_object(
     fdiml.cpp
   HDRS
     ../fdiml.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
 )
@@ -3586,8 +3114,6 @@ add_entrypoint_object(
     fdimf16.cpp
   HDRS
     ../fdimf16.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
@@ -3599,8 +3125,6 @@ add_entrypoint_object(
     fdimf128.cpp
   HDRS
     ../fdimf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
@@ -3612,8 +3136,6 @@ add_entrypoint_object(
     fdiv.cpp
   HDRS
     ../fdiv.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.generic.div
 )
@@ -3624,8 +3146,6 @@ add_entrypoint_object(
     fdivl.cpp
   HDRS
     ../fdivl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.generic.div
 )
@@ -3636,8 +3156,6 @@ add_entrypoint_object(
     fdivf128.cpp
   HDRS
     ../fdivf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.div
@@ -3649,8 +3167,6 @@ add_entrypoint_object(
     ffma.cpp
   HDRS
     ../ffma.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.fma
 )
@@ -3661,8 +3177,6 @@ add_entrypoint_object(
     ffmal.cpp
   HDRS
     ../ffmal.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.FPUtil.fma
 )
@@ -3673,8 +3187,6 @@ add_entrypoint_object(
     ffmaf128.cpp
   HDRS
     ../ffmaf128.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.fma
@@ -3688,8 +3200,6 @@ add_entrypoint_object(
     ../hypot.h
   DEPENDS
     libc.src.__support.FPUtil.hypot
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3698,8 +3208,6 @@ add_entrypoint_object(
     issignaling.cpp
   HDRS
     ../issignaling.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3708,8 +3216,6 @@ add_entrypoint_object(
     issignalingf.cpp
   HDRS
     ../issignalingf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3718,8 +3224,6 @@ add_entrypoint_object(
     issignalingl.cpp
   HDRS
     ../issignalingl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3728,8 +3232,6 @@ add_entrypoint_object(
     issignalingf16.cpp
   HDRS
     ../issignalingf16.h
-  COMPILE_OPTIONS
-      ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
 )
@@ -3740,8 +3242,6 @@ add_entrypoint_object(
     issignalingf128.cpp
   HDRS
     ../issignalingf128.h
-  COMPILE_OPTIONS
-      ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.macros.properties.types
 )
@@ -3752,8 +3252,6 @@ add_entrypoint_object(
     isnan.cpp
   HDRS
     ../isnan.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3762,8 +3260,6 @@ add_entrypoint_object(
     isnanf.cpp
   HDRS
     ../isnanf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3772,8 +3268,6 @@ add_entrypoint_object(
     isnanl.cpp
   HDRS
     ../isnanl.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3785,8 +3279,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.str_to_float
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3798,8 +3290,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.str_to_float
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3811,8 +3301,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.str_to_float
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3824,8 +3312,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.str_to_float
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3837,8 +3323,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.str_to_float
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3849,8 +3333,6 @@ add_entrypoint_object(
     ../nextafter.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3861,8 +3343,6 @@ add_entrypoint_object(
     ../nextafterf.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3873,8 +3353,6 @@ add_entrypoint_object(
     ../nextafterl.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3886,8 +3364,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3899,8 +3375,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3911,8 +3385,6 @@ add_entrypoint_object(
     ../nexttoward.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3923,8 +3395,6 @@ add_entrypoint_object(
     ../nexttowardf.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3935,8 +3405,6 @@ add_entrypoint_object(
     ../nexttowardl.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3948,8 +3416,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3960,8 +3426,6 @@ add_entrypoint_object(
     ../nextdown.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3972,8 +3436,6 @@ add_entrypoint_object(
     ../nextdownl.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3984,8 +3446,6 @@ add_entrypoint_object(
     ../nextdownf.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -3997,8 +3457,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4010,8 +3468,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4022,8 +3478,6 @@ add_entrypoint_object(
     ../nextup.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4034,8 +3488,6 @@ add_entrypoint_object(
     ../nextupl.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4046,8 +3498,6 @@ add_entrypoint_object(
     ../nextupf.h
   DEPENDS
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4059,8 +3509,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4072,8 +3520,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4084,8 +3530,6 @@ add_entrypoint_object(
     ../fmod.h
   DEPENDS
     libc.src.__support.FPUtil.generic.fmod
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4096,8 +3540,6 @@ add_entrypoint_object(
     ../fmodf.h
   DEPENDS
     libc.src.__support.FPUtil.generic.fmod
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4108,8 +3550,6 @@ add_entrypoint_object(
     ../fmodl.h
   DEPENDS
     libc.src.__support.FPUtil.generic.fmod
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4121,8 +3561,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.fmod
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4134,8 +3572,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.fmod
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4146,8 +3582,6 @@ add_entrypoint_object(
     ../fromfp.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4158,8 +3592,6 @@ add_entrypoint_object(
     ../fromfpf.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4170,8 +3602,6 @@ add_entrypoint_object(
     ../fromfpl.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4183,8 +3613,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4196,8 +3624,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4208,8 +3634,6 @@ add_entrypoint_object(
     ../fromfpx.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4220,8 +3644,6 @@ add_entrypoint_object(
     ../fromfpxf.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4232,8 +3654,6 @@ add_entrypoint_object(
     ../fromfpxl.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4245,8 +3665,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4258,8 +3676,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4270,8 +3686,6 @@ add_entrypoint_object(
     ../ufromfp.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4282,8 +3696,6 @@ add_entrypoint_object(
     ../ufromfpf.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4294,8 +3706,6 @@ add_entrypoint_object(
     ../ufromfpl.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4307,8 +3717,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4320,8 +3728,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4332,8 +3738,6 @@ add_entrypoint_object(
     ../ufromfpx.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4344,8 +3748,6 @@ add_entrypoint_object(
     ../ufromfpxf.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4356,8 +3758,6 @@ add_entrypoint_object(
     ../ufromfpxl.h
   DEPENDS
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4369,8 +3769,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4382,8 +3780,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 #TODO: Add errno include to the hyperbolic functions.
@@ -4406,8 +3802,6 @@ add_object_library(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.common
     libc.src.errno.errno
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4422,8 +3816,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4441,8 +3833,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4456,8 +3846,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4475,8 +3863,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4492,8 +3878,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4515,8 +3899,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4533,8 +3915,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4550,8 +3930,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4564,8 +3942,6 @@ add_entrypoint_object(
     .explogxf
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_object_library(
@@ -4594,8 +3970,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
     .inv_trigf_utils
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4612,8 +3986,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
     .inv_trigf_utils
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4631,8 +4003,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4641,8 +4011,6 @@ add_entrypoint_object(
     atan2f.cpp
   HDRS
     ../atan2f.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     .inv_trigf_utils
     libc.src.__support.FPUtil.fp_bits
@@ -4659,8 +4027,6 @@ add_entrypoint_object(
     atan2.cpp
   HDRS
     ../atan2.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     .inv_trigf_utils
     libc.src.__support.FPUtil.double_double
@@ -4679,8 +4045,6 @@ add_entrypoint_object(
     atan2l.cpp
   HDRS
     ../atan2l.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     .atan2
 )
@@ -4694,8 +4058,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.float_macros
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4707,8 +4069,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.float_macros
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4720,8 +4080,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.float_macros
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4734,8 +4092,6 @@ add_entrypoint_object(
     libc.hdr.float_macros
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4748,8 +4104,6 @@ add_entrypoint_object(
     libc.hdr.float_macros
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4761,8 +4115,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.float_macros
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4774,8 +4126,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.float_macros
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4787,8 +4137,6 @@ add_entrypoint_object(
   DEPENDS
     libc.hdr.float_macros
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4801,8 +4149,6 @@ add_entrypoint_object(
     libc.hdr.float_macros
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4815,8 +4161,6 @@ add_entrypoint_object(
     libc.hdr.float_macros
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.manipulation_functions
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4827,8 +4171,6 @@ add_entrypoint_object(
     ../fmaf.h
   DEPENDS
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4839,8 +4181,6 @@ add_entrypoint_object(
     ../fma.h
   DEPENDS
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4851,8 +4191,6 @@ add_entrypoint_object(
     ../totalorder.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4863,8 +4201,6 @@ add_entrypoint_object(
     ../totalorderf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4875,8 +4211,6 @@ add_entrypoint_object(
     ../totalorderl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4887,8 +4221,6 @@ add_entrypoint_object(
     ../totalorderf16.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4900,8 +4232,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.properties.types
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 add_entrypoint_object(
   totalordermag
@@ -4911,8 +4241,6 @@ add_entrypoint_object(
     ../totalordermag.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4923,8 +4251,6 @@ add_entrypoint_object(
     ../totalordermagf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4935,8 +4261,6 @@ add_entrypoint_object(
     ../totalordermagl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4947,8 +4271,6 @@ add_entrypoint_object(
     ../totalordermagf16.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4960,8 +4282,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
     libc.src.__support.macros.properties.types
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4972,8 +4292,6 @@ add_entrypoint_object(
     ../getpayload.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4984,8 +4302,6 @@ add_entrypoint_object(
     ../getpayloadf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -4996,8 +4312,6 @@ add_entrypoint_object(
     ../getpayloadl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5009,8 +4323,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5022,8 +4334,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5034,8 +4344,6 @@ add_entrypoint_object(
     ../setpayload.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5046,8 +4354,6 @@ add_entrypoint_object(
     ../setpayloadf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5058,8 +4364,6 @@ add_entrypoint_object(
     ../setpayloadl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5071,8 +4375,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5084,8 +4386,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5096,8 +4396,6 @@ add_entrypoint_object(
     ../setpayloadsig.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5108,8 +4406,6 @@ add_entrypoint_object(
     ../setpayloadsigf.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5120,8 +4416,6 @@ add_entrypoint_object(
     ../setpayloadsigl.h
   DEPENDS
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5133,8 +4427,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5146,8 +4438,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.basic_operations
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5159,8 +4449,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5172,8 +4460,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5185,8 +4471,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5198,8 +4482,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5211,8 +4493,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5224,8 +4504,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5237,8 +4515,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5250,8 +4526,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.add_sub
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5263,8 +4537,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.div
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5276,8 +4548,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.div
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5289,8 +4559,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.div
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5302,8 +4570,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.div
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5315,8 +4581,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5328,8 +4592,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5341,8 +4603,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5354,8 +4614,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.fma
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5367,8 +4625,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5380,8 +4636,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5393,8 +4647,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5406,8 +4658,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5418,8 +4668,6 @@ add_entrypoint_object(
     ../fsqrt.h
   DEPENDS
     libc.src.__support.FPUtil.generic.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5430,8 +4678,6 @@ add_entrypoint_object(
     ../fsqrtl.h
   DEPENDS
     libc.src.__support.FPUtil.generic.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5443,8 +4689,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.sqrt
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5453,8 +4697,6 @@ add_entrypoint_object(
     cbrtf.cpp
   HDRS
     ../cbrtf.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.hdr.fenv_macros
     libc.src.__support.FPUtil.fenv_impl
@@ -5469,8 +4711,6 @@ add_entrypoint_object(
     cbrt.cpp
   HDRS
     ../cbrt.h
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.hdr.fenv_macros
     libc.src.__support.FPUtil.double_double
@@ -5491,8 +4731,6 @@ add_entrypoint_object(
     ../dmull.h
   DEPENDS
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5504,8 +4742,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5517,8 +4753,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5530,8 +4764,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5543,8 +4775,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_entrypoint_object(
@@ -5556,8 +4786,6 @@ add_entrypoint_object(
   DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.generic.mul
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
 )
 
 add_header_library(

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -926,6 +926,16 @@ add_entrypoint_object(
   HDRS
     ../roundevenl.h
   DEPENDS
+    libc.src.__support.FPUtil.nearest_integer_operations
+)
+
+add_entrypoint_object(
+  roundevenf16
+  SRCS
+    roundevenf16.cpp
+  HDRS
+    ../roundevenf16.h
+  DEPENDS
     libc.src.__support.macros.properties.types
     libc.src.__support.FPUtil.nearest_integer_operations
     libc.src.__support.FPUtil.cast
@@ -1699,6 +1709,18 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  copysignf
+  SRCS
+    copysignf.cpp
+  HDRS
+    ../copysignf.h
+  DEPENDS
+    libc.src.__support.FPUtil.manipulation_functions
+  FLAGS
+    MISC_MATH_BASIC_OPS_OPT
+)
+
+add_entrypoint_object(
   copysignl
   SRCS
     copysignl.cpp
@@ -2082,7 +2104,7 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.fma
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
-  )
+)
 
 add_entrypoint_object(
   log2f16

--- a/libc/src/stdfix/CMakeLists.txt
+++ b/libc/src/stdfix/CMakeLists.txt
@@ -9,8 +9,6 @@ foreach(suffix IN ITEMS hr r lr hk k lk)
       abs${suffix}.h
     SRCS
       abs${suffix}.cpp
-    COMPILE_OPTIONS
-      ${libc_opt_high_flag}
     DEPENDS
       libc.src.__support.fixed_point.fx_bits
   )
@@ -23,8 +21,6 @@ foreach(suffix IN ITEMS uhr ur ulr uhk uk)
       sqrt${suffix}.h
     SRCS
       sqrt${suffix}.cpp
-    COMPILE_OPTIONS
-      ${libc_opt_high_flag}
     DEPENDS
       libc.src.__support.fixed_point.sqrt
   )
@@ -37,8 +33,6 @@ foreach(suffix IN ITEMS hr r lr hk k lk uhr ur ulr uhk uk ulk)
       round${suffix}.h
     SRCS
       round${suffix}.cpp
-    COMPILE_OPTIONS
-      ${libc_opt_high_flag}
     DEPENDS
       libc.src.__support.fixed_point.fx_bits
   )
@@ -61,8 +55,6 @@ add_entrypoint_object(
     uhksqrtus.h
   SRCS
     uhksqrtus.cpp
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.fixed_point.sqrt
 )
@@ -73,8 +65,6 @@ add_entrypoint_object(
     uksqrtui.h
   SRCS
     uksqrtui.cpp
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.fixed_point.sqrt
 )
@@ -85,8 +75,6 @@ add_entrypoint_object(
     exphk.h
   SRCS
     exphk.cpp
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.fixed_point.fx_rep
     libc.src.__support.CPP.bit
@@ -98,8 +86,6 @@ add_entrypoint_object(
     expk.h
   SRCS
     expk.cpp
-  COMPILE_OPTIONS
-    ${libc_opt_high_flag}
   DEPENDS
     libc.src.__support.fixed_point.fx_rep
     libc.src.__support.CPP.bit


### PR DESCRIPTION
This was originally done for testing purposes, but after #126315 we now do testing through GitHub Actions and should be instead using the optimization setting chosen by the user.