### PR TITLE
[libc] Fix implict cast to time_t warning

### DIFF
--- a/libc/src/time/time_utils.h
+++ b/libc/src/time/time_utils.h
@@ -328,7 +328,9 @@ public:
     return BASE_YEAR + IS_NEXT_YEAR;
   }
 
-  LIBC_INLINE time_t get_epoch() const { return mktime_internal(timeptr); }
+  LIBC_INLINE time_t get_epoch() const {
+    return static_cast<time_t>(mktime_internal(timeptr));
+  }
 
   // returns the timezone offset in microwave time:
   // return (hours * 100) + minutes;


### PR DESCRIPTION
On some systems time_t is 32 bit, causing build errors (with -Werror)
in get_epoch which attempts to implicitly convert an int64_t to a
time_t.

Fixes:

    error: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'time_t' (aka 'int') [-Werror,-Wshorten-64-to-32]
      332 |     return mktime_internal(timeptr);
          |     ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~
