### PR TITLE
[libc] Add UEFI headers

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -724,6 +724,19 @@ add_header_macro(
     .llvm-libc-macros.poll-macros
   )
 
+# UEFI spec references "Uefi.h" so we use that name for compatibility
+add_header_macro(
+  uefi
+  ../libc/include/Uefi.yaml
+  Uefi.h.def
+  Uefi.h
+  DEPENDS
+    .llvm_libc_common_h
+    .llvm-libc-types.EFI_GUID
+    .llvm-libc-types.EFI_STATUS
+    .llvm-libc-types.EFI_SYSTEM_TABLE
+)
+
 if(NOT LLVM_LIBC_FULL_BUILD)
   # We don't install headers in non-fullbuild mode.
   return()

--- a/libc/include/Uefi.h.def
+++ b/libc/include/Uefi.h.def
@@ -1,0 +1,16 @@
+//===-- UEFI header uefi.h --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_UEFI_H
+#define LLVM_LIBC_UEFI_H
+
+#include "__llvm-libc-common.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_UEFI_H

--- a/libc/include/Uefi.yaml
+++ b/libc/include/Uefi.yaml
@@ -1,0 +1,15 @@
+header: Uefi.h
+standards: UEFI
+macros: []
+types:
+  - type_name: EFI_BOOT_SERVICES
+  - type_name: EFI_GUID
+  - type_name: EFI_STATUS
+  - type_name: EFI_SYSTEM_TABLE
+enums: []
+functions: []
+objects:
+  - object_name: efi_system_table
+    object_type: EFI_SYSTEM_TABLE *
+  - object_name: efi_image_handle
+    object_type: EFI_HANDLE

--- a/libc/include/llvm-libc-macros/CMakeLists.txt
+++ b/libc/include/llvm-libc-macros/CMakeLists.txt
@@ -337,3 +337,9 @@ add_macro_header(
   HDR
     poll-macros.h
 )
+
+add_macro_header(
+  EFIAPI_macros
+  HDR
+    EFIAPI-macros.h
+)

--- a/libc/include/llvm-libc-macros/EFIAPI-macros.h
+++ b/libc/include/llvm-libc-macros/EFIAPI-macros.h
@@ -1,0 +1,18 @@
+//===-- Definition of EFIAPI macro ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_MACROS_EFIAPI_MACROS_H
+#define LLVM_LIBC_MACROS_EFIAPI_MACROS_H
+
+#if defined(__x86_64__) && !defined(__ILP32__)
+#define EFIAPI __attribute__((ms_abi))
+#else
+#define EFIAPI
+#endif
+
+#endif // LLVM_LIBC_MACROS_EFIAPI_MACROS_H

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -157,3 +157,127 @@ DEPENDS
 add_header(locale_t HDR locale_t.h)
 add_header(struct_lconv HDR struct_lconv.h)
 add_header(stdfix-types HDR stdfix-types.h)
