### PR TITLE
[WIP] [lldb][TypeSystemClang] Create clang::SourceLocation from DWARF and attach to AST

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1372,7 +1372,7 @@ DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
             ignore_containing_context ? m_ast.GetTranslationUnitDecl()
                                       : containing_decl_ctx,
             GetOwningClangModule(die), name, clang_type, attrs.storage,
-            attrs.is_inline);
+            attrs.is_inline, attrs.decl);
         std::free(name_buf);
 
         if (has_template_params) {
@@ -1382,11 +1382,11 @@ DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
               ignore_containing_context ? m_ast.GetTranslationUnitDecl()
                                         : containing_decl_ctx,
               GetOwningClangModule(die), attrs.name.GetStringRef(), clang_type,
-              attrs.storage, attrs.is_inline);
+              attrs.storage, attrs.is_inline, attrs.decl);
           clang::FunctionTemplateDecl *func_template_decl =
               m_ast.CreateFunctionTemplateDecl(
                   containing_decl_ctx, GetOwningClangModule(die),
-                  template_function_decl, template_param_infos);
+                  template_function_decl, template_param_infos, attrs.decl);
           m_ast.CreateFunctionTemplateSpecializationInfo(
               template_function_decl, func_template_decl, template_param_infos);
         }
@@ -1858,7 +1858,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
     clang::ClassTemplateSpecializationDecl *class_specialization_decl =
         m_ast.CreateClassTemplateSpecializationDecl(
             containing_decl_ctx, GetOwningClangModule(die), class_template_decl,
-            tag_decl_kind, template_param_infos);
+            tag_decl_kind, template_param_infos, attrs.decl);
     clang_type =
         m_ast.CreateClassTemplateSpecializationType(class_specialization_decl);
 
@@ -1870,7 +1870,7 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
     clang_type = m_ast.CreateRecordType(
         containing_decl_ctx, GetOwningClangModule(die), attrs.accessibility,
         attrs.name.GetCString(), tag_decl_kind, attrs.class_language, metadata,
-        attrs.exports_symbols);
+        attrs.exports_symbols, attrs.decl);
   }
 
   TypeSP type_sp = dwarf->MakeType(

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilder.cpp
@@ -1128,7 +1128,7 @@ void PdbAstBuilder::CreateFunctionParameters(PdbCompilandSymId func_id,
     CompilerType param_type_ct = m_clang.GetType(qt);
     clang::ParmVarDecl *param = m_clang.CreateParameterDeclaration(
         &function_decl, OptionalClangModuleID(), param_name.str().c_str(),
-        param_type_ct, clang::SC_None, true);
+        param_type_ct, clang::SC_None, clang::SourceLocation(), true);
     lldbassert(m_uid_to_decl.count(toOpaqueUid(param_uid)) == 0);
 
     m_uid_to_decl[toOpaqueUid(param_uid)] = param;

--- a/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/PDBASTParser.cpp
@@ -969,7 +969,8 @@ PDBASTParser::GetDeclForSymbol(const llvm::pdb::PDBSymbol &symbol) {
 
           clang::ParmVarDecl *param = m_ast.CreateParameterDeclaration(
               decl, OptionalClangModuleID(), nullptr,
-              arg_type->GetForwardCompilerType(), clang::SC_None, true);
+              arg_type->GetForwardCompilerType(), clang::SC_None,
+              clang::SourceLocation(), true);
           if (param)
             params.push_back(param);
         }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -326,13 +326,12 @@ public:
                                                bool is_framework = false,
                                                bool is_explicit = false);
 
