### PR TITLE
[profile] Use fprofile-continuous in compiler-rt tests

### DIFF
--- a/compiler-rt/test/profile/ContinuousSyncMode/basic.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/basic.c
@@ -1,8 +1,8 @@
 // REQUIRES: continuous-mode
 
-// RUN: %clang_profgen_cont -fcoverage-mapping -o %t.exe %s
+// RUN: %clang_profgen=%t.profraw -fprofile-continuous -fcoverage-mapping -o %t.exe %s
 // RUN: echo "garbage" > %t.profraw
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe
+// RUN: %run %t.exe
 // RUN: llvm-profdata show --counts --all-functions %t.profraw | FileCheck %s -check-prefix=CHECK-COUNTS
 // RUN: llvm-profdata merge -o %t.profdata %t.profraw
 //

--- a/compiler-rt/test/profile/ContinuousSyncMode/get-filename.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/get-filename.c
@@ -1,6 +1,6 @@
 // REQUIRES: continuous-mode
 
-// RUN: %clang_pgogen_cont -o %t.exe %s
+// RUN: %clang_pgogen -fprofile-continuous -o %t.exe %s
 // RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe %t.profraw
 // RUN: env LLVM_PROFILE_FILE="%t%c.profraw" %run %t.exe %t.profraw
 // RUN: env LLVM_PROFILE_FILE="%t.profraw%c" %run %t.exe %t.profraw

--- a/compiler-rt/test/profile/ContinuousSyncMode/image-with-mcdc.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/image-with-mcdc.c
@@ -1,7 +1,7 @@
 // REQUIRES: continuous-mode
 
-// RUN: %clang_profgen_cont -fcoverage-mapping -fcoverage-mcdc -O3 -o %t.exe %s
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe 3 3
+// RUN: %clang_profgen=%t.profraw -fprofile-continuous -fcoverage-mapping -fcoverage-mcdc -O3 -o %t.exe %s
+// RUN: %run %t.exe 3 3
 // RUN: llvm-profdata show --text --all-functions %t.profraw | FileCheck %s
 
 // CHECK: Num Bitmap Bytes:

--- a/compiler-rt/test/profile/ContinuousSyncMode/image-with-no-counters.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/image-with-no-counters.c
@@ -1,9 +1,9 @@
 // REQUIRES: target={{.*(darwin|aix).*}}
 
 // RUN: echo "static void dead_code(void) {}" > %t.dso.c
-// RUN: %clang_profgen_cont -fcoverage-mapping -O3 %shared_lib_flag -o %t.dso.dylib %t.dso.c
-// RUN: %clang_profgen_cont -fcoverage-mapping -O3 -o %t.exe %s %t.dso.dylib
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe 2>&1 | count 0
+// RUN: %clang_profgen=%t.profraw -fprofile-continuous -fcoverage-mapping -O3 %shared_lib_flag -o %t.dso.dylib %t.dso.c
+// RUN: %clang_profgen=%t.profraw -fprofile-continuous -fcoverage-mapping -O3 -o %t.exe %s %t.dso.dylib
+// RUN: %run %t.exe 2>&1 | count 0
 // RUN: llvm-profdata show --counts --all-functions %t.profraw | FileCheck %s
 
 // CHECK: Total functions: 1

--- a/compiler-rt/test/profile/ContinuousSyncMode/multi-threaded.cpp
+++ b/compiler-rt/test/profile/ContinuousSyncMode/multi-threaded.cpp
@@ -1,9 +1,9 @@
 // REQUIRES: continuous-mode
 
-// RUN: rm -f %t.profraw
-// RUN: %clangxx_pgogen_cont -lpthread %s -o %t.exe -mllvm -disable-vp -fprofile-update=atomic
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe
-// RUN: llvm-profdata show --counts --function=accum  %t.profraw | FileCheck %s
+// RUN: rm -rf %t.dir
+// RUN: %clangxx_pgogen=%t.dir -fprofile-continuous -lpthread %s -o %t.exe -mllvm -disable-vp -fprofile-update=atomic
+// RUN: %run %t.exe
+// RUN: llvm-profdata show --counts --function=accum  %t.dir/default_*.profraw | FileCheck %s
 // CHECK:    Block counts: [100000, 4]
 
 #include <thread>

