### PR TITLE
[libc++][CI] Updates Clang HEAD version in Docker.

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -7,18 +7,17 @@
 # ===----------------------------------------------------------------------===##
 #
 # This file defines the buildkite and github actions builder images.
-# You can build both images using:
+# This images are tagged with <tag>. You can build both images using:
 #
-#   docker compose build
+#   TAG=<tag> docker compose build
 #
 # Or you can select a single image to build
 #
-#  docker compose build buildkite-builder
+#  TAG=test docker compose build actions-builder
 #
 # The final images can be found at
 #
-#  ghcr.io/libcxx/buildkite-builder
-#  ghcr.io/libcxx/actions-builder
+#  ghcr.io/libcxx/libcxx-linux-builder
 #  ghcr.io/libcxx/android-buildkite-builder
 #
 # Members of the github.com/libcxx/ organizations can push new images to the CI.

--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -1,6 +1,6 @@
 x-versions: &compiler_versions
   GCC_LATEST_VERSION: 14
-  LLVM_HEAD_VERSION: 20
+  LLVM_HEAD_VERSION: 21
 
 services:
   actions-builder:


### PR DESCRIPTION
This is a preparation to test Clang 21 in the CI,

Drive-by: Updated some outdated documentation.