-  CompilerType
-  CreateRecordType(clang::DeclContext *decl_ctx,
-                   OptionalClangModuleID owning_module,
-                   lldb::AccessType access_type, llvm::StringRef name, int kind,
-                   lldb::LanguageType language,
-                   std::optional<ClangASTMetadata> metadata = std::nullopt,
-                   bool exports_symbols = false);
+  CompilerType CreateRecordType(
+      clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
+      lldb::AccessType access_type, llvm::StringRef name, int kind,
+      lldb::LanguageType language,
+      std::optional<ClangASTMetadata> metadata = std::nullopt,
+      bool exports_symbols = false, const Declaration &declaration = {});
 
   class TemplateParameterInfos {
   public:
@@ -420,7 +419,8 @@ public:
 
   clang::FunctionTemplateDecl *CreateFunctionTemplateDecl(
       clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
-      clang::FunctionDecl *func_decl, const TemplateParameterInfos &infos);
+      clang::FunctionDecl *func_decl, const TemplateParameterInfos &infos,
+      const Declaration &declaration);
 
   void CreateFunctionTemplateSpecializationInfo(
       clang::FunctionDecl *func_decl, clang::FunctionTemplateDecl *Template,
@@ -437,7 +437,7 @@ public:
   clang::ClassTemplateSpecializationDecl *CreateClassTemplateSpecializationDecl(
       clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
       clang::ClassTemplateDecl *class_template_decl, int kind,
-      const TemplateParameterInfos &infos);
+      const TemplateParameterInfos &infos, const Declaration &declaration);
 
   CompilerType
   CreateClassTemplateSpecializationType(clang::ClassTemplateSpecializationDecl *
@@ -476,7 +476,8 @@ public:
   clang::FunctionDecl *CreateFunctionDeclaration(
       clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
       llvm::StringRef name, const CompilerType &function_Type,
-      clang::StorageClass storage, bool is_inline);
+      clang::StorageClass storage, bool is_inline,
+      const Declaration &declaration = {});
 
   CompilerType
   CreateFunctionType(const CompilerType &result_type, const CompilerType *args,
@@ -484,11 +485,10 @@ public:
                      clang::CallingConv cc = clang::CC_C,
                      clang::RefQualifierKind ref_qual = clang::RQ_None);
 
-  clang::ParmVarDecl *
-  CreateParameterDeclaration(clang::DeclContext *decl_ctx,
-                             OptionalClangModuleID owning_module,
-                             const char *name, const CompilerType &param_type,
-                             int storage, bool add_decl = false);
+  clang::ParmVarDecl *CreateParameterDeclaration(
+      clang::DeclContext *decl_ctx, OptionalClangModuleID owning_module,
+      const char *name, const CompilerType &param_type, int storage,
+      clang::SourceLocation loc, bool add_decl = false);
 
   CompilerType CreateBlockPointerType(const CompilerType &function_type);
 
@@ -996,7 +996,8 @@ public:
       lldb::opaque_compiler_type_t type, llvm::StringRef name,
       const char *mangled_name, const CompilerType &method_type,
       lldb::AccessType access, bool is_virtual, bool is_static, bool is_inline,
-      bool is_explicit, bool is_attr_used, bool is_artificial);
+      bool is_explicit, bool is_attr_used, bool is_artificial,
+      const Declaration &declaration = {});
 
   void AddMethodOverridesForCXXRecordType(lldb::opaque_compiler_type_t type);
 
@@ -1187,6 +1188,19 @@ private:
 
   std::optional<uint64_t> GetObjCBitSize(clang::QualType qual_type,
                                          ExecutionContextScope *exe_scope);
+
+  /// Turns the given \c decl into a \c clang::SourceLocation.
+  ///
+  /// Will create a \c FileID in this \c DWARFASTParserClang's \c ASTContext
+  /// if necessary.
+  ///
+  /// If no \c FileID could be found/created, returns an empty \c
+  /// SourceLocation.
+  ///
+  /// FIXME: currently a no-op.
+  clang::SourceLocation GetLocForDecl(const lldb_private::Declaration &decl) {
+    return {};
+  }
 
   // Classes that inherit from TypeSystemClang can see and modify these
   std::string m_target_triple;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -1165,6 +1165,15 @@ public:
 
   bool SetDeclIsForcefullyCompleted(const clang::TagDecl *td);
 
