### PR TITLE
[lldb] Remove UtilityTests->Target dep

### DIFF
--- a/lldb/unittests/Utility/CMakeLists.txt
+++ b/lldb/unittests/Utility/CMakeLists.txt
@@ -52,7 +52,6 @@ add_lldb_unittest(UtilityTests
   XcodeSDKTest.cpp
 
   LINK_LIBS
-      lldbTarget
       lldbUtility
       lldbUtilityHelpers
       LLVMTestingSupport

--- a/lldb/unittests/Utility/ProcessInstanceInfoTest.cpp
+++ b/lldb/unittests/Utility/ProcessInstanceInfoTest.cpp
@@ -6,7 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "lldb/Target/Process.h"
+#include "lldb/Utility/ArchSpec.h"
+#include "lldb/Utility/ProcessInfo.h"
+#include "lldb/Utility/StreamString.h"
+#include "lldb/Utility/UserIDResolver.h"
+#include "llvm/ADT/Twine.h"
 #include "gtest/gtest.h"
 #include <optional>
 


### PR DESCRIPTION
It's completely unnecessary right now, but having it present means that some real unwanted dependencies could sneak in. (This also makes building the test binary much faster.)