### PR TITLE
[X86] combineConcatVectorOps - add EXTEND_VECTOR_INREG() 512-bit handling

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -57883,8 +57883,10 @@ static SDValue combineConcatVectorOps(const SDLoc &DL, MVT VT,
     case ISD::SIGN_EXTEND_VECTOR_INREG:
     case ISD::ZERO_EXTEND_VECTOR_INREG: {
       // TODO: Handle ANY_EXTEND combos with SIGN/ZERO_EXTEND.
-      if (!IsSplat && NumOps == 2 && VT.is256BitVector() &&
-          Subtarget.hasInt256() &&
+      if (!IsSplat && NumOps == 2 &&
+          ((VT.is256BitVector() && Subtarget.hasInt256()) ||
+           (VT.is512BitVector() && Subtarget.useAVX512Regs() &&
+            (EltSizeInBits >= 32 || Subtarget.useBWIRegs()))) &&
           Op0.getOperand(0).getValueType().is128BitVector() &&
           Op0.getOperand(0).getValueType() ==
               Ops[0].getOperand(0).getValueType()) {

--- a/llvm/test/CodeGen/X86/vector-interleaved-store-i8-stride-8.ll
+++ b/llvm/test/CodeGen/X86/vector-interleaved-store-i8-stride-8.ll
@@ -6721,7 +6721,7 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512-NEXT:    movq {{[0-9]+}}(%rsp), %r10
 ; AVX512-NEXT:    vmovdqa (%rcx), %xmm3
 ; AVX512-NEXT:    vmovdqa %xmm3, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
-; AVX512-NEXT:    vmovdqa 32(%rcx), %xmm11
+; AVX512-NEXT:    vmovdqa 32(%rcx), %xmm12
 ; AVX512-NEXT:    vmovdqa 48(%rcx), %xmm0
 ; AVX512-NEXT:    vmovdqa (%rdx), %xmm2
 ; AVX512-NEXT:    vmovdqa %xmm2, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
@@ -6729,11 +6729,11 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm2[8],xmm3[8],xmm2[9],xmm3[9],xmm2[10],xmm3[10],xmm2[11],xmm3[11],xmm2[12],xmm3[12],xmm2[13],xmm3[13],xmm2[14],xmm3[14],xmm2[15],xmm3[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm2[0,0,2,1,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
-; AVX512-NEXT:    vmovdqu %ymm3, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm10
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm3, %ymm6
+; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm3, %ymm2
+; AVX512-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vmovdqa (%r10), %xmm5
 ; AVX512-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
 ; AVX512-NEXT:    vmovdqa 48(%r10), %xmm3
@@ -6742,8 +6742,8 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512-NEXT:    vmovdqa 48(%rax), %xmm4
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm2[8],xmm5[8],xmm2[9],xmm5[9],xmm2[10],xmm5[10],xmm2[11],xmm5[11],xmm2[12],xmm5[12],xmm2[13],xmm5[13],xmm2[14],xmm5[14],xmm2[15],xmm5[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm7, %ymm5, %ymm5
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm6, %ymm5, %ymm5
 ; AVX512-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
@@ -6751,18 +6751,19 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vmovdqa (%r9), %xmm5
 ; AVX512-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
-; AVX512-NEXT:    vmovdqa 48(%r9), %xmm7
+; AVX512-NEXT:    vmovdqa 48(%r9), %xmm6
 ; AVX512-NEXT:    vmovdqa (%r8), %xmm2
 ; AVX512-NEXT:    vmovdqa %xmm2, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
-; AVX512-NEXT:    vmovdqa 48(%r8), %xmm12
+; AVX512-NEXT:    vmovdqa 48(%r8), %xmm8
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm2[8],xmm5[8],xmm2[9],xmm5[9],xmm2[10],xmm5[10],xmm2[11],xmm5[11],xmm2[12],xmm5[12],xmm2[13],xmm5[13],xmm2[14],xmm5[14],xmm2[15],xmm5[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,1,1,3,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm2[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm8, %ymm5, %ymm5
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm2[2,1,3,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm7, %ymm5, %ymm5
 ; AVX512-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,5,5,7]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,6,5,7,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm8
+; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm2
+; AVX512-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm1[0],xmm0[0],xmm1[1],xmm0[1],xmm1[2],xmm0[2],xmm1[3],xmm0[3],xmm1[4],xmm0[4],xmm1[5],xmm0[5],xmm1[6],xmm0[6],xmm1[7],xmm0[7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,0,2,1,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm2[0,2,2,3,4,5,6,7]
@@ -6770,80 +6771,80 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm9
+; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm2
+; AVX512-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm4[0],xmm3[0],xmm4[1],xmm3[1],xmm4[2],xmm3[2],xmm4[3],xmm3[3],xmm4[4],xmm3[4],xmm4[5],xmm3[5],xmm4[6],xmm3[6],xmm4[7],xmm3[7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm10 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm10, %ymm5, %ymm5
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm9, %ymm5, %ymm5
 ; AVX512-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
 ; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm2
 ; AVX512-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm12[0],xmm7[0],xmm12[1],xmm7[1],xmm12[2],xmm7[2],xmm12[3],xmm7[3],xmm12[4],xmm7[4],xmm12[5],xmm7[5],xmm12[6],xmm7[6],xmm12[7],xmm7[7]
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm8[0],xmm6[0],xmm8[1],xmm6[1],xmm8[2],xmm6[2],xmm8[3],xmm6[3],xmm8[4],xmm6[4],xmm8[5],xmm6[5],xmm8[6],xmm6[6],xmm8[7],xmm6[7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,1,1,3,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm2[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm13, %ymm5, %ymm5
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm2[2,1,3,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm9, %ymm5, %ymm5
 ; AVX512-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vmovdqa 32(%rdx), %xmm5
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm2[0,1,2,3,4,5,5,7]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm9 = xmm2[0,1,2,3,4,5,5,7]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,6,5,7,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm13, %ymm2
-; AVX512-NEXT:    vmovdqu %ymm2, (%rsp) # 32-byte Spill
+; AVX512-NEXT:    vinserti32x4 $1, %xmm2, %ymm9, %ymm26
 ; AVX512-NEXT:    vmovdqa 32(%r10), %xmm2
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm1[8],xmm0[8],xmm1[9],xmm0[9],xmm1[10],xmm0[10],xmm1[11],xmm0[11],xmm1[12],xmm0[12],xmm1[13],xmm0[13],xmm1[14],xmm0[14],xmm1[15],xmm0[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm1[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm13, %ymm0, %ymm10
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm1[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm9, %ymm0, %ymm28
 ; AVX512-NEXT:    vmovdqa 32(%rax), %xmm0
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm1[0,1,2,3,4,4,6,5]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm9 = xmm1[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm13, %ymm28
+; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm9, %ymm29
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm4[8],xmm3[8],xmm4[9],xmm3[9],xmm4[10],xmm3[10],xmm4[11],xmm3[11],xmm4[12],xmm3[12],xmm4[13],xmm3[13],xmm4[14],xmm3[14],xmm4[15],xmm3[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm30
+; AVX512-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm25
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm27
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm12[8],xmm7[8],xmm12[9],xmm7[9],xmm12[10],xmm7[10],xmm12[11],xmm7[11],xmm12[12],xmm7[12],xmm12[13],xmm7[13],xmm12[14],xmm7[14],xmm12[15],xmm7[15]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm23
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm8[8],xmm6[8],xmm8[9],xmm6[9],xmm8[10],xmm6[10],xmm8[11],xmm6[11],xmm8[12],xmm6[12],xmm8[13],xmm6[13],xmm8[14],xmm6[14],xmm8[15],xmm6[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,1,1,3,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm1[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm26
+; AVX512-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm19
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,5,5,7]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,6,5,7,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm22
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm5[0],xmm11[0],xmm5[1],xmm11[1],xmm5[2],xmm11[2],xmm5[3],xmm11[3],xmm5[4],xmm11[4],xmm5[5],xmm11[5],xmm5[6],xmm11[6],xmm5[7],xmm11[7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm17
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm5[0],xmm12[0],xmm5[1],xmm12[1],xmm5[2],xmm12[2],xmm5[3],xmm12[3],xmm5[4],xmm12[4],xmm5[5],xmm12[5],xmm5[6],xmm12[6],xmm5[7],xmm12[7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm20
+; AVX512-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm16
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm3, %ymm14
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3],xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm1[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm6, %ymm3, %ymm20
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
 ; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm18
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3],xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm7, %ymm3, %ymm25
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm21
 ; AVX512-NEXT:    vmovdqa 32(%r9), %xmm1
 ; AVX512-NEXT:    vmovdqa 32(%r8), %xmm3
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm7 = xmm3[0],xmm1[0],xmm3[1],xmm1[1],xmm3[2],xmm1[2],xmm3[3],xmm1[3],xmm3[4],xmm1[4],xmm3[5],xmm1[5],xmm3[6],xmm1[6],xmm3[7],xmm1[7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm12 = xmm7[0,1,1,3,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm7[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm13, %ymm12, %ymm19
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm12 = xmm7[0,1,2,3,4,5,5,7]
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm7[0,1,2,3,6,5,7,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm7, %ymm12, %ymm17
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm5 = xmm5[8],xmm11[8],xmm5[9],xmm11[9],xmm5[10],xmm11[10],xmm5[11],xmm11[11],xmm5[12],xmm11[12],xmm5[13],xmm11[13],xmm5[14],xmm11[14],xmm5[15],xmm11[15]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm5[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm11 = xmm5[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm11, %ymm7, %ymm4
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm6 = xmm3[0],xmm1[0],xmm3[1],xmm1[1],xmm3[2],xmm1[2],xmm3[3],xmm1[3],xmm3[4],xmm1[4],xmm3[5],xmm1[5],xmm3[6],xmm1[6],xmm3[7],xmm1[7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm6[0,1,1,3,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm6[2,1,3,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm9, %ymm8, %ymm15
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm8 = xmm6[0,1,2,3,4,5,5,7]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm6[0,1,2,3,6,5,7,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm6, %ymm8, %ymm13
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm5 = xmm5[8],xmm12[8],xmm5[9],xmm12[9],xmm5[10],xmm12[10],xmm5[11],xmm12[11],xmm5[12],xmm12[12],xmm5[13],xmm12[13],xmm5[14],xmm12[14],xmm5[15],xmm12[15]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm5[0,0,2,1,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm5[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm8, %ymm6, %ymm4
 ; AVX512-NEXT:    vmovdqu %ymm4, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm5[0,1,2,3,4,4,6,5]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm5[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm5[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm7, %ymm4
+; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm6, %ymm4
 ; AVX512-NEXT:    vmovdqu %ymm4, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm0 = xmm0[8],xmm2[8],xmm0[9],xmm2[9],xmm0[10],xmm2[10],xmm0[11],xmm2[11],xmm0[12],xmm2[12],xmm0[13],xmm2[13],xmm0[14],xmm2[14],xmm0[15],xmm2[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm2 = xmm0[0,0,2,1,4,5,6,7]
@@ -6863,273 +6864,244 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,6,5,7,7]
 ; AVX512-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
 ; AVX512-NEXT:    vmovdqu %ymm0, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512-NEXT:    vmovdqa 16(%rcx), %xmm11
-; AVX512-NEXT:    vmovdqa 16(%rdx), %xmm7
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm7[0],xmm11[0],xmm7[1],xmm11[1],xmm7[2],xmm11[2],xmm7[3],xmm11[3],xmm7[4],xmm11[4],xmm7[5],xmm11[5],xmm7[6],xmm11[6],xmm7[7],xmm11[7]
+; AVX512-NEXT:    vmovdqa 16(%rcx), %xmm4
+; AVX512-NEXT:    vmovdqa 16(%rdx), %xmm3
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm3[0],xmm4[0],xmm3[1],xmm4[1],xmm3[2],xmm4[2],xmm3[3],xmm4[3],xmm3[4],xmm4[4],xmm3[5],xmm4[5],xmm3[6],xmm4[6],xmm3[7],xmm4[7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm0[0,0,2,1,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm0[0,2,2,3,4,5,6,7]
 ; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm1, %ymm1
-; AVX512-NEXT:    vmovdqu %ymm1, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512-NEXT:    vmovdqu %ymm1, (%rsp) # 32-byte Spill
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm0[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,4,6,6,7]
 ; AVX512-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
 ; AVX512-NEXT:    vmovdqu %ymm0, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512-NEXT:    vmovdqa 16(%r10), %xmm1
-; AVX512-NEXT:    vmovdqa 16(%rax), %xmm15
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm15[0],xmm1[0],xmm15[1],xmm1[1],xmm15[2],xmm1[2],xmm15[3],xmm1[3],xmm15[4],xmm1[4],xmm15[5],xmm1[5],xmm15[6],xmm1[6],xmm15[7],xmm1[7]
-; AVX512-NEXT:    vmovdqa64 %xmm1, %xmm16
+; AVX512-NEXT:    vmovdqa 16(%r10), %xmm9
+; AVX512-NEXT:    vmovdqa 16(%rax), %xmm8
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm8[0],xmm9[0],xmm8[1],xmm9[1],xmm8[2],xmm9[2],xmm8[3],xmm9[3],xmm8[4],xmm9[4],xmm8[5],xmm9[5],xmm8[6],xmm9[6],xmm8[7],xmm9[7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm0[0,0,2,1,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm0[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm1, %ymm1
-; AVX512-NEXT:    vmovdqu %ymm1, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512-NEXT:    vinserti32x4 $1, %xmm5, %ymm1, %ymm30
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm0[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm0, %ymm1, %ymm29
-; AVX512-NEXT:    vmovdqa 16(%r9), %xmm14
-; AVX512-NEXT:    vmovdqa 16(%r8), %xmm12
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm4 = xmm12[0],xmm14[0],xmm12[1],xmm14[1],xmm12[2],xmm14[2],xmm12[3],xmm14[3],xmm12[4],xmm14[4],xmm12[5],xmm14[5],xmm12[6],xmm14[6],xmm12[7],xmm14[7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm4[0,1,1,3,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm4[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm13, %ymm1, %ymm31
-; AVX512-NEXT:    vmovdqa (%rsi), %xmm0
-; AVX512-NEXT:    vmovdqa (%rdi), %xmm2
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm2[8],xmm0[8],xmm2[9],xmm0[9],xmm2[10],xmm0[10],xmm2[11],xmm0[11],xmm2[12],xmm0[12],xmm2[13],xmm0[13],xmm2[14],xmm0[14],xmm2[15],xmm0[15]
-; AVX512-NEXT:    vmovdqa64 %xmm2, %xmm23
-; AVX512-NEXT:    vmovdqa64 %xmm0, %xmm24
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm13 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm0, %ymm1, %ymm31
+; AVX512-NEXT:    vmovdqa 16(%r9), %xmm6
+; AVX512-NEXT:    vmovdqa 16(%r8), %xmm5
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm5[0],xmm6[0],xmm5[1],xmm6[1],xmm5[2],xmm6[2],xmm5[3],xmm6[3],xmm5[4],xmm6[4],xmm5[5],xmm6[5],xmm5[6],xmm6[6],xmm5[7],xmm6[7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm2[0,1,1,3,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm11 = xmm2[2,1,3,3,4,5,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm11, %ymm1, %ymm27
 ; AVX512-NEXT:    vmovdqa 48(%rsi), %xmm1
-; AVX512-NEXT:    vmovdqa 48(%rdi), %xmm0
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm0[8],xmm1[8],xmm0[9],xmm1[9],xmm0[10],xmm1[10],xmm0[11],xmm1[11],xmm0[12],xmm1[12],xmm0[13],xmm1[13],xmm0[14],xmm1[14],xmm0[15],xmm1[15]
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm5 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm2 = xmm2[2,3,2,3]
-; AVX512-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm0 = mem[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm6 = ymm6[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm6, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm3 = xmm3[0],zero,zero,zero,xmm3[1],zero,zero,zero,xmm3[2],zero,zero,zero,xmm3[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm13, %zmm6
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} zmm13 = [65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535]
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm0 ^ (zmm13 & (zmm6 ^ zmm0))
+; AVX512-NEXT:    vmovdqa 48(%rdi), %xmm11
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm11[0],xmm1[0],xmm11[1],xmm1[1],xmm11[2],xmm1[2],xmm11[3],xmm1[3],xmm11[4],xmm1[4],xmm11[5],xmm1[5],xmm11[6],xmm1[6],xmm11[7],xmm1[7]
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm11[8],xmm1[8],xmm11[9],xmm1[9],xmm11[10],xmm1[10],xmm11[11],xmm1[11],xmm11[12],xmm1[12],xmm11[13],xmm1[13],xmm11[14],xmm1[14],xmm11[15],xmm1[15]
+; AVX512-NEXT:    vmovdqa (%rsi), %xmm7
+; AVX512-NEXT:    vmovdqa (%rdi), %xmm12
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm11 = xmm12[8],xmm7[8],xmm12[9],xmm7[9],xmm12[10],xmm7[10],xmm12[11],xmm7[11],xmm12[12],xmm7[12],xmm12[13],xmm7[13],xmm12[14],xmm7[14],xmm12[15],xmm7[15]
+; AVX512-NEXT:    vmovdqa64 %xmm7, %xmm21
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm22 = xmm11[0],zero,zero,zero,xmm11[1],zero,zero,zero,xmm11[2],zero,zero,zero,xmm11[3],zero,zero,zero,xmm11[4],zero,zero,zero,xmm11[5],zero,zero,zero,xmm11[6],zero,zero,zero,xmm11[7],zero,zero,zero
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm24 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm10[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm11 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm11 = mem[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm11, %zmm0, %zmm0
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} zmm11 = [65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535]
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm22 = zmm0 ^ (zmm11 & (zmm22 ^ zmm0))
 ; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
 ; AVX512-NEXT:    # ymm0 = mem[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm3 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm3 = mem[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm0, %zmm0
-; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm3 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm3 = mem[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm8 = ymm8[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm8, %zmm3, %zmm3
-; AVX512-NEXT:    vpbroadcastq {{.*#+}} zmm8 = [65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0]
-; AVX512-NEXT:    vpandnq %zmm0, %zmm8, %zmm0
-; AVX512-NEXT:    vpandq %zmm8, %zmm3, %zmm3
+; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm7 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm7 = mem[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm0, %zmm0
+; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm7 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm7 = mem[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm10 = mem[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm10, %zmm7, %zmm10
+; AVX512-NEXT:    vpbroadcastq {{.*#+}} zmm7 = [65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0]
+; AVX512-NEXT:    vpandnq %zmm0, %zmm7, %zmm0
+; AVX512-NEXT:    vpandq %zmm7, %zmm10, %zmm10
 ; AVX512-NEXT:    movw $-21846, %ax # imm = 0xAAAA
 ; AVX512-NEXT:    kmovw %eax, %k1
-; AVX512-NEXT:    vpord %zmm0, %zmm3, %zmm6 {%k1}
+; AVX512-NEXT:    vpord %zmm0, %zmm10, %zmm22 {%k1}
 ; AVX512-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
 ; AVX512-NEXT:    # ymm0 = mem[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm9[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm2 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm5, %zmm9
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm9 = zmm0 ^ (zmm13 & (zmm9 ^ zmm0))
+; AVX512-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm10 = mem[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm10, %zmm0, %zmm0
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm24 = zmm0 ^ (zmm11 & (zmm24 ^ zmm0))
 ; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
 ; AVX512-NEXT:    # ymm0 = mem[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm2 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm2 = mem[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm2 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm2 = mem[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd $232, (%rsp), %ymm3 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm3 = mem[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512-NEXT:    vpandnq %zmm0, %zmm8, %zmm0
-; AVX512-NEXT:    vpandq %zmm8, %zmm2, %zmm2
-; AVX512-NEXT:    vpord %zmm0, %zmm2, %zmm9 {%k1}
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm10[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm28[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm2 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm1 = xmm1[2,3,2,3]
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm2, %zmm10
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm10 = zmm0 ^ (zmm13 & (zmm10 ^ zmm0))
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm30[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm27[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm10 = mem[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm10, %zmm0, %zmm0
+; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm10 = mem[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm26 = ymm26[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm26, %zmm10, %zmm10
+; AVX512-NEXT:    vpandnq %zmm0, %zmm7, %zmm0
+; AVX512-NEXT:    vpandq %zmm7, %zmm10, %zmm10
+; AVX512-NEXT:    vpord %zmm0, %zmm10, %zmm24 {%k1}
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm28[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm10 = ymm29[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm10, %zmm0, %zmm0
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm10 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero,xmm1[4],zero,zero,zero,xmm1[5],zero,zero,zero,xmm1[6],zero,zero,zero,xmm1[7],zero,zero,zero
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm10 = zmm0 ^ (zmm11 & (zmm10 ^ zmm0))
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm25[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm23[0,2,2,3,4,6,6,7]
 ; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm26[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm22[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
-; AVX512-NEXT:    vpandnq %zmm0, %zmm8, %zmm0
-; AVX512-NEXT:    vpandq %zmm8, %zmm1, %zmm1
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm19[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm17, %zmm1, %zmm1
+; AVX512-NEXT:    vpandnq %zmm0, %zmm7, %zmm0
+; AVX512-NEXT:    vpandq %zmm7, %zmm1, %zmm1
 ; AVX512-NEXT:    vpord %zmm0, %zmm1, %zmm10 {%k1}
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm20[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm18[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm2
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm4[0,1,2,3,4,5,5,7]
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm4[0,1,2,3,6,5,7,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm0, %ymm27
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm7[8],xmm11[8],xmm7[9],xmm11[9],xmm7[10],xmm11[10],xmm7[11],xmm11[11],xmm7[12],xmm11[12],xmm7[13],xmm11[13],xmm7[14],xmm11[14],xmm7[15],xmm11[15]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm3[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm3[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm0, %ymm18
-; AVX512-NEXT:    vmovdqa 32(%rsi), %xmm1
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm16[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm14[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm1
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm2[0,1,2,3,4,5,5,7]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,6,5,7,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm2, %ymm0, %ymm17
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm3[8],xmm4[8],xmm3[9],xmm4[9],xmm3[10],xmm4[10],xmm3[11],xmm4[11],xmm3[12],xmm4[12],xmm3[13],xmm4[13],xmm3[14],xmm4[14],xmm3[15],xmm4[15]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm2[0,0,2,1,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm3, %ymm0, %ymm19
+; AVX512-NEXT:    vmovdqa 32(%rsi), %xmm14
 ; AVX512-NEXT:    vmovdqa 32(%rdi), %xmm0
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm4 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm5 = xmm4[0],zero,zero,zero,xmm4[1],zero,zero,zero,xmm4[2],zero,zero,zero,xmm4[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm4 = xmm4[2,3,2,3]
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm4 = xmm4[0],zero,zero,zero,xmm4[1],zero,zero,zero,xmm4[2],zero,zero,zero,xmm4[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm4, %zmm5, %zmm4
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm2 ^ (zmm13 & (zmm4 ^ zmm2))
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm25[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm5 = ymm21[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm2, %zmm2
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm5 = ymm19[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm7 = ymm17[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm5, %zmm5
-; AVX512-NEXT:    vpandnq %zmm2, %zmm8, %zmm2
-; AVX512-NEXT:    vpandq %zmm8, %zmm5, %zmm5
-; AVX512-NEXT:    vpord %zmm2, %zmm5, %zmm4 {%k1}
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm3[0,1,2,3,4,4,6,5]
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm3[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm3, %ymm2, %ymm17
-; AVX512-NEXT:    vmovdqa64 %xmm16, %xmm2
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm15[8],xmm2[8],xmm15[9],xmm2[9],xmm15[10],xmm2[10],xmm15[11],xmm2[11],xmm15[12],xmm2[12],xmm15[13],xmm2[13],xmm15[14],xmm2[14],xmm15[15],xmm2[15]
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm3 = xmm0[0],xmm14[0],xmm0[1],xmm14[1],xmm0[2],xmm14[2],xmm0[3],xmm14[3],xmm0[4],xmm14[4],xmm0[5],xmm14[5],xmm0[6],xmm14[6],xmm0[7],xmm14[7]
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm4 = xmm3[0],zero,zero,zero,xmm3[1],zero,zero,zero,xmm3[2],zero,zero,zero,xmm3[3],zero,zero,zero,xmm3[4],zero,zero,zero,xmm3[5],zero,zero,zero,xmm3[6],zero,zero,zero,xmm3[7],zero,zero,zero
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm1 ^ (zmm11 & (zmm4 ^ zmm1))
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm20[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm18[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm15[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm13 = ymm13[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm13, %zmm3, %zmm3
+; AVX512-NEXT:    vpandnq %zmm1, %zmm7, %zmm1
+; AVX512-NEXT:    vpandq %zmm7, %zmm3, %zmm3
+; AVX512-NEXT:    vpord %zmm1, %zmm3, %zmm4 {%k1}
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm2[0,1,2,3,4,4,6,5]
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm2, %ymm1, %ymm20
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm8[8],xmm9[8],xmm8[9],xmm9[9],xmm8[10],xmm9[10],xmm8[11],xmm9[11],xmm8[12],xmm9[12],xmm8[13],xmm9[13],xmm8[14],xmm9[14],xmm8[15],xmm9[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm2[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm5, %ymm3, %ymm21
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm8, %ymm3, %ymm23
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm2, %ymm3, %ymm22
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm12[8],xmm14[8],xmm12[9],xmm14[9],xmm12[10],xmm14[10],xmm12[11],xmm14[11],xmm12[12],xmm14[12],xmm12[13],xmm14[13],xmm12[14],xmm14[14],xmm12[15],xmm14[15]
+; AVX512-NEXT:    vinserti128 $1, %xmm2, %ymm3, %ymm9
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm5[8],xmm6[8],xmm5[9],xmm6[9],xmm5[10],xmm6[10],xmm5[11],xmm6[11],xmm5[12],xmm6[12],xmm5[13],xmm6[13],xmm5[14],xmm6[14],xmm5[15],xmm6[15]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm2 = xmm3[0,1,1,3,4,5,6,7]
 ; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm3[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm5, %ymm2, %ymm30
+; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm2, %ymm2
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm3[0,1,2,3,4,5,5,7]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm3[0,1,2,3,6,5,7,7]
 ; AVX512-NEXT:    vinserti128 $1, %xmm3, %ymm5, %ymm3
-; AVX512-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm5 # 16-byte Reload
-; AVX512-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm5, %xmm5 # 16-byte Folded Reload
-; AVX512-NEXT:    # xmm5 = xmm5[0],mem[0],xmm5[1],mem[1],xmm5[2],mem[2],xmm5[3],mem[3],xmm5[4],mem[4],xmm5[5],mem[5],xmm5[6],mem[6],xmm5[7],mem[7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm12 = xmm5[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm14 = xmm5[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm14, %ymm12, %ymm14
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm12 = xmm5[0,1,2,3,4,4,6,5]
+; AVX512-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm1 # 16-byte Reload
+; AVX512-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm5 # 16-byte Folded Reload
+; AVX512-NEXT:    # xmm5 = xmm1[0],mem[0],xmm1[1],mem[1],xmm1[2],mem[2],xmm1[3],mem[3],xmm1[4],mem[4],xmm1[5],mem[5],xmm1[6],mem[6],xmm1[7],mem[7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm5[0,0,2,1,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm5[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm13, %ymm6, %ymm13
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm5[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm5[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm12, %ymm15
-; AVX512-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm5 # 16-byte Reload
-; AVX512-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm5, %xmm5 # 16-byte Folded Reload
-; AVX512-NEXT:    # xmm5 = xmm5[0],mem[0],xmm5[1],mem[1],xmm5[2],mem[2],xmm5[3],mem[3],xmm5[4],mem[4],xmm5[5],mem[5],xmm5[6],mem[6],xmm5[7],mem[7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm12 = xmm5[0,0,2,1,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm5[0,2,2,3,4,5,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm7, %ymm12, %ymm19
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm5[0,1,2,3,4,4,6,5]
+; AVX512-NEXT:    vinserti128 $1, %xmm5, %ymm6, %ymm15
+; AVX512-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm1 # 16-byte Reload
+; AVX512-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm5 # 16-byte Folded Reload
+; AVX512-NEXT:    # xmm5 = xmm1[0],mem[0],xmm1[1],mem[1],xmm1[2],mem[2],xmm1[3],mem[3],xmm1[4],mem[4],xmm1[5],mem[5],xmm1[6],mem[6],xmm1[7],mem[7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm5[0,0,2,1,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm5[0,2,2,3,4,5,6,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm1, %ymm6, %ymm16
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm5[0,1,2,3,4,4,6,5]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm5[0,1,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti32x4 $1, %xmm5, %ymm7, %ymm20
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm5 = xmm0[8],xmm1[8],xmm0[9],xmm1[9],xmm0[10],xmm1[10],xmm0[11],xmm1[11],xmm0[12],xmm1[12],xmm0[13],xmm1[13],xmm0[14],xmm1[14],xmm0[15],xmm1[15]
-; AVX512-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm0 # 16-byte Reload
-; AVX512-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm0, %xmm1 # 16-byte Folded Reload
-; AVX512-NEXT:    # xmm1 = xmm0[0],mem[0],xmm0[1],mem[1],xmm0[2],mem[2],xmm0[3],mem[3],xmm0[4],mem[4],xmm0[5],mem[5],xmm0[6],mem[6],xmm0[7],mem[7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm1[0,1,1,3,4,5,6,7]
-; AVX512-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm1[2,1,3,3,4,5,6,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm7, %ymm0, %ymm0
-; AVX512-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm1[0,1,2,3,4,5,5,7]
+; AVX512-NEXT:    vinserti32x4 $1, %xmm5, %ymm1, %ymm18
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm0 = xmm0[8],xmm14[8],xmm0[9],xmm14[9],xmm0[10],xmm14[10],xmm0[11],xmm14[11],xmm0[12],xmm14[12],xmm0[13],xmm14[13],xmm0[14],xmm14[14],xmm0[15],xmm14[15]
+; AVX512-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm1 # 16-byte Reload
+; AVX512-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm1 # 16-byte Folded Reload
+; AVX512-NEXT:    # xmm1 = xmm1[0],mem[0],xmm1[1],mem[1],xmm1[2],mem[2],xmm1[3],mem[3],xmm1[4],mem[4],xmm1[5],mem[5],xmm1[6],mem[6],xmm1[7],mem[7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm1[0,1,1,3,4,5,6,7]
+; AVX512-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm1[2,1,3,3,4,5,6,7]
+; AVX512-NEXT:    vinserti128 $1, %xmm6, %ymm5, %ymm5
+; AVX512-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm1[0,1,2,3,4,5,5,7]
 ; AVX512-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,6,5,7,7]
-; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm7, %ymm1
-; AVX512-NEXT:    vmovdqa 16(%rsi), %xmm7
-; AVX512-NEXT:    vmovdqa 16(%rdi), %xmm12
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm11 = xmm12[0],xmm7[0],xmm12[1],xmm7[1],xmm12[2],xmm7[2],xmm12[3],xmm7[3],xmm12[4],xmm7[4],xmm12[5],xmm7[5],xmm12[6],xmm7[6],xmm12[7],xmm7[7]
-; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm12[8],xmm7[8],xmm12[9],xmm7[9],xmm12[10],xmm7[10],xmm12[11],xmm7[11],xmm12[12],xmm7[12],xmm12[13],xmm7[13],xmm12[14],xmm7[14],xmm12[15],xmm7[15]
-; AVX512-NEXT:    vmovdqa64 %xmm23, %xmm12
-; AVX512-NEXT:    vmovdqa64 %xmm24, %xmm2
-; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm12 = xmm12[0],xmm2[0],xmm12[1],xmm2[1],xmm12[2],xmm2[2],xmm12[3],xmm2[3],xmm12[4],xmm2[4],xmm12[5],xmm2[5],xmm12[6],xmm2[6],xmm12[7],xmm2[7]
-; AVX512-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm23 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm23 = mem[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm24 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm24 = mem[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm24, %zmm23, %zmm23
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm24 = xmm5[0],zero,zero,zero,xmm5[1],zero,zero,zero,xmm5[2],zero,zero,zero,xmm5[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm5 = xmm5[2,3,2,3]
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm5 = xmm5[0],zero,zero,zero,xmm5[1],zero,zero,zero,xmm5[2],zero,zero,zero,xmm5[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm5, %zmm24, %zmm5
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm23 ^ (zmm13 & (zmm5 ^ zmm23))
-; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm23 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm23 = mem[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm24 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm24 = mem[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm24, %zmm23, %zmm23
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm24 = xmm11[0],zero,zero,zero,xmm11[1],zero,zero,zero,xmm11[2],zero,zero,zero,xmm11[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm11 = xmm11[2,3,2,3]
+; AVX512-NEXT:    vinserti128 $1, %xmm1, %ymm6, %ymm1
+; AVX512-NEXT:    vmovdqa 16(%rsi), %xmm6
+; AVX512-NEXT:    vmovdqa 16(%rdi), %xmm14
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm8 = xmm14[0],xmm6[0],xmm14[1],xmm6[1],xmm14[2],xmm6[2],xmm14[3],xmm6[3],xmm14[4],xmm6[4],xmm14[5],xmm6[5],xmm14[6],xmm6[6],xmm14[7],xmm6[7]
+; AVX512-NEXT:    vpunpckhbw {{.*#+}} xmm6 = xmm14[8],xmm6[8],xmm14[9],xmm6[9],xmm14[10],xmm6[10],xmm14[11],xmm6[11],xmm14[12],xmm6[12],xmm14[13],xmm6[13],xmm14[14],xmm6[14],xmm14[15],xmm6[15]
+; AVX512-NEXT:    vmovdqa64 %xmm21, %xmm14
+; AVX512-NEXT:    vpunpcklbw {{.*#+}} xmm12 = xmm12[0],xmm14[0],xmm12[1],xmm14[1],xmm12[2],xmm14[2],xmm12[3],xmm14[3],xmm12[4],xmm14[4],xmm12[5],xmm14[5],xmm12[6],xmm14[6],xmm12[7],xmm14[7]
+; AVX512-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm14 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm14 = mem[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm25 = mem[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm14 ^ (zmm11 & (zmm0 ^ zmm14))
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm8 = xmm8[0],zero,zero,zero,xmm8[1],zero,zero,zero,xmm8[2],zero,zero,zero,xmm8[3],zero,zero,zero,xmm8[4],zero,zero,zero,xmm8[5],zero,zero,zero,xmm8[6],zero,zero,zero,xmm8[7],zero,zero,zero
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm6 = xmm6[0],zero,zero,zero,xmm6[1],zero,zero,zero,xmm6[2],zero,zero,zero,xmm6[3],zero,zero,zero,xmm6[4],zero,zero,zero,xmm6[5],zero,zero,zero,xmm6[6],zero,zero,zero,xmm6[7],zero,zero,zero
+; AVX512-NEXT:    vpmovzxwq {{.*#+}} zmm12 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero,xmm12[4],zero,zero,zero,xmm12[5],zero,zero,zero,xmm12[6],zero,zero,zero,xmm12[7],zero,zero,zero
+; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm14 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm14 = mem[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm25 = mem[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
 ; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
 ; AVX512-NEXT:    # ymm25 = mem[0,0,2,1,4,4,6,5]
 ; AVX512-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm26 # 32-byte Folded Reload
 ; AVX512-NEXT:    # ymm26 = mem[0,2,2,3,4,6,6,7]
 ; AVX512-NEXT:    vinserti64x4 $1, %ymm26, %zmm25, %zmm25
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm26 = xmm7[0],zero,zero,zero,xmm7[1],zero,zero,zero,xmm7[2],zero,zero,zero,xmm7[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm7 = xmm7[2,3,2,3]
-; AVX512-NEXT:    vpandnq %zmm23, %zmm8, %zmm23
-; AVX512-NEXT:    vpandq %zmm8, %zmm25, %zmm25
-; AVX512-NEXT:    vpord %zmm23, %zmm25, %zmm5 {%k1}
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm23 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512-NEXT:    vpshufd {{.*#+}} xmm12 = xmm12[2,3,2,3]
-; AVX512-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm25 = mem[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm28 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm28 = mem[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm28, %zmm25, %zmm25
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm11 = xmm11[0],zero,zero,zero,xmm11[1],zero,zero,zero,xmm11[2],zero,zero,zero,xmm11[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm11, %zmm24, %zmm11
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm11 = zmm25 ^ (zmm13 & (zmm11 ^ zmm25))
-; AVX512-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm24 # 32-byte Folded Reload
-; AVX512-NEXT:    # ymm24 = mem[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm25 = ymm29[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm25, %zmm24, %zmm24
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm25 = ymm31[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm16 = ymm27[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm16, %zmm25, %zmm16
-; AVX512-NEXT:    vpandnq %zmm24, %zmm8, %zmm24
-; AVX512-NEXT:    vpandq %zmm8, %zmm16, %zmm16
-; AVX512-NEXT:    vpord %zmm24, %zmm16, %zmm11 {%k1}
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm16 = ymm18[0,1,1,3,4,5,5,7]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[2,1,3,3,6,5,7,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm17, %zmm16, %zmm16
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm7 = xmm7[0],zero,zero,zero,xmm7[1],zero,zero,zero,xmm7[2],zero,zero,zero,xmm7[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm7, %zmm26, %zmm7
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm16 ^ (zmm13 & (zmm7 ^ zmm16))
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm16 = ymm21[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm17 = ymm22[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm17, %zmm16, %zmm16
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm30[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpandnq %zmm14, %zmm7, %zmm14
+; AVX512-NEXT:    vpandq %zmm7, %zmm25, %zmm25
+; AVX512-NEXT:    vpord %zmm14, %zmm25, %zmm0 {%k1}
+; AVX512-NEXT:    vpshufd $212, (%rsp), %ymm14 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm14 = mem[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
+; AVX512-NEXT:    # ymm25 = mem[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm8 = zmm14 ^ (zmm11 & (zmm8 ^ zmm14))
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm14 = ymm30[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm25 = ymm31[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm21 = ymm27[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm17, %zmm21, %zmm17
+; AVX512-NEXT:    vpandnq %zmm14, %zmm7, %zmm14
+; AVX512-NEXT:    vpandq %zmm7, %zmm17, %zmm17
+; AVX512-NEXT:    vpord %zmm14, %zmm17, %zmm8 {%k1}
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm14 = ymm19[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm17 = ymm20[2,1,3,3,6,5,7,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm17, %zmm14, %zmm14
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm14 ^ (zmm11 & (zmm6 ^ zmm14))
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm14 = ymm23[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm9 = ymm9[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm9, %zmm14, %zmm9
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm2[0,0,2,1,4,4,6,5]
 ; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm3[0,2,2,3,4,6,6,7]
 ; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512-NEXT:    vpandnq %zmm16, %zmm8, %zmm3
-; AVX512-NEXT:    vpandq %zmm8, %zmm2, %zmm2
-; AVX512-NEXT:    vpord %zmm3, %zmm2, %zmm7 {%k1}
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm14[0,1,1,3,4,5,5,7]
+; AVX512-NEXT:    vpandnq %zmm9, %zmm7, %zmm3
+; AVX512-NEXT:    vpandq %zmm7, %zmm2, %zmm2
+; AVX512-NEXT:    vpord %zmm3, %zmm2, %zmm6 {%k1}
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm13[0,1,1,3,4,5,5,7]
 ; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm15[2,1,3,3,6,5,7,7]
 ; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512-NEXT:    vpmovzxwq {{.*#+}} ymm3 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm23, %zmm3
-; AVX512-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm2 ^ (zmm13 & (zmm3 ^ zmm2))
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm19[0,0,2,1,4,4,6,5]
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm12 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm12, %zmm2, %zmm2
-; AVX512-NEXT:    vpshufd {{.*#+}} ymm0 = ymm0[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpternlogq {{.*#+}} zmm12 = zmm2 ^ (zmm11 & (zmm12 ^ zmm2))
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm2 = ymm16[0,0,2,1,4,4,6,5]
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm18[0,2,2,3,4,6,6,7]
+; AVX512-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
+; AVX512-NEXT:    vpshufd {{.*#+}} ymm3 = ymm5[0,0,2,1,4,4,6,5]
 ; AVX512-NEXT:    vpshufd {{.*#+}} ymm1 = ymm1[0,2,2,3,4,6,6,7]
-; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512-NEXT:    vpandnq %zmm2, %zmm8, %zmm1
-; AVX512-NEXT:    vpandq %zmm8, %zmm0, %zmm0
-; AVX512-NEXT:    vpord %zmm1, %zmm0, %zmm3 {%k1}
+; AVX512-NEXT:    vinserti64x4 $1, %ymm1, %zmm3, %zmm1
+; AVX512-NEXT:    vpandnq %zmm2, %zmm7, %zmm2
+; AVX512-NEXT:    vpandq %zmm7, %zmm1, %zmm1
+; AVX512-NEXT:    vpord %zmm2, %zmm1, %zmm12 {%k1}
 ; AVX512-NEXT:    movq {{[0-9]+}}(%rsp), %rax
-; AVX512-NEXT:    vmovdqa64 %zmm3, (%rax)
-; AVX512-NEXT:    vmovdqa64 %zmm7, 192(%rax)
-; AVX512-NEXT:    vmovdqa64 %zmm11, 128(%rax)
-; AVX512-NEXT:    vmovdqa64 %zmm5, 320(%rax)
+; AVX512-NEXT:    vmovdqa64 %zmm12, (%rax)
+; AVX512-NEXT:    vmovdqa64 %zmm6, 192(%rax)
+; AVX512-NEXT:    vmovdqa64 %zmm8, 128(%rax)
+; AVX512-NEXT:    vmovdqa64 %zmm0, 320(%rax)
 ; AVX512-NEXT:    vmovdqa64 %zmm4, 256(%rax)
 ; AVX512-NEXT:    vmovdqa64 %zmm10, 448(%rax)
-; AVX512-NEXT:    vmovdqa64 %zmm9, 384(%rax)
-; AVX512-NEXT:    vmovdqa64 %zmm6, 64(%rax)
+; AVX512-NEXT:    vmovdqa64 %zmm24, 384(%rax)
+; AVX512-NEXT:    vmovdqa64 %zmm22, 64(%rax)
 ; AVX512-NEXT:    addq $552, %rsp # imm = 0x228
 ; AVX512-NEXT:    vzeroupper
 ; AVX512-NEXT:    retq
@@ -7433,7 +7405,7 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-NEXT:    movq {{[0-9]+}}(%rsp), %r10
 ; AVX512DQ-NEXT:    vmovdqa (%rcx), %xmm3
 ; AVX512DQ-NEXT:    vmovdqa %xmm3, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
-; AVX512DQ-NEXT:    vmovdqa 32(%rcx), %xmm11
+; AVX512DQ-NEXT:    vmovdqa 32(%rcx), %xmm12
 ; AVX512DQ-NEXT:    vmovdqa 48(%rcx), %xmm0
 ; AVX512DQ-NEXT:    vmovdqa (%rdx), %xmm2
 ; AVX512DQ-NEXT:    vmovdqa %xmm2, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
@@ -7441,11 +7413,11 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm2[8],xmm3[8],xmm2[9],xmm3[9],xmm2[10],xmm3[10],xmm2[11],xmm3[11],xmm2[12],xmm3[12],xmm2[13],xmm3[13],xmm2[14],xmm3[14],xmm2[15],xmm3[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm2[0,0,2,1,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
-; AVX512DQ-NEXT:    vmovdqu %ymm3, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm10
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm3, %ymm6
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm3, %ymm2
+; AVX512DQ-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vmovdqa (%r10), %xmm5
 ; AVX512DQ-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
 ; AVX512DQ-NEXT:    vmovdqa 48(%r10), %xmm3
@@ -7454,8 +7426,8 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-NEXT:    vmovdqa 48(%rax), %xmm4
 ; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm2[8],xmm5[8],xmm2[9],xmm5[9],xmm2[10],xmm5[10],xmm2[11],xmm5[11],xmm2[12],xmm5[12],xmm2[13],xmm5[13],xmm2[14],xmm5[14],xmm2[15],xmm5[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm7, %ymm5, %ymm5
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm6, %ymm5, %ymm5
 ; AVX512DQ-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
@@ -7463,18 +7435,19 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vmovdqa (%r9), %xmm5
 ; AVX512DQ-NEXT:    vmovdqa %xmm5, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
-; AVX512DQ-NEXT:    vmovdqa 48(%r9), %xmm7
+; AVX512DQ-NEXT:    vmovdqa 48(%r9), %xmm6
 ; AVX512DQ-NEXT:    vmovdqa (%r8), %xmm2
 ; AVX512DQ-NEXT:    vmovdqa %xmm2, {{[-0-9]+}}(%r{{[sb]}}p) # 16-byte Spill
-; AVX512DQ-NEXT:    vmovdqa 48(%r8), %xmm12
+; AVX512DQ-NEXT:    vmovdqa 48(%r8), %xmm8
 ; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm2[8],xmm5[8],xmm2[9],xmm5[9],xmm2[10],xmm5[10],xmm2[11],xmm5[11],xmm2[12],xmm5[12],xmm2[13],xmm5[13],xmm2[14],xmm5[14],xmm2[15],xmm5[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,1,1,3,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm2[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm8, %ymm5, %ymm5
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm2[2,1,3,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm7, %ymm5, %ymm5
 ; AVX512DQ-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,5,5,7]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm8
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm2
+; AVX512DQ-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm1[0],xmm0[0],xmm1[1],xmm0[1],xmm1[2],xmm0[2],xmm1[3],xmm0[3],xmm1[4],xmm0[4],xmm1[5],xmm0[5],xmm1[6],xmm0[6],xmm1[7],xmm0[7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,0,2,1,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm2[0,2,2,3,4,5,6,7]
@@ -7482,80 +7455,80 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm9
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm2
+; AVX512DQ-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm4[0],xmm3[0],xmm4[1],xmm3[1],xmm4[2],xmm3[2],xmm4[3],xmm3[3],xmm4[4],xmm3[4],xmm4[5],xmm3[5],xmm4[6],xmm3[6],xmm4[7],xmm3[7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm10 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm10, %ymm5, %ymm5
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm9, %ymm5, %ymm5
 ; AVX512DQ-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
 ; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm5, %ymm2
 ; AVX512DQ-NEXT:    vmovdqu %ymm2, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm12[0],xmm7[0],xmm12[1],xmm7[1],xmm12[2],xmm7[2],xmm12[3],xmm7[3],xmm12[4],xmm7[4],xmm12[5],xmm7[5],xmm12[6],xmm7[6],xmm12[7],xmm7[7]
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm8[0],xmm6[0],xmm8[1],xmm6[1],xmm8[2],xmm6[2],xmm8[3],xmm6[3],xmm8[4],xmm6[4],xmm8[5],xmm6[5],xmm8[6],xmm6[6],xmm8[7],xmm6[7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,1,1,3,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm2[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm13, %ymm5, %ymm5
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm2[2,1,3,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm9, %ymm5, %ymm5
 ; AVX512DQ-NEXT:    vmovdqu %ymm5, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vmovdqa 32(%rdx), %xmm5
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm2[0,1,2,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm9 = xmm2[0,1,2,3,4,5,5,7]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm13, %ymm2
-; AVX512DQ-NEXT:    vmovdqu %ymm2, (%rsp) # 32-byte Spill
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm2, %ymm9, %ymm26
 ; AVX512DQ-NEXT:    vmovdqa 32(%r10), %xmm2
 ; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm1[8],xmm0[8],xmm1[9],xmm0[9],xmm1[10],xmm0[10],xmm1[11],xmm0[11],xmm1[12],xmm0[12],xmm1[13],xmm0[13],xmm1[14],xmm0[14],xmm1[15],xmm0[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm1[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm13, %ymm0, %ymm10
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm1[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm9, %ymm0, %ymm28
 ; AVX512DQ-NEXT:    vmovdqa 32(%rax), %xmm0
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm1[0,1,2,3,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm9 = xmm1[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm13, %ymm28
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm9, %ymm29
 ; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm4[8],xmm3[8],xmm4[9],xmm3[9],xmm4[10],xmm3[10],xmm4[11],xmm3[11],xmm4[12],xmm3[12],xmm4[13],xmm3[13],xmm4[14],xmm3[14],xmm4[15],xmm3[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm30
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm25
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm27
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm12[8],xmm7[8],xmm12[9],xmm7[9],xmm12[10],xmm7[10],xmm12[11],xmm7[11],xmm12[12],xmm7[12],xmm12[13],xmm7[13],xmm12[14],xmm7[14],xmm12[15],xmm7[15]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm23
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm8[8],xmm6[8],xmm8[9],xmm6[9],xmm8[10],xmm6[10],xmm8[11],xmm6[11],xmm8[12],xmm6[12],xmm8[13],xmm6[13],xmm8[14],xmm6[14],xmm8[15],xmm6[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,1,1,3,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm1[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm26
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm19
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,5,5,7]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm22
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm5[0],xmm11[0],xmm5[1],xmm11[1],xmm5[2],xmm11[2],xmm5[3],xmm11[3],xmm5[4],xmm11[4],xmm5[5],xmm11[5],xmm5[6],xmm11[6],xmm5[7],xmm11[7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm17
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm5[0],xmm12[0],xmm5[1],xmm12[1],xmm5[2],xmm12[2],xmm5[3],xmm12[3],xmm5[4],xmm12[4],xmm5[5],xmm12[5],xmm5[6],xmm12[6],xmm5[7],xmm12[7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm4 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm20
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm4, %ymm3, %ymm16
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm1, %ymm3, %ymm14
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3],xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm1[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm6, %ymm3, %ymm20
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
 ; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm18
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm0[0],xmm2[0],xmm0[1],xmm2[1],xmm0[2],xmm2[2],xmm0[3],xmm2[3],xmm0[4],xmm2[4],xmm0[5],xmm2[5],xmm0[6],xmm2[6],xmm0[7],xmm2[7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm1[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm1[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm7, %ymm3, %ymm25
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm3, %ymm21
 ; AVX512DQ-NEXT:    vmovdqa 32(%r9), %xmm1
 ; AVX512DQ-NEXT:    vmovdqa 32(%r8), %xmm3
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm7 = xmm3[0],xmm1[0],xmm3[1],xmm1[1],xmm3[2],xmm1[2],xmm3[3],xmm1[3],xmm3[4],xmm1[4],xmm3[5],xmm1[5],xmm3[6],xmm1[6],xmm3[7],xmm1[7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm12 = xmm7[0,1,1,3,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm7[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm13, %ymm12, %ymm19
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm12 = xmm7[0,1,2,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm7[0,1,2,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm7, %ymm12, %ymm17
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm5 = xmm5[8],xmm11[8],xmm5[9],xmm11[9],xmm5[10],xmm11[10],xmm5[11],xmm11[11],xmm5[12],xmm11[12],xmm5[13],xmm11[13],xmm5[14],xmm11[14],xmm5[15],xmm11[15]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm5[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm11 = xmm5[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm11, %ymm7, %ymm4
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm6 = xmm3[0],xmm1[0],xmm3[1],xmm1[1],xmm3[2],xmm1[2],xmm3[3],xmm1[3],xmm3[4],xmm1[4],xmm3[5],xmm1[5],xmm3[6],xmm1[6],xmm3[7],xmm1[7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm6[0,1,1,3,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm9 = xmm6[2,1,3,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm9, %ymm8, %ymm15
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm8 = xmm6[0,1,2,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm6[0,1,2,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm6, %ymm8, %ymm13
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm5 = xmm5[8],xmm12[8],xmm5[9],xmm12[9],xmm5[10],xmm12[10],xmm5[11],xmm12[11],xmm5[12],xmm12[12],xmm5[13],xmm12[13],xmm5[14],xmm12[14],xmm5[15],xmm12[15]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm5[0,0,2,1,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm5[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm8, %ymm6, %ymm4
 ; AVX512DQ-NEXT:    vmovdqu %ymm4, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm5[0,1,2,3,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm5[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm5[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm7, %ymm4
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm6, %ymm4
 ; AVX512DQ-NEXT:    vmovdqu %ymm4, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm0 = xmm0[8],xmm2[8],xmm0[9],xmm2[9],xmm0[10],xmm2[10],xmm0[11],xmm2[11],xmm0[12],xmm2[12],xmm0[13],xmm2[13],xmm0[14],xmm2[14],xmm0[15],xmm2[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm2 = xmm0[0,0,2,1,4,5,6,7]
@@ -7575,273 +7548,244 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,6,5,7,7]
 ; AVX512DQ-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
 ; AVX512DQ-NEXT:    vmovdqu %ymm0, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512DQ-NEXT:    vmovdqa 16(%rcx), %xmm11
-; AVX512DQ-NEXT:    vmovdqa 16(%rdx), %xmm7
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm7[0],xmm11[0],xmm7[1],xmm11[1],xmm7[2],xmm11[2],xmm7[3],xmm11[3],xmm7[4],xmm11[4],xmm7[5],xmm11[5],xmm7[6],xmm11[6],xmm7[7],xmm11[7]
+; AVX512DQ-NEXT:    vmovdqa 16(%rcx), %xmm4
+; AVX512DQ-NEXT:    vmovdqa 16(%rdx), %xmm3
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm3[0],xmm4[0],xmm3[1],xmm4[1],xmm3[2],xmm4[2],xmm3[3],xmm4[3],xmm3[4],xmm4[4],xmm3[5],xmm4[5],xmm3[6],xmm4[6],xmm3[7],xmm4[7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm0[0,0,2,1,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm0[0,2,2,3,4,5,6,7]
 ; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm1, %ymm1
-; AVX512DQ-NEXT:    vmovdqu %ymm1, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512DQ-NEXT:    vmovdqu %ymm1, (%rsp) # 32-byte Spill
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm0[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,4,6,6,7]
 ; AVX512DQ-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
 ; AVX512DQ-NEXT:    vmovdqu %ymm0, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
-; AVX512DQ-NEXT:    vmovdqa 16(%r10), %xmm1
-; AVX512DQ-NEXT:    vmovdqa 16(%rax), %xmm15
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm15[0],xmm1[0],xmm15[1],xmm1[1],xmm15[2],xmm1[2],xmm15[3],xmm1[3],xmm15[4],xmm1[4],xmm15[5],xmm1[5],xmm15[6],xmm1[6],xmm15[7],xmm1[7]
-; AVX512DQ-NEXT:    vmovdqa64 %xmm1, %xmm16
+; AVX512DQ-NEXT:    vmovdqa 16(%r10), %xmm9
+; AVX512DQ-NEXT:    vmovdqa 16(%rax), %xmm8
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm8[0],xmm9[0],xmm8[1],xmm9[1],xmm8[2],xmm9[2],xmm8[3],xmm9[3],xmm8[4],xmm9[4],xmm8[5],xmm9[5],xmm8[6],xmm9[6],xmm8[7],xmm9[7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm0[0,0,2,1,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm0[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm1, %ymm1
-; AVX512DQ-NEXT:    vmovdqu %ymm1, {{[-0-9]+}}(%r{{[sb]}}p) # 32-byte Spill
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm5, %ymm1, %ymm30
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm0[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm0[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm0, %ymm1, %ymm29
-; AVX512DQ-NEXT:    vmovdqa 16(%r9), %xmm14
-; AVX512DQ-NEXT:    vmovdqa 16(%r8), %xmm12
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm4 = xmm12[0],xmm14[0],xmm12[1],xmm14[1],xmm12[2],xmm14[2],xmm12[3],xmm14[3],xmm12[4],xmm14[4],xmm12[5],xmm14[5],xmm12[6],xmm14[6],xmm12[7],xmm14[7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm4[0,1,1,3,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm4[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm13, %ymm1, %ymm31
-; AVX512DQ-NEXT:    vmovdqa (%rsi), %xmm0
-; AVX512DQ-NEXT:    vmovdqa (%rdi), %xmm2
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm2[8],xmm0[8],xmm2[9],xmm0[9],xmm2[10],xmm0[10],xmm2[11],xmm0[11],xmm2[12],xmm0[12],xmm2[13],xmm0[13],xmm2[14],xmm0[14],xmm2[15],xmm0[15]
-; AVX512DQ-NEXT:    vmovdqa64 %xmm2, %xmm23
-; AVX512DQ-NEXT:    vmovdqa64 %xmm0, %xmm24
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm13 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm0, %ymm1, %ymm31
+; AVX512DQ-NEXT:    vmovdqa 16(%r9), %xmm6
+; AVX512DQ-NEXT:    vmovdqa 16(%r8), %xmm5
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm5[0],xmm6[0],xmm5[1],xmm6[1],xmm5[2],xmm6[2],xmm5[3],xmm6[3],xmm5[4],xmm6[4],xmm5[5],xmm6[5],xmm5[6],xmm6[6],xmm5[7],xmm6[7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm2[0,1,1,3,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm11 = xmm2[2,1,3,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm11, %ymm1, %ymm27
 ; AVX512DQ-NEXT:    vmovdqa 48(%rsi), %xmm1
-; AVX512DQ-NEXT:    vmovdqa 48(%rdi), %xmm0
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm0[8],xmm1[8],xmm0[9],xmm1[9],xmm0[10],xmm1[10],xmm0[11],xmm1[11],xmm0[12],xmm1[12],xmm0[13],xmm1[13],xmm0[14],xmm1[14],xmm0[15],xmm1[15]
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm5 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm2 = xmm2[2,3,2,3]
-; AVX512DQ-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm0 = mem[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm6 = ymm6[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm6, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm3 = xmm3[0],zero,zero,zero,xmm3[1],zero,zero,zero,xmm3[2],zero,zero,zero,xmm3[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm13, %zmm6
-; AVX512DQ-NEXT:    vpbroadcastq {{.*#+}} zmm13 = [65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535]
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm0 ^ (zmm13 & (zmm6 ^ zmm0))
+; AVX512DQ-NEXT:    vmovdqa 48(%rdi), %xmm11
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm11[0],xmm1[0],xmm11[1],xmm1[1],xmm11[2],xmm1[2],xmm11[3],xmm1[3],xmm11[4],xmm1[4],xmm11[5],xmm1[5],xmm11[6],xmm1[6],xmm11[7],xmm1[7]
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm11[8],xmm1[8],xmm11[9],xmm1[9],xmm11[10],xmm1[10],xmm11[11],xmm1[11],xmm11[12],xmm1[12],xmm11[13],xmm1[13],xmm11[14],xmm1[14],xmm11[15],xmm1[15]
+; AVX512DQ-NEXT:    vmovdqa (%rsi), %xmm7
+; AVX512DQ-NEXT:    vmovdqa (%rdi), %xmm12
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm11 = xmm12[8],xmm7[8],xmm12[9],xmm7[9],xmm12[10],xmm7[10],xmm12[11],xmm7[11],xmm12[12],xmm7[12],xmm12[13],xmm7[13],xmm12[14],xmm7[14],xmm12[15],xmm7[15]
+; AVX512DQ-NEXT:    vmovdqa64 %xmm7, %xmm21
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm22 = xmm11[0],zero,zero,zero,xmm11[1],zero,zero,zero,xmm11[2],zero,zero,zero,xmm11[3],zero,zero,zero,xmm11[4],zero,zero,zero,xmm11[5],zero,zero,zero,xmm11[6],zero,zero,zero,xmm11[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm24 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm10[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm11 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm11 = mem[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm11, %zmm0, %zmm0
+; AVX512DQ-NEXT:    vpbroadcastq {{.*#+}} zmm11 = [65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535]
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm22 = zmm0 ^ (zmm11 & (zmm22 ^ zmm0))
 ; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
 ; AVX512DQ-NEXT:    # ymm0 = mem[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm3 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm3 = mem[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm3 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm3 = mem[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm8 = ymm8[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm8, %zmm3, %zmm3
-; AVX512DQ-NEXT:    vpbroadcastq {{.*#+}} zmm8 = [65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0]
-; AVX512DQ-NEXT:    vpandnq %zmm0, %zmm8, %zmm0
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm3, %zmm3
+; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm7 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm7 = mem[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm7, %zmm0, %zmm0
+; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm7 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm7 = mem[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm10 = mem[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm10, %zmm7, %zmm10
+; AVX512DQ-NEXT:    vpbroadcastq {{.*#+}} zmm7 = [65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0,65535,65535,65535,0]
+; AVX512DQ-NEXT:    vpandnq %zmm0, %zmm7, %zmm0
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm10, %zmm10
 ; AVX512DQ-NEXT:    movw $-21846, %ax # imm = 0xAAAA
 ; AVX512DQ-NEXT:    kmovw %eax, %k1
-; AVX512DQ-NEXT:    vpord %zmm0, %zmm3, %zmm6 {%k1}
+; AVX512DQ-NEXT:    vpord %zmm0, %zmm10, %zmm22 {%k1}
 ; AVX512DQ-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
 ; AVX512DQ-NEXT:    # ymm0 = mem[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm9[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm2 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm2, %zmm5, %zmm9
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm9 = zmm0 ^ (zmm13 & (zmm9 ^ zmm0))
+; AVX512DQ-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm10 = mem[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm10, %zmm0, %zmm0
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm24 = zmm0 ^ (zmm11 & (zmm24 ^ zmm0))
 ; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm0 # 32-byte Folded Reload
 ; AVX512DQ-NEXT:    # ymm0 = mem[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm2 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm2 = mem[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm2 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm2 = mem[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd $232, (%rsp), %ymm3 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm3 = mem[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpandnq %zmm0, %zmm8, %zmm0
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpord %zmm0, %zmm2, %zmm9 {%k1}
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm10[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm28[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm2 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm1 = xmm1[2,3,2,3]
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm2, %zmm10
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm10 = zmm0 ^ (zmm13 & (zmm10 ^ zmm0))
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm30[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm27[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm10 = mem[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm10, %zmm0, %zmm0
+; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm10 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm10 = mem[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm26 = ymm26[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm26, %zmm10, %zmm10
+; AVX512DQ-NEXT:    vpandnq %zmm0, %zmm7, %zmm0
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm10, %zmm10
+; AVX512DQ-NEXT:    vpord %zmm0, %zmm10, %zmm24 {%k1}
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm28[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm10 = ymm29[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm10, %zmm0, %zmm0
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm10 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero,xmm1[4],zero,zero,zero,xmm1[5],zero,zero,zero,xmm1[6],zero,zero,zero,xmm1[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm10 = zmm0 ^ (zmm11 & (zmm10 ^ zmm0))
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm25[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm23[0,2,2,3,4,6,6,7]
 ; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm26[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm22[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
-; AVX512DQ-NEXT:    vpandnq %zmm0, %zmm8, %zmm0
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm1, %zmm1
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm19[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm17, %zmm1, %zmm1
+; AVX512DQ-NEXT:    vpandnq %zmm0, %zmm7, %zmm0
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm1, %zmm1
 ; AVX512DQ-NEXT:    vpord %zmm0, %zmm1, %zmm10 {%k1}
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm20[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm18[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm2
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm4[0,1,2,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm4[0,1,2,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm0, %ymm27
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm7[8],xmm11[8],xmm7[9],xmm11[9],xmm7[10],xmm11[10],xmm7[11],xmm11[11],xmm7[12],xmm11[12],xmm7[13],xmm11[13],xmm7[14],xmm11[14],xmm7[15],xmm11[15]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm3[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm3[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm0, %ymm18
-; AVX512DQ-NEXT:    vmovdqa 32(%rsi), %xmm1
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm16[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm14[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm1
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm0 = xmm2[0,1,2,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm2, %ymm0, %ymm17
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm3[8],xmm4[8],xmm3[9],xmm4[9],xmm3[10],xmm4[10],xmm3[11],xmm4[11],xmm3[12],xmm4[12],xmm3[13],xmm4[13],xmm3[14],xmm4[14],xmm3[15],xmm4[15]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm2[0,0,2,1,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm3, %ymm0, %ymm19
+; AVX512DQ-NEXT:    vmovdqa 32(%rsi), %xmm14
 ; AVX512DQ-NEXT:    vmovdqa 32(%rdi), %xmm0
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm4 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3],xmm0[4],xmm1[4],xmm0[5],xmm1[5],xmm0[6],xmm1[6],xmm0[7],xmm1[7]
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm5 = xmm4[0],zero,zero,zero,xmm4[1],zero,zero,zero,xmm4[2],zero,zero,zero,xmm4[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm4 = xmm4[2,3,2,3]
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm4 = xmm4[0],zero,zero,zero,xmm4[1],zero,zero,zero,xmm4[2],zero,zero,zero,xmm4[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm4, %zmm5, %zmm4
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm2 ^ (zmm13 & (zmm4 ^ zmm2))
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm25[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm5 = ymm21[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm5, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm5 = ymm19[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm7 = ymm17[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm7, %zmm5, %zmm5
-; AVX512DQ-NEXT:    vpandnq %zmm2, %zmm8, %zmm2
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm5, %zmm5
-; AVX512DQ-NEXT:    vpord %zmm2, %zmm5, %zmm4 {%k1}
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm3[0,1,2,3,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm3[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm3, %ymm2, %ymm17
-; AVX512DQ-NEXT:    vmovdqa64 %xmm16, %xmm2
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm15[8],xmm2[8],xmm15[9],xmm2[9],xmm15[10],xmm2[10],xmm15[11],xmm2[11],xmm15[12],xmm2[12],xmm15[13],xmm2[13],xmm15[14],xmm2[14],xmm15[15],xmm2[15]
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm3 = xmm0[0],xmm14[0],xmm0[1],xmm14[1],xmm0[2],xmm14[2],xmm0[3],xmm14[3],xmm0[4],xmm14[4],xmm0[5],xmm14[5],xmm0[6],xmm14[6],xmm0[7],xmm14[7]
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm4 = xmm3[0],zero,zero,zero,xmm3[1],zero,zero,zero,xmm3[2],zero,zero,zero,xmm3[3],zero,zero,zero,xmm3[4],zero,zero,zero,xmm3[5],zero,zero,zero,xmm3[6],zero,zero,zero,xmm3[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm4 = zmm1 ^ (zmm11 & (zmm4 ^ zmm1))
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm20[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm18[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm1, %zmm1
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm15[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm13 = ymm13[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm13, %zmm3, %zmm3
+; AVX512DQ-NEXT:    vpandnq %zmm1, %zmm7, %zmm1
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm3, %zmm3
+; AVX512DQ-NEXT:    vpord %zmm1, %zmm3, %zmm4 {%k1}
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm2[0,1,2,3,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm2, %ymm1, %ymm20
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm2 = xmm8[8],xmm9[8],xmm8[9],xmm9[9],xmm8[10],xmm9[10],xmm8[11],xmm9[11],xmm8[12],xmm9[12],xmm8[13],xmm9[13],xmm8[14],xmm9[14],xmm8[15],xmm9[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm3 = xmm2[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm2[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm5, %ymm3, %ymm21
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm8 = xmm2[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm8, %ymm3, %ymm23
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm2[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm2[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm2, %ymm3, %ymm22
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm12[8],xmm14[8],xmm12[9],xmm14[9],xmm12[10],xmm14[10],xmm12[11],xmm14[11],xmm12[12],xmm14[12],xmm12[13],xmm14[13],xmm12[14],xmm14[14],xmm12[15],xmm14[15]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm2, %ymm3, %ymm9
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm5[8],xmm6[8],xmm5[9],xmm6[9],xmm5[10],xmm6[10],xmm5[11],xmm6[11],xmm5[12],xmm6[12],xmm5[13],xmm6[13],xmm5[14],xmm6[14],xmm5[15],xmm6[15]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm2 = xmm3[0,1,1,3,4,5,6,7]
 ; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm3[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm5, %ymm2, %ymm30
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm2, %ymm2
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm3[0,1,2,3,4,5,5,7]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm3[0,1,2,3,6,5,7,7]
 ; AVX512DQ-NEXT:    vinserti128 $1, %xmm3, %ymm5, %ymm3
-; AVX512DQ-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm5 # 16-byte Reload
-; AVX512DQ-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm5, %xmm5 # 16-byte Folded Reload
-; AVX512DQ-NEXT:    # xmm5 = xmm5[0],mem[0],xmm5[1],mem[1],xmm5[2],mem[2],xmm5[3],mem[3],xmm5[4],mem[4],xmm5[5],mem[5],xmm5[6],mem[6],xmm5[7],mem[7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm12 = xmm5[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm14 = xmm5[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm14, %ymm12, %ymm14
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm12 = xmm5[0,1,2,3,4,4,6,5]
+; AVX512DQ-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm1 # 16-byte Reload
+; AVX512DQ-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm5 # 16-byte Folded Reload
+; AVX512DQ-NEXT:    # xmm5 = xmm1[0],mem[0],xmm1[1],mem[1],xmm1[2],mem[2],xmm1[3],mem[3],xmm1[4],mem[4],xmm1[5],mem[5],xmm1[6],mem[6],xmm1[7],mem[7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm5[0,0,2,1,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm13 = xmm5[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm13, %ymm6, %ymm13
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm5[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm5[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm12, %ymm15
-; AVX512DQ-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm5 # 16-byte Reload
-; AVX512DQ-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm5, %xmm5 # 16-byte Folded Reload
-; AVX512DQ-NEXT:    # xmm5 = xmm5[0],mem[0],xmm5[1],mem[1],xmm5[2],mem[2],xmm5[3],mem[3],xmm5[4],mem[4],xmm5[5],mem[5],xmm5[6],mem[6],xmm5[7],mem[7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm12 = xmm5[0,0,2,1,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm5[0,2,2,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm7, %ymm12, %ymm19
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm5[0,1,2,3,4,4,6,5]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm5, %ymm6, %ymm15
+; AVX512DQ-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm1 # 16-byte Reload
+; AVX512DQ-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm5 # 16-byte Folded Reload
+; AVX512DQ-NEXT:    # xmm5 = xmm1[0],mem[0],xmm1[1],mem[1],xmm1[2],mem[2],xmm1[3],mem[3],xmm1[4],mem[4],xmm1[5],mem[5],xmm1[6],mem[6],xmm1[7],mem[7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm5[0,0,2,1,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm1 = xmm5[0,2,2,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm1, %ymm6, %ymm16
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm5[0,1,2,3,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm5[0,1,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm5, %ymm7, %ymm20
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm5 = xmm0[8],xmm1[8],xmm0[9],xmm1[9],xmm0[10],xmm1[10],xmm0[11],xmm1[11],xmm0[12],xmm1[12],xmm0[13],xmm1[13],xmm0[14],xmm1[14],xmm0[15],xmm1[15]
-; AVX512DQ-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm0 # 16-byte Reload
-; AVX512DQ-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm0, %xmm1 # 16-byte Folded Reload
-; AVX512DQ-NEXT:    # xmm1 = xmm0[0],mem[0],xmm0[1],mem[1],xmm0[2],mem[2],xmm0[3],mem[3],xmm0[4],mem[4],xmm0[5],mem[5],xmm0[6],mem[6],xmm0[7],mem[7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm0 = xmm1[0,1,1,3,4,5,6,7]
-; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm7 = xmm1[2,1,3,3,4,5,6,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm7, %ymm0, %ymm0
-; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm7 = xmm1[0,1,2,3,4,5,5,7]
+; AVX512DQ-NEXT:    vinserti32x4 $1, %xmm5, %ymm1, %ymm18
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm0 = xmm0[8],xmm14[8],xmm0[9],xmm14[9],xmm0[10],xmm14[10],xmm0[11],xmm14[11],xmm0[12],xmm14[12],xmm0[13],xmm14[13],xmm0[14],xmm14[14],xmm0[15],xmm14[15]
+; AVX512DQ-NEXT:    vmovdqa {{[-0-9]+}}(%r{{[sb]}}p), %xmm1 # 16-byte Reload
+; AVX512DQ-NEXT:    vpunpcklbw {{[-0-9]+}}(%r{{[sb]}}p), %xmm1, %xmm1 # 16-byte Folded Reload
+; AVX512DQ-NEXT:    # xmm1 = xmm1[0],mem[0],xmm1[1],mem[1],xmm1[2],mem[2],xmm1[3],mem[3],xmm1[4],mem[4],xmm1[5],mem[5],xmm1[6],mem[6],xmm1[7],mem[7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm5 = xmm1[0,1,1,3,4,5,6,7]
+; AVX512DQ-NEXT:    vpshuflw {{.*#+}} xmm6 = xmm1[2,1,3,3,4,5,6,7]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm6, %ymm5, %ymm5
+; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm1[0,1,2,3,4,5,5,7]
 ; AVX512DQ-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm1[0,1,2,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti128 $1, %xmm1, %ymm7, %ymm1
-; AVX512DQ-NEXT:    vmovdqa 16(%rsi), %xmm7
-; AVX512DQ-NEXT:    vmovdqa 16(%rdi), %xmm12
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm11 = xmm12[0],xmm7[0],xmm12[1],xmm7[1],xmm12[2],xmm7[2],xmm12[3],xmm7[3],xmm12[4],xmm7[4],xmm12[5],xmm7[5],xmm12[6],xmm7[6],xmm12[7],xmm7[7]
-; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm12[8],xmm7[8],xmm12[9],xmm7[9],xmm12[10],xmm7[10],xmm12[11],xmm7[11],xmm12[12],xmm7[12],xmm12[13],xmm7[13],xmm12[14],xmm7[14],xmm12[15],xmm7[15]
-; AVX512DQ-NEXT:    vmovdqa64 %xmm23, %xmm12
-; AVX512DQ-NEXT:    vmovdqa64 %xmm24, %xmm2
-; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm12 = xmm12[0],xmm2[0],xmm12[1],xmm2[1],xmm12[2],xmm2[2],xmm12[3],xmm2[3],xmm12[4],xmm2[4],xmm12[5],xmm2[5],xmm12[6],xmm2[6],xmm12[7],xmm2[7]
-; AVX512DQ-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm23 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm23 = mem[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm24 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm24 = mem[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm24, %zmm23, %zmm23
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm24 = xmm5[0],zero,zero,zero,xmm5[1],zero,zero,zero,xmm5[2],zero,zero,zero,xmm5[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm5 = xmm5[2,3,2,3]
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm5 = xmm5[0],zero,zero,zero,xmm5[1],zero,zero,zero,xmm5[2],zero,zero,zero,xmm5[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm5, %zmm24, %zmm5
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm5 = zmm23 ^ (zmm13 & (zmm5 ^ zmm23))
-; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm23 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm23 = mem[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm24 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm24 = mem[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm24, %zmm23, %zmm23
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm24 = xmm11[0],zero,zero,zero,xmm11[1],zero,zero,zero,xmm11[2],zero,zero,zero,xmm11[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm11 = xmm11[2,3,2,3]
+; AVX512DQ-NEXT:    vinserti128 $1, %xmm1, %ymm6, %ymm1
+; AVX512DQ-NEXT:    vmovdqa 16(%rsi), %xmm6
+; AVX512DQ-NEXT:    vmovdqa 16(%rdi), %xmm14
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm8 = xmm14[0],xmm6[0],xmm14[1],xmm6[1],xmm14[2],xmm6[2],xmm14[3],xmm6[3],xmm14[4],xmm6[4],xmm14[5],xmm6[5],xmm14[6],xmm6[6],xmm14[7],xmm6[7]
+; AVX512DQ-NEXT:    vpunpckhbw {{.*#+}} xmm6 = xmm14[8],xmm6[8],xmm14[9],xmm6[9],xmm14[10],xmm6[10],xmm14[11],xmm6[11],xmm14[12],xmm6[12],xmm14[13],xmm6[13],xmm14[14],xmm6[14],xmm14[15],xmm6[15]
+; AVX512DQ-NEXT:    vmovdqa64 %xmm21, %xmm14
+; AVX512DQ-NEXT:    vpunpcklbw {{.*#+}} xmm12 = xmm12[0],xmm14[0],xmm12[1],xmm14[1],xmm12[2],xmm14[2],xmm12[3],xmm14[3],xmm12[4],xmm14[4],xmm12[5],xmm14[5],xmm12[6],xmm14[6],xmm12[7],xmm14[7]
+; AVX512DQ-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm14 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm14 = mem[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm25 = mem[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm0 = zmm14 ^ (zmm11 & (zmm0 ^ zmm14))
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm8 = xmm8[0],zero,zero,zero,xmm8[1],zero,zero,zero,xmm8[2],zero,zero,zero,xmm8[3],zero,zero,zero,xmm8[4],zero,zero,zero,xmm8[5],zero,zero,zero,xmm8[6],zero,zero,zero,xmm8[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm6 = xmm6[0],zero,zero,zero,xmm6[1],zero,zero,zero,xmm6[2],zero,zero,zero,xmm6[3],zero,zero,zero,xmm6[4],zero,zero,zero,xmm6[5],zero,zero,zero,xmm6[6],zero,zero,zero,xmm6[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} zmm12 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero,xmm12[4],zero,zero,zero,xmm12[5],zero,zero,zero,xmm12[6],zero,zero,zero,xmm12[7],zero,zero,zero
+; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm14 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm14 = mem[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm25 = mem[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
 ; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
 ; AVX512DQ-NEXT:    # ymm25 = mem[0,0,2,1,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufd $232, {{[-0-9]+}}(%r{{[sb]}}p), %ymm26 # 32-byte Folded Reload
 ; AVX512DQ-NEXT:    # ymm26 = mem[0,2,2,3,4,6,6,7]
 ; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm26, %zmm25, %zmm25
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm26 = xmm7[0],zero,zero,zero,xmm7[1],zero,zero,zero,xmm7[2],zero,zero,zero,xmm7[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm7 = xmm7[2,3,2,3]
-; AVX512DQ-NEXT:    vpandnq %zmm23, %zmm8, %zmm23
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm25, %zmm25
-; AVX512DQ-NEXT:    vpord %zmm23, %zmm25, %zmm5 {%k1}
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm23 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} xmm12 = xmm12[2,3,2,3]
-; AVX512DQ-NEXT:    vpshufd $212, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm25 = mem[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm28 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm28 = mem[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm28, %zmm25, %zmm25
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm11 = xmm11[0],zero,zero,zero,xmm11[1],zero,zero,zero,xmm11[2],zero,zero,zero,xmm11[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm11, %zmm24, %zmm11
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm11 = zmm25 ^ (zmm13 & (zmm11 ^ zmm25))
-; AVX512DQ-NEXT:    vpshufd $96, {{[-0-9]+}}(%r{{[sb]}}p), %ymm24 # 32-byte Folded Reload
-; AVX512DQ-NEXT:    # ymm24 = mem[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm25 = ymm29[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm25, %zmm24, %zmm24
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm25 = ymm31[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm16 = ymm27[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm16, %zmm25, %zmm16
-; AVX512DQ-NEXT:    vpandnq %zmm24, %zmm8, %zmm24
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm16, %zmm16
-; AVX512DQ-NEXT:    vpord %zmm24, %zmm16, %zmm11 {%k1}
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm16 = ymm18[0,1,1,3,4,5,5,7]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[2,1,3,3,6,5,7,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm17, %zmm16, %zmm16
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm7 = xmm7[0],zero,zero,zero,xmm7[1],zero,zero,zero,xmm7[2],zero,zero,zero,xmm7[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm7, %zmm26, %zmm7
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm7 = zmm16 ^ (zmm13 & (zmm7 ^ zmm16))
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm16 = ymm21[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm17 = ymm22[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm17, %zmm16, %zmm16
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm30[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpandnq %zmm14, %zmm7, %zmm14
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm25, %zmm25
+; AVX512DQ-NEXT:    vpord %zmm14, %zmm25, %zmm0 {%k1}
+; AVX512DQ-NEXT:    vpshufd $212, (%rsp), %ymm14 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm14 = mem[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufd $246, {{[-0-9]+}}(%r{{[sb]}}p), %ymm25 # 32-byte Folded Reload
+; AVX512DQ-NEXT:    # ymm25 = mem[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm8 = zmm14 ^ (zmm11 & (zmm8 ^ zmm14))
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm14 = ymm30[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm25 = ymm31[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm25, %zmm14, %zmm14
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm21 = ymm27[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm17, %zmm21, %zmm17
+; AVX512DQ-NEXT:    vpandnq %zmm14, %zmm7, %zmm14
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm17, %zmm17
+; AVX512DQ-NEXT:    vpord %zmm14, %zmm17, %zmm8 {%k1}
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm14 = ymm19[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm17 = ymm20[2,1,3,3,6,5,7,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm17, %zmm14, %zmm14
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm6 = zmm14 ^ (zmm11 & (zmm6 ^ zmm14))
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm14 = ymm23[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm9 = ymm9[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm9, %zmm14, %zmm9
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm2[0,0,2,1,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm3[0,2,2,3,4,6,6,7]
 ; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpandnq %zmm16, %zmm8, %zmm3
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpord %zmm3, %zmm2, %zmm7 {%k1}
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm14[0,1,1,3,4,5,5,7]
+; AVX512DQ-NEXT:    vpandnq %zmm9, %zmm7, %zmm3
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm2, %zmm2
+; AVX512DQ-NEXT:    vpord %zmm3, %zmm2, %zmm6 {%k1}
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm13[0,1,1,3,4,5,5,7]
 ; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm15[2,1,3,3,6,5,7,7]
 ; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpmovzxwq {{.*#+}} ymm3 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm23, %zmm3
-; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm3 = zmm2 ^ (zmm13 & (zmm3 ^ zmm2))
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm19[0,0,2,1,4,4,6,5]
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm12 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm12, %zmm2, %zmm2
-; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm0 = ymm0[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpternlogq {{.*#+}} zmm12 = zmm2 ^ (zmm11 & (zmm12 ^ zmm2))
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm2 = ymm16[0,0,2,1,4,4,6,5]
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm18[0,2,2,3,4,6,6,7]
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
+; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm3 = ymm5[0,0,2,1,4,4,6,5]
 ; AVX512DQ-NEXT:    vpshufd {{.*#+}} ymm1 = ymm1[0,2,2,3,4,6,6,7]
-; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpandnq %zmm2, %zmm8, %zmm1
-; AVX512DQ-NEXT:    vpandq %zmm8, %zmm0, %zmm0
-; AVX512DQ-NEXT:    vpord %zmm1, %zmm0, %zmm3 {%k1}
+; AVX512DQ-NEXT:    vinserti64x4 $1, %ymm1, %zmm3, %zmm1
+; AVX512DQ-NEXT:    vpandnq %zmm2, %zmm7, %zmm2
+; AVX512DQ-NEXT:    vpandq %zmm7, %zmm1, %zmm1
+; AVX512DQ-NEXT:    vpord %zmm2, %zmm1, %zmm12 {%k1}
 ; AVX512DQ-NEXT:    movq {{[0-9]+}}(%rsp), %rax
-; AVX512DQ-NEXT:    vmovdqa64 %zmm3, (%rax)
-; AVX512DQ-NEXT:    vmovdqa64 %zmm7, 192(%rax)
-; AVX512DQ-NEXT:    vmovdqa64 %zmm11, 128(%rax)
-; AVX512DQ-NEXT:    vmovdqa64 %zmm5, 320(%rax)
+; AVX512DQ-NEXT:    vmovdqa64 %zmm12, (%rax)
+; AVX512DQ-NEXT:    vmovdqa64 %zmm6, 192(%rax)
+; AVX512DQ-NEXT:    vmovdqa64 %zmm8, 128(%rax)
+; AVX512DQ-NEXT:    vmovdqa64 %zmm0, 320(%rax)
 ; AVX512DQ-NEXT:    vmovdqa64 %zmm4, 256(%rax)
 ; AVX512DQ-NEXT:    vmovdqa64 %zmm10, 448(%rax)
-; AVX512DQ-NEXT:    vmovdqa64 %zmm9, 384(%rax)
-; AVX512DQ-NEXT:    vmovdqa64 %zmm6, 64(%rax)
+; AVX512DQ-NEXT:    vmovdqa64 %zmm24, 384(%rax)
+; AVX512DQ-NEXT:    vmovdqa64 %zmm22, 64(%rax)
 ; AVX512DQ-NEXT:    addq $552, %rsp # imm = 0x228
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
@@ -8146,284 +8090,260 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512BW-NEXT:    vmovdqa 16(%r10), %xmm12
 ; AVX512BW-NEXT:    vmovdqa64 32(%r10), %xmm16
 ; AVX512BW-NEXT:    vmovdqa 48(%r10), %xmm15
-; AVX512BW-NEXT:    vmovdqa (%rax), %xmm2
+; AVX512BW-NEXT:    vmovdqa (%rax), %xmm1
 ; AVX512BW-NEXT:    vmovdqa 16(%rax), %xmm13
 ; AVX512BW-NEXT:    vmovdqa64 32(%rax), %xmm17
 ; AVX512BW-NEXT:    vmovdqa64 48(%rax), %xmm18
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm2[8],xmm0[8],xmm2[9],xmm0[9],xmm2[10],xmm0[10],xmm2[11],xmm0[11],xmm2[12],xmm0[12],xmm2[13],xmm0[13],xmm2[14],xmm0[14],xmm2[15],xmm0[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm4 = ymm3[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpmovsxbw {{.*#+}} ymm3 = [0,0,0,0,4,5,2,1,0,2,0,2,4,5,2,3]
-; AVX512BW-NEXT:    vpermw %ymm1, %ymm3, %ymm1
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm4, %zmm1, %zmm1
-; AVX512BW-NEXT:    vmovdqa (%r9), %xmm4
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm1[8],xmm0[8],xmm1[9],xmm0[9],xmm1[10],xmm0[10],xmm1[11],xmm0[11],xmm1[12],xmm0[12],xmm1[13],xmm0[13],xmm1[14],xmm0[14],xmm1[15],xmm0[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm3[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm3[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti128 $1, %xmm4, %ymm2, %ymm2
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm4 = ymm2[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpmovsxbw {{.*#+}} ymm2 = [0,0,0,0,4,5,2,1,0,2,0,2,4,5,2,3]
+; AVX512BW-NEXT:    vpermw %ymm3, %ymm2, %ymm3
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm6
+; AVX512BW-NEXT:    vmovdqa (%r9), %xmm3
 ; AVX512BW-NEXT:    vmovdqa64 48(%r9), %xmm19
-; AVX512BW-NEXT:    vmovdqa (%r8), %xmm5
-; AVX512BW-NEXT:    vmovdqa64 48(%r8), %xmm21
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm5[8],xmm4[8],xmm5[9],xmm4[9],xmm5[10],xmm4[10],xmm5[11],xmm4[11],xmm5[12],xmm4[12],xmm5[13],xmm4[13],xmm5[14],xmm4[14],xmm5[15],xmm4[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm7[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vmovdqa (%r8), %xmm4
+; AVX512BW-NEXT:    vmovdqa64 48(%r8), %xmm20
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm4[8],xmm3[8],xmm4[9],xmm3[9],xmm4[10],xmm3[10],xmm4[11],xmm3[11],xmm4[12],xmm3[12],xmm4[13],xmm3[13],xmm4[14],xmm3[14],xmm4[15],xmm3[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm7[0,1,2,3,4,5,5,7]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm8 = xmm7[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti128 $1, %xmm8, %ymm6, %ymm6
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm8 = ymm6[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpmovsxbw {{.*#+}} ymm6 = [0,1,0,1,4,5,1,3,2,1,2,1,4,5,3,3]
-; AVX512BW-NEXT:    vpermw %ymm7, %ymm6, %ymm7
+; AVX512BW-NEXT:    vinserti128 $1, %xmm8, %ymm5, %ymm5
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm8 = ymm5[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpmovsxbw {{.*#+}} ymm5 = [0,1,0,1,4,5,1,3,2,1,2,1,4,5,3,3]
+; AVX512BW-NEXT:    vpermw %ymm7, %ymm5, %ymm7
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm8, %zmm7, %zmm14
 ; AVX512BW-NEXT:    movl $-2004318072, %eax # imm = 0x88888888
 ; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    vmovdqu16 %zmm1, %zmm14 {%k1}
-; AVX512BW-NEXT:    vmovdqa (%rsi), %xmm7
+; AVX512BW-NEXT:    vmovdqu16 %zmm6, %zmm14 {%k1}
+; AVX512BW-NEXT:    vmovdqa (%rcx), %xmm6
+; AVX512BW-NEXT:    vmovdqa64 48(%rcx), %xmm21
+; AVX512BW-NEXT:    vmovdqa (%rdx), %xmm8
+; AVX512BW-NEXT:    vmovdqa64 48(%rdx), %xmm23
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm8[8],xmm6[8],xmm8[9],xmm6[9],xmm8[10],xmm6[10],xmm8[11],xmm6[11],xmm8[12],xmm6[12],xmm8[13],xmm6[13],xmm8[14],xmm6[14],xmm8[15],xmm6[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm9 = xmm7[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm10 = xmm7[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti128 $1, %xmm10, %ymm9, %ymm9
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm10 = ymm9[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpmovsxbw {{.*#+}} ymm9 = [0,0,2,1,2,1,6,7,0,2,2,3,2,3,6,7]
+; AVX512BW-NEXT:    vpermw %ymm7, %ymm9, %ymm7
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm10, %zmm7, %zmm22
+; AVX512BW-NEXT:    vmovdqa (%rsi), %xmm10
 ; AVX512BW-NEXT:    vmovdqa64 48(%rsi), %xmm24
-; AVX512BW-NEXT:    vmovdqa (%rdi), %xmm8
-; AVX512BW-NEXT:    vmovdqa64 48(%rdi), %xmm26
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm8[8],xmm7[8],xmm8[9],xmm7[9],xmm8[10],xmm7[10],xmm8[11],xmm7[11],xmm8[12],xmm7[12],xmm8[13],xmm7[13],xmm8[14],xmm7[14],xmm8[15],xmm7[15]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm9 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm1 = xmm1[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm1, %zmm9, %zmm1
-; AVX512BW-NEXT:    vmovdqa (%rcx), %xmm9
-; AVX512BW-NEXT:    vmovdqa64 48(%rcx), %xmm28
-; AVX512BW-NEXT:    vmovdqa (%rdx), %xmm10
-; AVX512BW-NEXT:    vmovdqa64 48(%rdx), %xmm30
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm20 = xmm10[8],xmm9[8],xmm10[9],xmm9[9],xmm10[10],xmm9[10],xmm10[11],xmm9[11],xmm10[12],xmm9[12],xmm10[13],xmm9[13],xmm10[14],xmm9[14],xmm10[15],xmm9[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm11 = xmm20[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm20[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm22, %ymm11, %ymm11
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm22 = ymm11[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpmovsxbw {{.*#+}} ymm11 = [0,0,2,1,2,1,6,7,0,2,2,3,2,3,6,7]
-; AVX512BW-NEXT:    vpermw %ymm20, %ymm11, %ymm20
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm20, %zmm20
+; AVX512BW-NEXT:    vmovdqa (%rdi), %xmm11
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm11[8],xmm10[8],xmm11[9],xmm10[9],xmm11[10],xmm10[10],xmm11[11],xmm10[11],xmm11[12],xmm10[12],xmm11[13],xmm10[13],xmm11[14],xmm10[14],xmm11[15],xmm10[15]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm7 = xmm7[0],zero,zero,zero,xmm7[1],zero,zero,zero,xmm7[2],zero,zero,zero,xmm7[3],zero,zero,zero,xmm7[4],zero,zero,zero,xmm7[5],zero,zero,zero,xmm7[6],zero,zero,zero,xmm7[7],zero,zero,zero
 ; AVX512BW-NEXT:    movl $572662306, %eax # imm = 0x22222222
 ; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    vmovdqu16 %zmm20, %zmm1 {%k2}
+; AVX512BW-NEXT:    vmovdqu16 %zmm22, %zmm7 {%k2}
 ; AVX512BW-NEXT:    movw $-21846, %ax # imm = 0xAAAA
 ; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    vmovdqa32 %zmm14, %zmm1 {%k3}
+; AVX512BW-NEXT:    vmovdqa32 %zmm14, %zmm7 {%k3}
 ; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm18[0],xmm15[0],xmm18[1],xmm15[1],xmm18[2],xmm15[2],xmm18[3],xmm15[3],xmm18[4],xmm15[4],xmm18[5],xmm15[5],xmm18[6],xmm15[6],xmm18[7],xmm15[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm14[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm14[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm22, %ymm20, %ymm20
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm14, %ymm3, %ymm14
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm14, %zmm14
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm21[0],xmm19[0],xmm21[1],xmm19[1],xmm21[2],xmm19[2],xmm21[3],xmm19[3],xmm21[4],xmm19[4],xmm21[5],xmm19[5],xmm21[6],xmm19[6],xmm21[7],xmm19[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm20[0,1,2,3,4,5,5,7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm20[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm22, %ymm22
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm14[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm14[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm22, %ymm22
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm22 = ymm22[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm20, %ymm6, %ymm20
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm20, %zmm23
-; AVX512BW-NEXT:    vmovdqu16 %zmm14, %zmm23 {%k1}
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm26[0],xmm24[0],xmm26[1],xmm24[1],xmm26[2],xmm24[2],xmm26[3],xmm24[3],xmm26[4],xmm24[4],xmm26[5],xmm24[5],xmm26[6],xmm24[6],xmm26[7],xmm24[7]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm20 = xmm14[0],zero,zero,zero,xmm14[1],zero,zero,zero,xmm14[2],zero,zero,zero,xmm14[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm14 = xmm14[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm14 = xmm14[0],zero,zero,zero,xmm14[1],zero,zero,zero,xmm14[2],zero,zero,zero,xmm14[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm14, %zmm20, %zmm14
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm30[0],xmm28[0],xmm30[1],xmm28[1],xmm30[2],xmm28[2],xmm30[3],xmm28[3],xmm30[4],xmm28[4],xmm30[5],xmm28[5],xmm30[6],xmm28[6],xmm30[7],xmm28[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm20[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm20[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm22, %ymm25
+; AVX512BW-NEXT:    vpermw %ymm14, %ymm2, %ymm14
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm14, %zmm14
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm22 = xmm20[0],xmm19[0],xmm20[1],xmm19[1],xmm20[2],xmm19[2],xmm20[3],xmm19[3],xmm20[4],xmm19[4],xmm20[5],xmm19[5],xmm20[6],xmm19[6],xmm20[7],xmm19[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm22[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm22[0,1,2,3,6,5,7,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm25, %ymm25
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpermw %ymm22, %ymm5, %ymm22
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm22, %zmm25
+; AVX512BW-NEXT:    vmovdqu16 %zmm14, %zmm25 {%k1}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm23[0],xmm21[0],xmm23[1],xmm21[1],xmm23[2],xmm21[2],xmm23[3],xmm21[3],xmm23[4],xmm21[4],xmm23[5],xmm21[5],xmm23[6],xmm21[6],xmm23[7],xmm21[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm14[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm14[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm22, %ymm22
+; AVX512BW-NEXT:    vmovdqa64 48(%rdi), %xmm27
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm22 = ymm22[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpermw %ymm14, %ymm9, %ymm14
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm14, %zmm22
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm27[0],xmm24[0],xmm27[1],xmm24[1],xmm27[2],xmm24[2],xmm27[3],xmm24[3],xmm27[4],xmm24[4],xmm27[5],xmm24[5],xmm27[6],xmm24[6],xmm27[7],xmm24[7]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm14 = xmm14[0],zero,zero,zero,xmm14[1],zero,zero,zero,xmm14[2],zero,zero,zero,xmm14[3],zero,zero,zero,xmm14[4],zero,zero,zero,xmm14[5],zero,zero,zero,xmm14[6],zero,zero,zero,xmm14[7],zero,zero,zero
+; AVX512BW-NEXT:    vmovdqu16 %zmm22, %zmm14 {%k2}
 ; AVX512BW-NEXT:    vmovdqa64 32(%r9), %xmm22
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpermw %ymm20, %ymm11, %ymm20
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm20, %zmm20
-; AVX512BW-NEXT:    vmovdqa64 32(%r8), %xmm25
-; AVX512BW-NEXT:    vmovdqu16 %zmm20, %zmm14 {%k2}
-; AVX512BW-NEXT:    vmovdqa64 32(%rsi), %xmm20
-; AVX512BW-NEXT:    vmovdqa32 %zmm23, %zmm14 {%k3}
+; AVX512BW-NEXT:    vmovdqa32 %zmm25, %zmm14 {%k3}
 ; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm18[8],xmm15[8],xmm18[9],xmm15[9],xmm18[10],xmm15[10],xmm18[11],xmm15[11],xmm18[12],xmm15[12],xmm18[13],xmm15[13],xmm18[14],xmm15[14],xmm18[15],xmm15[15]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm18 = xmm15[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm15[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm18, %ymm18
-; AVX512BW-NEXT:    vmovdqa64 32(%rdi), %xmm23
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm15[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm18, %ymm18
+; AVX512BW-NEXT:    vmovdqa64 32(%r8), %xmm25
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm18 = ymm18[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm15, %ymm3, %ymm15
+; AVX512BW-NEXT:    vpermw %ymm15, %ymm2, %ymm15
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm18, %zmm15, %zmm15
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm18 = xmm21[8],xmm19[8],xmm21[9],xmm19[9],xmm21[10],xmm19[10],xmm21[11],xmm19[11],xmm21[12],xmm19[12],xmm21[13],xmm19[13],xmm21[14],xmm19[14],xmm21[15],xmm19[15]
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm18 = xmm20[8],xmm19[8],xmm20[9],xmm19[9],xmm20[10],xmm19[10],xmm20[11],xmm19[11],xmm20[12],xmm19[12],xmm20[13],xmm19[13],xmm20[14],xmm19[14],xmm20[15],xmm19[15]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm18[0,1,2,3,4,5,5,7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm18[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
-; AVX512BW-NEXT:    vmovdqa64 32(%rcx), %xmm27
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm18[0,1,2,3,6,5,7,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm20, %ymm19, %ymm19
+; AVX512BW-NEXT:    vmovdqa64 32(%rcx), %xmm20
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm18, %ymm6, %ymm18
+; AVX512BW-NEXT:    vpermw %ymm18, %ymm5, %ymm18
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm18, %zmm18
-; AVX512BW-NEXT:    vmovdqa64 32(%rdx), %xmm29
+; AVX512BW-NEXT:    vmovdqa64 32(%rdx), %xmm26
 ; AVX512BW-NEXT:    vmovdqu16 %zmm15, %zmm18 {%k1}
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm26[8],xmm24[8],xmm26[9],xmm24[9],xmm26[10],xmm24[10],xmm26[11],xmm24[11],xmm26[12],xmm24[12],xmm26[13],xmm24[13],xmm26[14],xmm24[14],xmm26[15],xmm24[15]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm19 = xmm15[0],zero,zero,zero,xmm15[1],zero,zero,zero,xmm15[2],zero,zero,zero,xmm15[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm15 = xmm15[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm15 = xmm15[0],zero,zero,zero,xmm15[1],zero,zero,zero,xmm15[2],zero,zero,zero,xmm15[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm15, %zmm19, %zmm15
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm19 = xmm30[8],xmm28[8],xmm30[9],xmm28[9],xmm30[10],xmm28[10],xmm30[11],xmm28[11],xmm30[12],xmm28[12],xmm30[13],xmm28[13],xmm30[14],xmm28[14],xmm30[15],xmm28[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm19[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm21, %ymm21
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm21 = ymm21[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpermw %ymm19, %ymm11, %ymm19
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm21, %zmm19, %zmm19
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm23[8],xmm21[8],xmm23[9],xmm21[9],xmm23[10],xmm21[10],xmm23[11],xmm21[11],xmm23[12],xmm21[12],xmm23[13],xmm21[13],xmm23[14],xmm21[14],xmm23[15],xmm21[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm15[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm15[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
+; AVX512BW-NEXT:    vmovdqa64 32(%rsi), %xmm21
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpermw %ymm15, %ymm9, %ymm15
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm15, %zmm19
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm27[8],xmm24[8],xmm27[9],xmm24[9],xmm27[10],xmm24[10],xmm27[11],xmm24[11],xmm27[12],xmm24[12],xmm27[13],xmm24[13],xmm27[14],xmm24[14],xmm27[15],xmm24[15]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm15 = xmm15[0],zero,zero,zero,xmm15[1],zero,zero,zero,xmm15[2],zero,zero,zero,xmm15[3],zero,zero,zero,xmm15[4],zero,zero,zero,xmm15[5],zero,zero,zero,xmm15[6],zero,zero,zero,xmm15[7],zero,zero,zero
 ; AVX512BW-NEXT:    vmovdqu16 %zmm19, %zmm15 {%k2}
 ; AVX512BW-NEXT:    vmovdqa32 %zmm18, %zmm15 {%k3}
 ; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm17[0],xmm16[0],xmm17[1],xmm16[1],xmm17[2],xmm16[2],xmm17[3],xmm16[3],xmm17[4],xmm16[4],xmm17[5],xmm16[5],xmm17[6],xmm16[6],xmm17[7],xmm16[7]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm18[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm18[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm18[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm19, %ymm19
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm18, %ymm3, %ymm18
+; AVX512BW-NEXT:    vpermw %ymm18, %ymm2, %ymm18
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm18, %zmm18
 ; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm19 = xmm25[0],xmm22[0],xmm25[1],xmm22[1],xmm25[2],xmm22[2],xmm25[3],xmm22[3],xmm25[4],xmm22[4],xmm25[5],xmm22[5],xmm25[6],xmm22[6],xmm25[7],xmm22[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm19[0,1,2,3,4,5,5,7]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm19[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm21, %ymm21
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm21 = ymm21[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm19, %ymm6, %ymm19
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm21, %zmm19, %zmm24
-; AVX512BW-NEXT:    vmovdqu16 %zmm18, %zmm24 {%k1}
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm23[0],xmm20[0],xmm23[1],xmm20[1],xmm23[2],xmm20[2],xmm23[3],xmm20[3],xmm23[4],xmm20[4],xmm23[5],xmm20[5],xmm23[6],xmm20[6],xmm23[7],xmm20[7]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm19 = xmm18[0],zero,zero,zero,xmm18[1],zero,zero,zero,xmm18[2],zero,zero,zero,xmm18[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm18 = xmm18[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm18 = xmm18[0],zero,zero,zero,xmm18[1],zero,zero,zero,xmm18[2],zero,zero,zero,xmm18[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm18, %zmm19, %zmm18
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm19 = xmm29[0],xmm27[0],xmm29[1],xmm27[1],xmm29[2],xmm27[2],xmm29[3],xmm27[3],xmm29[4],xmm27[4],xmm29[5],xmm27[5],xmm29[6],xmm27[6],xmm29[7],xmm27[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm19[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm21, %ymm26
-; AVX512BW-NEXT:    vmovdqa64 16(%r9), %xmm21
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm26 = ymm26[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpermw %ymm19, %ymm11, %ymm19
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm26, %zmm19, %zmm19
-; AVX512BW-NEXT:    vmovdqa64 16(%r8), %xmm26
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm23, %ymm23
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm23 = ymm23[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpermw %ymm19, %ymm5, %ymm19
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm23, %zmm19, %zmm23
+; AVX512BW-NEXT:    vmovdqu16 %zmm18, %zmm23 {%k1}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm26[0],xmm20[0],xmm26[1],xmm20[1],xmm26[2],xmm20[2],xmm26[3],xmm20[3],xmm26[4],xmm20[4],xmm26[5],xmm20[5],xmm26[6],xmm20[6],xmm26[7],xmm20[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm18[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm18[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm19, %ymm19
+; AVX512BW-NEXT:    vmovdqa64 32(%rdi), %xmm27
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpermw %ymm18, %ymm9, %ymm18
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm18, %zmm19
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm27[0],xmm21[0],xmm27[1],xmm21[1],xmm27[2],xmm21[2],xmm27[3],xmm21[3],xmm27[4],xmm21[4],xmm27[5],xmm21[5],xmm27[6],xmm21[6],xmm27[7],xmm21[7]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm18 = xmm18[0],zero,zero,zero,xmm18[1],zero,zero,zero,xmm18[2],zero,zero,zero,xmm18[3],zero,zero,zero,xmm18[4],zero,zero,zero,xmm18[5],zero,zero,zero,xmm18[6],zero,zero,zero,xmm18[7],zero,zero,zero
 ; AVX512BW-NEXT:    vmovdqu16 %zmm19, %zmm18 {%k2}
-; AVX512BW-NEXT:    vmovdqa64 16(%rsi), %xmm19
-; AVX512BW-NEXT:    vmovdqa32 %zmm24, %zmm18 {%k3}
+; AVX512BW-NEXT:    vmovdqa64 16(%r9), %xmm19
+; AVX512BW-NEXT:    vmovdqa32 %zmm23, %zmm18 {%k3}
 ; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm17[8],xmm16[8],xmm17[9],xmm16[9],xmm17[10],xmm16[10],xmm17[11],xmm16[11],xmm17[12],xmm16[12],xmm17[13],xmm16[13],xmm17[14],xmm16[14],xmm17[15],xmm16[15]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm17 = xmm16[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm16[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm17, %ymm17
-; AVX512BW-NEXT:    vmovdqa64 16(%rdi), %xmm24
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm16[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm17, %ymm17
+; AVX512BW-NEXT:    vmovdqa64 16(%r8), %xmm23
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm16, %ymm3, %ymm16
+; AVX512BW-NEXT:    vpermw %ymm16, %ymm2, %ymm16
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm17, %zmm16, %zmm16
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm17 = xmm25[8],xmm22[8],xmm25[9],xmm22[9],xmm25[10],xmm22[10],xmm25[11],xmm22[11],xmm25[12],xmm22[12],xmm25[13],xmm22[13],xmm25[14],xmm22[14],xmm25[15],xmm22[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm17[0,1,2,3,4,5,5,7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm17[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm22, %ymm25
-; AVX512BW-NEXT:    vmovdqa64 16(%rcx), %xmm22
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm17, %ymm6, %ymm17
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm17, %zmm17
-; AVX512BW-NEXT:    vmovdqa64 16(%rdx), %xmm25
-; AVX512BW-NEXT:    vmovdqu16 %zmm16, %zmm17 {%k1}
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm23[8],xmm20[8],xmm23[9],xmm20[9],xmm23[10],xmm20[10],xmm23[11],xmm20[11],xmm23[12],xmm20[12],xmm23[13],xmm20[13],xmm23[14],xmm20[14],xmm23[15],xmm20[15]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm20 = xmm16[0],zero,zero,zero,xmm16[1],zero,zero,zero,xmm16[2],zero,zero,zero,xmm16[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm16 = xmm16[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm16 = xmm16[0],zero,zero,zero,xmm16[1],zero,zero,zero,xmm16[2],zero,zero,zero,xmm16[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm16, %zmm20, %zmm16
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm20 = xmm29[8],xmm27[8],xmm29[9],xmm27[9],xmm29[10],xmm27[10],xmm29[11],xmm27[11],xmm29[12],xmm27[12],xmm29[13],xmm27[13],xmm29[14],xmm27[14],xmm29[15],xmm27[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm20[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm27 = xmm20[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm27, %ymm23, %ymm23
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm23 = ymm23[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpermw %ymm20, %ymm11, %ymm20
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm23, %zmm20, %zmm20
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm22 = xmm25[8],xmm22[8],xmm25[9],xmm22[9],xmm25[10],xmm22[10],xmm25[11],xmm22[11],xmm25[12],xmm22[12],xmm25[13],xmm22[13],xmm25[14],xmm22[14],xmm25[15],xmm22[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm17 = xmm22[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm22[0,1,2,3,6,5,7,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm17, %ymm24
+; AVX512BW-NEXT:    vmovdqa64 16(%rcx), %xmm17
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm24 = ymm24[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpermw %ymm22, %ymm5, %ymm22
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm24, %zmm22, %zmm25
+; AVX512BW-NEXT:    vmovdqa64 16(%rdx), %xmm24
+; AVX512BW-NEXT:    vmovdqu16 %zmm16, %zmm25 {%k1}
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm26[8],xmm20[8],xmm26[9],xmm20[9],xmm26[10],xmm20[10],xmm26[11],xmm20[11],xmm26[12],xmm20[12],xmm26[13],xmm20[13],xmm26[14],xmm20[14],xmm26[15],xmm20[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm16[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm16[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm22, %ymm20, %ymm20
+; AVX512BW-NEXT:    vmovdqa64 16(%rsi), %xmm22
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpermw %ymm16, %ymm9, %ymm16
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm16, %zmm20
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm27[8],xmm21[8],xmm27[9],xmm21[9],xmm27[10],xmm21[10],xmm27[11],xmm21[11],xmm27[12],xmm21[12],xmm27[13],xmm21[13],xmm27[14],xmm21[14],xmm27[15],xmm21[15]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm16 = xmm16[0],zero,zero,zero,xmm16[1],zero,zero,zero,xmm16[2],zero,zero,zero,xmm16[3],zero,zero,zero,xmm16[4],zero,zero,zero,xmm16[5],zero,zero,zero,xmm16[6],zero,zero,zero,xmm16[7],zero,zero,zero
 ; AVX512BW-NEXT:    vmovdqu16 %zmm20, %zmm16 {%k2}
-; AVX512BW-NEXT:    vmovdqa32 %zmm17, %zmm16 {%k3}
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm17 = xmm13[0],xmm12[0],xmm13[1],xmm12[1],xmm13[2],xmm12[2],xmm13[3],xmm12[3],xmm13[4],xmm12[4],xmm13[5],xmm12[5],xmm13[6],xmm12[6],xmm13[7],xmm12[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm17[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm17[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm20, %ymm20
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm17, %ymm3, %ymm17
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm17, %zmm17
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm26[0],xmm21[0],xmm26[1],xmm21[1],xmm26[2],xmm21[2],xmm26[3],xmm21[3],xmm26[4],xmm21[4],xmm26[5],xmm21[5],xmm26[6],xmm21[6],xmm26[7],xmm21[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm20[0,1,2,3,4,5,5,7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm27 = xmm20[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm27, %ymm23, %ymm23
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm23 = ymm23[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm20, %ymm6, %ymm20
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm23, %zmm20, %zmm20
-; AVX512BW-NEXT:    vmovdqu16 %zmm17, %zmm20 {%k1}
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm17 = xmm24[0],xmm19[0],xmm24[1],xmm19[1],xmm24[2],xmm19[2],xmm24[3],xmm19[3],xmm24[4],xmm19[4],xmm24[5],xmm19[5],xmm24[6],xmm19[6],xmm24[7],xmm19[7]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm23 = xmm17[0],zero,zero,zero,xmm17[1],zero,zero,zero,xmm17[2],zero,zero,zero,xmm17[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm17 = xmm17[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm17 = xmm17[0],zero,zero,zero,xmm17[1],zero,zero,zero,xmm17[2],zero,zero,zero,xmm17[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm17, %zmm23, %zmm17
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm23 = xmm25[0],xmm22[0],xmm25[1],xmm22[1],xmm25[2],xmm22[2],xmm25[3],xmm22[3],xmm25[4],xmm22[4],xmm25[5],xmm22[5],xmm25[6],xmm22[6],xmm25[7],xmm22[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm27 = xmm23[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm28 = xmm23[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm28, %ymm27, %ymm27
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm27 = ymm27[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpermw %ymm23, %ymm11, %ymm23
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm27, %zmm23, %zmm23
-; AVX512BW-NEXT:    vmovdqu16 %zmm23, %zmm17 {%k2}
-; AVX512BW-NEXT:    vmovdqa32 %zmm20, %zmm17 {%k3}
+; AVX512BW-NEXT:    vmovdqa32 %zmm25, %zmm16 {%k3}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm13[0],xmm12[0],xmm13[1],xmm12[1],xmm13[2],xmm12[2],xmm13[3],xmm12[3],xmm13[4],xmm12[4],xmm13[5],xmm12[5],xmm13[6],xmm12[6],xmm13[7],xmm12[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm20[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm20[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm21, %ymm21
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm21 = ymm21[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpermw %ymm20, %ymm2, %ymm20
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm21, %zmm20, %zmm20
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm21 = xmm23[0],xmm19[0],xmm23[1],xmm19[1],xmm23[2],xmm19[2],xmm23[3],xmm19[3],xmm23[4],xmm19[4],xmm23[5],xmm19[5],xmm23[6],xmm19[6],xmm23[7],xmm19[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm21[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm21[0,1,2,3,6,5,7,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm25, %ymm25
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpermw %ymm21, %ymm5, %ymm21
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm21, %zmm21
+; AVX512BW-NEXT:    vmovdqu16 %zmm20, %zmm21 {%k1}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm24[0],xmm17[0],xmm24[1],xmm17[1],xmm24[2],xmm17[2],xmm24[3],xmm17[3],xmm24[4],xmm17[4],xmm24[5],xmm17[5],xmm24[6],xmm17[6],xmm24[7],xmm17[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm20[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm20[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm25, %ymm25
+; AVX512BW-NEXT:    vmovdqa64 16(%rdi), %xmm26
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpermw %ymm20, %ymm9, %ymm20
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm20, %zmm25
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm26[0],xmm22[0],xmm26[1],xmm22[1],xmm26[2],xmm22[2],xmm26[3],xmm22[3],xmm26[4],xmm22[4],xmm26[5],xmm22[5],xmm26[6],xmm22[6],xmm26[7],xmm22[7]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm20 = xmm20[0],zero,zero,zero,xmm20[1],zero,zero,zero,xmm20[2],zero,zero,zero,xmm20[3],zero,zero,zero,xmm20[4],zero,zero,zero,xmm20[5],zero,zero,zero,xmm20[6],zero,zero,zero,xmm20[7],zero,zero,zero
+; AVX512BW-NEXT:    vmovdqu16 %zmm25, %zmm20 {%k2}
+; AVX512BW-NEXT:    vmovdqa32 %zmm21, %zmm20 {%k3}
 ; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm12 = xmm13[8],xmm12[8],xmm13[9],xmm12[9],xmm13[10],xmm12[10],xmm13[11],xmm12[11],xmm13[12],xmm12[12],xmm13[13],xmm12[13],xmm13[14],xmm12[14],xmm13[15],xmm12[15]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm12[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm12[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm20, %ymm13, %ymm13
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm12[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm13, %ymm13
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm13 = ymm13[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm12, %ymm3, %ymm12
+; AVX512BW-NEXT:    vpermw %ymm12, %ymm2, %ymm12
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm13, %zmm12, %zmm12
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm13 = xmm26[8],xmm21[8],xmm26[9],xmm21[9],xmm26[10],xmm21[10],xmm26[11],xmm21[11],xmm26[12],xmm21[12],xmm26[13],xmm21[13],xmm26[14],xmm21[14],xmm26[15],xmm21[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm13[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm13 = xmm23[8],xmm19[8],xmm23[9],xmm19[9],xmm23[10],xmm19[10],xmm23[11],xmm19[11],xmm23[12],xmm19[12],xmm23[13],xmm19[13],xmm23[14],xmm19[14],xmm23[15],xmm19[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm13[0,1,2,3,4,5,5,7]
 ; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm13[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm20, %ymm20
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vpermw %ymm13, %ymm6, %ymm13
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm13, %zmm13
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vpermw %ymm13, %ymm5, %ymm13
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm13, %zmm13
 ; AVX512BW-NEXT:    vmovdqu16 %zmm12, %zmm13 {%k1}
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm12 = xmm24[8],xmm19[8],xmm24[9],xmm19[9],xmm24[10],xmm19[10],xmm24[11],xmm19[11],xmm24[12],xmm19[12],xmm24[13],xmm19[13],xmm24[14],xmm19[14],xmm24[15],xmm19[15]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm19 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm12 = xmm12[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm12 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm12, %zmm19, %zmm12
-; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm19 = xmm25[8],xmm22[8],xmm25[9],xmm22[9],xmm25[10],xmm22[10],xmm25[11],xmm22[11],xmm25[12],xmm22[12],xmm25[13],xmm22[13],xmm25[14],xmm22[14],xmm25[15],xmm22[15]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm19[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm20, %ymm20
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vpermw %ymm19, %ymm11, %ymm19
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm19, %zmm19
-; AVX512BW-NEXT:    vmovdqu16 %zmm19, %zmm12 {%k2}
-; AVX512BW-NEXT:    vmovdqa32 %zmm13, %zmm12 {%k3}
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1],xmm2[2],xmm0[2],xmm2[3],xmm0[3],xmm2[4],xmm0[4],xmm2[5],xmm0[5],xmm2[6],xmm0[6],xmm2[7],xmm0[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm0[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm0[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti128 $1, %xmm13, %ymm2, %ymm2
-; AVX512BW-NEXT:    vpermw %ymm0, %ymm3, %ymm0
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm12 = xmm24[8],xmm17[8],xmm24[9],xmm17[9],xmm24[10],xmm17[10],xmm24[11],xmm17[11],xmm24[12],xmm17[12],xmm24[13],xmm17[13],xmm24[14],xmm17[14],xmm24[15],xmm17[15]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm17 = xmm12[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm12[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti32x4 $1, %xmm19, %ymm17, %ymm17
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[2,1,3,3,6,5,7,7]
+; AVX512BW-NEXT:    vpermw %ymm12, %ymm9, %ymm12
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm17, %zmm12, %zmm12
+; AVX512BW-NEXT:    vpunpckhbw {{.*#+}} xmm17 = xmm26[8],xmm22[8],xmm26[9],xmm22[9],xmm26[10],xmm22[10],xmm26[11],xmm22[11],xmm26[12],xmm22[12],xmm26[13],xmm22[13],xmm26[14],xmm22[14],xmm26[15],xmm22[15]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm17 = xmm17[0],zero,zero,zero,xmm17[1],zero,zero,zero,xmm17[2],zero,zero,zero,xmm17[3],zero,zero,zero,xmm17[4],zero,zero,zero,xmm17[5],zero,zero,zero,xmm17[6],zero,zero,zero,xmm17[7],zero,zero,zero
+; AVX512BW-NEXT:    vmovdqu16 %zmm12, %zmm17 {%k2}
+; AVX512BW-NEXT:    vmovdqa32 %zmm13, %zmm17 {%k3}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1],xmm1[2],xmm0[2],xmm1[3],xmm0[3],xmm1[4],xmm0[4],xmm1[5],xmm0[5],xmm1[6],xmm0[6],xmm1[7],xmm0[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm0[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm12 = xmm0[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti128 $1, %xmm12, %ymm1, %ymm1
+; AVX512BW-NEXT:    vpermw %ymm0, %ymm2, %ymm0
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm1 = ymm1[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm4[0],xmm3[0],xmm4[1],xmm3[1],xmm4[2],xmm3[2],xmm4[3],xmm3[3],xmm4[4],xmm3[4],xmm4[5],xmm3[5],xmm4[6],xmm3[6],xmm4[7],xmm3[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm1[0,1,2,3,4,5,5,7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,6,5,7,7]
+; AVX512BW-NEXT:    vinserti128 $1, %xmm3, %ymm2, %ymm2
+; AVX512BW-NEXT:    vpermw %ymm1, %ymm5, %ymm1
 ; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm2 = ymm2[0,2,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
+; AVX512BW-NEXT:    vmovdqu16 %zmm0, %zmm1 {%k1}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm8[0],xmm6[0],xmm8[1],xmm6[1],xmm8[2],xmm6[2],xmm8[3],xmm6[3],xmm8[4],xmm6[4],xmm8[5],xmm6[5],xmm8[6],xmm6[6],xmm8[7],xmm6[7]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm0[0,1,2,3,4,4,6,5]
+; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm0[0,1,2,3,4,6,6,7]
+; AVX512BW-NEXT:    vinserti128 $1, %xmm3, %ymm2, %ymm2
+; AVX512BW-NEXT:    vpermw %ymm0, %ymm9, %ymm0
+; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm2 = ymm2[2,1,3,3,6,5,7,7]
 ; AVX512BW-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm5[0],xmm4[0],xmm5[1],xmm4[1],xmm5[2],xmm4[2],xmm5[3],xmm4[3],xmm5[4],xmm4[4],xmm5[5],xmm4[5],xmm5[6],xmm4[6],xmm5[7],xmm4[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm2[0,1,2,3,4,5,5,7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm2[0,1,2,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
-; AVX512BW-NEXT:    vpermw %ymm2, %ymm6, %ymm2
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm3 = ymm3[0,2,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512BW-NEXT:    vmovdqu16 %zmm0, %zmm2 {%k1}
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm8[0],xmm7[0],xmm8[1],xmm7[1],xmm8[2],xmm7[2],xmm8[3],xmm7[3],xmm8[4],xmm7[4],xmm8[5],xmm7[5],xmm8[6],xmm7[6],xmm8[7],xmm7[7]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm3 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero
-; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm0 = xmm0[2,3,2,3]
-; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} ymm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm0, %zmm3, %zmm0
-; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm3 = xmm10[0],xmm9[0],xmm10[1],xmm9[1],xmm10[2],xmm9[2],xmm10[3],xmm9[3],xmm10[4],xmm9[4],xmm10[5],xmm9[5],xmm10[6],xmm9[6],xmm10[7],xmm9[7]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm3[0,1,2,3,4,4,6,5]
-; AVX512BW-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm3[0,1,2,3,4,6,6,7]
-; AVX512BW-NEXT:    vinserti128 $1, %xmm5, %ymm4, %ymm4
-; AVX512BW-NEXT:    vpermw %ymm3, %ymm11, %ymm3
-; AVX512BW-NEXT:    vpshufd {{.*#+}} ymm4 = ymm4[2,1,3,3,6,5,7,7]
-; AVX512BW-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
-; AVX512BW-NEXT:    vmovdqu16 %zmm3, %zmm0 {%k2}
-; AVX512BW-NEXT:    vmovdqa32 %zmm2, %zmm0 {%k3}
+; AVX512BW-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm11[0],xmm10[0],xmm11[1],xmm10[1],xmm11[2],xmm10[2],xmm11[3],xmm10[3],xmm11[4],xmm10[4],xmm11[5],xmm10[5],xmm11[6],xmm10[6],xmm11[7],xmm10[7]
+; AVX512BW-NEXT:    vpmovzxwq {{.*#+}} zmm2 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero,xmm2[4],zero,zero,zero,xmm2[5],zero,zero,zero,xmm2[6],zero,zero,zero,xmm2[7],zero,zero,zero
+; AVX512BW-NEXT:    vmovdqu16 %zmm0, %zmm2 {%k2}
+; AVX512BW-NEXT:    vmovdqa32 %zmm1, %zmm2 {%k3}
 ; AVX512BW-NEXT:    movq {{[0-9]+}}(%rsp), %rax
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rax)
-; AVX512BW-NEXT:    vmovdqa64 %zmm12, 192(%rax)
-; AVX512BW-NEXT:    vmovdqa64 %zmm17, 128(%rax)
+; AVX512BW-NEXT:    vmovdqa64 %zmm2, (%rax)
+; AVX512BW-NEXT:    vmovdqa64 %zmm17, 192(%rax)
+; AVX512BW-NEXT:    vmovdqa64 %zmm20, 128(%rax)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm16, 320(%rax)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm18, 256(%rax)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm15, 448(%rax)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm14, 384(%rax)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 64(%rax)
+; AVX512BW-NEXT:    vmovdqa64 %zmm7, 64(%rax)
 ; AVX512BW-NEXT:    vzeroupper
 ; AVX512BW-NEXT:    retq
 ;
@@ -8608,284 +8528,260 @@ define void @store_i8_stride8_vf64(ptr %in.vecptr0, ptr %in.vecptr1, ptr %in.vec
 ; AVX512DQ-BW-NEXT:    vmovdqa 16(%r10), %xmm12
 ; AVX512DQ-BW-NEXT:    vmovdqa64 32(%r10), %xmm16
 ; AVX512DQ-BW-NEXT:    vmovdqa 48(%r10), %xmm15
-; AVX512DQ-BW-NEXT:    vmovdqa (%rax), %xmm2
+; AVX512DQ-BW-NEXT:    vmovdqa (%rax), %xmm1
 ; AVX512DQ-BW-NEXT:    vmovdqa 16(%rax), %xmm13
 ; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rax), %xmm17
 ; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rax), %xmm18
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm2[8],xmm0[8],xmm2[9],xmm0[9],xmm2[10],xmm0[10],xmm2[11],xmm0[11],xmm2[12],xmm0[12],xmm2[13],xmm0[13],xmm2[14],xmm0[14],xmm2[15],xmm0[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm1[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm4 = ymm3[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpmovsxbw {{.*#+}} ymm3 = [0,0,0,0,4,5,2,1,0,2,0,2,4,5,2,3]
-; AVX512DQ-BW-NEXT:    vpermw %ymm1, %ymm3, %ymm1
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm4, %zmm1, %zmm1
-; AVX512DQ-BW-NEXT:    vmovdqa (%r9), %xmm4
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm3 = xmm1[8],xmm0[8],xmm1[9],xmm0[9],xmm1[10],xmm0[10],xmm1[11],xmm0[11],xmm1[12],xmm0[12],xmm1[13],xmm0[13],xmm1[14],xmm0[14],xmm1[15],xmm0[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm3[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm3[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm4, %ymm2, %ymm2
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm4 = ymm2[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpmovsxbw {{.*#+}} ymm2 = [0,0,0,0,4,5,2,1,0,2,0,2,4,5,2,3]
+; AVX512DQ-BW-NEXT:    vpermw %ymm3, %ymm2, %ymm3
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm6
+; AVX512DQ-BW-NEXT:    vmovdqa (%r9), %xmm3
 ; AVX512DQ-BW-NEXT:    vmovdqa64 48(%r9), %xmm19
-; AVX512DQ-BW-NEXT:    vmovdqa (%r8), %xmm5
-; AVX512DQ-BW-NEXT:    vmovdqa64 48(%r8), %xmm21
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm5[8],xmm4[8],xmm5[9],xmm4[9],xmm5[10],xmm4[10],xmm5[11],xmm4[11],xmm5[12],xmm4[12],xmm5[13],xmm4[13],xmm5[14],xmm4[14],xmm5[15],xmm4[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm6 = xmm7[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vmovdqa (%r8), %xmm4
+; AVX512DQ-BW-NEXT:    vmovdqa64 48(%r8), %xmm20
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm4[8],xmm3[8],xmm4[9],xmm3[9],xmm4[10],xmm3[10],xmm4[11],xmm3[11],xmm4[12],xmm3[12],xmm4[13],xmm3[13],xmm4[14],xmm3[14],xmm4[15],xmm3[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm7[0,1,2,3,4,5,5,7]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm8 = xmm7[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm8, %ymm6, %ymm6
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm8 = ymm6[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpmovsxbw {{.*#+}} ymm6 = [0,1,0,1,4,5,1,3,2,1,2,1,4,5,3,3]
-; AVX512DQ-BW-NEXT:    vpermw %ymm7, %ymm6, %ymm7
+; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm8, %ymm5, %ymm5
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm8 = ymm5[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpmovsxbw {{.*#+}} ymm5 = [0,1,0,1,4,5,1,3,2,1,2,1,4,5,3,3]
+; AVX512DQ-BW-NEXT:    vpermw %ymm7, %ymm5, %ymm7
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm8, %zmm7, %zmm14
 ; AVX512DQ-BW-NEXT:    movl $-2004318072, %eax # imm = 0x88888888
 ; AVX512DQ-BW-NEXT:    kmovd %eax, %k1
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm1, %zmm14 {%k1}
-; AVX512DQ-BW-NEXT:    vmovdqa (%rsi), %xmm7
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm6, %zmm14 {%k1}
+; AVX512DQ-BW-NEXT:    vmovdqa (%rcx), %xmm6
+; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rcx), %xmm21
+; AVX512DQ-BW-NEXT:    vmovdqa (%rdx), %xmm8
+; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rdx), %xmm23
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm8[8],xmm6[8],xmm8[9],xmm6[9],xmm8[10],xmm6[10],xmm8[11],xmm6[11],xmm8[12],xmm6[12],xmm8[13],xmm6[13],xmm8[14],xmm6[14],xmm8[15],xmm6[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm9 = xmm7[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm10 = xmm7[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm10, %ymm9, %ymm9
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm10 = ymm9[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpmovsxbw {{.*#+}} ymm9 = [0,0,2,1,2,1,6,7,0,2,2,3,2,3,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm7, %ymm9, %ymm7
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm10, %zmm7, %zmm22
+; AVX512DQ-BW-NEXT:    vmovdqa (%rsi), %xmm10
 ; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rsi), %xmm24
-; AVX512DQ-BW-NEXT:    vmovdqa (%rdi), %xmm8
-; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rdi), %xmm26
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm1 = xmm8[8],xmm7[8],xmm8[9],xmm7[9],xmm8[10],xmm7[10],xmm8[11],xmm7[11],xmm8[12],xmm7[12],xmm8[13],xmm7[13],xmm8[14],xmm7[14],xmm8[15],xmm7[15]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm9 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm1 = xmm1[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm1, %zmm9, %zmm1
-; AVX512DQ-BW-NEXT:    vmovdqa (%rcx), %xmm9
-; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rcx), %xmm28
-; AVX512DQ-BW-NEXT:    vmovdqa (%rdx), %xmm10
-; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rdx), %xmm30
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm20 = xmm10[8],xmm9[8],xmm10[9],xmm9[9],xmm10[10],xmm9[10],xmm10[11],xmm9[11],xmm10[12],xmm9[12],xmm10[13],xmm9[13],xmm10[14],xmm9[14],xmm10[15],xmm9[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm11 = xmm20[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm20[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm22, %ymm11, %ymm11
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm22 = ymm11[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpmovsxbw {{.*#+}} ymm11 = [0,0,2,1,2,1,6,7,0,2,2,3,2,3,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm11, %ymm20
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm20, %zmm20
+; AVX512DQ-BW-NEXT:    vmovdqa (%rdi), %xmm11
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm7 = xmm11[8],xmm10[8],xmm11[9],xmm10[9],xmm11[10],xmm10[10],xmm11[11],xmm10[11],xmm11[12],xmm10[12],xmm11[13],xmm10[13],xmm11[14],xmm10[14],xmm11[15],xmm10[15]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm7 = xmm7[0],zero,zero,zero,xmm7[1],zero,zero,zero,xmm7[2],zero,zero,zero,xmm7[3],zero,zero,zero,xmm7[4],zero,zero,zero,xmm7[5],zero,zero,zero,xmm7[6],zero,zero,zero,xmm7[7],zero,zero,zero
 ; AVX512DQ-BW-NEXT:    movl $572662306, %eax # imm = 0x22222222
 ; AVX512DQ-BW-NEXT:    kmovd %eax, %k2
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm20, %zmm1 {%k2}
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm22, %zmm7 {%k2}
 ; AVX512DQ-BW-NEXT:    movw $-21846, %ax # imm = 0xAAAA
 ; AVX512DQ-BW-NEXT:    kmovd %eax, %k3
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm14, %zmm1 {%k3}
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm14, %zmm7 {%k3}
 ; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm18[0],xmm15[0],xmm18[1],xmm15[1],xmm18[2],xmm15[2],xmm18[3],xmm15[3],xmm18[4],xmm15[4],xmm18[5],xmm15[5],xmm18[6],xmm15[6],xmm18[7],xmm15[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm14[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm14[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm22, %ymm20, %ymm20
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm14, %ymm3, %ymm14
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm14, %zmm14
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm21[0],xmm19[0],xmm21[1],xmm19[1],xmm21[2],xmm19[2],xmm21[3],xmm19[3],xmm21[4],xmm19[4],xmm21[5],xmm19[5],xmm21[6],xmm19[6],xmm21[7],xmm19[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm20[0,1,2,3,4,5,5,7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm20[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm22, %ymm22
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm14[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm14[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm22, %ymm22
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm22 = ymm22[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm6, %ymm20
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm20, %zmm23
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm14, %zmm23 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm26[0],xmm24[0],xmm26[1],xmm24[1],xmm26[2],xmm24[2],xmm26[3],xmm24[3],xmm26[4],xmm24[4],xmm26[5],xmm24[5],xmm26[6],xmm24[6],xmm26[7],xmm24[7]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm20 = xmm14[0],zero,zero,zero,xmm14[1],zero,zero,zero,xmm14[2],zero,zero,zero,xmm14[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm14 = xmm14[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm14 = xmm14[0],zero,zero,zero,xmm14[1],zero,zero,zero,xmm14[2],zero,zero,zero,xmm14[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm14, %zmm20, %zmm14
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm30[0],xmm28[0],xmm30[1],xmm28[1],xmm30[2],xmm28[2],xmm30[3],xmm28[3],xmm30[4],xmm28[4],xmm30[5],xmm28[5],xmm30[6],xmm28[6],xmm30[7],xmm28[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm20[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm20[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm22, %ymm25
+; AVX512DQ-BW-NEXT:    vpermw %ymm14, %ymm2, %ymm14
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm14, %zmm14
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm22 = xmm20[0],xmm19[0],xmm20[1],xmm19[1],xmm20[2],xmm19[2],xmm20[3],xmm19[3],xmm20[4],xmm19[4],xmm20[5],xmm19[5],xmm20[6],xmm19[6],xmm20[7],xmm19[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm22[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm22[0,1,2,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm25, %ymm25
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm22, %ymm5, %ymm22
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm22, %zmm25
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm14, %zmm25 {%k1}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm23[0],xmm21[0],xmm23[1],xmm21[1],xmm23[2],xmm21[2],xmm23[3],xmm21[3],xmm23[4],xmm21[4],xmm23[5],xmm21[5],xmm23[6],xmm21[6],xmm23[7],xmm21[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm14[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm14[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm22, %ymm22
+; AVX512DQ-BW-NEXT:    vmovdqa64 48(%rdi), %xmm27
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm22 = ymm22[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm14, %ymm9, %ymm14
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm22, %zmm14, %zmm22
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm14 = xmm27[0],xmm24[0],xmm27[1],xmm24[1],xmm27[2],xmm24[2],xmm27[3],xmm24[3],xmm27[4],xmm24[4],xmm27[5],xmm24[5],xmm27[6],xmm24[6],xmm27[7],xmm24[7]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm14 = xmm14[0],zero,zero,zero,xmm14[1],zero,zero,zero,xmm14[2],zero,zero,zero,xmm14[3],zero,zero,zero,xmm14[4],zero,zero,zero,xmm14[5],zero,zero,zero,xmm14[6],zero,zero,zero,xmm14[7],zero,zero,zero
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm22, %zmm14 {%k2}
 ; AVX512DQ-BW-NEXT:    vmovdqa64 32(%r9), %xmm22
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm11, %ymm20
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm20, %zmm20
-; AVX512DQ-BW-NEXT:    vmovdqa64 32(%r8), %xmm25
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm20, %zmm14 {%k2}
-; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rsi), %xmm20
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm23, %zmm14 {%k3}
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm25, %zmm14 {%k3}
 ; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm18[8],xmm15[8],xmm18[9],xmm15[9],xmm18[10],xmm15[10],xmm18[11],xmm15[11],xmm18[12],xmm15[12],xmm18[13],xmm15[13],xmm18[14],xmm15[14],xmm18[15],xmm15[15]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm18 = xmm15[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm15[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm18, %ymm18
-; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rdi), %xmm23
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm15[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm18, %ymm18
+; AVX512DQ-BW-NEXT:    vmovdqa64 32(%r8), %xmm25
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm18 = ymm18[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm15, %ymm3, %ymm15
+; AVX512DQ-BW-NEXT:    vpermw %ymm15, %ymm2, %ymm15
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm18, %zmm15, %zmm15
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm18 = xmm21[8],xmm19[8],xmm21[9],xmm19[9],xmm21[10],xmm19[10],xmm21[11],xmm19[11],xmm21[12],xmm19[12],xmm21[13],xmm19[13],xmm21[14],xmm19[14],xmm21[15],xmm19[15]
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm18 = xmm20[8],xmm19[8],xmm20[9],xmm19[9],xmm20[10],xmm19[10],xmm20[11],xmm19[11],xmm20[12],xmm19[12],xmm20[13],xmm19[13],xmm20[14],xmm19[14],xmm20[15],xmm19[15]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm18[0,1,2,3,4,5,5,7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm18[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
-; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rcx), %xmm27
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm18[0,1,2,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm20, %ymm19, %ymm19
+; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rcx), %xmm20
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm18, %ymm6, %ymm18
+; AVX512DQ-BW-NEXT:    vpermw %ymm18, %ymm5, %ymm18
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm18, %zmm18
-; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rdx), %xmm29
+; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rdx), %xmm26
 ; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm15, %zmm18 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm26[8],xmm24[8],xmm26[9],xmm24[9],xmm26[10],xmm24[10],xmm26[11],xmm24[11],xmm26[12],xmm24[12],xmm26[13],xmm24[13],xmm26[14],xmm24[14],xmm26[15],xmm24[15]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm19 = xmm15[0],zero,zero,zero,xmm15[1],zero,zero,zero,xmm15[2],zero,zero,zero,xmm15[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm15 = xmm15[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm15 = xmm15[0],zero,zero,zero,xmm15[1],zero,zero,zero,xmm15[2],zero,zero,zero,xmm15[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm15, %zmm19, %zmm15
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm19 = xmm30[8],xmm28[8],xmm30[9],xmm28[9],xmm30[10],xmm28[10],xmm30[11],xmm28[11],xmm30[12],xmm28[12],xmm30[13],xmm28[13],xmm30[14],xmm28[14],xmm30[15],xmm28[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm19[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm21, %ymm21
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm21 = ymm21[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm19, %ymm11, %ymm19
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm21, %zmm19, %zmm19
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm23[8],xmm21[8],xmm23[9],xmm21[9],xmm23[10],xmm21[10],xmm23[11],xmm21[11],xmm23[12],xmm21[12],xmm23[13],xmm21[13],xmm23[14],xmm21[14],xmm23[15],xmm21[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm15[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm15[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
+; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rsi), %xmm21
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm15, %ymm9, %ymm15
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm15, %zmm19
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm15 = xmm27[8],xmm24[8],xmm27[9],xmm24[9],xmm27[10],xmm24[10],xmm27[11],xmm24[11],xmm27[12],xmm24[12],xmm27[13],xmm24[13],xmm27[14],xmm24[14],xmm27[15],xmm24[15]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm15 = xmm15[0],zero,zero,zero,xmm15[1],zero,zero,zero,xmm15[2],zero,zero,zero,xmm15[3],zero,zero,zero,xmm15[4],zero,zero,zero,xmm15[5],zero,zero,zero,xmm15[6],zero,zero,zero,xmm15[7],zero,zero,zero
 ; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm19, %zmm15 {%k2}
 ; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm18, %zmm15 {%k3}
 ; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm17[0],xmm16[0],xmm17[1],xmm16[1],xmm17[2],xmm16[2],xmm17[3],xmm16[3],xmm17[4],xmm16[4],xmm17[5],xmm16[5],xmm17[6],xmm16[6],xmm17[7],xmm16[7]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm18[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm18[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm18[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm19, %ymm19
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm18, %ymm3, %ymm18
+; AVX512DQ-BW-NEXT:    vpermw %ymm18, %ymm2, %ymm18
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm18, %zmm18
 ; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm19 = xmm25[0],xmm22[0],xmm25[1],xmm22[1],xmm25[2],xmm22[2],xmm25[3],xmm22[3],xmm25[4],xmm22[4],xmm25[5],xmm22[5],xmm25[6],xmm22[6],xmm25[7],xmm22[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm19[0,1,2,3,4,5,5,7]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm19[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm21, %ymm21
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm21 = ymm21[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm19, %ymm6, %ymm19
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm21, %zmm19, %zmm24
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm18, %zmm24 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm23[0],xmm20[0],xmm23[1],xmm20[1],xmm23[2],xmm20[2],xmm23[3],xmm20[3],xmm23[4],xmm20[4],xmm23[5],xmm20[5],xmm23[6],xmm20[6],xmm23[7],xmm20[7]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm19 = xmm18[0],zero,zero,zero,xmm18[1],zero,zero,zero,xmm18[2],zero,zero,zero,xmm18[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm18 = xmm18[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm18 = xmm18[0],zero,zero,zero,xmm18[1],zero,zero,zero,xmm18[2],zero,zero,zero,xmm18[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm18, %zmm19, %zmm18
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm19 = xmm29[0],xmm27[0],xmm29[1],xmm27[1],xmm29[2],xmm27[2],xmm29[3],xmm27[3],xmm29[4],xmm27[4],xmm29[5],xmm27[5],xmm29[6],xmm27[6],xmm29[7],xmm27[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm19[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm21, %ymm26
-; AVX512DQ-BW-NEXT:    vmovdqa64 16(%r9), %xmm21
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm26 = ymm26[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm19, %ymm11, %ymm19
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm26, %zmm19, %zmm19
-; AVX512DQ-BW-NEXT:    vmovdqa64 16(%r8), %xmm26
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm23, %ymm23
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm23 = ymm23[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm19, %ymm5, %ymm19
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm23, %zmm19, %zmm23
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm18, %zmm23 {%k1}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm26[0],xmm20[0],xmm26[1],xmm20[1],xmm26[2],xmm20[2],xmm26[3],xmm20[3],xmm26[4],xmm20[4],xmm26[5],xmm20[5],xmm26[6],xmm20[6],xmm26[7],xmm20[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm18[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm18[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm19, %ymm19
+; AVX512DQ-BW-NEXT:    vmovdqa64 32(%rdi), %xmm27
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm18, %ymm9, %ymm18
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm18, %zmm19
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm18 = xmm27[0],xmm21[0],xmm27[1],xmm21[1],xmm27[2],xmm21[2],xmm27[3],xmm21[3],xmm27[4],xmm21[4],xmm27[5],xmm21[5],xmm27[6],xmm21[6],xmm27[7],xmm21[7]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm18 = xmm18[0],zero,zero,zero,xmm18[1],zero,zero,zero,xmm18[2],zero,zero,zero,xmm18[3],zero,zero,zero,xmm18[4],zero,zero,zero,xmm18[5],zero,zero,zero,xmm18[6],zero,zero,zero,xmm18[7],zero,zero,zero
 ; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm19, %zmm18 {%k2}
-; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rsi), %xmm19
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm24, %zmm18 {%k3}
+; AVX512DQ-BW-NEXT:    vmovdqa64 16(%r9), %xmm19
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm23, %zmm18 {%k3}
 ; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm17[8],xmm16[8],xmm17[9],xmm16[9],xmm17[10],xmm16[10],xmm17[11],xmm16[11],xmm17[12],xmm16[12],xmm17[13],xmm16[13],xmm17[14],xmm16[14],xmm17[15],xmm16[15]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm17 = xmm16[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm16[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm17, %ymm17
-; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rdi), %xmm24
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm16[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm17, %ymm17
+; AVX512DQ-BW-NEXT:    vmovdqa64 16(%r8), %xmm23
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm16, %ymm3, %ymm16
+; AVX512DQ-BW-NEXT:    vpermw %ymm16, %ymm2, %ymm16
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm17, %zmm16, %zmm16
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm17 = xmm25[8],xmm22[8],xmm25[9],xmm22[9],xmm25[10],xmm22[10],xmm25[11],xmm22[11],xmm25[12],xmm22[12],xmm25[13],xmm22[13],xmm25[14],xmm22[14],xmm25[15],xmm22[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm17[0,1,2,3,4,5,5,7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm17[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm22, %ymm25
-; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rcx), %xmm22
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm17, %ymm6, %ymm17
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm17, %zmm17
-; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rdx), %xmm25
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm16, %zmm17 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm23[8],xmm20[8],xmm23[9],xmm20[9],xmm23[10],xmm20[10],xmm23[11],xmm20[11],xmm23[12],xmm20[12],xmm23[13],xmm20[13],xmm23[14],xmm20[14],xmm23[15],xmm20[15]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm20 = xmm16[0],zero,zero,zero,xmm16[1],zero,zero,zero,xmm16[2],zero,zero,zero,xmm16[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm16 = xmm16[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm16 = xmm16[0],zero,zero,zero,xmm16[1],zero,zero,zero,xmm16[2],zero,zero,zero,xmm16[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm16, %zmm20, %zmm16
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm20 = xmm29[8],xmm27[8],xmm29[9],xmm27[9],xmm29[10],xmm27[10],xmm29[11],xmm27[11],xmm29[12],xmm27[12],xmm29[13],xmm27[13],xmm29[14],xmm27[14],xmm29[15],xmm27[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm20[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm27 = xmm20[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm27, %ymm23, %ymm23
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm23 = ymm23[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm11, %ymm20
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm23, %zmm20, %zmm20
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm22 = xmm25[8],xmm22[8],xmm25[9],xmm22[9],xmm25[10],xmm22[10],xmm25[11],xmm22[11],xmm25[12],xmm22[12],xmm25[13],xmm22[13],xmm25[14],xmm22[14],xmm25[15],xmm22[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm17 = xmm22[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm24 = xmm22[0,1,2,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm24, %ymm17, %ymm24
+; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rcx), %xmm17
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm24 = ymm24[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm22, %ymm5, %ymm22
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm24, %zmm22, %zmm25
+; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rdx), %xmm24
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm16, %zmm25 {%k1}
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm26[8],xmm20[8],xmm26[9],xmm20[9],xmm26[10],xmm20[10],xmm26[11],xmm20[11],xmm26[12],xmm20[12],xmm26[13],xmm20[13],xmm26[14],xmm20[14],xmm26[15],xmm20[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm16[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm22 = xmm16[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm22, %ymm20, %ymm20
+; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rsi), %xmm22
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm16, %ymm9, %ymm16
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm16, %zmm20
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm16 = xmm27[8],xmm21[8],xmm27[9],xmm21[9],xmm27[10],xmm21[10],xmm27[11],xmm21[11],xmm27[12],xmm21[12],xmm27[13],xmm21[13],xmm27[14],xmm21[14],xmm27[15],xmm21[15]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm16 = xmm16[0],zero,zero,zero,xmm16[1],zero,zero,zero,xmm16[2],zero,zero,zero,xmm16[3],zero,zero,zero,xmm16[4],zero,zero,zero,xmm16[5],zero,zero,zero,xmm16[6],zero,zero,zero,xmm16[7],zero,zero,zero
 ; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm20, %zmm16 {%k2}
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm17, %zmm16 {%k3}
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm17 = xmm13[0],xmm12[0],xmm13[1],xmm12[1],xmm13[2],xmm12[2],xmm13[3],xmm12[3],xmm13[4],xmm12[4],xmm13[5],xmm12[5],xmm13[6],xmm12[6],xmm13[7],xmm12[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm17[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm17[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm23, %ymm20, %ymm20
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm17, %ymm3, %ymm17
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm17, %zmm17
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm26[0],xmm21[0],xmm26[1],xmm21[1],xmm26[2],xmm21[2],xmm26[3],xmm21[3],xmm26[4],xmm21[4],xmm26[5],xmm21[5],xmm26[6],xmm21[6],xmm26[7],xmm21[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm23 = xmm20[0,1,2,3,4,5,5,7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm27 = xmm20[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm27, %ymm23, %ymm23
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm23 = ymm23[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm6, %ymm20
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm23, %zmm20, %zmm20
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm17, %zmm20 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm17 = xmm24[0],xmm19[0],xmm24[1],xmm19[1],xmm24[2],xmm19[2],xmm24[3],xmm19[3],xmm24[4],xmm19[4],xmm24[5],xmm19[5],xmm24[6],xmm19[6],xmm24[7],xmm19[7]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm23 = xmm17[0],zero,zero,zero,xmm17[1],zero,zero,zero,xmm17[2],zero,zero,zero,xmm17[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm17 = xmm17[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm17 = xmm17[0],zero,zero,zero,xmm17[1],zero,zero,zero,xmm17[2],zero,zero,zero,xmm17[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm17, %zmm23, %zmm17
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm23 = xmm25[0],xmm22[0],xmm25[1],xmm22[1],xmm25[2],xmm22[2],xmm25[3],xmm22[3],xmm25[4],xmm22[4],xmm25[5],xmm22[5],xmm25[6],xmm22[6],xmm25[7],xmm22[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm27 = xmm23[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm28 = xmm23[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm28, %ymm27, %ymm27
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm27 = ymm27[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm23, %ymm11, %ymm23
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm27, %zmm23, %zmm23
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm23, %zmm17 {%k2}
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm20, %zmm17 {%k3}
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm25, %zmm16 {%k3}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm13[0],xmm12[0],xmm13[1],xmm12[1],xmm13[2],xmm12[2],xmm13[3],xmm12[3],xmm13[4],xmm12[4],xmm13[5],xmm12[5],xmm13[6],xmm12[6],xmm13[7],xmm12[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm20[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm20[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm25, %ymm21, %ymm21
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm21 = ymm21[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm2, %ymm20
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm21, %zmm20, %zmm20
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm21 = xmm23[0],xmm19[0],xmm23[1],xmm19[1],xmm23[2],xmm19[2],xmm23[3],xmm19[3],xmm23[4],xmm19[4],xmm23[5],xmm19[5],xmm23[6],xmm19[6],xmm23[7],xmm19[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm21[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm21[0,1,2,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm25, %ymm25
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm21, %ymm5, %ymm21
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm21, %zmm21
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm20, %zmm21 {%k1}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm24[0],xmm17[0],xmm24[1],xmm17[1],xmm24[2],xmm17[2],xmm24[3],xmm17[3],xmm24[4],xmm17[4],xmm24[5],xmm17[5],xmm24[6],xmm17[6],xmm24[7],xmm17[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm25 = xmm20[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm26 = xmm20[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm26, %ymm25, %ymm25
+; AVX512DQ-BW-NEXT:    vmovdqa64 16(%rdi), %xmm26
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm25 = ymm25[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm20, %ymm9, %ymm20
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm25, %zmm20, %zmm25
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm20 = xmm26[0],xmm22[0],xmm26[1],xmm22[1],xmm26[2],xmm22[2],xmm26[3],xmm22[3],xmm26[4],xmm22[4],xmm26[5],xmm22[5],xmm26[6],xmm22[6],xmm26[7],xmm22[7]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm20 = xmm20[0],zero,zero,zero,xmm20[1],zero,zero,zero,xmm20[2],zero,zero,zero,xmm20[3],zero,zero,zero,xmm20[4],zero,zero,zero,xmm20[5],zero,zero,zero,xmm20[6],zero,zero,zero,xmm20[7],zero,zero,zero
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm25, %zmm20 {%k2}
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm21, %zmm20 {%k3}
 ; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm12 = xmm13[8],xmm12[8],xmm13[9],xmm12[9],xmm13[10],xmm12[10],xmm13[11],xmm12[11],xmm13[12],xmm12[12],xmm13[13],xmm12[13],xmm13[14],xmm12[14],xmm13[15],xmm12[15]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm12[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm12[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm20, %ymm13, %ymm13
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm12[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm13, %ymm13
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm13 = ymm13[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm12, %ymm3, %ymm12
+; AVX512DQ-BW-NEXT:    vpermw %ymm12, %ymm2, %ymm12
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm13, %zmm12, %zmm12
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm13 = xmm26[8],xmm21[8],xmm26[9],xmm21[9],xmm26[10],xmm21[10],xmm26[11],xmm21[11],xmm26[12],xmm21[12],xmm26[13],xmm21[13],xmm26[14],xmm21[14],xmm26[15],xmm21[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm13[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm13 = xmm23[8],xmm19[8],xmm23[9],xmm19[9],xmm23[10],xmm19[10],xmm23[11],xmm19[11],xmm23[12],xmm19[12],xmm23[13],xmm19[13],xmm23[14],xmm19[14],xmm23[15],xmm19[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm13[0,1,2,3,4,5,5,7]
 ; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm13[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm20, %ymm20
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm13, %ymm6, %ymm13
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm13, %zmm13
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm19, %ymm19
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm19 = ymm19[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm13, %ymm5, %ymm13
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm19, %zmm13, %zmm13
 ; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm12, %zmm13 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm12 = xmm24[8],xmm19[8],xmm24[9],xmm19[9],xmm24[10],xmm19[10],xmm24[11],xmm19[11],xmm24[12],xmm19[12],xmm24[13],xmm19[13],xmm24[14],xmm19[14],xmm24[15],xmm19[15]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm19 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm12 = xmm12[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm12 = xmm12[0],zero,zero,zero,xmm12[1],zero,zero,zero,xmm12[2],zero,zero,zero,xmm12[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm12, %zmm19, %zmm12
-; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm19 = xmm25[8],xmm22[8],xmm25[9],xmm22[9],xmm25[10],xmm22[10],xmm25[11],xmm22[11],xmm25[12],xmm22[12],xmm25[13],xmm22[13],xmm25[14],xmm22[14],xmm25[15],xmm22[15]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm20 = xmm19[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm21 = xmm19[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm21, %ymm20, %ymm20
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm20 = ymm20[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vpermw %ymm19, %ymm11, %ymm19
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm20, %zmm19, %zmm19
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm19, %zmm12 {%k2}
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm13, %zmm12 {%k3}
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1],xmm2[2],xmm0[2],xmm2[3],xmm0[3],xmm2[4],xmm0[4],xmm2[5],xmm0[5],xmm2[6],xmm0[6],xmm2[7],xmm0[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm0[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm13 = xmm0[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm13, %ymm2, %ymm2
-; AVX512DQ-BW-NEXT:    vpermw %ymm0, %ymm3, %ymm0
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm12 = xmm24[8],xmm17[8],xmm24[9],xmm17[9],xmm24[10],xmm17[10],xmm24[11],xmm17[11],xmm24[12],xmm17[12],xmm24[13],xmm17[13],xmm24[14],xmm17[14],xmm24[15],xmm17[15]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm17 = xmm12[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm19 = xmm12[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti32x4 $1, %xmm19, %ymm17, %ymm17
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm17 = ymm17[2,1,3,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vpermw %ymm12, %ymm9, %ymm12
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm17, %zmm12, %zmm12
+; AVX512DQ-BW-NEXT:    vpunpckhbw {{.*#+}} xmm17 = xmm26[8],xmm22[8],xmm26[9],xmm22[9],xmm26[10],xmm22[10],xmm26[11],xmm22[11],xmm26[12],xmm22[12],xmm26[13],xmm22[13],xmm26[14],xmm22[14],xmm26[15],xmm22[15]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm17 = xmm17[0],zero,zero,zero,xmm17[1],zero,zero,zero,xmm17[2],zero,zero,zero,xmm17[3],zero,zero,zero,xmm17[4],zero,zero,zero,xmm17[5],zero,zero,zero,xmm17[6],zero,zero,zero,xmm17[7],zero,zero,zero
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm12, %zmm17 {%k2}
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm13, %zmm17 {%k3}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1],xmm1[2],xmm0[2],xmm1[3],xmm0[3],xmm1[4],xmm0[4],xmm1[5],xmm0[5],xmm1[6],xmm0[6],xmm1[7],xmm0[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm1 = xmm0[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm12 = xmm0[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm12, %ymm1, %ymm1
+; AVX512DQ-BW-NEXT:    vpermw %ymm0, %ymm2, %ymm0
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm1 = ymm1[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm1, %zmm0, %zmm0
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm1 = xmm4[0],xmm3[0],xmm4[1],xmm3[1],xmm4[2],xmm3[2],xmm4[3],xmm3[3],xmm4[4],xmm3[4],xmm4[5],xmm3[5],xmm4[6],xmm3[6],xmm4[7],xmm3[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm1[0,1,2,3,4,5,5,7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm1[0,1,2,3,6,5,7,7]
+; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm3, %ymm2, %ymm2
+; AVX512DQ-BW-NEXT:    vpermw %ymm1, %ymm5, %ymm1
 ; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm2 = ymm2[0,2,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm2, %zmm1, %zmm1
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm0, %zmm1 {%k1}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm8[0],xmm6[0],xmm8[1],xmm6[1],xmm8[2],xmm6[2],xmm8[3],xmm6[3],xmm8[4],xmm6[4],xmm8[5],xmm6[5],xmm8[6],xmm6[6],xmm8[7],xmm6[7]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm2 = xmm0[0,1,2,3,4,4,6,5]
+; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm0[0,1,2,3,4,6,6,7]
+; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm3, %ymm2, %ymm2
+; AVX512DQ-BW-NEXT:    vpermw %ymm0, %ymm9, %ymm0
+; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm2 = ymm2[2,1,3,3,6,5,7,7]
 ; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm2, %zmm0, %zmm0
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm5[0],xmm4[0],xmm5[1],xmm4[1],xmm5[2],xmm4[2],xmm5[3],xmm4[3],xmm5[4],xmm4[4],xmm5[5],xmm4[5],xmm5[6],xmm4[6],xmm5[7],xmm4[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm3 = xmm2[0,1,2,3,4,5,5,7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm2[0,1,2,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm4, %ymm3, %ymm3
-; AVX512DQ-BW-NEXT:    vpermw %ymm2, %ymm6, %ymm2
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm3 = ymm3[0,2,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm3, %zmm2, %zmm2
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm0, %zmm2 {%k1}
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm0 = xmm8[0],xmm7[0],xmm8[1],xmm7[1],xmm8[2],xmm7[2],xmm8[3],xmm7[3],xmm8[4],xmm7[4],xmm8[5],xmm7[5],xmm8[6],xmm7[6],xmm8[7],xmm7[7]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm3 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} xmm0 = xmm0[2,3,2,3]
-; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} ymm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm0, %zmm3, %zmm0
-; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm3 = xmm10[0],xmm9[0],xmm10[1],xmm9[1],xmm10[2],xmm9[2],xmm10[3],xmm9[3],xmm10[4],xmm9[4],xmm10[5],xmm9[5],xmm10[6],xmm9[6],xmm10[7],xmm9[7]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm4 = xmm3[0,1,2,3,4,4,6,5]
-; AVX512DQ-BW-NEXT:    vpshufhw {{.*#+}} xmm5 = xmm3[0,1,2,3,4,6,6,7]
-; AVX512DQ-BW-NEXT:    vinserti128 $1, %xmm5, %ymm4, %ymm4
-; AVX512DQ-BW-NEXT:    vpermw %ymm3, %ymm11, %ymm3
-; AVX512DQ-BW-NEXT:    vpshufd {{.*#+}} ymm4 = ymm4[2,1,3,3,6,5,7,7]
-; AVX512DQ-BW-NEXT:    vinserti64x4 $1, %ymm4, %zmm3, %zmm3
-; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm3, %zmm0 {%k2}
-; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm2, %zmm0 {%k3}
+; AVX512DQ-BW-NEXT:    vpunpcklbw {{.*#+}} xmm2 = xmm11[0],xmm10[0],xmm11[1],xmm10[1],xmm11[2],xmm10[2],xmm11[3],xmm10[3],xmm11[4],xmm10[4],xmm11[5],xmm10[5],xmm11[6],xmm10[6],xmm11[7],xmm10[7]
+; AVX512DQ-BW-NEXT:    vpmovzxwq {{.*#+}} zmm2 = xmm2[0],zero,zero,zero,xmm2[1],zero,zero,zero,xmm2[2],zero,zero,zero,xmm2[3],zero,zero,zero,xmm2[4],zero,zero,zero,xmm2[5],zero,zero,zero,xmm2[6],zero,zero,zero,xmm2[7],zero,zero,zero
+; AVX512DQ-BW-NEXT:    vmovdqu16 %zmm0, %zmm2 {%k2}
+; AVX512DQ-BW-NEXT:    vmovdqa32 %zmm1, %zmm2 {%k3}
 ; AVX512DQ-BW-NEXT:    movq {{[0-9]+}}(%rsp), %rax
-; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm0, (%rax)
-; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm12, 192(%rax)
-; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm17, 128(%rax)
+; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm2, (%rax)
+; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm17, 192(%rax)
+; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm20, 128(%rax)
 ; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm16, 320(%rax)
 ; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm18, 256(%rax)
 ; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm15, 448(%rax)
 ; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm14, 384(%rax)
-; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm1, 64(%rax)
+; AVX512DQ-BW-NEXT:    vmovdqa64 %zmm7, 64(%rax)
 ; AVX512DQ-BW-NEXT:    vzeroupper
 ; AVX512DQ-BW-NEXT:    retq
 ;


### PR DESCRIPTION
Support extension to 512-bit vectors on AVX512/BWI targets.