### PR TITLE
[clang] [Driver] Fix respecting libdir when locating flang runtime

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1367,7 +1367,7 @@ void tools::addFortranRuntimeLibraryPath(const ToolChain &TC,
   // lib64 instead of lib.
   SmallString<256> DefaultLibPath =
       llvm::sys::path::parent_path(TC.getDriver().Dir);
-  llvm::sys::path::append(DefaultLibPath, "lib");
+  llvm::sys::path::append(DefaultLibPath, CLANG_INSTALL_LIBDIR_BASENAME);
   if (TC.getTriple().isKnownWindowsMSVCEnvironment())
     CmdArgs.push_back(Args.MakeArgString("-libpath:" + DefaultLibPath));
   else


### PR DESCRIPTION
Fix `tools::addFortranRuntimeLibraryPath` to use
`CLANG_INSTALL_LIBDIR_BASENAME` rather than hardwired `lib` directory. This fixes flang being unable to find its runtime when installed into nonstandard directory on a system using `lib64` for 64-bit libraries. While technically flang runtime could be installed with a different libdir value than clang, it seems rather unlikely.