### PR TITLE
[llvm] DLLExport identify_magic

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Magic.h
+++ b/llvm/include/llvm/BinaryFormat/Magic.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_BINARYFORMAT_MAGIC_H
 #define LLVM_BINARYFORMAT_MAGIC_H
 
+#include "llvm/Support/Compiler.h"
+
 #include <system_error>
 
 namespace llvm {
@@ -72,7 +74,7 @@ private:
 };
 
 /// Identify the type of a binary file based on how magical it is.
-file_magic identify_magic(StringRef magic);
+LLVM_ABI file_magic identify_magic(StringRef magic);
 
 /// Get and identify \a path's type based on its content.
 ///
@@ -80,7 +82,7 @@ file_magic identify_magic(StringRef magic);
 /// @param result Set to the type of file, or file_magic::unknown.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code identify_magic(const Twine &path, file_magic &result);
+LLVM_ABI std::error_code identify_magic(const Twine &path, file_magic &result);
 } // namespace llvm
 
 #endif


### PR DESCRIPTION
## Overview
Annotate both overloads of the `llvm::identify_magic` function so they are explicitly included in LLVM's public interface. When building LLVM as a Windows DLL, this annotation exports them from the DLL.

## Background
This change is required as part of the overall project to build LLVM as a Windows DLL described in #109483. Without this change, LLVM tools fail to link.

## Validation
Built LLVM with MSVC on Windows 11:
```
cmake -B build -S llvm -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_OPTIMIZED_TABLEGEN -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON
ninja -C build llvm-rc llvm-ar
```
Verified the annotated interface no longer appears in the list of unresolved external symbols.