### PR TITLE
[libc++][format] Disables the FTM on older MacOS versions.

### DIFF
--- a/libcxx/include/version
+++ b/libcxx/include/version
@@ -417,7 +417,9 @@ __cpp_lib_void_t                                        201411L <type_traits>
 # define __cpp_lib_erase_if                             202002L
 # undef  __cpp_lib_execution
 // # define __cpp_lib_execution                            201902L
-# define __cpp_lib_format                               202110L
+# if _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   define __cpp_lib_format                             202110L
+# endif
 # define __cpp_lib_format_uchar                         202311L
 # define __cpp_lib_generic_unordered_lookup             201811L
 # define __cpp_lib_int_pow2                             202002L
@@ -499,7 +501,9 @@ __cpp_lib_void_t                                        201411L <type_traits>
 # undef  __cpp_lib_optional
 # define __cpp_lib_optional                             202110L
 # define __cpp_lib_out_ptr                              202106L
-# define __cpp_lib_print                                202207L
+# if _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   define __cpp_lib_print                              202207L
+# endif
 # undef  __cpp_lib_ranges
 # define __cpp_lib_ranges                               202406L
 // # define __cpp_lib_ranges_as_const                      202207L

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/format.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/format.version.compile.pass.cpp
@@ -68,11 +68,17 @@
 
 #elif TEST_STD_VER == 20
 
-# ifndef __cpp_lib_format
-#   error "__cpp_lib_format should be defined in c++20"
-# endif
-# if __cpp_lib_format != 202110L
-#   error "__cpp_lib_format should have the value 202110L in c++20"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_format
+#     error "__cpp_lib_format should be defined in c++20"
+#   endif
+#   if __cpp_lib_format != 202110L
+#     error "__cpp_lib_format should have the value 202110L in c++20"
+#   endif
+# else
+#   ifdef __cpp_lib_format
+#     error "__cpp_lib_format should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # ifdef __cpp_lib_format_ranges
@@ -88,11 +94,17 @@
 
 #elif TEST_STD_VER == 23
 
-# ifndef __cpp_lib_format
-#   error "__cpp_lib_format should be defined in c++23"
-# endif
-# if __cpp_lib_format != 202110L
-#   error "__cpp_lib_format should have the value 202110L in c++23"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_format
+#     error "__cpp_lib_format should be defined in c++23"
+#   endif
+#   if __cpp_lib_format != 202110L
+#     error "__cpp_lib_format should have the value 202110L in c++23"
+#   endif
+# else
+#   ifdef __cpp_lib_format
+#     error "__cpp_lib_format should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # ifndef __cpp_lib_format_ranges
@@ -111,11 +123,17 @@
 
 #elif TEST_STD_VER > 23
 
-# ifndef __cpp_lib_format
-#   error "__cpp_lib_format should be defined in c++26"
-# endif
-# if __cpp_lib_format != 202110L
-#   error "__cpp_lib_format should have the value 202110L in c++26"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_format
+#     error "__cpp_lib_format should be defined in c++26"
+#   endif
+#   if __cpp_lib_format != 202110L
+#     error "__cpp_lib_format should have the value 202110L in c++26"
+#   endif
+# else
+#   ifdef __cpp_lib_format
+#     error "__cpp_lib_format should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # ifndef __cpp_lib_format_ranges

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/ostream.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/ostream.version.compile.pass.cpp
@@ -89,11 +89,17 @@
 #   endif
 # endif
 
-# ifndef __cpp_lib_print
-#   error "__cpp_lib_print should be defined in c++23"
-# endif
-# if __cpp_lib_print != 202207L
-#   error "__cpp_lib_print should have the value 202207L in c++23"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_print
+#     error "__cpp_lib_print should be defined in c++23"
+#   endif
+#   if __cpp_lib_print != 202207L
+#     error "__cpp_lib_print should have the value 202207L in c++23"
+#   endif
+# else
+#   ifdef __cpp_lib_print
+#     error "__cpp_lib_print should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 #elif TEST_STD_VER > 23
@@ -111,11 +117,17 @@
 #   endif
 # endif
 
-# ifndef __cpp_lib_print
-#   error "__cpp_lib_print should be defined in c++26"
-# endif
-# if __cpp_lib_print != 202207L
-#   error "__cpp_lib_print should have the value 202207L in c++26"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_print
+#     error "__cpp_lib_print should be defined in c++26"
+#   endif
+#   if __cpp_lib_print != 202207L
+#     error "__cpp_lib_print should have the value 202207L in c++26"
+#   endif
+# else
+#   ifdef __cpp_lib_print
+#     error "__cpp_lib_print should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 #endif // TEST_STD_VER > 23

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/print.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/print.version.compile.pass.cpp
@@ -50,20 +50,32 @@
 
 #elif TEST_STD_VER == 23
 
-# ifndef __cpp_lib_print
-#   error "__cpp_lib_print should be defined in c++23"
-# endif
-# if __cpp_lib_print != 202207L
-#   error "__cpp_lib_print should have the value 202207L in c++23"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_print
+#     error "__cpp_lib_print should be defined in c++23"
+#   endif
+#   if __cpp_lib_print != 202207L
+#     error "__cpp_lib_print should have the value 202207L in c++23"
+#   endif
+# else
+#   ifdef __cpp_lib_print
+#     error "__cpp_lib_print should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 #elif TEST_STD_VER > 23
 
