### PR TITLE
[Clang][CMake][MSVC] Install PDBs alongside executables

### DIFF
--- a/clang/cmake/modules/AddClang.cmake
+++ b/clang/cmake/modules/AddClang.cmake
@@ -186,6 +186,10 @@ macro(add_clang_tool name)
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         COMPONENT ${name})
 
+      if (LLVM_ENABLE_PDB)
+        install(FILES $<TARGET_PDB_FILE:${name}> DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT ${name} OPTIONAL)
+      endif()
+
       if(NOT LLVM_ENABLE_IDE)
         add_llvm_install_targets(install-${name}
                                  DEPENDS ${name}


### PR DESCRIPTION
Fixes the changes introduced in https://github.com/llvm/llvm-project/pull/126675 and subsequently reverted by https://github.com/llvm/llvm-project/pull/126934 .

Originally, I mistakenly put the `install` in the wrong location (should have been in the `add_clang_tool` macro) which slipped through testing. I've verified locally using the same CMake configure options. 


For reference:
* **CMake Configure**
```
 cmake -B build -S llvm -GNinja -DLLVM_ENABLE_PROJECTS="llvm;clang;lld;compiler-rt" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PDB=ON -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_TARGETS_TO_BUILD=X86 -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
```
* **Error**
```
TARGET_PDB_FILE is allowed only for targets with linker created artifacts.
```