### PR TITLE
[libclc] Move modf to the CLC library

### DIFF
--- a/libclc/clc/include/clc/math/clc_modf.h
+++ b/libclc/clc/include/clc/math/clc_modf.h
@@ -1,0 +1,11 @@
+#ifndef __CLC_MATH_CLC_MODF_H__
+#define __CLC_MATH_CLC_MODF_H__
+
+#define __CLC_FUNCTION __clc_modf
+#define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
+#include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_MODF_H__

--- a/libclc/clc/include/clc/math/unary_decl_with_ptr.inc
+++ b/libclc/clc/include/clc/math/unary_decl_with_ptr.inc
@@ -1,0 +1,6 @@
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __CLC_FUNCTION(__CLC_GENTYPE x,
+                                                     global __CLC_GENTYPE *ptr);
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __CLC_FUNCTION(__CLC_GENTYPE x,
+                                                     local __CLC_GENTYPE *ptr);
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE
+__CLC_FUNCTION(__CLC_GENTYPE x, private __CLC_GENTYPE *ptr);

--- a/libclc/clc/include/clc/math/unary_def_with_ptr.inc
+++ b/libclc/clc/include/clc/math/unary_def_with_ptr.inc
@@ -1,0 +1,20 @@
+#include <clc/utils.h>
+
+#ifndef __CLC_FUNCTION
+#define __CLC_FUNCTION(x) __CLC_CONCAT(__clc_, x)
+#endif
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
+                                              private __CLC_GENTYPE *ptr) {
+  return __CLC_FUNCTION(FUNCTION)(x, ptr);
+}
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
+                                              global __CLC_GENTYPE *ptr) {
+  return __CLC_FUNCTION(FUNCTION)(x, ptr);
+}
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE FUNCTION(__CLC_GENTYPE x,
+                                              local __CLC_GENTYPE *ptr) {
+  return __CLC_FUNCTION(FUNCTION)(x, ptr);
+}

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -22,6 +22,7 @@ math/clc_copysign.cl
 math/clc_fabs.cl
 math/clc_floor.cl
 math/clc_mad.cl
+math/clc_modf.cl
 math/clc_nextafter.cl
 math/clc_rint.cl
 math/clc_trunc.cl

--- a/libclc/clc/lib/generic/math/clc_modf.cl
+++ b/libclc/clc/lib/generic/math/clc_modf.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015 Advanced Micro Devices, Inc.
+ * Copyright (c) 2015 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +20,11 @@
  * THE SOFTWARE.
  */
 
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE modf(__CLC_GENTYPE x, global __CLC_GENTYPE *iptr);
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE modf(__CLC_GENTYPE x, local __CLC_GENTYPE *iptr);
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE modf(__CLC_GENTYPE x, private __CLC_GENTYPE *iptr);
+#include <clc/internal/clc.h>
+#include <clc/math/clc_copysign.h>
+#include <clc/math/clc_trunc.h>
+#include <clc/math/math.h>
+#include <clc/relational/clc_isinf.h>
+
+#define __CLC_BODY <clc_modf.inc>
+#include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_modf.inc
+++ b/libclc/clc/lib/generic/math/clc_modf.inc
@@ -19,31 +19,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-#if __CLC_FPSIZE == 64
-#define ZERO 0.0
-#elif __CLC_FPSIZE == 32
-#define ZERO 0.0f
-#elif __CLC_FPSIZE == 16
-#define ZERO 0.0h
-#endif
-
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE modf(__CLC_GENTYPE x,
-                                          private __CLC_GENTYPE *iptr) {
-  *iptr = trunc(x);
-  return copysign(isinf(x) ? ZERO : x - *iptr, x);
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_modf(__CLC_GENTYPE x,
+                                                private __CLC_GENTYPE *iptr) {
+  *iptr = __clc_trunc(x);
+  return __clc_copysign(__clc_isinf(x) ? __CLC_FP_LIT(0.0) : x - *iptr, x);
 }
 
-#define MODF_DEF(addrspace)                                                    \
-  _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE modf(__CLC_GENTYPE x,                   \
-                                            addrspace __CLC_GENTYPE *iptr) {   \
+#define CLC_MODF_DEF(addrspace)                                                \
+  _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_modf(                             \
+      __CLC_GENTYPE x, addrspace __CLC_GENTYPE *iptr) {                        \
     __CLC_GENTYPE private_iptr;                                                \
-    __CLC_GENTYPE ret = modf(x, &private_iptr);                                \
+    __CLC_GENTYPE ret = __clc_modf(x, &private_iptr);                          \
     *iptr = private_iptr;                                                      \
     return ret;                                                                \
   }
 
-MODF_DEF(local);
-MODF_DEF(global);
+CLC_MODF_DEF(local);
+CLC_MODF_DEF(global);
 
-#undef ZERO
+#undef CLC_MODF_DEF

--- a/libclc/generic/include/clc/math/modf.h
+++ b/libclc/generic/include/clc/math/modf.h
@@ -20,5 +20,8 @@
  * THE SOFTWARE.
  */
 
-#define __CLC_BODY <clc/math/modf.inc>
+#define __CLC_FUNCTION modf
+#define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #include <clc/math/gentype.inc>
+
+#undef __CLC_FUNCTION

--- a/libclc/generic/lib/math/modf.cl
+++ b/libclc/generic/lib/math/modf.cl
@@ -21,7 +21,8 @@
  */
 
 #include <clc/clc.h>
-#include <clc/math/math.h>
+#include <clc/math/clc_modf.h>
 
-#define __CLC_BODY <modf.inc>
+#define FUNCTION modf
+#define __CLC_BODY <clc/math/unary_def_with_ptr.inc>
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
The "generic" unary_(def|decl)_with_ptr files are intended to be re-used by the sincos and fract builtins in the future as they share an identical type signature.