### PR TITLE
[NFC][Driver] Use InstalledDir instead of Build config as anchor in test

### DIFF
--- a/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
+++ b/clang/test/Driver/dep-file-flag-with-multiple-offload-archs.hip
@@ -1,6 +1,6 @@
 // RUN: %clang -### -nogpuinc -nogpulib --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 -MD -MF tmp.d %s 2>&1 | FileCheck %s
 
-// CHECK: Build config:
+// CHECK: InstalledDir:
 // CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1030"{{.*}}"-dependency-file" "tmp.d"
 // CHECK: {{.*}}lld{{.*}}"-plugin-opt=mcpu=gfx1030"
 // CHECK-NOT: {{.*}}clang{{.*}}"-target-cpu" "gfx1100"{{.*}}"-dependency-file" "tmp.d"


### PR DESCRIPTION
Build config is optional in build config, use InstalledDir instead to
avoid unexpected failures in different build config.
