### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Support [[clang::noescape]] on a constructor

### DIFF
--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -298,7 +298,11 @@ struct RefCountableWithLambdaCapturingThis {
     callLambda([&]() -> RefPtr<RefCountable> {
       return obj->next();
     });
+    WTF::HashMap<int, RefPtr<RefCountable>> anotherMap([&] {
+      return obj->next();
+    });
   }
+
 };
 
 struct NonRefCountableWithLambdaCapturingThis {


### PR DESCRIPTION
Added the support for annotating a constructor's argument with [[clang::noescape]].

We explicitly ignore CXXConstructExpr which is visited as a part of CallExpr so that construction of closures like Function, CompletionHandler, etc... don't result in a warning.