### PR TITLE
[libc++] Fixes (|multi)_set spaceship operator.

### DIFF
--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -1003,9 +1003,9 @@ operator<=(const set<_Key, _Compare, _Allocator>& __x, const set<_Key, _Compare,
 
 #  else // _LIBCPP_STD_VER <= 17
 
-template <class _Key, class _Allocator>
+template <class _Key, class _Compare, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Key>
-operator<=>(const set<_Key, _Allocator>& __x, const set<_Key, _Allocator>& __y) {
+operator<=>(const set<_Key, _Compare, _Allocator>& __x, const set<_Key, _Compare, _Allocator>& __y) {
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), std::__synth_three_way);
 }
 
@@ -1470,9 +1470,9 @@ operator<=(const multiset<_Key, _Compare, _Allocator>& __x, const multiset<_Key,
 
 #  else // _LIBCPP_STD_VER <= 17
 
-template <class _Key, class _Allocator>
+template <class _Key, class _Compare, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI __synth_three_way_result<_Key>
-operator<=>(const multiset<_Key, _Allocator>& __x, const multiset<_Key, _Allocator>& __y) {
+operator<=>(const multiset<_Key, _Compare, _Allocator>& __x, const multiset<_Key, _Compare, _Allocator>& __y) {
   return std::lexicographical_compare_three_way(__x.begin(), __x.end(), __y.begin(), __y.end(), __synth_three_way);
 }
 

--- a/libcxx/test/support/test_container_comparisons.h
+++ b/libcxx/test/support/test_container_comparisons.h
@@ -17,7 +17,7 @@
 #include "test_comparisons.h"
 
 // Implementation detail of `test_sequence_container_spaceship`
-template <template <typename...> typename Container, typename Elem, typename Allocator,  typename Order>
+template <template <typename...> typename Container, typename Elem, typename Allocator, typename Order>
 constexpr void test_sequence_container_spaceship_with_type() {
   // Empty containers
   {
@@ -71,12 +71,21 @@ constexpr bool test_sequence_container_spaceship() {
 
   // Test different comparison categories
   test_sequence_container_spaceship_with_type<Container, int, std::allocator<int>, std::strong_ordering>();
-  test_sequence_container_spaceship_with_type<Container, StrongOrder, test_allocator<StrongOrder>, std::strong_ordering>();
+  test_sequence_container_spaceship_with_type<Container,
+                                              StrongOrder,
+                                              test_allocator<StrongOrder>,
+                                              std::strong_ordering>();
   test_sequence_container_spaceship_with_type<Container, WeakOrder, std::allocator<WeakOrder>, std::weak_ordering>();
-  test_sequence_container_spaceship_with_type<Container, PartialOrder, test_allocator<PartialOrder>, std::partial_ordering>();
+  test_sequence_container_spaceship_with_type<Container,
+                                              PartialOrder,
+                                              test_allocator<PartialOrder>,
+                                              std::partial_ordering>();
 
   // `LessAndEqComp` does not have `operator<=>`. Ordering is synthesized based on `operator<`
-  test_sequence_container_spaceship_with_type<Container, LessAndEqComp, std::allocator<LessAndEqComp>, std::weak_ordering>();
+  test_sequence_container_spaceship_with_type<Container,
+                                              LessAndEqComp,
+                                              std::allocator<LessAndEqComp>,
+                                              std::weak_ordering>();
 
   // Thanks to SFINAE, the following is not a compiler error but returns `false`
   struct NonComparable {};
@@ -176,7 +185,12 @@ constexpr bool test_sequence_container_adaptor_spaceship() {
 }
 
 // Implementation detail of `test_ordered_map_container_spaceship`
-template <template <typename...> typename Container, typename Key, typename Val, typename Allocator, typename Order, typename Compare>
+template <template <typename...> typename Container,
+          typename Key,
+          typename Val,
+          typename Allocator,
+          typename Order,
+          typename Compare>
 constexpr void test_ordered_map_container_spaceship_with_type(Compare comp) {
   // Empty containers
   {
@@ -294,23 +308,63 @@ constexpr bool test_ordered_map_container_spaceship() {
   static_assert(std::three_way_comparable<Container<int, int>>);
 
   // Test different comparison categories
-  test_ordered_map_container_spaceship_with_type<Container, int, int, std::allocator<std::pair<const int, int>>, std::strong_ordering>(std::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, int, test_allocator<std::pair<const int, int>>, std::strong_ordering>(std::greater{});
-  test_ordered_map_container_spaceship_with_type<Container, int, StrongOrder, std::allocator<std::pair<const int, StrongOrder>>, std::strong_ordering>(std::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, StrongOrder, test_allocator<std::pair<const int, StrongOrder>>, std::strong_ordering>(std::greater{});
-  test_ordered_map_container_spaceship_with_type<Container, int, WeakOrder, std::allocator<std::pair<const int, WeakOrder>>, std::weak_ordering>(std::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, WeakOrder, test_allocator<std::pair<const int, WeakOrder>>, std::weak_ordering>(std::greater{});
-  test_ordered_map_container_spaceship_with_type<Container, int, PartialOrder, std::allocator<std::pair<const int, PartialOrder>>, std::partial_ordering>(std ::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, PartialOrder, test_allocator<std::pair<const int, PartialOrder>>, std::partial_ordering>(std ::greater{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 int,
+                                                 std::allocator<std::pair<const int, int>>,
+                                                 std::strong_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 int,
+                                                 test_allocator<std::pair<const int, int>>,
+                                                 std::strong_ordering>(std::greater{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 StrongOrder,
+                                                 std::allocator<std::pair<const int, StrongOrder>>,
+                                                 std::strong_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 StrongOrder,
+                                                 test_allocator<std::pair<const int, StrongOrder>>,
+                                                 std::strong_ordering>(std::greater{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 WeakOrder,
+                                                 std::allocator<std::pair<const int, WeakOrder>>,
+                                                 std::weak_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 WeakOrder,
+                                                 test_allocator<std::pair<const int, WeakOrder>>,
+                                                 std::weak_ordering>(std::greater{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 PartialOrder,
+                                                 std::allocator<std::pair<const int, PartialOrder>>,
+                                                 std::partial_ordering>(std ::less{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 PartialOrder,
+                                                 test_allocator<std::pair<const int, PartialOrder>>,
+                                                 std::partial_ordering>(std ::greater{});
 
   // `LessAndEqComp` does not have `operator<=>`. Ordering is synthesized based on `operator<`
-  test_ordered_map_container_spaceship_with_type<Container, int, LessAndEqComp, std::allocator<std::pair<const int, LessAndEqComp>>, std::weak_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container,
+                                                 int,
+                                                 LessAndEqComp,
+                                                 std::allocator<std::pair<const int, LessAndEqComp>>,
+                                                 std::weak_ordering>(std::less{});
 
   return true;
 }
 
 // Implementation detail of `test_ordered_set_container_spaceship`
-template <template <typename...> typename Container, typename Elem, typename Allocator, typename Order, typename Compare>
+template <template <typename...> typename Container,
+          typename Elem,
+          typename Allocator,
+          typename Order,
+          typename Compare>
 constexpr void test_ordered_set_spaceship_with_type(Compare comp) {
   // Empty containers
   {
@@ -399,15 +453,22 @@ constexpr bool test_ordered_set_container_spaceship() {
   // Test different comparison categories
   test_ordered_set_spaceship_with_type<Container, int, std::allocator<int>, std::strong_ordering>(std::less{});
   test_ordered_set_spaceship_with_type<Container, int, test_allocator<int>, std::strong_ordering>(std::greater{});
-  test_ordered_set_spaceship_with_type<Container, StrongOrder, std::allocator<StrongOrder>, std::strong_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, StrongOrder, test_allocator<StrongOrder>, std::strong_ordering>(std::greater{});
-  test_ordered_set_spaceship_with_type<Container, WeakOrder, std::allocator<WeakOrder>, std::weak_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, WeakOrder, test_allocator<WeakOrder>, std::weak_ordering>(std::greater{});
-  test_ordered_set_spaceship_with_type<Container, PartialOrder, std::allocator<PartialOrder>, std::partial_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, PartialOrder, test_allocator<PartialOrder>, std::partial_ordering>(std::greater{});
+  test_ordered_set_spaceship_with_type<Container, StrongOrder, std::allocator<StrongOrder>, std::strong_ordering>(
+      std::less{});
+  test_ordered_set_spaceship_with_type<Container, StrongOrder, test_allocator<StrongOrder>, std::strong_ordering>(
+      std::greater{});
+  test_ordered_set_spaceship_with_type<Container, WeakOrder, std::allocator<WeakOrder>, std::weak_ordering>(
+      std::less{});
+  test_ordered_set_spaceship_with_type<Container, WeakOrder, test_allocator<WeakOrder>, std::weak_ordering>(
+      std::greater{});
+  test_ordered_set_spaceship_with_type<Container, PartialOrder, std::allocator<PartialOrder>, std::partial_ordering>(
+      std::less{});
+  test_ordered_set_spaceship_with_type<Container, PartialOrder, test_allocator<PartialOrder>, std::partial_ordering>(
+      std::greater{});
 
   // `LessAndEqComp` does not have `operator<=>`. Ordering is synthesized based on `operator<`
-  test_ordered_set_spaceship_with_type<Container, LessAndEqComp, std::allocator<LessAndEqComp>, std::weak_ordering>(std::less{});
+  test_ordered_set_spaceship_with_type<Container, LessAndEqComp, std::allocator<LessAndEqComp>, std::weak_ordering>(
+      std::less{});
 
   return true;
 }

--- a/libcxx/test/support/test_container_comparisons.h
+++ b/libcxx/test/support/test_container_comparisons.h
@@ -13,51 +13,52 @@
 #include <functional>
 #include <set>
 
+#include "test_allocator.h"
 #include "test_comparisons.h"
 
 // Implementation detail of `test_sequence_container_spaceship`
-template <template <typename...> typename Container, typename Elem, typename Order>
+template <template <typename...> typename Container, typename Elem, typename Allocator,  typename Order>
 constexpr void test_sequence_container_spaceship_with_type() {
   // Empty containers
   {
-    Container<Elem> l1;
-    Container<Elem> l2;
+    Container<Elem, Allocator> l1;
+    Container<Elem, Allocator> l2;
     assert(testOrder(l1, l2, Order::equivalent));
   }
   // Identical contents
   {
-    Container<Elem> l1{1, 1};
-    Container<Elem> l2{1, 1};
+    Container<Elem, Allocator> l1{1, 1};
+    Container<Elem, Allocator> l2{1, 1};
     assert(testOrder(l1, l2, Order::equivalent));
   }
   // Less, due to contained values
   {
-    Container<Elem> l1{1, 1};
-    Container<Elem> l2{1, 2};
+    Container<Elem, Allocator> l1{1, 1};
+    Container<Elem, Allocator> l2{1, 2};
     assert(testOrder(l1, l2, Order::less));
   }
   // Greater, due to contained values
   {
-    Container<Elem> l1{1, 3};
-    Container<Elem> l2{1, 2};
+    Container<Elem, Allocator> l1{1, 3};
+    Container<Elem, Allocator> l2{1, 2};
     assert(testOrder(l1, l2, Order::greater));
   }
   // Shorter list
   {
-    Container<Elem> l1{1};
-    Container<Elem> l2{1, 2};
+    Container<Elem, Allocator> l1{1};
+    Container<Elem, Allocator> l2{1, 2};
     assert(testOrder(l1, l2, Order::less));
   }
   // Longer list
   {
-    Container<Elem> l1{1, 2};
-    Container<Elem> l2{1};
+    Container<Elem, Allocator> l1{1, 2};
+    Container<Elem, Allocator> l2{1};
     assert(testOrder(l1, l2, Order::greater));
   }
   // Unordered
   if constexpr (std::is_same_v<Elem, PartialOrder>) {
-    Container<Elem> l1{1, std::numeric_limits<int>::min()};
-    Container<Elem> l2{1, 2};
+    Container<Elem, Allocator> l1{1, std::numeric_limits<int>::min()};
+    Container<Elem, Allocator> l2{1, 2};
     assert(testOrder(l1, l2, Order::unordered));
   }
 }
@@ -69,13 +70,13 @@ constexpr bool test_sequence_container_spaceship() {
   static_assert(std::three_way_comparable<Container<int>>);
 
   // Test different comparison categories
-  test_sequence_container_spaceship_with_type<Container, int, std::strong_ordering>();
-  test_sequence_container_spaceship_with_type<Container, StrongOrder, std::strong_ordering>();
-  test_sequence_container_spaceship_with_type<Container, WeakOrder, std::weak_ordering>();
-  test_sequence_container_spaceship_with_type<Container, PartialOrder, std::partial_ordering>();
+  test_sequence_container_spaceship_with_type<Container, int, std::allocator<int>, std::strong_ordering>();
+  test_sequence_container_spaceship_with_type<Container, StrongOrder, test_allocator<StrongOrder>, std::strong_ordering>();
+  test_sequence_container_spaceship_with_type<Container, WeakOrder, std::allocator<WeakOrder>, std::weak_ordering>();
+  test_sequence_container_spaceship_with_type<Container, PartialOrder, test_allocator<PartialOrder>, std::partial_ordering>();
 
   // `LessAndEqComp` does not have `operator<=>`. Ordering is synthesized based on `operator<`
-  test_sequence_container_spaceship_with_type<Container, LessAndEqComp, std::weak_ordering>();
+  test_sequence_container_spaceship_with_type<Container, LessAndEqComp, std::allocator<LessAndEqComp>, std::weak_ordering>();
 
   // Thanks to SFINAE, the following is not a compiler error but returns `false`
   struct NonComparable {};
@@ -175,109 +176,109 @@ constexpr bool test_sequence_container_adaptor_spaceship() {
 }
 
 // Implementation detail of `test_ordered_map_container_spaceship`
-template <template <typename...> typename Container, typename Key, typename Val, typename Order, typename Compare>
+template <template <typename...> typename Container, typename Key, typename Val, typename Allocator, typename Order, typename Compare>
 constexpr void test_ordered_map_container_spaceship_with_type(Compare comp) {
   // Empty containers
   {
-    Container<Key, Val, Compare> l1{{}, comp};
-    Container<Key, Val, Compare> l2{{}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{}, comp};
     assert(testOrder(l1, l2, Order::equivalent));
   }
   // Identical contents
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 1}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 1}}, comp};
     assert(testOrder(l1, l2, Order::equivalent));
   }
   // Less, due to contained values
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 1}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::less));
   }
   // Greater, due to contained values
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 3}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 3}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::greater));
   }
   // Shorter list
   {
-    Container<Key, Val, Compare> l1{{{1, 1}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::less));
   }
   // Longer list
   {
-    Container<Key, Val, Compare> l1{{{1, 2}, {2, 2}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 2}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}}, comp};
     assert(testOrder(l1, l2, Order::greater));
   }
   // Unordered
   if constexpr (std::is_same_v<Val, PartialOrder>) {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, std::numeric_limits<int>::min()}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, std::numeric_limits<int>::min()}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::unordered));
   }
 
   // Identical contents
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 1}, {2, 2}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 1}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::equivalent));
 
-    Container<Key, Val, Compare> l3{{{1, 1}, {2, 1}, {2, 2}}, comp};
-    Container<Key, Val, Compare> l4{{{2, 1}, {2, 2}, {1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l3{{{1, 1}, {2, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l4{{{2, 1}, {2, 2}, {1, 1}}, comp};
     assert(testOrder(l3, l4, Order::equivalent));
   }
   // Less, due to contained values
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 1}, {2, 1}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 1}, {2, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::less));
 
-    Container<Key, Val, Compare> l3{{{1, 1}, {2, 1}, {2, 1}}, comp};
-    Container<Key, Val, Compare> l4{{{2, 2}, {2, 2}, {1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l3{{{1, 1}, {2, 1}, {2, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l4{{{2, 2}, {2, 2}, {1, 1}}, comp};
     assert(testOrder(l3, l4, Order::less));
   }
   // Greater, due to contained values
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 3}, {2, 3}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 3}, {2, 3}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::greater));
 
-    Container<Key, Val, Compare> l3{{{1, 1}, {2, 3}, {2, 3}}, comp};
-    Container<Key, Val, Compare> l4{{{2, 2}, {2, 2}, {1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l3{{{1, 1}, {2, 3}, {2, 3}}, comp};
+    Container<Key, Val, Compare, Allocator> l4{{{2, 2}, {2, 2}, {1, 1}}, comp};
     assert(testOrder(l3, l4, Order::greater));
   }
   // Shorter list
   {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, 2}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}, {2, 2}, {3, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}, {2, 2}, {3, 1}}, comp};
     assert(testOrder(l1, l2, Order::less));
 
-    Container<Key, Val, Compare> l3{{{1, 1}, {2, 2}}, comp};
-    Container<Key, Val, Compare> l4{{{3, 1}, {2, 2}, {2, 2}, {1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l3{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l4{{{3, 1}, {2, 2}, {2, 2}, {1, 1}}, comp};
     assert(testOrder(l3, l4, Order::less));
   }
   // Longer list
   {
-    Container<Key, Val, Compare> l1{{{1, 2}, {2, 2}, {2, 2}, {3, 1}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 2}, {2, 2}, {2, 2}, {3, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}}, comp};
     assert(testOrder(l1, l2, Order::greater));
 
-    Container<Key, Val, Compare> l3{{{1, 2}, {2, 2}, {2, 2}, {3, 1}}, comp};
-    Container<Key, Val, Compare> l4{{{2, 2}, {1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l3{{{1, 2}, {2, 2}, {2, 2}, {3, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l4{{{2, 2}, {1, 1}}, comp};
     assert(testOrder(l3, l4, Order::greater));
   }
   // Unordered
   if constexpr (std::is_same_v<Val, PartialOrder>) {
-    Container<Key, Val, Compare> l1{{{1, 1}, {2, std::numeric_limits<int>::min()}, {2, 3}}, comp};
-    Container<Key, Val, Compare> l2{{{1, 1}, {2, 2}, {2, 3}}, comp};
+    Container<Key, Val, Compare, Allocator> l1{{{1, 1}, {2, std::numeric_limits<int>::min()}, {2, 3}}, comp};
+    Container<Key, Val, Compare, Allocator> l2{{{1, 1}, {2, 2}, {2, 3}}, comp};
     assert(testOrder(l1, l2, Order::unordered));
 
-    Container<Key, Val, Compare> l3{{{1, 1}, {2, std::numeric_limits<int>::min()}, {2, 3}}, comp};
-    Container<Key, Val, Compare> l4{{{2, 3}, {2, 2}, {1, 1}}, comp};
+    Container<Key, Val, Compare, Allocator> l3{{{1, 1}, {2, std::numeric_limits<int>::min()}, {2, 3}}, comp};
+    Container<Key, Val, Compare, Allocator> l4{{{2, 3}, {2, 2}, {1, 1}}, comp};
     assert(testOrder(l3, l4, Order::unordered));
   }
 }
@@ -293,94 +294,94 @@ constexpr bool test_ordered_map_container_spaceship() {
   static_assert(std::three_way_comparable<Container<int, int>>);
 
   // Test different comparison categories
-  test_ordered_map_container_spaceship_with_type<Container, int, int, std::strong_ordering>(std::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, int, std::strong_ordering>(std::greater{});
-  test_ordered_map_container_spaceship_with_type<Container, int, StrongOrder, std::strong_ordering>(std::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, StrongOrder, std::strong_ordering>(std::greater{});
-  test_ordered_map_container_spaceship_with_type<Container, int, WeakOrder, std::weak_ordering>(std::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, WeakOrder, std::weak_ordering>(std::greater{});
-  test_ordered_map_container_spaceship_with_type<Container, int, PartialOrder, std::partial_ordering>(std ::less{});
-  test_ordered_map_container_spaceship_with_type<Container, int, PartialOrder, std::partial_ordering>(std ::greater{});
+  test_ordered_map_container_spaceship_with_type<Container, int, int, std::allocator<std::pair<const int, int>>, std::strong_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container, int, int, test_allocator<std::pair<const int, int>>, std::strong_ordering>(std::greater{});
+  test_ordered_map_container_spaceship_with_type<Container, int, StrongOrder, std::allocator<std::pair<const int, StrongOrder>>, std::strong_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container, int, StrongOrder, test_allocator<std::pair<const int, StrongOrder>>, std::strong_ordering>(std::greater{});
+  test_ordered_map_container_spaceship_with_type<Container, int, WeakOrder, std::allocator<std::pair<const int, WeakOrder>>, std::weak_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container, int, WeakOrder, test_allocator<std::pair<const int, WeakOrder>>, std::weak_ordering>(std::greater{});
+  test_ordered_map_container_spaceship_with_type<Container, int, PartialOrder, std::allocator<std::pair<const int, PartialOrder>>, std::partial_ordering>(std ::less{});
+  test_ordered_map_container_spaceship_with_type<Container, int, PartialOrder, test_allocator<std::pair<const int, PartialOrder>>, std::partial_ordering>(std ::greater{});
 
   // `LessAndEqComp` does not have `operator<=>`. Ordering is synthesized based on `operator<`
-  test_ordered_map_container_spaceship_with_type<Container, int, LessAndEqComp, std::weak_ordering>(std::less{});
+  test_ordered_map_container_spaceship_with_type<Container, int, LessAndEqComp, std::allocator<std::pair<const int, LessAndEqComp>>, std::weak_ordering>(std::less{});
 
   return true;
 }
 
 // Implementation detail of `test_ordered_set_container_spaceship`
-template <template <typename...> typename Container, typename Elem, typename Order, typename Compare>
+template <template <typename...> typename Container, typename Elem, typename Allocator, typename Order, typename Compare>
 constexpr void test_ordered_set_spaceship_with_type(Compare comp) {
   // Empty containers
   {
-    Container<Elem, Compare> l1{{}, comp};
-    Container<Elem, Compare> l2{{}, comp};
+    Container<Elem, Compare, Allocator> l1{{}, comp};
+    Container<Elem, Compare, Allocator> l2{{}, comp};
     assert(testOrder(l1, l2, Order::equivalent));
   }
   // Identical contents
   {
-    Container<Elem, Compare> l1{{1, 1, 2}, comp};
-    Container<Elem, Compare> l2{{1, 1, 2}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, 1, 2}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 1, 2}, comp};
     assert(testOrder(l1, l2, Order::equivalent));
   }
   // Less, due to contained values
   {
-    Container<Elem, Compare> l1{{1, 1, 2, 3}, comp};
-    Container<Elem, Compare> l2{{1, 2, 2, 4}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, 1, 2, 3}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 2, 2, 4}, comp};
     assert(testOrder(l1, l2, Order::less));
   }
   // Greater, due to contained values
   {
-    Container<Elem, Compare> l1{{1, 2, 2, 4}, comp};
-    Container<Elem, Compare> l2{{1, 1, 2, 3}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, 2, 2, 4}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 1, 2, 3}, comp};
     assert(testOrder(l1, l2, Order::greater));
   }
   // Shorter list
   {
-    Container<Elem, Compare> l1{{1, 1, 2, 2}, comp};
-    Container<Elem, Compare> l2{{1, 1, 2, 2, 3}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, 1, 2, 2}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 1, 2, 2, 3}, comp};
     assert(testOrder(l1, l2, Order::less));
   }
   // Longer list
   {
-    Container<Elem, Compare> l1{{1, 1, 2, 2, 3}, comp};
-    Container<Elem, Compare> l2{{1, 1, 2, 2}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, 1, 2, 2, 3}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 1, 2, 2}, comp};
     assert(testOrder(l1, l2, Order::greater));
   }
   // Unordered
   if constexpr (std::is_same_v< Container<Elem>, std::multiset<PartialOrder>>) {
     if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::less{})>) {
-      Container<Elem, Compare> l1{{1, std::numeric_limits<int>::min()}, comp};
-      Container<Elem, Compare> l2{{1, 2}, comp};
+      Container<Elem, Compare, Allocator> l1{{1, std::numeric_limits<int>::min()}, comp};
+      Container<Elem, Compare, Allocator> l2{{1, 2}, comp};
       assert(testOrder(l1, l2, Order::unordered));
     }
     if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::less{})>) {
-      Container<Elem, Compare> l1{{1, std::numeric_limits<int>::max()}, comp};
-      Container<Elem, Compare> l2{{1, 2}, comp};
+      Container<Elem, Compare, Allocator> l1{{1, std::numeric_limits<int>::max()}, comp};
+      Container<Elem, Compare, Allocator> l2{{1, 2}, comp};
       assert(testOrder(l1, l2, Order::unordered));
     }
   }
   if constexpr (std::is_same_v< Container<Elem>, std::set<PartialOrder>>) {
     // Unordered values are not supported for `set`
     if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::less{})>) {
-      Container<Elem, Compare> l1{{1, std::numeric_limits<int>::min()}, comp};
-      Container<Elem, Compare> l2{{1, 2}, comp};
+      Container<Elem, Compare, Allocator> l1{{1, std::numeric_limits<int>::min()}, comp};
+      Container<Elem, Compare, Allocator> l2{{1, 2}, comp};
       assert(testOrder(l1, l2, Order::less));
     }
     if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::less{})>) {
-      Container<Elem, Compare> l1{{1, std::numeric_limits<int>::max()}, comp};
-      Container<Elem, Compare> l2{{1, 2}, comp};
+      Container<Elem, Compare, Allocator> l1{{1, std::numeric_limits<int>::max()}, comp};
+      Container<Elem, Compare, Allocator> l2{{1, 2}, comp};
       assert(testOrder(l1, l2, Order::less));
     }
   }
   if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::greater{})>) {
-    Container<Elem, Compare> l1{{1, std::numeric_limits<int>::min()}, comp};
-    Container<Elem, Compare> l2{{1, 2}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, std::numeric_limits<int>::min()}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 2}, comp};
     assert(testOrder(l1, l2, Order::less));
   }
   if constexpr (std::is_same_v<Elem, PartialOrder> && std::is_same_v<Compare, decltype(std::greater{})>) {
-    Container<Elem, Compare> l1{{1, std::numeric_limits<int>::max()}, comp};
-    Container<Elem, Compare> l2{{1, 2}, comp};
+    Container<Elem, Compare, Allocator> l1{{1, std::numeric_limits<int>::max()}, comp};
+    Container<Elem, Compare, Allocator> l2{{1, 2}, comp};
     assert(testOrder(l1, l2, Order::less));
   }
 }
