### PR TITLE
[ORC][unittests] Remove hard coded 16k page size

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -66,10 +66,17 @@ protected:
       consumeError(DLOrErr.takeError());
       GTEST_SKIP();
     }
+
+    auto PageSize = sys::Process::getPageSize();
+    if (!PageSize) {
+      consumeError(PageSize.takeError());
+      GTEST_SKIP();
+    }
+
     ES = std::make_unique<ExecutionSession>(std::move(*EPC));
     JD = &ES->createBareJITDylib("main");
     ObjLinkingLayer = std::make_unique<ObjectLinkingLayer>(
-        *ES, std::make_unique<InProcessMemoryManager>(16384));
+        *ES, std::make_unique<InProcessMemoryManager>(*PageSize));
     DL = std::make_unique<DataLayout>(std::move(*DLOrErr));
 
     auto TM = JTMB->createTargetMachine();


### PR DESCRIPTION
Fixes a couple hard coded 16k values which is being used as the page size. Replaces the hard coded value with the system's page size. This fixes #116753 on an Ampere Altra Q64-22 

CC @lhames