### PR TITLE
[Hexagon] Explicitly truncate constant in UAddSubO

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLowering.cpp
@@ -3273,7 +3273,7 @@ HexagonTargetLowering::LowerUAddSubO(SDValue Op, SelectionDAG &DAG) const {
     if (Opc == ISD::USUBO) {
       SDValue Op = DAG.getNode(ISD::SUB, dl, VTs.VTs[0], {X, Y});
       SDValue Ov = DAG.getSetCC(dl, MVT::i1, Op,
-                                DAG.getConstant(-1, dl, ty(Op)), ISD::SETEQ);
+                                DAG.getAllOnesConstant(dl, ty(Op)), ISD::SETEQ);
       return DAG.getMergeValues({Op, Ov}, dl);
     }
   }

--- a/llvm/test/CodeGen/Hexagon/iss127296.ll
+++ b/llvm/test/CodeGen/Hexagon/iss127296.ll
@@ -1,0 +1,18 @@
+; RUN: llc -mtriple=hexagon -O0 < %s | FileCheck %s
+
+; CHECK: r0 = add(r0,#-1)
+
+define fastcc void @os.linux.tls.initStatic(i32 %x) {
+  %1 = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %x, i32 1)
+  br label %2
+
+  2:                                                ; preds = %0
+  %3 = extractvalue { i32, i1 } %1, 0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare { i32, i1 } @llvm.usub.with.overflow.i32(i32, i32) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+


### PR DESCRIPTION
After #117558 landed, this code would assert "Value is not an N-bit unsigned value" in getConstant(), from a test case in zig.

Co-authored-by:  Craig Topper <craig.topper@sifive.com>
Fixes #127296