### PR TITLE
LLVM/Test: Mark Mips readcyclecounter.ll XFAIL: expensive_checks

### DIFF
--- a/llvm/test/CodeGen/Mips/readcyclecounter.ll
+++ b/llvm/test/CodeGen/Mips/readcyclecounter.ll
@@ -7,6 +7,8 @@
 ;RUN: llc -mtriple=mipsel -mcpu=mips2 < %s | FileCheck %s --check-prefix=MIPSEL_NOT_SUPPORTED
 ;RUN: llc -mtriple=mips64el -mcpu=mips3 < %s | FileCheck %s --check-prefix=MIPS64EL_NOT_SUPPORTED
 
+; XFAIL: expensive_checks
+
 declare i64 @llvm.readcyclecounter() nounwind readnone
 
 define i64 @test_readcyclecounter() nounwind {


### PR DESCRIPTION
expsensive_check complains that:

bb.0.entry:
  %0:gpr32 = RDHWR $hwr2, 0
  %1:gpr32 = ADDiu $zero, 0
  $v0 = COPY %0:gpr32
  $v1 = COPY %1:gpr32
  RetRA implicit $v0, implicit $v1

*** Bad machine code: Using an undefined physical register ***
- function:    test_readcyclecounter
- basic block: %bb.0 entry (0xad97ee0)
- instruction: %0:gpr32 = RDHWR $hwr2, 0
- operand 1:   $hwr2
LLVM ERROR: Found 1 machine code errors.