### PR TITLE
[PPC] Implement `areInlineCompatible`

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
@@ -895,6 +895,20 @@ PPCTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
   return BaseT::getIntrinsicInstrCost(ICA, CostKind);
 }
 
+bool PPCTTIImpl::areInlineCompatible(const Function *Caller,
+                                     const Function *Callee) const {
+  const TargetMachine &TM = getTLI()->getTargetMachine();
+
+  const FeatureBitset &CallerBits =
+      TM.getSubtargetImpl(*Caller)->getFeatureBits();
+  const FeatureBitset &CalleeBits =
+      TM.getSubtargetImpl(*Callee)->getFeatureBits();
+
+  // Check that targets features are exactly the same. We can revisit to see if
+  // we can improve this.
+  return CallerBits == CalleeBits;
+}
+
 bool PPCTTIImpl::areTypesABICompatible(const Function *Caller,
                                        const Function *Callee,
                                        const ArrayRef<Type *> &Types) const {

--- a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.h
@@ -139,6 +139,8 @@ public:
       bool UseMaskForCond = false, bool UseMaskForGaps = false);
   InstructionCost getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
                                         TTI::TargetCostKind CostKind);
+  bool areInlineCompatible(const Function *Caller,
+                           const Function *Callee) const;
   bool areTypesABICompatible(const Function *Caller, const Function *Callee,
                              const ArrayRef<Type *> &Types) const;
   bool hasActiveVectorLength(unsigned Opcode, Type *DataType,

--- a/llvm/test/Transforms/Inline/PowerPC/inline-target-attr.ll
+++ b/llvm/test/Transforms/Inline/PowerPC/inline-target-attr.ll
@@ -4,31 +4,60 @@
 target datalayout = "E-m:e-i64:64-n32:64"
 target triple = "powerpc64le-ibm-linux-gnu"
 
-declare i32 @inlined()
+declare void @inlined()
 
-define i32 @foo() #0 {
-; CHECK-LABEL: foo
+define void @explicit() #0 {
+; CHECK-LABEL: explicit
 ; CHECK: entry
-; CHECK-NEXT: call i32 @bar()
-; CHECK-NEXT: call i32 @inlined()
+; CHECK-NEXT: call void @not_compatible1()
+; CHECK-NEXT: call void @inlined()
 entry:
-    %1 = call i32 @bar()
-    %2 = call i32 @baz()
-    %3 = add i32 %1, %2
-    ret i32 %3
+    call void @not_compatible1()
+    call void @compatible1()
+    ret void
 }
 
-define i32 @bar() #1 {
+define void @not_compatible1() #1 {
 entry:
-    %1 = call i32 @inlined()
-    ret i32 %1
+    call i32 @inlined()
+    ret void
 }
 
-define i32 @baz() #0 {
+define void @compatible1() #0 {
 entry:
-    %1 = call i32 @inlined()
-    ret i32 %1
+    call void @inlined()
+    ret void 
 }
 
+define void @default() #3 {
+; CHECK-LABEL: default
+; CHECK: entry
+; CHECK-NEXT: call void @not_compatible2()
+; CHECK-NEXT: call void @inlined()
+entry:
+    call void @not_compatible2()
+    call void @compatible2()
+    ret void
+}
+
+define void @not_compatible2() #4 {
+entry:
+    call void @inlined()
+    ret void
+}
+
+define void @compatible2() #5 {
+entry:
+    call void @inlined()
+    ret void 
+}
+
+; explicit
 attributes #0 = { "target-cpu"="pwr7" "target-features"="+allow-unaligned-fp-access" }
 attributes #1 = { "target-cpu"="pwr7" "target-features"="-allow-unaligned-fp-access" }
+
+; pwr7 by default implies +vsx
+attributes #3 = { "target-cpu"="pwr7" }
+attributes #4 = { "target-cpu"="pwr7" "target-features"="-vsx" }
+attributes #5 = { "target-cpu"="pwr7" "target-features"="+vsx" }
+

--- a/llvm/test/Transforms/Inline/PowerPC/inline-target-attr.ll
+++ b/llvm/test/Transforms/Inline/PowerPC/inline-target-attr.ll
@@ -1,0 +1,37 @@
+; RUN: opt < %s -mtriple=powerpc64le-ibm-linux-gnu -S -passes=inline | FileCheck %s
+; RUN: opt < %s -mtriple=powerpc64le-ibm-linux-gnu -S -passes='cgscc(inline)' | FileCheck %s
+
+target datalayout = "E-m:e-i64:64-n32:64"
+target triple = "powerpc64le-ibm-linux-gnu"
+
+declare i32 @inlined()
+
+define i32 @foo() #0 {
+; CHECK-LABEL: foo
+; CHECK: entry
+; CHECK-NEXT: call i32 @bar()
+; CHECK-NEXT: call i32 @inlined()
+entry:
+    %1 = call i32 @bar()
+    %2 = call i32 @baz()
+    %3 = add i32 %1, %2
+    ret i32 %3
+}
+
+define i32 @bar() #1 {
+entry:
+    %1 = call i32 @inlined()
+    ret i32 %1
+}
+
+define i32 @baz() #0 {
+entry:
+    %1 = call i32 @inlined()
+    ret i32 %1
+}
+
+attributes #0 = { "target-cpu"="pwr7" "target-features"="+allow-unaligned-fp-access" }
+
+; We explictly disable -power8-vector to avoid emitting those instructions
+; so we should not inline them into +power8-vector
+attributes #1 = { "target-cpu"="pwr7" "target-features"="-allow-unaligned-fp-access" }

--- a/llvm/test/Transforms/Inline/PowerPC/inline-target-attr.ll
+++ b/llvm/test/Transforms/Inline/PowerPC/inline-target-attr.ll
@@ -31,7 +31,4 @@ entry:
 }
 
 attributes #0 = { "target-cpu"="pwr7" "target-features"="+allow-unaligned-fp-access" }
-
-; We explictly disable -power8-vector to avoid emitting those instructions
-; so we should not inline them into +power8-vector
 attributes #1 = { "target-cpu"="pwr7" "target-features"="-allow-unaligned-fp-access" }


### PR DESCRIPTION
After the default implementation swap from https://github.com/llvm/llvm-project/pull/117493, where `areInlineCompatible` checks if the callee features are a subset of caller features. This is not a safe assumption in general on PPC. We fallback to check for strict feature set equality for now, and see what improvements we can make.