### PR TITLE
[HLSL] Update target test to use `-cc1` rather than the clang driver

### DIFF
--- a/clang/test/CodeGenHLSL/basic-target.c
+++ b/clang/test/CodeGenHLSL/basic-target.c
@@ -1,10 +1,10 @@
-// RUN: %clang -target dxil-pc-shadermodel6.0-pixel -S -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang -target dxil-pc-shadermodel6.0-vertex -S -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang -target dxil-pc-shadermodel6.0-compute -S -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang -target dxil-pc-shadermodel6.0-library -S -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang -target dxil-pc-shadermodel6.0-hull -S -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang -target dxil-pc-shadermodel6.0-domain -S -emit-llvm -o - %s | FileCheck %s
-// RUN: %clang -target dxil-pc-shadermodel6.0-geometry -S -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-pixel -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-vertex -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-compute -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-library -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-hull -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-domain -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -cc1 -triple dxil-pc-shadermodel6.0-geometry -emit-llvm -o - %s | FileCheck %s
 
 // CHECK: target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 // CHECK: target triple = "dxilv1.0-pc-shadermodel6.0-{{[a-z]+}}"


### PR DESCRIPTION
This test was unnecessarily invoking `dxv` if it was in your path since it used the driver rather than the `-cc1` command.