### PR TITLE
[libc] Elide extra space in hdrgen function declarations

### DIFF
--- a/libc/utils/hdrgen/function.py
+++ b/libc/utils/hdrgen/function.py
@@ -81,4 +81,7 @@ class Function:
     def __str__(self):
         attrs_str = "".join(f"{attr} " for attr in self.attributes)
         arguments_str = ", ".join(self.arguments) if self.arguments else "void"
-        return attrs_str + f"{self.return_type} {self.name}({arguments_str})"
+        type_str = str(self.return_type)
+        if type_str[-1].isalnum() or type_str[-1] == "_":
+            type_str += " "
+        return attrs_str + type_str + self.name + "(" + arguments_str + ")"

--- a/libc/utils/hdrgen/function.py
+++ b/libc/utils/hdrgen/function.py
@@ -81,6 +81,11 @@ class Function:
     def __str__(self):
         attrs_str = "".join(f"{attr} " for attr in self.attributes)
         arguments_str = ", ".join(self.arguments) if self.arguments else "void"
+        # The rendering of the return type may look like `int` or it may look
+        # like `int *` (and other examples).  For `int`, a space is always
+        # needed to separate the tokens.  For `int *`, no whitespace matters to
+        # the syntax one way or the other, but an extra space between `*` and
+        # the function identifier is not the canonical style.
         type_str = str(self.return_type)
         if type_str[-1].isalnum() or type_str[-1] == "_":
             type_str += " "

--- a/libc/utils/hdrgen/tests/expected_output/subdir/test.h
+++ b/libc/utils/hdrgen/tests/expected_output/subdir/test.h
@@ -19,6 +19,8 @@ type_a func(type_b) __NOEXCEPT;
 
 void gnufunc(type_a) __NOEXCEPT;
 
+int *ptrfunc(void) __NOEXCEPT;
+
 __END_C_DECLS
 
 #endif // LLVM_LIBC_SUBDIR_TEST_H

--- a/libc/utils/hdrgen/tests/input/subdir/test.yaml
+++ b/libc/utils/hdrgen/tests/input/subdir/test.yaml
@@ -12,3 +12,6 @@ functions:
       - type: type_a
     standards:
       - gnu
+  - name: ptrfunc
+    return_type: int *
+    arguments: []


### PR DESCRIPTION
When the return type's rendering already doesn't end with an
identifier character, such as when it's `T *`, then idiomatic
syntax does not include a space before the `(` and arguments.
