### PR TITLE
[flang][OpenMP] Support `bind` clause for `teams loop`

### DIFF
--- a/flang/lib/Optimizer/OpenMP/GenericLoopConversion.cpp
+++ b/flang/lib/Optimizer/OpenMP/GenericLoopConversion.cpp
@@ -84,9 +84,10 @@ public:
              << loopOp->getName() << " operation";
     };
 
-    // For standalone directives, `bind` is already supported. Other combined
-    // forms will be supported in a follow-up PR.
-    if (combinedInfo != GenericLoopCombinedInfo::Standalone &&
+    // For `loop` and `teams loop` directives, `bind` is supported.
+    // Additionally, for `teams loop`, semantic checking verifies that the
+    // `bind` clause modifier is `teams`, so no need to check this here again.
+    if (combinedInfo == GenericLoopCombinedInfo::ParallelLoop &&
         loopOp.getBindKind())
       return todo("bind");
 

--- a/flang/test/Lower/OpenMP/generic-loop-rewriting.f90
+++ b/flang/test/Lower/OpenMP/generic-loop-rewriting.f90
@@ -1,10 +1,28 @@
-!RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
+!RUN: split-file %s %t
 
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %t/no_bind_clause.f90 -o - \
+!RUN: | FileCheck %s
+
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 %t/bind_clause_teams.f90 -o - \
+!RUN: | FileCheck %s
+
+!--- no_bind_clause.f90
 subroutine target_teams_loop
     implicit none
     integer :: x, i
 
     !$omp target teams loop
+    do i = 0, 10
+      x = x + i
+    end do
+end subroutine target_teams_loop
+
+!--- bind_clause_teams.f90
+subroutine target_teams_loop
+    implicit none
+    integer :: x, i
+
+    !$omp target teams loop bind(teams)
     do i = 0, 10
       x = x + i
     end do

--- a/flang/test/Transforms/generic-loop-rewriting-todo.mlir
+++ b/flang/test/Transforms/generic-loop-rewriting-todo.mlir
@@ -16,22 +16,6 @@ func.func @_QPparallel_loop() {
   return
 }
 
-func.func @_QPloop_bind() {
-  omp.teams {
-    %c0 = arith.constant 0 : i32
-    %c10 = arith.constant 10 : i32
-    %c1 = arith.constant 1 : i32
-    // expected-error@below {{not yet implemented: Unhandled clause bind in omp.loop operation}}
-    omp.loop bind(thread) {
-      omp.loop_nest (%arg3) : i32 = (%c0) to (%c10) inclusive step (%c1) {
-        omp.yield
-      }
-    }
-    omp.terminator
-  }
-  return
-}
-
 omp.declare_reduction @add_reduction_i32 : i32 init {
   ^bb0(%arg0: i32):
     %c0_i32 = arith.constant 0 : i32


### PR DESCRIPTION
Extends generic `loop` directive support by supporting the `bind` clause. Since semantic checking does the heavy lifting of verifying the proper usage of the clause modifier, we can simply enable code-gen for `teams loop bind(...)` without the need to differentiate between the values the the clause can accept.