### PR TITLE
[RISCV] Set Feature32Bit/Feature64Bit based on triple for -mcpu=help.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -89,7 +89,22 @@ static MCSubtargetInfo *createRISCVMCSubtargetInfo(const Triple &TT,
   if (CPU.empty() || CPU == "generic")
     CPU = TT.isArch64Bit() ? "generic-rv64" : "generic-rv32";
 
-  return createRISCVMCSubtargetInfoImpl(TT, CPU, /*TuneCPU*/ CPU, FS);
+  MCSubtargetInfo *X =
+      createRISCVMCSubtargetInfoImpl(TT, CPU, /*TuneCPU*/ CPU, FS);
+
+  // If the CPU is "help" fill in 64 or 32 bit feature so we can pass
+  // RISCVFeatures::validate.
+  // FIXME: Why does llvm-mc still expect a source file with -mcpu=help?
+  if (CPU == "help") {
+    llvm::FeatureBitset Features = X->getFeatureBits();
+    if (TT.isArch64Bit())
+      Features.set(RISCV::Feature64Bit);
+    else
+      Features.set(RISCV::Feature32Bit);
+    X->setFeatureBits(Features);
+  }
+
+  return X;
 }
 
 static MCInstPrinter *createRISCVMCInstPrinter(const Triple &T,


### PR DESCRIPTION
llvm-mc keeps going after printing help text and creates an assembler. If we don't set one of the XLen sized feature bits we trip a fatal error in RISCVFeatures::validate.

llvm-mc should probably be fixed, but I don't know if its the only tool with this issue.