### PR TITLE
[MLIR][TableGen] Add gen-attrdef-list

### DIFF
--- a/mlir/test/mlir-tblgen/attrdefs.td
+++ b/mlir/test/mlir-tblgen/attrdefs.td
@@ -1,5 +1,6 @@
 // RUN: mlir-tblgen -gen-attrdef-decls -I %S/../../include %s | FileCheck %s --check-prefix=DECL
 // RUN: mlir-tblgen -gen-attrdef-defs -I %S/../../include %s | FileCheck %s --check-prefix=DEF
+// RUN: mlir-tblgen -gen-attrdef-list -I %S/../../include %s | FileCheck %s --check-prefix=LIST
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
@@ -19,6 +20,12 @@ include "mlir/IR/OpBase.td"
 // DEF: ::test::CompoundAAttr,
 // DEF: ::test::SingleParameterAttr
 
+// LIST: ATTRDEF(IndexAttr)
+// LIST: ATTRDEF(SimpleAAttr)
+// LIST: ATTRDEF(CompoundAAttr)
+// LIST: ATTRDEF(SingleParameterAttr)
+
+// LIST: #undef ATTRDEF
 // DEF-LABEL: ::mlir::OptionalParseResult generatedAttributeParser(
 // DEF-SAME: ::mlir::AsmParser &parser,
 // DEF-SAME: ::llvm::StringRef *mnemonic, ::mlir::Type type,


### PR DESCRIPTION
This adds a new mlir-tblgen option (-gen-attrdef-list) to generate a list of AttrDefs from a .td file in a format suitable for use in patterns where a macro is defined to expand various repeated code snippets for each item in the list. Specifically, the file will contain a list in this format

ATTRDEF(MyAttr)

This will be used in ClangIR to create an attribute visitor.