### PR TITLE
[RISCV][NFC] Move GenericModel to standalone file

### DIFF
--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -46,6 +46,7 @@ include "RISCVMacroFusion.td"
 // RISC-V Scheduling Models
 //===----------------------------------------------------------------------===//
 
+include "RISCVSchedGeneric.td"
 include "RISCVSchedMIPSP8700.td"
 include "RISCVSchedRocket.td"
 include "RISCVSchedSiFive7.td"

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -88,15 +88,6 @@ class RISCVTuneProcessorModel<string n,
 
 defvar GenericTuneFeatures = [TuneOptimizedNF2SegmentLoadStore];
 
-// Adjust the default cost model to enable all heuristics, not just latency
-// In particular, this enables register pressure heustics which are very
-// important for high LMUL vector code, and have little negative impact
-// on other configurations,
-def GenericModel : SchedMachineModel {
-  let MicroOpBufferSize = 1;
-  let CompleteModel = 0;
-}
-
 def GENERIC_RV32 : RISCVProcessorModel<"generic-rv32",
                                        GenericModel,
                                        [Feature32Bit,

--- a/llvm/lib/Target/RISCV/RISCVSchedGeneric.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedGeneric.td
@@ -1,0 +1,18 @@
+//===-- RISCVSchedGeneric.td - Generic In-order Processor --*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Adjust the default cost model to enable all scheduling heuristics, not just
+// latency.
+//
+// In particular, this enables register pressure heuristics which are very
+// important for vector code with high LMULs, and have little negative impact
+// on other configurations.
+def GenericModel : SchedMachineModel {
+  let MicroOpBufferSize = 1;
+  let CompleteModel = 0;
+}


### PR DESCRIPTION
And fix some typos in comments.

In the future, we may add more scheduling info to GenericModel.
