### PR TITLE
[HLSL] Add more tests to root signature metadata extraction

### DIFF
--- a/llvm/lib/Target/DirectX/DXILRootSignature.cpp
+++ b/llvm/lib/Target/DirectX/DXILRootSignature.cpp
@@ -150,11 +150,16 @@ analyzeModule(Module &M) {
       continue;
     }
 
-    MDNode *RootElementListNode =
-        dyn_cast<MDNode>(RSDefNode->getOperand(1).get());
+    Metadata *RootElementListOperand = RSDefNode->getOperand(1).get();
 
+    if (RootElementListOperand == nullptr) {
+      reportError(Ctx, "Root Element mdnode is null.");
+      continue;
+    }
+
+    MDNode *RootElementListNode = dyn_cast<MDNode>(RootElementListOperand);
     if (RootElementListNode == nullptr) {
-      reportError(Ctx, "Missing Root Element List Metadata node.");
+      reportError(Ctx, "Root Element is not a metadata node.");
       continue;
     }
 

--- a/llvm/lib/Target/DirectX/DXILRootSignature.cpp
+++ b/llvm/lib/Target/DirectX/DXILRootSignature.cpp
@@ -155,6 +155,7 @@ analyzeModule(Module &M) {
 
     if (RootElementListNode == nullptr) {
       reportError(Ctx, "Missing Root Element List Metadata node.");
+      continue;
     }
 
     mcdxbc::RootSignatureDesc RSD;

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-function.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-function.ll
@@ -1,0 +1,26 @@
+; RUN: not opt -passes='print<dxil-root-signature>' %s -S -o - 2>&1 | FileCheck %s
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+; CHECK: error: First element of root signature is not a Function
+; CHECK-NOT: Root Signature Definitions
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+define void @anotherMain() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!2 = !{ ptr @main, !3 } ; function, root signature
+!3 = !{ !4 } ; list of root signature elements
+!4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout
+!5 = !{ i32 -1, !6 } ; function, root signature
+!6 = !{ !7 } ; list of root signature elements
+!7 = !{ !"RootFlags", i32 2 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-value.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-value.ll
@@ -1,0 +1,26 @@
+; RUN: not opt -passes='print<dxil-root-signature>' %s -S -o - 2>&1 | FileCheck %s
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+; CHECK: error: First element of root signature is not a Value
+; CHECK-NOT: Root Signature Definitions
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+define void @anotherMain() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!2 = !{ ptr @main, !3 } ; function, root signature
+!3 = !{ !4 } ; list of root signature elements
+!4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout
+!5 = !{ !3, !6 } ; function, root signature
+!6 = !{ !7 } ; list of root signature elements
+!7 = !{ !"RootFlags", i32 2 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-no-root-element-list.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-no-root-element-list.ll
@@ -1,0 +1,26 @@
+; RUN: not opt -passes='print<dxil-root-signature>' %s -S -o - 2>&1 | FileCheck %s
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+; CHECK: error: Root Element mdnode is null.
+; CHECK-NOT: Root Signature Definitions
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+define void @anotherMain() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!2 = !{ ptr @main, null } ; function, root signature
+!3 = !{ !4 } ; list of root signature elements
+!4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout
+!5 = !{ i32 -1, !6 } ; function, root signature
+!6 = !{ !7 } ; list of root signature elements
+!7 = !{ !"RootFlags", i32 2 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-root-element-not-mdnode.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-root-element-not-mdnode.ll
@@ -1,0 +1,26 @@
+; RUN: not opt -passes='print<dxil-root-signature>' %s -S -o - 2>&1 | FileCheck %s
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+; CHECK: error: Root Element is not a metadata node.
+; CHECK-NOT: Root Signature Definitions
+
+define void @main() #0 {
+entry:
+  ret void
+}
+
+define void @anotherMain() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!2 = !{ ptr @main, i32 -1 } ; function, root signature
+!3 = !{ !4 } ; list of root signature elements
+!4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout
+!5 = !{ i32 -1, !6 } ; function, root signature
+!6 = !{ !7 } ; list of root signature elements
+!7 = !{ !"RootFlags", i32 2 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-MultipleEntryFunctions.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-MultipleEntryFunctions.ll
@@ -23,16 +23,16 @@ attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 !6 = !{ !7 } ; list of root signature elements
 !7 = !{ !"RootFlags", i32 2 } ; 1 = allow_input_assembler_input_layout
 
-; CHECK-LABEL: Definition for 'anotherMain':
-; CHECK-NEXT:   Flags: 0x000002
+; CHECK-LABEL: Definition for 'main':
+; CHECK-NEXT:   Flags: 0x000001
 ; CHECK-NEXT:   Version: 2
 ; CHECK-NEXT:   NumParameters: 0
 ; CHECK-NEXT:   RootParametersOffset: 0
 ; CHECK-NEXT:   NumStaticSamplers: 0
 ; CHECK-NEXT:   StaticSamplersOffset: 0
 
-; CHECK-LABEL: Definition for 'main':
-; CHECK-NEXT:   Flags: 0x000001
+; CHECK-LABEL: Definition for 'anotherMain':
+; CHECK-NEXT:   Flags: 0x000002
 ; CHECK-NEXT:   Version: 2
 ; CHECK-NEXT:   NumParameters: 0
 ; CHECK-NEXT:   RootParametersOffset: 0

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-MultipleEntryFunctions.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-MultipleEntryFunctions.ll
@@ -23,16 +23,16 @@ attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 !6 = !{ !7 } ; list of root signature elements
 !7 = !{ !"RootFlags", i32 2 } ; 1 = allow_input_assembler_input_layout
 
-; CHECK-LABEL: Definition for 'main':
-; CHECK-NEXT:   Flags: 0x000001
+; CHECK-LABEL: Definition for 'anotherMain':
+; CHECK-NEXT:   Flags: 0x000002
 ; CHECK-NEXT:   Version: 2
 ; CHECK-NEXT:   NumParameters: 0
 ; CHECK-NEXT:   RootParametersOffset: 0
 ; CHECK-NEXT:   NumStaticSamplers: 0
 ; CHECK-NEXT:   StaticSamplersOffset: 0
 
-; CHECK-LABEL: Definition for 'anotherMain':
-; CHECK-NEXT:   Flags: 0x000002
+; CHECK-LABEL: Definition for 'main':
+; CHECK-NEXT:   Flags: 0x000001
 ; CHECK-NEXT:   Version: 2
 ; CHECK-NEXT:   NumParameters: 0
 ; CHECK-NEXT:   RootParametersOffset: 0


### PR DESCRIPTION
This PR adds a few more tests to validate some error scenarios of root signature metadata representation.

Closes: https://github.com/llvm/llvm-project/issues/127280