### PR TITLE
[llvm][docs] Tweak backporting instructions a bit

### DIFF
--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -438,9 +438,13 @@ Releases
 Backporting Fixes to the Release Branches
 -----------------------------------------
 You can use special comments on issues or pull requests to make backport
-requests for the release branches.  This is done by making a comment containing
-the following command on any issue or pull request that has been added to one
-of the "X.Y.Z Release" milestones.
+requests for the release branches.  To do this, after your pull reuest has been
+merged:
+
+1. Edit "Milestone" at the right side of the isssue or pull request
+   to say "LLVM X.Y Release"
+
+2. Add a comment to it in the following format:
 
 ::
 


### PR DESCRIPTION
* Drop ".Z" in milestone name since we've been doing X.Y releases instead of X.Y.Z releases since LLVM 18

* Add "LLVM" prefix since that's what release milestones are named

* Use a numbered list to make it clearer that there are two steps needed, and add some more details to the first step