### PR TITLE
[mlir][dlti] Fix query keys preallocation

### DIFF
--- a/mlir/lib/Dialect/DLTI/DLTI.cpp
+++ b/mlir/lib/Dialect/DLTI/DLTI.cpp
@@ -571,7 +571,8 @@ FailureOr<Attribute> dlti::query(Operation *op, ArrayRef<StringRef> keys,
     return failure();
 
   MLIRContext *ctx = op->getContext();
-  SmallVector<DataLayoutEntryKey> entryKeys(keys.size());
+  SmallVector<DataLayoutEntryKey> entryKeys;
+  entryKeys.reserve(keys.size());
   for (StringRef key : keys)
     entryKeys.push_back(StringAttr::get(ctx, key));
 


### PR DESCRIPTION
Fixes upfront space allocation after #126716