### PR TITLE
[llvm] DLLExport OptTable and GenericOptTable

### DIFF
--- a/llvm/include/llvm/Option/OptTable.h
+++ b/llvm/include/llvm/Option/OptTable.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringTable.h"
 #include "llvm/Option/OptSpecifier.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/StringSaver.h"
 #include <cassert>
 #include <string>
@@ -50,7 +51,7 @@ public:
 /// be needed at runtime; the OptTable class maintains enough information to
 /// parse command lines without instantiating Options, while letting other
 /// parts of the driver still use Option instances where convenient.
-class OptTable {
+class LLVM_ABI OptTable {
 public:
   /// Entry for a single option instance in the option data table.
   struct Info {
@@ -423,7 +424,7 @@ private:
 };
 
 /// Specialization of OptTable
-class GenericOptTable : public OptTable {
+class LLVM_ABI GenericOptTable : public OptTable {
 protected:
   GenericOptTable(const StringTable &StrTable,
                   ArrayRef<StringTable::Offset> PrefixesTable,


### PR DESCRIPTION
## Overview
Annotate the `llvm::opt::OptTable` and `llvm::opt::GenericOptTable` classes so they are explicitly included in LLVM's public interface. When building LLVM as a Windows DLL, this annotation exports `OptTable`'s and `GenericOptTable`'s public methods from the DLL.

## Background
This change is required as part of the overall project to build LLVM as a Windows DLL described in #109483. Without this change, LLVM tools fail to link.

## Validation
Built LLVM with MSVC on Windows 11:
```
cmake -B build -S llvm -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_OPTIMIZED_TABLEGEN -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON
ninja -C build llvm-rc llvm-ar
```
Verified the annotated interface no longer appears in the list of unresolved external symbols.