### PR TITLE
[llvm][DebugInfo] Emit DW_AT_const_value for float non-type template parameters

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1147,6 +1147,8 @@ void DwarfUnit::constructTemplateValueParameterDIE(
   if (Metadata *Val = VP->getValue()) {
     if (ConstantInt *CI = mdconst::dyn_extract<ConstantInt>(Val))
       addConstantValue(ParamDIE, CI, VP->getType());
+    else if (ConstantFP *CF = mdconst::dyn_extract<ConstantFP>(Val))
+      addConstantFPValue(ParamDIE, CF);
     else if (GlobalValue *GV = mdconst::dyn_extract<GlobalValue>(Val)) {
       // We cannot describe the location of dllimport'd entities: the
       // computation of their address requires loads from the IAT.

--- a/llvm/test/DebugInfo/X86/debug-info-template-parameter.ll
+++ b/llvm/test/DebugInfo/X86/debug-info-template-parameter.ll
@@ -3,12 +3,12 @@
 
 ; C++ source to regenerate:
 
-;template <typename T = char, int i = 3 >
+;template <typename T = char, int i = 3, float f = 1.0f, double d = 2.0>
 ;class foo {
 ;};
 ;
 ;int main() {
-; foo<int,6> f1;
+; foo<int, 6, 1.9f, 1.9> f1;
 ; foo<> f2;
 ; return 0;
 ;}
@@ -20,20 +20,35 @@
 
 ; CHECK: debug_info contents:
 
-; CHECK: DW_AT_name {{.*}} "foo<int, 6>"
+; CHECK: DW_AT_name {{.*}} "foo<int, 6, 1.900000e+00, 1.900000e+00>"
 ; CHECK: DW_AT_type {{.*}} "int"
 ; CHECK-NEXT: DW_AT_name {{.*}} "T"
 ; CHECK-NOT: DW_AT_default_value
 ; CHECK: DW_AT_type {{.*}} "int"
 ; CHECK-NEXT: DW_AT_name {{.*}} "i"
+; CHECK-NEXT: DW_AT_const_value [DW_FORM_sdata] (6)
+; CHECK-NOT: DW_AT_default_value
+; CHECK: DW_AT_type {{.*}} "float"
+; CHECK-NEXT: DW_AT_name {{.*}} "f"
+; CHECK-NEXT: DW_AT_const_value [DW_FORM_udata] (1072902963)
+; CHECK-NOT: DW_AT_default_value
+; CHECK: DW_AT_type {{.*}} "double"
+; CHECK-NEXT: DW_AT_name {{.*}} "d"
+; CHECK-NEXT: DW_AT_const_value [DW_FORM_udata] (4611235658464650854)
 ; CHECK-NOT: DW_AT_default_value
 
-; CHECK: DW_AT_name {{.*}} "foo<char, 3>"
+; CHECK: DW_AT_name {{.*}} "foo<char, 3, 1.000000e+00, 2.000000e+00>"
 ; CHECK: DW_AT_type {{.*}} "char"
 ; CHECK-NEXT: DW_AT_name {{.*}} "T"
 ; CHECK-NEXT: DW_AT_default_value {{.*}} (true)
 ; CHECK: DW_AT_type {{.*}} "int"
 ; CHECK-NEXT: DW_AT_name {{.*}} "i"
+; CHECK-NEXT: DW_AT_default_value {{.*}} (true)
+; CHECK: DW_AT_type {{.*}} "float"
+; CHECK-NEXT: DW_AT_name {{.*}} "f"
+; CHECK-NEXT: DW_AT_default_value {{.*}} (true)
+; CHECK: DW_AT_type {{.*}} "double"
+; CHECK-NEXT: DW_AT_name {{.*}} "d"
 ; CHECK-NEXT: DW_AT_default_value {{.*}} (true)
 
 ; ModuleID = '/dir/test.cpp'
@@ -76,16 +91,22 @@ attributes #1 = { nounwind readnone speculatable willreturn }
 !9 = !{!10}
 !10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !11 = !DILocalVariable(name: "f1", scope: !7, file: !1, line: 30, type: !12)
-!12 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "foo<int, 6>", file: !1, line: 26, size: 8, flags: DIFlagTypePassByValue, elements: !2, templateParams: !13, identifier: "_ZTS3fooIiLi6EE")
-!13 = !{!14, !15}
+!12 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "foo<int, 6, 1.900000e+00, 1.900000e+00>", file: !1, line: 26, size: 8, flags: DIFlagTypePassByValue, elements: !2, templateParams: !13, identifier: "_ZTS3fooIiLi6ELf3ff33333ELd3ffe666666666666EE")
+!13 = !{!14, !15, !25, !27}
 !14 = !DITemplateTypeParameter(name: "T", type: !10)
 !15 = !DITemplateValueParameter(name: "i", type: !10, value: i32 6)
 !16 = !DILocation(line: 30, column: 14, scope: !7)
 !17 = !DILocalVariable(name: "f2", scope: !7, file: !1, line: 31, type: !18)
-!18 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "foo<char, 3>", file: !1, line: 26, size: 8, flags: DIFlagTypePassByValue, elements: !2, templateParams: !19, identifier: "_ZTS3fooIcLi3EE")
-!19 = !{!20, !22}
+!18 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "foo<char, 3, 1.000000e+00, 2.000000e+00>", file: !1, line: 26, size: 8, flags: DIFlagTypePassByValue, elements: !2, templateParams: !19, identifier: "_ZTS3fooIcLi3ELf3f800000ELd4000000000000000EE")
+!19 = !{!20, !22, !29, !30}
 !20 = !DITemplateTypeParameter(name: "T", type: !21, defaulted: true)
 !21 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
 !22 = !DITemplateValueParameter(name: "i", type: !10, defaulted: true, value: i32 3)
 !23 = !DILocation(line: 31, column: 9, scope: !7)
 !24 = !DILocation(line: 32, column: 3, scope: !7)
+!25 = !DITemplateValueParameter(name: "f", type: !26, value: float 0x3FFE666660000000)
+!26 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+!27 = !DITemplateValueParameter(name: "d", type: !28, value: double 1.900000e+00)
+!28 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
+!29 = !DITemplateValueParameter(name: "f", type: !26, defaulted: true, value: float 1.000000e+00)
+!30 = !DITemplateValueParameter(name: "d", type: !28, defaulted: true, value: double 2.000000e+00)


### PR DESCRIPTION
In C++20, non-type template parameters can be float/double. Clang didn't emit those constants in DWARF. This patch emits floating point constants the same way we do other integral template value parameters.