--- a/compiler-rt/test/profile/ContinuousSyncMode/online-merging-windows.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/online-merging-windows.c
@@ -10,14 +10,14 @@
 // RUN: rm -rf %t.dir && split-file %s %t.dir && cd %t.dir
 //
 // Create two DLLs and a driver program that uses them.
-// RUN: %clang_pgogen foo.c -mllvm -instrprof-atomic-counter-update-all=1 -mllvm -runtime-counter-relocation=true -fuse-ld=lld -Wl,-dll -o %t.dir/foo.dll
-// RUN: %clang_pgogen bar.c -mllvm -instrprof-atomic-counter-update-all=1 -mllvm -runtime-counter-relocation=true -fuse-ld=lld -Wl,-dll -o %t.dir/bar.dll
-// RUN: %clang_pgogen main.c -o main.exe %t.dir/foo.lib %t.dir/bar.lib -mllvm -instrprof-atomic-counter-update-all=1 -mllvm -runtime-counter-relocation=true -fuse-ld=lld
+// RUN: %clang_pgogen=%t.dir/profdir -fprofile-continuous -fprofile-update=atomic foo.c -fuse-ld=lld -Wl,-dll -o %t.dir/foo.dll
+// RUN: %clang_pgogen=%t.dir/profdir -fprofile-continuous -fprofile-update=atomic bar.c -fuse-ld=lld -Wl,-dll -o %t.dir/bar.dll
+// RUN: %clang_pgogen=%t.dir/profdir -fprofile-continuous -fprofile-update=atomic main.c -o main.exe %t.dir/foo.lib %t.dir/bar.lib -fuse-ld=lld
 //
 // === Round 1 ===
 // Test merging+continuous mode without any file contention.
 //
-// RUN: env LLVM_PROFILE_FILE="%t.dir/profdir/%m%c.profraw" %run %t.dir/main.exe nospawn
+// RUN: %run %t.dir/main.exe nospawn
 // RUN: llvm-profdata merge -o %t.profdata %t.dir/profdir
 // RUN: llvm-profdata show --counts --all-functions %t.profdata | FileCheck %s -check-prefix=ROUND1
 
@@ -37,7 +37,7 @@
 // === Round 2 ===
 // Test merging+continuous mode with some file contention.
 //
-// RUN: env LLVM_PROFILE_FILE="%t.dir/profdir/%m%c.profraw" %run %t.dir/main.exe spawn
+// RUN: %run %t.dir/main.exe spawn
 // RUN: llvm-profdata merge -o %t.profdata %t.dir/profdir
 // RUN: llvm-profdata show --counts --all-functions %t.profdata | FileCheck %s -check-prefix=ROUND2
 

--- a/compiler-rt/test/profile/ContinuousSyncMode/online-merging.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/online-merging.c
@@ -9,14 +9,14 @@
 // Create two DSOs and a driver program that uses them.
 // RUN: echo "void dso1(void) {}" > dso1.c
 // RUN: echo "void dso2(void) {}" > dso2.c
-// RUN: %clang_pgogen_cont %shared_lib_flag -o %t.dir/dso1.dylib dso1.c -fprofile-update=atomic
-// RUN: %clang_pgogen_cont %shared_lib_flag -o %t.dir/dso2.dylib dso2.c -fprofile-update=atomic
-// RUN: %clang_pgogen_cont -o main.exe %s %t.dir/dso1.dylib %t.dir/dso2.dylib -fprofile-update=atomic
+// RUN: %clang_pgogen=%t.dir/profdir -fprofile-continuous -fprofile-update=atomic %shared_lib_flag -o %t.dir/dso1.dylib dso1.c
+// RUN: %clang_pgogen=%t.dir/profdir -fprofile-continuous -fprofile-update=atomic %shared_lib_flag -o %t.dir/dso2.dylib dso2.c
+// RUN: %clang_pgogen=%t.dir/profdir -fprofile-continuous -fprofile-update=atomic -o main.exe %s %t.dir/dso1.dylib %t.dir/dso2.dylib
 //
 // === Round 1 ===
 // Test merging+continuous mode without any file contention.
 //
