### PR TITLE
[libc][docgen] make note of sys/time.h interfaces removed in POSIX.1-2024

### DIFF
--- a/libc/utils/docgen/docgen.py
+++ b/libc/utils/docgen/docgen.py
@@ -57,6 +57,7 @@ def check_api(header: Header, api: Dict):
         "c-definition",
         "in-latest-posix",
         "removed-in-posix-2008",
+        "removed-in-posix-2024",
     ]
 
     # Validate macros
@@ -139,6 +140,10 @@ def print_functions_rst(header: Header, functions: Dict):
         elif "removed-in-posix-2008" in functions[name]:
             print(
                 f"    - `removed in POSIX.1-2008 <https://pubs.opengroup.org/onlinepubs/007904875/functions/{name}.html>`__"
+            )
+        elif "removed-in-posix-2024" in functions[name]:
+            print(
+                f"    - `removed in POSIX.1-2024 <https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/{name}.html>`__"
             )
         else:
             print("    -")

--- a/libc/utils/docgen/sys/time.yaml
+++ b/libc/utils/docgen/sys/time.yaml
@@ -3,3 +3,9 @@ functions:
     in-latest-posix: ''
   utimes:
     in-latest-posix: ''
+  getitimer:
+    removed-in-posix-2024: ''
+  gettimeofday:
+    removed-in-posix-2024: ''
+  setitimer:
+    removed-in-posix-2024: ''


### PR DESCRIPTION
One of these days, we'll be able to specify time to a computer...

Also, POSIX can remove stuff all they want. Folks probably will
continue to depend on broken interfaces forever.

Link: #124654
Link: https://austingroupbugs.net/view.php?id=1330
