### PR TITLE
[lldb] Store the return SBValueList in the CommandReturnObject

### DIFF
--- a/lldb/include/lldb/API/SBCommandReturnObject.h
+++ b/lldb/include/lldb/API/SBCommandReturnObject.h
@@ -136,7 +136,7 @@ public:
 
   void SetError(const char *error_cstr);
 
-  lldb::SBValue GetReturnValue(lldb::DynamicValueType use_dynamic);
+  lldb::SBValueList GetValues(lldb::DynamicValueType use_dynamic);
 
 protected:
   friend class SBCommandInterpreter;

--- a/lldb/include/lldb/API/SBCommandReturnObject.h
+++ b/lldb/include/lldb/API/SBCommandReturnObject.h
@@ -136,6 +136,8 @@ public:
 
   void SetError(const char *error_cstr);
 
+  lldb::SBValue GetReturnValue(lldb::DynamicValueType use_dynamic);
+
 protected:
   friend class SBCommandInterpreter;
   friend class SBOptions;

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -442,6 +442,7 @@ public:
 
 protected:
   friend class SBBlock;
+  friend class SBCommandReturnObject;
   friend class SBFrame;
   friend class SBModule;
   friend class SBTarget;

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -14,6 +14,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StreamTee.h"
 #include "lldb/Utility/StructuredData.h"
+#include "lldb/ValueObject/ValueObjectList.h"
 #include "lldb/lldb-private.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -134,7 +135,7 @@ public:
       __attribute__((format(printf, 2, 3)));
 
   template <typename... Args>
-  void AppendMessageWithFormatv(const char *format, Args &&... args) {
+  void AppendMessageWithFormatv(const char *format, Args &&...args) {
     AppendMessage(llvm::formatv(format, std::forward<Args>(args)...).str());
   }
 
@@ -144,12 +145,12 @@ public:
   }
 
   template <typename... Args>
-  void AppendWarningWithFormatv(const char *format, Args &&... args) {
+  void AppendWarningWithFormatv(const char *format, Args &&...args) {
     AppendWarning(llvm::formatv(format, std::forward<Args>(args)...).str());
   }
 
   template <typename... Args>
-  void AppendErrorWithFormatv(const char *format, Args &&... args) {
+  void AppendErrorWithFormatv(const char *format, Args &&...args) {
     AppendError(llvm::formatv(format, std::forward<Args>(args)...).str());
   }
 
@@ -165,11 +166,9 @@ public:
     return m_diagnostic_indent;
   }
 
-  lldb::ValueObjectSP GetValueObjectSP() const { return m_value_object_sp; }
+  const ValueObjectList &GetValueObjectList() const { return m_value_objects; }
 
-  void SetValueObjectSP(lldb::ValueObjectSP value_object_sp) {
-    m_value_object_sp = value_object_sp;
-  }
+  ValueObjectList &GetValueObjectList() { return m_value_objects; }
 
   lldb::ReturnStatus GetStatus() const;
 
@@ -203,8 +202,8 @@ private:
 
   lldb::ReturnStatus m_status = lldb::eReturnStatusStarted;
 
-  /// An optional return ValueObjectSP.
-  lldb::ValueObjectSP m_value_object_sp;
+  /// An optionally empty list of values produced by this command.
+  ValueObjectList m_value_objects;
 
   bool m_did_change_process_state = false;
   bool m_suppress_immediate_output = false;

--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -165,6 +165,12 @@ public:
     return m_diagnostic_indent;
   }
 
+  lldb::ValueObjectSP GetValueObjectSP() const { return m_value_object_sp; }
+
+  void SetValueObjectSP(lldb::ValueObjectSP value_object_sp) {
+    m_value_object_sp = value_object_sp;
+  }
+
   lldb::ReturnStatus GetStatus() const;
 
   void SetStatus(lldb::ReturnStatus status);
@@ -196,6 +202,9 @@ private:
   std::optional<uint16_t> m_diagnostic_indent;
 
   lldb::ReturnStatus m_status = lldb::eReturnStatusStarted;
