### PR TITLE
[clang-repl] Disable EmulatedTLS on Windows for interpreter executor

### DIFF
--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -597,6 +597,9 @@ llvm::Error Interpreter::CreateExecutor() {
     auto JTMB = createJITTargetMachineBuilder(TT);
     if (!JTMB)
       return JTMB.takeError();
+#if defined(_WIN32)
+    JTMB->getOptions().EmulatedTLS = false;
+#endif
     auto JB = IncrementalExecutor::createDefaultJITBuilder(std::move(*JTMB));
     if (!JB)
       return JB.takeError();


### PR DESCRIPTION
When running the clang-repl interpreter on windows, calling

```cpp
Interpreter->Process(R"(
                     #include <iostream>
                     void f1(std::string &s) { std::cout<< s.c_str(); };
                      )");
```

Does not work, due to missing emulated tls symbols `__emutls_get_address` and `__emutls_v._Init_thread_epoch`. This requires disabling the option in the `orc::JITTargetMachineBuilder` when creating the executor

cc @vgvassilev 