### PR TITLE
[llvm] DLLExport dlltoolDriverMain and libDriverMain

### DIFF
--- a/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-dlltool/DlltoolDriver.h
@@ -14,10 +14,12 @@
 #ifndef LLVM_TOOLDRIVERS_LLVM_DLLTOOL_DLLTOOLDRIVER_H
 #define LLVM_TOOLDRIVERS_LLVM_DLLTOOL_DLLTOOLDRIVER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 template <typename T> class ArrayRef;
 
-int dlltoolDriverMain(ArrayRef<const char *> ArgsArr);
+LLVM_ABI int dlltoolDriverMain(ArrayRef<const char *> ArgsArr);
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -14,10 +14,12 @@
 #ifndef LLVM_TOOLDRIVERS_LLVM_LIB_LIBDRIVER_H
 #define LLVM_TOOLDRIVERS_LLVM_LIB_LIBDRIVER_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 template <typename T> class ArrayRef;
 
-int libDriverMain(ArrayRef<const char *> ARgs);
+LLVM_ABI int libDriverMain(ArrayRef<const char *> ARgs);
 
 }
 

--- a/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
+++ b/llvm/include/llvm/ToolDrivers/llvm-lib/LibDriver.h
@@ -20,7 +20,6 @@ namespace llvm {
 template <typename T> class ArrayRef;
 
 LLVM_ABI int libDriverMain(ArrayRef<const char *> ARgs);
-
 }
 
 #endif


### PR DESCRIPTION
## Overview
Annotate the `llvm::dlltoolDriverMain` and `llvm::libDriverMain` functions so they are explicitly included in LLVM's public interface. When building LLVM as a Windows DLL, this annotation exports them from the DLL.

## Background
This change is required as part of the overall project to build LLVM as a Windows DLL described in #109483. Without this change, LLVM tools fail to link.

## Validation
Built LLVM with MSVC on Windows 11:
```
cmake -B build -S llvm -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_OPTIMIZED_TABLEGEN -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON
ninja -C build llvm-rc llvm-ar
```
Verified the annotated interface no longer appears in the list of unresolved external symbols.