### PR TITLE
[offload] Remove redundant checks in MappingInfoTy::lookupMapping

### DIFF
--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -156,9 +156,9 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
 
     if (!LR.Flags.IsContained && Upper != HDTTMap->end()) {
       LR.TPR.setEntry(Upper->HDTT, OwnedTPR);
-      // This is a special case: HP is not really contained in a mapped
-      // region, but it's contained in the extended mapped region, which
-      // suffices to get the mapping of the base pointer.
+      // This is a special case: HP is not really contained in the mapped
+      // address range, but it's contained in the extended address range,
+      // which suffices to get the mapping of the base pointer.
       // We know that HP < LR.TPR.getEntry()->HstPtrBegin
       LR.Flags.IsContained = HP >= LR.TPR.getEntry()->HstPtrBase;
     }
@@ -168,7 +168,7 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
       // We know that HP >= LR.TPR.getEntry()->HstPtrBegin
       LR.Flags.IsContained = HP < LR.TPR.getEntry()->HstPtrEnd &&
                              (HP + Size) <= LR.TPR.getEntry()->HstPtrEnd;
-      // Does it extend beyond the mapped region?
+      // Does it extend beyond the mapped address range?
       LR.Flags.ExtendsAfter = HP < LR.TPR.getEntry()->HstPtrEnd &&
                               (HP + Size) > LR.TPR.getEntry()->HstPtrEnd;
     }
@@ -176,10 +176,10 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
     if (!(LR.Flags.IsContained || LR.Flags.ExtendsAfter) &&
         Upper != HDTTMap->end()) {
       LR.TPR.setEntry(Upper->HDTT, OwnedTPR);
-      // Does it extend into an already mapped region?
+      // Does it extend into an already mapped address range?
       // We know that HP < LR.TPR.getEntry()->HstPtrBegin
       LR.Flags.ExtendsBefore = (HP + Size) > LR.TPR.getEntry()->HstPtrBegin;
-      // Does it extend beyond the mapped region?
+      // Does it extend beyond the mapped address range?
       LR.Flags.ExtendsAfter = HP < LR.TPR.getEntry()->HstPtrEnd &&
                               (HP + Size) > LR.TPR.getEntry()->HstPtrEnd;
     }

--- a/offload/libomptarget/OpenMP/Mapping.cpp
+++ b/offload/libomptarget/OpenMP/Mapping.cpp
@@ -141,47 +141,44 @@ LookupResult MappingInfoTy::lookupMapping(HDTTMapAccessorTy &HDTTMap,
   if (HDTTMap->empty())
     return LR;
 
+  // HDTTMap is std::set, ordered by HstPtrBegin.
+  // Upper is the first element whose HstPtrBegin > HP.
   auto Upper = HDTTMap->upper_bound(HP);
 
   if (Size == 0) {
-    // specification v5.1 Pointer Initialization for Device Data Environments
-    // upper_bound satisfies
-    //   std::prev(upper)->HDTT.HstPtrBegin <= hp < upper->HDTT.HstPtrBegin
+    // HP satisfies
+    //   std::prev(Upper)->HDTT.HstPtrBegin <= HP < Upper->HDTT.HstPtrBegin
     if (Upper != HDTTMap->begin()) {
       LR.TPR.setEntry(std::prev(Upper)->HDTT, OwnedTPR);
-      // the left side of extended address range is satisfied.
-      // hp >= LR.TPR.getEntry()->HstPtrBegin || hp >=
-      // LR.TPR.getEntry()->HstPtrBase
-      LR.Flags.IsContained = HP < LR.TPR.getEntry()->HstPtrEnd ||
-                             HP < LR.TPR.getEntry()->HstPtrBase;
+      // We know that HP >= LR.TPR.getEntry()->HstPtrBegin
+      LR.Flags.IsContained = HP < LR.TPR.getEntry()->HstPtrEnd;
     }
 
     if (!LR.Flags.IsContained && Upper != HDTTMap->end()) {
       LR.TPR.setEntry(Upper->HDTT, OwnedTPR);
-      // the right side of extended address range is satisfied.
-      // hp < LR.TPR.getEntry()->HstPtrEnd || hp < LR.TPR.getEntry()->HstPtrBase
+      // This is a special case: HP is not really contained in a mapped
+      // region, but it's contained in the extended mapped region, which
+      // suffices to get the mapping of the base pointer.
+      // We know that HP < LR.TPR.getEntry()->HstPtrBegin
       LR.Flags.IsContained = HP >= LR.TPR.getEntry()->HstPtrBase;
     }
   } else {
-    // check the left bin
     if (Upper != HDTTMap->begin()) {
       LR.TPR.setEntry(std::prev(Upper)->HDTT, OwnedTPR);
-      // Is it contained?
-      LR.Flags.IsContained = HP >= LR.TPR.getEntry()->HstPtrBegin &&
-                             HP < LR.TPR.getEntry()->HstPtrEnd &&
+      // We know that HP >= LR.TPR.getEntry()->HstPtrBegin
+      LR.Flags.IsContained = HP < LR.TPR.getEntry()->HstPtrEnd &&
                              (HP + Size) <= LR.TPR.getEntry()->HstPtrEnd;
       // Does it extend beyond the mapped region?
       LR.Flags.ExtendsAfter = HP < LR.TPR.getEntry()->HstPtrEnd &&
                               (HP + Size) > LR.TPR.getEntry()->HstPtrEnd;
     }
 
-    // check the right bin
     if (!(LR.Flags.IsContained || LR.Flags.ExtendsAfter) &&
         Upper != HDTTMap->end()) {
       LR.TPR.setEntry(Upper->HDTT, OwnedTPR);
       // Does it extend into an already mapped region?
-      LR.Flags.ExtendsBefore = HP < LR.TPR.getEntry()->HstPtrBegin &&
-                               (HP + Size) > LR.TPR.getEntry()->HstPtrBegin;
+      // We know that HP < LR.TPR.getEntry()->HstPtrBegin
+      LR.Flags.ExtendsBefore = (HP + Size) > LR.TPR.getEntry()->HstPtrBegin;
       // Does it extend beyond the mapped region?
       LR.Flags.ExtendsAfter = HP < LR.TPR.getEntry()->HstPtrEnd &&
                               (HP + Size) > LR.TPR.getEntry()->HstPtrEnd;


### PR DESCRIPTION
Also add some clarifying comments.