+
+# UEFI
+add_header(EFI_GUID HDR EFI_GUID.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+add_header(EFI_CONFIGURATION_TABLE HDR EFI_CONFIGURATION_TABLE.h DEPENDS .EFI_GUID)
+
+add_header(EFI_PHYSICAL_ADDRESS HDR EFI_PHYSICAL_ADDRESS.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+add_header(EFI_VIRTUAL_ADDRESS HDR EFI_VIRTUAL_ADDRESS.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+
+add_header(EFI_MEMORY_DESCRIPTOR
+  HDR
+    EFI_MEMORY_DESCRIPTOR.h
+  DEPENDS
+    libc.include.llvm-libc-macros.stdint_macros
+    .EFI_PHYSICAL_ADDRESS
+    .EFI_VIRTUAL_ADDRESS
+)
+
+add_header(EFI_ALLOCATE_TYPE HDR EFI_ALLOCATE_TYPE.h)
+add_header(EFI_EVENT HDR EFI_EVENT.h)
+add_header(EFI_INTERFACE_TYPE HDR EFI_INTERFACE_TYPE.h)
+add_header(EFI_LOCATE_SEARCH_TYPE HDR EFI_LOCATE_SEARCH_TYPE.h)
+add_header(EFI_MEMORY_TYPE HDR EFI_MEMORY_TYPE.h)
+add_header(EFI_HANDLE HDR EFI_HANDLE.h)
+add_header(EFI_TIME HDR EFI_TIME.h DEPENDS libc.include.llvm-libc-macros.stdint_macros)
+add_header(EFI_TIMER_DELAY HDR EFI_TIMER_DELAY.h)
+add_header(EFI_TPL HDR EFI_TPL.h DEPENDS .size_t)
+add_header(EFI_STATUS HDR EFI_STATUS.h DEPENDS .size_t)
+
+add_header(EFI_OPEN_PROTOCOL_INFORMATION_ENTRY
+  HDR
+    EFI_OPEN_PROTOCOL_INFORMATION_ENTRY.h
+  DEPENDS
+    libc.include.llvm-libc-macros.stdint_macros
+    .EFI_HANDLE
+)
+
+add_header(EFI_CAPSULE
+  HDR
+    EFI_CAPSULE.h
+  DEPENDS
+    libc.include.llvm-libc-macros.stdint_macros
+    .EFI_GUID
+)
+
+add_header(EFI_TABLE_HEADER
+  HDR
+    EFI_TABLE_HEADER.h
+  DEPENDS
+    libc.include.llvm-libc-macros.stdint_macros
+)
+
+add_header(EFI_DEVICE_PATH_PROTOCOL
+  HDR
+    EFI_DEVICE_PATH_PROTOCOL.h
+  DEPENDS
+    libc.include.llvm-libc-macros.stdint_macros
+)
+
+add_header(EFI_SIMPLE_TEXT_INPUT_PROTOCOL
+  HDR
+    EFI_SIMPLE_TEXT_INPUT_PROTOCOL.h
+  DEPENDS
+    libc.include.llvm-libc-macros.EFIAPI_macros
+    libc.include.llvm-libc-macros.stdint_macros
+    .EFI_EVENT
+    .EFI_STATUS
+    .char16_t
+)
+
+add_header(EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL
+  HDR
+    EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h
+  DEPENDS
+    libc.include.llvm-libc-macros.stdint_macros
+    .EFI_STATUS
+    .size_t
+)
+
+add_header(EFI_BOOT_SERVICES
+  HDR
+    EFI_BOOT_SERVICES.h
+  DEPENDS
+    libc.include.llvm-libc-macros.EFIAPI_macros
+    .EFI_ALLOCATE_TYPE
+    .EFI_DEVICE_PATH_PROTOCOL
+    .EFI_EVENT
+    .EFI_INTERFACE_TYPE
+    .EFI_LOCATE_SEARCH_TYPE
+    .EFI_MEMORY_DESCRIPTOR
+    .EFI_MEMORY_TYPE
+    .EFI_OPEN_PROTOCOL_INFORMATION_ENTRY
+    .EFI_PHYSICAL_ADDRESS
+    .EFI_STATUS
+    .EFI_TABLE_HEADER
+    .EFI_TIMER_DELAY
+    .EFI_TPL
+    .char16_t
+)
+
+add_header(EFI_RUNTIME_SERVICES
+  HDR
+    EFI_RUNTIME_SERVICES.h
+  DEPENDS
+    .EFI_CAPSULE
+    .EFI_STATUS
+    .EFI_TABLE_HEADER
+    .EFI_TIME
+    .char16_t
+)
+
+add_header(EFI_SYSTEM_TABLE
+  HDR
+    EFI_SYSTEM_TABLE.h
+  DEPENDS
+    .EFI_BOOT_SERVICES
+    .EFI_CONFIGURATION_TABLE
+    .EFI_HANDLE
+    .EFI_RUNTIME_SERVICES
+    .EFI_SIMPLE_TEXT_INPUT_PROTOCOL
+    .EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL
+    .EFI_STATUS
+    .EFI_TABLE_HEADER
+    .char16_t
+)

--- a/libc/include/llvm-libc-types/EFI_ALLOCATE_TYPE.h
+++ b/libc/include/llvm-libc-types/EFI_ALLOCATE_TYPE.h
@@ -1,0 +1,19 @@
+//===-- Definition of EFI_ALLOCATE_TYPE type ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_ALLOCATE_TYPE_H
+#define LLVM_LIBC_TYPES_EFI_ALLOCATE_TYPE_H
+
+typedef enum {
+  AllocateAnyPages,
+  AllocateMaxAddress,
+  AllocateAddress,
+  MaxAllocateType
+} EFI_ALLOCATE_TYPE;
+
+#endif // LLVM_LIBC_TYPES_EFI_ALLOCATE_TYPE_H

--- a/libc/include/llvm-libc-types/EFI_BOOT_SERVICES.h
+++ b/libc/include/llvm-libc-types/EFI_BOOT_SERVICES.h
@@ -1,0 +1,250 @@
+//===-- Definition of EFI_BOOT_SERVICES type ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_BOOT_SERVICES_H
+#define LLVM_LIBC_TYPES_EFI_BOOT_SERVICES_H
+
+#include "../llvm-libc-macros/EFIAPI-macros.h"
+#include "EFI_ALLOCATE_TYPE.h"
+#include "EFI_DEVICE_PATH_PROTOCOL.h"
+#include "EFI_EVENT.h"
+#include "EFI_GUID.h"
+#include "EFI_INTERFACE_TYPE.h"
+#include "EFI_LOCATE_SEARCH_TYPE.h"
+#include "EFI_MEMORY_DESCRIPTOR.h"
+#include "EFI_MEMORY_TYPE.h"
+#include "EFI_OPEN_PROTOCOL_INFORMATION_ENTRY.h"
+#include "EFI_PHYSICAL_ADDRESS.h"
+#include "EFI_STATUS.h"
+#include "EFI_TABLE_HEADER.h"
+#include "EFI_TIMER_DELAY.h"
+#include "EFI_TPL.h"
+#include "char16_t.h"
+#include "size_t.h"
+
+#define EFI_BOOT_SERVICES_SIGNATURE 0x56524553544f4f42
+#define EFI_BOOT_SERVICES_REVISION EFI_SPECIFICATION_VERSION
+
+typedef EFI_TPL(EFIAPI *EFI_RAISE_TPL)(EFI_TPL NewTpl);
+typedef void(EFIAPI *EFI_RESTORE_TPL)(EFI_TPL OldTpl);
+
+typedef EFI_STATUS(EFIAPI *EFI_ALLOCATE_PAGES)(EFI_ALLOCATE_TYPE Type,
+                                               EFI_MEMORY_TYPE MemoryType,
+                                               size_t Pages,
+                                               EFI_PHYSICAL_ADDRESS *Memory);
+typedef EFI_STATUS(EFIAPI *EFI_FREE_PAGES)(EFI_PHYSICAL_ADDRESS Memory,
+                                           size_t Pages);
+typedef EFI_STATUS(EFIAPI *EFI_GET_MEMORY_MAP)(size_t *MemoryMapSize,
+                                               EFI_MEMORY_DESCRIPTOR *MemoryMap,
+                                               size_t *MapKey,
+                                               size_t *DescriptorSize,
+                                               uint32_t *DescriptorVersion);
+
+typedef EFI_STATUS(EFIAPI *EFI_ALLOCATE_POOL)(EFI_MEMORY_TYPE PoolType,
+                                              size_t Size, void **Buffer);
+typedef EFI_STATUS(EFIAPI *EFI_FREE_POOL)(void *Buffer);
+
+typedef void(EFIAPI *EFI_EVENT_NOTIFY)(EFI_EVENT Event, void *Context);
+
+typedef EFI_STATUS(EFIAPI *EFI_CREATE_EVENT)(uint32_t Type, EFI_TPL NotifyTpl,
+                                             EFI_EVENT_NOTIFY NotifyFunction,
+                                             void *NotifyContext,
+                                             EFI_EVENT *Event);
+typedef EFI_STATUS(EFIAPI *EFI_SET_TIMER)(EFI_EVENT Event, EFI_TIMER_DELAY Type,
+                                          uint64_t TriggerTime);
+typedef EFI_STATUS(EFIAPI *EFI_WAIT_FOR_EVENT)(size_t NumberOfEvents,
+                                               EFI_EVENT *Event, size_t *Index);
+typedef EFI_STATUS(EFIAPI *EFI_SIGNAL_EVENT)(EFI_EVENT Event);
+typedef EFI_STATUS(EFIAPI *EFI_CLOSE_EVENT)(EFI_EVENT Event);
+typedef EFI_STATUS(EFIAPI *EFI_CHECK_EVENT)(EFI_EVENT Event);
+
+typedef EFI_STATUS(EFIAPI *EFI_INSTALL_PROTOCOL_INTERFACE)(
+    EFI_HANDLE *Handle, EFI_GUID *Protocol, EFI_INTERFACE_TYPE InterfaceType,
+    void *Interface);
+typedef EFI_STATUS(EFIAPI *EFI_REINSTALL_PROTOCOL_INTERFACE)(
+    EFI_HANDLE Handle, EFI_GUID *Protocol, void *OldInterface,
+    void *NewInterface);
+typedef EFI_STATUS(EFIAPI *EFI_UNINSTALL_PROTOCOL_INTERFACE)(EFI_HANDLE Handle,
+                                                             EFI_GUID *Protocol,
+                                                             void *Interface);
+
+typedef EFI_STATUS(EFIAPI *EFI_HANDLE_PROTOCOL)(EFI_HANDLE Handle,
+                                                EFI_GUID *Protocol,
+                                                void **Interface);
+typedef EFI_STATUS(EFIAPI *EFI_REGISTER_PROTOCOL_NOTIFY)(EFI_GUID *Protocol,
+                                                         EFI_EVENT Event,
+                                                         void **Registration);
+
+typedef EFI_STATUS(EFIAPI *EFI_LOCATE_HANDLE)(EFI_LOCATE_SEARCH_TYPE SearchType,
+                                              EFI_GUID *Protocol,
+                                              void *SearchKey,
+                                              size_t *BufferSize,
+                                              EFI_HANDLE *Buffer);
+typedef EFI_STATUS(EFIAPI *EFI_LOCATE_DEVICE_PATH)(
+    EFI_GUID *Protocol, EFI_DEVICE_PATH_PROTOCOL **DevicePath,
+    EFI_HANDLE *Device);
+
+typedef EFI_STATUS(EFIAPI *EFI_INSTALL_CONFIGURATION_TABLE)(EFI_GUID *Guid,
+                                                            void *Table);
+typedef EFI_STATUS(EFIAPI *EFI_IMAGE_UNLOAD)(EFI_HANDLE ImageHandle);
+typedef EFI_STATUS(EFIAPI *EFI_IMAGE_START)(EFI_HANDLE ImageHandle,
+                                            size_t *ExitDataSize,
+                                            char16_t **ExitData);
+
+typedef EFI_STATUS(EFIAPI *EFI_EXIT)(EFI_HANDLE ImageHandle,
+                                     EFI_STATUS ExitStatus, size_t ExitDataSize,
+                                     char16_t *ExitData);
+typedef EFI_STATUS(EFIAPI *EFI_EXIT_BOOT_SERVICES)(EFI_HANDLE ImageHandle,
+                                                   size_t MapKey);
+typedef EFI_STATUS(EFIAPI *EFI_GET_NEXT_MONOTONIC_COUNT)(uint64_t *Count);
+typedef EFI_STATUS(EFIAPI *EFI_STALL)(size_t Microseconds);
+typedef EFI_STATUS(EFIAPI *EFI_SET_WATCHDOG_TIMER)(size_t Timeout,
+                                                   uint64_t WatchdogCode,
+                                                   size_t DataSize,
+                                                   char16_t *WatchdogData);
+
+typedef EFI_STATUS(EFIAPI *EFI_CONNECT_CONTROLLER)(
+    EFI_HANDLE ControllerHandle, EFI_HANDLE *DriverImageHandle,
+    EFI_DEVICE_PATH_PROTOCOL *RemainingDevicePath, bool Recursive);
+
+typedef EFI_STATUS(EFIAPI *EFI_DISCONNECT_CONTROLLER)(
+    EFI_HANDLE ControllerHandle, EFI_HANDLE DriverImageHandle,
+    EFI_HANDLE ChildHandle);
+
+typedef EFI_STATUS(EFIAPI *EFI_OPEN_PROTOCOL)(
+    EFI_HANDLE Handle, EFI_GUID *Protocol, void **Interface,
+    EFI_HANDLE AgentHandle, EFI_HANDLE ControllerHandle, uint32_t Attributes);
+
+typedef EFI_STATUS(EFIAPI *EFI_CLOSE_PROTOCOL)(EFI_HANDLE Handle,
+                                               EFI_GUID *Protocol,
+                                               EFI_HANDLE AgentHandle,
+                                               EFI_HANDLE ControllerHandle);
+
+typedef EFI_STATUS(EFIAPI *EFI_OPEN_PROTOCOL_INFORMATION)(
+    EFI_HANDLE Handle, EFI_GUID *Protocol,
+    EFI_OPEN_PROTOCOL_INFORMATION_ENTRY **EntryBuffer, size_t *EntryCount);
+
+typedef EFI_STATUS(EFIAPI *EFI_PROTOCOLS_PER_HANDLE)(
+    EFI_HANDLE Handle, EFI_GUID ***ProtocolBuffer, size_t *ProtocolBufferCount);
+
+typedef EFI_STATUS(EFIAPI *EFI_LOCATE_HANDLE_BUFFER)(
+    EFI_LOCATE_SEARCH_TYPE SearchType, EFI_GUID *Protocol, void *SearchKey,
+    size_t *NoHandles, EFI_HANDLE **Buffer);
+
+typedef EFI_STATUS(EFIAPI *EFI_LOCATE_PROTOCOL)(EFI_GUID *Protocol,
+                                                void *Registration,
+                                                void **Interface);
+
+typedef EFI_STATUS(EFIAPI *EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)(
+    EFI_HANDLE Handle, ...);
+typedef EFI_STATUS(EFIAPI *EFI_CALCULATE_CRC32)(void *Data, size_t DataSize,
+                                                uint32_t *Crc32);
+
+typedef void(EFIAPI *EFI_COPY_MEM)(void *Destination, void *Source,
+                                   size_t Length);
+typedef void(EFIAPI *EFI_SET_MEM)(void *Buffer, size_t Size, uint8_t Value);
+
+typedef EFI_STATUS(EFIAPI *EFI_CREATE_EVENT_EX)(
+    uint32_t Type, EFI_TPL NotifyTpl, EFI_EVENT_NOTIFY NotifyFunction,
+    const void *NotifyContext, const EFI_GUID *EventGroup, EFI_EVENT *Event);
+
+typedef struct {
+  EFI_TABLE_HEADER Hdr;
+
+  //
+  // Task Priority Services
+  //
+  EFI_RAISE_TPL RaiseTPL;     // EFI 1.0+
+  EFI_RESTORE_TPL RestoreTPL; // EFI 1.0+
+
+  //
+  // Memory Services
+  //
+  EFI_ALLOCATE_PAGES AllocatePages; // EFI 1.0+
+  EFI_FREE_PAGES FreePages;         // EFI 1.0+
+  EFI_GET_MEMORY_MAP GetMemoryMap;  // EFI 1.0+
+  EFI_ALLOCATE_POOL AllocatePool;   // EFI 1.0+
+  EFI_FREE_POOL FreePool;           // EFI 1.0+
+
+  //
+  // Event & Timer Services
+  //
+  EFI_CREATE_EVENT CreateEvent;    // EFI 1.0+
+  EFI_SET_TIMER SetTimer;          // EFI 1.0+
+  EFI_WAIT_FOR_EVENT WaitForEvent; // EFI 1.0+
+  EFI_SIGNAL_EVENT SignalEvent;    // EFI 1.0+
+  EFI_CLOSE_EVENT CloseEvent;      // EFI 1.0+
+  EFI_CHECK_EVENT CheckEvent;      // EFI 1.0+
+
+  //
+  // Protocol Handler Services
+  //
+  EFI_INSTALL_PROTOCOL_INTERFACE InstallProtocolInterface;     // EFI 1.0+
+  EFI_REINSTALL_PROTOCOL_INTERFACE ReinstallProtocolInterface; // EFI 1.0+
+  EFI_UNINSTALL_PROTOCOL_INTERFACE UninstallProtocolInterface; // EFI 1.0+
+  EFI_HANDLE_PROTOCOL HandleProtocol;                          // EFI 1.0+
+  void *Reserved;                                              // EFI 1.0+
+  EFI_REGISTER_PROTOCOL_NOTIFY RegisterProtocolNotify;         // EFI 1.0+
+  EFI_LOCATE_HANDLE LocateHandle;                              // EFI 1.+
+  EFI_LOCATE_DEVICE_PATH LocateDevicePath;                     // EFI 1.0+
+  EFI_INSTALL_CONFIGURATION_TABLE InstallConfigurationTable;   // EFI 1.0+
+
+  //
+  // Image Services
+  //
+  EFI_IMAGE_UNLOAD LoadImage;              // EFI 1.0+
+  EFI_IMAGE_START StartImage;              // EFI 1.0+
+  EFI_EXIT Exit;                           // EFI 1.0+
+  EFI_IMAGE_UNLOAD UnloadImage;            // EFI 1.0+
+  EFI_EXIT_BOOT_SERVICES ExitBootServices; // EFI 1.0+
+
+  //
+  // Miscellaneous Services
+  //
+  EFI_GET_NEXT_MONOTONIC_COUNT GetNextMonotonicCount; // EFI 1.0+
+  EFI_STALL Stall;                                    // EFI 1.0+
+  EFI_SET_WATCHDOG_TIMER SetWatchdogTimer;            // EFI 1.0+
+
+  //
+  // DriverSupport Services
+  //
+  EFI_CONNECT_CONTROLLER ConnectController;       // EFI 1.1
+  EFI_DISCONNECT_CONTROLLER DisconnectController; // EFI 1.1+
+
+  //
+  // Open and Close Protocol Services
+  //
+  EFI_OPEN_PROTOCOL OpenProtocol;                        // EFI 1.1+
+  EFI_CLOSE_PROTOCOL CloseProtocol;                      // EFI 1.1+
+  EFI_OPEN_PROTOCOL_INFORMATION OpenProtocolInformation; // EFI 1.1+
+
+  //
+  // Library Services
+  //
+  EFI_PROTOCOLS_PER_HANDLE ProtocolsPerHandle; // EFI 1.1+
+  EFI_LOCATE_HANDLE_BUFFER LocateHandleBuffer; // EFI 1.1+
+  EFI_LOCATE_PROTOCOL LocateProtocol;          // EFI 1.1+
+  EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
+  InstallMultipleProtocolInterfaces; // EFI 1.1+
+  EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
+  UninstallMultipleProtocolInterfaces; // EFI 1.1+*
+
+  //
+  // 32-bit CRC Services
+  //
+  EFI_CALCULATE_CRC32 CalculateCrc32; // EFI 1.1+
+
+  //
+  // Miscellaneous Services
+  //
+  EFI_COPY_MEM CopyMem;              // EFI 1.1+
+  EFI_SET_MEM SetMem;                // EFI 1.1+
+  EFI_CREATE_EVENT_EX CreateEventEx; // UEFI 2.0+
+} EFI_BOOT_SERVICES;
+
+#endif // LLVM_LIBC_TYPES_EFI_BOOT_SERVICES_H

--- a/libc/include/llvm-libc-types/EFI_CAPSULE.h
+++ b/libc/include/llvm-libc-types/EFI_CAPSULE.h
@@ -1,0 +1,26 @@
+//===-- Definition of EFI_CAPSULE type ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_CAPSULE_H
+#define LLVM_LIBC_TYPES_EFI_CAPSULE_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "EFI_GUID.h"
+
+typedef struct {
+  EFI_GUID CapsuleGuid;
+  uint32_t HeaderSize;
+  uint32_t Flags;
+  uint32_t CapsuleImageSize;
+} EFI_CAPSULE_HEADER;
+
+#define CAPSULE_FLAGS_PERSIST_ACROSS_RESET 0x00010000
+#define CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE 0x00020000
+#define CAPSULE_FLAGS_INITIATE_RESET 0x00040000
+
+#endif // LLVM_LIBC_TYPES_EFI_CAPSULE_H

--- a/libc/include/llvm-libc-types/EFI_CONFIGURATION_TABLE.h
+++ b/libc/include/llvm-libc-types/EFI_CONFIGURATION_TABLE.h
@@ -1,0 +1,19 @@
+//===-- Definition of EFI_CONFIGURATION_TABLE type ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_CONFIGURATION_TABLE_H
+#define LLVM_LIBC_TYPES_EFI_CONFIGURATION_TABLE_H
+
+#include "EFI_GUID.h"
+
+typedef struct {
+  EFI_GUID VendorGuid;
+  void *VendorTable;
+} EFI_CONFIGURATION_TABLE;
+
+#endif // LLVM_LIBC_TYPES_EFI_CONFIGURATION_TABLE_H

--- a/libc/include/llvm-libc-types/EFI_DEVICE_PATH_PROTOCOL.h
+++ b/libc/include/llvm-libc-types/EFI_DEVICE_PATH_PROTOCOL.h
@@ -1,0 +1,23 @@
+//===-- Definition of EFI_DEVICE_PATH_PROTOCOL type -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_DEVICE_PATH_PROTOCOL_H
+#define LLVM_LIBC_TYPES_EFI_DEVICE_PATH_PROTOCOL_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+#define EFI_DEVICE_PATH_PROTOCOL_GUID                                          \
+  {0x09576e91, 0x6d3f, 0x11d2, {0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b}}
+
+typedef struct _EFI_DEVICE_PATH_PROTOCOL {
+  uint8_t Type;
+  uint8_t SubType;
+  uint8_t Length[2];
+} EFI_DEVICE_PATH_PROTOCOL;
+
+#endif // LLVM_LIBC_TYPES_EFI_DEVICE_PATH_PROTOCOL_H

--- a/libc/include/llvm-libc-types/EFI_EVENT.h
+++ b/libc/include/llvm-libc-types/EFI_EVENT.h
@@ -1,0 +1,21 @@
+//===-- Definition of EFI_EVENT type --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_EVENT_H
+#define LLVM_LIBC_TYPES_EFI_EVENT_H
+
+typedef void *EFI_EVENT;
+
+#define EVT_TIMER 0x80000000
+#define EVT_RUNTIME 0x40000000
+#define EVT_NOTIFY_WAIT 0x00000100
+#define EVT_NOTIFY_SIGNAL 0x00000200
+#define EVT_SIGNAL_EXIT_BOOT_SERVICES 0x00000201
+#define EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE 0x60000202
+
+#endif // LLVM_LIBC_TYPES_EFI_EVENT_H

--- a/libc/include/llvm-libc-types/EFI_GUID.h
+++ b/libc/include/llvm-libc-types/EFI_GUID.h
@@ -1,0 +1,21 @@
+//===-- Definition of EFI_GUID type -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_GUID_H
+#define LLVM_LIBC_TYPES_EFI_GUID_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef struct {
+  uint32_t Data1;
+  uint16_t Data2;
+  uint16_t Data3;
+  uint8_t Data4[8];
+} EFI_GUID;
+
+#endif // LLVM_LIBC_TYPES_EFI_GUID_H

--- a/libc/include/llvm-libc-types/EFI_HANDLE.h
+++ b/libc/include/llvm-libc-types/EFI_HANDLE.h
@@ -1,0 +1,14 @@
+//===-- Definition of EFI_HANDLE type ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_HANDLE_H
+#define LLVM_LIBC_TYPES_EFI_HANDLE_H
+
+typedef void *EFI_HANDLE;
+
+#endif // LLVM_LIBC_TYPES_EFI_HANDLE_H

--- a/libc/include/llvm-libc-types/EFI_INTERFACE_TYPE.h
+++ b/libc/include/llvm-libc-types/EFI_INTERFACE_TYPE.h
@@ -1,0 +1,16 @@
+//===-- Definition of EFI_INTERFACE_TYPE type -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_INTERFACE_TYPE_H
+#define LLVM_LIBC_TYPES_EFI_INTERFACE_TYPE_H
+
+typedef enum {
+  EFI_NATIVE_INTERFACE,
+} EFI_INTERFACE_TYPE;
+
+#endif // LLVM_LIBC_TYPES_EFI_INTERFACE_TYPE_H

--- a/libc/include/llvm-libc-types/EFI_LOCATE_SEARCH_TYPE.h
+++ b/libc/include/llvm-libc-types/EFI_LOCATE_SEARCH_TYPE.h
@@ -1,0 +1,18 @@
+//===-- Definition of EFI_LOCATE_SEARCH_TYPE type -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_LOCATE_SEARCH_TYPE_H
+#define LLVM_LIBC_TYPES_EFI_LOCATE_SEARCH_TYPE_H
+
+typedef enum {
+  AllHandles,
+  ByRegisterNotify,
+  ByProtocol,
+} EFI_LOCATE_SEARCH_TYPE;
+
+#endif // LLVM_LIBC_TYPES_EFI_LOCATE_SEARCH_TYPE_H

--- a/libc/include/llvm-libc-types/EFI_MEMORY_DESCRIPTOR.h
+++ b/libc/include/llvm-libc-types/EFI_MEMORY_DESCRIPTOR.h
@@ -1,0 +1,43 @@
+//===-- Definition of EFI_MEMORY_DESCRIPTOR type --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_MEMORY_DESCRIPTOR_H
+#define LLVM_LIBC_TYPES_EFI_MEMORY_DESCRIPTOR_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "EFI_PHYSICAL_ADDRESS.h"
+#include "EFI_VIRTUAL_ADDRESS.h"
+
+#define EFI_MEMORY_DESCRIPTOR_VERSION 1
+
+#define EFI_MEMORY_UC 0x0000000000000001
+#define EFI_MEMORY_WC 0x0000000000000002
+#define EFI_MEMORY_WT 0x0000000000000004
+#define EFI_MEMORY_WB 0x0000000000000008
+#define EFI_MEMORY_UCE 0x0000000000000010
+#define EFI_MEMORY_WP 0x0000000000001000
+#define EFI_MEMORY_RP 0x0000000000002000
+#define EFI_MEMORY_XP 0x0000000000004000
+#define EFI_MEMORY_NV 0x0000000000008000
+#define EFI_MEMORY_MORE_RELIABLE 0x0000000000010000
+#define EFI_MEMORY_RO 0x0000000000020000
+#define EFI_MEMORY_SP 0x0000000000040000
+#define EFI_MEMORY_CPU_CRYPTO 0x0000000000080000
+#define EFI_MEMORY_RUNTIME 0x8000000000000000
+#define EFI_MEMORY_ISA_VALID 0x4000000000000000
+#define EFI_MEMORY_ISA_MASK 0x0FFFF00000000000
+
+typedef struct {
+  uint32_t Type;
+  EFI_PHYSICAL_ADDRESS PhysicalStart;
+  EFI_VIRTUAL_ADDRESS VirtualStart;
+  uint64_t NumberOfPages;
+  uint64_t Attribute;
+} EFI_MEMORY_DESCRIPTOR;
+
+#endif // LLVM_LIBC_TYPES_EFI_MEMORY_DESCRIPTOR_H

--- a/libc/include/llvm-libc-types/EFI_MEMORY_TYPE.h
+++ b/libc/include/llvm-libc-types/EFI_MEMORY_TYPE.h
@@ -1,0 +1,32 @@
+//===-- Definition of EFI_MEMORY_TYPE type --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_MEMORY_TYPE_H
+#define LLVM_LIBC_TYPES_EFI_MEMORY_TYPE_H
+
+typedef enum {
+  EfiReservedMemoryType,
+  EfiLoaderCode,
+  EfiLoaderData,
+  EfiBootServicesCode,
+  EfiBootServicesData,
+  EfiRuntimeServicesCode,
+  EfiRuntimeServicesData,
+  EfiConventionalMemory,
+  EfiUnusableMemory,
+  EfiACPIReclaimMemory,
+  EfiACPIMemoryNVS,
+  EfiMemoryMappedIO,
+  EfiMemoryMappedIOPortSpace,
+  EfiPalCode,
+  EfiPersistentMemory,
+  EfiUnacceptedMemoryType,
+  EfiMaxMemoryType
+} EFI_MEMORY_TYPE;
+
+#endif // LLVM_LIBC_TYPES_EFI_MEMORY_TYPE_H

--- a/libc/include/llvm-libc-types/EFI_OPEN_PROTOCOL_INFORMATION_ENTRY.h
+++ b/libc/include/llvm-libc-types/EFI_OPEN_PROTOCOL_INFORMATION_ENTRY.h
@@ -1,0 +1,22 @@
+//===-- Definition of EFI_OPEN_PROTOCOL_INFORMATION_ENTRY type ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_OPEN_PROTOCOL_INFORMATION_ENTRY_H
+#define LLVM_LIBC_TYPES_EFI_OPEN_PROTOCOL_INFORMATION_ENTRY_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "EFI_HANDLE.h"
+
+typedef struct {
+  EFI_HANDLE AgentHandle;
+  EFI_HANDLE ControllerHandle;
+  uint32_t Attributes;
+  uint32_t OpenCount;
+} EFI_OPEN_PROTOCOL_INFORMATION_ENTRY;
+
+#endif // LLVM_LIBC_TYPES_EFI_OPEN_PROTOCOL_INFORMATION_ENTRY_H

--- a/libc/include/llvm-libc-types/EFI_PHYSICAL_ADDRESS.h
+++ b/libc/include/llvm-libc-types/EFI_PHYSICAL_ADDRESS.h
@@ -1,0 +1,16 @@
+//===-- Definition of EFI_PHYSICAL_ADDRESS type ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_PHYSICAL_ADDRESS_H
+#define LLVM_LIBC_TYPES_EFI_PHYSICAL_ADDRESS_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef uint64_t EFI_PHYSICAL_ADDRESS;
+
+#endif // LLVM_LIBC_TYPES_EFI_PHYSICAL_ADDRESS_H

--- a/libc/include/llvm-libc-types/EFI_RUNTIME_SERVICES.h
+++ b/libc/include/llvm-libc-types/EFI_RUNTIME_SERVICES.h
@@ -1,0 +1,134 @@
+//===-- Definition of EFI_RUNTIME_SERVICES type ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_RUNTIME_SERVICES_H
+#define LLVM_LIBC_TYPES_EFI_RUNTIME_SERVICES_H
+
+#include "../llvm-libc-macros/EFIAPI-macros.h"
+#include "EFI_CAPSULE.h"
+#include "EFI_MEMORY_DESCRIPTOR.h"
+#include "EFI_PHYSICAL_ADDRESS.h"
+#include "EFI_STATUS.h"
+#include "EFI_TABLE_HEADER.h"
+#include "EFI_TIME.h"
+#include "char16_t.h"
+
+#define EFI_RUNTIME_SERVICES_SIGNATURE 0x56524553544e5552
+#define EFI_RUNTIME_SERVICES_REVISION EFI_SPECIFICATION_VERSION
+
+#define EFI_VARIABLE_NON_VOLATILE 0x00000001
+#define EFI_VARIABLE_BOOTSERVICE_ACCESS 0x00000002
+#define EFI_VARIABLE_RUNTIME_ACCESS 0x00000004
+#define EFI_VARIABLE_HARDWARE_ERROR_RECORD 0x00000008
+// This attribute is identified by the mnemonic 'HR' elsewhere
+// in this specification.
+#define EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS 0x00000010
+// NOTE: EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS is deprecated
+// and should be considered reserved.
+#define EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS 0x00000020
+#define EFI_VARIABLE_APPEND_WRITE 0x00000040
+#define EFI_VARIABLE_ENHANCED_AUTHENTICATED_ACCESS 0x00000080
+
+typedef enum {
+  EfiResetCold,
+  EfiResetWarm,
+  EfiResetShutdown,
+  EfiResetPlatformSpecific,
+} EFI_RESET_TYPE;
+
+#define EFI_VARIABLE_AUTHENTICATION_3_CERT_ID_SHA256 1
+
+typedef struct {
+  uint8_t Type;
+  uint32_t IdSize;
+  // uint8_t Id[IdSize];
+} EFI_VARIABLE_AUTHENTICATION_3_CERT_ID;
+
+typedef EFI_STATUS(EFIAPI *EFI_GET_TIME)(EFI_TIME *Time,
+                                         EFI_TIME_CAPABILITIES *Capabilities);
+typedef EFI_STATUS(EFIAPI *EFI_SET_TIME)(EFI_TIME *Time);
+typedef EFI_STATUS(EFIAPI *EFI_GET_WAKEUP_TIME)(bool *Enabled, bool *Pending,
+                                                EFI_TIME *Time);
+typedef EFI_STATUS(EFIAPI *EFI_SET_WAKEUP_TIME)(bool *Enabled, EFI_TIME *Time);
+
+typedef EFI_STATUS(EFIAPI *EFI_SET_VIRTUAL_ADDRESS_MAP)(
+    size_t MemoryMapSize, size_t DescriptorSize, uint32_t DescriptorVersion,
+    EFI_MEMORY_DESCRIPTOR *VirtualMap);
+typedef EFI_STATUS(EFIAPI *EFI_CONVERT_POINTER)(size_t DebugDisposition,
+                                                void **Address);
+
+typedef EFI_STATUS(EFIAPI *EFI_GET_VARIABLE)(char16_t *VariableName,
+                                             EFI_GUID *VendorGuid,
+                                             uint32_t *Attributes,
+                                             size_t *DataSize, void *Data);
+typedef EFI_STATUS(EFIAPI *EFI_GET_NEXT_VARIABLE_NAME)(size_t *VariableNameSize,
+                                                       char16_t *VariableName,
+                                                       EFI_GUID *VendorGuid);
+typedef EFI_STATUS(EFIAPI *EFI_SET_VARIABLE)(char16_t *VariableName,
+                                             EFI_GUID *VendorGuid,
+                                             uint32_t Attributes,
+                                             size_t DataSize, void *Data);
+
+typedef EFI_STATUS(EFIAPI *EFI_GET_NEXT_HIGH_MONO_COUNT)(uint32_t *HighCount);
+typedef void(EFIAPI *EFI_RESET_SYSTEM)(EFI_RESET_TYPE ResetType,
+                                       EFI_STATUS ResetStatus, size_t DataSize,
+                                       void *ResetData);
+
+typedef EFI_STATUS(EFIAPI *EFI_UPDATE_CAPSULE)(
+    EFI_CAPSULE_HEADER **CapsuleHeaderArray, size_t CapsuleCount,
+    EFI_PHYSICAL_ADDRESS ScatterGatherList);
+typedef EFI_STATUS(EFIAPI *EFI_QUERY_CAPSULE_CAPABILITIES)(
+    EFI_CAPSULE_HEADER **CapsuleHeaderArray, size_t CapsuleCount,
+    uint64_t *MaximumCapsuleSize, EFI_RESET_TYPE ResetType);
+
+typedef EFI_STATUS(EFIAPI *EFI_QUERY_VARIABLE_INFO)(
+    uint32_t Attributes, uint64_t *MaximumVariableStorageSize,
+    uint64_t *RemainingVariableStorageSize, uint64_t *MaximumVariableSize);
+
+typedef struct {
+  EFI_TABLE_HEADER Hdr;
+
+  ///
+  /// Time Services
+  EFI_GET_TIME GetTime;
+  EFI_SET_TIME SetTime;
+  EFI_GET_WAKEUP_TIME GetWakeupTime;
+  EFI_SET_WAKEUP_TIME SetWakeupTime;
+
+  //
+  // Virtual Memory Services
+  //
+  EFI_SET_VIRTUAL_ADDRESS_MAP SetVirtualAddressMap;
+  EFI_CONVERT_POINTER ConvertPointer;
+
+  //
+  // Variable Services
+  //
+  EFI_GET_VARIABLE GetVariable;
+  EFI_GET_NEXT_VARIABLE_NAME GetNextVariableName;
+  EFI_SET_VARIABLE SetVariable;
+
+  //
+  // Miscellaneous Services
+  //
+  EFI_GET_NEXT_HIGH_MONO_COUNT GetNextHighMonotonicCount;
+  EFI_RESET_SYSTEM ResetSystem;
+
+  //
+  // UEFI 2.0 Capsule Services
+  //
+  EFI_UPDATE_CAPSULE UpdateCapsule;
+  EFI_QUERY_CAPSULE_CAPABILITIES QueryCapsuleCapabilities;
+
+  //
+  // Miscellaneous UEFI 2.0 Service
+  //
+  EFI_QUERY_VARIABLE_INFO QueryVariableInfo;
+} EFI_RUNTIME_SERVICES;
+
+#endif // LLVM_LIBC_TYPES_EFI_RUNTIME_SERVICES_H

--- a/libc/include/llvm-libc-types/EFI_RUNTIME_SERVICES.h
+++ b/libc/include/llvm-libc-types/EFI_RUNTIME_SERVICES.h
@@ -10,6 +10,7 @@
 #define LLVM_LIBC_TYPES_EFI_RUNTIME_SERVICES_H
 
 #include "../llvm-libc-macros/EFIAPI-macros.h"
+#include "../llvm-libc-macros/stdint-macros.h"
 #include "EFI_CAPSULE.h"
 #include "EFI_MEMORY_DESCRIPTOR.h"
 #include "EFI_PHYSICAL_ADDRESS.h"
@@ -17,6 +18,7 @@
 #include "EFI_TABLE_HEADER.h"
 #include "EFI_TIME.h"
 #include "char16_t.h"
+#include "size_t.h"
 
 #define EFI_RUNTIME_SERVICES_SIGNATURE 0x56524553544e5552
 #define EFI_RUNTIME_SERVICES_REVISION EFI_SPECIFICATION_VERSION
@@ -46,6 +48,7 @@ typedef enum {
 typedef struct {
   uint8_t Type;
   uint32_t IdSize;
+  // Value is defined as:
   // uint8_t Id[IdSize];
 } EFI_VARIABLE_AUTHENTICATION_3_CERT_ID;
 

--- a/libc/include/llvm-libc-types/EFI_SIMPLE_TEXT_INPUT_PROTOCOL.h
+++ b/libc/include/llvm-libc-types/EFI_SIMPLE_TEXT_INPUT_PROTOCOL.h
@@ -1,0 +1,39 @@
+//===-- Definition of EFI_SIMPLE_TEXT_INPUT_PROTOCOL type -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_INPUT_PROTOCOL_H
+#define LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_INPUT_PROTOCOL_H
+
+#include "../llvm-libc-macros/EFIAPI-macros.h"
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "EFI_EVENT.h"
+#include "EFI_STATUS.h"
+#include "char16_t.h"
+
+#define EFI_SIMPLE_TEXT_INPUT_PROTOCOL_GUID                                    \
+  {0x387477c1, 0x69c7, 0x11d2, {0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b}}
+
+typedef struct {
+  uint16_t ScanCode;
+  char16_t UnicodeChar;
+} EFI_INPUT_KEY;
+
+struct _EFI_SIMPLE_TEXT_INPUT_PROTOCOL;
+
+typedef EFI_STATUS(EFIAPI *EFI_INPUT_RESET)(
+    struct _EFI_SIMPLE_TEXT_INPUT_PROTOCOL *This, bool ExtendedVerification);
+typedef EFI_STATUS(EFIAPI *EFI_INPUT_READ_KEY)(
+    struct _EFI_SIMPLE_TEXT_INPUT_PROTOCOL *This, EFI_INPUT_KEY *Key);
+
+typedef struct _EFI_SIMPLE_TEXT_INPUT_PROTOCOL {
+  EFI_INPUT_RESET Reset;
+  EFI_INPUT_READ_KEY ReadKeyStroke;
+  EFI_EVENT WaitForKey;
+} EFI_SIMPLE_TEXT_INPUT_PROTOCOL;
+
+#endif // LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_INPUT_PROTOCOL_H

--- a/libc/include/llvm-libc-types/EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h
+++ b/libc/include/llvm-libc-types/EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h
@@ -1,0 +1,64 @@
+//===-- Definition of EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL type ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_H
+#define LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+#include "EFI_STATUS.h"
+#include "size_t.h"
+
+#define EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_GUID                                   \
+  {0x387477c2, 0x69c7, 0x11d2, {0x8e, 0x39, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b}}
+
+struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
+
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_RESET)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, bool ExtendedVerification);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_STRING)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, const char16_t *String);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_TEST_STRING)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, const char16_t *String);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_QUERY_MODE)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, size_t ModeNumber,
+    size_t *Columns, size_t *Rows);
+
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_SET_MODE)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, size_t ModeNumber);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_SET_ATTRIBUTE)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, size_t Attribute);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_CLEAR_SCREEN)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_SET_CURSOR_POSITION)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, size_t Column, size_t Row);
+typedef EFI_STATUS(EFIAPI *EFI_TEXT_ENABLE_CURSOR)(
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This, bool Visible);
+
+typedef struct {
+  int32_t MaxMode;
+  int32_t Mode;
+  int32_t Attribute;
+  int32_t CursorColumn;
+  int32_t CursorRow;
+  bool CursorVisible;
+} SIMPLE_TEXT_OUTPUT_MODE;
+
+typedef struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL {
+  EFI_TEXT_RESET Reset;
+  EFI_TEXT_STRING OutputString;
+  EFI_TEXT_TEST_STRING TestString;
+  EFI_TEXT_QUERY_MODE QueryMode;
+  EFI_TEXT_SET_MODE SetMode;
+  EFI_TEXT_SET_ATTRIBUTE SetAttribute;
+  EFI_TEXT_CLEAR_SCREEN ClearScreen;
+  EFI_TEXT_SET_CURSOR_POSITION SetCursorPosition;
+  EFI_TEXT_ENABLE_CURSOR EnableCursor;
+  SIMPLE_TEXT_OUTPUT_MODE *Mode;
+} EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
+
+#endif // LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_H

