### PR TITLE
[mlir][bufferization] Module bufferization: Delete obsolete code

### DIFF
--- a/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize-analysis.mlir
+++ b/mlir/test/Dialect/Bufferization/Transforms/one-shot-module-bufferize-analysis.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries test-analysis-only" -split-input-file | FileCheck %s
+// RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries test-analysis-only dump-alias-sets" -split-input-file | FileCheck %s --check-prefix=CHECK-ALIAS
 
 // Run fuzzer with different seeds.
 // RUN: mlir-opt %s -one-shot-bufferize="bufferize-function-boundaries test-analysis-only analysis-heuristic=fuzzer analysis-fuzzer-seed=23" -split-input-file -o /dev/null
@@ -1406,3 +1407,21 @@ func.func @caller(%c: i1, %t0: tensor<5xf32>, %t1: tensor<5xf32>, %t2: tensor<5x
   return %r : tensor<5xf32>
 }
 
+// -----
+
+// CHECK-ALIAS-LABEL: func @foo
+func.func @foo(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  // CHECK-ALIAS: return
+  // CHECK-ALIAS-SAME: __equivalent_func_args__ = [0]
+  return %arg0 : tensor<?xf32>
+}
+
+// CHECK-ALIAS: func @bar(%[[arg0:.*]]: tensor<?xf32>
+func.func @bar(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  // CHECK-ALIAS: %[[call:.*]] = call @foo(%[[arg0]])
+  // CHECK-ALIAS-SAME: {__inplace_operands_attr__ = ["true"], __opresult_alias_set_attr__ = [{{\[}}"%[[call]]", "%[[arg0]]"]]}
+  %x = call @foo(%arg0) : (tensor<?xf32>) -> tensor<?xf32>
+  // CHECK-ALIAS: return
+  // CHECK-ALIAS-SAME: __equivalent_func_args__ = [0]
+  return %x : tensor<?xf32>
+}


### PR DESCRIPTION
Delete `equivalenceAnalysis`, which has been incorporated into the `getAliasingValues` API. Also add an additional test case to ensure that equivalence is properly propagated across function boundaries.
