### PR TITLE
[mlir][affine] Add Check for 'affine.for' Bound Map Results

### DIFF
--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -1902,6 +1902,7 @@ LogicalResult AffineForOp::verifyRegions() {
     if (failed(verifyDimAndSymbolIdentifiers(*this, getUpperBoundOperands(),
                                              getUpperBoundMap().getNumDims())))
       return failure();
+      
   // Verify that the bound maps produce at least one result.
   /// Lower bound.
   if (getLowerBoundMap().getNumResults() < 1)

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -1901,7 +1901,7 @@ LogicalResult AffineForOp::verifyRegions() {
   if (getUpperBoundMap().getNumInputs() > 0)
     if (failed(verifyDimAndSymbolIdentifiers(*this, getUpperBoundOperands(),
                                              getUpperBoundMap().getNumDims())))
-      return failure();    
+      return failure();
   // Verify that the bound maps produce at least one result.
   /// Lower bound.
   if (getLowerBoundMap().getNumResults() < 1)

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -1901,8 +1901,7 @@ LogicalResult AffineForOp::verifyRegions() {
   if (getUpperBoundMap().getNumInputs() > 0)
     if (failed(verifyDimAndSymbolIdentifiers(*this, getUpperBoundOperands(),
                                              getUpperBoundMap().getNumDims())))
-      return failure();
-      
+      return failure();    
   // Verify that the bound maps produce at least one result.
   /// Lower bound.
   if (getLowerBoundMap().getNumResults() < 1)

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -1903,6 +1903,12 @@ LogicalResult AffineForOp::verifyRegions() {
                                              getUpperBoundMap().getNumDims())))
       return failure();
 
+  if (getLowerBoundMap().getNumResults() < 1)
+    return emitOpError("expected lower bound map to have at least one result");
+
+  if (getUpperBoundMap().getNumResults() < 1)
+    return emitOpError("expected upper bound map to have at least one result");
+    
   unsigned opNumResults = getNumResults();
   if (opNumResults == 0)
     return success();

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -1902,11 +1902,8 @@ LogicalResult AffineForOp::verifyRegions() {
     if (failed(verifyDimAndSymbolIdentifiers(*this, getUpperBoundOperands(),
                                              getUpperBoundMap().getNumDims())))
       return failure();
-  // Verify that the bound maps produce at least one result.
-  /// Lower bound.
   if (getLowerBoundMap().getNumResults() < 1)
     return emitOpError("expected lower bound map to have at least one result");
-  /// Upper bound.
   if (getUpperBoundMap().getNumResults() < 1)
     return emitOpError("expected upper bound map to have at least one result");
 

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -1902,13 +1902,14 @@ LogicalResult AffineForOp::verifyRegions() {
     if (failed(verifyDimAndSymbolIdentifiers(*this, getUpperBoundOperands(),
                                              getUpperBoundMap().getNumDims())))
       return failure();
-
+  // Verify that the bound maps produce at least one result.
+  /// Lower bound.
   if (getLowerBoundMap().getNumResults() < 1)
     return emitOpError("expected lower bound map to have at least one result");
-
+  /// Upper bound.
   if (getUpperBoundMap().getNumResults() < 1)
     return emitOpError("expected upper bound map to have at least one result");
-    
+
   unsigned opNumResults = getNumResults();
   if (opNumResults == 0)
     return success();

--- a/mlir/test/Dialect/Affine/invalid.mlir
+++ b/mlir/test/Dialect/Affine/invalid.mlir
@@ -541,3 +541,25 @@ func.func @dynamic_dimension_index() {
   }) : () -> ()
   return
 }
+
+// -----
+
+#map = affine_map<() -> ()>
+#map1 = affine_map<() -> (1)>
+func.func @no_lower_bound() {
+  // expected-error@+1 {{'affine.for' op expected lower bound map to have at least one result}}
+  affine.for %i = max #map() to min #map1() {
+  }
+  return
+}
+
+// -----
+
+#map = affine_map<() -> ()>
+#map1 = affine_map<() -> (1)>
+func.func @no_upper_bound() {
+  // expected-error@+1 {{'affine.for' op expected upper bound map to have at least one result}}
+  affine.for %i = max #map1() to min #map() {
+  }
+  return
+}


### PR DESCRIPTION
Fixes issue #120001.

I learnt that we shouldn’t assert on IR that can be constructed and passes the verifier. In this case, it appears that the verifier is insufficiently strict and should be tightened. Since the maps used in the `affine.for` op do not have results, I believe the IR verification should fail however it does not. 

Minimal example:

`#map = affine_map<() -> ()>`
`module {`
` func.func @main() {`
`    affine.for %arg0 = max #map() to min #map() {`
`    }`
`    return`
`  }`
`}`

This gets past the verifier, but I added a check to see that it causes an error if an affine.for has a bound map with no result.

@krzysz00 @matthias-springer @kazutakahirata @MaheshRavishankar  Open to any comments or clarifications :)

