### PR TITLE
[BOLT] Use restored names in funcs-{,file-}no-regex

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2976,8 +2976,7 @@ void RewriteInstance::selectFunctionsToProcess() {
   populateFunctionNames(opts::FunctionNamesFileNR, opts::ForceFunctionNamesNR);
 
   // Make a set of functions to process to speed up lookups.
-  std::unordered_set<std::string> ForceFunctionsNR(
-      opts::ForceFunctionNamesNR.begin(), opts::ForceFunctionNamesNR.end());
+  StringSet<> ForceFunctionsNR(opts::ForceFunctionNamesNR);
 
   if ((!opts::ForceFunctionNames.empty() ||
        !opts::ForceFunctionNamesNR.empty()) &&
@@ -3051,9 +3050,10 @@ void RewriteInstance::selectFunctionsToProcess() {
           return true;
 
       // Non-regex check (-funcs-no-regex and -funcs-file-no-regex).
-      for (const StringRef Name : Function.getNames())
-        if (ForceFunctionsNR.count(Name.str()))
-          return true;
+      if (Function.forEachName([&](StringRef Name) {
+            return ForceFunctionsNR.contains(NameResolver::restore(Name));
+          }))
+        return true;
 
       return false;
     }

--- a/bolt/test/X86/funcs-no-regex.s
+++ b/bolt/test/X86/funcs-no-regex.s
@@ -1,0 +1,16 @@
+## Checks handling of function names passed via -funcs-no-regex
+
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-unknown %s -o %t.o
+# RUN: ld.lld %t.o -o %t.exe -nostdlib
+# RUN: llvm-bolt %t.exe -o %t.out -funcs-no-regex=func -print-cfg | FileCheck %s
+# CHECK: Binary Function "func/1"
+
+.globl _start
+.type _start, @function
+_start:
+  ret
+  .size _start, .-_start
+
+.type func, @function
+func:
+  ud2


### PR DESCRIPTION
Since function names given via funcs-no-regex are supposed to be verbatim
and don't contain BOLT-added suffixes, the check should use "restored"
BinaryFunction names stripped of suffixes.

Test Plan: added funcs-no-regex.s
