### PR TITLE
[libc++] Make benchmarks dry-run by default on the release branch

### DIFF
--- a/libcxx/utils/libcxx/test/params.py
+++ b/libcxx/utils/libcxx/test/params.py
@@ -371,7 +371,7 @@ DEFAULT_PARAMETERS = [
         name="enable_benchmarks",
         choices=["no", "run", "dry-run"],
         type=str,
-        default="run",
+        default="dry-run",
         help="Whether to run the benchmarks in the test suite, to only dry-run them or to disable them entirely.",
         actions=lambda mode: [AddFeature(f"enable-benchmarks={mode}")],
     ),


### PR DESCRIPTION
As reported in #125510, doing a full run of the benchmarks during release testing breaks for some of the testers, and it also takes a long time. The proper fix would be for the release testing process to call `check-cxx` instead of running lit directly inside libc++'s test directory: that will also have the benefit of actually running all of our tests, not only the Lit ones.

However, since that fix may take longer to happen, this patch tries to reduce the pain of release testers by dry-running benchmarks by default instead.