### PR TITLE
[Github][CI] Enable New Premerge on PRs

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -14,8 +14,6 @@ on:
       # do this is that it allows us to take advantage of concurrency groups
       # to cancel in progress CI jobs whenever the PR is closed.
       - closed
-    paths:
-      - .github/workflows/premerge.yaml
   push:
     branches:
       - 'main'


### PR DESCRIPTION
This patch gets rid of the file restriction for running the new premerge Github workflow on PRs. This will cause the jobs to be run on all the PRs. Currently the jobs will succeed regardless of build/test failure results. This will let us test the new infra hopefully without too much disruption before eventually letting jobs fail when builds/tests fail and deprecating the existing premerge system.

This is part of the launch plan as outlined in
https://discourse.llvm.org/t/googles-plan-for-the-llvm-presubmit-infrastructure/78940.