### PR TITLE
[llvm-dwarfdump] Print number of out-of-line functions described by DWARF

### DIFF
--- a/llvm/test/tools/llvm-dwarfdump/X86/statistics-dwo.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/statistics-dwo.test
@@ -72,6 +72,7 @@ RUN: llvm-dwarfdump --statistics statistics-fib.split-dwarf.o | FileCheck %s
 CHECK:      "version": 9,
 CHECK:      "#functions": 3,
 CHECK:      "#functions with location": 3,
+CHECK:      "#out-of-line functions": 3,
 CHECK:      "#inlined functions": 7,
 CHECK:      "#inlined functions with abstract origins": 7,
 CHECK:      "#unique source variables": 9,

--- a/llvm/test/tools/llvm-dwarfdump/X86/statistics-v3.test
+++ b/llvm/test/tools/llvm-dwarfdump/X86/statistics-v3.test
@@ -67,6 +67,7 @@ RUN: llvm-dwarfdump --statistics %t-statistics-fib.o | FileCheck %s
 CHECK:      "version": 9,
 CHECK:      "#functions": 3,
 CHECK:      "#functions with location": 3,
+CHECK:      "#out-of-line functions": 3,
 CHECK:      "#inlined functions": 8,
 CHECK:      "#inlined functions with abstract origins": 8,
 CHECK:      "#unique source variables": 9,

--- a/llvm/test/tools/llvm-dwarfdump/X86/stats-inlining-multi-cu.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/stats-inlining-multi-cu.ll
@@ -4,6 +4,7 @@
 ; Test that abstract origins in multiple CUs are uniqued.
 
 ; CHECK:      "#functions": 4,
+; CHECK:      "#out-of-line functions": 3,
 ; CHECK:      "#inlined functions": 2,
 ; CHECK:      "#unique source variables": 4,
 ; CHECK-NEXT: "#source variables": 6,

--- a/llvm/test/tools/llvm-dwarfdump/X86/stats-inlining-single-cu.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/stats-inlining-single-cu.ll
@@ -5,6 +5,7 @@
 ; The results for both tests should be identical.
 
 ; CHECK:      "#functions": 4,
+; CHECK:      "#out-of-line functions": 3,
 ; CHECK:      "#inlined functions": 2,
 ; CHECK:      "#unique source variables": 4,
 ; CHECK-NEXT: "#source variables": 6,

--- a/llvm/test/tools/llvm-dwarfdump/X86/stats-mulitple-cu-out-of-line.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/stats-mulitple-cu-out-of-line.ll
@@ -20,6 +20,7 @@
 
 ; CHECK:      "#functions": 3,
 ; CHECK-NEXT: "#functions with location": 3,
+; CHECK-NEXT: "#out-of-line functions": 4,
 ; CHECK-NEXT: "#inlined functions": 0,
 ; CHECK-NEXT: "#inlined functions with abstract origins": 0,
 ; CHECK-NEXT: "#unique source variables": 1,

--- a/llvm/test/tools/llvm-dwarfdump/X86/stats-multiple-cu-same-name.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/stats-multiple-cu-same-name.ll
@@ -4,6 +4,7 @@
 ; Test that statistics distinguish functions with the same name.
 
 ; CHECK:      "#functions": 4,
+; CHECK:      "#out-of-line functions": 4,
 ; CHECK:      "#unique source variables": 2,
 ; CHECK-NEXT: "#source variables": 2,
 

--- a/llvm/tools/llvm-dwarfdump/Statistics.cpp
+++ b/llvm/tools/llvm-dwarfdump/Statistics.cpp
@@ -971,6 +971,7 @@ bool dwarfdump::collectStatsForObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
   SaturatingUINT64 VarParamUnique = 0;
   SaturatingUINT64 VarParamWithLoc = 0;
   SaturatingUINT64 NumFunctions = 0;
+  SaturatingUINT64 NumOutOfLineFunctions = 0;
   SaturatingUINT64 NumInlinedFunctions = 0;
   SaturatingUINT64 NumFuncsWithSrcLoc = 0;
   SaturatingUINT64 NumAbstractOrigins = 0;
@@ -999,6 +1000,7 @@ bool dwarfdump::collectStatsForObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
                << Entry.getKey() << ": " << V.getKey() << "\n");
     NumFunctions += Stats.IsFunction;
     NumFuncsWithSrcLoc += Stats.HasSourceLocation;
+    NumOutOfLineFunctions += Stats.IsFunction * Stats.NumFnOutOfLine;
     NumInlinedFunctions += Stats.IsFunction * Stats.NumFnInlined;
     NumAbstractOrigins += Stats.IsFunction * Stats.NumAbstractOrigins;
     ParamTotal += Stats.NumParams;
@@ -1024,6 +1026,7 @@ bool dwarfdump::collectStatsForObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
 
   printDatum(J, "#functions", NumFunctions.Value);
   printDatum(J, "#functions with location", NumFuncsWithSrcLoc.Value);
+  printDatum(J, "#out-of-line functions", NumOutOfLineFunctions.Value);
   printDatum(J, "#inlined functions", NumInlinedFunctions.Value);
   printDatum(J, "#inlined functions with abstract origins",
              NumAbstractOrigins.Value);


### PR DESCRIPTION
Some of the functions in `#functions` may have several inlined instances, but also an out-of-line definition.

Therefore, for complex enough DWARF input, `#functions` - `#inlined functions` would not give us the number of out-of-line function definitions.
`llvm-dwarfdump`, however, already keeps track of those; print it as part of the statistics, as this number is useful in certain scenarios.