### PR TITLE
[Diagnostics] Return rvalue reference from temporary argument

### DIFF
--- a/llvm/include/llvm/Analysis/OptimizationRemarkEmitter.h
+++ b/llvm/include/llvm/Analysis/OptimizationRemarkEmitter.h
@@ -69,6 +69,11 @@ public:
   /// Output the remark via the diagnostic handler and to the
   /// optimization record file.
   void emit(DiagnosticInfoOptimizationBase &OptDiag);
+  /// Also allow r-value for OptDiag to allow emitting a temporarily-constructed
+  /// diagnostic.
+  void emit(DiagnosticInfoOptimizationBase &&OptDiag) {
+    emit(static_cast<DiagnosticInfoOptimizationBase &>(OptDiag));
+  }
 
   /// Take a lambda that returns a remark which will be emitted.  Second
   /// argument is only used to restrict this to functions.

--- a/llvm/include/llvm/Analysis/OptimizationRemarkEmitter.h
+++ b/llvm/include/llvm/Analysis/OptimizationRemarkEmitter.h
@@ -71,9 +71,7 @@ public:
   void emit(DiagnosticInfoOptimizationBase &OptDiag);
   /// Also allow r-value for OptDiag to allow emitting a temporarily-constructed
   /// diagnostic.
-  void emit(DiagnosticInfoOptimizationBase &&OptDiag) {
-    emit(static_cast<DiagnosticInfoOptimizationBase &>(OptDiag));
-  }
+  void emit(DiagnosticInfoOptimizationBase &&OptDiag) { emit(OptDiag); }
 
   /// Take a lambda that returns a remark which will be emitted.  Second
   /// argument is only used to restrict this to functions.

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -30,6 +30,7 @@
 #include <iterator>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace llvm {
 
