### PR TITLE
[NFC][clang] Cleanup in APValue and SemaInit

### DIFF
--- a/clang/lib/AST/APValue.cpp
+++ b/clang/lib/AST/APValue.cpp
@@ -390,7 +390,6 @@ APValue &APValue::operator=(const APValue &RHS) {
   if (this != &RHS)
     *this = APValue(RHS);
 
-  AllowConstexprUnknown = RHS.AllowConstexprUnknown;
   return *this;
 }
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -4577,7 +4577,6 @@ static void TryConstructorInitialization(Sema &S,
     if (!IsListInit &&
         (Kind.getKind() == InitializationKind::IK_Default ||
          Kind.getKind() == InitializationKind::IK_Direct) &&
-        DestRecordDecl != nullptr &&
         !(CtorDecl->isCopyOrMoveConstructor() && CtorDecl->isImplicit()) &&
         DestRecordDecl->isAggregate() &&
         DestRecordDecl->hasUninitializedExplicitInitFields()) {


### PR DESCRIPTION
APValue:
Additional assignment of AllowConstexprUnknown is not required since it will be handled by copy constructor called above.
SemaInit:
Remove unnecessary null check. DestRecordDecl can't be null due to being obtained using `cast` and assertion that DestRecordType is present.

Spotted by a static analysis tool.