### PR TITLE
[compiler-rt][asan] Re-enable ManyThreadsTest on AArch64

### DIFF
--- a/compiler-rt/lib/asan/tests/asan_test.cpp
+++ b/compiler-rt/lib/asan/tests/asan_test.cpp
@@ -369,8 +369,7 @@ void *ManyThreadsWorker(void *a) {
   return 0;
 }
 
-#if !defined(__aarch64__) && !defined(__powerpc64__)
-// FIXME: Infinite loop in AArch64 (PR24389).
+#if !defined(__powerpc64__)
 // FIXME: Also occasional hang on powerpc.  Maybe same problem as on AArch64?
 TEST(AddressSanitizer, ManyThreadsTest) {
   const size_t kNumThreads =


### PR DESCRIPTION
Disabled in 2ab51bf13a1f6ca96823b755c036227dfd0892f9, doesn't hang for me on AArch64 (Graviton 3, tested 1000 iterations). May still be an issue, but hard to know unless we enable it again to find out.

n.b. test was also disabled on PowerPC in
467afc5f847f72221a42d9142c5b4733b44b52dc for same reason and it has also been observed on x86:
https://lists.llvm.org/pipermail/llvm-dev/2016-January/094607.html

Fixes: https://github.com/llvm/llvm-project/issues/24763