### PR TITLE
[flang-rt] Fixed uninitialized class member variable

### DIFF
--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -627,7 +627,7 @@ private:
   Fortran::common::optional<Action> action_;
   Convert convert_{Convert::Unknown};
   OwningPtr<char> path_;
-  std::size_t pathLength_;
+  std::size_t pathLength_{};
   Fortran::common::optional<bool> isUnformatted_;
   Fortran::common::optional<Access> access_;
 };


### PR DESCRIPTION
valgrind complained that `OpenStatementState::pathLength_` was used before it was initialized, when a file was opened with `status='scratch'`. The code seems to expect that `pathLengh_` should be initialized to 0, so added default initialization to the declaration.