### PR TITLE
fixed #95641 pointless string copy

### DIFF
--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -1967,7 +1967,7 @@ public:
   }
 
   void saveInputFilename(std::string Filename) {
-    InputFilename = Filename;
+    InputFilename = std::move(Filename);
   }
 
   void addClass(std::unique_ptr<Record> R) {


### PR DESCRIPTION
fixed #95641 by using std::move for T&&.  