### PR TITLE
[lldb][NFC] Replace GetLocalBufferSize() with GetLocalBuffer()

### DIFF
--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -865,17 +865,18 @@ public:
 
   virtual void SetLanguageFlags(uint64_t flags) { m_language_flags = flags; }
 
-  /// Returns the size of the local buffer if it's available.
+  /// Returns the local buffer that this ValueObject points to if it's
+  /// available.
   /// \return
-  ///     The size of the local buffer if this value object's value points to a
-  ///     host address, and if that size can be determined. Otherwise, returns
-  ///     LLDB_INVALID_ADDRESS.
+  ///     The local buffer if this value object's value points to a
+  ///     host address, and if that buffer can be determined. Otherwise, returns
+  ///     an empty ArrayRef.
   ///
   /// TODO: Because a ValueObject's Value can point to any arbitrary memory
-  /// location, it is possible that the size of the local buffer can't be
-  /// determined at all. See the comment in Value::m_value for a more thorough
-  /// explanation of why that is.
-  uint64_t GetLocalBufferSize();
+  /// location, it is possible that we can't find what what buffer we're
+  /// pointing to, and thus also can't know its size. See the comment in
+  /// Value::m_value for a more thorough explanation of why that is.
+  llvm::ArrayRef<uint8_t> GetLocalBuffer() const;
 
 protected:
   typedef ClusterManager<ValueObject> ValueObjectManager;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -849,20 +849,20 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
   return true;
 }
 
-uint64_t ValueObject::GetLocalBufferSize() {
+llvm::ArrayRef<uint8_t> ValueObject::GetLocalBuffer() const {
   if (m_value.GetValueType() != Value::ValueType::HostAddress)
-    return LLDB_INVALID_ADDRESS;
+    return {};
   auto start = m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
   if (start == LLDB_INVALID_ADDRESS)
-    return LLDB_INVALID_ADDRESS;
+    return {};
   // Does our pointer point to this value object's m_data buffer?
   if ((uint64_t)m_data.GetDataStart() == start)
-    return m_data.GetByteSize();
+    return m_data.GetData();
   // Does our pointer point to the value's buffer?
   if ((uint64_t)m_value.GetBuffer().GetBytes() == start)
-    return m_value.GetBuffer().GetByteSize();
+    return m_value.GetBuffer().GetData();
   // Our pointer points to something else. We can't know what the size is.
-  return LLDB_INVALID_ADDRESS;
+  return {};
 }
 
 static bool CopyStringDataToBufferSP(const StreamString &source,

--- a/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
+++ b/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
@@ -241,7 +241,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       SetValueDidChange(true);
 
     // If we found a host address, and the dynamic type fits in the local buffer
-    // that was found, point to thar buffer. Later on this function will copy
+    // that was found, point to that buffer. Later on this function will copy
     // the buffer over.
     if (value_type == Value::ValueType::HostAddress && !local_buffer.empty()) {
       auto *exe_scope = exe_ctx.GetBestExecutionContextScope();

--- a/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
+++ b/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
@@ -66,11 +66,8 @@ struct MockLanguageRuntime : public LanguageRuntime {
         *ast, "TypeWitInt", ast->GetBasicType(lldb::BasicType::eBasicTypeInt),
         "theIntField", LanguageType::eLanguageTypeC_plus_plus);
     class_type_or_name.SetCompilerType(int_type);
-    local_buffer = {(uint8_t *)in_value.GetValue().GetScalar().ULongLong(
-                        LLDB_INVALID_ADDRESS),
-                    static_cast<size_t>(in_value.GetLocalBufferSize())};
+    local_buffer = in_value.GetLocalBuffer();
     value_type = Value::ValueType::HostAddress;
-
     return true;
   }
 


### PR DESCRIPTION
GetLocalBuffer() makes more sense as an API.