### PR TITLE
Revert "[mlir] Python: Parse ModuleOp from file path"

### DIFF
--- a/mlir/include/mlir-c/IR.h
+++ b/mlir/include/mlir-c/IR.h
@@ -309,10 +309,6 @@ MLIR_CAPI_EXPORTED MlirModule mlirModuleCreateEmpty(MlirLocation location);
 MLIR_CAPI_EXPORTED MlirModule mlirModuleCreateParse(MlirContext context,
                                                     MlirStringRef module);
 
-/// Parses a module from file and transfers ownership to the caller.
-MLIR_CAPI_EXPORTED MlirModule
-mlirModuleCreateParseFromFile(MlirContext context, MlirStringRef fileName);
-
 /// Gets the context that a module was created with.
 MLIR_CAPI_EXPORTED MlirContext mlirModuleGetContext(MlirModule module);
 

--- a/mlir/include/mlir/Bindings/Python/Nanobind.h
+++ b/mlir/include/mlir/Bindings/Python/Nanobind.h
@@ -23,7 +23,6 @@
 #endif
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
-#include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <filesystem>
 #include <optional>
 #include <utility>
 
@@ -300,7 +299,7 @@ struct PyAttrBuilderMap {
     return *builder;
   }
   static void dunderSetItemNamed(const std::string &attributeKind,
-                                 nb::callable func, bool replace) {
+                                nb::callable func, bool replace) {
     PyGlobals::get().registerAttributeBuilder(attributeKind, std::move(func),
                                               replace);
   }
@@ -3044,19 +3043,6 @@ void mlir::python::populateIRCore(nb::module_ &m) {
             PyMlirContext::ErrorCapture errors(context->getRef());
             MlirModule module = mlirModuleCreateParse(
                 context->get(), toMlirStringRef(moduleAsm));
-            if (mlirModuleIsNull(module))
-              throw MLIRError("Unable to parse module assembly", errors.take());
-            return PyModule::forModule(module).releaseObject();
-          },
-          nb::arg("asm"), nb::arg("context").none() = nb::none(),
-          kModuleParseDocstring)
-      .def_static(
-          "parse",
-          [](const std::filesystem::path &path,
-             DefaultingPyMlirContext context) {
-            PyMlirContext::ErrorCapture errors(context->getRef());
-            MlirModule module = mlirModuleCreateParseFromFile(
-                context->get(), toMlirStringRef(path.string()));
             if (mlirModuleIsNull(module))
               throw MLIRError("Unable to parse module assembly", errors.take());
             return PyModule::forModule(module).releaseObject();

--- a/mlir/lib/CAPI/IR/IR.cpp
+++ b/mlir/lib/CAPI/IR/IR.cpp
@@ -22,7 +22,6 @@
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/OperationSupport.h"
-#include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Verifier.h"
@@ -324,15 +323,6 @@ MlirModule mlirModuleCreateEmpty(MlirLocation location) {
 MlirModule mlirModuleCreateParse(MlirContext context, MlirStringRef module) {
   OwningOpRef<ModuleOp> owning =
       parseSourceString<ModuleOp>(unwrap(module), unwrap(context));
-  if (!owning)
-    return MlirModule{nullptr};
-  return MlirModule{owning.release().getOperation()};
-}
-
-MlirModule mlirModuleCreateParseFromFile(MlirContext context,
-                                         MlirStringRef fileName) {
-  OwningOpRef<ModuleOp> owning =
-      parseSourceFile<ModuleOp>(unwrap(fileName), unwrap(context));
   if (!owning)
     return MlirModule{nullptr};
   return MlirModule{owning.release().getOperation()};

--- a/mlir/python/mlir/_mlir_libs/_mlir/ir.pyi
+++ b/mlir/python/mlir/_mlir_libs/_mlir/ir.pyi
@@ -46,7 +46,6 @@ import abc
 import collections
 from collections.abc import Callable, Sequence
 import io
-from pathlib import Path
 from typing import Any, ClassVar, TypeVar, overload
 
 __all__ = [
@@ -2124,7 +2123,7 @@ class Module:
         Creates an empty module
         """
     @staticmethod
-    def parse(asm: str | bytes | Path, context: Context | None = None) -> Module:
+    def parse(asm: str | bytes, context: Context | None = None) -> Module:
         """
         Parses a module's assembly format from a string.
 

--- a/mlir/test/python/ir/module.py
+++ b/mlir/test/python/ir/module.py
@@ -1,8 +1,6 @@
 # RUN: %PYTHON %s | FileCheck %s
 
 import gc
-from pathlib import Path
-from tempfile import NamedTemporaryFile
 from mlir.ir import *
 
 
@@ -27,24 +25,6 @@ def testParseSuccess():
     gc.collect()
     module.dump()  # Just outputs to stderr. Verifies that it functions.
     print(str(module))
-
-
-# Verify successful parse from file.
-# CHECK-LABEL: TEST: testParseFromFileSuccess
-# CHECK: module @successfulParse
-@run
-def testParseFromFileSuccess():
-    ctx = Context()
-    with NamedTemporaryFile(mode="w") as tmp_file:
-        tmp_file.write(r"""module @successfulParse {}""")
-        tmp_file.flush()
-        module = Module.parse(Path(tmp_file.name), ctx)
-        assert module.context is ctx
-        print("CLEAR CONTEXT")
-        ctx = None  # Ensure that module captures the context.
-        gc.collect()
-        module.operation.verify()
-        print(str(module))
 
 
 # Verify parse error.


### PR DESCRIPTION
Reverts llvm/llvm-project#125736

The gcc7 Bot is broken at the moment.