### PR TITLE
[analyzer] Limit Store by region-store-binding-limit

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
+++ b/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
@@ -489,7 +489,7 @@ ANALYZER_OPTION(
     "scatter into. For example, binding an array would scatter into binding "
     "each individual element. Setting this to zero means unlimited, but then "
     "modelling large array initializers may take proportional time to their "
-    "size.", 100)
+    "size.", 128)
 
 //===----------------------------------------------------------------------===//
 // String analyzer options.

--- a/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
+++ b/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
@@ -483,6 +483,14 @@ ANALYZER_OPTION(
     "behavior, set the option to 0.",
     5)
 
+ANALYZER_OPTION(
+    unsigned, RegionStoreMaxBindingFanOut, "region-store-max-binding-fanout",
+    "This option limits how many sub-bindings a single binding operation can "
+    "scatter into. For example, binding an array would scatter into binding "
+    "each individual element. Setting this to zero means unlimited, but then "
+    "modelling large array initializers may take proportional time to their "
+    "size.", 100)
+
 //===----------------------------------------------------------------------===//
 // String analyzer options.
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -659,13 +659,13 @@ private:
                               SVal Loc, SVal Val,
                               const LocationContext *LCtx);
 
+public:
   /// A simple wrapper when you only need to notify checkers of pointer-escape
   /// of some values.
   ProgramStateRef escapeValues(ProgramStateRef State, ArrayRef<SVal> Vs,
                                PointerEscapeKind K,
                                const CallEvent *Call = nullptr) const;
 
-public:
   // FIXME: 'tag' should be removed, and a LocationContext should be used
   // instead.
   // FIXME: Comment on the meaning of the arguments, when 'St' may not

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -126,6 +126,7 @@ private:
   /// makeWithStore - Return a ProgramState with the same values as the current
   ///  state with the exception of using the specified Store.
   ProgramStateRef makeWithStore(const StoreRef &store) const;
+  ProgramStateRef makeWithStore(const BindResult &BindRes) const;
 
   void setStore(const StoreRef &storeRef);
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
@@ -50,6 +50,14 @@ class SymbolReaper;
 
 using InvalidatedSymbols = llvm::DenseSet<SymbolRef>;
 
+struct BindResult {
+  StoreRef ResultingStore;
+
+  // If during the bind operation we exhaust the allowed binding budget, we set
+  // this to the beginning of the escaped part of the region.
+  llvm::SmallVector<SVal, 0> FailedToBindValues;
+};
+
 class StoreManager {
 protected:
   SValBuilder &svalBuilder;
@@ -105,7 +113,7 @@ public:
   /// \return A StoreRef object that contains the same
   ///   bindings as \c store with the addition of having the value specified
   ///   by \c val bound to the location given for \c loc.
-  virtual StoreRef Bind(Store store, Loc loc, SVal val) = 0;
+  virtual BindResult Bind(Store store, Loc loc, SVal val) = 0;
 
   /// Return a store with the specified value bound to all sub-regions of the
   /// region. The region must not have previous bindings. If you need to

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
@@ -118,12 +118,12 @@ public:
   /// Return a store with the specified value bound to all sub-regions of the
   /// region. The region must not have previous bindings. If you need to
   /// invalidate existing bindings, consider invalidateRegions().
-  virtual StoreRef BindDefaultInitial(Store store, const MemRegion *R,
-                                      SVal V) = 0;
+  virtual BindResult BindDefaultInitial(Store store, const MemRegion *R,
+                                        SVal V) = 0;
 
   /// Return a store with in which all values within the given region are
   /// reset to zero. This method is allowed to overwrite previous bindings.
-  virtual StoreRef BindDefaultZero(Store store, const MemRegion *R) = 0;
+  virtual BindResult BindDefaultZero(Store store, const MemRegion *R) = 0;
 
   /// Create a new store with the specified binding removed.
   /// \param ST the original store, that is the basis for the new store.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/Store.h
@@ -248,9 +248,8 @@ public:
 
   /// enterStackFrame - Let the StoreManager to do something when execution
   /// engine is about to execute into a callee.
-  StoreRef enterStackFrame(Store store,
-                           const CallEvent &Call,
-                           const StackFrameContext *CalleeCtx);
+  BindResult enterStackFrame(Store store, const CallEvent &Call,
+                             const StackFrameContext *CalleeCtx);
 
   /// Finds the transitive closure of symbols within the given region.
   ///

--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -607,17 +607,14 @@ public: // Part of public interface to class.
   // a default value.
   BindResult BindDefaultInitial(Store store, const MemRegion *R,
                                 SVal V) override {
-    llvm::SmallVector<SVal, 0> EscapedValuesDuringBind;
-    BoundedRegionBindingsRef B =
-        getRegionBindings(store, EscapedValuesDuringBind);
+    RegionBindingsRef B = getRegionBindings(store);
     // Use other APIs when you have to wipe the region that was initialized
     // earlier.
     assert(!(B.getDefaultBinding(R) || B.getDirectBinding(R)) &&
            "Double initialization!");
     B = B.addBinding(BindingKey::Make(R, BindingKey::Default), V);
     return BindResult{
-        StoreRef(B.asImmutableMap().getRootWithoutRetain(), *this),
-        std::move(EscapedValuesDuringBind)};
+        StoreRef(B.asImmutableMap().getRootWithoutRetain(), *this), {}};
   }
 
   // BindDefaultZero is used for zeroing constructors that may accidentally

