### PR TITLE
[clang][bytecode] Fix diagnosing replaceable global allocator functions

### DIFF
--- a/clang/test/AST/ByteCode/cxx26.cpp
+++ b/clang/test/AST/ByteCode/cxx26.cpp
@@ -1,10 +1,33 @@
 // RUN: %clang_cc1 -std=c++26 -fsyntax-only -fcxx-exceptions -verify=ref,both %s
 // RUN: %clang_cc1 -std=c++26 -fsyntax-only -fcxx-exceptions -verify=expected,both %s -fexperimental-new-constant-interpreter
 
-// both-no-diagnostics
+namespace std {
+  using size_t = decltype(sizeof(0));
+}
 
 namespace VoidCast {
   constexpr void* p = nullptr;
   constexpr int* q = static_cast<int*>(p);
   static_assert(q == nullptr);
+}
+
+namespace ReplaceableAlloc {
+  struct F {
+    static void* operator new(std::size_t n) {
+      return nullptr; // both-warning {{should not return a null pointer}}
+    }
+  };
+
+  constexpr F *createF() {
+    return new F(); // both-note {{call to class-specific 'operator new'}}
+  }
+
+  constexpr bool foo() {
+    F *f = createF(); // both-note {{in call to}}
+
+    delete f;
+    return true;
+  }
+  static_assert(foo()); // both-error {{not an integral constant expression}} \
+                        // both-note {{in call to}}
 }


### PR DESCRIPTION
Don't return true here in InvalidNewDeleteExpr just because we are in C++26 mode. This invalid there as well.

Testcase reduced from libcxx/test/std/utilities/smartptr/unique.ptr/unique.ptr.create/make_unique_for_overwrite.pass.cpp