### PR TITLE
[clang][dataflow] Remove a deprecated CachedConstAccessorsLattice API

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/CachedConstAccessorsLattice.h
+++ b/clang/include/clang/Analysis/FlowSensitive/CachedConstAccessorsLattice.h
@@ -65,23 +65,6 @@ public:
 
   /// Creates or returns a previously created `StorageLocation` associated with
   /// a const method call `obj.getFoo()` where `RecordLoc` is the
-  /// `RecordStorageLocation` of `obj`.
-  ///
-  /// The callback `Initialize` runs on the storage location if newly created.
-  /// Returns nullptr if unable to find or create a value.
-  ///
-  /// Requirements:
-  ///
-  ///  - `CE` should return a location (GLValue or a record type).
-  ///
-  /// DEPRECATED: switch users to the below overload which takes Callee and Type
-  /// directly.
-  StorageLocation *getOrCreateConstMethodReturnStorageLocation(
-      const RecordStorageLocation &RecordLoc, const CallExpr *CE,
-      Environment &Env, llvm::function_ref<void(StorageLocation &)> Initialize);
-
-  /// Creates or returns a previously created `StorageLocation` associated with
-  /// a const method call `obj.getFoo()` where `RecordLoc` is the
   /// `RecordStorageLocation` of `obj`, `Callee` is the decl for `getFoo`.
   ///
   /// The callback `Initialize` runs on the storage location if newly created.
@@ -206,29 +189,6 @@ Value *CachedConstAccessorsLattice<Base>::getOrCreateConstMethodReturnValue(
   if (Val != nullptr)
     ObjMap.insert({DirectCallee, Val});
   return Val;
-}
-
-template <typename Base>
-StorageLocation *
-CachedConstAccessorsLattice<Base>::getOrCreateConstMethodReturnStorageLocation(
-    const RecordStorageLocation &RecordLoc, const CallExpr *CE,
-    Environment &Env, llvm::function_ref<void(StorageLocation &)> Initialize) {
-  assert(!CE->getType().isNull());
-  assert(CE->isGLValue() || CE->getType()->isRecordType());
-  auto &ObjMap = ConstMethodReturnStorageLocations[&RecordLoc];
-  const FunctionDecl *DirectCallee = CE->getDirectCallee();
-  if (DirectCallee == nullptr)
-    return nullptr;
-  auto it = ObjMap.find(DirectCallee);
-  if (it != ObjMap.end())
-    return it->second;
-
-  StorageLocation &Loc =
-      Env.createStorageLocation(CE->getType().getNonReferenceType());
-  Initialize(Loc);
-
-  ObjMap.insert({DirectCallee, &Loc});
-  return &Loc;
 }
 
 template <typename Base>

