### PR TITLE
[NFC][MLIR] Make file-local cl::opt global variables static

### DIFF
--- a/mlir/tools/mlir-rewrite/mlir-rewrite.cpp
+++ b/mlir/tools/mlir-rewrite/mlir-rewrite.cpp
@@ -348,11 +348,11 @@ static mlir::RewriterRegistration
     rewriteMarkRanges("mark-ranges", "Indicate ranges parsed", markRanges);
 
 int main(int argc, char **argv) {
-  static llvm::cl::opt<std::string> inputFilename(
-      llvm::cl::Positional, llvm::cl::desc("<input file>"),
-      llvm::cl::init("-"));
+  llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional,
+                                           llvm::cl::desc("<input file>"),
+                                           llvm::cl::init("-"));
 
-  static llvm::cl::opt<std::string> outputFilename(
+  llvm::cl::opt<std::string> outputFilename(
       "o", llvm::cl::desc("Output filename"), llvm::cl::value_desc("filename"),
       llvm::cl::init("-"));
 

--- a/mlir/tools/mlir-runner/mlir-runner.cpp
+++ b/mlir/tools/mlir-runner/mlir-runner.cpp
@@ -32,7 +32,7 @@ using namespace mlir;
 // TODO: Consider removing this linking functionality from the SPIR-V CPU Runner
 //       flow in favour of a more proper host/device split like other runners.
 //       https://github.com/llvm/llvm-project/issues/115348
-llvm::cl::opt<bool> LinkNestedModules(
+static llvm::cl::opt<bool> LinkNestedModules(
     "link-nested-modules",
     llvm::cl::desc("Link two nested MLIR modules into a single LLVM IR module. "
                    "Useful if both the host and device code can be run on the "

--- a/mlir/tools/mlir-tblgen/DialectGen.cpp
+++ b/mlir/tools/mlir-tblgen/DialectGen.cpp
@@ -34,7 +34,7 @@ using llvm::Record;
 using llvm::RecordKeeper;
 
 static llvm::cl::OptionCategory dialectGenCat("Options for -gen-dialect-*");
-llvm::cl::opt<std::string>
+static llvm::cl::opt<std::string>
     selectedDialect("dialect", llvm::cl::desc("The dialect to gen for"),
                     llvm::cl::cat(dialectGenCat), llvm::cl::CommaSeparated);
 

--- a/mlir/tools/mlir-tblgen/OpDocGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDocGen.cpp
@@ -44,11 +44,11 @@ using mlir::tblgen::Operator;
 //===----------------------------------------------------------------------===//
 static cl::OptionCategory
     docCat("Options for -gen-(attrdef|typedef|enum|op|dialect)-doc");
-cl::opt<std::string>
+static cl::opt<std::string>
     stripPrefix("strip-prefix",
                 cl::desc("Strip prefix of the fully qualified names"),
                 cl::init("::mlir::"), cl::cat(docCat));
-cl::opt<bool> allowHugoSpecificFeatures(
+static cl::opt<bool> allowHugoSpecificFeatures(
     "allow-hugo-specific-features",
     cl::desc("Allows using features specific to Hugo"), cl::init(false),
     cl::cat(docCat));

--- a/mlir/tools/tblgen-to-irdl/OpDefinitionsGen.cpp
+++ b/mlir/tools/tblgen-to-irdl/OpDefinitionsGen.cpp
@@ -36,7 +36,7 @@ using namespace mlir;
 using tblgen::NamedTypeConstraint;
 
 static llvm::cl::OptionCategory dialectGenCat("Options for -gen-irdl-dialect");
-llvm::cl::opt<std::string>
+static llvm::cl::opt<std::string>
     selectedDialect("dialect", llvm::cl::desc("The dialect to gen for"),
                     llvm::cl::cat(dialectGenCat), llvm::cl::Required);
 


### PR DESCRIPTION
Fix #125983.
We split it on some PR as suggested by @jurahul here #126243
This one is for MLIR. I also made it for clang, clang-tools-extra, lldb, and Polly projects, which will be in other PRs, but check this one first so that any comments may be valid for other projects too.  