### PR TITLE
Revert "[llvm-jitlink] Explicit exports for builtin runtime functions in MinGW executables"

### DIFF
--- a/llvm/tools/llvm-jitlink/CMakeLists.txt
+++ b/llvm/tools/llvm-jitlink/CMakeLists.txt
@@ -37,30 +37,3 @@ endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
   target_link_libraries(llvm-jitlink PRIVATE socket)
 endif()
-
-if(WIN32)
-  set(builtin_runtime_functions
-    llvm_orc_registerEHFrameSectionWrapper
-    llvm_orc_deregisterEHFrameSectionWrapper
-    llvm_orc_registerJITLoaderGDBWrapper
-    llvm_orc_registerJITLoaderGDBAllocAction
-    llvm_orc_registerJITLoaderPerfStart
-    llvm_orc_registerJITLoaderPerfEnd
-    llvm_orc_registerJITLoaderPerfImpl
-    llvm_orc_registerVTuneImpl
-    llvm_orc_unregisterVTuneImpl
-    llvm_orc_test_registerVTuneImpl
-    )
-
-  foreach(entry IN LISTS builtin_runtime_functions)
-    string(APPEND exports_multiline "${entry}\n")
-  endforeach()
-
-  set(file_stem ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/llvm-jitlink)
-  file(WRITE ${file_stem}.symbols ${exports_multiline})
-  file(WRITE ${file_stem}.def "EXPORTS\n${exports_multiline}")
-
-  add_llvm_symbol_exports(llvm-jitlink ${file_stem}.symbols)
-else()
-  export_executable_symbols(llvm-jitlink)
-endif(WIN32)


### PR DESCRIPTION
Reverts llvm/llvm-project#107375

This was causing a build bot failure (https://lab.llvm.org/buildbot/#/builders/201/builds/2954) and also breaks building with VS2019. See https://github.com/llvm/llvm-project/pull/107375#issuecomment-2660709198 for details.