### PR TITLE
[clang-linker-wrapper][lit] Fix SPIR-V ELF test when spirv-tools feature is available

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -103,6 +103,15 @@ if(CLANG_BUILD_EXAMPLES AND CLANG_PLUGIN_SUPPORT)
     )
 endif ()
 
+if(LLVM_INCLUDE_SPIRV_TOOLS_TESTS)
+  list(APPEND CLANG_TEST_DEPS
+    spirv-dis
+    spirv-val
+    spirv-as
+    spirv-link
+    )
+endif()    
+
 set(CLANG_TEST_PARAMS
   USE_Z3_SOLVER=0
   )

--- a/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
+++ b/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
@@ -1,6 +1,7 @@
 // Verify the ELF packaging of OpenMP SPIR-V device images.
 // REQUIRES: system-linux
 // REQUIRES: spirv-tools
+// REQUIRES: llvm-spirv
 // RUN: mkdir -p %t_tmp
 // RUN: cd %t_tmp
 // RUN: %clangxx -fopenmp -fopenmp-targets=spirv64-intel -nogpulib -c -o %t_clang-linker-wrapper-spirv-elf.o %s

--- a/clang/test/Tooling/lit.local.cfg
+++ b/clang/test/Tooling/lit.local.cfg
@@ -1,3 +1,5 @@
+import shutil
+
 if not config.root.clang_staticanalyzer:
     config.unsupported = True
 
@@ -6,3 +8,7 @@ if config.spirv_tools_tests:
     config.substitutions.append(("spirv-dis", os.path.join(config.llvm_tools_dir, "spirv-dis")))
     config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
     config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
+    config.substitutions.append(("spirv-link", os.path.join(config.llvm_tools_dir, "spirv-link")))
+
+if shutil.which("llvm-spirv"):
+    config.available_features.add("llvm-spirv")

--- a/clang/test/Tooling/lit.local.cfg
+++ b/clang/test/Tooling/lit.local.cfg
@@ -1,4 +1,4 @@
-import shutil
+import lit.util
 
 if not config.root.clang_staticanalyzer:
     config.unsupported = True
@@ -10,5 +10,5 @@ if config.spirv_tools_tests:
     config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
     config.substitutions.append(("spirv-link", os.path.join(config.llvm_tools_dir, "spirv-link")))
 
-if shutil.which("llvm-spirv"):
+if lit.util.which("llvm-spirv"):
     config.available_features.add("llvm-spirv")


### PR DESCRIPTION
My last change made the test not run when the `spirv-tools` feature is not available, which is always the case in CI for clang tests, but it fails if `spirv-tools` is available for the following reasons:
1) We didn't build `spirv-link` as part of the internal `SPIRV-Tools` build, which is required by the `clang` call in `clang-linker-wrapper`, I already fixed that [here](https://github.com/llvm/llvm-project/pull/126319).
2) We didn't depend on the `SPIRV-Tools` CMake targets in clang tests, so depending on what CMake targets were built before running `check-clang`, `SPIRV-Tools` might not have been built.
3) We didn't check for `llvm-spirv` being available, which is not part of `SPIRV-Tools` but is currently required for SPIR-V compilation.

Manually confirmed this works. This test is the bane of my existence.