### PR TITLE
[libc++] Do not guard inclusion of wchar.h with _LIBCPP_HAS_WIDE_CHARACTERS

### DIFF
--- a/libcxx/include/__mbstate_t.h
+++ b/libcxx/include/__mbstate_t.h
@@ -43,12 +43,12 @@
 #  include <bits/types/mbstate_t.h> // works on most Unixes
 #elif __has_include(<sys/_types/_mbstate_t.h>)
 #  include <sys/_types/_mbstate_t.h> // works on Darwin
-#elif _LIBCPP_HAS_WIDE_CHARACTERS && __has_include_next(<wchar.h>)
-#  include_next <wchar.h> // fall back to the C standard provider of mbstate_t
+#elif __has_include_next(<wchar.h>)
+#  include_next <wchar.h> // use the C standard provider of mbstate_t if present
 #elif __has_include_next(<uchar.h>)
-#  include_next <uchar.h> // <uchar.h> is also required to make mbstate_t visible
+#  include_next <uchar.h> // Try <uchar.h> in absence of <wchar.h> for mbstate_t
 #else
-#  error "We don't know how to get the definition of mbstate_t without <wchar.h> on your platform."
+#  error "We don't know how to get the definition of mbstate_t on your platform."
 #endif
 
 #endif // _LIBCPP___MBSTATE_T_H


### PR DESCRIPTION
`mbstate_t` needs to be visible to libcpp, even when it is not providing wide
character functionality (i.e. `_LIBCPP_HAS_WIDE_CHARACTERS` is turned off)
and thus not using any of the C library's wide character functions.

There are C libraries (such as newlib-nano/nanolib/picolibc) which do
provide their definition of `mbstate_t` in `<wchar.h>` even though they do not
come with wide character functions.

Since there is a way to conditionally include the C library's `<wchar.h>`
only if it exists, we should rely on the fact that if it exists, it will
provide `mbstate_t`. Removing this guard will allow using libc++ on top of
newlib-nano/picolibc while not breaking the cases where it is used on top
of a C library which doesn't provide `<wchar.h>` (since it would then still
go look for `<uchar.h>` or error out).