### PR TITLE
[libc] Add --json mode for hdrgen

### DIFF
--- a/libc/utils/hdrgen/header.py
+++ b/libc/utils/hdrgen/header.py
@@ -233,3 +233,12 @@ class HeaderFile:
         content.append("__END_C_DECLS")
 
         return "\n".join(content)
+
+    def json_data(self):
+        return {
+            "name": self.name,
+            "standards": self.standards,
+            "includes": [
+                str(file) for file in sorted({COMMON_HEADER} | self.includes())
+            ],
+        }

--- a/libc/utils/hdrgen/tests/expected_output/test_small.json
+++ b/libc/utils/hdrgen/tests/expected_output/test_small.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "test_small.h",
+    "standards": [],
+    "includes": [
+      "__llvm-libc-common.h",
+      "llvm-libc-macros/test_more-macros.h",
+      "llvm-libc-macros/test_small-macros.h",
+      "llvm-libc-types/float128.h",
+      "llvm-libc-types/type_a.h",
+      "llvm-libc-types/type_b.h"
+    ]
+  }
+]

--- a/libc/utils/hdrgen/tests/test_integration.py
+++ b/libc/utils/hdrgen/tests/test_integration.py
@@ -12,14 +12,15 @@ class TestHeaderGenIntegration(unittest.TestCase):
         self.main_script = self.source_dir.parent / "main.py"
         self.maxDiff = 80 * 100
 
-    def run_script(self, yaml_file, output_file, entry_points=[]):
+    def run_script(self, yaml_file, output_file, entry_points=[],
+                   switches=[]):
         command = [
             "python3",
             str(self.main_script),
             str(yaml_file),
             "--output",
             str(output_file),
-        ]
+        ] + switches
 
         for entry_point in entry_points:
             command.extend(["--entry-point", entry_point])
@@ -58,6 +59,16 @@ class TestHeaderGenIntegration(unittest.TestCase):
         output_file = self.output_dir / "subdir" / "test.h"
         self.run_script(yaml_file, output_file)
         self.compare_files(output_file, expected_output_file)
+
+    def test_generate_json(self):
+        yaml_file = self.source_dir / "input/test_small.yaml"
+        expected_output_file = self.source_dir / "expected_output/test_small.json"
+        output_file = self.output_dir / "test_small.json"
+
+        self.run_script(yaml_file, output_file, switches=["--json"])
+
+        self.compare_files(output_file, expected_output_file)
+
 
 
 def main():

--- a/libc/utils/hdrgen/tests/test_integration.py
+++ b/libc/utils/hdrgen/tests/test_integration.py
@@ -12,8 +12,7 @@ class TestHeaderGenIntegration(unittest.TestCase):
         self.main_script = self.source_dir.parent / "main.py"
         self.maxDiff = 80 * 100
 
-    def run_script(self, yaml_file, output_file, entry_points=[],
-                   switches=[]):
+    def run_script(self, yaml_file, output_file, entry_points=[], switches=[]):
         command = [
             "python3",
             str(self.main_script),
@@ -68,7 +67,6 @@ class TestHeaderGenIntegration(unittest.TestCase):
         self.run_script(yaml_file, output_file, switches=["--json"])
 
         self.compare_files(output_file, expected_output_file)
-
 
 
 def main():


### PR DESCRIPTION
This adds a feature to hdrgen to emit JSON summaries of header
files for build system integration.  For now the summaries have
only the basic information about each header that is relevant for
build and testing purposes: the standards and includes lists.
