### PR TITLE
[lldb-dap] add `debugAdapterExecutable` property to launch configuration

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -86,7 +86,7 @@
           "default": {},
           "description": "The environment of the lldb-dap process.",
           "additionalProperties": {
-             "type": "string"
+            "type": "string"
           }
         }
       }
@@ -152,6 +152,10 @@
               "program"
             ],
             "properties": {
+              "debugAdapterExecutable": {
+                "type": "string",
+                "markdownDescription": "The LLDB debug adapter executable to use. Either an absolute path or the name of a debug adapter executable available on the `PATH`."
+              },
               "program": {
                 "type": "string",
                 "description": "Path to the program to debug."
@@ -338,6 +342,10 @@
           },
           "attach": {
             "properties": {
+              "debugAdapterExecutable": {
+                "type": "string",
+                "markdownDescription": "The LLDB debug adapter executable to use. Either an absolute path or the name of a debug adapter executable available on the `PATH`."
+              },
               "program": {
                 "type": "string",
                 "description": "Path to the program to attach to."

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -154,7 +154,7 @@
             "properties": {
               "debugAdapterExecutable": {
                 "type": "string",
-                "markdownDescription": "The LLDB debug adapter executable to use. Either an absolute path or the name of a debug adapter executable available on the `PATH`."
+                "markdownDescription": "The absolute path to the LLDB debug adapter executable to use."
               },
               "program": {
                 "type": "string",
@@ -344,7 +344,7 @@
             "properties": {
               "debugAdapterExecutable": {
                 "type": "string",
-                "markdownDescription": "The LLDB debug adapter executable to use. Either an absolute path or the name of a debug adapter executable available on the `PATH`."
+                "markdownDescription": "The absolute path to the LLDB debug adapter executable to use."
               },
               "program": {
                 "type": "string",

--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -67,12 +67,17 @@ async function findDAPExecutable(): Promise<string | undefined> {
 async function getDAPExecutable(
   session: vscode.DebugSession,
 ): Promise<string | undefined> {
+  // Check if the executable was provided in the launch configuration.
+  const launchConfigPath = session.configuration["debugAdapterExecutable"];
+  if (typeof launchConfigPath === "string" && launchConfigPath.length !== 0) {
+    return launchConfigPath;
+  }
+
+  // Check if the executable was provided in the extension's configuration.
   const config = vscode.workspace.getConfiguration(
     "lldb-dap",
     session.workspaceFolder,
   );
-
-  // Prefer the explicitly specified path in the extension's configuration.
   const configPath = config.get<string>("executable-path");
   if (configPath && configPath.length !== 0) {
     return configPath;


### PR DESCRIPTION
The Swift extension for VS Code requires that the `lldb-dap` executable come from the Swift toolchain which may or may not be configured in `PATH`. At the moment, this can be configured via LLDB DAP's extension settings, but experience has shown that modifying other extensions' settings on behalf of the user (especially those subject to change whenever a new toolchain is selected) causes issues. Instead, it would be easier to have this configurable in the launch configuration and let the Swift extension (or any other extension that wanted to, really) configure the path to `lldb-dap` that way. This allows the Swift extension to have its own launch configuration type that delegates to the LLDB DAP extension in order to provide a more seamless debugging experience for Swift executables.

This PR adds a new property to the launch configuration object called `debugAdapterExecutable` which allows overriding the `lldb-dap` executable path for a specific debug session.