### PR TITLE
[libc] Add strftime_l

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -248,6 +248,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.gmtime
     libc.src.time.gmtime_r
     libc.src.time.mktime
+    libc.src.time.strftime
+    libc.src.time.strftime_l
     libc.src.time.timespec_get
 
     # internal entrypoints

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -248,6 +248,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.gmtime
     libc.src.time.gmtime_r
     libc.src.time.mktime
+    libc.src.time.strftime
+    libc.src.time.strftime_l
     libc.src.time.timespec_get
 
     # internal entrypoints

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -244,6 +244,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.gmtime
     libc.src.time.gmtime_r
     libc.src.time.mktime
+    libc.src.time.strftime
+    libc.src.time.strftime_l
     libc.src.time.timespec_get
 
     # internal entrypoints

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1128,6 +1128,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.time.mktime
     libc.src.time.nanosleep
     libc.src.time.strftime
+    libc.src.time.strftime_l
     libc.src.time.time
     libc.src.time.timespec_get
 

--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -9,6 +9,7 @@ types:
   - type_name: time_t
   - type_name: clock_t
   - type_name: size_t
+  - type_name: locale_t
 enums: []
 objects: []
 functions:
@@ -100,6 +101,16 @@ functions:
       - type: size_t
       - type: const char *__restrict
       - type: const struct tm *__restrict
+  - name: strftime_l
+    standard:
+      - stdc
+    return_type: size_t
+    arguments:
+      - type: char *__restrict
+      - type: size_t
+      - type: const char *__restrict
+      - type: const struct tm *__restrict
+      - type: locale_t
   - name: time
     standard:
       - stdc

--- a/libc/src/time/CMakeLists.txt
+++ b/libc/src/time/CMakeLists.txt
@@ -151,6 +151,20 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  strftime_l
+  SRCS
+    strftime_l.cpp
+  HDRS
+    strftime_l.h
+  DEPENDS
+    libc.hdr.types.locale_t
+    libc.hdr.types.size_t
+    libc.hdr.types.struct_tm
+    libc.src.stdio.printf_core.writer
+    libc.src.time.strftime_core.strftime_main
+)
+
+add_entrypoint_object(
   time
   SRCS
     time.cpp

--- a/libc/src/time/strftime_l.cpp
+++ b/libc/src/time/strftime_l.cpp
@@ -1,4 +1,4 @@
-//===-- Implementation of strftime function -------------------------------===//
+//===-- Implementation of strftime_l function -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/time/strftime.h"
+#include "src/time/strftime_l.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/struct_tm.h"
+#include "include/llvm-libc-types/locale_t.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/printf_core/writer.h"
@@ -16,9 +17,11 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(size_t, strftime,
+// TODO: Add support for locales.
+LLVM_LIBC_FUNCTION(size_t, strftime_l,
                    (char *__restrict buffer, size_t buffsz,
-                    const char *__restrict format, const tm *timeptr)) {
+                    const char *__restrict format,
+                    const struct tm *__restrict tp, locale_t)) {
   printf_core::WriteBuffer wb(buffer, (buffsz > 0 ? buffsz - 1 : 0));
   printf_core::Writer writer(&wb);
   int ret = strftime_core::strftime_main(&writer, format, timeptr);

--- a/libc/src/time/strftime_l.cpp
+++ b/libc/src/time/strftime_l.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/time/strftime_l.h"
+#include "hdr/types/locale_t.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/struct_tm.h"
-#include "include/llvm-libc-types/locale_t.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/stdio/printf_core/writer.h"
@@ -20,8 +20,8 @@ namespace LIBC_NAMESPACE_DECL {
 // TODO: Add support for locales.
 LLVM_LIBC_FUNCTION(size_t, strftime_l,
                    (char *__restrict buffer, size_t buffsz,
-                    const char *__restrict format,
-                    const struct tm *__restrict tp, locale_t)) {
+                    const char *__restrict format, const tm *timeptr,
+                    locale_t)) {
   printf_core::WriteBuffer wb(buffer, (buffsz > 0 ? buffsz - 1 : 0));
   printf_core::Writer writer(&wb);
   int ret = strftime_core::strftime_main(&writer, format, timeptr);

--- a/libc/src/time/strftime_l.h
+++ b/libc/src/time/strftime_l.h
@@ -17,8 +17,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 size_t strftime_l(char *__restrict buffer, size_t count,
-                  const char *__restrict format, const tm *timeptr,
-                  locale_t);
+                  const char *__restrict format, const tm *timeptr, locale_t);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/time/strftime_l.h
+++ b/libc/src/time/strftime_l.h
@@ -1,0 +1,25 @@
+//===-- Implementation header for strftime_l --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_TIME_STRFTIME_L_H
+#define LLVM_LIBC_SRC_TIME_STRFTIME_L_H
+
+#include "hdr/types/size_t.h"
+#include "hdr/types/struct_tm.h"
+#include "include/llvm-libc-types/locale_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+size_t strftime_l(char *__restrict buffer, size_t count,
+                  const char *__restrict format, const struct tm *__restrict tp,
+                  locale_t);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_TIME_STRFTIME_L_H

--- a/libc/src/time/strftime_l.h
+++ b/libc/src/time/strftime_l.h
@@ -9,15 +9,15 @@
 #ifndef LLVM_LIBC_SRC_TIME_STRFTIME_L_H
 #define LLVM_LIBC_SRC_TIME_STRFTIME_L_H
 
+#include "hdr/types/locale_t.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/struct_tm.h"
-#include "include/llvm-libc-types/locale_t.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 size_t strftime_l(char *__restrict buffer, size_t count,
-                  const char *__restrict format, const struct tm *__restrict tp,
+                  const char *__restrict format, const tm *timeptr,
                   locale_t);
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This is a (no-op) locale version of strftime.

Fixes: https://github.com/llvm/llvm-project/issues/106630