### PR TITLE
[lldb] Don't warn that libobjc was read from memory in corefile

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2666,6 +2666,9 @@ void AppleObjCRuntimeV2::WarnIfNoExpandedSharedCache() {
   if (!object_file->IsInMemory())
     return;
 
+  if (!GetProcess()->IsLiveDebugSession())
+    return;
+
   Target &target = GetProcess()->GetTarget();
   Debugger &debugger = target.GetDebugger();
 


### PR DESCRIPTION
AppleObjCRuntimeV2 prints a warning when we read libobjc.A.dylib from memory, as a canary to detect that we are reading system binaries out of memory (which is slow, and we try hard to avoid). But with a corefile, reading out of "memory" is fine, and may be the only way we can find the correct binary.

rdar://144322688