### PR TITLE
[HLSL] Allow arrays to copy-initialize

### DIFF
--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -104,6 +104,7 @@ namespace {
     void CheckStaticCast();
     void CheckDynamicCast();
     void CheckCXXCStyleCast(bool FunctionalCast, bool ListInitialization);
+    bool CheckHLSLCStyleCast(CheckedConversionKind CCK);
     void CheckCStyleCast();
     void CheckBuiltinBitCast();
     void CheckAddrspaceCast();
@@ -2776,47 +2777,9 @@ void CastOperation::CheckCXXCStyleCast(bool FunctionalStyle,
   CheckedConversionKind CCK = FunctionalStyle
                                   ? CheckedConversionKind::FunctionalCast
                                   : CheckedConversionKind::CStyleCast;
-
-  QualType SrcTy = SrcExpr.get()->getType();
-  // HLSL has several unique forms of C-style casts which support aggregate to
-  // aggregate casting.
   if (Self.getLangOpts().HLSL) {
-    // This case should not trigger on regular vector cast, vector truncation
-    if (Self.HLSL().CanPerformElementwiseCast(SrcExpr.get(), DestType)) {
-      if (SrcTy->isConstantArrayType())
-        SrcExpr = Self.ImpCastExprToType(
-            SrcExpr.get(), Self.Context.getArrayParameterType(SrcTy),
-            CK_HLSLArrayRValue, VK_PRValue, nullptr, CCK);
-      Kind = CK_HLSLElementwiseCast;
+    if (CheckHLSLCStyleCast(CCK))
       return;
-    }
-
-    // This case should not trigger on regular vector splat
-    // If the relative order of this and the HLSLElementWise cast checks
-    // are changed, it might change which cast handles what in a few cases
-    if (Self.HLSL().CanPerformAggregateSplatCast(SrcExpr.get(), DestType)) {
-      const VectorType *VT = SrcTy->getAs<VectorType>();
-      // change splat from vec1 case to splat from scalar
-      if (VT && VT->getNumElements() == 1)
-        SrcExpr = Self.ImpCastExprToType(
-            SrcExpr.get(), VT->getElementType(), CK_HLSLVectorTruncation,
-            SrcExpr.get()->getValueKind(), nullptr, CCK);
-      // Inserting a scalar cast here allows for a simplified codegen in
-      // the case the destTy is a vector
-      if (const VectorType *DVT = DestType->getAs<VectorType>())
-        SrcExpr = Self.ImpCastExprToType(
-            SrcExpr.get(), DVT->getElementType(),
-            Self.PrepareScalarCast(SrcExpr, DVT->getElementType()),
-            SrcExpr.get()->getValueKind(), nullptr, CCK);
-      Kind = CK_HLSLAggregateSplatCast;
-      return;
-    }
-    if (DestType->isArrayType()) {
-      Self.Diag(OpRange.getBegin(), diag::err_bad_cxx_cast_generic)
-          << 4 << SrcTy << DestType;
-      SrcExpr = ExprError();
-      return;
-    }
   }
 
   if (ValueKind == VK_PRValue && !DestType->isRecordType() &&
@@ -2933,6 +2896,53 @@ void CastOperation::CheckCXXCStyleCast(bool FunctionalStyle,
   } else {
     SrcExpr = ExprError();
   }
+}
+
+// CheckHLSLCStyleCast - Returns `true` ihe cast is handled or errored as an
+// HLSL-specific cast. Returns false if the cast should be checked as a CXX
+// C-Style cast.
+bool CastOperation::CheckHLSLCStyleCast(CheckedConversionKind CCK) {
+  assert(Self.getLangOpts().HLSL && "Must be HLSL!");
+  QualType SrcTy = SrcExpr.get()->getType();
+  // HLSL has several unique forms of C-style casts which support aggregate to
+  // aggregate casting.
+  // This case should not trigger on regular vector cast, vector truncation
+  if (Self.HLSL().CanPerformElementwiseCast(SrcExpr.get(), DestType)) {
+    if (SrcTy->isConstantArrayType())
+      SrcExpr = Self.ImpCastExprToType(
+          SrcExpr.get(), Self.Context.getArrayParameterType(SrcTy),
+          CK_HLSLArrayRValue, VK_PRValue, nullptr, CCK);
+    Kind = CK_HLSLElementwiseCast;
+    return true;
+  }
+
+  // This case should not trigger on regular vector splat
+  // If the relative order of this and the HLSLElementWise cast checks
+  // are changed, it might change which cast handles what in a few cases
+  if (Self.HLSL().CanPerformAggregateSplatCast(SrcExpr.get(), DestType)) {
+    const VectorType *VT = SrcTy->getAs<VectorType>();
+    // change splat from vec1 case to splat from scalar
+    if (VT && VT->getNumElements() == 1)
+      SrcExpr = Self.ImpCastExprToType(
+          SrcExpr.get(), VT->getElementType(), CK_HLSLVectorTruncation,
+          SrcExpr.get()->getValueKind(), nullptr, CCK);
+    // Inserting a scalar cast here allows for a simplified codegen in
+    // the case the destTy is a vector
+    if (const VectorType *DVT = DestType->getAs<VectorType>())
+      SrcExpr = Self.ImpCastExprToType(
+          SrcExpr.get(), DVT->getElementType(),
+          Self.PrepareScalarCast(SrcExpr, DVT->getElementType()),
+          SrcExpr.get()->getValueKind(), nullptr, CCK);
+    Kind = CK_HLSLAggregateSplatCast;
+    return true;
+  }
+  if (DestType->isArrayType()) {
+    Self.Diag(OpRange.getBegin(), diag::err_bad_cxx_cast_generic)
+        << 4 << SrcTy << DestType;
+    SrcExpr = ExprError();
+    return true;
+  }
+  return false;
 }
 
 /// DiagnoseBadFunctionCast - Warn whenever a function call is cast to a

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -2936,6 +2936,9 @@ bool CastOperation::CheckHLSLCStyleCast(CheckedConversionKind CCK) {
     Kind = CK_HLSLAggregateSplatCast;
     return true;
   }
+
+  // If the destination is an array, we've exhausted the valid HLSL casts, so we
+  // should emit a dignostic and stop processing.
   if (DestType->isArrayType()) {
     Self.Diag(OpRange.getBegin(), diag::err_bad_cxx_cast_generic)
         << 4 << SrcTy << DestType;

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -6585,6 +6585,18 @@ void InitializationSequence::InitializeFrom(Sema &S,
       }
     }
 
+    if (S.getLangOpts().HLSL && Initializer && isa<ConstantArrayType>(DestAT)) {
+      QualType SrcType = Entity.getType();
+      if (SrcType->isArrayParameterType())
+        SrcType =
+            cast<ArrayParameterType>(SrcType)->getConstantArrayType(Context);
+      if (S.Context.hasSameUnqualifiedType(DestType, SrcType)) {
+        TryArrayCopy(S, Kind, Entity, Initializer, DestType, *this,
+                     TreatUnavailableAsInvalid);
+        return;
+      }
+    }
+
     // Some kinds of initialization permit an array to be initialized from
     // another array of the same type, and perform elementwise initialization.
     if (Initializer && isa<ConstantArrayType>(DestAT) &&

--- a/clang/test/SemaHLSL/Language/AssignArray.hlsl
+++ b/clang/test/SemaHLSL/Language/AssignArray.hlsl
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library %s -ast-dump | FileCheck %s
+
+typedef vector<int,4> int8[2];
+
+export void fn(int8 A) {
+  int8 a = {A};
+// CHECK-LABEL: VarDecl {{.*}} b 'int8':'vector<int, 4>[2]' cinit
+// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'int8':'vector<int, 4>[2]'
+// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int8':'vector<int, 4>[2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int8':'vector<int, 4>[2]' lvalue Var {{.*}} 'a' 'int8':'vector<int, 4>[2]'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<int, 4>' <LValueToRValue>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'vector<int, 4>' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<int, 4> *' <ArrayToPointerDecay>
+// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int8':'vector<int, 4>[2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} 'int8':'vector<int, 4>[2]' lvalue Var {{.*}} 'a' 'int8':'vector<int, 4>[2]'
+// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned long'
+  int8 b = a;
+
+// CHECK-LABEL: VarDecl {{.*}} c 'int8':'vector<int, 4>[2]' cinit
+// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'int8':'vector<int, 4>[2]'
+// CHECK-NEXT: OpaqueValueExpr {{.*}} 'vector<int, 4>[2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, 4>[2]' lvalue ParmVar {{.*}} 'A' 'vector<int, 4>[2]'
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<int, 4>' <LValueToRValue>
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'vector<int, 4>' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'vector<int, 4> *' <ArrayToPointerDecay>
+// CHECK-NEXT: OpaqueValueExpr {{.*}} 'vector<int, 4>[2]' lvalue
+// CHECK-NEXT: DeclRefExpr {{.*}} 'vector<int, 4>[2]' lvalue ParmVar {{.*}} 'A' 'vector<int, 4>[2]'
+// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned long'
+  int8 c = A;
+}
+
+
+
+

--- a/clang/test/SemaHLSL/Language/ElementwiseCast-errors.hlsl
+++ b/clang/test/SemaHLSL/Language/ElementwiseCast-errors.hlsl
@@ -4,7 +4,7 @@ export void cantCast() {
   int A[3] = {1,2,3};
   int B[4] = {1,2,3,4};
   B = (int[4])A;
-  // expected-error@-1 {{C-style cast from 'int *' to 'int[4]' is not allowed}}
+  // expected-error@-1 {{C-style cast from 'int[3]' to 'int[4]' is not allowed}}
 }
 
 struct S {


### PR DESCRIPTION
This change allows array variables to copy-initialize from other arrays. It also corrects a small error in HLSL C-Style casting that did not error on casting to arrays if elementwise and splat conversions fail.

Fixes #127551