### PR TITLE
[globals-aa] Improved isNonEscapingGlobalNoAlias.

### DIFF
--- a/llvm/include/llvm/Analysis/GlobalsModRef.h
+++ b/llvm/include/llvm/Analysis/GlobalsModRef.h
@@ -118,7 +118,8 @@ private:
   bool AnalyzeIndirectGlobalMemory(GlobalVariable *GV);
   void CollectSCCMembership(CallGraph &CG);
 
-  bool isNonEscapingGlobalNoAlias(const GlobalValue *GV, const Value *V);
+  bool isNonEscapingGlobalNoAlias(const GlobalValue *GV, const Value *V,
+                                  const Instruction *CtxI);
   ModRefInfo getModRefInfoForArgument(const CallBase *Call,
                                       const GlobalValue *GV, AAQueryInfo &AAQI);
 };

--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -767,13 +767,14 @@ bool GlobalsAAResult::isNonEscapingGlobalNoAlias(const GlobalValue *GV,
     if (!Input->getType()->isPointerTy())
       continue;
 
-    if (CtxI) {
-      // Null pointer cannot alias with a non-addr-taken global.
-      const Function *F = CtxI->getFunction();
-      if (const ConstantPointerNull *CPN = dyn_cast<ConstantPointerNull>(Input))
+    if (CtxI)
+      if (const ConstantPointerNull *CPN =
+              dyn_cast<ConstantPointerNull>(Input)) {
+        // Null pointer cannot alias with a non-addr-taken global.
+        const Function *F = CtxI->getFunction();
         if (!NullPointerIsDefined(F, CPN->getType()->getAddressSpace()))
           continue;
-    }
+      }
 
     // Recurse through a limited number of selects, loads and PHIs. This is an
     // arbitrary depth of 4, lower numbers could be used to fix compile time

--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -724,8 +724,8 @@ bool GlobalsAAResult::isNonEscapingGlobalNoAlias(const GlobalValue *GV,
 
   // A non-addr-taken global cannot alias with any non-pointer value.
   // Check this early and exit.
-  if (!Input->getType()->isPointerTy())
-    continue;
+  if (!V->getType()->isPointerTy())
+    return true;
 
   SmallPtrSet<const Value *, 8> Visited;
   SmallVector<const Value *, 8> Inputs;

--- a/llvm/test/Analysis/GlobalsModRef/nonescaping-noalias.ll
+++ b/llvm/test/Analysis/GlobalsModRef/nonescaping-noalias.ll
@@ -175,3 +175,24 @@ entry:
   %v = load i32, ptr @g1
   ret i32 %v
 }
+
+define i32 @test6(ptr %param) {
+; Ensure that we can fold a store to a load of a global across a set of
+; calls that cannot use in any way a non-escaping global.
+;
+; CHECK-LABEL: @test6(
+; CHECK: store i32 42, ptr @g1
+; CHECK-NOT: load i32
+; CHECK: ret i32 42
+entry:
+  store i32 42, ptr @g1
+  %1 = call ptr @_FortranAioBeginExternalFormattedOutput(ptr null, i64 3, ptr null, i32 6, ptr null, i32 2)
+  %2 = call i1 @_FortranAioOutputAscii(ptr %1, ptr null, i64 4)
+  %3 = call i32 @_FortranAioEndIoStatement(ptr %1)
+  %v = load i32, ptr @g1
+  ret i32 %v
+}
+declare ptr @_FortranAioBeginExternalFormattedOutput(ptr, i64, ptr, i32, ptr, i32) #0
+declare zeroext i1 @_FortranAioOutputAscii(ptr, ptr, i64) #0
+declare i32 @_FortranAioEndIoStatement(ptr) #0
+attributes #0 = { nocallback nosync }


### PR DESCRIPTION
A non-escaping global should never alias with non-pointer values
and `ptr null`. This should improve disambiguation of global
pointers with relation to Flang runtime calls (given that
`nosync nocallback` attributes are properly set).
It also seems to be an obvious improvement with little overhead.
