### PR TITLE
IR, CodeGen: Add command line flags for dumping instruction addresses and debug locations.

### DIFF
--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -63,6 +63,10 @@
 
 using namespace llvm;
 
+static cl::opt<bool>
+    PrintMIAddrs("print-mi-addrs", cl::Hidden,
+                 cl::desc("Print addresses of MachineInstrs when dumping"));
+
 static const MachineFunction *getMFIfAvailable(const MachineInstr &MI) {
   if (const MachineBasicBlock *MBB = MI.getParent())
     if (const MachineFunction *MF = MBB->getParent())
@@ -2058,6 +2062,9 @@ void MachineInstr::print(raw_ostream &OS, ModuleSlotTracker &MST,
     }
   }
   // TODO: DBG_LABEL
+
+  if (PrintMIAddrs)
+    OS << " ; " << this;
 
   if (AddNewLine)
     OS << '\n';

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -88,6 +88,14 @@
 
 using namespace llvm;
 
+static cl::opt<bool>
+    PrintInstAddrs("print-inst-addrs", cl::Hidden,
+                   cl::desc("Print addresses of instructions when dumping"));
+
+static cl::opt<bool> PrintInstDebugLocs(
+    "print-inst-debug-locs", cl::Hidden,
+    cl::desc("Pretty print debug locations of instructions when dumping"));
+
 // Make virtual table appear in this compilation unit.
 AssemblyAnnotationWriter::~AssemblyAnnotationWriter() = default;
 
@@ -4236,6 +4244,18 @@ void AssemblyWriter::printInfoComment(const Value &V) {
   if (AnnotationWriter) {
     AnnotationWriter->printInfoComment(V, Out);
   }
+
+  if (PrintInstDebugLocs) {
+    if (auto *I = dyn_cast<Instruction>(&V)) {
+      if (I->getDebugLoc()) {
+        Out << " ; ";
+        I->getDebugLoc().print(Out);
+      }
+    }
+  }
+
+  if (PrintInstAddrs)
+    Out << " ; " << &V;
 }
 
 static void maybePrintCallAddrSpace(const Value *Operand, const Instruction *I,

--- a/llvm/test/Other/print-inst-addrs.ll
+++ b/llvm/test/Other/print-inst-addrs.ll
@@ -1,0 +1,6 @@
+; RUN: opt -S -print-inst-addrs %s | FileCheck %s
+
+define void @foo() {
+  ; CHECK: ret void ; 0x
+  ret void
+}

--- a/llvm/test/Other/print-inst-debug-locs.ll
+++ b/llvm/test/Other/print-inst-debug-locs.ll
@@ -1,0 +1,20 @@
+; RUN: opt -S -print-inst-debug-locs < %s | FileCheck %s
+
+define weak i32 @foo(i32 %a, i32 %b) !dbg !3 {
+entry:
+  ; CHECK: call {{.*}} ; foo.c:52
+  %sum = call i32 @fastadd(i32 %a, i32 %b), !dbg !DILocation(line: 52, scope: !3)
+  ; CHECK: ret {{.*}} ; foo.c:53
+  ret i32 %sum, !dbg !DILocation(line: 53, scope: !3)
+}
+
+declare i32 @fastadd(i32, i32)
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+
+!llvm.dbg.cu = !{!1}
+!1 = distinct !DICompileUnit(language: DW_LANG_C99, file: !2, emissionKind: FullDebug)
+!2 = !DIFile(filename: "foo.c", directory: "/path/to/dir")
+!3 = distinct !DISubprogram(file: !2, scope: !2, line: 51, name: "foo", type: !4, unit: !1)
+!4 = !DISubroutineType(types: !{})

--- a/llvm/test/Other/print-mi-addrs.ll
+++ b/llvm/test/Other/print-mi-addrs.ll
@@ -1,0 +1,11 @@
+; RUN: llc -print-after=slotindexes -print-mi-addrs < %s 2>&1 | FileCheck %s
+; REQUIRES: default_triple
+
+; CHECK: IR Dump {{.*}}
+; CHECK: # Machine code for function foo{{.*}}
+
+define void @foo() {
+  ; CHECK: ; 0x
+  ret void
+}
+


### PR DESCRIPTION
As previously discussed [1], it is sometimes useful to be able to see
instruction addresses and debug locations as part of IR dumps. The
same applies to MachineInstrs which already dump debug locations but
not addresses. Therefore add some flags that can be used to enable
dumping of this information.

[1] https://discourse.llvm.org/t/small-improvement-to-llvm-debugging-experience/79914
