### PR TITLE
[IR][Instructions] Add `CallBase::getCalledFunctionName` helper

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -41,7 +41,7 @@ class VFDatabase {
   /// a vector Function ABI.
   static void getVFABIMappings(const CallInst &CI,
                                SmallVectorImpl<VFInfo> &Mappings) {
-    const auto ScalarName = CI.getCalledFunctionName();
+    const std::optional<StringRef> ScalarName = CI.getCalledFunctionName();
     if (!ScalarName.has_value())
       return;
 

--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -41,10 +41,9 @@ class VFDatabase {
   /// a vector Function ABI.
   static void getVFABIMappings(const CallInst &CI,
                                SmallVectorImpl<VFInfo> &Mappings) {
-    if (!CI.getCalledFunction())
+    const auto ScalarName = CI.getCalledFunctionName();
+    if (!ScalarName.has_value())
       return;
-
-    const StringRef ScalarName = CI.getCalledFunction()->getName();
 
     SmallVector<std::string, 8> ListOfStrings;
     // The check for the vector-function-abi-variant attribute is done when
@@ -59,7 +58,7 @@ class VFDatabase {
       // ensuring that the variant described in the attribute has a
       // corresponding definition or declaration of the vector
       // function in the Module M.
-      if (Shape && (Shape->ScalarName == ScalarName)) {
+      if (Shape && (Shape->ScalarName == *ScalarName)) {
         assert(CI.getModule()->getFunction(Shape->VectorName) &&
                "Vector function is missing.");
         Mappings.push_back(*Shape);

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1345,6 +1345,16 @@ public:
     return nullptr;
   }
 
+  /// Shortcut to retrieving the name of the called function.
+  /// Returns std::nullopt, if the function cannot be found.
+  std::optional<StringRef> getCalledFunctionName() const {
+    Function *F = getCalledFunction();
+    if (F)
+      return F->getName();
+
+    return std::nullopt;
+  }
+
   /// Return true if the callsite is an indirect call.
   bool isIndirectCall() const;
 

--- a/llvm/lib/Analysis/IRSimilarityIdentifier.cpp
+++ b/llvm/lib/Analysis/IRSimilarityIdentifier.cpp
@@ -153,7 +153,7 @@ void IRInstructionData::setCalleeName(bool MatchByName) {
   }
 
   if (!CI->isIndirectCall() && MatchByName)
-    CalleeName = CI->getCalledFunction()->getName().str();
+    CalleeName = CI->getCalledFunctionName()->str();
 }
 
 void IRInstructionData::setPHIPredecessors(

--- a/llvm/lib/Analysis/KernelInfo.cpp
+++ b/llvm/lib/Analysis/KernelInfo.cpp
@@ -159,7 +159,7 @@ static void remarkFlatAddrspaceAccess(OptimizationRemarkEmitter &ORE,
     R << "in ";
     identifyFunction(R, Caller);
     if (const IntrinsicInst *II = dyn_cast<IntrinsicInst>(&Inst)) {
-      R << ", '" << II->getCalledFunction()->getName() << "' call";
+      R << ", '" << *II->getCalledFunctionName() << "' call";
     } else {
       R << ", '" << Inst.getOpcodeName() << "' instruction";
     }

--- a/llvm/lib/Analysis/ReplayInlineAdvisor.cpp
+++ b/llvm/lib/Analysis/ReplayInlineAdvisor.cpp
@@ -108,7 +108,7 @@ std::unique_ptr<InlineAdvice> ReplayInlineAdvisor::getAdviceImpl(CallBase &CB) {
 
   std::string CallSiteLoc =
       formatCallSiteLocation(CB.getDebugLoc(), ReplaySettings.ReplayFormat);
-  StringRef Callee = CB.getCalledFunction()->getName();
+  StringRef Callee = *CB.getCalledFunctionName();
   std::string Combined = (Callee + CallSiteLoc).str();
 
   // Replay decision, if it has one

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4398,7 +4398,7 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     if (CI->getFunctionType() == NewFn->getFunctionType()) {
       // Handle generic mangling change.
       assert(
-          (CI->getCalledFunction()->getName() != NewFn->getName()) &&
+          (CI->getCalledFunctionName().value_or("") != NewFn->getName()) &&
           "Unknown function for CallBase upgrade and isn't just a name change");
       CI->setCalledFunction(NewFn);
       return;

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -9034,21 +9034,19 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
     CalleeAttrs = SMEAttrs(ES->getSymbol());
 
   auto DescribeCallsite =
-          [&](OptimizationRemarkAnalysis &R) -> OptimizationRemarkAnalysis & {
-      R << "call from '" << ore::NV("Caller", MF.getName()) << "' to '";
-      if (auto *ES = dyn_cast<ExternalSymbolSDNode>(CLI.Callee)) {
-          R << ore::NV("Callee", ES->getSymbol());
-      }
-      else if (CLI.CB) {
-          const std::optional<StringRef> CalleeName =
-                  CLI.CB->getCalledFunctionName();
-          R << ore::NV("Callee", CalleeName.value_or("unknown callee"));
-      }
-      else {
-          R << "unknown callee";
-      }
-      R << "'";
-      return R;
+      [&](OptimizationRemarkAnalysis &R) -> OptimizationRemarkAnalysis & {
+    R << "call from '" << ore::NV("Caller", MF.getName()) << "' to '";
+    if (auto *ES = dyn_cast<ExternalSymbolSDNode>(CLI.Callee)) {
+      R << ore::NV("Callee", ES->getSymbol());
+    } else if (CLI.CB) {
+      const std::optional<StringRef> CalleeName =
+          CLI.CB->getCalledFunctionName();
+      R << ore::NV("Callee", CalleeName.value_or("unknown callee"));
+    } else {
+      R << "unknown callee";
+    }
+    R << "'";
+    return R;
   };
 
   bool RequiresLazySave = CallerAttrs.requiresLazySave(CalleeAttrs);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -9034,21 +9034,21 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
     CalleeAttrs = SMEAttrs(ES->getSymbol());
 
   auto DescribeCallsite =
-      [&](OptimizationRemarkAnalysis &R) -> OptimizationRemarkAnalysis & {
-    R << "call from '" << ore::NV("Caller", MF.getName()) << "' to '";
-    if (auto *ES = dyn_cast<ExternalSymbolSDNode>(CLI.Callee)) {
-      R << ore::NV("Callee", ES->getSymbol());
-    }
-     else if (CLI.CB) {
-      const std::optional<StringRef> CalleeName =
-          CLI.CB->getCalledFunctionName();
-      R << ore::NV("Callee", CalleeName.value_or("unknown callee"));
-    }
-    else {
-      R << "unknown callee";
-    }
-    R << "'";
-    return R;
+          [&](OptimizationRemarkAnalysis &R) -> OptimizationRemarkAnalysis & {
+      R << "call from '" << ore::NV("Caller", MF.getName()) << "' to '";
+      if (auto *ES = dyn_cast<ExternalSymbolSDNode>(CLI.Callee)) {
+          R << ore::NV("Callee", ES->getSymbol());
+      }
+      else if (CLI.CB) {
+          const std::optional<StringRef> CalleeName =
+                  CLI.CB->getCalledFunctionName();
+          R << ore::NV("Callee", CalleeName.value_or("unknown callee"));
+      }
+      else {
+          R << "unknown callee";
+      }
+      R << "'";
+      return R;
   };
 
   bool RequiresLazySave = CallerAttrs.requiresLazySave(CalleeAttrs);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -9036,12 +9036,17 @@ AArch64TargetLowering::LowerCall(CallLoweringInfo &CLI,
   auto DescribeCallsite =
       [&](OptimizationRemarkAnalysis &R) -> OptimizationRemarkAnalysis & {
     R << "call from '" << ore::NV("Caller", MF.getName()) << "' to '";
-    if (auto *ES = dyn_cast<ExternalSymbolSDNode>(CLI.Callee))
+    if (auto *ES = dyn_cast<ExternalSymbolSDNode>(CLI.Callee)) {
       R << ore::NV("Callee", ES->getSymbol());
-    else if (CLI.CB && CLI.CB->getCalledFunction())
-      R << ore::NV("Callee", CLI.CB->getCalledFunction()->getName());
-    else
+    }
+     else if (CLI.CB) {
+      const std::optional<StringRef> CalleeName =
+          CLI.CB->getCalledFunctionName();
+      R << ore::NV("Callee", CalleeName.value_or("unknown callee"));
+    }
+    else {
       R << "unknown callee";
+    }
     R << "'";
     return R;
   };

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -1389,8 +1389,9 @@ bool AMDGPULibCalls::fold_sincos(FPMathOperator *FPOp, IRBuilder<> &B,
                        fInfo);
   const std::string PairName = PartnerInfo.mangle();
 
-  StringRef SinName = isSin ? CI->getCalledFunction()->getName() : PairName;
-  StringRef CosName = isSin ? PairName : CI->getCalledFunction()->getName();
+  const std::optional<StringRef> CalleeName = CI->getCalledFunctionName();
+  StringRef SinName = isSin ? *CalleeName : PairName;
+  StringRef CosName = isSin ? PairName : *CalleeName;
   const std::string SinCosPrivateName = SinCosLibFuncPrivate.mangle();
   const std::string SinCosGenericName = SinCosLibFuncGeneric.mangle();
 

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -1638,9 +1638,9 @@ void SPIRVEmitIntrinsics::insertPtrCastOrAssignTypeInstr(Instruction *I,
     return;
 
   // collect information about formal parameter types
-  std::string DemangledName =
-      getOclOrSpirvBuiltinDemangledName(CI->getCalledFunction()->getName());
   Function *CalledF = CI->getCalledFunction();
+  std::string DemangledName =
+      getOclOrSpirvBuiltinDemangledName(CalledF->getName());
   SmallVector<Type *, 4> CalledArgTys;
   bool HaveTypes = false;
   for (unsigned OpIdx = 0; OpIdx < CalledF->arg_size(); ++OpIdx) {

--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -1962,7 +1962,7 @@ std::string ModuleCallsiteContextGraph::getLabel(const Function *Func,
                                                  const Instruction *Call,
                                                  unsigned CloneNo) const {
   return (Twine(Call->getFunction()->getName()) + " -> " +
-          cast<CallBase>(Call)->getCalledFunction()->getName())
+          *cast<CallBase>(Call)->getCalledFunctionName())
       .str();
 }
 

--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -5278,12 +5278,12 @@ struct AAFoldRuntimeCallCallSiteReturned : AAFoldRuntimeCall {
 
       CallBase *CB = dyn_cast<CallBase>(&I);
       auto Remark = [&](OptimizationRemark OR) {
+        const std::optional<StringRef> CalleeName = CB->getCalledFunctionName();
         if (auto *C = dyn_cast<ConstantInt>(*SimplifiedValue))
-          return OR << "Replacing OpenMP runtime call "
-                    << CB->getCalledFunction()->getName() << " with "
-                    << ore::NV("FoldedValue", C->getZExtValue()) << ".";
-        return OR << "Replacing OpenMP runtime call "
-                  << CB->getCalledFunction()->getName() << ".";
+          return OR << "Replacing OpenMP runtime call " << *CalleeName
+                    << " with " << ore::NV("FoldedValue", C->getZExtValue())
+                    << ".";
+        return OR << "Replacing OpenMP runtime call " << *CalleeName << ".";
       };
 
       if (CB && EnableVerboseRemarks)

--- a/llvm/lib/Transforms/IPO/SampleProfile.cpp
+++ b/llvm/lib/Transforms/IPO/SampleProfile.cpp
@@ -1043,8 +1043,7 @@ void SampleProfileLoader::findExternalInlineCandidate(
     // Samples may not exist for replayed function, if so
     // just add the direct GUID and move on
     if (!Samples) {
-      InlinedGUIDs.insert(
-          Function::getGUID(CB->getCalledFunction()->getName()));
+      InlinedGUIDs.insert(Function::getGUID(*CB->getCalledFunctionName()));
       return;
     }
     // Otherwise, drop the threshold to import everything that we can

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -5458,7 +5458,7 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
   void dumpInst(Instruction &I) {
     if (CallInst *CI = dyn_cast<CallInst>(&I)) {
-      errs() << "ZZZ call " << CI->getCalledFunction()->getName() << "\n";
+      errs() << "ZZZ call " << *CI->getCalledFunctionName() << "\n";
     } else {
       errs() << "ZZZ " << I.getOpcodeName() << "\n";
     }

--- a/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOMemOPSizeOpt.cpp
@@ -132,8 +132,8 @@ struct MemOp {
   }
   StringRef getFuncName() {
     if (auto MI = asMI())
-      return MI->getCalledFunction()->getName();
-    return asCI()->getCalledFunction()->getName();
+      return *MI->getCalledFunctionName();
+    return *asCI()->getCalledFunctionName();
   }
   bool isMemmove() {
     if (auto MI = asMI())

--- a/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
@@ -2301,7 +2301,7 @@ public:
       if (!CI->getCalledFunction())
         write("<no called fn>");
       else {
-        StringRef Name = CI->getCalledFunction()->getName();
+        StringRef Name = *CI->getCalledFunctionName();
         if (!Name.starts_with("llvm.matrix")) {
           write(Name);
           return;

--- a/llvm/lib/Transforms/Utils/InjectTLIMappings.cpp
+++ b/llvm/lib/Transforms/Utils/InjectTLIMappings.cpp
@@ -75,15 +75,16 @@ static void addMappingsFromTLI(const TargetLibraryInfo &TLI, CallInst &CI) {
   // bitcast (i32 (...)* @goo to i32 (i32*, ...)*)(i32* nonnull %i)`,
   // as such calls make the `isFunctionVectorizable` raise an
   // exception.
-  if (CI.isNoBuiltin() || !CI.getCalledFunction())
+  if (CI.isNoBuiltin())
     return;
 
-  StringRef ScalarName = CI.getCalledFunction()->getName();
+  const std::optional<StringRef> ScalarName = CI.getCalledFunctionName();
 
   // Nothing to be done if the TLI thinks the function is not
   // vectorizable.
-  if (!TLI.isFunctionVectorizable(ScalarName))
+  if (!ScalarName.has_value() || !TLI.isFunctionVectorizable(*ScalarName))
     return;
+
   SmallVector<std::string, 8> Mappings;
   VFABI::getVectorVariantNames(CI, Mappings);
   Module *M = CI.getModule();
@@ -91,7 +92,7 @@ static void addMappingsFromTLI(const TargetLibraryInfo &TLI, CallInst &CI) {
                                                    Mappings.end());
 
   auto AddVariantDecl = [&](const ElementCount &VF, bool Predicate) {
-    const VecDesc *VD = TLI.getVectorMappingInfo(ScalarName, VF, Predicate);
+    const VecDesc *VD = TLI.getVectorMappingInfo(*ScalarName, VF, Predicate);
     if (VD && !VD->getVectorFnName().empty()) {
       std::string MangledName = VD->getVectorFunctionABIVariantString();
       if (!OriginalSetOfMappings.count(MangledName)) {
@@ -106,7 +107,7 @@ static void addMappingsFromTLI(const TargetLibraryInfo &TLI, CallInst &CI) {
 
   //  All VFs in the TLI are powers of 2.
   ElementCount WidestFixedVF, WidestScalableVF;
-  TLI.getWidestVF(ScalarName, WidestFixedVF, WidestScalableVF);
+  TLI.getWidestVF(*ScalarName, WidestFixedVF, WidestScalableVF);
 
   for (bool Predicated : {false, true}) {
     for (ElementCount VF = ElementCount::getFixed(2);

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1983,7 +1983,7 @@ static void trackInlinedStores(Function::iterator Start, Function::iterator End,
                                const CallBase &CB) {
   LLVM_DEBUG(errs() << "trackInlinedStores into "
                     << Start->getParent()->getName() << " from "
-                    << CB.getCalledFunction()->getName() << "\n");
+                    << *CB.getCalledFunctionName() << "\n");
   const DataLayout &DL = CB.getDataLayout();
   at::trackAssignments(Start, End, collectEscapedLocals(DL, CB), DL);
 }

--- a/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
+++ b/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
@@ -58,8 +58,11 @@ public:
   bool perform() {
     bool Changed = false;
     for (auto &CI : WorkList) {
-      LLVM_DEBUG(dbgs() << "CDCE calls: " << CI->getCalledFunction()->getName()
-                        << "\n");
+      auto CalleeName = CI->getCalledFunctionName();
+      assert(CalleeName.has_value() &&
+             "perform() should apply to a non-empty callee");
+
+      LLVM_DEBUG(dbgs() << "CDCE calls: " << *CalleeName << "\n");
       if (perform(CI)) {
         Changed = true;
         LLVM_DEBUG(dbgs() << "Transformed\n");
@@ -487,7 +490,6 @@ void LibCallsShrinkWrap::shrinkWrapCI(CallInst *CI, Value *Cond) {
 bool LibCallsShrinkWrap::perform(CallInst *CI) {
   LibFunc Func;
   Function *Callee = CI->getCalledFunction();
-  assert(Callee && "perform() should apply to a non-empty callee");
   TLI.getLibFunc(*Callee, Func);
   assert(Func && "perform() is not expecting an empty function");
 

--- a/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
+++ b/llvm/lib/Transforms/Utils/LibCallsShrinkWrap.cpp
@@ -58,7 +58,7 @@ public:
   bool perform() {
     bool Changed = false;
     for (auto &CI : WorkList) {
-      auto CalleeName = CI->getCalledFunctionName();
+      std::optional<StringRef> CalleeName = CI->getCalledFunctionName();
       assert(CalleeName.has_value() &&
              "perform() should apply to a non-empty callee");
 

--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -4041,11 +4041,11 @@ Value *LibCallSimplifier::optimizeFloatingPointLibCall(CallInst *CI,
   case LibFunc_cos:
   case LibFunc_sin:
   case LibFunc_tanh:
-    if (UnsafeFPShrink && hasFloatVersion(M, CI->getCalledFunction()->getName()))
+    if (UnsafeFPShrink && hasFloatVersion(M, *CI->getCalledFunctionName()))
       return optimizeUnaryDoubleFP(CI, Builder, TLI, true);
     return nullptr;
   case LibFunc_copysign:
-    if (hasFloatVersion(M, CI->getCalledFunction()->getName()))
+    if (hasFloatVersion(M, *CI->getCalledFunctionName()))
       return optimizeBinaryDoubleFP(CI, Builder, TLI);
     return nullptr;
   case LibFunc_fdim:

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -759,10 +759,10 @@ bool LoopVectorizationLegality::setupOuterLoopInductions() {
 ///      {"llvm.phx.abs.i32", "", 4}
 ///    };
 static bool isTLIScalarize(const TargetLibraryInfo &TLI, const CallInst &CI) {
-  const StringRef ScalarName = CI.getCalledFunction()->getName();
+  const StringRef ScalarName = *CI.getCalledFunctionName();
   bool Scalarize = TLI.isFunctionVectorizable(ScalarName);
   // Check that all known VFs are not associated to a vector
-  // function, i.e. the vector name is emty.
+  // function, i.e. the vector name is empty.
   if (Scalarize) {
     ElementCount WidestFixedVF, WidestScalableVF;
     TLI.getWidestVF(ScalarName, WidestFixedVF, WidestScalableVF);
@@ -907,11 +907,10 @@ bool LoopVectorizationLegality::canVectorizeInstrs() {
         // If the call is a recognized math libary call, it is likely that
         // we can vectorize it given loosened floating-point constraints.
         LibFunc Func;
+        const std::optional<StringRef> FuncName = CI->getCalledFunctionName();
         bool IsMathLibCall =
-            TLI && CI->getCalledFunction() &&
-            CI->getType()->isFloatingPointTy() &&
-            TLI->getLibFunc(CI->getCalledFunction()->getName(), Func) &&
-            TLI->hasOptimizedCodeGen(Func);
+            TLI && FuncName.has_value() && CI->getType()->isFloatingPointTy() &&
+            TLI->getLibFunc(*FuncName, Func) && TLI->hasOptimizedCodeGen(Func);
 
         if (IsMathLibCall) {
           // TODO: Ideally, we should not use clang-specific language here,

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2439,7 +2439,7 @@ void VPReplicateRecipe::print(raw_ostream &O, const Twine &Indent,
   if (auto *CB = dyn_cast<CallBase>(getUnderlyingInstr())) {
     O << "call";
     printFlags(O);
-    O << "@" << CB->getCalledFunction()->getName() << "(";
+    O << "@" << *CB->getCalledFunctionName() << "(";
     interleaveComma(make_range(op_begin(), op_begin() + (getNumOperands() - 1)),
                     O, [&O, &SlotTracker](VPValue *Op) {
                       Op->printAsOperand(O, SlotTracker);

--- a/llvm/unittests/Analysis/InlineOrderPlugin/InlineOrderPlugin.cpp
+++ b/llvm/unittests/Analysis/InlineOrderPlugin/InlineOrderPlugin.cpp
@@ -21,7 +21,7 @@ public:
   size_t size() override { return DefaultInlineOrder->size(); }
   void push(const std::pair<CallBase *, int> &Elt) override {
     // We ignore calles named "foo"
-    if (Elt.first->getCalledFunction()->getName() == "foo") {
+    if (*Elt.first->getCalledFunctionName() == "foo") {
       DefaultInlineOrder->push(Elt);
     }
   }

--- a/llvm/unittests/Analysis/PluginInlineAdvisorAnalysisTest.cpp
+++ b/llvm/unittests/Analysis/PluginInlineAdvisorAnalysisTest.cpp
@@ -35,7 +35,7 @@ public:
       : InlineAdvisor(M, FAM, IC) {}
 
   std::unique_ptr<InlineAdvice> getAdviceImpl(CallBase &CB) override {
-    if (CB.getCalledFunction()->getName() == "foo")
+    if (*CB.getCalledFunctionName() == "foo")
       return std::make_unique<InlineAdvice>(this, CB, getCallerORE(CB), true);
     return std::make_unique<InlineAdvice>(this, CB, getCallerORE(CB), false);
   }

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -388,14 +388,14 @@ TEST_F(OpenMPIRBuilderTest, CreateBarrier) {
   CallInst *GTID = dyn_cast<CallInst>(&BB->front());
   EXPECT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotFreeMemory());
 
   CallInst *Barrier = dyn_cast<CallInst>(GTID->getNextNode());
   EXPECT_NE(Barrier, nullptr);
   EXPECT_EQ(Barrier->arg_size(), 2U);
-  EXPECT_EQ(Barrier->getCalledFunction()->getName(), "__kmpc_barrier");
+  EXPECT_EQ(*Barrier->getCalledFunctionName(), "__kmpc_barrier");
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotFreeMemory());
 
@@ -433,14 +433,14 @@ TEST_F(OpenMPIRBuilderTest, CreateCancel) {
   CallInst *GTID = dyn_cast<CallInst>(&BB->front());
   EXPECT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotFreeMemory());
 
   CallInst *Cancel = dyn_cast<CallInst>(GTID->getNextNode());
   EXPECT_NE(Cancel, nullptr);
   EXPECT_EQ(Cancel->arg_size(), 3U);
-  EXPECT_EQ(Cancel->getCalledFunction()->getName(), "__kmpc_cancel");
+  EXPECT_EQ(*Cancel->getCalledFunctionName(), "__kmpc_cancel");
   EXPECT_FALSE(Cancel->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(Cancel->getCalledFunction()->doesNotFreeMemory());
   EXPECT_EQ(Cancel->getNumUses(), 1U);
@@ -451,13 +451,13 @@ TEST_F(OpenMPIRBuilderTest, CreateCancel) {
   CallInst *GTID1 = dyn_cast<CallInst>(&CancelBBTI->getSuccessor(1)->front());
   EXPECT_NE(GTID1, nullptr);
   EXPECT_EQ(GTID1->arg_size(), 1U);
-  EXPECT_EQ(GTID1->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID1->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID1->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID1->getCalledFunction()->doesNotFreeMemory());
   CallInst *Barrier = dyn_cast<CallInst>(GTID1->getNextNode());
   EXPECT_NE(Barrier, nullptr);
   EXPECT_EQ(Barrier->arg_size(), 2U);
-  EXPECT_EQ(Barrier->getCalledFunction()->getName(), "__kmpc_cancel_barrier");
+  EXPECT_EQ(*Barrier->getCalledFunctionName(), "__kmpc_cancel_barrier");
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotFreeMemory());
   EXPECT_EQ(Barrier->getNumUses(), 0U);
@@ -506,14 +506,14 @@ TEST_F(OpenMPIRBuilderTest, CreateCancelIfCond) {
   CallInst *GTID = dyn_cast<CallInst>(&BB->front());
   EXPECT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotFreeMemory());
 
   CallInst *Cancel = dyn_cast<CallInst>(GTID->getNextNode());
   EXPECT_NE(Cancel, nullptr);
   EXPECT_EQ(Cancel->arg_size(), 3U);
-  EXPECT_EQ(Cancel->getCalledFunction()->getName(), "__kmpc_cancel");
+  EXPECT_EQ(*Cancel->getCalledFunctionName(), "__kmpc_cancel");
   EXPECT_FALSE(Cancel->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(Cancel->getCalledFunction()->doesNotFreeMemory());
   EXPECT_EQ(Cancel->getNumUses(), 1U);
@@ -526,13 +526,13 @@ TEST_F(OpenMPIRBuilderTest, CreateCancelIfCond) {
   CallInst *GTID1 = dyn_cast<CallInst>(&CancelBBTI->getSuccessor(1)->front());
   EXPECT_NE(GTID1, nullptr);
   EXPECT_EQ(GTID1->arg_size(), 1U);
-  EXPECT_EQ(GTID1->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID1->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID1->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID1->getCalledFunction()->doesNotFreeMemory());
   CallInst *Barrier = dyn_cast<CallInst>(GTID1->getNextNode());
   EXPECT_NE(Barrier, nullptr);
   EXPECT_EQ(Barrier->arg_size(), 2U);
-  EXPECT_EQ(Barrier->getCalledFunction()->getName(), "__kmpc_cancel_barrier");
+  EXPECT_EQ(*Barrier->getCalledFunctionName(), "__kmpc_cancel_barrier");
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotFreeMemory());
   EXPECT_EQ(Barrier->getNumUses(), 0U);
@@ -576,14 +576,14 @@ TEST_F(OpenMPIRBuilderTest, CreateCancelBarrier) {
   CallInst *GTID = dyn_cast<CallInst>(&BB->front());
   EXPECT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotFreeMemory());
 
   CallInst *Barrier = dyn_cast<CallInst>(GTID->getNextNode());
   EXPECT_NE(Barrier, nullptr);
   EXPECT_EQ(Barrier->arg_size(), 2U);
-  EXPECT_EQ(Barrier->getCalledFunction()->getName(), "__kmpc_cancel_barrier");
+  EXPECT_EQ(*Barrier->getCalledFunctionName(), "__kmpc_cancel_barrier");
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(Barrier->getCalledFunction()->doesNotFreeMemory());
   EXPECT_EQ(Barrier->getNumUses(), 1U);
@@ -747,7 +747,7 @@ TEST_F(OpenMPIRBuilderTest, ParallelSimpleGPU) {
   CallInst *Parallel51CI = dyn_cast<CallInst>(Usr);
   ASSERT_NE(Parallel51CI, nullptr);
 
-  EXPECT_EQ(Parallel51CI->getCalledFunction()->getName(), "__kmpc_parallel_51");
+  EXPECT_EQ(*Parallel51CI->getCalledFunctionName(), "__kmpc_parallel_51");
   EXPECT_EQ(Parallel51CI->arg_size(), 9U);
   EXPECT_EQ(Parallel51CI->getArgOperand(5), OutlinedFn);
   EXPECT_TRUE(
@@ -855,7 +855,7 @@ TEST_F(OpenMPIRBuilderTest, ParallelSimple) {
   CallInst *ForkCI = dyn_cast<CallInst>(Usr);
   ASSERT_NE(ForkCI, nullptr);
 
-  EXPECT_EQ(ForkCI->getCalledFunction()->getName(), "__kmpc_fork_call");
+  EXPECT_EQ(*ForkCI->getCalledFunctionName(), "__kmpc_fork_call");
   EXPECT_EQ(ForkCI->arg_size(), 4U);
   EXPECT_TRUE(isa<GlobalVariable>(ForkCI->getArgOperand(0)));
   EXPECT_EQ(ForkCI->getArgOperand(1),
@@ -958,7 +958,7 @@ TEST_F(OpenMPIRBuilderTest, ParallelNested) {
     CallInst *ForkCI = dyn_cast<CallInst>(Usr);
     ASSERT_NE(ForkCI, nullptr);
 
-    EXPECT_EQ(ForkCI->getCalledFunction()->getName(), "__kmpc_fork_call");
+    EXPECT_EQ(*ForkCI->getCalledFunctionName(), "__kmpc_fork_call");
     EXPECT_EQ(ForkCI->arg_size(), 3U);
     EXPECT_TRUE(isa<GlobalVariable>(ForkCI->getArgOperand(0)));
     EXPECT_EQ(ForkCI->getArgOperand(1),
@@ -1077,7 +1077,7 @@ TEST_F(OpenMPIRBuilderTest, ParallelNested2Inner) {
     CallInst *ForkCI = dyn_cast<CallInst>(Usr);
     ASSERT_NE(ForkCI, nullptr);
 
-    EXPECT_EQ(ForkCI->getCalledFunction()->getName(), "__kmpc_fork_call");
+    EXPECT_EQ(*ForkCI->getCalledFunctionName(), "__kmpc_fork_call");
     EXPECT_EQ(ForkCI->arg_size(), 3U);
     EXPECT_TRUE(isa<GlobalVariable>(ForkCI->getArgOperand(0)));
     EXPECT_EQ(ForkCI->getArgOperand(1),
@@ -1186,7 +1186,7 @@ TEST_F(OpenMPIRBuilderTest, ParallelIfCond) {
     ForkCI = cast<CallInst>(Usr);
   }
 
-  EXPECT_EQ(ForkCI->getCalledFunction()->getName(), "__kmpc_fork_call_if");
+  EXPECT_EQ(*ForkCI->getCalledFunctionName(), "__kmpc_fork_call_if");
   EXPECT_EQ(ForkCI->arg_size(), 5U);
   EXPECT_TRUE(isa<GlobalVariable>(ForkCI->getArgOperand(0)));
   EXPECT_EQ(ForkCI->getArgOperand(1),
@@ -2404,7 +2404,7 @@ TEST_F(OpenMPIRBuilderTest, StaticWorkshareLoopTarget) {
     if (!Call->getCalledFunction())
       continue;
 
-    if (Call->getCalledFunction()->getName() == "__kmpc_for_static_loop_4u") {
+    if (*Call->getCalledFunctionName() == "__kmpc_for_static_loop_4u") {
       WorkshareLoopRuntimeCall = Call;
       WorkshareLoopRuntimeCallCnt++;
     }
@@ -2697,14 +2697,12 @@ TEST_P(OpenMPIRBuilderTestWithParams, DynamicWorkShareLoop) {
 
   CallInst *ThreadIdCall = dyn_cast<CallInst>(&*(PreheaderIter++));
   ASSERT_NE(ThreadIdCall, nullptr);
-  EXPECT_EQ(ThreadIdCall->getCalledFunction()->getName(),
-            "__kmpc_global_thread_num");
+  EXPECT_EQ(*ThreadIdCall->getCalledFunctionName(), "__kmpc_global_thread_num");
 
   CallInst *InitCall = dyn_cast<CallInst>(&*PreheaderIter);
 
   ASSERT_NE(InitCall, nullptr);
-  EXPECT_EQ(InitCall->getCalledFunction()->getName(),
-            "__kmpc_dispatch_init_4u");
+  EXPECT_EQ(*InitCall->getCalledFunctionName(), "__kmpc_dispatch_init_4u");
   EXPECT_EQ(InitCall->arg_size(), 7U);
   EXPECT_EQ(InitCall->getArgOperand(6), ConstantInt::get(LCTy, ChunkSize));
   ConstantInt *SchedVal = cast<ConstantInt>(InitCall->getArgOperand(2));
@@ -2826,7 +2824,7 @@ TEST_F(OpenMPIRBuilderTest, DynamicWorkShareLoopOrdered) {
     Instruction *Cur = &EI;
     if (isa<CallInst>(Cur)) {
       InitCall = cast<CallInst>(Cur);
-      if (InitCall->getCalledFunction()->getName() == "__kmpc_dispatch_init_4u")
+      if (*InitCall->getCalledFunctionName() == "__kmpc_dispatch_init_4u")
         break;
       InitCall = nullptr;
     }
@@ -2840,8 +2838,7 @@ TEST_F(OpenMPIRBuilderTest, DynamicWorkShareLoopOrdered) {
   CallInst *FiniCall = dyn_cast<CallInst>(
       &*(LatchBlock->getTerminator()->getPrevNonDebugInstruction(true)));
   ASSERT_NE(FiniCall, nullptr);
-  EXPECT_EQ(FiniCall->getCalledFunction()->getName(),
-            "__kmpc_dispatch_fini_4u");
+  EXPECT_EQ(*FiniCall->getCalledFunctionName(), "__kmpc_dispatch_fini_4u");
   EXPECT_EQ(FiniCall->arg_size(), 2U);
   EXPECT_EQ(InitCall->getArgOperand(0), FiniCall->getArgOperand(0));
   EXPECT_EQ(InitCall->getArgOperand(1), FiniCall->getArgOperand(1));
@@ -2919,7 +2916,7 @@ TEST_F(OpenMPIRBuilderTest, MasterDirective) {
 
   CallInst *MasterEntryCI = cast<CallInst>(CondInst->getOperand(0));
   EXPECT_EQ(MasterEntryCI->arg_size(), 2U);
-  EXPECT_EQ(MasterEntryCI->getCalledFunction()->getName(), "__kmpc_master");
+  EXPECT_EQ(*MasterEntryCI->getCalledFunctionName(), "__kmpc_master");
   EXPECT_TRUE(isa<GlobalVariable>(MasterEntryCI->getArgOperand(0)));
 
   CallInst *MasterEndCI = nullptr;
@@ -2927,7 +2924,7 @@ TEST_F(OpenMPIRBuilderTest, MasterDirective) {
     Instruction *cur = &FI;
     if (isa<CallInst>(cur)) {
       MasterEndCI = cast<CallInst>(cur);
-      if (MasterEndCI->getCalledFunction()->getName() == "__kmpc_end_master")
+      if (*MasterEndCI->getCalledFunctionName() == "__kmpc_end_master")
         break;
       MasterEndCI = nullptr;
     }
@@ -3001,7 +2998,7 @@ TEST_F(OpenMPIRBuilderTest, MaskedDirective) {
 
   CallInst *MaskedEntryCI = cast<CallInst>(CondInst->getOperand(0));
   EXPECT_EQ(MaskedEntryCI->arg_size(), 3U);
-  EXPECT_EQ(MaskedEntryCI->getCalledFunction()->getName(), "__kmpc_masked");
+  EXPECT_EQ(*MaskedEntryCI->getCalledFunctionName(), "__kmpc_masked");
   EXPECT_TRUE(isa<GlobalVariable>(MaskedEntryCI->getArgOperand(0)));
 
   CallInst *MaskedEndCI = nullptr;
@@ -3009,7 +3006,7 @@ TEST_F(OpenMPIRBuilderTest, MaskedDirective) {
     Instruction *cur = &FI;
     if (isa<CallInst>(cur)) {
       MaskedEndCI = cast<CallInst>(cur);
-      if (MaskedEndCI->getCalledFunction()->getName() == "__kmpc_end_masked")
+      if (*MaskedEndCI->getCalledFunctionName() == "__kmpc_end_masked")
         break;
       MaskedEndCI = nullptr;
     }
@@ -3062,14 +3059,14 @@ TEST_F(OpenMPIRBuilderTest, CriticalDirective) {
     Instruction *cur = &EI;
     if (isa<CallInst>(cur)) {
       CriticalEntryCI = cast<CallInst>(cur);
-      if (CriticalEntryCI->getCalledFunction()->getName() == "__kmpc_critical")
+      if (*CriticalEntryCI->getCalledFunctionName() == "__kmpc_critical")
         break;
       CriticalEntryCI = nullptr;
     }
   }
   EXPECT_NE(CriticalEntryCI, nullptr);
   EXPECT_EQ(CriticalEntryCI->arg_size(), 3U);
-  EXPECT_EQ(CriticalEntryCI->getCalledFunction()->getName(), "__kmpc_critical");
+  EXPECT_EQ(*CriticalEntryCI->getCalledFunctionName(), "__kmpc_critical");
   EXPECT_TRUE(isa<GlobalVariable>(CriticalEntryCI->getArgOperand(0)));
 
   CallInst *CriticalEndCI = nullptr;
@@ -3077,8 +3074,7 @@ TEST_F(OpenMPIRBuilderTest, CriticalDirective) {
     Instruction *cur = &FI;
     if (isa<CallInst>(cur)) {
       CriticalEndCI = cast<CallInst>(cur);
-      if (CriticalEndCI->getCalledFunction()->getName() ==
-          "__kmpc_end_critical")
+      if (*CriticalEndCI->getCalledFunctionName() == "__kmpc_end_critical")
         break;
       CriticalEndCI = nullptr;
     }
@@ -3172,14 +3168,14 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSource) {
   CallInst *GTID = dyn_cast<CallInst>(DependBaseAddrGEP->getNextNode());
   ASSERT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotFreeMemory());
 
   CallInst *Depend = dyn_cast<CallInst>(GTID->getNextNode());
   ASSERT_NE(Depend, nullptr);
   EXPECT_EQ(Depend->arg_size(), 3U);
-  EXPECT_EQ(Depend->getCalledFunction()->getName(), "__kmpc_doacross_post");
+  EXPECT_EQ(*Depend->getCalledFunctionName(), "__kmpc_doacross_post");
   EXPECT_TRUE(isa<GlobalVariable>(Depend->getArgOperand(0)));
   EXPECT_EQ(Depend->getArgOperand(1), GTID);
   EXPECT_EQ(Depend->getArgOperand(2), DependBaseAddrGEP);
@@ -3257,14 +3253,14 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveDependSink) {
   CallInst *GTID = dyn_cast<CallInst>(DependBaseAddrGEP->getNextNode());
   ASSERT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotAccessMemory());
   EXPECT_FALSE(GTID->getCalledFunction()->doesNotFreeMemory());
 
   CallInst *Depend = dyn_cast<CallInst>(GTID->getNextNode());
   ASSERT_NE(Depend, nullptr);
   EXPECT_EQ(Depend->arg_size(), 3U);
-  EXPECT_EQ(Depend->getCalledFunction()->getName(), "__kmpc_doacross_wait");
+  EXPECT_EQ(*Depend->getCalledFunctionName(), "__kmpc_doacross_wait");
   EXPECT_TRUE(isa<GlobalVariable>(Depend->getArgOperand(0)));
   EXPECT_EQ(Depend->getArgOperand(1), GTID);
   EXPECT_EQ(Depend->getArgOperand(2), DependBaseAddrGEP);
@@ -3318,14 +3314,14 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
     Instruction *Cur = &EI;
     if (isa<CallInst>(Cur)) {
       OrderedEntryCI = cast<CallInst>(Cur);
-      if (OrderedEntryCI->getCalledFunction()->getName() == "__kmpc_ordered")
+      if (*OrderedEntryCI->getCalledFunctionName() == "__kmpc_ordered")
         break;
       OrderedEntryCI = nullptr;
     }
   }
   EXPECT_NE(OrderedEntryCI, nullptr);
   EXPECT_EQ(OrderedEntryCI->arg_size(), 2U);
-  EXPECT_EQ(OrderedEntryCI->getCalledFunction()->getName(), "__kmpc_ordered");
+  EXPECT_EQ(*OrderedEntryCI->getCalledFunctionName(), "__kmpc_ordered");
   EXPECT_TRUE(isa<GlobalVariable>(OrderedEntryCI->getArgOperand(0)));
 
   CallInst *OrderedEndCI = nullptr;
@@ -3333,7 +3329,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveThreads) {
     Instruction *Cur = &FI;
     if (isa<CallInst>(Cur)) {
       OrderedEndCI = cast<CallInst>(Cur);
-      if (OrderedEndCI->getCalledFunction()->getName() == "__kmpc_end_ordered")
+      if (*OrderedEndCI->getCalledFunctionName() == "__kmpc_end_ordered")
         break;
       OrderedEndCI = nullptr;
     }
@@ -3392,7 +3388,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveSimd) {
     Instruction *Cur = &EI;
     if (isa<CallInst>(Cur)) {
       OrderedEntryCI = cast<CallInst>(Cur);
-      if (OrderedEntryCI->getCalledFunction()->getName() == "__kmpc_ordered")
+      if (*OrderedEntryCI->getCalledFunctionName() == "__kmpc_ordered")
         break;
       OrderedEntryCI = nullptr;
     }
@@ -3404,7 +3400,7 @@ TEST_F(OpenMPIRBuilderTest, OrderedDirectiveSimd) {
     Instruction *Cur = &FI;
     if (isa<CallInst>(Cur)) {
       OrderedEndCI = cast<CallInst>(Cur);
-      if (OrderedEndCI->getCalledFunction()->getName() == "__kmpc_end_ordered")
+      if (*OrderedEndCI->getCalledFunctionName() == "__kmpc_end_ordered")
         break;
       OrderedEndCI = nullptr;
     }
@@ -3511,7 +3507,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
 
   CallInst *SingleEntryCI = cast<CallInst>(CondInst->getOperand(0));
   EXPECT_EQ(SingleEntryCI->arg_size(), 2U);
-  EXPECT_EQ(SingleEntryCI->getCalledFunction()->getName(), "__kmpc_single");
+  EXPECT_EQ(*SingleEntryCI->getCalledFunctionName(), "__kmpc_single");
   EXPECT_TRUE(isa<GlobalVariable>(SingleEntryCI->getArgOperand(0)));
 
   CallInst *SingleEndCI = nullptr;
@@ -3519,7 +3515,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
     Instruction *cur = &FI;
     if (isa<CallInst>(cur)) {
       SingleEndCI = cast<CallInst>(cur);
-      if (SingleEndCI->getCalledFunction()->getName() == "__kmpc_end_single")
+      if (*SingleEndCI->getCalledFunctionName() == "__kmpc_end_single")
         break;
       SingleEndCI = nullptr;
     }
@@ -3533,7 +3529,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirective) {
   for (auto &FI : *ExitBB) {
     Instruction *cur = &FI;
     if (auto CI = dyn_cast<CallInst>(cur)) {
-      if (CI->getCalledFunction()->getName() == "__kmpc_barrier") {
+      if (*CI->getCalledFunctionName() == "__kmpc_barrier") {
         FoundBarrier = true;
         break;
       }
@@ -3604,7 +3600,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
 
   CallInst *SingleEntryCI = cast<CallInst>(CondInst->getOperand(0));
   EXPECT_EQ(SingleEntryCI->arg_size(), 2U);
-  EXPECT_EQ(SingleEntryCI->getCalledFunction()->getName(), "__kmpc_single");
+  EXPECT_EQ(*SingleEntryCI->getCalledFunctionName(), "__kmpc_single");
   EXPECT_TRUE(isa<GlobalVariable>(SingleEntryCI->getArgOperand(0)));
 
   CallInst *SingleEndCI = nullptr;
@@ -3612,7 +3608,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
     Instruction *cur = &FI;
     if (isa<CallInst>(cur)) {
       SingleEndCI = cast<CallInst>(cur);
-      if (SingleEndCI->getCalledFunction()->getName() == "__kmpc_end_single")
+      if (*SingleEndCI->getCalledFunctionName() == "__kmpc_end_single")
         break;
       SingleEndCI = nullptr;
     }
@@ -3626,7 +3622,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveNowait) {
   for (auto &FI : *ExitBB) {
     Instruction *cur = &FI;
     if (auto CI = dyn_cast<CallInst>(cur)) {
-      if (CI->getCalledFunction()->getName() == "__kmpc_barrier") {
+      if (*CI->getCalledFunctionName() == "__kmpc_barrier") {
         ExitBarrier = CI;
         break;
       }
@@ -3727,7 +3723,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
 
   CallInst *SingleEntryCI = cast<CallInst>(CondInst->getOperand(0));
   EXPECT_EQ(SingleEntryCI->arg_size(), 2U);
-  EXPECT_EQ(SingleEntryCI->getCalledFunction()->getName(), "__kmpc_single");
+  EXPECT_EQ(*SingleEntryCI->getCalledFunctionName(), "__kmpc_single");
   EXPECT_TRUE(isa<GlobalVariable>(SingleEntryCI->getArgOperand(0)));
 
   // check ThenBB
@@ -3747,7 +3743,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
   // call __kmpc_end_single
   auto *SingleEndCI = ThenBBI.next<CallInst>();
   EXPECT_NE(SingleEndCI, nullptr);
-  EXPECT_EQ(SingleEndCI->getCalledFunction()->getName(), "__kmpc_end_single");
+  EXPECT_EQ(*SingleEndCI->getCalledFunctionName(), "__kmpc_end_single");
   EXPECT_EQ(SingleEndCI->arg_size(), 2U);
   EXPECT_TRUE(isa<GlobalVariable>(SingleEndCI->getArgOperand(0)));
   EXPECT_EQ(SingleEndCI->getArgOperand(1), SingleEntryCI->getArgOperand(1));
@@ -3763,8 +3759,7 @@ TEST_F(OpenMPIRBuilderTest, SingleDirectiveCopyPrivate) {
   // call __kmpc_global_thread_num
   auto *ThreadNumCI = ExitBBI.next<CallInst>();
   EXPECT_NE(ThreadNumCI, nullptr);
-  EXPECT_EQ(ThreadNumCI->getCalledFunction()->getName(),
-            "__kmpc_global_thread_num");
+  EXPECT_EQ(*ThreadNumCI->getCalledFunctionName(), "__kmpc_global_thread_num");
   // load DidIt
   auto *DidItLI = ExitBBI.next<LoadInst>();
   EXPECT_NE(DidItLI, nullptr);
@@ -5647,7 +5642,7 @@ TEST_F(OpenMPIRBuilderTest, CreateSections) {
   bool FoundForInit = false;
   for (Instruction &Inst : *LoopPreheaderBB) {
     if (isa<CallInst>(Inst)) {
-      if (cast<CallInst>(&Inst)->getCalledFunction()->getName() ==
+      if (*cast<CallInst>(&Inst)->getCalledFunctionName() ==
           "__kmpc_for_static_init_4u") {
         FoundForInit = true;
       }
@@ -5659,12 +5654,11 @@ TEST_F(OpenMPIRBuilderTest, CreateSections) {
   bool FoundBarrier = false;
   for (Instruction &Inst : *ForExitBB) {
     if (isa<CallInst>(Inst)) {
-      if (cast<CallInst>(&Inst)->getCalledFunction()->getName() ==
+      if (*cast<CallInst>(&Inst)->getCalledFunctionName() ==
           "__kmpc_for_static_fini") {
         FoundForExit = true;
       }
-      if (cast<CallInst>(&Inst)->getCalledFunction()->getName() ==
-          "__kmpc_barrier") {
+      if (*cast<CallInst>(&Inst)->getCalledFunctionName() == "__kmpc_barrier") {
         FoundBarrier = true;
       }
       if (FoundForExit && FoundBarrier)
@@ -5718,7 +5712,7 @@ TEST_F(OpenMPIRBuilderTest, CreateSectionsNoWait) {
   Builder.CreateRetVoid(); // Required at the end of the function
   for (auto &Inst : instructions(*F)) {
     EXPECT_FALSE(isa<CallInst>(Inst) &&
-                 cast<CallInst>(&Inst)->getCalledFunction()->getName() ==
+                 *cast<CallInst>(&Inst)->getCalledFunctionName() ==
                      "__kmpc_barrier" &&
                  "call to function __kmpc_barrier found with nowait");
   }
@@ -5882,7 +5876,7 @@ TEST_F(OpenMPIRBuilderTest, EmitMapperCall) {
   CallInst *MapperCall = dyn_cast<CallInst>(&BB->back());
   EXPECT_NE(MapperCall, nullptr);
   EXPECT_EQ(MapperCall->arg_size(), 9U);
-  EXPECT_EQ(MapperCall->getCalledFunction()->getName(),
+  EXPECT_EQ(*MapperCall->getCalledFunctionName(),
             "__tgt_target_data_begin_mapper");
   EXPECT_EQ(MapperCall->getOperand(0), SrcLocInfo);
   EXPECT_TRUE(MapperCall->getOperand(1)->getType()->isIntegerTy(64));
@@ -5945,7 +5939,7 @@ TEST_F(OpenMPIRBuilderTest, TargetEnterData) {
   CallInst *TargetDataCall = dyn_cast<CallInst>(&BB->back());
   EXPECT_NE(TargetDataCall, nullptr);
   EXPECT_EQ(TargetDataCall->arg_size(), 9U);
-  EXPECT_EQ(TargetDataCall->getCalledFunction()->getName(),
+  EXPECT_EQ(*TargetDataCall->getCalledFunctionName(),
             "__tgt_target_data_begin_mapper");
   EXPECT_TRUE(TargetDataCall->getOperand(1)->getType()->isIntegerTy(64));
   EXPECT_TRUE(TargetDataCall->getOperand(2)->getType()->isIntegerTy(32));
@@ -6007,7 +6001,7 @@ TEST_F(OpenMPIRBuilderTest, TargetExitData) {
   CallInst *TargetDataCall = dyn_cast<CallInst>(&BB->back());
   EXPECT_NE(TargetDataCall, nullptr);
   EXPECT_EQ(TargetDataCall->arg_size(), 9U);
-  EXPECT_EQ(TargetDataCall->getCalledFunction()->getName(),
+  EXPECT_EQ(*TargetDataCall->getCalledFunctionName(),
             "__tgt_target_data_end_mapper");
   EXPECT_TRUE(TargetDataCall->getOperand(1)->getType()->isIntegerTy(64));
   EXPECT_TRUE(TargetDataCall->getOperand(2)->getType()->isIntegerTy(32));
@@ -6089,7 +6083,7 @@ TEST_F(OpenMPIRBuilderTest, TargetDataRegion) {
           dyn_cast<CallInst>(BB->back().getPrevNode()->getPrevNode());
       EXPECT_NE(TargetDataCall, nullptr);
       EXPECT_EQ(TargetDataCall->arg_size(), 9U);
-      EXPECT_EQ(TargetDataCall->getCalledFunction()->getName(),
+      EXPECT_EQ(*TargetDataCall->getCalledFunctionName(),
                 "__tgt_target_data_begin_mapper");
       EXPECT_TRUE(TargetDataCall->getOperand(1)->getType()->isIntegerTy(64));
       EXPECT_TRUE(TargetDataCall->getOperand(2)->getType()->isIntegerTy(32));
@@ -6118,7 +6112,7 @@ TEST_F(OpenMPIRBuilderTest, TargetDataRegion) {
   CallInst *TargetDataCall = dyn_cast<CallInst>(&BB->back());
   EXPECT_NE(TargetDataCall, nullptr);
   EXPECT_EQ(TargetDataCall->arg_size(), 9U);
-  EXPECT_EQ(TargetDataCall->getCalledFunction()->getName(),
+  EXPECT_EQ(*TargetDataCall->getCalledFunctionName(),
             "__tgt_target_data_end_mapper");
   EXPECT_TRUE(TargetDataCall->getOperand(1)->getType()->isIntegerTy(64));
   EXPECT_TRUE(TargetDataCall->getOperand(2)->getType()->isIntegerTy(32));
@@ -6467,7 +6461,7 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
 
   auto *InitCall = dyn_cast<CallInst>(Store2->getNextNode());
   EXPECT_NE(InitCall, nullptr);
-  EXPECT_EQ(InitCall->getCalledFunction()->getName(), "__kmpc_target_init");
+  EXPECT_EQ(*InitCall->getCalledFunctionName(), "__kmpc_target_init");
   EXPECT_EQ(InitCall->arg_size(), 2U);
   EXPECT_TRUE(isa<GlobalVariable>(InitCall->getArgOperand(0)));
   auto *KernelEnvGV = cast<GlobalVariable>(InitCall->getArgOperand(0));
@@ -6508,7 +6502,7 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
 
   auto *DeinitCall = dyn_cast<CallInst>(Deinit);
   EXPECT_NE(DeinitCall, nullptr);
-  EXPECT_EQ(DeinitCall->getCalledFunction()->getName(), "__kmpc_target_deinit");
+  EXPECT_EQ(*DeinitCall->getCalledFunctionName(), "__kmpc_target_deinit");
   EXPECT_EQ(DeinitCall->arg_size(), 0U);
 
   EXPECT_TRUE(isa<ReturnInst>(DeinitCall->getNextNode()));
@@ -6844,7 +6838,7 @@ TEST_F(OpenMPIRBuilderTest, ConstantAllocaRaise) {
 
   auto *InitCall = dyn_cast<CallInst>(Store2->getNextNode());
   EXPECT_NE(InitCall, nullptr);
-  EXPECT_EQ(InitCall->getCalledFunction()->getName(), "__kmpc_target_init");
+  EXPECT_EQ(*InitCall->getCalledFunctionName(), "__kmpc_target_init");
   EXPECT_EQ(InitCall->arg_size(), 2U);
   EXPECT_TRUE(isa<GlobalVariable>(InitCall->getArgOperand(0)));
   auto *KernelEnvGV = cast<GlobalVariable>(InitCall->getArgOperand(0));
@@ -6884,7 +6878,7 @@ TEST_F(OpenMPIRBuilderTest, ConstantAllocaRaise) {
 
   auto *DeinitCall = dyn_cast<CallInst>(Deinit);
   EXPECT_NE(DeinitCall, nullptr);
-  EXPECT_EQ(DeinitCall->getCalledFunction()->getName(), "__kmpc_target_deinit");
+  EXPECT_EQ(*DeinitCall->getCalledFunctionName(), "__kmpc_target_deinit");
   EXPECT_EQ(DeinitCall->arg_size(), 0U);
 
   EXPECT_TRUE(isa<ReturnInst>(DeinitCall->getNextNode()));
@@ -6964,7 +6958,7 @@ TEST_F(OpenMPIRBuilderTest, CreateTask) {
   CallInst *GTID = dyn_cast<CallInst>(TaskAllocCall->getArgOperand(1));
   ASSERT_NE(GTID, nullptr);
   EXPECT_EQ(GTID->arg_size(), 1U);
-  EXPECT_EQ(GTID->getCalledFunction()->getName(), "__kmpc_global_thread_num");
+  EXPECT_EQ(*GTID->getCalledFunctionName(), "__kmpc_global_thread_num");
 
   // Verify the flags
   // TODO: Check for others flags. Currently testing only for tiedness.

--- a/llvm/unittests/IR/IRBuilderTest.cpp
+++ b/llvm/unittests/IR/IRBuilderTest.cpp
@@ -152,17 +152,16 @@ TEST_F(IRBuilderTest, IntrinsicMangling) {
 
   // Mangled return type, no arguments.
   Call = Builder.CreateIntrinsic(Int64Ty, Intrinsic::coro_size, {});
-  EXPECT_EQ(Call->getCalledFunction()->getName(), "llvm.coro.size.i64");
+  EXPECT_EQ(*Call->getCalledFunctionName(), "llvm.coro.size.i64");
 
   // Void return type, mangled argument type.
   Call =
       Builder.CreateIntrinsic(VoidTy, Intrinsic::set_loop_iterations, Int64Val);
-  EXPECT_EQ(Call->getCalledFunction()->getName(),
-            "llvm.set.loop.iterations.i64");
+  EXPECT_EQ(*Call->getCalledFunctionName(), "llvm.set.loop.iterations.i64");
 
   // Mangled return type and argument type.
   Call = Builder.CreateIntrinsic(Int64Ty, Intrinsic::lround, DoubleVal);
-  EXPECT_EQ(Call->getCalledFunction()->getName(), "llvm.lround.i64.f64");
+  EXPECT_EQ(*Call->getCalledFunctionName(), "llvm.lround.i64.f64");
 }
 
 TEST_F(IRBuilderTest, IntrinsicsWithScalableVectors) {

--- a/llvm/unittests/Transforms/Coroutines/ExtraRematTest.cpp
+++ b/llvm/unittests/Transforms/Coroutines/ExtraRematTest.cpp
@@ -48,9 +48,11 @@ struct ExtraRematTest : public testing::Test {
 
   CallInst *getCallByName(BasicBlock *BB, StringRef Name) const {
     for (Instruction &I : *BB) {
-      if (CallInst *CI = dyn_cast<CallInst>(&I))
-        if (CI->getCalledFunction()->getName() == Name)
+      if (CallInst *CI = dyn_cast<CallInst>(&I)) {
+        const std::optional<StringRef> CalleeName = CI->getCalledFunctionName();
+        if (CalleeName.has_value() && *CalleeName == Name)
           return CI;
+      }
     }
     return nullptr;
   }


### PR DESCRIPTION
There's a lot of uses of `getCalledFunction()->getName()`, without ever checking if `getCalledFunction()` returns a nullptr. Add a new helper that returns an `std::optional<StringRef>`, that can be used to

- Avoid method chaining
- Have a more safe shortcut to get the callee name.