### PR TITLE
[mlir][acc] Add inline interface to acc dialect.

### DIFF
--- a/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
+++ b/mlir/lib/Dialect/OpenACC/IR/OpenACC.cpp
@@ -87,8 +87,7 @@ struct ACCInlinerInterface : public DialectInlinerInterface {
   bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
     return true;
   }
-  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {
-  }
+  void handleTerminator(Operation *op, ValueRange valuesToRepl) const final {}
 };
 } // namespace
 


### PR DESCRIPTION
Inliner interface could make inlining happens within OpenACC region.  For example, the call site is as follows
```
      acc.loop  gang control(%arg2 : index) = (%c0_i64 : i64) to (%arg1 : i64)  step (%c1_i64 : i64) {
        %0 = arith.index_cast %arg2 : index to i64
        func.call @_mlir_set(%arg0, %0, %0) : (memref<?xf64>, i64, i64) -> ()
        acc.yield
      }
```
Inliner will check whether the acc.loop operation is valid to inline any function calls. With this change, mlir-opt -inline could inline function "mlir_set" into acc.loop region to get better performance. 