### PR TITLE
Fix #126355: Force "/utf-8" for msvc compilers

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -48,6 +48,11 @@ project(LLVM
   VERSION ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}
   LANGUAGES C CXX ASM)
 
+# Force UTF-8 encoding for MSVC compiler. This ensures that the MSVC compilers
+# interpret source files as UTF-8 encoded.
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 if (NOT DEFINED CMAKE_INSTALL_LIBDIR AND DEFINED LLVM_LIBDIR_SUFFIX)
   # Must go before `include(GNUInstallDirs)`.
   set(CMAKE_INSTALL_LIBDIR "lib${LLVM_LIBDIR_SUFFIX}")


### PR DESCRIPTION
The MSVC compiler determines the encoding of the source code based on the BOM of the source code when reading it. If there is no BOM, it defaults to the local encoding, which is gb2312, codepage 936, on Simplified Chinese Windows. This can cause errors such as newline characters in strings.