### PR TITLE
[libc++] Fix shrink_to_fit to swap buffer only when capacity is strictly smaller

### DIFF
--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -3495,7 +3495,7 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void basic_string<_CharT, _Traits, _Allocat
     // The Standard mandates shrink_to_fit() does not increase the capacity.
     // With equal capacity keep the existing buffer. This avoids extra work
     // due to swapping the elements.
-    if (__allocation.count - 1 > capacity()) {
+    if (__allocation.count - 1 >= capacity()) {
       __alloc_traits::deallocate(__alloc_, __allocation.ptr, __allocation.count);
       return;
     }

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
@@ -12,11 +12,11 @@
 
 // void shrink_to_fit(); // constexpr since C++20
 
-// Make sure we use an allocation returned by allocate_at_least if it is smaller than the current allocation
-// even if it contains more bytes than we requested
-
 #include <cassert>
 #include <string>
+
+#include "asan_testing.h"
+#include "increasing_allocator.h"
 
 template <typename T>
 struct oversizing_allocator {
@@ -37,6 +37,9 @@ bool operator==(oversizing_allocator<T>, oversizing_allocator<U>) {
   return true;
 }
 
+// Make sure we use an allocation returned by allocate_at_least if it is smaller than the current allocation
+// even if it contains more bytes than we requested.
+// Fix issue: https://github.com/llvm/llvm-project/pull/115659
 void test_oversizing_allocator() {
   std::basic_string<char, std::char_traits<char>, oversizing_allocator<char>> s{
       "String does not fit in the internal buffer and is a bit longer"};
@@ -48,8 +51,37 @@ void test_oversizing_allocator() {
   assert(s.size() == size);
 }
 
+// Ensure that the libc++ implementation of shrink_to_fit does NOT swap buffer with equal allocation sizes
+void test_no_swap_with_equal_allocation_size() {
+  { // Test with custom allocator with a minimum allocation size
+    std::basic_string<char, std::char_traits<char>, min_size_allocator<128, char> > s(
+        "A long string exceeding SSO limit but within min alloc size");
+    std::size_t capacity = s.capacity();
+    std::size_t size     = s.size();
+    auto data            = s.data();
+    s.shrink_to_fit();
+    assert(s.capacity() <= capacity);
+    assert(s.size() == size);
+    assert(is_string_asan_correct(s));
+    assert(s.capacity() == capacity && s.data() == data);
+  }
+  { // Test with custom allocator with a minimum power of two allocation size
+    std::basic_string<char, std::char_traits<char>, pow2_allocator<char> > s(
+        "This is a long string that exceeds the SSO limit");
+    std::size_t capacity = s.capacity();
+    std::size_t size     = s.size();
+    auto data            = s.data();
+    s.shrink_to_fit();
+    assert(s.capacity() <= capacity);
+    assert(s.size() == size);
+    assert(is_string_asan_correct(s));
+    assert(s.capacity() == capacity && s.data() == data);
+  }
+}
+
 int main(int, char**) {
   test_oversizing_allocator();
+  test_no_swap_with_equal_allocation_size();
 
   return 0;
 }

--- a/libcxx/test/libcxx/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/libcxx/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
@@ -51,7 +51,7 @@ void test_oversizing_allocator() {
   assert(s.size() == size);
 }
 
-// Ensure that the libc++ implementation of shrink_to_fit does NOT swap buffer with equal allocation sizes
+// Make sure libc++ shrink_to_fit does NOT swap buffer with equal allocation sizes
 void test_no_swap_with_equal_allocation_size() {
   { // Test with custom allocator with a minimum allocation size
     std::basic_string<char, std::char_traits<char>, min_size_allocator<128, char> > s(

--- a/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
@@ -75,33 +75,6 @@ TEST_CONSTEXPR_CXX20 bool test() {
   }
 #endif
 
-  {   // Ensure that the libc++ implementation of shrink_to_fit does NOT swap buffer with equal allocation sizes
-    { // Test with custom allocator with a minimum allocation size
-      std::basic_string<char, std::char_traits<char>, min_size_allocator<128, char> > s(
-          "A long string exceeding SSO limit but within min alloc size");
-      std::size_t capacity = s.capacity();
-      std::size_t size     = s.size();
-      auto data            = s.data();
-      s.shrink_to_fit();
-      assert(s.capacity() <= capacity);
-      assert(s.size() == size);
-      LIBCPP_ASSERT(is_string_asan_correct(s));
-      LIBCPP_ASSERT(s.capacity() == capacity && s.data() == data);
-    }
-    { // Test with custom allocator with a minimum power of two allocation size
-      std::basic_string<char, std::char_traits<char>, pow2_allocator<char> > s(
-          "This is a long string that exceeds the SSO limit");
-      std::size_t capacity = s.capacity();
-      std::size_t size     = s.size();
-      auto data            = s.data();
-      s.shrink_to_fit();
-      assert(s.capacity() <= capacity);
-      assert(s.size() == size);
-      LIBCPP_ASSERT(is_string_asan_correct(s));
-      LIBCPP_ASSERT(s.capacity() == capacity && s.data() == data);
-    }
-  }
-
   return true;
 }
 

--- a/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
@@ -61,28 +61,54 @@ TEST_CONSTEXPR_CXX20 bool test() {
   test_string<std::basic_string<char, std::char_traits<char>, safe_allocator<char>>>();
 #endif
 
+#if TEST_STD_VER >= 23
+  { // Make sure shrink_to_fit never increases capacity
+    // See: https://github.com/llvm/llvm-project/issues/95161
+    std::basic_string<char, std::char_traits<char>, increasing_allocator<char>> s{
+        "String does not fit in the internal buffer"};
+    std::size_t capacity = s.capacity();
+    std::size_t size     = s.size();
+    s.shrink_to_fit();
+    assert(s.capacity() <= capacity);
+    assert(s.size() == size);
+    LIBCPP_ASSERT(is_string_asan_correct(s));
+  }
+#endif
+
+  {   // Ensure that the libc++ implementation of shrink_to_fit does NOT swap buffer with equal allocation sizes
+    { // Test with custom allocator with a minimum allocation size
+      std::basic_string<char, std::char_traits<char>, min_size_allocator<128, char> > s(
+          "A long string exceeding SSO limit but within min alloc size");
+      std::size_t capacity = s.capacity();
+      std::size_t size     = s.size();
+      auto data            = s.data();
+      s.shrink_to_fit();
+      assert(s.capacity() <= capacity);
+      assert(s.size() == size);
+      LIBCPP_ASSERT(is_string_asan_correct(s));
+      if (s.capacity() == capacity)
+        LIBCPP_ASSERT(s.data() == data);
+    }
+    { // Test with custom allocator with a minimum power of two allocation size
+      std::basic_string<char, std::char_traits<char>, pow2_allocator<char> > s(
+          "This is a long string that exceeds the SSO limit");
+      std::size_t capacity = s.capacity();
+      std::size_t size     = s.size();
+      auto data            = s.data();
+      s.shrink_to_fit();
+      assert(s.capacity() <= capacity);
+      assert(s.size() == size);
+      LIBCPP_ASSERT(is_string_asan_correct(s));
+      if (s.capacity() == capacity)
+        LIBCPP_ASSERT(s.data() == data);
+    }
+  }
+
   return true;
 }
 
-#if TEST_STD_VER >= 23
-// https://github.com/llvm/llvm-project/issues/95161
-void test_increasing_allocator() {
-  std::basic_string<char, std::char_traits<char>, increasing_allocator<char>> s{
-      "String does not fit in the internal buffer"};
-  std::size_t capacity = s.capacity();
-  std::size_t size     = s.size();
-  s.shrink_to_fit();
-  assert(s.capacity() <= capacity);
-  assert(s.size() == size);
-  LIBCPP_ASSERT(is_string_asan_correct(s));
-}
-#endif // TEST_STD_VER >= 23
-
 int main(int, char**) {
   test();
-#if TEST_STD_VER >= 23
-  test_increasing_allocator();
-#endif
 #if TEST_STD_VER > 17
   static_assert(test());
 #endif

--- a/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
@@ -86,8 +86,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
       assert(s.capacity() <= capacity);
       assert(s.size() == size);
       LIBCPP_ASSERT(is_string_asan_correct(s));
-      if (s.capacity() == capacity)
-        LIBCPP_ASSERT(s.data() == data);
+      LIBCPP_ASSERT(s.capacity() == capacity && s.data() == data);
     }
     { // Test with custom allocator with a minimum power of two allocation size
       std::basic_string<char, std::char_traits<char>, pow2_allocator<char> > s(
@@ -99,8 +98,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
       assert(s.capacity() <= capacity);
       assert(s.size() == size);
       LIBCPP_ASSERT(is_string_asan_correct(s));
-      if (s.capacity() == capacity)
-        LIBCPP_ASSERT(s.data() == data);
+      LIBCPP_ASSERT(s.capacity() == capacity && s.data() == data);
     }
   }
 

--- a/libcxx/test/support/increasing_allocator.h
+++ b/libcxx/test/support/increasing_allocator.h
@@ -59,14 +59,6 @@ public:
   template <typename U>
   TEST_CONSTEXPR_CXX20 min_size_allocator(const min_size_allocator<MinAllocSize, U>&) TEST_NOEXCEPT {}
 
-#if TEST_STD_VER >= 23
-  TEST_CONSTEXPR_CXX23 std::allocation_result<T*> allocate_at_least(std::size_t n) {
-    if (n < MinAllocSize)
-      n = MinAllocSize;
-    return std::allocator<T>{}.allocate_at_least(n);
-  }
-#endif // TEST_STD_VER >= 23
-
   TEST_NODISCARD TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
     if (n < MinAllocSize)
       n = MinAllocSize;
@@ -101,12 +93,6 @@ public:
 
   template <typename U>
   TEST_CONSTEXPR_CXX20 pow2_allocator(const pow2_allocator<U>&) TEST_NOEXCEPT {}
-
-#if TEST_STD_VER >= 23
-  TEST_CONSTEXPR_CXX23 std::allocation_result<T*> allocate_at_least(std::size_t n) {
-    return std::allocator<T>{}.allocate_at_least(next_power_of_two(n));
-  }
-#endif // TEST_STD_VER >= 23
 
   TEST_NODISCARD TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
     return std::allocator<T>().allocate(next_power_of_two(n));

--- a/libcxx/test/support/increasing_allocator.h
+++ b/libcxx/test/support/increasing_allocator.h
@@ -10,6 +10,7 @@
 #define TEST_SUPPORT_INCREASING_ALLOCATOR_H
 
 #include <cstddef>
+#include <limits>
 #include <memory>
 
 #include "test_macros.h"
@@ -47,6 +48,91 @@ struct increasing_allocator {
 template <typename T, typename U>
 TEST_CONSTEXPR_CXX20 bool operator==(increasing_allocator<T>, increasing_allocator<U>) TEST_NOEXCEPT {
   return true;
+}
+
+template <std::size_t MinAllocSize, typename T>
+class min_size_allocator {
+public:
+  using value_type     = T;
+  min_size_allocator() = default;
+
+  template <typename U>
+  TEST_CONSTEXPR_CXX20 min_size_allocator(const min_size_allocator<MinAllocSize, U>&) TEST_NOEXCEPT {}
+
+#if TEST_STD_VER >= 23
+  TEST_CONSTEXPR_CXX23 std::allocation_result<T*> allocate_at_least(std::size_t n) {
+    if (n < MinAllocSize)
+      n = MinAllocSize;
+    return std::allocator<T>{}.allocate_at_least(n);
+  }
+#endif // TEST_STD_VER >= 23
+
+  TEST_NODISCARD TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
+    if (n < MinAllocSize)
+      n = MinAllocSize;
+    return std::allocator<T>().allocate(n);
+  }
+
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) TEST_NOEXCEPT { std::allocator<T>().deallocate(p, n); }
+
+  template <typename U>
+  struct rebind {
+    using other = min_size_allocator<MinAllocSize, U>;
+  };
+};
+
+template <std::size_t MinAllocSize, typename T, typename U>
+TEST_CONSTEXPR_CXX20 bool
+operator==(const min_size_allocator<MinAllocSize, T>&, const min_size_allocator<MinAllocSize, U>&) {
+  return true;
+}
+
+template <std::size_t MinAllocSize, typename T, typename U>
+TEST_CONSTEXPR_CXX20 bool
+operator!=(const min_size_allocator<MinAllocSize, T>&, const min_size_allocator<MinAllocSize, U>&) {
+  return false;
+}
+
+template <typename T>
+class pow2_allocator {
+public:
+  using value_type = T;
+  pow2_allocator() = default;
+
+  template <typename U>
+  TEST_CONSTEXPR_CXX20 pow2_allocator(const pow2_allocator<U>&) TEST_NOEXCEPT {}
+
+#if TEST_STD_VER >= 23
+  TEST_CONSTEXPR_CXX23 std::allocation_result<T*> allocate_at_least(std::size_t n) {
+    return std::allocator<T>{}.allocate_at_least(next_power_of_two(n));
+  }
+#endif // TEST_STD_VER >= 23
+
+  TEST_NODISCARD TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
+    return std::allocator<T>().allocate(next_power_of_two(n));
+  }
+
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) TEST_NOEXCEPT { std::allocator<T>().deallocate(p, n); }
+
+private:
+  TEST_CONSTEXPR_CXX20 std::size_t next_power_of_two(std::size_t n) const {
+    if ((n & (n - 1)) == 0)
+      return n;
+    for (std::size_t shift = 1; shift < std::numeric_limits<std::size_t>::digits; shift <<= 1) {
+      n |= n >> shift;
+    }
+    return n + 1;
+  }
+};
+
+template <typename T, typename U>
+TEST_CONSTEXPR_CXX20 bool operator==(const pow2_allocator<T>&, const pow2_allocator<U>&) {
+  return true;
+}
+
+template <typename T, typename U>
+TEST_CONSTEXPR_CXX20 bool operator!=(const pow2_allocator<T>&, const pow2_allocator<U>&) {
+  return false;
 }
 
 #endif // TEST_SUPPORT_INCREASING_ALLOCATOR_H

--- a/libcxx/test/support/increasing_allocator.h
+++ b/libcxx/test/support/increasing_allocator.h
@@ -62,10 +62,10 @@ public:
   TEST_NODISCARD TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
     if (n < MinAllocSize)
       n = MinAllocSize;
-    return std::allocator<T>().allocate(n);
+    return static_cast<T*>(::operator new(n * sizeof(T)));
   }
 
-  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) TEST_NOEXCEPT { std::allocator<T>().deallocate(p, n); }
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t) TEST_NOEXCEPT { ::operator delete(static_cast<void*>(p)); }
 
   template <typename U>
   struct rebind {
@@ -95,10 +95,10 @@ public:
   TEST_CONSTEXPR_CXX20 pow2_allocator(const pow2_allocator<U>&) TEST_NOEXCEPT {}
 
   TEST_NODISCARD TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) {
-    return std::allocator<T>().allocate(next_power_of_two(n));
+    return static_cast<T*>(::operator new(next_power_of_two(n) * sizeof(T)));
   }
 
-  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) TEST_NOEXCEPT { std::allocator<T>().deallocate(p, n); }
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t) TEST_NOEXCEPT { ::operator delete(static_cast<void*>(p)); }
 
 private:
   TEST_CONSTEXPR_CXX20 std::size_t next_power_of_two(std::size_t n) const {


### PR DESCRIPTION
The current implementation of the `shrink_to_fit()` function of `basic_string` swaps to the newly allocated buffer when the new buffer has the same capacity as the existing one. While this is not incorrect, it is truly unnecessary to swap to an equally-sized buffer. With equal capacity, we should keep using the existing buffer and simply deallocate the new one, avoiding the extra work of copying elements. 

The desired behavior was documented in the following comment within the function:

https://github.com/llvm/llvm-project/blob/61ad08792a86e62309b982189a600f4342a38d91/libcxx/include/string#L3560-L3566

However, the existing implementation did not exactly conform to this guideline, which is a QoI matter. 

This PR modifies the `shrink_to_fit()` function to ensure that the buffer is only swapped when the new allocation is strictly smaller than the existing one. When the capacities are equal, the new buffer will be discarded without copying the elements. This is achieved by including the `==` check in the above conditional logic.