### PR TITLE
[lldb] Gardening in StreamAsynchronousIO (NFC)

### DIFF
--- a/lldb/include/lldb/Core/StreamAsynchronousIO.h
+++ b/lldb/include/lldb/Core/StreamAsynchronousIO.h
@@ -18,9 +18,17 @@
 namespace lldb_private {
 class Debugger;
 
+/// A stream meant for asynchronously printing output. Output is buffered until
+/// the stream is flushed or destroyed. Printing is handled by the currently
+/// active IOHandler, or the debugger's output or error stream if there is none.
 class StreamAsynchronousIO : public Stream {
 public:
-  StreamAsynchronousIO(Debugger &debugger, bool for_stdout, bool colors);
+  enum ForSTDOUT : bool {
+    STDOUT = true,
+    STDERR = false,
+  };
+
+  StreamAsynchronousIO(Debugger &debugger, ForSTDOUT for_stdout);
 
   ~StreamAsynchronousIO() override;
 
@@ -32,7 +40,7 @@ protected:
 private:
   Debugger &m_debugger;
   std::string m_data;
-  bool m_for_stdout;
+  ForSTDOUT m_for_stdout;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1321,11 +1321,13 @@ bool Debugger::PopIOHandler(const IOHandlerSP &pop_reader_sp) {
 }
 
 StreamSP Debugger::GetAsyncOutputStream() {
-  return std::make_shared<StreamAsynchronousIO>(*this, true, GetUseColor());
+  return std::make_shared<StreamAsynchronousIO>(*this,
+                                                StreamAsynchronousIO::STDOUT);
 }
 
 StreamSP Debugger::GetAsyncErrorStream() {
-  return std::make_shared<StreamAsynchronousIO>(*this, false, GetUseColor());
+  return std::make_shared<StreamAsynchronousIO>(*this,
+                                                StreamAsynchronousIO::STDERR);
 }
 
 void Debugger::RequestInterrupt() {

--- a/lldb/source/Core/StreamAsynchronousIO.cpp
+++ b/lldb/source/Core/StreamAsynchronousIO.cpp
@@ -14,20 +14,20 @@
 using namespace lldb;
 using namespace lldb_private;
 
-StreamAsynchronousIO::StreamAsynchronousIO(Debugger &debugger, bool for_stdout,
-                                           bool colors)
-    : Stream(0, 4, eByteOrderBig, colors), m_debugger(debugger), m_data(),
-      m_for_stdout(for_stdout) {}
+StreamAsynchronousIO::StreamAsynchronousIO(
+    Debugger &debugger, StreamAsynchronousIO::ForSTDOUT for_stdout)
+    : Stream(0, 4, eByteOrderBig, debugger.GetUseColor()), m_debugger(debugger),
+      m_data(), m_for_stdout(for_stdout) {}
 
 StreamAsynchronousIO::~StreamAsynchronousIO() {
-  // Flush when we destroy to make sure we display the data
+  // Flush when we destroy to make sure we display the data.
   Flush();
 }
 
 void StreamAsynchronousIO::Flush() {
   if (!m_data.empty()) {
     m_debugger.PrintAsync(m_data.data(), m_data.size(), m_for_stdout);
-    m_data = std::string();
+    m_data.clear();
   }
 }
 


### PR DESCRIPTION
A handful of minor improvements to StreamAsynchronousIO:

 - Document the class.
 - Use a named enum value to distinguishing between stdout and stderr.
 - Add missing period to comment.
 - Clear the string instead of assigning to it.
 - Eliminate color argument.