### PR TITLE
[MLIR][NFC] Retire `let constructor` for passes in Conversion directory (part1)

### DIFF
--- a/flang/include/flang/Optimizer/Support/InitFIR.h
+++ b/flang/include/flang/Optimizer/Support/InitFIR.h
@@ -112,7 +112,7 @@ inline void registerMLIRPassesForFortranTools() {
   mlir::affine::registerAffineLoopTilingPass();
   mlir::affine::registerAffineDataCopyGenerationPass();
 
-  mlir::registerConvertAffineToStandardPass();
+  mlir::registerLowerAffinePass();
 }
 
 /// Register the interfaces needed to lower to LLVM IR.

--- a/flang/lib/Optimizer/Passes/Pipelines.cpp
+++ b/flang/lib/Optimizer/Passes/Pipelines.cpp
@@ -205,7 +205,7 @@ void createDefaultFIROptimizerPassPipeline(mlir::PassManager &pm,
       pm, fir::createStackReclaim);
   // convert control flow to CFG form
   fir::addCfgConversionPass(pm, pc);
-  pm.addPass(mlir::createConvertSCFToCFPass());
+  pm.addPass(mlir::createSCFToControlFlowPass());
 
   pm.addPass(mlir::createCanonicalizerPass(config));
   pm.addPass(fir::createSimplifyRegionLite());

--- a/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
+++ b/mlir/include/mlir/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.h
@@ -18,7 +18,7 @@ class LLVMTypeConverter;
 class RewritePatternSet;
 class Pass;
 
-#define GEN_PASS_DECL_CONVERTAMDGPUTOROCDL
+#define GEN_PASS_DECL_CONVERTAMDGPUTOROCDLPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Note: The ROCDL target does not support the LLVM bfloat type at this time
@@ -27,8 +27,6 @@ class Pass;
 void populateAMDGPUToROCDLConversionPatterns(const LLVMTypeConverter &converter,
                                              RewritePatternSet &patterns,
                                              amdgpu::Chipset chipset);
-
-std::unique_ptr<Pass> createConvertAMDGPUToROCDLPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/AffineToStandard/AffineToStandard.h
+++ b/mlir/include/mlir/Conversion/AffineToStandard/AffineToStandard.h
@@ -24,7 +24,7 @@ namespace affine {
 class AffineForOp;
 } // namespace affine
 
-#define GEN_PASS_DECL_LOWERAFFINE
+#define GEN_PASS_DECL_LOWERAFFINEPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Collect a set of patterns to convert from the Affine dialect to the Standard
@@ -43,11 +43,6 @@ Value lowerAffineLowerBound(affine::AffineForOp op, OpBuilder &builder);
 /// Emit code that computes the upper bound of the given affine loop using
 /// standard arithmetic operations.
 Value lowerAffineUpperBound(affine::AffineForOp op, OpBuilder &builder);
-
-/// Lowers affine control flow operations (ForStmt, IfStmt and AffineApplyOp)
-/// to equivalent lower-level constructs (flow of basic blocks and arithmetic
-/// primitives).
-std::unique_ptr<Pass> createLowerAffinePass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/AffineToStandard/AffineToStandard.h
+++ b/mlir/include/mlir/Conversion/AffineToStandard/AffineToStandard.h
@@ -24,7 +24,7 @@ namespace affine {
 class AffineForOp;
 } // namespace affine
 
-#define GEN_PASS_DECL_CONVERTAFFINETOSTANDARD
+#define GEN_PASS_DECL_LOWERAFFINE
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Collect a set of patterns to convert from the Affine dialect to the Standard

--- a/mlir/include/mlir/Conversion/ArithToSPIRV/ArithToSPIRV.h
+++ b/mlir/include/mlir/Conversion/ArithToSPIRV/ArithToSPIRV.h
@@ -18,7 +18,7 @@ class SPIRVTypeConverter;
 class RewritePatternSet;
 class Pass;
 
-#define GEN_PASS_DECL_CONVERTARITHTOSPIRV
+#define GEN_PASS_DECL_CONVERTARITHTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 namespace arith {

