### PR TITLE
[AArch64][TargetParser] Add ProcessorAlias unit test machinery. NFC.

### DIFF
--- a/llvm/unittests/TargetParser/TargetParserTest.cpp
+++ b/llvm/unittests/TargetParser/TargetParserTest.cpp
@@ -1165,6 +1165,92 @@ INSTANTIATE_TEST_SUITE_P(
                       AArch64CPUTestParams("oryon-1", "armv8.6-a")),
     AArch64CPUTestParams::PrintToStringParamName);
 
+struct AArch64CPUAliasTestParams {
+  AArch64CPUAliasTestParams(std::vector<StringRef> Aliases)
+      : Aliases(Aliases) {}
+
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const AArch64CPUAliasTestParams &params) {
+    raw_os_ostream oss(os);
+    interleave(params.Aliases, oss, ", ");
+    return os;
+  }
+
+  /// Print a gtest-compatible facsimile of the first cpu (the aliasee), to make
+  /// the test's name human-readable.
+  static std::string PrintToStringParamName(
+      const testing::TestParamInfo<AArch64CPUAliasTestParams> &Info) {
+    std::string Name = Info.param.Aliases.front().str();
+    for (char &C : Name)
+      if (!std::isalnum(C))
+        C = '_';
+    return Name;
+  }
+
+  std::vector<StringRef> Aliases;
+};
+
+class AArch64CPUAliasTestFixture
+    : public ::testing::TestWithParam<AArch64CPUAliasTestParams> {};
+
+static std::string aarch64FeaturesFromBits(AArch64::ExtensionBitset BitFlags) {
+  std::vector<StringRef> Flags;
+  bool OK = AArch64::getExtensionFeatures(BitFlags, Flags);
+  assert(OK);
+  (void)OK;
+  std::string S;
+  raw_string_ostream OS(S);
+  interleave(Flags, OS, ", ");
+  return OS.str();
+}
+
+TEST_P(AArch64CPUAliasTestFixture, testCPUAlias) {
+  AArch64CPUAliasTestParams params = GetParam();
+
+  StringRef MainName = params.Aliases[0];
+  const std::optional<AArch64::CpuInfo> Cpu = AArch64::parseCpu(MainName);
+  const AArch64::ArchInfo &MainAI = Cpu->Arch;
+  AArch64::ExtensionBitset MainFlags = Cpu->getImpliedExtensions();
+
+  for (size_t I = 1, E = params.Aliases.size(); I != E; ++I) {
+    StringRef OtherName = params.Aliases[I];
+    const std::optional<AArch64::CpuInfo> OtherCpu =
+        AArch64::parseCpu(OtherName);
+    const AArch64::ArchInfo &OtherAI = OtherCpu->Arch;
+
+    EXPECT_EQ(MainAI.Version, OtherAI.Version)
+        << MainName << " vs " << OtherName;
+    EXPECT_EQ(MainAI.Name, OtherAI.Name) << MainName << " vs " << OtherName;
+    EXPECT_EQ(MainAI.Profile, OtherAI.Profile)
+        << MainName << " vs " << OtherName;
+    EXPECT_EQ(MainAI.DefaultExts, OtherAI.DefaultExts)
+        << MainName << " vs " << OtherName;
+    EXPECT_EQ(MainAI, OtherAI) << MainName << " vs " << OtherName;
+
+    AArch64::ExtensionBitset OtherFlags = OtherCpu->getImpliedExtensions();
+
+    EXPECT_EQ(MainFlags, OtherFlags) << MainName << " vs " << OtherName;
+
+    EXPECT_EQ(aarch64FeaturesFromBits(MainFlags),
+              aarch64FeaturesFromBits(OtherFlags))
+        << MainName << " vs " << OtherName << "\n        Diff: "
+        << (aarch64FeaturesFromBits(MainFlags ^ OtherFlags));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AArch64CPUAliasTests, AArch64CPUAliasTestFixture,
+    ::testing::Values(AArch64CPUAliasTestParams({"neoverse-n2", "cobalt-100"}),
+                      AArch64CPUAliasTestParams({"neoverse-v2", "grace"}),
+                      AArch64CPUAliasTestParams({"apple-a7", "cyclone",
+                                                 "apple-a8", "apple-a9"}),
+                      AArch64CPUAliasTestParams({"apple-a12", "apple-s4",
+                                                 "apple-s5"}),
+                      AArch64CPUAliasTestParams({"apple-a14", "apple-m1"}),
+                      AArch64CPUAliasTestParams({"apple-a15", "apple-m2"}),
+                      AArch64CPUAliasTestParams({"apple-a16", "apple-m3"})),
+    AArch64CPUAliasTestParams::PrintToStringParamName);
+
 // Note: number of CPUs includes aliases.
 static constexpr unsigned NumAArch64CPUArchs = 82;
 


### PR DESCRIPTION
The patch itself is mainly the expected unittest boilerplate.
This adds tests for the aliases we have today.

We could alternatively test these via the driver with additional run-lines in print-enable-extensions tests, and eventually should consider that instead.