### PR TITLE
[DSE] Make iter order deterministic in removePartiallyOverlappedStores. NFC

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -174,7 +174,7 @@ static cl::opt<bool> EnableInitializesImprovement(
 // Helper functions
 //===----------------------------------------------------------------------===//
 using OverlapIntervalsTy = std::map<int64_t, int64_t>;
-using InstOverlapIntervalsTy = DenseMap<Instruction *, OverlapIntervalsTy>;
+using InstOverlapIntervalsTy = MapVector<Instruction *, OverlapIntervalsTy>;
 
 /// Returns true if the end of this instruction can be safely shortened in
 /// length.


### PR DESCRIPTION
In removePartiallyOverlappedStores we iterate over InstOverlapIntervalsTy which is a DenseMap. Change that map into using MapVector to ensure that we apply the transforms in a deterministic order. I've only seen that the order matters if starting to use names for the instructions created when doing the transforms. But such things are a bit annoying when debugging etc.