### PR TITLE
[Flang] fix initializer with empty string to fix aarch64 build

### DIFF
--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -325,8 +325,8 @@ void createDefaultFIRCodeGenPassPipeline(mlir::PassManager &pm,
 
   pm.addPass(fir::createFunctionAttr(
       {framePointerKind, config.NoInfsFPMath, config.NoNaNsFPMath,
-       config.ApproxFuncFPMath, config.NoSignedZerosFPMath,
-       config.UnsafeFPMath}));
+       config.ApproxFuncFPMath, config.NoSignedZerosFPMath, config.UnsafeFPMath,
+       ""}));
 
   fir::addFIRToLLVMPass(pm, config);
 }


### PR DESCRIPTION
After tuneCPU was changed to std::string in c8376a93bb9853cbcedeb22d80a9b200060eaf85 the flang builds broke, due to a missing initializer.

If we want to add tuneCPU to the MLIRToLLVMPassPipelineConfig, we might want to tackle that separately after the build is restored. This should be no different than the previous behaviour.