--- a/libc/include/llvm-libc-types/EFI_STATUS.h
+++ b/libc/include/llvm-libc-types/EFI_STATUS.h
@@ -1,0 +1,16 @@
+//===-- Definition of EFI_STATUS type ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_STATUS_H
+#define LLVM_LIBC_TYPES_EFI_STATUS_H
+
+#include "size_t.h"
+
+typedef size_t EFI_STATUS;
+
+#endif // LLVM_LIBC_TYPES_EFI_STATUS_H

--- a/libc/include/llvm-libc-types/EFI_SYSTEM_TABLE.h
+++ b/libc/include/llvm-libc-types/EFI_SYSTEM_TABLE.h
@@ -1,0 +1,63 @@
+//===-- Definition of EFI_SYSTEM_TABLE type -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_SYSTEM_TABLE_H
+#define LLVM_LIBC_TYPES_EFI_SYSTEM_TABLE_H
+
+#include "EFI_BOOT_SERVICES.h"
+#include "EFI_CONFIGURATION_TABLE.h"
+#include "EFI_HANDLE.h"
+#include "EFI_RUNTIME_SERVICES.h"
+#include "EFI_SIMPLE_TEXT_INPUT_PROTOCOL.h"
+#include "EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h"
+#include "EFI_STATUS.h"
+#include "EFI_TABLE_HEADER.h"
+
+#include "char16_t.h"
+
+#define EFI_SYSTEM_TABLE_SIGNATURE 0x5453595320494249
+#define EFI_2_100_SYSTEM_TABLE_REVISION ((2 << 16) | (100))
+#define EFI_2_90_SYSTEM_TABLE_REVISION ((2 << 16) | (90))
+#define EFI_2_80_SYSTEM_TABLE_REVISION ((2 << 16) | (80))
+#define EFI_2_70_SYSTEM_TABLE_REVISION ((2 << 16) | (70))
+#define EFI_2_60_SYSTEM_TABLE_REVISION ((2 << 16) | (60))
+#define EFI_2_50_SYSTEM_TABLE_REVISION ((2 << 16) | (50))
+#define EFI_2_40_SYSTEM_TABLE_REVISION ((2 << 16) | (40))
+#define EFI_2_31_SYSTEM_TABLE_REVISION ((2 << 16) | (31))
+#define EFI_2_30_SYSTEM_TABLE_REVISION ((2 << 16) | (30))
+#define EFI_2_20_SYSTEM_TABLE_REVISION ((2 << 16) | (20))
+#define EFI_2_10_SYSTEM_TABLE_REVISION ((2 << 16) | (10))
+#define EFI_2_00_SYSTEM_TABLE_REVISION ((2 << 16) | (00))
+#define EFI_1_10_SYSTEM_TABLE_REVISION ((1 << 16) | (10))
+#define EFI_1_02_SYSTEM_TABLE_REVISION ((1 << 16) | (02))
+#define EFI_SPECIFICATION_VERSION EFI_SYSTEM_TABLE_REVISION
+#define EFI_SYSTEM_TABLE_REVISION EFI_2_100_SYSTEM_TABLE_REVISION
+
+typedef struct {
+  EFI_TABLE_HEADER Hdr;
+
+  char16_t *FirmwareVendor;
+  uint32_t FirmwareRevision;
+
+  EFI_HANDLE ConsoleInHandle;
+  EFI_SIMPLE_TEXT_INPUT_PROTOCOL *ConIn;
+
+  EFI_HANDLE ConsoleOutHandle;
+  EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut;
+
+  EFI_HANDLE StandardErrorHandle;
+  EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *StdErr;
+
+  EFI_RUNTIME_SERVICES *RuntimeServices;
+  EFI_BOOT_SERVICES *BootServices;
+
+  size_t NumberOfTableEntries;
+  EFI_CONFIGURATION_TABLE *ConfigurationTable;
+} EFI_SYSTEM_TABLE;
+
+#endif // LLVM_LIBC_TYPES_EFI_SYSTEM_TABLE_H