-// RUN: env LLVM_PROFILE_FILE="%t.dir/profdir/%m%c.profraw" %run %t.dir/main.exe nospawn
+// RUN: %run %t.dir/main.exe nospawn
 // RUN: llvm-profdata merge -o %t.profdata %t.dir/profdir
 // RUN: llvm-profdata show --counts --all-functions %t.profdata | FileCheck %s -check-prefix=ROUND1
 
@@ -40,7 +40,7 @@
 // === Round 2 ===
 // Test merging+continuous mode with some file contention.
 //
-// RUN: env LLVM_PROFILE_FILE="%t.dir/profdir/%m%c.profraw" %run %t.dir/main.exe spawn 'LLVM_PROFILE_FILE=%t.dir/profdir/%m%c.profraw'
+// RUN: %run %t.dir/main.exe spawn 'LLVM_PROFILE_FILE=%t.dir/profdir/%m%c.profraw'
 // RUN: llvm-profdata merge -o %t.profdata %t.dir/profdir
 // RUN: llvm-profdata show --counts --all-functions %t.profdata | FileCheck %s -check-prefix=ROUND2
 

--- a/compiler-rt/test/profile/ContinuousSyncMode/pid-substitution.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/pid-substitution.c
@@ -1,9 +1,11 @@
 // REQUIRES: continuous-mode
 
 // RUN: rm -rf %t.dir && mkdir -p %t.dir
-// RUN: %clang_pgogen_cont -o %t.exe %s
 //
 // Note: %%p is needed here, not %p, because of lit's path substitution.
+// RUN: %clang_profgen=%t.dir/-%%p -fprofile-continuous -o %t.exe %s
+// RUN: %run %t.exe
+// RUN: %clang_pgogen -fprofile-continuous -o %t.exe %s
 // RUN: env LLVM_PROFILE_FILE="%t.dir/%c-%%p" %run %t.exe
 
 #include <stdlib.h>

--- a/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/reset-default-profile.c
@@ -4,7 +4,7 @@
 
 // Create & cd into a temporary directory.
 // RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
-// RUN: %clang -fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation=true -o %t.exe %s
+// RUN: %clang_profgen -fprofile-continuous -fcoverage-mapping -o %t.exe %s
 // RUN: env LLVM_PROFILE_FILE="incorrect-profile-name%m%c%c.profraw" %run %t.exe
 // RUN: ls -l | FileCheck %s
 

--- a/compiler-rt/test/profile/ContinuousSyncMode/runtime-counter-relocation.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/runtime-counter-relocation.c
@@ -1,8 +1,8 @@
 // REQUIRES: target={{.*(linux|solaris|windows-msvc|aix).*}}
 
-// RUN: %clang -fprofile-instr-generate -fcoverage-mapping -mllvm -runtime-counter-relocation=true -o %t.exe %s
+// RUN: %clang_profgen=%t.profraw -fprofile-continuous -fcoverage-mapping -o %t.exe %s
 // RUN: echo "garbage" > %t.profraw
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe
+// RUN: %run %t.exe
 // RUN: llvm-profdata show --counts --all-functions %t.profraw | FileCheck %s -check-prefix=CHECK-COUNTS
 // RUN: llvm-profdata merge -o %t.profdata %t.profraw
 // RUN: %if !target={{.*aix.*}} %{ llvm-cov report %t.exe -instr-profile %t.profdata | FileCheck %s -check-prefix=CHECK-COVERAGE %}

--- a/compiler-rt/test/profile/ContinuousSyncMode/set-file-object.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/set-file-object.c
@@ -4,8 +4,7 @@
 // Create & cd into a temporary directory.
 // RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 
-// The -mllvm -runtime-counter-relocation=true flag has effect only on linux.
-// RUN: %clang -fprofile-instr-generate -fcoverage-mapping -fprofile-update=atomic -mllvm -runtime-counter-relocation=true -o main.exe %s
+// RUN: %clang_profgen -fprofile-continuous -fcoverage-mapping -fprofile-update=atomic -o main.exe %s
 
 // Test continuous mode with __llvm_profile_set_file_object with mergin disabled.
 // RUN: env LLVM_PROFILE_FILE="%t.dir/profdir/%c%mprofraw.old" %run  %t.dir/main.exe nomerge %t.dir/profdir/profraw.new 2>&1 | FileCheck %s -check-prefix=WARN

