### PR TITLE
[mlir][spirv] Update example of `spirv.Constant`(NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVStructureOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVStructureOps.td
@@ -101,7 +101,7 @@ def SPIRV_ConstantOp : SPIRV_Op<"Constant",
 
     ```mlir
     %0 = spirv.Constant true
-    %1 = spirv.Constant dense<[2, 3]> : vector<2xf32>
+    %1 = spirv.Constant dense<[2.0, 3.0]> : vector<2xf32>
     %2 = spirv.Constant [dense<3.0> : vector<2xf32>] : !spirv.array<1xvector<2xf32>>
     ```
 


### PR DESCRIPTION
Actually the `spirv.Constant dense<[2, 3]> : vector<2xf32>` will cause a error:
```
error: unexpected decimal integer literal for a floating point value
    %cst = spirv.Constant dense<[2, 3]> : vector<2xf32>
                                 ^
```
The value should be an explicit float.