### PR TITLE
[flang][OpenMP] Catch threadprivate common block vars that appear in equivalence

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1479,7 +1479,22 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
                 }
               }
             },
-            [&](const parser::Name &) {}, // common block
+            [&](const parser::Name &name) {
+              if (!name.symbol) {
+                return;
+              }
+              if (auto *cb{name.symbol->detailsIf<CommonBlockDetails>()}) {
+                for (const auto &obj : cb->objects()) {
+                  if (FindEquivalenceSet(*obj)) {
+                    context_.Say(name.source,
+                        "A variable in a %s directive cannot appear in an EQUIVALENCE statement"
+                        " (variable '%s' from common block '/%s/')"_err_en_US,
+                        ContextDirectiveAsFortran(), obj->name(),
+                        name.symbol->name());
+                  }
+                }
+              }
+            },
         },
         ompObject.u);
   }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1480,17 +1480,15 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
               }
             },
             [&](const parser::Name &name) {
-              if (!name.symbol) {
-                return;
-              }
-              if (auto *cb{name.symbol->detailsIf<CommonBlockDetails>()}) {
-                for (const auto &obj : cb->objects()) {
-                  if (FindEquivalenceSet(*obj)) {
-                    context_.Say(name.source,
-                        "A variable in a %s directive cannot appear in an EQUIVALENCE statement"
-                        " (variable '%s' from common block '/%s/')"_err_en_US,
-                        ContextDirectiveAsFortran(), obj->name(),
-                        name.symbol->name());
+              if (name.symbol) {
+                if (auto *cb{name.symbol->detailsIf<CommonBlockDetails>()}) {
+                  for (const auto &obj : cb->objects()) {
+                    if (FindEquivalenceSet(*obj)) {
+                      context_.Say(name.source,
+                          "A variable in a %s directive cannot appear in an EQUIVALENCE statement (variable '%s' from common block '/%s/')"_err_en_US,
+                          ContextDirectiveAsFortran(), obj->name(),
+                          name.symbol->name());
+                    }
                   }
                 }
               }

--- a/flang/test/Semantics/OpenMP/threadprivate02.f90
+++ b/flang/test/Semantics/OpenMP/threadprivate02.f90
@@ -7,6 +7,9 @@ program threadprivate02
   integer :: arr1(10)
   common /blk1/ a1
   real, save :: eq_a, eq_b, eq_c, eq_d
+  integer :: eq_e, eq_f
+  equivalence(eq_e, eq_f)
+  common /blk2/ eq_e
 
   !$omp threadprivate(arr1)
 
@@ -24,6 +27,9 @@ program threadprivate02
   !ERROR: A variable in a THREADPRIVATE directive cannot appear in an EQUIVALENCE statement
   !$omp threadprivate(eq_c)
   equivalence(eq_c, eq_d)
+
+  !ERROR: A variable in a THREADPRIVATE directive cannot appear in an EQUIVALENCE statement (variable 'eq_e' from common block '/blk2/')
+  !$omp threadprivate(/blk2/)
 
 contains
   subroutine func()


### PR DESCRIPTION
Semantics were not checking for variables appearing in equivalence
statements when those were part of a threadprivate common block.

Fixes #122825
