### PR TITLE
[StaleProfileMatching] Use only profile anchor size for similarity calculation

### DIFF
--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -23,7 +23,7 @@ using namespace sampleprof;
 #define DEBUG_TYPE "sample-profile-matcher"
 
 static cl::opt<unsigned> FuncProfileSimilarityThreshold(
-    "func-profile-similarity-threshold", cl::Hidden, cl::init(80),
+    "func-profile-similarity-threshold", cl::Hidden, cl::init(70),
     cl::desc("Consider a profile matches a function if the similarity of their "
              "callee sequences is above the specified percentile."));
 
@@ -790,9 +790,8 @@ bool SampleProfileMatcher::functionMatchesProfileHelper(
       longestCommonSequence(FilteredIRAnchorsList, FilteredProfileAnchorList,
                             false /* Match unused functions */);
 
-  Similarity =
-      static_cast<float>(MatchedAnchors.size()) * 2 /
-      (FilteredIRAnchorsList.size() + FilteredProfileAnchorList.size());
+  Similarity = static_cast<float>(MatchedAnchors.size()) /
+               FilteredProfileAnchorList.size();
 
   LLVM_DEBUG(dbgs() << "The similarity between " << IRFunc.getName()
                     << "(IR) and " << ProfFunc << "(profile) is "

--- a/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfileMatcher.cpp
@@ -23,7 +23,7 @@ using namespace sampleprof;
 #define DEBUG_TYPE "sample-profile-matcher"
 
 static cl::opt<unsigned> FuncProfileSimilarityThreshold(
-    "func-profile-similarity-threshold", cl::Hidden, cl::init(70),
+    "func-profile-similarity-threshold", cl::Hidden, cl::init(80),
     cl::desc("Consider a profile matches a function if the similarity of their "
              "callee sequences is above the specified percentile."));
 

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -8,7 +8,7 @@
 ; CHECK: Function new_foo is not in profile or profile symbol list.
 
 ; CHECK: Run stale profile matching for main
-; CHECK: The similarity between new_foo(IR) and foo(profile) is 0.86
+; CHECK: The similarity between new_foo(IR) and foo(profile) is 0.75
 ; CHECK: Function:new_foo matches profile:foo
 ; CHECK: Run stale profile matching for cold_func
 ; CHECK: The checksums for new_block_only(IR) and block_only(Profile) match.

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-stale-profile-renaming.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: x86_64-linux
 ; REQUIRES: asserts
-; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -report-profile-staleness -persist-profile-staleness -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl -pass-remarks=inline --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 2>&1 | FileCheck %s
+; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -report-profile-staleness -persist-profile-staleness -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl -pass-remarks=inline --min-call-count-for-cg-matching=0 --min-func-count-for-cg-matching=0 --func-profile-similarity-threshold=70 2>&1 | FileCheck %s
 ; RUN: opt < %s -passes=sample-profile -sample-profile-file=%S/Inputs/pseudo-probe-stale-profile-renaming.prof --salvage-stale-profile --salvage-unused-profile -S --debug-only=sample-profile,sample-profile-matcher,sample-profile-impl --min-call-count-for-cg-matching=10 --min-func-count-for-cg-matching=10 2>&1 | FileCheck %s  --check-prefix=TINY-FUNC
 
 ; Verify find new IR functions.


### PR DESCRIPTION
We observed that the number of IR anchors is usually greater than the number of profile anchors, because IR anchors can be optimized away later and llvm-profgen might not generate profiles for cold callsites. This can cause missing function matches. I’m changing the similarity calculation to use only the profile anchor size. In another point of view, It also makes sense to reuse as many profile anchors as possible regardless of the new functions in the IR.