--- a/mlir/include/mlir/Conversion/ArmNeon2dToIntr/ArmNeon2dToIntr.h
+++ b/mlir/include/mlir/Conversion/ArmNeon2dToIntr/ArmNeon2dToIntr.h
@@ -15,17 +15,12 @@ namespace mlir {
 class Pass;
 class RewritePatternSet;
 
-#define GEN_PASS_DECL_CONVERTARMNEON2DTOINTR
+#define GEN_PASS_DECL_CONVERTARMNEON2DTOINTRPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Populates patterns for the lowering of Arm NEON 2D ops to intrinsics.
 /// See createConvertArmNeon2dToIntrPass.
 void populateConvertArmNeon2dToIntrPatterns(RewritePatternSet &patterns);
-
-/// Creates a pass to lower Arm NEON 2D ops to intrinsics, i.e.
-/// equivalent ops operating on flattened 1D vectors and mapping more
-/// directly to the corresponding Arm NEON instruction.
-std::unique_ptr<Pass> createConvertArmNeon2dToIntrPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/ArmSMEToSCF/ArmSMEToSCF.h
+++ b/mlir/include/mlir/Conversion/ArmSMEToSCF/ArmSMEToSCF.h
@@ -15,14 +15,11 @@ namespace mlir {
 class Pass;
 class RewritePatternSet;
 
-#define GEN_PASS_DECL_CONVERTARMSMETOSCF
+#define GEN_PASS_DECL_CONVERTARMSMETOSCFPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Collect a set of patterns to convert from the ArmSME dialect to SCF.
 void populateArmSMEToSCFConversionPatterns(RewritePatternSet &patterns);
-
-/// Create a pass to convert a subset of ArmSME ops to SCF.
-std::unique_ptr<Pass> createConvertArmSMEToSCFPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/BufferizationToMemRef/BufferizationToMemRef.h
+++ b/mlir/include/mlir/Conversion/BufferizationToMemRef/BufferizationToMemRef.h
@@ -15,10 +15,9 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_CONVERTBUFFERIZATIONTOMEMREF
+#define GEN_PASS_DECL_CONVERTBUFFERIZATIONTOMEMREFPASS
 #include "mlir/Conversion/Passes.h.inc"
 
-std::unique_ptr<Pass> createBufferizationToMemRefPass();
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_BUFFERIZATIONTOMEMREF_BUFFERIZATIONTOMEMREF_H

--- a/mlir/include/mlir/Conversion/ComplexToLibm/ComplexToLibm.h
+++ b/mlir/include/mlir/Conversion/ComplexToLibm/ComplexToLibm.h
@@ -8,6 +8,7 @@
 #ifndef MLIR_CONVERSION_COMPLEXTOLIBM_COMPLEXTOLIBM_H_
 #define MLIR_CONVERSION_COMPLEXTOLIBM_COMPLEXTOLIBM_H_
 
+#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
@@ -21,9 +22,6 @@ class OperationPass;
 /// calls.
 void populateComplexToLibmConversionPatterns(RewritePatternSet &patterns,
                                              PatternBenefit benefit);
-
-/// Create a pass to convert Complex operations to libm calls.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertComplexToLibmPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/ComplexToStandard/ComplexToStandard.h
+++ b/mlir/include/mlir/Conversion/ComplexToStandard/ComplexToStandard.h
@@ -16,7 +16,7 @@ namespace mlir {
 class RewritePatternSet;
 class Pass;
 
-#define GEN_PASS_DECL_CONVERTCOMPLEXTOSTANDARD
+#define GEN_PASS_DECL_CONVERTCOMPLEXTOSTANDARDPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Populate the given list with patterns that convert from Complex to Standard.
@@ -24,11 +24,6 @@ void populateComplexToStandardConversionPatterns(
     RewritePatternSet &patterns,
     mlir::complex::ComplexRangeFlags complexRange =
         mlir::complex::ComplexRangeFlags::improved);
-
-/// Create a pass to convert Complex operations to the Standard dialect.
-std::unique_ptr<Pass> createConvertComplexToStandardPass();
-std::unique_ptr<Pass>
-createConvertComplexToStandardPass(ConvertComplexToStandardOptions options);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.h
+++ b/mlir/include/mlir/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.h
@@ -18,11 +18,8 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_CONVERTCONTROLFLOWTOSPIRV
+#define GEN_PASS_DECL_CONVERTCONTROLFLOWTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates a pass to convert ControlFlow ops to SPIR-V ops.
-std::unique_ptr<OperationPass<>> createConvertControlFlowToSPIRVPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/ConvertToLLVM/ToLLVMPass.h
+++ b/mlir/include/mlir/Conversion/ConvertToLLVM/ToLLVMPass.h
@@ -13,14 +13,10 @@
 
 #include "mlir/Pass/Pass.h"
 
-#define GEN_PASS_DECL_CONVERTTOLLVMPASS
-#include "mlir/Conversion/Passes.h.inc"
-
 namespace mlir {
 
-/// Create a pass that performs dialect conversion to LLVM  for all dialects
-/// implementing `ConvertToLLVMPatternInterface`.
-std::unique_ptr<Pass> createConvertToLLVMPass();
+#define GEN_PASS_DECL_CONVERTTOLLVMPASS
+#include "mlir/Conversion/Passes.h.inc"
 
 /// Register the extension that will load dependent dialects for LLVM
 /// conversion. This is useful to implement a pass similar to "convert-to-llvm".

--- a/mlir/include/mlir/Conversion/FuncToSPIRV/FuncToSPIRVPass.h
+++ b/mlir/include/mlir/Conversion/FuncToSPIRV/FuncToSPIRVPass.h
@@ -18,11 +18,8 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_CONVERTFUNCTOSPIRV
+#define GEN_PASS_DECL_CONVERTFUNCTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates a pass to convert Func ops to SPIR-V ops.
-std::unique_ptr<OperationPass<>> createConvertFuncToSPIRVPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/LinalgToStandard/LinalgToStandard.h
+++ b/mlir/include/mlir/Conversion/LinalgToStandard/LinalgToStandard.h
@@ -10,6 +10,7 @@
 #define MLIR_CONVERSION_LINALGTOSTANDARD_LINALGTOSTANDARD_H_
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
@@ -17,7 +18,7 @@ class ModuleOp;
 template <typename T>
 class OperationPass;
 
-#define GEN_PASS_DECL_CONVERTLINALGTOSTANDARD
+#define GEN_PASS_DECL_CONVERTLINALGTOSTANDARDPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 namespace linalg {
@@ -46,10 +47,6 @@ public:
 void populateLinalgToStandardConversionPatterns(RewritePatternSet &patterns);
 
 } // namespace linalg
-
-/// Create a pass to convert Linalg operations to the Standard dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertLinalgToStandardPass();
-
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_LINALGTOSTANDARD_LINALGTOSTANDARD_H_

--- a/mlir/include/mlir/Conversion/MathToLibm/MathToLibm.h
+++ b/mlir/include/mlir/Conversion/MathToLibm/MathToLibm.h
@@ -9,21 +9,19 @@
 #define MLIR_CONVERSION_MATHTOLIBM_MATHTOLIBM_H_
 
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
 
 namespace mlir {
 template <typename T>
 class OperationPass;
 
-#define GEN_PASS_DECL_CONVERTMATHTOLIBM
+#define GEN_PASS_DECL_CONVERTMATHTOLIBMPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Populate the given list with patterns that convert from Math to Libm calls.
 /// If log1pBenefit is present, use it instead of benefit for the Log1p op.
 void populateMathToLibmConversionPatterns(RewritePatternSet &patterns,
                                           PatternBenefit benefit = 1);
-
-/// Create a pass to convert Math operations to libm calls.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertMathToLibmPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/MathToSPIRV/MathToSPIRVPass.h
+++ b/mlir/include/mlir/Conversion/MathToSPIRV/MathToSPIRVPass.h
@@ -18,11 +18,8 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_CONVERTMATHTOSPIRV
+#define GEN_PASS_DECL_CONVERTMATHTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates a pass to convert Math ops to SPIR-V ops.
-std::unique_ptr<OperationPass<>> createConvertMathToSPIRVPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.h
+++ b/mlir/include/mlir/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.h
@@ -20,15 +20,12 @@ namespace mlir {
 class ModuleOp;
 
 #define GEN_PASS_DECL_MAPMEMREFSTORAGECLASS
-#define GEN_PASS_DECL_CONVERTMEMREFTOSPIRV
+#define GEN_PASS_DECL_CONVERTMEMREFTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Creates a pass to map numeric MemRef memory spaces to symbolic SPIR-V
 /// storage classes. The mapping is read from the command-line option.
 std::unique_ptr<OperationPass<>> createMapMemRefStorageClassPass();
-
-/// Creates a pass to convert MemRef ops to SPIR-V ops.
-std::unique_ptr<OperationPass<>> createConvertMemRefToSPIRVPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/MeshToMPI/MeshToMPI.h
+++ b/mlir/include/mlir/Conversion/MeshToMPI/MeshToMPI.h
@@ -18,10 +18,6 @@ class Pass;
 #define GEN_PASS_DECL_CONVERTMESHTOMPIPASS
 #include "mlir/Conversion/Passes.h.inc"
 
-/// Lowers Mesh communication operations (updateHalo, AllGater, ...)
-/// to MPI primitives.
-std::unique_ptr<::mlir::Pass> createConvertMeshToMPIPass();
-
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_MESHTOMPI_MESHTOMPI_H

--- a/mlir/include/mlir/Conversion/OpenACCToSCF/ConvertOpenACCToSCF.h
+++ b/mlir/include/mlir/Conversion/OpenACCToSCF/ConvertOpenACCToSCF.h
@@ -8,6 +8,7 @@
 #ifndef MLIR_CONVERSION_OPENACCTOSCF_CONVERTOPENACCTOSCF_H
 #define MLIR_CONVERSION_OPENACCTOSCF_CONVERTOPENACCTOSCF_H
 
+#include "mlir/Pass/Pass.h"
 #include <memory>
 
 namespace mlir {
@@ -16,15 +17,12 @@ template <typename T>
 class OperationPass;
 class RewritePatternSet;
 
-#define GEN_PASS_DECL_CONVERTOPENACCTOSCF
+#define GEN_PASS_DECL_CONVERTOPENACCTOSCFPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Collect the patterns to convert from the OpenACC dialect to OpenACC with
 /// SCF dialect.
 void populateOpenACCToSCFConversionPatterns(RewritePatternSet &patterns);
-
-/// Create a pass to convert the OpenACC dialect into the LLVMIR dialect.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertOpenACCToSCFPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/PDLToPDLInterp/PDLToPDLInterp.h
+++ b/mlir/include/mlir/Conversion/PDLToPDLInterp/PDLToPDLInterp.h
@@ -13,6 +13,7 @@
 #ifndef MLIR_CONVERSION_PDLTOPDLINTERP_PDLTOPDLINTERP_H
 #define MLIR_CONVERSION_PDLTOPDLINTERP_PDLTOPDLINTERP_H
 
+#include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {
@@ -22,16 +23,13 @@ template <typename OpT>
 class OperationPass;
 class PDLPatternConfigSet;
 
-#define GEN_PASS_DECL_CONVERTPDLTOPDLINTERP
+#define GEN_PASS_DECL_CONVERTPDLTOPDLINTERPPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates and returns a pass to convert PDL ops to PDL interpreter ops.
-std::unique_ptr<OperationPass<ModuleOp>> createPDLToPDLInterpPass();
 
 /// Creates and returns a pass to convert PDL ops to PDL interpreter ops.
 /// `configMap` holds a map of the configurations for each pattern being
 /// compiled.
-std::unique_ptr<OperationPass<ModuleOp>> createPDLToPDLInterpPass(
+std::unique_ptr<OperationPass<ModuleOp>> createConvertPDLToPDLInterpPass(
     DenseMap<Operation *, PDLPatternConfigSet *> &configMap);
 
 } // namespace mlir

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -42,7 +42,7 @@ def ConvertToLLVMPass : Pass<"convert-to-llvm"> {
 // LowerAffine
 //===----------------------------------------------------------------------===//
 
-def LowerAffine : Pass<"lower-affine"> {
+def LowerAffinePass : Pass<"lower-affine"> {
   let summary = "Lower Affine operations to a combination of Arith and SCF "
                 "operations";
   let description = [{

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -30,7 +30,6 @@ def ConvertToLLVMPass : Pass<"convert-to-llvm"> {
     extra overhead.
   }];
 
-  let constructor = "mlir::createConvertToLLVMPass()";
   let options = [
     ListOption<"filterDialects", "filter-dialects", "std::string",
                "Test conversion patterns of only the specified dialects">,
@@ -40,11 +39,11 @@ def ConvertToLLVMPass : Pass<"convert-to-llvm"> {
 }
 
 //===----------------------------------------------------------------------===//
-// AffineToStandard
+// LowerAffine
 //===----------------------------------------------------------------------===//
 
-def ConvertAffineToStandard : Pass<"lower-affine"> {
-  let summary = "Lower Affine operations to a combination of Standard and SCF "
+def LowerAffine : Pass<"lower-affine"> {
+  let summary = "Lower Affine operations to a combination of Arith and SCF "
                 "operations";
   let description = [{
 
@@ -55,7 +54,7 @@ def ConvertAffineToStandard : Pass<"lower-affine"> {
     of certain structural restrictions (on their bounds and step). `affine.if`
     is similarly converted to the `scf.if` operation. `affine.apply` operations
     are converted into sequences of primitive arithmetic operations from the
-    standard dialect that have the same effect, using operands of the `index`
+    arith dialect that have the same effect, using operands of the `index`
     type. Consequently, named maps and sets thare are no longer in use may be
     removed from the module.
 
@@ -93,24 +92,19 @@ def ConvertAffineToStandard : Pass<"lower-affine"> {
         if they do not depend on the loop iterator value or on the result of
         `affine.apply`.
   }];
-  let constructor = "mlir::createLowerAffinePass()";
-  let dependentDialects = [
-    "memref::MemRefDialect",
-    "scf::SCFDialect",
-    "vector::VectorDialect"
-  ];
+  let dependentDialects = ["arith::ArithDialect", "memref::MemRefDialect",
+                           "scf::SCFDialect", "vector::VectorDialect"];
 }
 
 //===----------------------------------------------------------------------===//
 // AMDGPUToROCDL
 //===----------------------------------------------------------------------===//
 
-def ConvertAMDGPUToROCDL : Pass<"convert-amdgpu-to-rocdl"> {
+def ConvertAMDGPUToROCDLPass : Pass<"convert-amdgpu-to-rocdl"> {
   let summary = "Convert AMDGPU dialect to ROCDL dialect";
   let description = [{
     This pass converts supported AMDGPU ops to ROCDL dialect intrinsics.
   }];
-  let constructor = "mlir::createConvertAMDGPUToROCDLPass()";
   let dependentDialects = [
     "LLVM::LLVMDialect",
     "ROCDL::ROCDLDialect",
@@ -177,9 +171,8 @@ def ArithToLLVMConversionPass : Pass<"convert-arith-to-llvm"> {
 // ArithToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertArithToSPIRV : Pass<"convert-arith-to-spirv"> {
+def ConvertArithToSPIRVPass : Pass<"convert-arith-to-spirv"> {
   let summary = "Convert Arith dialect to SPIR-V dialect";
-  let constructor = "mlir::arith::createConvertArithToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
   let options = [
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
@@ -202,9 +195,13 @@ def ArithToArmSMEConversionPass : Pass<"convert-arith-to-arm-sme"> {
 // ArmNeon2dToIntr
 //===----------------------------------------------------------------------===//
 
-def ConvertArmNeon2dToIntr : Pass<"arm-neon-2d-to-intr"> {
+def ConvertArmNeon2dToIntrPass : Pass<"arm-neon-2d-to-intr"> {
   let summary = "Convert Arm NEON structured ops to intrinsics";
-  let constructor = "mlir::createConvertArmNeon2dToIntrPass()";
+  let description = [{
+    Creates a pass to lower Arm NEON 2D ops to intrinsics, i.e.
+    equivalent ops operating on flattened 1D vectors and mapping more
+    directly to the corresponding Arm NEON instruction.
+  }];
   let dependentDialects = ["arm_neon::ArmNeonDialect", "vector::VectorDialect"];
 }
 
@@ -231,7 +228,7 @@ def ConvertAsyncToLLVMPass : Pass<"convert-async-to-llvm", "ModuleOp"> {
 // BufferizationToMemRef
 //===----------------------------------------------------------------------===//
 
-def ConvertBufferizationToMemRef : Pass<"convert-bufferization-to-memref"> {
+def ConvertBufferizationToMemRefPass : Pass<"convert-bufferization-to-memref"> {
   let summary = "Convert operations from the Bufferization dialect to the "
                 "MemRef dialect";
   let description = [{
@@ -260,7 +257,6 @@ def ConvertBufferizationToMemRef : Pass<"convert-bufferization-to-memref"> {
     and hence does not resolve any memory leaks.
 
   }];
-  let constructor = "mlir::createBufferizationToMemRefPass()";
   let dependentDialects = [
     "arith::ArithDialect", "memref::MemRefDialect", "scf::SCFDialect",
     "func::FuncDialect"
@@ -296,10 +292,7 @@ def ConvertComplexToLibm : Pass<"convert-complex-to-libm", "ModuleOp"> {
   let description = [{
     This pass converts supported Complex ops to libm calls.
   }];
-  let constructor = "mlir::createConvertComplexToLibmPass()";
-  let dependentDialects = [
-    "func::FuncDialect",
-  ];
+  let dependentDialects = ["func::FuncDialect"];
 }
 
 //===----------------------------------------------------------------------===//
@@ -315,9 +308,8 @@ def ConvertComplexToSPIRVPass : Pass<"convert-complex-to-spirv"> {
 // ComplexToStandard
 //===----------------------------------------------------------------------===//
 
-def ConvertComplexToStandard : Pass<"convert-complex-to-standard"> {
+def ConvertComplexToStandardPass : Pass<"convert-complex-to-standard"> {
   let summary = "Convert Complex dialect to standard dialect";
-  let constructor = "mlir::createConvertComplexToStandardPass()";
   let dependentDialects = ["math::MathDialect"];
 
   let options = [
@@ -388,9 +380,8 @@ def LiftControlFlowToSCFPass : Pass<"lift-cf-to-scf"> {
 // ControlFlowToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertControlFlowToSPIRV : Pass<"convert-cf-to-spirv"> {
+def ConvertControlFlowToSPIRVPass : Pass<"convert-cf-to-spirv"> {
   let summary = "Convert ControlFlow dialect to SPIR-V dialect";
-  let constructor = "mlir::createConvertControlFlowToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
   let options = [
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
@@ -473,9 +464,8 @@ def ConvertFuncToLLVMPass : Pass<"convert-func-to-llvm", "ModuleOp"> {
 // FuncToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertFuncToSPIRV : Pass<"convert-func-to-spirv"> {
+def ConvertFuncToSPIRVPass : Pass<"convert-func-to-spirv"> {
   let summary = "Convert Func dialect to SPIR-V dialect";
-  let constructor = "mlir::createConvertFuncToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
   let options = [
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
@@ -702,10 +692,9 @@ def ConvertIndexToSPIRVPass : Pass<"convert-index-to-spirv"> {
 // LinalgToStandard
 //===----------------------------------------------------------------------===//
 
-def ConvertLinalgToStandard : Pass<"convert-linalg-to-std", "ModuleOp"> {
+def ConvertLinalgToStandardPass : Pass<"convert-linalg-to-std", "ModuleOp"> {
   let summary = "Convert the operations from the linalg dialect into the "
                 "Standard dialect";
-  let constructor = "mlir::createConvertLinalgToStandardPass()";
   let dependentDialects = ["func::FuncDialect", "memref::MemRefDialect"];
 }
 
@@ -713,12 +702,11 @@ def ConvertLinalgToStandard : Pass<"convert-linalg-to-std", "ModuleOp"> {
 // MathToLibm
 //===----------------------------------------------------------------------===//
 
-def ConvertMathToLibm : Pass<"convert-math-to-libm", "ModuleOp"> {
+def ConvertMathToLibmPass : Pass<"convert-math-to-libm", "ModuleOp"> {
   let summary = "Convert Math dialect to libm calls";
   let description = [{
     This pass converts supported Math ops to libm calls.
   }];
-  let constructor = "mlir::createConvertMathToLibmPass()";
   let dependentDialects = [
     "arith::ArithDialect",
     "func::FuncDialect",
@@ -760,9 +748,8 @@ def ConvertMathToROCDL : Pass<"convert-math-to-rocdl", "ModuleOp"> {
 // MathToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertMathToSPIRV : Pass<"convert-math-to-spirv"> {
+def ConvertMathToSPIRVPass : Pass<"convert-math-to-spirv"> {
   let summary = "Convert Math dialect to SPIR-V dialect";
-  let constructor = "mlir::createConvertMathToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
 }
 
@@ -872,9 +859,8 @@ def MapMemRefStorageClass : Pass<"map-memref-spirv-storage-class"> {
   ];
 }
 
-def ConvertMemRefToSPIRV : Pass<"convert-memref-to-spirv"> {
+def ConvertMemRefToSPIRVPass : Pass<"convert-memref-to-spirv"> {
   let summary = "Convert MemRef dialect to SPIR-V dialect";
-  let constructor = "mlir::createConvertMemRefToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
   let options = [
     Option<"boolNumBits", "bool-num-bits",
@@ -892,7 +878,6 @@ def ConvertMemRefToSPIRV : Pass<"convert-memref-to-spirv"> {
 
 def ConvertMeshToMPIPass : Pass<"convert-mesh-to-mpi"> {
   let summary = "Convert Mesh dialect to MPI dialect.";
-  let constructor = "mlir::createConvertMeshToMPIPass()";
   let description = [{
     This pass converts communication operations from the Mesh dialect to the
     MPI dialect.
@@ -944,9 +929,8 @@ def ConvertNVGPUToNVVMPass : Pass<"convert-nvgpu-to-nvvm"> {
 // OpenACCToSCF
 //===----------------------------------------------------------------------===//
 
-def ConvertOpenACCToSCF : Pass<"convert-openacc-to-scf", "ModuleOp"> {
+def ConvertOpenACCToSCFPass : Pass<"convert-openacc-to-scf", "ModuleOp"> {
   let summary = "Convert the OpenACC ops to OpenACC with SCF dialect";
-  let constructor = "mlir::createConvertOpenACCToSCFPass()";
   let dependentDialects = ["scf::SCFDialect", "acc::OpenACCDialect"];
 }
 
@@ -963,9 +947,8 @@ def ConvertOpenMPToLLVMPass : Pass<"convert-openmp-to-llvm", "ModuleOp"> {
 // PDLToPDLInterp
 //===----------------------------------------------------------------------===//
 
-def ConvertPDLToPDLInterp : Pass<"convert-pdl-to-pdl-interp", "ModuleOp"> {
+def ConvertPDLToPDLInterpPass : Pass<"convert-pdl-to-pdl-interp", "ModuleOp"> {
   let summary = "Convert PDL ops to PDL interpreter ops";
-  let constructor = "mlir::createPDLToPDLInterpPass()";
   let dependentDialects = ["pdl_interp::PDLInterpDialect"];
 }
 
@@ -973,7 +956,7 @@ def ConvertPDLToPDLInterp : Pass<"convert-pdl-to-pdl-interp", "ModuleOp"> {
 // ReconcileUnrealizedCasts
 //===----------------------------------------------------------------------===//
 
-def ReconcileUnrealizedCasts : Pass<"reconcile-unrealized-casts"> {
+def ReconcileUnrealizedCastsPass : Pass<"reconcile-unrealized-casts"> {
   let summary = "Simplify and eliminate unrealized conversion casts";
   let description = [{
     Eliminate `unrealized_conversion_cast` operations, commonly introduced by
@@ -992,17 +975,15 @@ def ReconcileUnrealizedCasts : Pass<"reconcile-unrealized-casts"> {
     and the producer operation is converted by another pass, each of which
     produces an unrealized cast. This pass can be used to clean up the IR.
   }];
-  let constructor = "mlir::createReconcileUnrealizedCastsPass()";
 }
 
 //===----------------------------------------------------------------------===//
 // SCFToControlFlow
 //===----------------------------------------------------------------------===//
 
-def SCFToControlFlow : Pass<"convert-scf-to-cf"> {
+def SCFToControlFlowPass : Pass<"convert-scf-to-cf"> {
   let summary = "Convert SCF dialect to ControlFlow dialect, replacing structured"
                 " control flow with a CFG";
-  let constructor = "mlir::createConvertSCFToCFPass()";
   let dependentDialects = ["cf::ControlFlowDialect"];
 }
 
@@ -1044,10 +1025,9 @@ def SCFToSPIRV : Pass<"convert-scf-to-spirv"> {
 // SCFToGPU
 //===----------------------------------------------------------------------===//
 
-def ConvertAffineForToGPU
+def ConvertAffineForToGPUPass
     : InterfacePass<"convert-affine-for-to-gpu", "FunctionOpInterface"> {
   let summary = "Convert top-level AffineFor Ops to GPU kernels";
-  let constructor = "mlir::createAffineForToGPUPass()";
   let dependentDialects = ["gpu::GPUDialect"];
   let options = [
     Option<"numBlockDims", "gpu-block-dims", "unsigned", /*default=*/"1u",
@@ -1057,9 +1037,14 @@ def ConvertAffineForToGPU
   ];
 }
 
-def ConvertParallelLoopToGpu : Pass<"convert-parallel-loops-to-gpu"> {
+def ConvertParallelLoopToGpuPass : Pass<"convert-parallel-loops-to-gpu"> {
   let summary = "Convert mapped scf.parallel ops to gpu launch operations";
-  let constructor = "mlir::createParallelLoopToGpuPass()";
+  let description = [{
+    Creates a pass that converts scf.parallel operations into a gpu.launch
+    operation. The mapping of loop dimensions to launch dimensions is derived
+    from mapping attributes. See ParallelToGpuLaunchLowering::matchAndRewrite
+    for a description of the used attributes.
+  }];
   let dependentDialects = ["affine::AffineDialect", "gpu::GPUDialect"];
 }
 
@@ -1077,16 +1062,13 @@ def SCFToEmitC : Pass<"convert-scf-to-emitc"> {
 // ShapeToStandard
 //===----------------------------------------------------------------------===//
 
-def ConvertShapeToStandard : Pass<"convert-shape-to-std", "ModuleOp"> {
+def ConvertShapeToStandardPass : Pass<"convert-shape-to-std", "ModuleOp"> {
   let summary = "Convert operations from the shape dialect into the standard "
                 "dialect";
-  let constructor = "mlir::createConvertShapeToStandardPass()";
-  let dependentDialects = [
-    "scf::SCFDialect",
-  ];
+  let dependentDialects = ["scf::SCFDialect"];
 }
 
-def ConvertShapeConstraints : Pass<"convert-shape-constraints"> {
+def ConvertShapeConstraintsPass : Pass<"convert-shape-constraints"> {
   let summary = "Convert shape constraint operations to the standard dialect";
   let description = [{
     This pass eliminates shape constraints from the program, converting them to
@@ -1097,7 +1079,6 @@ def ConvertShapeConstraints : Pass<"convert-shape-constraints"> {
     can happen at a different part of the program than general shape
     computation lowering.
   }];
-  let constructor = "mlir::createConvertShapeConstraintsPass()";
   let dependentDialects = ["cf::ControlFlowDialect", "scf::SCFDialect"];
 }
 
@@ -1131,9 +1112,8 @@ def ConvertSPIRVToLLVMPass : Pass<"convert-spirv-to-llvm", "ModuleOp"> {
 // TensorToLinalg
 //===----------------------------------------------------------------------===//
 
-def ConvertTensorToLinalg : Pass<"convert-tensor-to-linalg", "ModuleOp"> {
+def ConvertTensorToLinalgPass : Pass<"convert-tensor-to-linalg", "ModuleOp"> {
   let summary = "Convert some Tensor dialect ops to Linalg dialect";
-  let constructor = "mlir::createConvertTensorToLinalgPass()";
   let dependentDialects = [
     "arith::ArithDialect",
     "linalg::LinalgDialect",
@@ -1144,9 +1124,8 @@ def ConvertTensorToLinalg : Pass<"convert-tensor-to-linalg", "ModuleOp"> {
 // TensorToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertTensorToSPIRV : Pass<"convert-tensor-to-spirv"> {
+def ConvertTensorToSPIRVPass : Pass<"convert-tensor-to-spirv"> {
   let summary = "Convert Tensor dialect to SPIR-V dialect";
-  let constructor = "mlir::createConvertTensorToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
   let options = [
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
@@ -1160,7 +1139,7 @@ def ConvertTensorToSPIRV : Pass<"convert-tensor-to-spirv"> {
 // TosaToArith
 //===----------------------------------------------------------------------===//
 
-def TosaToArith : Pass<"tosa-to-arith"> {
+def TosaToArithPass : Pass<"tosa-to-arith"> {
   let summary = "Lower TOSA to the Arith dialect";
   let dependentDialects = [
     "arith::ArithDialect",
@@ -1179,8 +1158,6 @@ def TosaToArith : Pass<"tosa-to-arith"> {
            "bool", /*default=*/"false",
            "Whether to prioritze lowering to 32-bit operations">
   ];
-
-  let constructor = "tosa::createTosaToArith()";
 }
 
 //===----------------------------------------------------------------------===//
@@ -1244,22 +1221,20 @@ def TosaToMLProgram : Pass<"tosa-to-mlprogram", "ModuleOp"> {
 // TosaToSCF
 //===----------------------------------------------------------------------===//
 
-def TosaToSCF : Pass<"tosa-to-scf"> {
+def TosaToSCFPass : Pass<"tosa-to-scf"> {
   let summary = "Lower TOSA to the SCF dialect";
   let dependentDialects = ["tensor::TensorDialect, scf::SCFDialect"];
   let description = [{
     Pass that converts TOSA's control flow operations to the equivalent SCF
     operations.
   }];
-
-  let constructor = "tosa::createTosaToSCF()";
 }
 
 //===----------------------------------------------------------------------===//
 // TosaToTensor
 //===----------------------------------------------------------------------===//
 
-def TosaToTensor : Pass<"tosa-to-tensor"> {
+def TosaToTensorPass : Pass<"tosa-to-tensor"> {
   let summary = "Lower TOSA to the Tensor dialect";
   let dependentDialects = [
     "tensor::TensorDialect",
@@ -1268,8 +1243,6 @@ def TosaToTensor : Pass<"tosa-to-tensor"> {
     Pass that converts TOSA operations to the equivalent operations using the
     operations in the Tensor dialect.
   }];
-
-  let constructor = "tosa::createTosaToTensor()";
 }
 
 //===----------------------------------------------------------------------===//
@@ -1350,10 +1323,9 @@ def ConvertVectorToSCF : Pass<"convert-vector-to-scf"> {
 // VectorToArmSME
 //===----------------------------------------------------------------------===//
 
-def ConvertVectorToArmSME : Pass<"convert-vector-to-arm-sme"> {
+def ConvertVectorToArmSMEPass : Pass<"convert-vector-to-arm-sme"> {
   let summary = "Lower the operations from the vector dialect into the ArmSME "
                 "dialect";
-  let constructor = "mlir::createConvertVectorToArmSMEPass()";
   let description = [{
     Pass that converts vector dialect operations into equivalent ArmSME dialect
     operations.
@@ -1365,10 +1337,9 @@ def ConvertVectorToArmSME : Pass<"convert-vector-to-arm-sme"> {
 // ArmSMEToSCF
 //===----------------------------------------------------------------------===//
 
-def ConvertArmSMEToSCF : Pass<"convert-arm-sme-to-scf"> {
+def ConvertArmSMEToSCFPass : Pass<"convert-arm-sme-to-scf"> {
   let summary = "Lower the operations from the ArmSME dialect into the SCF "
                 "dialect";
-  let constructor = "mlir::createConvertArmSMEToSCFPass()";
   let dependentDialects = [
     "scf::SCFDialect",
     "arith::ArithDialect",
@@ -1450,9 +1421,8 @@ def ConvertVectorToLLVMPass : Pass<"convert-vector-to-llvm"> {
 // VectorToSPIRV
 //===----------------------------------------------------------------------===//
 
-def ConvertVectorToSPIRV : Pass<"convert-vector-to-spirv"> {
+def ConvertVectorToSPIRVPass : Pass<"convert-vector-to-spirv"> {
   let summary = "Convert Vector dialect to SPIR-V dialect";
-  let constructor = "mlir::createConvertVectorToSPIRVPass()";
   let dependentDialects = [
     "spirv::SPIRVDialect",
     "ub::UBDialect"
@@ -1466,7 +1436,6 @@ def ConvertVectorToSPIRV : Pass<"convert-vector-to-spirv"> {
 def ConvertVectorToXeGPU : Pass<"convert-vector-to-xegpu"> {
   let summary = "Lower the operations from the vector dialect into the XeGPU "
                 "dialect";
-  let constructor = "mlir::createConvertVectorToXeGPUPass()";
   let dependentDialects = [
     "memref::MemRefDialect", "arith::ArithDialect",
     "vector::VectorDialect", "xegpu::XeGPUDialect"

--- a/mlir/include/mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h
+++ b/mlir/include/mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h
@@ -15,12 +15,9 @@ namespace mlir {
 class Pass;
 class RewritePatternSet;
 
-#define GEN_PASS_DECL_RECONCILEUNREALIZEDCASTS
+#define GEN_PASS_DECL_RECONCILEUNREALIZEDCASTSPASS
 #include "mlir/Conversion/Passes.h.inc"
 
-/// Creates a pass that eliminates noop `unrealized_conversion_cast` operation
-/// sequences.
-std::unique_ptr<Pass> createReconcileUnrealizedCastsPass();
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_RECONCILEUNREALIZEDCASTS_RECONCILEUNREALIZEDCASTS_H_

--- a/mlir/include/mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h
+++ b/mlir/include/mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h
@@ -15,16 +15,12 @@ namespace mlir {
 class Pass;
 class RewritePatternSet;
 
-#define GEN_PASS_DECL_SCFTOCONTROLFLOW
+#define GEN_PASS_DECL_SCFTOCONTROLFLOWPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Collect a set of patterns to convert SCF operations to CFG branch-based
 /// operations within the ControlFlow dialect.
 void populateSCFToControlFlowConversionPatterns(RewritePatternSet &patterns);
-
-/// Creates a pass to convert SCF operations to CFG branch-based operation in
-/// the ControlFlow dialect.
-std::unique_ptr<Pass> createConvertSCFToCFPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/SCFToGPU/SCFToGPUPass.h
+++ b/mlir/include/mlir/Conversion/SCFToGPU/SCFToGPUPass.h
@@ -9,6 +9,7 @@
 #define MLIR_CONVERSION_SCFTOGPU_SCFTOGPUPASS_H_
 
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 
 #include <memory>
@@ -18,27 +19,9 @@ template <typename T>
 class InterfacePass;
 class Pass;
 
-#define GEN_PASS_DECL_CONVERTAFFINEFORTOGPU
-#define GEN_PASS_DECL_CONVERTPARALLELLOOPTOGPU
+#define GEN_PASS_DECL_CONVERTAFFINEFORTOGPUPASS
+#define GEN_PASS_DECL_CONVERTPARALLELLOOPTOGPUPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Create a pass that converts loop nests into GPU kernels.  It considers
-/// top-level affine.for operations as roots of loop nests and converts them to
-/// the gpu.launch operations if possible.
-///
-/// No check on the size of the block or grid, or on the validity of
-/// parallelization is performed, it is under the responsibility of the caller
-/// to strip-mine the loops and to perform the dependence analysis before
-/// calling the conversion.
-std::unique_ptr<InterfacePass<FunctionOpInterface>>
-createAffineForToGPUPass(unsigned numBlockDims, unsigned numThreadDims);
-std::unique_ptr<InterfacePass<FunctionOpInterface>> createAffineForToGPUPass();
-
-/// Creates a pass that converts scf.parallel operations into a gpu.launch
-/// operation. The mapping of loop dimensions to launch dimensions is derived
-/// from mapping attributes. See ParallelToGpuLaunchLowering::matchAndRewrite
-/// for a description of the used attributes.
-std::unique_ptr<Pass> createParallelLoopToGpuPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/ShapeToStandard/ShapeToStandard.h
+++ b/mlir/include/mlir/Conversion/ShapeToStandard/ShapeToStandard.h
@@ -19,18 +19,14 @@ template <typename T>
 class OperationPass;
 class RewritePatternSet;
 
-#define GEN_PASS_DECL_CONVERTSHAPECONSTRAINTS
-#define GEN_PASS_DECL_CONVERTSHAPETOSTANDARD
+#define GEN_PASS_DECL_CONVERTSHAPECONSTRAINTSPASS
+#define GEN_PASS_DECL_CONVERTSHAPETOSTANDARDPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 void populateShapeToStandardConversionPatterns(RewritePatternSet &patterns);
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertShapeToStandardPass();
-
 void populateConvertShapeConstraintsConversionPatterns(
     RewritePatternSet &patterns);
-
-std::unique_ptr<Pass> createConvertShapeConstraintsPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/TensorToLinalg/TensorToLinalgPass.h
+++ b/mlir/include/mlir/Conversion/TensorToLinalg/TensorToLinalgPass.h
@@ -18,11 +18,8 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_CONVERTTENSORTOLINALG
+#define GEN_PASS_DECL_CONVERTTENSORTOLINALGPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates a pass to convert Tensor ops to Linalg ops.
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTensorToLinalgPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/TensorToSPIRV/TensorToSPIRVPass.h
+++ b/mlir/include/mlir/Conversion/TensorToSPIRV/TensorToSPIRVPass.h
@@ -18,11 +18,8 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_CONVERTTENSORTOSPIRV
+#define GEN_PASS_DECL_CONVERTTENSORTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates a pass to convert Tensor ops to SPIR-V ops.
-std::unique_ptr<OperationPass<>> createConvertTensorToSPIRVPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/TosaToArith/TosaToArith.h
+++ b/mlir/include/mlir/Conversion/TosaToArith/TosaToArith.h
@@ -17,13 +17,10 @@
 
 namespace mlir {
 
-#define GEN_PASS_DECL_TOSATOARITH
+#define GEN_PASS_DECL_TOSATOARITHPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 namespace tosa {
-
-std::unique_ptr<Pass> createTosaToArith(bool includeApplyRescale = false,
-                                        bool use32BitApplyRescale = false);
 
 void populateTosaToArithConversionPatterns(RewritePatternSet *patterns);
 

--- a/mlir/include/mlir/Conversion/TosaToSCF/TosaToSCF.h
+++ b/mlir/include/mlir/Conversion/TosaToSCF/TosaToSCF.h
@@ -17,12 +17,10 @@
 
 namespace mlir {
 
-#define GEN_PASS_DECL_TOSATOSCF
+#define GEN_PASS_DECL_TOSATOSCFPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 namespace tosa {
-
-std::unique_ptr<Pass> createTosaToSCF();
 
 void populateTosaToSCFConversionPatterns(RewritePatternSet *patterns);
 

--- a/mlir/include/mlir/Conversion/TosaToTensor/TosaToTensor.h
+++ b/mlir/include/mlir/Conversion/TosaToTensor/TosaToTensor.h
@@ -18,12 +18,10 @@
 namespace mlir {
 class TypeConverter;
 
-#define GEN_PASS_DECL_TOSATOTENSOR
+#define GEN_PASS_DECL_TOSATOTENSORPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 namespace tosa {
-
-std::unique_ptr<Pass> createTosaToTensor();
 
 void populateTosaToTensorConversionPatterns(const TypeConverter &converter,
                                             RewritePatternSet *patterns);

--- a/mlir/include/mlir/Conversion/VectorToArmSME/VectorToArmSME.h
+++ b/mlir/include/mlir/Conversion/VectorToArmSME/VectorToArmSME.h
@@ -13,16 +13,13 @@
 namespace mlir {
 class Pass;
 
-#define GEN_PASS_DECL_CONVERTVECTORTOARMSME
+#define GEN_PASS_DECL_CONVERTVECTORTOARMSMEPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 /// Collect a set of patterns to lower Vector ops to ArmSME ops that map to LLVM
 /// intrinsics.
 void populateVectorToArmSMEPatterns(RewritePatternSet &patterns,
                                     MLIRContext &ctx);
-
-/// Create a pass to lower operations from the vector dialect to Arm SME.
-std::unique_ptr<Pass> createConvertVectorToArmSMEPass();
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/VectorToSPIRV/VectorToSPIRVPass.h
+++ b/mlir/include/mlir/Conversion/VectorToSPIRV/VectorToSPIRVPass.h
@@ -18,11 +18,8 @@
 namespace mlir {
 class ModuleOp;
 
-#define GEN_PASS_DECL_VECTORTOSPIRVPASS
+#define GEN_PASS_DECL_CONVERTVECTORTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
-
-/// Creates a pass to convert Vector Ops to SPIR-V ops.
-std::unique_ptr<OperationPass<>> createConvertVectorToSPIRVPass();
 
 } // namespace mlir
 

--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -23,7 +23,7 @@
 #include <optional>
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTAMDGPUTOROCDL
+#define GEN_PASS_DEF_CONVERTAMDGPUTOROCDLPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -1037,8 +1037,8 @@ struct AMDGPUDPPLowering : public ConvertOpToLLVMPattern<DPPOp> {
 };
 
 struct ConvertAMDGPUToROCDLPass
-    : public impl::ConvertAMDGPUToROCDLBase<ConvertAMDGPUToROCDLPass> {
-  ConvertAMDGPUToROCDLPass() = default;
+    : public impl::ConvertAMDGPUToROCDLPassBase<ConvertAMDGPUToROCDLPass> {
+  using ConvertAMDGPUToROCDLPassBase::ConvertAMDGPUToROCDLPassBase;
 
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();
@@ -1082,8 +1082,4 @@ void mlir::populateAMDGPUToROCDLConversionPatterns(
            MFMAOpLowering, WMMAOpLowering, ExtPackedFp8OpLowering,
            PackedTrunc2xFp8OpLowering, PackedStochRoundFp8OpLowering>(converter,
                                                                       chipset);
-}
-
-std::unique_ptr<Pass> mlir::createConvertAMDGPUToROCDLPass() {
-  return std::make_unique<ConvertAMDGPUToROCDLPass>();
 }

--- a/mlir/lib/Conversion/AffineToStandard/AffineToStandard.cpp
+++ b/mlir/lib/Conversion/AffineToStandard/AffineToStandard.cpp
@@ -26,7 +26,7 @@
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_LOWERAFFINE
+#define GEN_PASS_DEF_LOWERAFFINEPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -553,7 +553,7 @@ void mlir::populateAffineToVectorConversionPatterns(
 }
 
 namespace {
-class LowerAffine : public impl::LowerAffineBase<LowerAffine> {
+class LowerAffine : public impl::LowerAffinePassBase<LowerAffine> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populateAffineToStdConversionPatterns(patterns);

--- a/mlir/lib/Conversion/AffineToStandard/AffineToStandard.cpp
+++ b/mlir/lib/Conversion/AffineToStandard/AffineToStandard.cpp
@@ -26,7 +26,7 @@
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTAFFINETOSTANDARD
+#define GEN_PASS_DEF_LOWERAFFINE
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -553,8 +553,7 @@ void mlir::populateAffineToVectorConversionPatterns(
 }
 
 namespace {
-class LowerAffinePass
-    : public impl::ConvertAffineToStandardBase<LowerAffinePass> {
+class LowerAffine : public impl::LowerAffineBase<LowerAffine> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populateAffineToStdConversionPatterns(patterns);
@@ -569,9 +568,3 @@ class LowerAffinePass
   }
 };
 } // namespace
-
-/// Lowers If and For operations within a function into their lower level CFG
-/// equivalent blocks.
-std::unique_ptr<Pass> mlir::createLowerAffinePass() {
-  return std::make_unique<LowerAffinePass>();
-}

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -27,7 +27,7 @@
 #include <memory>
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTARITHTOSPIRV
+#define GEN_PASS_DEF_CONVERTARITHTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -1337,7 +1337,9 @@ void mlir::arith::populateArithToSPIRVPatterns(
 
 namespace {
 struct ConvertArithToSPIRVPass
-    : public impl::ConvertArithToSPIRVBase<ConvertArithToSPIRVPass> {
+    : public impl::ConvertArithToSPIRVPassBase<ConvertArithToSPIRVPass> {
+  using ConvertArithToSPIRVPassBase::ConvertArithToSPIRVPassBase;
+
   void runOnOperation() override {
     Operation *op = getOperation();
     spirv::TargetEnvAttr targetAttr = spirv::lookupTargetEnvOrDefault(op);
@@ -1363,7 +1365,3 @@ struct ConvertArithToSPIRVPass
   }
 };
 } // namespace
-
-std::unique_ptr<OperationPass<>> mlir::arith::createConvertArithToSPIRVPass() {
-  return std::make_unique<ConvertArithToSPIRVPass>();
-}

--- a/mlir/lib/Conversion/ArmNeon2dToIntr/ArmNeon2dToIntr.cpp
+++ b/mlir/lib/Conversion/ArmNeon2dToIntr/ArmNeon2dToIntr.cpp
@@ -16,7 +16,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTARMNEON2DTOINTR
+#define GEN_PASS_DEF_CONVERTARMNEON2DTOINTRPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -52,7 +52,7 @@ public:
 };
 
 class ConvertArmNeon2dToIntr
-    : public impl::ConvertArmNeon2dToIntrBase<ConvertArmNeon2dToIntr> {
+    : public impl::ConvertArmNeon2dToIntrPassBase<ConvertArmNeon2dToIntr> {
   void runOnOperation() override {
     auto *context = &getContext();
 
@@ -68,8 +68,4 @@ class ConvertArmNeon2dToIntr
 
 void mlir::populateConvertArmNeon2dToIntrPatterns(RewritePatternSet &patterns) {
   patterns.add<Sdot2dLoweringPattern>(patterns.getContext());
-}
-
-std::unique_ptr<Pass> mlir::createConvertArmNeon2dToIntrPass() {
-  return std::make_unique<ConvertArmNeon2dToIntr>();
 }

--- a/mlir/lib/Conversion/ArmSMEToSCF/ArmSMEToSCF.cpp
+++ b/mlir/lib/Conversion/ArmSMEToSCF/ArmSMEToSCF.cpp
@@ -19,7 +19,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTARMSMETOSCF
+#define GEN_PASS_DEF_CONVERTARMSMETOSCFPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -397,7 +397,7 @@ void mlir::populateArmSMEToSCFConversionPatterns(RewritePatternSet &patterns) {
 namespace {
 
 struct ConvertArmSMEToSCFPass
-    : public impl::ConvertArmSMEToSCFBase<ConvertArmSMEToSCFPass> {
+    : public impl::ConvertArmSMEToSCFPassBase<ConvertArmSMEToSCFPass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     ConversionTarget target(getContext());
@@ -412,7 +412,3 @@ struct ConvertArmSMEToSCFPass
 };
 
 } // namespace
-
-std::unique_ptr<Pass> mlir::createConvertArmSMEToSCFPass() {
-  return std::make_unique<ConvertArmSMEToSCFPass>();
-}

--- a/mlir/lib/Conversion/BufferizationToMemRef/BufferizationToMemRef.cpp
+++ b/mlir/lib/Conversion/BufferizationToMemRef/BufferizationToMemRef.cpp
@@ -24,7 +24,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTBUFFERIZATIONTOMEMREF
+#define GEN_PASS_DEF_CONVERTBUFFERIZATIONTOMEMREFPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -121,7 +121,8 @@ struct CloneOpConversion : public OpConversionPattern<bufferization::CloneOp> {
 
 namespace {
 struct BufferizationToMemRefPass
-    : public impl::ConvertBufferizationToMemRefBase<BufferizationToMemRefPass> {
+    : public impl::ConvertBufferizationToMemRefPassBase<
+          BufferizationToMemRefPass> {
   BufferizationToMemRefPass() = default;
 
   void runOnOperation() override {
@@ -167,7 +168,3 @@ struct BufferizationToMemRefPass
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::createBufferizationToMemRefPass() {
-  return std::make_unique<BufferizationToMemRefPass>();
-}

--- a/mlir/lib/Conversion/ComplexToLibm/ComplexToLibm.cpp
+++ b/mlir/lib/Conversion/ComplexToLibm/ComplexToLibm.cpp
@@ -143,8 +143,3 @@ void ConvertComplexToLibmPass::runOnOperation() {
   if (failed(applyPartialConversion(module, target, std::move(patterns))))
     signalPassFailure();
 }
-
-std::unique_ptr<OperationPass<ModuleOp>>
-mlir::createConvertComplexToLibmPass() {
-  return std::make_unique<ConvertComplexToLibmPass>();
-}

--- a/mlir/lib/Conversion/ComplexToStandard/ComplexToStandard.cpp
+++ b/mlir/lib/Conversion/ComplexToStandard/ComplexToStandard.cpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTCOMPLEXTOSTANDARD
+#define GEN_PASS_DEF_CONVERTCOMPLEXTOSTANDARDPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -1070,11 +1070,9 @@ void mlir::populateComplexToStandardConversionPatterns(
 
 namespace {
 struct ConvertComplexToStandardPass
-    : public impl::ConvertComplexToStandardBase<ConvertComplexToStandardPass> {
-  ConvertComplexToStandardPass() = default;
-  ConvertComplexToStandardPass(const ConvertComplexToStandardOptions &options)
-      : impl::ConvertComplexToStandardBase<ConvertComplexToStandardPass>(
-            options) {}
+    : public impl::ConvertComplexToStandardPassBase<
+          ConvertComplexToStandardPass> {
+  using ConvertComplexToStandardPassBase::ConvertComplexToStandardPassBase;
 
   void runOnOperation() override;
 };
@@ -1092,12 +1090,3 @@ void ConvertComplexToStandardPass::runOnOperation() {
     signalPassFailure();
 }
 } // namespace
-
-std::unique_ptr<Pass> mlir::createConvertComplexToStandardPass() {
-  return std::make_unique<ConvertComplexToStandardPass>();
-}
-
-std::unique_ptr<Pass> mlir::createConvertComplexToStandardPass(
-    ConvertComplexToStandardOptions options) {
-  return std::make_unique<ConvertComplexToStandardPass>(std::move(options));
-}

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTCONTROLFLOWTOSPIRV
+#define GEN_PASS_DEF_CONVERTCONTROLFLOWTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -26,8 +26,9 @@ using namespace mlir;
 namespace {
 /// A pass converting MLIR ControlFlow operations into the SPIR-V dialect.
 class ConvertControlFlowToSPIRVPass final
-    : public impl::ConvertControlFlowToSPIRVBase<
+    : public impl::ConvertControlFlowToSPIRVPassBase<
           ConvertControlFlowToSPIRVPass> {
+  using ConvertControlFlowToSPIRVPassBase::ConvertControlFlowToSPIRVPassBase;
   void runOnOperation() override;
 };
 } // namespace
@@ -51,8 +52,4 @@ void ConvertControlFlowToSPIRVPass::runOnOperation() {
 
   if (failed(applyPartialConversion(op, *target, std::move(patterns))))
     return signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<>> mlir::createConvertControlFlowToSPIRVPass() {
-  return std::make_unique<ConvertControlFlowToSPIRVPass>();
 }

--- a/mlir/lib/Conversion/ConvertToLLVM/ConvertToLLVMPass.cpp
+++ b/mlir/lib/Conversion/ConvertToLLVM/ConvertToLLVMPass.cpp
@@ -280,7 +280,3 @@ void mlir::registerConvertToLLVMDependentDialectLoading(
     DialectRegistry &registry) {
   registry.addExtensions<LoadDependentDialectExtension>();
 }
-
-std::unique_ptr<Pass> mlir::createConvertToLLVMPass() {
-  return std::make_unique<ConvertToLLVMPass>();
-}

--- a/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTFUNCTOSPIRV
+#define GEN_PASS_DEF_CONVERTFUNCTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -26,7 +26,8 @@ using namespace mlir;
 namespace {
 /// A pass converting MLIR Func operations into the SPIR-V dialect.
 class ConvertFuncToSPIRVPass
-    : public impl::ConvertFuncToSPIRVBase<ConvertFuncToSPIRVPass> {
+    : public impl::ConvertFuncToSPIRVPassBase<ConvertFuncToSPIRVPass> {
+  using ConvertFuncToSPIRVPassBase::ConvertFuncToSPIRVPassBase;
   void runOnOperation() override;
 };
 } // namespace
@@ -49,8 +50,4 @@ void ConvertFuncToSPIRVPass::runOnOperation() {
 
   if (failed(applyPartialConversion(op, *target, std::move(patterns))))
     return signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<>> mlir::createConvertFuncToSPIRVPass() {
-  return std::make_unique<ConvertFuncToSPIRVPass>();
 }

--- a/mlir/lib/Conversion/LinalgToStandard/LinalgToStandard.cpp
+++ b/mlir/lib/Conversion/LinalgToStandard/LinalgToStandard.cpp
@@ -18,7 +18,7 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTLINALGTOSTANDARD
+#define GEN_PASS_DEF_CONVERTLINALGTOSTANDARDPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -133,7 +133,8 @@ void mlir::linalg::populateLinalgToStandardConversionPatterns(
 
 namespace {
 struct ConvertLinalgToStandardPass
-    : public impl::ConvertLinalgToStandardBase<ConvertLinalgToStandardPass> {
+    : public impl::ConvertLinalgToStandardPassBase<
+          ConvertLinalgToStandardPass> {
   void runOnOperation() override;
 };
 } // namespace
@@ -149,9 +150,4 @@ void ConvertLinalgToStandardPass::runOnOperation() {
   populateLinalgToStandardConversionPatterns(patterns);
   if (failed(applyFullConversion(module, target, std::move(patterns))))
     signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<ModuleOp>>
-mlir::createConvertLinalgToStandardPass() {
-  return std::make_unique<ConvertLinalgToStandardPass>();
 }

--- a/mlir/lib/Conversion/MathToLibm/MathToLibm.cpp
+++ b/mlir/lib/Conversion/MathToLibm/MathToLibm.cpp
@@ -20,7 +20,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTMATHTOLIBM
+#define GEN_PASS_DEF_CONVERTMATHTOLIBMPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -212,7 +212,7 @@ void mlir::populateMathToLibmConversionPatterns(RewritePatternSet &patterns,
 
 namespace {
 struct ConvertMathToLibmPass
-    : public impl::ConvertMathToLibmBase<ConvertMathToLibmPass> {
+    : public impl::ConvertMathToLibmPassBase<ConvertMathToLibmPass> {
   void runOnOperation() override;
 };
 } // namespace
@@ -229,8 +229,4 @@ void ConvertMathToLibmPass::runOnOperation() {
   target.addIllegalDialect<math::MathDialect>();
   if (failed(applyPartialConversion(module, target, std::move(patterns))))
     signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<ModuleOp>> mlir::createConvertMathToLibmPass() {
-  return std::make_unique<ConvertMathToLibmPass>();
 }

--- a/mlir/lib/Conversion/MathToSPIRV/MathToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/MathToSPIRV/MathToSPIRVPass.cpp
@@ -15,10 +15,9 @@
 #include "mlir/Conversion/MathToSPIRV/MathToSPIRV.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
-#include "mlir/Pass/Pass.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTMATHTOSPIRV
+#define GEN_PASS_DEF_CONVERTMATHTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -27,7 +26,7 @@ using namespace mlir;
 namespace {
 /// A pass converting MLIR Math operations into the SPIR-V dialect.
 class ConvertMathToSPIRVPass
-    : public impl::ConvertMathToSPIRVBase<ConvertMathToSPIRVPass> {
+    : public impl::ConvertMathToSPIRVPassBase<ConvertMathToSPIRVPass> {
   void runOnOperation() override;
 };
 } // namespace
@@ -51,8 +50,4 @@ void ConvertMathToSPIRVPass::runOnOperation() {
 
   if (failed(applyPartialConversion(op, *target, std::move(patterns))))
     return signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<>> mlir::createConvertMathToSPIRVPass() {
-  return std::make_unique<ConvertMathToSPIRVPass>();
 }

--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTMEMREFTOSPIRV
+#define GEN_PASS_DEF_CONVERTMEMREFTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -26,7 +26,8 @@ using namespace mlir;
 namespace {
 /// A pass converting MLIR MemRef operations into the SPIR-V dialect.
 class ConvertMemRefToSPIRVPass
-    : public impl::ConvertMemRefToSPIRVBase<ConvertMemRefToSPIRVPass> {
+    : public impl::ConvertMemRefToSPIRVPassBase<ConvertMemRefToSPIRVPass> {
+  using ConvertMemRefToSPIRVPassBase::ConvertMemRefToSPIRVPassBase;
   void runOnOperation() override;
 };
 } // namespace
@@ -53,8 +54,4 @@ void ConvertMemRefToSPIRVPass::runOnOperation() {
 
   if (failed(applyPartialConversion(op, *target, std::move(patterns))))
     return signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<>> mlir::createConvertMemRefToSPIRVPass() {
-  return std::make_unique<ConvertMemRefToSPIRVPass>();
 }

--- a/mlir/lib/Conversion/MeshToMPI/MeshToMPI.cpp
+++ b/mlir/lib/Conversion/MeshToMPI/MeshToMPI.cpp
@@ -431,8 +431,3 @@ struct ConvertMeshToMPIPass
 };
 
 } // namespace
-
-// Create a pass that convert Mesh to MPI
-std::unique_ptr<::mlir::Pass> mlir::createConvertMeshToMPIPass() {
-  return std::make_unique<ConvertMeshToMPIPass>();
-}

--- a/mlir/lib/Conversion/OpenACCToSCF/OpenACCToSCF.cpp
+++ b/mlir/lib/Conversion/OpenACCToSCF/OpenACCToSCF.cpp
@@ -16,7 +16,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTOPENACCTOSCF
+#define GEN_PASS_DEF_CONVERTOPENACCTOSCFPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -66,7 +66,7 @@ void mlir::populateOpenACCToSCFConversionPatterns(RewritePatternSet &patterns) {
 
 namespace {
 struct ConvertOpenACCToSCFPass
-    : public impl::ConvertOpenACCToSCFBase<ConvertOpenACCToSCFPass> {
+    : public impl::ConvertOpenACCToSCFPassBase<ConvertOpenACCToSCFPass> {
   void runOnOperation() override;
 };
 } // namespace
@@ -93,8 +93,4 @@ void ConvertOpenACCToSCFPass::runOnOperation() {
 
   if (failed(applyPartialConversion(op, target, std::move(patterns))))
     signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<ModuleOp>> mlir::createConvertOpenACCToSCFPass() {
-  return std::make_unique<ConvertOpenACCToSCFPass>();
 }

--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -21,7 +21,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTPDLTOPDLINTERP
+#define GEN_PASS_DEF_CONVERTPDLTOPDLINTERPPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -967,7 +967,7 @@ void PatternLowering::generateOperationResultTypeRewriter(
 
 namespace {
 struct PDLToPDLInterpPass
-    : public impl::ConvertPDLToPDLInterpBase<PDLToPDLInterpPass> {
+    : public impl::ConvertPDLToPDLInterpPassBase<PDLToPDLInterpPass> {
   PDLToPDLInterpPass() = default;
   PDLToPDLInterpPass(const PDLToPDLInterpPass &rhs) = default;
   PDLToPDLInterpPass(DenseMap<Operation *, PDLPatternConfigSet *> &configMap)
@@ -1013,10 +1013,7 @@ void PDLToPDLInterpPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> mlir::createPDLToPDLInterpPass() {
-  return std::make_unique<PDLToPDLInterpPass>();
-}
-std::unique_ptr<OperationPass<ModuleOp>> mlir::createPDLToPDLInterpPass(
+std::unique_ptr<OperationPass<ModuleOp>> mlir::createConvertPDLToPDLInterpPass(
     DenseMap<Operation *, PDLPatternConfigSet *> &configMap) {
   return std::make_unique<PDLToPDLInterpPass>(configMap);
 }

--- a/mlir/lib/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.cpp
+++ b/mlir/lib/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.cpp
@@ -13,7 +13,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_RECONCILEUNREALIZEDCASTS
+#define GEN_PASS_DEF_RECONCILEUNREALIZEDCASTSPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -36,7 +36,7 @@ namespace {
 /// In the above example, %0 can be used instead of %3 and all cast ops are
 /// folded away.
 struct ReconcileUnrealizedCasts
-    : public impl::ReconcileUnrealizedCastsBase<ReconcileUnrealizedCasts> {
+    : public impl::ReconcileUnrealizedCastsPassBase<ReconcileUnrealizedCasts> {
   ReconcileUnrealizedCasts() = default;
 
   void runOnOperation() override {
@@ -48,7 +48,3 @@ struct ReconcileUnrealizedCasts
 };
 
 } // namespace
-
-std::unique_ptr<Pass> mlir::createReconcileUnrealizedCastsPass() {
-  return std::make_unique<ReconcileUnrealizedCasts>();
-}

--- a/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
+++ b/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
@@ -27,7 +27,7 @@
 #include "mlir/Transforms/Passes.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_SCFTOCONTROLFLOW
+#define GEN_PASS_DEF_SCFTOCONTROLFLOWPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -37,7 +37,7 @@ using namespace mlir::scf;
 namespace {
 
 struct SCFToControlFlowPass
-    : public impl::SCFToControlFlowBase<SCFToControlFlowPass> {
+    : public impl::SCFToControlFlowPassBase<SCFToControlFlowPass> {
   void runOnOperation() override;
 };
 
@@ -725,8 +725,4 @@ void SCFToControlFlowPass::runOnOperation() {
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))
     signalPassFailure();
-}
-
-std::unique_ptr<Pass> mlir::createConvertSCFToCFPass() {
-  return std::make_unique<SCFToControlFlowPass>();
 }

--- a/mlir/lib/Conversion/SCFToGPU/SCFToGPUPass.cpp
+++ b/mlir/lib/Conversion/SCFToGPU/SCFToGPUPass.cpp
@@ -20,8 +20,8 @@
 #include "llvm/Support/CommandLine.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTAFFINEFORTOGPU
-#define GEN_PASS_DEF_CONVERTPARALLELLOOPTOGPU
+#define GEN_PASS_DEF_CONVERTAFFINEFORTOGPUPASS
+#define GEN_PASS_DEF_CONVERTPARALLELLOOPTOGPUPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -32,12 +32,9 @@ namespace {
 // A pass that traverses top-level loops in the function and converts them to
 // GPU launch operations.  Nested launches are not allowed, so this does not
 // walk the function recursively to avoid considering nested loops.
-struct ForLoopMapper : public impl::ConvertAffineForToGPUBase<ForLoopMapper> {
-  ForLoopMapper() = default;
-  ForLoopMapper(unsigned numBlockDims, unsigned numThreadDims) {
-    this->numBlockDims = numBlockDims;
-    this->numThreadDims = numThreadDims;
-  }
+struct ForLoopMapper
+    : public impl::ConvertAffineForToGPUPassBase<ForLoopMapper> {
+  using ConvertAffineForToGPUPassBase::ConvertAffineForToGPUPassBase;
 
   void runOnOperation() override {
     for (Operation &op : llvm::make_early_inc_range(
@@ -52,7 +49,7 @@ struct ForLoopMapper : public impl::ConvertAffineForToGPUBase<ForLoopMapper> {
 };
 
 struct ParallelLoopToGpuPass
-    : public impl::ConvertParallelLoopToGpuBase<ParallelLoopToGpuPass> {
+    : public impl::ConvertParallelLoopToGpuPassBase<ParallelLoopToGpuPass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     populateParallelLoopToGPUPatterns(patterns);
@@ -67,16 +64,3 @@ struct ParallelLoopToGpuPass
 };
 
 } // namespace
-
-std::unique_ptr<InterfacePass<FunctionOpInterface>>
-mlir::createAffineForToGPUPass(unsigned numBlockDims, unsigned numThreadDims) {
-  return std::make_unique<ForLoopMapper>(numBlockDims, numThreadDims);
-}
-std::unique_ptr<InterfacePass<FunctionOpInterface>>
-mlir::createAffineForToGPUPass() {
-  return std::make_unique<ForLoopMapper>();
-}
-
-std::unique_ptr<Pass> mlir::createParallelLoopToGpuPass() {
-  return std::make_unique<ParallelLoopToGpuPass>();
-}

--- a/mlir/lib/Conversion/ShapeToStandard/ConvertShapeConstraints.cpp
+++ b/mlir/lib/Conversion/ShapeToStandard/ConvertShapeConstraints.cpp
@@ -18,7 +18,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTSHAPECONSTRAINTS
+#define GEN_PASS_DEF_CONVERTSHAPECONSTRAINTSPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -54,7 +54,7 @@ namespace {
 // is emitted, witnesses are satisfied, so they are replace with
 // `shape.const_witness true`.
 class ConvertShapeConstraints
-    : public impl::ConvertShapeConstraintsBase<ConvertShapeConstraints> {
+    : public impl::ConvertShapeConstraintsPassBase<ConvertShapeConstraints> {
   void runOnOperation() override {
     auto *func = getOperation();
     auto *context = &getContext();
@@ -67,7 +67,3 @@ class ConvertShapeConstraints
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::createConvertShapeConstraintsPass() {
-  return std::make_unique<ConvertShapeConstraints>();
-}

--- a/mlir/lib/Conversion/ShapeToStandard/ShapeToStandard.cpp
+++ b/mlir/lib/Conversion/ShapeToStandard/ShapeToStandard.cpp
@@ -20,7 +20,7 @@
 #include "llvm/ADT/STLExtras.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTSHAPETOSTANDARD
+#define GEN_PASS_DEF_CONVERTSHAPETOSTANDARDPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -681,7 +681,7 @@ namespace {
 namespace {
 /// Conversion pass.
 class ConvertShapeToStandardPass
-    : public impl::ConvertShapeToStandardBase<ConvertShapeToStandardPass> {
+    : public impl::ConvertShapeToStandardPassBase<ConvertShapeToStandardPass> {
 
   void runOnOperation() override;
 };
@@ -726,9 +726,4 @@ void mlir::populateShapeToStandardConversionPatterns(
       SplitAtOpConversion,
       ToExtentTensorOpConversion>(patterns.getContext());
   // clang-format on
-}
-
-std::unique_ptr<OperationPass<ModuleOp>>
-mlir::createConvertShapeToStandardPass() {
-  return std::make_unique<ConvertShapeToStandardPass>();
 }

--- a/mlir/lib/Conversion/TensorToLinalg/TensorToLinalgPass.cpp
+++ b/mlir/lib/Conversion/TensorToLinalg/TensorToLinalgPass.cpp
@@ -18,7 +18,7 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTTENSORTOLINALG
+#define GEN_PASS_DEF_CONVERTTENSORTOLINALGPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -27,7 +27,7 @@ using namespace mlir;
 namespace {
 /// A pass converting MLIR Tensor operations into the Linalg dialect.
 class ConvertTensorToLinalgPass
-    : public impl::ConvertTensorToLinalgBase<ConvertTensorToLinalgPass> {
+    : public impl::ConvertTensorToLinalgPassBase<ConvertTensorToLinalgPass> {
   void runOnOperation() override {
     auto &context = getContext();
     ConversionTarget target(context);
@@ -45,8 +45,3 @@ class ConvertTensorToLinalgPass
   }
 };
 } // namespace
-
-std::unique_ptr<OperationPass<ModuleOp>>
-mlir::createConvertTensorToLinalgPass() {
-  return std::make_unique<ConvertTensorToLinalgPass>();
-}

--- a/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
@@ -19,7 +19,7 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTTENSORTOSPIRV
+#define GEN_PASS_DEF_CONVERTTENSORTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -28,7 +28,9 @@ using namespace mlir;
 namespace {
 /// A pass converting MLIR Tensor operations into the SPIR-V dialect.
 class ConvertTensorToSPIRVPass
-    : public impl::ConvertTensorToSPIRVBase<ConvertTensorToSPIRVPass> {
+    : public impl::ConvertTensorToSPIRVPassBase<ConvertTensorToSPIRVPass> {
+  using ConvertTensorToSPIRVPassBase::ConvertTensorToSPIRVPassBase;
+
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     Operation *op = getOperation();
@@ -53,7 +55,3 @@ class ConvertTensorToSPIRVPass
   }
 };
 } // namespace
-
-std::unique_ptr<OperationPass<>> mlir::createConvertTensorToSPIRVPass() {
-  return std::make_unique<ConvertTensorToSPIRVPass>();
-}

--- a/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
+++ b/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
@@ -21,7 +21,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_TOSATOARITH
+#define GEN_PASS_DEF_TOSATOARITHPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -29,9 +29,8 @@ using namespace mlir;
 using namespace tosa;
 
 namespace {
-struct TosaToArith : public impl::TosaToArithBase<TosaToArith> {
-public:
-  TosaToArith(TosaToArithOptions &options) : TosaToArithBase(options) {}
+struct TosaToArith : public impl::TosaToArithPassBase<TosaToArith> {
+  using TosaToArithPassBase::TosaToArithPassBase;
 
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
@@ -53,9 +52,3 @@ public:
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::tosa::createTosaToArith(bool includeApplyRescale,
-                                                    bool use32BitApplyRescale) {
-  TosaToArithOptions options = {includeApplyRescale, use32BitApplyRescale};
-  return std::make_unique<TosaToArith>(options);
-}

--- a/mlir/lib/Conversion/TosaToSCF/TosaToSCFPass.cpp
+++ b/mlir/lib/Conversion/TosaToSCF/TosaToSCFPass.cpp
@@ -23,7 +23,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_TOSATOSCF
+#define GEN_PASS_DEF_TOSATOSCFPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -31,7 +31,7 @@ using namespace mlir;
 using namespace tosa;
 
 namespace {
-struct TosaToSCF : public impl::TosaToSCFBase<TosaToSCF> {
+struct TosaToSCF : public impl::TosaToSCFPassBase<TosaToSCF> {
 public:
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
@@ -48,10 +48,6 @@ public:
 };
 } // namespace
 
-std::unique_ptr<Pass> mlir::tosa::createTosaToSCF() {
-  return std::make_unique<TosaToSCF>();
-}
-
 void mlir::tosa::addTosaToSCFPasses(OpPassManager &pm) {
-  pm.addNestedPass<func::FuncOp>(createTosaToSCF());
+  pm.addNestedPass<func::FuncOp>(createTosaToSCFPass());
 }

--- a/mlir/lib/Conversion/TosaToTensor/TosaToTensorPass.cpp
+++ b/mlir/lib/Conversion/TosaToTensor/TosaToTensorPass.cpp
@@ -22,7 +22,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_TOSATOTENSOR
+#define GEN_PASS_DEF_TOSATOTENSORPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -30,7 +30,7 @@ using namespace mlir;
 using namespace tosa;
 
 namespace {
-struct TosaToTensor : public impl::TosaToTensorBase<TosaToTensor> {
+struct TosaToTensor : public impl::TosaToTensorPassBase<TosaToTensor> {
 public:
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
@@ -53,7 +53,3 @@ public:
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::tosa::createTosaToTensor() {
-  return std::make_unique<TosaToTensor>();
-}

--- a/mlir/lib/Conversion/VectorToArmSME/VectorToArmSMEPass.cpp
+++ b/mlir/lib/Conversion/VectorToArmSME/VectorToArmSMEPass.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTVECTORTOARMSME
+#define GEN_PASS_DEF_CONVERTVECTORTOARMSMEPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -23,7 +23,7 @@ using namespace mlir::vector;
 
 namespace {
 struct ConvertVectorToArmSMEPass
-    : public impl::ConvertVectorToArmSMEBase<ConvertVectorToArmSMEPass> {
+    : public impl::ConvertVectorToArmSMEPassBase<ConvertVectorToArmSMEPass> {
 
   void runOnOperation() override;
 };
@@ -34,8 +34,4 @@ void ConvertVectorToArmSMEPass::runOnOperation() {
   populateVectorToArmSMEPatterns(patterns, getContext());
 
   (void)applyPatternsGreedily(getOperation(), std::move(patterns));
-}
-
-std::unique_ptr<Pass> mlir::createConvertVectorToArmSMEPass() {
-  return std::make_unique<ConvertVectorToArmSMEPass>();
 }

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRVPass.cpp
@@ -21,7 +21,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTVECTORTOSPIRV
+#define GEN_PASS_DEF_CONVERTVECTORTOSPIRVPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -29,7 +29,7 @@ using namespace mlir;
 
 namespace {
 struct ConvertVectorToSPIRVPass
-    : public impl::ConvertVectorToSPIRVBase<ConvertVectorToSPIRVPass> {
+    : public impl::ConvertVectorToSPIRVPassBase<ConvertVectorToSPIRVPass> {
   void runOnOperation() override;
 };
 } // namespace
@@ -55,8 +55,4 @@ void ConvertVectorToSPIRVPass::runOnOperation() {
 
   if (failed(applyPartialConversion(op, *target, std::move(patterns))))
     return signalPassFailure();
-}
-
-std::unique_ptr<OperationPass<>> mlir::createConvertVectorToSPIRVPass() {
-  return std::make_unique<ConvertVectorToSPIRVPass>();
 }

--- a/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
+++ b/mlir/lib/Conversion/VectorToXeGPU/VectorToXeGPU.cpp
@@ -329,7 +329,3 @@ void mlir::populateVectorToXeGPUConversionPatterns(
   patterns.add<TransferReadLowering, TransferWriteLowering, LoadLowering,
                StoreLowering>(patterns.getContext());
 }
-
-std::unique_ptr<Pass> mlir::createConvertVectorToXeGPUPass() {
-  return std::make_unique<ConvertVectorToXeGPUPass>();
-}

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToNVVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToNVVMPipeline.cpp
@@ -48,7 +48,7 @@ void buildCommonPassPipeline(
   pm.addPass(createConvertNVGPUToNVVMPass());
   pm.addPass(createGpuKernelOutliningPass());
   pm.addPass(createConvertVectorToSCFPass());
-  pm.addPass(createConvertSCFToCFPass());
+  pm.addPass(createSCFToControlFlowPass());
   pm.addPass(createConvertNVVMToLLVMPass());
   pm.addPass(createConvertFuncToLLVMPass());
   pm.addPass(memref::createExpandStridedMetadataPass());
@@ -59,7 +59,7 @@ void buildCommonPassPipeline(
   nvvmTargetOptions.features = options.cubinFeatures;
   nvvmTargetOptions.optLevel = options.optLevel;
   pm.addPass(createGpuNVVMAttachTarget(nvvmTargetOptions));
-  pm.addPass(createLowerAffinePass());
+  pm.addPass(createLowerAffine());
   pm.addPass(createArithToLLVMConversionPass());
   ConvertIndexToLLVMPassOptions convertIndexToLLVMPassOpt;
   convertIndexToLLVMPassOpt.indexBitwidth = options.indexBitWidth;

--- a/mlir/lib/Dialect/GPU/Pipelines/GPUToNVVMPipeline.cpp
+++ b/mlir/lib/Dialect/GPU/Pipelines/GPUToNVVMPipeline.cpp
@@ -59,7 +59,7 @@ void buildCommonPassPipeline(
   nvvmTargetOptions.features = options.cubinFeatures;
   nvvmTargetOptions.optLevel = options.optLevel;
   pm.addPass(createGpuNVVMAttachTarget(nvvmTargetOptions));
-  pm.addPass(createLowerAffine());
+  pm.addPass(createLowerAffinePass());
   pm.addPass(createArithToLLVMConversionPass());
   ConvertIndexToLLVMPassOptions convertIndexToLLVMPassOpt;
   convertIndexToLLVMPassOpt.indexBitwidth = options.indexBitWidth;

--- a/mlir/lib/Dialect/SparseTensor/Pipelines/SparseTensorPipelines.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Pipelines/SparseTensorPipelines.cpp
@@ -55,7 +55,7 @@ void mlir::sparse_tensor::buildSparsifier(OpPassManager &pm,
   if (gpuCodegen) {
     pm.addPass(createSparseGPUCodegenPass());
     pm.addNestedPass<gpu::GPUModuleOp>(createStripDebugInfoPass());
-    pm.addNestedPass<gpu::GPUModuleOp>(createConvertSCFToCFPass());
+    pm.addNestedPass<gpu::GPUModuleOp>(createSCFToControlFlowPass());
     pm.addNestedPass<gpu::GPUModuleOp>(createConvertGpuOpsToNVVMOps());
   }
 
@@ -66,9 +66,9 @@ void mlir::sparse_tensor::buildSparsifier(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
   pm.addNestedPass<func::FuncOp>(createConvertVectorToSCFPass());
   pm.addNestedPass<func::FuncOp>(memref::createExpandReallocPass());
-  pm.addNestedPass<func::FuncOp>(createConvertSCFToCFPass());
+  pm.addNestedPass<func::FuncOp>(createSCFToControlFlowPass());
   pm.addPass(memref::createExpandStridedMetadataPass());
-  pm.addPass(createLowerAffinePass());
+  pm.addPass(createLowerAffine());
   pm.addPass(
       createConvertVectorToLLVMPass(options.convertVectorToLLVMOptions()));
   pm.addPass(createFinalizeMemRefToLLVMConversionPass());
@@ -76,7 +76,7 @@ void mlir::sparse_tensor::buildSparsifier(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(arith::createArithExpandOpsPass());
   pm.addNestedPass<func::FuncOp>(createConvertMathToLLVMPass());
   pm.addPass(createConvertMathToLibmPass());
-  pm.addPass(createConvertComplexToLibmPass());
+  pm.addPass(createConvertComplexToLibm());
   pm.addPass(
       createConvertVectorToLLVMPass(options.convertVectorToLLVMOptions()));
   pm.addPass(createConvertComplexToLLVMPass());

--- a/mlir/lib/Dialect/SparseTensor/Pipelines/SparseTensorPipelines.cpp
+++ b/mlir/lib/Dialect/SparseTensor/Pipelines/SparseTensorPipelines.cpp
@@ -68,7 +68,7 @@ void mlir::sparse_tensor::buildSparsifier(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(memref::createExpandReallocPass());
   pm.addNestedPass<func::FuncOp>(createSCFToControlFlowPass());
   pm.addPass(memref::createExpandStridedMetadataPass());
-  pm.addPass(createLowerAffine());
+  pm.addPass(createLowerAffinePass());
   pm.addPass(
       createConvertVectorToLLVMPass(options.convertVectorToLLVMOptions()));
   pm.addPass(createFinalizeMemRefToLLVMConversionPass());

--- a/mlir/lib/Rewrite/FrozenRewritePatternSet.cpp
+++ b/mlir/lib/Rewrite/FrozenRewritePatternSet.cpp
@@ -43,7 +43,7 @@ convertPDLToPDLInterp(ModuleOp pdlModule,
   // mode.
   pdlPipeline.enableVerifier(false);
 #endif
-  pdlPipeline.addPass(createPDLToPDLInterpPass(configMap));
+  pdlPipeline.addPass(createConvertPDLToPDLInterpPass(configMap));
   if (failed(pdlPipeline.run(pdlModule)))
     return failure();
 

--- a/mlir/test/lib/Dialect/ArmSME/TestLowerToArmSME.cpp
+++ b/mlir/test/lib/Dialect/ArmSME/TestLowerToArmSME.cpp
@@ -77,7 +77,7 @@ void buildTestLowerToArmSME(OpPassManager &pm,
       /*ifRequiredByOps=*/true));
 
   // Convert SCF to CF (required for ArmSME tile allocation).
-  pm.addPass(createConvertSCFToCFPass());
+  pm.addPass(createSCFToControlFlowPass());
 
   // Convert ArmSME to LLVM.
   pm.addNestedPass<func::FuncOp>(

--- a/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
+++ b/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
@@ -53,9 +53,9 @@ void buildTestLowerToLLVM(OpPassManager &pm,
   // Blanket-convert any remaining linalg ops to loops if any remain.
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
   // Blanket-convert any remaining affine ops if any remain.
-  pm.addPass(createLowerAffinePass());
+  pm.addPass(createLowerAffine());
   // Convert SCF to CF (always needed).
-  pm.addPass(createConvertSCFToCFPass());
+  pm.addPass(createSCFToControlFlowPass());
   // Sprinkle some cleanups.
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
@@ -68,7 +68,7 @@ void buildTestLowerToLLVM(OpPassManager &pm,
   // Expand complicated MemRef operations before lowering them.
   pm.addPass(memref::createExpandStridedMetadataPass());
   // The expansion may create affine expressions. Get rid of them.
-  pm.addPass(createLowerAffinePass());
+  pm.addPass(createLowerAffine());
   // Convert MemRef to LLVM (always needed).
   pm.addPass(createFinalizeMemRefToLLVMConversionPass());
   // Convert Func to LLVM (always needed).

--- a/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
+++ b/mlir/test/lib/Dialect/LLVM/TestLowerToLLVM.cpp
@@ -53,7 +53,7 @@ void buildTestLowerToLLVM(OpPassManager &pm,
   // Blanket-convert any remaining linalg ops to loops if any remain.
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
   // Blanket-convert any remaining affine ops if any remain.
-  pm.addPass(createLowerAffine());
+  pm.addPass(createLowerAffinePass());
   // Convert SCF to CF (always needed).
   pm.addPass(createSCFToControlFlowPass());
   // Sprinkle some cleanups.
@@ -68,7 +68,7 @@ void buildTestLowerToLLVM(OpPassManager &pm,
   // Expand complicated MemRef operations before lowering them.
   pm.addPass(memref::createExpandStridedMetadataPass());
   // The expansion may create affine expressions. Get rid of them.
-  pm.addPass(createLowerAffine());
+  pm.addPass(createLowerAffinePass());
   // Convert MemRef to LLVM (always needed).
   pm.addPass(createFinalizeMemRefToLLVMConversionPass());
   // Convert Func to LLVM (always needed).


### PR DESCRIPTION
`let constructor` is deprecated since the table gen backend emits most of the glue logic to build a pass. This PR retires the td method for most (I need another pass) passes in the Conversion directory.