### PR TITLE
Add back deleted test for llvm-dwarfdump JSON output

### DIFF
--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-json-output.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-json-output.s
@@ -1,0 +1,172 @@
+# RUN: llvm-mc -triple x86_64-pc-linux %s -filetype=obj -o - | not llvm-dwarfdump -verify --verify-json=%t.json -
+# RUN: FileCheck %s --input-file %t.json
+
+# CHECK: {"error-categories":{"Name Index DIE entry missing name":{"count":10}},"error-count":10}
+# CHECK-NOT: error: Name Index @ 0x0: Entry for DIE @ {{.*}} (DW_TAG_variable) with name var_block_addr missing.
+
+        .section        .debug_loc,"",@progbits
+.Ldebug_loc0:
+        .quad   0
+        .quad   1
+        .short  .Lloc0_end-.Lloc0_start # Loc expr size
+.Lloc0_start:
+        .byte   3                       # DW_OP_addr
+        .quad 0x47
+.Lloc0_end:
+        .quad   0
+        .quad   0
+
+        .section        .debug_abbrev,"",@progbits
+        .byte   1                       # Abbreviation Code
+        .byte   17                      # DW_TAG_compile_unit
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   37                      # DW_AT_producer
+        .byte   8                       # DW_FORM_string
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   6                       # DW_FORM_data4
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   2                       # Abbreviation Code
+        .byte   52                      # DW_TAG_variable
+        .byte   0                       # DW_CHILDREN_no
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   2                       # DW_AT_location
+        .byte   24                      # DW_FORM_exprloc
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   3                       # Abbreviation Code
+        .byte   46                      # DW_TAG_subprogram
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   110                     # DW_AT_linkage_name
+        .byte   8                       # DW_FORM_string
+        .byte   82                      # DW_AT_entry_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   4                       # Abbreviation Code
+        .byte   57                      # DW_TAG_namespace
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   5                       # Abbreviation Code
+        .byte   52                      # DW_TAG_variable
+        .byte   0                       # DW_CHILDREN_no
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   2                       # DW_AT_location
+        .byte   23                      # DW_FORM_sec_offset
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   6                       # Abbreviation Code
+        .byte   57                      # DW_TAG_namespace
+        .byte   1                       # DW_CHILDREN_yes
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   7                       # Abbreviation Code
+        .byte   29                      # DW_TAG_inlined_subroutine
+        .byte   0                       # DW_CHILDREN_no
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   17                      # DW_AT_low_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   18                      # DW_AT_high_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   8                       # Abbreviation Code
+        .byte   10                      # DW_TAG_label
+        .byte   0                       # DW_CHILDREN_no
+        .byte   3                       # DW_AT_name
+        .byte   8                       # DW_FORM_string
+        .byte   82                      # DW_AT_entry_pc
+        .byte   1                       # DW_FORM_addr
+        .byte   0                       # EOM(1)
+        .byte   0                       # EOM(2)
+
+        .byte   0                       # EOM(3)
+        .section        .debug_info,"",@progbits
+
+.Lcu_begin0:
+        .long   .Lcu_end0-.Lcu_start0   # Length of Unit
+.Lcu_start0:
+        .short  4                       # DWARF version number
+        .long   .debug_abbrev           # Offset Into Abbrev. Section
+        .byte   8                       # Address Size (in bytes)
+        .byte   1                       # Abbrev [1] DW_TAG_compile_unit
+        .asciz  "hand-written DWARF"    # DW_AT_producer
+        .quad   0x0                     # DW_AT_low_pc
+        .long   0x100                   # DW_AT_high_pc
+
+        .byte   4                       # Abbrev [4] DW_TAG_namespace
+        .asciz  "namesp"                # DW_AT_name
+        .byte   2                       # Abbrev [2] DW_TAG_variable
+        .asciz  "var_block_addr"        # DW_AT_name
+        .byte   9                       # DW_AT_location
+        .byte   3                       # DW_OP_addr
+        .quad   0x47
+        .byte   0                       # End Of Children Mark
+
+        .byte   6                       # Abbrev [6] DW_TAG_namespace
+        .byte   5                       # Abbrev [5] DW_TAG_variable
+        .asciz  "var_loc_addr"          # DW_AT_name
+        .long   .Ldebug_loc0            # DW_AT_location
+        .byte   0                       # End Of Children Mark
+
+        .byte   2                       # Abbrev [2] DW_TAG_variable
+        .asciz  "var_loc_tls"           # DW_AT_name
+        .byte   1                       # DW_AT_location
+        .byte   0x9b                    # DW_OP_form_tls_address
+
+        .byte   2                       # Abbrev [2] DW_TAG_variable
+        .asciz  "var_loc_gnu_tls"       # DW_AT_name
+        .byte   1                       # DW_AT_location
+        .byte   0xe0                    # DW_OP_GNU_push_tls_address
+
+        .byte   3                       # Abbrev [3] DW_TAG_subprogram
+        .asciz  "fun_name"              # DW_AT_name
+        .asciz  "_Z8fun_name"           # DW_AT_linkage_name
+        .quad   0x47                    # DW_AT_entry_pc
+        .byte   7                       # Abbrev [7] DW_TAG_inlined_subroutine
+        .asciz  "fun_inline"            # DW_AT_name
+        .quad   0x48                    # DW_AT_low_pc
+        .quad   0x49                    # DW_AT_high_pc
+        .byte   8                       # Abbrev [8] DW_TAG_label
+        .asciz  "label"                 # DW_AT_name
+        .quad   0x4a                    # DW_AT_entry_pc
+        .byte   0                       # End Of Children Mark
+
+        .byte   0                       # End Of Children Mark
+.Lcu_end0:
+
+        .section        .debug_names,"",@progbits
+        .long   .Lnames_end0-.Lnames_start0 # Header: contribution length
+.Lnames_start0:
+        .short  5                       # Header: version
+        .short  0                       # Header: padding
+        .long   1                       # Header: compilation unit count
+        .long   0                       # Header: local type unit count
+        .long   0                       # Header: foreign type unit count
+        .long   0                       # Header: bucket count
+        .long   0                       # Header: name count
+        .long   .Lnames_abbrev_end0-.Lnames_abbrev_start0 # Header: abbreviation table size
+        .long   0                       # Header: augmentation length
+        .long   .Lcu_begin0             # Compilation unit 0
+.Lnames_abbrev_start0:
+        .byte   0                       # End of abbrev list
+.Lnames_abbrev_end0:
+.Lnames_entries0:
+.Lnames_end0:

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-cu-lists-json-output.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-cu-lists-json-output.s
@@ -1,0 +1,111 @@
+# RUN: llvm-mc -triple x86_64-pc-linux %s -filetype=obj | \
+# RUN:   not llvm-dwarfdump -verify -verify-json=%t.json -
+# RUN: FileCheck %s --input-file %t.json
+
+# CHECK: {"error-categories":{"Duplicate Name Index":{"count":1},"Name Index doesn't index any CU":{"count":1},"Name Index references non-existing CU":{"count":1}},"error-count":3}
+# CHECK-NOT : error: Name Index @ 0x58 references a CU @ 0x0, but this CU is already indexed by Name Index @ 0x28
+# CHECK-NOT: warning: CU @ 0x13 not covered by any Name Index
+
+
+	.section	.debug_str,"MS",@progbits,1
+.Lstring_foo:
+	.asciz	"foo"
+.Lstring_foo_mangled:
+	.asciz	"_Z3foov"
+.Lstring_bar:
+	.asciz	"bar"
+.Lstring_producer:
+	.asciz	"Hand-written dwarf"
+
+	.section	.debug_abbrev,"",@progbits
+.Lsection_abbrev:
+	.byte	1                       # Abbreviation Code
+	.byte	17                      # DW_TAG_compile_unit
+	.byte	1                       # DW_CHILDREN_yes
+	.byte	37                      # DW_AT_producer
+	.byte	14                      # DW_FORM_strp
+	.byte	19                      # DW_AT_language
+	.byte	5                       # DW_FORM_data2
+	.byte	0                       # EOM(1)
+	.byte	0                       # EOM(2)
+	.byte	0                       # EOM(3)
+
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Lcu_end0-.Lcu_start0   # Length of Unit
+.Lcu_start0:
+	.short	4                       # DWARF version number
+	.long	.Lsection_abbrev        # Offset Into Abbrev. Section
+	.byte	8                       # Address Size (in bytes)
+	.byte	1                       # Abbrev [1] DW_TAG_compile_unit
+	.long	.Lstring_producer       # DW_AT_producer
+	.short	12                      # DW_AT_language
+	.byte	0                       # End Of Children Mark
+.Lcu_end0:
+
+.Lcu_begin1:
+	.long	.Lcu_end1-.Lcu_start1   # Length of Unit
+.Lcu_start1:
+	.short	4                       # DWARF version number
+	.long	.Lsection_abbrev        # Offset Into Abbrev. Section
+	.byte	8                       # Address Size (in bytes)
+	.byte	1                       # Abbrev [1] DW_TAG_compile_unit
+	.long	.Lstring_producer       # DW_AT_producer
+	.short	12                      # DW_AT_language
+	.byte	0                       # End Of Children Mark
+.Lcu_end1:
+
+	.section	.debug_names,"",@progbits
+	.long	.Lnames_end0-.Lnames_start0 # Header: contribution length
+.Lnames_start0:
+	.short	5                       # Header: version
+	.short	0                       # Header: padding
+	.long	0                       # Header: compilation unit count
+	.long	0                       # Header: local type unit count
+	.long	0                       # Header: foreign type unit count
+	.long	0                       # Header: bucket count
+	.long	0                       # Header: name count
+	.long	.Lnames_abbrev_end0-.Lnames_abbrev_start0 # Header: abbreviation table size
+	.long	0                       # Header: augmentation length
+.Lnames_abbrev_start0:
+	.byte	0                       # End of abbrev list
+.Lnames_abbrev_end0:
+.p2align 2
+.Lnames_end0:
+
+	.long	.Lnames_end1-.Lnames_start1 # Header: contribution length
+.Lnames_start1:
+	.short	5                       # Header: version
+	.short	0                       # Header: padding
+	.long	2                       # Header: compilation unit count
+	.long	0                       # Header: local type unit count
+	.long	0                       # Header: foreign type unit count
+	.long	0                       # Header: bucket count
+	.long	0                       # Header: name count
+	.long	.Lnames_abbrev_end1-.Lnames_abbrev_start1 # Header: abbreviation table size
+	.long	0                       # Header: augmentation length
+	.long	.Lcu_begin0             # Compilation unit 0
+	.long	.Lcu_begin0+1           # Compilation unit 0
+.Lnames_abbrev_start1:
+	.byte	0                       # End of abbrev list
+.Lnames_abbrev_end1:
+.p2align 2
+.Lnames_end1:
+
+	.long	.Lnames_end2-.Lnames_start2 # Header: contribution length
+.Lnames_start2:
+	.short	5                       # Header: version
+	.short	0                       # Header: padding
+	.long	1                       # Header: compilation unit count
+	.long	0                       # Header: local type unit count
+	.long	0                       # Header: foreign type unit count
+	.long	0                       # Header: bucket count
+	.long	0                       # Header: name count
+	.long	.Lnames_abbrev_end2-.Lnames_abbrev_start2 # Header: abbreviation table size
+	.long	0                       # Header: augmentation length
+	.long	.Lcu_begin0             # Compilation unit 0
+.Lnames_abbrev_start2:
+	.byte	0                       # End of abbrev list
+.Lnames_abbrev_end2:
+.p2align 2
+.Lnames_end2:


### PR DESCRIPTION
Looks like https://github.com/llvm/llvm-project/pull/124936 was reverted (for modifying JSON output), but the test for JSON output with errors was deleted in https://github.com/llvm/llvm-project/pull/126587 (to attempt to fix failing build)
This will add back a test and a new one for llvm-dwarfdump to validate the JSON for errors. One case where the sub-categories will eventually appear and another where not.

test plan:
ninja check-llvm-tools-llvm-dwarfdump