### PR TITLE
[Clang][Driver][HIP] Do not specify explicit target cpu in host compilation run line

### DIFF
--- a/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
+++ b/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
@@ -8,6 +8,6 @@
 // CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1101"{{.*}}"-dependency-file" "tmp.d"
 // CHECK: {{.*}}lld{{.*}}"-plugin-opt=mcpu=gfx1101"
 // CHECK: {{.*}}clang-offload-bundler
-// CHECK: {{.*}}clang{{.*}}"-target-cpu" "x86-64"{{.*}}"-dependency-file" "tmp.d"
+// CHECK: {{.*}}clang{{.*}}"-target-cpu"{{.*}}"-dependency-file" "tmp.d"
 
 void main(){}


### PR DESCRIPTION
This PR fixes the post merge check fails from PR https://github.com/llvm/llvm-project/pull/125646