### PR TITLE
[IR] Remove CreateElementUnorderedAtomicMemMove

### DIFF
--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -746,21 +746,6 @@ public:
                                  NoAliasTag);
   }
 
-  /// \brief Create and insert an element unordered-atomic memmove between the
-  /// specified pointers.
-  ///
-  /// DstAlign/SrcAlign are the alignments of the Dst/Src pointers,
-  /// respectively.
-  ///
-  /// If the pointers aren't i8*, they will be converted.  If a TBAA tag is
-  /// specified, it will be added to the instruction. Likewise with alias.scope
-  /// and noalias tags.
-  CallInst *CreateElementUnorderedAtomicMemMove(
-      Value *Dst, Align DstAlign, Value *Src, Align SrcAlign, Value *Size,
-      uint32_t ElementSize, MDNode *TBAATag = nullptr,
-      MDNode *TBAAStructTag = nullptr, MDNode *ScopeTag = nullptr,
-      MDNode *NoAliasTag = nullptr);
-
 private:
   CallInst *getReductionIntrinsic(Intrinsic::ID ID, Value *Src);
 

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -358,41 +358,6 @@ CallInst *IRBuilderBase::CreateFree(Value *Source,
   return Result;
 }
 
-CallInst *IRBuilderBase::CreateElementUnorderedAtomicMemMove(
-    Value *Dst, Align DstAlign, Value *Src, Align SrcAlign, Value *Size,
-    uint32_t ElementSize, MDNode *TBAATag, MDNode *TBAAStructTag,
-    MDNode *ScopeTag, MDNode *NoAliasTag) {
-  assert(DstAlign >= ElementSize &&
-         "Pointer alignment must be at least element size");
-  assert(SrcAlign >= ElementSize &&
-         "Pointer alignment must be at least element size");
-  Value *Ops[] = {Dst, Src, Size, getInt32(ElementSize)};
-  Type *Tys[] = {Dst->getType(), Src->getType(), Size->getType()};
-
-  CallInst *CI =
-      CreateIntrinsic(Intrinsic::memmove_element_unordered_atomic, Tys, Ops);
-
-  // Set the alignment of the pointer args.
-  CI->addParamAttr(0, Attribute::getWithAlignment(CI->getContext(), DstAlign));
-  CI->addParamAttr(1, Attribute::getWithAlignment(CI->getContext(), SrcAlign));
-
-  // Set the TBAA info if present.
-  if (TBAATag)
-    CI->setMetadata(LLVMContext::MD_tbaa, TBAATag);
-
-  // Set the TBAA Struct info if present.
-  if (TBAAStructTag)
-    CI->setMetadata(LLVMContext::MD_tbaa_struct, TBAAStructTag);
-
-  if (ScopeTag)
-    CI->setMetadata(LLVMContext::MD_alias_scope, ScopeTag);
-
-  if (NoAliasTag)
-    CI->setMetadata(LLVMContext::MD_noalias, NoAliasTag);
-
-  return CI;
-}
-
 CallInst *IRBuilderBase::getReductionIntrinsic(Intrinsic::ID ID, Value *Src) {
   Value *Ops[] = {Src};
   Type *Tys[] = { Src->getType() };


### PR DESCRIPTION
The last use was removed in:

  commit f515ca8995ce3695c6e92d83ffca2012dc753bb3
  Author: Nikita Popov <nikita.ppv@gmail.com>
  Date:   Sat Feb 13 16:39:44 2021 +0100