--- a/libc/include/llvm-libc-types/EFI_SYSTEM_TABLE.h
+++ b/libc/include/llvm-libc-types/EFI_SYSTEM_TABLE.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_EFI_SYSTEM_TABLE_H
 #define LLVM_LIBC_TYPES_EFI_SYSTEM_TABLE_H
 
+#include "../llvm-libc-macros/stdint-macros.h"
 #include "EFI_BOOT_SERVICES.h"
 #include "EFI_CONFIGURATION_TABLE.h"
 #include "EFI_HANDLE.h"
@@ -19,6 +20,7 @@
 #include "EFI_TABLE_HEADER.h"
 
 #include "char16_t.h"
+#include "size_t.h"
 
 #define EFI_SYSTEM_TABLE_SIGNATURE 0x5453595320494249
 #define EFI_2_100_SYSTEM_TABLE_REVISION ((2 << 16) | (100))

--- a/libc/include/llvm-libc-types/EFI_TABLE_HEADER.h
+++ b/libc/include/llvm-libc-types/EFI_TABLE_HEADER.h
@@ -1,0 +1,22 @@
+//===-- Definition of EFI_TABLE_HEADER type -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_TABLE_HEADER_H
+#define LLVM_LIBC_TYPES_EFI_TABLE_HEADER_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef struct {
+  uint64_t Signature;
+  uint32_t Revision;
+  uint32_t HeaderSize;
+  uint32_t CRC32;
+  uint32_t Reserved;
+} EFI_TABLE_HEADER;
+
+#endif // LLVM_LIBC_TYPES_EFI_TABLE_HEADER_H

