### PR TITLE
Full slices when tiling full loop trip count

### DIFF
--- a/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
+++ b/mlir/lib/Dialect/Linalg/Utils/Utils.cpp
@@ -56,10 +56,23 @@ namespace {
 //   `d0 + 2 * d1 + d3` is tiled by [0, 0, 0, 2] but not by [0, 0, 2, 0]
 //
 struct TileCheck : public AffineExprVisitor<TileCheck> {
-  TileCheck(ArrayRef<OpFoldResult> tileSizes) : tileSizes(tileSizes) {}
+  TileCheck(ArrayRef<OpFoldResult> tileSizes, ArrayRef<OpFoldResult> sizeBounds)
+      : tileSizes(tileSizes), sizeBounds(sizeBounds) {}
 
   void visitDimExpr(AffineDimExpr expr) {
-    isTiled |= !isZeroIndex(tileSizes[expr.getPosition()]);
+    unsigned pos = expr.getPosition();
+
+    // This dimension is tiled if the tile size is larger than zero and not
+    // equal to its domain size (if statically known).
+    std::optional<int64_t> tileSize = getConstantIntValue(tileSizes[pos]);
+    if (tileSize && !sizeBounds.empty()) {
+      std::optional<int64_t> sizeBound = getConstantIntValue(sizeBounds[pos]);
+      if (sizeBound && *sizeBound == *tileSize) {
+        return;
+      }
+    }
+
+    isTiled |= !isZeroIndex(tileSizes[pos]);
   }
   void visitAffineBinaryOpExpr(AffineBinaryOpExpr expr) {
     visit(expr.getLHS());
@@ -70,24 +83,27 @@ struct TileCheck : public AffineExprVisitor<TileCheck> {
   }
   bool isTiled = false;
   ArrayRef<OpFoldResult> tileSizes;
+  ArrayRef<OpFoldResult> sizeBounds;
 };
 
 } // namespace
 
-static bool isTiled(AffineExpr expr, ArrayRef<OpFoldResult> tileSizes) {
+static bool isTiled(AffineExpr expr, ArrayRef<OpFoldResult> tileSizes,
+                    ArrayRef<OpFoldResult> sizeBounds) {
   if (!expr)
     return false;
-  TileCheck t(tileSizes);
+  TileCheck t(tileSizes, sizeBounds);
   t.visit(expr);
   return t.isTiled;
 }
 
 // Checks whether the `map  varies with respect to a non-zero `tileSize`.
-static bool isTiled(AffineMap map, ArrayRef<OpFoldResult> tileSizes) {
+static bool isTiled(AffineMap map, ArrayRef<OpFoldResult> tileSizes,
+                    ArrayRef<OpFoldResult> sizeBounds) {
   if (!map)
     return false;
   for (unsigned r = 0; r < map.getNumResults(); ++r)
-    if (isTiled(map.getResult(r), tileSizes))
+    if (isTiled(map.getResult(r), tileSizes, sizeBounds))
       return true;
   return false;
 }
@@ -581,7 +597,7 @@ computeSliceParameters(OpBuilder &builder, Location loc, Value valueToTile,
   sliceParams.strides.reserve(rank);
   for (unsigned r = 0; r < rank; ++r) {
     LLVM_DEBUG(llvm::dbgs() << "computeSliceParameters: for dim#" << r);
-    if (!isTiled(map.getSubMap({r}), tileSizes)) {
+    if (!isTiled(map.getSubMap({r}), tileSizes, ubs)) {
       sliceParams.offsets.push_back(builder.getIndexAttr(0));
       OpFoldResult dim = createFoldedDimOp(builder, loc, valueToTile, r);
       sliceParams.sizes.push_back(dim);
@@ -781,10 +797,9 @@ computeAllSliceParameters(OpBuilder &builder, Location loc, LinalgOp linalgOp,
     // transformations such as padding and bufferization since the
     // extract/insert slice pairs make the accessed iteration argument
     // subdomains explicit.
-
     Type operandType = opOperand.get().getType();
-    if (!isTiled(map, tileSizes) && !(isa<RankedTensorType>(operandType) &&
-                                      linalgOp.isDpsInit(&opOperand))) {
+    if (!isTiled(map, tileSizes, {}) && !(isa<RankedTensorType>(operandType) &&
+                                          linalgOp.isDpsInit(&opOperand))) {
       allSliceParams.push_back(std::nullopt);
       LLVM_DEBUG(llvm::dbgs()
                  << ": not tiled: use shape: " << operandType << "\n");

--- a/mlir/test/Dialect/Linalg/tile-tensors.mlir
+++ b/mlir/test/Dialect/Linalg/tile-tensors.mlir
@@ -214,3 +214,35 @@ module attributes {transform.with_named_sequence} {
     transform.yield
   }
 }
+
+// -----
+
+// CHECK-LABEL: func @non_monotonic_affine_expr
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: tensor<7xf32>
+func.func @non_monotonic_affine_expr(%arg0 : tensor<7xf32>) -> tensor<7xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = tensor.dim %arg0, %c0 : tensor<7xf32>
+  %empty = tensor.empty() : tensor<7xf32>
+
+  // CHECK: %[[OUT:.*]] = tensor.empty() : tensor<7xf32>
+  // CHECK: scf.for {{.*}} to {{.*}} step {{.*}} iter_args(%[[TC0:.*]] = %[[OUT]]) -> (tensor<7xf32>) {
+  // CHECK: tensor.extract_slice %[[TC0]][0] [7] [1] : tensor<7xf32> to tensor<7xf32>
+  %generic = linalg.generic
+    {indexing_maps = [affine_map<(d0) -> (d0 mod 4)>,
+                      affine_map<(d0) -> (d0)>],
+     iterator_types = ["parallel"]}
+    ins(%arg0: tensor<7xf32>)
+    outs(%empty : tensor<7xf32>) {
+    ^bb0(%in : f32, %out: f32):
+      linalg.yield %in : f32
+    } -> tensor<7xf32>
+  return %generic : tensor<7xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1 : (!transform.any_op) -> !transform.any_op
+    %1, %loop = transform.structured.tile_using_for %0 tile_sizes [7] : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    transform.yield
+  }
+}

--- a/mlir/test/Dialect/Linalg/transform-op-fuse-into-containing.mlir
+++ b/mlir/test/Dialect/Linalg/transform-op-fuse-into-containing.mlir
@@ -555,11 +555,12 @@ module {
 
       // CHECK: %[[T1:.*]] = linalg.generic {{.*}}
       // CHECK: %[[T2:.*]] = linalg.generic {{.*}}
+      // CHECK: %[[T3:.*]] = linalg.generic {{.*}}
       %7 = tensor.extract_slice %1[%4] [%5] [1] : tensor<?xf32> to tensor<?xf32>
 
       %8 = linalg.elemwise_unary ins(%7 : tensor<?xf32>) outs(%6 : tensor<?xf32>) -> tensor<?xf32>
       scf.forall.in_parallel {
-        // CHECK: tensor.parallel_insert_slice %[[T2]] into %[[ARG7]][%[[I0]]] [%[[I1]]] [1] : tensor<?xf32> into tensor<?xf32>
+        // CHECK: tensor.parallel_insert_slice %[[T3]] into %[[ARG7]][%[[I0]]] [%[[I1]]] [1] : tensor<?xf32> into tensor<?xf32>
         tensor.parallel_insert_slice %8 into %o[%2] [%5] [1] : tensor<?xf32> into tensor<?xf32>
       }
     }


### PR DESCRIPTION
When tiling a chain of linalg.ops, we can only set the tile sizes of the first one to 0 to say untiled, but producers of it will get a tile size of <loop trip count>. We must return the full slice in those cases because the code that computes the slices sizes in the general case doesn't handle non-monotonic affine expressions. Otherwise we would generate invalid code for non-monotonic expressions even if all involved dimensions are effectively untiled.

Example running on trunk : https://godbolt.org/z/sj3Yv9j9j

The example in [0] currently results in the having the `%in` slice with size `[3, 5]`  (see [1]) instead of `[7, 5]` (see [2]). Size `[3, 5]` is incorrect and results from composing `d0 mod 4` with the dim size 7. After the fix we see [2].

[0]

```
#non_monotonic_map = affine_map<(d0, d1) -> (d0 mod 4, d1)>
#identity = affine_map<(d0, d1) -> (d0, d1)>

func.func @example(%in: tensor<7x10xf32>) -> tensor<7x10xf32> {
  %empty = tensor.empty() : tensor<7x10xf32>
  %empty2 = tensor.empty() : tensor<7x10xf32>

  %1 = linalg.generic {indexing_maps = [#non_monotonic_map, #identity], iterator_types = ["parallel", "parallel"]}
    ins(%in : tensor<7x10xf32>) outs(%empty : tensor<7x10xf32>) {
    ^bb1(%a: f32, %b: f32):
      %res = arith.addf %a, %a : f32
      linalg.yield %res : f32
  } -> tensor<7x10xf32>

  %empty3 = tensor.empty() : tensor<7x10xf32>
  %3 = linalg.generic 
  {__consumer__, indexing_maps = [#identity, #identity], iterator_types = ["parallel", "parallel"]} ins(%1 : tensor<7x10xf32>) outs(%empty3 : tensor<7x10xf32>) {
    ^bb1(%a: f32, %b: f32):
      %res = arith.mulf %a, %a : f32
      linalg.yield %res : f32
  } -> tensor<7x10xf32>

 return %3 : tensor<7x10xf32>
}

module attributes {transform.with_named_sequence} {
  transform.named_sequence @__transform_main(%arg1: !transform.any_op {transform.readonly}) {
    %0 = transform.structured.match attributes{"__consumer__"} in %arg1 : (!transform.any_op) -> !transform.any_op
    %loops:2 = transform.structured.fuse %0 {tile_sizes = [0, 5]}
      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
    transform.yield
  }
}
```

[1]
```
....
    %4 = scf.for %arg1 = %c0 to %c10 step %c5 iter_args(%arg2 = %3) -> (tensor<7x10xf32>) {
      %extracted_slice = tensor.extract_slice %arg0[0, %arg1] [3, 5] [1, 1] : tensor<7x10xf32> to tensor<3x5xf32>
      %5 = tensor.empty() : tensor<7x10xf32>
      %extracted_slice_0 = tensor.extract_slice %5[0, %arg1] [7, 5] [1, 1] : tensor<7x10xf32> to tensor<7x5xf32>
      %extracted_slice_1 = tensor.extract_slice %0[0, %arg1] [7, 5] [1, 1] : tensor<7x10xf32> to tensor<7x5xf32>
      %6 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%extracted_slice : tensor<3x5xf32>) outs(%extracted_slice_1 : tensor<7x5xf32>) {
      ^bb0(%in: f32, %out: f32):
        %9 = arith.addf %in, %in : f32
        linalg.yield %9 : f32
      } -> tensor<7x5xf32>

....
```

[2]

```
...
%3 = scf.for %arg1 = %c0 to %c10 step %c5 iter_args(%arg2 = %2) -> (tensor<7x10xf32>) {
      %extracted_slice = tensor.extract_slice %arg0[0, %arg1] [7, 5] [1, 1] : tensor<7x10xf32> to tensor<7x5xf32>
      %4 = tensor.empty() : tensor<7x10xf32>
      %extracted_slice_0 = tensor.extract_slice %4[0, %arg1] [7, 5] [1, 1] : tensor<7x10xf32> to tensor<7x5xf32>
      %extracted_slice_1 = tensor.extract_slice %0[0, %arg1] [7, 5] [1, 1] : tensor<7x10xf32> to tensor<7x5xf32>
      %5 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%extracted_slice : tensor<7x5xf32>) outs(%extracted_slice_1 : tensor<7x5xf32>) {
      ^bb0(%in: f32, %out: f32):
        %8 = arith.addf %in, %in : f32
        linalg.yield %8 : f32
      } -> tensor<7x5xf32>
...
```