### PR TITLE
[MLIR][NFC] Use base alias for constructor inheritance

### DIFF
--- a/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
+++ b/mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp
@@ -1038,7 +1038,7 @@ struct AMDGPUDPPLowering : public ConvertOpToLLVMPattern<DPPOp> {
 
 struct ConvertAMDGPUToROCDLPass
     : public impl::ConvertAMDGPUToROCDLPassBase<ConvertAMDGPUToROCDLPass> {
-  using ConvertAMDGPUToROCDLPassBase::ConvertAMDGPUToROCDLPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     MLIRContext *ctx = &getContext();

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -1338,7 +1338,7 @@ void mlir::arith::populateArithToSPIRVPatterns(
 namespace {
 struct ConvertArithToSPIRVPass
     : public impl::ConvertArithToSPIRVPassBase<ConvertArithToSPIRVPass> {
-  using ConvertArithToSPIRVPassBase::ConvertArithToSPIRVPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     Operation *op = getOperation();

--- a/mlir/lib/Conversion/ComplexToStandard/ComplexToStandard.cpp
+++ b/mlir/lib/Conversion/ComplexToStandard/ComplexToStandard.cpp
@@ -1072,7 +1072,7 @@ namespace {
 struct ConvertComplexToStandardPass
     : public impl::ConvertComplexToStandardPassBase<
           ConvertComplexToStandardPass> {
-  using ConvertComplexToStandardPassBase::ConvertComplexToStandardPassBase;
+  using Base::Base;
 
   void runOnOperation() override;
 };

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
@@ -28,7 +28,7 @@ namespace {
 class ConvertControlFlowToSPIRVPass final
     : public impl::ConvertControlFlowToSPIRVPassBase<
           ConvertControlFlowToSPIRVPass> {
-  using ConvertControlFlowToSPIRVPassBase::ConvertControlFlowToSPIRVPassBase;
+  using Base::Base;
   void runOnOperation() override;
 };
 } // namespace

--- a/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
@@ -27,7 +27,7 @@ namespace {
 /// A pass converting MLIR Func operations into the SPIR-V dialect.
 class ConvertFuncToSPIRVPass
     : public impl::ConvertFuncToSPIRVPassBase<ConvertFuncToSPIRVPass> {
-  using ConvertFuncToSPIRVPassBase::ConvertFuncToSPIRVPassBase;
+  using Base::Base;
   void runOnOperation() override;
 };
 } // namespace

--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.cpp
@@ -27,7 +27,7 @@ namespace {
 /// A pass converting MLIR MemRef operations into the SPIR-V dialect.
 class ConvertMemRefToSPIRVPass
     : public impl::ConvertMemRefToSPIRVPassBase<ConvertMemRefToSPIRVPass> {
-  using ConvertMemRefToSPIRVPassBase::ConvertMemRefToSPIRVPassBase;
+  using Base::Base;
   void runOnOperation() override;
 };
 } // namespace

--- a/mlir/lib/Conversion/SCFToGPU/SCFToGPUPass.cpp
+++ b/mlir/lib/Conversion/SCFToGPU/SCFToGPUPass.cpp
@@ -34,7 +34,7 @@ namespace {
 // walk the function recursively to avoid considering nested loops.
 struct ForLoopMapper
     : public impl::ConvertAffineForToGPUPassBase<ForLoopMapper> {
-  using ConvertAffineForToGPUPassBase::ConvertAffineForToGPUPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     for (Operation &op : llvm::make_early_inc_range(

--- a/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
@@ -29,7 +29,7 @@ namespace {
 /// A pass converting MLIR Tensor operations into the SPIR-V dialect.
 class ConvertTensorToSPIRVPass
     : public impl::ConvertTensorToSPIRVPassBase<ConvertTensorToSPIRVPass> {
-  using ConvertTensorToSPIRVPassBase::ConvertTensorToSPIRVPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();

--- a/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
+++ b/mlir/lib/Conversion/TosaToArith/TosaToArithPass.cpp
@@ -30,7 +30,7 @@ using namespace tosa;
 
 namespace {
 struct TosaToArith : public impl::TosaToArithPassBase<TosaToArith> {
-  using TosaToArithPassBase::TosaToArithPassBase;
+  using Base::Base;
 
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
During my previous cleanup (#127403), I did not notice that we defined a type alias for the base class. This type alias allows us to use the shorter form Base::Base, and this PR switches to that.