+  /// Turns the given \c decl into a \c clang::SourceLocation.
+  ///
+  /// Will create a \c FileID in this \c DWARFASTParserClang's \c ASTContext
+  /// if necessary.
+  ///
+  /// If no \c FileID could be found/created, returns an empty \c
+  /// SourceLocation.
+  clang::SourceLocation GetLocForDecl(const lldb_private::Declaration &decl);
+
 private:
   /// Returns the PrintingPolicy used when generating the internal type names.
   /// These type names are mostly used for the formatter selection.
@@ -1188,19 +1197,6 @@ private:
 
   std::optional<uint64_t> GetObjCBitSize(clang::QualType qual_type,
                                          ExecutionContextScope *exe_scope);
-
-  /// Turns the given \c decl into a \c clang::SourceLocation.
-  ///
-  /// Will create a \c FileID in this \c DWARFASTParserClang's \c ASTContext
-  /// if necessary.
-  ///
-  /// If no \c FileID could be found/created, returns an empty \c
-  /// SourceLocation.
-  ///
-  /// FIXME: currently a no-op.
-  clang::SourceLocation GetLocForDecl(const lldb_private::Declaration &decl) {
-    return {};
-  }
 
   // Classes that inherit from TypeSystemClang can see and modify these
   std::string m_target_triple;

--- a/lldb/test/API/commands/expression/diagnostics/lib.h
+++ b/lldb/test/API/commands/expression/diagnostics/lib.h
@@ -1,0 +1,2 @@
+void foo() {}
+void foo(char, char const *x) {}

--- a/lldb/test/API/commands/expression/diagnostics/main.cpp
+++ b/lldb/test/API/commands/expression/diagnostics/main.cpp
@@ -1,11 +1,22 @@
+#include "lib.h"
+
 void foo(int x) {}
 
 struct FooBar {
   int i;
 };
 
+enum class EnumInSource { A, B, C };
+
+template <typename T> void templateFunc() {}
+
 int main() {
   FooBar f;
   foo(1);
+  foo('c', "abc");
+  foo();
+  EnumInSource e = EnumInSource::A;
+  templateFunc<int>();
+
   return 0; // Break here
 }

--- a/lldb/test/API/lang/cpp/function-local-class/TestCppFunctionLocalClass.py
+++ b/lldb/test/API/lang/cpp/function-local-class/TestCppFunctionLocalClass.py
@@ -34,16 +34,8 @@ class TestCase(TestBase):
             result_type="TypedefUnnamed2",
             result_children=[ValueCheck(name="b", value="3")],
         )
-        self.expect_expr(
-            "unnamed",
-            result_type="(unnamed struct)",
-            result_children=[ValueCheck(name="i", value="4")],
-        )
-        self.expect_expr(
-            "unnamed2",
-            result_type="(unnamed struct)",
-            result_children=[ValueCheck(name="j", value="5")],
-        )
+        self.expect("expression unnamed", substrs=["(unnamed struct at", "i = 4"])
+        self.expect("expression unnamed2", substrs=["(unnamed struct at", "j = 5"])
 
         # Try a class that is only forward declared.
         self.expect_expr("fwd", result_type="Forward *")

--- a/lldb/test/Shell/Settings/TestFrameFormatName.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatName.test
@@ -16,7 +16,7 @@ run
 c
 # NAME_WITH_ARGS: frame int ns::foo<int ()>(str="bar")
 c
-# NAME_WITH_ARGS: frame int ns::foo<(anonymous namespace)::$_0>(t=(anonymous namespace)::(unnamed class) @ {{.*}})
+# NAME_WITH_ARGS: frame int ns::foo<(anonymous namespace)::$_0>(t=(anonymous namespace)::(unnamed class at {{.*}}) @ {{.*}})
 c
 # NAME_WITH_ARGS: frame int ns::foo<int (*)()>(t=({{.*}}`(anonymous namespace)::anon_bar() at {{.*}}))
 c

