### PR TITLE
[profile] runtime counter relocation is needed on windows-msvc targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -795,7 +795,7 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
     else {
       CmdArgs.push_back("-fprofile-continuous");
       // Platforms that require a bias variable:
-      if (T.isOSBinFormatELF() || T.isOSAIX()) {
+      if (T.isOSBinFormatELF() || T.isOSAIX() || T.isKnownWindowsMSVCEnvironment()) {
         CmdArgs.push_back("-mllvm");
         CmdArgs.push_back("-runtime-counter-relocation");
       }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -795,7 +795,8 @@ static void addPGOAndCoverageFlags(const ToolChain &TC, Compilation &C,
     else {
       CmdArgs.push_back("-fprofile-continuous");
       // Platforms that require a bias variable:
-      if (T.isOSBinFormatELF() || T.isOSAIX() || T.isKnownWindowsMSVCEnvironment()) {
+      if (T.isOSBinFormatELF() || T.isOSAIX() ||
+          T.isKnownWindowsMSVCEnvironment()) {
         CmdArgs.push_back("-mllvm");
         CmdArgs.push_back("-runtime-counter-relocation");
       }

--- a/clang/test/Driver/fprofile-continuous.c
+++ b/clang/test/Driver/fprofile-continuous.c
@@ -6,6 +6,7 @@
 
 // RUN: %clang --target=powerpc64-ibm-aix -fprofile-generate -fprofile-continuous -### -c %s 2>&1 | FileCheck %s --check-prefix=RELOC
 // RUN: %clang --target=x86_64-unknown-fuchsia -fprofile-generate -fprofile-continuous -### -c %s 2>&1 | FileCheck %s --check-prefix=RELOC
+// RUN: %clang --target=x86_64-windows-msvc -fprofile-generate -fprofile-continuous -### -c %s 2>&1 | FileCheck %s --check-prefix=RELOC
 // RELOC: "-cc1" {{.*}} "-fprofile-continuous" "-mllvm" "-runtime-counter-relocation"
 
 // 2) test -fprofile-continuous with cs-profile-generate and -fprofile-instr-generate


### PR DESCRIPTION
Continuous profiling syncing is [supported on windows,](https://github.com/llvm/llvm-project/pull/124353#issuecomment-2649075857) and it also relies on runtime counter relocation (based on this [test](https://github.com/llvm/llvm-project/blob/main/compiler-rt/test/profile/ContinuousSyncMode/runtime-counter-relocation.c))

Thanks to @anhtuyenibm for pointing it out to me.