### PR TITLE
[WebKit Checkers] Treat attributes as trivial

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -392,6 +392,11 @@ public:
     return false;
   }
 
+  bool VisitAttributedStmt(const AttributedStmt *AS) {
+    // Ignore attributes.
+    return Visit(AS->getSubStmt());
+  }
+
   bool VisitCompoundStmt(const CompoundStmt *CS) {
     // A compound statement is allowed as long each individual sub-statement
     // is trivial.

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -376,6 +376,7 @@ public:
   };
   void trivial68() { point pt = { 1.0 }; }
   unsigned trivial69() { return offsetof(RefCounted, children); }
+  DerivedNumber* trivial70() { [[clang::suppress]] return static_cast<DerivedNumber*>(number); }
 
   static RefCounted& singleton() {
     static RefCounted s_RefCounted;
@@ -564,6 +565,7 @@ public:
     getFieldTrivial().trivial67()->trivial6(); // no-warning
     getFieldTrivial().trivial68(); // no-warning
     getFieldTrivial().trivial69(); // no-warning
+    getFieldTrivial().trivial70(); // no-warning
 
     RefCounted::singleton().trivial18(); // no-warning
     RefCounted::singleton().someFunction(); // no-warning


### PR DESCRIPTION
For the purpose of determining triviality, ignore all attributes.