### PR TITLE
[GitHub] Skip undefcheck if no relevant files changed

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -353,6 +353,8 @@ You can test this locally with the following command:
 
     def format_run(self, changed_files: List[str], args: FormatArgs) -> Optional[str]:
         files = self.filter_changed_files(changed_files)
+        if not files:
+            return None
 
         # Use git to find files that have had a change in the number of undefs
         regex = "([^a-zA-Z0-9#_-]undef[^a-zA-Z0-9_-]|UndefValue::get)"
@@ -379,10 +381,6 @@ You can test this locally with the following command:
         # Each file is prefixed like:
         # diff --git a/file b/file
         for file in re.split("^diff --git ", stdout, 0, re.MULTILINE):
-            # We skip checking in MIR files as undef is a valid token and not
-            # going away.
-            if file.endswith(".mir"):
-                continue
             # search for additions of undef
             if re.search(r"^[+](?!\s*#\s*).*(\bundef\b|UndefValue::get)", file, re.MULTILINE):
                 files.append(re.match("a/([^ ]+)", file.splitlines()[0])[1])


### PR DESCRIPTION
If the list of filtered files was empty the check would process every file in the diff.