### PR TITLE
[lldb] Support stepping through C++ thunks

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -201,6 +201,8 @@ public:
     return false;
   }
 
+  virtual bool IsSymbolARuntimeThunk(const Symbol &symbol) { return false; }
+
   // Given the name of a runtime symbol (e.g. in Objective-C, an ivar offset
   // symbol), try to determine from the runtime what the value of that symbol
   // would be. Useful when the underlying binary is stripped.

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -478,10 +478,10 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
 }
 
 bool CPPLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
-  // Virtual function override thunks come in two forms. Those overriding from a
-  // non-virtual base, with fixed this adjustments, use a "Th" prefix and encode
-  // the required adjustment offset, probably negative, indicated by a 'n'
-  // prefix, and the encoding of the target function.
-  return symbol.GetMangled().GetMangledName().GetStringRef().starts_with(
-      "_ZTh");
+  llvm::StringRef mangled_name = symbol.GetMangled().GetMangledName().GetStringRef();
+  // Virtual function overriding from a non-virtual base use a "Th" prefix.
+  // Virtual function overriding from a virtual base must use a "Tv" prefix.
+  // Virtual function overriding thunks with covariant returns use a "Tc" prefix.
+  return mangled_name.starts_with("_ZTh") || mangled_name.starts_with("_ZTv") ||
+         mangled_name.starts_with("_ZTc");
 }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -478,10 +478,12 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
 }
 
 bool CPPLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
-  llvm::StringRef mangled_name = symbol.GetMangled().GetMangledName().GetStringRef();
+  llvm::StringRef mangled_name =
+      symbol.GetMangled().GetMangledName().GetStringRef();
   // Virtual function overriding from a non-virtual base use a "Th" prefix.
   // Virtual function overriding from a virtual base must use a "Tv" prefix.
-  // Virtual function overriding thunks with covariant returns use a "Tc" prefix.
+  // Virtual function overriding thunks with covariant returns use a "Tc"
+  // prefix.
   return mangled_name.starts_with("_ZTh") || mangled_name.starts_with("_ZTv") ||
          mangled_name.starts_with("_ZTc");
 }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -478,7 +478,10 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
 }
 
 bool CPPLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
-  llvm::outs() << symbol.GetMangled().GetMangledName().GetStringRef() << '\n';
+  // Virtual function override thunks come in two forms. Those overriding from a
+  // non-virtual base, with fixed this adjustments, use a "Th" prefix and encode
+  // the required adjustment offset, probably negative, indicated by a 'n'
+  // prefix, and the encoding of the target function.
   return symbol.GetMangled().GetMangledName().GetStringRef().starts_with(
-      "_ZThn");
+      "_ZTh");
 }

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.cpp
@@ -476,3 +476,9 @@ CPPLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
 
   return ret_plan_sp;
 }
+
+bool CPPLanguageRuntime::IsSymbolARuntimeThunk(const Symbol &symbol) {
+  llvm::outs() << symbol.GetMangled().GetMangledName().GetStringRef() << '\n';
+  return symbol.GetMangled().GetMangledName().GetStringRef().starts_with(
+      "_ZThn");
+}

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h
@@ -78,6 +78,9 @@ public:
                                                   bool stop_others) override;
 
   bool IsAllowedRuntimeValue(ConstString name) override;
+
+  bool IsSymbolARuntimeThunk(const Symbol &symbol) override;
+
 protected:
   // Classes that inherit from CPPLanguageRuntime can see and modify these
   CPPLanguageRuntime(Process *process);

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -80,12 +80,13 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
   // Check whether the frame we are in is a language runtime thunk, only for
   // step out:
   if (operation == eFrameCompareOlder) {
-    Symbol *symbol = frame->GetSymbolContext(eSymbolContextSymbol).symbol;
-    if (symbol) {
+    if (Symbol *symbol = frame->GetSymbolContext(eSymbolContextSymbol).symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
       for (auto *runtime : process_sp->GetLanguageRuntimes()) {
-        if (runtime->IsSymbolARuntimeThunk(*symbol))
+        if (runtime->IsSymbolARuntimeThunk(*symbol)) {
           should_stop_here = false;
+          break;
+        }
       }
     }
   }
@@ -134,6 +135,7 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
           LLDB_LOGF(log, "In runtime thunk %s - stepping out.",
                     sc.symbol->GetName().GetCString());
           is_thunk = true;
+          break;
         }
       }
 

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Target/ThreadPlanShouldStopHere.h"
 #include "lldb/Symbol/Symbol.h"
+#include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/Thread.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -76,6 +77,18 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
     }
   }
 
+  // Check whether the frame we are in is a language runtime thunk, only for
+  // step out:
+  if (operation == eFrameCompareOlder) {
+    Symbol *symbol = frame->GetSymbolContext(eSymbolContextSymbol).symbol;
+    if (symbol) {
+      ProcessSP process_sp(current_plan->GetThread().GetProcess());
+      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+        if (runtime->IsSymbolARuntimeThunk(*symbol))
+          should_stop_here = false;
+      }
+    }
+  }
   // Always avoid code with line number 0.
   // FIXME: At present the ShouldStop and the StepFromHere calculate this
   // independently.  If this ever
