### PR TITLE
[C++20] [Modules] Instantiate pending instantiations when GMF ends

### DIFF
--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1104,9 +1104,13 @@ void Sema::ActOnStartOfTranslationUnit() {
 }
 
 void Sema::ActOnEndOfTranslationUnitFragment(TUFragmentKind Kind) {
-  // No explicit actions are required at the end of the global module fragment.
-  if (Kind == TUFragmentKind::Global)
+  if (Kind == TUFragmentKind::Global) {
+    // Perform Pending Instantiations at the end of global module fragment so
+    // that the module ownership of TU-level decls won't get messed.
+    llvm::TimeTraceScope TimeScope("PerformPendingInstantiations");
+    PerformPendingInstantiations();
     return;
+  }
 
   // Transfer late parsed template instantiations over to the pending template
   // instantiation list. During normal compilation, the late template parser

--- a/clang/test/Modules/pr125999.cppm
+++ b/clang/test/Modules/pr125999.cppm
@@ -1,0 +1,33 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/foo.cppm -verify -fsyntax-only
+
+//--- bar.h
+template <typename T>
+struct Singleton {
+    static T* instance_;
+    static T* get() {
+        static bool init = false;
+        if (!init) {
+            init = true;
+            instance_ = ::new T();
+        }
+        return instance_;
+    }
+};
+
+template <typename T>
+T* Singleton<T>::instance_ = nullptr;
+
+struct s{};
+inline void* foo() {
+    return Singleton<s>::get();
+}
+
+//--- foo.cppm
+// expected-no-diagnostics
+module;
+#include "bar.h"
+export module foo;


### PR DESCRIPTION
Close https://github.com/llvm/llvm-project/issues/125999

The cause of the problem is, when we instantiate the pending instantiation, the owning module of the TU gets into 'foo' instead of the GMF.

The concern of the patch is, I am not sure the point of 'pending' instantiations. I mean, if there is a reason we **must** pending the intantiations to the end of the TU.