### PR TITLE
[clangd] Enable parsing of forwarding functions in the preamble by default

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.h
+++ b/clang-tools-extra/clangd/ClangdServer.h
@@ -184,7 +184,7 @@ public:
     bool UseDirtyHeaders = false;
 
     // If true, parse emplace-like functions in the preamble.
-    bool PreambleParseForwardingFunctions = false;
+    bool PreambleParseForwardingFunctions = true;
 
     /// Whether include fixer insertions for Objective-C code should use #import
     /// instead of #include.
@@ -501,7 +501,7 @@ private:
   // Whether the client supports folding only complete lines.
   bool LineFoldingOnly = false;
 
-  bool PreambleParseForwardingFunctions = false;
+  bool PreambleParseForwardingFunctions = true;
 
   bool ImportInsertions = false;
 

--- a/clang-tools-extra/clangd/Compiler.h
+++ b/clang-tools-extra/clangd/Compiler.h
@@ -40,7 +40,7 @@ public:
 
 // Options to run clang e.g. when parsing AST.
 struct ParseOptions {
-  bool PreambleParseForwardingFunctions = false;
+  bool PreambleParseForwardingFunctions = true;
 
   bool ImportInsertions = false;
 };


### PR DESCRIPTION
Fixes https://github.com/clangd/clangd/issues/2324