### PR TITLE
[clang][Sema] Combine fallout warnings to just one warning

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -713,12 +713,8 @@ def err_thread_non_global : Error<
 def err_thread_unsupported : Error<
   "thread-local storage is not supported for the current target">;
 
-// FIXME: Combine fallout warnings to just one warning.
-def warn_maybe_falloff_nonvoid_function : Warning<
-  "non-void function does not return a value in all control paths">,
-  InGroup<ReturnType>;
 def warn_falloff_nonvoid_function : Warning<
-  "non-void function does not return a value">,
+  "non-void function does not return a value%select{| in all control paths}0">,
   InGroup<ReturnType>;
 def warn_const_attr_with_pure_attr : Warning<
   "'const' attribute imposes more restrictions; 'pure' attribute ignored">,
@@ -727,15 +723,10 @@ def warn_pure_function_returns_void : Warning<
   "'%select{pure|const}0' attribute on function returning 'void'; attribute ignored">,
   InGroup<IgnoredAttributes>;
 
-def err_maybe_falloff_nonvoid_block : Error<
-  "non-void block does not return a value in all control paths">;
 def err_falloff_nonvoid_block : Error<
-  "non-void block does not return a value">;
-def warn_maybe_falloff_nonvoid_coroutine : Warning<
-  "non-void coroutine does not return a value in all control paths">,
-  InGroup<ReturnType>;
+  "non-void block does not return a value%select{| in all control paths}0">;
 def warn_falloff_nonvoid_coroutine : Warning<
-  "non-void coroutine does not return a value">,
+  "non-void coroutine does not return a value%select{| in all control paths}0">,
   InGroup<ReturnType>;
 def warn_suggest_noreturn_function : Warning<
   "%select{function|method}0 %1 could be declared with attribute 'noreturn'">,
