### PR TITLE
[PartialInlining] Use DenseSet instead of DenseMap (NFC)

### DIFF
--- a/llvm/lib/Transforms/IPO/PartialInlining.cpp
+++ b/llvm/lib/Transforms/IPO/PartialInlining.cpp
@@ -412,7 +412,7 @@ PartialInlinerImpl::computeOutliningColdRegionsInfo(
   bool ColdCandidateFound = false;
   BasicBlock *CurrEntry = EntryBlock;
   std::vector<BasicBlock *> DFS;
-  DenseSet<BasicBlock *> VisitedSet;
+  SmallPtrSet<BasicBlock *, 8> VisitedSet;
   DFS.push_back(CurrEntry);
   VisitedSet.insert(CurrEntry);
 

--- a/llvm/lib/Transforms/IPO/PartialInlining.cpp
+++ b/llvm/lib/Transforms/IPO/PartialInlining.cpp
@@ -412,9 +412,9 @@ PartialInlinerImpl::computeOutliningColdRegionsInfo(
   bool ColdCandidateFound = false;
   BasicBlock *CurrEntry = EntryBlock;
   std::vector<BasicBlock *> DFS;
-  DenseMap<BasicBlock *, bool> VisitedMap;
+  DenseSet<BasicBlock *> VisitedSet;
   DFS.push_back(CurrEntry);
-  VisitedMap[CurrEntry] = true;
+  VisitedSet.insert(CurrEntry);
 
   // Use Depth First Search on the basic blocks to find CFG edges that are
   // considered cold.
@@ -432,9 +432,8 @@ PartialInlinerImpl::computeOutliningColdRegionsInfo(
         BBProfileCount(ThisBB) < MinBlockCounterExecution)
       continue;
     for (auto SI = succ_begin(ThisBB); SI != succ_end(ThisBB); ++SI) {
-      if (VisitedMap[*SI])
+      if (!VisitedSet.insert(*SI).second)
         continue;
-      VisitedMap[*SI] = true;
       DFS.push_back(*SI);
       // If branch isn't cold, we skip to the next one.
       BranchProbability SuccProb = BPI.getEdgeProbability(ThisBB, *SI);
@@ -492,7 +491,7 @@ PartialInlinerImpl::computeOutliningColdRegionsInfo(
       // at inner regions because the outer region may have live-exit
       // variables.
       for (auto *BB : DominateVector)
-        VisitedMap[BB] = true;
+        VisitedSet.insert(BB);
 
       // ReturnBlock here means the block after the outline call
       BasicBlock *ReturnBlock = ExitBlock->getSingleSuccessor();


### PR DESCRIPTION
This patch changes the type of VisitedMap to DenseSet from DenseMap
because the value side of the map is always "true".

Technically:

  if (VisitedMap[*SI])

inserts "false" as a value, but the value is immediately overridden
with:

  VisitedMap[*SI] = true;

While we are at it, this patch removes the repeated hash lookups
around the "if" statement.
