### PR TITLE
[X86] Add missing explicit conversion for AMXAVX512 and SHA

### DIFF
--- a/clang/lib/Headers/amxavx512intrin.h
+++ b/clang/lib/Headers/amxavx512intrin.h
@@ -228,7 +228,7 @@
 ///             dst.byte[i] := a.row[row_index].byte[row_chunk+i]
 /// ENDFOR
 /// \endcode
-#define _tile_movrow(a, b) __builtin_ia32_tilemovrow(a, b)
+#define _tile_movrow(a, b) ((__m512i)__builtin_ia32_tilemovrow(a, b))
 
 /// This is internal intrinsic. C/C++ user should avoid calling it directly.
 

--- a/clang/lib/Headers/shaintrin.h
+++ b/clang/lib/Headers/shaintrin.h
@@ -47,8 +47,9 @@
 ///    An immediate value where bits [1:0] select among four possible
 ///    combining functions and rounding constants (not specified here).
 /// \returns A 128-bit vector of [4 x i32] containing the updated SHA-1 state.
-#define _mm_sha1rnds4_epu32(V1, V2, M) \
-  __builtin_ia32_sha1rnds4((__v4si)(__m128i)(V1), (__v4si)(__m128i)(V2), (M))
+#define _mm_sha1rnds4_epu32(V1, V2, M)                                         \
+  ((__m128i)__builtin_ia32_sha1rnds4((__v4si)(__m128i)(V1),                    \
+                                     (__v4si)(__m128i)(V2), (M)))
 
 /// Calculates the SHA-1 state variable E from the SHA-1 state variables in
 ///    the 128-bit vector of [4 x i32] in \a __X, adds that to the next set of

--- a/clang/test/CodeGen/X86/amxavx512-builtins.c
+++ b/clang/test/CodeGen/X86/amxavx512-builtins.c
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 %s -ffreestanding -triple=x86_64-unknown-unknown -target-feature +amx-tile -target-feature +amx-avx512 \
-// RUN: -target-feature +avx10.2-512 -emit-llvm -o - -Wall -Werror -pedantic -Wno-gnu-statement-expression | FileCheck %s
+// RUN: -target-feature +avx10.2-512 -emit-llvm -o - -Wall -Werror -pedantic -Wno-gnu-statement-expression -flax-vector-conversions=none | FileCheck %s
 
 #include <immintrin.h>
 #include <stddef.h>

--- a/clang/test/CodeGen/X86/sha-builtins.c
+++ b/clang/test/CodeGen/X86/sha-builtins.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -ffreestanding %s -triple=x86_64-unknown-unknown -target-feature +sha -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -ffreestanding %s -triple=x86_64-unknown-unknown -target-feature +sha -emit-llvm -flax-vector-conversions=none -o - | FileCheck %s
 
 
 #include <immintrin.h>


### PR DESCRIPTION
Address the X86 part of #126491