### PR TITLE
[mlir][nfc] Add a negative test for --linalg-specialize-generic-ops

### DIFF
--- a/mlir/test/Dialect/Linalg/specialize-generic-ops-fail.mlir
+++ b/mlir/test/Dialect/Linalg/specialize-generic-ops-fail.mlir
@@ -6,11 +6,26 @@
 // CHECK-LABEL: @transpose_and_broadcast
 // CHECK: linalg.generic
 func.func @transpose_and_broadcast(%arg0: tensor<7x8xf32>, %arg1: tensor<8x7x9xf32>) -> tensor<8x7x9xf32> {
-  %0 = linalg.generic
-        {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel"]}
-        ins(%arg0 : tensor<7x8xf32>) outs(%arg1 : tensor<8x7x9xf32>) {
-        ^bb0(%in: f32, %out: f32):
-           linalg.yield %in : f32
+  %res = linalg.generic {
+    indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel"]
+  } ins(%arg0 : tensor<7x8xf32>) outs(%arg1 : tensor<8x7x9xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    linalg.yield %in : f32
   } -> tensor<8x7x9xf32>
-  return %0 : tensor<8x7x9xf32>
+  return %res : tensor<8x7x9xf32>
+}
+
+// -----
+
+#map = affine_map<(d0) -> (d0)>
+// CHECK-LABEL: @neither_permutation_nor_broadcast
+// CHECK: linalg.generic
+func.func @neither_permutation_nor_broadcast(%init : tensor<8xi32>) -> tensor<8xi32> {
+  %res = linalg.generic {
+    indexing_maps = [#map], iterator_types = ["parallel"]
+  } outs(%init: tensor<8xi32>) {
+  ^bb0(%out: i32):
+    linalg.yield %out: i32
+  } -> tensor<8xi32>
+  return %res : tensor<8xi32>
 }


### PR DESCRIPTION
Following on from #126737, adds a negative test that:
* prior to #126737, would incorrectly generated empty output,
* with the fix in-tree, simply outputs the input IR (i.e. the
  specialization "fails").

I've also made minor editorial changes.
