### PR TITLE
[flang] Set compile definitions for flang-rt build on AIX

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -229,7 +229,7 @@ endif ()
 
 # Build with _XOPEN_SOURCE on AIX to avoid errors caused by _ALL_SOURCE.
 # We need to enable the large-file API as well.
-if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+if (UNIX AND CMAKE_SYSTEM_NAME MATCHES "AIX")
   add_compile_definitions(_XOPEN_SOURCE=700)
   add_compile_definitions(_LARGE_FILE_API)
 endif ()

--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -227,6 +227,12 @@ if (WIN32)
   find_compiler_rt_library(builtins FLANG_RT_BUILTINS_LIBRARY)
 endif ()
 
+# Build with _XOPEN_SOURCE on AIX to avoid errors caused by _ALL_SOURCE.
+# We need to enable the large-file API as well.
+if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+  add_compile_definitions(_XOPEN_SOURCE=700)
+  add_compile_definitions(_LARGE_FILE_API)
+endif ()
 
 # Check whether the compiler can undefine a macro using the "-U" flag.
 # Aternatively, we could use


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/commit/b55f7512a76f2358000139074c79d4c2521588de (PR https://github.com/llvm/llvm-project/pull/110217), the flang-rt build on AIX is missing `-D_LARGE_FILE_API -D_XOPEN_SOURCE=700` in compiling the source. This patch is to add the compile definitions.