### PR TITLE
[libc][test][stdbit] fix -Wimplicit-int-conversion

### DIFF
--- a/libc/test/src/stdbit/stdc_bit_ceil_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_bit_ceil_uc_test.cpp
@@ -17,18 +17,21 @@ TEST(LlvmLibcStdcBitceilUcTest, Zero) {
 
 TEST(LlvmLibcStdcBitceilUcTest, Ones) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_uc(1U << i),
-              static_cast<unsigned char>(1U << i));
+    EXPECT_EQ(
+        LIBC_NAMESPACE::stdc_bit_ceil_uc(static_cast<unsigned char>(1U << i)),
+        static_cast<unsigned char>(1U << i));
 }
 
 TEST(LlvmLibcStdcBitceilUcTest, OneLessThanPowsTwo) {
   for (unsigned i = 2U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_uc((1U << i) - 1),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_uc(
+                  static_cast<unsigned char>((1U << i) - 1)),
               static_cast<unsigned char>(1U << i));
 }
 
 TEST(LlvmLibcStdcBitceilUcTest, OneMoreThanPowsTwo) {
   for (unsigned i = 1U; i != UCHAR_WIDTH - 1; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_uc((1U << i) + 1),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_uc(
+                  static_cast<unsigned char>((1U << i) + 1)),
               static_cast<unsigned char>(1U << (i + 1)));
 }

--- a/libc/test/src/stdbit/stdc_bit_ceil_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_bit_ceil_us_test.cpp
@@ -17,18 +17,21 @@ TEST(LlvmLibcStdcBitceilUsTest, Zero) {
 
 TEST(LlvmLibcStdcBitceilUsTest, Ones) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_us(1U << i),
-              static_cast<unsigned short>(1U << i));
+    EXPECT_EQ(
+        LIBC_NAMESPACE::stdc_bit_ceil_us(static_cast<unsigned short>(1U << i)),
+        static_cast<unsigned short>(1U << i));
 }
 
 TEST(LlvmLibcStdcBitceilUsTest, OneLessThanPowsTwo) {
   for (unsigned i = 2U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_us((1U << i) - 1),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_us(
+                  static_cast<unsigned short>((1U << i) - 1)),
               static_cast<unsigned short>(1U << i));
 }
 
 TEST(LlvmLibcStdcBitceilUsTest, OneMoreThanPowsTwo) {
   for (unsigned i = 1U; i != USHRT_WIDTH - 1; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_us((1U << i) + 1),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_bit_ceil_us(
+                  static_cast<unsigned short>((1U << i) + 1)),
               static_cast<unsigned short>(1U << (i + 1)));
 }

--- a/libc/test/src/stdbit/stdc_first_leading_one_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_leading_one_uc_test.cpp
@@ -16,6 +16,7 @@ TEST(LlvmLibcStdcFirstLeadingOneUcTest, Zero) {
 
 TEST(LlvmLibcStdcFirstLeadingOneUcTest, OneHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_one_uc(1U << i),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_one_uc(
+                  static_cast<unsigned char>(1U << i)),
               UCHAR_WIDTH - i);
 }

--- a/libc/test/src/stdbit/stdc_first_leading_one_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_leading_one_us_test.cpp
@@ -16,6 +16,7 @@ TEST(LlvmLibcStdcFirstLeadingOneUsTest, Zero) {
 
 TEST(LlvmLibcStdcFirstLeadingOneUsTest, OneHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_one_us(1U << i),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_one_us(
+                  static_cast<unsigned short>(1U << i)),
               USHRT_WIDTH - i);
 }

--- a/libc/test/src/stdbit/stdc_first_leading_zero_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_leading_zero_uc_test.cpp
@@ -16,6 +16,7 @@ TEST(LlvmLibcStdcFirstLeadingZeroUcTest, ALL) {
 
 TEST(LlvmLibcStdcFirstLeadingZeroUcTest, ZeroHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_zero_uc(~(1U << i)),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_zero_uc(
+                  static_cast<unsigned char>(~(1U << i))),
               UCHAR_WIDTH - i);
 }

--- a/libc/test/src/stdbit/stdc_first_leading_zero_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_leading_zero_us_test.cpp
@@ -16,6 +16,7 @@ TEST(LlvmLibcStdcFirstLeadingZeroUsTest, ALL) {
 
 TEST(LlvmLibcStdcFirstLeadingZeroUsTest, ZeroHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_zero_us(~(1U << i)),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_leading_zero_us(
+                  static_cast<unsigned short>(~(1U << i))),
               USHRT_WIDTH - i);
 }

--- a/libc/test/src/stdbit/stdc_first_trailing_one_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_trailing_one_uc_test.cpp
@@ -16,5 +16,7 @@ TEST(LlvmLibcStdcFirstTrailingOneUcTest, ALL) {
 
 TEST(LlvmLibcStdcFirstTrailingOneUcTest, OneHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_one_uc(1U << i), i + 1);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_one_uc(
+                  static_cast<unsigned char>(1U << i)),
+              i + 1);
 }

--- a/libc/test/src/stdbit/stdc_first_trailing_one_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_trailing_one_us_test.cpp
@@ -16,5 +16,7 @@ TEST(LlvmLibcStdcFirstTrailingOneUsTest, ALL) {
 
 TEST(LlvmLibcStdcFirstTrailingOneUsTest, OneHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_one_us(1U << i), i + 1);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_one_us(
+                  static_cast<unsigned short>(1U << i)),
+              i + 1);
 }

