### PR TITLE
[mlir][ODS] Allow inferring operand types from multiple variables

### DIFF
--- a/mlir/include/mlir/IR/OpBase.td
+++ b/mlir/include/mlir/IR/OpBase.td
@@ -556,19 +556,29 @@ class AllShapesMatch<list<string> names> :
 class AllTypesMatch<list<string> names> :
     AllMatchSameOperatorTrait<names, "$_self.getType()", "type">;
 
+// A type constraint that denotes `transform(unpack(lhs.getTypes())) == rhs.getType()`.
+// An optional comparator function may be provided that changes the above form
+// into: `comparator(transform(unpack(lhs.getTypes())), rhs.getType())`.
+class InferTypesFrom<string summary, list<string> lhsArg, string rhsArg,
+                     string transform, 
+                     string comparator = "std::equal_to<>()">
+  : PredOpTrait<summary, CPred<
+    comparator # "(" #
+    !foldl(transform, !range(lhsArg), acc, i, !subst("$arg" # i, "$" # lhsArg[i] # ".getType()", acc)) #
+    ", $" # rhsArg # ".getType()" # ")">> {
+  list<string> args = lhsArg;
+  string target = rhsArg;
+  string transformer = transform;
+}
+
 // A type constraint that denotes `transform(lhs.getType()) == rhs.getType()`.
 // An optional comparator function may be provided that changes the above form
 // into: `comparator(transform(lhs.getType()), rhs.getType())`.
 class TypesMatchWith<string summary, string lhsArg, string rhsArg,
-                     string transform, string comparator = "std::equal_to<>()">
-  : PredOpTrait<summary, CPred<
-      comparator # "(" #
-      !subst("$_self", "$" # lhsArg # ".getType()", transform) #
-      ", $" # rhsArg # ".getType())">> {
-  string lhs = lhsArg;
-  string rhs = rhsArg;
-  string transformer = transform;
-}
+                     string transform, string comparator = "std::equal_to<>()"> 
+  : InferTypesFrom<summary, [lhsArg], rhsArg, 
+                   !subst("$_self", "$arg0", transform), 
+                   comparator>;
 
 // The same as TypesMatchWith but if either `lhsArg` or `rhsArg` are optional
 // and not present returns success.

--- a/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
+++ b/mlir/test/lib/Dialect/Test/TestOpsSyntax.td
@@ -654,6 +654,19 @@ def FormatTypesMatchContextOp : TEST_Op<"format_types_match_context", [
 }
 
 //===----------------------------------------------------------------------===//
+// InferTypesFrom type inference
+
+def FormatTypesMatchMultipleVarOp : TEST_Op<"format_types_match_multiple_var", [
+    InferTypesFrom<"result type is a tuple of types of value1 and value2",
+                   ["value1", "result"], "value2",
+                   "TupleType::get($_ctxt, {$arg0, $arg1})">]> {
+  let arguments = (ins AnyType:$value1,
+                       AnyType:$value2);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = "attr-dict $value1 `,` $value2 `:` type($value1) `->` type($result)";
+}
+
+//===----------------------------------------------------------------------===//
 // InferTypeOpInterface type inference in assembly format
 
 def FormatInferTypeOp : TEST_Op<"format_infer_type", [InferTypeOpInterface]> {

--- a/mlir/test/mlir-tblgen/op-format.mlir
+++ b/mlir/test/mlir-tblgen/op-format.mlir
@@ -4,6 +4,8 @@
 %i64 = "foo.op"() : () -> (i64)
 // CHECK: %[[I32:.*]] =
 %i32 = "foo.op"() : () -> (i32)
+// CHECK: %[[I64_I32_TUP:.*]]
+%i64_i32_tuple = "foo.op"() : () -> (tuple<i64, i32>)
 // CHECK: %[[MEMREF:.*]] =
 %memref = "foo.op"() : () -> (memref<1xf64>)
 
@@ -480,6 +482,13 @@ test.format_infer_variadic_type_from_non_variadic %i64, %i64 : i64
 
 // CHECK: test.format_types_match_context %[[I64]] : i64
 %ignored_res6 = test.format_types_match_context %i64 : i64
+
+//===----------------------------------------------------------------------===//
+// InferTypesFrom type inference
+//===----------------------------------------------------------------------===//
+
+// CHECK: test.format_types_match_multiple_var
+%ignored_res6a = test.format_types_match_multiple_var %i64, %i64_i32_tuple  : i64 -> i32
 
 //===----------------------------------------------------------------------===//
 // InferTypeOpInterface type inference

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -3707,7 +3707,6 @@ void OpEmitter::genTypeInterfaceMethods() {
           typeStr = ("operands[" + Twine(arg.operandOrAttributeIndex()) +
                      "].getType()")
                         .str();
-
           // If this is an attribute, index into the attribute dictionary.
         } else {
           auto *attr =
@@ -3743,7 +3742,8 @@ void OpEmitter::genTypeInterfaceMethods() {
         continue;
       }
       body << "  ::mlir::Type odsInferredType" << inferredTypeIdx++ << " = "
-           << tgfmt(infer.getTransformer(), &fctx.withSelf(typeStr)) << ";\n";
+           << tgfmt(infer.getTransformer(), &fctx.addSubst("arg0", typeStr))
+           << ";\n";
       constructedIndices[i] = inferredTypeIdx - 1;
     }
   }


### PR DESCRIPTION
This patch adds support for inferring operand types from multiple operand types.

The patch introduces a new `InferTypesFrom` class and makes the backend rely on it, since it's a more general class. The older `TypesMatchWith` class is backwards compatible with this change and works the same as before.

Inferring result types could also be added with this change, but is more complex as we need to generate a different builder call as well (which needs more intrusive changes into the operation definition builder)