### PR TITLE
[libc][docs] Add glob implementation status doc and include in CMakeLists

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -43,6 +43,7 @@ if (SPHINX_FOUND)
       errno
       fenv
       float
+      glob
       inttypes
       locale
       net/if

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -14,6 +14,7 @@ Implementation Status
    errno
    fenv
    float
+   glob
    inttypes
    locale
    math/index.rst

--- a/libc/utils/docgen/glob.yaml
+++ b/libc/utils/docgen/glob.yaml
@@ -1,0 +1,27 @@
+macros:
+  GLOB_APPEND:
+    in-latest-posix: ''
+  GLOB_DOOFFS:
+    in-latest-posix: ''
+  GLOB_ERR:
+    in-latest-posix: ''
+  GLOB_MARK:
+    in-latest-posix: ''
+  GLOB_NOCHECK:
+    in-latest-posix: ''
+  GLOB_NOESCAPE:
+    in-latest-posix: ''
+  GLOB_NOSORT:
+    in-latest-posix: ''
+  GLOB_ABORTED:
+    in-latest-posix: ''
+  GLOB_NOMATCH:
+    in-latest-posix: ''
+  GLOB_NOSPACE:
+    in-latest-posix: ''
+
+functions:
+  glob:
+    in-latest-posix: ''
+  globfree:
+    in-latest-posix: ''

--- a/libc/utils/docgen/glob.yaml
+++ b/libc/utils/docgen/glob.yaml
@@ -25,3 +25,4 @@ functions:
     in-latest-posix: ''
   globfree:
     in-latest-posix: ''
+    


### PR DESCRIPTION
These changes tracks `glob.h` for the implementation status of functions and macros, with respect to the issue ( #122006 ) .

cc @nickdesaulniers