### PR TITLE
[lldb][sbapi] Namespace CommandReturnObjectCallbackResult in SBDefines

### DIFF
--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -144,7 +144,7 @@ typedef bool (*SBBreakpointHitCallback)(void *baton, lldb::SBProcess &process,
 typedef void (*SBDebuggerDestroyCallback)(lldb::user_id_t debugger_id,
                                           void *baton);
 
-typedef CommandReturnObjectCallbackResult (*SBCommandPrintCallback)(
+typedef lldb::CommandReturnObjectCallbackResult (*SBCommandPrintCallback)(
     lldb::SBCommandReturnObject &result, void *baton);
 
 typedef lldb::SBError (*SBPlatformLocateModuleCallback)(


### PR DESCRIPTION
A new callback was added with the type
CommandReturnObjectCallbackResult, this commit namespaces that type to match the format of other callback functions that have a non-primitive return type in the lldb namespace.

rdar://144553496