### PR TITLE
[ValueTracking] Handle not cond to assume.

### DIFF
--- a/llvm/test/Transforms/InstCombine/assume.ll
+++ b/llvm/test/Transforms/InstCombine/assume.ll
@@ -983,8 +983,7 @@ define i1 @not_cond_use(i8 %x) {
 ; CHECK-NEXT:    tail call void @use(i1 [[CMP]])
 ; CHECK-NEXT:    [[NOT:%.*]] = xor i1 [[CMP]], true
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[NOT]])
-; CHECK-NEXT:    [[RVAL:%.*]] = icmp eq i8 [[X]], 0
-; CHECK-NEXT:    ret i1 [[RVAL]]
+; CHECK-NEXT:    ret i1 false
 ;
   %cmp = icmp eq i8 %x, 0
   tail call void @use(i1 %cmp)


### PR DESCRIPTION
Addresses this comment https://github.com/llvm/llvm-project/pull/126423#discussion_r1948227236.
Also solves the ephemeral issue from https://github.com/llvm/llvm-project/pull/118406 for known bits of x in `assume (not trunc x to i1)`

Proof: https://alive2.llvm.org/ce/z/Bkg2f6