### PR TITLE
[AVX10.2] Fix wrong intrinsic names after rename 

### DIFF
--- a/clang/lib/Headers/avx10_2_512convertintrin.h
+++ b/clang/lib/Headers/avx10_2_512convertintrin.h
@@ -213,19 +213,19 @@ _mm512_maskz_cvts2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
       (__v64qi)(__m512i)_mm512_setzero_si512());
 }
 
-static __inline__ __m512h __DEFAULT_FN_ATTRS512 _mm512_cvthf8(__m256i __A) {
+static __inline__ __m512h __DEFAULT_FN_ATTRS512 _mm512_cvthf8_ph(__m256i __A) {
   return (__m512h)__builtin_ia32_vcvthf8_2ph512_mask(
       (__v32qi)__A, (__v32hf)(__m512h)_mm512_undefined_ph(), (__mmask32)-1);
 }
 
 static __inline__ __m512h __DEFAULT_FN_ATTRS512
-_mm512_mask_cvthf8(__m512h __W, __mmask32 __U, __m256i __A) {
+_mm512_mask_cvthf8_ph(__m512h __W, __mmask32 __U, __m256i __A) {
   return (__m512h)__builtin_ia32_vcvthf8_2ph512_mask(
       (__v32qi)__A, (__v32hf)(__m512h)__W, (__mmask32)__U);
 }
 
 static __inline__ __m512h __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvthf8(__mmask32 __U, __m256i __A) {
+_mm512_maskz_cvthf8_ph(__mmask32 __U, __m256i __A) {
   return (__m512h)__builtin_ia32_vcvthf8_2ph512_mask(
       (__v32qi)__A, (__v32hf)(__m512h)_mm512_setzero_ph(), (__mmask32)__U);
 }

--- a/clang/lib/Headers/avx10_2convertintrin.h
+++ b/clang/lib/Headers/avx10_2convertintrin.h
@@ -381,37 +381,37 @@ _mm256_maskz_cvts2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
       (__v32qi)(__m256i)_mm256_setzero_si256());
 }
 
-static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_cvthf8(__m128i __A) {
+static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_cvthf8_ph(__m128i __A) {
   return (__m128h)__builtin_ia32_vcvthf8_2ph128_mask(
       (__v16qi)__A, (__v8hf)(__m128h)_mm_undefined_ph(), (__mmask8)-1);
 }
 
-static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_mask_cvthf8(__m128h __W,
+static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_mask_cvthf8_ph(__m128h __W,
                                                                 __mmask8 __U,
                                                                 __m128i __A) {
   return (__m128h)__builtin_ia32_vcvthf8_2ph128_mask(
       (__v16qi)__A, (__v8hf)(__m128h)__W, (__mmask8)__U);
 }
 
-static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_maskz_cvthf8(__mmask8 __U,
+static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_maskz_cvthf8_ph(__mmask8 __U,
                                                                  __m128i __A) {
   return (__m128h)__builtin_ia32_vcvthf8_2ph128_mask(
       (__v16qi)__A, (__v8hf)(__m128h)_mm_setzero_ph(), (__mmask8)__U);
 }
 
-static __inline__ __m256h __DEFAULT_FN_ATTRS256 _mm256_cvthf8(__m128i __A) {
+static __inline__ __m256h __DEFAULT_FN_ATTRS256 _mm256_cvthf8_ph(__m128i __A) {
   return (__m256h)__builtin_ia32_vcvthf8_2ph256_mask(
       (__v16qi)__A, (__v16hf)(__m256h)_mm256_undefined_ph(), (__mmask16)-1);
 }
 
 static __inline__ __m256h __DEFAULT_FN_ATTRS256
-_mm256_mask_cvthf8(__m256h __W, __mmask16 __U, __m128i __A) {
+_mm256_mask_cvthf8_ph(__m256h __W, __mmask16 __U, __m128i __A) {
   return (__m256h)__builtin_ia32_vcvthf8_2ph256_mask(
       (__v16qi)__A, (__v16hf)(__m256h)__W, (__mmask16)__U);
 }
 
 static __inline__ __m256h __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvthf8(__mmask16 __U, __m128i __A) {
+_mm256_maskz_cvthf8_ph(__mmask16 __U, __m128i __A) {
   return (__m256h)__builtin_ia32_vcvthf8_2ph256_mask(
       (__v16qi)__A, (__v16hf)(__m256h)_mm256_setzero_ph(), (__mmask16)__U);
 }

--- a/clang/lib/Headers/avx10_2convertintrin.h
+++ b/clang/lib/Headers/avx10_2convertintrin.h
@@ -386,15 +386,14 @@ static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_cvthf8_ph(__m128i __A) {
       (__v16qi)__A, (__v8hf)(__m128h)_mm_undefined_ph(), (__mmask8)-1);
 }
 
-static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_mask_cvthf8_ph(__m128h __W,
-                                                                __mmask8 __U,
-                                                                __m128i __A) {
+static __inline__ __m128h __DEFAULT_FN_ATTRS128
+_mm_mask_cvthf8_ph(__m128h __W, __mmask8 __U, __m128i __A) {
   return (__m128h)__builtin_ia32_vcvthf8_2ph128_mask(
       (__v16qi)__A, (__v8hf)(__m128h)__W, (__mmask8)__U);
 }
 
-static __inline__ __m128h __DEFAULT_FN_ATTRS128 _mm_maskz_cvthf8_ph(__mmask8 __U,
-                                                                 __m128i __A) {
+static __inline__ __m128h __DEFAULT_FN_ATTRS128
+_mm_maskz_cvthf8_ph(__mmask8 __U, __m128i __A) {
   return (__m128h)__builtin_ia32_vcvthf8_2ph128_mask(
       (__v16qi)__A, (__v8hf)(__m128h)_mm_setzero_ph(), (__mmask8)__U);
 }

--- a/clang/test/CodeGen/X86/avx10_2_512convert-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2_512convert-builtins.c
@@ -201,22 +201,22 @@ __m512i test_mm512_maskz_cvts2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
   return _mm512_maskz_cvts2ph_hf8(__U, __A, __B);
 }
 
-__m512h test_mm512_cvthf8(__m256i __A) {
-  // CHECK-LABEL: @test_mm512_cvthf8(
+__m512h test_mm512_cvthf8_ph(__m256i __A) {
+  // CHECK-LABEL: @test_mm512_cvthf8_ph(
   // CHECK: call <32 x half> @llvm.x86.avx10.mask.vcvthf82ph512(
-  return _mm512_cvthf8(__A);
+  return _mm512_cvthf8_ph(__A);
 }
 
-__m512h test_mm512_mask_cvthf8(__m512h __A, __mmask32 __B, __m256i __C) {
-  // CHECK-LABEL: @test_mm512_mask_cvthf8(
+__m512h test_mm512_mask_cvthf8_ph(__m512h __A, __mmask32 __B, __m256i __C) {
+  // CHECK-LABEL: @test_mm512_mask_cvthf8_ph(
   // CHECK: call <32 x half> @llvm.x86.avx10.mask.vcvthf82ph512(
-  return _mm512_mask_cvthf8(__A, __B, __C);
+  return _mm512_mask_cvthf8_ph(__A, __B, __C);
 }
 
-__m512h test_mm512_maskz_cvthf8(__mmask32 __A, __m256i __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvthf8(
+__m512h test_mm512_maskz_cvthf8_ph(__mmask32 __A, __m256i __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvthf8_ph(
   // CHECK: call <32 x half> @llvm.x86.avx10.mask.vcvthf82ph512(
-  return _mm512_maskz_cvthf8(__A, __B);
+  return _mm512_maskz_cvthf8_ph(__A, __B);
 }
 
 __m256i test_mm512_cvtph_bf8(__m512h __A) {

--- a/clang/test/CodeGen/X86/avx10_2convert-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2convert-builtins.c
@@ -379,40 +379,40 @@ __m256i test_mm256_maskz_cvts2ph_hf8(__mmask16 __U, __m256h __A, __m256h __B) {
   return _mm256_maskz_cvts2ph_hf8(__U, __A, __B);
 }
 
-__m128h test_mm_cvthf8(__m128i __A) {
-  // CHECK-LABEL: @test_mm_cvthf8(
+__m128h test_mm_cvthf8_ph(__m128i __A) {
+  // CHECK-LABEL: @test_mm_cvthf8_ph(
   // CHECK: call <8 x half> @llvm.x86.avx10.mask.vcvthf82ph128(
-  return _mm_cvthf8(__A);
+  return _mm_cvthf8_ph(__A);
 }
 
-__m128h test_mm_mask_cvthf8(__m128h __A, __mmask8 __B, __m128i __C) {
-  // CHECK-LABEL: @test_mm_mask_cvthf8(
+__m128h test_mm_mask_cvthf8_ph(__m128h __A, __mmask8 __B, __m128i __C) {
+  // CHECK-LABEL: @test_mm_mask_cvthf8_ph(
   // CHECK: call <8 x half> @llvm.x86.avx10.mask.vcvthf82ph128(
-  return _mm_mask_cvthf8(__A, __B, __C);
+  return _mm_mask_cvthf8_ph(__A, __B, __C);
 }
 
-__m128h test_mm_maskz_cvthf8(__mmask8 __A, __m128i __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvthf8(
+__m128h test_mm_maskz_cvthf8_ph(__mmask8 __A, __m128i __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvthf8_ph(
   // CHECK: call <8 x half> @llvm.x86.avx10.mask.vcvthf82ph128(
-  return _mm_maskz_cvthf8(__A, __B);
+  return _mm_maskz_cvthf8_ph(__A, __B);
 }
 
-__m256h test_mm256_cvthf8(__m128i __A) {
-  // CHECK-LABEL: @test_mm256_cvthf8(
+__m256h test_mm256_cvthf8_ph(__m128i __A) {
+  // CHECK-LABEL: @test_mm256_cvthf8_ph(
   // CHECK: call <16 x half> @llvm.x86.avx10.mask.vcvthf82ph256(
-  return _mm256_cvthf8(__A);
+  return _mm256_cvthf8_ph(__A);
 }
 
-__m256h test_mm256_mask_cvthf8(__m256h __A, __mmask16 __B, __m128i __C) {
-  // CHECK-LABEL: @test_mm256_mask_cvthf8(
+__m256h test_mm256_mask_cvthf8_ph(__m256h __A, __mmask16 __B, __m128i __C) {
+  // CHECK-LABEL: @test_mm256_mask_cvthf8_ph(
   // CHECK: call <16 x half> @llvm.x86.avx10.mask.vcvthf82ph256(
-  return _mm256_mask_cvthf8(__A, __B, __C);
+  return _mm256_mask_cvthf8_ph(__A, __B, __C);
 }
 
-__m256h test_mm256_maskz_cvthf8(__mmask16 __A, __m128i __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvthf8(
+__m256h test_mm256_maskz_cvthf8_ph(__mmask16 __A, __m128i __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvthf8_ph(
   // CHECK: call <16 x half> @llvm.x86.avx10.mask.vcvthf82ph256(
-  return _mm256_maskz_cvthf8(__A, __B);
+  return _mm256_maskz_cvthf8_ph(__A, __B);
 }
 
 __m128i test_mm_cvtph_bf8(__m128h __A) {


### PR DESCRIPTION
In my previous PR (#123656) to update the names of AVX10.2 intrinsics and mnemonics, I have erroneously deleted `_ph` from few intrinsics. This PR corrects this.