### PR TITLE
[AMDGPU][docs][NFC] Replace gfx940 with gfx942 in the gfx940 ISA doc

### DIFF
--- a/llvm/docs/AMDGPU/AMDGPUAsmGFX940.rst
+++ b/llvm/docs/AMDGPU/AMDGPUAsmGFX940.rst
@@ -6,7 +6,7 @@
     **************************************************
 
 ====================================================================================
-Syntax of gfx940 Instructions
+Syntax of gfx942 Instructions
 ====================================================================================
 
 .. contents::
@@ -15,7 +15,7 @@ Syntax of gfx940 Instructions
 Introduction
 ============
 
-This document describes the syntax of gfx940 instructions.
+This document describes the syntax of gfx942 instructions.
 
 Notation
 ========


### PR DESCRIPTION
gfx940 and gfx941 are no longer supported. This is the last one of a
series of PRs to remove them from the code base.

The ISA documentation still contains a lot of links and file names with
the "gfx940" identifier. Changing them to "gfx942" is probably not worth
the cost of breaking all URLs to these pages that users might have saved
in the past.

For SWDEV-512631