### PR TITLE
[NVPTX] Fix vaarg store alignment

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -1609,8 +1609,8 @@ SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
 
         if (!IsByVal && IsVAArg) {
           // Align each part of the variadic argument to their type.
-          VAOffset = alignTo(VAOffset, DL.getABITypeAlign(
-              EltVT.getTypeForEVT(*DAG.getContext())));
+          VAOffset = alignTo(VAOffset, DL.getABITypeAlign(EltVT.getTypeForEVT(
+                                           *DAG.getContext())));
         }
 
         StoreOperands.push_back(DAG.getConstant(

--- a/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXISelLowering.cpp
@@ -1607,6 +1607,12 @@ SDValue NVPTXTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
         StoreOperands.push_back(
             DAG.getConstant(IsVAArg ? FirstVAArg : ParamCount, dl, MVT::i32));
 
+        if (!IsByVal && IsVAArg) {
+          // Align each part of the variadic argument to their type.
+          VAOffset = alignTo(VAOffset, DL.getABITypeAlign(
+              EltVT.getTypeForEVT(*DAG.getContext())));
+        }
+
         StoreOperands.push_back(DAG.getConstant(
             IsByVal ? CurOffset + VAOffset : (IsVAArg ? VAOffset : CurOffset),
             dl, MVT::i32));

--- a/llvm/test/CodeGen/NVPTX/vaargs.ll
+++ b/llvm/test/CodeGen/NVPTX/vaargs.ll
@@ -89,12 +89,12 @@ define i32 @test_foo(i32 %i, i64 %l, double %d, ptr %p) {
 ; CHECK-NEXT:    ld.param.u32 [[ARG_I32:%r[0-9]+]], [test_foo_param_0];
 
 ; Store arguments to an array
-; CHECK32:  .param .align 8 .b8 param1[24];
-; CHECK64:  .param .align 8 .b8 param1[28];
+; CHECK32:  .param .align 8 .b8 param1[28];
+; CHECK64:  .param .align 8 .b8 param1[32];
 ; CHECK-NEXT:    st.param.b32 [param1], [[ARG_I32]];
-; CHECK-NEXT:    st.param.b64 [param1+4], [[ARG_I64]];
-; CHECK-NEXT:    st.param.f64 [param1+12], [[ARG_DOUBLE]];
-; CHECK-NEXT:    st.param.b[[BITS]] [param1+20], [[ARG_VOID_PTR]];
+; CHECK-NEXT:    st.param.b64 [param1+8], [[ARG_I64]];
+; CHECK-NEXT:    st.param.f64 [param1+16], [[ARG_DOUBLE]];
+; CHECK-NEXT:    st.param.b[[BITS]] [param1+24], [[ARG_VOID_PTR]];
 ; CHECK-NEXT:    .param .b32 retval0;
 ; CHECK-NEXT:    prototype_1 : .callprototype (.param .b32 _) _ (.param .b32 _, .param .align 8 .b8 _[]
 


### PR DESCRIPTION
There is an issue with different alignment applied to store and load of vaargs in NVPTX backend.
Current `CodeGen/NVPTX/vaargs.ll` demonstrates this discrepancy. Store occurs with offsets `0,4,12,20`, but load with `0,8,16,24`.

This patch attempts to unify the alignment approach for callee and caller.