### PR TITLE
[clang-tidy] Fix invalid fixit from modernize-use-ranges for nullptr used with std::unique_ptr

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -126,6 +126,10 @@ Changes in existing checks
 - Improved :doc:`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` check by providing additional
   examples and fixing some macro related false positives.
+  
+- Improved :doc:`modernize-use-ranges
+  <clang-tidy/checks/modernize/use-ranges>` check by updating suppress 
+  warnings logic for ``nullptr`` in ``std::find``.
 
 - Improved :doc:`performance/unnecessary-value-param
   <clang-tidy/checks/performance/unnecessary-value-param>` check performance by

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges.cpp
@@ -1,14 +1,25 @@
-// RUN: %check_clang_tidy -std=c++20 %s modernize-use-ranges %t -- -- -I %S/Inputs/use-ranges/
-// RUN: %check_clang_tidy -std=c++23 %s modernize-use-ranges %t -check-suffixes=,CPP23 -- -I %S/Inputs/use-ranges/
+// RUN: %check_clang_tidy -std=c++20 %s modernize-use-ranges %t -- -- -I %S/Inputs/
+// RUN: %check_clang_tidy -std=c++23 %s modernize-use-ranges %t -check-suffixes=,CPP23 -- -I %S/Inputs/
+// Example: ./check_clang_tidy.py -std=c++20 checkers/modernize/use-ranges.cpp modernize-use-ranges temp.txt -- -- -I ~/llvm-project/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/
 
 // CHECK-FIXES: #include <algorithm>
 // CHECK-FIXES-CPP23: #include <numeric>
 // CHECK-FIXES: #include <ranges>
 
-#include "fake_std.h"
+#include "use-ranges/fake_std.h"
+#include "smart-ptr/unique_ptr.h"
 
 void Positives() {
   std::vector<int> I, J;
+  std::vector<std::unique_ptr<int>> K;
+
+  // Expect to have no check messages
+  std::find(K.begin(), K.end(), nullptr);
+
+  std::find(K.begin(), K.end(), std::unique_ptr<int>());
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
+  // CHECK-FIXES: std::ranges::find(K, std::unique_ptr<int>());
+
   std::find(I.begin(), I.end(), 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
   // CHECK-FIXES: std::ranges::find(I, 0);
@@ -76,6 +87,15 @@ void Positives() {
 
 void Reverse(){
   std::vector<int> I, J;
+  std::vector<std::unique_ptr<int>> K;
+  
+  // Expect to have no check messages
+  std::find(K.rbegin(), K.rend(), nullptr);
+
+  std::find(K.rbegin(), K.rend(), std::unique_ptr<int>());
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
+  // CHECK-FIXES: std::ranges::find(std::ranges::reverse_view(K), std::unique_ptr<int>());
+
   std::find(I.rbegin(), I.rend(), 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
   // CHECK-FIXES: std::ranges::find(std::ranges::reverse_view(I), 0);


### PR DESCRIPTION
This PR fixes issue #124815 by correcting the handling of `nullptr` with `std::unique_ptr` in the `modernize-use-ranges` check.

### Changes:
1. **Modified `clang-tools-extra/clang-tidy/modernize/UseRangesCheck.cpp`**:
    - Updated the logic to suppress warnings for `nullptr` in `std::find`.

2. **Added unit tests**:
   - Added new test cases to verify no warning is generated for `nullptr`.
   - Ensured existing behavior for `std::unique_ptr<int>()` remains unchanged.

### Linked Issue:
Fixes #124815.

### Testing:
- All existing unit tests pass.
- New unit tests have been added to verify the fix.

Note:
This is my first PR to the LLVM project. If there are any issues or areas for improvement, please let me know—I’m happy to make adjustments and learn from your feedback! Thank you for your patience and guidance.