### PR TITLE
[libc] Produce standard-compliant header guard macros in hdrgen

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_COMMON_H
-#define LLVM_LIBC_COMMON_H
+#ifndef _LLVM_LIBC_COMMON_H
+#define _LLVM_LIBC_COMMON_H
 
 #define __LLVM_LIBC__ 1
 
@@ -87,4 +87,4 @@
 
 #endif // __cplusplus
 
-#endif // LLVM_LIBC_COMMON_H
+#endif // _LLVM_LIBC_COMMON_H

--- a/libc/utils/hdrgen/header.py
+++ b/libc/utils/hdrgen/header.py
@@ -124,7 +124,7 @@ class HeaderFile:
         }
 
     def header_guard(self):
-        return "LLVM_LIBC_" + "_".join(
+        return "_LLVM_LIBC_" + "_".join(
             word.upper() for word in NONIDENTIFIER.split(self.name) if word
         )
 

--- a/libc/utils/hdrgen/tests/expected_output/subdir/test.h
+++ b/libc/utils/hdrgen/tests/expected_output/subdir/test.h
@@ -6,8 +6,8 @@
 //
 //===---------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SUBDIR_TEST_H
-#define LLVM_LIBC_SUBDIR_TEST_H
+#ifndef _LLVM_LIBC_SUBDIR_TEST_H
+#define _LLVM_LIBC_SUBDIR_TEST_H
 
 #include "../__llvm-libc-common.h"
 #include "../llvm-libc-types/type_a.h"
@@ -23,4 +23,4 @@ int *ptrfunc(void) __NOEXCEPT;
 
 __END_C_DECLS
 
-#endif // LLVM_LIBC_SUBDIR_TEST_H
+#endif // _LLVM_LIBC_SUBDIR_TEST_H


### PR DESCRIPTION
Macros starting with alphabetic characters such as "LLVM" are in
the application name space and cannot be defined or used by a
conforming implementation's headers.  This fixes the headers that
are entirely generated, and the __llvm-libc-common.h header to
use a conforming macro name for the header guard.  That is, it
starts with "_LLVM_LIBC_" instead of "LLVM_LIBC_", as identifiers
starting with an underscore followed by a capital letter are in
the name space reserved for the implementation.

The remaining headers either will be fixed implicitly by removal
of their custom template files, or will need to be fixed by hand.
