### PR TITLE
[WebKit Checkers] Allow operator T&() in a const member function

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -154,10 +154,10 @@ bool isConstOwnerPtrMemberExpr(const clang::Expr *E) {
   if (auto *MCE = dyn_cast<CXXMemberCallExpr>(E)) {
     if (auto *Callee = MCE->getDirectCallee()) {
       auto Name = safeGetName(Callee);
-      if (Name == "get" || Name == "ptr") {
-        auto *ThisArg = MCE->getImplicitObjectArgument();
-        E = ThisArg;
-      }
+      if (Name == "get" || Name == "ptr")
+        E = MCE->getImplicitObjectArgument();
+      if (auto *CD = dyn_cast<CXXConversionDecl>(Callee))
+        E = MCE->getImplicitObjectArgument();
     }
   } else if (auto *OCE = dyn_cast<CXXOperatorCallExpr>(E)) {
     if (OCE->getOperator() == OO_Star && OCE->getNumArgs() == 1)

--- a/clang/test/Analysis/Checkers/WebKit/call-args-counted-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-counted-const-member.cpp
@@ -31,6 +31,7 @@ class Foo {
 public:
   Foo();
   void bar();
+  RefCountable& obj1() const { return m_obj1; }
 
 private:
   const Ref<RefCountable> m_obj1;
@@ -41,6 +42,7 @@ void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
   // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  obj1().method();
 }
 
 } // namespace call_args_const_ref_member
@@ -100,6 +102,7 @@ class Foo {
 public:
   Foo();
   void bar();
+  RefCountable& obj1() { return m_obj1; }
 
 private:
   const UniqueRef<RefCountable> m_obj1;
@@ -110,6 +113,7 @@ void Foo::bar() {
   m_obj1->method();
   m_obj2->method();
   // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
+  obj1().method();
 }
 
 } // namespace call_args_const_unique_ref

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -289,6 +289,7 @@ public:
     u.t = nullptr;
   }
   T &get() const { return *t; }
+  operator T&() const { return *t; }
   T *operator->() const { return t; }
   UniqueRef &operator=(T &) { return *this; }
 };


### PR DESCRIPTION
Allow operator T&() in a member function which returns a const member variable.

In particular, this will allow UniqueRef::operator T&() and Ref::operator T&() to be treated as a safe pointer origin when they're called on a const member.