### PR TITLE
[Clang][PGO] Fix profile function visibility bug

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1480,11 +1480,15 @@ void Darwin::addProfileRTLibs(const ArgList &Args,
   // If we have a symbol export directive and we're linking in the profile
   // runtime, automatically export symbols necessary to implement some of the
   // runtime's functionality.
-  if (hasExportSymbolDirective(Args) && ForGCOV) {
-    addExportedSymbol(CmdArgs, "___gcov_dump");
-    addExportedSymbol(CmdArgs, "___gcov_reset");
-    addExportedSymbol(CmdArgs, "_writeout_fn_list");
-    addExportedSymbol(CmdArgs, "_reset_fn_list");
+  if (hasExportSymbolDirective(Args)) {
+    if (ForGCOV) {
+      addExportedSymbol(CmdArgs, "___gcov_dump");
+      addExportedSymbol(CmdArgs, "___gcov_reset");
+      addExportedSymbol(CmdArgs, "_writeout_fn_list");
+      addExportedSymbol(CmdArgs, "_reset_fn_list");
+    } else {
+      addExportedSymbol(CmdArgs, "___llvm_write_custom_profile");
+    }
   }
 
   // Align __llvm_prf_{cnts,bits,data} sections to the maximum expected page

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -1362,12 +1362,10 @@ COMPILER_RT_VISIBILITY int __llvm_profile_set_file_object(FILE *File,
   return 0;
 }
 
-int __llvm_write_custom_profile(const char *Target,
-                                const __llvm_profile_data *DataBegin,
-                                const __llvm_profile_data *DataEnd,
-                                const char *CountersBegin,
-                                const char *CountersEnd, const char *NamesBegin,
-                                const char *NamesEnd) {
+COMPILER_RT_USED int __llvm_write_custom_profile(
+    const char *Target, const __llvm_profile_data *DataBegin,
+    const __llvm_profile_data *DataEnd, const char *CountersBegin,
+    const char *CountersEnd, const char *NamesBegin, const char *NamesEnd) {
   int ReturnValue = 0, FilenameLength, TargetLength;
   char *FilenameBuf, *TargetFilename;
   const char *Filename;


### PR DESCRIPTION
This pull request fixes an issue that was introduced in #93365. `__llvm_write_custom_profile` visibility was causing issues on Darwin. This function needs to be publicly accessible in order to be accessed by libomptarget, so this pull request makes `__llvm_write_custom_profile` an explicitly exported symbol on Darwin. Tested on M3 and X86 macs.