### PR TITLE
[ReleaseNotes][RemoveDIs] Add release note for deprecated insertion methods

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -116,7 +116,7 @@ Changes to the LLVM IR
 Changes to LLVM infrastructure
 ------------------------------
 
- * Several methods that use Instruction pointers as insertion positions (moveBefore, getFirstNonPHI) have been deprecated in favour of overloads and variants that use `BasicBlock::iterator`s instead. The instruction-flavoured methods will be removed in a future release. This work is part of the [RemoveDIs](https://llvm.org/docs/RemoveDIsDebugInfo.html) project, the documentation for which contains instructions for updating call-sites using the deprecated methods.
+ * Two methods that use Instruction pointers as code positions (moveBefore, getFirstNonPHI) have been deprecated in favour of overloads and variants that use `BasicBlock::iterator`s instead. The pointer-flavoured methods will be removed in a future release. This work is part of the [RemoveDIs](https://llvm.org/docs/RemoveDIsDebugInfo.html) project, the documentation for which contains instructions for updating call-sites using the deprecated methods.
 
 Changes to building LLVM
 ------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -116,6 +116,8 @@ Changes to the LLVM IR
 Changes to LLVM infrastructure
 ------------------------------
 
+ * Several methods that use Instruction pointers as insertion positions (moveBefore, getFirstNonPHI) have been deprecated in favour of overloads and variants that use `BasicBlock::iterator`s instead. The instruction-flavoured methods will be removed in a future release. This work is part of the [RemoveDIs](https://llvm.org/docs/RemoveDIsDebugInfo.html) project, the documentation for which contains instructions for updating call-sites using the deprecated methods.
+
 Changes to building LLVM
 ------------------------
 


### PR DESCRIPTION
I've stuck this under "LLVM Infrastructure" as the IR plumbing methods feel like infrastructure. The LLVM17 release notes stuck similar notes in that section too.