### PR TITLE
[lldb-dap] Upgrade @types/node to fix TS2386 in node/module.d.ts

### DIFF
--- a/lldb/tools/lldb-dap/package-lock.json
+++ b/lldb/tools/lldb-dap/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lldb-dap",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lldb-dap",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache 2.0 License with LLVM exceptions",
       "devDependencies": {
-        "@types/node": "^18.11.18",
+        "@types/node": "^18.19.41",
         "@types/vscode": "1.75.0",
         "@vscode/vsce": "^3.2.2",
         "prettier": "^3.4.2",
@@ -389,10 +389,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.6.tgz",
-      "integrity": "sha512-X36s5CXMrrJOs2lQCdDF68apW4Rfx9ixYMawlepwmE4Anezv/AV2LSpKD1Ub8DAc+urp5bk0BGZ6NtmBitfnsg==",
+      "version": "18.19.75",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.75.tgz",
+      "integrity": "sha512-UIksWtThob6ZVSyxcOqCLOUNg/dyO1Qvx4McgeuhrEtHTLFTf7BBhEazaE4K806FGTPtzd/2sE90qn4fVr7cyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -27,7 +27,7 @@
     "Debuggers"
   ],
   "devDependencies": {
-    "@types/node": "^18.11.18",
+    "@types/node": "^18.19.41",
     "@types/vscode": "1.75.0",
     "@vscode/vsce": "^3.2.2",
     "prettier-plugin-curly": "^0.3.1",


### PR DESCRIPTION
Upgrade @types/node to work around an issue in TypeScript [1] that caused our "publish to VSCode Marketplace" github action [2] to fail:

```
node_modules/@types/node/module.d.ts:290:13 - error TS2386: Overload signatures must all be optional or required.

290             resolve?(specified: string, parent?: string | URL): Promise<string>;
```

[1] https://github.com/microsoft/TypeScript/pull/59259#issuecomment-2228833941
[2] https://github.com/llvm/vscode-lldb/actions/runs/13298213337/job/37134713009