### PR TITLE
[libcxx] Work around picolibc argv handling in tests.

### DIFF
--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -274,12 +274,15 @@ def hasAnyLocale(config, locales):
     depending on the %{exec} substitution.
     """
 
-    # Convert the locale names into C string literals, by escaping \
-    # and " and wrapping each one in double quotes.
-    name_string_literals = ", ".join(
-        '"' + locale.replace("\\", r"\\").replace('"', r"\"") + '"'
+    # Convert the locale names into C string literals. We expect all currently
+    # known locale names to be printable ASCII and not contain awkward
+    # characters like \ or ", so this should be trivial.
+    assert all(
+        0x20 <= ord(ch) <= 0x7E and ch not in {'"', "\\"}
         for locale in locales
+        for ch in locale
     )
+    name_string_literals = ", ".join('"' + locale + '"' for locale in locales)
 
     program = (
         """

--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -280,9 +280,10 @@ def hasAnyLocale(config, locales):
     # spaces in argv words. Work around this by applying URL-style
     # %-encoding to the locale names, and undoing it in our test
     # program.
-    percent_encode = lambda s: ''.join(
-        "%{:02x}".format(c) if c in b' %\\"\'' or c >= 128 else chr(c)
-        for c in s.encode())
+    percent_encode = lambda s: "".join(
+        "%{:02x}".format(c) if c in b" %\\\"'" or c >= 128 else chr(c)
+        for c in s.encode()
+    )
 
     program = """
     #include <stddef.h>
@@ -314,8 +315,9 @@ def hasAnyLocale(config, locales):
       }
     #endif
   """
-    return programSucceeds(config, program, args=[
-        shlex.quote(percent_encode(l)) for l in locales])
+    return programSucceeds(
+        config, program, args=[shlex.quote(percent_encode(l)) for l in locales]
+    )
 
 
 @_memoizeExpensiveOperation(lambda c, flags="": (c.substitutions, c.environment, flags))

--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -278,18 +278,21 @@ def hasAnyLocale(config, locales):
     # Convert the locale names into C string literals, by escaping \
     # and " and wrapping each one in double quotes.
     name_string_literals = ", ".join(
-        '"' + locale.replace("\\", r'\\').replace("\"", r'\"') + '"'
+        '"' + locale.replace("\\", r"\\").replace('"', r"\"") + '"'
         for locale in locales
     )
 
-    program = """
+    program = (
+        """
     #include <stddef.h>
     #if defined(_LIBCPP_VERSION) && !_LIBCPP_HAS_LOCALIZATION
       int main(int, char**) { return 1; }
     #else
       #include <locale.h>
       static const char *const test_locale_names[] = {
-          """ + name_string_literals + """, nullptr,
+          """
+        + name_string_literals
+        + """, nullptr,
       };
       int main() {
         for (size_t i = 0; test_locale_names[i]; i++) {
@@ -301,6 +304,7 @@ def hasAnyLocale(config, locales):
       }
     #endif
     """
+    )
     return programSucceeds(config, program)
 
 

--- a/libcxx/utils/libcxx/test/dsl.py
+++ b/libcxx/utils/libcxx/test/dsl.py
@@ -9,7 +9,6 @@
 import os
 import pickle
 import platform
-import shlex
 import shutil
 import tempfile
 


### PR DESCRIPTION
This fixes some test failures when the libcxx tests are run against an up-to-date picolibc on embedded Arm, because those tests depend on an unsupported locale but the `hasAnyLocale` preliminary check wrongly concluded that the locale _was_ supported.

`hasAnyLocale` passes a set of locale strings to a test program via the command line, and checks if the libc under test reports that any of the locales can be successfully set via setlocale(). In some invocations one of the locale names contains a space, e.g. the Windows-style locale name "English_United States.1252".

Unfortunately picolibc's crt0, when running under Arm semihosting, fetches the single command string from the host and then splits it up at spaces without implementing any kind of quoting. So it simply isn't possible to get a space into an argv word. As a result, we end up testing for the locale (in this example) "English_United". In up-to-date versions of picolibc, this is actually accepted, since it contains no objectionable character set specification (or indeed any at all). So the lit check wrongly concludes that libc supports that locale, and enables some locale tests, which fail.

This patch works around the issue entirely within `hasAnyLocale()`, by abandoning the use of argv completely, and instead encoding the list of locales to check as an array of strings inside the test program.