### PR TITLE
p/libc malloc decls

### DIFF
--- a/libc/include/malloc.yaml
+++ b/libc/include/malloc.yaml
@@ -9,6 +9,12 @@ macros:
   - macro_name: M_PURGE_ALL
     macro_header: malloc-macros.h
 functions:
+  - name: malloc_usable_size
+    standards:
+      - gnu
+    return_type: size_t
+    arguments:
+      - type: void *
   - name: mallopt
     standards:
       - gnu
@@ -16,3 +22,10 @@ functions:
     arguments:
       - type: int
       - type: int
+  - name: pvalloc
+    standards:
+      - bsd
+      - gnu
+    return_type: void *
+    arguments:
+      - type: size_t

--- a/libc/include/stdlib-malloc.yaml
+++ b/libc/include/stdlib-malloc.yaml
@@ -1,4 +1,10 @@
 # This file has declarations that appear both in <stdlib.h> and in <malloc.h>.
+# These include the subset of GNU extensions that Scudo supports.
+#
+# Note: glibc's <stdlib.h> and <malloc.h> both also have `reallocarray`,
+# which Scudo does not support and is omitted here.  (Each of those glibc
+# headers also has related functions the other lacks, but those should be
+# covered separately in stdlib.yaml and malloc.yaml instead.)
 
 functions:
   - name: aligned_alloc
@@ -27,6 +33,13 @@ functions:
     return_type: void *
     arguments:
       - type: size_t
+  - name: memalign
+    standards:
+      - gnu
+    return_type: void *
+    arguments:
+      - type: size_t
+      - type: size_t
   - name: realloc
     standards:
       - stdc
@@ -34,11 +47,10 @@ functions:
     arguments:
       - type: void *
       - type: size_t
-
-# Note: glibc's <stdlib.h> and <malloc.h> both have these, which are
-# currently missing here:
-#  - name: reallocarray
-#  - name: memalign
-#  - name: valloc
-# Each of those glibc headers also has related functions the other lacks.
-# Only the common subset is mentioned here for future consideration.
+  - name: valloc
+    standards:
+      - bsd
+      - gnu
+    return_type: void *
+    arguments:
+      - type: size_t

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -127,6 +127,14 @@ functions:
     arguments:
       - type: long long
       - type: long long
+  - name: posix_memalign
+    standards:
+      - posix
+    return_type: int
+    arguments:
+      - type: void **
+      - type: size_t
+      - type: size_t
   - name: qsort
     standards:
       - stdc

--- a/libc/utils/hdrgen/function.py
+++ b/libc/utils/hdrgen/function.py
@@ -81,4 +81,7 @@ class Function:
     def __str__(self):
         attrs_str = "".join(f"{attr} " for attr in self.attributes)
         arguments_str = ", ".join(self.arguments) if self.arguments else "void"
-        return attrs_str + f"{self.return_type} {self.name}({arguments_str})"
+        type_str = str(self.return_type)
+        if type_str[-1].isalnum() or type_str[-1] == "_":
+            type_str += " "
+        return attrs_str + type_str + self.name + "(" + arguments_str + ")"

--- a/libc/utils/hdrgen/tests/expected_output/subdir/test.h
+++ b/libc/utils/hdrgen/tests/expected_output/subdir/test.h
@@ -19,6 +19,8 @@ type_a func(type_b) __NOEXCEPT;
 
 void gnufunc(type_a) __NOEXCEPT;
 
+int *ptrfunc(void) __NOEXCEPT;
+
 __END_C_DECLS
 
 #endif // LLVM_LIBC_SUBDIR_TEST_H

--- a/libc/utils/hdrgen/tests/input/subdir/test.yaml
+++ b/libc/utils/hdrgen/tests/input/subdir/test.yaml
@@ -12,3 +12,6 @@ functions:
       - type: type_a
     standards:
       - gnu
+  - name: ptrfunc
+    return_type: int *
+    arguments: []


### PR DESCRIPTION
- **[libc] Elide extra space in hdrgen function declarations**
- **[libc] Fill out generated malloc.h and related stdlib.h extensions**
