### PR TITLE
[llvm][GitHub] Move PR project status to Done once backport PR is made

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -472,6 +472,99 @@ class ReleaseWorkflow:
             return m.group(1)
         return None
 
+    def update_issue_project_status(self) -> None:
+        """
+        A common workflow is to merge a PR and then use the /cherry-pick
+        command in a pull request comment to backport the change to the
+        release branch.  In this case, once the new PR for the backport has
+        been created, we want to mark the project status for the original PR
+        as Done.  This is becuase we can track progress now on the new PR
+        which is targeting the release branch.
+
+        """
+
+        pr = self.issue.as_pull_request()
+        if not pr:
+            return
+
+        if pr.state != "closed":
+            return
+
+        gh = github.Github(login_or_token=self.token)
+        query = """
+            query($node_id: ID!) {
+              node(id: $node_id) {
+                ... on PullRequest {
+                  url
+                  projectItems(first:100){
+                    nodes {
+                        id
+                        project {
+                          id
+                          number
+                          field(name: "Status") {
+                            ... on ProjectV2SingleSelectField {
+                              id
+                              name
+                              options {
+                                id
+                                name
+                              }
+                            }
+                          }
+                        }
+                    }
+                  }
+                }
+              }
+            }
+        """
+        variables = {
+            "node_id" : pr.node_id
+        }
+        res_header, res_data = gh._Github__requester.graphql_query(
+            query=query, variables=variables
+        )
+        print(res_header)
+
+        for item in res_data['data']['node']['projectItems']['nodes']:
+            project = item['project']
+            if project['number'] != 3:
+                continue
+            status_field = project['field']
+            for option in status_field['options']:
+                if option['name'] != "Done":
+                    continue
+                variables = {
+                    "project" : project["id"],
+                    "item" : item["id"],
+                    "status_field" : status_field["id"],
+                    "status_value" : option["id"],
+                }
+
+                query = """
+                    mutation($project: ID!, $item: ID!, $status_field: ID!, $status_value: String!) {
+                      set_status:
+                      updateProjectV2ItemFieldValue(input: {
+                        projectId: $project
+                        itemId: $item
+                        fieldId: $status_field
+                        value: {
+                          singleSelectOptionId: $status_value
+                        }
+                      }) {
+                        projectV2Item {
+                          id
+                        }
+                      }
+                    }
+                """
+
+                res_header, res_data = gh._Github__requester.graphql_query(
+                    query=query, variables=variables
+                )
+                print(res_header)
+
     def print_release_branch(self) -> None:
         print(self.release_branch_for_issue)
 
@@ -664,6 +757,7 @@ class ReleaseWorkflow:
 
         self.issue_notify_pull_request(pull)
         self.issue_remove_cherry_pick_failed_label()
+        self.update_issue_project_status()
 
         # TODO(tstellar): Do you really want to always return True?
         return True

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -519,7 +519,7 @@ class ReleaseWorkflow:
               }
             }
         """
-        variables = {"node_id": pr.node_id }
+        variables = {"node_id": pr.node_id}
         res_header, res_data = gh._Github__requester.graphql_query(
             query=query, variables=variables
         )

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -498,66 +498,65 @@ class ReleaseWorkflow:
                   url
                   projectItems(first:100){
                     nodes {
+                      id
+                      project {
                         id
-                        project {
-                          id
-                          number
-                          field(name: "Status") {
-                            ... on ProjectV2SingleSelectField {
+                        number
+                        field(name: "Status") {
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options {
                               id
                               name
-                              options {
-                                id
-                                name
-                              }
                             }
                           }
                         }
+                      }
                     }
                   }
                 }
               }
             }
         """
-        variables = {
-            "node_id" : pr.node_id
-        }
+        variables = {"node_id": pr.node_id }
         res_header, res_data = gh._Github__requester.graphql_query(
             query=query, variables=variables
         )
         print(res_header)
 
-        for item in res_data['data']['node']['projectItems']['nodes']:
-            project = item['project']
-            if project['number'] != 3:
+        llvm_release_status_project_number = 3
+        for item in res_data["data"]["node"]["projectItems"]["nodes"]:
+            project = item["project"]
+            if project["number"] != llvm_release_status_project_number:
                 continue
-            status_field = project['field']
-            for option in status_field['options']:
-                if option['name'] != "Done":
+            status_field = project["field"]
+            for option in status_field["options"]:
+                if option["name"] != "Done":
                     continue
                 variables = {
-                    "project" : project["id"],
-                    "item" : item["id"],
-                    "status_field" : status_field["id"],
-                    "status_value" : option["id"],
+                    "project": project["id"],
+                    "item": item["id"],
+                    "status_field": status_field["id"],
+                    "status_value": option["id"],
                 }
 
                 query = """
-                    mutation($project: ID!, $item: ID!, $status_field: ID!, $status_value: String!) {
-                      set_status:
-                      updateProjectV2ItemFieldValue(input: {
-                        projectId: $project
-                        itemId: $item
-                        fieldId: $status_field
-                        value: {
-                          singleSelectOptionId: $status_value
-                        }
-                      }) {
-                        projectV2Item {
-                          id
-                        }
+                  mutation($project: ID!, $item: ID!, $status_field: ID!, $status_value: String!) {
+                    set_status:
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $project
+                      itemId: $item
+                      fieldId: $status_field
+                      value: {
+                        singleSelectOptionId: $status_value
+                      }
+                    }) {
+                      projectV2Item {
+                        id
                       }
                     }
+                  }
                 """
 
                 res_header, res_data = gh._Github__requester.graphql_query(


### PR DESCRIPTION
It's common to use the /cherry-pick command on a PR to create a backport request.  However, this creates a lot of clutter in the LLVM Release Status project, because we end up with two items in the project, one for the original PR and one for the new PR.

This change will set the status of the original PR to Done once the new PR (for the release branch) is created.  This will save release managers a lot of work of having to manually updated the status for PRs that contain backport requests.