### PR TITLE
[SandboxVec][Scheduler] Don't insert scheduled instrs into the ready list

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/DependencyGraph.h
@@ -123,6 +123,10 @@ public:
     --UnscheduledSuccs;
   }
   void incrUnscheduledSuccs() { ++UnscheduledSuccs; }
+  void resetScheduleState() {
+    UnscheduledSuccs = 0;
+    Scheduled = false;
+  }
   /// \Returns true if all dependent successors have been scheduled.
   bool ready() const { return UnscheduledSuccs == 0; }
   /// \Returns true if this node has been scheduled.

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -61,7 +61,18 @@ class ReadyListContainer {
 
 public:
   ReadyListContainer() : List(Cmp) {}
-  void insert(DGNode *N) { List.push(N); }
+  void insert(DGNode *N) {
+#ifndef NDEBUG
+    assert(!N->scheduled() && "Don't insert a scheduled node!");
+    auto ListCopy = List;
+    while (!ListCopy.empty()) {
+      DGNode *Top = ListCopy.top();
+      ListCopy.pop();
+      assert(Top != N && "Node already exists in ready list!");
+    }
+#endif
+    List.push(N);
+  }
   DGNode *pop() {
     auto *Back = List.top();
     List.pop();

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -246,6 +246,77 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   EXPECT_TRUE(Sched.trySchedule({L0, L1}));
 }
 
+// Check scheduling in the following order: {A0,A1},{B0,B1},{C0,C1},{D0,D1}
+// assuming program order: B0,B1,C0,C1,D0,D1,E0,D1.
+// This will effectively schedule nodes below already scheduled nodes, which
+// can expose issues in the code that adds nodes to the ready list.
+// For example, we schedule {D0,D1} while {C0,C1} are scheduled and there is
+// a dependency D0->C0 and D1->C1.
+//
+//                   {A0,A1}  {B0,B1}  {C0,C1}  {D0,D1}
+//   B0,B1                    | S
+//   |\                       |
+//   | C0,C1                  |        | S      | S
+//   |  | \                   |                 |
+//   |  |  D0,D1              |                 | S
+//   | /                      |
+//   A0,A1             | S    | S
+//                 +------------------------+
+//                 | Legend   |: DAG        |
+//                 |          S: Scheduled  |
+TEST_F(SchedulerTest, ScheduledPredecessors) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptrA0, ptr noalias %ptrA1,
+                 ptr noalias %ptrB0, ptr noalias %ptrB1,
+                 ptr noalias %ptrD0, ptr noalias %ptrD1) {
+  %B0 = load i8, ptr %ptrB0
+  %B1 = load i8, ptr %ptrB1
+  %C0 = add i8 %B0, 0
+  %C1 = add i8 %B1, 1
+  store i8 %C0, ptr %ptrD0
+  store i8 %C1, ptr %ptrD1
+  store i8 %B0, ptr %ptrA0
+  store i8 %B1, ptr %ptrA1
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *B1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *B0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *C1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *C0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *D1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *D0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *A1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *A0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *Ret = cast<sandboxir::ReturnInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+  EXPECT_TRUE(Sched.trySchedule({A0, A1}));
+  // NOTE: We schedule the intermediate nodes between {A0,A1} and {B0,B1} by
+  // hand one by one to make sure they are scheduled in that order because
+  // the scheduler may reorder them a bit if we let it do it.
+  EXPECT_TRUE(Sched.trySchedule(D0));
+  EXPECT_TRUE(Sched.trySchedule(D1));
+  EXPECT_TRUE(Sched.trySchedule(C0));
+  EXPECT_TRUE(Sched.trySchedule(C1));
+  EXPECT_TRUE(Sched.trySchedule({B0, B1}));
+  // At this point all nodes must have been scheduled from B0,B1 to A0,A1.
+  // The ones in between are scheduled as single-instruction nodes.
+  // So when we attempt to schedule {C0,C1} we will need to reschedule.
+  // At this point we will trim the schedule from {C0,C1} upwards.
+  EXPECT_TRUE(Sched.trySchedule({C0, C1}));
+  // Now the schedule should only contain {C0,C1} which should be marked as
+  // "scheduled".
+  // {D0,D1} are below {C0,C1}, so we grow the DAG downwards, while
+  // {C0,C1} are marked as "scheduled" above them.
+  EXPECT_TRUE(Sched.trySchedule({D0, D1}));
+}
+
 TEST_F(SchedulerTest, DontCrossBBs) {
   parseIR(C, R"IR(
 define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, i8 %v0, i8 %v1) {


### PR DESCRIPTION
In a particular scenario (see test) we used to insert scheduled instructions into the ready list. This patch fixes this by fixing the trimSchedule() function.