### PR TITLE
[lldb] Remove Debugger::Get{Output,Error}Stream (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -143,10 +143,6 @@ public:
 
   File &GetErrorFile() { return m_error_stream_sp->GetFile(); }
 
-  StreamFile &GetOutputStream() { return *m_output_stream_sp; }
-
-  StreamFile &GetErrorStream() { return *m_error_stream_sp; }
-
   repro::DataRecorder *GetInputRecorder();
 
   Status SetInputString(const char *data);

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -508,39 +508,31 @@ SBFile SBDebugger::GetInputFile() {
 
 FILE *SBDebugger::GetOutputFileHandle() {
   LLDB_INSTRUMENT_VA(this);
-  if (m_opaque_sp) {
-    StreamFile &stream_file = m_opaque_sp->GetOutputStream();
-    return stream_file.GetFile().GetStream();
-  }
+  if (m_opaque_sp)
+    return m_opaque_sp->GetOutputStreamSP()->GetFile().GetStream();
   return nullptr;
 }
 
 SBFile SBDebugger::GetOutputFile() {
   LLDB_INSTRUMENT_VA(this);
-  if (m_opaque_sp) {
-    SBFile file(m_opaque_sp->GetOutputStream().GetFileSP());
-    return file;
-  }
+  if (m_opaque_sp)
+    return SBFile(m_opaque_sp->GetOutputStreamSP()->GetFileSP());
   return SBFile();
 }
 
 FILE *SBDebugger::GetErrorFileHandle() {
   LLDB_INSTRUMENT_VA(this);
 
-  if (m_opaque_sp) {
-    StreamFile &stream_file = m_opaque_sp->GetErrorStream();
-    return stream_file.GetFile().GetStream();
-  }
+  if (m_opaque_sp)
+    return m_opaque_sp->GetErrorStreamSP()->GetFile().GetStream();
   return nullptr;
 }
 
 SBFile SBDebugger::GetErrorFile() {
   LLDB_INSTRUMENT_VA(this);
   SBFile file;
-  if (m_opaque_sp) {
-    SBFile file(m_opaque_sp->GetErrorStream().GetFileSP());
-    return file;
-  }
+  if (m_opaque_sp)
+    return SBFile(m_opaque_sp->GetErrorStreamSP()->GetFileSP());
   return SBFile();
 }
 
@@ -581,8 +573,8 @@ void SBDebugger::HandleCommand(const char *command) {
 
     sb_interpreter.HandleCommand(command, result, false);
 
-    result.PutError(m_opaque_sp->GetErrorStream().GetFileSP());
-    result.PutOutput(m_opaque_sp->GetOutputStream().GetFileSP());
+    result.PutError(m_opaque_sp->GetErrorStreamSP()->GetFileSP());
+    result.PutOutput(m_opaque_sp->GetOutputStreamSP()->GetFileSP());
 
     if (!m_opaque_sp->GetAsyncExecution()) {
       SBProcess process(GetCommandInterpreter().GetProcess());

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -257,12 +257,11 @@ Status Debugger::SetPropertyValue(const ExecutionContext *exe_ctx,
         std::list<Status> errors;
         StreamString feedback_stream;
         if (!target_sp->LoadScriptingResources(errors, feedback_stream)) {
-          Stream &s = GetErrorStream();
-          for (auto &error : errors) {
-            s.Printf("%s\n", error.AsCString());
-          }
+          lldb::StreamSP s = GetAsyncErrorStream();
+          for (auto &error : errors)
+            s->Printf("%s\n", error.AsCString());
           if (feedback_stream.GetSize())
-            s.PutCString(feedback_stream.GetString());
+            s->PutCString(feedback_stream.GetString());
         }
       }
     }

--- a/lldb/source/Core/DynamicLoader.cpp
+++ b/lldb/source/Core/DynamicLoader.cpp
@@ -263,7 +263,7 @@ ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
         module_sp = std::make_shared<Module>(module_spec);
       } else if (force_symbol_search && error.AsCString("") &&
                  error.AsCString("")[0] != '\0') {
-        target.GetDebugger().GetErrorStream() << error.AsCString();
+        *target.GetDebugger().GetAsyncErrorStream() << error.AsCString();
       }
     }
 
@@ -328,19 +328,19 @@ ModuleSP DynamicLoader::LoadBinaryWithUUIDAndAddress(
     }
   } else {
     if (force_symbol_search) {
-      Stream &s = target.GetDebugger().GetErrorStream();
-      s.Printf("Unable to find file");
+      lldb::StreamSP s = target.GetDebugger().GetAsyncErrorStream();
+      s->Printf("Unable to find file");
       if (!name.empty())
-        s.Printf(" %s", name.str().c_str());
+        s->Printf(" %s", name.str().c_str());
       if (uuid.IsValid())
-        s.Printf(" with UUID %s", uuid.GetAsString().c_str());
+        s->Printf(" with UUID %s", uuid.GetAsString().c_str());
       if (value != LLDB_INVALID_ADDRESS) {
         if (value_is_offset)
-          s.Printf(" with slide 0x%" PRIx64, value);
+          s->Printf(" with slide 0x%" PRIx64, value);
         else
-          s.Printf(" at address 0x%" PRIx64, value);
+          s->Printf(" at address 0x%" PRIx64, value);
       }
-      s.Printf("\n");
+      s->Printf("\n");
     }
     LLDB_LOGF(log,
               "Unable to find binary %s with UUID %s and load it at "

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -245,8 +245,8 @@ ScriptInterpreterIORedirect::ScriptInterpreterIORedirect(
       if (outfile_handle)
         ::setbuf(outfile_handle, nullptr);
 
-      result->SetImmediateOutputFile(debugger.GetOutputStream().GetFileSP());
-      result->SetImmediateErrorFile(debugger.GetErrorStream().GetFileSP());
+      result->SetImmediateOutputFile(debugger.GetOutputStreamSP()->GetFileSP());
+      result->SetImmediateErrorFile(debugger.GetErrorStreamSP()->GetFileSP());
     }
   }
 

--- a/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/FreeBSD-Kernel/DynamicLoaderFreeBSDKernel.cpp
@@ -327,9 +327,9 @@ bool DynamicLoaderFreeBSDKernel::KModImageInfo::LoadImageUsingMemoryModule(
   Target &target = process->GetTarget();
 
   if (IsKernel() && m_uuid.IsValid()) {
-    Stream &s = target.GetDebugger().GetOutputStream();
-    s.Printf("Kernel UUID: %s\n", m_uuid.GetAsString().c_str());
-    s.Printf("Load Address: 0x%" PRIx64 "\n", m_load_address);
+    lldb::StreamSP s = target.GetDebugger().GetAsyncOutputStream();
+    s->Printf("Kernel UUID: %s\n", m_uuid.GetAsString().c_str());
+    s->Printf("Load Address: 0x%" PRIx64 "\n", m_load_address);
   }
 
   // Test if the module is loaded into the taget,
@@ -355,9 +355,9 @@ bool DynamicLoaderFreeBSDKernel::KModImageInfo::LoadImageUsingMemoryModule(
       if (!m_module_sp)
         m_module_sp = target.GetOrCreateModule(module_spec, true);
       if (IsKernel() && !m_module_sp) {
-        Stream &s = target.GetDebugger().GetOutputStream();
-        s.Printf("WARNING: Unable to locate kernel binary on the debugger "
-                 "system.\n");
+        lldb::StreamSP s = target.GetDebugger().GetAsyncOutputStream();
+        s->Printf("WARNING: Unable to locate kernel binary on the debugger "
+                  "system.\n");
       }
     }
 
@@ -464,20 +464,19 @@ bool DynamicLoaderFreeBSDKernel::KModImageInfo::LoadImageUsingMemoryModule(
   }
 
   if (IsLoaded() && m_module_sp && IsKernel()) {
-    Stream &s = target.GetDebugger().GetOutputStream();
+    lldb::StreamSP s = target.GetDebugger().GetAsyncOutputStream();
     ObjectFile *kernel_object_file = m_module_sp->GetObjectFile();
     if (kernel_object_file) {
       addr_t file_address =
           kernel_object_file->GetBaseAddress().GetFileAddress();
       if (m_load_address != LLDB_INVALID_ADDRESS &&
           file_address != LLDB_INVALID_ADDRESS) {
-        s.Printf("Kernel slide 0x%" PRIx64 " in memory.\n",
-                 m_load_address - file_address);
-        s.Printf("Loaded kernel file %s\n",
-                 m_module_sp->GetFileSpec().GetPath().c_str());
+        s->Printf("Kernel slide 0x%" PRIx64 " in memory.\n",
+                  m_load_address - file_address);
+        s->Printf("Loaded kernel file %s\n",
+                  m_module_sp->GetFileSpec().GetPath().c_str());
       }
     }
-    s.Flush();
   }
 
   return IsLoaded();

--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -864,13 +864,14 @@ bool InstrumentationRuntimeTSan::NotifyBreakpointHit(
               CreateStopReasonWithInstrumentationData(
                   *thread_sp, stop_reason_description, report));
 
-    StreamFile &s = process_sp->GetTarget().GetDebugger().GetOutputStream();
-    s.Printf("ThreadSanitizer report breakpoint hit. Use 'thread "
-             "info -s' to get extended information about the "
-             "report.\n");
+    lldb::StreamSP s =
+        process_sp->GetTarget().GetDebugger().GetAsyncOutputStream();
+    s->Printf("ThreadSanitizer report breakpoint hit. Use 'thread "
+              "info -s' to get extended information about the "
+              "report.\n");
 
     return true; // Return true to stop the target
-  } else
+  }
     return false; // Let target run
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCTrampolineHandler.cpp
@@ -622,14 +622,14 @@ AppleObjCTrampolineHandler::AppleObjCTrampolineHandler(
     // step through any method dispatches.  Warn to that effect and get out of
     // here.
     if (process_sp->CanJIT()) {
-      process_sp->GetTarget().GetDebugger().GetErrorStream().Printf(
+      process_sp->GetTarget().GetDebugger().GetAsyncErrorStream()->Printf(
           "Could not find implementation lookup function \"%s\""
           " step in through ObjC method dispatch will not work.\n",
           get_impl_name.AsCString());
     }
     return;
   }
-  
+
   // We will either set the implementation to the _stret or non_stret version,
   // so either way it's safe to start filling the m_lookup_..._code here.
   m_lookup_implementation_function_code.assign(

--- a/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
@@ -289,7 +289,7 @@ bool ScriptInterpreterLua::BreakpointCallbackFunction(
   llvm::Expected<bool> BoolOrErr = lua.CallBreakpointCallback(
       baton, stop_frame_sp, bp_loc_sp, bp_option_data->m_extra_args_sp);
   if (llvm::Error E = BoolOrErr.takeError()) {
-    debugger.GetErrorStream() << toString(std::move(E));
+    *debugger.GetAsyncErrorStream() << toString(std::move(E));
     return true;
   }
 
@@ -316,7 +316,7 @@ bool ScriptInterpreterLua::WatchpointCallbackFunction(
   llvm::Expected<bool> BoolOrErr =
       lua.CallWatchpointCallback(baton, stop_frame_sp, wp_sp);
   if (llvm::Error E = BoolOrErr.takeError()) {
-    debugger.GetErrorStream() << toString(std::move(E));
+    *debugger.GetAsyncErrorStream() << toString(std::move(E));
     return true;
   }
 

--- a/lldb/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/None/ScriptInterpreterNone.cpp
@@ -33,12 +33,12 @@ static const char *no_interpreter_err_msg =
 bool ScriptInterpreterNone::ExecuteOneLine(llvm::StringRef command,
                                            CommandReturnObject *,
                                            const ExecuteScriptOptions &) {
-  m_debugger.GetErrorStream().PutCString(no_interpreter_err_msg);
+  m_debugger.GetAsyncErrorStream()->PutCString(no_interpreter_err_msg);
   return false;
 }
 
 void ScriptInterpreterNone::ExecuteInterpreterLoop() {
-  m_debugger.GetErrorStream().PutCString(no_interpreter_err_msg);
+  m_debugger.GetAsyncErrorStream()->PutCString(no_interpreter_err_msg);
 }
 
 void ScriptInterpreterNone::Initialize() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -1910,10 +1910,10 @@ bool ScriptInterpreterPythonImpl::BreakpointCallbackFunction(
             llvm::handleAllErrors(
                 maybe_ret_val.takeError(),
                 [&](PythonException &E) {
-                  debugger.GetErrorStream() << E.ReadBacktrace();
+                  *debugger.GetAsyncErrorStream() << E.ReadBacktrace();
                 },
                 [&](const llvm::ErrorInfoBase &E) {
-                  debugger.GetErrorStream() << E.message();
+                  *debugger.GetAsyncErrorStream() << E.message();
                 });
 
           } else {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1664,7 +1664,7 @@ Process::CreateBreakpointSite(const BreakpointLocationSP &constituent,
       Address symbol_address = symbol->GetAddress();
       load_addr = ResolveIndirectFunction(&symbol_address, error);
       if (!error.Success() && show_error) {
-        GetTarget().GetDebugger().GetErrorStream().Printf(
+        GetTarget().GetDebugger().GetAsyncErrorStream()->Printf(
             "warning: failed to resolve indirect function at 0x%" PRIx64
             " for breakpoint %i.%i: %s\n",
             symbol->GetLoadAddress(&GetTarget()),
@@ -1703,7 +1703,7 @@ Process::CreateBreakpointSite(const BreakpointLocationSP &constituent,
         } else {
           if (show_error || use_hardware) {
             // Report error for setting breakpoint...
-            GetTarget().GetDebugger().GetErrorStream().Printf(
+            GetTarget().GetDebugger().GetAsyncErrorStream()->Printf(
                 "warning: failed to set breakpoint site at 0x%" PRIx64
                 " for breakpoint %i.%i: %s\n",
                 load_addr, constituent->GetBreakpoint().GetID(),

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1532,15 +1532,15 @@ static void LoadScriptingResourceForModule(const ModuleSP &module_sp,
   if (module_sp && !module_sp->LoadScriptingResourceInTarget(target, error,
                                                              feedback_stream)) {
     if (error.AsCString())
-      target->GetDebugger().GetErrorStream().Printf(
+      target->GetDebugger().GetAsyncErrorStream()->Printf(
           "unable to load scripting data for module %s - error reported was "
           "%s\n",
           module_sp->GetFileSpec().GetFileNameStrippingExtension().GetCString(),
           error.AsCString());
   }
   if (feedback_stream.GetSize())
-    target->GetDebugger().GetErrorStream().Printf("%s\n",
-                                                  feedback_stream.GetData());
+    target->GetDebugger().GetAsyncErrorStream()->Printf(
+        "%s\n", feedback_stream.GetData());
 }
 
 void Target::ClearModules(bool delete_locations) {

--- a/lldb/source/Target/ThreadPlanTracer.cpp
+++ b/lldb/source/Target/ThreadPlanTracer.cpp
@@ -47,7 +47,7 @@ Stream *ThreadPlanTracer::GetLogStream() {
   else {
     TargetSP target_sp(GetThread().CalculateTarget());
     if (target_sp)
-      return &(target_sp->GetDebugger().GetOutputStream());
+      return target_sp->GetDebugger().GetOutputStreamSP().get();
   }
   return nullptr;
 }


### PR DESCRIPTION
Remove Debugger::GetOutputStream and Debugger::GetErrorStream in preparation for replacing both with a new variant that needs to be locked and hence can't be handed out like we do right now.

The patch replaces most uses with GetAsyncOutputStream and GetAsyncErrorStream respectively. There methods return new StreamSP objects that automatically get flushed on destruction.

See #126630 for more details.