### PR TITLE
[clang][bytecode] Restructure Program::CurrentDeclaration handling

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -29,7 +29,7 @@ namespace interp {
 template <class Emitter> class DeclScope final : public LocalScope<Emitter> {
 public:
   DeclScope(Compiler<Emitter> *Ctx, const ValueDecl *VD)
-      : LocalScope<Emitter>(Ctx, VD), Scope(Ctx->P, VD),
+      : LocalScope<Emitter>(Ctx, VD), Scope(Ctx->P),
         OldInitializingDecl(Ctx->InitializingDecl) {
     Ctx->InitializingDecl = VD;
     Ctx->InitStack.push_back(InitLink::Decl(VD));

--- a/clang/test/AST/ByteCode/libcxx/global-decl-id.cpp
+++ b/clang/test/AST/ByteCode/libcxx/global-decl-id.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -std=c++2c -fexperimental-new-constant-interpreter -verify=expected,both %s
+// RUN: %clang_cc1 -std=c++2c  -verify=ref,both %s
+
+// both-no-diagnostics
+
+namespace std {
+constexpr int
+midpoint(int __a, int ) {
+  constexpr unsigned  __half_diff = 0;
+  return __half_diff;
+}
+}
+struct Tuple {
+  int min;
+  int mid;
+  constexpr Tuple() {
+    min = 0;
+    mid = std::midpoint(min, min);
+  }
+};
+constexpr Tuple tup;
+


### PR DESCRIPTION
Properly reset to the last ID and return the current ID from getCurrentDecl().