### PR TITLE
[Analysis] Remove getGuaranteedWellDefinedOps

### DIFF
--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -1004,12 +1004,6 @@ bool propagatesPoison(const Use &PoisonOp);
 void getGuaranteedNonPoisonOps(const Instruction *I,
                                SmallVectorImpl<const Value *> &Ops);
 
-/// Insert operands of I into Ops such that I will trigger undefined behavior
-/// if I is executed and that operand is not a well-defined value
-/// (i.e. has undef bits or poison).
-void getGuaranteedWellDefinedOps(const Instruction *I,
-                                 SmallVectorImpl<const Value *> &Ops);
-
 /// Return true if the given instruction must trigger undefined behavior
 /// when I is executed with any operands which appear in KnownPoison holding
 /// a poison value at the point of execution.

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -8175,14 +8175,6 @@ static bool handleGuaranteedWellDefinedOps(const Instruction *I,
   return false;
 }
 
-void llvm::getGuaranteedWellDefinedOps(
-    const Instruction *I, SmallVectorImpl<const Value *> &Operands) {
-  handleGuaranteedWellDefinedOps(I, [&](const Value *V) {
-    Operands.push_back(V);
-    return false;
-  });
-}
-
 /// Enumerates all operands of \p I that are guaranteed to not be poison.
 template <typename CallableT>
 static bool handleGuaranteedNonPoisonOps(const Instruction *I,


### PR DESCRIPTION
The last use was removed in:

  commit ac9e67756e0157793d565c2cceaf82e4403f58ba
  Author: Yingwei Zheng <dtcxzyw2333@gmail.com>
  Date:   Mon Feb 26 01:53:16 2024 +0800