+
+  /// An optional return ValueObjectSP.
+  lldb::ValueObjectSP m_value_object_sp;
 
   bool m_did_change_process_state = false;
   bool m_suppress_immediate_output = false;

--- a/lldb/include/lldb/ValueObject/ValueObjectList.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectList.h
@@ -22,8 +22,6 @@ class ValueObject;
 /// A collection of ValueObject values that.
 class ValueObjectList {
 public:
-  const ValueObjectList &operator=(const ValueObjectList &rhs);
-
   void Append(const lldb::ValueObjectSP &val_obj_sp);
 
   void Append(const ValueObjectList &valobj_list);

--- a/lldb/source/API/SBCommandReturnObject.cpp
+++ b/lldb/source/API/SBCommandReturnObject.cpp
@@ -13,11 +13,13 @@
 #include "lldb/API/SBStream.h"
 #include "lldb/API/SBStructuredData.h"
 #include "lldb/API/SBValue.h"
+#include "lldb/API/SBValueList.h"
 #include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Instrumentation.h"
 #include "lldb/Utility/Status.h"
+#include "lldb/lldb-forward.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -358,11 +360,17 @@ void SBCommandReturnObject::SetError(const char *error_cstr) {
     ref().AppendError(error_cstr);
 }
 
-SBValue
-SBCommandReturnObject::GetReturnValue(lldb::DynamicValueType use_dynamic) {
+SBValueList
+SBCommandReturnObject::GetValues(lldb::DynamicValueType use_dynamic) {
   LLDB_INSTRUMENT_VA(this, use_dynamic);
 
-  SBValue sb_value;
-  sb_value.SetSP(ref().GetValueObjectSP(), use_dynamic);
-  return sb_value;
+  SBValueList value_list;
+  for (ValueObjectSP value_object_sp :
+       ref().GetValueObjectList().GetObjects()) {
+    SBValue value_sb;
+    value_sb.SetSP(value_object_sp, use_dynamic);
+    value_list.Append(value_sb);
+  }
+
+  return value_list;
 }

--- a/lldb/source/API/SBCommandReturnObject.cpp
+++ b/lldb/source/API/SBCommandReturnObject.cpp
@@ -12,6 +12,7 @@
 #include "lldb/API/SBFile.h"
 #include "lldb/API/SBStream.h"
 #include "lldb/API/SBStructuredData.h"
+#include "lldb/API/SBValue.h"
 #include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Utility/ConstString.h"
@@ -355,4 +356,13 @@ void SBCommandReturnObject::SetError(const char *error_cstr) {
 
   if (error_cstr)
     ref().AppendError(error_cstr);
+}
+
+SBValue
+SBCommandReturnObject::GetReturnValue(lldb::DynamicValueType use_dynamic) {
+  LLDB_INSTRUMENT_VA(this, use_dynamic);
+
+  SBValue sb_value;
+  sb_value.SetSP(ref().GetValueObjectSP(), use_dynamic);
+  return sb_value;
 }

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -205,6 +205,9 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     ExpressionResults expr_result = target.EvaluateExpression(
         expr, exe_scope, valobj_sp, eval_options, &fixed_expression);
 
+    if (valobj_sp)
+      result.SetValueObjectSP(valobj_sp);
+
     // Record the position of the expression in the command.
     std::optional<uint16_t> indent;
     if (fixed_expression.empty()) {

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -206,7 +206,7 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
         expr, exe_scope, valobj_sp, eval_options, &fixed_expression);
 
     if (valobj_sp)
-      result.SetValueObjectSP(valobj_sp);
+      result.GetValueObjectList().Append(valobj_sp);
 
     // Record the position of the expression in the command.
     std::optional<uint16_t> indent;

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -434,6 +434,8 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
   }
 
   if (result_valobj_sp) {
+    result.SetValueObjectSP(result_valobj_sp);
+
     Format format = m_format_options.GetFormat();
 
     if (result_valobj_sp->GetError().Success()) {

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -434,7 +434,7 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
   }
 
   if (result_valobj_sp) {
-    result.SetValueObjectSP(result_valobj_sp);
+    result.GetValueObjectList().Append(result_valobj_sp);
 
     Format format = m_format_options.GetFormat();
 

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -152,7 +152,7 @@ protected:
       return;
     }
 
-    result.SetValueObjectSP(valobj_sp);
+    result.GetValueObjectList().Append(valobj_sp);
     DumpValueObjectOptions::DeclPrintingHelper helper =
         [&valobj_sp](ConstString type, ConstString var,
                      const DumpValueObjectOptions &opts,
@@ -318,10 +318,10 @@ protected:
       } else if (*m_options.relative_frame_offset > 0) {
         // I don't want "up 20" where "20" takes you past the top of the stack
         // to produce an error, but rather to just go to the top.  OTOH, start
-        // by seeing if the requested frame exists, in which case we can avoid 
+        // by seeing if the requested frame exists, in which case we can avoid
         // counting the stack here...
-        const uint32_t frame_requested = frame_idx 
-            + *m_options.relative_frame_offset;
+        const uint32_t frame_requested =
+            frame_idx + *m_options.relative_frame_offset;
         StackFrameSP frame_sp = thread->GetStackFrameAtIndex(frame_requested);
         if (frame_sp)
           frame_idx = frame_requested;
@@ -516,8 +516,8 @@ protected:
 
     if (error.Fail() && (!variable_list || variable_list->GetSize() == 0)) {
       result.AppendError(error.AsCString());
-
     }
+
     ValueObjectSP valobj_sp;
 
     TypeSummaryImplSP summary_format_sp;
@@ -565,6 +565,8 @@ protected:
                 valobj_sp = frame->GetValueObjectForFrameVariable(
                     var_sp, m_varobj_options.use_dynamic);
                 if (valobj_sp) {
+                  result.GetValueObjectList().Append(valobj_sp);
+
                   std::string scope_string;
                   if (m_option_variable.show_scope)
                     scope_string = GetScopeString(var_sp).str();
@@ -605,6 +607,8 @@ protected:
                 entry.ref(), m_varobj_options.use_dynamic, expr_path_options,
                 var_sp, error);
             if (valobj_sp) {
+              result.GetValueObjectList().Append(valobj_sp);
+
               std::string scope_string;
               if (m_option_variable.show_scope)
                 scope_string = GetScopeString(var_sp).str();
@@ -654,6 +658,8 @@ protected:
             valobj_sp = frame->GetValueObjectForFrameVariable(
                 var_sp, m_varobj_options.use_dynamic);
             if (valobj_sp) {
+              result.GetValueObjectList().Append(valobj_sp);
+
               // When dumping all variables, don't print any variables that are
               // not in scope to avoid extra unneeded output
               if (valobj_sp->IsInScope()) {
@@ -695,6 +701,7 @@ protected:
             recognized_frame->GetRecognizedArguments();
         if (recognized_arg_list) {
           for (auto &rec_value_sp : recognized_arg_list->GetObjects()) {
+            result.GetValueObjectList().Append(rec_value_sp);
             options.SetFormat(m_option_format.GetFormat());
             options.SetVariableFormatDisplayLanguage(
                 rec_value_sp->GetPreferredDisplayLanguage());

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -152,6 +152,7 @@ protected:
       return;
     }
 
+    result.SetValueObjectSP(valobj_sp);
     DumpValueObjectOptions::DeclPrintingHelper helper =
         [&valobj_sp](ConstString type, ConstString var,
                      const DumpValueObjectOptions &opts,

--- a/lldb/source/ValueObject/ValueObjectList.cpp
+++ b/lldb/source/ValueObject/ValueObjectList.cpp
@@ -16,12 +16,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-const ValueObjectList &ValueObjectList::operator=(const ValueObjectList &rhs) {
-  if (this != &rhs)
-    m_value_objects = rhs.m_value_objects;
-  return *this;
-}
-
 void ValueObjectList::Append(const ValueObjectSP &val_obj_sp) {
   m_value_objects.push_back(val_obj_sp);
 }

--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -33,3 +33,16 @@ class TestSBCommandReturnObject(TestBase):
         ci.HandleCommand("help help", res)
         self.assertTrue(res.Succeeded())
         self.assertEqual(res.GetCommand(), "help help")
+
+        value = res.GetReturnValue(lldb.eNoDynamicValues)
+        self.assertFalse(value)
+
+    def test_get_value(self):
+        res = lldb.SBCommandReturnObject()
+        ci = self.dbg.GetCommandInterpreter()
+        ci.HandleCommand("p 1 + 1", res)
+        self.assertTrue(res.Succeeded())
+
+        value = res.GetReturnValue(lldb.eNoDynamicValues)
+        self.assertTrue(value)
+        self.assertEqual(value.GetValue(), "2")

--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -34,8 +34,8 @@ class TestSBCommandReturnObject(TestBase):
         self.assertTrue(res.Succeeded())
         self.assertEqual(res.GetCommand(), "help help")
 
-        value = res.GetReturnValue(lldb.eNoDynamicValues)
-        self.assertFalse(value)
+        value_list = res.GetValues(lldb.eNoDynamicValues)
+        self.assertEqual(value_list.GetSize(), 0)
 
     def test_get_value(self):
         res = lldb.SBCommandReturnObject()
@@ -43,6 +43,6 @@ class TestSBCommandReturnObject(TestBase):
         ci.HandleCommand("p 1 + 1", res)
         self.assertTrue(res.Succeeded())
 
-        value = res.GetReturnValue(lldb.eNoDynamicValues)
-        self.assertTrue(value)
-        self.assertEqual(value.GetValue(), "2")
+        value_list = res.GetValues(lldb.eNoDynamicValues)
+        self.assertEqual(value_list.GetSize(), 1)
+        self.assertEqual(value_list.GetValueAtIndex(0).GetValue(), "2")

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -2,7 +2,6 @@
 Make sure the frame variable -g, -a, and -l flags work.
 """
 
-
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.decorators import *
@@ -78,6 +77,14 @@ class TestFrameVar(TestBase):
         self.assertIn("argv", output, "Args didn't find argv")
         self.assertNotIn("test_var", output, "Args found a local")
         self.assertNotIn("g_var", output, "Args found a global")
+
+        value_list = command_result.GetValues(lldb.eNoDynamicValues)
+        self.assertGreaterEqual(value_list.GetSize(), 2)
+        value_names = []
+        for value in value_list:
+            value_names.append(value.GetName())
+        self.assertIn("argc", value_names)
+        self.assertIn("argv", value_names)
 
         # Just get locals:
         result = interp.HandleCommand("frame var -a", command_result)

--- a/lldb/test/API/functionalities/target_var/TestTargetVar.py
+++ b/lldb/test/API/functionalities/target_var/TestTargetVar.py
@@ -34,3 +34,12 @@ class targetCommandTestCase(TestBase):
             error=True,
             substrs=["can't find global variable 'var[0]'"],
         )
+
+        command_result = lldb.SBCommandReturnObject()
+        result = self.ci.HandleCommand("target var", command_result)
+        value_list = command_result.GetValues(lldb.eNoDynamicValues)
+        self.assertGreaterEqual(value_list.GetSize(), 2)
+        value_names = []
+        for value in value_list:
+            value_names.append(value.GetName())
+        self.assertIn("i", value_names)


### PR DESCRIPTION
There are a lot of lldb commands whose result is really one or more ValueObjects that we then print with the ValueObjectPrinter. Now that we have the ability to access the SBCommandReturnObject through a callback (#125006), we can store the resultant ValueObjects in the return object, allowing an IDE  to access the SBValues and do its own rich formatting.

rdar://143965453