### PR TITLE
[CodeGen] Remove AnalyzeVirtRegLanesInBundle

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstrBundle.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBundle.h
@@ -241,13 +241,6 @@ VirtRegInfo AnalyzeVirtRegInBundle(
     MachineInstr &MI, Register Reg,
     SmallVectorImpl<std::pair<MachineInstr *, unsigned>> *Ops = nullptr);
 
-/// Return a pair of lane masks (reads, writes) indicating which lanes this
-/// instruction uses with Reg.
-std::pair<LaneBitmask, LaneBitmask>
-AnalyzeVirtRegLanesInBundle(const MachineInstr &MI, Register Reg,
-                            const MachineRegisterInfo &MRI,
-                            const TargetRegisterInfo &TRI);
-
 /// Information about how a physical register Reg is used by a set of
 /// operands.
 struct PhysRegInfo {

--- a/llvm/lib/CodeGen/MachineInstrBundle.cpp
+++ b/llvm/lib/CodeGen/MachineInstrBundle.cpp
@@ -304,33 +304,6 @@ VirtRegInfo llvm::AnalyzeVirtRegInBundle(
   return RI;
 }
 
-std::pair<LaneBitmask, LaneBitmask>
-llvm::AnalyzeVirtRegLanesInBundle(const MachineInstr &MI, Register Reg,
-                                  const MachineRegisterInfo &MRI,
-                                  const TargetRegisterInfo &TRI) {
-
-  LaneBitmask UseMask, DefMask;
-
-  for (const MachineOperand &MO : const_mi_bundle_ops(MI)) {
-    if (!MO.isReg() || MO.getReg() != Reg)
-      continue;
-
-    unsigned SubReg = MO.getSubReg();
-    if (SubReg == 0 && MO.isUse() && !MO.isUndef())
-      UseMask |= MRI.getMaxLaneMaskForVReg(Reg);
-
-    LaneBitmask SubRegMask = TRI.getSubRegIndexLaneMask(SubReg);
-    if (MO.isDef()) {
-      if (!MO.isUndef())
-        UseMask |= ~SubRegMask;
-      DefMask |= SubRegMask;
-    } else if (!MO.isUndef())
-      UseMask |= SubRegMask;
-  }
-
-  return {UseMask, DefMask};
-}
-
 PhysRegInfo llvm::AnalyzePhysRegInBundle(const MachineInstr &MI, Register Reg,
                                          const TargetRegisterInfo *TRI) {
   bool AllDefsDead = true;


### PR DESCRIPTION
The function has was added without a use in:

  commit 7dcb9c0f09f89e2d6f527a480f214cf872c85b20
  Author: Matt Arsenault <Matthew.Arsenault@amd.com>
  Date:   Mon Mar 20 18:49:17 2023 -0400