--- a/clang/unittests/Analysis/FlowSensitive/CachedConstAccessorsLatticeTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/CachedConstAccessorsLatticeTest.cpp
@@ -130,33 +130,6 @@ TEST_F(CachedConstAccessorsLatticeTest, SameLocBeforeClearOrDiffAfterClear) {
 
   LatticeT Lattice;
   auto NopInit = [](StorageLocation &) {};
-  StorageLocation *Loc1 = Lattice.getOrCreateConstMethodReturnStorageLocation(
-      Loc, CE, Env, NopInit);
-  auto NotCalled = [](StorageLocation &) {
-    ASSERT_TRUE(false) << "Not reached";
-  };
-  StorageLocation *Loc2 = Lattice.getOrCreateConstMethodReturnStorageLocation(
-      Loc, CE, Env, NotCalled);
-
-  EXPECT_EQ(Loc1, Loc2);
-
-  Lattice.clearConstMethodReturnStorageLocations(Loc);
-  StorageLocation *Loc3 = Lattice.getOrCreateConstMethodReturnStorageLocation(
-      Loc, CE, Env, NopInit);
-
-  EXPECT_NE(Loc3, Loc1);
-  EXPECT_NE(Loc3, Loc2);
-}
-
-TEST_F(CachedConstAccessorsLatticeTest,
-       SameLocBeforeClearOrDiffAfterClearWithCallee) {
-  CommonTestInputs Inputs;
-  auto *CE = Inputs.CallRef;
-  RecordStorageLocation Loc(Inputs.SType, RecordStorageLocation::FieldToLoc(),
-                            {});
-
-  LatticeT Lattice;
-  auto NopInit = [](StorageLocation &) {};
   const FunctionDecl *Callee = CE->getDirectCallee();
   ASSERT_NE(Callee, nullptr);
   StorageLocation &Loc1 = Lattice.getOrCreateConstMethodReturnStorageLocation(
@@ -204,22 +177,24 @@ TEST_F(CachedConstAccessorsLatticeTest,
   // Accessors that return a record by value are modeled by a record storage
   // location (instead of a Value).
   auto NopInit = [](StorageLocation &) {};
-  StorageLocation *Loc1 = Lattice.getOrCreateConstMethodReturnStorageLocation(
-      Loc, CE, Env, NopInit);
+  const FunctionDecl *Callee = CE->getDirectCallee();
+  ASSERT_NE(Callee, nullptr);
+  StorageLocation &Loc1 = Lattice.getOrCreateConstMethodReturnStorageLocation(
+      Loc, Callee, Env, NopInit);
   auto NotCalled = [](StorageLocation &) {
     ASSERT_TRUE(false) << "Not reached";
   };
-  StorageLocation *Loc2 = Lattice.getOrCreateConstMethodReturnStorageLocation(
-      Loc, CE, Env, NotCalled);
+  StorageLocation &Loc2 = Lattice.getOrCreateConstMethodReturnStorageLocation(
+      Loc, Callee, Env, NotCalled);
 
-  EXPECT_EQ(Loc1, Loc2);
+  EXPECT_EQ(&Loc1, &Loc2);
 
   Lattice.clearConstMethodReturnStorageLocations(Loc);
-  StorageLocation *Loc3 = Lattice.getOrCreateConstMethodReturnStorageLocation(
-      Loc, CE, Env, NopInit);
+  StorageLocation &Loc3 = Lattice.getOrCreateConstMethodReturnStorageLocation(
+      Loc, Callee, Env, NopInit);
 
-  EXPECT_NE(Loc3, Loc1);
-  EXPECT_NE(Loc3, Loc1);
+  EXPECT_NE(&Loc3, &Loc1);
+  EXPECT_NE(&Loc3, &Loc1);
 }
 
 TEST_F(CachedConstAccessorsLatticeTest, ClearDifferentLocs) {
@@ -232,18 +207,20 @@ TEST_F(CachedConstAccessorsLatticeTest, ClearDifferentLocs) {
 
   LatticeT Lattice;
   auto NopInit = [](StorageLocation &) {};
-  StorageLocation *RetLoc1 =
-      Lattice.getOrCreateConstMethodReturnStorageLocation(LocS1, CE, Env,
+  const FunctionDecl *Callee = CE->getDirectCallee();
+  ASSERT_NE(Callee, nullptr);
+  StorageLocation &RetLoc1 =
+      Lattice.getOrCreateConstMethodReturnStorageLocation(LocS1, Callee, Env,
                                                           NopInit);
   Lattice.clearConstMethodReturnStorageLocations(LocS2);
   auto NotCalled = [](StorageLocation &) {
     ASSERT_TRUE(false) << "Not reached";
   };
-  StorageLocation *RetLoc2 =
-      Lattice.getOrCreateConstMethodReturnStorageLocation(LocS1, CE, Env,
+  StorageLocation &RetLoc2 =
+      Lattice.getOrCreateConstMethodReturnStorageLocation(LocS1, Callee, Env,
                                                           NotCalled);
 
-  EXPECT_EQ(RetLoc1, RetLoc2);
+  EXPECT_EQ(&RetLoc1, &RetLoc2);
 }
 
 TEST_F(CachedConstAccessorsLatticeTest, DifferentValsFromDifferentLocs) {


### PR DESCRIPTION
We've already migrated known users from the old to the new version of getOrCreateConstMethodReturnStorageLocation. The conversion is pretty straightforward as well, if there are out-of-tree users:

Previously: use CallExpr as argument
New: get the direct Callee from CallExpr, null check, and use that as the argument instead.
