### PR TITLE
[OpenMP] Silently accept `neon_vector_type` for the offloading device

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8337,7 +8337,7 @@ static bool verifyValidIntegerConstantExpr(Sema &S, const ParsedAttr &Attr,
 static void HandleNeonVectorTypeAttr(QualType &CurType, const ParsedAttr &Attr,
                                      Sema &S, VectorKind VecKind) {
   const TargetInfo *AuxTI = S.getASTContext().getAuxTargetInfo();
-  bool IsArm = AuxTI->getTriple().isAArch64() || AuxTI->getTriple().isARM();
+  bool IsArm = AuxTI && (AuxTI->getTriple().isAArch64() || AuxTI->getTriple().isARM());
 
   bool IsTargetCUDAAndHostARM = IsArm && S.getLangOpts().CUDAIsDevice;
   bool IsTargetOpenMPDeviceAndHostARM = IsArm && S.getLangOpts().OpenMPIsTargetDevice;

--- a/clang/test/Sema/bug113094.cpp
+++ b/clang/test/Sema/bug113094.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang -fopenmp --offload-arch=sm_90 -nocudalib -target aarch64-unknown-linux-gnu -c -Xclang -verify %s
+// REQUIRES: aarch64-registered-target
+
+// expected-no-diagnostics
+
+typedef __attribute__ ((__neon_vector_type__ (4))) float __f32x4_t;


### PR DESCRIPTION
This addresses issue #113094 