### PR TITLE
[libclc] Suppress data-layout warnings during linking

### DIFF
--- a/libclc/amdgcn/lib/cl_khr_int64_extended_atomics/minmax_helpers.ll
+++ b/libclc/amdgcn/lib/cl_khr_int64_extended_atomics/minmax_helpers.ll
@@ -1,9 +1,3 @@
-#if __clang_major__ >= 7
-target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5"
-#else
-target datalayout = "e-p:32:32-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
-#endif
-
 define i64 @__clc__sync_fetch_and_min_global_8(i64 addrspace(1)* nocapture %ptr, i64 %value) nounwind alwaysinline {
 entry:
   %0 = atomicrmw volatile min i64 addrspace(1)* %ptr, i64 %value seq_cst

--- a/libclc/r600/lib/image/get_image_attributes_impl.ll
+++ b/libclc/r600/lib/image/get_image_attributes_impl.ll
@@ -1,5 +1,3 @@
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
-
 %opencl.image2d_t = type opaque
 %opencl.image3d_t = type opaque
 

--- a/libclc/r600/lib/image/read_image_impl.ll
+++ b/libclc/r600/lib/image/read_image_impl.ll
@@ -1,5 +1,3 @@
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
-
 %opencl.image2d_t = type opaque
 
 declare <4 x float> @llvm.R600.tex(<4 x float>, i32, i32, i32, i32, i32, i32,

--- a/libclc/r600/lib/image/write_image_impl.ll
+++ b/libclc/r600/lib/image/write_image_impl.ll
@@ -1,5 +1,3 @@
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
-
 %opencl.image2d_t = type opaque
 %opencl.image3d_t = type opaque
 


### PR DESCRIPTION
libclc uses llvm-link to link together all of the individually built
libclc builtins files into one module. Some of these builtins files are
compiled from source by clang whilst others are converted from LLVM IR
directly to bytecode.

When llvm-link links a 'source' module into a 'destination' module, it
warns if the two modules have differing data layouts.

The LLVM IR files libclc links either have no data layout (shared
submodule files) or an explicit data layout in the case of certain
amdgcn/r600 files.

The warnings are very noisy and largely inconsequential. We can suppress
them exploiting a specific behaviours exhibited by llvm-link. When the
destination module has no data layout, it is given the source module's
data layout. Thus, if we link together all IR files first, followed by
the clang-compiled modules, 99% of the warnings are suppressed as they
arose from linking an empty data layout into a non-empty one.

The remaining warnings came from the amdgcn and r600 targets. Some of
these were because the data layouts were out of date compared with what
clang currently produced, so those could have been updated.

However, even with those changes and by grouping the IR files together,
the linker may still link explicit data layouts with empty ones
depending on the order the IR files are processed.

As it happens, the data layouts aren't essential. With the changes to
the link line we can rely on those IR files receiving the correct data
layout from the clang-compiled modules later in the link line. This also
makes the previously AMDGPU-specific IR files available to be used by
all targets in a generic capacity in the future.