### PR TITLE
[clang][x86] Support -masm=intel in cpuid.h

### DIFF
--- a/clang/lib/Headers/cpuid.h
+++ b/clang/lib/Headers/cpuid.h
@@ -268,16 +268,16 @@
 #else
 /* x86-64 uses %rbx as the base register, so preserve it. */
 #define __cpuid(__leaf, __eax, __ebx, __ecx, __edx) \
-    __asm("  xchgq  %%rbx,%q1\n" \
+    __asm("  xchg{q|}  {%%|}rbx,%q1\n" \
           "  cpuid\n" \
-          "  xchgq  %%rbx,%q1" \
+          "  xchg{q|}  {%%|}rbx,%q1" \
         : "=a"(__eax), "=r" (__ebx), "=c"(__ecx), "=d"(__edx) \
         : "0"(__leaf))
 
 #define __cpuid_count(__leaf, __count, __eax, __ebx, __ecx, __edx) \
-    __asm("  xchgq  %%rbx,%q1\n" \
+    __asm("  xchg{q|}  {%%|}rbx,%q1\n" \
           "  cpuid\n" \
-          "  xchgq  %%rbx,%q1" \
+          "  xchg{q|}  {%%|}rbx,%q1" \
         : "=a"(__eax), "=r" (__ebx), "=c"(__ecx), "=d"(__edx) \
         : "0"(__leaf), "2"(__count))
 #endif
@@ -289,18 +289,18 @@ static __inline unsigned int __get_cpuid_max (unsigned int __leaf,
 #ifdef __i386__
     int __cpuid_supported;
 
-    __asm("  pushfl\n"
-          "  popl   %%eax\n"
-          "  movl   %%eax,%%ecx\n"
-          "  xorl   $0x00200000,%%eax\n"
-          "  pushl  %%eax\n"
-          "  popfl\n"
-          "  pushfl\n"
-          "  popl   %%eax\n"
-          "  movl   $0,%0\n"
-          "  cmpl   %%eax,%%ecx\n"
+    __asm("  pushf{l|d}\n"
+          "  pop{l|}   {%%|}eax\n"
+          "  mov{l|}   {%%eax,%%ecx|ecx,eax}\n"
+          "  xor{l|}   {$0x00200000,%%eax|eax,0x00200000}\n"
+          "  push{l|}  {%%|}eax\n"
+          "  popf{l|d}\n"
+          "  pushf{l|d}\n"
+          "  pop{l|}   {%%|}eax\n"
+          "  mov{l|}   {$0,%0|%0,0}\n"
+          "  cmp{l|}   {%%eax,%%ecx|ecx,eax}\n"
           "  je     1f\n"
-          "  movl   $1,%0\n"
+          "  mov{l|}   {$1,%0|%0,1}\n"
           "1:"
         : "=r" (__cpuid_supported) : : "eax", "ecx");
     if (!__cpuid_supported)

--- a/clang/lib/Headers/cpuid.h
+++ b/clang/lib/Headers/cpuid.h
@@ -267,7 +267,6 @@
                   : "0"(__leaf), "2"(__count))
 #else
 /* x86-64 uses %rbx as the base register, so preserve it. */
-#define __cpuid(__leaf, __eax, __ebx, __ecx, __edx) \
 #define __cpuid(__leaf, __eax, __ebx, __ecx, __edx)                            \
   __asm("  xchg{q|}  {%%|}rbx,%q1\n"                                           \
         "  cpuid\n"                                                            \

--- a/clang/lib/Headers/cpuid.h
+++ b/clang/lib/Headers/cpuid.h
@@ -268,17 +268,18 @@
 #else
 /* x86-64 uses %rbx as the base register, so preserve it. */
 #define __cpuid(__leaf, __eax, __ebx, __ecx, __edx) \
-    __asm("  xchg{q|}  {%%|}rbx,%q1\n" \
-          "  cpuid\n" \
-          "  xchg{q|}  {%%|}rbx,%q1" \
-        : "=a"(__eax), "=r" (__ebx), "=c"(__ecx), "=d"(__edx) \
+#define __cpuid(__leaf, __eax, __ebx, __ecx, __edx)                            \
+  __asm("  xchg{q|}  {%%|}rbx,%q1\n"                                           \
+        "  cpuid\n"                                                            \
+        "  xchg{q|}  {%%|}rbx,%q1"                                             \
+        : "=a"(__eax), "=r"(__ebx), "=c"(__ecx), "=d"(__edx)                   \
         : "0"(__leaf))
 
-#define __cpuid_count(__leaf, __count, __eax, __ebx, __ecx, __edx) \
-    __asm("  xchg{q|}  {%%|}rbx,%q1\n" \
-          "  cpuid\n" \
-          "  xchg{q|}  {%%|}rbx,%q1" \
-        : "=a"(__eax), "=r" (__ebx), "=c"(__ecx), "=d"(__edx) \
+#define __cpuid_count(__leaf, __count, __eax, __ebx, __ecx, __edx)             \
+  __asm("  xchg{q|}  {%%|}rbx,%q1\n"                                           \
+        "  cpuid\n"                                                            \
+        "  xchg{q|}  {%%|}rbx,%q1"                                             \
+        : "=a"(__eax), "=r"(__ebx), "=c"(__ecx), "=d"(__edx)                   \
         : "0"(__leaf), "2"(__count))
 #endif
 
@@ -302,7 +303,9 @@ static __inline unsigned int __get_cpuid_max (unsigned int __leaf,
           "  je     1f\n"
           "  mov{l|}   {$1,%0|%0,1}\n"
           "1:"
-        : "=r" (__cpuid_supported) : : "eax", "ecx");
+          : "=r"(__cpuid_supported)
+          :
+          : "eax", "ecx");
     if (!__cpuid_supported)
         return 0;
 #endif

--- a/clang/test/Headers/cpuid.c
+++ b/clang/test/Headers/cpuid.c
@@ -4,9 +4,9 @@
 #include <cpuid.h>
 #include <cpuid.h> // Make sure multiple inclusion protection works.
 
-// CHECK-64: {{.*}} call { i32, i32, i32, i32 } asm "  xchgq  %rbx,${1:q}\0A cpuid\0A xchgq %rbx,${1:q}", "={ax},=r,={cx},={dx},0,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}})
-// CHECK-64: {{.*}} call { i32, i32, i32, i32 } asm "  xchgq  %rbx,${1:q}\0A  cpuid\0A  xchgq  %rbx,${1:q}", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}}, i32 %{{[a-z0-9]+}})
-// CHECK-64: {{.*}} call { i32, i32, i32, i32 } asm "  xchgq  %rbx,${1:q}\0A  cpuid\0A  xchgq  %rbx,${1:q}", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}}, i32 %{{[a-z0-9]+}})
+// CHECK-64: {{.*}} call { i32, i32, i32, i32 } asm "  xchg$(q$|$)  $(%$|$)rbx,${1:q}\0A  cpuid\0A  xchg$(q$|$)  $(%$|$)rbx,${1:q}", "={ax},=r,={cx},={dx},0,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}})
+// CHECK-64: {{.*}} call { i32, i32, i32, i32 } asm "  xchg$(q$|$)  $(%$|$)rbx,${1:q}\0A  cpuid\0A  xchg$(q$|$)  $(%$|$)rbx,${1:q}", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}}, i32 %{{[a-z0-9]+}})
+// CHECK-64: {{.*}} call { i32, i32, i32, i32 } asm "  xchg$(q$|$)  $(%$|$)rbx,${1:q}\0A  cpuid\0A  xchg$(q$|$)  $(%$|$)rbx,${1:q}", "={ax},=r,={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}}, i32 %{{[a-z0-9]+}})
 
 // CHECK-32: {{.*}} call { i32, i32, i32, i32 } asm "cpuid", "={ax},={bx},={cx},={dx},0,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}})
 // CHECK-32: {{.*}} call { i32, i32, i32, i32 } asm "cpuid", "={ax},={bx},={cx},={dx},0,2,~{dirflag},~{fpsr},~{flags}"(i32 %{{[a-z0-9]+}}, i32 %{{[a-z0-9]+}})


### PR DESCRIPTION
Fixes #127271

Testing mostly done in Compiler Explorer https://godbolt.org/z/q1h3ohxr7