### PR TITLE
[CIR] Initial implementation of lowering CIR to MLIR

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -55,7 +55,7 @@ public:
   void Initialize(clang::ASTContext &astContext) override;
   bool HandleTopLevelDecl(clang::DeclGroupRef group) override;
   mlir::ModuleOp getModule() const;
-  mlir::MLIRContext &getContext() { return *mlirContext; }
+  mlir::MLIRContext &getMLIRContext() { return *mlirContext; }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -56,6 +56,7 @@ public:
   bool HandleTopLevelDecl(clang::DeclGroupRef group) override;
   mlir::ModuleOp getModule() const;
   mlir::MLIRContext &getMLIRContext() { return *mlirContext; }
+  const mlir::MLIRContext &getMLIRContext() const { return *mlirContext; }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -55,6 +55,7 @@ public:
   void Initialize(clang::ASTContext &astContext) override;
   bool HandleTopLevelDecl(clang::DeclGroupRef group) override;
   mlir::ModuleOp getModule() const;
+  mlir::MLIRContext &getContext() { return *mlirContext; }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -26,10 +26,9 @@ class CIRGenAction : public clang::ASTFrontendAction {
 public:
   enum class OutputType {
     EmitAssembly,
-    EmitCIR,
+    EmitMLIR,
     EmitLLVM,
     EmitBC,
-    EmitMLIR,
     EmitObj,
   };
 
@@ -51,13 +50,6 @@ public:
   ~CIRGenAction() override;
 
   OutputType Action;
-};
-
-class EmitCIRAction : public CIRGenAction {
-  virtual void anchor();
-
-public:
-  EmitCIRAction(mlir::MLIRContext *MLIRCtx = nullptr);
 };
 
 class EmitMLIRAction : public CIRGenAction {

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -29,6 +29,7 @@ public:
     EmitCIR,
     EmitLLVM,
     EmitBC,
+    EmitMLIR,
     EmitObj,
   };
 
@@ -57,6 +58,13 @@ class EmitCIRAction : public CIRGenAction {
 
 public:
   EmitCIRAction(mlir::MLIRContext *MLIRCtx = nullptr);
+};
+
+class EmitMLIRAction : public CIRGenAction {
+  virtual void anchor();
+
+public:
+  EmitMLIRAction(mlir::MLIRContext *MLIRCtx = nullptr);
 };
 
 class EmitLLVMAction : public CIRGenAction {

--- a/clang/include/clang/CIR/LowerToLLVM.h
+++ b/clang/include/clang/CIR/LowerToLLVM.h
@@ -20,6 +20,7 @@ class Module;
 } // namespace llvm
 
 namespace mlir {
+class MLIRContext;
 class ModuleOp;
 } // namespace mlir
 
@@ -30,6 +31,9 @@ std::unique_ptr<llvm::Module>
 lowerDirectlyFromCIRToLLVMIR(mlir::ModuleOp mlirModule,
                              llvm::LLVMContext &llvmCtx);
 } // namespace direct
