### PR TITLE
Allow option to ignore module load errors in ScriptedProcess

### DIFF
--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -446,7 +446,6 @@ ScriptedProcess::GetLoadedDynamicLibrariesInfos() {
       return error_with_message("Couldn't cast image object into dictionary.");
 
     ModuleSpec module_spec;
-    llvm::StringRef value;
 
     bool has_path = dict->HasKey("path");
     bool has_uuid = dict->HasKey("uuid");
@@ -461,9 +460,10 @@ ScriptedProcess::GetLoadedDynamicLibrariesInfos() {
       module_spec.GetFileSpec().SetPath(path);
     }
 
+    llvm::StringRef uuid = "";
     if (has_uuid) {
-      dict->GetValueForKeyAsString("uuid", value);
-      module_spec.GetUUID().SetFromStringRef(value);
+      dict->GetValueForKeyAsString("uuid", uuid);
+      module_spec.GetUUID().SetFromStringRef(uuid);
     }
 
     lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -96,7 +96,6 @@ class StackCoreScriptedProcesTestCase(TestBase):
                         {
                             "path": "/random/path/random.dylib",
                             "load_addr": 12345678,
-                            "ignore_module_load_error": True,
                         },
                     ],
                 }

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -78,7 +78,9 @@ class StackCoreScriptedProcesTestCase(TestBase):
 
         # Create a random lib which does not exist in the corefile.
         random_dylib = self.get_module_with_name(corefile_target, "random.dylib")
-        self.assertFalse(random_dylib, "Dynamic library random.dylib should not be found.")
+        self.assertFalse(
+            random_dylib, "Dynamic library random.dylib should not be found."
+        )
 
         structured_data = lldb.SBStructuredData()
         structured_data.SetFromJSON(
@@ -94,9 +96,9 @@ class StackCoreScriptedProcesTestCase(TestBase):
                         {
                             "path": "/random/path/random.dylib",
                             "load_addr": 12345678,
-                            "ignore_module_load_error": True
-                        }
-                    ]
+                            "ignore_module_load_error": True,
+                        },
+                    ],
                 }
             )
         )

--- a/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestStackCoreScriptedProcess.py
@@ -76,6 +76,10 @@ class StackCoreScriptedProcesTestCase(TestBase):
             )
         self.assertTrue(corefile_process, PROCESS_IS_VALID)
 
+        # Create a random lib which does not exist in the corefile.
+        random_dylib = self.get_module_with_name(corefile_target, "random.dylib")
+        self.assertFalse(random_dylib, "Dynamic library random.dylib should not be found.")
+
         structured_data = lldb.SBStructuredData()
         structured_data.SetFromJSON(
             json.dumps(
@@ -83,7 +87,16 @@ class StackCoreScriptedProcesTestCase(TestBase):
                     "backing_target_idx": self.dbg.GetIndexOfTarget(
                         corefile_process.GetTarget()
                     ),
-                    "libbaz_path": self.getBuildArtifact("libbaz.dylib"),
+                    "custom_modules": [
+                        {
+                            "path": self.getBuildArtifact("libbaz.dylib"),
+                        },
+                        {
+                            "path": "/random/path/random.dylib",
+                            "load_addr": 12345678,
+                            "ignore_module_load_error": True
+                        }
+                    ]
                 }
             )
         )

--- a/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
@@ -66,7 +66,7 @@ class StackCoreScriptedProcess(ScriptedProcess):
                     or not module_path_arg.IsValid()
                     or not module_path_arg.GetType() == lldb.eStructuredDataTypeString
                 ):
-                    return
+                    continue
 
                 module_path = module_path_arg.GetStringValue(100)
 
@@ -89,7 +89,7 @@ class StackCoreScriptedProcess(ScriptedProcess):
                     )
 
                     if not corefile_module or not corefile_module.IsValid():
