### PR TITLE
[AArch64][Build Attributes] Remove wrong assertion

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64TargetStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64TargetStreamer.cpp
@@ -222,13 +222,9 @@ void AArch64TargetStreamer::emitAttribute(StringRef VendorName, unsigned Tag,
                      "Can not add AArch64 build attribute: An attribute with "
                      "the same tag and a different value already exists");
               return;
-            } else {
-              // Case Item.IntValue == Value, no need to emit twice
-              assert(0 &&
-                     "AArch64 build attribute: An attribute with the same tag "
-                     "and a same value already exists");
-              return;
             }
+            // Case (Item.IntValue == Value) is legal.
+            return;
           }
         }
       }


### PR DESCRIPTION
Adding an existing AArch64 Build Attributes value is legal. Asserting this case is wrong, it cause wrong behavior when assertions are enabled.