### PR TITLE
[OpenMP] Missing implicit otherwise clause in metadirective.

### DIFF
--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2886,7 +2886,8 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
     // OMP5.2 Chapter 7.4: If no otherwise clause is specified the effect is as
     // if one was specified without an associated directive variant.
     if (BestIdx == -1 && Idx == 1) {
-      SkipUntil(tok::annot_pragma_openmp_end,tok::identifier);
+      ConsumeAnnotationToken();
+      return StmtEmpty();
     }
     break;
   }

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2886,6 +2886,8 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
     // OMP5.2 Chapter 7.4: If no otherwise clause is specified the effect is as
     // if one was specified without an associated directive variant.
     if (BestIdx == -1 && Idx == 1) {
+      assert(Tok.is(tok::annot_pragma_openmp_end) &&
+             "Expecting the end of the pragma here");
       ConsumeAnnotationToken();
       return StmtEmpty();
     }

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2886,7 +2886,7 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
     // OMP5.2 Chapter 7.4: If no otherwise clause is specified the effect is as
     // if one was specified without an associated directive variant.
     if (BestIdx == -1 && Idx == 1) {
-      SkipUntil(tok::annot_pragma_openmp_end);
+      SkipUntil(tok::annot_pragma_openmp_end,tok::identifier);
     }
     break;
   }

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -2882,6 +2882,12 @@ StmtResult Parser::ParseOpenMPDeclarativeOrExecutableDirective(
           /*ReadDirectiveWithinMetadirective=*/true);
       break;
     }
+    // If no match is found and no otherwise clause is present, skip
+    // OMP5.2 Chapter 7.4: If no otherwise clause is specified the effect is as
+    // if one was specified without an associated directive variant.
+    if (BestIdx == -1 && Idx == 1) {
+      SkipUntil(tok::annot_pragma_openmp_end);
+    }
     break;
   }
   case OMPD_threadprivate: {

--- a/clang/test/OpenMP/metadirective_ast_print.c
+++ b/clang/test/OpenMP/metadirective_ast_print.c
@@ -86,6 +86,11 @@ void foo(void) {
 			       : parallel for)
   for (int i=0; i<10; i++)
     ;
+#pragma omp metadirective when(user = {condition(0)}		  \
+			       : parallel for) when(implementation = {extension(match_none)} \
+						    : parallel) default(parallel for)
+  for (int i=0; i<10; i++)
+    ;
 
 #pragma omp metadirective when(user = {condition(1)}	\
 			       : parallel for) otherwise()
@@ -93,6 +98,11 @@ void foo(void) {
     ;
 #pragma omp metadirective when(user = {condition(1)}	\
 			       : parallel for)
+  for (int i=0; i<10; i++)
+    ;
+#pragma omp metadirective when(user = {condition(1)}		  \
+			       : parallel for) when(implementation = {extension(match_none)} \
+						    : parallel) default(parallel for)
   for (int i=0; i<10; i++)
     ;
 }

--- a/clang/test/OpenMP/metadirective_ast_print.c
+++ b/clang/test/OpenMP/metadirective_ast_print.c
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -verify -fopenmp -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -verify -fopenmp -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s
 
-// RUN: %clang_cc1 -verify -fopenmp-simd -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang_cc1 -verify -fopenmp-simd -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s
 
-// RUN: %clang_cc1 -verify -fopenmp -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK-AMDGCN
+// RUN: %clang_cc1 -verify -fopenmp -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefix=CHECK-AMDGCN
 
-// RUN: %clang_cc1 -verify -fopenmp-simd -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK-AMDGCN
+// RUN: %clang_cc1 -verify -fopenmp-simd -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefix=CHECK-AMDGCN
 // expected-no-diagnostics
 
 #ifndef HEADER
@@ -87,6 +87,14 @@ void foo(void) {
   for (int i=0; i<10; i++)
     ;
 
+#pragma omp metadirective when(user = {condition(1)}	\
+			       : parallel for) otherwise()
+  for (int i=0; i<10; i++)
+    ;
+#pragma omp metadirective when(user = {condition(1)}	\
+			       : parallel for)
+  for (int i=0; i<10; i++)
+    ;
 }
 
 // CHECK: void bar(void);

--- a/clang/test/OpenMP/metadirective_ast_print.c
+++ b/clang/test/OpenMP/metadirective_ast_print.c
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -verify -fopenmp -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s
+// RUN: %clang_cc1 -verify -fopenmp -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK
 
-// RUN: %clang_cc1 -verify -fopenmp-simd -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s
+// RUN: %clang_cc1 -verify -fopenmp-simd -triple x86_64-unknown-linux-gnu -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK
 
-// RUN: %clang_cc1 -verify -fopenmp -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefix=CHECK-AMDGCN
+// RUN: %clang_cc1 -verify -fopenmp -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK-AMDGCN
 