-                        return
+                        continue
 
                     module_load_addr = (
                         corefile_module.GetObjectFileHeaderAddress().GetLoadAddress(

--- a/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
@@ -69,25 +69,6 @@ class StackCoreScriptedProcess(ScriptedProcess):
                     return
 
                 module_path = module_path_arg.GetStringValue(100)
-                module_name = os.path.basename(module_path)
-
-                # Get ignore_module_load_error boolean from args
-                ignore_module_load_error = False
-                ignore_module_load_error_arg = custom_module.GetValueForKey(
-                    "ignore_module_load_error"
-                )
-                if (
-                    ignore_module_load_error_arg
-                    and ignore_module_load_error_arg.IsValid()
-                    and ignore_module_load_error_arg.GetType()
-                    == lldb.eStructuredDataTypeBoolean
-                ):
-                    ignore_module_load_error = (
-                        ignore_module_load_error_arg.GetBooleanValue()
-                    )
-
-                if not os.path.exists(module_path) and not ignore_module_load_error:
-                    return
 
                 # Get custom module load address from args
                 module_load_addr = None
@@ -102,6 +83,7 @@ class StackCoreScriptedProcess(ScriptedProcess):
 
                 # If module load address is not specified/valid, try to find it from corefile module
                 if module_load_addr is None:
+                    module_name = os.path.basename(module_path)
                     corefile_module = self.get_module_with_name(
                         self.corefile_target, module_name
                     )
@@ -119,7 +101,6 @@ class StackCoreScriptedProcess(ScriptedProcess):
                     {
                         "path": module_path,
                         "load_addr": module_load_addr,
-                        "ignore_module_load_error": ignore_module_load_error,
                     }
                 )
 

--- a/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
@@ -223,9 +223,9 @@ class StackCoreScriptedThread(ScriptedThread):
             if self.is_stopped:
                 if "arm64" in self.scripted_process.arch:
                     stop_reason["type"] = lldb.eStopReasonException
-                    stop_reason["data"]["desc"] = (
-                        self.corefile_thread.GetStopDescription(100)
-                    )
+                    stop_reason["data"][
+                        "desc"
+                    ] = self.corefile_thread.GetStopDescription(100)
                 elif self.scripted_process.arch == "x86_64":
                     stop_reason["type"] = lldb.eStopReasonSignal
                     stop_reason["data"]["signal"] = signal.SIGTRAP

--- a/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
@@ -46,22 +46,52 @@ class StackCoreScriptedProcess(ScriptedProcess):
         if len(self.threads) == 2:
             self.threads[len(self.threads) - 1].is_stopped = True
 
-        corefile_module = self.get_module_with_name(
-            self.corefile_target, "libbaz.dylib"
-        )
-        if not corefile_module or not corefile_module.IsValid():
-            return
-        module_path = os.path.join(
-            corefile_module.GetFileSpec().GetDirectory(),
-            corefile_module.GetFileSpec().GetFilename(),
-        )
-        if not os.path.exists(module_path):
-            return
-        module_load_addr = corefile_module.GetObjectFileHeaderAddress().GetLoadAddress(
-            self.corefile_target
-        )
+        custom_modules = args.GetValueForKey("custom_modules")
+        if custom_modules.GetType() == lldb.eStructuredDataTypeArray:
+            for id in range(custom_modules.GetSize()):
 
-        self.loaded_images.append({"path": module_path, "load_addr": module_load_addr})
+                custom_module = custom_modules.GetItemAtIndex(id)
+                if not custom_module or not custom_module.IsValid() or not custom_module.GetType() == lldb.eStructuredDataTypeDictionary:
+                    continue
+
+                # Get custom module path from args
+                module_path_arg = custom_module.GetValueForKey("path")
+                module_path = None
+                if not module_path_arg or not module_path_arg.IsValid() or not module_path_arg.GetType() == lldb.eStructuredDataTypeString:
+                    return
+
+                module_path = module_path_arg.GetStringValue(100)
+                module_name = os.path.basename(module_path)
+
+                # Get ignore_module_load_error boolean from args
+                ignore_module_load_error = False
+                ignore_module_load_error_arg = custom_module.GetValueForKey("ignore_module_load_error")
+                if ignore_module_load_error_arg and ignore_module_load_error_arg.IsValid() and ignore_module_load_error_arg.GetType() == lldb.eStructuredDataTypeBoolean:
+                    ignore_module_load_error = ignore_module_load_error_arg.GetBooleanValue()
+
+                if not os.path.exists(module_path) and not ignore_module_load_error:
+                    return
+
+                # Get custom module load address from args
+                module_load_addr = None
+                module_load_addr_arg = custom_module.GetValueForKey("load_addr")
+                if module_load_addr_arg and module_load_addr_arg.IsValid() and module_load_addr_arg.GetType() == lldb.eStructuredDataTypeInteger:
+                    module_load_addr = module_load_addr_arg.GetIntegerValue()
+
+                # If module load address is not specified/valid, try to find it from corefile module
+                if module_load_addr is None:
+                    corefile_module = self.get_module_with_name(
+                        self.corefile_target, module_name
+                    )
+
+                    if not corefile_module or not corefile_module.IsValid():
+                        return
+
+                    module_load_addr = corefile_module.GetObjectFileHeaderAddress().GetLoadAddress(
+                        self.corefile_target
+                    )
+
+                self.loaded_images.append({"path": module_path, "load_addr": module_load_addr, "ignore_module_load_error": ignore_module_load_error})
 
     def get_memory_region_containing_address(
         self, addr: int

--- a/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/stack_core_scripted_process.py
@@ -51,13 +51,21 @@ class StackCoreScriptedProcess(ScriptedProcess):
             for id in range(custom_modules.GetSize()):
 
                 custom_module = custom_modules.GetItemAtIndex(id)
-                if not custom_module or not custom_module.IsValid() or not custom_module.GetType() == lldb.eStructuredDataTypeDictionary:
+                if (
+                    not custom_module
+                    or not custom_module.IsValid()
+                    or not custom_module.GetType() == lldb.eStructuredDataTypeDictionary
+                ):
                     continue
 
                 # Get custom module path from args
                 module_path_arg = custom_module.GetValueForKey("path")
                 module_path = None
-                if not module_path_arg or not module_path_arg.IsValid() or not module_path_arg.GetType() == lldb.eStructuredDataTypeString:
+                if (
+                    not module_path_arg
+                    or not module_path_arg.IsValid()
+                    or not module_path_arg.GetType() == lldb.eStructuredDataTypeString
+                ):
                     return
 
                 module_path = module_path_arg.GetStringValue(100)
@@ -65,9 +73,18 @@ class StackCoreScriptedProcess(ScriptedProcess):
 
                 # Get ignore_module_load_error boolean from args
                 ignore_module_load_error = False
-                ignore_module_load_error_arg = custom_module.GetValueForKey("ignore_module_load_error")
-                if ignore_module_load_error_arg and ignore_module_load_error_arg.IsValid() and ignore_module_load_error_arg.GetType() == lldb.eStructuredDataTypeBoolean:
-                    ignore_module_load_error = ignore_module_load_error_arg.GetBooleanValue()
+                ignore_module_load_error_arg = custom_module.GetValueForKey(
+                    "ignore_module_load_error"
+                )
+                if (
+                    ignore_module_load_error_arg
+                    and ignore_module_load_error_arg.IsValid()
+                    and ignore_module_load_error_arg.GetType()
+                    == lldb.eStructuredDataTypeBoolean
+                ):
+                    ignore_module_load_error = (
+                        ignore_module_load_error_arg.GetBooleanValue()
+                    )
 
                 if not os.path.exists(module_path) and not ignore_module_load_error:
                     return
@@ -75,7 +92,12 @@ class StackCoreScriptedProcess(ScriptedProcess):
                 # Get custom module load address from args
                 module_load_addr = None
                 module_load_addr_arg = custom_module.GetValueForKey("load_addr")
-                if module_load_addr_arg and module_load_addr_arg.IsValid() and module_load_addr_arg.GetType() == lldb.eStructuredDataTypeInteger:
+                if (
+                    module_load_addr_arg
+                    and module_load_addr_arg.IsValid()
+                    and module_load_addr_arg.GetType()
+                    == lldb.eStructuredDataTypeInteger
+                ):
                     module_load_addr = module_load_addr_arg.GetIntegerValue()
 
                 # If module load address is not specified/valid, try to find it from corefile module
@@ -87,11 +109,19 @@ class StackCoreScriptedProcess(ScriptedProcess):
                     if not corefile_module or not corefile_module.IsValid():
                         return
 
-                    module_load_addr = corefile_module.GetObjectFileHeaderAddress().GetLoadAddress(
-                        self.corefile_target
+                    module_load_addr = (
+                        corefile_module.GetObjectFileHeaderAddress().GetLoadAddress(
+                            self.corefile_target
+                        )
                     )
 
-                self.loaded_images.append({"path": module_path, "load_addr": module_load_addr, "ignore_module_load_error": ignore_module_load_error})
+                self.loaded_images.append(
+                    {
+                        "path": module_path,
+                        "load_addr": module_load_addr,
+                        "ignore_module_load_error": ignore_module_load_error,
+                    }
+                )
 
     def get_memory_region_containing_address(
         self, addr: int
@@ -193,9 +223,9 @@ class StackCoreScriptedThread(ScriptedThread):
             if self.is_stopped:
                 if "arm64" in self.scripted_process.arch:
                     stop_reason["type"] = lldb.eStopReasonException
-                    stop_reason["data"][
-                        "desc"
-                    ] = self.corefile_thread.GetStopDescription(100)
+                    stop_reason["data"]["desc"] = (
+                        self.corefile_thread.GetStopDescription(100)
+                    )
                 elif self.scripted_process.arch == "x86_64":
                     stop_reason["type"] = lldb.eStopReasonSignal
                     stop_reason["data"]["signal"] = signal.SIGTRAP


### PR DESCRIPTION
Current state in scripted process expects [all the modules](https://github.com/llvm/llvm-project/blob/912b154f3a3f8c3cebf5cc5731fd8b0749762da5/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp#L498) passed into "get_loaded_images" to load successfully else none of them load. Even if a module loads fine, [but has already been appended](https://github.com/llvm/llvm-project/blob/912b154f3a3f8c3cebf5cc5731fd8b0749762da5/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp#L495) it still fails. This is restrictive and does not help our usecase. 

**Usecase**: We have a parent scripted process using coredump + tombstone. 

1) Scripted process uses child elf-core process to read memory dump

2) Uses tombstones to pass thread names and modules.

We do not know whether the modules will be successfully downloaded before creating the scripted process. We use [python module callbacks](https://github.com/llvm/llvm-project/blob/a57e58dbfaae0e86eb5cafeddf8b598f14b96e36/lldb/source/Target/Platform.cpp#L1593) to download a module from symbol server at LLDB load time when the scripted process is being created. The issue is that if one of the symbol is not found from the list specified in tombstone, none of the modules load in scripted process. Even if we ensure symbols are present in symbol server before creating the scripted process, if the load address is wrong or if the module is already appended, all module loads are skipped.

**Solution**: Pass in a custom boolean option arg for every module from python scripted process plugin which will indicate whether to ignore the module load error. This will provide the flexibility to user for loading the successfully fetched modules into target while ignoring the failed ones