### PR TITLE
[AMDGPU] Try to fix -mattr=dumpcode on big-endian hosts

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMCInstLower.cpp
@@ -29,6 +29,7 @@
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCObjectStreamer.h"
 #include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Format.h"
 #include <algorithm>
@@ -316,7 +317,8 @@ void AMDGPUAsmPrinter::emitInstruction(const MachineInstr *MI) {
       raw_string_ostream HexStream(HexLine);
 
       for (size_t i = 0; i < CodeBytes.size(); i += 4) {
-        unsigned int CodeDWord = *(unsigned int *)&CodeBytes[i];
+        unsigned int CodeDWord =
+            support::endian::read32le(CodeBytes.data() + i);
         HexStream << format("%s%08X", (i > 0 ? " " : ""), CodeDWord);
       }
 


### PR DESCRIPTION
Blind fix for #116982 failing on big-endian buildbots.
