### PR TITLE
[llvm] replace static_assert with std::enable_if_t in ilist_node_impl

### DIFF
--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -149,6 +149,11 @@ public:
   ///
   /// This requires sentinel tracking to be explicitly enabled.  Use the
   /// ilist_sentinel_tracking<true> option to get this API.
+  ///
+  /// Rather than using static_assert to enforce the API is not called when
+  /// configured with is_sentinel_tracking_explicit=false, the method is
+  /// conditionally provided using std::enable_if.  This way, clients of
+  /// ilist_node_impl can be fully instantiated for DLLExport on Windows.
   template <typename T = OptionsT>
   std::enable_if_t<T::is_sentinel_tracking_explicit, bool> isSentinel() const {
     return node_base_type::isSentinel();

--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -149,9 +149,8 @@ public:
   ///
   /// This requires sentinel tracking to be explicitly enabled.  Use the
   /// ilist_sentinel_tracking<true> option to get this API.
-  template <
-      typename = std::enable_if_t<OptionsT::is_sentinel_tracking_explicit>>
-  bool isSentinel() const {
+  template <typename T = OptionsT>
+  std::enable_if_t<T::is_sentinel_tracking_explicit, bool> isSentinel() const {
     return node_base_type::isSentinel();
   }
 };

--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -18,6 +18,8 @@
 #include "llvm/ADT/ilist_node_base.h"
 #include "llvm/ADT/ilist_node_options.h"
 
+#include <type_traits>
+
 namespace llvm {
 
 namespace ilist_detail {
@@ -147,9 +149,8 @@ public:
   ///
   /// This requires sentinel tracking to be explicitly enabled.  Use the
   /// ilist_sentinel_tracking<true> option to get this API.
+  template <typename = std::enable_if_t<OptionsT::is_sentinel_tracking_explicit>>
   bool isSentinel() const {
-    static_assert(OptionsT::is_sentinel_tracking_explicit,
-                  "Use ilist_sentinel_tracking<true> to enable isSentinel()");
     return node_base_type::isSentinel();
   }
 };

--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -149,7 +149,8 @@ public:
   ///
   /// This requires sentinel tracking to be explicitly enabled.  Use the
   /// ilist_sentinel_tracking<true> option to get this API.
-  template <typename = std::enable_if_t<OptionsT::is_sentinel_tracking_explicit>>
+  template <
+      typename = std::enable_if_t<OptionsT::is_sentinel_tracking_explicit>>
   bool isSentinel() const {
     return node_base_type::isSentinel();
   }


### PR DESCRIPTION
##  Purpose
Remove `static_assert` in `ilist_node_impl::isSentinel` and conditionally include the functino using `std::enable_if_t` instead. 

## Background
This fix is necessary to support building LLVM as a Windows DLL, tracked by #109483.

The `static_assert` in `ilist_node_impl::isSentinel` fails when compiling LLVM as a Windows DLL with the options `-D LLVM_BUILD_LLVM_DYLIB=ON -D LLVM_BUILD_LLVM_DYLIB_VIS=ON -D LLVM_LINK_LLVM_DYLIB=ON`:
```
S:\llvm\llvm-project\llvm\include\llvm/ADT/ilist_node.h(151): error C2338: static_assert failed: 'Use ilist_sentinel_tracking<true> to enable isSentinel()'
S:\llvm\llvm-project\llvm\include\llvm/ADT/ilist_node.h(151): note: the template instantiation context (the oldest one first) is
S:\llvm\llvm-project\llvm\include\llvm/IR/SymbolTableListTraits.h(113): note: see reference to class template instantiation 'llvm::SymbolTableListTraits<llvm::Function>' being compiled
S:\llvm\llvm-project\llvm\include\llvm/IR/SymbolTableListTraits.h(69): note: see reference to class template instantiation 'llvm::simple_ilist<ValueSubClass>' being compiled
        with
        [
            ValueSubClass=llvm::Function
        ]
S:\llvm\llvm-project\llvm\include\llvm/ADT/simple_ilist.h(87): note: see reference to class template instantiation 'llvm::ilist_sentinel<llvm::ilist_detail::node_options<T,true,false,llvm::ilist_detail::extract_tag<>::type,false,llvm::ilist_detail::extract_parent<>::type>>' being compiled
        with
        [
            T=llvm::Function
        ]
S:\llvm\llvm-project\llvm\include\llvm/ADT/ilist_node.h(301): note: see reference to class template instantiation 'llvm::ilist_node_impl<OptionsT>' being compiled
        with
        [
            OptionsT=llvm::ilist_detail::node_options<llvm::Function,true,false,llvm::ilist_detail::extract_tag<>::type,false,llvm::ilist_detail::extract_parent<>::type>
        ]
S:\llvm\llvm-project\llvm\include\llvm/ADT/ilist_node.h(150): note: while compiling class template member function 'bool llvm::ilist_node_impl<OptionsT>::isSentinel(void) const'
        with
        [
            OptionsT=llvm::ilist_detail::node_options<llvm::Function,true,false,llvm::ilist_detail::extract_tag<>::type,false,llvm::ilist_detail::extract_parent<>::type>
        ]
```
Conditionally including the function using `std::enable_if_t` has the same effect of preventing the function's use when `is_sentinel_tracking_explicit=false`, but avoids the issue when DLL-exporting downstream classes.

## Validation
Verified I no longer fail compilation due to the `static_assert` when building LLVM on Windows 11 with the options `-D LLVM_BUILD_LLVM_DYLIB=ON -D LLVM_BUILD_LLVM_DYLIB_VIS=ON -D LLVM_LINK_LLVM_DYLIB=ON`.