### PR TITLE
[AMDGPU] Skip -mattr=dumpcode test on big-endian hosts

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/dumpcode.ll
+++ b/llvm/test/CodeGen/AMDGPU/dumpcode.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=dumpcode -filetype=obj < %s | llvm-objcopy --dump-section .AMDGPU.disasm=- - /dev/null | FileCheck %s -check-prefix=GFX10
+; REQUIRES: host-byteorder-little-endian
 
 ; GFX10: f:
 ; GFX10-NEXT: BB0_0:


### PR DESCRIPTION
I did not know that the output is different depending on the host
endianness. This should be fixed properly but in the mean time this
patch fixes the buildbot failures.
