### PR TITLE
[flang] Fix standalone builds against installed MLIR

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -228,6 +228,11 @@ if (FLANG_STANDALONE_BUILD)
     add_custom_target(doxygen ALL)
   endif()
 
+  # Override the value from installed CMake files, as they refer
+  # to the directory used during the original MLIR package build,
+  # which may be no longer available.  Instead, use the current checkout.
+  set(MLIR_MAIN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../mlir )
+
 else()
   option(FLANG_INCLUDE_TESTS
          "Generate build targets for the Flang unit tests."

--- a/flang/cmake/modules/AddFlang.cmake
+++ b/flang/cmake/modules/AddFlang.cmake
@@ -18,7 +18,7 @@ endmacro()
 
 function(add_flang_library name)
   set(options SHARED STATIC INSTALL_WITH_TOOLCHAIN)
-  set(multiValueArgs ADDITIONAL_HEADERS CLANG_LIBS MLIR_LIBS)
+  set(multiValueArgs ADDITIONAL_HEADERS CLANG_LIBS MLIR_LIBS MLIR_DEPS)
   cmake_parse_arguments(ARG
     "${options}"
     ""
@@ -68,6 +68,9 @@ function(add_flang_library name)
   clang_target_link_libraries(${name} PRIVATE ${ARG_CLANG_LIBS})
   if (ARG_MLIR_LIBS)
     mlir_target_link_libraries(${name} PRIVATE ${ARG_MLIR_LIBS})
+  endif()
+  if (ARG_MLIR_DEPS AND NOT FLANG_STANDALONE_BUILD)
+    add_dependencies(${name} ${ARG_MLIR_DEPS})
   endif()
 
   if (TARGET ${name})

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -18,9 +18,6 @@ add_flang_library(flangFrontend
   FIROptCodeGenPassIncGen
   FIROptTransformsPassIncGen
   HLFIRDialect
-  MLIRIR
-  ${dialect_libs}
-  ${extension_libs}
 
   LINK_LIBS
   CUFDialect
@@ -55,6 +52,11 @@ add_flang_library(flangFrontend
   FrontendDriver
   FrontendOpenACC
   FrontendOpenMP
+
+  MLIR_DEPS
+  MLIRIR
+  ${dialect_libs}
+  ${extension_libs}
 
   MLIR_LIBS
   MLIRTransforms

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -44,8 +44,6 @@ add_flang_library(FortranLower
   FIRDialect
   FIRTransforms
   HLFIRDialect
-  ${dialect_libs}
-  ${extension_libs}
 
   LINK_LIBS
   CUFAttrs
@@ -63,6 +61,10 @@ add_flang_library(FortranLower
 
   LINK_COMPONENTS
   Support
+
+  MLIR_DEPS
+  ${dialect_libs}
+  ${extension_libs}
 
   MLIR_LIBS
   ${dialect_libs}

--- a/flang/lib/Optimizer/Analysis/CMakeLists.txt
+++ b/flang/lib/Optimizer/Analysis/CMakeLists.txt
@@ -6,14 +6,16 @@ add_flang_library(FIRAnalysis
   FIRDialect
   FIRSupport
   HLFIRDialect
-  MLIRIR
-  MLIROpenMPDialect
 
   LINK_LIBS
   FIRBuilder
   FIRDialect
   FIRSupport
   HLFIRDialect
+
+  MLIR_DEPS
+  MLIRIR
+  MLIROpenMPDialect
 
   MLIR_LIBS
   MLIRFuncDialect

--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -40,8 +40,6 @@ add_flang_library(FIRBuilder
   CUFDialect
   FIRDialect
   HLFIRDialect
-  ${dialect_libs}
-  ${extension_libs}
 
   LINK_LIBS
   CUFAttrs
@@ -51,6 +49,10 @@ add_flang_library(FIRBuilder
   FIRSupport
   FortranEvaluate
   HLFIRDialect
+
+  MLIR_DEPS
+  ${dialect_libs}
+  ${extension_libs}
 
   MLIR_LIBS
   ${dialect_libs}

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -12,7 +12,6 @@ add_flang_library(FIRDialect
 
   DEPENDS
   CanonicalizationPatternsIncGen
-  MLIRIR
   FIROpsIncGen
   CUFAttrsIncGen
   intrinsics_gen
@@ -25,6 +24,9 @@ add_flang_library(FIRDialect
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_DEPS
+  MLIRIR
 
   MLIR_LIBS
   MLIRArithDialect

--- a/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CUF/Attributes/CMakeLists.txt
@@ -3,7 +3,6 @@ add_flang_library(CUFAttrs
   CUFAttr.cpp
 
   DEPENDS
-  MLIRIR
   CUFAttrsIncGen
   CUFOpsIncGen
 
@@ -11,6 +10,9 @@ add_flang_library(CUFAttrs
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_DEPS
+  MLIRIR
 
   MLIR_LIBS
   MLIRTargetLLVMIRExport

--- a/flang/lib/Optimizer/Dialect/CUF/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CUF/CMakeLists.txt
@@ -6,7 +6,6 @@ add_flang_library(CUFDialect
   CUFToLLVMIRTranslation.cpp
 
   DEPENDS
-  MLIRIR
   CUFAttrsIncGen
   CUFOpsIncGen
 
@@ -19,6 +18,9 @@ add_flang_library(CUFDialect
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_DEPS
+  MLIRIR
 
   MLIR_LIBS
   MLIRIR

--- a/flang/lib/Optimizer/Dialect/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/Support/CMakeLists.txt
@@ -5,8 +5,10 @@ add_flang_library(FIRDialectSupport
   FIRContext.cpp
 
   DEPENDS
-  MLIRIR
   intrinsics_gen
+
+  MLIR_DEPS
+  MLIRIR
 
   MLIR_LIBS
   ${dialect_libs}

--- a/flang/lib/Optimizer/HLFIR/IR/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/IR/CMakeLists.txt
@@ -8,7 +8,6 @@ add_flang_library(HLFIRDialect
   CUFAttrsIncGen
   FIRDialect
   HLFIROpsIncGen
-  ${dialect_libs}
 
   LINK_LIBS
   CUFAttrs
@@ -18,6 +17,9 @@ add_flang_library(HLFIRDialect
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_DEPS
+  ${dialect_libs}
 
   MLIR_LIBS
   MLIRIR

--- a/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
@@ -15,7 +15,6 @@ add_flang_library(HLFIRTransforms
   CUFAttrsIncGen
   FIRDialect
   HLFIROpsIncGen
-  ${dialect_libs}
 
   LINK_LIBS
   CUFAttrs
@@ -32,6 +31,9 @@ add_flang_library(HLFIRTransforms
   AsmParser
   AsmPrinter
   Remarks
+
+  MLIR_DEPS
+  ${dialect_libs}
 
   MLIR_LIBS
   MLIRIR

--- a/flang/lib/Optimizer/OpenACC/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/CMakeLists.txt
@@ -10,7 +10,6 @@ add_flang_library(FIROpenACCSupport
   FIRDialectSupport
   FIRSupport
   HLFIRDialect
-  MLIROpenACCDialect
 
   LINK_LIBS
   FIRBuilder
@@ -18,6 +17,9 @@ add_flang_library(FIROpenACCSupport
   FIRDialectSupport
   FIRSupport
   HLFIRDialect
+
+  MLIR_DEPS
+  MLIROpenACCDialect
 
   MLIR_LIBS
   MLIROpenACCDialect

--- a/flang/lib/Optimizer/OpenMP/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenMP/CMakeLists.txt
@@ -12,7 +12,6 @@ add_flang_library(FlangOpenMPTransforms
   FIRDialect
   HLFIROpsIncGen
   FlangOpenMPPassesIncGen
-  ${dialect_libs}
 
   LINK_LIBS
   FIRAnalysis
@@ -23,6 +22,9 @@ add_flang_library(FlangOpenMPTransforms
   FIRSupport
   FortranSupport
   HLFIRDialect
+
+  MLIR_DEPS
+  ${dialect_libs}
 
   MLIR_LIBS
   MLIRFuncDialect

--- a/flang/lib/Optimizer/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/Support/CMakeLists.txt
@@ -10,15 +10,17 @@ add_flang_library(FIRSupport
   DEPENDS
   FIROpsIncGen
   HLFIROpsIncGen
-  MLIRIR
-  ${dialect_libs}
-  ${extension_libs}
 
   LINK_LIBS
   FIRDialect
 
   LINK_COMPONENTS
   TargetParser
+
+  MLIR_DEPS
+  MLIRIR
+  ${dialect_libs}
+  ${extension_libs}
 
   MLIR_LIBS
   ${dialect_libs}

--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -59,26 +59,30 @@ set(FLANG_TEST_PARAMS
 
 set(FLANG_TEST_DEPENDS
   flang
-  llvm-config
-  FileCheck
-  count
-  not
   module_files
   fir-opt
   tco
   bbc
-  llvm-dis
-  llvm-objdump
-  llvm-readobj
-  split-file
   FortranDecimal
 )
+if (NOT FLANG_STANDALONE_BUILD)
+  list(APPEND FLANG_TEST_DEPENDS
+    llvm-config
+    FileCheck
+    count
+    not
+    llvm-dis
+    llvm-objdump
+    llvm-readobj
+    split-file
+  )
+endif ()
 
 if (FLANG_INCLUDE_RUNTIME)
   list(APPEND FLANG_TEST_DEPENDS FortranRuntime)
 endif ()
 
-if (LLVM_ENABLE_PLUGINS AND NOT WIN32)
+if (LLVM_ENABLE_PLUGINS AND NOT WIN32 AND NOT FLANG_STANDALONE_BUILD)
   list(APPEND FLANG_TEST_DEPENDS Bye)
 endif()
 

--- a/flang/test/lib/Analysis/AliasAnalysis/CMakeLists.txt
+++ b/flang/test/lib/Analysis/AliasAnalysis/CMakeLists.txt
@@ -8,7 +8,6 @@ add_flang_library(FIRTestAnalysis
   FIRSupport
   FIRTransforms
   FIRAnalysis
-  ${dialect_libs}
 
   LINK_LIBS
   FIRDialect
@@ -17,6 +16,9 @@ add_flang_library(FIRTestAnalysis
   FIRTransforms
   FIRAnalysis
   MLIRTestAnalysis
+
+  MLIR_DEPS
+  ${dialect_libs}
 
   MLIR_LIBS
   ${dialect_libs}

--- a/flang/test/lib/OpenACC/CMakeLists.txt
+++ b/flang/test/lib/OpenACC/CMakeLists.txt
@@ -5,15 +5,17 @@ add_flang_library(FIRTestOpenACCInterfaces
   FIRDialect
   FIROpenACCSupport
   FIRSupport
-  MLIRIR
-  MLIROpenACCDialect
-  MLIRPass
-  MLIRSupport
 
   LINK_LIBS
   FIRDialect
   FIROpenACCSupport
   FIRSupport
+
+  MLIR_DEPS
+  MLIRIR
+  MLIROpenACCDialect
+  MLIRPass
+  MLIRSupport
 
   MLIR_LIBS
   MLIRIR

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -1,6 +1,10 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 
+set(LLVM_LINK_COMPONENTS
+  TargetParser
+)
+
 set(LIBS
   CUFDialect
   FIRBuilder
@@ -9,7 +13,6 @@ set(LIBS
   FIRDialectSupport
   FIRSupport
   HLFIRDialect
-  LLVMTargetParser
 )
 
 add_flang_unittest(FlangOptimizerTests

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -39,8 +39,12 @@ DEPENDS
   CUFDialect
   FIRDialect
   FIRSupport
-  HLFIRDialect
-  ${dialect_libs})
+  HLFIRDialect)
+
+if(NOT FLANG_STANDALONE_BUILD)
+  add_dependencies(FlangOptimizerTests
+    ${dialect_libs})
+endif()
 
 target_link_libraries(FlangOptimizerTests
   PRIVATE


### PR DESCRIPTION
1. Add a new `MLIR_DEPS` argument group to `flang_add_library()`, and move MLIR-specific dependencies to that group.  These dependencies are added as usual in regular builds, and are skipped in standalone builds, since MLIR targets are not visible there (and were already built and installed).
2. Fix the value of `MLIR_MAIN_SRC_DIR` to refer to the current source directory rather than the directory written into MLIR CMake files. The latter refers to the directory used to build the MLIR package, and is no longer valid.
3. Fix non-dylib friendly linking of `LLVMTargetParser` in `Optimizer` unittests.

With these changes, I can run Flang's regression tests, and get only two failures (to be investigated later, both fail on linker errors):

```
Failed Tests (2):
  Flang :: Driver/exec.f90
  Flang :: Runtime/no-cpp-dep.c
```