### PR TITLE
[libc++] Explicitly mention vector_bool in the name of benchmarks

### DIFF
--- a/libcxx/test/benchmarks/algorithms/fill.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/fill.bench.cpp
@@ -12,40 +12,40 @@
 #include <benchmark/benchmark.h>
 #include <vector>
 
-static void bm_fill_n(benchmark::State& state) {
+static void bm_fill_n_vector_bool(benchmark::State& state) {
   std::vector<bool> vec1(state.range());
   for (auto _ : state) {
     benchmark::DoNotOptimize(vec1);
     benchmark::DoNotOptimize(std::fill_n(vec1.begin(), vec1.size(), false));
   }
 }
-BENCHMARK(bm_fill_n)->DenseRange(1, 8)->Range(16, 1 << 20);
+BENCHMARK(bm_fill_n_vector_bool)->DenseRange(1, 8)->Range(16, 1 << 20);
 
-static void bm_ranges_fill_n(benchmark::State& state) {
+static void bm_ranges_fill_n_vector_bool(benchmark::State& state) {
   std::vector<bool> vec1(state.range());
   for (auto _ : state) {
     benchmark::DoNotOptimize(vec1);
     benchmark::DoNotOptimize(std::ranges::fill_n(vec1.begin(), vec1.size(), false));
   }
 }
-BENCHMARK(bm_ranges_fill_n)->DenseRange(1, 8)->Range(16, 1 << 20);
+BENCHMARK(bm_ranges_fill_n_vector_bool)->DenseRange(1, 8)->Range(16, 1 << 20);
 
-static void bm_fill(benchmark::State& state) {
+static void bm_fill_vector_bool(benchmark::State& state) {
   std::vector<bool> vec1(state.range());
   for (auto _ : state) {
     benchmark::DoNotOptimize(vec1);
     std::fill(vec1.begin(), vec1.end(), false);
   }
 }
-BENCHMARK(bm_fill)->DenseRange(1, 8)->Range(16, 1 << 20);
+BENCHMARK(bm_fill_vector_bool)->DenseRange(1, 8)->Range(16, 1 << 20);
 
-static void bm_ranges_fill(benchmark::State& state) {
+static void bm_ranges_fill_vector_bool(benchmark::State& state) {
   std::vector<bool> vec1(state.range());
   for (auto _ : state) {
     benchmark::DoNotOptimize(vec1);
     benchmark::DoNotOptimize(std::ranges::fill(vec1, false));
   }
 }
-BENCHMARK(bm_ranges_fill)->DenseRange(1, 8)->Range(16, 1 << 20);
+BENCHMARK(bm_ranges_fill_vector_bool)->DenseRange(1, 8)->Range(16, 1 << 20);
 
 BENCHMARK_MAIN();

--- a/libcxx/test/benchmarks/algorithms/ranges_contains.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/ranges_contains.bench.cpp
@@ -15,7 +15,7 @@
 
 #include "test_iterators.h"
 
-static void bm_contains_char(benchmark::State& state) {
+static void bm_contains_vector_char(benchmark::State& state) {
   std::vector<char> a(state.range(), 'a');
 
   for (auto _ : state) {
@@ -24,9 +24,9 @@ static void bm_contains_char(benchmark::State& state) {
     benchmark::DoNotOptimize(std::ranges::contains(a.begin(), a.end(), 'B'));
   }
 }
-BENCHMARK(bm_contains_char)->RangeMultiplier(16)->Range(16, 16 << 20);
+BENCHMARK(bm_contains_vector_char)->RangeMultiplier(16)->Range(16, 16 << 20);
 
-static void bm_contains_int(benchmark::State& state) {
+static void bm_contains_vector_int(benchmark::State& state) {
   std::vector<int> a(state.range(), 1);
 
   for (auto _ : state) {
@@ -35,9 +35,9 @@ static void bm_contains_int(benchmark::State& state) {
     benchmark::DoNotOptimize(std::ranges::contains(a.begin(), a.end(), 2));
   }
 }
-BENCHMARK(bm_contains_int)->RangeMultiplier(16)->Range(16, 16 << 20);
+BENCHMARK(bm_contains_vector_int)->RangeMultiplier(16)->Range(16, 16 << 20);
 
-static void bm_contains_bool(benchmark::State& state) {
+static void bm_contains_vector_bool(benchmark::State& state) {
   std::vector<bool> a(state.range(), true);
 
   for (auto _ : state) {
@@ -46,6 +46,6 @@ static void bm_contains_bool(benchmark::State& state) {
     benchmark::DoNotOptimize(std::ranges::contains(a.begin(), a.end(), false));
   }
 }
-BENCHMARK(bm_contains_bool)->RangeMultiplier(16)->Range(16, 16 << 20);
+BENCHMARK(bm_contains_vector_bool)->RangeMultiplier(16)->Range(16, 16 << 20);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
We have some benchmarks that were benchmarking very specific functionality, namely the optimizations in vector<bool>::iterator. Call this out in the benchmarks by renaming them appropriately. In the future we will also increase the coverage of these benchmarks to test other containers.