### PR TITLE
[libc++][Github] Remove workflow-scoped write permissions

### DIFF
--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -9,7 +9,6 @@ name: Build Docker images for libc++ CI
 
 permissions:
   contents: read
-  packages: write
 
 on:
   push:


### PR DESCRIPTION
This patch removes the workflow-scoped package write permissions in the libcxx-build-containers workflow. The relevant permissions are already present in the job, so this raises the potential for new jobs being added to the workflow that do not need the permissions but having them anyways. Not having workflow-scoped write permissions is security best practice.

Fixes #126230.