### PR TITLE
[clang][Tooling] Support relative directory in compilation database

### DIFF
--- a/clang/lib/Tooling/JSONCompilationDatabase.cpp
+++ b/clang/lib/Tooling/JSONCompilationDatabase.cpp
@@ -419,6 +419,7 @@ bool JSONCompilationDatabase::parse(std::string &ErrorMessage) {
     if (llvm::sys::path::is_relative(FileName)) {
       SmallString<8> DirectoryStorage;
       SmallString<128> AbsolutePath(Directory->getValue(DirectoryStorage));
+      llvm::sys::fs::make_absolute(AbsolutePath);
       llvm::sys::path::append(AbsolutePath, FileName);
       llvm::sys::path::native(AbsolutePath, NativeFilePath);
     } else {

--- a/clang/unittests/Tooling/CompilationDatabaseTest.cpp
+++ b/clang/unittests/Tooling/CompilationDatabaseTest.cpp
@@ -399,6 +399,32 @@ TEST(findCompileArgsInJsonDatabase, FindsEntry) {
   EXPECT_EQ("command4", FoundCommand.CommandLine[0]) << ErrorMessage;
 }
 
+TEST(findCompileArgsInJsonDatabase, FindsEntryRelativeDirectory) {
+  StringRef Directory(".");
+  StringRef FileName("file");
+  StringRef Command("command");
+  std::string JsonDatabase = "[";
+  JsonDatabase +=
+      ("{\"directory\":\"" + Directory + "\"," + "\"command\":\"" + Command +
+       "\","
+       "\"file\":\"" +
+       FileName + "\"}")
+          .str();
+  JsonDatabase += "]";
+
+  SmallString<256> Result;
+  llvm::sys::fs::current_path(Result);
+  llvm::sys::path::append(Result, FileName);
+
+  std::string ErrorMessage;
+  CompileCommand FoundCommand =
+      findCompileArgsInJsonDatabase(Result, JsonDatabase, ErrorMessage);
+
+  EXPECT_EQ(".", FoundCommand.Directory) << ErrorMessage;
+  ASSERT_EQ(1u, FoundCommand.CommandLine.size()) << ErrorMessage;
+  EXPECT_EQ("command", FoundCommand.CommandLine[0]) << ErrorMessage;
+}
+
 TEST(findCompileArgsInJsonDatabase, ParsesCompilerWrappers) {
   std::vector<std::pair<std::string, std::string>> Cases = {
       {"distcc gcc foo.c", "gcc foo.c"},


### PR DESCRIPTION
This allows you to use `"directory": ".",` in `compile_commands.json`
and have it be understood for file lookup by `clangd`.
