### PR TITLE
[Modules] Add `clang/Lex/HLSLRootSignatureTokenKinds.def` to clang's `modulemap`

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -135,7 +135,16 @@ module Clang_Frontend {
 
 module Clang_FrontendTool { requires cplusplus umbrella "clang/FrontendTool" module * { export * } }
 module Clang_Index { requires cplusplus umbrella "clang/Index" module * { export * } }
-module Clang_Lex { requires cplusplus umbrella "clang/Lex" module * { export * } }
+
+module Clang_Lex {
+  requires cplusplus
+  umbrella "clang/Lex"
+
+  textual header "clang/Lex/HLSLRootSignatureTokenKinds.def"
+
+  module * { export * }
+}
+
 module Clang_Parse { requires cplusplus umbrella "clang/Parse" module * { export * } }
 module Clang_Rewrite { requires cplusplus umbrella "clang/Rewrite/Core" module * { export * } }
 module Clang_RewriteFrontend { requires cplusplus umbrella "clang/Rewrite/Frontend" module * { export * } }


### PR DESCRIPTION
b41b86a907f653f79bab10d4c80b3a41d146c71b added a new textual header `clang/Lex/HLSLRootSignatureTokenKinds.def` but did not add it to `clang`'s module map. This causes build failure when building llvm with `-DLLVM_ENABLE_MODULES=ON`. This PR adds the new textual header to the module map and fixes the build break. 

Fixing rdar://145148093. 