### PR TITLE
[WIP][OpenMP] dispatch directive semantics/codegen

### DIFF
--- a/clang/include/clang/AST/StmtOpenMP.h
+++ b/clang/include/clang/AST/StmtOpenMP.h
@@ -5984,6 +5984,7 @@ public:
   static OMPDispatchDirective *
   Create(const ASTContext &C, SourceLocation StartLoc, SourceLocation EndLoc,
          ArrayRef<OMPClause *> Clauses, Stmt *AssociatedStmt,
+         Stmt *CallNoContext, Stmt *CallInContext,
          SourceLocation TargetCallLoc);
 
   /// Creates an empty directive with the place for \a NumClauses
@@ -5997,6 +5998,22 @@ public:
 
   /// Return location of target-call.
   SourceLocation getTargetCallLoc() const { return TargetCallLoc; }
+
+  void setCallNocontext(Stmt *S) {
+    Data->getChildren()[0] = S;
+  }
+
+  Stmt* getCallNocontext() const {
+    return cast_or_null<Stmt>(Data->getChildren()[0]);
+  }
+
+  void setCallInContext(Stmt *S) {
+    Data->getChildren()[1] = S;
+  }
+
+  Stmt* getCallInContext() const {
+    return cast_or_null<Stmt>(Data->getChildren()[1]);
+  }
 
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == OMPDispatchDirectiveClass;

--- a/clang/include/clang/Basic/OpenMPKinds.h
+++ b/clang/include/clang/Basic/OpenMPKinds.h
@@ -308,6 +308,12 @@ bool isOpenMPTeamsDirective(OpenMPDirectiveKind DKind);
 /// otherwise - false.
 bool isOpenMPSimdDirective(OpenMPDirectiveKind DKind);
 
+/// Checks if the specified directive is a dispatch directive.
+/// \param DKind Specified directive.
+/// \return true - the directive is a dispatch directive like 'omp dispatch',
+/// otherwise - false.
+bool isOpenMPDispatchDirective(OpenMPDirectiveKind DKind);
+
 /// Checks if the specified directive is a distribute directive.
 /// \param DKind Specified directive.
 /// \return true - the directive is a distribute-directive like 'omp

--- a/clang/include/clang/Sema/Scope.h
+++ b/clang/include/clang/Sema/Scope.h
@@ -163,6 +163,9 @@ public:
 
     /// This is a scope of friend declaration.
     FriendScope = 0x40000000,
+
+    /// This is an OpenMP dispatch construct scope.
+    OpenMPDispatchDirectiveScope = 0x80000000,
   };
 
 private:
@@ -530,6 +533,10 @@ public:
   /// order clause which specifies concurrent scope.
   bool isOpenMPOrderClauseScope() const {
     return getFlags() & Scope::OpenMPOrderClauseScope;
+  }
+
+  bool isOpenMPDispatchDirectiveScope() const {
+    return getFlags() & Scope::OpenMPDispatchDirectiveScope;
   }
 
   /// Determine whether this scope is the statement associated with an OpenACC

--- a/clang/include/clang/Sema/SemaOpenMP.h
+++ b/clang/include/clang/Sema/SemaOpenMP.h
@@ -123,7 +123,9 @@ public:
   /// original \p Call.
   ExprResult ActOnOpenMPCall(ExprResult Call, Scope *Scope,
                              SourceLocation LParenLoc, MultiExprArg ArgExprs,
-                             SourceLocation RParenLoc, Expr *ExecConfig);
+                             SourceLocation RParenLoc, Expr *ExecConfig,
+                             ArrayRef<OMPClause *> DispatchClauses =
+                               ArrayRef<OMPClause *>());
 
   /// Handle a `omp begin declare variant`.
   void ActOnOpenMPBeginDeclareVariant(SourceLocation Loc, OMPTraitInfo &TI);
@@ -397,7 +399,7 @@ public:
   /// \returns Statement for finished OpenMP region.
   StmtResult ActOnOpenMPRegionEnd(StmtResult S, ArrayRef<OMPClause *> Clauses);
   StmtResult ActOnOpenMPExecutableDirective(
-      OpenMPDirectiveKind Kind, const DeclarationNameInfo &DirName,
+      OpenMPDirectiveKind Kind, Scope *Scope, const DeclarationNameInfo &DirName,
       OpenMPDirectiveKind CancelRegion, ArrayRef<OMPClause *> Clauses,
       Stmt *AStmt, SourceLocation StartLoc, SourceLocation EndLoc);
   /// Process an OpenMP informational directive.
