### PR TITLE
[MC] Remove MCRegister::isStackSlot.

### DIFF
--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -42,11 +42,12 @@ public:
   ///
   /// FIXME: remove in favor of member.
   static constexpr bool isStackSlot(unsigned Reg) {
-    return MCRegister::isStackSlot(Reg);
+    return MCRegister::FirstStackSlot <= Reg &&
+           Reg < MCRegister::VirtualRegFlag;
   }
 
   /// Return true if this is a stack slot.
-  constexpr bool isStack() const { return MCRegister::isStackSlot(Reg); }
+  constexpr bool isStack() const { return isStackSlot(Reg); }
 
   /// Compute the frame index from a register value representing a stack slot.
   static int stackSlot2Index(Register Reg) {

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -54,14 +54,6 @@ public:
   static constexpr unsigned FirstStackSlot = 1u << 30;
   static constexpr unsigned VirtualRegFlag = 1u << 31;
 
-  /// This is the portion of the positive number space that is not a physical
-  /// register. StackSlot values do not exist in the MC layer, see
-  /// Register::isStackSlot() for the more information on them.
-  ///
-  static constexpr bool isStackSlot(unsigned Reg) {
-    return FirstStackSlot <= Reg && Reg < VirtualRegFlag;
-  }
-
   /// Return true if the specified register number is in
   /// the physical register namespace.
   static constexpr bool isPhysicalRegister(unsigned Reg) {


### PR DESCRIPTION
Stack slots should only be stored in Register. The only caller was Register::isStackSlot so just inline it there.