### PR TITLE
workflows/release-binaries-all: Add missing secret input

### DIFF
--- a/.github/workflows/release-binaries-all.yml
+++ b/.github/workflows/release-binaries-all.yml
@@ -27,6 +27,10 @@ on:
         required: true
         default: false
         type: boolean
+    secrets:
+      RELEASE_TASKS_USER_TOKEN:
+        description: "Secret used to check user permissions."
+        required: false
 
   pull_request:
     types:


### PR DESCRIPTION
Since d194c6b9a7fdda7a61abcd6bfe39ab465bf0cc87 this workflow was missing the secret input which was causing it to fail.