### PR TITLE
[alpha.webkit.UnretainedLocalVarsChecker] Add a checker for local variables to NS and CF types.

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -3674,6 +3674,45 @@ The goal of this rule is to make sure that any NS or CF local variable is backed
 
 The rules of when to use and not to use RetainPtr are same as alpha.webkit.UncountedCallArgsChecker for ref-counted objects.
 
+These are examples of cases that we consider safe:
+
+  .. code-block:: cpp
+
+    void foo1() {
+      RetainPtr<NSObject> retained;
+      // The scope of unretained is EMBEDDED in the scope of retained.
+      {
+        NSObject* unretained = retained.get(); // ok
+      }
+    }
+
+    void foo2(RetainPtr<NSObject> retained_param) {
+      NSObject* unretained = retained_param.get(); // ok
+    }
+
+    void FooClass::foo_method() {
+      NSObject* unretained = this; // ok
+    }
+
+Here are some examples of situations that we warn about as they *might* be potentially unsafe. The logic is that either we're able to guarantee that a local variable is safe or it's considered unsafe.
+
+  .. code-block:: cpp
+
+    void foo1() {
+      NSObject* unretained = [[NSObject alloc] init]; // warn
+    }
+
+    NSObject* global_unretained;
+    void foo2() {
+      NSObject* unretained = global_unretained; // warn
+    }
+
+    void foo3() {
+      RetainPtr<NSObject> retained;
+      // The scope of unretained is not EMBEDDED in the scope of retained.
+      NSObject* unretained = retained.get(); // warn
+    }
+
 Debug Checkers
 ---------------
 

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -3669,7 +3669,7 @@ Here are some examples of situations that we warn about as they *might* be poten
     }
 
 alpha.webkit.UnretainedLocalVarsChecker
-""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""
 The goal of this rule is to make sure that any NS or CF local variable is backed by a RetainPtr with lifetime that is strictly larger than the scope of the unretained local variable. To be on the safe side we require the scope of an unretained variable to be embedded in the scope of Retainptr object that backs it.
 
 The rules of when to use and not to use RetainPtr are same as alpha.webkit.UncountedCallArgsChecker for ref-counted objects.

--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -3668,6 +3668,12 @@ Here are some examples of situations that we warn about as they *might* be poten
       RefCountable* uncounted = counted.get(); // warn
     }
 
+alpha.webkit.UnretainedLocalVarsChecker
+""""""""""""""""""""""""""""""""""""""
+The goal of this rule is to make sure that any NS or CF local variable is backed by a RetainPtr with lifetime that is strictly larger than the scope of the unretained local variable. To be on the safe side we require the scope of an unretained variable to be embedded in the scope of Retainptr object that backs it.
+
+The rules of when to use and not to use RetainPtr are same as alpha.webkit.UncountedCallArgsChecker for ref-counted objects.
+
 Debug Checkers
 ---------------
 

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -1782,4 +1782,8 @@ def UncheckedLocalVarsChecker : Checker<"UncheckedLocalVarsChecker">,
   HelpText<"Check unchecked local variables.">,
   Documentation<HasDocumentation>;
 
+def UnretainedLocalVarsChecker : Checker<"UnretainedLocalVarsChecker">,
+  HelpText<"Check unretained local variables.">,
+  Documentation<HasDocumentation>;
+
 } // end alpha.webkit

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
@@ -54,6 +54,8 @@ class Expr;
 /// Returns false if any of calls to callbacks returned false. Otherwise true.
 bool tryToFindPtrOrigin(
     const clang::Expr *E, bool StopAtFirstRefCountedObj,
+    std::function<bool(const clang::CXXRecordDecl *)> isSafePtr,
+    std::function<bool(const clang::QualType)> isSafePtrType,
     std::function<bool(const clang::Expr *, bool)> callback);
 
 /// For \p E referring to a ref-countable/-counted pointer/reference we return

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -209,7 +209,8 @@ std::optional<bool> isUnchecked(const QualType T) {
   return isUnchecked(T->getAsCXXRecordDecl());
 }
 
