### PR TITLE
Reapply "Make llvm::telemetry::Manager::preDispatch protected.  (#127114)

### DIFF
--- a/llvm/include/llvm/Telemetry/Telemetry.h
+++ b/llvm/include/llvm/Telemetry/Telemetry.h
@@ -138,10 +138,6 @@ class Manager {
 public:
   virtual ~Manager() = default;
 
-  // Optional callback for subclasses to perform additional tasks before
-  // dispatching to Destinations.
-  virtual Error preDispatch(TelemetryInfo *Entry) = 0;
-
   // Dispatch Telemetry data to the Destination(s).
   // The argument is non-const because the Manager may add or remove
   // data from the entry.
@@ -149,6 +145,11 @@ public:
 
   // Register a Destination.
   void addDestination(std::unique_ptr<Destination> Destination);
+
+protected:
+  // Optional callback for subclasses to perform additional tasks before
+  // dispatching to Destinations.
+  virtual Error preDispatch(TelemetryInfo *Entry);
 
 private:
   std::vector<std::unique_ptr<Destination>> Destinations;

--- a/llvm/lib/Telemetry/Telemetry.cpp
+++ b/llvm/lib/Telemetry/Telemetry.cpp
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file provides the basic framework for Telemetry.
+/// Refer to its documentation at llvm/docs/Telemetry.rst for more details.
+//===---------------------------------------------------------------------===//
+
 #include "llvm/Telemetry/Telemetry.h"
 
 namespace llvm {
@@ -21,6 +34,8 @@ Error Manager::dispatch(TelemetryInfo *Entry) {
 void Manager::addDestination(std::unique_ptr<Destination> Dest) {
   Destinations.push_back(std::move(Dest));
 }
+
+Error Manager::preDispatch(TelemetryInfo *Entry) { return Error::success(); }
 
 } // namespace telemetry
 } // namespace llvm


### PR DESCRIPTION
This reverts commit 66465c3b0ab1b32403ad5a1c3114174d87830f54.

New change: added missing return statement.