### PR TITLE
[ADT] Add set_intersects to check if there is any intersection

### DIFF
--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -157,6 +157,23 @@ bool set_is_subset(const S1Ty &S1, const S2Ty &S2) {
   return true;
 }
 
+template <class S1Ty, class S2Ty>
+bool set_intersects_impl(const S1Ty &S1, const S2Ty &S2) {
+  for (const auto &E : S1)
+    if (S2.count(E))
+      return true;
+  return false;
+}
+
+/// set_intersects(A, B) - Return true iff A ^ B is non empty
+template <class S1Ty, class S2Ty>
+bool set_intersects(const S1Ty &S1, const S2Ty &S2) {
+  if (S1.size() < S2.size())
+    return set_intersects_impl(S1, S2);
+  else
+    return set_intersects_impl(S2, S1);
+}
+
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -157,6 +157,8 @@ bool set_is_subset(const S1Ty &S1, const S2Ty &S2) {
   return true;
 }
 
+namespace detail {
+
 template <class S1Ty, class S2Ty>
 bool set_intersects_impl(const S1Ty &S1, const S2Ty &S2) {
   for (const auto &E : S1)
@@ -165,13 +167,14 @@ bool set_intersects_impl(const S1Ty &S1, const S2Ty &S2) {
   return false;
 }
 
+} // namespace detail
+
 /// set_intersects(A, B) - Return true iff A ^ B is non empty
 template <class S1Ty, class S2Ty>
 bool set_intersects(const S1Ty &S1, const S2Ty &S2) {
   if (S1.size() < S2.size())
-    return set_intersects_impl(S1, S2);
-  else
-    return set_intersects_impl(S2, S1);
+    return detail::set_intersects_impl(S1, S2);
+  return detail::set_intersects_impl(S2, S1);
 }
 
 } // namespace llvm

--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -282,6 +282,12 @@ TEST(SetOperationsTest, SetIntersects) {
   Set2 = {5, 6, 7};
   EXPECT_FALSE(set_intersects(Set1, Set2));
   EXPECT_FALSE(set_intersects(Set2, Set1));
+
+  // Check that intersecting with a null set returns false.
+  Set1.clear();
+  EXPECT_FALSE(set_intersects(Set1, Set2));
+  EXPECT_FALSE(set_intersects(Set2, Set1));
+  EXPECT_FALSE(set_intersects(Set1, Set1));
 }
 
 } // namespace

--- a/llvm/unittests/ADT/SetOperationsTest.cpp
+++ b/llvm/unittests/ADT/SetOperationsTest.cpp
@@ -273,4 +273,15 @@ TEST(SetOperationsTest, SetIsSubset) {
   EXPECT_FALSE(set_is_subset(Set1, Set2));
 }
 
+TEST(SetOperationsTest, SetIntersects) {
+  std::set<int> Set1 = {1, 2, 3, 4};
+  std::set<int> Set2 = {3, 4, 5};
+  EXPECT_TRUE(set_intersects(Set1, Set2));
+  EXPECT_TRUE(set_intersects(Set2, Set1));
+
+  Set2 = {5, 6, 7};
+  EXPECT_FALSE(set_intersects(Set1, Set2));
+  EXPECT_FALSE(set_intersects(Set2, Set1));
+}
+
 } // namespace


### PR DESCRIPTION
Add a facility to check if there is any intersection between 2 sets.
This will be used in some follow on changes to MemProf.
