### PR TITLE
[DTLTO][LLVM] Integrated Distributed ThinLTO (DTLTO)

### DIFF
--- a/llvm/docs/DTLTO.rst
+++ b/llvm/docs/DTLTO.rst
@@ -1,0 +1,186 @@
+===================
+DTLTO
+===================
+.. contents::
+   :local:
+   :depth: 2
+
+.. toctree::
+   :maxdepth: 1
+
+Distributed ThinLTO (DTLTO)
+===========================
+
+Distributed ThinLTO (DTLTO) enables the distribution of backend ThinLTO
+compilations via external distribution systems, such as Incredibuild, during the
+link step.
+
+DTLTO extends the existing ThinLTO distribution support which uses separate
+*thin-link*, *backend compilation*, and *link* steps. This method is documented
+here:
+
+    https://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html
+
+Using the *separate thin-link* approach requires a build system capable of
+handling the dynamic dependencies specified in the individual summary index
+files, such as Bazel. DTLTO removes this requirement, allowing it to be used
+with any build process that supports in-process ThinLTO.
+
+The following commands show the steps used for the *separate thin-link*
+approach for a basic example:
+
+.. code-block:: console
+
+    1. clang -flto=thin -O2 t1.c t2.c -c
+    2. clang -flto=thin -O2 t1.o t2.o -fuse-ld=lld -Wl,--thinlto-index-only
+    3. clang -O2 -o t1.native.o t1.o -c -fthinlto-index=t1.o.thinlto.bc
+    4. clang -O2 -o t2.native.o t2.o -c -fthinlto-index=t2.o.thinlto.bc
+    5. clang t1.native.o t2.native.o -o a.out -fuse-ld=lld
+
+With DTLTO, steps 2-5 are performed internally as part of the link step. The
+equivalent DTLTO commands for the above are:
+
+.. code-block:: console
+
+    clang -flto=thin -O2 t1.c t2.c -c
+    clang -flto=thin -O2 t1.o t2.o -fuse-ld=lld -fthinlto-distributor=<distributor_process>
+
+For DTLTO, LLD prepares the following for each ThinLTO backend compilation job:
+
+- An individual index file and a list of input and output files (corresponds to
+  step 2 above).
+- A Clang command line to perform the ThinLTO backend compilations.
+
+This information is supplied, via a JSON file, to ``distributor_process``, which
+executes the backend compilations using a distribution system (corresponds to
+steps 3 and 4 above). Upon completion, LLD integrates the compiled native object
+files into the link process and completes the link (corresponds to step 5
+above).
+
+This design keeps the details of distribution systems out of the LLVM source
+code.
+
+An example distributor that performs all work on the local system is included in
+the LLVM source tree. To run an example with that distributor, a command line
+such as the following can be used:
+
+.. code-block:: console
+
+   clang -flto=thin -fuse-ld=lld -O2 t1.o t2.o -fthinlto-distributor=$(which python3) \
+     -Xthinlto-distributor=$LLVMSRC/llvm/utils/dtlto/local.py
+
+Distributors
+------------
+
+Distributors are programs responsible for:
+
+1. Consuming the JSON backend compilations job description file.
+2. Translating job descriptions into requests for the distribution system.
+3. Blocking execution until all backend compilations are complete.
+
+Distributors must return a non-zero exit code on failure. They can be
+implemented as platform native executables or in a scripting language, such as
+Python.
+
+Clang and LLD provide options to specify a distributor program for managing
+backend compilations. Distributor options and backend compilation options can
+also be specified. Such options are transparently forwarded.
+
+The backend compilations are currently performed by invoking Clang. For further
+details, refer to:
+
+* Clang documentation: https://clang.llvm.org/docs/ThinLTO.html
+* LLD documentation: https://lld.llvm.org/DTLTO.html
+
+When invoked with a distributor, LLD generates a JSON file describing the
+backend compilation jobs and executes the distributor, passing it this file.
+
+JSON Schema
+-----------
+
+The JSON format is explained by reference to the following example, which
+describes the backend compilation of the modules ``t1.o`` and ``t2.o``:
+
+.. code-block:: json
+
+    {
+        "common": {
+            "linker_output": "dtlto.elf",
+            "args": ["/usr/bin/clang", "-O2", "-c", "-fprofile-sample-use=my.prof"],
+            "inputs": ["my.prof"]
+        },
+        "jobs": [
+            {
+                "args": ["t1.o", "-fthinlto-index=t1.o.thinlto.bc", "-o", "t1.native.o", "-fproc-stat-report=t1.stats.txt"],
+                "inputs": ["t1.o", "t1.o.thinlto.bc"],
+                "outputs": ["t1.native.o", "t1.stats.txt"]
+            },
+            {
+                "args": ["t2.o", "-fthinlto-index=t2.o.thinlto.bc", "-o", "t2.native.o", "-fproc-stat-report=t2.stats.txt"],
+                "inputs": ["t2.o", "t2.o.thinlto.bc"],
+                "outputs": ["t2.native.o", "t2.stats.txt"]
+            }
+        ]
+    }
+
+Each entry in the ``jobs`` array represents a single backend compilation job.
+Each job object records its own command-line arguments and input/output files.
+Shared arguments and inputs are defined once in the ``common`` object.
+
+Reserved Entries:
+
+- The first entry in the ``common.args`` array specifies the compiler
+  executable to invoke.
+- The first entry in each job's ``inputs`` array is the bitcode file for the
+  module being compiled.
+- The second entry in each job's ``inputs`` array is the corresponding
+  individual summary index file.
+- The first entry in each job's ``outputs`` array is the primary output object
+  file.
+
+For the ``outputs`` array, only the first entry is reserved for the primary
+output file; there is no guaranteed order for the remaining entries. The primary
+output file is specified in a reserved entry because some distribution systems
+rely on this path - for example, to provide a meaningful user label for
+compilation jobs. Initially, the DTLTO implementation will not produce more than
+one output file. However, in the future, if LTO options are added that imply
+additional output files, those files will also be included in this array.
+
+Command-line arguments and input/output files are stored separately to allow
+the remote compiler to be changed without updating the distributors, as the
+distributors do not need to understand the details of the compiler command
+line.
+
+To generate the backend compilation commands, the common and job-specific
+arguments are concatenated.
+
+When consuming the example JSON above, a distributor is expected to issue the
+following backend compilation commands with maximum parallelism:
+
+.. code-block:: console
+
+    /usr/bin/clang -O2 -c -fprofile-sample-use=my.prof t1.o -fthinlto-index=t1.o.thinlto.bc -o t1.native.o \
+      -fproc-stat-report=t1.stats.txt
+
+    /usr/bin/clang -O2 -c -fprofile-sample-use=my.prof t2.o  -fthinlto-index=t2.o.thinlto.bc -o t2.native.o \
+      -fproc-stat-report=t2.stats.txt
+
+TODOs
+-----
+
+The following features are planned for DTLTO but not yet implemented:
+
+- Support for the ThinLTO in-process cache.
+- Support for platforms other than ELF and COFF.
+- Support for archives with bitcode members.
+- Support for more LTO configurations; only a very limited set of LTO
+  configurations is supported currently, e.g., support for basic block sections
+  is not currently available.
+
+Constraints
+-----------
+
+- Matching versions of Clang and LLD should be used.
+- The distributor used must support the JSON schema generated by the version of
+  LLD in use.
+

