### PR TITLE
[libc++] Verifies std::forward_like's mandates clause.

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -213,7 +213,7 @@
 "`LWG3753 <https://wg21.link/LWG3753>`__","Clarify entity vs. freestanding entity","2022-11 (Kona)","","",""
 "`LWG3754 <https://wg21.link/LWG3754>`__","Class template expected synopsis contains declarations that do not match the detailed description","2022-11 (Kona)","|Nothing To Do|","",""
 "`LWG3755 <https://wg21.link/LWG3755>`__","``tuple-for-each`` can call ``user-defined`` ``operator,``","2022-11 (Kona)","|Complete|","17",""
-"`LWG3757 <https://wg21.link/LWG3757>`__","What's the effect of ``std::forward_like<void>(x)``?","2022-11 (Kona)","","",""
+"`LWG3757 <https://wg21.link/LWG3757>`__","What's the effect of ``std::forward_like<void>(x)``?","2022-11 (Kona)","|Nothing To Do|","",""
 "`LWG3759 <https://wg21.link/LWG3759>`__","``ranges::rotate_copy`` should use ``std::move``","2022-11 (Kona)","|Complete|","15",""
 "`LWG3760 <https://wg21.link/LWG3760>`__","``cartesian_product_view::iterator``'s ``parent_`` is never valid","2022-11 (Kona)","","",""
 "`LWG3761 <https://wg21.link/LWG3761>`__","``cartesian_product_view::iterator::operator-`` should pass by reference","2022-11 (Kona)","","",""

--- a/libcxx/test/std/utilities/utility/forward/forward_like.verify.cpp
+++ b/libcxx/test/std/utilities/utility/forward/forward_like.verify.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++23
+
+// <utility>
+
+// template <typename T>
+// [[nodiscard]] constexpr
+// auto forward_like(auto&& x) noexcept -> see below;
+
+// Mandates: T is a referenceable type (3.45 [defns.referenceable]).
+
+#include <utility>
+
+struct incomplete;
+
+void test() {
+  int i;
+  (void)std::forward_like<incomplete>(i);
+
+  (void)std::forward_like<void>(i);                // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<const void>(i);          // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<volatile void>(i);       // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<const volatile void>(i); // expected-error {{no matching function for call to 'forward_like'}}
+
+  using fp   = void();
+  using cfp  = void() const;
+  using vfp  = void() volatile;
+  using cvfp = void() const volatile;
+  (void)std::forward_like<fp>(i);
+  (void)std::forward_like<cfp>(i);  // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<cfp>(i);  // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<vfp>(i);  // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<cvfp>(i); // expected-error {{no matching function for call to 'forward_like'}}
+
+  using fpr  = void()&;
+  using fprr = void()&&;
+  (void)std::forward_like<fpr>(i);  // expected-error {{no matching function for call to 'forward_like'}}
+  (void)std::forward_like<fprr>(i); // expected-error {{no matching function for call to 'forward_like'}}
+}


### PR DESCRIPTION
The existing using _ForwardLike declaration already fails with a subsitution failure. The LWG issue was filed to clarify what should happen for non-referencable types.

Added test to verify libc++ is already enforcing the new Mandates.

Implements:
- LWG3757 What's the effect of std::forward_like<void>(x)

Closes: #105026