### PR TITLE
[-Wunsafe-buffer-usage] Add absl::{Span,string_view} to UnsafeBufferUsage analysis

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -891,7 +891,9 @@ AST_MATCHER(CallExpr, hasUnsafeSnprintfBuffer) {
 
   // Pattern 1:
   static StringRef SizedObjs[] = {"span", "array", "vector",
-                                  "basic_string_view", "basic_string"};
+                                  "basic_string_view", "basic_string",
+                                   // Support absl::Span and absl::string_view
+                                  "Span", "string_view" };
   Buf = Buf->IgnoreParenImpCasts();
   Size = Size->IgnoreParenImpCasts();
   if (auto *MCEPtr = dyn_cast<CXXMemberCallExpr>(Buf))


### PR DESCRIPTION
Add support for absl Span and string_view types to warn on their unsafe usage. 