### PR TITLE
[llvm-objcopy] MachO: Fix section finding policy for object files

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -146,6 +146,8 @@ Changes to the Debug Info
 Changes to the LLVM tools
 ---------------------------------
 
+* llvm-objcopy now supports the `--update-section` flag for intermediate Mach-O object files.
+
 Changes to LLDB
 ---------------------------------
 

--- a/llvm/lib/ObjCopy/MachO/MachOObjcopy.cpp
+++ b/llvm/lib/ObjCopy/MachO/MachOObjcopy.cpp
@@ -360,6 +360,12 @@ static Error addSection(const NewSectionInfo &NewSection, Object &Obj) {
 static Expected<Section &> findSection(StringRef SecName, Object &O) {
   StringRef SegName;
   std::tie(SegName, SecName) = SecName.split(",");
+  if (O.Header.FileType == MachO::HeaderFileType::MH_OBJECT) {
+    for (const auto& LC : O.LoadCommands)
+      for (const auto& Sec : LC.Sections)
+        if (Sec->Segname == SegName && Sec->Sectname == SecName)
+          return *Sec;
+  }
   auto FoundSeg =
       llvm::find_if(O.LoadCommands, [SegName](const LoadCommand &LC) {
         return LC.getSegmentName() == SegName;

--- a/llvm/lib/ObjCopy/MachO/MachOObjcopy.cpp
+++ b/llvm/lib/ObjCopy/MachO/MachOObjcopy.cpp
@@ -360,11 +360,23 @@ static Error addSection(const NewSectionInfo &NewSection, Object &Obj) {
 static Expected<Section &> findSection(StringRef SecName, Object &O) {
   StringRef SegName;
   std::tie(SegName, SecName) = SecName.split(",");
+  // For compactness, intermediate object files (MH_OBJECT) contain
+  // only one segment in which all sections are placed.
+  // The static linker places each section in the named segment when building
+  // the final product (any file that is not of type MH_OBJECT).
+  //
+  // Source:
+  // https://math-atlas.sourceforge.net/devel/assembly/MachORuntime.pdf
+  // page 57
   if (O.Header.FileType == MachO::HeaderFileType::MH_OBJECT) {
     for (const auto& LC : O.LoadCommands)
       for (const auto& Sec : LC.Sections)
         if (Sec->Segname == SegName && Sec->Sectname == SecName)
           return *Sec;
+
+    StringRef ErrMsg = "could not find section with name '%s' in '%s' segment";
+    return createStringError(errc::invalid_argument, ErrMsg.str().c_str(),
+                             SecName.str().c_str(), SegName.str().c_str());
   }
   auto FoundSeg =
       llvm::find_if(O.LoadCommands, [SegName](const LoadCommand &LC) {

--- a/llvm/test/tools/llvm-objcopy/MachO/Inputs/macho_sections.s
+++ b/llvm/test/tools/llvm-objcopy/MachO/Inputs/macho_sections.s
@@ -1,0 +1,30 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.build_version macos, 11, 0
+	.globl	_main                           ; -- Begin function main
+	.p2align	2
+_main:                                  ; @main
+	.cfi_startproc
+; %bb.0:
+	sub	sp, sp, #32
+	stp	x29, x30, [sp, #16]             ; 16-byte Folded Spill
+	add	x29, sp, #16
+	.cfi_def_cfa w29, 16
+	.cfi_offset w30, -8
+	.cfi_offset w29, -16
+	mov	w8, #0                          ; =0x0
+	str	w8, [sp, #8]                    ; 4-byte Folded Spill
+	stur	wzr, [x29, #-4]
+	adrp	x0, __ZL7storage@PAGE
+	add	x0, x0, __ZL7storage@PAGEOFF
+	bl	__Z3fooPKc
+	ldr	w0, [sp, #8]                    ; 4-byte Folded Reload
+	ldp	x29, x30, [sp, #16]             ; 16-byte Folded Reload
+	add	sp, sp, #32
+	ret
+	.cfi_endproc
+                                        ; -- End function
+	.section	__DATA,__storage
+__ZL7storage:                           ; @_ZL7storage
+	.space	1383                        ; 0x567
+
+.subsections_via_symbols

--- a/llvm/test/tools/llvm-objcopy/MachO/Inputs/macho_sections.s
+++ b/llvm/test/tools/llvm-objcopy/MachO/Inputs/macho_sections.s
@@ -1,30 +1,4 @@
-	.section	__TEXT,__text,regular,pure_instructions
-	.build_version macos, 11, 0
-	.globl	_main                           ; -- Begin function main
-	.p2align	2
-_main:                                  ; @main
-	.cfi_startproc
-; %bb.0:
-	sub	sp, sp, #32
-	stp	x29, x30, [sp, #16]             ; 16-byte Folded Spill
-	add	x29, sp, #16
-	.cfi_def_cfa w29, 16
-	.cfi_offset w30, -8
-	.cfi_offset w29, -16
-	mov	w8, #0                          ; =0x0
-	str	w8, [sp, #8]                    ; 4-byte Folded Spill
-	stur	wzr, [x29, #-4]
-	adrp	x0, __ZL7storage@PAGE
-	add	x0, x0, __ZL7storage@PAGEOFF
-	bl	__Z3fooPKc
-	ldr	w0, [sp, #8]                    ; 4-byte Folded Reload
-	ldp	x29, x30, [sp, #16]             ; 16-byte Folded Reload
-	add	sp, sp, #32
-	ret
-	.cfi_endproc
-                                        ; -- End function
-	.section	__DATA,__storage
-__ZL7storage:                           ; @_ZL7storage
-	.space	1383                        ; 0x567
-
-.subsections_via_symbols
+.section    __TEXT,__text
+  .space 64
+.section    __DATA,__storage
+  .space 128

--- a/llvm/test/tools/llvm-objcopy/MachO/update-section-object.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/update-section-object.test
@@ -7,7 +7,6 @@
 # RUN: llvm-objcopy %t.o --update-section __DATA,__storage=%p/Inputs/macho_sections.s %t.new.o
 # RUN: llvm-otool -l %t.new.o | FileCheck %s --check-prefix=UPDATED
 
-
 # ORIG:      cmd LC_SEGMENT_64
 # ORIG-NEXT: cmdsize 312
 # ORIG-NEXT: segname

--- a/llvm/test/tools/llvm-objcopy/MachO/update-section-object.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/update-section-object.test
@@ -1,0 +1,48 @@
+# REQUIRES: aarch64-registered-target
+
+# RUN: llvm-mc -assemble -triple=arm64-apple-macos11 -filetype=obj %p/Inputs/macho_sections.s -o %t.o
+# RUN: llvm-otool -l %t.o | FileCheck %s --check-prefix=ORIG
+
+
+# RUN: llvm-objcopy %t.o --update-section __DATA,__storage=%p/Inputs/macho_sections.s %t.new.o
+# RUN: llvm-otool -l %t.new.o | FileCheck %s --check-prefix=UPDATED
+
+
+# ORIG:      cmd LC_SEGMENT_64
+# ORIG-NEXT: cmdsize 312
+# ORIG-NEXT: segname
+# ORIG-NEXT: vmaddr 0x0000000000000000
+# ORIG-NEXT: vmsize 0x00000000000005c0
+# ORIG-NEXT: fileoff 472
+# ORIG-NEXT: filesize 1472
+# ORIG-NEXT: maxprot 0x00000007
+# ORIG-NEXT: initprot 0x00000007
+# ORIG-NEXT: nsects 3
+# ORIG-NEXT: flags 0x0
+
+# ORIG:      Section
+# ORIG:      sectname __storage
+# ORIG-NEXT: segname __DATA
+# ORIG-NEXT: addr 0x0000000000000034
+# ORIG-NEXT: size 0x0000000000000567
+
+
+### Make sure the file size and segment size have changed
+# UPDATED:      cmd LC_SEGMENT_64
+# UPDATED-NEXT: cmdsize 312
+# UPDATED-NEXT: segname
+# UPDATED-NEXT: vmaddr 0x0000000000000000
+# UPDATED-NEXT: vmsize 0x00000000000005c0
+# UPDATED-NEXT: fileoff 472
+# UPDATED-NEXT: filesize 1048
+# UPDATED-NEXT: maxprot 0x00000007
+# UPDATED-NEXT: initprot 0x00000007
+# UPDATED-NEXT: nsects 3
+# UPDATED-NEXT: flags 0x0
+
+# UPDATED:      Section
+# UPDATED:      sectname __storage
+# UPDATED-NEXT: segname __DATA
+# UPDATED-NEXT: addr 0x0000000000000034
+# UPDATED-NEXT: size 0x00000000000003be
+

--- a/llvm/test/tools/llvm-objcopy/MachO/update-section-object.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/update-section-object.test
@@ -8,40 +8,40 @@
 # RUN: llvm-otool -l %t.new.o | FileCheck %s --check-prefix=UPDATED
 
 # ORIG:      cmd LC_SEGMENT_64
-# ORIG-NEXT: cmdsize 312
+# ORIG-NEXT: cmdsize 232
 # ORIG-NEXT: segname
 # ORIG-NEXT: vmaddr 0x0000000000000000
-# ORIG-NEXT: vmsize 0x00000000000005c0
-# ORIG-NEXT: fileoff 472
-# ORIG-NEXT: filesize 1472
+# ORIG-NEXT: vmsize 0x00000000000000c0
+# ORIG-NEXT: fileoff 392
+# ORIG-NEXT: filesize 192
 # ORIG-NEXT: maxprot 0x00000007
 # ORIG-NEXT: initprot 0x00000007
-# ORIG-NEXT: nsects 3
+# ORIG-NEXT: nsects 2
 # ORIG-NEXT: flags 0x0
 
 # ORIG:      Section
 # ORIG:      sectname __storage
 # ORIG-NEXT: segname __DATA
-# ORIG-NEXT: addr 0x0000000000000034
-# ORIG-NEXT: size 0x0000000000000567
+# ORIG-NEXT: addr 0x0000000000000040
+# ORIG-NEXT: size 0x0000000000000080
 
 
 ### Make sure the file size and segment size have changed
 # UPDATED:      cmd LC_SEGMENT_64
-# UPDATED-NEXT: cmdsize 312
+# UPDATED-NEXT: cmdsize 232
 # UPDATED-NEXT: segname
 # UPDATED-NEXT: vmaddr 0x0000000000000000
-# UPDATED-NEXT: vmsize 0x00000000000005c0
-# UPDATED-NEXT: fileoff 472
-# UPDATED-NEXT: filesize 1048
+# UPDATED-NEXT: vmsize 0x0000000000000090
+# UPDATED-NEXT: fileoff 392
+# UPDATED-NEXT: filesize 144
 # UPDATED-NEXT: maxprot 0x00000007
 # UPDATED-NEXT: initprot 0x00000007
-# UPDATED-NEXT: nsects 3
+# UPDATED-NEXT: nsects 2
 # UPDATED-NEXT: flags 0x0
 
 # UPDATED:      Section
 # UPDATED:      sectname __storage
 # UPDATED-NEXT: segname __DATA
-# UPDATED-NEXT: addr 0x0000000000000034
-# UPDATED-NEXT: size 0x00000000000003be
+# UPDATED-NEXT: addr 0x0000000000000040
+# UPDATED-NEXT: size 0x0000000000000050
 

--- a/llvm/test/tools/llvm-objcopy/MachO/update-section.test
+++ b/llvm/test/tools/llvm-objcopy/MachO/update-section.test
@@ -16,7 +16,7 @@
 # RUN: not llvm-objcopy --update-section __TEXT,__text=%t.noexist %t /dev/null
 
 # RUN: not llvm-objcopy --update-section __NOEXIST,__text=%t.diff %t /dev/null 2>&1 | FileCheck %s --check-prefix=NO-SEGMENT
-# NO-SEGMENT: error: {{.*}}could not find segment with name '__NOEXIST'
+# NO-SEGMENT: error: {{.*}}could not find section with name '__text' in '__NOEXIST' segment
 
 # RUN: not llvm-objcopy --update-section __TEXT,__noexist=%t.diff %t /dev/null 2>&1 | FileCheck %s --check-prefix=NO-SECTION
 # NO-SECTION: error: {{.*}}could not find section with name '__noexist'


### PR DESCRIPTION
llvm-objcopy is unable to find the specified segment when the `--update-section` flag is used. The input file is object.

This PR fixes #127495 