### PR TITLE
[lldb] Fix broken pipe error

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -249,14 +249,11 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
 
     def _verify_socket(self, sock):
         # Normally, when the remote stub is not ready, we will get ECONNREFUSED during the
-        # connect() attempt. However, due to the way how ADB forwarding works, on android targets
+        # connect() attempt. However, due to the way how port forwarding can work, on some targets
         # the connect() will always be successful, but the connection will be immediately dropped
-        # if ADB could not connect on the remote side. This function tries to detect this
+        # if we could not connect on the remote side. This function tries to detect this
         # situation, and report it as "connection refused" so that the upper layers attempt the
         # connection again.
-        triple = self.dbg.GetSelectedPlatform().GetTriple()
-        if not re.match(".*-.*-.*-android", triple):
-            return  # Not android.
         can_read, _, _ = select.select([sock], [], [], 0.1)
         if sock not in can_read:
             return  # Data is not available, but the connection is alive.

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -397,13 +397,13 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
             # Schedule debug monitor to be shut down during teardown.
             logger = self.logger
 
-            connect_attemps = 0
+            connect_attempts = 0
             MAX_CONNECT_ATTEMPTS = 10
 
-            while connect_attemps < MAX_CONNECT_ATTEMPTS:
+            while connect_attempts < MAX_CONNECT_ATTEMPTS:
                 # Create a socket to talk to the server
                 try:
-                    logger.info("Connect attempt %d", connect_attemps + 1)
+                    logger.info("Connect attempt %d", connect_attempts + 1)
                     self.sock = self.create_socket()
                     self._server = Server(self.sock, server)
                     return server
@@ -411,7 +411,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
                     # Ignore, and try again.
                     pass
                 time.sleep(0.5)
-                connect_attemps += 1
+                connect_attempts += 1
 
             # We should close the server here to be safe.
             server.terminate()


### PR DESCRIPTION
During LLDB testing on slow machines with the remote-linux platform all tests from llgs category fail with python exception `BrokenPipeError`. The main reason of these failures is slow start of lldb-server in gdbserver mode. Due to this desired gdbserver socket does not have time to open by the time the Python script tries to establish a connection.

List of failed tests:

```
TestAppleSimulatorOSType.py
TestGdbRemoteAttach.py
TestGdbRemoteAuxvSupport.py
TestGdbRemoteCompletion.py
TestGdbRemoteExitCode.py
TestGdbRemoteExpeditedRegisters.py
TestGdbRemoteHostInfo.py
TestGdbRemoteKill.py
TestGdbRemoteLaunch.py
TestGdbRemoteModuleInfo.py
TestGdbRemotePlatformFile.py
TestGdbRemoteProcessInfo.py
TestGdbRemoteRegisterState.py
TestGdbRemoteSaveCore.py
TestGdbRemoteSingleStep.py
TestGdbRemoteThreadsInStopReply.py
TestGdbRemote_qThreadStopInfo.py
TestGdbRemote_vCont.py
TestLldbGdbServer.py
TestNonStop.py
TestPtyServer.py
TestGdbRemoteAttachWait.py
TestGdbRemoteConnection.py
TestStubSetSID.py
TestGdbRemoteAbort.py
TestGdbRemoteSegFault.py
TestGdbRemoteLibrariesSvr4Support.py
TestGdbRemoteMemoryAllocation.py
TestGdbRemoteMemoryTagging.py
TestGdbRemoteGPacket.py
TestGdbRemoteTargetXmlPacket.py
TestGdbRemote_QPassSignals.py
TestGdbRemoteThreadName.py
TestPartialResume.py
TestSignal.py
```

This patch implements an additional check for the opened socket on lldb-server side and fixes this error.