### PR TITLE
[RISCV] Improve Errors for GPRNoX0X2/SP Reg Classes

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -252,7 +252,10 @@ def GPRX5 : GPRRegisterClass<(add X5)>;
 
 def GPRNoX0 : GPRRegisterClass<(sub GPR, X0)>;
 
-def GPRNoX0X2 : GPRRegisterClass<(sub GPR, X0, X2)>;
+def GPRNoX0X2 : GPRRegisterClass<(sub GPR, X0, X2)> {
+  let DiagnosticType = "InvalidRegClassGPRNoX0X2";
+  let DiagnosticString = "register must be a GPR excluding zero (x0) and sp (x2)";
+}
 
 def GPRX7 : GPRRegisterClass<(add X7)>;
 
@@ -276,7 +279,10 @@ def GPRTC : GPRRegisterClass<(add (sequence "X%u", 6, 7),
                                   (sequence "X%u", 28, 31))>;
 def GPRTCNonX7 : GPRRegisterClass<(sub GPRTC, X7)>;
 
-def SP : GPRRegisterClass<(add X2)>;
+def SP : GPRRegisterClass<(add X2)> {
+  let DiagnosticType = "InvalidRegClassSP";
+  let DiagnosticString = "register must be sp (x2)";
+}
 
 // Saved Registers from s0 to s7, for C.MVA01S07 instruction in Zcmp extension
 def SR07 : GPRRegisterClass<(add (sequence "X%u", 8, 9),

--- a/llvm/test/MC/RISCV/rv32c-invalid.s
+++ b/llvm/test/MC/RISCV/rv32c-invalid.s
@@ -33,11 +33,11 @@ c.add  zero, zero, sp # CHECK: :[[@LINE]]:14: error: invalid operand for instruc
 
 ## GPRNoX0X2
 c.lui x0, 4 # CHECK: :[[@LINE]]:1: error: instruction requires the following: RVC Hint Instructions{{$}}
-c.lui x2, 4 # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
+c.lui x2, 4 # CHECK: :[[@LINE]]:7: error: register must be a GPR excluding zero (x0) and sp (x2){{$}}
 
 ## SP
-c.addi4spn  a0, a0, 12 # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
-c.addi16sp  t0, 16 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+c.addi4spn  a0, a0, 12 # CHECK: :[[@LINE]]:17: error: register must be sp (x2)
+c.addi16sp  t0, 16 # CHECK: :[[@LINE]]:13: error: register must be sp (x2)
 
 # Out of range immediates
 

--- a/llvm/test/MC/RISCV/xwchc-invalid.s
+++ b/llvm/test/MC/RISCV/xwchc-invalid.s
@@ -8,13 +8,13 @@ qk.c.sh x8, 1(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be a mul
 qk.c.lhu x8, 64(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be a multiple of 2 bytes in the range [0, 62]
 qk.c.sh x8, 64(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be a multiple of 2 bytes in the range [0, 62]
 
-qk.c.lbusp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-qk.c.sbsp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+qk.c.lbusp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: register must be sp (x2)
+qk.c.sbsp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: register must be sp (x2)
 qk.c.lbusp x8, 32(sp) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be an integer in the range [0, 15]
 qk.c.sbsp x8, 32(sp) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be an integer in the range [0, 15]
 
-qk.c.lhusp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
-qk.c.shsp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: invalid operand for instruction
+qk.c.lhusp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: register must be sp (x2)
+qk.c.shsp x8, 0(x8) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: register must be sp (x2)
 qk.c.lhusp x8, 1(sp) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be a multiple of 2 bytes in the range [0, 30]
 qk.c.shsp x8, 1(sp) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be a multiple of 2 bytes in the range [0, 30]
 qk.c.lhusp x8, 32(sp) # CHECK: :[[@LINE]]:{{[0-9]+}}: error: immediate must be a multiple of 2 bytes in the range [0, 30]


### PR DESCRIPTION
More adoption of better diagnostics for RISC-V register classes:
- GPRNoX0X2 (GPRs excluding `zero` and `x2`, used for `c.lui`)
- SP (only contains `sp`)