@@ -8408,11 +8399,8 @@ let CategoryName = "Lambda Issue" in {
     "incomplete result type %0 in lambda expression">;
   def err_noreturn_lambda_has_return_expr : Error<
     "lambda declared 'noreturn' should not return">;
-  def warn_maybe_falloff_nonvoid_lambda : Warning<
-    "non-void lambda does not return a value in all control paths">,
-    InGroup<ReturnType>;
   def warn_falloff_nonvoid_lambda : Warning<
-    "non-void lambda does not return a value">,
+    "non-void lambda does not return a value%select{| in all control paths}0">,
     InGroup<ReturnType>;
   def err_access_lambda_capture : Error<
     // The ERRORs represent other special members that aren't constructors, in

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8396,8 +8396,6 @@ let CategoryName = "Lambda Issue" in {
     "lambda expression in default argument cannot capture any entity">;
   def err_lambda_incomplete_result : Error<
     "incomplete result type %0 in lambda expression">;
-  def err_noreturn_lambda_has_return_expr : Error<
-    "lambda declared 'noreturn' should not return">;
   def err_access_lambda_capture : Error<
     // The ERRORs represent other special members that aren't constructors, in
     // hopes that someone will bother noticing and reporting if they appear
@@ -10587,14 +10585,16 @@ def err_ctor_dtor_returns_void : Error<
 def warn_noreturn_function_has_return_expr : Warning<
   "function %0 declared 'noreturn' should not return">,
   InGroup<InvalidNoreturn>;
-def warn_falloff_noreturn_function : Warning<
-  "function declared 'noreturn' should not return">,
+def warn_noreturn_has_return_expr : Warning<
+  "%select{function|block|lambda|coroutine}0 "
+  "declared 'noreturn' should not return">,
   InGroup<InvalidNoreturn>;
+def err_noreturn_has_return_expr : Error<
+  "%select{function|block|lambda|coroutine}0 "
+  "declared 'noreturn' should not return">;
 def warn_noreturn_coroutine : Warning<
   "coroutine %0 cannot be declared 'noreturn' as it always returns a coroutine handle">,
   InGroup<InvalidNoreturn>;
-def err_noreturn_block_has_return_expr : Error<
-  "block declared 'noreturn' should not return">;
 def err_carries_dependency_missing_on_first_decl : Error<
   "%select{function|parameter}0 declared '[[carries_dependency]]' "
   "after its first declaration">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -714,8 +714,9 @@ def err_thread_unsupported : Error<
   "thread-local storage is not supported for the current target">;
 
 def warn_falloff_nonvoid : Warning<
-  "non-void %select{function|block|lambda|coroutine}0 "
-  "does not return a value%select{| in all control paths}1">,
+  "non-void "
+  "%enum_select<FunModes>{%Function{function}|%Block{block}|%Lambda{lambda}|%Coroutine{coroutine}}0"
+  " does not return a value%select{| in all control paths}1">,
   InGroup<ReturnType>;
 def err_falloff_nonvoid : Error<
   "non-void %select{function|block|lambda|coroutine}0 "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -717,10 +717,9 @@ def warn_falloff_nonvoid : Warning<
   "non-void %select{function|block|lambda|coroutine}0 "
   "does not return a value%select{| in all control paths}1">,
   InGroup<ReturnType>;
-def err_falloff_nonvoid : Warning<
+def err_falloff_nonvoid : Error<
   "non-void %select{function|block|lambda|coroutine}0 "
-  "does not return a value%select{| in all control paths}1">,
-  InGroup<ReturnType>;
+  "does not return a value%select{| in all control paths}1">;
 def warn_const_attr_with_pure_attr : Warning<
   "'const' attribute imposes more restrictions; 'pure' attribute ignored">,
   InGroup<IgnoredAttributes>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -715,7 +715,7 @@ def err_thread_unsupported : Error<
 
 def warn_falloff_nonvoid : Warning<
   "non-void "
-  "%enum_select<FunModes>{%Function{function}|%Block{block}|%Lambda{lambda}|%Coroutine{coroutine}}0"
+  "%enum_select<FalloffFunctionKind>{%Function{function}|%Block{block}|%Lambda{lambda}|%Coroutine{coroutine}}0"
   " does not return a value%select{| in all control paths}1">,
   InGroup<ReturnType>;
 def err_falloff_nonvoid : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -713,8 +713,13 @@ def err_thread_non_global : Error<
 def err_thread_unsupported : Error<
   "thread-local storage is not supported for the current target">;
 
-def warn_falloff_nonvoid_function : Warning<
-  "non-void function does not return a value%select{| in all control paths}0">,
+def warn_falloff_nonvoid : Warning<
+  "non-void %select{function|block|lambda|coroutine}0 "
+  "does not return a value%select{| in all control paths}1">,
+  InGroup<ReturnType>;
+def err_falloff_nonvoid : Warning<
+  "non-void %select{function|block|lambda|coroutine}0 "
+  "does not return a value%select{| in all control paths}1">,
   InGroup<ReturnType>;
 def warn_const_attr_with_pure_attr : Warning<
   "'const' attribute imposes more restrictions; 'pure' attribute ignored">,
@@ -723,11 +728,6 @@ def warn_pure_function_returns_void : Warning<
   "'%select{pure|const}0' attribute on function returning 'void'; attribute ignored">,
   InGroup<IgnoredAttributes>;
 
-def err_falloff_nonvoid_block : Error<
-  "non-void block does not return a value%select{| in all control paths}0">;
-def warn_falloff_nonvoid_coroutine : Warning<
-  "non-void coroutine does not return a value%select{| in all control paths}0">,
-  InGroup<ReturnType>;
 def warn_suggest_noreturn_function : Warning<
   "%select{function|method}0 %1 could be declared with attribute 'noreturn'">,
   InGroup<MissingNoreturn>, DefaultIgnore;
@@ -8399,9 +8399,6 @@ let CategoryName = "Lambda Issue" in {
     "incomplete result type %0 in lambda expression">;
   def err_noreturn_lambda_has_return_expr : Error<
     "lambda declared 'noreturn' should not return">;
-  def warn_falloff_nonvoid_lambda : Warning<
-    "non-void lambda does not return a value%select{| in all control paths}0">,
-    InGroup<ReturnType>;
   def err_access_lambda_capture : Error<
     // The ERRORs represent other special members that aren't constructors, in
     // hopes that someone will bother noticing and reporting if they appear

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -553,10 +553,8 @@ struct CheckFallThroughDiagnostics {
   static CheckFallThroughDiagnostics MakeForFunction(const Decl *Func) {
     CheckFallThroughDiagnostics D;
     D.FuncLoc = Func->getLocation();
-    D.diag_FallThrough_HasNoReturn =
-      diag::warn_falloff_noreturn_function;
-    D.diag_FallThrough_ReturnsNonVoid =
-      diag::warn_falloff_nonvoid_function;
+    D.diag_FallThrough_HasNoReturn = diag::warn_falloff_noreturn_function;
+    D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid_function;
 
     // Don't suggest that virtual functions be marked "noreturn", since they
     // might be overridden by non-noreturn functions.
@@ -570,8 +568,7 @@ struct CheckFallThroughDiagnostics {
       isTemplateInstantiation = Function->isTemplateInstantiation();
 
     if (!isVirtualMethod && !isTemplateInstantiation)
-      D.diag_NeverFallThroughOrReturn =
-        diag::warn_suggest_noreturn_function;
+      D.diag_NeverFallThroughOrReturn = diag::warn_suggest_noreturn_function;
     else
       D.diag_NeverFallThroughOrReturn = 0;
 
@@ -583,8 +580,7 @@ struct CheckFallThroughDiagnostics {
     CheckFallThroughDiagnostics D;
     D.FuncLoc = Func->getLocation();
     D.diag_FallThrough_HasNoReturn = 0;
-    D.diag_FallThrough_ReturnsNonVoid =
-        diag::warn_falloff_nonvoid_coroutine;
+    D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid_coroutine;
     D.diag_NeverFallThroughOrReturn = 0;
     D.funMode = Coroutine;
     return D;
@@ -592,10 +588,8 @@ struct CheckFallThroughDiagnostics {
 
   static CheckFallThroughDiagnostics MakeForBlock() {
     CheckFallThroughDiagnostics D;
-    D.diag_FallThrough_HasNoReturn =
-      diag::err_noreturn_block_has_return_expr;
-    D.diag_FallThrough_ReturnsNonVoid =
-      diag::err_falloff_nonvoid_block;
+    D.diag_FallThrough_HasNoReturn = diag::err_noreturn_block_has_return_expr;
+    D.diag_FallThrough_ReturnsNonVoid = diag::err_falloff_nonvoid_block;
     D.diag_NeverFallThroughOrReturn = 0;
     D.funMode = Block;
     return D;
@@ -603,10 +597,8 @@ struct CheckFallThroughDiagnostics {
 
   static CheckFallThroughDiagnostics MakeForLambda() {
     CheckFallThroughDiagnostics D;
-    D.diag_FallThrough_HasNoReturn =
-      diag::err_noreturn_lambda_has_return_expr;
-    D.diag_FallThrough_ReturnsNonVoid =
-      diag::warn_falloff_nonvoid_lambda;
+    D.diag_FallThrough_HasNoReturn = diag::err_noreturn_lambda_has_return_expr;
+    D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid_lambda;
     D.diag_NeverFallThroughOrReturn = 0;
     D.funMode = Lambda;
     return D;
@@ -616,8 +608,7 @@ struct CheckFallThroughDiagnostics {
                         bool HasNoReturn) const {
     if (funMode == Function) {
       return (ReturnsVoid ||
-              D.isIgnored(diag::warn_falloff_nonvoid_function,
-                          FuncLoc)) &&
+              D.isIgnored(diag::warn_falloff_nonvoid_function, FuncLoc)) &&
              (!HasNoReturn ||
               D.isIgnored(diag::warn_noreturn_function_has_return_expr,
                           FuncLoc)) &&
@@ -627,8 +618,7 @@ struct CheckFallThroughDiagnostics {
     if (funMode == Coroutine) {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_falloff_nonvoid_function, FuncLoc) ||
-              D.isIgnored(diag::warn_falloff_nonvoid_coroutine,
-                          FuncLoc)) &&
+              D.isIgnored(diag::warn_falloff_nonvoid_coroutine, FuncLoc)) &&
              (!HasNoReturn);
     }
     // For blocks / lambdas.
@@ -694,34 +684,34 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
 
   // Either in a function body compound statement, or a function-try-block.
   switch (CheckFallThrough(AC)) {
-    case UnknownFallThrough:
-      break;
+  case UnknownFallThrough:
+    break;
 
-    case MaybeFallThrough:
-      if (HasNoReturn)
-        EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn);
-      else if (!ReturnsVoid)
-        S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << 1;
-      break;
-    case AlwaysFallThrough:
-      if (HasNoReturn)
-        EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn);
-      else if (!ReturnsVoid)
-        S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << 0;
-      break;
-    case NeverFallThroughOrReturn:
-      if (ReturnsVoid && !HasNoReturn && CD.diag_NeverFallThroughOrReturn) {
-        if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
-          S.Diag(LBrace, CD.diag_NeverFallThroughOrReturn) << 0 << FD;
-        } else if (const ObjCMethodDecl *MD = dyn_cast<ObjCMethodDecl>(D)) {
-          S.Diag(LBrace, CD.diag_NeverFallThroughOrReturn) << 1 << MD;
-        } else {
-          S.Diag(LBrace, CD.diag_NeverFallThroughOrReturn);
-        }
+  case MaybeFallThrough:
+    if (HasNoReturn)
+      EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn);
+    else if (!ReturnsVoid)
+      S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << 1;
+    break;
+  case AlwaysFallThrough:
+    if (HasNoReturn)
+      EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn);
+    else if (!ReturnsVoid)
+      S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << 0;
+    break;
+  case NeverFallThroughOrReturn:
+    if (ReturnsVoid && !HasNoReturn && CD.diag_NeverFallThroughOrReturn) {
+      if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+        S.Diag(LBrace, CD.diag_NeverFallThroughOrReturn) << 0 << FD;
+      } else if (const ObjCMethodDecl *MD = dyn_cast<ObjCMethodDecl>(D)) {
+        S.Diag(LBrace, CD.diag_NeverFallThroughOrReturn) << 1 << MD;
+      } else {
+        S.Diag(LBrace, CD.diag_NeverFallThroughOrReturn);
       }
-      break;
-    case NeverFallThrough:
-      break;
+    }
+    break;
+  case NeverFallThrough:
+    break;
   }
 }
 

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -547,7 +547,7 @@ struct CheckFallThroughDiagnostics {
   unsigned diag_FallThrough_HasNoReturn;
   unsigned diag_FallThrough_ReturnsNonVoid;
   unsigned diag_NeverFallThroughOrReturn;
-  enum { Function = 0, Block, Lambda, Coroutine } funMode;
+  unsigned funMode; // TODO: use diag::FunModes
   SourceLocation FuncLoc;
 
   static CheckFallThroughDiagnostics MakeForFunction(const Decl *Func) {
@@ -572,7 +572,7 @@ struct CheckFallThroughDiagnostics {
     else
       D.diag_NeverFallThroughOrReturn = 0;
 
-    D.funMode = Function;
+    D.funMode = diag::FunModes::Function;
     return D;
   }
 
@@ -582,7 +582,7 @@ struct CheckFallThroughDiagnostics {
     D.diag_FallThrough_HasNoReturn = 0;
     D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid;
     D.diag_NeverFallThroughOrReturn = 0;
-    D.funMode = Coroutine;
+    D.funMode = diag::FunModes::Coroutine;
     return D;
   }
 
@@ -591,7 +591,7 @@ struct CheckFallThroughDiagnostics {
     D.diag_FallThrough_HasNoReturn = diag::err_noreturn_has_return_expr;
     D.diag_FallThrough_ReturnsNonVoid = diag::err_falloff_nonvoid;
     D.diag_NeverFallThroughOrReturn = 0;
-    D.funMode = Block;
+    D.funMode = diag::FunModes::Block;
     return D;
   }
 
@@ -600,13 +600,13 @@ struct CheckFallThroughDiagnostics {
     D.diag_FallThrough_HasNoReturn = diag::err_noreturn_has_return_expr;
     D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid;
     D.diag_NeverFallThroughOrReturn = 0;
-    D.funMode = Lambda;
+    D.funMode = diag::FunModes::Lambda;
     return D;
   }
 
   bool checkDiagnostics(DiagnosticsEngine &D, bool ReturnsVoid,
                         bool HasNoReturn) const {
-    if (funMode == Function) {
+    if (funMode == diag::FunModes::Function) {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_falloff_nonvoid, FuncLoc)) &&
              (!HasNoReturn ||
@@ -615,7 +615,7 @@ struct CheckFallThroughDiagnostics {
              (!ReturnsVoid ||
               D.isIgnored(diag::warn_suggest_noreturn_block, FuncLoc));
     }
-    if (funMode == Coroutine) {
+    if (funMode == diag::FunModes::Coroutine) {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_falloff_nonvoid, FuncLoc)) &&
              (!HasNoReturn);

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -547,7 +547,7 @@ struct CheckFallThroughDiagnostics {
   unsigned diag_FallThrough_HasNoReturn = 0;
   unsigned diag_FallThrough_ReturnsNonVoid = 0;
   unsigned diag_NeverFallThroughOrReturn = 0;
-  unsigned funMode; // TODO: use diag::FunModes
+  unsigned FunMode; // TODO: use diag::FunModes
   SourceLocation FuncLoc;
 
   static CheckFallThroughDiagnostics MakeForFunction(const Decl *Func) {
@@ -570,7 +570,7 @@ struct CheckFallThroughDiagnostics {
     if (!isVirtualMethod && !isTemplateInstantiation)
       D.diag_NeverFallThroughOrReturn = diag::warn_suggest_noreturn_function;
 
-    D.funMode = diag::FunModes::Function;
+    D.FunMode = diag::FunModes::Function;
     return D;
   }
 
@@ -578,7 +578,7 @@ struct CheckFallThroughDiagnostics {
     CheckFallThroughDiagnostics D;
     D.FuncLoc = Func->getLocation();
     D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid;
-    D.funMode = diag::FunModes::Coroutine;
+    D.FunMode = diag::FunModes::Coroutine;
     return D;
   }
 
@@ -586,7 +586,7 @@ struct CheckFallThroughDiagnostics {
     CheckFallThroughDiagnostics D;
     D.diag_FallThrough_HasNoReturn = diag::err_noreturn_has_return_expr;
     D.diag_FallThrough_ReturnsNonVoid = diag::err_falloff_nonvoid;
-    D.funMode = diag::FunModes::Block;
+    D.FunMode = diag::FunModes::Block;
     return D;
   }
 
@@ -594,13 +594,13 @@ struct CheckFallThroughDiagnostics {
     CheckFallThroughDiagnostics D;
     D.diag_FallThrough_HasNoReturn = diag::err_noreturn_has_return_expr;
     D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid;
-    D.funMode = diag::FunModes::Lambda;
+    D.FunMode = diag::FunModes::Lambda;
     return D;
   }
 
   bool checkDiagnostics(DiagnosticsEngine &D, bool ReturnsVoid,
                         bool HasNoReturn) const {
-    if (funMode == diag::FunModes::Function) {
+    if (FunMode == diag::FunModes::Function) {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_falloff_nonvoid, FuncLoc)) &&
              (!HasNoReturn ||
@@ -608,7 +608,7 @@ struct CheckFallThroughDiagnostics {
              (!ReturnsVoid ||
               D.isIgnored(diag::warn_suggest_noreturn_block, FuncLoc));
     }
-    if (funMode == diag::FunModes::Coroutine) {
+    if (FunMode == diag::FunModes::Coroutine) {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_falloff_nonvoid, FuncLoc)) &&
              (!HasNoReturn);
@@ -681,15 +681,15 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
 
   case MaybeFallThrough:
     if (HasNoReturn)
-      EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn, CD.funMode);
+      EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn, CD.FunMode);
     else if (!ReturnsVoid)
-      S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << CD.funMode << 1;
+      S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << CD.FunMode << 1;
     break;
   case AlwaysFallThrough:
     if (HasNoReturn)
-      EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn, CD.funMode);
+      EmitDiag(RBrace, CD.diag_FallThrough_HasNoReturn, CD.FunMode);
     else if (!ReturnsVoid)
-      S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << CD.funMode << 0;
+      S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid) << CD.FunMode << 0;
     break;
   case NeverFallThroughOrReturn:
     if (ReturnsVoid && !HasNoReturn && CD.diag_NeverFallThroughOrReturn) {

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -665,20 +665,19 @@ static void CheckFallThroughForBody(Sema &S, const Decl *D, const Stmt *Body,
     return;
 
   // Either in a function body compound statement, or a function-try-block.
-  int FallThroughType = CheckFallThrough(AC);
-  switch (FallThroughType) {
+  switch (int FallThroughType = CheckFallThrough(AC)) {
   case UnknownFallThrough:
     break;
 
   case MaybeFallThrough:
   case AlwaysFallThrough:
-    if (HasNoReturn && CD.diag_FallThrough_HasNoReturn != 0) {
-      S.Diag(RBrace, CD.diag_FallThrough_HasNoReturn) << CD.FunMode;
-    } else if (!ReturnsVoid && CD.diag_FallThrough_ReturnsNonVoid != 0) {
-      unsigned NotInAllControlPath =
-          FallThroughType == MaybeFallThrough ? 1 : 0;
+    if (HasNoReturn) {
+      if (CD.diag_FallThrough_HasNoReturn)
+        S.Diag(RBrace, CD.diag_FallThrough_HasNoReturn) << CD.FunMode;
+    } else if (!ReturnsVoid && CD.diag_FallThrough_ReturnsNonVoid) {
+      bool NotInAllControlPaths = FallThroughType == MaybeFallThrough;
       S.Diag(RBrace, CD.diag_FallThrough_ReturnsNonVoid)
-          << CD.FunMode << NotInAllControlPath;
+          << CD.FunMode << NotInAllControlPaths;
     }
     break;
   case NeverFallThroughOrReturn:

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -610,8 +610,7 @@ struct CheckFallThroughDiagnostics {
       return (ReturnsVoid ||
               D.isIgnored(diag::warn_falloff_nonvoid, FuncLoc)) &&
              (!HasNoReturn ||
-              D.isIgnored(diag::warn_noreturn_has_return_expr,
-                          FuncLoc)) &&
+              D.isIgnored(diag::warn_noreturn_has_return_expr, FuncLoc)) &&
              (!ReturnsVoid ||
               D.isIgnored(diag::warn_suggest_noreturn_block, FuncLoc));
     }

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -544,9 +544,9 @@ static ControlFlowKind CheckFallThrough(AnalysisDeclContext &AC) {
 namespace {
 
 struct CheckFallThroughDiagnostics {
-  unsigned diag_FallThrough_HasNoReturn;
-  unsigned diag_FallThrough_ReturnsNonVoid;
-  unsigned diag_NeverFallThroughOrReturn;
+  unsigned diag_FallThrough_HasNoReturn = 0;
+  unsigned diag_FallThrough_ReturnsNonVoid = 0;
+  unsigned diag_NeverFallThroughOrReturn = 0;
   unsigned funMode; // TODO: use diag::FunModes
   SourceLocation FuncLoc;
 
@@ -569,8 +569,6 @@ struct CheckFallThroughDiagnostics {
 
     if (!isVirtualMethod && !isTemplateInstantiation)
       D.diag_NeverFallThroughOrReturn = diag::warn_suggest_noreturn_function;
-    else
-      D.diag_NeverFallThroughOrReturn = 0;
 
     D.funMode = diag::FunModes::Function;
     return D;
@@ -579,9 +577,7 @@ struct CheckFallThroughDiagnostics {
   static CheckFallThroughDiagnostics MakeForCoroutine(const Decl *Func) {
     CheckFallThroughDiagnostics D;
     D.FuncLoc = Func->getLocation();
-    D.diag_FallThrough_HasNoReturn = 0;
     D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid;
-    D.diag_NeverFallThroughOrReturn = 0;
     D.funMode = diag::FunModes::Coroutine;
     return D;
   }
@@ -590,7 +586,6 @@ struct CheckFallThroughDiagnostics {
     CheckFallThroughDiagnostics D;
     D.diag_FallThrough_HasNoReturn = diag::err_noreturn_has_return_expr;
     D.diag_FallThrough_ReturnsNonVoid = diag::err_falloff_nonvoid;
-    D.diag_NeverFallThroughOrReturn = 0;
     D.funMode = diag::FunModes::Block;
     return D;
   }
@@ -599,7 +594,6 @@ struct CheckFallThroughDiagnostics {
     CheckFallThroughDiagnostics D;
     D.diag_FallThrough_HasNoReturn = diag::err_noreturn_has_return_expr;
     D.diag_FallThrough_ReturnsNonVoid = diag::warn_falloff_nonvoid;
-    D.diag_NeverFallThroughOrReturn = 0;
     D.funMode = diag::FunModes::Lambda;
     return D;
   }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3591,7 +3591,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
   if (auto *CurBlock = dyn_cast<BlockScopeInfo>(CurCap)) {
     if (CurBlock->FunctionType->castAs<FunctionType>()->getNoReturnAttr()) {
       Diag(ReturnLoc, diag::err_noreturn_has_return_expr)
-          << diag::FunModes::Block;
+          << diag::FalloffFunctionKind::Block;
       return StmtError();
     }
   } else if (auto *CurRegion = dyn_cast<CapturedRegionScopeInfo>(CurCap)) {
@@ -3603,7 +3603,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
             ->castAs<FunctionType>()
             ->getNoReturnAttr()) {
       Diag(ReturnLoc, diag::err_noreturn_has_return_expr)
-          << diag::FunModes::Lambda;
+          << diag::FalloffFunctionKind::Lambda;
       return StmtError();
     }
   }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3590,7 +3590,8 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
 
   if (auto *CurBlock = dyn_cast<BlockScopeInfo>(CurCap)) {
     if (CurBlock->FunctionType->castAs<FunctionType>()->getNoReturnAttr()) {
-      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << diag::FunModes::Block;
+      Diag(ReturnLoc, diag::err_noreturn_has_return_expr)
+          << diag::FunModes::Block;
       return StmtError();
     }
   } else if (auto *CurRegion = dyn_cast<CapturedRegionScopeInfo>(CurCap)) {
@@ -3601,7 +3602,8 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
     if (CurLambda->CallOperator->getType()
             ->castAs<FunctionType>()
             ->getNoReturnAttr()) {
-      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << diag::FunModes::Lambda;
+      Diag(ReturnLoc, diag::err_noreturn_has_return_expr)
+          << diag::FunModes::Lambda;
       return StmtError();
     }
   }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3590,7 +3590,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
 
   if (auto *CurBlock = dyn_cast<BlockScopeInfo>(CurCap)) {
     if (CurBlock->FunctionType->castAs<FunctionType>()->getNoReturnAttr()) {
-      Diag(ReturnLoc, diag::err_noreturn_block_has_return_expr);
+      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << 1;
       return StmtError();
     }
   } else if (auto *CurRegion = dyn_cast<CapturedRegionScopeInfo>(CurCap)) {
@@ -3601,7 +3601,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
     if (CurLambda->CallOperator->getType()
             ->castAs<FunctionType>()
             ->getNoReturnAttr()) {
-      Diag(ReturnLoc, diag::err_noreturn_lambda_has_return_expr);
+      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << 2;
       return StmtError();
     }
   }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3590,7 +3590,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
 
   if (auto *CurBlock = dyn_cast<BlockScopeInfo>(CurCap)) {
     if (CurBlock->FunctionType->castAs<FunctionType>()->getNoReturnAttr()) {
-      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << 1;
+      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << diag::FunModes::Block;
       return StmtError();
     }
   } else if (auto *CurRegion = dyn_cast<CapturedRegionScopeInfo>(CurCap)) {
@@ -3601,7 +3601,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
     if (CurLambda->CallOperator->getType()
             ->castAs<FunctionType>()
             ->getNoReturnAttr()) {
-      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << 2;
+      Diag(ReturnLoc, diag::err_noreturn_has_return_expr) << diag::FunModes::Lambda;
       return StmtError();
     }
   }


### PR DESCRIPTION
This PR fixes `FIXME: Combine fallout warnings to just one warning.` at `DiagnosticssSemaKinds.td`.

Changes:
- `warn_maybe_falloff_nonvoid_function` and `warn_falloff_nonvoid_function`, `warn_maybe_falloff_nonvoid_coroutine` and `warn_falloff_nonvoid_coroutine`, `warn_maybe_falloff_nonvoid_lambda` and `warn_falloff_nonvoid_lambda` were combined into `warn_falloff_nonvoid`,
- `err_maybe_falloff_nonvoid_block` and `err_falloff_nonvoid_block` were combined into `err_falloff_nonvoid`
- `err_noreturn_block_has_return_expr` and `err_noreturn_lambda_has_return_expr` were merged into `err_noreturn_has_return_expr` with the same semantics as `warn_falloff_nonvoid` or `err_falloff_nonvoid`.
- Some code was removed as unnecessary now.