### PR TITLE
Remove xbegin and _xend

### DIFF
--- a/clang/lib/Headers/intrin.h
+++ b/clang/lib/Headers/intrin.h
@@ -162,8 +162,6 @@ void _Store_HLERelease(long volatile *, long);
 void _Store64_HLERelease(__int64 volatile *, __int64);
 void _StorePointer_HLERelease(void *volatile *, void *);
 void _WriteBarrier(void);
-unsigned __int32 xbegin(void);
-void _xend(void);
 
 /* These additional intrinsics are turned on in x64/amd64/x86_64 mode. */
 #if defined(__x86_64__) && !defined(__arm64ec__)

--- a/clang/test/Headers/no-xend.cpp
+++ b/clang/test/Headers/no-xend.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -triple x86_64-pc-win32 \
+// RUN:     -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 \
+// RUN:     -ffreestanding -fsyntax-only -Werror -Wsystem-headers \
+// RUN:     -isystem %S/Inputs/include %s
+
+#include <immintrin.h>
+
+#pragma clang attribute push(__attribute__((target("avx"))), apply_to=function)
+#include <intrin.h>
+#pragma clang attribute pop


### PR DESCRIPTION
`intrin.h` contains declarations for both `xbegin` and `_xend`, but they should already be included transitively from `rtmintrin.h` via `immintrin.h` and/or `x86intrin.h`. Having them in both places causes problems if both headers are included.

Furthermore, the `intrin.h` declaration of `xbegin` seems to be bugged anyway, since it's missing its leading underscore.

Fixes #95133