### PR TITLE
[mlir] Update docs for Greedy Pattern Rewrite Driver(NFC)

### DIFF
--- a/mlir/docs/PatternRewriter.md
+++ b/mlir/docs/PatternRewriter.md
@@ -361,7 +361,7 @@ This driver comes in two fashions:
 *   `applyPatternsGreedily` ("region-based driver") applies patterns to
     all ops in a given region or a given container op (but not the container op
     itself). I.e., the worklist is initialized with all containing ops.
-*   `applyOpPatternsAndFold` ("op-based driver") applies patterns to the
+*   `applyOpPatternsGreedily` ("op-based driver") applies patterns to the
     provided list of operations. I.e., the worklist is initialized with the
     specified list of ops.
 

--- a/mlir/lib/Reducer/ReductionTreePass.cpp
+++ b/mlir/lib/Reducer/ReductionTreePass.cpp
@@ -56,13 +56,14 @@ static void applyPatterns(Region &region,
       opsInRange.push_back(&op.value());
   }
 
-  // `applyOpPatternsAndFold` may erase the ops so we can't do the pattern
-  // matching in above iteration. Besides, erase op not-in-range may end up in
-  // invalid module, so `applyOpPatternsAndFold` should come before that
-  // transform.
+  // `applyOpPatternsGreedily` with folding may erase the ops so we can't do the
+  // pattern matching in above iteration. Besides, erase op not-in-range may end
+  // up in invalid module, so `applyOpPatternsGreedily` with folding should come
+  // before that transform.
   for (Operation *op : opsInRange) {
-    // `applyOpPatternsAndFold` returns whether the op is convered. Omit it
-    // because we don't have expectation this reduction will be success or not.
+    // `applyOpPatternsGreedily` with folding returns whether the op is
+    // convered. Omit it because we don't have expectation this reduction will
+    // be success or not.
     GreedyRewriteConfig config;
     config.strictMode = GreedyRewriteStrictness::ExistingOps;
     (void)applyOpPatternsGreedily(op, patterns, config);


### PR DESCRIPTION
The `applyOpPatternsAndFold` is deprecated, use `applyOpPatternsGreedily` instead.