### PR TITLE
[BOLT][NFC] Set NeedsConvertRetProfileToCallCont for pre-aggregated profile

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -197,6 +197,10 @@ private:
 
   BoltAddressTranslation *BAT{nullptr};
 
+  /// Whether pre-aggregated profile needs to convert branch profile into call
+  /// to continuation fallthrough profile.
+  bool NeedsConvertRetProfileToCallCont{false};
+
   /// Update function execution profile with a recorded trace.
   /// A trace is region of code executed between two LBR entries supplied in
   /// execution order.
@@ -268,8 +272,7 @@ private:
                      uint64_t Mispreds);
 
   /// Register a \p Branch.
-  bool doBranch(uint64_t From, uint64_t To, uint64_t Count, uint64_t Mispreds,
-                bool IsPreagg);
+  bool doBranch(uint64_t From, uint64_t To, uint64_t Count, uint64_t Mispreds);
 
   /// Register a trace between two LBR entries supplied in execution order.
   bool doTrace(const LBREntry &First, const LBREntry &Second,


### PR DESCRIPTION
Instead of passing `IsPreagg` to decide whether or not return profile
needs to be converted into call to continuation fallthrough, set
`NeedsConvertRetProfileToCallCont` based on whether pre-aggregated
profile has a certain format (B, F, or f).

Test Plan: ninja check-bolt