@@ -780,7 +782,8 @@ public:
                                          SourceLocation EndLoc);
   /// Called on well-formed '\#pragma omp dispatch' after parsing of the
   // /associated statement.
-  StmtResult ActOnOpenMPDispatchDirective(ArrayRef<OMPClause *> Clauses,
+  StmtResult ActOnOpenMPDispatchDirective(Scope *Scope,
+                                          ArrayRef<OMPClause *> Clauses,
                                           Stmt *AStmt, SourceLocation StartLoc,
                                           SourceLocation EndLoc);
   /// Called on well-formed '\#pragma omp masked' after parsing of the

--- a/clang/lib/AST/StmtOpenMP.cpp
+++ b/clang/lib/AST/StmtOpenMP.cpp
@@ -2348,11 +2348,13 @@ OMPInteropDirective *OMPInteropDirective::CreateEmpty(const ASTContext &C,
 
 OMPDispatchDirective *OMPDispatchDirective::Create(
     const ASTContext &C, SourceLocation StartLoc, SourceLocation EndLoc,
-    ArrayRef<OMPClause *> Clauses, Stmt *AssociatedStmt,
-    SourceLocation TargetCallLoc) {
+    ArrayRef<OMPClause *> Clauses, Stmt *AssociatedStmt, Stmt *CalleeNoCtx,
+    Stmt *CalleeInCtx, SourceLocation TargetCallLoc) {
   auto *Dir = createDirective<OMPDispatchDirective>(
-      C, Clauses, AssociatedStmt, /*NumChildren=*/0, StartLoc, EndLoc);
+      C, Clauses, AssociatedStmt, /*NumChildren=*/2, StartLoc, EndLoc);
   Dir->setTargetCallLoc(TargetCallLoc);
+  Dir->setCallNocontext(CalleeNoCtx);
+  Dir->setCallInContext(CalleeInCtx);
   return Dir;
 }
 

--- a/clang/lib/Basic/OpenMPKinds.cpp
+++ b/clang/lib/Basic/OpenMPKinds.cpp
@@ -654,6 +654,10 @@ bool clang::isOpenMPSimdDirective(OpenMPDirectiveKind DKind) {
          llvm::is_contained(getLeafConstructs(DKind), OMPD_simd);
 }
 
+bool clang::isOpenMPDispatchDirective(OpenMPDirectiveKind DKind) {
+  return DKind == OMPD_dispatch;
+}
+
 bool clang::isOpenMPNestingDistributeDirective(OpenMPDirectiveKind Kind) {
   if (Kind == OMPD_distribute)
     return true;
@@ -818,6 +822,8 @@ void clang::getOpenMPCaptureRegions(
         return true;
       break;
     case OMPD_dispatch:
+      CaptureRegions.push_back(OMPD_dispatch);
+      break;
     case OMPD_distribute:
     case OMPD_for:
     case OMPD_ordered:

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1297,9 +1297,11 @@ llvm::Function *CGOpenMPRuntime::emitTaskOutlinedFunction(
   CodeGen.setAction(Action);
   assert(!ThreadIDVar->getType()->isPointerType() &&
          "thread id variable must be of type kmp_int32 for tasks");
+  const OpenMPDirectiveKind DK = D.getDirectiveKind();
   const OpenMPDirectiveKind Region =
-      isOpenMPTaskLoopDirective(D.getDirectiveKind()) ? OMPD_taskloop
-                                                      : OMPD_task;
+      isOpenMPDispatchDirective(DK) ? OMPD_dispatch
+        : isOpenMPTaskLoopDirective(DK) ? OMPD_taskloop
+        : OMPD_task;
   const CapturedStmt *CS = D.getCapturedStmt(Region);
   bool HasCancel = false;
   if (const auto *TD = dyn_cast<OMPTaskDirective>(&D))

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -421,7 +421,7 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
     EmitOMPInteropDirective(cast<OMPInteropDirective>(*S));
     break;
   case Stmt::OMPDispatchDirectiveClass:
-    CGM.ErrorUnsupported(S, "OpenMP dispatch directive");
+    EmitOMPDispatchDirective(cast<OMPDispatchDirective>(*S));
     break;
   case Stmt::OMPScopeDirectiveClass:
     EmitOMPScopeDirective(cast<OMPScopeDirective>(*S));

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3902,6 +3902,7 @@ public:
   void EmitOMPTargetParallelForSimdDirective(
       const OMPTargetParallelForSimdDirective &S);
   void EmitOMPTargetSimdDirective(const OMPTargetSimdDirective &S);
+  void EmitOMPDispatchDirective(const OMPDispatchDirective &S);
   void EmitOMPTeamsDistributeDirective(const OMPTeamsDistributeDirective &S);
   void
   EmitOMPTeamsDistributeSimdDirective(const OMPTeamsDistributeSimdDirective &S);

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2480,6 +2480,8 @@ StmtResult Parser::ParseOpenMPExecutableDirective(
     ScopeFlags |= Scope::OpenMPLoopDirectiveScope;
   if (isOpenMPSimdDirective(DKind))
     ScopeFlags |= Scope::OpenMPSimdDirectiveScope;
+  if (DKind == OMPD_dispatch)
+    ScopeFlags |= Scope::OpenMPDispatchDirectiveScope;
   ParseScope OMPDirectiveScope(this, ScopeFlags);
   Actions.OpenMP().StartOpenMPDSABlock(DKind, DirName, Actions.getCurScope(),
                                        Loc);
@@ -2583,7 +2585,8 @@ StmtResult Parser::ParseOpenMPExecutableDirective(
   }
 
   StmtResult Directive = Actions.OpenMP().ActOnOpenMPExecutableDirective(
-      DKind, DirName, CancelRegion, Clauses, AssociatedStmt.get(), Loc, EndLoc);
+      DKind, getCurScope(), DirName, CancelRegion, Clauses,
+      AssociatedStmt.get(), Loc, EndLoc);
 
   // Exit scope.
   Actions.OpenMP().EndOpenMPDSABlock(Directive.get());

--- a/clang/lib/Sema/Scope.cpp
+++ b/clang/lib/Sema/Scope.cpp
@@ -221,6 +221,7 @@ void Scope::dumpImpl(raw_ostream &OS) const {
       {OpenMPDirectiveScope, "OpenMPDirectiveScope"},
       {OpenMPLoopDirectiveScope, "OpenMPLoopDirectiveScope"},
       {OpenMPSimdDirectiveScope, "OpenMPSimdDirectiveScope"},
+      {OpenMPDispatchDirectiveScope, "OpenMPDispatchDirectiveScope"},
       {EnumScope, "EnumScope"},
       {SEHTryScope, "SEHTryScope"},
       {SEHExceptScope, "SEHExceptScope"},

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6468,7 +6468,10 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
         << ULE->getName();
   }
 
-  if (LangOpts.OpenMP)
+  // Process function calls for OpenMP, except when we're in an OpenMP dispatch
+  // directive, in which case we need to defer processing of the call until
+  // we've processed the directive too.
+  if (LangOpts.OpenMP && (!Scope || !Scope->isOpenMPDispatchDirectiveScope()))
     Call = OpenMP().ActOnOpenMPCall(Call, Scope, LParenLoc, ArgExprs, RParenLoc,
                                     ExecConfig);
   if (LangOpts.CPlusPlus) {

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -3744,6 +3744,7 @@ class DSAAttrChecker final : public StmtVisitor<DSAAttrChecker, void> {
         S->getDirectiveKind() == OMPD_masked ||
         S->getDirectiveKind() == OMPD_scope ||
         S->getDirectiveKind() == OMPD_assume ||
+        S->getDirectiveKind() == OMPD_dispatch ||
         isOpenMPLoopTransformationDirective(S->getDirectiveKind())) {
       Visit(S->getAssociatedStmt());
       return;
@@ -4213,6 +4214,8 @@ static void handleDeclareVariantConstructTrait(DSAStackTy *Stack,
     Traits.emplace_back(llvm::omp::TraitProperty::construct_for_for);
   if (isOpenMPSimdDirective(DKind))
     Traits.emplace_back(llvm::omp::TraitProperty::construct_simd_simd);
+  if (isOpenMPDispatchDirective(DKind))
+    Traits.emplace_back(llvm::omp::TraitProperty::construct_dispatch_dispatch);
   Stack->handleConstructTrait(Traits, ScopeEntry);
 }
 
@@ -4265,6 +4268,11 @@ getTaskRegionParams(Sema &SemaRef) {
       std::make_pair(StringRef(), QualType()) // __context with shared vars
   };
   return Params;
+}
+
+static SmallVector<SemaOpenMP::CapturedParamNameType>
+getDispatchRegionParams(Sema &SemaRef) {
+  return getTaskRegionParams(SemaRef);
 }
 
 static SmallVector<SemaOpenMP::CapturedParamNameType>
@@ -4350,6 +4358,14 @@ static void processCapturedRegions(Sema &SemaRef, OpenMPDirectiveKind DKind,
     case OMPD_task:
       SemaRef.ActOnCapturedRegionStart(Loc, CurScope, CR_OpenMP,
                                        getTaskRegionParams(SemaRef), Level);
+      // Mark this captured region as inlined, because we don't use outlined
+      // function directly.
+      MarkAsInlined(SemaRef.getCurCapturedRegion());
+      break;
+    case OMPD_dispatch:
+      SemaRef.ActOnCapturedRegionStart(Loc, CurScope, CR_OpenMP,
+                                       /*getDispatchRegionParams(SemaRef)*/
+                                       getUnknownRegionParams(SemaRef), Level);
       // Mark this captured region as inlined, because we don't use outlined
       // function directly.
       MarkAsInlined(SemaRef.getCurCapturedRegion());
@@ -5979,7 +5995,7 @@ static bool teamsLoopCanBeParallelFor(Stmt *AStmt, Sema &SemaRef) {
 }
 
 StmtResult SemaOpenMP::ActOnOpenMPExecutableDirective(
-    OpenMPDirectiveKind Kind, const DeclarationNameInfo &DirName,
+    OpenMPDirectiveKind Kind, Scope *Scope, const DeclarationNameInfo &DirName,
     OpenMPDirectiveKind CancelRegion, ArrayRef<OMPClause *> Clauses,
     Stmt *AStmt, SourceLocation StartLoc, SourceLocation EndLoc) {
   assert(isOpenMPExecutableDirective(Kind) && "Unexpected directive category");
@@ -6473,8 +6489,8 @@ StmtResult SemaOpenMP::ActOnOpenMPExecutableDirective(
     Res = ActOnOpenMPInteropDirective(ClausesWithImplicit, StartLoc, EndLoc);
     break;
   case OMPD_dispatch:
-    Res = ActOnOpenMPDispatchDirective(ClausesWithImplicit, AStmt, StartLoc,
-                                       EndLoc);
+    Res = ActOnOpenMPDispatchDirective(Scope, ClausesWithImplicit, AStmt,
+                                       StartLoc, EndLoc);
     break;
   case OMPD_loop:
     Res = ActOnOpenMPGenericLoopDirective(ClausesWithImplicit, AStmt, StartLoc,
@@ -7116,7 +7132,8 @@ ExprResult SemaOpenMP::ActOnOpenMPCall(ExprResult Call, Scope *Scope,
                                        SourceLocation LParenLoc,
                                        MultiExprArg ArgExprs,
                                        SourceLocation RParenLoc,
-                                       Expr *ExecConfig) {
+                                       Expr *ExecConfig,
+                                       ArrayRef<OMPClause *> DispatchClauses) {
   // The common case is a regular call we do not want to specialize at all. Try
   // to make that case fast by bailing early.
   CallExpr *CE = dyn_cast<CallExpr>(Call.get());
@@ -7196,11 +7213,13 @@ ExprResult SemaOpenMP::ActOnOpenMPCall(ExprResult Call, Scope *Scope,
       Sema::TentativeAnalysisScope Trap(SemaRef);
 
       if (auto *SpecializedMethod = dyn_cast<CXXMethodDecl>(BestDecl)) {
-        auto *MemberCall = dyn_cast<CXXMemberCallExpr>(CE);
-        BestExpr = MemberExpr::CreateImplicit(
-            Context, MemberCall->getImplicitObjectArgument(),
-            /*IsArrow=*/false, SpecializedMethod, Context.BoundMemberTy,
-            MemberCall->getValueKind(), MemberCall->getObjectKind());
+        if (!SpecializedMethod->isStatic()) {
+          auto *MemberCall = dyn_cast<CXXMemberCallExpr>(CE);
+          BestExpr = MemberExpr::CreateImplicit(
+              Context, MemberCall->getImplicitObjectArgument(),
+              /*IsArrow=*/false, SpecializedMethod, Context.BoundMemberTy,
+              MemberCall->getValueKind(), MemberCall->getObjectKind());
+        }
       }
       NewCall = SemaRef.BuildCallExpr(Scope, BestExpr, LParenLoc, ArgExprs,
                                       RParenLoc, ExecConfig);
@@ -10543,13 +10562,17 @@ static Expr *getDirectCallExpr(Expr *E) {
 }
 
 StmtResult
-SemaOpenMP::ActOnOpenMPDispatchDirective(ArrayRef<OMPClause *> Clauses,
+SemaOpenMP::ActOnOpenMPDispatchDirective(Scope *Scope,
+                                         ArrayRef<OMPClause *> Clauses,
                                          Stmt *AStmt, SourceLocation StartLoc,
                                          SourceLocation EndLoc) {
   if (!AStmt)
     return StmtError();
 
-  Stmt *S = cast<CapturedStmt>(AStmt)->getCapturedStmt();
+  Stmt *S = AStmt;
+  if (auto *Cap = dyn_cast<CapturedStmt>(S)) {
+    S = Cap->getCapturedStmt();
+  }
 
   // 5.1 OpenMP
   // expression-stmt : an expression statement with one of the following forms:
@@ -10557,6 +10580,8 @@ SemaOpenMP::ActOnOpenMPDispatchDirective(ArrayRef<OMPClause *> Clauses,
   //   target-call ( [expression-list] );
 
   SourceLocation TargetCallLoc;
+
+  ExprResult CalleeExprCtx{}, CalleeExprNoctx{};
 
   if (!SemaRef.CurContext->isDependentContext()) {
     Expr *TargetCall = nullptr;
@@ -10583,13 +10608,76 @@ SemaOpenMP::ActOnOpenMPDispatchDirective(ArrayRef<OMPClause *> Clauses,
       Diag(E->getBeginLoc(), diag::err_omp_dispatch_statement_call);
       return StmtError();
     }
+
+    auto *CE = dyn_cast<CallExpr>(TargetCall);
+    SourceLocation LParenLoc = CE->getBeginLoc(); // might not be quite right but eh
+    MultiExprArg ArgExprs(CE->getArgs(), CE->getNumArgs());
+    SourceLocation RParenLoc = CE->getRParenLoc();
+    DSAStack->setContext(SemaRef.CurContext);
+    handleDeclareVariantConstructTrait(DSAStack, OMPD_dispatch, /*ScopeEntry=*/true);
+    CalleeExprCtx = ActOnOpenMPCall(ExprResult(TargetCall), Scope, LParenLoc,
+                                    ArgExprs, RParenLoc, nullptr, Clauses);
+    handleDeclareVariantConstructTrait(DSAStack, OMPD_dispatch, /*ScopeEntry=*/false);
+    CalleeExprNoctx = ActOnOpenMPCall(ExprResult(TargetCall), Scope,
+                                      LParenLoc, ArgExprs, RParenLoc,
+                                      nullptr, Clauses);
+
     TargetCallLoc = TargetCall->getExprLoc();
   }
 
+  auto &&SubstituteCall = [&S, &Scope](Sema &SemaRef, Expr *WithCall) -> Stmt * {
+    const Expr *E = dyn_cast<Expr>(S);
+    E = E->IgnoreParenCasts()->IgnoreImplicit();
+    if (auto *BO = dyn_cast<BinaryOperator>(E)) {
+      if (BO->getOpcode() == BO_Assign) {
+        Expr *RHS = BO->getRHS();
+
+        if (isa<CXXMemberCallExpr, PseudoObjectExpr>(RHS)) {
+          CaptureVars CopyTransformer(SemaRef);
+          if (auto *POE = dyn_cast<PseudoObjectExpr>(WithCall)) {
+            // The 'CaptureVars' CopyTransformer ignores the semantic expr,
+            // but that's the one we want.  Extract it first.
+            WithCall = POE->getSemanticExpr(0);
+          }
+          WithCall = AssertSuccess(CopyTransformer.TransformExpr(WithCall));
+        }
+
+        Expr *LHS = BO->getLHS();
+        CaptureVars CopyTransformer(SemaRef);
+        Expr *LHSCopy = AssertSuccess(CopyTransformer.TransformExpr(LHS));
+        return AssertSuccess(SemaRef.BuildBinOp(Scope, {}, BO_Assign, LHSCopy,
+                                                WithCall));
+      }
+    } else if (isa<CXXMemberCallExpr, PseudoObjectExpr>(E)) {
+      if (auto *POE = dyn_cast<PseudoObjectExpr>(WithCall)) {
+        WithCall = POE->getSemanticExpr(0);
+      }
+      CaptureVars CopyTransformer(SemaRef);
+      return AssertSuccess(CopyTransformer.TransformExpr(WithCall));
+    } else {
+      // FIXME: Handle CXXOperatorCallExpr, etc.
+      return WithCall;
+    }
+  };
+
+  Stmt *CallStmtNoctx = nullptr;
+  Stmt *CallStmtCtx = nullptr;
+
   SemaRef.setFunctionHasBranchProtectedScope();
 
+  if (!SemaRef.CurContext->isDependentContext()) {
+    if (CalleeExprNoctx.isUsable()) {
+      CallStmtNoctx = SubstituteCall(SemaRef, CalleeExprNoctx.get());
+    }
+
+    if (CalleeExprCtx.isUsable()) {
+      CallStmtCtx = SubstituteCall(SemaRef, CalleeExprCtx.get());
+    }
+  }
+
   return OMPDispatchDirective::Create(getASTContext(), StartLoc, EndLoc,
-                                      Clauses, AStmt, TargetCallLoc);
+                                      Clauses, AStmt, CallStmtNoctx,
+                                      CallStmtCtx, TargetCallLoc);
 }
 
 static bool checkGenericLoopLastprivate(Sema &S, ArrayRef<OMPClause *> Clauses,

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -423,8 +423,8 @@ static void instantiateOMPDeclareVariantAttr(
   auto *FD = cast<FunctionDecl>(New);
   auto *ThisContext = dyn_cast_or_null<CXXRecordDecl>(FD->getDeclContext());
 
-  auto &&SubstExpr = [FD, ThisContext, &S, &TemplateArgs](Expr *E) {
-    if (auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts()))
+  auto &&SubstExpr = [FD, ThisContext, &S, &TemplateArgs, New](Expr *E) {
+    if (auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts())) {
       if (auto *PVD = dyn_cast<ParmVarDecl>(DRE->getDecl())) {
         Sema::ContextRAII SavedContext(S, FD);
         LocalInstantiationScope Local(S);
@@ -432,7 +432,29 @@ static void instantiateOMPDeclareVariantAttr(
           Local.InstantiatedLocal(
               PVD, FD->getParamDecl(PVD->getFunctionScopeIndex()));
         return S.SubstExpr(E, TemplateArgs);
+      } else if (auto *CMD = dyn_cast<CXXMethodDecl>(DRE->getDecl())) {
+        const TemplateArgumentList *TAL = TemplateArgumentList::CreateCopy(
+            S.Context, TemplateArgs.getInnermost());
+        auto *TPL = CMD->getTemplateParameterList(0);
+        TemplateDeclInstantiator Instantiator(S, CMD->getDeclContext(),
+                                              TemplateArgs);
+        CXXMethodDecl *MD = cast<CXXMethodDecl>(Instantiator.VisitCXXMethodDecl(CMD, TPL));
+        QualType FnPtrType;
+        if (MD && !MD->isStatic()) {
+          const Type *ClassType =
+              S.Context.getTypeDeclType(MD->getParent()).getTypePtr();
+          FnPtrType = S.Context.getMemberPointerType(MD->getType(), ClassType);
+        } else {
+          FnPtrType = MD->getType();
+        }
+        E = DeclRefExpr::Create(S.Context, NestedNameSpecifierLoc(),
+             SourceLocation(), MD,
+             /* RefersToEnclosingVariableOrCapture */ false,
+             /* NameLoc */ MD->getLocation(), FnPtrType,
+             ExprValueKind::VK_PRValue);
+        return ExprResult(E);
       }
+    }
     Sema::CXXThisScopeRAII ThisScope(S, ThisContext, Qualifiers(),
                                      FD->isCXXInstanceMember());
     return S.SubstExpr(E, TemplateArgs);

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1678,7 +1678,7 @@ public:
                                            SourceLocation EndLoc) {
 
     return getSema().OpenMP().ActOnOpenMPExecutableDirective(
-        Kind, DirName, CancelRegion, Clauses, AStmt, StartLoc, EndLoc);
+        Kind, nullptr, DirName, CancelRegion, Clauses, AStmt, StartLoc, EndLoc);
   }
 
   /// Build a new OpenMP informational directive.


### PR DESCRIPTION
This patch contains WIP support for semantics/codegen for the OpenMP 5.1 "dispatch" construct.  Only the nocontext/novariants clauses are handled for now, and support for use of dispatch with templates (of whichever kind) is unfinished.

Nevertheless, most of the OpenMP_VV "dispatch" tests run with this patch, with the exception of tests/5.1/dispatch/test_dispatch_device.c (due to missing "device" clause support).