### PR TITLE
[NFC] Add release notes for -Wunsafe-buffer-usage-in-libc-call

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -135,6 +135,9 @@ Improvements to Clang's diagnostics
 - Fixed a bug where Clang's Analysis did not correctly model the destructor behavior of ``union`` members (#GH119415).
 - A statement attribute applied to a ``case`` label no longer suppresses
   'bypassing variable initialization' diagnostics (#84072).
+- The ``-Wunsafe-buffer-usage`` warning has been updated to warn
+  about unsafe libc function calls.  Those new warnings are emitted
+  under the subgroup ``-Wunsafe-buffer-usage-in-libc-call``.
 
 Improvements to Clang's time-trace
 ----------------------------------


### PR DESCRIPTION
`-Wunsafe-buffer-usage-in-libc-call` is a subgroup of `-Wunsafe-buffer-usage` that warns about unsafe libc function calls.