-// RUN: %clang_cc1 -verify -fopenmp-simd -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefix=CHECK-AMDGCN
+// RUN: %clang_cc1 -verify -fopenmp-simd -triple amdgcn-amd-amdhsa -x c -std=c99 -ast-print %s -o - | FileCheck %s --check-prefixes=CHECK-AMDGCN
 // expected-no-diagnostics
 
 #ifndef HEADER
@@ -77,6 +77,16 @@ void foo(void) {
                                : parallel) default(nothing)
   for (int i = 0; i < 16; i++)
     ;
+
+#pragma omp metadirective when(user = {condition(0)}	\
+			       : parallel for) otherwise()
+  for (int i=0; i<10; i++)
+    ;
+#pragma omp metadirective when(user = {condition(0)}	\
+			       : parallel for)
+  for (int i=0; i<10; i++)
+    ;
+
 }
 
 // CHECK: void bar(void);

--- a/clang/test/OpenMP/metadirective_otherwise.cpp
+++ b/clang/test/OpenMP/metadirective_otherwise.cpp
@@ -14,6 +14,16 @@ void func1() {
 			       : parallel for)
   for (int i = 0; i < 100; i++)
     ;
+
+#pragma omp metadirective when(user = {condition(0)}			\
+			       : parallel for)                          \
+  when(implementation = {extension(match_none)}				\
+       : parallel) default(parallel for)
+
+  for (int i = 0; i < 100; i++)
+    ;
+
+
 }
 
 // CHECK-LABEL: define dso_local void @_Z5func1v()
@@ -48,7 +58,7 @@ void func1() {
 // CHECK-NEXT:    store i32 [[INC6]], ptr [[I1]], align 4
 // CHECK-NEXT:    br label %[[FOR_COND2]], !llvm.loop [[LOOP5:![0-9]+]]
 // CHECK:       [[FOR_END7]]:
-// CHECK-NEXT:    ret void
+// CHECK:    ret void
 
 void func2() {
 #pragma omp metadirective when(user = {condition(1)}	\
@@ -68,5 +78,48 @@ void func2() {
 // CHECK-NEXT:    call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr @[[GLOB2]], i32 0, ptr @_Z5func2v.omp_outlined.1)
 // CHECK-NEXT:    ret void
 
+
+void func3() {
+#pragma omp metadirective when(user = {condition(0)}			\
+			       : parallel for)                          \
+  when(implementation = {extension(match_none)}				\
+       : parallel) default(parallel for)
+
+  for (int i = 0; i < 100; i++)
+    ;
+
+}
+
+// CHECK-LABEL: define dso_local void @_Z5func3v()
+// CHECK:       entry
+// CHECK-NEXT:    call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr @1, i32 0, ptr @_Z5func3v.omp_outlined)
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:   }
+
+// CHECK-LABEL: define internal void @_Z5func3v.omp_outlined
+// CHECK-SAME: (ptr noalias noundef [[DOTGLOBAL_TID_:%.*]],
+// CHECK-SAME:  ptr noalias noundef [[DOTBOUND_TID_:%.*]])
+// CHECK-NEXT:  entry
+// CHECK-NEXT:    [[GLOB_TID__ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[BOUND_TID__ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[I:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store ptr [[DOTGLOBAL_TID_]], ptr [[GLOB_TID__ADDR]], align 8
+// CHECK-NEXT:    store ptr [[DOTBOUND_TID_]], ptr [[BOUND_TID__ADDR]], align 8
+// CHECK-NEXT:    store i32 0, ptr [[I]], align 4
+// CHECK-NEXT:    br label %for.cond
+// CHECK:for.cond:
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[I]], align 4
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP0]], 100
+// CHECK-NEXT:    br i1 [[CMP]], label [[FOR_BODY:%.*]], label [[FOR_END:%.*]]
+// CHECK:for.body:
+// CHECK-NEXT:    br label [[FOR_INC:%.*]]
+// CHECK:for.inc:
+// CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[I]], align 4
+// CHECK-NEXT:    [[INC:%.*]] = add nsw i32 [[TMP1]], 1
+// CHECK-NEXT:    store i32 [[INC]], ptr [[I]], align 4
+// CHECK-NEXT:    br label [[FOR_COND:%.*]]
+// CHECK:for.end:
+// CHECK-NEXT:  ret void
+// CHECK-NEXT:}
 
 #endif