--- a/compiler-rt/test/profile/ContinuousSyncMode/set-filename.c
+++ b/compiler-rt/test/profile/ContinuousSyncMode/set-filename.c
@@ -1,6 +1,6 @@
 // REQUIRES: continuous-mode
 
-// RUN: %clang_pgogen_cont -o %t.exe %s
+// RUN: %clang_pgogen -fprofile-continuous -o %t.exe %s
 // RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe %t.profraw %t.bad
 
 #include <string.h>

--- a/compiler-rt/test/profile/lit.cfg.py
+++ b/compiler-rt/test/profile/lit.cfg.py
@@ -30,9 +30,6 @@ if (
 
 target_is_msvc = bool(re.match(r".*-windows-msvc$", config.target_triple))
 
-# Whether continous profile collection (%c) requires runtime counter relocation on this platform
-runtime_reloc = bool(config.host_os in ["AIX", "Linux"])
-
 if config.host_os in ["Linux"]:
     extra_link_flags = ["-ldl"]
 elif target_is_msvc:
@@ -99,14 +96,6 @@ config.substitutions.append(
 )
 config.substitutions.append(
     (
-        "%clang_profgen_cont ",
-        build_invocation(clang_cflags)
-        + " -fprofile-instr-generate "
-        + ("-mllvm -runtime-counter-relocation " if runtime_reloc else ""),
-    )
-)
-config.substitutions.append(
-    (
         "%clangxx_profgen ",
         build_invocation(clang_cxxflags) + " -fprofile-instr-generate ",
     )
@@ -125,26 +114,10 @@ config.substitutions.append(
     ("%clang_pgogen=", build_invocation(clang_cflags) + " -fprofile-generate=")
 )
 config.substitutions.append(
-    (
-        "%clang_pgogen_cont ",
-        build_invocation(clang_cflags)
-        + " -fprofile-generate "
-        + ("-mllvm -runtime-counter-relocation " if runtime_reloc else ""),
-    )
-)
-config.substitutions.append(
     ("%clangxx_pgogen ", build_invocation(clang_cxxflags) + " -fprofile-generate ")
 )
 config.substitutions.append(
     ("%clangxx_pgogen=", build_invocation(clang_cxxflags) + " -fprofile-generate=")
-)
-config.substitutions.append(
-    (
-        "%clangxx_pgogen_cont ",
-        build_invocation(clang_cxxflags)
-        + " -fprofile-generate "
-        + ("-mllvm -runtime-counter-relocation " if runtime_reloc else ""),
-    )
 )
 
 config.substitutions.append(


### PR DESCRIPTION
PR #124353 introduced the clang option `-fprofile-continuous` to enable continuous mode. 
Use this option in all compiler-rt tests, where applicable.

Changes can be summarized as follows:
1) tests that use `-fprofile-instr-generate` (`%clang_profgen`), which is an option that takes profile file name, are changed like so:
```
-// RUN: %clang_profgen_cont <SOME-OPTIONS> -o %t.exe %s
-// RUN: env LLVM_PROFILE_FILE="%c%t.profraw" %run %t.exe
+// RUN: %clang_profgen=%t.profraw -fprofile-continuous <SOME-OPTIONS> -o %t.exe %s
+// RUN: %run %t.exe
```
2) tests that use `-fprofile-generate` (`%clang_pgogen`), which is an option that takes a profile directory, are on case-by-case basis. Where the default name "default_%m.profraw" works, those tests were changed to use `%clang_pgogen=<dir>`, and the rest (`set-filename.c` and `get-filename.c`) continued to use the `LLVM_PROFILE_FILE` environment variable .
3) `set-file-object.c` uses different filename for different run of the same executable, so it continued to use the `LLVM_PROFILE_FILE` environment variable.
4) `pid-substitution.c` add a clang_profgen variation.