### PR TITLE
[AMDGPU] Add `isAsCheapAsAMove` for `v_pk_mov_b32`

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3PInstructions.td
@@ -1151,7 +1151,7 @@ let isCommutable = 1, isReMaterializable = 1 in {
     defm V_PK_ADD_F32 : VOP3PInst<"v_pk_add_f32", VOP3P_Profile<VOP_V2F32_V2F32_V2F32, VOP3_PACKED>, any_fadd>;
   } // End SubtargetPredicate = HasPackedFP32Ops
 
-  let SubtargetPredicate = HasPkMovB32 in
+  let SubtargetPredicate = HasPkMovB32, isAsCheapAsAMove = 1 in
   defm V_PK_MOV_B32 : VOP3PInst<"v_pk_mov_b32", VOP3P_Profile<VOP_V2I32_V2I32_V2I32, VOP3_PACKED>>;
 } // End isCommutable = 1, isReMaterializable = 1
 

--- a/llvm/test/CodeGen/AMDGPU/vgpr-remat-v_pk_mov_b32.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-remat-v_pk_mov_b32.mir
@@ -11,22 +11,22 @@ body: |
   ; CHECK-NEXT:   liveins: $sgpr0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[V_PK_MOV_B32_:%[0-9]+]]:vreg_64_align2 = V_PK_MOV_B32 8, 0, 8, 0, 0, 0, 0, 0, 0, implicit $exec
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vreg_64_align2 = COPY [[V_PK_MOV_B32_]]
-  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vreg_64_align2 = COPY [[V_PK_MOV_B32_]]
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:sreg_64 = COPY $sgpr0
-  ; CHECK-NEXT:   $exec = S_MOV_B64_term [[COPY2]]
+  ; CHECK-NEXT:   [[V_PK_MOV_B32_1:%[0-9]+]]:vreg_64_align2 = V_PK_MOV_B32 8, 0, 8, 0, 0, 0, 0, 0, 0, implicit $exec
+  ; CHECK-NEXT:   [[V_PK_MOV_B32_2:%[0-9]+]]:vreg_64_align2 = V_PK_MOV_B32 8, 0, 8, 0, 0, 0, 0, 0, 0, implicit $exec
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:sreg_64 = COPY $sgpr0
+  ; CHECK-NEXT:   $exec = S_MOV_B64_term [[COPY]]
   ; CHECK-NEXT:   S_CBRANCH_EXECZ %bb.2, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vreg_64_align2 = V_PK_ADD_F32 8, [[COPY]], 8, [[COPY]], 11, 0, 0, 0, 0, implicit $mode, implicit $exec
-  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vreg_64_align2 = V_PK_ADD_F32 8, [[COPY1]], 8, [[COPY1]], 11, 0, 0, 0, 0, implicit $mode, implicit $exec
+  ; CHECK-NEXT:   [[V_PK_MOV_B32_1:%[0-9]+]]:vreg_64_align2 = V_PK_ADD_F32 8, [[V_PK_MOV_B32_1]], 8, [[V_PK_MOV_B32_1]], 11, 0, 0, 0, 0, implicit $mode, implicit $exec
+  ; CHECK-NEXT:   [[V_PK_MOV_B32_2:%[0-9]+]]:vreg_64_align2 = V_PK_ADD_F32 8, [[V_PK_MOV_B32_2]], 8, [[V_PK_MOV_B32_2]], 11, 0, 0, 0, 0, implicit $mode, implicit $exec
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
-  ; CHECK-NEXT:   S_NOP 0, implicit [[COPY]]
-  ; CHECK-NEXT:   S_NOP 0, implicit [[COPY1]]
+  ; CHECK-NEXT:   S_NOP 0, implicit [[V_PK_MOV_B32_1]]
+  ; CHECK-NEXT:   S_NOP 0, implicit [[V_PK_MOV_B32_2]]
   ; CHECK-NEXT:   S_ENDPGM 0, implicit [[V_PK_MOV_B32_]]
   bb.0:
     liveins: $sgpr0


### PR DESCRIPTION
Co-authored-by: Matt Arsenault <Matthew.Arsenault@amd.com>