### PR TITLE
[flang] Revert MLIR_MAIN_SRC_DIR override

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -230,11 +230,6 @@ if (FLANG_STANDALONE_BUILD)
     add_custom_target(doxygen ALL)
   endif()
 
-  # Override the value from installed CMake files, as they refer
-  # to the directory used during the original MLIR package build,
-  # which may be no longer available.  Instead, use the current checkout.
-  set(MLIR_MAIN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../mlir )
-
 else()
   option(FLANG_INCLUDE_TESTS
          "Generate build targets for the Flang unit tests."


### PR DESCRIPTION
This change is no longer necessary after #125842.  Thanks to @nikic for letting me know.