### PR TITLE
Fixing the logic issue in TransformTypos::TransformDesignatedInitExpr…

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -13672,7 +13672,7 @@ TreeTransform<Derived>::TransformDesignatedInitExpr(DesignatedInitExpr *E) {
       Desig.AddDesignator(
           Designator::CreateArrayDesignator(Index.get(), D.getLBracketLoc()));
 
-      ExprChanged = ExprChanged || Init.get() != E->getArrayIndex(D);
+      ExprChanged = ExprChanged || Index.get() != E->getArrayIndex(D);
       ArrayExprs.push_back(Index.get());
       continue;
     }


### PR DESCRIPTION
… #126113

-Transforming Indices: For array designators, transform the index expression and update ExprChanged if it's modified.
-Correct Initializer Check: Compare the transformed initializer against the original to accurately track changes.
-Single Initializer Transformation: The initializer is processed once, not per designator, as each DesignatedInitExpr has one initializer.

Fixes #126113