### PR TITLE
[lldb/DWARF] Resolve type unit references in llvm DWARFDIE compatibility wrappers

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -622,12 +622,12 @@ std::optional<uint64_t> DWARFDIE::getLanguage() const {
 }
 
 DWARFDIE DWARFDIE::resolveReferencedType(dw_attr_t attr) const {
-  return GetReferencedDIE(attr);
+  return GetReferencedDIE(attr).resolveTypeUnitReference();
 }
 
 DWARFDIE DWARFDIE::resolveReferencedType(DWARFFormValue v) const {
   if (IsValid())
-    return v.Reference();
+    return v.Reference().resolveTypeUnitReference();
   return {};
 }
 


### PR DESCRIPTION
The llvm versions of these functions do that, so we must to so as well. Practically this meant that were were unable to correctly un-simplify the names of some types when using type units, which resulted in type lookup errors.