--- a/libc/include/llvm-libc-types/EFI_TIME.h
+++ b/libc/include/llvm-libc-types/EFI_TIME.h
@@ -1,0 +1,37 @@
+//===-- Definition of EFI_TIME type ---------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_TIME_H
+#define LLVM_LIBC_TYPES_EFI_TIME_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef struct {
+  uint16_t Year;  // 1900 - 9999
+  uint8_t Month;  // 1 - 12
+  uint8_t Day;    // 1 - 31
+  uint8_t Hour;   // 0 - 23
+  uint8_t Minute; // 0 - 59
+  uint8_t Second; // 0 - 59
+  uint8_t Pad1;
+  uint32_t Nanosecond; // 0 - 999,999,999
+  int16_t TimeZone;    // --1440 to 1440 or 2047
+} EFI_TIME;
+
+#define EFI_TIME_ADJUST_DAYLIGHT 0x01
+#define EFI_TIME_IN_DAYLIGHT 0x02
+
+#define EFI_UNSPECIFIED_TIMEZONE 0x07FF
+
+typedef struct {
+  uint32_t Resolution;
+  uint32_t Accuracy;
+  bool SetsToZero;
+} EFI_TIME_CAPABILITIES;
+
+#endif // LLVM_LIBC_TYPES_EFI_TIME_H