--- a/clang/test/OpenMP/metadirective_otherwise.cpp
+++ b/clang/test/OpenMP/metadirective_otherwise.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang_cc1 -verify -fopenmp -x c++ -triple x86_64-unknown-linux -emit-llvm %s -o - | FileCheck %s
+// expected-no-diagnostics
+
+#ifndef HEADER
+#define HEADER
+
+void func1() {
+#pragma omp metadirective when(user = {condition(0)}	\
+			       : parallel for) otherwise()
+  for (int i = 0; i < 100; i++)
+    ;
+
+#pragma omp metadirective when(user = {condition(0)}	\
+			       : parallel for)
+  for (int i = 0; i < 100; i++)
+    ;
+}
+
+// CHECK-LABEL: define dso_local void @_Z5func1v()
+// CHECK:       entry
+// CHECK-NEXT:    [[I:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[I1:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store i32 0, ptr [[I]], align 4
+// CHECK-NEXT:    br label %[[FOR_COND:.*]]
+// CHECK:       [[FOR_COND]]:
+// CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[I]], align 4
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP0]], 100
+// CHECK-NEXT:    br i1 [[CMP]], label %[[FOR_BODY:.*]], label %[[FOR_END:.*]]
+// CHECK:       [[FOR_BODY]]:
+// CHECK-NEXT:    br label %[[FOR_INC:.*]]
+// CHECK:       [[FOR_INC]]:
+// CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[I]], align 4
+// CHECK-NEXT:    [[INC:%.*]] = add nsw i32 [[TMP1]], 1
+// CHECK-NEXT:    store i32 [[INC]], ptr [[I]], align 4
+// CHECK-NEXT:    br label %[[FOR_COND]], !llvm.loop [[LOOP3:![0-9]+]]
+// CHECK:       [[FOR_END]]:
+// CHECK-NEXT:    store i32 0, ptr [[I1]], align 4
+// CHECK-NEXT:    br label %[[FOR_COND2:.*]]
+// CHECK:       [[FOR_COND2]]:
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[I1]], align 4
+// CHECK-NEXT:    [[CMP3:%.*]] = icmp slt i32 [[TMP2]], 100
+// CHECK-NEXT:    br i1 [[CMP3]], label %[[FOR_BODY4:.*]], label %[[FOR_END7:.*]]
+// CHECK:       [[FOR_BODY4]]:
+// CHECK-NEXT:    br label %[[FOR_INC5:.*]]
+// CHECK:       [[FOR_INC5]]:
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[I1]], align 4
+// CHECK-NEXT:    [[INC6:%.*]] = add nsw i32 [[TMP3]], 1
+// CHECK-NEXT:    store i32 [[INC6]], ptr [[I1]], align 4
+// CHECK-NEXT:    br label %[[FOR_COND2]], !llvm.loop [[LOOP5:![0-9]+]]
+// CHECK:       [[FOR_END7]]:
+// CHECK-NEXT:    ret void
+
+void func2() {
+#pragma omp metadirective when(user = {condition(1)}	\
+			       : parallel for) otherwise()
+  for (int i = 0; i < 100; i++)
+    ;
+
+#pragma omp metadirective when(user = {condition(1)}	\
+			       : parallel for)
+  for (int i = 0; i < 100; i++)
+    ;
+}
+
+// CHECK-LABEL: define dso_local void @_Z5func2v()
+// CHECK:       entry
+// CHECK-NEXT:    call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr @[[GLOB2:[0-9]+]], i32 0, ptr @_Z5func2v.omp_outlined)
+// CHECK-NEXT:    call void (ptr, i32, ptr, ...) @__kmpc_fork_call(ptr @[[GLOB2]], i32 0, ptr @_Z5func2v.omp_outlined.1)
+// CHECK-NEXT:    ret void
+
+
+#endif

--- a/llvm/include/llvm/Frontend/OpenMP/OMPContext.h
+++ b/llvm/include/llvm/Frontend/OpenMP/OMPContext.h
@@ -188,7 +188,7 @@ bool isVariantApplicableInContext(const VariantMatchInfo &VMI,
                                   bool DeviceSetOnly = false);
 
 /// Return the index (into \p VMIs) of the variant with the highest score
-/// from the ones applicble in \p Ctx. See llvm::isVariantApplicableInContext.
+/// from the ones applicable in \p Ctx. See llvm::isVariantApplicableInContext.
 int getBestVariantMatchForContext(const SmallVectorImpl<VariantMatchInfo> &VMIs,
                                   const OMPContext &Ctx);
 


### PR DESCRIPTION
Compiling this:
 `int main() {`
 ` #pragma omp metadirective when(use r= {condition(0)}`
                                                            `: parallel for)`
  `for (int i=0; i<10; i++)`
  ;
}`

is generating an error:
`error: expected expression`
The compiler is interpreting this as if it's compiling a `#pragma omp metadirective` with no `otherwise` clause.
In the OMP5.2 specs chapter 7.4 it's mentioned that: 
`If no otherwise clause is specified the effect is as if one was specified without an associated directive variant.`
This patch fixes the issue.