### PR TITLE
[llvm] Make target triple in TLII const reference

### DIFF
--- a/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
+++ b/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
@@ -33,7 +33,7 @@ enum class VectorLibrary {
   AMDLIBM             // AMD vector math library.
 };
 
-TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
+TargetLibraryInfoImpl *createTLII(const llvm::Triple &TargetTriple,
                                   VectorLibrary Veclib);
 
 } // end namespace llvm::driver

--- a/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
+++ b/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
@@ -12,7 +12,7 @@
 
 namespace llvm::driver {
 
-TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
+TargetLibraryInfoImpl *createTLII(const llvm::Triple &TargetTriple,
                                   driver::VectorLibrary Veclib) {
   TargetLibraryInfoImpl *TLII = new TargetLibraryInfoImpl(TargetTriple);
 


### PR DESCRIPTION
This avoids making a copy whenever the function is being called with an argument coming from const& values returned from TM