--- a/libc/test/src/stdbit/stdc_first_trailing_zero_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_trailing_zero_uc_test.cpp
@@ -16,5 +16,7 @@ TEST(LlvmLibcStdcFirstTrailingZeroUcTest, ALL) {
 
 TEST(LlvmLibcStdcFirstTrailingZeroUcTest, ZeroHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_zero_uc(~(1U << i)), i + 1);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_zero_uc(
+                  static_cast<unsigned char>(~(1U << i))),
+              i + 1);
 }

--- a/libc/test/src/stdbit/stdc_first_trailing_zero_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_first_trailing_zero_us_test.cpp
@@ -16,5 +16,7 @@ TEST(LlvmLibcStdcFirstTrailingZeroUsTest, ALL) {
 
 TEST(LlvmLibcStdcFirstTrailingZeroUsTest, ZeroHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_zero_us(~(1U << i)), i + 1);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_first_trailing_zero_us(
+                  static_cast<unsigned short>(~(1U << i))),
+              i + 1);
 }

--- a/libc/test/src/stdbit/stdc_has_single_bit_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_has_single_bit_uc_test.cpp
@@ -16,5 +16,7 @@ TEST(LlvmLibcStdcHasSingleBitUcTest, Zero) {
 
 TEST(LlvmLibcStdcHasSingleBitUcTest, OneHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_has_single_bit_uc(1U << i), true);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_has_single_bit_uc(
+                  static_cast<unsigned char>(1U << i)),
+              true);
 }

--- a/libc/test/src/stdbit/stdc_has_single_bit_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_has_single_bit_us_test.cpp
@@ -16,5 +16,7 @@ TEST(LlvmLibcStdcHasSingleBitUsTest, Zero) {
 
 TEST(LlvmLibcStdcHasSingleBitUsTest, OneHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_has_single_bit_us(1U << i), true);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_has_single_bit_us(
+                  static_cast<unsigned short>(1U << i)),
+              true);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_uc_test.cpp
@@ -17,6 +17,7 @@ TEST(LlvmLibcStdcLeadingOnesUcTest, All) {
 
 TEST(LlvmLibcStdcLeadingOnesUcTest, ZeroHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(~(1U << i)),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_uc(
+                  static_cast<unsigned char>(~(1U << i))),
               UCHAR_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_ones_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_ones_us_test.cpp
@@ -17,6 +17,7 @@ TEST(LlvmLibcStdcLeadingOnesUsTest, All) {
 
 TEST(LlvmLibcStdcLeadingOnesUsTest, ZeroHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_us(~(1U << i)),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_ones_us(
+                  static_cast<unsigned short>(~(1U << i))),
               USHRT_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_uc_test.cpp
@@ -17,6 +17,7 @@ TEST(LlvmLibcStdcLeadingZerosUcTest, Zero) {
 
 TEST(LlvmLibcStdcLeadingZerosUcTest, OneHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(1U << i),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_uc(
+                  static_cast<unsigned char>(1U << i)),
               UCHAR_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_leading_zeros_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_leading_zeros_us_test.cpp
@@ -17,6 +17,7 @@ TEST(LlvmLibcStdcLeadingZerosUsTest, Zero) {
 
 TEST(LlvmLibcStdcLeadingZerosUsTest, OneHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_us(1U << i),
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_leading_zeros_us(
+                  static_cast<unsigned short>(1U << i)),
               USHRT_WIDTH - i - 1U);
 }

--- a/libc/test/src/stdbit/stdc_trailing_ones_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_trailing_ones_uc_test.cpp
@@ -17,5 +17,7 @@ TEST(LlvmLibcStdcTrailingOnesUcTest, ALL) {
 
 TEST(LlvmLibcStdcTrailingOnesUcTest, ZeroHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_ones_uc(~(1U << i)), i);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_ones_uc(
+                  static_cast<unsigned char>(~(1U << i))),
+              i);
 }

--- a/libc/test/src/stdbit/stdc_trailing_ones_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_trailing_ones_us_test.cpp
@@ -17,5 +17,7 @@ TEST(LlvmLibcStdcTrailingOnesUsTest, ALL) {
 
 TEST(LlvmLibcStdcTrailingOnesUsTest, ZeroHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_ones_us(~(1U << i)), i);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_ones_us(
+                  static_cast<unsigned short>(~(1U << i))),
+              i);
 }

--- a/libc/test/src/stdbit/stdc_trailing_zeros_uc_test.cpp
+++ b/libc/test/src/stdbit/stdc_trailing_zeros_uc_test.cpp
@@ -17,5 +17,7 @@ TEST(LlvmLibcStdcTrailingZerosUcTest, Zero) {
 
 TEST(LlvmLibcStdcTrailingZerosUcTest, OneHot) {
   for (unsigned i = 0U; i != UCHAR_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_zeros_uc(1U << i), i);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_zeros_uc(
+                  static_cast<unsigned char>(1U << i)),
+              i);
 }

--- a/libc/test/src/stdbit/stdc_trailing_zeros_us_test.cpp
+++ b/libc/test/src/stdbit/stdc_trailing_zeros_us_test.cpp
@@ -17,5 +17,7 @@ TEST(LlvmLibcStdcTrailingZerosUsTest, Zero) {
 
 TEST(LlvmLibcStdcTrailingZerosUsTest, OneHot) {
   for (unsigned i = 0U; i != USHRT_WIDTH; ++i)
-    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_zeros_us(1U << i), i);
+    EXPECT_EQ(LIBC_NAMESPACE::stdc_trailing_zeros_us(
+                  static_cast<unsigned short>(1U << i)),
+              i);
 }


### PR DESCRIPTION
When cross compiling the libc-stdbit-tests, the existing tests trigger numerous
instances of -Wimplicit-int-conversion. The truncation of these implicit
promotions is intentional.