-# ifndef __cpp_lib_print
-#   error "__cpp_lib_print should be defined in c++26"
-# endif
-# if __cpp_lib_print != 202207L
-#   error "__cpp_lib_print should have the value 202207L in c++26"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_print
+#     error "__cpp_lib_print should be defined in c++26"
+#   endif
+#   if __cpp_lib_print != 202207L
+#     error "__cpp_lib_print should have the value 202207L in c++26"
+#   endif
+# else
+#   ifdef __cpp_lib_print
+#     error "__cpp_lib_print should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 #endif // TEST_STD_VER > 23

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
@@ -3685,11 +3685,17 @@
 #   error "__cpp_lib_flat_set should not be defined before c++23"
 # endif
 
-# ifndef __cpp_lib_format
-#   error "__cpp_lib_format should be defined in c++20"
-# endif
-# if __cpp_lib_format != 202110L
-#   error "__cpp_lib_format should have the value 202110L in c++20"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_format
+#     error "__cpp_lib_format should be defined in c++20"
+#   endif
+#   if __cpp_lib_format != 202110L
+#     error "__cpp_lib_format should have the value 202110L in c++20"
+#   endif
+# else
+#   ifdef __cpp_lib_format
+#     error "__cpp_lib_format should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # ifdef __cpp_lib_format_path
@@ -5146,11 +5152,17 @@
 #   endif
 # endif
 
-# ifndef __cpp_lib_format
-#   error "__cpp_lib_format should be defined in c++23"
-# endif
-# if __cpp_lib_format != 202110L
-#   error "__cpp_lib_format should have the value 202110L in c++23"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_format
+#     error "__cpp_lib_format should be defined in c++23"
+#   endif
+#   if __cpp_lib_format != 202110L
+#     error "__cpp_lib_format should have the value 202110L in c++23"
+#   endif
+# else
+#   ifdef __cpp_lib_format
+#     error "__cpp_lib_format should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # ifdef __cpp_lib_format_path
@@ -5679,11 +5691,17 @@
 #   endif
 # endif
 
-# ifndef __cpp_lib_print
-#   error "__cpp_lib_print should be defined in c++23"
-# endif
-# if __cpp_lib_print != 202207L
-#   error "__cpp_lib_print should have the value 202207L in c++23"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_print
+#     error "__cpp_lib_print should be defined in c++23"
+#   endif
+#   if __cpp_lib_print != 202207L
+#     error "__cpp_lib_print should have the value 202207L in c++23"
+#   endif
+# else
+#   ifdef __cpp_lib_print
+#     error "__cpp_lib_print should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # if !defined(_LIBCPP_VERSION) || _LIBCPP_HAS_LOCALIZATION
@@ -6853,11 +6871,17 @@
 #   endif
 # endif
 
-# ifndef __cpp_lib_format
-#   error "__cpp_lib_format should be defined in c++26"
-# endif
-# if __cpp_lib_format != 202110L
-#   error "__cpp_lib_format should have the value 202110L in c++26"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_format
+#     error "__cpp_lib_format should be defined in c++26"
+#   endif
+#   if __cpp_lib_format != 202110L
+#     error "__cpp_lib_format should have the value 202110L in c++26"
+#   endif
+# else
+#   ifdef __cpp_lib_format
+#     error "__cpp_lib_format should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # if !defined(_LIBCPP_VERSION)
@@ -7557,11 +7581,17 @@
 #   endif
 # endif
 
-# ifndef __cpp_lib_print
-#   error "__cpp_lib_print should be defined in c++26"
-# endif
-# if __cpp_lib_print != 202207L
-#   error "__cpp_lib_print should have the value 202207L in c++26"
+# if !defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT
+#   ifndef __cpp_lib_print
+#     error "__cpp_lib_print should be defined in c++26"
+#   endif
+#   if __cpp_lib_print != 202207L
+#     error "__cpp_lib_print should have the value 202207L in c++26"
+#   endif
+# else
+#   ifdef __cpp_lib_print
+#     error "__cpp_lib_print should not be defined when the requirement '!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT' is not met!"
+#   endif
 # endif
 
 # if !defined(_LIBCPP_VERSION) || _LIBCPP_HAS_LOCALIZATION

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -536,6 +536,11 @@ feature_test_macros = [
             # 202305 P2757R3 Type-checking format args
             # 202306 P2637R3 Member Visit
             "headers": ["format"],
+            # Trying to use `std::format` where to_chars floating-point is not
+            # available causes compilation errors, even with non floating-point types.
+            # https://github.com/llvm/llvm-project/issues/125353
+            "test_suite_guard": "!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
+            "libcxx_guard": "_LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
         },
         {
             "name": "__cpp_lib_format_path",
@@ -1011,6 +1016,11 @@ feature_test_macros = [
                 # "c++26": 202406, # P3235R3 std::print more types faster with less memory
             },
             "headers": ["ostream", "print"],
+            # Trying to use `std::print` where to_chars floating-point is not
+            # available causes compilation errors, even with non floating-point types.
+            # https://github.com/llvm/llvm-project/issues/125353
+            "test_suite_guard": "!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
+            "libcxx_guard": "_LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
         },
         {
             "name": "__cpp_lib_quoted_string_io",


### PR DESCRIPTION
On older MacOS versions where `std::to_chars` for floating-point types is not available the format library can't be used. Due to some issue with the availability macro used to disable format on MacOS the issue triggers regardless of the type being formatted.

The print library has the same issue.

Fixes: #125353