### PR TITLE
[mlir] Improve GreedyPatternRewriteDriver logging

### DIFF
--- a/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -615,14 +615,14 @@ bool GreedyPatternRewriteDriver::processWorklist() {
         matcher.matchAndRewrite(op, rewriter, canApply, onFailure, onSuccess);
 
     if (succeeded(matchResult)) {
-      LLVM_DEBUG(logResultWithLine("success", "pattern matched"));
+      LLVM_DEBUG(logResultWithLine("success", "at least one pattern matched"));
 #if MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS
       expensiveChecks.notifyRewriteSuccess();
 #endif // MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS
       changed = true;
       ++numRewrites;
     } else {
-      LLVM_DEBUG(logResultWithLine("failure", "pattern failed to match"));
+      LLVM_DEBUG(logResultWithLine("failure", "all patterns failed to match"));
 #if MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS
       expensiveChecks.notifyRewriteFailure();
 #endif // MLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS


### PR DESCRIPTION
Currently, when `GreedyPatternRewriteDriver` fails, the log output
contains nested failure messages:

```bash
   } -> failure : pattern failed to match
} -> failure : pattern failed to match
```

This may seem redundant, but these messages refer to different aspects
of the pattern application logic. This patch clarifies the distinction
by separately logging:

* Success/failure for a specific pattern (e.g., "_this pattern_ failed
  to match on the Op currently being processed").
* Success/failure for an operation as a whole (e.g., "_all patterns_
  failed to match the Op currently being processed").

Before (example with success):
```bash
Processing operation : (...) {

  * Pattern (...) -> ()' {
Trying to match "..."
    ** Match Failure : (...)
  } -> failure : pattern failed to match

  * Pattern (...) -> ()' {
Trying to match "..."
  } -> success : pattern applied successfully
} -> success : pattern matched
```

After (example with success):
```bash
Processing operation : (...) {

  * Pattern (...) -> ()' {
Trying to match "..."
    ** Match Failure : (...)
  } -> failure : pattern failed to match

  * Pattern (...) -> ()' {
Trying to match "..."
  } -> success : pattern applied successfully
} -> success : at least one pattern matched
```

This improves log clarity, making it easier to distinguish pattern-level
failures from operation-level outcomes.
