### PR TITLE
[llvm] DLLExport BinaryStreamError

### DIFF
--- a/llvm/include/llvm/Support/BinaryStreamError.h
+++ b/llvm/include/llvm/Support/BinaryStreamError.h
@@ -10,6 +10,7 @@
 #define LLVM_SUPPORT_BINARYSTREAMERROR_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <string>
@@ -24,7 +25,7 @@ enum class stream_error_code {
 };
 
 /// Base class for errors originating when parsing raw PDB files
-class BinaryStreamError : public ErrorInfo<BinaryStreamError> {
+class LLVM_ABI BinaryStreamError : public ErrorInfo<BinaryStreamError> {
 public:
   static char ID;
   explicit BinaryStreamError(stream_error_code C);


### PR DESCRIPTION
## Overview
Annotate the `llvm::BinaryStreamError` class so it is explicitly included in LLVM's public interface. When building LLVM as a Windows DLL, this annotation exports `BinaryStreamError`'s public methods from the DLL.

## Background
This change is required as part of the overall project to build LLVM as a Windows DLL described in #109483. Without this change, LLVM tools fail to link.

## Validation
Built LLVM with MSVC on Windows 11:
```
cmake -B build -S llvm -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_OPTIMIZED_TABLEGEN -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON
ninja -C build llvm-rc llvm-ar
```
Verified the annotated interface no longer appears in the list of unresolved external symbols.