### PR TITLE
[NFC][AMDGPU] Remove an obsolete debug assertion trigger

### DIFF
--- a/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
@@ -512,10 +512,6 @@ bool PhiLoweringHelper::lowerPhis() {
              DT->getNode(RHS.Block)->getDFSNumIn();
     });
 
-#ifndef NDEBUG
-    PhiRegisters.insert(DstReg);
-#endif
-
     // Phis in a loop that are observed outside the loop receive a simple but
     // conservatively correct treatment.
     std::vector<MachineBasicBlock *> DomBlocks = {&MBB};


### PR DESCRIPTION
The removed code block was previously used to trigger an assertion, which has
since been fixed. However, its presence could cause inconsistent check lines
between debug (or assertion-enabled) builds and release builds. The fact that no
test updates were needed further confirms that this issue no longer exists.

Fixes SWDEV-515712.