### PR TITLE
[lldb] Fix build problem in llgs tests for RISC-V

### DIFF
--- a/lldb/test/API/tools/lldb-server/main.cpp
+++ b/lldb/test/API/tools/lldb-server/main.cpp
@@ -148,7 +148,7 @@ static void trap() {
   asm volatile("udf #254");
 #elif defined(__powerpc__)
   asm volatile("trap");
-#elif __has_builtin(__builtin_debugtrap())
+#elif __has_builtin(__builtin_debugtrap)
   __builtin_debugtrap();
 #else
 #warning Don't know how to generate a trap. Some tests may fail.


### PR DESCRIPTION
During testing of LLDB on RISC-V target, tests from the llgs category were built with an error: `Error when building test subject.`

```
llvm-project/lldb/test/API/tools/lldb-server/main.cpp:151:40: error: missing ')' after '__builtin_debugtrap'
  151 | #elif __has_builtin(__builtin_debugtrap())
      |                     ~~~~~~~~~~~~~~~~~~~^
llvm-project/lldb/test/API/tools/lldb-server/main.cpp:151:20: note: to match this '('
  151 | #elif __has_builtin(__builtin_debugtrap())
      |                    ^
```

This patch fixes this error.