### PR TITLE
[InstCombine] Detect different vscales in div by shift combine.

### DIFF
--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-counting-elems.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-counting-elems.ll
@@ -242,13 +242,7 @@ define i64 @cntd_all() {
 
 define i64 @udiv() vscale_range(1, 16) {
 ; CHECK-LABEL: @udiv(
-; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK-NEXT:    [[B:%.*]] = shl nuw nsw i64 [[TMP2]], 4
-; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.vscale.i64()
-; CHECK-NEXT:    [[B1:%.*]] = shl nuw nsw i64 [[TMP3]], 2
-; CHECK-NEXT:    [[TMP4:%.*]] = call range(i64 2, 65) i64 @llvm.cttz.i64(i64 [[B1]], i1 true)
-; CHECK-NEXT:    [[C:%.*]] = lshr i64 [[B]], [[TMP4]]
-; CHECK-NEXT:    ret i64 [[C]]
+; CHECK-NEXT:    ret i64 4
 ;
   %a = call i64 @llvm.aarch64.sve.cntb(i32 31)
   %b = call i64 @llvm.aarch64.sve.cntw(i32 31)

--- a/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-counting-elems.ll
+++ b/llvm/test/Transforms/InstCombine/AArch64/sve-intrinsic-opts-counting-elems.ll
@@ -240,6 +240,23 @@ define i64 @cntd_all() {
 }
 
 
+define i64 @udiv() vscale_range(1, 16) {
+; CHECK-LABEL: @udiv(
+; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.vscale.i64()
+; CHECK-NEXT:    [[B:%.*]] = shl nuw nsw i64 [[TMP2]], 4
+; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @llvm.vscale.i64()
+; CHECK-NEXT:    [[B1:%.*]] = shl nuw nsw i64 [[TMP3]], 2
+; CHECK-NEXT:    [[TMP4:%.*]] = call range(i64 2, 65) i64 @llvm.cttz.i64(i64 [[B1]], i1 true)
+; CHECK-NEXT:    [[C:%.*]] = lshr i64 [[B]], [[TMP4]]
+; CHECK-NEXT:    ret i64 [[C]]
+;
+  %a = call i64 @llvm.aarch64.sve.cntb(i32 31)
+  %b = call i64 @llvm.aarch64.sve.cntw(i32 31)
+  %c = udiv i64 %a, %b
+  ret i64 %c
+}
+
+
 declare i64 @llvm.aarch64.sve.cntb(i32 %pattern)
 declare i64 @llvm.aarch64.sve.cnth(i32 %pattern)
 declare i64 @llvm.aarch64.sve.cntw(i32 %pattern)

--- a/llvm/test/Transforms/InstCombine/div-shift.ll
+++ b/llvm/test/Transforms/InstCombine/div-shift.ll
@@ -1399,3 +1399,23 @@ start:
   %div = udiv i8 %x, %y
   ret i8 %div
 }
+
+define i32 @udiv_shl_pair_const_vscale() vscale_range(1, 16) {
+; CHECK-LABEL: @udiv_shl_pair_const_vscale(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[A:%.*]] = call i32 @llvm.vscale.i32()
+; CHECK-NEXT:    [[B:%.*]] = call i32 @llvm.vscale.i32()
+; CHECK-NEXT:    [[LHS:%.*]] = shl nuw nsw i32 [[A]], 2
+; CHECK-NEXT:    [[RHS:%.*]] = shl nuw nsw i32 [[B]], 1
+; CHECK-NEXT:    [[TMP0:%.*]] = call range(i32 1, 33) i32 @llvm.cttz.i32(i32 [[RHS]], i1 true)
+; CHECK-NEXT:    [[DIV:%.*]] = lshr i32 [[LHS]], [[TMP0]]
+; CHECK-NEXT:    ret i32 [[DIV]]
+;
+entry:
+  %a = call i32 @llvm.vscale()
+  %b = call i32 @llvm.vscale()
+  %lhs = shl nuw i32 %a, 2
+  %rhs = shl nuw i32 %b, 1
+  %div = udiv i32 %lhs, %rhs
+  ret i32 %div
+}

--- a/llvm/test/Transforms/InstCombine/div-shift.ll
+++ b/llvm/test/Transforms/InstCombine/div-shift.ll
@@ -1403,13 +1403,7 @@ start:
 define i32 @udiv_shl_pair_const_vscale() vscale_range(1, 16) {
 ; CHECK-LABEL: @udiv_shl_pair_const_vscale(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[A:%.*]] = call i32 @llvm.vscale.i32()
-; CHECK-NEXT:    [[B:%.*]] = call i32 @llvm.vscale.i32()
-; CHECK-NEXT:    [[LHS:%.*]] = shl nuw nsw i32 [[A]], 2
-; CHECK-NEXT:    [[RHS:%.*]] = shl nuw nsw i32 [[B]], 1
-; CHECK-NEXT:    [[TMP0:%.*]] = call range(i32 1, 33) i32 @llvm.cttz.i32(i32 [[RHS]], i1 true)
-; CHECK-NEXT:    [[DIV:%.*]] = lshr i32 [[LHS]], [[TMP0]]
-; CHECK-NEXT:    ret i32 [[DIV]]
+; CHECK-NEXT:    ret i32 2
 ;
 entry:
   %a = call i32 @llvm.vscale()


### PR DESCRIPTION
This attempts to fix a regression in code that performs `svcntb() / svcntw()`
(which is just a constant). https://godbolt.org/z/4o3a67s6n. We would previous
expand the svcnt into two different vscale intrinsics, CSE them in a later pass
and then fold udiv of shifts into a constant in a second instcombine.

After #121386 we now introduce a cttz. This patch just adds an additional check
for vscale to the div of shift fold, allowing it to happen earlier and avoiding
the need to look through the awkward (but probably not impossible) cttz that
was introduced.