### PR TITLE
[lld,CMake] Include Version.inc when LLVM_DISTRIBUTION_COMPONENTS contains lld-headers

### DIFF
--- a/lld/CMakeLists.txt
+++ b/lld/CMakeLists.txt
@@ -207,6 +207,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     COMPONENT lld-headers
     FILES_MATCHING
     PATTERN "*.h"
+    PATTERN "*.inc"
     )
 
   if (NOT LLVM_ENABLE_IDE)


### PR DESCRIPTION
Without this inc file `getLLDVersion` cannot be called; see https://github.com/llvm/llvm-project/blob/main/lld/include/lld/Common/Version.h#L16.

Fixes incomplete solution introduced by https://github.com/llvm/llvm-project/pull/127123.