### PR TITLE
[flang][NFC] AliasAnalysis: Use Indirect not Unknown for LoadOp

### DIFF
--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -644,6 +644,11 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
             } else {
               type = SourceKind::Indirect;
             }
+	    // TODO: This assignment is redundant but somehow works around an
+	    // apparent MSVC bug reporting "undeclared identifier" at the next
+	    // "breakFromLoop = true;".  See
+	    // <https://github.com/llvm/llvm-project/pull/127845#issuecomment-2669829610>.
+            breakFromLoop = true;
           } else {
             // No further tracking for addresses loaded from memory for now.
             type = SourceKind::Indirect;

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -644,10 +644,10 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
             } else {
               type = SourceKind::Indirect;
             }
-	    // TODO: This assignment is redundant but somehow works around an
-	    // apparent MSVC bug reporting "undeclared identifier" at the next
-	    // "breakFromLoop = true;".  See
-	    // <https://github.com/llvm/llvm-project/pull/127845#issuecomment-2669829610>.
+            // TODO: This assignment is redundant but somehow works around an
+            // apparent MSVC bug reporting "undeclared identifier" at the next
+            // "breakFromLoop = true;".  See
+            // <https://github.com/llvm/llvm-project/pull/127845#issuecomment-2669829610>.
             breakFromLoop = true;
           } else {
             // No further tracking for addresses loaded from memory for now.

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -641,14 +641,13 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
             } else if (isDummyArgument(def)) {
               defOp = nullptr;
               v = def;
+            } else {
+              type = SourceKind::Indirect;
             }
-
-            breakFromLoop = true;
-            return;
+          } else {
+            // No further tracking for addresses loaded from memory for now.
+            type = SourceKind::Indirect;
           }
-
-          // No further tracking for addresses loaded from memory for now.
-          type = SourceKind::Indirect;
           breakFromLoop = true;
         })
         .Case<fir::AddrOfOp>([&](auto op) {


### PR DESCRIPTION
As mentioned at <https://github.com/llvm/llvm-project/pull/126156#discussion_r1953523892>: PR #126156 causes AliasAnalysis::getSource to sometimes return SourceKind::Unknown when it used to return SourceKind::Indirect for a LoadOp.  This patch restores that part of the old behavior.  It should not affect user-visible behavior because AliasAnalysis::alias treats SourceKind::Unknown and SourceKind::Indirect equivalently, but it does improve debugging output.