### PR TITLE
[AsmParser] Remove OperandMatchResultTy

### DIFF
--- a/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
@@ -122,15 +122,13 @@ struct ParseInstructionInfo {
     : AsmRewrites(rewrites) {}
 };
 
-enum OperandMatchResultTy {
-  MatchOperand_Success,  // operand matched successfully
-  MatchOperand_NoMatch,  // operand did not match
-  MatchOperand_ParseFail // operand matched but had errors
-};
-
 /// Ternary parse status returned by various parse* methods.
 class ParseStatus {
-  enum class StatusTy { Success, Failure, NoMatch } Status;
+  enum class StatusTy {
+    Success, // operand matched successfully
+    Failure, // operand matched but had errors
+    NoMatch  // operand did not match
+  } Status;
 
 public:
 #if __cplusplus >= 202002L
@@ -152,19 +150,6 @@ public:
   constexpr bool isSuccess() const { return Status == StatusTy::Success; }
   constexpr bool isFailure() const { return Status == StatusTy::Failure; }
   constexpr bool isNoMatch() const { return Status == StatusTy::NoMatch; }
-
-  // Allow implicit conversions to / from OperandMatchResultTy.
-  LLVM_DEPRECATED("Migrate to ParseStatus", "")
-  constexpr ParseStatus(OperandMatchResultTy R)
-      : Status(R == MatchOperand_Success     ? Success
-               : R == MatchOperand_ParseFail ? Failure
-                                             : NoMatch) {}
-  LLVM_DEPRECATED("Migrate to ParseStatus", "")
-  constexpr operator OperandMatchResultTy() const {
-    return isSuccess()   ? MatchOperand_Success
-           : isFailure() ? MatchOperand_ParseFail
-                         : MatchOperand_NoMatch;
-  }
 };
 
 enum class DiagnosticPredicateTy {

--- a/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
@@ -125,9 +125,9 @@ struct ParseInstructionInfo {
 /// Ternary parse status returned by various parse* methods.
 class ParseStatus {
   enum class StatusTy {
-    Success, // operand matched successfully
-    Failure, // operand matched but had errors
-    NoMatch  // operand did not match
+    Success, // Parsing Succeeded
+    Failure, // Parsing Failed after consuming some tokens
+    NoMatch, // Parsing Failed without consuming any tokens
   } Status;
 
 public:


### PR DESCRIPTION
This has been deprecated since a479be0f39a3301e9ca634d37cf6454b6d3865c6 from September 2023, before LLVM 18. Surely now enough release cycles have happened that it can be removed upstream.