### PR TITLE
Revert "[bazel] Temporarily disable a broken LookupAddressRangeWithSt…

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
@@ -224,8 +224,6 @@ cc_test(
         # Skip a test that relies on reading files in a way that doesn't easily
         # work with Bazel.
         "--gtest_filter=-NativeSymbolReuseTest.*",
-        # TODO: this test is failing on some configs, investigate and re-enable it.
-        "--gtest_filter=-DebugLineBasicFixture.LookupAddressRangeWithStmtSequenceOffset",
     ],
     features = ["-layering_check"],  # #include "../lib/CodeGen/AsmPrinter/DwarfStringPool.h"
     deps = [


### PR DESCRIPTION
…mtSequenceOffset debug info test"

This reverts commit 247430e9c41c61b66e2ee95c29a05de3e24c19b9.

The breakage has been fixed by 343bbda140d5a15cd7d7fbfc6041a7506da5cdae.