@@ -625,14 +626,14 @@ operator<<(RemarkT &R,
 /// Also allow r-value for the remark to allow insertion into a
 /// temporarily-constructed remark.
 template <class RemarkT>
-RemarkT &
+RemarkT &&
 operator<<(RemarkT &&R,
            std::enable_if_t<
                std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
                StringRef>
                S) {
   R.insert(S);
-  return R;
+  return std::move(R);
 }
 
 template <class RemarkT>
@@ -647,14 +648,14 @@ operator<<(RemarkT &R,
 }
 
 template <class RemarkT>
-RemarkT &
+RemarkT &&
 operator<<(RemarkT &&R,
            std::enable_if_t<
                std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
                DiagnosticInfoOptimizationBase::Argument>
                A) {
   R.insert(A);
-  return R;
+  return std::move(R);
 }
 
 template <class RemarkT>
@@ -669,14 +670,14 @@ operator<<(RemarkT &R,
 }
 
 template <class RemarkT>
-RemarkT &
+RemarkT &&
 operator<<(RemarkT &&R,
            std::enable_if_t<
                std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
                DiagnosticInfoOptimizationBase::setIsVerbose>
                V) {
   R.insert(V);
-  return R;
+  return std::move(R);
 }
 
 template <class RemarkT>
@@ -688,6 +689,17 @@ operator<<(RemarkT &R,
                EA) {
   R.insert(EA);
   return R;
+}
+
+template <class RemarkT>
+RemarkT &&
+operator<<(RemarkT &&R,
+           std::enable_if_t<
+               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
+               DiagnosticInfoOptimizationBase::setExtraArgs>
+               EA) {
+  R.insert(EA);
+  return std::move(R);
 }
 
 /// Common features for diagnostics dealing with optimization remarks

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -613,45 +613,45 @@ protected:
 /// common base class.  This allows returning the result of the insertion
 /// directly by value, e.g. return OptimizationRemarkAnalysis(...) << "blah".
 template <class RemarkT>
-decltype(auto) operator<<(
-    RemarkT &&R,
-    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
-                                     std::remove_reference_t<RemarkT>>::value,
-                     StringRef>
-        S) {
+decltype(auto)
+operator<<(RemarkT &&R,
+           std::enable_if_t<std::is_base_of_v<DiagnosticInfoOptimizationBase,
+                                              std::remove_reference_t<RemarkT>>,
+                            StringRef>
+               S) {
   R.insert(S);
   return std::forward<RemarkT>(R);
 }
 
 template <class RemarkT>
-decltype(auto) operator<<(
-    RemarkT &&R,
-    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
-                                     std::remove_reference_t<RemarkT>>::value,
-                     DiagnosticInfoOptimizationBase::Argument>
-        A) {
+decltype(auto)
+operator<<(RemarkT &&R,
+           std::enable_if_t<std::is_base_of_v<DiagnosticInfoOptimizationBase,
+                                              std::remove_reference_t<RemarkT>>,
+                            DiagnosticInfoOptimizationBase::Argument>
+               A) {
   R.insert(A);
   return std::forward<RemarkT>(R);
 }
 
 template <class RemarkT>
-decltype(auto) operator<<(
-    RemarkT &&R,
-    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
-                                     std::remove_reference_t<RemarkT>>::value,
-                     DiagnosticInfoOptimizationBase::setIsVerbose>
-        V) {
+decltype(auto)
+operator<<(RemarkT &&R,
+           std::enable_if_t<std::is_base_of_v<DiagnosticInfoOptimizationBase,
+                                              std::remove_reference_t<RemarkT>>,
+                            DiagnosticInfoOptimizationBase::setIsVerbose>
+               V) {
   R.insert(V);
   return std::forward<RemarkT>(R);
 }
 
 template <class RemarkT>
-decltype(auto) operator<<(
-    RemarkT &&R,
-    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
-                                     std::remove_reference_t<RemarkT>>::value,
-                     DiagnosticInfoOptimizationBase::setExtraArgs>
-        EA) {
+decltype(auto)
+operator<<(RemarkT &&R,
+           std::enable_if_t<std::is_base_of_v<DiagnosticInfoOptimizationBase,
+                                              std::remove_reference_t<RemarkT>>,
+                            DiagnosticInfoOptimizationBase::setExtraArgs>
+               EA) {
   R.insert(EA);
   return std::forward<RemarkT>(R);
 }

--- a/llvm/include/llvm/IR/DiagnosticInfo.h
+++ b/llvm/include/llvm/IR/DiagnosticInfo.h
@@ -613,93 +613,47 @@ protected:
 /// common base class.  This allows returning the result of the insertion
 /// directly by value, e.g. return OptimizationRemarkAnalysis(...) << "blah".
 template <class RemarkT>
-RemarkT &
-operator<<(RemarkT &R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               StringRef>
-               S) {
+decltype(auto) operator<<(
+    RemarkT &&R,
+    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
+                                     std::remove_reference_t<RemarkT>>::value,
+                     StringRef>
+        S) {
   R.insert(S);
-  return R;
-}
-
-/// Also allow r-value for the remark to allow insertion into a
-/// temporarily-constructed remark.
-template <class RemarkT>
-RemarkT &&
-operator<<(RemarkT &&R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               StringRef>
-               S) {
-  R.insert(S);
-  return std::move(R);
+  return std::forward<RemarkT>(R);
 }
 
 template <class RemarkT>
-RemarkT &
-operator<<(RemarkT &R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               DiagnosticInfoOptimizationBase::Argument>
-               A) {
+decltype(auto) operator<<(
+    RemarkT &&R,
+    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
+                                     std::remove_reference_t<RemarkT>>::value,
+                     DiagnosticInfoOptimizationBase::Argument>
+        A) {
   R.insert(A);
-  return R;
+  return std::forward<RemarkT>(R);
 }
 
 template <class RemarkT>
-RemarkT &&
-operator<<(RemarkT &&R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               DiagnosticInfoOptimizationBase::Argument>
-               A) {
-  R.insert(A);
-  return std::move(R);
-}
-
-template <class RemarkT>
-RemarkT &
-operator<<(RemarkT &R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               DiagnosticInfoOptimizationBase::setIsVerbose>
-               V) {
+decltype(auto) operator<<(
+    RemarkT &&R,
+    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
+                                     std::remove_reference_t<RemarkT>>::value,
+                     DiagnosticInfoOptimizationBase::setIsVerbose>
+        V) {
   R.insert(V);
-  return R;
+  return std::forward<RemarkT>(R);
 }
 
 template <class RemarkT>
-RemarkT &&
-operator<<(RemarkT &&R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               DiagnosticInfoOptimizationBase::setIsVerbose>
-               V) {
-  R.insert(V);
-  return std::move(R);
-}
-
-template <class RemarkT>
-RemarkT &
-operator<<(RemarkT &R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               DiagnosticInfoOptimizationBase::setExtraArgs>
-               EA) {
+decltype(auto) operator<<(
+    RemarkT &&R,
+    std::enable_if_t<std::is_base_of<DiagnosticInfoOptimizationBase,
+                                     std::remove_reference_t<RemarkT>>::value,
+                     DiagnosticInfoOptimizationBase::setExtraArgs>
+        EA) {
   R.insert(EA);
-  return R;
-}
-
-template <class RemarkT>
-RemarkT &&
-operator<<(RemarkT &&R,
-           std::enable_if_t<
-               std::is_base_of<DiagnosticInfoOptimizationBase, RemarkT>::value,
-               DiagnosticInfoOptimizationBase::setExtraArgs>
-               EA) {
-  R.insert(EA);
-  return std::move(R);
+  return std::forward<RemarkT>(R);
 }
 
 /// Common features for diagnostics dealing with optimization remarks

--- a/llvm/lib/Analysis/InlineAdvisor.cpp
+++ b/llvm/lib/Analysis/InlineAdvisor.cpp
@@ -337,8 +337,7 @@ static raw_ostream &operator<<(raw_ostream &R, const ore::NV &Arg) {
   return R << Arg.Val;
 }
 
-template <class RemarkT>
-RemarkT &operator<<(RemarkT &&R, const InlineCost &IC) {
+template <class RemarkT> RemarkT &operator<<(RemarkT &R, const InlineCost &IC) {
   using namespace ore;
   if (IC.isAlways()) {
     R << "(cost=always)";
@@ -351,6 +350,12 @@ RemarkT &operator<<(RemarkT &&R, const InlineCost &IC) {
   if (const char *Reason = IC.getReason())
     R << ": " << ore::NV("Reason", Reason);
   return R;
+}
+
+template <class RemarkT>
+RemarkT &&operator<<(RemarkT &&R, const InlineCost &IC) {
+  static_cast<RemarkT &>(R) << IC;
+  return std::move(R);
 }
 } // namespace llvm
 

--- a/llvm/lib/Analysis/InlineAdvisor.cpp
+++ b/llvm/lib/Analysis/InlineAdvisor.cpp
@@ -337,7 +337,8 @@ static raw_ostream &operator<<(raw_ostream &R, const ore::NV &Arg) {
   return R << Arg.Val;
 }
 
-template <class RemarkT> RemarkT &operator<<(RemarkT &R, const InlineCost &IC) {
+template <class RemarkT>
+decltype(auto) operator<<(RemarkT &&R, const InlineCost &IC) {
   using namespace ore;
   if (IC.isAlways()) {
     R << "(cost=always)";
@@ -349,13 +350,7 @@ template <class RemarkT> RemarkT &operator<<(RemarkT &R, const InlineCost &IC) {
   }
   if (const char *Reason = IC.getReason())
     R << ": " << ore::NV("Reason", Reason);
-  return R;
-}
-
-template <class RemarkT>
-RemarkT &&operator<<(RemarkT &&R, const InlineCost &IC) {
-  static_cast<RemarkT &>(R) << IC;
-  return std::move(R);
+  return std::forward<RemarkT>(R);
 }
 } // namespace llvm
 


### PR DESCRIPTION
This fixes compilation issues with GCC and C++23:
```
error: cannot bind non-const lvalue reference of type
'llvm::OptimizationRemarkMissed&' to an rvalue of type
'llvm::OptimizationRemarkMissed'
```

Closes #105778