### PR TITLE
[CFIInserter] Fix handling of OpRelOffset.

### DIFF
--- a/llvm/lib/CodeGen/CFIInstrInserter.cpp
+++ b/llvm/lib/CodeGen/CFIInstrInserter.cpp
@@ -217,7 +217,7 @@ void CFIInstrInserter::calculateOutgoingCFAInfo(MBBCFAInfo &MBBInfo) {
         CSRReg = CFI.getRegister2();
         break;
       case MCCFIInstruction::OpRelOffset:
-        CSROffset = CFI.getOffset() - SetOffset;
+        CSROffset = CFI.getOffset() + SetOffset;
         break;
       case MCCFIInstruction::OpRestore:
         CSRRestored.set(CFI.getRegister());


### PR DESCRIPTION
The variable `SetOffset` holds the offset of CFA from CFA register. The cfi_rel_offset directive means we should add relative offset to `SetOffset`.