### PR TITLE
[clangd] Update XRefs to support overriden ObjC methods

### DIFF
--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -446,9 +446,8 @@ locateASTReferent(SourceLocation CurLoc, const syntax::Token *TouchedIdentifier,
     // FIXME: Support jumping from a protocol decl to overrides on go-to
     // definition.
     if (const auto *OMD = llvm::dyn_cast<ObjCMethodDecl>(D)) {
-      if (TouchedIdentifier &&
-          objcMethodIsTouched(SM, OMD, TouchedIdentifier->location()) &&
-          OMD->isThisDeclarationADefinition()) {
+      if (OMD->isThisDeclarationADefinition() && TouchedIdentifier &&
+          objcMethodIsTouched(SM, OMD, TouchedIdentifier->location())) {
         llvm::SmallVector<const ObjCMethodDecl *, 4> Overrides;
         OMD->getOverriddenMethods(Overrides);
         if (!Overrides.empty()) {

--- a/clang-tools-extra/clangd/XRefs.cpp
+++ b/clang-tools-extra/clangd/XRefs.cpp
@@ -439,14 +439,16 @@ locateASTReferent(SourceLocation CurLoc, const syntax::Token *TouchedIdentifier,
         continue;
       }
     }
-    // Special case: - (void)^method; should jump to overrides. Note that an
-    // Objective-C method can override a parent class or protocol.
+    // Special case: - (void)^method {} should jump to overrides, but the decl
+    // shouldn't, only the definition. Note that an Objective-C method can
+    // override a parent class or protocol.
     //
     // FIXME: Support jumping from a protocol decl to overrides on go-to
     // definition.
     if (const auto *OMD = llvm::dyn_cast<ObjCMethodDecl>(D)) {
       if (TouchedIdentifier &&
-          objcMethodIsTouched(SM, OMD, TouchedIdentifier->location())) {
+          objcMethodIsTouched(SM, OMD, TouchedIdentifier->location()) &&
+          OMD->isThisDeclarationADefinition()) {
         llvm::SmallVector<const ObjCMethodDecl *, 4> Overrides;
         OMD->getOverriddenMethods(Overrides);
         if (!Overrides.empty()) {

--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -1335,6 +1335,42 @@ TEST_F(SymbolCollectorTest, OverrideRelationsMultipleInheritance) {
                           OverriddenBy(CBar, DBar), OverriddenBy(CBaz, DBaz)));
 }
 
+TEST_F(SymbolCollectorTest, ObjCOverrideRelationsSimpleInheritance) {
+  std::string Header = R"cpp(
+    @interface A
+    - (void)foo;
+    @end
+    @interface B : A
+    - (void)foo;  // A::foo
+    - (void)bar;
+    @end
+    @interface C : B
+    - (void)bar;  // B::bar
+    @end
+    @interface D : C
+    - (void)foo;  // B::foo
+    - (void)bar;  // C::bar
+    @end
+  )cpp";
+  runSymbolCollector(Header, /*Main=*/"",
+                     {"-xobjective-c++", "-Wno-objc-root-class"});
+  const Symbol &AFoo = findSymbol(Symbols, "A::foo");
+  const Symbol &BFoo = findSymbol(Symbols, "B::foo");
+  const Symbol &DFoo = findSymbol(Symbols, "D::foo");
+
+  const Symbol &BBar = findSymbol(Symbols, "B::bar");
+  const Symbol &CBar = findSymbol(Symbols, "C::bar");
+  const Symbol &DBar = findSymbol(Symbols, "D::bar");
+
+  std::vector<Relation> Result;
+  for (const Relation &R : Relations)
+    if (R.Predicate == RelationKind::OverriddenBy)
+      Result.push_back(R);
+  EXPECT_THAT(Result, UnorderedElementsAre(
+                          OverriddenBy(AFoo, BFoo), OverriddenBy(BBar, CBar),
+                          OverriddenBy(BFoo, DFoo), OverriddenBy(CBar, DBar)));
+}
+
 TEST_F(SymbolCollectorTest, CountReferences) {
   const std::string Header = R"(
     class W;

--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -426,9 +426,10 @@ TEST(LocateSymbol, FindOverridesObjC) {
   TestTU TU = TestTU::withCode(Code.code());
   TU.ExtraArgs.push_back("-xobjective-c++");
   auto AST = TU.build();
-  EXPECT_THAT(locateSymbolAt(AST, Code.point(), TU.index().get()),
-              UnorderedElementsAre(sym("foo", Code.range("1"), std::nullopt),
-                                   sym("foo", Code.range("2"), Code.range("2"))));
+  EXPECT_THAT(
+      locateSymbolAt(AST, Code.point(), TU.index().get()),
+      UnorderedElementsAre(sym("foo", Code.range("1"), std::nullopt),
+                           sym("foo", Code.range("2"), Code.range("2"))));
 }
 
 TEST(LocateSymbol, WithIndexPreferredLocation) {
@@ -1878,15 +1879,15 @@ TEST(FindImplementations, InheritanceObjC) {
   TU.ExtraArgs.push_back("-xobjective-c++");
   auto AST = TU.build();
   auto Index = TU.index();
-  EXPECT_THAT(
-    findImplementations(AST, Code.point("base"), Index.get()),
-    UnorderedElementsAre(sym("Child", Code.range("ChildDecl"), Code.range("ChildDef"))));
-  EXPECT_THAT(
-    findImplementations(AST, Code.point("foo"), Index.get()),
-    UnorderedElementsAre(sym("foo", Code.range("fooDecl"), Code.range("fooDef"))));
-  EXPECT_THAT(
-    findImplementations(AST, Code.point("protocol"), Index.get()),
-    UnorderedElementsAre(sym("protocol", Code.range("protocolDef"), Code.range("protocolDef"))));
+  EXPECT_THAT(findImplementations(AST, Code.point("base"), Index.get()),
+              UnorderedElementsAre(sym("Child", Code.range("ChildDecl"),
+                                       Code.range("ChildDef"))));
+  EXPECT_THAT(findImplementations(AST, Code.point("foo"), Index.get()),
+              UnorderedElementsAre(
+                  sym("foo", Code.range("fooDecl"), Code.range("fooDef"))));
+  EXPECT_THAT(findImplementations(AST, Code.point("protocol"), Index.get()),
+              UnorderedElementsAre(sym("protocol", Code.range("protocolDef"),
+                                       Code.range("protocolDef"))));
 }
 
 TEST(FindImplementations, CaptureDefinition) {


### PR DESCRIPTION
- Support finding implementors of a protocol and  discovering subclasses for ObjC interfaces via the implementations call
- Add tests