### PR TITLE
[libc] fix get_epoch constexpr error

### DIFF
--- a/libc/src/time/time_utils.h
+++ b/libc/src/time/time_utils.h
@@ -328,9 +328,7 @@ public:
     return BASE_YEAR + IS_NEXT_YEAR;
   }
 
-  LIBC_INLINE constexpr time_t get_epoch() const {
-    return mktime_internal(timeptr);
-  }
+  LIBC_INLINE time_t get_epoch() const { return mktime_internal(timeptr); }
 
   // returns the timezone offset in microwave time:
   // return (hours * 100) + minutes;


### PR DESCRIPTION
get_epoch calls mktime_internal which isn't constexpr. For now, just
remove the constexpr from get_epoch.
