### PR TITLE
[flang][cuda] Set cudadevice interfaces as public by default

### DIFF
--- a/flang/module/__cuda_device.f90
+++ b/flang/module/__cuda_device.f90
@@ -11,7 +11,4 @@
 module __cuda_device
 implicit none
 
-  ! Set PRIVATE by default to explicitly only export what is meant
-  ! to be exported by this MODULE.
-
 end module

--- a/flang/module/cudadevice.f90
+++ b/flang/module/cudadevice.f90
@@ -15,45 +15,36 @@ module cudadevice
   use, intrinsic :: __fortran_builtins, only: c_devloc => __builtin_c_devloc
 implicit none
 
-  ! Set PRIVATE by default to explicitly only export what is meant
-  ! to be exported by this MODULE.
-  private
-
   ! Synchronization Functions
 
   interface
     attributes(device) subroutine syncthreads()
     end subroutine
   end interface
-  public :: syncthreads
 
   interface
     attributes(device) integer function syncthreads_and(value)
       integer, value :: value
     end function
   end interface
-  public :: syncthreads_and
 
   interface
     attributes(device) integer function syncthreads_count(value)
       integer, value :: value
     end function
   end interface
-  public :: syncthreads_count
 
   interface
     attributes(device) integer function syncthreads_or(value)
       integer, value :: value
     end function
   end interface
-  public :: syncthreads_or
 
   interface
     attributes(device) subroutine syncwarp(mask)
       integer, value :: mask
     end subroutine
   end interface
-  public :: syncwarp
 
   ! Memory Fences
 
@@ -61,19 +52,16 @@ implicit none
     attributes(device) subroutine threadfence()
     end subroutine
   end interface
-  public :: threadfence
 
   interface
     attributes(device) subroutine threadfence_block()
     end subroutine
   end interface
-  public :: threadfence_block
 
   interface
     attributes(device) subroutine threadfence_system()
     end subroutine
   end interface
-  public :: threadfence_system
 
   ! Math API
 
@@ -83,7 +71,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fadd_rn
   
   interface __fadd_rz
    attributes(device) real function __fadd_rz(a,b) bind(c, name='__nv_fadd_rz')
@@ -91,7 +78,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fadd_rz
 
   interface
     attributes(device) function __fadd_rd(x, y) bind(c, name='__nv_fadd_rd')
@@ -99,7 +85,6 @@ implicit none
       real :: __fadd_rd
     end function
   end interface
-  public :: __fadd_rd
 
   interface
     attributes(device) function __fadd_ru(x, y) bind(c, name='__nv_fadd_ru')
@@ -107,7 +92,6 @@ implicit none
       real :: __fadd_ru
     end function
   end interface
-  public :: __fadd_ru
 
   interface __fmul_rn
    attributes(device) real function __fmul_rn(a,b) bind(c, name='__nv_fmul_rn')
@@ -115,7 +99,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fmul_rn
 
   interface __fmul_rz
    attributes(device) real function __fmul_rz(a,b) bind(c, name='__nv_fmul_rz')
@@ -123,7 +106,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fmul_rz
 
   interface __fmul_ru
    attributes(device) real function __fmul_ru(a,b) bind(c, name='__nv_fmul_ru')
@@ -131,7 +113,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fmul_ru
 
   interface __fmul_rd
    attributes(device) real function __fmul_rd(a,b) bind(c, name='__nv_fmul_rd')
@@ -139,7 +120,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fmul_rd
 
   interface __fmaf_rn
    attributes(device) real function __fmaf_rn(a,b,c) bind(c, name='__nv_fmaf_rn')
@@ -147,7 +127,6 @@ implicit none
     real, value :: a, b, c
    end function
   end interface
-  public :: __fmaf_rn
 
   interface __fmaf_rz
    attributes(device) real function __fmaf_rz(a,b,c) bind(c, name='__nv_fmaf_rz')
@@ -155,7 +134,6 @@ implicit none
     real, value :: a, b, c
    end function
   end interface
-  public :: __fmaf_rz
   
   interface __fmaf_ru
    attributes(device) real function __fmaf_ru(a,b,c) bind(c, name='__nv_fmaf_ru')
@@ -163,7 +141,6 @@ implicit none
     real, value :: a, b, c
    end function
   end interface
-  public :: __fmaf_ru
   
   interface __fmaf_rd
    attributes(device) real function __fmaf_rd(a,b,c) bind(c, name='__nv_fmaf_rd')
@@ -171,7 +148,6 @@ implicit none
     real, value :: a, b, c
    end function
   end interface
-  public :: __fmaf_rd
 
   interface __frcp_rn
    attributes(device) real function __frcp_rn(a) bind(c, name='__nv_frcp_rn')
@@ -179,7 +155,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __frcp_rn
 
   interface __frcp_rz
    attributes(device) real function __frcp_rz(a) bind(c, name='__nv_frcp_rz')
@@ -187,7 +162,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __frcp_rz
 
   interface __frcp_ru
    attributes(device) real function __frcp_ru(a) bind(c, name='__nv_frcp_ru')
