### PR TITLE
[llvm] Remove `br i1 undef` in `llvm/test/CodeGen` tests

### DIFF
--- a/llvm/test/CodeGen/X86/coalescer-subreg.ll
+++ b/llvm/test/CodeGen/X86/coalescer-subreg.ll
@@ -3,9 +3,9 @@
 ; the sub_8bit_hi subregister with a class like GR16_ABCD that did.
 target triple = "x86_64-apple-macosx10.10.0"
 
-define void @test() #0 {
+define void @test(i1 %arg) #0 {
 entry:
-  br i1 undef, label %loop, label %for.end597
+  br i1 %arg, label %loop, label %for.end597
 
 loop:
   %0 = load i16, ptr null, align 4

--- a/llvm/test/CodeGen/X86/code_placement_eh.ll
+++ b/llvm/test/CodeGen/X86/code_placement_eh.ll
@@ -6,12 +6,12 @@
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:128:128-n8:16:32"
 target triple = "i386-apple-darwin10.0"
 
-define void @foo() personality ptr @__gxx_personality_v0 {
+define void @foo(i1 %arg) personality ptr @__gxx_personality_v0 {
 invcont5:
   br label %bb15
 
 .noexc3:                                          ; preds = %bb15
-  br i1 undef, label %bb18.i5.i, label %bb15
+  br i1 %arg, label %bb18.i5.i, label %bb15
 
 .noexc6.i.i:                                      ; preds = %bb18.i5.i
   %tmp2021 = invoke float @cosf(float 0.000000e+00) readonly

--- a/llvm/test/CodeGen/X86/codegen-prepare-cast.ll
+++ b/llvm/test/CodeGen/X86/codegen-prepare-cast.ll
@@ -12,10 +12,10 @@ target triple = "x86_64-unknown-linux-gnu"
 ; CHECK-LABEL: @_Dmain
 ; CHECK: load i8, ptr %tmp4
 ; CHECK: ret
-define fastcc i32 @_Dmain(%"char[][]" %unnamed) {
+define fastcc i32 @_Dmain(%"char[][]" %unnamed, i1 %arg) {
 entry:
         %tmp = getelementptr [7 x i8], ptr @.str, i32 0, i32 0              ; <ptr> [#uses=1]
-        br i1 undef, label %foreachbody, label %foreachend
+        br i1 %arg, label %foreachbody, label %foreachend
 
 foreachbody:            ; preds = %entry
         %tmp4 = getelementptr i8, ptr %tmp, i32 undef               ; <ptr> [#uses=1]

--- a/llvm/test/CodeGen/X86/discontiguous-loops.ll
+++ b/llvm/test/CodeGen/X86/discontiguous-loops.ll
@@ -3,7 +3,7 @@
 
 @.str96 = external constant [37 x i8], align 8    ; <ptr> [#uses=1]
 
-define void @foo() nounwind {
+define void @foo(i1 %arg) nounwind {
 bb:
   br label %ybb1
 
@@ -24,7 +24,7 @@ bb3:                                              ; preds = %ybb2
 
 xbb4:                                              ; preds = %xbb6
   store i32 0, ptr undef, align 8
-  br i1 undef, label %xbb6, label %bb5
+  br i1 %arg, label %xbb6, label %bb5
 
 bb5:                                              ; preds = %xbb4
   call fastcc void @decl_mode_check_failed() nounwind
@@ -44,7 +44,7 @@ bb10:                                             ; preds = %ybb8
   unreachable
 
 ybb12:                                             ; preds = %ybb8
-  br i1 undef, label %bb15, label %ybb13
+  br i1 %arg, label %bb15, label %ybb13
 
 ybb13:                                             ; preds = %ybb12
   %tmp14 = icmp sgt i32 undef, 0                  ; <i1> [#uses=1]

--- a/llvm/test/CodeGen/X86/early-ifcvt-crash.ll
+++ b/llvm/test/CodeGen/X86/early-ifcvt-crash.ll
@@ -10,15 +10,15 @@ target triple = "x86_64-apple-macosx10.8.0"
 ; MachineTraceMetrics::Ensemble::addLiveIns crashes because the first operand
 ; on an inline asm instruction is not a vreg def.
 ; <rdar://problem/12472811>
-define void @f1() nounwind {
+define void @f1(i1 %arg) nounwind {
 entry:
-  br i1 undef, label %if.then6.i, label %if.end.i
+  br i1 %arg, label %if.then6.i, label %if.end.i
 
 if.then6.i:
   br label %if.end.i
 
 if.end.i:
-  br i1 undef, label %if.end25.i, label %if.else17.i
+  br i1 %arg, label %if.end25.i, label %if.else17.i
 
 if.else17.i:
   %shl24.i = shl i32 undef, undef

--- a/llvm/test/CodeGen/X86/fast-isel-stackcheck.ll
+++ b/llvm/test/CodeGen/X86/fast-isel-stackcheck.ll
@@ -19,16 +19,16 @@ entry:
 ; CHECK-DAG: movq ___stack_chk_guard@GOTPCREL(%rip), %[[GUARD:r.x]]
 ; CHECK-DAG: movq {{[0-9]+}}(%rsp), %[[CANARY:r.x]]
 ; CHECK: subq %[[CANARY]], %[[GUARD]]
-define void @bar() #1 {
+define void @bar(i1 %arg) #1 {
 entry:
   %vt = alloca [2 x double], align 16
-  br i1 undef, label %cleanup.4091, label %for.cond.3850
+  br i1 %arg, label %cleanup.4091, label %for.cond.3850
 
 unreachable:
   unreachable
 
 for.cond.3850:
-  br i1 undef, label %land.rhs.3853, label %land.end.3857
+  br i1 %arg, label %land.rhs.3853, label %land.end.3857
 
 land.rhs.3853:
   br label %land.end.3857

--- a/llvm/test/CodeGen/X86/fp-stack-O0-crash.ll
+++ b/llvm/test/CodeGen/X86/fp-stack-O0-crash.ll
@@ -31,14 +31,14 @@ if.end:                                           ; preds = %if.then, %cond.fals
 
 ; PR10575
 ; This produces a FP0 = IMPLICIT_DEF instruction.
-define void @__m_rankmerge_MOD_dindexmerge_() nounwind {
+define void @__m_rankmerge_MOD_dindexmerge_(i1 %arg) nounwind {
 entry:
   br label %"20"
 
 "20":                                             ; preds = %"23", %entry
     %0 = phi double [ undef, %entry ], [ %0, %"23" ]
     %1 = phi double [ 0.000000e+00, %entry ], [ %2, %"23" ]
-    br i1 undef, label %"21", label %"23"
+    br i1 %arg, label %"21", label %"23"
 
 "21":                                             ; preds = %"20"
     ret void

--- a/llvm/test/CodeGen/X86/fp-stack.ll
+++ b/llvm/test/CodeGen/X86/fp-stack.ll
@@ -3,12 +3,12 @@
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:32:32-n8:16:32"
 target triple = "i386-pc-linux-gnu"
 
-define void @foo() nounwind {
+define void @foo(i1 %arg) nounwind {
 entry:
   %tmp6 = load x86_fp80, ptr undef                       ; <x86_fp80> [#uses=2]
   %tmp15 = load x86_fp80, ptr undef                      ; <x86_fp80> [#uses=2]
   %tmp24 = load x86_fp80, ptr undef                      ; <x86_fp80> [#uses=1]
-  br i1 undef, label %return, label %bb.nph
+  br i1 %arg, label %return, label %bb.nph
 
 bb.nph:                                           ; preds = %entry
   %cmp139 = fcmp ogt x86_fp80 %tmp15, %tmp6          ; <i1> [#uses=1]

--- a/llvm/test/CodeGen/X86/implicit-null-chk-reg-rewrite.mir
+++ b/llvm/test/CodeGen/X86/implicit-null-chk-reg-rewrite.mir
@@ -1,9 +1,9 @@
 # RUN: llc -mtriple=x86_64 -run-pass=implicit-null-checks %s -o - | FileCheck %s
 --- |
 
-  define i32 @reg-rewrite(ptr %x) {
+  define i32 @reg-rewrite(ptr %x, i1 %arg) {
   entry:
-    br i1 undef, label %is_null, label %not_null, !make.implicit !0
+    br i1 %arg, label %is_null, label %not_null, !make.implicit !0
 
   is_null:
     ret i32 42

--- a/llvm/test/CodeGen/X86/insert-positions.ll
+++ b/llvm/test/CodeGen/X86/insert-positions.ll
@@ -2,12 +2,12 @@
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 
-define void @test0() nounwind {
+define void @test0(i1 %arg) nounwind {
 if.end90.i.i:
   br label %while.body.i.i221.i
 
 while.body.i.i221.i:                              ; preds = %while.cond.backedge.i.i.i, %if.end90.i.i
-  br i1 undef, label %if.then.i.i224.i, label %while.cond.backedge.i.i.i
+  br i1 %arg, label %if.then.i.i224.i, label %while.cond.backedge.i.i.i
 
 while.cond.backedge.i.i.i:                        ; preds = %for.end.i.i.i, %while.body.i.i221.i
   br label %while.body.i.i221.i
@@ -29,10 +29,10 @@ for.cond.i.i226.i:                                ; preds = %for.body.i.i.i, %if
   %0 = phi i64 [ %tmp154.i.i.i, %for.body.i.i.i ], [ 0, %if.then.i.i224.i ] ; <i64> [#uses=2]
   %tmp154.i.i.i = add i64 %0, 1                   ; <i64> [#uses=2]
   %i.0.i.i.i = trunc i64 %0 to i32                ; <i32> [#uses=1]
-  br i1 undef, label %land.rhs.i.i.i, label %for.end.i.i.i
+  br i1 %arg, label %land.rhs.i.i.i, label %for.end.i.i.i
 
 land.rhs.i.i.i:                                   ; preds = %for.cond.i.i226.i
-  br i1 undef, label %for.body.i.i.i, label %for.end.i.i.i
+  br i1 %arg, label %for.body.i.i.i, label %for.end.i.i.i
 
 for.body.i.i.i:                                   ; preds = %land.rhs.i.i.i
   br label %for.cond.i.i226.i
@@ -45,7 +45,7 @@ for.end.i.i.i:                                    ; preds = %land.rhs.i.i.i, %fo
   br label %while.cond.backedge.i.i.i
 }
 
-define void @test1() nounwind {
+define void @test1(i1 %arg) nounwind {
 entry:
   %t = shl i32 undef, undef                     ; <i32> [#uses=1]
   %t9 = sub nsw i32 0, %t                     ; <i32> [#uses=1]
@@ -59,7 +59,7 @@ outer:                                             ; preds = %bb18, %bb
 inner:                                             ; preds = %bb16, %bb11
   %t17 = phi i32 [ %i13, %outer ], [ undef, %inner ] ; <i32> [#uses=1]
   store i32 %t17, ptr undef
-  br i1 undef, label %bb18, label %inner
+  br i1 %arg, label %bb18, label %inner
 
 bb18:                                             ; preds = %bb16
   %t19 = add i32 %i13, %t9                 ; <i32> [#uses=1]

--- a/llvm/test/CodeGen/X86/legalize-sub-zero-2.ll
+++ b/llvm/test/CodeGen/X86/legalize-sub-zero-2.ll
@@ -1,6 +1,6 @@
 ; RUN: llc < %s -mtriple=i386-apple-darwin
 
-define fastcc void @foo(i32 %type) nounwind optsize {
+define fastcc void @foo(i32 %type, i1 %arg) nounwind optsize {
 entry:
   switch i32 %type, label %bb26 [
     i32 33634, label %bb11
@@ -15,19 +15,19 @@ bb26:                                             ; preds = %entry
 
 bb27:                                             ; preds = %bb11, %entry
   %srcpb.0 = phi i32 [ 1, %bb11 ], [ 0, %entry ]
-  br i1 undef, label %bb348, label %bb30.lr.ph
+  br i1 %arg, label %bb348, label %bb30.lr.ph
 
 bb30.lr.ph:                                       ; preds = %bb27
   %.sum743 = shl i32 %srcpb.0, 1
   %0 = mul i32 %srcpb.0, -2
   %.sum745 = add i32 %.sum743, %0
-  br i1 undef, label %bb70, label %bb71
+  br i1 %arg, label %bb70, label %bb71
 
 bb70:                                             ; preds = %bb30.lr.ph
   unreachable
 
 bb71:                                             ; preds = %bb30.lr.ph
-  br i1 undef, label %bb92, label %bb80
+  br i1 %arg, label %bb92, label %bb80
 
 bb80:                                             ; preds = %bb71
   unreachable

--- a/llvm/test/CodeGen/X86/licm-symbol.ll
+++ b/llvm/test/CodeGen/X86/licm-symbol.ll
@@ -21,12 +21,12 @@ target triple = "i386-apple-darwin8"
 
 declare i32 @fprintf(ptr nocapture) nounwind
 
-define void @gcov_exit() nounwind {
+define void @gcov_exit(i1 %arg) nounwind {
 entry:
   br label %bb151
 
 bb151:                                            ; preds = %bb59, %bb56, %bb14
-  br i1 undef, label %bb56, label %bb59
+  br i1 %arg, label %bb56, label %bb59
 
 bb56:                                             ; preds = %bb151
   %t0 = call i32 (ptr) @fprintf(ptr getelementptr inbounds ([0 x %struct.FILE], ptr @__sF, i32 0, i32 2)) nounwind

--- a/llvm/test/CodeGen/X86/liveness-local-regalloc.ll
+++ b/llvm/test/CodeGen/X86/liveness-local-regalloc.ll
@@ -9,7 +9,7 @@
 
 declare fastcc i32 @func(ptr, i32, i32) nounwind ssp
 
-define fastcc void @func2(ptr %arg, i32 %arg1) nounwind ssp {
+define fastcc void @func2(ptr %arg, i32 %arg1, i1 %arg2) nounwind ssp {
 bb:
   br label %.exit3
 
@@ -20,7 +20,7 @@ bb:
   ]
 
 bb2:                                              ; preds = %bb5, %bb3, %.exit3
-  br i1 undef, label %bb3, label %bb5
+  br i1 %arg2, label %bb3, label %bb5
 
 bb3:                                              ; preds = %bb2
   switch i32 undef, label %infloop [
@@ -41,7 +41,7 @@ bb5:                                              ; preds = %bb2
 
 .loopexit:                                        ; preds = %bb5, %bb4, %bb3, %.exit3
   %.04 = phi i32 [ %tmp, %bb4 ], [ undef, %bb3 ], [ undef, %.exit3 ], [ undef, %bb5 ] ; <i32> [#uses=2]
-  br i1 undef, label %bb8, label %bb6
+  br i1 %arg2, label %bb8, label %bb6
 
 bb6:                                              ; preds = %.loopexit
   %tmp7 = tail call fastcc i32 @func(ptr %arg, i32 %.04, i32 undef) nounwind ssp ; <i32> [#uses=0]

--- a/llvm/test/CodeGen/X86/lsr-overflow.ll
+++ b/llvm/test/CodeGen/X86/lsr-overflow.ll
@@ -26,7 +26,7 @@ __ABContainsLabel.exit:
   ret i1 %cmp
 }
 
-define void @func_37() noreturn nounwind readonly {
+define void @func_37(i1 %arg) noreturn nounwind readonly {
 entry:
   br label %for.body
 
@@ -34,7 +34,7 @@ for.body:                                         ; preds = %for.inc8, %entry
   %indvar = phi i64 [ 0, %entry ], [ %indvar.next, %for.inc8 ]
   %sub.i = add i64 undef, %indvar
   %cmp.i = icmp eq i64 %sub.i, -9223372036854775808
-  br i1 undef, label %for.inc8, label %for.cond4
+  br i1 %arg, label %for.inc8, label %for.cond4
 
 for.cond4:                                        ; preds = %for.cond4, %for.body
   br label %for.cond4

--- a/llvm/test/CodeGen/XCore/2010-02-25-LSR-Crash.ll
+++ b/llvm/test/CodeGen/XCore/2010-02-25-LSR-Crash.ll
@@ -7,9 +7,9 @@ target triple = "xcore-xmos-elf"
 %struct.object = type { ptr, ptr, ptr, %union.anon, %0, ptr }
 %union.anon = type { ptr }
 
-define ptr @search_object(ptr %ob, ptr %pc) {
+define ptr @search_object(ptr %ob, ptr %pc, i1 %arg) {
 entry:
-  br i1 undef, label %bb3.i15.i.i, label %bb2
+  br i1 %arg, label %bb3.i15.i.i, label %bb2
 
 bb3.i15.i.i:                                      ; preds = %bb3.i15.i.i, %entry
   %indvar.i.i.i = phi i32 [ %indvar.next.i.i.i, %bb3.i15.i.i ], [ 0, %entry ] ; <i32> [#uses=2]


### PR DESCRIPTION
This PR replaces some instances of `br i1 undef` with function argument value in several tests under `llvm/test/CodeGen/` directory. This PR is a continuation of PR #125460

@nunoplopes 