### PR TITLE
[lldb] fix software breakpoint removing in multithreaded process while stepping

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
@@ -1959,6 +1959,7 @@ void NativeProcessLinux::SignalIfAllThreadsStopped() {
 
   // Clear any temporary breakpoints we used to implement software single
   // stepping.
+  SetCurrentThreadID(m_pending_notification_tid);
   for (const auto &thread_info : m_threads_stepping_with_breakpoint) {
     Status error = RemoveBreakpoint(thread_info.second);
     if (error.Fail())
@@ -1968,7 +1969,6 @@ void NativeProcessLinux::SignalIfAllThreadsStopped() {
   m_threads_stepping_with_breakpoint.clear();
 
   // Notify the delegate about the stop
-  SetCurrentThreadID(m_pending_notification_tid);
   SetState(StateType::eStateStopped, true);
   m_pending_notification_tid = LLDB_INVALID_THREAD_ID;
 }


### PR DESCRIPTION
I have encountered with the issue that sometimes lldb-server can't remove internal software breakpoints in a multithread process and as a result the process freezes.

The source of the issue was that lldb-server tried to read/write memory of the process using a tid of the exited thread and received 'No such process' error from ptrace.

This patch sets an existing thread as the current one for this process before software breakpoints removing.