### PR TITLE
[mlir][bazel] Port https://github.com/llvm/llvm-project/commit/517800e37e8d3a4ee84214bef65e227612c2a98b

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
@@ -13,8 +13,6 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineExprVisitor.h"
 #include "mlir/IR/AffineMap.h"

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -10,7 +10,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -7763,7 +7763,6 @@ td_library(
     name = "TensorOpsTdFiles",
     srcs = [
         "include/mlir/Dialect/Tensor/IR/TensorBase.td",
-        "include/mlir/Dialect/Tensor/IR/TensorInterfaces.td",
         "include/mlir/Dialect/Tensor/IR/TensorOps.td",
     ],
     includes = ["include"],
@@ -7813,23 +7812,6 @@ gentbl_cc_library(
     deps = [":TensorOpsTdFiles"],
 )
 
-gentbl_cc_library(
-    name = "TensorInterfacesIncGen",
-    tbl_outs = [
-        (
-            ["--gen-op-interface-decls"],
-            "include/mlir/Dialect/Tensor/IR/TensorInterfaces.h.inc",
-        ),
-        (
-            ["--gen-op-interface-defs"],
-            "include/mlir/Dialect/Tensor/IR/TensorInterfaces.cpp.inc",
-        ),
-    ],
-    tblgen = ":mlir-tblgen",
-    td_file = "include/mlir/Dialect/Tensor/IR/TensorInterfaces.td",
-    deps = [":TensorOpsTdFiles"],
-)
-
 cc_library(
     name = "TensorDialect",
     srcs = [
@@ -7859,13 +7841,13 @@ cc_library(
         ":InferIntRangeInterface",
         ":InferTypeOpInterface",
         ":InliningUtils",
+        ":LinalgInterfaces",
         ":LoopLikeInterface",
         ":ParallelCombiningOpInterface",
         ":ShapedOpInterfaces",
         ":SideEffectInterfaces",
         ":SubsetOpInterface",
         ":Support",
-        ":TensorInterfacesIncGen",
         ":TensorOpsIncGen",
         ":TilingInterface",
         ":TransformDialectInterfaces",
@@ -11207,6 +11189,23 @@ gentbl_cc_library(
 )
 
 gentbl_cc_library(
+    name = "LinalgRelayoutOpsIncGen",
+    tbl_outs = [
+        (
+            ["-gen-op-decls"],
+            "include/mlir/Dialect/Linalg/IR/LinalgRelayoutOps.h.inc",
+        ),
+        (
+            ["-gen-op-defs"],
+            "include/mlir/Dialect/Linalg/IR/LinalgRelayoutOps.cpp.inc",
+        ),
+    ],
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/Linalg/IR/LinalgRelayoutOps.td",
+    deps = [":LinalgOpsTdFiles"],
+)
+
+gentbl_cc_library(
     name = "LinalgEnumsIncGen",
     tbl_outs = [
         (
@@ -11533,9 +11532,49 @@ cc_library(
 )
 
 cc_library(
+    name = "LinalgInterfaces",
+    srcs = [
+        "include/mlir/Dialect/Linalg/IR/Linalg.h",
+        "lib/Dialect/Linalg/IR/LinalgInterfaces.cpp",
+    ],
+    hdrs = ["include/mlir/Dialect/Linalg/IR/LinalgInterfaces.h"],
+    includes = ["include"],
+    deps = [
+        ":AffineDialect",
+        ":ArithDialect",
+        ":ArithUtils",
+        ":BytecodeOpInterface",
+        ":ComplexDialect",
+        ":ControlFlowInterfaces",
+        ":CopyOpInterface",
+        ":DestinationStyleOpInterface",
+        ":DialectUtils",
+        ":IR",
+        ":InferTypeOpInterface",
+        ":LinalgEnumsIncGen",
+        ":LinalgInterfacesIncGen",
+        ":LinalgOpsIncGen",
+        ":LinalgRelayoutOpsIncGen",
+        ":LinalgStructuredOpsIncGen",
+        ":SideEffectInterfaces",
+        ":Support",
+        ":TilingInterface",
+        ":ViewLikeInterface",
+        "//third_party/llvm/llvm-project/llvm:Support",
+    ],
+)
+
+cc_library(
     name = "LinalgDialect",
-    srcs = glob(["lib/Dialect/Linalg/IR/*.cpp"]),
-    hdrs = glob(["include/mlir/Dialect/Linalg/IR/*.h"]),
+    srcs = [
+        "lib/Dialect/Linalg/IR/LinalgDialect.cpp",
+        "lib/Dialect/Linalg/IR/LinalgOps.cpp",
+        "lib/Dialect/Linalg/IR/ValueBoundsOpInterfaceImpl.cpp",
+    ],
+    hdrs = [
+        "include/mlir/Dialect/Linalg/IR/Linalg.h",
+        "include/mlir/Dialect/Linalg/IR/ValueBoundsOpInterfaceImpl.h",
+    ],
     includes = ["include"],
     deps = [
         ":AffineDialect",
@@ -11554,9 +11593,10 @@ cc_library(
         ":InferTypeOpInterface",
         ":InliningUtils",
         ":LinalgEnumsIncGen",
-        ":LinalgInterfacesIncGen",
+        ":LinalgInterfaces",
         ":LinalgNamedStructuredOpsYamlIncGen",
         ":LinalgOpsIncGen",
+        ":LinalgRelayoutOpsIncGen",
         ":LinalgStructuredOpsIncGen",
         ":MathDialect",
         ":MemRefDialect",
@@ -11568,6 +11608,7 @@ cc_library(
         ":SubsetOpInterface",
         ":Support",
         ":TensorDialect",
+        ":TensorUtils",
         ":TilingInterface",
         ":ValueBoundsOpInterface",
         ":ViewLikeInterface",
@@ -11599,6 +11640,7 @@ cc_library(
         ":IR",
         ":IndexDialect",
         ":LinalgDialect",
+        ":LinalgInterfaces",
         ":LinalgMatchOpsIncGen",
         ":LinalgTransformEnumsIncGen",
         ":LinalgTransformOpsIncGen",
@@ -11710,6 +11752,7 @@ cc_library(
         ":IR",
         ":IndexDialect",
         ":LinalgDialect",
+        ":LinalgInterfaces",
         ":LinalgPassIncGen",
         ":LinalgStructuredOpsIncGen",
         ":LinalgUtils",

--- a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
@@ -425,6 +425,7 @@ cc_library(
         "//mlir:LLVMDialect",
         "//mlir:LLVMIRToLLVMTranslation",
         "//mlir:LinalgDialect",
+        "//mlir:LinalgInterfaces",
         "//mlir:LoopLikeInterface",
         "//mlir:MemorySlotInterfaces",
         "//mlir:Pass",


### PR DESCRIPTION
Introduces a `LinalgInterfaces` target so that `TensorDialect` doesn't need to depend on `LinalgDialect`, which would introduce a circular dependency.