### PR TITLE
[Xtensa] Add XtensaDesc dependency to LLVMXtensaDisassembler

### DIFF
--- a/llvm/lib/Target/Xtensa/Disassembler/CMakeLists.txt
+++ b/llvm/lib/Target/Xtensa/Disassembler/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_component_library(LLVMXtensaDisassembler
   LINK_COMPONENTS
   MCDisassembler
   Support
+  XtensaDesc
   XtensaInfo
 
   ADD_TO_COMPONENT


### PR DESCRIPTION
There is an undefined reference to checkRegister in shared lib builds

Suspecting #124656