### PR TITLE
[MLIR][Affine] Add missing check in affine data copy nest generation

### DIFF
--- a/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
@@ -2001,8 +2001,15 @@ static LogicalResult generateCopy(
   }
 
   SmallVector<AffineMap, 4> lbMaps(rank), ubMaps(rank);
-  for (unsigned i = 0; i < rank; ++i)
+  for (unsigned i = 0; i < rank; ++i) {
     region.getLowerAndUpperBound(i, lbMaps[i], ubMaps[i]);
+    if (lbMaps[i].getNumResults() == 0 || ubMaps[i].getNumResults() == 0) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Missing lower or upper bound for region along dimension: "
+                 << i << '\n');
+      return failure();
+    }
+  }
 
   const FlatAffineValueConstraints *cst = region.getConstraints();
   // 'regionSymbols' hold values that this memory region is symbolic/parametric

--- a/mlir/test/Dialect/Affine/affine-data-copy.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy.mlir
@@ -300,14 +300,15 @@ func.func @affine_parallel(%85:memref<2x5x4x2xi64>) {
       }
     }
   }
-  // CHECK:     affine.for
-  // CHECK-NEXT:  affine.for %{{.*}} = 0 to 5
-  // CHECK-NEXT:    affine.for %{{.*}} = 0 to 4
-  // CHECK-NEXT:      affine.for %{{.*}} = 0 to 2
-
+  // Lower and upper bounds for the region can't be determined for the outermost
+  // dimension. No fast buffer generation.
   // CHECK:     affine.for
   // CHECK-NEXT:  affine.parallel
   // CHECK-NEXT:    affine.parallel
+  // CHECK-NEXT:      affine.for
+  // CHECK-NOT:      affine.for
+
+
   return
 }
 


### PR DESCRIPTION
Handle case where no lower or upper bound could be found for a
dimension. Invalid IR was being generated silently for a test case.

Fixes: https://github.com/llvm/llvm-project/issues/127808
