### PR TITLE
[lldb][NFC] remove AdaptedConstIterator and AdaptedIterable

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointList.h
@@ -163,8 +163,7 @@ protected:
   bool m_is_internal;
 
 public:
-  typedef LockingAdaptedIterable<bp_collection, lldb::BreakpointSP,
-                                 list_adapter, std::recursive_mutex>
+  typedef LockingAdaptedIterable<std::recursive_mutex, bp_collection>
       BreakpointIterable;
   BreakpointIterable Breakpoints() {
     return BreakpointIterable(m_breakpoints, GetMutex());

--- a/lldb/include/lldb/Breakpoint/BreakpointLocationCollection.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointLocationCollection.h
@@ -165,8 +165,7 @@ private:
   mutable std::mutex m_collection_mutex;
 
 public:
-  typedef AdaptedIterable<collection, lldb::BreakpointLocationSP,
-                          vector_adapter>
+  typedef llvm::iterator_range<collection::const_iterator>
       BreakpointLocationCollectionIterable;
   BreakpointLocationCollectionIterable BreakpointLocations() {
     return BreakpointLocationCollectionIterable(m_break_loc_collection);

--- a/lldb/include/lldb/Breakpoint/BreakpointLocationList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointLocationList.h
@@ -204,8 +204,7 @@ protected:
   BreakpointLocationCollection *m_new_location_recorder;
 
 public:
-  typedef AdaptedIterable<collection, lldb::BreakpointLocationSP,
-                          vector_adapter>
+  typedef llvm::iterator_range<collection::const_iterator>
       BreakpointLocationIterable;
 
   BreakpointLocationIterable BreakpointLocations() {

--- a/lldb/include/lldb/Breakpoint/WatchpointList.h
+++ b/lldb/include/lldb/Breakpoint/WatchpointList.h
@@ -39,8 +39,7 @@ public:
   ~WatchpointList();
 
   typedef std::list<lldb::WatchpointSP> wp_collection;
-  typedef LockingAdaptedIterable<wp_collection, lldb::WatchpointSP,
-                                 vector_adapter, std::recursive_mutex>
+  typedef LockingAdaptedIterable<std::recursive_mutex, wp_collection>
       WatchpointIterable;
 
   /// Add a Watchpoint to the list.

--- a/lldb/include/lldb/Breakpoint/WatchpointResource.h
+++ b/lldb/include/lldb/Breakpoint/WatchpointResource.h
@@ -39,8 +39,7 @@ public:
   void SetType(bool read, bool write);
 
   typedef std::vector<lldb::WatchpointSP> WatchpointCollection;
-  typedef LockingAdaptedIterable<WatchpointCollection, lldb::WatchpointSP,
-                                 vector_adapter, std::mutex>
+  typedef LockingAdaptedIterable<std::mutex, WatchpointCollection>
       WatchpointIterable;
 
   /// Iterate over the watchpoint constituents for this resource

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -521,14 +521,13 @@ protected:
   Notifier *m_notifier = nullptr;
 
 public:
-  typedef LockingAdaptedIterable<collection, lldb::ModuleSP, vector_adapter,
-                                 std::recursive_mutex>
+  typedef LockingAdaptedIterable<std::recursive_mutex, collection>
       ModuleIterable;
   ModuleIterable Modules() const {
     return ModuleIterable(m_modules, GetMutex());
   }
 
-  typedef AdaptedIterable<collection, lldb::ModuleSP, vector_adapter>
+  typedef llvm::iterator_range<collection::const_iterator>
       ModuleIterableNoLocking;
   ModuleIterableNoLocking ModulesNoLocking() const {
     return ModuleIterableNoLocking(m_modules);

--- a/lldb/include/lldb/Core/ModuleSpec.h
+++ b/lldb/include/lldb/Core/ModuleSpec.h
@@ -389,8 +389,7 @@ public:
   }
 
   typedef std::vector<ModuleSpec> collection;
-  typedef LockingAdaptedIterable<collection, ModuleSpec, vector_adapter,
-                                 std::recursive_mutex>
+  typedef LockingAdaptedIterable<std::recursive_mutex, collection>
       ModuleSpecIterable;
 
   ModuleSpecIterable ModuleSpecs() {

--- a/lldb/include/lldb/Host/common/NativeProcessProtocol.h
+++ b/lldb/include/lldb/Host/common/NativeProcessProtocol.h
@@ -51,13 +51,9 @@ public:
   virtual ~NativeProcessProtocol() = default;
 
   typedef std::vector<std::unique_ptr<NativeThreadProtocol>> thread_collection;
-  template <typename I>
-  static NativeThreadProtocol &thread_list_adapter(I &iter) {
-    assert(*iter);
-    return **iter;
-  }
-  typedef LockingAdaptedIterable<thread_collection, NativeThreadProtocol &,
-                                 thread_list_adapter, std::recursive_mutex>
+  typedef LockingAdaptedIterable<
+      std::recursive_mutex, thread_collection,
+      llvm::pointee_iterator<thread_collection::const_iterator>>
       ThreadIterable;
 
   virtual Status Resume(const ResumeActionList &resume_actions) = 0;

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -467,7 +467,7 @@ public:
   const_iterator begin() const { return m_symbol_contexts.begin(); }
   const_iterator end() const { return m_symbol_contexts.end(); }
 
-  typedef AdaptedIterable<collection, SymbolContext, vector_adapter>
+  typedef llvm::iterator_range<collection::const_iterator>
       SymbolContextIterable;
   SymbolContextIterable SymbolContexts() {
     return SymbolContextIterable(m_symbol_contexts);

--- a/lldb/include/lldb/Symbol/TypeList.h
+++ b/lldb/include/lldb/Symbol/TypeList.h
@@ -39,8 +39,7 @@ public:
   lldb::TypeSP GetTypeAtIndex(uint32_t idx);
 
   typedef std::vector<lldb::TypeSP> collection;
-  typedef AdaptedIterable<collection, lldb::TypeSP, vector_adapter>
-      TypeIterable;
+  typedef llvm::iterator_range<collection::const_iterator> TypeIterable;
 
   TypeIterable Types() { return TypeIterable(m_types); }
 

--- a/lldb/include/lldb/Symbol/TypeMap.h
+++ b/lldb/include/lldb/Symbol/TypeMap.h
@@ -44,7 +44,8 @@ public:
   lldb::TypeSP FirstType() const;
 
   typedef std::multimap<lldb::user_id_t, lldb::TypeSP> collection;
-  typedef AdaptedIterable<collection, lldb::TypeSP, map_adapter> TypeIterable;
+  typedef llvm::iterator_range<ValueMapIterator<collection::const_iterator>>
+      TypeIterable;
 
   TypeIterable Types() const { return TypeIterable(m_types); }
 

--- a/lldb/include/lldb/Target/QueueList.h
+++ b/lldb/include/lldb/Target/QueueList.h
@@ -48,9 +48,7 @@ public:
   lldb::QueueSP GetQueueAtIndex(uint32_t idx);
 
   typedef std::vector<lldb::QueueSP> collection;
-  typedef LockingAdaptedIterable<collection, lldb::QueueSP, vector_adapter,
-                                 std::mutex>
-      QueueIterable;
+  typedef LockingAdaptedIterable<std::mutex, collection> QueueIterable;
 
   /// Iterate over the list of queues
   ///

--- a/lldb/include/lldb/Target/TargetList.h
+++ b/lldb/include/lldb/Target/TargetList.h
@@ -44,8 +44,7 @@ public:
   }
 
   typedef std::vector<lldb::TargetSP> collection;
-  typedef LockingAdaptedIterable<collection, lldb::TargetSP, vector_adapter,
-                                 std::recursive_mutex>
+  typedef LockingAdaptedIterable<std::recursive_mutex, collection>
       TargetIterable;
 
   /// Create a new Target.

--- a/lldb/include/lldb/Target/ThreadCollection.h
+++ b/lldb/include/lldb/Target/ThreadCollection.h
@@ -20,8 +20,7 @@ namespace lldb_private {
 class ThreadCollection {
 public:
   typedef std::vector<lldb::ThreadSP> collection;
-  typedef LockingAdaptedIterable<collection, lldb::ThreadSP, vector_adapter,
-                                 std::recursive_mutex>
+  typedef LockingAdaptedIterable<std::recursive_mutex, collection>
       ThreadIterable;
 
   ThreadCollection();

--- a/lldb/include/lldb/Utility/Iterable.h
+++ b/lldb/include/lldb/Utility/Iterable.h
@@ -11,172 +11,37 @@
 
 #include <utility>
 
+#include <llvm/ADT/iterator.h>
 
 namespace lldb_private {
 
-template <typename I, typename E> E map_adapter(I &iter) {
-  return iter->second;
-}
+template <typename WrappedIteratorT,
+          typename T = typename std::iterator_traits<
+              WrappedIteratorT>::value_type::second_type>
+struct ValueMapIterator
+    : llvm::iterator_adaptor_base<
+          ValueMapIterator<WrappedIteratorT, T>, WrappedIteratorT,
+          typename std::iterator_traits<WrappedIteratorT>::iterator_category,
+          T> {
+  ValueMapIterator() = default;
+  explicit ValueMapIterator(WrappedIteratorT u)
+      : ValueMapIterator::iterator_adaptor_base(std::move(u)) {}
 
-template <typename I, typename E> E vector_adapter(I &iter) { return *iter; }
-
-template <typename I, typename E> E list_adapter(I &iter) { return *iter; }
-
-template <typename C, typename E, E (*A)(typename C::const_iterator &)>
-class AdaptedConstIterator {
-public:
-  typedef typename C::const_iterator BackingIterator;
-
-  // Wrapping constructor
-  AdaptedConstIterator(BackingIterator backing_iterator)
-      : m_iter(backing_iterator) {}
-
-  // Default-constructible
-  AdaptedConstIterator() : m_iter() {}
-
-  // Copy-constructible
-  AdaptedConstIterator(const AdaptedConstIterator &rhs) : m_iter(rhs.m_iter) {}
-
-  // Copy-assignable
-  AdaptedConstIterator &operator=(const AdaptedConstIterator &rhs) {
-    m_iter = rhs.m_iter;
-    return *this;
-  }
-
-  // Destructible
-  ~AdaptedConstIterator() = default;
-
-  // Comparable
-  bool operator==(const AdaptedConstIterator &rhs) {
-    return m_iter == rhs.m_iter;
-  }
-
-  bool operator!=(const AdaptedConstIterator &rhs) {
-    return m_iter != rhs.m_iter;
-  }
-
-  // Rvalue dereferenceable
-  E operator*() { return (*A)(m_iter); }
-
-  E operator->() { return (*A)(m_iter); }
-
-  // Offset dereferenceable
-  E operator[](typename BackingIterator::difference_type offset) {
-    return AdaptedConstIterator(m_iter + offset);
-  }
-
-  // Incrementable
-  AdaptedConstIterator &operator++() {
-    m_iter++;
-    return *this;
-  }
-
-  // Decrementable
-  AdaptedConstIterator &operator--() {
-    m_iter--;
-    return *this;
-  }
-
-  // Compound assignment
-  AdaptedConstIterator &
-  operator+=(typename BackingIterator::difference_type offset) {
-    m_iter += offset;
-    return *this;
-  }
-
-  AdaptedConstIterator &
-  operator-=(typename BackingIterator::difference_type offset) {
-    m_iter -= offset;
-    return *this;
-  }
-
-  // Arithmetic
-  AdaptedConstIterator
-  operator+(typename BackingIterator::difference_type offset) {
-    return AdaptedConstIterator(m_iter + offset);
-  }
-
-  AdaptedConstIterator
-  operator-(typename BackingIterator::difference_type offset) {
-    return AdaptedConstIterator(m_iter - offset);
-  }
-
-  // Comparable
-  bool operator<(AdaptedConstIterator &rhs) { return m_iter < rhs.m_iter; }
-
-  bool operator<=(AdaptedConstIterator &rhs) { return m_iter <= rhs.m_iter; }
-
-  bool operator>(AdaptedConstIterator &rhs) { return m_iter > rhs.m_iter; }
-
-  bool operator>=(AdaptedConstIterator &rhs) { return m_iter >= rhs.m_iter; }
-
-  template <typename C1, typename E1, E1 (*A1)(typename C1::const_iterator &)>
-  friend AdaptedConstIterator<C1, E1, A1>
-  operator+(typename C1::const_iterator::difference_type,
-            AdaptedConstIterator<C1, E1, A1> &);
-
-  template <typename C1, typename E1, E1 (*A1)(typename C1::const_iterator &)>
-  friend typename C1::const_iterator::difference_type
-  operator-(AdaptedConstIterator<C1, E1, A1> &,
-            AdaptedConstIterator<C1, E1, A1> &);
-
-  template <typename C1, typename E1, E1 (*A1)(typename C1::const_iterator &)>
-  friend void swap(AdaptedConstIterator<C1, E1, A1> &,
-                   AdaptedConstIterator<C1, E1, A1> &);
-
-private:
-  BackingIterator m_iter;
+  const T &operator*() { return (*this->I).second; }
+  const T &operator*() const { return (*this->I).second; }
 };
 
-template <typename C, typename E, E (*A)(typename C::const_iterator &)>
-AdaptedConstIterator<C, E, A> operator+(
-    typename AdaptedConstIterator<C, E, A>::BackingIterator::difference_type
-        offset,
-    AdaptedConstIterator<C, E, A> &rhs) {
-  return rhs.operator+(offset);
-}
-
-template <typename C, typename E, E (*A)(typename C::const_iterator &)>
-typename AdaptedConstIterator<C, E, A>::BackingIterator::difference_type
-operator-(AdaptedConstIterator<C, E, A> &lhs,
-          AdaptedConstIterator<C, E, A> &rhs) {
-  return (lhs.m_iter - rhs.m_iter);
-}
-
-template <typename C, typename E, E (*A)(typename C::const_iterator &)>
-void swap(AdaptedConstIterator<C, E, A> &lhs,
-          AdaptedConstIterator<C, E, A> &rhs) {
-  std::swap(lhs.m_iter, rhs.m_iter);
-}
-
-template <typename C, typename E, E (*A)(typename C::const_iterator &)>
-class AdaptedIterable {
-private:
-  const C &m_container;
-
-public:
-  AdaptedIterable(const C &container) : m_container(container) {}
-
-  AdaptedConstIterator<C, E, A> begin() {
-    return AdaptedConstIterator<C, E, A>(m_container.begin());
-  }
-
-  AdaptedConstIterator<C, E, A> end() {
-    return AdaptedConstIterator<C, E, A>(m_container.end());
-  }
-};
-
-template <typename C, typename E, E (*A)(typename C::const_iterator &),
-          typename MutexType>
-class LockingAdaptedIterable : public AdaptedIterable<C, E, A> {
+template <typename MutexType, typename C,
+          typename IteratorT = typename C::const_iterator>
+class LockingAdaptedIterable : public llvm::iterator_range<IteratorT> {
 public:
   LockingAdaptedIterable(const C &container, MutexType &mutex)
-      : AdaptedIterable<C, E, A>(container), m_mutex(&mutex) {
+      : llvm::iterator_range<IteratorT>(container), m_mutex(&mutex) {
     m_mutex->lock();
   }
 
   LockingAdaptedIterable(LockingAdaptedIterable &&rhs)
-      : AdaptedIterable<C, E, A>(rhs), m_mutex(rhs.m_mutex) {
+      : llvm::iterator_range<IteratorT>(rhs), m_mutex(rhs.m_mutex) {
     rhs.m_mutex = nullptr;
   }
 


### PR DESCRIPTION
AdaptedConstIterator currently doesn't have iterator traits, so I can't use STL algorithms with containers like WatchpointList.

This patch replaces AdaptedConstIterator and AdaptedIterable with llvm::iterator_adaped_base and llvm::iterator_range respectively.