### PR TITLE
[HLSL] Change clang Driver Options to not set CXXOperatorNames

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3397,7 +3397,7 @@ def fno_objc_weak : Flag<["-"], "fno-objc-weak">, Group<f_Group>,
 def fno_omit_frame_pointer : Flag<["-"], "fno-omit-frame-pointer">, Group<f_Group>,
   Visibility<[ClangOption, FlangOption]>;
 defm operator_names : BoolFOption<"operator-names",
-  LangOpts<"CXXOperatorNames">, Default<cplusplus.KeyPath>,
+  LangOpts<"CXXOperatorNames">, Default<!strconcat(cplusplus.KeyPath, " && !",hlsl.KeyPath)>,
   NegFlag<SetFalse, [], [ClangOption, CC1Option],
           "Do not treat C++ operator name keywords as synonyms for operators">,
   PosFlag<SetTrue>>;

--- a/clang/test/CodeGenHLSL/use-cxx-alt-operator-names.hlsl
+++ b/clang/test/CodeGenHLSL/use-cxx-alt-operator-names.hlsl
@@ -1,0 +1,41 @@
+
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s  \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
+// RUN: spirv-unknown-vulkan-compute %s \
+// RUN: -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+// CHECK-LABEL: and
+void and() {}
+
+// CHECK-LABEL: and_eq
+void and_eq() {}
+
+// CHECK-LABEL: bitand
+void bitand() {}
+
+// CHECK-LABEL: bitor
+void bitor() {}
+
+// CHECK-LABEL: compl
+void compl() {}
+
+// CHECK-LABEL: not
+void not() {}
+
+// CHECK-LABEL: not_eq
+void not_eq() {}
+
+// CHECK-LABEL: or
+void or() {}
+
+// CHECK-LABEL: or_eq
+void or_eq() {}
+
+// CHECK-LABEL: xor
+void xor() {}
+
+// CHECK-LABEL: xor_eq
+void xor_eq() {}

--- a/clang/test/SemaHLSL/use-cxx-alt-operator-names.hlsl
+++ b/clang/test/SemaHLSL/use-cxx-alt-operator-names.hlsl
@@ -1,34 +1,34 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -ast-dump | FileCheck %s
 
-// CHECK-LABEL: and
+// CHECK: -FunctionDecl {{.*}} and 'void ()'
 void and() {}
 
-// CHECK-LABEL: and_eq
+// CHECK: -FunctionDecl {{.*}} and_eq 'void ()'
 void and_eq() {}
 
-// CHECK-LABEL: bitand
+// CHECK: -FunctionDecl {{.*}} bitand 'void ()'
 void bitand() {}
 
-// CHECK-LABEL: bitor
+// CHECK: -FunctionDecl {{.*}} bitor 'void ()'
 void bitor() {}
 
-// CHECK-LABEL: compl
+// CHECK: -FunctionDecl {{.*}} compl 'void ()'
 void compl() {}
 
-// CHECK-LABEL: not
+// CHECK: -FunctionDecl {{.*}} not 'void ()'
 void not() {}
 
-// CHECK-LABEL: not_eq
+// CHECK: -FunctionDecl {{.*}} not_eq 'void ()'
 void not_eq() {}
 
-// CHECK-LABEL: or
+// CHECK: -FunctionDecl {{.*}} or 'void ()'
 void or() {}
 
-// CHECK-LABEL: or_eq
+// CHECK: -FunctionDecl {{.*}} or_eq 'void ()'
 void or_eq() {}
 
-// CHECK-LABEL: xor
+// CHECK: -FunctionDecl {{.*}} xor 'void ()'
 void xor() {}
 
-// CHECK-LABEL: xor_eq
+// CHECK: -FunctionDecl {{.*}} xor_eq 'void ()'
 void xor_eq() {}

--- a/clang/test/SemaHLSL/use-cxx-alt-operator-names.hlsl
+++ b/clang/test/SemaHLSL/use-cxx-alt-operator-names.hlsl
@@ -1,11 +1,4 @@
-
-// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s  \
-// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s
-
-// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple \
-// RUN: spirv-unknown-vulkan-compute %s \
-// RUN: -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -ast-dump | FileCheck %s
 
 // CHECK-LABEL: and
 void and() {}


### PR DESCRIPTION
- Disable `CXXOperatorNames` for HLSL
- Add tests to confirm we can use the alt names as functions