### PR TITLE
[WebKit Checkers] Treat const Objective-C ivar as a safe origin

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -163,10 +163,13 @@ bool isConstOwnerPtrMemberExpr(const clang::Expr *E) {
     if (OCE->getOperator() == OO_Star && OCE->getNumArgs() == 1)
       E = OCE->getArg(0);
   }
-  auto *ME = dyn_cast<MemberExpr>(E);
-  if (!ME)
+  const ValueDecl *D = nullptr;
+  if (auto *ME = dyn_cast<MemberExpr>(E))
+    D = ME->getMemberDecl();
+  else if (auto *IVR = dyn_cast<ObjCIvarRefExpr>(E))
+    D = IVR->getDecl();
+  else
     return false;
-  auto *D = ME->getMemberDecl();
   if (!D)
     return false;
   auto T = D->getType();

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -168,8 +168,6 @@ bool isConstOwnerPtrMemberExpr(const clang::Expr *E) {
     D = ME->getMemberDecl();
   else if (auto *IVR = dyn_cast<ObjCIvarRefExpr>(E))
     D = IVR->getDecl();
-  else
-    return false;
   if (!D)
     return false;
   auto T = D->getType();

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
@@ -1,5 +1,4 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
-// expected-no-diagnostics
 
 #import "mock-types.h"
 #import "mock-system-header.h"
@@ -8,6 +7,7 @@
 @interface Foo : NSObject {
   const Ref<RefCountable> _obj1;
   const RefPtr<RefCountable> _obj2;
+  Ref<RefCountable> _obj3;
 }
 
 @property (nonatomic, readonly) RefPtr<RefCountable> countable;
@@ -23,6 +23,8 @@
   _obj1->method();
   _obj1.get().method();
   (*_obj2).method();
+  _obj3->method();
+  // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
 }
 
 - (RefPtr<RefCountable>)_protectedRefCountable {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
@@ -5,7 +5,10 @@
 #import "mock-system-header.h"
 #import "../../Inputs/system-header-simulator-for-objc-dealloc.h"
 
-@interface Foo : NSObject
+@interface Foo : NSObject {
+  const Ref<RefCountable> _obj1;
+  const RefPtr<RefCountable> _obj2;
+}
 
 @property (nonatomic, readonly) RefPtr<RefCountable> countable;
 
@@ -17,6 +20,9 @@
 
 - (void)execute {
   self._protectedRefCountable->method();
+  _obj1->method();
+  _obj1.get().method();
+  (*_obj2).method();
 }
 
 - (RefPtr<RefCountable>)_protectedRefCountable {
@@ -30,6 +36,7 @@ public:
   void ref() const;
   void deref() const;
   Ref<RefCountedObject> copy() const;
+  void method();
 };
 
 @interface WrapperObj : NSObject


### PR DESCRIPTION
Like const C++ member variables, treat const Ref, RefPtr, CheckedRef, CheckedPtr Objective-C ivars as a safe pointer origin in WebKit checkers.