### PR TITLE
[llvm] Remove `br i1 undef` in `llvm/test/CodeGen` tests

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-storebytesmerge.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-storebytesmerge.ll
@@ -14,12 +14,12 @@
 @q = external dso_local unnamed_addr global ptr, align 8
 
 ; Function Attrs: nounwind
-define void @test() local_unnamed_addr #0 {
+define void @test(i1 %arg) local_unnamed_addr #0 {
 entry:
   br label %for.body453.i
 
 for.body453.i:                                    ; preds = %for.body453.i, %entry
-  br i1 undef, label %for.body453.i, label %for.end705.i
+  br i1 %arg, label %for.body453.i, label %for.end705.i
 
 for.end705.i:                                     ; preds = %for.body453.i
   %0 = load ptr, ptr @q, align 8

--- a/llvm/test/CodeGen/AArch64/br-to-eh-lpad.ll
+++ b/llvm/test/CodeGen/AArch64/br-to-eh-lpad.ll
@@ -7,16 +7,16 @@
 ; that case, the machine verifier, which relies on analyzing branches for this
 ; kind of verification, is unable to check anything, so accepts the CFG.
 
-define void @test_branch_to_landingpad() personality ptr @__objc_personality_v0 {
+define void @test_branch_to_landingpad(i1 %arg) personality ptr @__objc_personality_v0 {
 entry:
-  br i1 undef, label %if.end50.thread, label %if.then6
+  br i1 %arg, label %if.end50.thread, label %if.then6
 
 lpad:
   %0 = landingpad { ptr, i32 }
           catch ptr @"OBJC_EHTYPE_$_NSString"
           catch ptr @OBJC_EHTYPE_id
           catch ptr null
-  br i1 undef, label %invoke.cont33, label %catch.fallthrough
+  br i1 %arg, label %invoke.cont33, label %catch.fallthrough
 
 catch.fallthrough:
   %matches31 = icmp eq i32 undef, 0

--- a/llvm/test/CodeGen/AArch64/br-undef-cond.ll
+++ b/llvm/test/CodeGen/AArch64/br-undef-cond.ll
@@ -7,9 +7,9 @@ target triple = "arm64-apple-ios"
 
 declare void @bar(ptr)
 
-define void @foo(ptr %m, i32 %off0) {
+define void @foo(ptr %m, i32 %off0, i1 %arg) {
 .thread1653:
-  br i1 undef, label %0, label %.thread1880
+  br i1 %arg, label %0, label %.thread1880
 
   %1 = icmp eq i32 undef, 0
   %.not = xor i1 %1, true

--- a/llvm/test/CodeGen/AArch64/br-undef-cond.ll
+++ b/llvm/test/CodeGen/AArch64/br-undef-cond.ll
@@ -7,9 +7,9 @@ target triple = "arm64-apple-ios"
 
 declare void @bar(ptr)
 
-define void @foo(ptr %m, i32 %off0, i1 %arg) {
+define void @foo(ptr %m, i32 %off0) {
 .thread1653:
-  br i1 %arg, label %0, label %.thread1880
+  br i1 poison, label %0, label %.thread1880
 
   %1 = icmp eq i32 undef, 0
   %.not = xor i1 %1, true

--- a/llvm/test/CodeGen/AArch64/early-ifcvt-regclass-mismatch.mir
+++ b/llvm/test/CodeGen/AArch64/early-ifcvt-regclass-mismatch.mir
@@ -3,9 +3,9 @@
 --- |
   target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
   target triple = "arm64-apple-ios13.3.0"
-  define hidden void @phi_operands_regclasses_different(i1 %arg) #0 {
+  define hidden void @phi_operands_regclasses_different() #0 {
   entry:
-    br i1 %arg, label %if.then139.i, label %if.else142.i
+    br i1 undef, label %if.then139.i, label %if.else142.i
 
   if.then139.i:                                     ; preds = %entry
     %0 = load double, ptr undef, align 8

--- a/llvm/test/CodeGen/AArch64/early-ifcvt-regclass-mismatch.mir
+++ b/llvm/test/CodeGen/AArch64/early-ifcvt-regclass-mismatch.mir
@@ -3,9 +3,9 @@
 --- |
   target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
   target triple = "arm64-apple-ios13.3.0"
-  define hidden void @phi_operands_regclasses_different() #0 {
+  define hidden void @phi_operands_regclasses_different(i1 %arg) #0 {
   entry:
-    br i1 undef, label %if.then139.i, label %if.else142.i
+    br i1 %arg, label %if.then139.i, label %if.else142.i
 
   if.then139.i:                                     ; preds = %entry
     %0 = load double, ptr undef, align 8

--- a/llvm/test/CodeGen/AArch64/gep-nullptr.ll
+++ b/llvm/test/CodeGen/AArch64/gep-nullptr.ll
@@ -6,9 +6,9 @@ target triple = "aarch64--linux-gnu"
 %unionMV = type { i32 }
 
 ; Function Attrs: nounwind
-define void @test(ptr %mi_block) {
+define void @test(ptr %mi_block, i1 %arg) {
 entry:
-  br i1 undef, label %for.body13.us, label %if.else
+  br i1 %arg, label %for.body13.us, label %if.else
 
 ; Just make sure we don't get a compiler ICE due to dereferncing a nullptr.
 ; CHECK-LABEL: test

--- a/llvm/test/CodeGen/AArch64/machine-sink-getmemoperandwithoffset.mir
+++ b/llvm/test/CodeGen/AArch64/machine-sink-getmemoperandwithoffset.mir
@@ -1,8 +1,8 @@
 # RUN: llc -mtriple=aarch64-none-linux-gnu -run-pass machine-sink -o - %s | FileCheck %s
 --- |
-  define i8 @g() {
+  define i8 @g(i1 %arg) {
   else.7:
-    br i1 undef, label %then.8, label %else.8, !make.implicit !0
+    br i1 %arg, label %then.8, label %else.8, !make.implicit !0
 
   then.8:                                           ; preds = %else.8, %else.7
     %merge = phi i8 [ 1, %else.7 ], [ 0, %else.8 ]

--- a/llvm/test/CodeGen/AArch64/madd-combiner.ll
+++ b/llvm/test/CodeGen/AArch64/madd-combiner.ll
@@ -53,7 +53,7 @@ define void @mul_add_imm2() {
 entry:
   br label %for.body
 for.body:
-  br i1 undef, label %for.body, label %for.body8
+  br i1 poison, label %for.body, label %for.body8
 for.body8:
   %0 = mul i64 undef, -3
   %mul1971 = add i64 %0, -3

--- a/llvm/test/CodeGen/AArch64/optimize-cond-branch.ll
+++ b/llvm/test/CodeGen/AArch64/optimize-cond-branch.ll
@@ -38,7 +38,7 @@ define void @func() uwtable {
   br i1 %c0, label %b1, label %b6
 
 b1:
-  br i1 undef, label %b3, label %b2
+  br i1 poison, label %b3, label %b2
 
 b2:
   %v0 = tail call i32 @extfunc()

--- a/llvm/test/CodeGen/AArch64/shrink-wrap.ll
+++ b/llvm/test/CodeGen/AArch64/shrink-wrap.ll
@@ -31,7 +31,7 @@ declare fastcc i32 @foo()
 
 declare fastcc i32 @bar()
 
-define internal fastcc i32 @func(i32 %alpha, i32 %beta) {
+define internal fastcc i32 @func(i32 %alpha, i32 %beta, i1 %arg) {
 entry:
   %v1 = alloca [2 x [11 x i32]], align 4
   %v2 = alloca [11 x i32], align 16
@@ -69,7 +69,7 @@ for.body:
   %a.0983 = phi i32 [ 1, %if.end.9 ], [ %a.1, %for.inc ]
   %arrayidx = getelementptr inbounds [62 x i32], ptr @g17, i64 0, i64 undef
   %tmp5 = load i32, ptr %arrayidx, align 4
-  br i1 undef, label %for.inc, label %if.else.51
+  br i1 %arg, label %for.inc, label %if.else.51
 
 if.else.51:
   %idxprom53 = sext i32 %tmp5 to i64

--- a/llvm/test/CodeGen/AArch64/tail-call-unused-zext.ll
+++ b/llvm/test/CodeGen/AArch64/tail-call-unused-zext.ll
@@ -6,10 +6,10 @@
 ; the attributes of the caller and the callee match.
 
 declare zeroext i1 @zcallee()
-define void @zcaller() {
+define void @zcaller(i1 %arg) {
 ; CHECK-LABEL: name: zcaller
 entry:
-  br i1 undef, label %calllabel, label %retlabel
+  br i1 %arg, label %calllabel, label %retlabel
 calllabel:
 ; CHECK: bb.1.calllabel:
 ; CHECK-NOT: BL @zcallee
@@ -21,10 +21,10 @@ retlabel:
 }
 
 declare signext i1 @scallee()
-define void @scaller() {
+define void @scaller(i1 %arg) {
 ; CHECK-LABEL: name: scaller
 entry:
-  br i1 undef, label %calllabel, label %retlabel
+  br i1 %arg, label %calllabel, label %retlabel
 calllabel:
 ; CHECK: bb.1.calllabel:
 ; CHECK-NOT: BL @scallee

--- a/llvm/test/CodeGen/AArch64/tailcall-ssp-split-debug.ll
+++ b/llvm/test/CodeGen/AArch64/tailcall-ssp-split-debug.ll
@@ -1,9 +1,9 @@
 ; RUN: llc -mtriple=arm64-apple-ios %s -o - | FileCheck %s
 
-define swifttailcc void @foo(ptr %call) ssp {
+define swifttailcc void @foo(ptr %call, i1 %arg) ssp {
 ; CHECK-LABEL: foo:
   %var = alloca [28 x i8], align 16
-  br i1 undef, label %if.then, label %if.end
+  br i1 %arg, label %if.then, label %if.end
 
 if.then:
   ret void

--- a/llvm/test/CodeGen/AMDGPU/cgp-bitfield-extract.ll
+++ b/llvm/test/CodeGen/AMDGPU/cgp-bitfield-extract.ll
@@ -35,10 +35,10 @@
 
 ; GCN: buffer_store_dword
 ; GCN: s_endpgm
-define amdgpu_kernel void @sink_ubfe_i32(ptr addrspace(1) %out, i32 %arg1) #0 {
+define amdgpu_kernel void @sink_ubfe_i32(ptr addrspace(1) %out, i32 %arg1, i1 %arg) #0 {
 entry:
   %shr = lshr i32 %arg1, 8
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
   %val0 = and i32 %shr, 255
@@ -75,10 +75,10 @@ ret:
 ; OPT: ret
 
 ; GCN-LABEL: {{^}}sink_sbfe_i32:
-define amdgpu_kernel void @sink_sbfe_i32(ptr addrspace(1) %out, i32 %arg1) #0 {
+define amdgpu_kernel void @sink_sbfe_i32(ptr addrspace(1) %out, i32 %arg1, i1 %arg) #0 {
 entry:
   %shr = ashr i32 %arg1, 8
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
   %val0 = and i32 %shr, 255
@@ -183,10 +183,10 @@ ret:
 ; GCN: v_and_b32_e32 v{{[0-9]+}}, 0xff, v[[LO]]
 
 ; GCN: buffer_store_dwordx2
-define amdgpu_kernel void @sink_ubfe_i64_span_midpoint(ptr addrspace(1) %out, i64 %arg1) #0 {
+define amdgpu_kernel void @sink_ubfe_i64_span_midpoint(ptr addrspace(1) %out, i64 %arg1, i1 %arg) #0 {
 entry:
   %shr = lshr i64 %arg1, 30
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
   %val0 = and i64 %shr, 255
@@ -231,10 +231,10 @@ ret:
 ; GCN: s_bfe_u32 s{{[0-9]+}}, s{{[0-9]+}}, 0x8000f
 
 ; GCN: buffer_store_dwordx2
-define amdgpu_kernel void @sink_ubfe_i64_low32(ptr addrspace(1) %out, i64 %arg1) #0 {
+define amdgpu_kernel void @sink_ubfe_i64_low32(ptr addrspace(1) %out, i64 %arg1, i1 %arg) #0 {
 entry:
   %shr = lshr i64 %arg1, 15
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
   %val0 = and i64 %shr, 255
@@ -277,10 +277,10 @@ ret:
 ; GCN: s_bfe_u32 s{{[0-9]+}}, s{{[0-9]+}}, 0x80003
 
 ; GCN: buffer_store_dwordx2
-define amdgpu_kernel void @sink_ubfe_i64_high32(ptr addrspace(1) %out, i64 %arg1) #0 {
+define amdgpu_kernel void @sink_ubfe_i64_high32(ptr addrspace(1) %out, i64 %arg1, i1 %arg) #0 {
 entry:
   %shr = lshr i64 %arg1, 35
-  br i1 undef, label %bb0, label %bb1
+  br i1 %arg, label %bb0, label %bb1
 
 bb0:
   %val0 = and i64 %shr, 255

--- a/llvm/test/CodeGen/AMDGPU/dagcomb-shuffle-vecextend-non2.ll
+++ b/llvm/test/CodeGen/AMDGPU/dagcomb-shuffle-vecextend-non2.ll
@@ -10,9 +10,9 @@
 ;
 ; GCN: s_endpgm
 
-define amdgpu_ps void @main(i32 %in1) local_unnamed_addr {
+define amdgpu_ps void @main(i32 %in1, i1 %arg) local_unnamed_addr {
 .entry:
-  br i1 undef, label %bb12, label %bb
+  br i1 %arg, label %bb12, label %bb
 
 bb:
   %__llpc_global_proxy_r5.12.vec.insert = insertelement <4 x i32> undef, i32 %in1, i32 3


### PR DESCRIPTION
This PR replaces some instances of `br i1 undef` with function argument value in several tests under `llvm/test/CodeGen/ `directory. This PR is a continuation of PR #125460

@nunoplopes