### PR TITLE
[libc++] Deprecate and remove member types of `hash` in `<variant>`

### DIFF
--- a/libcxx/include/__variant/monostate.h
+++ b/libcxx/include/__variant/monostate.h
@@ -49,10 +49,12 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator>=(monostate, monostate) noe
 
 template <>
 struct _LIBCPP_TEMPLATE_VIS hash<monostate> {
-  using argument_type = monostate;
-  using result_type   = size_t;
+#  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
+  using argument_type _LIBCPP_DEPRECATED_IN_CXX17 = monostate;
+  using result_type _LIBCPP_DEPRECATED_IN_CXX17   = size_t;
+#  endif
 
-  inline _LIBCPP_HIDE_FROM_ABI result_type operator()(const argument_type&) const _NOEXCEPT {
+  inline _LIBCPP_HIDE_FROM_ABI size_t operator()(const monostate&) const noexcept {
     return 66740831; // return a fundamentally attractive random value.
   }
 };

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1585,10 +1585,12 @@ swap(variant<_Types...>& __lhs,
 
 template <class... _Types>
 struct _LIBCPP_TEMPLATE_VIS hash< __enable_hash_helper<variant<_Types...>, remove_const_t<_Types>...>> {
-  using argument_type = variant<_Types...>;
-  using result_type   = size_t;
+#    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
+  using argument_type _LIBCPP_DEPRECATED_IN_CXX17 = variant<_Types...>;
+  using result_type _LIBCPP_DEPRECATED_IN_CXX17   = size_t;
+#    endif
 
-  _LIBCPP_HIDE_FROM_ABI result_type operator()(const argument_type& __v) const {
+  _LIBCPP_HIDE_FROM_ABI size_t operator()(const variant<_Types...>& __v) const {
     using __variant_detail::__visitation::__variant;
     size_t __res =
         __v.valueless_by_exception()

--- a/libcxx/test/std/utilities/variant/variant.hash/hash.depr.verify.cpp
+++ b/libcxx/test/std/utilities/variant/variant.hash/hash.depr.verify.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: std-at-least-c++17
+
+#include <variant>
+
+#include "test_macros.h"
+
+using A1 [[maybe_unused]] = std::hash<std::variant<int, long>>::argument_type;
+using R1 [[maybe_unused]] = std::hash<std::variant<int, long>>::result_type;
+#if TEST_STD_VER >= 20
+// expected-error@-3 {{no type named 'argument_type' in 'std::hash<std::variant<int, long>>'}}
+// expected-error@-3 {{no type named 'result_type' in 'std::hash<std::variant<int, long>>'}}
+#else
+// expected-warning@-6 {{'argument_type' is deprecated}}
+// expected-warning@-6 {{'result_type' is deprecated}}
+#endif
+
+using A2 [[maybe_unused]] = std::hash<std::monostate>::argument_type;
+using R2 [[maybe_unused]] = std::hash<std::monostate>::result_type;
+#if TEST_STD_VER >= 20
+// expected-error@-3 {{no type named 'argument_type' in 'std::hash<monostate>'}}
+// expected-error@-3 {{no type named 'result_type' in 'std::hash<monostate>'}}
+#else
+// expected-warning@-6 {{'argument_type' is deprecated}}
+// expected-warning@-6 {{'result_type' is deprecated}}
+#endif


### PR DESCRIPTION
These member types were deprecated in C++17 by P0174R2 and removed in C++20 by P0619R4, but the changes in `<variant>` seem missing.

Drive-by: Replace one `_NOEXCEPT` with `noexcept` as the `hash` specialization is C++17-and-later only.