### PR TITLE
[CodeGen] Remove getSubReg from TargetRegisterInfo. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -1232,13 +1232,6 @@ public:
     return nullptr;
   }
 
-  /// Returns the physical register number of sub-register "Index"
-  /// for physical register RegNo. Return zero if the sub-register does not
-  /// exist.
-  inline MCRegister getSubReg(MCRegister Reg, unsigned Idx) const {
-    return static_cast<const MCRegisterInfo *>(this)->getSubReg(Reg, Idx);
-  }
-
   /// Some targets have non-allocatable registers that aren't technically part
   /// of the explicit callee saved register list, but should be handled as such
   /// in certain cases.


### PR DESCRIPTION
Users can use the version inherited from MCRegisterInfo.

This version was added by e7694f34ab6a1 to return a Register. It was later changed to return MCRegister by bab72dd5d5122 making it identical MCRegisterInfo.