+
+mlir::ModuleOp lowerFromCIRToMLIR(mlir::ModuleOp mlirModule,
+                                  mlir::MLIRContext &mlirCtx);
 } // namespace cir
 
 #endif // CLANG_CIR_LOWERTOLLVM_H

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -35,7 +35,7 @@ struct MissingFeatures {
   static bool opGlobalThreadLocal() { return false; }
   static bool opGlobalConstant() { return false; }
   static bool opGlobalAlignment() { return false; }
-
+  static bool opGlobalMlirLinkage() { return false; }
   static bool supportIFuncAttr() { return false; }
   static bool supportVisibility() { return false; }
   static bool supportComdat() { return false; }

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2987,8 +2987,8 @@ defm clangir : BoolFOption<"clangir",
   BothFlags<[], [ClangOption, CC1Option], "">>;
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR">;
-def emit_cir_mlir : Flag<["-"], "emit-cir-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
-  HelpText<"Build ASTs and then lower through ClangIR to MLIR, emit the .milr file">;
+def emit_core_mlir : Flag<["-"], "emit-core-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Build ASTs and then lower through ClangIR to core MLIR dialects, emit the .milr file">;
 /// ClangIR-specific options - END
 
 def flto_EQ : Joined<["-"], "flto=">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2985,15 +2985,16 @@ defm clangir : BoolFOption<"clangir",
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Use the ClangIR pipeline to compile">,
   NegFlag<SetFalse, [], [ClangOption, CC1Option], "Use the AST -> LLVM pipeline to compile">,
   BothFlags<[], [ClangOption, CC1Option], "">>;
-def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
-  Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR">;
-def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[CC1Option]>, Group<Action_Group>,
-  HelpText<"Build ASTs and then generate/lower to the selected MLIR dialect, emit the .mlir or .cir file. "
+def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[ClangOption, CC1Option]>, Group<Action_Group>,
+  HelpText<"Build ASTs and then generate/lower to the selected MLIR dialect, emit the .mlir file. "
   "Allowed values are `core` for MLIR core dialects and `cir` for ClangIR">,
   Values<"core,cir">,
   NormalizedValuesScope<"clang::frontend">,
-  NormalizedValues<["MLIR_Core", "MLIR_CIR"]>,
-  MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_CIR">;
+  NormalizedValues<["MLIR_CORE", "MLIR_CIR"]>,
+  MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_CORE">;
+def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
+  Group<Action_Group>, Alias<emit_mlir_EQ>, AliasArgs<["cir"]>,
+  HelpText<"Build ASTs and then lower to ClangIR">;
 /// ClangIR-specific options - END
 
 def flto_EQ : Joined<["-"], "flto=">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2987,8 +2987,13 @@ defm clangir : BoolFOption<"clangir",
   BothFlags<[], [ClangOption, CC1Option], "">>;
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR">;
-def emit_core_mlir : Flag<["-"], "emit-core-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
-  HelpText<"Build ASTs and then lower through ClangIR to core MLIR dialects, emit the .milr file">;
+def emit_mlir_EQ : Joined<["-"], "emit-mlir=">, Visibility<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Build ASTs and then generate/lower to the selected MLIR dialect, emit the .mlir or .cir file. "
+  "Allowed values are `core` for MLIR core dialects and `cir` for ClangIR">,
+  Values<"core,cir">,
+  NormalizedValuesScope<"clang::frontend">,
+  NormalizedValues<["MLIR_Core", "MLIR_CIR"]>,
+  MarshallingInfoEnum<FrontendOpts<"MLIRTargetDialect">, "MLIR_CIR">;
 /// ClangIR-specific options - END
 
 def flto_EQ : Joined<["-"], "flto=">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2987,6 +2987,8 @@ defm clangir : BoolFOption<"clangir",
   BothFlags<[], [ClangOption, CC1Option], "">>;
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR">;
+def emit_cir_mlir : Flag<["-"], "emit-cir-mlir">, Visibility<[CC1Option]>, Group<Action_Group>,
+  HelpText<"Build ASTs and then lower through ClangIR to MLIR, emit the .milr file">;
 /// ClangIR-specific options - END
 
 def flto_EQ : Joined<["-"], "flto=">,

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -99,7 +99,7 @@ TYPE("ir",                       LLVM_BC,      INVALID,         "bc",     phases
 TYPE("lto-ir",                   LTO_IR,       INVALID,         "s",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("lto-bc",                   LTO_BC,       INVALID,         "o",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
-TYPE("cir",                      CIR,          INVALID,         "cir",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("mlir",                     MLIR,         INVALID,         "mlir",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 // Misc.
 TYPE("ast",                      AST,          INVALID,         "ast",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("ifs",                      IFS,          INVALID,         "ifs",    phases::IfsMerge)

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -65,9 +65,6 @@ enum ActionKind {
   /// Translate input source into HTML.
   EmitHTML,
 
-  /// Emit a .cir file
-  EmitCIR,
-
   /// Emit a .mlir file
   EmitMLIR,
 
@@ -151,7 +148,7 @@ enum ActionKind {
   PrintDependencyDirectivesSourceMinimizerOutput
 };
 
-enum MLIRDialectKind { MLIR_CIR, MLIR_Core };
+enum MLIRDialectKind { MLIR_CORE, MLIR_CIR };
 
 } // namespace frontend
 
@@ -422,7 +419,7 @@ public:
   /// Specifies the output format of the AST.
   ASTDumpOutputFormat ASTDumpFormat = ADOF_Default;
 
-  frontend::MLIRDialectKind MLIRTargetDialect = frontend::MLIR_CIR;
+  frontend::MLIRDialectKind MLIRTargetDialect;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -69,7 +69,7 @@ enum ActionKind {
   EmitCIR,
 
   /// Emit a .mlir file
-  EmitMLIR,
+  EmitCoreMLIR,
 
   /// Emit a .ll file.
   EmitLLVM,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -68,6 +68,9 @@ enum ActionKind {
   /// Emit a .cir file
   EmitCIR,
 
+  /// Emit a .mlir file
+  EmitMLIR,
+
   /// Emit a .ll file.
   EmitLLVM,
 

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -69,7 +69,7 @@ enum ActionKind {
   EmitCIR,
 
   /// Emit a .mlir file
-  EmitCoreMLIR,
+  EmitMLIR,
 
   /// Emit a .ll file.
   EmitLLVM,
@@ -150,6 +150,8 @@ enum ActionKind {
   /// Print the output of the dependency directives source minimizer.
   PrintDependencyDirectivesSourceMinimizerOutput
 };
+
+enum MLIRDialectKind { MLIR_CIR, MLIR_Core };
 
 } // namespace frontend
 
@@ -419,6 +421,8 @@ public:
 
   /// Specifies the output format of the AST.
   ASTDumpOutputFormat ASTDumpFormat = ADOF_Default;
+
+  frontend::MLIRDialectKind MLIRTargetDialect = frontend::MLIR_CIR;
 
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -83,7 +83,7 @@ public:
   void HandleTranslationUnit(ASTContext &C) override {
     Gen->HandleTranslationUnit(C);
     mlir::ModuleOp MlirModule = Gen->getModule();
-    mlir::MLIRContext &MlirCtx = Gen->getContext();
+    mlir::MLIRContext &MlirCtx = Gen->getMLIRContext();
     switch (Action) {
     case CIRGenAction::OutputType::EmitCIR:
       if (OutputStream && MlirModule) {

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -93,7 +93,8 @@ public:
       }
       break;
     case CIRGenAction::OutputType::EmitMLIR: {
-      auto LoweredMlirModule = lowerFromCIRToMLIR(MlirModule, MlirCtx);
+      mlir::ModuleOp LoweredMlirModule =
+          lowerFromCIRToMLIR(MlirModule, MlirCtx);
       assert(OutputStream && "No output stream when lowering to MLIR!");
       // FIXME: we cannot roundtrip prettyForm=true right now.
       mlir::OpPrintingFlags Flags;

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -17,6 +17,7 @@ add_clang_library(clangCIRFrontendAction
   clangFrontend
   clangCIR
   clangCIRLoweringDirectToLLVM
+  clangCIRLoweringThroughMLIR
   clangCodeGen
   MLIRCIR
   MLIRIR

--- a/clang/lib/CIR/Lowering/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(DirectToLLVM)
+add_subdirectory(ThroughMLIR)

--- a/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  )
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+add_clang_library(clangCIRLoweringThroughMLIR
+  LowerCIRToMLIR.cpp
+
+  DEPENDS
+  LINK_LIBS
+  MLIRIR
+  ${dialect_libs}
+  MLIRCIR
+)

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -48,15 +48,15 @@ public:
   mlir::LogicalResult
   matchAndRewrite(cir::GlobalOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+    mlir::ModuleOp moduleOp = op->getParentOfType<mlir::ModuleOp>();
     if (!moduleOp)
       return mlir::failure();
 
     mlir::OpBuilder b(moduleOp.getContext());
 
-    const auto cirSymType = op.getSymType();
+    const mlir::Type cirSymType = op.getSymType();
     assert(!cir::MissingFeatures::convertTypeForMemory());
-    auto convertedType = getTypeConverter()->convertType(cirSymType);
+    mlir::Type convertedType = getTypeConverter()->convertType(cirSymType);
     if (!convertedType)
       return mlir::failure();
     auto memrefType = dyn_cast<mlir::MemRefType>(convertedType);
@@ -156,9 +156,9 @@ static mlir::TypeConverter prepareTypeConverter() {
 }
 
 void ConvertCIRToMLIRPass::runOnOperation() {
-  auto module = getOperation();
+  mlir::ModuleOp module = getOperation();
 
-  auto converter = prepareTypeConverter();
+  mlir::TypeConverter converter = prepareTypeConverter();
 
   mlir::RewritePatternSet patterns(&getContext());
 
@@ -185,7 +185,7 @@ mlir::ModuleOp lowerFromCIRToMLIR(mlir::ModuleOp mlirModule,
 
   pm.addPass(createConvertCIRToMLIRPass());
 
-  auto result = !mlir::failed(pm.run(mlirModule));
+  bool result = !mlir::failed(pm.run(mlirModule));
   if (!result)
     llvm::report_fatal_error(
         "The pass manager failed to lower CIR to MLIR standard dialects!");

--- a/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
+++ b/clang/lib/CIR/Lowering/ThroughMLIR/LowerCIRToMLIR.cpp
@@ -1,0 +1,201 @@
+//====- LowerCIRToMLIR.cpp - Lowering from CIR to MLIR --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements lowering of CIR operations to MLIR.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "clang/CIR/LowerToLLVM.h"
+#include "clang/CIR/MissingFeatures.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/TimeProfiler.h"
+
+using namespace cir;
+using namespace llvm;
+
+namespace cir {
+
+struct ConvertCIRToMLIRPass
+    : public mlir::PassWrapper<ConvertCIRToMLIRPass,
+                               mlir::OperationPass<mlir::ModuleOp>> {
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::BuiltinDialect, mlir::memref::MemRefDialect>();
+  }
+  void runOnOperation() final;
+
+  StringRef getDescription() const override {
+    return "Convert the CIR dialect module to MLIR standard dialects";
+  }
+
+  StringRef getArgument() const override { return "cir-to-mlir"; }
+};
+
+class CIRGlobalOpLowering : public mlir::OpConversionPattern<cir::GlobalOp> {
+public:
+  using OpConversionPattern<cir::GlobalOp>::OpConversionPattern;
+  mlir::LogicalResult
+  matchAndRewrite(cir::GlobalOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto moduleOp = op->getParentOfType<mlir::ModuleOp>();
+    if (!moduleOp)
+      return mlir::failure();
+
+    mlir::OpBuilder b(moduleOp.getContext());
+
+    const auto cirSymType = op.getSymType();
+    assert(!cir::MissingFeatures::convertTypeForMemory());
+    auto convertedType = getTypeConverter()->convertType(cirSymType);
+    if (!convertedType)
+      return mlir::failure();
+    auto memrefType = dyn_cast<mlir::MemRefType>(convertedType);
+    if (!memrefType)
+      memrefType = mlir::MemRefType::get({}, convertedType);
+    // Add an optional alignment to the global memref.
+    assert(!cir::MissingFeatures::opGlobalAlignment());
+    mlir::IntegerAttr memrefAlignment = mlir::IntegerAttr();
+    // Add an optional initial value to the global memref.
+    mlir::Attribute initialValue = mlir::Attribute();
+    std::optional<mlir::Attribute> init = op.getInitialValue();
+    if (init.has_value()) {
+      initialValue =
+          llvm::TypeSwitch<mlir::Attribute, mlir::Attribute>(init.value())
+              .Case<cir::IntAttr>([&](cir::IntAttr attr) {
+                auto rtt = mlir::RankedTensorType::get({}, convertedType);
+                return mlir::DenseIntElementsAttr::get(rtt, attr.getValue());
+              })
+              .Case<cir::FPAttr>([&](cir::FPAttr attr) {
+                auto rtt = mlir::RankedTensorType::get({}, convertedType);
+                return mlir::DenseFPElementsAttr::get(rtt, attr.getValue());
+              })
+              .Default([&](mlir::Attribute attr) {
+                llvm_unreachable("GlobalOp lowering with initial value is not "
+                                 "fully supported yet");
+                return mlir::Attribute();
+              });
+    }
+
+    // Add symbol visibility
+    assert(!cir::MissingFeatures::opGlobalLinkage());
+    std::string symVisibility = "public";
+
+    assert(!cir::MissingFeatures::opGlobalConstant());
+    bool isConstant = false;
+
+    rewriter.replaceOpWithNewOp<mlir::memref::GlobalOp>(
+        op, b.getStringAttr(op.getSymName()),
+        /*sym_visibility=*/b.getStringAttr(symVisibility),
+        /*type=*/memrefType, initialValue,
+        /*constant=*/isConstant,
+        /*alignment=*/memrefAlignment);
+
+    return mlir::success();
+  }
+};
+
+void populateCIRToMLIRConversionPatterns(mlir::RewritePatternSet &patterns,
+                                         mlir::TypeConverter &converter) {
+  patterns.add<CIRGlobalOpLowering>(converter, patterns.getContext());
+}
+
+static mlir::TypeConverter prepareTypeConverter() {
+  mlir::TypeConverter converter;
+  converter.addConversion([&](cir::PointerType type) -> mlir::Type {
+    assert(!cir::MissingFeatures::convertTypeForMemory());
+    mlir::Type ty = converter.convertType(type.getPointee());
+    // FIXME: The pointee type might not be converted (e.g. struct)
+    if (!ty)
+      return nullptr;
+    return mlir::MemRefType::get({}, ty);
+  });
+  converter.addConversion(
+      [&](mlir::IntegerType type) -> mlir::Type { return type; });
+  converter.addConversion(
+      [&](mlir::FloatType type) -> mlir::Type { return type; });
+  converter.addConversion([&](cir::VoidType type) -> mlir::Type { return {}; });
+  converter.addConversion([&](cir::IntType type) -> mlir::Type {
+    // arith dialect ops doesn't take signed integer -- drop cir sign here
+    return mlir::IntegerType::get(
+        type.getContext(), type.getWidth(),
+        mlir::IntegerType::SignednessSemantics::Signless);
+  });
+  converter.addConversion([&](cir::SingleType type) -> mlir::Type {
+    return mlir::Float32Type::get(type.getContext());
+  });
+  converter.addConversion([&](cir::DoubleType type) -> mlir::Type {
+    return mlir::Float64Type::get(type.getContext());
+  });
+  converter.addConversion([&](cir::FP80Type type) -> mlir::Type {
+    return mlir::Float80Type::get(type.getContext());
+  });
+  converter.addConversion([&](cir::LongDoubleType type) -> mlir::Type {
+    return converter.convertType(type.getUnderlying());
+  });
+  converter.addConversion([&](cir::FP128Type type) -> mlir::Type {
+    return mlir::Float128Type::get(type.getContext());
+  });
+  converter.addConversion([&](cir::FP16Type type) -> mlir::Type {
+    return mlir::Float16Type::get(type.getContext());
+  });
+  converter.addConversion([&](cir::BF16Type type) -> mlir::Type {
+    return mlir::BFloat16Type::get(type.getContext());
+  });
+
+  return converter;
+}
+
+void ConvertCIRToMLIRPass::runOnOperation() {
+  auto module = getOperation();
+
+  auto converter = prepareTypeConverter();
+
+  mlir::RewritePatternSet patterns(&getContext());
+
+  populateCIRToMLIRConversionPatterns(patterns, converter);
+
+  mlir::ConversionTarget target(getContext());
+  target.addLegalOp<mlir::ModuleOp>();
+  target.addLegalDialect<mlir::memref::MemRefDialect>();
+  target.addIllegalDialect<cir::CIRDialect>();
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> createConvertCIRToMLIRPass() {
+  return std::make_unique<ConvertCIRToMLIRPass>();
+}
+
+mlir::ModuleOp lowerFromCIRToMLIR(mlir::ModuleOp mlirModule,
+                                  mlir::MLIRContext &mlirCtx) {
+  llvm::TimeTraceScope scope("Lower CIR To MLIR");
+
+  mlir::PassManager pm(&mlirCtx);
+
+  pm.addPass(createConvertCIRToMLIRPass());
+
+  auto result = !mlir::failed(pm.run(mlirModule));
+  if (!result)
+    llvm::report_fatal_error(
+        "The pass manager failed to lower CIR to MLIR standard dialects!");
+
+  // Now that we ran all the lowering passes, verify the final output.
+  if (mlirModule.verify().failed())
+    llvm::report_fatal_error(
+        "Verification of the final MLIR in standard dialects failed!");
+
+  return mlirModule;
+}
+
+} // namespace cir

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5127,8 +5127,8 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<AnalyzeJobAction>(Input, types::TY_Plist);
     if (Args.hasArg(options::OPT_emit_ast))
       return C.MakeAction<CompileJobAction>(Input, types::TY_AST);
-    if (Args.hasArg(options::OPT_emit_cir))
-      return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
+    if (Args.hasArg(options::OPT_emit_mlir_EQ))
+      return C.MakeAction<CompileJobAction>(Input, types::TY_MLIR);
     if (Args.hasArg(options::OPT_module_file_info))
       return C.MakeAction<CompileJobAction>(Input, types::TY_ModuleFile);
     if (Args.hasArg(options::OPT_verify_pch))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5386,9 +5386,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-rewrite-objc");
       rewriteKind = RK_Fragile;
     } else if (JA.getType() == types::TY_MLIR) {
-      CmdArgs.push_back(Args.MakeArgString(
-          Twine("-emit-mlir=") +
-          Args.getLastArgValue(options::OPT_emit_mlir_EQ)));
+      CmdArgs.push_back(
+          Args.MakeArgString(Twine("-emit-mlir=") +
+                             Args.getLastArgValue(options::OPT_emit_mlir_EQ)));
     } else {
       assert(JA.getType() == types::TY_PP_Asm && "Unexpected output type!");
     }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5215,7 +5215,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  if (Args.hasArg(options::OPT_fclangir))
+  if (Args.hasArg(options::OPT_fclangir) ||
+      Args.hasArg(options::OPT_emit_mlir_EQ))
     CmdArgs.push_back("-fclangir");
 
   if (IsOpenMPDevice) {
@@ -5384,8 +5385,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     } else if (JA.getType() == types::TY_RewrittenLegacyObjC) {
       CmdArgs.push_back("-rewrite-objc");
       rewriteKind = RK_Fragile;
-    } else if (JA.getType() == types::TY_CIR) {
-      CmdArgs.push_back("-emit-cir");
+    } else if (JA.getType() == types::TY_MLIR) {
+      CmdArgs.push_back(Args.MakeArgString(
+          Twine("-emit-mlir=") +
+          Args.getLastArgValue(options::OPT_emit_mlir_EQ)));
     } else {
       assert(JA.getType() == types::TY_PP_Asm && "Unexpected output type!");
     }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2739,7 +2739,6 @@ static const auto &getFrontendActionTable() {
       {frontend::DumpTokens, OPT_dump_tokens},
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
-      {frontend::EmitCIR, OPT_emit_cir},
       {frontend::EmitMLIR, OPT_emit_mlir_EQ},
       {frontend::EmitHTML, OPT_emit_html},
       {frontend::EmitLLVM, OPT_emit_llvm},
@@ -2859,8 +2858,8 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
 
   if (Opts.ProgramAction == frontend::EmitMLIR) {
     GenerateProgramAction = [&]() {
-      if (Opts.MLIRTargetDialect == frontend::MLIR_CIR)
-        GenerateArg(Consumer, OPT_emit_cir);
+      if (Opts.MLIRTargetDialect == frontend::MLIR_CORE)
+        GenerateArg(Consumer, OPT_emit_mlir_EQ, "core");
     };
   }
 
@@ -3110,7 +3109,7 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"
                                                            << "-emit-module";
-  if (Args.hasArg(OPT_fclangir) || Args.hasArg(OPT_emit_cir))
+  if (Args.hasArg(OPT_fclangir) || Args.hasArg(OPT_emit_mlir_EQ))
     Opts.UseClangIRPipeline = true;
 
   if (Args.hasArg(OPT_aux_target_cpu))
@@ -4638,7 +4637,6 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::ASTView:
   case frontend::EmitAssembly:
   case frontend::EmitBC:
-  case frontend::EmitCIR:
   case frontend::EmitMLIR:
   case frontend::EmitHTML:
   case frontend::EmitLLVM:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2740,6 +2740,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
       {frontend::EmitCIR, OPT_emit_cir},
+      {frontend::EmitMLIR, OPT_emit_cir_mlir},
       {frontend::EmitHTML, OPT_emit_html},
       {frontend::EmitLLVM, OPT_emit_llvm},
       {frontend::EmitLLVMOnly, OPT_emit_llvm_only},
@@ -4631,6 +4632,7 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitAssembly:
   case frontend::EmitBC:
   case frontend::EmitCIR:
+  case frontend::EmitMLIR:
   case frontend::EmitHTML:
   case frontend::EmitLLVM:
   case frontend::EmitLLVMOnly:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2740,7 +2740,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
       {frontend::EmitCIR, OPT_emit_cir},
-      {frontend::EmitCoreMLIR, OPT_emit_core_mlir},
+      {frontend::EmitMLIR, OPT_emit_mlir_EQ},
       {frontend::EmitHTML, OPT_emit_html},
       {frontend::EmitLLVM, OPT_emit_llvm},
       {frontend::EmitLLVMOnly, OPT_emit_llvm_only},
@@ -2854,6 +2854,13 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
   if (Opts.ProgramAction == frontend::FixIt && !Opts.FixItSuffix.empty()) {
     GenerateProgramAction = [&]() {
       GenerateArg(Consumer, OPT_fixit_EQ, Opts.FixItSuffix);
+    };
+  }
+
+  if (Opts.ProgramAction == frontend::EmitMLIR) {
+    GenerateProgramAction = [&]() {
+      if (Opts.MLIRTargetDialect == frontend::MLIR_CIR)
+        GenerateArg(Consumer, OPT_emit_cir);
     };
   }
 
@@ -4632,7 +4639,7 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitAssembly:
   case frontend::EmitBC:
   case frontend::EmitCIR:
-  case frontend::EmitCoreMLIR:
+  case frontend::EmitMLIR:
   case frontend::EmitHTML:
   case frontend::EmitLLVM:
   case frontend::EmitLLVMOnly:

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2740,7 +2740,7 @@ static const auto &getFrontendActionTable() {
       {frontend::EmitAssembly, OPT_S},
       {frontend::EmitBC, OPT_emit_llvm_bc},
       {frontend::EmitCIR, OPT_emit_cir},
-      {frontend::EmitMLIR, OPT_emit_cir_mlir},
+      {frontend::EmitCoreMLIR, OPT_emit_core_mlir},
       {frontend::EmitHTML, OPT_emit_html},
       {frontend::EmitLLVM, OPT_emit_llvm},
       {frontend::EmitLLVMOnly, OPT_emit_llvm_only},
@@ -4632,7 +4632,7 @@ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
   case frontend::EmitAssembly:
   case frontend::EmitBC:
   case frontend::EmitCIR:
-  case frontend::EmitMLIR:
+  case frontend::EmitCoreMLIR:
   case frontend::EmitHTML:
   case frontend::EmitLLVM:
   case frontend::EmitLLVMOnly:

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -80,7 +80,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 #else
     llvm_unreachable("CIR suppport not built into clang");
 #endif
-  case EmitMLIR:
+  case EmitCoreMLIR:
 #if CLANG_ENABLE_CIR
     return std::make_unique<cir::EmitMLIRAction>();
 #else

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -48,7 +48,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 
   unsigned UseCIR = CI.getFrontendOpts().UseClangIRPipeline;
   frontend::ActionKind Act = CI.getFrontendOpts().ProgramAction;
-  bool EmitsCIR = Act == EmitCIR;
+  bool EmitsCIR = Act == EmitMLIR;
 
   if (!UseCIR && EmitsCIR)
     llvm::report_fatal_error("-emit-cir and only valid when using -fclangir");
@@ -74,12 +74,6 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
       return std::make_unique<cir::EmitBCAction>();
 #endif
     return std::make_unique<EmitBCAction>();
-  case EmitCIR:
-#if CLANG_ENABLE_CIR
-    return std::make_unique<cir::EmitCIRAction>();
-#else
-    llvm_unreachable("CIR suppport not built into clang");
-#endif
   case EmitMLIR:
 #if CLANG_ENABLE_CIR
     return std::make_unique<cir::EmitMLIRAction>();

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -80,6 +80,12 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 #else
     llvm_unreachable("CIR suppport not built into clang");
 #endif
+  case EmitMLIR:
+#if CLANG_ENABLE_CIR
+    return std::make_unique<cir::EmitMLIRAction>();
+#else
+    llvm_unreachable("CIR suppport not built into clang");
+#endif
   case EmitHTML:               return std::make_unique<HTMLPrintAction>();
   case EmitLLVM: {
 #if CLANG_ENABLE_CIR

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -80,7 +80,7 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 #else
     llvm_unreachable("CIR suppport not built into clang");
 #endif
-  case EmitCoreMLIR:
+  case EmitMLIR:
 #if CLANG_ENABLE_CIR
     return std::make_unique<cir::EmitMLIRAction>();
 #else

--- a/clang/test/CIR/Lowering/ThroughMLIR/global-ptrs.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global-ptrs.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-core-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 // XFAIL: *

--- a/clang/test/CIR/Lowering/ThroughMLIR/global-ptrs.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global-ptrs.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-mlir %s -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+// XFAIL: *
+
+// Note: This is here to track the failed lowering of global pointers. When
+//       this test starts passing, the checks should be updated with more
+//       specifics.
+
+void *vp;
+// CHECK: memref.global "public" @vp
+
+int *ip = 0;
+// CHECK: memref.global "public" @ip
+
+double *dp;
+// CHECK: memref.global "public" @dp
+
+char **cpp;
+// CHECK: memref.global "public" @cpp
+
+void (*fp)();
+// CHECK: memref.global "public" @fp
+
+int (*fpii)(int) = 0;
+// CHECK: memref.global "public" @fpii
+
+void (*fpvar)(int, ...);
+// CHECK: memref.global "public" @fpvar

--- a/clang/test/CIR/Lowering/ThroughMLIR/global-ptrs.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global-ptrs.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-core-mlir %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 // XFAIL: *

--- a/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
@@ -1,0 +1,79 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-mlir %s -o %t.mlir
+// RUN: FileCheck --input-file=%t.mlir %s
+
+char c;
+// CHECK: memref.global "public" @c : memref<i8>
+
+signed char sc;
+// CHECK: memref.global "public" @sc : memref<i8>
+
+unsigned char uc;
+// CHECK: memref.global "public" @uc : memref<i8>
+
+short ss;
+// CHECK: memref.global "public" @ss : memref<i16>
+
+unsigned short us = 100;
+// CHECK: memref.global "public" @us : memref<i16> = dense<100>
+
+int si = 42;
+// CHECK: memref.global "public" @si : memref<i32> = dense<42>
+
+unsigned ui;
+// CHECK: memref.global "public" @ui : memref<i32>
+
+long sl;
+// CHECK: memref.global "public" @sl : memref<i64>
+
+unsigned long ul;
+// CHECK: memref.global "public" @ul : memref<i64>
+
+long long sll;
+// CHECK: memref.global "public" @sll : memref<i64>
+
+unsigned long long ull = 123456;
+// CHECK: memref.global "public" @ull : memref<i64> = dense<123456>
+
+__int128 s128;
+// CHECK: memref.global "public" @s128 : memref<i128>
+
+unsigned __int128 u128;
+// CHECK: memref.global "public" @u128 : memref<i128>
+
+wchar_t wc;
+// CHECK: memref.global "public" @wc : memref<i32>
+
+char8_t c8;
+// CHECK: memref.global "public" @c8 : memref<i8>
+
+char16_t c16;
+// CHECK: memref.global "public" @c16 : memref<i16>
+
+char32_t c32;
+// CHECK: memref.global "public" @c32 : memref<i32>
+
+_BitInt(20) sb20;
+// CHECK: memref.global "public" @sb20 : memref<i20>
+
+unsigned _BitInt(48) ub48;
+// CHECK: memref.global "public" @ub48 : memref<i48>
+
+_Float16 f16;
+// CHECK: memref.global "public" @f16 : memref<f16>
+
+__bf16 bf16;
+// CHECK: memref.global "public" @bf16 : memref<bf16>
+
+float f;
+// CHECK: memref.global "public" @f : memref<f32>
+
+double d = 1.25;
+// CHECK: memref.global "public" @d : memref<f64> = dense<1.250000e+00>
+
+long double ld;
+// CHECK: memref.global "public" @ld : memref<f80>
+
+__float128 f128;
+// CHECK: memref.global "public" @f128 : memref<f128>
+
+// FIXME: Add global pointers when they can be lowered to MLIR

--- a/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-core-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=core %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 char c;

--- a/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
+++ b/clang/test/CIR/Lowering/ThroughMLIR/global.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir-mlir %s -o %t.mlir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-core-mlir %s -o %t.mlir
 // RUN: FileCheck --input-file=%t.mlir %s
 
 char c;

--- a/clang/test/CIR/global-var-simple.cpp
+++ b/clang/test/CIR/global-var-simple.cpp
@@ -1,5 +1,5 @@
-// Global variables of scalar typees with initial values
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
+// Global variables of scalar types with initial values
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir %s -o -  | FileCheck %s
 
 char c;
 // CHECK: cir.global external @c : !cir.int<s, 8>

--- a/clang/test/CIR/hello.c
+++ b/clang/test/CIR/hello.c
@@ -1,0 +1,6 @@
+// Smoke test for ClangIR code generation
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir %s -o -  | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
+
+void foo() {}
+// CHECK: cir.func @foo

--- a/clang/test/CIR/hello.c
+++ b/clang/test/CIR/hello.c
@@ -1,6 +1,0 @@
-// Smoke test for ClangIR code generation
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-mlir=cir %s -o -  | FileCheck %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
-
-void foo() {}
-// CHECK: cir.func @foo


### PR DESCRIPTION
Add support for lowering CIR to more general MLIR and emitting an MLIR text file, including a new command-line option for emitting MLIR via ClangIR. This does not yet support lowering to LLVM IR or other target-specific formats, but that is the ultimate goal, which is why the newly added directory is named "ThroughMLIR".

The intent here is to allow MLIR optimizations that don't recognize the ClangIR dialect to be run before LLVM IR is generated.

Lowering of global pointers to MLIR is not yet supported (here or in the incubator). A test is added here to track that.