### PR TITLE
[libc++][TZDB] Fixes mapping of nonexisting time.

### DIFF
--- a/libcxx/include/__chrono/time_zone.h
+++ b/libcxx/include/__chrono/time_zone.h
@@ -103,9 +103,13 @@ public:
   to_sys(const local_time<_Duration>& __time, choose __z) const {
     local_info __info = get_info(__time);
     switch (__info.result) {
-    case local_info::unique:
-    case local_info::nonexistent: // first and second are the same
+    case local_info::unique: // first and second are the same
       return sys_time<common_type_t<_Duration, seconds>>{__time.time_since_epoch() - __info.first.offset};
+
+    case local_info::nonexistent:
+      // first and second are the same
+      // All non-existing values are converted to the same time.
+      return sys_time<common_type_t<_Duration, seconds>>{__info.first.end};
 
     case local_info::ambiguous:
       switch (__z) {


### PR DESCRIPTION
All non-existing local times in a contiguous range should map to the same time point. This fixes a bug, were the times inside the range were mapped to the wrong time.

Fixes: #113654