### PR TITLE
[Driver][MSVC] Pass profile file to lld-link via -lto-sample-profile option

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -233,7 +233,7 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (C.getDriver().isUsingLTO()) {
-    if (Arg *A = Args.getLastArg(options::OPT_fprofile_sample_use_EQ))
+    if (Arg *A = tools::getLastProfileSampleUseArg(Args))
       CmdArgs.push_back(Args.MakeArgString(std::string("-lto-sample-profile:") +
                                            A->getValue()));
   }

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -232,9 +232,11 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  if (Arg *A = Args.getLastArg(options::OPT_fprofile_sample_use_EQ))
-    CmdArgs.push_back(Args.MakeArgString(std::string("-lto-sample-profile:") +
-                                         A->getValue()));
+  if (C.getDriver().isUsingLTO()) {
+    if (Arg *A = Args.getLastArg(options::OPT_fprofile_sample_use_EQ))
+      CmdArgs.push_back(Args.MakeArgString(std::string("-lto-sample-profile:") +
+                                           A->getValue()));
+  }
   Args.AddAllArgValues(CmdArgs, options::OPT__SLASH_link);
 
   // Control Flow Guard checks

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -232,6 +232,9 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
+  if (Arg *A = Args.getLastArg(options::OPT_fprofile_sample_use_EQ))
+    CmdArgs.push_back(Args.MakeArgString(std::string("-lto-sample-profile:") +
+                                         A->getValue()));
   Args.AddAllArgValues(CmdArgs, options::OPT__SLASH_link);
 
   // Control Flow Guard checks

--- a/clang/test/Driver/cl-link.c
+++ b/clang/test/Driver/cl-link.c
@@ -72,5 +72,5 @@
 // INFER-LLD: lld-link
 // INFER-LLD-NOT: INFERASANLIBS
 
-// RUN: %clang_cl --target=x86_64-unknown-windows-msvc -flto -fuse-ld=lld -### -S -fprofile-sample-use=%S/Inputs/file.prof %s 2>&1 | FileCheck -check-prefix=CHECK-SAMPLE-PROFILE %s
+// RUN: %clang_cl --target=x86_64-unknown-windows-msvc /Tc%s -flto -fuse-ld=lld -### -fprofile-sample-use=%S/Inputs/file.prof 2>&1 | FileCheck -check-prefix=CHECK-SAMPLE-PROFILE %s
 // CHECK-SAMPLE-PROFILE: "-lto-sample-profile:{{.*}}/file.prof"

--- a/clang/test/Driver/cl-link.c
+++ b/clang/test/Driver/cl-link.c
@@ -72,5 +72,5 @@
 // INFER-LLD: lld-link
 // INFER-LLD-NOT: INFERASANLIBS
 
-// RUN: %clang_cl --target=x86_64-unknown-windows-msvc -fuse-ld=lld -### -S -fprofile-sample-use=%S/Inputs/file.prof %s 2>&1 | FileCheck -check-prefix=CHECK-SAMPLE-PROFILE %s
+// RUN: %clang_cl --target=x86_64-unknown-windows-msvc -flto -fuse-ld=lld -### -S -fprofile-sample-use=%S/Inputs/file.prof %s 2>&1 | FileCheck -check-prefix=CHECK-SAMPLE-PROFILE %s
 // CHECK-SAMPLE-PROFILE: "-lto-sample-profile:{{.*}}/file.prof"

--- a/clang/test/Driver/cl-link.c
+++ b/clang/test/Driver/cl-link.c
@@ -71,3 +71,6 @@
 // RUN: %clang_cl -m32 -arch:IA32 --target=i386-pc-win32 /Tc%s -fuse-ld=lld -### -fsanitize=address 2>&1 | FileCheck --check-prefix=INFER-LLD %s
 // INFER-LLD: lld-link
 // INFER-LLD-NOT: INFERASANLIBS
+
+// RUN: %clang_cl --target=x86_64-unknown-windows-msvc -fuse-ld=lld -### -S -fprofile-sample-use=%S/Inputs/file.prof %s 2>&1 | FileCheck -check-prefix=CHECK-SAMPLE-PROFILE %s
+// CHECK-SAMPLE-PROFILE: "-lto-sample-profile:{{.*}}/file.prof"


### PR DESCRIPTION
In SPGO lto mode, linker needs -lto-sample-profile option to set sample profile file. 
Linux adds this option by transferring fprofile-sample-use to -plugin-opt=sample-profile=, which is alias of lto-sample-profile. (in clang\lib\Driver\ToolChains\CommonArgs.cpp: tools::addLTOOptions()).
But clang on Windows misses the transferring. So add it now.