-void RetainTypeChecker::visitTranslationUnitDecl(const TranslationUnitDecl *TUD) {
+void RetainTypeChecker::visitTranslationUnitDecl(
+    const TranslationUnitDecl *TUD) {
   IsARCEnabled = TUD->getLangOpts().ObjCAutoRefCount;
 }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -118,9 +118,7 @@ bool isRefType(const std::string &Name) {
          Name == "RefPtr" || Name == "RefPtrAllowingPartiallyDestroyed";
 }
 
-bool isRetainPtr(const std::string &Name) {
-  return Name == "RetainPtr";
-}
+bool isRetainPtr(const std::string &Name) { return Name == "RetainPtr"; }
 
 bool isCheckedPtr(const std::string &Name) {
   return Name == "CheckedPtr" || Name == "CheckedRef";
@@ -152,8 +150,7 @@ bool isCtorOfRetainPtr(const clang::FunctionDecl *F) {
 }
 
 bool isCtorOfSafePtr(const clang::FunctionDecl *F) {
-  return isCtorOfRefCounted(F) || isCtorOfCheckedPtr(F) ||
-         isCtorOfRetainPtr(F);
+  return isCtorOfRefCounted(F) || isCtorOfCheckedPtr(F) || isCtorOfRetainPtr(F);
 }
 
 template <typename Predicate>
@@ -181,8 +178,7 @@ bool isRefOrCheckedPtrType(const clang::QualType T) {
 }
 
 bool isRetainPtrType(const clang::QualType T) {
-  return isPtrOfType(
-      T, [](auto Name) { return Name == "RetainPtr"; });
+  return isPtrOfType(T, [](auto Name) { return Name == "RetainPtr"; });
 }
 
 bool isOwnerPtrType(const clang::QualType T) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -51,6 +51,9 @@ bool isRefCounted(const clang::CXXRecordDecl *Class);
 /// \returns true if \p Class is a CheckedPtr / CheckedRef, false if not.
 bool isCheckedPtr(const clang::CXXRecordDecl *Class);
 
+/// \returns true if \p Class is a RetainPtr, false if not.
+bool isRetainPtr(const clang::CXXRecordDecl *Class);
+
 /// \returns true if \p Class is ref-countable AND not ref-counted, false if
 /// not, std::nullopt if inconclusive.
 std::optional<bool> isUncounted(const clang::QualType T);
@@ -58,6 +61,10 @@ std::optional<bool> isUncounted(const clang::QualType T);
 /// \returns true if \p Class is CheckedPtr capable AND not checked, false if
 /// not, std::nullopt if inconclusive.
 std::optional<bool> isUnchecked(const clang::QualType T);
+
+/// \returns true if \p Class is NS or CF objects AND not retained, false if
+/// not, std::nullopt if inconclusive.
+std::optional<bool> isUnretained(const clang::QualType T, bool IsARCEnabled);
 
 /// \returns true if \p Class is ref-countable AND not ref-counted, false if
 /// not, std::nullopt if inconclusive.
@@ -77,11 +84,14 @@ std::optional<bool> isUncheckedPtr(const clang::QualType T);
 
 /// \returns true if \p T is either a raw pointer or reference to an uncounted
 /// or unchecked class, false if not, std::nullopt if inconclusive.
-std::optional<bool> isUnsafePtr(const QualType T);
+std::optional<bool> isUnsafePtr(const QualType T, bool IsArcEnabled);
 
 /// \returns true if \p T is a RefPtr, Ref, CheckedPtr, CheckedRef, or its
 /// variant, false if not.
-bool isSafePtrType(const clang::QualType T);
+bool isRefOrCheckedPtrType(const clang::QualType T);
+
+/// \returns true if \p T is a RetainPtr, false if not.
+bool isRetainPtrType(const clang::QualType T);
 
 /// \returns true if \p T is a RefPtr, Ref, CheckedPtr, CheckedRef, or
 /// unique_ptr, false if not.

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/PointerUnion.h"
 #include <optional>
 
@@ -21,8 +22,11 @@ class CXXRecordDecl;
 class Decl;
 class FunctionDecl;
 class QualType;
+class RecordType;
 class Stmt;
+class TranslationUnitDecl;
 class Type;
+class TypedefDecl;
 
 // Ref-countability of a type is implicitly defined by Ref<T> and RefPtr<T>
 // implementation. It can be modeled as: type T having public methods ref() and
@@ -61,6 +65,17 @@ std::optional<bool> isUncounted(const clang::QualType T);
 /// \returns true if \p Class is CheckedPtr capable AND not checked, false if
 /// not, std::nullopt if inconclusive.
 std::optional<bool> isUnchecked(const clang::QualType T);
+
+/// An inter-procedural analysis facility that detects CF types with the
+/// underlying pointer type.
+class RetainTypeChecker {
+  llvm::DenseSet<const RecordType*> CFPointees;
+  bool IsARCEnabled{false};
+public:
+  void visitTranslationUnitDecl(const TranslationUnitDecl *);
+  void visitTypedef(const TypedefDecl *);
+  bool isUnretained(const QualType);
+};
 
 /// \returns true if \p Class is NS or CF objects AND not retained, false if
 /// not, std::nullopt if inconclusive.

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -69,8 +69,9 @@ std::optional<bool> isUnchecked(const clang::QualType T);
 /// An inter-procedural analysis facility that detects CF types with the
 /// underlying pointer type.
 class RetainTypeChecker {
-  llvm::DenseSet<const RecordType*> CFPointees;
+  llvm::DenseSet<const RecordType *> CFPointees;
   bool IsARCEnabled{false};
+
 public:
   void visitTranslationUnitDecl(const TranslationUnitDecl *);
   void visitTypedef(const TypedefDecl *);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -41,6 +41,8 @@ public:
 
   virtual std::optional<bool> isUnsafeType(QualType) const = 0;
   virtual std::optional<bool> isUnsafePtr(QualType) const = 0;
+  virtual bool isSafePtr(const CXXRecordDecl *Record) const = 0;
+  virtual bool isSafePtrType(const QualType type) const = 0;
   virtual const char *ptrKind() const = 0;
 
   void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
@@ -141,6 +143,12 @@ public:
 
   bool isPtrOriginSafe(const Expr *Arg) const {
     return tryToFindPtrOrigin(Arg, /*StopAtFirstRefCountedObj=*/true,
+                              [&](const clang::CXXRecordDecl *Record) {
+                                return isSafePtr(Record);
+                              },
+                              [&](const clang::QualType T) {
+                                return isSafePtrType(T);
+                              },
                               [&](const clang::Expr *ArgOrigin, bool IsSafe) {
                                 if (IsSafe)
                                   return true;
@@ -315,6 +323,14 @@ public:
     return isUncountedPtr(QT);
   }
 
+  bool isSafePtr(const CXXRecordDecl *Record) const final {
+    return isRefCounted(Record) || isCheckedPtr(Record);
+  }
+
+  bool isSafePtrType(const QualType type) const final {
+    return isRefOrCheckedPtrType(type);
+  }
+
   const char *ptrKind() const final { return "uncounted"; }
 };
 
@@ -330,6 +346,14 @@ public:
 
   std::optional<bool> isUnsafePtr(QualType QT) const final {
     return isUncheckedPtr(QT);
+  }
+
+  bool isSafePtr(const CXXRecordDecl *Record) const final {
+    return isRefCounted(Record) || isCheckedPtr(Record);
+  }
+
+  bool isSafePtrType(const QualType type) const final {
+    return isRefOrCheckedPtrType(type);
   }
 
   const char *ptrKind() const final { return "unchecked"; }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -142,31 +142,28 @@ public:
   }
 
   bool isPtrOriginSafe(const Expr *Arg) const {
-    return tryToFindPtrOrigin(Arg, /*StopAtFirstRefCountedObj=*/true,
-                              [&](const clang::CXXRecordDecl *Record) {
-                                return isSafePtr(Record);
-                              },
-                              [&](const clang::QualType T) {
-                                return isSafePtrType(T);
-                              },
-                              [&](const clang::Expr *ArgOrigin, bool IsSafe) {
-                                if (IsSafe)
-                                  return true;
-                                if (isa<CXXNullPtrLiteralExpr>(ArgOrigin)) {
-                                  // foo(nullptr)
-                                  return true;
-                                }
-                                if (isa<IntegerLiteral>(ArgOrigin)) {
-                                  // FIXME: Check the value.
-                                  // foo(NULL)
-                                  return true;
-                                }
-                                if (isASafeCallArg(ArgOrigin))
-                                  return true;
-                                if (EFA.isACallToEnsureFn(ArgOrigin))
-                                  return true;
-                                return false;
-                              });
+    return tryToFindPtrOrigin(
+        Arg, /*StopAtFirstRefCountedObj=*/true,
+        [&](const clang::CXXRecordDecl *Record) { return isSafePtr(Record); },
+        [&](const clang::QualType T) { return isSafePtrType(T); },
+        [&](const clang::Expr *ArgOrigin, bool IsSafe) {
+          if (IsSafe)
+            return true;
+          if (isa<CXXNullPtrLiteralExpr>(ArgOrigin)) {
+            // foo(nullptr)
+            return true;
+          }
+          if (isa<IntegerLiteral>(ArgOrigin)) {
+            // FIXME: Check the value.
+            // foo(NULL)
+            return true;
+          }
+          if (isASafeCallArg(ArgOrigin))
+            return true;
+          if (EFA.isACallToEnsureFn(ArgOrigin))
+            return true;
+          return false;
+        });
   }
 
   bool shouldSkipCall(const CallExpr *CE) const {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -324,6 +324,8 @@ public:
 
   bool shouldSkipVarDecl(const VarDecl *V) const {
     assert(V);
+    if (isa<ImplicitParamDecl>(V))
+      return true;
     return BR->getSourceManager().isInSystemHeader(V->getLocation());
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -14,8 +14,8 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/ParentMapContext.h"
-#include "clang/Basic/SourceLocation.h"
 #include "clang/Analysis/DomainSpecific/CocoaConventions.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugType.h"
@@ -269,9 +269,7 @@ public:
               [&](const clang::CXXRecordDecl *Record) {
                 return isSafePtr(Record);
               },
-              [&](const clang::QualType Type) {
-                return isSafePtrType(Type);
-              },
+              [&](const clang::QualType Type) { return isSafePtrType(Type); },
               [&](const clang::Expr *InitArgOrigin, bool IsSafe) {
                 if (!InitArgOrigin || IsSafe)
                   return true;
@@ -401,6 +399,7 @@ public:
 
 class UnretainedLocalVarsChecker final : public RawPtrRefLocalVarsChecker {
   mutable bool IsARCEnabled{false};
+
 public:
   UnretainedLocalVarsChecker()
       : RawPtrRefLocalVarsChecker("Unretained raw pointer or reference not "
@@ -416,8 +415,8 @@ public:
   }
   const char *ptrKind() const final { return "unretained"; }
 
-  void checkASTDecl(const TranslationUnitDecl *TUD,
-                    AnalysisManager &MGR, BugReporter &BRArg) const final {
+  void checkASTDecl(const TranslationUnitDecl *TUD, AnalysisManager &MGR,
+                    BugReporter &BRArg) const final {
     IsARCEnabled = TUD->getLangOpts().ObjCAutoRefCount;
     RawPtrRefLocalVarsChecker::checkASTDecl(TUD, MGR, BRArg);
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -61,7 +61,8 @@ public:
       }
 
       bool shouldCheckThis() {
-        auto result = !ClsType.isNull() ? isUnsafePtr(ClsType, false) : std::nullopt;
+        auto result =
+            !ClsType.isNull() ? isUnsafePtr(ClsType, false) : std::nullopt;
         return result && *result;
       }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/UncountedLambdaCapturesChecker.cpp
@@ -61,7 +61,7 @@ public:
       }
 
       bool shouldCheckThis() {
-        auto result = !ClsType.isNull() ? isUnsafePtr(ClsType) : std::nullopt;
+        auto result = !ClsType.isNull() ? isUnsafePtr(ClsType, false) : std::nullopt;
         return result && *result;
       }
 
@@ -305,7 +305,7 @@ public:
         if (ignoreParamVarDecl && isa<ParmVarDecl>(CapturedVar))
           continue;
         QualType CapturedVarQualType = CapturedVar->getType();
-        auto IsUncountedPtr = isUnsafePtr(CapturedVar->getType());
+        auto IsUncountedPtr = isUnsafePtr(CapturedVar->getType(), false);
         if (IsUncountedPtr && *IsUncountedPtr)
           reportBug(C, CapturedVar, CapturedVarQualType);
       } else if (C.capturesThis() && shouldCheckThis) {

--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -1,0 +1,148 @@
+
+typedef const void * CFTypeRef;
+typedef signed long CFIndex;
+typedef const struct __CFAllocator * CFAllocatorRef;
+typedef const struct __CFString * CFStringRef;
+typedef const struct __CFArray * CFArrayRef;
+typedef struct __CFArray * CFMutableArrayRef;
+extern const CFAllocatorRef kCFAllocatorDefault;
+CFMutableArrayRef CFArrayCreateMutable(CFAllocatorRef allocator, CFIndex capacity);
+extern void CFArrayAppendValue(CFMutableArrayRef theArray, const void *value);
+CFArrayRef CFArrayCreate(CFAllocatorRef allocator, const void **values, CFIndex numValues);
+CFIndex CFArrayGetCount(CFArrayRef theArray);
+extern CFTypeRef CFRetain(CFTypeRef cf);
+extern void CFRelease(CFTypeRef cf);
+
+__attribute__((objc_root_class))
+@interface NSObject
++ (instancetype) alloc;
+- (instancetype) init;
+- (instancetype)retain;
+- (void)release;
+@end
+
+@interface SomeObj : NSObject
+- (void)doWork;
+- (SomeObj *)other;
+- (SomeObj *)next;
+- (int)value;
+@end
+
+@interface OtherObj : SomeObj
+- (void)doMoreWork:(OtherObj *)other;
+@end
+
+namespace WTF {
+
+template<typename T> class RetainPtr;
+template<typename T> RetainPtr<T> adoptNS(T*);
+template<typename T> RetainPtr<T> adoptCF(T);
+
+template <typename T, typename S> T *downcast(S *t) { return static_cast<T*>(t); }
+
+template <typename T> struct RemovePointer {
+  typedef T Type;
+};
+
+template <typename T> struct RemovePointer<T*> {
+  typedef T Type;
+};
+
+template <typename T> struct IsPointer {
+  static constexpr bool value = false;
+};
+
+template <typename T> struct IsPointer<T*> {
+  static constexpr bool value = true;
+};
+
+template <typename T, bool isPointer> struct PtrTypeToCFOrObjC {
+  using PtrType = T;
+};
+
+template <typename T> struct PtrTypeToCFOrObjC<T, true> {
+  using PtrType = T;
+};
+
+template <typename T> struct PtrTypeToCFOrObjC<T, false> {
+  using PtrType = T*;
+};
+
+template <typename T> struct RetainPtr {
+//  using ValueType = typename RemovePointer<T>::Type;
+  using PtrType = typename PtrTypeToCFOrObjC<T, IsPointer<T>::value>::PtrType;
+  PtrType t;
+
+  RetainPtr() : t(nullptr) { }
+
+  RetainPtr(PtrType t)
+    : t(t) {
+    if (t)
+      CFRetain(t);
+  }
+  RetainPtr(RetainPtr&& o)
+    : RetainPtr(o.t)
+  {
+    o.t = nullptr;
+  }
+  RetainPtr(const RetainPtr& o)
+    : RetainPtr(o.t)
+  {
+  }
+  RetainPtr operator=(const RetainPtr& o)
+  {
+    if (t)
+      CFRelease(t);
+    t = o.t;
+    if (t)
+      CFRetain(t);
+    return *this;
+  }
+  ~RetainPtr() {
+    clear();
+  }
+  void clear() {
+    if (t)
+      CFRelease(t);
+    t = nullptr;
+  }
+  void swap(RetainPtr& o) {
+    PtrType tmp = t;
+    t = o.t;
+    o.t = tmp;
+  }
+  PtrType get() const { return t; }
+  PtrType operator->() const { return t; }
+  T &operator*() const { return *t; }
+  RetainPtr &operator=(PtrType t) {
+    RetainPtr o(t);
+    swap(o);
+    return *this;
+  }
+  operator PtrType() const { return t; }
+  operator bool() const { return t; }
+
+private:
+  template <typename U> friend RetainPtr<U> adoptNS(U*);
+  template <typename U> friend RetainPtr<U> adoptCF(U);
+
+  enum AdoptTag { Adopt };
+  RetainPtr(PtrType t, AdoptTag) : t(t) { }
+};
+
+template <typename T>
+RetainPtr<T> adoptNS(T* t) {
+  return RetainPtr<T>(t, RetainPtr<T>::Adopt);
+}
+
+template <typename T>
+RetainPtr<T> adoptCF(T t) {
+  return RetainPtr<T>(t, RetainPtr<T>::Adopt);
+}
+
+}
+
+using WTF::RetainPtr;
+using WTF::adoptNS;
+using WTF::adoptCF;
+using WTF::downcast;

--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -1,10 +1,13 @@
-
-typedef const void * CFTypeRef;
+@class NSString;
+@class NSArray;
+@class NSMutableArray;
+#define CF_BRIDGED_TYPE(T) __attribute__((objc_bridge(T)))
+typedef CF_BRIDGED_TYPE(id) void * CFTypeRef;
 typedef signed long CFIndex;
 typedef const struct __CFAllocator * CFAllocatorRef;
-typedef const struct __CFString * CFStringRef;
-typedef const struct __CFArray * CFArrayRef;
-typedef struct __CFArray * CFMutableArrayRef;
+typedef const struct CF_BRIDGED_TYPE(NSString) __CFString * CFStringRef;
+typedef const struct CF_BRIDGED_TYPE(NSArray) __CFArray * CFArrayRef;
+typedef struct CF_BRIDGED_TYPE(NSMutableArray) __CFArray * CFMutableArrayRef;
 extern const CFAllocatorRef kCFAllocatorDefault;
 CFMutableArrayRef CFArrayCreateMutable(CFAllocatorRef allocator, CFIndex capacity);
 extern void CFArrayAppendValue(CFMutableArrayRef theArray, const void *value);
@@ -48,29 +51,9 @@ template <typename T> struct RemovePointer<T*> {
   typedef T Type;
 };
 
-template <typename T> struct IsPointer {
-  static constexpr bool value = false;
-};
-
-template <typename T> struct IsPointer<T*> {
-  static constexpr bool value = true;
-};
-
-template <typename T, bool isPointer> struct PtrTypeToCFOrObjC {
-  using PtrType = T;
-};
-
-template <typename T> struct PtrTypeToCFOrObjC<T, true> {
-  using PtrType = T;
-};
-
-template <typename T> struct PtrTypeToCFOrObjC<T, false> {
-  using PtrType = T*;
-};
-
 template <typename T> struct RetainPtr {
-//  using ValueType = typename RemovePointer<T>::Type;
-  using PtrType = typename PtrTypeToCFOrObjC<T, IsPointer<T>::value>::PtrType;
+  using ValueType = typename RemovePointer<T>::Type;
+  using PtrType = ValueType*;
   PtrType t;
 
   RetainPtr() : t(nullptr) { }

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
@@ -1,0 +1,46 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UnretainedLocalVarsChecker -fobjc-arc -verify %s
+
+#import "objc-mock-types.h"
+
+SomeObj *provide();
+void someFunction();
+
+namespace raw_ptr {
+
+void foo() {
+  SomeObj *bar = [[SomeObj alloc] init];
+  [bar doWork];
+}
+
+void foo2() {
+  SomeObj *bar = provide();
+  [bar doWork];
+}
+
+void bar() {
+  CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
+  // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  CFArrayAppendValue(array, nullptr);
+}
+
+} // namespace raw_ptr
+
+@interface AnotherObj : NSObject
+- (void)foo:(SomeObj *)obj;
+@end
+
+@implementation AnotherObj
+- (void)foo:(SomeObj*)obj {
+  SomeObj* obj2 = obj;
+  SomeObj* obj3 = provide();
+  obj = nullptr;
+  [obj2 doWork];
+  [obj3 doWork];
+}
+
+- (void)bar {
+  CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
+  // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  CFArrayAppendValue(array, nullptr);
+}
+@end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
@@ -1,0 +1,360 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UnretainedLocalVarsChecker -verify %s
+
+#import "objc-mock-types.h"
+
+void someFunction();
+
+namespace raw_ptr {
+void foo() {
+  SomeObj *bar;
+  // FIXME: later on we might warn on uninitialized vars too
+}
+
+void bar(SomeObj *) {}
+} // namespace raw_ptr
+
+namespace pointer {
+void foo_ref() {
+  SomeObj *bar = [[SomeObj alloc] init];
+  // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  [bar doWork];
+}
+
+bool bar_ref(SomeObj *obj) {
+    return !!obj;
+}
+
+void cf_ptr() {
+  CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorDefault, 10);
+  // expected-warning@-1{{Local variable 'array' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  CFArrayAppendValue(array, nullptr);
+}
+} // namespace pointer
+
+namespace guardian_scopes {
+void foo1() {
+  RetainPtr<SomeObj> foo;
+  {
+    SomeObj *bar = foo.get();
+  }
+}
+
+void foo2() {
+  RetainPtr<SomeObj> foo;
+  // missing embedded scope here
+  SomeObj *bar = foo.get();
+  // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  [bar doWork];
+}
+
+void foo3() {
+  RetainPtr<SomeObj> foo;
+  {
+    { SomeObj *bar = foo.get(); }
+  }
+}
+
+void foo4() {
+  {
+    RetainPtr<SomeObj> foo;
+    { SomeObj *bar = foo.get(); }
+  }
+}
+
+struct SelfReferencingStruct {
+  SelfReferencingStruct* ptr;
+  SomeObj* obj { nullptr };
+};
+
+void foo7(SomeObj* obj) {
+  SelfReferencingStruct bar = { &bar, obj };
+  [bar.obj doWork];
+}
+
+void foo8(SomeObj* obj) {
+  RetainPtr<SomeObj> foo;
+
+  {
+    SomeObj *bar = foo.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    foo = nullptr;
+    [bar doWork];
+  }
+  RetainPtr<SomeObj> baz;
+  {
+    SomeObj *bar = baz.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    baz = obj;
+    [bar doWork];
+  }
+
+  foo = nullptr;
+  {
+    SomeObj *bar = foo.get();
+    // No warning. It's okay to mutate RefPtr in an outer scope.
+    [bar doWork];
+  }
+  foo = obj;
+  {
+    SomeObj *bar = foo.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    foo.clear();
+    [bar doWork];
+  }
+  {
+    SomeObj *bar = foo.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    foo = obj ? obj : nullptr;
+    [bar doWork];
+  }
+  {
+    SomeObj *bar = [foo.get() other] ? foo.get() : nullptr;
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    foo = nullptr;
+    [bar doWork];
+  }
+}
+
+void foo9(SomeObj* o) {
+  RetainPtr<SomeObj> guardian(o);
+  {
+    SomeObj *bar = guardian.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    guardian = o; // We don't detect that we're setting it to the same value.
+    [bar doWork];
+  }
+  {
+    SomeObj *bar = guardian.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    RetainPtr<SomeObj> other(bar); // We don't detect other has the same value as guardian.
+    guardian.swap(other);
+    [bar doWork];
+  }
+  {
+    SomeObj *bar = guardian.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    RetainPtr<SomeObj> other(static_cast<RetainPtr<SomeObj>&&>(guardian));
+    [bar doWork];
+  }
+  {
+    SomeObj *bar = guardian.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    guardian.clear();
+    [bar doWork];
+  }
+  {
+    SomeObj *bar = guardian.get();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    guardian = [o other] ? o : bar;
+    [bar doWork];
+  }
+}
+
+bool trivialFunction(CFMutableArrayRef array) { return !!array; }
+void foo10() {
+  RetainPtr<CFMutableArrayRef> array = adoptCF(CFArrayCreateMutable(kCFAllocatorDefault, 10));
+  {
+    CFMutableArrayRef arrayRef = array.get();
+    CFArrayAppendValue(arrayRef, nullptr);
+  }
+  {
+    CFMutableArrayRef arrayRef = array.get();
+    // expected-warning@-1{{Local variable 'arrayRef' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    array = nullptr;
+    CFArrayAppendValue(arrayRef, nullptr);
+  }
+  {
+    CFMutableArrayRef arrayRef = array.get();
+    if (trivialFunction(arrayRef))
+      arrayRef = nullptr;
+  }
+}
+
+} // namespace guardian_scopes
+
+namespace auto_keyword {
+class Foo {
+  SomeObj *provide_obj();
+  CFMutableArrayRef provide_cf_array();
+  void doWork(CFMutableArrayRef);
+
+  void evil_func() {
+    SomeObj *bar = provide_obj();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    auto *baz = provide_obj();
+    // expected-warning@-1{{Local variable 'baz' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    auto *baz2 = this->provide_obj();
+    // expected-warning@-1{{Local variable 'baz2' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    [[clang::suppress]] auto *baz_suppressed = provide_obj(); // no-warning
+  }
+
+  void func() {
+    SomeObj *bar = provide_obj();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    if (bar)
+      [bar doWork];
+  }
+
+  void bar() {
+    auto bar = provide_cf_array();
+    // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    doWork(bar);
+    [[clang::suppress]] auto baz = provide_cf_array(); // no-warning
+    doWork(baz);
+  }
+
+};
+} // namespace auto_keyword
+
+namespace guardian_casts {
+void foo1() {
+  RetainPtr<NSObject> foo;
+  {
+    SomeObj *bar = downcast<SomeObj>(foo.get());
+    [bar doWork];
+  }
+}
+
+void foo2() {
+  RetainPtr<NSObject> foo;
+  {
+    SomeObj *bar = static_cast<SomeObj *>(downcast<SomeObj>(foo.get()));
+    someFunction();
+  }
+}
+} // namespace guardian_casts
+
+namespace conditional_op {
+SomeObj *provide_obj();
+bool bar();
+
+void foo() {
+  SomeObj *a = bar() ? nullptr : provide_obj();
+  // expected-warning@-1{{Local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  RetainPtr<SomeObj> b = provide_obj();
+  {
+    SomeObj* c = bar() ? nullptr : b.get();
+    [c doWork];
+    SomeObj* d = bar() ? b.get() : nullptr;
+    [d doWork];
+  }
+}
+
+} // namespace conditional_op
+
+namespace local_assignment_basic {
+
+SomeObj *provide_obj();
+
+void foo(SomeObj* a) {
+  SomeObj* b = a;
+  // expected-warning@-1{{Local variable 'b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  if ([b other])
+    b = provide_obj();
+}
+
+void bar(SomeObj* a) {
+  SomeObj* b;
+  // expected-warning@-1{{Local variable 'b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  b = provide_obj();
+}
+
+void baz() {
+  RetainPtr<SomeObj> a = provide_obj();
+  {
+    SomeObj* b = a.get();
+    // expected-warning@-1{{Local variable 'b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+    b = provide_obj();
+  }
+}
+
+} // namespace local_assignment_basic
+
+namespace local_assignment_to_parameter {
+
+SomeObj *provide_obj();
+void someFunction();
+
+void foo(SomeObj* a) {
+  a = provide_obj();
+  // expected-warning@-1{{Assignment to an unretained parameter 'a' is unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  someFunction();
+  [a doWork];
+}
+
+CFMutableArrayRef provide_cf_array();
+void doWork(CFMutableArrayRef);
+
+void bar(CFMutableArrayRef a) {
+  a = provide_cf_array();
+  // expected-warning@-1{{Assignment to an unretained parameter 'a' is unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  doWork(a);
+}
+
+} // namespace local_assignment_to_parameter
+
+namespace local_assignment_to_static_local {
+
+SomeObj *provide_obj();
+void someFunction();
+
+void foo() {
+  static SomeObj* a = nullptr;
+  // expected-warning@-1{{Static local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  a = provide_obj();
+  someFunction();
+  [a doWork];
+}
+
+CFMutableArrayRef provide_cf_array();
+void doWork(CFMutableArrayRef);
+
+void bar() {
+  static CFMutableArrayRef a = nullptr;
+  // expected-warning@-1{{Static local variable 'a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  a = provide_cf_array();
+  doWork(a);
+}
+
+} // namespace local_assignment_to_static_local
+
+namespace local_assignment_to_global {
+
+SomeObj *provide_obj();
+void someFunction();
+
+SomeObj* g_a = nullptr;
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_a' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+
+void foo() {
+  g_a = provide_obj();
+  someFunction();
+  [g_a doWork];
+}
+
+CFMutableArrayRef provide_cf_array();
+void doWork(CFMutableArrayRef);
+
+CFMutableArrayRef g_b = nullptr;
+// expected-warning@-1{{Global variable 'local_assignment_to_global::g_b' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+
+void bar() {
+  g_b = provide_cf_array();
+  doWork(g_b);
+}
+
+} // namespace local_assignment_to_global
+
+namespace local_var_for_singleton {
+  SomeObj *singleton();
+  SomeObj *otherSingleton();
+  void foo() {
+    SomeObj* bar = singleton();
+    SomeObj* baz = otherSingleton();
+  }
+
+  CFMutableArrayRef cfSingleton();
+  void bar() {
+    CFMutableArrayRef cf = cfSingleton();
+  }
+}

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
@@ -358,3 +358,16 @@ namespace local_var_for_singleton {
     CFMutableArrayRef cf = cfSingleton();
   }
 }
+
+bool doMoreWorkOpaque(OtherObj*);
+
+@implementation OtherObj
+- (instancetype)init {
+  self = [super init];
+  return self;
+}
+
+- (void)doMoreWork:(OtherObj *)other {
+  doMoreWorkOpaque(other);
+}
+@end


### PR DESCRIPTION
This PR adds alpha.webkit.UnretainedLocalVarsChecker by generalizing RawPtrRefLocalVarsChecker. It checks local variables to NS or CF types are guarded with a RetainPtr or not. The new checker is effective for NS and CF types in Objective-C++ code without ARC, and it's effective for CF types in code with ARC.