### PR TITLE
[AMDGPU] Remove materializeImmediate

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -267,10 +267,6 @@ public:
                    bool KillSrc, bool RenamableDest = false,
                    bool RenamableSrc = false) const override;
 
-  void materializeImmediate(MachineBasicBlock &MBB,
-                            MachineBasicBlock::iterator MI, const DebugLoc &DL,
-                            Register DestReg, int64_t Value) const;
-
   const TargetRegisterClass *getPreferredSelectRegClass(
                                unsigned Size) const;
 


### PR DESCRIPTION
The lase use was removed in:

  commit cbf34a5f7701148d68951320a72f483849b22eaf
  Author: Juan Manuel Martinez Caamaño <jmartinezcaamao@gmail.com>
  Date:   Fri Aug 23 14:06:17 2024 +0200