@@ -396,17 +397,17 @@ constexpr bool test_ordered_set_container_spaceship() {
   static_assert(std::three_way_comparable<Container<int>>);
 
   // Test different comparison categories
-  test_ordered_set_spaceship_with_type<Container, int, std::strong_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, int, std::strong_ordering>(std::greater{});
-  test_ordered_set_spaceship_with_type<Container, StrongOrder, std::strong_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, StrongOrder, std::strong_ordering>(std::greater{});
-  test_ordered_set_spaceship_with_type<Container, WeakOrder, std::weak_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, WeakOrder, std::weak_ordering>(std::greater{});
-  test_ordered_set_spaceship_with_type<Container, PartialOrder, std::partial_ordering>(std::less{});
-  test_ordered_set_spaceship_with_type<Container, PartialOrder, std::partial_ordering>(std::greater{});
+  test_ordered_set_spaceship_with_type<Container, int, std::allocator<int>, std::strong_ordering>(std::less{});
+  test_ordered_set_spaceship_with_type<Container, int, test_allocator<int>, std::strong_ordering>(std::greater{});
+  test_ordered_set_spaceship_with_type<Container, StrongOrder, std::allocator<StrongOrder>, std::strong_ordering>(std::less{});
+  test_ordered_set_spaceship_with_type<Container, StrongOrder, test_allocator<StrongOrder>, std::strong_ordering>(std::greater{});
+  test_ordered_set_spaceship_with_type<Container, WeakOrder, std::allocator<WeakOrder>, std::weak_ordering>(std::less{});
+  test_ordered_set_spaceship_with_type<Container, WeakOrder, test_allocator<WeakOrder>, std::weak_ordering>(std::greater{});
+  test_ordered_set_spaceship_with_type<Container, PartialOrder, std::allocator<PartialOrder>, std::partial_ordering>(std::less{});
+  test_ordered_set_spaceship_with_type<Container, PartialOrder, test_allocator<PartialOrder>, std::partial_ordering>(std::greater{});
 
   // `LessAndEqComp` does not have `operator<=>`. Ordering is synthesized based on `operator<`
-  test_ordered_set_spaceship_with_type<Container, LessAndEqComp, std::weak_ordering>(std::less{});
+  test_ordered_set_spaceship_with_type<Container, LessAndEqComp, std::allocator<LessAndEqComp>, std::weak_ordering>(std::less{});
 
   return true;
 }


### PR DESCRIPTION
The operators did not have a _Compare template arguement. The fix updates the generic container test to use allocators for all types used. No other issues were found.

Fixes: #127095