--- a/lldb/test/Shell/SymbolFile/DWARF/clang-ast-from-dwarf-unamed-and-anon-structs.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/clang-ast-from-dwarf-unamed-and-anon-structs.cpp
@@ -15,7 +15,7 @@ struct A {
   } C;
 } a;
 
-// CHECK: A::(anonymous struct)
+// CHECK: A::(anonymous struct at
 // CHECK: |-DefinitionData is_anonymous pass_in_registers aggregate standard_layout trivially_copyable pod trivial literal
-// CHECK: A::(unnamed struct)
+// CHECK: A::(unnamed struct at
 // CHECK: |-DefinitionData pass_in_registers aggregate standard_layout trivially_copyable pod trivial literal

--- a/lldb/unittests/Symbol/CMakeLists.txt
+++ b/lldb/unittests/Symbol/CMakeLists.txt
@@ -27,5 +27,8 @@ add_lldb_unittest(SymbolTests
 
 set(test_inputs
   inlined-functions.yaml
+  dummy.cpp
+  dummy_header1.h
+  dummy_header2.h
   )
 add_unittest_inputs(SymbolTests "${test_inputs}")

--- a/lldb/unittests/Symbol/Inputs/dummy.cpp
+++ b/lldb/unittests/Symbol/Inputs/dummy.cpp
@@ -1,0 +1,7 @@
+// Some comment
+
+#include "dummy_header1.h"
+
+int main() { return 0; }
+
+// Some comment at the end

--- a/lldb/unittests/Symbol/Inputs/dummy_header1.h
+++ b/lldb/unittests/Symbol/Inputs/dummy_header1.h
@@ -1,0 +1,1 @@
+#include "dummy_header2.h"

--- a/lldb/unittests/Symbol/Inputs/dummy_header2.h
+++ b/lldb/unittests/Symbol/Inputs/dummy_header2.h
@@ -1,0 +1,3 @@
+namespace ns {
+struct Foo {};
+} // namespace ns

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -545,7 +545,8 @@ TEST_F(TestTypeSystemClang, TemplateArguments) {
   ClassTemplateSpecializationDecl *spec_decl =
       m_ast->CreateClassTemplateSpecializationDecl(
           m_ast->GetTranslationUnitDecl(), OptionalClangModuleID(), decl,
-          llvm::to_underlying(clang::TagTypeKind::Struct), infos);
+          llvm::to_underlying(clang::TagTypeKind::Struct), infos,
+          Declaration());
   ASSERT_NE(spec_decl, nullptr);
   CompilerType type = m_ast->CreateClassTemplateSpecializationType(spec_decl);
   ASSERT_TRUE(type);
@@ -876,7 +877,7 @@ TEST_F(TestTypeSystemClang, TestFunctionTemplateConstruction) {
   // Create the actual function template.
   clang::FunctionTemplateDecl *func_template =
       m_ast->CreateFunctionTemplateDecl(TU, OptionalClangModuleID(), func,
-                                        empty_params);
+                                        empty_params, Declaration());
 
   EXPECT_EQ(TU, func_template->getDeclContext());
   EXPECT_EQ("foo", func_template->getName());
@@ -908,7 +909,7 @@ TEST_F(TestTypeSystemClang, TestFunctionTemplateInRecordConstruction) {
   // Create the actual function template.
   clang::FunctionTemplateDecl *func_template =
       m_ast->CreateFunctionTemplateDecl(record, OptionalClangModuleID(), func,
-                                        empty_params);
+                                        empty_params, Declaration());
 
   EXPECT_EQ(record, func_template->getDeclContext());
   EXPECT_EQ("foo", func_template->getName());

--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -1252,3 +1252,11 @@ DWARF:
   EXPECT_EQ(func->getParamDecl(1)->getDeclContext(), func);
   EXPECT_EQ(func->getParamDecl(1)->getName(), "namedParam");
 }
