### PR TITLE
[clang][bytecode] Add Descriptor::dumpFull

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.h
+++ b/clang/lib/AST/ByteCode/Descriptor.h
@@ -274,6 +274,7 @@ public:
 
   void dump() const;
   void dump(llvm::raw_ostream &OS) const;
+  void dumpFull(unsigned Offset = 0, unsigned Indent = 0) const;
 };
 
 /// Bitfield tracking the initialisation status of elements of primitive arrays.

--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -251,6 +251,38 @@ LLVM_DUMP_METHOD void Descriptor::dump(llvm::raw_ostream &OS) const {
     OS << " dummy";
 }
 
+/// Dump descriptor, including all valid offsets.
+LLVM_DUMP_METHOD void Descriptor::dumpFull(unsigned Offset,
+                                           unsigned Indent) const {
+  unsigned Spaces = Indent * 2;
+  llvm::raw_ostream &OS = llvm::errs();
+  OS.indent(Spaces);
+  dump(OS);
+  OS << '\n';
+  OS.indent(Spaces) << "Metadata: " << getMetadataSize() << " bytes\n";
+  OS.indent(Spaces) << "Size: " << getSize() << " bytes\n";
+  OS.indent(Spaces) << "AllocSize: " << getAllocSize() << " bytes\n";
+  Offset += getMetadataSize();
+  if (isCompositeArray()) {
+    OS.indent(Spaces) << "Elements: " << getNumElems() << '\n';
+    unsigned FO = Offset;
+    for (unsigned I = 0; I != getNumElems(); ++I) {
+      FO += sizeof(InlineDescriptor);
+      assert(ElemDesc->getMetadataSize() == 0);
+      OS.indent(Spaces) << "Element " << I << " offset: " << FO << '\n';
+      ElemDesc->dumpFull(FO, Indent + 1);
+
+      FO += ElemDesc->getAllocSize();
+    }
+  } else if (isRecord()) {
+    ElemRecord->dump(OS, Indent + 1, Offset);
+  } else if (isPrimitive()) {
+  } else {
+  }
+
+  OS << '\n';
+}
+
 LLVM_DUMP_METHOD void InlineDescriptor::dump(llvm::raw_ostream &OS) const {
   {
     ColorScope SC(OS, true, {llvm::raw_ostream::BLUE, true});


### PR DESCRIPTION
This is useful to print all (or most) of the valid offsets into a block of the given descriptor.