### PR TITLE
[NFC] Avoid potential null dereference.

### DIFF
--- a/clang/lib/Format/UnwrappedLineFormatter.cpp
+++ b/clang/lib/Format/UnwrappedLineFormatter.cpp
@@ -1596,7 +1596,7 @@ static auto computeNewlines(const AnnotatedLine &Line,
     if (Line.startsWith(TT_NamespaceRBrace)) {
       if (Style.WrapNamespaceBodyWithEmptyLines == FormatStyle::WNBWELS_Never)
         Newlines = 1;
-      else if (!PreviousLine->startsWith(TT_NamespaceRBrace))
+      else if (PreviousLine && !PreviousLine->startsWith(TT_NamespaceRBrace))
         Newlines = std::max(Newlines, 2u);
     }
   }


### PR DESCRIPTION
Add a null check.