--- a/libc/include/llvm-libc-types/EFI_TIMER_DELAY.h
+++ b/libc/include/llvm-libc-types/EFI_TIMER_DELAY.h
@@ -1,0 +1,18 @@
+//===-- Definition of EFI_TIMER_DELAY type --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_TIMER_DELAY_H
+#define LLVM_LIBC_TYPES_EFI_TIMER_DELAY_H
+
+typedef enum {
+  TimerCancel,
+  TimerPeriodic,
+  TimerRelative,
+} EFI_TIMER_DELAY;
+
+#endif // LLVM_LIBC_TYPES_EFI_TIMER_DELAY_H

--- a/libc/include/llvm-libc-types/EFI_TPL.h
+++ b/libc/include/llvm-libc-types/EFI_TPL.h
@@ -1,0 +1,21 @@
+//===-- Definition of EFI_TPL type ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_TPL_H
+#define LLVM_LIBC_TYPES_EFI_TPL_H
+
+#include "size_t.h"
+
+typedef size_t EFI_TPL;
+
+#define TPL_APPLICATION 4
+#define TPL_CALLBACK 8
+#define TPL_NOTIFY 16
+#define TPL_HIGH_LEVEL 31
+
+#endif // LLVM_LIBC_TYPES_EFI_TPL_H

--- a/libc/include/llvm-libc-types/EFI_VIRTUAL_ADDRESS.h
+++ b/libc/include/llvm-libc-types/EFI_VIRTUAL_ADDRESS.h
@@ -1,0 +1,16 @@
+//===-- Definition of EFI_VIRTUAL_ADDRESS type ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TYPES_EFI_VIRTUAL_ADDRESS_H
+#define LLVM_LIBC_TYPES_EFI_VIRTUAL_ADDRESS_H
+
+#include "../llvm-libc-macros/stdint-macros.h"
+
+typedef uint64_t EFI_VIRTUAL_ADDRESS;
+
+#endif // LLVM_LIBC_TYPES_EFI_VIRTUAL_ADDRESS_H


### PR DESCRIPTION
Originated from #120687

This PR simply adds the necessary headers for UEFI which defines all the necessary types. This PR unlocks the ability to work on other PR's for UEFI support.