### PR TITLE
[BitcodeReader] Use `poison` instead of `undef` to represent unsupported constexprs in metadata

### DIFF
--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1229,13 +1229,13 @@ static Value *getValueFwdRef(BitcodeReaderValueList &ValueList, unsigned Idx,
 
   // This is a reference to a no longer supported constant expression.
   // Pretend that the constant was deleted, which will replace metadata
-  // references with undef.
+  // references with poison.
   // TODO: This is a rather indirect check. It would be more elegant to use
   // a separate ErrorInfo for constant materialization failure and thread
   // the error reporting through getValueFwdRef().
   if (Idx < ValueList.size() && ValueList[Idx] &&
       ValueList[Idx]->getType() == Ty)
-    return UndefValue::get(Ty);
+    return PoisonValue::get(Ty);
 
   return nullptr;
 }

--- a/llvm/test/Bitcode/constexpr-to-instr-metadata-2.ll
+++ b/llvm/test/Bitcode/constexpr-to-instr-metadata-2.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-dis -expand-constant-exprs < %S/Inputs/constexpr-to-instr-metadata-2.bc | FileCheck %s
 
 ; CHECK-LABEL: define void @_ZN4alsa3pcm3PCM17hw_params_current17hf1c237aece2f69c4E() {
-; CHECK: #dbg_value(ptr undef, !4, !DIExpression(DW_OP_LLVM_fragment, 0, 64), !14
+; CHECK: #dbg_value(ptr poison, !4, !DIExpression(DW_OP_LLVM_fragment, 0, 64), !14
 
 ; CHECK-LABEL: define void @_ZN4alsa3pcm8HwParams3any17h02a64cfc85ce8a66E() {
-; CHECK: #dbg_value(ptr undef, !23, !DIExpression(DW_OP_LLVM_fragment, 0, 64), !28
+; CHECK: #dbg_value(ptr poison, !23, !DIExpression(DW_OP_LLVM_fragment, 0, 64), !28

--- a/llvm/test/Bitcode/constexpr-to-instr-metadata.ll
+++ b/llvm/test/Bitcode/constexpr-to-instr-metadata.ll
@@ -1,4 +1,4 @@
 ; RUN: llvm-dis -expand-constant-exprs < %S/Inputs/constexpr-to-instr-metadata.bc | FileCheck %s
 
 ; CHECK-LABEL: define void @test() {
-; CHECK: #dbg_value(i64 undef, !4, !DIExpression(DW_OP_LLVM_fragment, 64, 64), !13
+; CHECK: #dbg_value(i64 poison, !4, !DIExpression(DW_OP_LLVM_fragment, 64, 64), !13


### PR DESCRIPTION
Metadata that references unsupported constant expressions can be represented with `poison` metadata instead of `undef` metadata.