### PR TITLE
[flang][OpenMP] Map `teams loop` to `teams distribute` when required.

### DIFF
--- a/flang/test/Lower/OpenMP/loop-directive.f90
+++ b/flang/test/Lower/OpenMP/loop-directive.f90
@@ -1,7 +1,8 @@
 ! This test checks lowering of OpenMP loop Directive.
 
-! RUN: bbc -emit-hlfir -fopenmp -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
+! REQUIRES: openmp_runtime
+
+! RUN: %flang_fc1 -emit-hlfir %openmp_flags -fopenmp-version=50 -o - %s 2>&1 | FileCheck %s
 
 ! CHECK: omp.declare_reduction @[[RED:add_reduction_i32]] : i32
 ! CHECK: omp.private {type = private} @[[DUMMY_PRIV:.*test_privateEdummy_private.*]] : i32
@@ -178,4 +179,85 @@ subroutine test_standalone_bind_parallel
   do i=1,N
     c(i) = a(i) * b(i)
   end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPteams_loop_cannot_be_parallel_for
+subroutine teams_loop_cannot_be_parallel_for
+  implicit none
+  integer :: iter, iter2, val(20)
+  val = 0
+  ! CHECK: omp.teams {
+
+  ! Verify the outer `loop` directive was mapped to only `distribute`.
+  ! CHECK-NOT: omp.parallel {{.*}}
+  ! CHECK:     omp.distribute {{.*}} {
+  ! CHECK-NEXT:  omp.loop_nest {{.*}} {
+
+  ! Verify the inner `loop` directive was mapped to a worksharing loop.
+  ! CHECK:         omp.wsloop {{.*}} {
+  ! CHECK-NEXT:      omp.loop_nest {{.*}} {
+  ! CHECK:           }
+  ! CHECK:         }
+
+  ! CHECK:       }
+  ! CHECK:     }
+
+  ! CHECK: }
+  !$omp target teams loop map(tofrom:val)
+  DO iter = 1, 5
+    !$omp loop bind(parallel)
+    DO iter2 = 1, 5
+      val(iter+iter2) = iter+iter2
+    END DO
+  END DO
+end subroutine
+
+subroutine foo()
+end subroutine
+
+! CHECK-LABEL: func.func @_QPteams_loop_cannot_be_parallel_for_2
+subroutine teams_loop_cannot_be_parallel_for_2
+  implicit none
+  integer :: iter, val(20)
+  val = 0
+
+  ! CHECK: omp.teams {
+
+  ! Verify the `loop` directive was mapped to only `distribute`.
+  ! CHECK-NOT: omp.parallel {{.*}}
+  ! CHECK:     omp.distribute {{.*}} {
+  ! CHECK-NEXT:  omp.loop_nest {{.*}} {
+  ! CHECK:         fir.call @_QPfoo
+  ! CHECK:       }
+  ! CHECK:     }
+
+  ! CHECK: }
+  !$omp target teams loop map(tofrom:val)
+  DO iter = 1, 5
+    call foo()
+  END DO
+end subroutine
+
+! CHECK-LABEL: func.func @_QPteams_loop_can_be_parallel_for
+subroutine teams_loop_can_be_parallel_for
+  use omp_lib
+  implicit none
+  integer :: iter, tid, val(20)
+  val = 0
+
+  !CHECK: omp.teams {
+  !CHECK:   omp.parallel {{.*}} {
+  !CHECK:     omp.distribute {
+  !CHECK:       omp.wsloop {
+  !CHECK:         omp.loop_nest {{.*}} {
+  !CHECK:           fir.call @omp_get_thread_num()
+  !CHECK:         }
+  !CHECK:       }
+  !CHECK:     }
+  !CHECK:   }
+  !CHECK: }
+  !$omp target teams loop map(tofrom:val)
+  DO iter = 1, 5
+    tid = omp_get_thread_num()
+  END DO
 end subroutine


### PR DESCRIPTION
This extends support for generic `loop` rewriting by:
1. Preventing nesting multiple worksharing loops inside each other. This is checked by walking the `teams loop` region searching for any `loop` directive whose `bind` modifier is `parallel`.
2. Preventing convert to worksharing loop if calls to unknow functions are found in the `loop` directive's body.

We walk the `teams loop` body to identify either of the above 2 conditions, if either of them is found to be true, we map the `loop` directive to `distribute`.