### PR TITLE
[lldb] Fix ubsan violation with plugin loading

### DIFF
--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -185,7 +185,7 @@ lldb::SBError SBDebugger::InitializeWithErrorHandling() {
     llvm::sys::DynamicLibrary dynlib =
         llvm::sys::DynamicLibrary::getPermanentLibrary(spec.GetPath().c_str());
     if (dynlib.isValid()) {
-      typedef bool (*LLDBCommandPluginInit)(lldb::SBDebugger & debugger);
+      typedef bool (*LLDBCommandPluginInit)(lldb::SBDebugger debugger);
 
       lldb::SBDebugger debugger_sb(debugger_sp);
       // This calls the bool lldb::PluginInitialize(lldb::SBDebugger debugger)


### PR DESCRIPTION
This typedef doesn't match the signature below, specifically the signature takes a `lldb:SBDebugger` vs this was defined as `lldb:SBDebugger&`.

```
lldb/source/API/SBDebugger.cpp:199:13: runtime error: call to function lldb::PluginInitialize(lldb::SBDebugger) through pointer to incorrect function type 'bool (*)(lldb::SBDebugger &)'
.../CustomPlugin.cpp:134: note: lldb::PluginInitialize(lldb::SBDebugger) defined here
```