### PR TITLE
[lld] enable installing lld headers and libraries as part of distribution

### DIFF
--- a/lld/CMakeLists.txt
+++ b/lld/CMakeLists.txt
@@ -180,14 +180,6 @@ include_directories(BEFORE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   )
 
-if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-  install(DIRECTORY include/
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    FILES_MATCHING
-    PATTERN "*.h"
-    )
-endif()
-
 add_subdirectory(Common)
 add_subdirectory(tools/lld)
 
@@ -206,5 +198,42 @@ add_subdirectory(ELF)
 add_subdirectory(MachO)
 add_subdirectory(MinGW)
 add_subdirectory(wasm)
+
+add_custom_target(lld-headers)
+set_target_properties(lld-headers PROPERTIES FOLDER "Misc")
+if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+  install(DIRECTORY include/lld
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT lld-headers
+    FILES_MATCHING
+    PATTERN "*.h"
+    )
+
+  if (NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-lld-headers
+                             DEPENDS lld-headers
+                             COMPONENT lld-headers)
+  endif()
+endif()
+
+# Custom target to install all lld libraries
+add_custom_target(lld-libraries)
+if (NOT LLVM_ENABLE_IDE)
+  add_llvm_install_targets(install-lld-libraries
+                           DEPENDS lld-libraries
+                           COMPONENT lld-libraries)
+endif()
+
+get_property(LLD_LIBS GLOBAL PROPERTY LLD_ALL_LIBS)
+if(LLD_LIBS)
+  list(REMOVE_DUPLICATES LLD_LIBS)
+  foreach(lib ${LLD_LIBS})
+    add_dependencies(lld-libraries ${lib})
+    if(NOT LLVM_ENABLE_IDE)
+      add_dependencies(install-lld-libraries install-${lib})
+      add_dependencies(install-lld-libraries-stripped install-${lib}-stripped)
+    endif()
+  endforeach()
+endif()
 
 add_subdirectory(cmake/modules)

--- a/lld/cmake/modules/AddLLD.cmake
+++ b/lld/cmake/modules/AddLLD.cmake
@@ -13,7 +13,7 @@ macro(add_lld_library name)
   llvm_add_library(${name} ${ARG_ENABLE_SHARED} ${ARG_UNPARSED_ARGUMENTS})
 
   if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-    get_target_export_arg(${name} LLD export_to_lldtargets)
+    get_target_export_arg(${name} LLD export_to_lldtargets UMBRELLA lld-libraries)
     install(TARGETS ${name}
       COMPONENT ${name}
       ${export_to_lldtargets}
@@ -21,11 +21,12 @@ macro(add_lld_library name)
       ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
       RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
-    if (${ARG_SHARED} AND NOT CMAKE_CONFIGURATION_TYPES)
+    if (NOT CMAKE_CONFIGURATION_TYPES)
       add_llvm_install_targets(install-${name}
         DEPENDS ${name}
         COMPONENT ${name})
     endif()
+    set_property(GLOBAL APPEND PROPERTY LLD_ALL_LIBS ${name})
     set_property(GLOBAL APPEND PROPERTY LLD_EXPORTS ${name})
   endif()
 endmacro(add_lld_library)


### PR DESCRIPTION
This patch allows `lld-headers` and `lld-libraries` in `LLVM_DISTRIBUTION_COMPONENTS` to be specified and thus enable piecewise installation of `lld/**/*.h` headers and/or lld libraries (both in shared and static builds).
This is similar to use cases such as `clang;clang-headers;clang-libraries`. Note when `lld-libraries` is present, `llvm-libraries` must be present as well because various lld libraries depend on various llvm libraries.
