### PR TITLE
[compiler-rt][asan] Re-enable forkpty test on AArch64 (NFC)

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/getpass.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/getpass.cpp
@@ -3,7 +3,6 @@
 // Ignore leaks as this is not the point of test, but HWASAN repors one here.
 // RUN: %env_tool_opts=detect_leaks=0 %run %t | FileCheck %s
 
-// REQUIRES: stable-runtime
 // XFAIL: android && asan
 
 // No libutil.


### PR DESCRIPTION
Disabled in 86474c7a1addf59d511050552b697b8b2af61838, no longer failing on AArch64 (for me at least).

Fixes: https://github.com/llvm/llvm-project/issues/24774