--- a/llvm/docs/UserGuides.rst
+++ b/llvm/docs/UserGuides.rst
@@ -32,6 +32,7 @@ intermediate LLVM representation.
    DebuggingJITedCode
    DirectXUsage
    Docker
+   DTLTO
    FatLTO
    ExtendingLLVM
    GitHub
@@ -163,6 +164,11 @@ Optimizations
 :doc:`LinkTimeOptimization`
    This document describes the interface between LLVM intermodular optimizer
    and the linker and its design
+
+:doc:`DTLTO`
+   This document describes the DTLTO implementation, which allows for
+   distributing ThinLTO backend compilations without requiring support from
+   the build system.
 
 :doc:`GoldPlugin`
    How to build your programs with link-time optimization on Linux.

--- a/llvm/include/llvm/Transforms/IPO/FunctionImport.h
+++ b/llvm/include/llvm/Transforms/IPO/FunctionImport.h
@@ -421,6 +421,12 @@ Error EmitImportsFiles(
     StringRef ModulePath, StringRef OutputFilename,
     const ModuleToSummariesForIndexTy &ModuleToSummariesForIndex);
 
+/// Call \p F passing each of the files module \p ModulePath will import from.
+void processImportsFiles(
+    StringRef ModulePath,
+    const ModuleToSummariesForIndexTy &ModuleToSummariesForIndex,
+    function_ref<void(const std::string &)> F);
+
 /// Based on the information recorded in the summaries during global
 /// summary-based analysis:
 /// 1. Resolve prevailing symbol linkages and constrain visibility (CanAutoHide

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -829,7 +829,7 @@ void ThinLTOCodeGenerator::emitImports(Module &TheModule, StringRef OutputName,
 
   // 'EmitImportsFiles' emits the list of modules from which to import from, and
   // the set of keys in `ModuleToSummariesForIndex` should be a superset of keys
-  // in `DecSummaries`, so no need to use `DecSummaries` in `EmitImportFiles`.
+  // in `DecSummaries`, so no need to use `DecSummaries` in `EmitImportsFiles`.
   GVSummaryPtrSet DecSummaries;
   ModuleToSummariesForIndexTy ModuleToSummariesForIndex;
   llvm::gatherImportedSummariesForModule(

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -1608,13 +1608,23 @@ Error llvm::EmitImportsFiles(
   if (EC)
     return createFileError("cannot open " + OutputFilename,
                            errorCodeToError(EC));
+  processImportsFiles(ModulePath, ModuleToSummariesForIndex,
+                      [&](StringRef M) { ImportsOS << M << "\n"; });
+  return Error::success();
+}
+
+/// Invoke callback \p F on the file paths from which \p ModulePath
+/// will import.
+void llvm::processImportsFiles(
+    StringRef ModulePath,
+    const ModuleToSummariesForIndexTy &ModuleToSummariesForIndex,
+    function_ref<void(const std::string &)> F) {
   for (const auto &ILI : ModuleToSummariesForIndex)
     // The ModuleToSummariesForIndex map includes an entry for the current
     // Module (needed for writing out the index files). We don't want to
     // include it in the imports file, however, so filter it out.
     if (ILI.first != ModulePath)
-      ImportsOS << ILI.first << "\n";
-  return Error::success();
+      F(ILI.first);
 }
 
 bool llvm::convertToDeclaration(GlobalValue &GV) {

--- a/llvm/test/ThinLTO/X86/dtlto/dtlto.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/dtlto.ll
@@ -1,0 +1,80 @@
+; Test DTLTO output with llvm-lto2.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+; Generate bitcode files with summary.
+RUN: opt -thinlto-bc t1.ll -o t1.bc
+RUN: opt -thinlto-bc t2.ll -o t2.bc
+
+; Generate fake object files for mock.py to return.
+RUN: touch t1.o t2.o
+
+; Create an empty subdirectory to avoid having to account for the input files.
+RUN: mkdir %t/out && cd %t/out
+
+; Define a substitution to share the common DTLTO arguments.
+DEFINE: %{command} = llvm-lto2 run ../t1.bc ../t2.bc -o t.o \
+DEFINE:   -dtlto-distributor=%python \
+DEFINE:   -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py,../t1.o,../t2.o \
+DEFINE:   -r=../t1.bc,t1,px \
+DEFINE:   -r=../t2.bc,t2,px
+
+; Perform DTLTO. mock.py does not do any compilation, instead it simply writes
+; the contents of the object files supplied on the command line into the
+; output object files in job order.
+RUN: %{command}
+
+; Check that the expected output files have been created.
+RUN: ls | count 2
+RUN: ls | FileCheck %s --check-prefix=THINLTO
+
+; llvm-lto2 ThinLTO output files.
+THINLTO-DAG: {{^}}t.o.1{{$}}
+THINLTO-DAG: {{^}}t.o.2{{$}}
+
+RUN: cd .. && rm -rf %t/out && mkdir %t/out && cd %t/out
+
+; Perform DTLTO with --save-temps.
+RUN: %{command} --save-temps
+
+; Check that the expected output files have been created.
+RUN: ls | count 12
+RUN: ls | FileCheck %s --check-prefixes=THINLTO,SAVETEMPS
+
+; Common -save-temps files from llvm-lto2.
+SAVETEMPS-DAG: {{^}}t.o.resolution.txt{{$}}
+SAVETEMPS-DAG: {{^}}t.o.index.bc{{$}}
+SAVETEMPS-DAG: {{^}}t.o.index.dot{{$}}
+
+; -save-temps incremental files.
+SAVETEMPS-DAG: {{^}}t.o.0.0.preopt.bc{{$}}
+SAVETEMPS-DAG: {{^}}t.o.0.2.internalize.bc{{$}}
+
+; A jobs description JSON.
+SAVETEMPS-DAG: {{^}}t.[[#]].dist-file.json{{$}}
+
+; Summary shards emitted for DTLTO.
+SAVETEMPS-DAG: {{^}}t1.1.[[#]].native.o.thinlto.bc{{$}}
+SAVETEMPS-DAG: {{^}}t2.2.[[#]].native.o.thinlto.bc{{$}}
+
+; DTLTO native output files (the results of the external backend compilations).
+SAVETEMPS-DAG: {{^}}t1.1.[[#]].native.o{{$}}
+SAVETEMPS-DAG: {{^}}t2.2.[[#]].native.o{{$}}
+
+;--- t1.ll
+
+target triple = "x86_64-unknown-linux-gnu"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @t1() {
+  ret void
+}
+
+;--- t2.ll
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t2() {
+  ret void
+}

--- a/llvm/test/ThinLTO/X86/dtlto/imports.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/imports.ll
@@ -1,0 +1,73 @@
+; Check that DTLTO creates imports lists correctly.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+; Generate ThinLTO bitcode files.
+RUN: opt -thinlto-bc 0.ll -o 0.bc -O2
+RUN: opt -thinlto-bc 1.ll -o 1.bc -O2
+
+; Define a substitution to share the common DTLTO arguments. Note that the use
+; of validate.py will cause a failure as it does not create output files.
+DEFINE: %{command} = llvm-lto2 run 0.bc 1.bc -o t.o \
+DEFINE:    -dtlto-distributor=%python \
+DEFINE:    -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
+DEFINE:    -r=0.bc,g,px \
+DEFINE:    -r=1.bc,f,px \
+DEFINE:    -r=1.bc,g
+
+; We expect an import from 0.bc into 1.bc but no imports into 0.bc. Check that
+; the expected input files have been added to the JSON to account for this.
+RUN: not %{command} 2>&1 | FileCheck %s --check-prefixes=INPUTS,ERR
+
+; 1.bc should not appear in the list of inputs for 0.bc.
+INPUTS:      "jobs":
+INPUTS:      "inputs": [
+INPUTS-NEXT:   "0.bc",
+INPUTS-NEXT:   "0.1.[[#]].native.o.thinlto.bc"
+INPUTS-NEXT: ]
+
+; 0.bc should appear in the list of inputs for 1.bc.
+INPUTS:      "inputs": [
+INPUTS-NEXT:   "1.bc",
+INPUTS-NEXT:   "1.2.[[#]].native.o.thinlto.bc",
+INPUTS-NEXT:   "0.bc"
+INPUTS-NEXT: ]
+
+; This check ensures that we have failed for the expected reason.
+ERR: failed: DTLTO backend compilation: cannot open native object file:
+
+
+; Check that imports files are not created even if -save-temps is active.
+RUN: not %{command} -save-temps 2>&1 \
+RUN:   | FileCheck %s --check-prefixes=ERR
+RUN: ls | FileCheck %s --check-prefix=NOIMPORTSFILES
+NOIMPORTSFILES-NOT: imports
+
+
+; Check that imports files are created with -thinlto-emit-imports.
+RUN: not %{command} -thinlto-emit-imports 2>&1 \
+RUN:   | FileCheck %s --check-prefixes=ERR
+RUN: ls | FileCheck %s --check-prefix=IMPORTSFILES
+IMPORTSFILES: 0.bc.imports
+IMPORTSFILES: 1.bc.imports
+
+;--- 0.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @g() {
+entry:
+  ret void
+}
+
+;--- 1.ll
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @g(...)
+
+define void @f() {
+entry:
+  call void (...) @g()
+  ret void
+}

--- a/llvm/test/ThinLTO/X86/dtlto/json.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/json.ll
@@ -1,0 +1,84 @@
+; Check that the JSON output from DTLTO is as expected. Note that validate.py
+; checks the JSON structure so we just check the field contents in this test.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+; Generate bitcode files with summary.
+RUN: opt -thinlto-bc t1.ll -o t1.bc
+RUN: opt -thinlto-bc t2.ll -o t2.bc
+
+; Perform DTLTO.
+RUN: not llvm-lto2 run t1.bc t2.bc -o my.output \
+RUN:     -r=t1.bc,t1,px -r=t2.bc,t2,px \
+RUN:     -dtlto-distributor=%python \
+RUN:     -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py,--da1=10,--da2=10 \
+RUN:     -dtlto-compiler=my_clang.exe \
+RUN:     -dtlto-compiler-arg=--rota1=10,--rota2=20 \
+RUN:   2>&1 | FileCheck %s
+
+CHECK: distributor_args=['--da1=10', '--da2=10']
+
+; Check the common object.
+CHECK:      "linker_output": "my.output"
+CHECK:      "args":
+CHECK-NEXT: "my_clang.exe"
+CHECK-NEXT: "-c"
+CHECK-NEXT: "--target=x86_64-unknown-linux-gnu"
+CHECK-NEXT: "-O2"
+CHECK-NEXT: "-fpic"
+CHECK-NEXT: "-Wno-unused-command-line-argument"
+CHECK-NEXT: "--rota1=10"
+CHECK-NEXT: "--rota2=20"
+CHECK-NEXT: ]
+CHECK: "inputs": []
+
+; Check the first job entry.
+CHECK:      "args":
+CHECK-NEXT: "t1.bc"
+CHECK-NEXT: "-fthinlto-index=t1.1.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: "-o"
+CHECK-NEXT: "t1.1.[[#]].native.o"
+CHECK-NEXT: ]
+CHECK:      "inputs": [
+CHECK-NEXT: "t1.bc"
+CHECK-NEXT: "t1.1.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: ]
+CHECK:      "outputs": [
+CHECK-NEXT: "t1.1.[[#]].native.o"
+CHECK-NEXT: ]
+
+; Check the second job entry.
+CHECK:      "args": [
+CHECK-NEXT: "t2.bc"
+CHECK-NEXT: "-fthinlto-index=t2.2.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: "-o"
+CHECK-NEXT: "t2.2.[[#]].native.o"
+CHECK-NEXT: ]
+CHECK-NEXT: "inputs": [
+CHECK-NEXT: "t2.bc"
+CHECK-NEXT: "t2.2.[[#]].native.o.thinlto.bc"
+CHECK-NEXT: ]
+CHECK-NEXT: "outputs": [
+CHECK-NEXT: "t2.2.[[#]].native.o"
+CHECK-NEXT: ]
+
+; This check ensures that we have failed for the expected reason.
+CHECK: failed: DTLTO backend compilation: cannot open native object file:
+
+;--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}
+
+;--- t2.ll
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t2() {
+entry:
+  ret void
+}

--- a/llvm/test/ThinLTO/X86/dtlto/summary.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/summary.ll
@@ -1,0 +1,51 @@
+; Check that DTLTO creates identical summary index shard files as are created
+; for an equivalent ThinLTO link.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+; Generate ThinLTO bitcode files.
+RUN: opt -thinlto-bc t1.ll -o t1.bc
+RUN: opt -thinlto-bc t2.ll -o t2.bc
+
+; Generate fake object files for mock.py to return.
+RUN: touch t1.o t2.o
+
+; Define a substitution to share the common arguments.
+DEFINE: %{command} = llvm-lto2 run t1.bc t2.bc -o t.o \
+DEFINE:     -r=t1.bc,t1,px \
+DEFINE:     -r=t2.bc,t2,px \
+DEFINE:     -r=t2.bc,t1 \
+DEFINE:     -thinlto-emit-indexes
+
+; Perform DTLTO.
+RUN: %{command} \
+RUN:     -dtlto-distributor=%python \
+RUN:     -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py,t1.o,t2.o
+
+; Perform ThinLTO.
+RUN: %{command}
+
+; Check for equivalence. We use a wildcard to account for the PID.
+RUN: cmp t1.1.*.native.o.thinlto.bc t1.bc.thinlto.bc
+RUN: cmp t2.2.*.native.o.thinlto.bc t2.bc.thinlto.bc
+
+;--- t1.ll
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+entry:
+  ret void
+}
+
+;--- t2.ll
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare void @t1(...)
+
+define void @t2() {
+entry:
+  call void (...) @t1()
+  ret void
+}

--- a/llvm/test/ThinLTO/X86/dtlto/triple.ll
+++ b/llvm/test/ThinLTO/X86/dtlto/triple.ll
@@ -1,0 +1,44 @@
+; Test that DTLTO uses the target triple from the first file in the link.
+
+RUN: rm -rf %t && split-file %s %t && cd %t
+
+; Generate bitcode files with summary.
+RUN: opt -thinlto-bc t1.ll -o t1.bc
+RUN: opt -thinlto-bc t2.ll -o t2.bc
+
+; Define a substitution to share the common DTLTO arguments. Note that the use
+; of validate.py will cause a failure as it does not create output files.
+DEFINE: %{command} = llvm-lto2 run -o t.o -save-temps \
+DEFINE:    -dtlto-distributor=%python \
+DEFINE:    -dtlto-distributor-arg=%llvm_src_root/utils/dtlto/validate.py \
+DEFINE:    -r=t1.bc,t1,px \
+DEFINE:    -r=t2.bc,t2,px
+
+; Test case where t1.bc is first.
+RUN: not %{command} t1.bc t2.bc 2>&1 | FileCheck %s \
+RUN:   --check-prefixes=TRIPLE1,ERR --implicit-check-not=--target
+TRIPLE1: --target=x86_64-unknown-linux-gnu
+
+; Test case where t2.bc is first.
+RUN: not %{command} t2.bc t1.bc 2>&1 | FileCheck %s \
+RUN:   --check-prefixes=TRIPLE2,ERR --implicit-check-not=--target
+TRIPLE2: --target=x86_64-unknown-unknown-gnu
+
+; This check ensures that we have failed for the expected reason.
+ERR: failed: DTLTO backend compilation: cannot open native object file:
+
+;--- t1.ll
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @t1() {
+  ret void
+}
+
+;--- t2.ll
+
+target triple = "x86_64-unknown-unknown-gnu"
+
+define void @t2() {
+  ret void
+}

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -91,6 +91,7 @@ config.substitutions.append(("%llvmshlibdir", config.llvm_shlib_dir))
 config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
 config.substitutions.append(("%pluginext", config.llvm_plugin_ext))
 config.substitutions.append(("%exeext", config.llvm_exe_ext))
+config.substitutions.append(("%llvm_src_root", config.llvm_src_root))
 
 
 lli_args = []

--- a/llvm/utils/dtlto/local.py
+++ b/llvm/utils/dtlto/local.py
@@ -1,0 +1,28 @@
+"""
+DTLTO local serial distributor.
+
+This script parses the Distributed ThinLTO (DTLTO) JSON file and serially
+executes the specified code generation tool on the local host to perform each 
+backend compilation job. This simple functional distributor is intended to be
+used for integration tests.
+
+Usage:
+    python local.py <json_file>
+
+Arguments:
+    - <json_file> : JSON file describing the DTLTO jobs.
+"""
+
+import subprocess
+import sys
+import json
+from pathlib import Path
+
+if __name__ == "__main__":
+    # Load the DTLTO information from the input JSON file.
+    with Path(sys.argv[-1]).open() as f:
+        data = json.load(f)
+
+    # Iterate over the jobs and execute the codegen tool.
+    for job in data["jobs"]:
+        subprocess.check_call(data["common"]["args"] + job["args"])

--- a/llvm/utils/dtlto/mock.py
+++ b/llvm/utils/dtlto/mock.py
@@ -1,0 +1,42 @@
+"""
+DTLTO Mock Distributor.
+
+This script acts as a mock distributor for Distributed ThinLTO (DTLTO). It is
+used for testing DTLTO when a Clang binary is not be available to invoke to
+perform the backend compilation jobs.
+
+Usage:
+    python mock.py <input_file1> <input_file2> ... <json_file>
+
+Arguments:
+    - <input_file1>, <input_file2>, ...  : Input files to be copied.
+    - <json_file>                        : JSON file describing the DTLTO jobs.
+
+The script performs the following:
+    1. Reads the JSON file containing job descriptions.
+    2. For each job copies the corresponding input file to the output location
+       specified for that job.
+    3. Validates the JSON format using the `validate` module.
+"""
+
+import sys
+import json
+import shutil
+from pathlib import Path
+import validate
+
+if __name__ == "__main__":
+    json_arg = sys.argv[-1]
+    input_files = sys.argv[1:-1]
+
+    # Load the DTLTO information from the input JSON file.
+    with Path(json_arg).open() as f:
+        data = json.load(f)
+
+    # Iterate over the jobs and create the output
+    # files by copying over the supplied input files.
+    for job_index, job in enumerate(data["jobs"]):
+        shutil.copy(input_files[job_index], job["outputs"][0])
+
+    # Check the format of the JSON.
+    validate.validate(data)

--- a/llvm/utils/dtlto/validate.py
+++ b/llvm/utils/dtlto/validate.py
@@ -1,0 +1,78 @@
+"""
+DTLTO JSON Validator.
+
+This script is used for DTLTO testing to check that the distributor has
+been invoked correctly.
+
+Usage:
+    python validate.py <json_file>
+
+Arguments:
+    - <json_file> : JSON file describing the DTLTO jobs.
+
+The script does the following:
+    1. Prints the supplied distributor arguments.
+    2. Loads the JSON file.
+    3. Pretty prints the JSON.
+    4. Validates the structure and required fields.
+"""
+
+import sys
+import json
+from pathlib import Path
+
+
+def take(jvalue, jpath):
+    parts = jpath.split(".")
+    for part in parts[:-1]:
+        jvalue = jvalue[part]
+    return jvalue.pop(parts[-1], KeyError)
+
+
+def validate(jdoc):
+    # Check the format of the JSON
+    assert type(take(jdoc, "common.linker_output")) is str
+
+    args = take(jdoc, "common.args")
+    assert type(args) is list
+    assert len(args) > 0
+    assert all(type(i) is str for i in args)
+
+    inputs = take(jdoc, "common.inputs")
+    assert type(inputs) is list
+    assert all(type(i) is str for i in inputs)
+
+    assert len(take(jdoc, "common")) == 0
+
+    jobs = take(jdoc, "jobs")
+    assert type(jobs) is list
+    for j in jobs:
+        assert type(j) is dict
+
+        for attr, min_size in (("args", 0), ("inputs", 2), ("outputs", 1)):
+            array = take(j, attr)
+            assert len(array) >= min_size
+            assert type(array) is list
+            assert all(type(a) is str for a in array)
+
+        assert len(j) == 0
+
+    assert len(jdoc) == 0
+
+
+if __name__ == "__main__":
+    json_arg = Path(sys.argv[-1])
+    distributor_args = sys.argv[1:-1]
+
+    # Print the supplied distributor arguments.
+    print(f"{distributor_args=}")
+
+    # Load the DTLTO information from the input JSON file.
+    with json_arg.open() as f:
+        jdoc = json.load(f)
+
+    # Write the input JSON to stdout.
+    print(json.dumps(jdoc, indent=4))
+
+    # Check the format of the JSON.
+    validate(jdoc)


### PR DESCRIPTION
This PR introduces initial support for Integrated Distributed ThinLTO (DTLTO) in LLVM. 

DTLTO enables the distribution of backend ThinLTO compilations via external distribution systems, such as Incredibuild. Existing support for distributing ThinLTO compilations typically involves separate thin-link (`--thinlto-index-only`), backend compilation, and link steps coordinated by a modern build system, like Bazel. This "Bazel-style" distributed ThinLTO requires a modern build system as it must handle the [dynamic dependencies](https://buck2.build/docs/rule_authors/dynamic_dependencies/) specified in the summary index file shards. However, adopting a modern build system can be prohibitive for users with established build infrastructure. In contrast, DTLTO manages distribution within LLVM during the traditional link step. This approach means that DTLTO is usable with any build process that supports in-process ThinLTO.

This PR provides a minimal but functional implementation of DTLTO, which will be expanded in subsequent commits. It implements basic support for distributing backend ThinLTO compilation jobs via an external process that coordinates with a distribution system (such as Incredibuild). A JSON interface is used for communication with this external process. The JSON interface allows new distribution systems to be supported without modifying LLVM. Please see the documentation added in this PR: `llvm/docs/dtlto.rst` for more details.

Subsequent commits will add:
- Support for the ThinLTO cache.
- Support for more LTO configuration states e.g., basic block sections.
- Performance improvements, for example, improving the performance of the temporary file removal.

**RFC**: [Integrated Distributed ThinLTO RFC](https://discourse.llvm.org/t/rfc-integrated-distributed-thinlto/69641)
For the design of the DTLTO feature, see: https://github.com/llvm/llvm-project/pull/126654.
