### PR TITLE
[libc++] Fix initialization-order-fiasco with iostream.cpp constructors

### DIFF
--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -40,7 +40,7 @@ union stream_data {
 
 #ifdef _LIBCPP_ABI_MICROSOFT
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
-    constinit stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                           \
+    constinit stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                 \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
         "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A")
 #else

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -38,13 +38,20 @@ union stream_data {
 #define CHAR_MANGLING_wchar_t "_W"
 #define CHAR_MANGLING(CharT) CHAR_MANGLING_##CharT
 
+#ifdef _LIBCPP_COMPILER_CLANG_BASED
+#  define STRING_DATA_CONSTINIT constinit
+#else
+#  define STRING_DATA_CONSTINIT
+#endif
+
 #ifdef _LIBCPP_ABI_MICROSOFT
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
-    constinit stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                 \
+    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                     \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
         "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A") var = {}
 #else
-#  define STREAM(StreamT, BufferT, CharT, var) constinit stream_data<StreamT<CharT>, BufferT<CharT>> var = {}
+#  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
+    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var = {}
 #endif
 
 // These definitions and the declarations in <iostream> technically cause ODR violations, since they have different

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -40,11 +40,11 @@ union stream_data {
 
 #ifdef _LIBCPP_ABI_MICROSOFT
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
-    stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                           \
+    constinit stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                           \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
         "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A")
 #else
-#  define STREAM(StreamT, BufferT, CharT, var) stream_data<StreamT<CharT>, BufferT<CharT>> var
+#  define STREAM(StreamT, BufferT, CharT, var) constinit stream_data<StreamT<CharT>, BufferT<CharT>> var
 #endif
 
 // These definitions and the declarations in <iostream> technically cause ODR violations, since they have different

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -46,9 +46,9 @@ union stream_data {
 
 #ifdef _LIBCPP_ABI_MICROSOFT
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
-    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                     \
+    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                           \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
-        "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A") var
+        "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A")
 #else
 #  define STREAM(StreamT, BufferT, CharT, var) STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var
 #endif

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -48,10 +48,9 @@ union stream_data {
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
     STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                     \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
-        "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A") var = {}
+        "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A") var
 #else
-#  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
-    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var = {}
+#  define STREAM(StreamT, BufferT, CharT, var) STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var
 #endif
 
 // These definitions and the declarations in <iostream> technically cause ODR violations, since they have different

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -42,9 +42,9 @@ union stream_data {
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
     constinit stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                 \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
-        "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A")
+        "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A") var = {}
 #else
-#  define STREAM(StreamT, BufferT, CharT, var) constinit stream_data<StreamT<CharT>, BufferT<CharT>> var
+#  define STREAM(StreamT, BufferT, CharT, var) constinit stream_data<StreamT<CharT>, BufferT<CharT>> var = {}
 #endif
 
 // These definitions and the declarations in <iostream> technically cause ODR violations, since they have different

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -18,8 +18,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class StreamT, class BufferT>
 union stream_data {
-  stream_data() {}
-  ~stream_data() {}
+  constexpr stream_data() {}
+  constexpr ~stream_data() {}
   struct {
     // The stream has to be the first element, since that's referenced by the stream declarations in <iostream>
     StreamT stream;

--- a/libcxx/src/iostream.cpp
+++ b/libcxx/src/iostream.cpp
@@ -46,7 +46,7 @@ union stream_data {
 
 #ifdef _LIBCPP_ABI_MICROSOFT
 #  define STREAM(StreamT, BufferT, CharT, var)                                                                         \
-    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                                           \
+    STRING_DATA_CONSTINIT stream_data<StreamT<CharT>, BufferT<CharT>> var __asm__(                                     \
         "?" #var "@" ABI_NAMESPACE_STR "@std@@3V?$" #StreamT                                                           \
         "@" CHAR_MANGLING(CharT) "U?$char_traits@" CHAR_MANGLING(CharT) "@" ABI_NAMESPACE_STR "@std@@@12@A")
 #else

--- a/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
+++ b/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
@@ -8,20 +8,12 @@
 
 #include <iostream>
 
-extern "C" const char *__asan_default_options() {
-  return "check_initialization_order=true:strict_init_order=true";
-}
+extern "C" const char* __asan_default_options() { return "check_initialization_order=true:strict_init_order=true"; }
 
-// Test that ios used from globals constructors doesn't trigger
-// Asan initialization-order-fiasco.
+// Test that ios used from globals constructors doesn't trigger Asan initialization-order-fiasco.
 
 struct Global {
-  Global() {
-    std::cout << "Hello!";
-  }
+  Global() { std::cout << "Hello!"; }
 } global;
 
-int main(int, char**)
-{
-    return 0;
-}
+int main(int, char**) { return 0; }

--- a/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
+++ b/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 
+// FIXME: Remove after issue https://github.com/llvm/llvm-project/issues/127348 resolved.
 extern "C" const char* __asan_default_options() { return "check_initialization_order=true:strict_init_order=true"; }
 
 // Test that ios used from globals constructors doesn't trigger Asan initialization-order-fiasco.

--- a/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
+++ b/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <iostream>
+
+extern "C" const char *__asan_default_options() {
+  return "check_initialization_order=true:strict_init_order=true";
+}
+
+// Test that ios used from globals constructors doesn't trigger
+// Asan initialization-order-fiasco.
+
+struct Global {
+  Global() {
+    std::cout << "Hello!";
+  }
+} global;
+
+int main(int, char**)
+{
+    return 0;
+}


### PR DESCRIPTION
Asan reports it after #124103.

It's know case of false positive for Asan.
https://github.com/google/sanitizers/wiki/AddressSanitizerInitializationOrderFiasco#false-positives

It's can be avoided with `constexpr` constructors.

In general order global constructors in different
modules is undefined. If global constructor uses
external global, they can be not constructed yet.

However, implementation may contain workaround for
that, or the state of non-constructed global can
be still valid.

Asan will still falsely report such cases, as it
has no machinery to detect correctness of such
cases.

We need to fix/workaround the issue in libc++, as
it will affect many libc++ with Asan users.
