### PR TITLE
[LLD][COFF] Support alternate names in both symbol tables on ARM64X

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -220,9 +220,6 @@ struct Configuration {
   // Used for /failifmismatch.
   std::map<StringRef, std::pair<StringRef, InputFile *>> mustMatch;
 
-  // Used for /alternatename.
-  std::map<StringRef, StringRef> alternateNames;
-
   // Used for /order.
   llvm::StringMap<int> order;
 

--- a/lld/COFF/Driver.h
+++ b/lld/COFF/Driver.h
@@ -209,7 +209,6 @@ private:
   void parseSubsystem(StringRef arg, WindowsSubsystem *sys, uint32_t *major,
                       uint32_t *minor, bool *gotVersion = nullptr);
 
-  void parseAlternateName(StringRef);
   void parseMerge(StringRef);
   void parsePDBPageSize(StringRef);
   void parseSection(StringRef);

--- a/lld/COFF/DriverUtils.cpp
+++ b/lld/COFF/DriverUtils.cpp
@@ -147,18 +147,6 @@ void LinkerDriver::parseSubsystem(StringRef arg, WindowsSubsystem *sys,
 
 // Parse a string of the form of "<from>=<to>".
 // Results are directly written to Config.
-void LinkerDriver::parseAlternateName(StringRef s) {
-  auto [from, to] = s.split('=');
-  if (from.empty() || to.empty())
-    Fatal(ctx) << "/alternatename: invalid argument: " << s;
-  auto it = ctx.config.alternateNames.find(from);
-  if (it != ctx.config.alternateNames.end() && it->second != to)
-    Fatal(ctx) << "/alternatename: conflicts: " << s;
-  ctx.config.alternateNames.insert(it, std::make_pair(from, to));
-}
-
-// Parse a string of the form of "<from>=<to>".
-// Results are directly written to Config.
 void LinkerDriver::parseMerge(StringRef s) {
   auto [from, to] = s.split('=');
   if (from.empty() || to.empty())

--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -1320,6 +1320,17 @@ void SymbolTable::parseModuleDefs(StringRef path) {
   }
 }
 
+// Parse a string of the form of "<from>=<to>".
+void SymbolTable::parseAlternateName(StringRef s) {
+  auto [from, to] = s.split('=');
+  if (from.empty() || to.empty())
+    Fatal(ctx) << "/alternatename: invalid argument: " << s;
+  auto it = alternateNames.find(from);
+  if (it != alternateNames.end() && it->second != to)
+    Fatal(ctx) << "/alternatename: conflicts: " << s;
+  alternateNames.insert(it, std::make_pair(from, to));
+}
+
 Symbol *SymbolTable::addUndefined(StringRef name) {
   return addUndefined(name, nullptr, false);
 }

--- a/lld/COFF/SymbolTable.h
+++ b/lld/COFF/SymbolTable.h
@@ -171,9 +171,13 @@ public:
   // A list of wrapped symbols.
   std::vector<WrappedSymbol> wrapped;
 
+  // Used for /alternatename.
+  std::map<StringRef, StringRef> alternateNames;
+
   void fixupExports();
   void assignExportOrdinals();
   void parseModuleDefs(StringRef path);
+  void parseAlternateName(StringRef);
 
   // Iterates symbols in non-determinstic hash table order.
   template <typename T> void forEachSymbol(T callback) {

--- a/lld/test/COFF/arm64x-altnames.s
+++ b/lld/test/COFF/arm64x-altnames.s
@@ -1,0 +1,44 @@
+// REQUIRES: aarch64
+// RUN: split-file %s %t.dir && cd %t.dir
+
+// RUN: llvm-mc -filetype=obj -triple=aarch64-windows test.s -o test-arm64.obj
+// RUN: llvm-mc -filetype=obj -triple=arm64ec-windows test.s -o test-arm64ec.obj
+// RUN: llvm-mc -filetype=obj -triple=aarch64-windows drectve.s -o drectve-arm64.obj
+// RUN: llvm-mc -filetype=obj -triple=arm64ec-windows drectve.s -o drectve-arm64ec.obj
+
+// Check that the -alternatename command-line argument applies only to the EC namespace.
+
+// RUN: not lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj -alternatename:sym=altsym \
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
+
+// ERR-NATIVE-NOT:  test-arm64ec.obj
+// ERR-NATIVE:      lld-link: error: undefined symbol: sym
+// ERR-NATIVE-NEXT: >>> referenced by test-arm64.obj:(.test)
+// ERR-NATIVE-NOT:  test-arm64ec.obj
+
+// Check that the -alternatename .drectve directive applies only to the namespace in which it is defined.
+
+// RUN: not lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64ec.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
+
+// RUN: not lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64.obj \
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-EC %s
+
+// ERR-EC-NOT:  test-arm64.obj
+// ERR-EC:      lld-link: error: undefined symbol: sym
+// ERR-EC-NEXT: >>> referenced by test-arm64ec.obj:(.test)
+// ERR-EC-NOT:  test-arm64.obj
+
+// RUN: lld-link -out:out.dll -machine:arm64x -dll -noentry test-arm64.obj test-arm64ec.obj drectve-arm64.obj drectve-arm64ec.obj
+
+#--- test.s
+        .section .test,"dr"
+        .rva sym
+        .data
+        .globl altsym
+altsym:
+        .word 0
+
+#--- drectve.s
+        .section .drectve
+        .ascii "-alternatename:sym=altsym"


### PR DESCRIPTION
The `.drectve` directive applies only to the namespace in which it is defined, while the command-line argument applies only to the EC namespace.