### PR TITLE
release/20.x: [llvm-objcopy][ReleaseNotes] Fix prints wrong path when dump-section output path doesn't exist #125345

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -460,7 +460,7 @@ Changes to the LLVM tools
   `--localize-symbol`, `--localize-symbols`,
   `--skip-symbol`, `--skip-symbols`.
 
-* llvm-objcopy now prints the correct file path in the error message when the output file specified by --dump-section cannot be opened.
+* llvm-objcopy now prints the correct file path in the error message when the output file specified by `--dump-section` cannot be opened.
 
 Changes to LLDB
 ---------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -460,6 +460,8 @@ Changes to the LLVM tools
   `--localize-symbol`, `--localize-symbols`,
   `--skip-symbol`, `--skip-symbols`.
 
+* llvm-objcopy now prints the correct file path in the error message when the output file specified by --dump-section cannot be opened.
+
 Changes to LLDB
 ---------------------------------
 


### PR DESCRIPTION
Add release note for llvm-objcopy fixing prints wrong path when dump-section output path doesn't exist in #125345