### PR TITLE
[clang-tidy] Fix false negative `modernize-use-ranges` when using getter function

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/UseRangesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/utils/UseRangesCheck.cpp
@@ -51,7 +51,13 @@ static std::string getFullPrefix(ArrayRef<UseRangesCheck::Indexes> Signature) {
 namespace {
 
 AST_MATCHER(Expr, hasSideEffects) {
-  return Node.HasSideEffects(Finder->getASTContext());
+  bool CheckArg = true;
+  if (const CXXMemberCallExpr *Call = dyn_cast<CXXMemberCallExpr>(&Node)) {
+    if (Call->isLValue() && Call->getMethodDecl()->isConst()) {
+      CheckArg = false;
+    }
+  }
+  return Node.HasSideEffects(Finder->getASTContext(), CheckArg);
 }
 } // namespace
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -188,6 +188,11 @@ Changes in existing checks
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
 
+- Improved :doc:`modernize-use-ranges
+  <clang-tidy/checks/modernize/use-ranges>` check by correctly recognizes 
+  const member functions returning lvalues as side-effect-free, preventing 
+  missed transformations.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-ranges.cpp
@@ -9,7 +9,15 @@
 #include "use-ranges/fake_std.h"
 #include "smart-ptr/unique_ptr.h"
 
-void Positives() {
+struct S {
+  std::vector<int> v;
+
+  const std::vector<int>& get() const { return v; }
+  std::vector<int>& getMutable() { return v; } 
+  std::vector<int> getVal() const { return v; } 
+};
+
+void Positives(S& s) {
   std::vector<int> I, J;
   std::vector<std::unique_ptr<int>> K;
 
@@ -83,9 +91,19 @@ void Positives() {
   my_std::find(I.begin(), I.end(), 6);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
   // CHECK-FIXES: std::ranges::find(I, 6);
+
+  std::find(s.get().begin(), s.get().end(), 0); 
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
+  // CHECK-FIXES: std::ranges::find(s.get(), 0);
+
+  // Return non-const function, should not generate message
+  std::find(s.getMutable().begin(), s.getMutable().end(), 0);
+
+  // Return value, should not generate message
+  std::find(s.getVal().begin(), s.getVal().end(), 0); 
 }
 
-void Reverse(){
+void Reverse(S& s){
   std::vector<int> I, J;
   std::vector<std::unique_ptr<int>> K;
   
@@ -107,6 +125,16 @@ void Reverse(){
   std::equal(I.begin(), I.end(), std::crbegin(J), std::crend(J));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
   // CHECK-FIXES: std::ranges::equal(I, std::ranges::reverse_view(J));
+
+  std::find(s.get().rbegin(), s.get().rend(), 0); 
+  // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use a ranges version of this algorithm
+  // CHECK-FIXES: std::ranges::find(std::ranges::reverse_view(s.get()), 0);
+
+  // Return non-const function, should not generate message
+  std::find(s.getMutable().rbegin(), s.getMutable().rend(), 0);
+
+  // Return value, should not generate message
+  std::find(s.getVal().rbegin(), s.getVal().rend(), 0); 
 }
 
 void Negatives() {


### PR DESCRIPTION
This PR fixes issue #124906, where `modernize-use-ranges` failed to detect cases where a `const` member function returning an lvalue was incorrectly assumed to have side effects, preventing the transformation.


### Changes:
1. **Modified `clang-tools-extra/clang-tidy/utils/UseRangesCheck.cpp`**:
   - Updated `hasSideEffects` AST matcher to correctly treat `const` member functions returning lvalues as side-effect-free.
   
2. **Added unit tests**:
  - `const` getters returning lvalues (should trigger transformation).
  - Non-const getters returning lvalues (should not trigger transformation).
  - Getters returning rvalues (should not trigger transformation).
  - Corresponding reverse iterators usage.

### Linked Issue:
Fixes #124906 .

### Testing:
- All existing unit tests pass.
- New unit tests have been added to verify the fix.

### Note:
- This issue occurs when the function is called with its default argument (`true`), which leads to the incorrect assumption that the member function has side effects.
- Passing `false` explicitly does not trigger this issue.
- This patch ensures that `const` member functions returning lvalues are correctly recognized as side-effect-free, preventing incorrect behavior.