### PR TITLE
[clang-tidy] Add AllowFalseEvaluated flag to clang-tidy noexcept-move-constructor check

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/NoexceptFunctionBaseCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptFunctionBaseCheck.cpp
@@ -30,7 +30,7 @@ void NoexceptFunctionBaseCheck::check(const MatchFinder::MatchResult &Result) {
   const Expr *NoexceptExpr = ProtoType->getNoexceptExpr();
   if (NoexceptExpr) {
     NoexceptExpr = NoexceptExpr->IgnoreImplicit();
-    if (!isa<CXXBoolLiteralExpr>(NoexceptExpr))
+    if (!isa<CXXBoolLiteralExpr>(NoexceptExpr) && !AllowFalseEvaluated)
       reportNoexceptEvaluatedToFalse(FuncDecl, NoexceptExpr);
     return;
   }

--- a/clang-tools-extra/clang-tidy/performance/NoexceptFunctionBaseCheck.h
+++ b/clang-tools-extra/clang-tidy/performance/NoexceptFunctionBaseCheck.h
@@ -22,7 +22,8 @@ namespace clang::tidy::performance {
 class NoexceptFunctionBaseCheck : public ClangTidyCheck {
 public:
   NoexceptFunctionBaseCheck(StringRef Name, ClangTidyContext *Context)
-      : ClangTidyCheck(Name, Context) {}
+      : ClangTidyCheck(Name, Context),
+        AllowFalseEvaluated(Options.get("AllowFalseEvaluated", false)) {}
 
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus11 && LangOpts.CXXExceptions;
@@ -31,6 +32,10 @@ public:
   check(const ast_matchers::MatchFinder::MatchResult &Result) final override;
   std::optional<TraversalKind> getCheckTraversalKind() const override {
     return TK_IgnoreUnlessSpelledInSource;
+  }
+
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override {
+    Options.store(Opts, "AllowFalseEvaluated", AllowFalseEvaluated);
   }
 
 protected:
@@ -42,6 +47,7 @@ protected:
   static constexpr StringRef BindFuncDeclName = "FuncDecl";
 
 private:
+  bool AllowFalseEvaluated;
   utils::ExceptionSpecAnalyzer SpecAnalyzer;
 };
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -253,6 +253,12 @@ Changes in existing checks
   <clang-tidy/checks/readability/redundant-smartptr-get>` check by fixing
   some false positives involving smart pointers to arrays.
 
+- Improved :doc:`performance-noexcept-move-constructor
+  <clang-tidy/checks/performance/noexcept-move-constructor>` check by adding
+  a new (off-by-default) option `AllowFalseEvaluated`, which allows marking
+  move constructors with ``noexcept(expr)`` even if ``expr``
+  evaluates to ``false``.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.rst
@@ -11,3 +11,12 @@ evaluates to ``false`` (but is not a ``false`` literal itself).
 Move constructors of all the types used with STL containers, for example,
 need to be declared ``noexcept``. Otherwise STL will choose copy constructors
 instead. The same is valid for move assignment operations.
+
+Options
+-------
+
+.. option:: AllowFalseEvaluated
+
+    When `true`, the check will not generate any warning
+    if the ``expr`` in ``noexcept(expr)`` evaluates to ``false``.
+    Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-allow-false-evaluated.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-allow-false-evaluated.cpp
@@ -1,5 +1,3 @@
-// RUN: %check_clang_tidy %s performance-noexcept-move-constructor %t -- -- -fexceptions
-
 // RUN: %check_clang_tidy -check-suffix=CONFIG %s performance-noexcept-move-constructor,performance-noexcept-destructor %t -- \
 // RUN: -config="{CheckOptions: {performance-noexcept-move-constructor.AllowFalseEvaluated: true}}" \
 // RUN: -- -fexceptions
@@ -16,8 +14,6 @@ namespace std
 struct ThrowOnAnything {
   ThrowOnAnything() noexcept(false);
   ThrowOnAnything(ThrowOnAnything&&) noexcept(false);
-  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: move constructors should be marked noexcept
-  // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:3: warning: move constructors should be marked noexcept
   ThrowOnAnything& operator=(ThrowOnAnything &&) noexcept(false);
   ~ThrowOnAnything() noexcept(false);
 };
@@ -25,12 +21,7 @@ struct ThrowOnAnything {
 struct C_1 {
     static constexpr bool kFalse = false;
     C_1(C_1&&) noexcept(kFalse) = default;
-    // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
-    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
-
     C_1 &operator=(C_1 &&) noexcept(kFalse);
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
-    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
 };
 
 struct C_2 {
@@ -38,12 +29,7 @@ struct C_2 {
     static_assert(!kEval); // kEval == false;
 
     C_2(C_2&&) noexcept(kEval) = default;
-    // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
-    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
-
     C_2 &operator=(C_2 &&) noexcept(kEval);
-    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
-    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
 
     ThrowOnAnything field;
 };
@@ -53,9 +39,6 @@ struct C_3 {
     static_assert(!kEval); // kEval == false;
 
     C_3(C_3&&) noexcept(kEval) = default;
-    // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
-    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
-
     ~C_3() noexcept(kEval) = default;
     // CHECK-MESSAGES-CONFIG: :[[@LINE-1]]:21: warning: noexcept specifier on the destructor evaluates to 'false'
 

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-allow-false-evaluated.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-allow-false-evaluated.cpp
@@ -1,0 +1,63 @@
+// RUN: %check_clang_tidy %s performance-noexcept-move-constructor %t -- -- -fexceptions
+
+// RUN: %check_clang_tidy -check-suffix=CONFIG %s performance-noexcept-move-constructor,performance-noexcept-destructor %t -- \
+// RUN: -config="{CheckOptions: {performance-noexcept-move-constructor.AllowFalseEvaluated: true}}" \
+// RUN: -- -fexceptions
+
+namespace std
+{
+  template <typename T>
+  struct is_nothrow_move_constructible
+  {
+    static constexpr bool value = __is_nothrow_constructible(T, __add_rvalue_reference(T));
+  };
+} // namespace std
+
+struct ThrowOnAnything {
+  ThrowOnAnything() noexcept(false);
+  ThrowOnAnything(ThrowOnAnything&&) noexcept(false);
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:3: warning: move constructors should be marked noexcept
+  // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:3: warning: move constructors should be marked noexcept
+  ThrowOnAnything& operator=(ThrowOnAnything &&) noexcept(false);
+  ~ThrowOnAnything() noexcept(false);
+};
+
+struct C_1 {
+    static constexpr bool kFalse = false;
+    C_1(C_1&&) noexcept(kFalse) = default;
+    // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
+    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
+
+    C_1 &operator=(C_1 &&) noexcept(kFalse);
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
+    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
+};
+
+struct C_2 {
+    static constexpr bool kEval = std::is_nothrow_move_constructible<ThrowOnAnything>::value;
+    static_assert(!kEval); // kEval == false;
+
+    C_2(C_2&&) noexcept(kEval) = default;
+    // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
+    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
+
+    C_2 &operator=(C_2 &&) noexcept(kEval);
+    // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
+    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:37: warning: noexcept specifier on the move assignment operator evaluates to 'false' [performance-noexcept-move-constructor]
+
+    ThrowOnAnything field;
+};
+
+struct C_3 {
+    static constexpr bool kEval = std::is_nothrow_move_constructible<ThrowOnAnything>::value;
+    static_assert(!kEval); // kEval == false;
+
+    C_3(C_3&&) noexcept(kEval) = default;
+    // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
+    // CHECK-MESSAGES-CONFIG-NOT: :[[@LINE-2]]:25: warning: noexcept specifier on the move constructor evaluates to 'false' [performance-noexcept-move-constructor]
+
+    ~C_3() noexcept(kEval) = default;
+    // CHECK-MESSAGES-CONFIG: :[[@LINE-1]]:21: warning: noexcept specifier on the destructor evaluates to 'false'
+
+    ThrowOnAnything field;
+};


### PR DESCRIPTION
This pull request aims to add a new flag to customize the `noexcept-move-constructor` check in clang-tidy.

Problem. Now the code below triggers the warning:
```cpp
#include <type_traits>

/* External class */
struct NotMarkedNoexcept {
    int x;
    NotMarkedNoexcept() = default;
    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
    NotMarkedNoexcept(NotMarkedNoexcept&& rhs);
};

struct Complicated {
    static constexpr bool NOEXCEPT_MOVE = std::is_nothrow_move_constructible_v<NotMarkedNoexcept>;

    Complicated() = default;
    Complicated(Complicated&&) noexcept(NOEXCEPT_MOVE) = default; // Warning

    NotMarkedNoexcept inner;
};

int main() {}
```
https://godbolt.org/z/E4E65jdhh

I had created a related issue: https://github.com/llvm/llvm-project/issues/126702

My proposal is to add an option to allow `noexcept(expr)`, even if this expression can be folded to false. This would force users to mark their move constructors as noexcept, while at the same time, the check would not trigger if the move constructor is not actually noexcept.