### PR TITLE
[SandboxIR] OpaqueValue

### DIFF
--- a/llvm/include/llvm/SandboxIR/Value.h
+++ b/llvm/include/llvm/SandboxIR/Value.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SANDBOXIR_VALUE_H
 #define LLVM_SANDBOXIR_VALUE_H
 
+#include "llvm/IR/Metadata.h"
 #include "llvm/IR/Value.h"
 #include "llvm/SandboxIR/Use.h"
 
@@ -280,6 +281,28 @@ public:
   virtual void dumpOS(raw_ostream &OS) const = 0;
   LLVM_DUMP_METHOD void dump() const;
 #endif
+};
+
+class OpaqueValue : public Value {
+protected:
+  OpaqueValue(llvm::Value *V, Context &Ctx)
+      : Value(ClassID::OpaqueValue, V, Ctx) {}
+  friend class Context; // For constructor.
+
+public:
+  static bool classof(const Value *From) {
+    return From->getSubclassID() == ClassID::OpaqueValue;
+  }
+#ifndef NDEBUG
+  void verify() const override {
+    assert((isa<llvm::MetadataAsValue>(Val) || isa<llvm::InlineAsm>(Val)) &&
+           "Expected Metadata or InlineAssembly!");
+  }
+  void dumpOS(raw_ostream &OS) const override {
+    dumpCommonPrefix(OS);
+    dumpCommonSuffix(OS);
+  }
+#endif // NDEBUG
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/include/llvm/SandboxIR/Values.def
+++ b/llvm/include/llvm/SandboxIR/Values.def
@@ -21,6 +21,7 @@
 
 DEF_CONST(Function, Function)
 DEF_VALUE(Argument, Argument)
+DEF_VALUE(OpaqueValue, OpaqueValue)
 
 DEF_USER(User, User)
 DEF_VALUE(Block, BasicBlock)

--- a/llvm/lib/SandboxIR/BasicBlock.cpp
+++ b/llvm/lib/SandboxIR/BasicBlock.cpp
@@ -67,12 +67,6 @@ void BasicBlock::buildBasicBlockFromLLVMIR(llvm::BasicBlock *LLVMBB) {
       // Skip instruction's label operands
       if (isa<llvm::BasicBlock>(Op))
         continue;
-      // Skip metadata
-      if (isa<llvm::MetadataAsValue>(Op))
-        continue;
-      // Skip asm
-      if (isa<llvm::InlineAsm>(Op))
-        continue;
       Ctx.getOrCreateValue(Op);
     }
   }

--- a/llvm/lib/SandboxIR/Context.cpp
+++ b/llvm/lib/SandboxIR/Context.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/SandboxIR/Context.h"
+#include "llvm/IR/InlineAsm.h"
 #include "llvm/SandboxIR/Function.h"
 #include "llvm/SandboxIR/Instruction.h"
 #include "llvm/SandboxIR/Module.h"
@@ -168,6 +169,15 @@ Value *Context::getOrCreateValueInternal(llvm::Value *LLVMV, llvm::User *U) {
     if (auto *SBBB = getValue(BB))
       return SBBB;
     return nullptr;
+  }
+  // TODO: Move these checks after more common Values, like after Instruction.
+  if (auto *MD = dyn_cast<llvm::MetadataAsValue>(LLVMV)) {
+    It->second = std::unique_ptr<OpaqueValue>(new OpaqueValue(MD, *this));
+    return It->second.get();
+  }
+  if (auto *Asm = dyn_cast<llvm::InlineAsm>(LLVMV)) {
+    It->second = std::unique_ptr<OpaqueValue>(new OpaqueValue(Asm, *this));
+    return It->second.get();
   }
   assert(isa<llvm::Instruction>(LLVMV) && "Expected Instruction");
 


### PR DESCRIPTION
This patch implements a new subclass of the Value class used for Sandbox IR Values that we don't support, like metadata or inline asm. The goal is to never have null sandboxir::Value objects, because this is not the expected behavior.