### PR TITLE
[JumpThreading] Clear LoopLatches for each invocation of JumpThreading pass.

### DIFF
--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -379,6 +379,7 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
     }
 
   LoopHeaders.clear();
+  LoopLatches.clear();
   return EverChanged;
 }
 


### PR DESCRIPTION
Clear LoopLatches after each resolved function is finished to avoid 
non-determinisc that I encountered in mingw environment.