@@ -109,18 +122,34 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
 
   if (sc.line_entry.line == 0) {
     AddressRange range = sc.line_entry.range;
-
-    // If the whole function is marked line 0 just step out, that's easier &
-    // faster than continuing to step through it.
     bool just_step_out = false;
-    if (sc.symbol && sc.symbol->ValueIsAddress()) {
-      Address symbol_end = sc.symbol->GetAddress();
-      symbol_end.Slide(sc.symbol->GetByteSize() - 1);
-      if (range.ContainsFileAddress(sc.symbol->GetAddress()) &&
-          range.ContainsFileAddress(symbol_end)) {
-        LLDB_LOGF(log, "Stopped in a function with only line 0 lines, just "
-                       "stepping out.");
-        just_step_out = true;
+    if (sc.symbol) {
+      ProcessSP process_sp(current_plan->GetThread().GetProcess());
+
+      // If this is a runtime thunk, step through it, rather than stepping out
+      // because it's marked line 0.
+      bool is_thunk = false;
+      for (auto *runtime : process_sp->GetLanguageRuntimes()) {
+        if (runtime->IsSymbolARuntimeThunk(*sc.symbol)) {
+          LLDB_LOGF(log, "In runtime thunk %s - stepping out.",
+                    sc.symbol->GetName().GetCString());
+          is_thunk = true;
+        }
+      }
+
+      // If the whole function is marked line 0 just step out, that's easier &
+      // faster than continuing to step through it.
+      // FIXME: This assumes that the function is a single line range.  It could
+      // be a series of contiguous line 0 ranges.  Check for that too.
+      if (!is_thunk && sc.symbol->ValueIsAddress()) {
+        Address symbol_end = sc.symbol->GetAddress();
+        symbol_end.Slide(sc.symbol->GetByteSize() - 1);
+        if (range.ContainsFileAddress(sc.symbol->GetAddress()) &&
+            range.ContainsFileAddress(symbol_end)) {
+          LLDB_LOGF(log, "Stopped in a function with only line 0 lines, just "
+                         "stepping out.");
+          just_step_out = true;
+        }
       }
     }
     if (!just_step_out) {

--- a/lldb/test/API/lang/cpp/thunk/Makefile
+++ b/lldb/test/API/lang/cpp/thunk/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/thunk/TestThunk.py
+++ b/lldb/test/API/lang/cpp/thunk/TestThunk.py
@@ -29,10 +29,12 @@ class ThunkTest(TestBase):
         lldbutil.run_to_name_breakpoint(self, "testit_debug")
 
         # Make sure we step out of the thunk and end up in testit_debug.
+        source = "main.cpp"
+        line = line_number(source, "// Step here")
         self.expect(
             "step",
             STEP_IN_SUCCEEDED,
-            substrs=["stop reason = step in", "main.cpp:34"],
+            substrs=["stop reason = step in", "{}:{}".format(source, line)],
         )
 
         self.runCmd("continue")

--- a/lldb/test/API/lang/cpp/thunk/TestThunk.py
+++ b/lldb/test/API/lang/cpp/thunk/TestThunk.py
@@ -5,10 +5,11 @@ from lldbsuite.test import lldbutil
 
 
 class ThunkTest(TestBase):
-    def test(self):
+    def test_step_through_thunk(self):
         self.build()
         lldbutil.run_to_name_breakpoint(self, "testit")
 
+        # Make sure we step through the thunk into Derived1::doit
         self.expect(
             "step",
             STEP_IN_SUCCEEDED,
@@ -21,4 +22,23 @@ class ThunkTest(TestBase):
             "step",
             STEP_IN_SUCCEEDED,
             substrs=["stop reason = step in", "Derived2::doit"],
+        )
+
+    def test_step_out_thunk(self):
+        self.build()
+        lldbutil.run_to_name_breakpoint(self, "testit_debug")
+
+        # Make sure we step out of the thunk and don't end up in Derived1::doit.
+        self.expect(
+            "step",
+            STEP_IN_SUCCEEDED,
+            substrs=["stop reason = step in", "main at main.cpp"],
+        )
+
+        self.runCmd("continue")
+
+        self.expect(
+            "step",
+            STEP_IN_SUCCEEDED,
+            substrs=["stop reason = step in", "Derived2::doit_debug"],
         )

--- a/lldb/test/API/lang/cpp/thunk/TestThunk.py
+++ b/lldb/test/API/lang/cpp/thunk/TestThunk.py
@@ -28,11 +28,11 @@ class ThunkTest(TestBase):
         self.build()
         lldbutil.run_to_name_breakpoint(self, "testit_debug")
 
-        # Make sure we step out of the thunk and don't end up in Derived1::doit.
+        # Make sure we step out of the thunk and end up in testit_debug.
         self.expect(
             "step",
             STEP_IN_SUCCEEDED,
-            substrs=["stop reason = step in", "main at main.cpp"],
+            substrs=["stop reason = step in", "main.cpp:34"],
         )
 
         self.runCmd("continue")

--- a/lldb/test/API/lang/cpp/thunk/TestThunk.py
+++ b/lldb/test/API/lang/cpp/thunk/TestThunk.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class ThunkTest(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_name_breakpoint(self, "testit")
+
+        self.expect(
+            "step",
+            STEP_IN_SUCCEEDED,
+            substrs=["stop reason = step in", "Derived1::doit"],
+        )
+
+        self.runCmd("continue")
+
+        self.expect(
+            "step",
+            STEP_IN_SUCCEEDED,
+            substrs=["stop reason = step in", "Derived2::doit"],
+        )

--- a/lldb/test/API/lang/cpp/thunk/main.cpp
+++ b/lldb/test/API/lang/cpp/thunk/main.cpp
@@ -10,7 +10,7 @@ public:
   virtual void doit() = 0;
 };
 
-Base2 *b = nullptr;
+Base2 *b;
 
 class Derived1 : public Base1, public Base2 {
 public:

--- a/lldb/test/API/lang/cpp/thunk/main.cpp
+++ b/lldb/test/API/lang/cpp/thunk/main.cpp
@@ -29,7 +29,10 @@ public:
 
 void testit() { b->doit(); }
 
-void testit_debug() { b->doit_debug(); }
+void testit_debug() {
+  b->doit_debug();
+  printf("This is where I should step out to with nodebug.\n");
+}
 
 int main() {
 

--- a/lldb/test/API/lang/cpp/thunk/main.cpp
+++ b/lldb/test/API/lang/cpp/thunk/main.cpp
@@ -16,7 +16,9 @@ Base2 *b;
 class Derived1 : public Base1, public Base2 {
 public:
   virtual void doit() { printf("Derived1\n"); }
-  virtual void __attribute__((nodebug)) doit_debug() { printf("Derived1 (no debug)\n"); }
+  virtual void __attribute__((nodebug)) doit_debug() {
+    printf("Derived1 (no debug)\n");
+  }
 };
 
 class Derived2 : public Base2 {

--- a/lldb/test/API/lang/cpp/thunk/main.cpp
+++ b/lldb/test/API/lang/cpp/thunk/main.cpp
@@ -31,7 +31,7 @@ void testit() { b->doit(); }
 
 void testit_debug() {
   b->doit_debug();
-  printf("This is where I should step out to with nodebug.\n");
+  printf("This is where I should step out to with nodebug.\n"); // Step here
 }
 
 int main() {

--- a/lldb/test/API/lang/cpp/thunk/main.cpp
+++ b/lldb/test/API/lang/cpp/thunk/main.cpp
@@ -8,6 +8,7 @@ public:
 class Base2 {
 public:
   virtual void doit() = 0;
+  virtual void doit_debug() = 0;
 };
 
 Base2 *b;
@@ -15,22 +16,28 @@ Base2 *b;
 class Derived1 : public Base1, public Base2 {
 public:
   virtual void doit() { printf("Derived1\n"); }
+  virtual void __attribute__((nodebug)) doit_debug() { printf("Derived1 (no debug)\n"); }
 };
 
 class Derived2 : public Base2 {
 public:
   virtual void doit() { printf("Derived2\n"); }
+  virtual void doit_debug() { printf("Derived2 (debug)\n"); }
 };
 
 void testit() { b->doit(); }
+
+void testit_debug() { b->doit_debug(); }
 
 int main() {
 
   b = new Derived1();
   testit();
+  testit_debug();
 
   b = new Derived2();
   testit();
+  testit_debug();
 
   return 0;
 }

--- a/lldb/test/API/lang/cpp/thunk/main.cpp
+++ b/lldb/test/API/lang/cpp/thunk/main.cpp
@@ -1,0 +1,36 @@
+#include <stdio.h>
+
+class Base1 {
+public:
+  virtual ~Base1() {}
+};
+
+class Base2 {
+public:
+  virtual void doit() = 0;
+};
+
+Base2 *b = nullptr;
+
+class Derived1 : public Base1, public Base2 {
+public:
+  virtual void doit() { printf("Derived1\n"); }
+};
+
+class Derived2 : public Base2 {
+public:
+  virtual void doit() { printf("Derived2\n"); }
+};
+
+void testit() { b->doit(); }
+
+int main() {
+
+  b = new Derived1();
+  testit();
+
+  b = new Derived2();
+  testit();
+
+  return 0;
+}


### PR DESCRIPTION
This PR fixes LLDB stepping out, rather than stepping through a C++ thunk. The implementation is based on, and upstreams, the support for runtime thunks in the Swift fork.

Fixes #43413