### PR TITLE
[lldb] Use preprocessor guard for `LLVM_BUILD_TELEMETRY`

### DIFF
--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 if (LLVM_BUILD_TELEMETRY)
    set(TELEMETRY_DEPS Telemetry)
-   add_definitions(-DLLVM_BUILD_TELEMETRY)
+   add_definitions(-DLLDB_BUILD_TELEMETRY)
 endif()
 
 # TODO: Add property `NO_PLUGIN_DEPENDENCIES` to lldbCore

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -17,8 +17,8 @@ if (LLDB_ENABLE_CURSES)
 endif()
 
 if (LLVM_BUILD_TELEMETRY)
-   set(TELEMETRY_SOURCES Telemetry.cpp)
    set(TELEMETRY_DEPS Telemetry)
+   add_definitions(-DLLVM_BUILD_TELEMETRY)
 endif()
 
 # TODO: Add property `NO_PLUGIN_DEPENDENCIES` to lldbCore
@@ -57,11 +57,10 @@ add_lldb_library(lldbCore
   SourceLocationSpec.cpp
   SourceManager.cpp
   StreamAsynchronousIO.cpp
+  Telemetry.cpp
   ThreadedCommunication.cpp
   UserSettingsController.cpp
   Value.cpp
-  ${TELEMETRY_SOURCES}
-  PARTIAL_SOURCES_INTENDED
   DEPENDS
     clang-tablegen-targets
 

--- a/lldb/source/Core/Telemetry.cpp
+++ b/lldb/source/Core/Telemetry.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifdef LLVM_BUILD_TELEMETRY
+#ifdef LLDB_BUILD_TELEMETRY
 
 #include "lldb/Core/Telemetry.h"
 #include "lldb/Core/Debugger.h"
@@ -71,4 +71,4 @@ llvm::Error TelemetryManager::preDispatch(TelemetryInfo *entry) {
 } // namespace telemetry
 } // namespace lldb_private
 
-#endif // LLVM_BUILD_TELEMETRY
+#endif // LLDB_BUILD_TELEMETRY

--- a/lldb/source/Core/Telemetry.cpp
+++ b/lldb/source/Core/Telemetry.cpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+#ifdef LLVM_BUILD_TELEMETRY
+
 #include "lldb/Core/Telemetry.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -67,3 +70,5 @@ llvm::Error TelemetryManager::preDispatch(TelemetryInfo *entry) {
 
 } // namespace telemetry
 } // namespace lldb_private
+
+#endif // LLVM_BUILD_TELEMETRY


### PR DESCRIPTION
Use a preprocessor `#ifdef LLVM_BUILD_TELEMETRY` guard rather than `PARTIAL_SOURCES_INTENDED` for the `Telemetry.cpp` file, to fix building with telemetry disabled.  `PARTIAL_SOURCES_INTENDED` does not currently work in `lldb_add_library()`, and while it could be fixed, it seems to be used contrary to its purpose — in other parts of LLVM project, the option is used to indicate that the sources found in the directory are split between different targets (e.g. a library and a tool), not to include sources conditionally.