### PR TITLE
[compiler-rt] Add support for big endian for Arm's __negdf2vfp

### DIFF
--- a/compiler-rt/lib/builtins/arm/negdf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/negdf2vfp.S
@@ -20,7 +20,11 @@ DEFINE_COMPILERRT_FUNCTION(__negdf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vneg.f64 d0, d0
 #else
-	eor	r1, r1, #-2147483648	// flip sign bit on double in r0/r1 pair
+#if _YUGA_BIG_ENDIAN
+	eor	r0, r0, #0x80000000	// flip sign bit on double in r0/r1 pair
+#else
+	eor	r1, r1, #0x80000000	// flip sign bit on double in r0/r1 pair
+#endif
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__negdf2vfp)


### PR DESCRIPTION
In soft floating-point ABI, this function takes the double argument as a pair of registers r0 and r1.

The ordering of these two registers follow the endianness rules, therefore the register on which the bit flipping must happen depends on the endianness.