### PR TITLE
[Clang][Docs] Document -Xarch_ better

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -935,7 +935,7 @@ def Xanalyzer : Separate<["-"], "Xanalyzer">,
 def Xarch__
     : JoinedAndSeparate<["-"], "Xarch_">,
       Flags<[NoXarchOption]>,
-      HelpText<"Pass <arg> to the compiliation if the target matches <arch>">,
+      HelpText<"Pass <arg> to the compilation if the target matches <arch>">,
       DocBrief<
           [{Specifies that the argument should only be used if the compilation
   target matches the specified architecture. This can be used with the target

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -937,7 +937,7 @@ def Xarch__
       Flags<[NoXarchOption]>,
       HelpText<"Pass <arg> to the compiliation if the target matches <arch>">,
       DocBrief<
-          [{Specifies that the argument should only be used if the compileation
+          [{Specifies that the argument should only be used if the compilation
   target matches the specified architecture. This can be used with the target
   CPU, triple architecture, or offloading host and device. This is most useful
   for separating behavior undesirable on one of the targets when combining many

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -939,7 +939,7 @@ def Xarch__
       DocBrief<
           [{Specifies that the argument should only be used if the compilation
   target matches the specified architecture. This can be used with the target
-  CPU, triple architecture, or offloading host and device. This is most useful
+  CPU, triple architecture, or offloading host and device. It is most useful
   for separating behavior undesirable on one of the targets when combining many
   compilation jobs, as is commong with offloading. For example, -Xarch_x86_64,
   -Xarch_gfx90a, and -Xarch_device are all valid selectors.}]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -932,9 +932,18 @@ def W_Joined : Joined<["-"], "W">, Group<W_Group>,
 def Xanalyzer : Separate<["-"], "Xanalyzer">,
   HelpText<"Pass <arg> to the static analyzer">, MetaVarName<"<arg>">,
   Group<StaticAnalyzer_Group>;
-def Xarch__ : JoinedAndSeparate<["-"], "Xarch_">, Flags<[NoXarchOption]>,
-  HelpText<"Pass <arg> to the compiliation if the target matches <arch>">,
-  MetaVarName<"<arch> <arg>">;
+def Xarch__
+    : JoinedAndSeparate<["-"], "Xarch_">,
+      Flags<[NoXarchOption]>,
+      HelpText<"Pass <arg> to the compiliation if the target matches <arch>">,
+      DocBrief<
+          [{Specifies that the argument should only be used if the compileation
+  target matches the specified architecture. This can be used with the target
+  CPU, triple architecture, or offloading host and device. This is most useful
+  for separating behavior undesirable on one of the targets when combining many
+  compilation jobs, as is commong with offloading. For example, -Xarch_x86_64,
+  -Xarch_gfx90a, and -Xarch_device are all valid selectors.}]>,
+      MetaVarName<"<arch> <arg>">;
 def Xarch_host : Separate<["-"], "Xarch_host">, Flags<[NoXarchOption]>,
   HelpText<"Pass <arg> to the CUDA/HIP host compilation">, MetaVarName<"<arg>">;
 def Xarch_device : Separate<["-"], "Xarch_device">, Flags<[NoXarchOption]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -942,7 +942,9 @@ def Xarch__
   CPU, triple architecture, or offloading host and device. It is most useful
   for separating behavior undesirable on one of the targets when combining many
   compilation jobs, as is commong with offloading. For example, -Xarch_x86_64,
-  -Xarch_gfx90a, and -Xarch_device are all valid selectors.}]>,
+  -Xarch_gfx90a, and -Xarch_device are all valid selectors. -Xarch_device will
+  forward the argument to the offloading device while -Xarch_host will target
+  the host system, which can be used to suppress incompatible GPU arguments.}]>,
       MetaVarName<"<arch> <arg>">;
 def Xarch_host : Separate<["-"], "Xarch_host">, Flags<[NoXarchOption]>,
   HelpText<"Pass <arg> to the CUDA/HIP host compilation">, MetaVarName<"<arg>">;


### PR DESCRIPTION
Summary:
This argument is esoteric and previously didn't even work consistently
across the targets. Now that's fixed we should document it better.
