### PR TITLE
[libc++][test] Fixes for `hash<Emplaceable>` and value discarding

### DIFF
--- a/libcxx/test/std/containers/Emplaceable.h
+++ b/libcxx/test/std/containers/Emplaceable.h
@@ -45,7 +45,7 @@ struct std::hash<Emplaceable> {
   typedef Emplaceable argument_type;
   typedef std::size_t result_type;
 
-  std::size_t operator()(const Emplaceable& x) const { return x.get(); }
+  std::size_t operator()(const Emplaceable& x) const { return static_cast<std::size_t>(x.get()); }
 };
 
 #endif // TEST_STD_VER >= 11

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp
@@ -103,7 +103,7 @@ int main(int, char**) {
     TransparentComparator c(transparent_used);
     std::flat_map<int, int, TransparentComparator> m(std::sorted_unique, {{1, 1}, {2, 2}, {3, 3}}, c);
     assert(!transparent_used);
-    m.at(Transparent<int>{3});
+    TEST_IGNORE_NODISCARD m.at(Transparent<int>{3});
     assert(transparent_used);
   }
 


### PR DESCRIPTION
Currently `std::hash<Emplaceable>::operator()` relies implicit conversion from `int` to `size_t`, which makes MSVC compelling. This PR switches to use `static_cast`.

In `flat.map/flat.map.access/at_transparent.pass.cpp`, there's one value-discarding use of `at` that wasn't marked `TEST_IGNORE_NODISCARD`. This PR adds the missing `TEST_IGNORE_NODISCARD`.