### PR TITLE
[Flang][OpenMP] Allow copyprivate and nowait on the directive clauses

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1856,8 +1856,8 @@ void OmpStructureChecker::Enter(const parser::OpenMPDispatchConstruct &x) {
 
   auto it{block.begin()};
   bool passChecks{false};
-  if (const parser::AssignmentStmt *assignStmt{
-          parser::Unwrap<parser::AssignmentStmt>(*it)}) {
+  if (const parser::AssignmentStmt *
+      assignStmt{parser::Unwrap<parser::AssignmentStmt>(*it)}) {
     if (parser::Unwrap<parser::FunctionReference>(assignStmt->t)) {
       passChecks = true;
     }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2885,12 +2885,6 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
   // clause
   CheckMultListItems();
 
-  // 2.7.3 Single Construct Restriction
-  if (GetContext().directive == llvm::omp::Directive::OMPD_end_single) {
-    CheckNotAllowedIfClause(
-        llvm::omp::Clause::OMPC_copyprivate, {llvm::omp::Clause::OMPC_nowait});
-  }
-
   auto testThreadprivateVarErr = [&](Symbol sym, parser::Name name,
                                      llvmOmpClause clauseTy) {
     if (sym.test(Symbol::Flag::OmpThreadprivate))

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -334,8 +334,8 @@ use omp_lib
   !$omp single private(a) lastprivate(c) nowait
   a = 3.14
   !ERROR: COPYPRIVATE variable 'a' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
-  !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
-  !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
+  !WARNING: NOWAIT clause is already used on the SINGLE directive
+  !WARNING: NOWAIT clause is already used on the SINGLE directive
   !ERROR: At most one NOWAIT clause can appear on the END SINGLE directive
   !$omp end single copyprivate(a) nowait nowait
   c = 2

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -330,10 +330,13 @@ use omp_lib
   !$omp parallel
   b = 1
   !ERROR: LASTPRIVATE clause is not allowed on the SINGLE directive
+  !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
   !$omp single private(a) lastprivate(c) nowait
   a = 3.14
   !ERROR: Clause NOWAIT is not allowed if clause COPYPRIVATE appears on the END SINGLE directive
   !ERROR: COPYPRIVATE variable 'a' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
+  !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
+  !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
   !ERROR: At most one NOWAIT clause can appear on the END SINGLE directive
   !$omp end single copyprivate(a) nowait nowait
   c = 2

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -333,7 +333,6 @@ use omp_lib
   !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
   !$omp single private(a) lastprivate(c) nowait
   a = 3.14
-  !ERROR: Clause NOWAIT is not allowed if clause COPYPRIVATE appears on the END SINGLE directive
   !ERROR: COPYPRIVATE variable 'a' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
   !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
   !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
@@ -428,7 +427,7 @@ use omp_lib
      enddo
   enddo
   !omp end do nowait
-  !$omp end parallel
+  !$omp end parallel 
 
 ! 2.11.4 parallel-do-simd-clause -> parallel-clause |
 !                                   do-simd-clause
@@ -586,7 +585,7 @@ use omp_lib
      allc = 3.14
   enddo
 
-  !$omp target enter data map(alloc:A) device(0)
-  !$omp target exit data map(delete:A) device(0)
+  !$omp target enter data map(alloc:A) device(0) 
+  !$omp target exit data map(delete:A) device(0) 
 
 end program

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -330,7 +330,6 @@ use omp_lib
   !$omp parallel
   b = 1
   !ERROR: LASTPRIVATE clause is not allowed on the SINGLE directive
-  !ERROR: NOWAIT clause is not allowed on the OMP SINGLE directive, use it on OMP END SINGLE directive or try -fopenmp-version=52
   !$omp single private(a) lastprivate(c) nowait
   a = 3.14
   !ERROR: Clause NOWAIT is not allowed if clause COPYPRIVATE appears on the END SINGLE directive
@@ -351,7 +350,6 @@ use omp_lib
   a = 1.0
   !ERROR: COPYPRIVATE clause is not allowed on the END WORKSHARE directive
   !$omp end workshare nowait copyprivate(a)
-  !ERROR: NOWAIT clause is not allowed on the OMP WORKSHARE directive, use it on OMP END WORKSHARE directive or try -fopenmp-version=52
   !$omp workshare nowait
   !$omp end workshare
   !$omp end parallel
@@ -420,7 +418,6 @@ use omp_lib
   !$omp parallel
   !ERROR: No ORDERED clause with a parameter can be specified on the DO SIMD directive
   !ERROR: NOGROUP clause is not allowed on the DO SIMD directive
-  !ERROR: NOWAIT clause is not allowed on the OMP DO SIMD directive, use it on OMP END DO SIMD directive or try -fopenmp-version=52
   !$omp do simd ordered(2) NOGROUP nowait
   do i = 1, N
      do j = 1, N
@@ -428,7 +425,7 @@ use omp_lib
      enddo
   enddo
   !omp end do nowait
-  !$omp end parallel 
+  !$omp end parallel
 
 ! 2.11.4 parallel-do-simd-clause -> parallel-clause |
 !                                   do-simd-clause
@@ -586,7 +583,7 @@ use omp_lib
      allc = 3.14
   enddo
 
-  !$omp target enter data map(alloc:A) device(0) 
-  !$omp target exit data map(delete:A) device(0) 
+  !$omp target enter data map(alloc:A) device(0)
+  !$omp target exit data map(delete:A) device(0)
 
 end program

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -330,7 +330,7 @@ use omp_lib
   !$omp parallel
   b = 1
   !ERROR: LASTPRIVATE clause is not allowed on the SINGLE directive
-  !ERROR: NOWAIT clause is not allowed on the OMP SINGLE directive, use it on OMP END SINGLE directive 
+  !ERROR: NOWAIT clause is not allowed on the OMP SINGLE directive, use it on OMP END SINGLE directive or try -fopenmp-version=52
   !$omp single private(a) lastprivate(c) nowait
   a = 3.14
   !ERROR: Clause NOWAIT is not allowed if clause COPYPRIVATE appears on the END SINGLE directive
@@ -351,7 +351,7 @@ use omp_lib
   a = 1.0
   !ERROR: COPYPRIVATE clause is not allowed on the END WORKSHARE directive
   !$omp end workshare nowait copyprivate(a)
-  !ERROR: NOWAIT clause is not allowed on the OMP WORKSHARE directive, use it on OMP END WORKSHARE directive 
+  !ERROR: NOWAIT clause is not allowed on the OMP WORKSHARE directive, use it on OMP END WORKSHARE directive or try -fopenmp-version=52
   !$omp workshare nowait
   !$omp end workshare
   !$omp end parallel
@@ -420,7 +420,7 @@ use omp_lib
   !$omp parallel
   !ERROR: No ORDERED clause with a parameter can be specified on the DO SIMD directive
   !ERROR: NOGROUP clause is not allowed on the DO SIMD directive
-  !ERROR: NOWAIT clause is not allowed on the OMP DO SIMD directive, use it on OMP END DO SIMD directive 
+  !ERROR: NOWAIT clause is not allowed on the OMP DO SIMD directive, use it on OMP END DO SIMD directive or try -fopenmp-version=52
   !$omp do simd ordered(2) NOGROUP nowait
   do i = 1, N
      do j = 1, N

--- a/flang/test/Semantics/OpenMP/clause-validity01.f90
+++ b/flang/test/Semantics/OpenMP/clause-validity01.f90
@@ -334,8 +334,8 @@ use omp_lib
   !$omp single private(a) lastprivate(c) nowait
   a = 3.14
   !ERROR: COPYPRIVATE variable 'a' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
-  !WARNING: NOWAIT clause is already used on the SINGLE directive
-  !WARNING: NOWAIT clause is already used on the SINGLE directive
+  !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
+  !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
   !ERROR: At most one NOWAIT clause can appear on the END SINGLE directive
   !$omp end single copyprivate(a) nowait nowait
   c = 2

--- a/flang/test/Semantics/OpenMP/single03.f90
+++ b/flang/test/Semantics/OpenMP/single03.f90
@@ -38,13 +38,13 @@ subroutine omp_single
         !ERROR: COPYPRIVATE variable 'j' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
         !$omp single private(j) copyprivate(j)
             print *, "omp single", j
-        !ERROR: At most one COPYPRIVATE clause can appear on the SINGLE directive
         !ERROR: COPYPRIVATE variable 'j' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
+        !WARNING: The COPYPRIVATE clause with 'j' is already used on the SINGLE directive
         !$omp end single copyprivate(j)
 
         !$omp single nowait
             print *, "omp single", j
-        !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
+        !WARNING: NOWAIT clause is already used on the SINGLE directive
         !$omp end single nowait
     !$omp end parallel
 

--- a/flang/test/Semantics/OpenMP/single03.f90
+++ b/flang/test/Semantics/OpenMP/single03.f90
@@ -1,0 +1,54 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp -fopenmp-version=52
+!
+! OpenMP Version 5.2
+!
+! 2.10.2 single Construct
+! Copyprivate and Nowait clauses are allowed in both clause and end clause
+
+subroutine omp_single
+    integer, save :: i
+    integer       :: j
+    i = 10; j = 11
+
+    !ERROR: COPYPRIVATE variable 'i' is not PRIVATE or THREADPRIVATE in outer context
+    !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+    !$omp single copyprivate(i) nowait
+        print *, "omp single", i
+    !$omp end single
+
+    !$omp parallel private(i)
+        !$omp single copyprivate(i)
+            print *, "omp single", i
+        !$omp end single
+    !$omp end parallel
+
+    !$omp parallel
+        !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+        !$omp single nowait
+            print *, "omp single", i
+        !ERROR: COPYPRIVATE variable 'i' is not PRIVATE or THREADPRIVATE in outer context
+        !$omp end single copyprivate(i)
+
+        !ERROR: COPYPRIVATE variable 'i' is not PRIVATE or THREADPRIVATE in outer context
+        !$omp single copyprivate(i)
+            print *, "omp single", i
+        !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+        !$omp end single nowait
+
+        !ERROR: COPYPRIVATE variable 'j' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
+        !$omp single private(j) copyprivate(j)
+            print *, "omp single", j
+        !ERROR: At most one COPYPRIVATE clause can appear on the SINGLE directive
+        !ERROR: COPYPRIVATE variable 'j' may not appear on a PRIVATE or FIRSTPRIVATE clause on a SINGLE construct
+        !$omp end single copyprivate(j)
+
+        !$omp single nowait
+            print *, "omp single", j
+        !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
+        !$omp end single nowait
+    !$omp end parallel
+
+    !$omp single nowait
+        print *, "omp single", i
+    !$omp end single
+end subroutine omp_single

--- a/flang/test/Semantics/OpenMP/single03.f90
+++ b/flang/test/Semantics/OpenMP/single03.f90
@@ -44,7 +44,7 @@ subroutine omp_single
 
         !$omp single nowait
             print *, "omp single", j
-        !WARNING: NOWAIT clause is already used on the SINGLE directive
+        !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
         !$omp end single nowait
     !$omp end parallel
 

--- a/flang/test/Semantics/OpenMP/single04.f90
+++ b/flang/test/Semantics/OpenMP/single04.f90
@@ -1,0 +1,81 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 -fopenmp -fopenmp-version=52
+!
+! OpenMP Version 5.2
+!
+! 2.10.2 single Construct
+! Valid and invalid testcases for copyprivate and nowait clause on the single directive
+
+program single
+    ! Valid testcases
+    !$omp single
+        print *, x
+    !$omp end single
+
+    !$omp single nowait
+        print *, x
+    !$omp end single
+
+    !$omp single copyprivate(x, y, z)
+        print *, x
+    !$omp end single
+
+    !$omp single
+        print *, x
+    !$omp end single copyprivate(x)
+
+    ! Invalid testcases
+    !$omp single
+        print *, x
+    !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+    !$omp end single copyprivate(x) nowait
+
+    !ERROR: 'x' appears in more than one COPYPRIVATE clause on the SINGLE directive
+    !$omp single copyprivate(x) copyprivate(x)
+        print *, x
+    !$omp end single
+
+    !$omp single
+        print *, x
+    !ERROR: 'x' appears in more than one COPYPRIVATE clause on the END SINGLE directive
+    !$omp end single copyprivate(x) copyprivate(x)
+
+    !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
+    !$omp single nowait nowait
+        print *, x
+    !$omp end single
+
+    !$omp single
+        print *, x
+    !ERROR: At most one NOWAIT clause can appear on the END SINGLE directive
+    !$omp end single nowait nowait
+
+    !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+    !$omp single copyprivate(x) nowait
+        print *, x
+    !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
+    !WARNING: NOWAIT clause is already used on the SINGLE directive
+    !$omp end single copyprivate(x) nowait
+
+    !$omp single copyprivate(x)
+        print *, x
+    !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
+    !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+    !$omp end single copyprivate(x) nowait
+
+    !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+    !$omp single copyprivate(x, y) nowait
+        print *, x
+    !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
+    !ERROR: 'z' appears in more than one COPYPRIVATE clause on the END SINGLE directive
+    !WARNING: NOWAIT clause is already used on the SINGLE directive
+    !$omp end single copyprivate(x, z) copyprivate(z) nowait
+
+    !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
+    !$omp single copyprivate(x) nowait copyprivate(y) copyprivate(z)
+        print *, x
+    !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
+    !WARNING: The COPYPRIVATE clause with 'y' is already used on the SINGLE directive
+    !WARNING: The COPYPRIVATE clause with 'z' is already used on the SINGLE directive
+    !WARNING: NOWAIT clause is already used on the SINGLE directive
+    !$omp end single copyprivate(x, y, z) nowait
+end program

--- a/flang/test/Semantics/OpenMP/single04.f90
+++ b/flang/test/Semantics/OpenMP/single04.f90
@@ -53,7 +53,7 @@ program single
     !$omp single copyprivate(x) nowait
         print *, x
     !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
-    !WARNING: NOWAIT clause is already used on the SINGLE directive
+    !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
     !$omp end single copyprivate(x) nowait
 
     !$omp single copyprivate(x)
@@ -67,7 +67,7 @@ program single
         print *, x
     !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
     !ERROR: 'z' appears in more than one COPYPRIVATE clause on the END SINGLE directive
-    !WARNING: NOWAIT clause is already used on the SINGLE directive
+    !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
     !$omp end single copyprivate(x, z) copyprivate(z) nowait
 
     !ERROR: NOWAIT clause must not be used with COPYPRIVATE clause on the SINGLE directive
@@ -76,6 +76,6 @@ program single
     !WARNING: The COPYPRIVATE clause with 'x' is already used on the SINGLE directive
     !WARNING: The COPYPRIVATE clause with 'y' is already used on the SINGLE directive
     !WARNING: The COPYPRIVATE clause with 'z' is already used on the SINGLE directive
-    !WARNING: NOWAIT clause is already used on the SINGLE directive
+    !ERROR: At most one NOWAIT clause can appear on the SINGLE directive
     !$omp end single copyprivate(x, y, z) nowait
 end program

--- a/flang/test/Semantics/OpenMP/threadprivate04.f90
+++ b/flang/test/Semantics/OpenMP/threadprivate04.f90
@@ -14,7 +14,6 @@ program main
   !$omp parallel num_threads(x1)
   !$omp end parallel
 
-  !ERROR: COPYPRIVATE clause is not allowed on the OMP SINGLE directive, use it on OMP END SINGLE directive or try -fopenmp-version=52
   !$omp single copyprivate(x2, /blk1/)
   !$omp end single
 

--- a/flang/test/Semantics/OpenMP/threadprivate04.f90
+++ b/flang/test/Semantics/OpenMP/threadprivate04.f90
@@ -14,7 +14,7 @@ program main
   !$omp parallel num_threads(x1)
   !$omp end parallel
 
-  !ERROR: COPYPRIVATE clause is not allowed on the OMP SINGLE directive, use it on OMP END SINGLE directive 
+  !ERROR: COPYPRIVATE clause is not allowed on the OMP SINGLE directive, use it on OMP END SINGLE directive or try -fopenmp-version=52
   !$omp single copyprivate(x2, /blk1/)
   !$omp end single
 

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -998,8 +998,10 @@ def OMP_Single : Directive<"single"> {
     VersionedClause<OMPC_Allocate>,
     VersionedClause<OMPC_CopyPrivate>,
     VersionedClause<OMPC_FirstPrivate>,
-    VersionedClause<OMPC_NoWait>,
     VersionedClause<OMPC_Private>,
+  ];
+  let allowedOnceClauses = [
+    VersionedClause<OMPC_NoWait>,
   ];
   let association = AS_Block;
   let category = CA_Executable;


### PR DESCRIPTION
Issue:
- Single construct used to throw semantic error for copyprivate and nowiat clause when used in the single directive.
- Also, the Nowait and copyprivate restrictions has be removed from OpenMP 6.0

Fix:
- The above mentioned semantic error was valid until OpenMP 5.1.
- From OpenMP 5.2, copyprivate and nowait is allowed in both clause and end-clause

From Reference guide (OpenMP 5.2, 2.10.2):
```
!$omp single [clause[ [,]clause] ... ]
loosely-structured-block
!$omp end single [end-clause[ [,]end-clause] ...]

clause:
  copyprivate (list)
  nowait
  [...]

end-clause:
  copyprivate (list)
  nowait
```

Towards: https://github.com/llvm/llvm-project/issues/110008