### PR TITLE
[libclc] [cmake] Fix per-target *_convert.cl dependencies

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -249,13 +249,19 @@ function(add_libclc_builtin_set)
 
     get_filename_component( file_dir ${file} DIRECTORY )
 
+    if( ARG_ARCH STREQUAL spirv OR ARG_ARCH STREQUAL spirv64 )
+      set(CONVERT_DEP clspv-generate_convert.cl)
+    else()
+      set(CONVERT_DEP generate_convert.cl)
+    endif()
+
     compile_to_bc(
       TRIPLE ${ARG_TRIPLE}
       INPUT ${input_file}
       OUTPUT ${output_file}
       EXTRA_OPTS -fno-builtin -nostdlib
         "${ARG_COMPILE_FLAGS}" -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
-      DEPENDENCIES generate_convert.cl clspv-generate_convert.cl
+      DEPENDENCIES ${CONVERT_DEP}
     )
     list( APPEND bytecode_files ${output_file} )
   endforeach()


### PR DESCRIPTION
Fix `add_libclc_builtin_set` to add an appropriate dependency to either `clspv-generate_convert.cl` or `generate_convert.cl` based on the `ARCH` argument, rather than to both unconditionally.  This fixes build failures due to missing dependencies when `clspv*` targets are not enabled.

The added check mirrors the one from `libclc/CMakeLists.txt`.

Fixes: #127378