### PR TITLE
[GlobalOpt] Don't query TTI on a llvm.memcpy declaration.

### DIFF
--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2186,8 +2186,10 @@ static bool tryWidenGlobalArraysUsedByMemcpy(
     if (NumElementsToCopy != DZSize || DZSize != SZSize)
       continue;
 
-    unsigned NumBytesToPad = GetTTI(*F).getNumBytesToPadGlobalArray(
-        NumBytesToCopy, SourceDataArray->getType());
+    unsigned NumBytesToPad =
+        GetTTI(*CI->getFunction())
+            .getNumBytesToPadGlobalArray(NumBytesToCopy,
+                                         SourceDataArray->getType());
     if (NumBytesToPad) {
       return tryWidenGlobalArrayAndDests(F, GV, NumBytesToPad, NumBytesToCopy,
                                          BytesToCopyOp, SourceDataArray);


### PR DESCRIPTION
Querying TTI creates a Subtarget object, but an llvm.memcpy declaration doesn't have target-cpu and target-feature attributes like functions with definitions. This can cause a warning to be printed on RISC-V because the target-abi in the Module requires floating point, but the subtarget features don't enable floating point. So far we've only seen this in LTO when an -mcpu is not supplied for the TargetMachine.

To fix this, get TTI for the calling function instead.

Fixes the issue reported here https://github.com/llvm/llvm-project/issues/69780#issuecomment-2665273161