### PR TITLE
[RISCV] Include RISCVGenSearchTable.inc in RISCVISelDAGToDAG.h

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.h
@@ -278,6 +278,7 @@ struct VLX_VSXPseudo {
 #define GET_RISCVVSETable_DECL
 #define GET_RISCVVLXTable_DECL
 #define GET_RISCVVSXTable_DECL
+#include "RISCVGenSearchableTables.inc"
 } // namespace RISCV
 
 } // namespace llvm


### PR DESCRIPTION
This line was previously removed when 12d47247e5046b959af180e12f648c54e2c5e863 moved it to RISCVInstrInfo.h. But we probably don't want to have dangling `#define *_DECL` (RISCVGenSearchableTables.inc will `#undef` these macros) and I think there is no harm putting declarations of those search table functions in RISCVISelDAGToDAG.h.