### PR TITLE
obj2yaml: Introduce CovMap dump

### DIFF
--- a/llvm/include/llvm/ProfileData/InstrProf.h
+++ b/llvm/include/llvm/ProfileData/InstrProf.h
@@ -545,6 +545,12 @@ public:
   /// This method is a wrapper to \c readAndDecodeStrings method.
   Error create(StringRef NameStrings);
 
+  // PrfNames is nested array.
+  using PrfNamesTy = SmallVector<std::string>;
+  using PrfNamesChunksTy = SmallVector<PrfNamesTy, 1>;
+
+  Expected<PrfNamesChunksTy> createAndGetList(ArrayRef<uint8_t> Content);
+
   /// Initialize symtab states with function names and vtable names. \c
   /// FuncNameStrings is a string composed of one or more encoded function name
   /// strings, and \c VTableNameStrings composes of one or more encoded vtable

--- a/llvm/lib/ObjectYAML/CovMap.cpp
+++ b/llvm/lib/ObjectYAML/CovMap.cpp
@@ -374,7 +374,7 @@ Expected<uint64_t> CovMapTy::decode(const ArrayRef<uint8_t> Content,
 
 #define COVMAP_HEADER(Type, LLVMType, Name, Initializer)                       \
   static_assert(sizeof(Type) == sizeof(uint32_t));                             \
-  Type Name = Data.getU32();
+  [[maybe_unused]] Type Name = Data.getU32();
 #include "llvm/ProfileData/InstrProfData.inc"
   if (!Data)
     return Data.takeError();

--- a/llvm/test/tools/obj2yaml/ELF/covmap-be.yaml
+++ b/llvm/test/tools/obj2yaml/ELF/covmap-be.yaml
@@ -1,6 +1,8 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: obj2yaml %t.o > %t.plain.yaml
+# RUN: obj2yaml --covmap-raw %t.o > %t.raw.yaml
 # RUN: yaml2obj %t.plain.yaml -o - | cmp %t.o -
+# RUN: yaml2obj %t.raw.yaml -o - | cmp %t.o -
 
 # FIXME: This is synthetically created. s/ELFDATA2LSB/ELF2DATAMSB/ s/EM_X86_64/EM_PPC64/
 --- !ELF

--- a/llvm/test/tools/obj2yaml/ELF/covmap.yaml
+++ b/llvm/test/tools/obj2yaml/ELF/covmap.yaml
@@ -48,7 +48,7 @@ Sections:
 # DLOC:   dLoc: [ 3, 17, 11, 2 ]
 # RAW:     Tag: Ref, Val: 0
               - { dLoc: [ 3, 17, 11, 2 ], Tag: Ref, Val: 0 }
-# DLOC    dLoc: [ 3, 6, 5, 4 ]
+# DLOC:   dLoc: [ 3, 6, 5, 4 ]
 # RAW:     Tag: Add, Val: 0
               - { dLoc: [ 3, 6, 5, 4 ], Tag: Add, Val: 0 }
 # RAW:    Tag: Zero, Val: 3,

--- a/llvm/test/tools/obj2yaml/ELF/covmap.yaml
+++ b/llvm/test/tools/obj2yaml/ELF/covmap.yaml
@@ -1,6 +1,8 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: obj2yaml %t.o | tee %t.plain.yaml | FileCheck %s --check-prefixes=CHECK,PLAIN
+# RUN: obj2yaml --covmap-raw %t.o | tee %t.raw.yaml | FileCheck %s --check-prefixes=CHECK,COVMAP,RAWONLY,RAW,DLOC
 # RUN: yaml2obj %t.plain.yaml -o - | cmp %t.o -
+# RUN: yaml2obj %t.raw.yaml -o - | cmp %t.o -
 
 --- !ELF
 FileHeader:

--- a/llvm/tools/obj2yaml/elf2yaml.cpp
+++ b/llvm/tools/obj2yaml/elf2yaml.cpp
@@ -11,8 +11,10 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/Object/ELFObjectFile.h"
+#include "llvm/ObjectYAML/CovMap.h"
 #include "llvm/ObjectYAML/DWARFYAML.h"
 #include "llvm/ObjectYAML/ELFYAML.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -20,6 +22,10 @@
 #include <optional>
 
 using namespace llvm;
+
+static cl::opt<bool> CovMapRaw("covmap-raw",
+                               cl::desc("Dump raw YAML in Coverage Map."),
+                               cl::cat(Cat));
 
 namespace {
 
@@ -97,6 +103,8 @@ class ELFDumper {
   dumpStackSizesSection(const Elf_Shdr *Shdr);
   Expected<ELFYAML::BBAddrMapSection *>
   dumpBBAddrMapSection(const Elf_Shdr *Shdr);
+  Expected<ELFYAML::Section *> dumpCovMap(const Elf_Shdr *Shdr, StringRef Name,
+                                          covmap::Decoder *CovMapDecoder);
   Expected<ELFYAML::RawContentSection *>
   dumpPlaceholderSection(const Elf_Shdr *Shdr);
 
@@ -580,6 +588,30 @@ ELFDumper<ELFT>::dumpSections() {
     return Error::success();
   };
 
+  auto CovMapDecoder = covmap::Decoder::get(ELFT::Endianness, CovMapRaw);
+  if (covmap::Decoder::enabled) {
+    // Look up covmap-related sections in advance.
+    for (const auto &Sec : Sections) {
+      if (Sec.sh_type != ELF::SHT_PROGBITS)
+        continue;
+
+      auto NameOrErr = Obj.getSectionName(Sec);
+      if (!NameOrErr)
+        return NameOrErr.takeError();
+
+      if (!covmap::nameMatches(*NameOrErr))
+        continue;
+
+      auto ContentOrErr = Obj.getSectionContents(Sec);
+      if (!ContentOrErr)
+        return ContentOrErr.takeError();
+
+      if (auto E = CovMapDecoder->acquire(Sec.sh_addralign, *NameOrErr,
+                                          *ContentOrErr))
+        return std::move(E);
+    }
+  }
+
   auto GetDumper = [this](unsigned Type)
       -> std::function<Expected<ELFYAML::Chunk *>(const Elf_Shdr *)> {
     if (Obj.getHeader().e_machine == ELF::EM_ARM && Type == ELF::SHT_ARM_EXIDX)
@@ -659,6 +691,10 @@ ELFDumper<ELFT>::dumpSections() {
 
       if (ELFYAML::StackSizesSection::nameMatches(*NameOrErr)) {
         if (Error E = Add(dumpStackSizesSection(&Sec)))
+          return std::move(E);
+        continue;
+      } else if (covmap::Decoder::enabled && covmap::nameMatches(*NameOrErr)) {
+        if (Error E = Add(dumpCovMap(&Sec, *NameOrErr, CovMapDecoder.get())))
           return std::move(E);
         continue;
       }
@@ -1663,6 +1699,26 @@ ELFDumper<ELFT>::dumpMipsABIFlags(const Elf_Shdr *Shdr) {
 }
 
 template <class ELFT>
+Expected<ELFYAML::Section *>
+ELFDumper<ELFT>::dumpCovMap(const Elf_Shdr *Shdr, StringRef Name,
+                            covmap::Decoder *CovMapDecoder) {
+  auto S = covmap::make_unique(Name);
+  assert(S);
+
+  if (Error E = dumpCommonSection(Shdr, *S))
+    return std::move(E);
+
+  auto ContentOrErr = Obj.getSectionContents(*Shdr);
+  if (!ContentOrErr)
+    return ContentOrErr.takeError();
+
+  if (auto E = CovMapDecoder->make(S.get(), *ContentOrErr))
+    return std::move(E);
+
+  return S.release();
+}
+
+template <class ELFT>
 static Error elf2yaml(raw_ostream &Out, const object::ELFFile<ELFT> &Obj,
                       std::unique_ptr<DWARFContext> DWARFCtx) {
   ELFDumper<ELFT> Dumper(Obj, std::move(DWARFCtx));
@@ -1671,7 +1727,8 @@ static Error elf2yaml(raw_ostream &Out, const object::ELFFile<ELFT> &Obj,
     return YAMLOrErr.takeError();
 
   std::unique_ptr<ELFYAML::Object> YAML(YAMLOrErr.get());
-  yaml::Output Yout(Out);
+  yaml::Output Yout(Out, nullptr, /*WrapColumn*/
+                    (covmap::Decoder::enabled ? 160 : 70));
   Yout << *YAML;
 
   return Error::success();

--- a/llvm/tools/obj2yaml/obj2yaml.cpp
+++ b/llvm/tools/obj2yaml/obj2yaml.cpp
@@ -20,7 +20,7 @@
 using namespace llvm;
 using namespace llvm::object;
 
-static cl::OptionCategory Cat("obj2yaml Options");
+cl::OptionCategory Cat("obj2yaml Options");
 
 static cl::opt<std::string>
     InputFilename(cl::Positional, cl::desc("<input file>"), cl::init("-"));

--- a/llvm/tools/obj2yaml/obj2yaml.h
+++ b/llvm/tools/obj2yaml/obj2yaml.h
@@ -16,11 +16,15 @@
 #include "llvm/Object/Minidump.h"
 #include "llvm/Object/Wasm.h"
 #include "llvm/Object/XCOFFObjectFile.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include <system_error>
 
 enum RawSegments : unsigned { none = 0, data = 1, linkedit = 1 << 1 };
+
+extern llvm::cl::OptionCategory Cat;
+
 std::error_code coff2yaml(llvm::raw_ostream &Out,
                           const llvm::object::COFFObjectFile &Obj);
 llvm::Error elf2yaml(llvm::raw_ostream &Out,


### PR DESCRIPTION
`obj2yaml` is able to understand and dump Coverage Mapping related sections with `--covmap-raw`.

For now, this is dedicated to ELF and disabled by default. Affected sections are as below:
- `__llvm_covmap`
- `__llvm_covfun`
- `__llvm_prf_names`

Depends on #129472 