### PR TITLE
[InstCombine] Fold shift+cttz with power of 2 operands

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1613,6 +1613,22 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
   if (Instruction *Overflow = foldLShrOverflowBit(I))
     return Overflow;
 
+  // Transform ((pow2 << x) >> cttz(pow2 << y)) -> ((1 << x) >> y)
+  Value *Shl0_Op0, *Shl0_Op1, *Shl1_Op0, *Shl1_Op1;
+  BinaryOperator *Shl1;
+  if (match(Op0, m_Shl(m_Value(Shl0_Op0), m_Value(Shl0_Op1))) &&
+      match(Op1, m_Intrinsic<Intrinsic::cttz>(m_BinOp(Shl1))) &&
+      match(Shl1, m_Shl(m_Value(Shl1_Op0), m_Value(Shl1_Op1))) &&
+      isKnownToBeAPowerOfTwo(Shl1, false, 0, SQ.getWithInstruction(&I).CxtI) &&
+      Shl0_Op0 == Shl1_Op0) {
+    auto *Shl0 = cast<BinaryOperator>(Op0);
+    if ((Shl0->hasNoUnsignedWrap() && Shl1->hasNoUnsignedWrap()) ||
+        (Shl0->hasNoSignedWrap() && Shl1->hasNoSignedWrap())) {
+      Value *NewShl =
+          Builder.CreateShl(ConstantInt::get(Shl1->getType(), 1), Shl0_Op1);
+      return BinaryOperator::CreateLShr(NewShl, Shl1_Op1);
+    }
+  }
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1614,18 +1614,19 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
     return Overflow;
 
   // Transform ((pow2 << x) >> cttz(pow2 << y)) -> ((1 << x) >> y)
-  Value *Shl0_Op0, *Shl0_Op1, *Shl1_Op0, *Shl1_Op1;
+  Value *Shl0_Op0, *Shl0_Op1, *Shl1_Op1;
   BinaryOperator *Shl1;
   if (match(Op0, m_Shl(m_Value(Shl0_Op0), m_Value(Shl0_Op1))) &&
       match(Op1, m_Intrinsic<Intrinsic::cttz>(m_BinOp(Shl1))) &&
-      match(Shl1, m_Shl(m_Value(Shl1_Op0), m_Value(Shl1_Op1))) &&
-      isKnownToBeAPowerOfTwo(Shl1, false, 0, SQ.getWithInstruction(&I).CxtI) &&
-      Shl0_Op0 == Shl1_Op0) {
+      match(Shl1, m_Shl(m_Specific(Shl0_Op0), m_Value(Shl1_Op1))) &&
+      isKnownToBeAPowerOfTwo(Shl0_Op0, /*OrZero=*/true, 0, &I)) {
     auto *Shl0 = cast<BinaryOperator>(Op0);
-    if ((Shl0->hasNoUnsignedWrap() && Shl1->hasNoUnsignedWrap()) ||
-        (Shl0->hasNoSignedWrap() && Shl1->hasNoSignedWrap())) {
-      Value *NewShl =
-          Builder.CreateShl(ConstantInt::get(Shl1->getType(), 1), Shl0_Op1);
+    bool HasNUW = Shl0->hasNoUnsignedWrap() && Shl1->hasNoUnsignedWrap();
+    bool HasNSW = Shl0->hasNoSignedWrap() && Shl1->hasNoSignedWrap();
+    if (HasNUW || HasNSW) {
+      Value *NewShl = Builder.CreateShl(ConstantInt::get(Shl1->getType(), 1),
+                                        Shl0_Op1, "", HasNUW, HasNSW);
+      Builder.CreateShl(ConstantInt::get(Shl1->getType(), 1), Shl0_Op1);
       return BinaryOperator::CreateLShr(NewShl, Shl1_Op1);
     }
   }

--- a/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineShifts.cpp
@@ -1626,7 +1626,6 @@ Instruction *InstCombinerImpl::visitLShr(BinaryOperator &I) {
     if (HasNUW || HasNSW) {
       Value *NewShl = Builder.CreateShl(ConstantInt::get(Shl1->getType(), 1),
                                         Shl0_Op1, "", HasNUW, HasNSW);
-      Builder.CreateShl(ConstantInt::get(Shl1->getType(), 1), Shl0_Op1);
       return BinaryOperator::CreateLShr(NewShl, Shl1_Op1);
     }
   }

--- a/llvm/test/Transforms/InstCombine/shift-cttz-ctlz.ll
+++ b/llvm/test/Transforms/InstCombine/shift-cttz-ctlz.ll
@@ -110,11 +110,11 @@ define i64 @fold_cttz_64() vscale_range(1,16) {
 ; CHECK-NEXT:    ret i64 4
 ;
 entry:
-  %0 = tail call i64 @llvm.vscale.i64()
-  %1 = shl nuw nsw i64 %0, 4
-  %2 = shl nuw nsw i64 %0, 2
-  %3 = tail call range(i64 2, 65) i64 @llvm.cttz.i64(i64 %2, i1 true)
-  %div1 = lshr i64 %1, %3
+  %vscale = tail call i64 @llvm.vscale.i64()
+  %shl0 = shl nuw nsw i64 %vscale, 4
+  %shl1 = shl nuw nsw i64 %vscale, 2
+  %cttz = tail call range(i64 2, 65) i64 @llvm.cttz.i64(i64 %shl1, i1 true)
+  %div1 = lshr i64 %shl0, %cttz
   ret i64 %div1
 }
 
@@ -125,16 +125,12 @@ define i32 @fold_cttz_32() vscale_range(1,16) {
 ; CHECK-NEXT:    ret i32 4
 ;
 entry:
-  %0 = tail call i32 @llvm.vscale.i32()
-  %1 = shl nuw nsw i32 %0, 4
-  %2 = shl nuw nsw i32 %0, 2
-  %3 = tail call range(i32 2, 65) i32 @llvm.cttz.i32(i32 %2, i1 true)
-  %div1 = lshr i32 %1, %3
+  %vscale = tail call i32 @llvm.vscale.i32()
+  %shl0 = shl nuw nsw i32 %vscale, 4
+  %shl1 = shl nuw nsw i32 %vscale, 2
+  %cttz = tail call range(i32 2, 65) i32 @llvm.cttz.i32(i32 %shl1, i1 true)
+  %div1 = lshr i32 %shl0, %cttz
   ret i32 %div1
 }
 
-declare i64 @llvm.vscale.i64()
-declare i64 @llvm.cttz.i64(i64, i1 immarg)
-declare i32 @llvm.vscale.i32()
-declare i32 @llvm.cttz.i32(i32, i1 immarg)
 declare void @use(i32)

--- a/llvm/test/Transforms/InstCombine/shift-cttz-ctlz.ll
+++ b/llvm/test/Transforms/InstCombine/shift-cttz-ctlz.ll
@@ -103,4 +103,38 @@ entry:
   ret i32 %res
 }
 
