### PR TITLE
[lldb] Add a test for terminal dimensions

### DIFF
--- a/lldb/test/API/driver/terminal/TestTerminalDimensions.py
+++ b/lldb/test/API/driver/terminal/TestTerminalDimensions.py
@@ -1,0 +1,22 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+
+class TerminalDimensionsTest(PExpectTest):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipIfAsan
+    def test(self):
+        """Test that the lldb driver correctly reports the (PExpect) terminal dimension."""
+        self.launch(dimensions=(40, 40), timeout=1)
+
+        # Tests clear all the settings so we lose the launch values. Resize the
+        # window to update the settings. These new values need to be different
+        # to trigger a SIGWINCH.
+        self.child.setwinsize(20, 60)
+
+        self.expect("settings show term-height", ["term-height (unsigned) = 20"])
+        self.expect("settings show term-width", ["term-width (unsigned) = 60"])

--- a/lldb/test/API/driver/terminal/TestTerminalDimensions.py
+++ b/lldb/test/API/driver/terminal/TestTerminalDimensions.py
@@ -11,7 +11,7 @@ class TerminalDimensionsTest(PExpectTest):
     @skipIfAsan
     def test(self):
         """Test that the lldb driver correctly reports the (PExpect) terminal dimension."""
-        self.launch(dimensions=(40, 40), timeout=1)
+        self.launch(dimensions=(40, 40))
 
         # Tests clear all the settings so we lose the launch values. Resize the
         # window to update the settings. These new values need to be different


### PR DESCRIPTION
Add a test for the `term-width` and `term-height` settings. I thought I was hitting bug because in my statusline test I was getting the default values when running under PExpect. It turned out hat the issue is that we clear the settings at the start of the test. The Editline tests aren't affected by this because Editline provides its own functions to get the terminal dimensions and explicitly does not rely on LLDB's settings (presumably exactly because of this behavior). 