+
+// TODO: test cases
+// - DW_TAG_subprogram with DW_TAG_formal_parameter with invalid file
+// - DW_TAG_subprogram with DW_TAG_formal_parameter with valid file
+// - structures
+// - enums
+// - template functions
+// - template classes


### PR DESCRIPTION
This patch revives https://reviews.llvm.org/D78095 with some changes.

This patch uses the `DW_AT_decl_XXX` DWARF attributes to create `clang::SourceLocation`s and attach them to the Clang decls that LLDB creates. The primary motivation for this is better expression evaluator diagnostics. Instead of:
```
(lldb) expr func()
            ˄
            ╰─ error: no matching function for call to 'func'
note: note: candidate function not viable: requires 1 argument, but 0 were provided
note: note: candidate function not viable: requires 1 argument, but 0 were provided
note: note: candidate function not viable: requires single argument 'x', but no arguments were provided
note: note: candidate function not viable: requires single argument 'y', but no arguments were provided
note: note: candidate function not viable: requires 2 arguments, but 0 were provided
```
We would see:
```
(lldb) expr func()
            ˄
            ╰─ error: no matching function for call to 'func'
note: /Users/michaelbuch/source-locs/lib.h:4:1: candidate function not viable: requires 1 argument, but 0 were provided
    4 | void func(char const* c, char) {}; void func(bool) {}
      | ^
note: /Users/michaelbuch/source-locs/lib.h:4:1: candidate function not viable: requires 2 arguments, but 0 were provided
    4 | void func(char const* c, char) {}; void func(bool) {}
      | ^
note: /Users/michaelbuch/source-locs/main.cpp:5:1: candidate function not viable: requires single argument 'x', but no arguments were provided
    5 | void func(int x) { var = 6; }
      | ^
note: /Users/michaelbuch/source-locs/main.cpp:6:1: candidate function not viable: requires single argument 'y', but no arguments were provided
    6 | void func(float y) { var = 6; }
      | ^
```

There's a couple of quirks in the output still, mainly because Clang doesn't emit `DW_AT_decl_column`, so Clang has to place the caret on column `1`. But this is something we can probably configure (either as a pre-requisite to this patch or as a follow-up).

This is currently WIP. It's lacking tests and we probably also want to make sure we only use `DW_AT_decl_file` if the file hasn't changed since the debug-info was generated (i think there's some checksum we can use for this, like we do in the SupportFiles?). Another open question is whether we want to adjust our typename printer to omit the locations of unnamed/anonymous structures/enums (i.e., `(unnamed struct at /path/to/some/file.cpp:12:1)` vs. `(unnamed struct)`...this can be configured in `clang::PrintingPolicy::AnonymousTagLocations`).

Just looking for early concerns/feedback.

I split up the patch into 3 separate commits:
1. Commit 1: makes sure each ASTContext that LLDB creates (apart from the scratch AST), has a `MainFileID`. LLDB will pretend that this dummy file is the main source file, and all other FileIDs (those that we create in commit 3) are included into it
2. Commit 2: makes sure we call `setLocation` in all the appropriate places.
3. Implements `GetLocForDecl` which turns a `lldb_private::Declaration` into `clang::SourceLocation`

The three main differences to https://reviews.llvm.org/D78095 are:
1. we no longer hide this feature behind a flag
2. the original patch didn't yet support using `DW_AT_decl_file` for displaying source snippets
3. we no longer have a separate `clang::TextDiagnosticPrinter` for printing these source snippets. In theory it would be nice to do this, because we could configure it separately (e.g., to hide the column number). I didn't carry that over because (1) setting `ShowCarets` to `false` causes the source snippet to not be printed (probably something we could change in Clang), and (2) we somehow need to differentiate whether a `FileID` was created by LLDB versus Clang, which got tricky because we need to have cross-`DWARFASTParserClang` state, which also meant that we have to copy over this metadata to the expression context. All of that didn't seem worth it, but we could definitely add this back

rdar://8670536