### PR TITLE
Revert "SCEV: teach isImpliedViaOperations about samesign"

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -11860,13 +11860,15 @@ bool ScalarEvolution::isImpliedCondBalancedTypes(
   }
 
   // Check whether the found predicate is the same as the desired predicate.
-  if (auto P = CmpPredicate::getMatching(FoundPred, Pred))
-    return isImpliedCondOperands(*P, LHS, RHS, FoundLHS, FoundRHS, CtxI);
+  // FIXME: use CmpPredicate::getMatching here.
+  if (FoundPred == static_cast<CmpInst::Predicate>(Pred))
+    return isImpliedCondOperands(Pred, LHS, RHS, FoundLHS, FoundRHS, CtxI);
 
   // Check whether swapping the found predicate makes it the same as the
   // desired predicate.
-  if (auto P = CmpPredicate::getMatching(
-          ICmpInst::getSwappedCmpPredicate(FoundPred), Pred)) {
+  // FIXME: use CmpPredicate::getMatching here.
+  if (ICmpInst::getSwappedCmpPredicate(FoundPred) ==
+      static_cast<CmpInst::Predicate>(Pred)) {
     // We can write the implication
     // 0.  LHS Pred      RHS  <-   FoundLHS SwapPred  FoundRHS
     // using one of the following ways:
@@ -11877,23 +11879,22 @@ bool ScalarEvolution::isImpliedCondBalancedTypes(
     // Forms 1. and 2. require swapping the operands of one condition. Don't
     // do this if it would break canonical constant/addrec ordering.
     if (!isa<SCEVConstant>(RHS) && !isa<SCEVAddRecExpr>(LHS))
-      return isImpliedCondOperands(ICmpInst::getSwappedCmpPredicate(*P), RHS,
-                                   LHS, FoundLHS, FoundRHS, CtxI);
+      return isImpliedCondOperands(FoundPred, RHS, LHS, FoundLHS, FoundRHS,
+                                   CtxI);
     if (!isa<SCEVConstant>(FoundRHS) && !isa<SCEVAddRecExpr>(FoundLHS))
-      return isImpliedCondOperands(*P, LHS, RHS, FoundRHS, FoundLHS, CtxI);
+      return isImpliedCondOperands(Pred, LHS, RHS, FoundRHS, FoundLHS, CtxI);
 
     // There's no clear preference between forms 3. and 4., try both.  Avoid
     // forming getNotSCEV of pointer values as the resulting subtract is
     // not legal.
     if (!LHS->getType()->isPointerTy() && !RHS->getType()->isPointerTy() &&
-        isImpliedCondOperands(ICmpInst::getSwappedCmpPredicate(*P),
-                              getNotSCEV(LHS), getNotSCEV(RHS), FoundLHS,
-                              FoundRHS, CtxI))
+        isImpliedCondOperands(FoundPred, getNotSCEV(LHS), getNotSCEV(RHS),
+                              FoundLHS, FoundRHS, CtxI))
       return true;
 
     if (!FoundLHS->getType()->isPointerTy() &&
         !FoundRHS->getType()->isPointerTy() &&
-        isImpliedCondOperands(*P, LHS, RHS, getNotSCEV(FoundLHS),
+        isImpliedCondOperands(Pred, LHS, RHS, getNotSCEV(FoundLHS),
                               getNotSCEV(FoundRHS), CtxI))
       return true;
 
@@ -12563,16 +12564,14 @@ bool ScalarEvolution::isImpliedViaOperations(CmpPredicate Pred, const SCEV *LHS,
     return false;
 
   // We only want to work with GT comparison so far.
-  if (ICmpInst::isLT(Pred)) {
+  if (Pred == ICmpInst::ICMP_ULT || Pred == ICmpInst::ICMP_SLT) {
     Pred = ICmpInst::getSwappedCmpPredicate(Pred);
     std::swap(LHS, RHS);
     std::swap(FoundLHS, FoundRHS);
   }
 
-  CmpInst::Predicate P = Pred.getPreferredSignedPredicate();
-
   // For unsigned, try to reduce it to corresponding signed comparison.
-  if (P == ICmpInst::ICMP_UGT)
+  if (Pred == ICmpInst::ICMP_UGT)
     // We can replace unsigned predicate with its signed counterpart if all
     // involved values are non-negative.
     // TODO: We could have better support for unsigned.
@@ -12585,10 +12584,10 @@ bool ScalarEvolution::isImpliedViaOperations(CmpPredicate Pred, const SCEV *LHS,
                                 FoundRHS) &&
           isImpliedCondOperands(ICmpInst::ICMP_SGT, RHS, MinusOne, FoundLHS,
                                 FoundRHS))
-        P = ICmpInst::ICMP_SGT;
+        Pred = ICmpInst::ICMP_SGT;
     }
 
-  if (P != ICmpInst::ICMP_SGT)
+  if (Pred != ICmpInst::ICMP_SGT)
     return false;
 
   auto GetOpFromSExt = [&](const SCEV *S) {

--- a/llvm/test/Analysis/ScalarEvolution/exit-count-samesign.ll
+++ b/llvm/test/Analysis/ScalarEvolution/exit-count-samesign.ll
@@ -5,9 +5,9 @@
 define i32 @exit_count_samesign(i32 %iter.count, ptr %ptr) {
 ; CHECK-LABEL: 'exit_count_samesign'
 ; CHECK-NEXT:  Determining loop execution counts for: @exit_count_samesign
-; CHECK-NEXT:  Loop %inner.loop: backedge-taken count is {(-2 + %iter.count),+,-1}<nw><%outer.loop>
+; CHECK-NEXT:  Loop %inner.loop: backedge-taken count is (-1 + (1 smax {(-1 + %iter.count)<nsw>,+,-1}<nsw><%outer.loop>))<nsw>
 ; CHECK-NEXT:  Loop %inner.loop: constant max backedge-taken count is i32 2147483646
-; CHECK-NEXT:  Loop %inner.loop: symbolic max backedge-taken count is {(-2 + %iter.count),+,-1}<nw><%outer.loop>
+; CHECK-NEXT:  Loop %inner.loop: symbolic max backedge-taken count is (-1 + (1 smax {(-1 + %iter.count)<nsw>,+,-1}<nsw><%outer.loop>))<nsw>
 ; CHECK-NEXT:  Loop %inner.loop: Trip multiple is 1
 ; CHECK-NEXT:  Loop %outer.loop: <multiple exits> Unpredictable backedge-taken count.
 ; CHECK-NEXT:  Loop %outer.loop: Unpredictable constant max backedge-taken count.

--- a/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
+++ b/llvm/test/Analysis/ScalarEvolution/implied-via-division.ll
@@ -2,10 +2,12 @@
 ; RUN: opt < %s -disable-output -passes="print<scalar-evolution>" \
 ; RUN:   -scalar-evolution-classify-expressions=0 2>&1 | FileCheck %s
 
-define void @implied1(i32 %n) {
-; Prove that (n s> 1) ===> (n / 2 s> 0).
-; CHECK-LABEL: 'implied1'
-; CHECK-NEXT:  Determining loop execution counts for: @implied1
+declare void @llvm.experimental.guard(i1, ...)
+
+define void @test_1(i32 %n) nounwind {
+; Prove that (n > 1) ===> (n / 2 > 0).
+; CHECK-LABEL: 'test_1'
+; CHECK-NEXT:  Determining loop execution counts for: @test_1
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741822
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 + %n.div.2)<nsw>
@@ -27,35 +29,10 @@ exit:
   ret void
 }
 
-define void @implied1_samesign(i32 %n) {
-; Prove that (n > 1) ===> (n / 2 s> 0).
-; CHECK-LABEL: 'implied1_samesign'
-; CHECK-NEXT:  Determining loop execution counts for: @implied1_samesign
-; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 + %n.div.2)<nsw>
-; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741822
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 + %n.div.2)<nsw>
-; CHECK-NEXT:  Loop %header: Trip multiple is 1
-;
-entry:
-  %cmp1 = icmp samesign ugt i32 %n, 1
-  %n.div.2 = sdiv i32 %n, 2
-  call void @llvm.assume(i1 %cmp1)
-  br label %header
-
-header:
-  %indvar = phi i32 [ %indvar.next, %header ], [ 0, %entry ]
-  %indvar.next = add i32 %indvar, 1
-  %exitcond = icmp sgt i32 %n.div.2, %indvar.next
-  br i1 %exitcond, label %header, label %exit
-
-exit:
-  ret void
-}
-
-define void @implied1_neg(i32 %n) {
-; Prove that (n s> 0) =\=> (n / 2 s> 0).
-; CHECK-LABEL: 'implied1_neg'
-; CHECK-NEXT:  Determining loop execution counts for: @implied1_neg
+define void @test_1neg(i32 %n) nounwind {
+; Prove that (n > 0) =\=> (n / 2 > 0).
+; CHECK-LABEL: 'test_1neg'
+; CHECK-NEXT:  Determining loop execution counts for: @test_1neg
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 + (1 smax %n.div.2))<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741822
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 + (1 smax %n.div.2))<nsw>
@@ -77,10 +54,10 @@ exit:
   ret void
 }
 
-define void @implied2(i32 %n) {
-; Prove that (n s>= 2) ===> (n / 2 s> 0).
-; CHECK-LABEL: 'implied2'
-; CHECK-NEXT:  Determining loop execution counts for: @implied2
+define void @test_2(i32 %n) nounwind {
+; Prove that (n >= 2) ===> (n / 2 > 0).
+; CHECK-LABEL: 'test_2'
+; CHECK-NEXT:  Determining loop execution counts for: @test_2
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741822
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 + %n.div.2)<nsw>
@@ -102,35 +79,10 @@ exit:
   ret void
 }
 
-define void @implied2_samesign(i32 %n) {
-; Prove that (n >= 2) ===> (n / 2 s> 0).
-; CHECK-LABEL: 'implied2_samesign'
-; CHECK-NEXT:  Determining loop execution counts for: @implied2_samesign
-; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 + (1 smax %n.div.2))<nsw>
-; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741822
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 + (1 smax %n.div.2))<nsw>
-; CHECK-NEXT:  Loop %header: Trip multiple is 1
-;
-entry:
-  %cmp1 = icmp samesign uge i32 %n, 2
-  %n.div.2 = sdiv i32 %n, 2
-  call void @llvm.assume(i1 %cmp1)
-  br label %header
-
-header:
-  %indvar = phi i32 [ %indvar.next, %header ], [ 0, %entry ]
-  %indvar.next = add i32 %indvar, 1
-  %exitcond = icmp sgt i32 %n.div.2, %indvar.next
-  br i1 %exitcond, label %header, label %exit
-
-exit:
-  ret void
-}
-
-define void @implied2_neg(i32 %n) {
-; Prove that (n s>= 1) =\=> (n / 2 s> 0).
-; CHECK-LABEL: 'implied2_neg'
-; CHECK-NEXT:  Determining loop execution counts for: @implied2_neg
+define void @test_2neg(i32 %n) nounwind {
+; Prove that (n >= 1) =\=> (n / 2 > 0).
+; CHECK-LABEL: 'test_2neg'
+; CHECK-NEXT:  Determining loop execution counts for: @test_2neg
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (-1 + (1 smax %n.div.2))<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741822
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (-1 + (1 smax %n.div.2))<nsw>
@@ -152,10 +104,10 @@ exit:
   ret void
 }
 
-define void @implied3(i32 %n) {
-; Prove that (n s> -2) ===> (n / 2 s>= 0).
-; CHECK-LABEL: 'implied3'
-; CHECK-NEXT:  Determining loop execution counts for: @implied3
+define void @test_3(i32 %n) nounwind {
+; Prove that (n > -2) ===> (n / 2 >= 0).
+; CHECK-LABEL: 'test_3'
+; CHECK-NEXT:  Determining loop execution counts for: @test_3
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
@@ -177,35 +129,10 @@ exit:
   ret void
 }
 
-define void @implied3_samesign(i32 %n) {
-; Prove that (n > -2) ===> (n / 2 s>= 0).
-; CHECK-LABEL: 'implied3_samesign'
-; CHECK-NEXT:  Determining loop execution counts for: @implied3_samesign
-; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
-; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
-; CHECK-NEXT:  Loop %header: Trip multiple is 1
-;
-entry:
-  %cmp1 = icmp samesign ugt i32 %n, -2
-  %n.div.2 = sdiv i32 %n, 2
-  call void @llvm.assume(i1 %cmp1)
-  br label %header
-
-header:
-  %indvar = phi i32 [ %indvar.next, %header ], [ 0, %entry ]
-  %indvar.next = add i32 %indvar, 1
-  %exitcond = icmp sge i32 %n.div.2, %indvar
-  br i1 %exitcond, label %header, label %exit
-
-exit:
-  ret void
-}
-
-define void @implied3_neg(i32 %n) {
+define void @test_3neg(i32 %n) nounwind {
 ; Prove that (n > -3) =\=> (n / 2 >= 0).
-; CHECK-LABEL: 'implied3_neg'
-; CHECK-NEXT:  Determining loop execution counts for: @implied3_neg
+; CHECK-LABEL: 'test_3neg'
+; CHECK-NEXT:  Determining loop execution counts for: @test_3neg
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (0 smax (1 + %n.div.2)<nsw>)
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (0 smax (1 + %n.div.2)<nsw>)
@@ -227,10 +154,10 @@ exit:
   ret void
 }
 
-define void @implied4(i32 %n) {
-; Prove that (n s>= -1) ===> (n / 2 s>= 0).
-; CHECK-LABEL: 'implied4'
-; CHECK-NEXT:  Determining loop execution counts for: @implied4
+define void @test_4(i32 %n) nounwind {
+; Prove that (n >= -1) ===> (n / 2 >= 0).
+; CHECK-LABEL: 'test_4'
+; CHECK-NEXT:  Determining loop execution counts for: @test_4
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
@@ -252,35 +179,10 @@ exit:
   ret void
 }
 
-define void @implied4_samesign(i32 %n) {
-; Prove that (n >= -1) ===> (n / 2 s>= 0).
-; CHECK-LABEL: 'implied4_samesign'
-; CHECK-NEXT:  Determining loop execution counts for: @implied4_samesign
-; CHECK-NEXT:  Loop %header: backedge-taken count is (1 + %n.div.2)<nsw>
-; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1
-; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (1 + %n.div.2)<nsw>
-; CHECK-NEXT:  Loop %header: Trip multiple is 1
-;
-entry:
-  %cmp1 = icmp samesign uge i32 %n, -1
-  %n.div.2 = sdiv i32 %n, 2
-  call void @llvm.assume(i1 %cmp1)
-  br label %header
-
-header:
-  %indvar = phi i32 [ %indvar.next, %header ], [ 0, %entry ]
-  %indvar.next = add i32 %indvar, 1
-  %exitcond = icmp sge i32 %n.div.2, %indvar
-  br i1 %exitcond, label %header, label %exit
-
-exit:
-  ret void
-}
-
-define void @implied4_neg(i32 %n) {
-; Prove that (n s>= -2) =\=> (n / 2 s>= 0).
-; CHECK-LABEL: 'implied4_neg'
-; CHECK-NEXT:  Determining loop execution counts for: @implied4_neg
+define void @test_4neg(i32 %n) nounwind {
+; Prove that (n >= -2) =\=> (n / 2 >= 0).
+; CHECK-LABEL: 'test_4neg'
+; CHECK-NEXT:  Determining loop execution counts for: @test_4neg
 ; CHECK-NEXT:  Loop %header: backedge-taken count is (0 smax (1 + %n.div.2)<nsw>)
 ; CHECK-NEXT:  Loop %header: constant max backedge-taken count is i32 1073741824
 ; CHECK-NEXT:  Loop %header: symbolic max backedge-taken count is (0 smax (1 + %n.div.2)<nsw>)

--- a/llvm/test/Transforms/IndVarSimplify/iv-ext-samesign.ll
+++ b/llvm/test/Transforms/IndVarSimplify/iv-ext-samesign.ll
@@ -68,32 +68,28 @@ define i32 @iv_zext_zext_gt_slt(i32 %iter.count, ptr %ptr) {
 ; CHECK-LABEL: define i32 @iv_zext_zext_gt_slt(
 ; CHECK-SAME: i32 [[ITER_COUNT:%.*]], ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
-; CHECK-NEXT:    [[TMP0:%.*]] = add nsw i32 [[ITER_COUNT]], -1
+; CHECK-NEXT:    [[TMP0:%.*]] = sext i32 [[ITER_COUNT]] to i64
 ; CHECK-NEXT:    br label %[[OUTER_LOOP:.*]]
 ; CHECK:       [[PH_LOOPEXIT:.*]]:
 ; CHECK-NEXT:    br label %[[PH:.*]]
 ; CHECK:       [[PH]]:
-; CHECK-NEXT:    [[INDVARS_IV_NEXT3:%.*]] = add i32 [[INDVARS_IV1:%.*]], -1
 ; CHECK-NEXT:    br label %[[OUTER_LOOP]]
 ; CHECK:       [[OUTER_LOOP]]:
-; CHECK-NEXT:    [[INDVARS_IV1]] = phi i32 [ [[INDVARS_IV_NEXT3]], %[[PH]] ], [ [[TMP0]], %[[ENTRY]] ]
-; CHECK-NEXT:    [[IV_OUTER:%.*]] = phi i32 [ [[IV_OUTER_1:%.*]], %[[PH]] ], [ [[ITER_COUNT]], %[[ENTRY]] ]
-; CHECK-NEXT:    [[IV_OUTER_1]] = add nsw i32 [[IV_OUTER]], -1
-; CHECK-NEXT:    [[INDVARS_IV_NEXT2:%.*]] = zext nneg i32 [[IV_OUTER_1]] to i64
+; CHECK-NEXT:    [[INDVARS_IV1:%.*]] = phi i64 [ [[INDVARS_IV_NEXT2:%.*]], %[[PH]] ], [ [[TMP0]], %[[ENTRY]] ]
+; CHECK-NEXT:    [[INDVARS_IV_NEXT2]] = add nsw i64 [[INDVARS_IV1]], -1
 ; CHECK-NEXT:    [[GEP_OUTER:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDVARS_IV_NEXT2]]
 ; CHECK-NEXT:    store i8 0, ptr [[GEP_OUTER]], align 1
-; CHECK-NEXT:    [[EXIT_COND_OUTER:%.*]] = icmp samesign ugt i32 [[IV_OUTER]], 1
+; CHECK-NEXT:    [[EXIT_COND_OUTER:%.*]] = icmp samesign ugt i64 [[INDVARS_IV1]], 1
 ; CHECK-NEXT:    br i1 [[EXIT_COND_OUTER]], label %[[INNER_LOOP_PREHEADER:.*]], label %[[PH]]
 ; CHECK:       [[INNER_LOOP_PREHEADER]]:
-; CHECK-NEXT:    [[WIDE_TRIP_COUNT:%.*]] = zext i32 [[INDVARS_IV1]] to i64
 ; CHECK-NEXT:    br label %[[INNER_LOOP:.*]]
 ; CHECK:       [[INNER_LOOP]]:
 ; CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ 0, %[[INNER_LOOP_PREHEADER]] ], [ [[INDVARS_IV_NEXT:%.*]], %[[INNER_LOOP]] ]
 ; CHECK-NEXT:    [[GEP_INNER:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDVARS_IV]]
 ; CHECK-NEXT:    store i8 0, ptr [[GEP_INNER]], align 1
 ; CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
-; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp ne i64 [[INDVARS_IV_NEXT]], [[WIDE_TRIP_COUNT]]
-; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[INNER_LOOP]], label %[[PH_LOOPEXIT]]
+; CHECK-NEXT:    [[EXIT_COND_INNER:%.*]] = icmp slt i64 [[INDVARS_IV_NEXT]], [[INDVARS_IV_NEXT2]]
+; CHECK-NEXT:    br i1 [[EXIT_COND_INNER]], label %[[INNER_LOOP]], label %[[PH_LOOPEXIT]]
 ; CHECK:       [[EXIT:.*:]]
 ; CHECK-NEXT:    ret i32 0
 ;
@@ -428,32 +424,28 @@ define i32 @iv_sext_sext_gt_slt(i32 %iter.count, ptr %ptr) {
 ; CHECK-LABEL: define i32 @iv_sext_sext_gt_slt(
 ; CHECK-SAME: i32 [[ITER_COUNT:%.*]], ptr [[PTR:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
-; CHECK-NEXT:    [[TMP1:%.*]] = add nsw i32 [[ITER_COUNT]], -1
 ; CHECK-NEXT:    [[TMP0:%.*]] = sext i32 [[ITER_COUNT]] to i64
 ; CHECK-NEXT:    br label %[[OUTER_LOOP:.*]]
 ; CHECK:       [[PH_LOOPEXIT:.*]]:
 ; CHECK-NEXT:    br label %[[PH:.*]]
 ; CHECK:       [[PH]]:
-; CHECK-NEXT:    [[INDVARS_IV_NEXT3:%.*]] = add i32 [[INDVARS_IV2:%.*]], -1
 ; CHECK-NEXT:    br label %[[OUTER_LOOP]]
 ; CHECK:       [[OUTER_LOOP]]:
 ; CHECK-NEXT:    [[INDVARS_IV1:%.*]] = phi i64 [ [[INDVARS_IV_NEXT2:%.*]], %[[PH]] ], [ [[TMP0]], %[[ENTRY]] ]
-; CHECK-NEXT:    [[INDVARS_IV2]] = phi i32 [ [[INDVARS_IV_NEXT3]], %[[PH]] ], [ [[TMP1]], %[[ENTRY]] ]
 ; CHECK-NEXT:    [[INDVARS_IV_NEXT2]] = add nsw i64 [[INDVARS_IV1]], -1
 ; CHECK-NEXT:    [[GEP_OUTER:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDVARS_IV_NEXT2]]
 ; CHECK-NEXT:    store i8 0, ptr [[GEP_OUTER]], align 1
 ; CHECK-NEXT:    [[EXIT_COND_OUTER:%.*]] = icmp samesign ugt i64 [[INDVARS_IV1]], 1
 ; CHECK-NEXT:    br i1 [[EXIT_COND_OUTER]], label %[[INNER_LOOP_PREHEADER:.*]], label %[[PH]]
 ; CHECK:       [[INNER_LOOP_PREHEADER]]:
-; CHECK-NEXT:    [[WIDE_TRIP_COUNT:%.*]] = zext i32 [[INDVARS_IV2]] to i64
 ; CHECK-NEXT:    br label %[[INNER_LOOP:.*]]
 ; CHECK:       [[INNER_LOOP]]:
 ; CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ 0, %[[INNER_LOOP_PREHEADER]] ], [ [[INDVARS_IV_NEXT:%.*]], %[[INNER_LOOP]] ]
 ; CHECK-NEXT:    [[GEP_INNER:%.*]] = getelementptr i8, ptr [[PTR]], i64 [[INDVARS_IV]]
 ; CHECK-NEXT:    store i8 0, ptr [[GEP_INNER]], align 1
 ; CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
-; CHECK-NEXT:    [[EXITCOND:%.*]] = icmp ne i64 [[INDVARS_IV_NEXT]], [[WIDE_TRIP_COUNT]]
-; CHECK-NEXT:    br i1 [[EXITCOND]], label %[[INNER_LOOP]], label %[[PH_LOOPEXIT]]
+; CHECK-NEXT:    [[EXIT_COND_INNER:%.*]] = icmp slt i64 [[INDVARS_IV_NEXT]], [[INDVARS_IV_NEXT2]]
+; CHECK-NEXT:    br i1 [[EXIT_COND_INNER]], label %[[INNER_LOOP]], label %[[PH_LOOPEXIT]]
 ; CHECK:       [[EXIT:.*:]]
 ; CHECK-NEXT:    ret i32 0
 ;


### PR DESCRIPTION
The commit f5d24e6c is buggy, and following miscompiles have been reported: #126409 and
https://github.com/llvm/llvm-project/pull/124270#issuecomment-2647222903

Revert it while we investigate.