### PR TITLE
[clang][bytecode] Fix rejecting non-constexpr array ctors

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -3029,7 +3029,7 @@ bool Compiler<Emitter>::VisitCXXConstructExpr(const CXXConstructExpr *E) {
 
     size_t NumElems = CAT->getZExtSize();
     const Function *Func = getFunction(E->getConstructor());
-    if (!Func || !Func->isConstexpr())
+    if (!Func)
       return false;
 
     // FIXME(perf): We're calling the constructor once per array element here,

--- a/clang/test/AST/ByteCode/new-delete.cpp
+++ b/clang/test/AST/ByteCode/new-delete.cpp
@@ -865,7 +865,6 @@ constexpr unsigned short ssmall = SS<unsigned short>(100)[42];
 constexpr auto Ss = SS<S>()[0];
 
 
-
 namespace IncompleteArray {
   struct A {
     int b = 10;
@@ -908,8 +907,19 @@ namespace IncompleteArray {
     return c;
   }
   static_assert(test4() == 12);
+}
 
+namespace NonConstexprArrayCtor {
+  struct S {
+    S() {} // both-note 2{{declared here}}
+  };
 
+  constexpr bool test() { // both-error {{never produces a constant expression}}
+     auto s = new S[1]; // both-note 2{{non-constexpr constructor}}
+     return true;
+  }
+  static_assert(test()); // both-error {{not an integral constant expression}} \
+                         // both-note {{in call to}}
 }
 
 #else


### PR DESCRIPTION
We shouldn't abort here when compiling, this is happening (and properly diagnosed) when interpreting the bytecode.