### PR TITLE
[libc] implement endian related macros

### DIFF
--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -314,6 +314,8 @@ add_macro_header(
   endian_macros
   HDR
     endian-macros.h
+  DEPENDS
+    .stdint_macros
 )
 
 add_macro_header(

--- a/libc/include/llvm-libc-macros/endian-macros.h
+++ b/libc/include/llvm-libc-macros/endian-macros.h
@@ -9,8 +9,42 @@
 #ifndef LLVM_LIBC_MACROS_ENDIAN_MACROS_H
 #define LLVM_LIBC_MACROS_ENDIAN_MACROS_H
 
+#include "stdint-macros.h"
+
 #define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
 #define BIG_ENDIAN __ORDER_BIG_ENDIAN__
 #define BYTE_ORDER __BYTE_ORDER__
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+#define htobe16(x) __builtin_bswap16((x))
+#define htobe32(x) __builtin_bswap32((x))
+#define htobe64(x) __builtin_bswap64((x))
+#define htole16(x) ((uint16_t)(x))
+#define htole32(x) ((uint32_t)(x))
+#define htole64(x) ((uint64_t)(x))
+#define be16toh(x) __builtin_bswap16((x))
+#define be32toh(x) __builtin_bswap32((x))
+#define be64toh(x) __builtin_bswap64((x))
+#define le16toh(x) ((uint16_t)(x))
+#define le32toh(x) ((uint32_t)(x))
+#define le64toh(x) ((uint64_t)(x))
+
+#else
+
+#define htobe16(x) ((uint16_t)(x))
+#define htobe32(x) ((uint32_t)(x))
+#define htobe64(x) ((uint64_t)(x))
+#define htole16(x) __builtin_bswap16((x))
+#define htole32(x) __builtin_bswap32((x))
+#define htole64(x) __builtin_bswap64((x))
+#define be16toh(x) ((uint16_t)(x))
+#define be32toh(x) ((uint32_t)(x))
+#define be64toh(x) ((uint64_t)(x))
+#define le16toh(x) __builtin_bswap16((x))
+#define le32toh(x) __builtin_bswap32((x))
+#define le64toh(x) __builtin_bswap64((x))
+
+#endif
 
 #endif // LLVM_LIBC_MACROS_ENDIAN_MACROS_H


### PR DESCRIPTION
Follow up of #125168.

This patch adds endian-related macros to `endian.h`. We utilize compiler built-ins for byte swap functions, which are already included in our minimal supported compiler version.