### PR TITLE
[sanitizer_common][test] Remove second SanitizerCommon.ReportFile tem…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_libc_test.cpp
@@ -352,6 +352,7 @@ TEST(SanitizerCommon, ReportFile) {
   // This will close tmpfile.
   report_file.SetReportPath("stderr");
   Unlink(tmpfile);
+  Unlink(path);
 }
 
 TEST(SanitizerCommon, FileExists) {


### PR DESCRIPTION
…p file

The `SanitizerCommon.ReportFile` test leaves a temp file behind on every run. While this is not a problem for manual builds, on buildbots those files accumulate over time, interfering with other bots on the same system.

The files in question are named like
`sanitizer_common.reportfile.tmp.XXXXXX.<pid>`.  The issue can be seen in Solaris `truss` output:
```
22633:	fstatat64(AT_FDCWD, "/tmp/sanitizer_common.reportfile.tmp.rzVEja", 0xFEFFBAD0, AT_SYMLINK_NOFOLLOW) Err#2 ENOENT
22633:	openat64(AT_FDCWD, "/tmp/sanitizer_common.reportfile.tmp.rzVEja", O_RDWR|O_CREAT|O_EXCL, 0600) = 3
22633:	openat64(AT_FDCWD, "/tmp/sanitizer_common.reportfile.tmp.rzVEja.22633", O_WRONLY|O_CREAT|O_TRUNC, 0660) = 4
22633:	unlinkat(AT_FDCWD, "/tmp/sanitizer_common.reportfile.tmp.rzVEja", 0) = 0
```
The first temp file, created by `temp_file_name`, is removed at the end of the test, the second one, created in `ReportFile::GetReportPath` using `OpenFile`, is not.

This patch fixes this, simply removing the file.

Tested on `amd64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.