### PR TITLE
[ORC] Switch to singleton pattern for UnwindInfoManager.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h
@@ -90,10 +90,6 @@ using SPSRunAsIntFunctionSignature = int32_t(shared::SPSExecutorAddr, int32_t);
 } // end namespace rt
 
 namespace rt_alt {
-extern const char *UnwindInfoManagerInstanceName;
-extern const char *UnwindInfoManagerFindSectionsHelperName;
-extern const char *UnwindInfoManagerEnableWrapperName;
-extern const char *UnwindInfoManagerDisableWrapperName;
 extern const char *UnwindInfoManagerRegisterActionName;
 extern const char *UnwindInfoManagerDeregisterActionName;
 } // end namespace rt_alt

--- a/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/UnwindInfoRegistrationPlugin.h
@@ -19,15 +19,17 @@ namespace llvm::orc {
 
 class UnwindInfoRegistrationPlugin : public LinkGraphLinkingLayer::Plugin {
 public:
-  static Expected<std::shared_ptr<UnwindInfoRegistrationPlugin>>
-  Create(IRLayer &IRL, JITDylib &PlatformJD, ExecutorAddr Instance,
-         ExecutorAddr FindHelper, ExecutorAddr Enable, ExecutorAddr Disable,
-         ExecutorAddr Register, ExecutorAddr Deregister);
+  UnwindInfoRegistrationPlugin(ExecutionSession &ES, ExecutorAddr Register,
+                               ExecutorAddr Deregister)
+      : ES(ES), Register(Register), Deregister(Deregister) {
+    DSOBaseName = ES.intern("__jitlink$libunwind_dso_base");
+  }
 
   static Expected<std::shared_ptr<UnwindInfoRegistrationPlugin>>
-  Create(IRLayer &IRL, JITDylib &PlatformJD);
+  Create(ExecutionSession &ES, ExecutorAddr Register, ExecutorAddr Deregister);
 
-  ~UnwindInfoRegistrationPlugin();
+  static Expected<std::shared_ptr<UnwindInfoRegistrationPlugin>>
+  Create(ExecutionSession &ES);
 
   void modifyPassConfig(MaterializationResponsibility &MR,
                         jitlink::LinkGraph &G,
@@ -49,20 +51,11 @@ public:
                                    ResourceKey SrcKey) override {}
 
 private:
-  UnwindInfoRegistrationPlugin(ExecutionSession &ES, ExecutorAddr Instance,
-                               ExecutorAddr Disable, ExecutorAddr Register,
-                               ExecutorAddr Deregister)
-      : ES(ES), Instance(Instance), Disable(Disable), Register(Register),
-        Deregister(Deregister) {
-    DSOBaseName = ES.intern("__jitlink$libunwind_dso_base");
-  }
-
-  static Expected<ThreadSafeModule> makeBouncerModule(ExecutionSession &ES);
   Error addUnwindInfoRegistrationActions(jitlink::LinkGraph &G);
 
   ExecutionSession &ES;
   SymbolStringPtr DSOBaseName;
-  ExecutorAddr Instance, Disable, Register, Deregister;
+  ExecutorAddr Register, Deregister;
 };
 
 } // namespace llvm::orc

--- a/llvm/lib/ExecutionEngine/Orc/ExecutorProcessControl.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/ExecutorProcessControl.cpp
@@ -54,9 +54,8 @@ SelfExecutorProcessControl::SelfExecutorProcessControl(
   // FIXME: Don't add an UnwindInfoManager by default -- it's redundant when
   //        the ORC runtime is loaded. We'll need a way to document this and
   //        allow clients to choose.
-  this->UnwindInfoMgr = UnwindInfoManager::TryCreate();
-  if (this->UnwindInfoMgr)
-    this->UnwindInfoMgr->addBootstrapSymbols(this->BootstrapSymbols);
+  if (UnwindInfoManager::TryEnable())
+    UnwindInfoManager::addBootstrapSymbols(this->BootstrapSymbols);
 #endif // __APPLE__
 }
 

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -1241,8 +1241,8 @@ Expected<JITDylibSP> setUpGenericLLVMIRPlatform(LLJIT &J) {
 
       // If UseEHFrames hasn't been set then we're good to use compact-unwind.
       if (!UseEHFrames) {
-        if (auto UIRP = UnwindInfoRegistrationPlugin::Create(
-                J.getIRCompileLayer(), PlatformJD)) {
+        if (auto UIRP =
+                UnwindInfoRegistrationPlugin::Create(J.getExecutionSession())) {
           OLL->addPlugin(std::move(*UIRP));
           LLVM_DEBUG(dbgs() << "Enabled compact-unwind support.\n");
         } else

--- a/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/OrcRTBridge.cpp
@@ -65,14 +65,6 @@ const char *RunAsIntFunctionWrapperName =
 
 } // end namespace rt
 namespace rt_alt {
-const char *UnwindInfoManagerInstanceName =
-    "orc_rt_alt_UnwindInfoManager_Instance";
-const char *UnwindInfoManagerFindSectionsHelperName =
-    "orc_rt_alt_UnwindInfoManager_findSectionsHelper";
-const char *UnwindInfoManagerEnableWrapperName =
-    "orc_rt_alt_UnwindInfoManager_enable";
-const char *UnwindInfoManagerDisableWrapperName =
-    "orc_rt_alt_UnwindInfoManager_disable";
 const char *UnwindInfoManagerRegisterActionName =
     "orc_rt_alt_UnwindInfoManager_register";
 const char *UnwindInfoManagerDeregisterActionName =

--- a/llvm/tools/llvm-jitlink/llvm-jitlink-executor/llvm-jitlink-executor.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-executor/llvm-jitlink-executor.cpp
@@ -18,6 +18,7 @@
 #include "llvm/ExecutionEngine/Orc/TargetProcess/RegisterEHFrames.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleExecutorMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/TargetProcess/SimpleRemoteEPCServer.h"
+#include "llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -190,6 +191,10 @@ int main(int argc, char *argv[]) {
                 SimpleRemoteEPCServer::defaultBootstrapSymbols();
             addDefaultBootstrapValuesForHostProcess(S.bootstrapMap(),
                                                     S.bootstrapSymbols());
+#ifdef __APPLE__
+            if (UnwindInfoManager::TryEnable())
+              UnwindInfoManager::addBootstrapSymbols(S.bootstrapSymbols());
+#endif // __APPLE__
             S.services().push_back(
                 std::make_unique<rt_bootstrap::SimpleExecutorMemoryManager>());
             S.services().push_back(


### PR DESCRIPTION
The find-dynamic-unwind-info callback registration APIs in libunwind limit the number of callbacks that can be registered. If we use multiple UnwindInfoManager instances, each with their own own callback function (as was the case prior to this patch) we can quickly exceed this limit (see https://github.com/llvm/llvm-project/issues/126611).

This patch updates the UnwindInfoManager class to use a singleton pattern, with the single instance shared between all LLVM JITs in the process.

This change does _not_ apply to compact unwind info registered through the ORC runtime (which currently installs its own callbacks).

As a bonus this change eliminates the need to load an IR "bouncer" module to supply the unique callback for each instance, so support for compact-unwind can be extended to the llvm-jitlink tools (which does not support adding IR).