### PR TITLE
[llvm] DLLExport llvm::allocate_buffer and llvm::deallocate_buffer

### DIFF
--- a/llvm/include/llvm/Support/MemAlloc.h
+++ b/llvm/include/llvm/Support/MemAlloc.h
@@ -71,7 +71,7 @@ LLVM_ATTRIBUTE_RETURNS_NONNULL inline void *safe_realloc(void *Ptr, size_t Sz) {
 /// like posix_memalign due to portability. It is mostly intended to allow
 /// compatibility with platforms that, after aligned allocation was added, use
 /// reduced default alignment.
-LLVM_ATTRIBUTE_RETURNS_NONNULL LLVM_ATTRIBUTE_RETURNS_NOALIAS void *
+LLVM_ABI LLVM_ATTRIBUTE_RETURNS_NONNULL LLVM_ATTRIBUTE_RETURNS_NOALIAS void *
 allocate_buffer(size_t Size, size_t Alignment);
 
 /// Deallocate a buffer of memory with the given size and alignment.
@@ -81,6 +81,7 @@ allocate_buffer(size_t Size, size_t Alignment);
 ///
 /// The pointer must have been allocated with the corresponding new operator,
 /// most likely using the above helper.
+LLVM_ABI
 void deallocate_buffer(void *Ptr, size_t Size, size_t Alignment);
 
 } // namespace llvm


### PR DESCRIPTION
## Overview
Annotate the `llvm::allocate_buffer` and `llvm::deallocate_buffer` functions so they are explicitly included in LLVM's public interface. When building LLVM as a Windows DLL, this annotation exports them from the DLL.

## Background
This change is required as part of the overall project to build LLVM as a Windows DLL described in #109483. Without this change, LLVM tools fail to link.

## Validation
Built LLVM with MSVC on Windows 11:
```
cmake -B build -S llvm -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_OPTIMIZED_TABLEGEN -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON
ninja -C build llvm-rc llvm-ar
```
Verified the annotated interface no longer appears in the list of unresolved external symbols.