### PR TITLE
[libc] Make test macros suppress the -Wdangling-else warnings

### DIFF
--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -400,6 +400,14 @@ CString libc_make_test_file_path_func(const char *file_name);
   SuiteClass##_##TestName SuiteClass##_##TestName##_Instance;                  \
   void SuiteClass##_##TestName::Run()
 
+// Helper to trick the compiler into ignoring lack of braces on the else
+// branch.  We cannot introduce braces at this point, since it would prevent
+// using `<< ...` after the test macro for additional failure output.
+#define LIBC_TEST_DISABLE_DANGLING_ELSE                                        \
+  switch (0)                                                                   \
+  case 0:                                                                      \
+  default: // NOLINT
+
 // If RET_OR_EMPTY is the 'return' keyword we perform an early return which
 // corresponds to an assert. If it is empty the execution continues, this
 // corresponds to an expect.
@@ -411,6 +419,7 @@ CString libc_make_test_file_path_func(const char *file_name);
 // returning a boolean. This expression is responsible for logging the
 // diagnostic in case of failure.
 #define LIBC_TEST_SCAFFOLDING_(TEST, RET_OR_EMPTY)                             \
+  LIBC_TEST_DISABLE_DANGLING_ELSE                                              \
   if (TEST)                                                                    \
     ;                                                                          \
   else                                                                         \


### PR DESCRIPTION
Use the trick from gtest to allow `ASSERT_...` and `EXPECT_...`
macros to be used in braceless `if` without producing warnings
about the nested `if`-`else` that results.
