### PR TITLE
workflows: Automatically make backport requests from merged PRs

### DIFF
--- a/.github/workflows/pr-release-workflow.yml
+++ b/.github/workflows/pr-release-workflow.yml
@@ -1,0 +1,29 @@
+name: PR Release Workflow
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types:
+      - milestoned
+      - closed
+
+jobs:
+  backport-commit:
+    runs-on: ubuntu-22.04
+    if: >-
+      github.repository == 'llvm/llvm-project' &&
+      github.event.pull_request.merged &&
+      contains(github.event.pull_request.milestone.title, 'Release')
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        with:
+          github-token: ${{ secrets.ISSUE_SUBSCRIBER_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+               issue_number: context.issue.number,
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               body: `/cherry-pick ${context.sha}`
+            });

--- a/llvm/docs/GitHub.rst
+++ b/llvm/docs/GitHub.rst
@@ -437,12 +437,14 @@ Releases
 
 Backporting Fixes to the Release Branches
 -----------------------------------------
-You can use special comments on issues or pull requests to make backport
-requests for the release branches.  To do this, after your pull reuest has been
-merged:
 
-1. Edit "Milestone" at the right side of the isssue or pull request
-   to say "LLVM X.Y Release"
+Issues
+^^^^^^
+
+You can use special comments on issues to make backport requests for the
+release branches.  To do this:
+
+1. Edit "Milestone" at the right side of the issue to say "LLVM X.Y Release"
 
 2. Add a comment to it in the following format:
 
@@ -459,6 +461,20 @@ will be created with the specified commits.
 If a commit you want to backport does not apply cleanly, you may resolve
 the conflicts locally and then create a pull request against the release
 branch.  Just make sure to add the release milestone to the pull request.
+
+
+Pull Requests
+^^^^^^^^^^^^^
+
+If you add the current Release Milestone to a pull request, then a backport
+request will be made automatically without the need to add any additional
+comments like you must do for issues.  You can even add the Milestone after
+the pull request has been merged and the backport request will still automatically
+be created.
+
+If for some reason the automation doesn't work, you may also manually request a
+backport by following the same steps listed above for issues.
+
 
 Getting admin access to CI infrastructure
 =========================================


### PR DESCRIPTION
This adds a new workflow called pr-release-workflow, which will automatically create backport requests for merged PRs with the latest Release Milestone.  This way users can simply add the milestone to PRs with fixes that they want to backport and no longer need to manually add the comments.

However, you do still need to use the comments if you are making a backport request from an issue.