### PR TITLE
[flang][Driver] Add support of -fd-lines-as-comments and -fd-lines-as-code flags

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6747,8 +6747,16 @@ defm backtrace : BooleanFFlag<"backtrace">, Group<gfortran_Group>;
 defm bounds_check : BooleanFFlag<"bounds-check">, Group<gfortran_Group>;
 defm check_array_temporaries : BooleanFFlag<"check-array-temporaries">, Group<gfortran_Group>;
 defm cray_pointer : BooleanFFlag<"cray-pointer">, Group<gfortran_Group>;
-defm d_lines_as_code : BooleanFFlag<"d-lines-as-code">, Group<gfortran_Group>;
-defm d_lines_as_comments : BooleanFFlag<"d-lines-as-comments">, Group<gfortran_Group>;
+defm d_lines_as_code : BooleanFFlag<"d-lines-as-code">,
+                       HelpText<"Treat fixed form lines with 'd' or 'D' in the "
+                                "first column as blank.">,
+                       Group<f_Group>,
+                       Visibility<[FlangOption, FC1Option]>;
+defm d_lines_as_comments : BooleanFFlag<"d-lines-as-comments">,
+                           HelpText<"Treat fixed form lines with 'd' or 'D' in "
+                                    "the first column as comments.">,
+                           Group<f_Group>,
+                           Visibility<[FlangOption, FC1Option]>;
 defm dollar_ok : BooleanFFlag<"dollar-ok">, Group<gfortran_Group>;
 defm dump_fortran_optimized : BooleanFFlag<"dump-fortran-optimized">, Group<gfortran_Group>;
 defm dump_fortran_original : BooleanFFlag<"dump-fortran-original">, Group<gfortran_Group>;

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -60,6 +60,8 @@ void Flang::addFortranDialectOptions(const ArgList &Args,
                             options::OPT_frealloc_lhs,
                             options::OPT_fno_realloc_lhs,
                             options::OPT_fsave_main_program,
+                            options::OPT_fd_lines_as_code,
+                            options::OPT_fd_lines_as_comments,
                             options::OPT_fno_save_main_program});
 }
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -957,6 +957,32 @@ static bool parseDialectArgs(CompilerInvocation &res, llvm::opt::ArgList &args,
                              clang::DiagnosticsEngine &diags) {
   unsigned numErrorsBefore = diags.getNumErrors();
 
+  // -fd-lines-as-code
+  if (args.hasArg(clang::driver::options::OPT_fd_lines_as_code)) {
+    if (res.getFrontendOpts().fortranForm == FortranForm::FreeForm) {
+      const unsigned fdLinesAsWarning = diags.getCustomDiagID(
+          clang::DiagnosticsEngine::Warning,
+          "‘-fd-lines-as-code’ has no effect in free form.");
+      diags.Report(fdLinesAsWarning);
+    } else {
+      res.getFrontendOpts().features.Enable(
+          Fortran::common::LanguageFeature::OldDebugLines, true);
+    }
+  }
+
+  // -fd-lines-as-comments
+  if (args.hasArg(clang::driver::options::OPT_fd_lines_as_comments)) {
+    if (res.getFrontendOpts().fortranForm == FortranForm::FreeForm) {
+      const unsigned fdLinesAsWarning = diags.getCustomDiagID(
+          clang::DiagnosticsEngine::Warning,
+          "‘-fd-lines-as-comments’ has no effect in free form.");
+      diags.Report(fdLinesAsWarning);
+    } else {
+      res.getFrontendOpts().features.Enable(
+          Fortran::common::LanguageFeature::OldDebugLines, false);
+    }
+  }
+
   // -fdefault* family
   if (args.hasArg(clang::driver::options::OPT_fdefault_real_8)) {
     res.getDefaultKinds().set_defaultRealKind(8);

--- a/flang/test/Driver/fd-lines-as.f90
+++ b/flang/test/Driver/fd-lines-as.f90
@@ -1,0 +1,29 @@
+! Ensure arguments -fd-lines-as-comments and -fd-lines-as-code as expected.
+
+!--------------------------
+! FLANG DRIVER (flang)
+!--------------------------
+! Default behavior is equivalent as -fd-lines-as-comments
+!--------------------------
+! RUN: %flang -fsyntax-only -ffixed-form %s 2>&1
+! RUN: %flang -fsyntax-only -ffixed-form -fd-lines-as-comments %s 2>&1
+! RUN: not %flang -fsyntax-only -ffixed-form -fd-lines-as-code %s 2>&1 | FileCheck %s --check-prefix=CODE
+! RUN: not %flang -fsyntax-only -ffree-form -fd-lines-as-comments %s 2>&1 | FileCheck %s --check-prefix=WARNING-COMMENTS
+! RUN: not %flang -fsyntax-only -ffree-form -fd-lines-as-code %s 2>&1 | FileCheck %s --check-prefix=WARNING-CODE
+
+!----------------------------------------
+! FRONTEND FLANG DRIVER (flang -fc1)
+!----------------------------------------
+! RUN: %flang_fc1 -fsyntax-only -ffixed-form %s 2>&1
+! RUN: %flang_fc1 -fsyntax-only -ffixed-form -fd-lines-as-comments %s 2>&1
+! RUN: not %flang_fc1 -fsyntax-only -ffixed-form -fd-lines-as-code %s 2>&1 | FileCheck %s --check-prefix=CODE
+! RUN: not %flang_fc1 -fsyntax-only -ffree-form -fd-lines-as-comments %s 2>&1 | FileCheck %s --check-prefix=WARNING-COMMENTS
+! RUN: not %flang_fc1 -fsyntax-only -ffree-form -fd-lines-as-code %s 2>&1 | FileCheck %s --check-prefix=WARNING-CODE
+
+! CODE: Semantic errors
+! WARNING-COMMENTS: warning: ‘-fd-lines-as-comments’ has no effect in free form.
+! WARNING-CODE: warning: ‘-fd-lines-as-code’ has no effect in free form.
+
+      program FixedForm
+d     end
+      end

--- a/flang/test/Preprocessing/fd-lines-as.f90
+++ b/flang/test/Preprocessing/fd-lines-as.f90
@@ -1,0 +1,23 @@
+! Ensure arguments -fd-lines-as-comments and -fd-lines-as-code display the correct output with -E.
+
+!--------------------------
+! Default behavior is equivalent as -fd-lines-as-comments
+!--------------------------
+! RUN: %flang -E -ffixed-form %s 2>&1 | FileCheck %s --check-prefix=COMMENT
+! RUN: %flang -E -ffixed-form -fd-lines-as-comments %s 2>&1 | FileCheck %s --check-prefix=COMMENT
+! RUN: %flang -E -ffixed-form -fd-lines-as-code %s 2>&1 | FileCheck %s --check-prefix=CODE
+
+      program FixedForm
+d     end
+D     end
+      end
+
+! COMMENT: program FixedForm
+! COMMENT: end
+! COMMENT-NOT: end
+! COMMENT-NOT: end
+
+! CODE: program FixedForm
+! CODE: end
+! CODE: end
+! CODE: end


### PR DESCRIPTION
`-fd-lines-as-code` and `-fd-lines-as-comments` enables treatment for lines beginning with `d` or `D` in fixed form sources. 
Using these options in free form has no effect.
If the `-fd-lines-as-code` option is given they are treated as if the first column contained a blank. 
If the `-fd-lines-as-comments` option is given, they are treated as comment lines.