### PR TITLE
[llvm] DLLExport json::Value

### DIFF
--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -285,7 +285,7 @@ inline bool operator!=(const Array &L, const Array &R) { return !(L == R); }
 /// And parsed:
 ///   Expected<Value> E = json::parse("[1, 2, null]");
 ///   assert(E && E->kind() == Value::Array);
-class Value {
+class LLVM_ABI Value {
 public:
   enum Kind {
     Null,


### PR DESCRIPTION
## Overview
Annotate the `llvm::json::Value` class so it is explicitly included in LLVM's public interface. When building LLVM as a Windows DLL, this annotation exports `Value`'s public methods from the DLL.

## Background
This change is required as part of the overall project to build LLVM as a Windows DLL described in #109483. Without this change, LLVM tools fail to link.

## Validation
Built LLVM with MSVC on Windows 11:
```
cmake -B build -S llvm -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_OPTIMIZED_TABLEGEN -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON
ninja -C build llvm-rc llvm-ar
```
Verified the annotated interface no longer appears in the list of unresolved external symbols.