### PR TITLE
[lld][MachO] Test with exported_symbol and exported_symbols_list together

### DIFF
--- a/lld/test/MachO/export-options.s
+++ b/lld/test/MachO/export-options.s
@@ -117,13 +117,15 @@
 ## Check that only string-literal patterns match
 ## Check that comments and blank lines are stripped from symbol list
 # RUN: %lld -dylib %t/symdefs.o -o %t/literal \
-# RUN:     -exported_symbols_list %t/literals.txt
+# RUN:     -exported_symbols_list %t/literals.txt \
+# RUN:     -exported_symbol singleton
 # RUN: llvm-objdump --macho --exports-trie %t/literal | \
 # RUN:     FileCheck --check-prefix=LITERAL %s
 
 # LITERAL-DAG: literal_only
 # LITERAL-DAG: literal_also
 # LITERAL-DAG: globby_also
+# LITERAL-DAG: singleton
 # LITERAL-NOT: globby_only
 
 ## Check that only glob patterns match
@@ -245,7 +247,7 @@ _keep_lazy:
 
 #--- symdefs.s
 
-.globl literal_only, literal_also, globby_only, globby_also
+.globl literal_only, literal_also, globby_only, globby_also, singleton
 literal_only:
   retq
 literal_also:
@@ -253,6 +255,8 @@ literal_also:
 globby_only:
   retq
 globby_also:
+  retq
+singleton:
   retq
 
 #--- literals.txt


### PR DESCRIPTION
I've been investigating a bug involving `-exported_symbol` and I discovered that we have no test that uses both `-exported_symbol` and `-exported_symbols_list` together. Add this test to ensure they do not override each other now or in the future.