+define i64 @fold_cttz_64() vscale_range(1,16) {
+; CHECK-LABEL: define i64 @fold_cttz_64(
+; CHECK-SAME: ) #[[ATTR0:[0-9]+]] {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i64 4
+;
+entry:
+  %0 = tail call i64 @llvm.vscale.i64()
+  %1 = shl nuw nsw i64 %0, 4
+  %2 = shl nuw nsw i64 %0, 2
+  %3 = tail call range(i64 2, 65) i64 @llvm.cttz.i64(i64 %2, i1 true)
+  %div1 = lshr i64 %1, %3
+  ret i64 %div1
+}
+
+define i32 @fold_cttz_32() vscale_range(1,16) {
+; CHECK-LABEL: define i32 @fold_cttz_32(
+; CHECK-SAME: ) #[[ATTR0]] {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret i32 4
+;
+entry:
+  %0 = tail call i32 @llvm.vscale.i32()
+  %1 = shl nuw nsw i32 %0, 4
+  %2 = shl nuw nsw i32 %0, 2
+  %3 = tail call range(i32 2, 65) i32 @llvm.cttz.i32(i32 %2, i1 true)
+  %div1 = lshr i32 %1, %3
+  ret i32 %div1
+}
+
+declare i64 @llvm.vscale.i64()
+declare i64 @llvm.cttz.i64(i64, i1 immarg)
+declare i32 @llvm.vscale.i32()
+declare i32 @llvm.cttz.i32(i32, i1 immarg)
 declare void @use(i32)


### PR DESCRIPTION
#121386 Introduced cttz intrinsics which caused a regression where vscale/vscale divisions could no longer be constant folded.

This fold was suggested as a fix in #126411. https://alive2.llvm.org/ce/z/gWbtPw