### PR TITLE
[analyzer] Add hack in ArrayBound to cover up missing casts

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
@@ -34,24 +34,37 @@ using namespace taint;
 using llvm::formatv;
 
 namespace {
-/// If `E` is a "clean" array subscript expression, return the type of the
-/// accessed element. If the base of the subscript expression is modified by
-/// pointer arithmetic (and not the beginning of a "full" memory region), this
-/// always returns nullopt because that's the right (or the least bad) thing to
-/// do for the diagnostic output that's relying on this.
-static std::optional<QualType> determineElementType(const Expr *E,
-                                                    const CheckerContext &C) {
+/// If `E` is an array subscript expression with a base that is "clean" (= not
+/// modified by pointer arithmetic = the beginning of a memory region), return
+/// it as a pointer to ArraySubscriptExpr; otherwise return nullptr.
+/// This helper function is used by two separate heuristics that are only valid
+/// in these "clean" cases.
+static const ArraySubscriptExpr *
+getAsCleanArraySubscriptExpr(const Expr *E, const CheckerContext &C) {
   const auto *ASE = dyn_cast<ArraySubscriptExpr>(E);
   if (!ASE)
-    return std::nullopt;
+    return nullptr;
 
   const MemRegion *SubscriptBaseReg = C.getSVal(ASE->getBase()).getAsRegion();
   if (!SubscriptBaseReg)
-    return std::nullopt;
+    return nullptr;
 
   // The base of the subscript expression is affected by pointer arithmetics,
-  // so we want to report byte offsets instead of indices.
+  // so we want to report byte offsets instead of indices and we don't want to
+  // activate the "index is unsigned -> cannot be negative" shortcut.
   if (isa<ElementRegion>(SubscriptBaseReg->StripCasts()))
+    return nullptr;
+
+  return ASE;
+}
+
+/// If `E` is a "clean" array subscript expression, return the type of the
+/// accessed element; otherwise return std::nullopt because that's the best (or
+/// least bad) option for the diagnostic generation that relies on this.
+static std::optional<QualType> determineElementType(const Expr *E,
+                                                    const CheckerContext &C) {
+  const auto *ASE = getAsCleanArraySubscriptExpr(E, C);
+  if (!ASE)
     return std::nullopt;
 
   return ASE->getType();
@@ -140,7 +153,9 @@ class ArrayBoundChecker : public Checker<check::PostStmt<ArraySubscriptExpr>,
                                    ProgramStateRef ErrorState, NonLoc Val,
                                    bool MarkTaint);
 
-  static bool isFromCtypeMacro(const Stmt *S, ASTContext &AC);
+  static bool isFromCtypeMacro(const Expr *E, ASTContext &AC);
+
+  static bool isOffsetObviouslyNonnegative(const Expr *E, CheckerContext &C);
 
   static bool isIdiomaticPastTheEndPtr(const Expr *E, ProgramStateRef State,
                                        NonLoc Offset, NonLoc Limit,
@@ -588,20 +603,48 @@ void ArrayBoundChecker::performCheck(const Expr *E, CheckerContext &C) const {
         State, ByteOffset, SVB.makeZeroArrayIndex(), SVB);
 
     if (PrecedesLowerBound) {
-      // The offset may be invalid (negative)...
-      if (!WithinLowerBound) {
-        // ...and it cannot be valid (>= 0), so report an error.
-        Messages Msgs = getPrecedesMsgs(Reg, ByteOffset);
-        reportOOB(C, PrecedesLowerBound, Msgs, ByteOffset, std::nullopt);
-        return;
+      // The analyzer thinks that the offset may be invalid (negative)...
+
+      if (isOffsetObviouslyNonnegative(E, C)) {
+        // ...but the offset is obviously non-negative (clear array subscript
+        // with an unsigned index), so we're in a buggy situation.
+
+        // TODO: Currently the analyzer ignores many casts (e.g. signed ->
+        // unsigned casts), so it can easily reach states where it will load a
+        // signed (and negative) value from an unsigned variable. This sanity
+        // check is a duct tape "solution" that silences most of the ugly false
+        // positives that are caused by this buggy behavior. Note that this is
+        // not a complete solution: this cannot silence reports where pointer
+        // arithmetic complicates the picture and cannot ensure modeling of the
+        // "unsigned index is positive with highest bit set" cases which are
+        // "usurped" by the nonsense "unsigned index is negative" case.
+        // For more information about this topic, see the umbrella ticket
+        // https://github.com/llvm/llvm-project/issues/39492
+        // TODO: Remove this hack once 'SymbolCast's are modeled properly.
+
+        if (!WithinLowerBound) {
+          // The state is completely nonsense -- let's just sink it!
+          C.addSink();
+          return;
+        }
+        // Otherwise continue on the 'WithinLowerBound' branch where the
+        // unsigned index _is_ non-negative. Don't mention this assumption as a
+        // note tag, because it would just confuse the users!
+      } else {
+        if (!WithinLowerBound) {
+          // ...and it cannot be valid (>= 0), so report an error.
+          Messages Msgs = getPrecedesMsgs(Reg, ByteOffset);
+          reportOOB(C, PrecedesLowerBound, Msgs, ByteOffset, std::nullopt);
+          return;
+        }
+        // ...but it can be valid as well, so the checker will (optimistically)
+        // assume that it's valid and mention this in the note tag.
+        SUR.recordNonNegativeAssumption();
       }
-      // ...but it can be valid as well, so the checker will (optimistically)
-      // assume that it's valid and mention this in the note tag.
-      SUR.recordNonNegativeAssumption();
     }
 
     // Actually update the state. The "if" only fails in the extremely unlikely
-    // case when compareValueToThreshold returns {nullptr, nullptr} becasue
+    // case when compareValueToThreshold returns {nullptr, nullptr} because
     // evalBinOpNN fails to evaluate the less-than operator.
     if (WithinLowerBound)
       State = WithinLowerBound;
@@ -661,7 +704,7 @@ void ArrayBoundChecker::performCheck(const Expr *E, CheckerContext &C) const {
     }
 
     // Actually update the state. The "if" only fails in the extremely unlikely
-    // case when compareValueToThreshold returns {nullptr, nullptr} becasue
+    // case when compareValueToThreshold returns {nullptr, nullptr} because
     // evalBinOpNN fails to evaluate the less-than operator.
     if (WithinUpperBound)
       State = WithinUpperBound;
@@ -726,8 +769,8 @@ void ArrayBoundChecker::reportOOB(CheckerContext &C, ProgramStateRef ErrorState,
   C.emitReport(std::move(BR));
 }
 
-bool ArrayBoundChecker::isFromCtypeMacro(const Stmt *S, ASTContext &ACtx) {
-  SourceLocation Loc = S->getBeginLoc();
+bool ArrayBoundChecker::isFromCtypeMacro(const Expr *E, ASTContext &ACtx) {
+  SourceLocation Loc = E->getBeginLoc();
   if (!Loc.isMacroID())
     return false;
 
@@ -743,6 +786,14 @@ bool ArrayBoundChecker::isFromCtypeMacro(const Stmt *S, ASTContext &ACtx) {
           (MacroName == "isnctrl") || (MacroName == "isprint") ||
           (MacroName == "ispunct") || (MacroName == "isspace") ||
           (MacroName == "isupper") || (MacroName == "isxdigit"));
+}
+
+bool ArrayBoundChecker::isOffsetObviouslyNonnegative(const Expr *E,
+                                                     CheckerContext &C) {
+  const ArraySubscriptExpr *ASE = getAsCleanArraySubscriptExpr(E, C);
+  if (!ASE)
+    return false;
+  return ASE->getIdx()->getType()->isUnsignedIntegerOrEnumerationType();
 }
 
 bool ArrayBoundChecker::isInAddressOf(const Stmt *S, ASTContext &ACtx) {

--- a/clang/test/Analysis/out-of-bounds.c
+++ b/clang/test/Analysis/out-of-bounds.c
@@ -1,7 +1,6 @@
 // RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection -verify %s
 
 void clang_analyzer_value(int);
-void clang_analyzer_dump(int);
 
 // Tests doing an out-of-bounds access after the end of an array using:
 // - constant integer index
@@ -209,25 +208,6 @@ int test_cast_to_unsigned_overflow(signed char x) {
   // but the hack in ArrayBound just silences reports and cannot "restore" the
   // real execution paths.
   return small_table[y]; // no-warning
-}
-
-int test_cast_to_unsigned_with_ptr_arith(signed char x) {
-  unsigned char y = x;
-  int *p = table - 10;
-
-  if (x >= 0)
-    return x;
-  // FIXME: As in 'test_cast_to_unsigned', the analyzer thinks that this
-  // unsigned variable contains a negative value.
-  clang_analyzer_value(y); // expected-warning {{8s:{ [-128, -1] } }}
-  // In this case, the hack in ArrayBound cannot suppress the false positive
-  // underflow report because 'p' is not the beginning of a memory region, so
-  // it cannot clearly say that an unsigned index guarantees no overflow.
-  // However, we still don't get an underflow report because (for some unclear
-  // reason) the analyzer fails to evaluate this more complex expression.
-  clang_analyzer_dump(p[y]); // expected-warning {{Unknown}}
-  return p[y]; // no-warning
-
 }
 
 int test_negative_offset_with_unsigned_idx(void) {


### PR DESCRIPTION
Currently there are many casts that are not modeled (i.e. ignored) by the analyzer, which can cause paradox states (e.g. negative value stored in `unsigned` variable) and false positive reports from various checkers, e.g. from `security.ArrayBound`.

Unfortunately this issue is deeply rooted in the architectural limitations of the analyzer (if we started to model the casts, it would break other things). For details see the umbrella ticket https://github.com/llvm/llvm-project/issues/39492

This commit adds an ugly hack in `security.ArrayBound` to silence most of the false positives caused by this shortcoming of the engine.

Fixes #126884

-----

Evaluation of this patch on open source projects (New = with this patch, Resolved = its parent):

| Project | New Reports | Resolved Reports |
|---------|-------------|------------------|
| memcached | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=memcached_1.6.8_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=memcached_1.6.8_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [1 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=memcached_1.6.8_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=memcached_1.6.8_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| tmux | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=tmux_2.6_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=tmux_2.6_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=tmux_2.6_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=tmux_2.6_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| curl | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=curl_curl-7_66_0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=curl_curl-7_66_0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [1 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=curl_curl-7_66_0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=curl_curl-7_66_0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| twin | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=twin_v0.8.1_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=twin_v0.8.1_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=twin_v0.8.1_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=twin_v0.8.1_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| vim | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=vim_v8.2.1920_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=vim_v8.2.1920_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=vim_v8.2.1920_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=vim_v8.2.1920_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| openssl | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=openssl_openssl-3.0.0-alpha7_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=openssl_openssl-3.0.0-alpha7_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=openssl_openssl-3.0.0-alpha7_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=openssl_openssl-3.0.0-alpha7_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| sqlite | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=sqlite_version-3.33.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=sqlite_version-3.33.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=sqlite_version-3.33.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=sqlite_version-3.33.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| ffmpeg | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=ffmpeg_n4.3.1_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=ffmpeg_n4.3.1_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [2 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=ffmpeg_n4.3.1_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=ffmpeg_n4.3.1_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| postgres | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=postgres_REL_13_0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=postgres_REL_13_0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [3 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=postgres_REL_13_0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=postgres_REL_13_0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| tinyxml2 | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=tinyxml2_8.0.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=tinyxml2_8.0.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=tinyxml2_8.0.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=tinyxml2_8.0.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| libwebm | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=libwebm_libwebm-1.0.0.27_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=libwebm_libwebm-1.0.0.27_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [3 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=libwebm_libwebm-1.0.0.27_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=libwebm_libwebm-1.0.0.27_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| xerces | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=xerces_v3.2.3_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=xerces_v3.2.3_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=xerces_v3.2.3_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=xerces_v3.2.3_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| bitcoin | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=bitcoin_v0.20.1_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=bitcoin_v0.20.1_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=bitcoin_v0.20.1_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=bitcoin_v0.20.1_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| protobuf | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=protobuf_v3.13.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=protobuf_v3.13.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [1 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=protobuf_v3.13.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=protobuf_v3.13.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 
| qtbase | [0 new reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=qtbase_v6.2.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=qtbase_v6.2.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=New) | [0 resolved reports](https://codechecker-demo.eastus.cloudapp.azure.com/Default/reports?run=qtbase_v6.2.0_edonnag_8da8ff8768bc0115f21d7d8fe8d47872190f8de1_1883de3&newcheck=qtbase_v6.2.0_edonnag_Ericsson-arraybound-hack-for-sign-cast-bug_1883de3&diff-type=Resolved) 

I checked the resolved reports: they are all false positives and many of them are glaringly nonsense.