### PR TITLE
[CodeGen] Remove static member function Register::virtReg2Index. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -60,13 +60,6 @@ public:
     return Reg & MCRegister::VirtualRegFlag;
   }
 
-  /// Convert a virtual register number to a 0-based index.
-  /// The first virtual register in a function will get the index 0.
-  static unsigned virtReg2Index(Register Reg) {
-    assert(Reg.isVirtual() && "Not a virtual register");
-    return Reg.id() & ~MCRegister::VirtualRegFlag;
-  }
-
   /// Convert a 0-based index to a virtual register number.
   /// This is the inverse operation of VirtReg2IndexFunctor below.
   static Register index2VirtReg(unsigned Index) {
@@ -84,7 +77,10 @@ public:
 
   /// Convert a virtual register number to a 0-based index. The first virtual
   /// register in a function will get the index 0.
-  unsigned virtRegIndex() const { return virtReg2Index(Reg); }
+  unsigned virtRegIndex() const {
+    assert(isVirtual() && "Not a virtual register");
+    return Reg & ~MCRegister::VirtualRegFlag;
+  }
 
   /// Compute the frame index from a register value representing a stack slot.
   int stackSlotIndex() const {

--- a/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
@@ -59,7 +59,7 @@ namespace llvm {
       : VirtReg(VReg), LaneMask(LaneMask), SU(SU) {}
 
     unsigned getSparseSetIndex() const {
-      return Register::virtReg2Index(VirtReg);
+      return Register(VirtReg).virtRegIndex();
     }
   };
 

--- a/llvm/lib/CodeGen/DetectDeadLanes.cpp
+++ b/llvm/lib/CodeGen/DetectDeadLanes.cpp
@@ -276,7 +276,7 @@ LaneBitmask DeadLaneDetector::determineInitialDefinedLanes(unsigned Reg) {
   if (lowersToCopies(DefMI)) {
     // Start optimisatically with no used or defined lanes for copy
     // instructions. The following dataflow analysis will add more bits.
-    unsigned RegIdx = Register::virtReg2Index(Reg);
+    unsigned RegIdx = Register(Reg).virtRegIndex();
     DefinedByCopy.set(RegIdx);
     PutInWorklist(RegIdx);
 

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -161,7 +161,7 @@ Printable printRegUnit(unsigned Unit, const TargetRegisterInfo *TRI) {
 Printable printVRegOrUnit(unsigned Unit, const TargetRegisterInfo *TRI) {
   return Printable([Unit, TRI](raw_ostream &OS) {
     if (Register::isVirtualRegister(Unit)) {
-      OS << '%' << Register::virtReg2Index(Unit);
+      OS << '%' << Register(Unit).virtRegIndex();
     } else {
       OS << printRegUnit(Unit, TRI);
     }

--- a/llvm/lib/Target/Hexagon/BitTracker.cpp
+++ b/llvm/lib/Target/Hexagon/BitTracker.cpp
@@ -84,7 +84,7 @@ namespace {
 
   raw_ostream &operator<< (raw_ostream &OS, const printv &PV) {
     if (PV.R)
-      OS << 'v' << Register::virtReg2Index(PV.R);
+      OS << 'v' << Register(PV.R).virtRegIndex();
     else
       OS << 's';
     return OS;

--- a/llvm/lib/Target/Hexagon/HexagonBitSimplify.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonBitSimplify.cpp
@@ -176,7 +176,7 @@ namespace {
     }
 
     static inline unsigned v2x(unsigned v) {
-      return Register::virtReg2Index(v);
+      return Register(v).virtRegIndex();
     }
 
     static inline unsigned x2v(unsigned x) {

--- a/llvm/lib/Target/Hexagon/HexagonGenInsert.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenInsert.cpp
@@ -167,7 +167,7 @@ namespace {
     }
 
     static inline unsigned v2x(unsigned v) {
-      return Register::virtReg2Index(v);
+      return Register(v).virtRegIndex();
     }
 
     static inline unsigned x2v(unsigned x) {
@@ -271,7 +271,7 @@ namespace {
     CellMapShadow(const BitTracker &T) : BT(T) {}
 
     const BitTracker::RegisterCell &lookup(unsigned VR) {
-      unsigned RInd = Register::virtReg2Index(VR);
+      unsigned RInd = Register(VR).virtRegIndex();
       // Grow the vector to at least 32 elements.
       if (RInd >= CVect.size())
         CVect.resize(std::max(RInd+16, 32U), nullptr);
@@ -1578,7 +1578,7 @@ bool HexagonGenInsert::runOnMachineFunction(MachineFunction &MF) {
 
     IterListType Out;
     for (IFMapType::iterator I = IFMap.begin(), E = IFMap.end(); I != E; ++I) {
-      unsigned Idx = Register::virtReg2Index(I->first);
+      unsigned Idx = Register(I->first).virtRegIndex();
       if (Idx >= Cutoff)
         Out.push_back(I);
     }

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -336,7 +336,7 @@ void SPIRVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   if (OpNo < MI->getNumOperands()) {
     const MCOperand &Op = MI->getOperand(OpNo);
     if (Op.isReg())
-      O << '%' << (Register::virtReg2Index(Op.getReg()) + 1);
+      O << '%' << (Register(Op.getReg()).virtRegIndex() + 1);
     else if (Op.isImm())
       O << formatImm((int64_t)Op.getImm());
     else if (Op.isDFPImm())

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCCodeEmitter.cpp
@@ -77,7 +77,7 @@ static void emitOperand(const MCOperand &Op, SmallVectorImpl<char> &CB) {
   if (Op.isReg()) {
     // Emit the id index starting at 1 (0 is an invalid index).
     support::endian::write<uint32_t>(
-        CB, Register::virtReg2Index(Op.getReg()) + 1, llvm::endianness::little);
+        CB, Register(Op.getReg()).virtRegIndex() + 1, llvm::endianness::little);
   } else if (Op.isImm()) {
     support::endian::write(CB, static_cast<uint32_t>(Op.getImm()),
                            llvm::endianness::little);

--- a/llvm/lib/Target/WebAssembly/WebAssemblyExplicitLocals.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyExplicitLocals.cpp
@@ -65,7 +65,7 @@ static void checkFrameBase(WebAssemblyFunctionInfo &MFI, unsigned Local,
   if (MFI.isFrameBaseVirtual() && Reg == MFI.getFrameBaseVreg()) {
     LLVM_DEBUG({
       dbgs() << "Allocating local " << Local << "for VReg "
-             << Register::virtReg2Index(Reg) << '\n';
+             << Register(Reg).virtRegIndex() << '\n';
     });
     MFI.setFrameBaseLocal(Local);
   }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyMachineFunctionInfo.h
@@ -121,18 +121,18 @@ public:
 
   void stackifyVReg(MachineRegisterInfo &MRI, unsigned VReg) {
     assert(MRI.getUniqueVRegDef(VReg));
-    auto I = Register::virtReg2Index(VReg);
+    auto I = Register(VReg).virtRegIndex();
     if (I >= VRegStackified.size())
       VRegStackified.resize(I + 1);
     VRegStackified.set(I);
   }
   void unstackifyVReg(unsigned VReg) {
-    auto I = Register::virtReg2Index(VReg);
+    auto I = Register(VReg).virtRegIndex();
     if (I < VRegStackified.size())
       VRegStackified.reset(I);
   }
   bool isVRegStackified(unsigned VReg) const {
-    auto I = Register::virtReg2Index(VReg);
+    auto I = Register(VReg).virtRegIndex();
     if (I >= VRegStackified.size())
       return false;
     return VRegStackified.test(I);
@@ -141,12 +141,12 @@ public:
   void initWARegs(MachineRegisterInfo &MRI);
   void setWAReg(unsigned VReg, unsigned WAReg) {
     assert(WAReg != WebAssembly::UnusedReg);
-    auto I = Register::virtReg2Index(VReg);
+    auto I = Register(VReg).virtRegIndex();
     assert(I < WARegs.size());
     WARegs[I] = WAReg;
   }
   unsigned getWAReg(unsigned VReg) const {
-    auto I = Register::virtReg2Index(VReg);
+    auto I = Register(VReg).virtRegIndex();
     assert(I < WARegs.size());
     return WARegs[I];
   }

--- a/llvm/lib/Target/WebAssembly/WebAssemblyReplacePhysRegs.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyReplacePhysRegs.cpp
@@ -93,7 +93,7 @@ bool WebAssemblyReplacePhysRegs::runOnMachineFunction(MachineFunction &MF) {
             FI->setFrameBaseVreg(VReg);
             LLVM_DEBUG({
               dbgs() << "replacing preg " << PReg << " with " << VReg << " ("
-                     << Register::virtReg2Index(VReg) << ")\n";
+                     << Register(VReg).virtRegIndex() << ")\n";
             });
           }
         }


### PR DESCRIPTION
Use the nonstatic member instead.

I'm pretty sure the code in SPRIV is a layering violation. MC layer files are using a CodeGen header.