### PR TITLE
[ELF] Add support for CREL to getSectionAndRelocations

### DIFF
--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -6838,7 +6838,7 @@ void ELFDumper<ELFT>::printRelocatableStackSizes(
     if (RelocSec->sh_type == ELF::SHT_CREL) {
       reportWarning(createError(".stack_sizes (" + describe(*StackSizesELFSec) +
                                 ") has a corresponding CREL relocation "
-                                "section, which is not currently supported."),
+                                "section, which is not currently supported"),
                     FileName);
       continue;
     }

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -6833,6 +6833,16 @@ void ELFDumper<ELFT>::printRelocatableStackSizes(
       continue;
     }
 
+    // We might end up with relocations in CREL here. If we do, report a
+    // warning since we do not currently support them.
+    if (RelocSec->sh_type == ELF::SHT_CREL) {
+      reportWarning(createError(".stack_sizes (" + describe(*StackSizesELFSec) +
+                                ") has a corresponding CREL relocation "
+                                "section, which is not currently supported."),
+                    FileName);
+      continue;
+    }
+
     // A .stack_sizes section header's sh_link field is supposed to point
     // to the section that contains the functions whose stack sizes are
     // described in it.


### PR DESCRIPTION
This patch updates the getSectionAndRelocations function to also support
CREL relocation sections. Unit tests have been added. This patch also
updates consumers to say they explicitly do not support CREL format
relocations. Subsequent patches will make the consumers work with CREL
format relocations and also add in testing support.
