### PR TITLE
[clang] CTAD: Remove an incorrect assertion in BuildDeductionGuideForTypeAlias

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -998,8 +998,6 @@ getRHSTemplateDeclAndArgs(Sema &SemaRef, TypeAliasTemplateDecl *AliasTemplate) {
       Template = CTSD->getSpecializedTemplate();
       AliasRhsTemplateArgs = CTSD->getTemplateArgs().asArray();
     }
-  } else {
-    assert(false && "unhandled RHS type of the alias");
   }
   return {Template, AliasRhsTemplateArgs};
 }

--- a/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
+++ b/clang/test/SemaCXX/cxx20-ctad-type-alias.cpp
@@ -525,3 +525,17 @@ template <ArrayType<int>::Array array> void test() {}
 void foo() { test<{1, 2, 3}>(); }
 
 } // namespace GH113518
+
+namespace GH125821 {
+template<typename T>
+struct A { A(T){} };
+
+template<typename T>
+using Proxy = T;
+
+template<typename T>
+using C = Proxy< A<T> >;
+
+C test{ 42 }; // expected-error {{no viable constructor or deduction guide for deduction of template arguments}}
+
+} // namespace GH125821


### PR DESCRIPTION
Fixes #125821

The assertion was too strict, as Clang can reach this code path when recursively generating deduction guides for alias templates. See the detailed explanation [here](https://github.com/llvm/llvm-project/issues/125821#issuecomment-2639130893).

No release notes needed, as there is no behavior change in release builds.