@@ -195,7 +169,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __frcp_ru
 
   interface __frcp_rd
    attributes(device) real function __frcp_rd(a) bind(c, name='__nv_frcp_rd')
@@ -203,7 +176,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __frcp_rd
 
   interface __fsqrt_rn
    attributes(device) real function __fsqrt_rn(a) bind(c, name='__nv_fsqrt_rn')
@@ -211,7 +183,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __fsqrt_rn
 
   interface __fsqrt_rz
    attributes(device) real function __fsqrt_rz(a) bind(c, name='__nv_fsqrt_rz')
@@ -219,7 +190,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __fsqrt_rz
 
   interface __fsqrt_ru
    attributes(device) real function __fsqrt_ru(a) bind(c, name='__nv_fsqrt_ru')
@@ -227,7 +197,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __fsqrt_ru
 
   interface __fsqrt_rd
    attributes(device) real function __fsqrt_rd(a) bind(c, name='__nv_fsqrt_rd')
@@ -235,7 +204,6 @@ implicit none
     real, value :: a
    end function
   end interface
-  public :: __fsqrt_rd
 
   interface __fdiv_rn
    attributes(device) real function __fdiv_rn(a,b) bind(c, name='__nv_fdiv_rn')
@@ -243,7 +211,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fdiv_rn
 
   interface __fdiv_rz
    attributes(device) real function __fdiv_rz(a,b) bind(c, name='__nv_fdiv_rz')
@@ -251,7 +218,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fdiv_rz
 
   interface __fdiv_ru
    attributes(device) real function __fdiv_ru(a,b) bind(c, name='__nv_fdiv_ru')
@@ -259,7 +225,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fdiv_ru
 
   interface __fdiv_rd
    attributes(device) real function __fdiv_rd(a,b) bind(c, name='__nv_fdiv_rd')
@@ -267,7 +232,6 @@ implicit none
     real, value :: a, b
    end function
   end interface
-  public :: __fdiv_rd
 
   interface __dadd_rn
    attributes(device) real(8) function __dadd_rn(a,b) bind(c, name='__nv_dadd_rn')
@@ -275,7 +239,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dadd_rn
 
   interface __dadd_rz
    attributes(device) real(8) function __dadd_rz(a,b) bind(c, name='__nv_dadd_rz')
@@ -283,7 +246,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dadd_rz
 
   interface __dadd_ru
    attributes(device) real(8) function __dadd_ru(a,b) bind(c, name='__nv_dadd_ru')
@@ -291,7 +253,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dadd_ru
 
   interface __dadd_rd
    attributes(device) real(8) function __dadd_rd(a,b) bind(c, name='__nv_dadd_rd')
@@ -299,7 +260,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dadd_rd
 
   interface __dmul_rn
    attributes(device) real(8) function __dmul_rn(a,b) bind(c, name='__nv_dmul_rn')
@@ -307,7 +267,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dmul_rn
 
   interface __dmul_rz
    attributes(device) real(8) function __dmul_rz(a,b) bind(c, name='__nv_dmul_rz')
@@ -315,7 +274,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dmul_rz
 
   interface __dmul_ru
    attributes(device) real(8) function __dmul_ru(a,b) bind(c, name='__nv_dmul_ru')
@@ -323,7 +281,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dmul_ru
 
   interface __dmul_rd
    attributes(device) real(8) function __dmul_rd(a,b) bind(c, name='__nv_dmul_rd')
@@ -331,7 +288,6 @@ implicit none
     real(8), value :: a, b
    end function
   end interface
-  public :: __dmul_rd
 
   interface __fma_rn
    attributes(device) real(8) function __fma_rn(a,b,c) bind(c, name='__nv_fma_rn')
@@ -339,7 +295,6 @@ implicit none
     real(8), value :: a, b, c
    end function
   end interface
-  public :: __fma_rn
 
   interface __fma_rz
    attributes(device) real(8) function __fma_rz(a,b,c) bind(c, name='__nv_fma_rz')
@@ -347,7 +302,6 @@ implicit none
     real(8), value :: a, b, c
    end function
   end interface
-  public :: __fma_rz
 
   interface __fma_ru
    attributes(device) real(8) function __fma_ru(a,b,c) bind(c, name='__nv_fma_ru')
@@ -355,7 +309,6 @@ implicit none
     real(8), value :: a, b, c
    end function
   end interface
-  public :: __fma_ru
 
   interface __fma_rd
    attributes(device) real(8) function __fma_rd(a,b,c) bind(c, name='__nv_fma_rd')
@@ -363,7 +316,6 @@ implicit none
     real(8), value :: a, b, c
    end function
   end interface
-  public :: __fma_rd
 
   interface rsqrt
     attributes(device) real(4) function rsqrtf(x) bind(c,name='__nv_rsqrtf')
@@ -373,7 +325,6 @@ implicit none
       real(8), value :: x
     end function
   end interface
-  public :: rsqrt
   
   interface signbit
     attributes(device) integer(4) function signbitf(x) bind(c,name='__nv_signbitf')
