### PR TITLE
[LTO] Override TargetABI from module flags if present when creating TargetMachine

### DIFF
--- a/lld/test/ELF/lto/riscv-ilp32e.ll
+++ b/lld/test/ELF/lto/riscv-ilp32e.ll
@@ -1,0 +1,25 @@
+; REQUIRES: riscv
+;
+; Check that we don't crash on DataLayout incompatibility issue.
+;
+; RUN: llvm-as %s -o %t.o
+; RUN: ld.lld %t.o -o %t.elf
+; RUN: llvm-readobj -h %t.elf | FileCheck %s --check-prefixes=CHECK
+;
+; CHECK:  Machine: EM_RISCV (0xF3)
+; CHECK:  EF_RISCV_RVE (0x8)
+
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S32"
+target triple = "riscv32-unknown-unknown-elf"
+
+define dso_local i32 @_start() #0 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { "target-cpu"="generic-rv32" "target-features"="+32bit,+e" }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 1, !"target-abi", !"ilp32e"}

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -1067,6 +1067,9 @@ public:
 
   /// Set the target variant version build SDK version metadata.
   void setDarwinTargetVariantSDKVersion(VersionTuple Version);
+
+  /// Returns target-abi from MDString, null if target-abi is absent.
+  StringRef getTargetABIFromMD();
 };
 
 /// Given "llvm.used" or "llvm.compiler.used" as a global name, collect the

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -915,3 +915,11 @@ VersionTuple Module::getDarwinTargetVariantSDKVersion() const {
 void Module::setDarwinTargetVariantSDKVersion(VersionTuple Version) {
   addSDKVersionMD(Version, *this, "darwin.target_variant.SDK Version");
 }
+
+StringRef Module::getTargetABIFromMD() {
+  StringRef TargetABI = "";
+  if (auto *TargetABIMD =
+          dyn_cast_or_null<MDString>(getModuleFlag("target-abi")))
+    TargetABI = TargetABIMD->getString();
+  return TargetABI;
+}

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -917,7 +917,7 @@ void Module::setDarwinTargetVariantSDKVersion(VersionTuple Version) {
 }
 
 StringRef Module::getTargetABIFromMD() {
-  StringRef TargetABI = "";
+  StringRef TargetABI;
   if (auto *TargetABIMD =
           dyn_cast_or_null<MDString>(getModuleFlag("target-abi")))
     TargetABI = TargetABIMD->getString();

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -223,10 +223,7 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
 
   TargetOptions TargetOpts = Conf.Options;
   if (TargetOpts.MCOptions.ABIName.empty()) {
-    StringRef ModABI = M.getTargetABIFromMD();
-    if (!ModABI.empty()) {
-      TargetOpts.MCOptions.ABIName = ModABI;
-    }
+    TargetOpts.MCOptions.ABIName = M.getTargetABIFromMD();
   }
 
   std::unique_ptr<TargetMachine> TM(TheTarget->createTargetMachine(

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -224,9 +224,8 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
   TargetOptions TargetOpts = Conf.Options;
 
   if (TargetOpts.MCOptions.ABIName.empty()) {
-    Metadata *ABI = M.getModuleFlag("target-abi");
-    if (ABI) {
-      const StringRef &ModABI = cast<MDString>(ABI)->getString();
+    StringRef ModABI = M.getTargetABIFromMD();
+    if (!ABI.empty()) {
       TargetOpts.MCOptions.ABIName = ModABI;
     }
   }

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -222,7 +222,6 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
     CodeModel = M.getCodeModel();
 
   TargetOptions TargetOpts = Conf.Options;
-
   if (TargetOpts.MCOptions.ABIName.empty()) {
     StringRef ModABI = M.getTargetABIFromMD();
     if (!ModABI.empty()) {

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -225,7 +225,7 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
 
   if (TargetOpts.MCOptions.ABIName.empty()) {
     StringRef ModABI = M.getTargetABIFromMD();
-    if (!ABI.empty()) {
+    if (!ModABI.empty()) {
       TargetOpts.MCOptions.ABIName = ModABI;
     }
   }

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -221,8 +221,18 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
   else
     CodeModel = M.getCodeModel();
 
+  TargetOptions TargetOpts = Conf.Options;
+
+  if (TargetOpts.MCOptions.ABIName.empty()) {
+    Metadata *ABI = M.getModuleFlag("target-abi");
+    if (ABI) {
+      const StringRef &ModABI = cast<MDString>(ABI)->getString();
+      TargetOpts.MCOptions.ABIName = ModABI;
+    }
+  }
+
   std::unique_ptr<TargetMachine> TM(TheTarget->createTargetMachine(
-      TheTriple.str(), Conf.CPU, Features.getString(), Conf.Options, RelocModel,
+      TheTriple.str(), Conf.CPU, Features.getString(), TargetOpts, RelocModel,
       CodeModel, Conf.CGOptLevel));
 
   assert(TM && "Failed to create target machine");

--- a/llvm/test/LTO/RISCV/lit.local.cfg
+++ b/llvm/test/LTO/RISCV/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "RISCV" in config.root.targets:
+    config.unsupported = True

--- a/llvm/test/LTO/RISCV/lit.local.cfg
+++ b/llvm/test/LTO/RISCV/lit.local.cfg
@@ -1,2 +1,2 @@
-if not "RISCV" in config.root.targets:
+if "RISCV" not in config.root.targets:
     config.unsupported = True

--- a/llvm/test/LTO/RISCV/riscv-ilp32e.ll
+++ b/llvm/test/LTO/RISCV/riscv-ilp32e.ll
@@ -1,10 +1,8 @@
-; REQUIRES: riscv
-;
 ; Check that we don't crash on DataLayout incompatibility issue.
 ;
 ; RUN: llvm-as %s -o %t.o
-; RUN: ld.lld %t.o -o %t.elf
-; RUN: llvm-readobj -h %t.elf | FileCheck %s --check-prefixes=CHECK
+; RUN: llvm-lto2 run -r %t.o,_start %t.o -o %t.elf
+; RUN: llvm-readobj -h %t.elf.0 | FileCheck %s --check-prefixes=CHECK
 ;
 ; CHECK:  Machine: EM_RISCV (0xF3)
 ; CHECK:  EF_RISCV_RVE (0x8)

--- a/llvm/test/LTO/RISCV/riscv-ilp32e.ll
+++ b/llvm/test/LTO/RISCV/riscv-ilp32e.ll
@@ -1,9 +1,7 @@
 ; Check that we don't crash on DataLayout incompatibility issue.
-;
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-lto2 run -r %t.o,_start %t.o -o %t.elf
 ; RUN: llvm-readobj -h %t.elf.0 | FileCheck %s --check-prefixes=CHECK
-;
 ; CHECK:  Machine: EM_RISCV (0xF3)
 ; CHECK:  EF_RISCV_RVE (0x8)
 


### PR DESCRIPTION
…argetMachine

RISC-V's data layout is determined by the ABI, not just the target triple. However, the TargetMachine is created using the data layout from the target triple, which is not always correct. This patch uses the target ABI from the module and passes it to the TargetMachine, ensuring that the data layout is set correctly according to the ABI.

The same problem will happen with other targets like MIPS, but unfortunately, MIPS didn't emit the target-abi into the module flags, so this patch only fixes the issue for RISC-V.

NOTE: MIPS with -mabi=n32 can trigger the same issue.

Another possible solution is add new parameter to the TargetMachine constructor, but that would require changes in all the targets.