### PR TITLE
[libclc] Clean up directory search procedure

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -20,16 +20,12 @@ include( GNUInstallDirs )
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
   amdgcn-amdhsa/lib/SOURCES;
   amdgcn/lib/SOURCES;
-  amdgcn-mesa3d/lib/SOURCES;
   amdgpu/lib/SOURCES;
   clspv/lib/SOURCES;
-  clspv64/lib/SOURCES;
   generic/lib/SOURCES;
-  ptx/lib/SOURCES;
   ptx-nvidiacl/lib/SOURCES;
   r600/lib/SOURCES;
   spirv/lib/SOURCES;
-  spirv64/lib/SOURCES;
   # CLC internal libraries
   clc/lib/generic/SOURCES;
 )
@@ -280,11 +276,6 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 
   set( opencl_dirs )
 
-  if ( NOT ${ARCH} STREQUAL spirv AND NOT ${ARCH} STREQUAL spirv64 AND
-       NOT ${ARCH} STREQUAL clspv AND NOT ${ARCH} STREQUAL clspv64)
-    LIST( APPEND opencl_dirs generic )
-  endif()
-
   if( ${ARCH} STREQUAL r600 OR ${ARCH} STREQUAL amdgcn )
     list( APPEND opencl_dirs amdgpu )
   endif()
@@ -302,8 +293,25 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     set( DARCH ${ARCH} )
   endif()
 
+  # Append a variety of target- and triple-based directories to search,
+  # increasing in specificity.
+  list( APPEND opencl_dirs ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS} )
+
+  # The 'generic' directory contains all of the generic implementations of the
+  # builtins. It is included first so it has the lowest search priority,
+  # allowing targets to override builtins based on file names found later in
+  # the list of search directories.
+  # CLC builds all builtins for all targets, so unconditionally prepend the
+  # 'generic' directory.
+  set( clc_dirs generic ${opencl_dirs} )
+  # Some OpenCL targets don't build all builtins, in which case they don't want
+  # the 'generic' directory. Otherwise, prepend the 'generic' directory.
+  if ( NOT ARCH STREQUAL spirv AND NOT ARCH STREQUAL spirv64 AND
+       NOT ARCH STREQUAL clspv AND NOT ARCH STREQUAL clspv64)
+    list( PREPEND opencl_dirs generic )
+  endif()
+
   set( clc_lib_files )
-  set( clc_dirs ${dirs} generic )
 
   if( ARCH STREQUAL clspv OR ARCH STREQUAL clspv64 )
     set( clc_gen_files clc-clspv-convert.cl )
@@ -315,7 +323,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     clc_lib_files
     CLC_INTERNAL
     LIB_ROOT_DIR clc
-    DIRS ${clc_dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
+    DIRS ${clc_dirs}
   )
 
   set( opencl_lib_files )
@@ -334,7 +342,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 
   libclc_configure_lib_source(
     opencl_lib_files
-    DIRS ${opencl_dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
+    DIRS ${opencl_dirs}
   )
 
   foreach( d ${${t}_devices} )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -402,7 +402,8 @@ endfunction(add_libclc_builtin_set)
 #     directory. If not provided, is set to '.'.
 # * DIRS <string> ...
 #     List of directories under LIB_ROOT_DIR to walk over searching for SOURCES
-#     files
+#     files. Directories earlier in the list have lower priority than
+#     subsequent ones.
 function(libclc_configure_lib_source LIB_FILE_LIST)
   cmake_parse_arguments(ARG
     "CLC_INTERNAL"
@@ -417,7 +418,7 @@ function(libclc_configure_lib_source LIB_FILE_LIST)
 
   # Enumerate SOURCES* files
   set( source_list )
-  foreach( l ${ARG_DIRS} )
+  foreach( l IN LISTS ARG_DIRS )
     foreach( s "SOURCES" "SOURCES_${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}" )
       if( ARG_CLC_INTERNAL )
         file( TO_CMAKE_PATH ${ARG_LIB_ROOT_DIR}/lib/${l}/${s} file_loc )
@@ -425,10 +426,10 @@ function(libclc_configure_lib_source LIB_FILE_LIST)
         file( TO_CMAKE_PATH ${ARG_LIB_ROOT_DIR}/${l}/lib/${s} file_loc )
       endif()
       file( TO_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${file_loc} loc )
-      # Prepend the location to give higher priority to
-      # specialized implementation
+      # Prepend the location to give higher priority to the specialized
+      # implementation
       if( EXISTS ${loc} )
-        set( source_list ${file_loc} ${source_list} )
+        list( PREPEND source_list ${file_loc} )
       endif()
     endforeach()
   endforeach()


### PR DESCRIPTION
During a recent change, the build system accidentally dropped the (theoretical) support for the CLC builtins library to build target-specific builtins from the 'amdgpu' directory, due to a change in variable names. This functionality wasn't being used but was spotted during another code review.

This commit takes the opportunity to clean up and better document the code that manages the list of directories to search for builtin implementations.

While fixing this, some references to now-removed SOURCES files were discovered which have been cleaned up.