### PR TITLE
[flang][rt] Add decimal files to device runtime

### DIFF
--- a/flang/runtime/CMakeLists.txt
+++ b/flang/runtime/CMakeLists.txt
@@ -189,6 +189,8 @@ include(AddFlangOffloadRuntime)
 
 # List of files that are buildable for all devices.
 set(supported_files
+  ${FLANG_SOURCE_DIR}/lib/Decimal/binary-to-decimal.cpp
+  ${FLANG_SOURCE_DIR}/lib/Decimal/decimal-to-binary.cpp
   ISO_Fortran_binding.cpp
   allocatable.cpp
   allocator-registry.cpp


### PR DESCRIPTION
The library FortranDecimal is not used anymore with the runtime but its files are now integrated. Add the files for the device build as well. 