@@ -383,7 +334,6 @@ implicit none
       real(8), value :: x
     end function
   end interface
-  public :: signbit
 
   interface
     attributes(device) subroutine sincosf(x, y, z) bind(c,name='__nv_sincosf')
@@ -392,7 +342,6 @@ implicit none
       real(4), device :: z
     end subroutine
   end interface
-  public :: sincosf
   interface
     attributes(device) subroutine sincos(x, y, z) bind(c,name='__nv_sincos')
       real(8), value :: x
@@ -404,7 +353,6 @@ implicit none
     procedure :: sincosf
     procedure :: sincos
   end interface
-  public :: sincos
 
   interface
     attributes(device) subroutine sincospif(x, y, z) bind(c,name='__nv_sincospif')
@@ -413,7 +361,6 @@ implicit none
       real(4), device :: z
     end subroutine
   end interface
-  public :: sincospif
   interface
     attributes(device) subroutine sincospi(x, y, z) bind(c,name='__nv_sincospi')
       real(8), value :: x
@@ -425,14 +372,12 @@ implicit none
     procedure :: sincospif
     procedure :: sincospi
   end interface
-  public :: sincospi
 
   interface
     attributes(device) real(4) function cospif(x) bind(c,name='__nv_cospif')
       real(4), value :: x
     end function
   end interface
-  public :: cospif
   interface
     attributes(device) real(8) function cospi(x) bind(c,name='__nv_cospi')
       real(8), value :: x
@@ -442,14 +387,12 @@ implicit none
     procedure :: cospif
     procedure :: cospi
   end interface
-  public :: cospi
 
   interface  
     attributes(device) real(4) function sinpif(x) bind(c,name='__nv_sinpif')
       real(4), value :: x
     end function
   end interface
-  public :: sinpif
   interface
     attributes(device) real(8) function sinpi(x) bind(c,name='__nv_sinpi')
       real(8), value :: x
@@ -459,7 +402,6 @@ implicit none
     procedure :: sinpif
     procedure :: sinpi
   end interface
-  public :: sinpi
   
   interface mulhi
    attributes(device) integer function __mulhi(i,j) bind(c,name='__nv_mulhi')
@@ -467,7 +409,6 @@ implicit none
     integer, value :: i,j
    end function
   end interface
-  public :: mulhi
 
   interface umulhi
    attributes(device) integer function __umulhi(i,j) bind(c,name='__nv_umulhi')
@@ -475,7 +416,6 @@ implicit none
     integer, value :: i,j
    end function
   end interface
-  public :: umulhi
   
   interface mul64hi
    attributes(device) integer(8) function __mul64hi(i,j) bind(c,name='__nv_mul64hi')
@@ -483,7 +423,6 @@ implicit none
     integer(8), value :: i,j
    end function
   end interface
-  public :: mul64hi
   
   interface umul64hi
    attributes(device) integer(8) function __umul64hi(i,j) bind(c,name='__nv_umul64hi')
@@ -491,8 +430,6 @@ implicit none
     integer(8), value :: i,j
    end function
   end interface
-  public :: umul64hi
-
 
   ! Atomic Operations
 
@@ -517,8 +454,7 @@ implicit none
     integer(8), intent(inout) :: address
     integer(8), value :: val
     end function
-  end interface 
-  public :: atomicadd
+  end interface
 
   interface atomicsub
     attributes(device) pure integer function atomicsubi(address, val)
@@ -542,7 +478,6 @@ implicit none
     integer(8), value :: val
     end function
   end interface
-  public :: atomicsub
   
   interface atomicmax
     attributes(device) pure integer function atomicmaxi(address, val)
@@ -566,7 +501,6 @@ implicit none
     integer(8), value :: val
     end function
   end interface
-  public :: atomicmax
   
   interface atomicmin
     attributes(device) pure integer function atomicmini(address, val)
@@ -590,7 +524,6 @@ implicit none
     integer(8), value :: val
     end function
   end interface
-  public :: atomicmin
   
   interface atomicand
     attributes(device) pure integer function atomicandi(address, val)
@@ -599,7 +532,6 @@ implicit none
     integer, value :: val
     end function
   end interface
-  public :: atomicand
   
   interface atomicor
     attributes(device) pure integer function atomicori(address, val)
@@ -608,7 +540,6 @@ implicit none
     integer, value :: val
     end function
   end interface
-  public :: atomicor
 
   interface atomicinc
     attributes(device) pure integer function atomicinci(address, val)
@@ -617,7 +548,6 @@ implicit none
     integer, value :: val
     end function
   end interface
-  public :: atomicinc
   
   interface atomicdec
     attributes(device) pure integer function atomicdeci(address, val)
@@ -626,12 +556,10 @@ implicit none
     integer, value :: val
     end function
   end interface
-  public :: atomicdec
 
   interface
     attributes(device) integer(8) function clock64()
     end function
   end interface
-  public :: clock64
 
 end module


### PR DESCRIPTION
Remove the PRIVATE statement from cudadevice as it hides any interfaces from the used __cuda_device module. 