--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -29,6 +29,7 @@
 #include "clang/StaticAnalyzer/Core/PathSensitive/StoreRef.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/SymExpr.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -43,21 +44,21 @@ StoreManager::StoreManager(ProgramStateManager &stateMgr)
     : svalBuilder(stateMgr.getSValBuilder()), StateMgr(stateMgr),
       MRMgr(svalBuilder.getRegionManager()), Ctx(stateMgr.getContext()) {}
 
-StoreRef StoreManager::enterStackFrame(Store OldStore,
-                                       const CallEvent &Call,
-                                       const StackFrameContext *LCtx) {
-  StoreRef Store = StoreRef(OldStore, *this);
+BindResult StoreManager::enterStackFrame(Store OldStore, const CallEvent &Call,
+                                         const StackFrameContext *LCtx) {
+  BindResult Result{StoreRef(OldStore, *this), {}};
 
   SmallVector<CallEvent::FrameBindingTy, 16> InitialBindings;
   Call.getInitialStackFrameContents(LCtx, InitialBindings);
 
   for (const auto &[Location, Val] : InitialBindings) {
-    BindResult Res = Bind(Store.getStore(), Location.castAs<Loc>(), Val);
-    assert(Res.FailedToBindValues.empty());
-    Store = Res.ResultingStore;
+    Store S = Result.ResultingStore.getStore();
+    BindResult Curr = Bind(S, Location.castAs<Loc>(), Val);
+    Result.ResultingStore = Curr.ResultingStore;
+    llvm::append_range(Result.FailedToBindValues, Curr.FailedToBindValues);
   }
 
-  return Store;
+  return Result;
 }
 
 const ElementRegion *StoreManager::MakeElementRegion(const SubRegion *Base,

--- a/clang/lib/StaticAnalyzer/Core/Store.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Store.cpp
@@ -51,8 +51,11 @@ StoreRef StoreManager::enterStackFrame(Store OldStore,
   SmallVector<CallEvent::FrameBindingTy, 16> InitialBindings;
   Call.getInitialStackFrameContents(LCtx, InitialBindings);
 
-  for (const auto &I : InitialBindings)
-    Store = Bind(Store.getStore(), I.first.castAs<Loc>(), I.second);
+  for (const auto &[Location, Val] : InitialBindings) {
+    BindResult Res = Bind(Store.getStore(), Location.castAs<Loc>(), Val);
+    assert(Res.FailedToBindValues.empty());
+    Store = Res.ResultingStore;
+  }
 
   return Store;
 }

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -116,7 +116,7 @@
 // CHECK-NEXT: osx.NumberObjectConversion:Pedantic = false
 // CHECK-NEXT: osx.cocoa.RetainCount:TrackNSCFStartParam = false
 // CHECK-NEXT: prune-paths = true
-// CHECK-NEXT: region-store-max-binding-fanout = 100
+// CHECK-NEXT: region-store-max-binding-fanout = 128
 // CHECK-NEXT: region-store-small-array-limit = 5
 // CHECK-NEXT: region-store-small-struct-limit = 2
 // CHECK-NEXT: report-in-main-source-file = false

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -116,6 +116,7 @@
 // CHECK-NEXT: osx.NumberObjectConversion:Pedantic = false
 // CHECK-NEXT: osx.cocoa.RetainCount:TrackNSCFStartParam = false
 // CHECK-NEXT: prune-paths = true
+// CHECK-NEXT: region-store-max-binding-fanout = 100
 // CHECK-NEXT: region-store-small-array-limit = 5
 // CHECK-NEXT: region-store-small-struct-limit = 2
 // CHECK-NEXT: report-in-main-source-file = false

--- a/clang/test/Analysis/region-store.cpp
+++ b/clang/test/Analysis/region-store.cpp
@@ -358,3 +358,31 @@ void theValueOfTheEscapedRegionRemainsTheSame() {
 
   escape(l, l2);
 }
+
+void calleeWithManyParms(BigArray<int, 7> arr7, BigArray<int, 100> arr100) {
+  clang_analyzer_dump(arr7.array[0]);    // default-warning {{0 S32b}} unlimited-warning {{0 S32b}} limit10-warning {{0 S32b}}
+  clang_analyzer_dump(arr7.array[6]);    // default-warning {{6 S32b}} unlimited-warning {{6 S32b}} limit10-warning {{6 S32b}}
+
+  clang_analyzer_dump(arr100.array[0]);  // default-warning {{10 S32b}} unlimited-warning {{10 S32b}} limit10-warning {{10 S32b}}
+  clang_analyzer_dump(arr100.array[6]);  // default-warning {{16 S32b}} unlimited-warning {{16 S32b}} limit10-warning {{16 S32b}}
+
+  clang_analyzer_dump(arr100.array[8]);  // default-warning {{18 S32b}} unlimited-warning {{18 S32b}} limit10-warning {{18 S32b}}
+  clang_analyzer_dump(arr100.array[9]);  // default-warning {{19 S32b}} unlimited-warning {{19 S32b}} limit10-warning {{19 S32b}}
+  clang_analyzer_dump(arr100.array[10]); // default-warning {{20 S32b}} unlimited-warning {{20 S32b}} limit10-warning {{Unknown}}
+  clang_analyzer_dump(arr100.array[99]); // default-warning {{19 S32b}} unlimited-warning {{19 S32b}} limit10-warning {{Unknown}}
+}
+
+void tooManyFnArgumentsWhenInlining() {
+  calleeWithManyParms({0,1,2,3,4,5,6}, {
+    10,11,12,13,14,15,16,17,18,19,
+    20,21,22,23,24,25,26,27,28,29,
+    30,31,32,33,34,35,36,37,38,39,
+    40,41,42,43,44,45,46,47,48,49,
+    50,51,52,53,54,55,56,57,58,59,
+    60,61,62,63,64,65,66,67,68,69,
+    70,71,72,73,74,75,76,77,78,79,
+    80,81,82,83,84,85,86,87,88,89,
+    90,91,92,93,94,95,96,97,98,99,
+    10,11,12,13,14,15,16,17,18,19,
+  });
+}

--- a/clang/test/Analysis/region-store.cpp
+++ b/clang/test/Analysis/region-store.cpp
@@ -1,5 +1,15 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix -verify %s
-// expected-no-diagnostics
+// DEFINE: %{analyzer} = %clang_analyze_cc1 -Wno-array-bounds %s \
+// DEFINE:   -analyzer-checker=core,cplusplus,unix,debug.ExprInspection
+
+// RUN: %{analyzer} -verify=default
+// RUN: %{analyzer} -analyzer-config region-store-max-binding-fanout=10 -verify=limit10
+// RUN: %{analyzer} -analyzer-config region-store-max-binding-fanout=0  -verify=unlimited
+
+template <class T> void clang_analyzer_dump(T);
+void clang_analyzer_eval(bool);
+
+template <class... Ts> void escape(Ts...);
+bool coin();
 
 class Loc {
   int x;
@@ -25,4 +35,326 @@ int radar13445834(Derived *Builder, Loc l) {
   Builder->setLoc(l);
   return Builder->accessBase();
   
+}
+
+void boundedNumberOfBindings() {
+  int array[] {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22};
+  clang_analyzer_dump(array[0]);  // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{0 S32b}}
+  clang_analyzer_dump(array[1]);  // default-warning  {{1 S32b}}  unlimited-warning  {{1 S32b}}  limit10-warning  {{1 S32b}}
+  clang_analyzer_dump(array[2]);  // default-warning  {{2 S32b}}  unlimited-warning  {{2 S32b}}  limit10-warning  {{2 S32b}}
+  clang_analyzer_dump(array[3]);  // default-warning  {{3 S32b}}  unlimited-warning  {{3 S32b}}  limit10-warning  {{3 S32b}}
+  clang_analyzer_dump(array[4]);  // default-warning  {{4 S32b}}  unlimited-warning  {{4 S32b}}  limit10-warning  {{4 S32b}}
+  clang_analyzer_dump(array[5]);  // default-warning  {{5 S32b}}  unlimited-warning  {{5 S32b}}  limit10-warning  {{5 S32b}}
+  clang_analyzer_dump(array[6]);  // default-warning  {{6 S32b}}  unlimited-warning  {{6 S32b}}  limit10-warning  {{6 S32b}}
+  clang_analyzer_dump(array[7]);  // default-warning  {{7 S32b}}  unlimited-warning  {{7 S32b}}  limit10-warning  {{7 S32b}}
+  clang_analyzer_dump(array[8]);  // default-warning  {{8 S32b}}  unlimited-warning  {{8 S32b}}  limit10-warning  {{8 S32b}}
+  clang_analyzer_dump(array[9]);  // default-warning  {{9 S32b}}  unlimited-warning  {{9 S32b}}  limit10-warning  {{9 S32b}}
+  clang_analyzer_dump(array[10]); // default-warning {{10 S32b}}  unlimited-warning {{10 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[11]); // default-warning {{11 S32b}}  unlimited-warning {{11 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[12]); // default-warning {{12 S32b}}  unlimited-warning {{12 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[13]); // default-warning {{13 S32b}}  unlimited-warning {{13 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[14]); // default-warning {{14 S32b}}  unlimited-warning {{14 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[15]); // default-warning {{15 S32b}}  unlimited-warning {{15 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[16]); // default-warning {{16 S32b}}  unlimited-warning {{16 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[17]); // default-warning {{17 S32b}}  unlimited-warning {{17 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[18]); // default-warning {{18 S32b}}  unlimited-warning {{18 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[19]); // default-warning {{19 S32b}}  unlimited-warning {{19 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[20]); // default-warning {{20 S32b}}  unlimited-warning {{20 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[21]); // default-warning {{21 S32b}}  unlimited-warning {{21 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[22]); // default-warning {{22 S32b}}  unlimited-warning {{22 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(array[23]); //          see below                     see below            limit10-warning {{Unknown}}
+  // default-warning@-1   {{1st function call argument is an uninitialized value}}
+  // unlimited-warning@-2 {{1st function call argument is an uninitialized value}}
+  // FIXME: The last dump at index 23 should be Undefined due to out of bounds access.
+}
+
+void incompleteInitList() {
+  int array[23] {0,1,2,3,4,5,6,7,8,9,10,11 /*rest are zeroes*/ };
+  clang_analyzer_dump(array[0]);  // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{0 S32b}}
+  clang_analyzer_dump(array[1]);  // default-warning  {{1 S32b}}  unlimited-warning  {{1 S32b}}  limit10-warning  {{1 S32b}}
+  clang_analyzer_dump(array[2]);  // default-warning  {{2 S32b}}  unlimited-warning  {{2 S32b}}  limit10-warning  {{2 S32b}}
+  clang_analyzer_dump(array[3]);  // default-warning  {{3 S32b}}  unlimited-warning  {{3 S32b}}  limit10-warning  {{3 S32b}}
+  clang_analyzer_dump(array[4]);  // default-warning  {{4 S32b}}  unlimited-warning  {{4 S32b}}  limit10-warning  {{4 S32b}}
+  clang_analyzer_dump(array[5]);  // default-warning  {{5 S32b}}  unlimited-warning  {{5 S32b}}  limit10-warning  {{5 S32b}}
+  clang_analyzer_dump(array[6]);  // default-warning  {{6 S32b}}  unlimited-warning  {{6 S32b}}  limit10-warning  {{6 S32b}}
+  clang_analyzer_dump(array[7]);  // default-warning  {{7 S32b}}  unlimited-warning  {{7 S32b}}  limit10-warning  {{7 S32b}}
+  clang_analyzer_dump(array[8]);  // default-warning  {{8 S32b}}  unlimited-warning  {{8 S32b}}  limit10-warning  {{8 S32b}}
+  clang_analyzer_dump(array[9]);  // default-warning  {{9 S32b}}  unlimited-warning  {{9 S32b}}  limit10-warning  {{9 S32b}}
+  clang_analyzer_dump(array[10]); // default-warning {{10 S32b}}  unlimited-warning {{10 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[11]); // default-warning {{11 S32b}}  unlimited-warning {{11 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[12]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[13]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[14]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[15]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[16]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[17]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[18]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[19]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[20]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[21]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[22]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  clang_analyzer_dump(array[23]); // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{Unknown}}
+  // FIXME: The last dump at index 23 should be Undefined due to out of bounds access.
+}
+
+struct Inner {
+  int first;
+  int second;
+};
+struct Outer {
+  Inner upper;
+  Inner lower;
+};
+
+void nestedStructInitLists() {
+  Outer array[]{ // 7*4: 28 values
+    {{00, 01}, {02, 03}},
+    {{10, 11}, {12, 13}},
+    {{20, 21}, {22, 23}},
+    {{30, 31}, {32, 33}},
+    {{40, 41}, {42, 43}},
+    {{50, 51}, {52, 53}},
+    {{60, 61}, {62, 63}},
+  };
+
+  int *p = (int*)array;
+  clang_analyzer_dump(p[0]);  // default-warning  {{0 S32b}}  unlimited-warning  {{0 S32b}}  limit10-warning  {{0 S32b}}
+  clang_analyzer_dump(p[1]);  // default-warning  {{1 S32b}}  unlimited-warning  {{1 S32b}}  limit10-warning  {{1 S32b}}
+  clang_analyzer_dump(p[2]);  // default-warning  {{2 S32b}}  unlimited-warning  {{2 S32b}}  limit10-warning  {{2 S32b}}
+  clang_analyzer_dump(p[3]);  // default-warning  {{3 S32b}}  unlimited-warning  {{3 S32b}}  limit10-warning  {{3 S32b}}
+  clang_analyzer_dump(p[4]);  // default-warning {{10 S32b}}  unlimited-warning {{10 S32b}}  limit10-warning {{10 S32b}}
+  clang_analyzer_dump(p[5]);  // default-warning {{11 S32b}}  unlimited-warning {{11 S32b}}  limit10-warning {{11 S32b}}
+  clang_analyzer_dump(p[6]);  // default-warning {{12 S32b}}  unlimited-warning {{12 S32b}}  limit10-warning {{12 S32b}}
+  clang_analyzer_dump(p[7]);  // default-warning {{13 S32b}}  unlimited-warning {{13 S32b}}  limit10-warning {{13 S32b}}
+  clang_analyzer_dump(p[8]);  // default-warning {{20 S32b}}  unlimited-warning {{20 S32b}}  limit10-warning {{20 S32b}}
+  clang_analyzer_dump(p[9]);  // default-warning {{21 S32b}}  unlimited-warning {{21 S32b}}  limit10-warning {{21 S32b}}
+  clang_analyzer_dump(p[10]); // default-warning {{22 S32b}}  unlimited-warning {{22 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[11]); // default-warning {{23 S32b}}  unlimited-warning {{23 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[12]); // default-warning {{30 S32b}}  unlimited-warning {{30 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[13]); // default-warning {{31 S32b}}  unlimited-warning {{31 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[14]); // default-warning {{32 S32b}}  unlimited-warning {{32 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[15]); // default-warning {{33 S32b}}  unlimited-warning {{33 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[16]); // default-warning {{40 S32b}}  unlimited-warning {{40 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[17]); // default-warning {{41 S32b}}  unlimited-warning {{41 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[18]); // default-warning {{42 S32b}}  unlimited-warning {{42 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[19]); // default-warning {{43 S32b}}  unlimited-warning {{43 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[20]); // default-warning {{50 S32b}}  unlimited-warning {{50 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[21]); // default-warning {{51 S32b}}  unlimited-warning {{51 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[22]); // default-warning {{52 S32b}}  unlimited-warning {{52 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[23]); // default-warning {{53 S32b}}  unlimited-warning {{53 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[24]); // default-warning {{60 S32b}}  unlimited-warning {{60 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[25]); // default-warning {{61 S32b}}  unlimited-warning {{61 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[26]); // default-warning {{62 S32b}}  unlimited-warning {{62 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[27]); // default-warning {{63 S32b}}  unlimited-warning {{63 S32b}}  limit10-warning {{Unknown}}
+  clang_analyzer_dump(p[28]); //          see below                     see below            limit10-warning {{Unknown}}
+  // default-warning@-1   {{1st function call argument is an uninitialized value}}
+  // unlimited-warning@-2 {{1st function call argument is an uninitialized value}}
+  // FIXME: The last dump at index 28 should be Undefined due to out of bounds access.
+}
+
+void expectNoLeaksInWidenedInitLists() {
+  int *p[] {
+    new int(0),
+    new int(1),
+    new int(2),
+    new int(3),
+    new int(4),
+    new int(5),
+    new int(6),
+    new int(7),
+    new int(8),
+    new int(9),
+    new int(10),
+    new int(11),
+    new int(12),
+    new int(13),
+    new int(14),
+    new int(15),
+    new int(16),
+    new int(17),
+    new int(18),
+    new int(19),
+    new int(20),
+    new int(21),
+    new int(22),
+    new int(23),
+    new int(24),
+  };
+  clang_analyzer_dump(*p[0]);  // default-warning  {{0 S32b}} unlimited-warning  {{0 S32b}} limit10-warning {{0 S32b}}
+  clang_analyzer_dump(*p[12]); // default-warning {{12 S32b}} unlimited-warning {{12 S32b}} limit10-warning {{Unknown}}
+  escape(p); // no-leaks
+}
+
+void rawArrayWithSelfReference() {
+  // If a pointer to some object escapes, that pointed object should escape too.
+  // Consequently, if the 22th initializer would escape, then the p[6] should also escape - clobbering any loads from that location later.
+  int *p[25] = {
+    new int(0),
+    new int(1),
+    new int(2),
+    new int(3),
+    new int(4),
+    new int(5),
+    new int(6),
+    new int(7),
+    p[5], // Should be a pointer to the 6th array element, but we get Undefined as the analyzer thinks that "p" is not yet initialized, thus loading from index 5 is UB. This is wrong.
+    new int(9),
+    new int(10),
+    new int(11),
+    new int(12),
+    new int(13),
+    new int(14),
+    new int(15),
+    new int(16),
+    new int(17),
+    new int(18),
+    new int(19),
+    new int(20),
+    new int(21),
+    p[6], // Should be a pointer to the 6th array element, but we get Undefined as the analyzer thinks that "p" is not yet initialized, thus loading from index 5 is UB. This is wrong.
+    new int(23),
+    new int(24),
+  };
+  clang_analyzer_dump(*p[5]);  // default-warning {{5 S32b}} unlimited-warning {{5 S32b}} limit10-warning {{5 S32b}}
+  clang_analyzer_dump(*p[6]);  // default-warning {{6 S32b}} unlimited-warning {{6 S32b}} limit10-warning {{6 S32b}}
+
+  if (coin()) {
+    clang_analyzer_dump(*p[8]);
+    // default-warning@-1   {{Dereference of undefined pointer value}}
+    // unlimited-warning@-2 {{Dereference of undefined pointer value}}
+    // limit10-warning@-3   {{Dereference of undefined pointer value}}
+  }
+
+  clang_analyzer_dump(*p[12]); // default-warning {{12 S32b}} unlimited-warning {{12 S32b}} limit10-warning {{Unknown}}
+
+  if (coin()) {
+    clang_analyzer_dump(*p[22]);
+    // default-warning@-1   {{Dereference of undefined pointer value}}
+    // unlimited-warning@-2 {{Dereference of undefined pointer value}}
+    // limit10-warning@-3   {{Unknown}}
+  }
+
+  clang_analyzer_dump(*p[23]); // default-warning {{23 S32b}} unlimited-warning {{23 S32b}} limit10-warning {{Unknown}}
+
+  escape(p); // no-leaks
+}
+
+template <class T, unsigned Size> struct BigArray {
+  T array[Size];
+};
+
+void fieldArrayWithSelfReference() {
+  // Similar to "rawArrayWithSelfReference", but using an aggregate object and assignment operator to achieve the element-wise binds.
+  BigArray<int *, 25> p;
+  p = {
+    new int(0),
+    new int(1),
+    new int(2),
+    new int(3),
+    new int(4),
+    new int(5),
+    new int(6),
+    new int(7),
+    p.array[5], // Pointer to the 6th array element.
+    new int(9),
+    new int(10),
+    new int(11),
+    new int(12),
+    new int(13),
+    new int(14),
+    new int(15),
+    new int(16),
+    new int(17),
+    new int(18),
+    new int(19),
+    new int(20),
+    new int(21),
+    p.array[6], // Pointer to the 7th array element.
+    new int(23),
+    new int(24),
+  };
+  clang_analyzer_dump(*p.array[5]);  // default-warning {{5 S32b}} unlimited-warning {{5 S32b}} limit10-warning {{5 S32b}}
+  clang_analyzer_dump(*p.array[6]);  // default-warning {{6 S32b}} unlimited-warning {{6 S32b}} limit10-warning {{6 S32b}}
+
+  if (coin()) {
+    clang_analyzer_dump(*p.array[8]);
+    // default-warning@-1   {{Unknown}}
+    // unlimited-warning@-2 {{Unknown}}
+    // limit10-warning@-3   {{Unknown}}
+  }
+
+  clang_analyzer_dump(*p.array[12]); // default-warning {{12 S32b}} unlimited-warning {{12 S32b}} limit10-warning {{Unknown}}
+
+  if (coin()) {
+    clang_analyzer_dump(*p.array[22]);
+    // default-warning@-1   {{Unknown}}
+    // unlimited-warning@-2 {{Unknown}}
+    // limit10-warning@-3   {{Unknown}}
+  }
+
+  clang_analyzer_dump(*p.array[23]); // default-warning {{23 S32b}} unlimited-warning {{23 S32b}} limit10-warning {{Unknown}}
+
+  escape(p); // no-leaks
+}
+
+struct PtrHolderBase {
+  int *ptr;
+};
+struct BigStruct : BigArray<int, 1000>, PtrHolderBase {};
+void largeBaseClasses() {
+  BigStruct D{{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}, {new int(25)}};
+  (void)D; // no-leak here, the PtrHolderBase subobject is properly escaped.
+
+  clang_analyzer_dump(*D.ptr);  // default-warning {{25 S32b}} unlimited-warning {{25 S32b}} limit10-warning {{Unknown}}
+  escape(D);
+}
+
+struct List {
+  int* ptr;
+  BigArray<int, 30> head;
+  List *tail;
+};
+void tempObjectMayEscapeArgumentsInAssignment() {
+  // This will be leaked after the assignment. However, we should not diagnose
+  // this because in the RHS of the assignment the temporary couldn't be really
+  // materialized due to the number of bindings, thus the address of `l` will
+  // escape there.
+  List l{new int(404)};
+
+  // ExprWithCleanups wraps the assignment operator call, which assigns a MaterializeTemporaryExpr.
+  l = List{new int(42), {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}, &l};
+  (void)l;
+  // default-warning@-1   {{Potential memory leak}} We detect the leak with the default settings.
+  // unlimited-warning@-2 {{Potential memory leak}} We detect the leak with the default settings.
+  // limit10 is missing! It's because in that case we escape `&l`, thus we assume freed. This is good.
+
+  clang_analyzer_dump(*l.ptr); // default-warning {{42 S32b}} unlimited-warning {{42 S32b}} limit10-warning {{42 S32b}}
+  escape(l);
+}
+
+void tempObjNotMaterializedThusDoesntEscapeAnything() {
+  List l{new int(404)};
+  // We have no ExprWithCleanups or MaterializeTemporaryExpr here, so `&l` is never escaped. This is good.
+  (void)List{new int(42), {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}, &l};
+  (void)l;
+  // default-warning@-1   {{Potential memory leak}} We detect the leak with the default settings.
+  // limit10-warning@-2   {{Potential memory leak}} We detect the leak with the default settings.
+  // unlimited-warning@-3 {{Potential memory leak}} We detect the leak with the default settings.
+
+  clang_analyzer_dump(*l.ptr); // default-warning {{404 S32b}} unlimited-warning {{404 S32b}} limit10-warning {{404 S32b}}
+  escape(l);
+}
+
+void theValueOfTheEscapedRegionRemainsTheSame() {
+  int *p = new int(404);
+  List l{p};
+  List l2{new int(42), {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}, &l};
+
+  // The value of l.ptr shouldn't be clobbered after a failing to copy `&l`.
+  clang_analyzer_eval(p == l.ptr); // default-warning {{TRUE}} unlimited-warning {{TRUE}} limit10-warning {{TRUE}}
+
+  // If the bindings fit, we will know that it aliases with `p`. Otherwise, it's unknown. This is good.
+  clang_analyzer_dump(*l2.tail->ptr); // default-warning {{404 S32b}} unlimited-warning {{404 S32b}} limit10-warning {{Unknown}}
+
+  escape(l, l2);
 }

--- a/clang/unittests/StaticAnalyzer/StoreTest.cpp
+++ b/clang/unittests/StaticAnalyzer/StoreTest.cpp
@@ -69,7 +69,7 @@ class VariableBindConsumer : public StoreTestConsumer {
     SVal NarrowZero = Builder.makeZeroVal(ASTCtxt.CharTy);
 
     // Bind(Zero)
-    Store StX0 = SManager.Bind(StInit, LX0, Zero).getStore();
+    Store StX0 = SManager.Bind(StInit, LX0, Zero).ResultingStore.getStore();
     EXPECT_EQ(Zero, SManager.getBinding(StX0, LX0, ASTCtxt.IntTy));
 
     // BindDefaultInitial(Zero)
@@ -87,7 +87,7 @@ class VariableBindConsumer : public StoreTestConsumer {
     EXPECT_EQ(NarrowZero, *SManager.getDefaultBinding(StZ0, LZ0.getAsRegion()));
 
     // Bind(One)
-    Store StX1 = SManager.Bind(StInit, LX1, One).getStore();
+    Store StX1 = SManager.Bind(StInit, LX1, One).ResultingStore.getStore();
     EXPECT_EQ(One, SManager.getBinding(StX1, LX1, ASTCtxt.IntTy));
 
     // BindDefaultInitial(One)
@@ -134,7 +134,8 @@ class LiteralCompoundConsumer : public StoreTestConsumer {
     Store StInit = SManager.getInitialStore(SFC).getStore();
     // Let's bind constant 1 to 'test[0]'
     SVal One = Builder.makeIntVal(1, Int);
-    Store StX = SManager.Bind(StInit, ZeroElement, One).getStore();
+    Store StX =
+        SManager.Bind(StInit, ZeroElement, One).ResultingStore.getStore();
 
     // And make sure that we can read this binding back as it was
     EXPECT_EQ(One, SManager.getBinding(StX, ZeroElement, Int));

--- a/clang/unittests/StaticAnalyzer/StoreTest.cpp
+++ b/clang/unittests/StaticAnalyzer/StoreTest.cpp
@@ -73,13 +73,14 @@ class VariableBindConsumer : public StoreTestConsumer {
     EXPECT_EQ(Zero, SManager.getBinding(StX0, LX0, ASTCtxt.IntTy));
 
     // BindDefaultInitial(Zero)
-    Store StY0 =
-        SManager.BindDefaultInitial(StInit, LY0.getAsRegion(), Zero).getStore();
+    Store StY0 = SManager.BindDefaultInitial(StInit, LY0.getAsRegion(), Zero)
+                     .ResultingStore.getStore();
     EXPECT_EQ(Zero, SManager.getBinding(StY0, LY0, ASTCtxt.IntTy));
     EXPECT_EQ(Zero, *SManager.getDefaultBinding(StY0, LY0.getAsRegion()));
 
     // BindDefaultZero()
-    Store StZ0 = SManager.BindDefaultZero(StInit, LZ0.getAsRegion()).getStore();
+    Store StZ0 = SManager.BindDefaultZero(StInit, LZ0.getAsRegion())
+                     .ResultingStore.getStore();
     // BindDefaultZero wipes the region with '0 S8b', not with out Zero.
     // Direct load, however, does give us back the object of the type
     // that we specify for loading.
@@ -91,8 +92,8 @@ class VariableBindConsumer : public StoreTestConsumer {
     EXPECT_EQ(One, SManager.getBinding(StX1, LX1, ASTCtxt.IntTy));
 
     // BindDefaultInitial(One)
-    Store StY1 =
-        SManager.BindDefaultInitial(StInit, LY1.getAsRegion(), One).getStore();
+    Store StY1 = SManager.BindDefaultInitial(StInit, LY1.getAsRegion(), One)
+                     .ResultingStore.getStore();
     EXPECT_EQ(One, SManager.getBinding(StY1, LY1, ASTCtxt.IntTy));
     EXPECT_EQ(One, *SManager.getDefaultBinding(StY1, LY1.getAsRegion()));
   }


### PR DESCRIPTION
In our test pool, the max entry point RT was improved by this change: 1'181 seconds (~19.7 minutes) -> 94 seconds (1.6 minutes)

BTW, the 1.6 minutes is still really bad. But a few orders of magnitude better than it was before.

This was the most servere RT edge-case as you can see from the numbers. There are are more known RT bottlenecks, such as:

 - Large environment sizes, and `removeDead`. See more about the failed attempt on improving it at: https://discourse.llvm.org/t/unsuccessful-attempts-to-fix-a-slow-analysis-case-related-to-removedead-and-environment-size/84650

 - Large chunk of time could be spend inside `assume`, to reach a fixed point. This is something we want to look into a bit later if we have time.

We have 3'075'607 entry points in our test set.
About 393'352 entry points ran longer than 1 second when measured.

To give a sense of the distribution, if we ignore the slowest 500 entry points, then the maximum entry point runs for about 14 seconds. These 500 slow entry points are in 332 translation units.

By this patch, out of the slowest 500 entry points, 72 entry points were improved by at least 10x after this change.

We measured no RT regression on the "usual" entry points.

![slow-entrypoints-before-and-after-bind-limit](https://github.com/user-attachments/assets/44425a76-f1cb-449c-bc3e-f44beb8c5dc7)
(The dashed lines represent the maximum of their RT)

CPP-6092