### PR TITLE
[CodeGen] Remove static member function Register::isVirtualRegister. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -114,7 +114,7 @@ struct RegisterRef {
     return Register::isPhysicalRegister(Id);
   }
   static constexpr bool isUnitId(unsigned Id) {
-    return Register::isVirtualRegister(Id);
+    return Register(Id).isVirtual();
   }
   static constexpr bool isMaskId(unsigned Id) { return Register(Id).isStack(); }
 

--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -54,12 +54,6 @@ public:
     return MCRegister::isPhysicalRegister(Reg);
   }
 
-  /// Return true if the specified register number is in
-  /// the virtual register namespace.
-  static constexpr bool isVirtualRegister(unsigned Reg) {
-    return Reg & MCRegister::VirtualRegFlag;
-  }
-
   /// Convert a 0-based index to a virtual register number.
   /// This is the inverse operation of VirtReg2IndexFunctor below.
   static Register index2VirtReg(unsigned Index) {
@@ -69,7 +63,7 @@ public:
 
   /// Return true if the specified register number is in the virtual register
   /// namespace.
-  constexpr bool isVirtual() const { return isVirtualRegister(Reg); }
+  constexpr bool isVirtual() const { return Reg & MCRegister::VirtualRegFlag; }
 
   /// Return true if the specified register number is in the physical register
   /// namespace.
@@ -156,14 +150,14 @@ class VirtRegOrUnit {
 
 public:
   constexpr explicit VirtRegOrUnit(MCRegUnit Unit) : VRegOrUnit(Unit) {
-    assert(!Register::isVirtualRegister(VRegOrUnit));
+    assert(!Register(VRegOrUnit).isVirtual());
   }
   constexpr explicit VirtRegOrUnit(Register Reg) : VRegOrUnit(Reg.id()) {
     assert(Reg.isVirtual());
   }
 
   constexpr bool isVirtualReg() const {
-    return Register::isVirtualRegister(VRegOrUnit);
+    return Register(VRegOrUnit).isVirtual();
   }
 
   constexpr MCRegUnit asMCRegUnit() const {

--- a/llvm/lib/CodeGen/EarlyIfConversion.cpp
+++ b/llvm/lib/CodeGen/EarlyIfConversion.cpp
@@ -522,8 +522,8 @@ bool SSAIfConv::canConvertIf(MachineBasicBlock *MBB, bool Predicate) {
       if (PI.PHI->getOperand(i+1).getMBB() == FPred)
         PI.FReg = PI.PHI->getOperand(i).getReg();
     }
-    assert(Register::isVirtualRegister(PI.TReg) && "Bad PHI");
-    assert(Register::isVirtualRegister(PI.FReg) && "Bad PHI");
+    assert(Register(PI.TReg).isVirtual() && "Bad PHI");
+    assert(Register(PI.FReg).isVirtual() && "Bad PHI");
 
     // Get target information.
     if (!TII->canInsertSelect(*Head, Cond, PI.PHI->getOperand(0).getReg(),

--- a/llvm/lib/CodeGen/LiveInterval.cpp
+++ b/llvm/lib/CodeGen/LiveInterval.cpp
@@ -876,7 +876,7 @@ static void stripValuesNotDefiningMask(unsigned Reg, LiveInterval::SubRange &SR,
                                        unsigned ComposeSubRegIdx) {
   // Phys reg should not be tracked at subreg level.
   // Same for noreg (Reg == 0).
-  if (!Register::isVirtualRegister(Reg) || !Reg)
+  if (!Register(Reg).isVirtual() || !Reg)
     return;
   // Remove the values that don't define those lanes.
   SmallVector<VNInfo *, 8> ToBeRemoved;

--- a/llvm/lib/CodeGen/MIRVRegNamerUtils.cpp
+++ b/llvm/lib/CodeGen/MIRVRegNamerUtils.cpp
@@ -137,7 +137,7 @@ std::string VRegRenamer::getInstructionOpcodeHash(MachineInstr &MI) {
 }
 
 unsigned VRegRenamer::createVirtualRegister(unsigned VReg) {
-  assert(Register::isVirtualRegister(VReg) && "Expected Virtual Registers");
+  assert(Register(VReg).isVirtual() && "Expected Virtual Registers");
   std::string Name = getInstructionOpcodeHash(*MRI.getVRegDef(VReg));
   return createVirtualRegisterWithLowerName(VReg, Name);
 }

--- a/llvm/lib/CodeGen/MachineTraceMetrics.cpp
+++ b/llvm/lib/CodeGen/MachineTraceMetrics.cpp
@@ -682,7 +682,7 @@ struct DataDep {
   /// Create a DataDep from an SSA form virtual register.
   DataDep(const MachineRegisterInfo *MRI, unsigned VirtReg, unsigned UseOp)
     : UseOp(UseOp) {
-    assert(Register::isVirtualRegister(VirtReg));
+    assert(Register(VirtReg).isVirtual());
     MachineOperand *DefMO = MRI->getOneDef(VirtReg);
     assert(DefMO && "Register does not have unique def");
     DefMI = DefMO->getParent();

--- a/llvm/lib/CodeGen/RegisterPressure.cpp
+++ b/llvm/lib/CodeGen/RegisterPressure.cpp
@@ -231,7 +231,7 @@ void LiveRegSet::clear() {
 }
 
 static const LiveRange *getLiveRange(const LiveIntervals &LIS, unsigned Reg) {
-  if (Register::isVirtualRegister(Reg))
+  if (Register(Reg).isVirtual())
     return &LIS.getInterval(Reg);
   return LIS.getCachedRegUnit(Reg);
 }

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -2229,8 +2229,7 @@ Register FastISel::fastEmitInst_i(unsigned MachineInstOpcode,
 Register FastISel::fastEmitInst_extractsubreg(MVT RetVT, unsigned Op0,
                                               uint32_t Idx) {
   Register ResultReg = createResultReg(TLI.getRegClassFor(RetVT));
-  assert(Register::isVirtualRegister(Op0) &&
-         "Cannot yet extract from physregs");
+  assert(Register(Op0).isVirtual() && "Cannot yet extract from physregs");
   const TargetRegisterClass *RC = MRI.getRegClass(Op0);
   MRI.constrainRegClass(Op0, TRI.getSubClassWithSubReg(RC, Idx));
   BuildMI(*FuncInfo.MBB, FuncInfo.InsertPt, MIMD, TII.get(TargetOpcode::COPY),

--- a/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/ScheduleDAGSDNodes.cpp
@@ -116,11 +116,11 @@ static void CheckForPhysRegDependency(SDNode *Def, SDNode *User, unsigned Op,
   if (Op != 2 || User->getOpcode() != ISD::CopyToReg)
     return;
 
-  unsigned Reg = cast<RegisterSDNode>(User->getOperand(1))->getReg();
+  Register Reg = cast<RegisterSDNode>(User->getOperand(1))->getReg();
   if (TLI.checkForPhysRegDependency(Def, User, Op, TRI, TII, PhysReg, Cost))
     return;
 
-  if (Register::isVirtualRegister(Reg))
+  if (Reg.isVirtual())
     return;
 
   unsigned ResNo = User->getOperand(2).getResNo();
@@ -664,8 +664,8 @@ void ScheduleDAGSDNodes::computeOperandLatency(SDNode *Def, SDNode *Use,
       TII->getOperandLatency(InstrItins, Def, DefIdx, Use, OpIdx);
   if (Latency > 1U && Use->getOpcode() == ISD::CopyToReg &&
       !BB->succ_empty()) {
-    unsigned Reg = cast<RegisterSDNode>(Use->getOperand(1))->getReg();
-    if (Register::isVirtualRegister(Reg))
+    Register Reg = cast<RegisterSDNode>(Use->getOperand(1))->getReg();
+    if (Reg.isVirtual())
       // This copy is a liveout value. It is likely coalesced, so reduce the
       // latency so not to penalize the def.
       // FIXME: need target specific adjustment here?

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -908,8 +908,7 @@ SDValue RegsForValue::getCopyFromRegs(SelectionDAG &DAG,
 
       // If the source register was virtual and if we know something about it,
       // add an assert node.
-      if (!Register::isVirtualRegister(Regs[Part + i]) ||
-          !RegisterVT.isInteger())
+      if (!Regs[Part + i].isVirtual() || !RegisterVT.isInteger())
         continue;
 
       const FunctionLoweringInfo::LiveOutInfo *LOI =
@@ -1023,7 +1022,7 @@ void RegsForValue::AddInlineAsmOperands(InlineAsm::Kind Code, bool HasMatching,
   InlineAsm::Flag Flag(Code, Regs.size());
   if (HasMatching)
     Flag.setMatchingOp(MatchingIdx);
-  else if (!Regs.empty() && Register::isVirtualRegister(Regs.front())) {
+  else if (!Regs.empty() && Regs.front().isVirtual()) {
     // Put the register class of the virtual registers in the flag word.  That
     // way, later passes can recompute register class constraints for inline
     // assembly as well as normal instructions.

--- a/llvm/lib/CodeGen/TargetRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/TargetRegisterInfo.cpp
@@ -160,7 +160,7 @@ Printable printRegUnit(unsigned Unit, const TargetRegisterInfo *TRI) {
 
 Printable printVRegOrUnit(unsigned Unit, const TargetRegisterInfo *TRI) {
   return Printable([Unit, TRI](raw_ostream &OS) {
-    if (Register::isVirtualRegister(Unit)) {
+    if (Register(Unit).isVirtual()) {
       OS << '%' << Register(Unit).virtRegIndex();
     } else {
       OS << printRegUnit(Unit, TRI);

--- a/llvm/lib/Target/AArch64/AArch64AdvSIMDScalarPass.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AdvSIMDScalarPass.cpp
@@ -105,14 +105,14 @@ static bool isGPR64(unsigned Reg, unsigned SubReg,
                     const MachineRegisterInfo *MRI) {
   if (SubReg)
     return false;
-  if (Register::isVirtualRegister(Reg))
+  if (Register(Reg).isVirtual())
     return MRI->getRegClass(Reg)->hasSuperClassEq(&AArch64::GPR64RegClass);
   return AArch64::GPR64RegClass.contains(Reg);
 }
 
 static bool isFPR64(unsigned Reg, unsigned SubReg,
                     const MachineRegisterInfo *MRI) {
-  if (Register::isVirtualRegister(Reg))
+  if (Register(Reg).isVirtual())
     return (MRI->getRegClass(Reg)->hasSuperClassEq(&AArch64::FPR64RegClass) &&
             SubReg == 0) ||
            (MRI->getRegClass(Reg)->hasSuperClassEq(&AArch64::FPR128RegClass) &&

--- a/llvm/lib/Target/AArch64/AArch64ConditionalCompares.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionalCompares.cpp
@@ -258,7 +258,7 @@ bool SSACCmpConv::isDeadDef(unsigned DstReg) {
   // Writes to the zero register are dead.
   if (DstReg == AArch64::WZR || DstReg == AArch64::XZR)
     return true;
-  if (!Register::isVirtualRegister(DstReg))
+  if (!Register(DstReg).isVirtual())
     return false;
   // A virtual register def without any uses will be marked dead later, and
   // eventually replaced by the zero register.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -677,7 +677,7 @@ unsigned AArch64InstrInfo::insertBranch(
 
 // Find the original register that VReg is copied from.
 static unsigned removeCopies(const MachineRegisterInfo &MRI, unsigned VReg) {
-  while (Register::isVirtualRegister(VReg)) {
+  while (Register(VReg).isVirtual()) {
     const MachineInstr *DefMI = MRI.getVRegDef(VReg);
     if (!DefMI->isFullCopy())
       return VReg;
@@ -692,7 +692,7 @@ static unsigned removeCopies(const MachineRegisterInfo &MRI, unsigned VReg) {
 static unsigned canFoldIntoCSel(const MachineRegisterInfo &MRI, unsigned VReg,
                                 unsigned *NewVReg = nullptr) {
   VReg = removeCopies(MRI, VReg);
-  if (!Register::isVirtualRegister(VReg))
+  if (!Register(VReg).isVirtual())
     return 0;
 
   bool Is64Bit = AArch64::GPR64allRegClass.hasSubClassEq(MRI.getRegClass(VReg));
@@ -6121,9 +6121,9 @@ MachineInstr *AArch64InstrInfo::foldMemoryOperandImpl(
     Register SrcReg = SrcMO.getReg();
     // This is slightly expensive to compute for physical regs since
     // getMinimalPhysRegClass is slow.
-    auto getRegClass = [&](unsigned Reg) {
-      return Register::isVirtualRegister(Reg) ? MRI.getRegClass(Reg)
-                                              : TRI.getMinimalPhysRegClass(Reg);
+    auto getRegClass = [&](Register Reg) {
+      return Reg.isVirtual() ? MRI.getRegClass(Reg)
+                             : TRI.getMinimalPhysRegClass(Reg);
     };
 
     if (DstMO.getSubReg() == 0 && SrcMO.getSubReg() == 0) {
@@ -7456,7 +7456,7 @@ static MachineInstr *genMaddR(MachineFunction &MF, MachineRegisterInfo &MRI,
     MRI.constrainRegClass(SrcReg0, RC);
   if (SrcReg1.isVirtual())
     MRI.constrainRegClass(SrcReg1, RC);
-  if (Register::isVirtualRegister(VR))
+  if (Register(VR).isVirtual())
     MRI.constrainRegClass(VR, RC);
 
   MachineInstrBuilder MIB =

--- a/llvm/lib/Target/ARC/ARCOptAddrMode.cpp
+++ b/llvm/lib/Target/ARC/ARCOptAddrMode.cpp
@@ -151,7 +151,7 @@ static bool dominatesAllUsesOf(const MachineInstr *MI, unsigned VReg,
                                MachineDominatorTree *MDT,
                                MachineRegisterInfo *MRI) {
 
-  assert(Register::isVirtualRegister(VReg) && "Expected virtual register!");
+  assert(Register(VReg).isVirtual() && "Expected virtual register!");
 
   for (const MachineOperand &Use : MRI->use_nodbg_operands(VReg)) {
     const MachineInstr *User = Use.getParent();
@@ -216,7 +216,7 @@ MachineInstr *ARCOptAddrMode::tryToCombine(MachineInstr &Ldst) {
   }
 
   Register B = Base.getReg();
-  if (!Register::isVirtualRegister(B)) {
+  if (!B.isVirtual())
     LLVM_DEBUG(dbgs() << "[ABAW] Base is not VReg\n");
     return nullptr;
   }

--- a/llvm/lib/Target/ARM/A15SDOptimizer.cpp
+++ b/llvm/lib/Target/ARM/A15SDOptimizer.cpp
@@ -152,7 +152,7 @@ unsigned A15SDOptimizer::getDPRLaneFromSPR(unsigned SReg) {
 // Get the subreg type that is most likely to be coalesced
 // for an SPR register that will be used in VDUP32d pseudo.
 unsigned A15SDOptimizer::getPrefSPRLane(unsigned SReg) {
-  if (!Register::isVirtualRegister(SReg))
+  if (!Register(SReg).isVirtual())
     return getDPRLaneFromSPR(SReg);
 
   MachineInstr *MI = MRI->getVRegDef(SReg);
@@ -166,7 +166,7 @@ unsigned A15SDOptimizer::getPrefSPRLane(unsigned SReg) {
     SReg = MI->getOperand(1).getReg();
   }
 
-  if (Register::isVirtualRegister(SReg)) {
+  if (Register(SReg).isVirtual()) {
     if (MO->getSubReg() == ARM::ssub_1) return ARM::ssub_1;
     return ARM::ssub_0;
   }
@@ -598,7 +598,7 @@ bool A15SDOptimizer::runOnInstruction(MachineInstr *MI) {
     // we can end up with multiple defs of this DPR.
 
     SmallVector<MachineInstr *, 8> DefSrcs;
-    if (!Register::isVirtualRegister(I))
+    if (!Register(I).isVirtual())
       continue;
     MachineInstr *Def = MRI->getVRegDef(I);
     if (!Def)

--- a/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
+++ b/llvm/lib/Target/ARM/ARMLatencyMutations.cpp
@@ -756,7 +756,7 @@ signed M85Overrides::modifyMixedWidthFP(const MachineInstr *SrcMI,
       !II->producesQP(SrcMI->getOpcode()))
     return 0;
 
-  if (Register::isVirtualRegister(RegID)) {
+  if (Register(RegID).isVirtual()) {
     if (II->producesSP(SrcMI->getOpcode()) &&
         II->consumesDP(DstMI->getOpcode())) {
       for (auto &OP : SrcMI->operands())

--- a/llvm/lib/Target/AVR/AVRISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AVR/AVRISelDAGToDAG.cpp
@@ -253,15 +253,15 @@ bool AVRDAGToDAGISel::SelectInlineAsmMemoryOperand(
     SDValue ImmOp = Op->getOperand(1);
     ConstantSDNode *ImmNode = dyn_cast<ConstantSDNode>(ImmOp);
 
-    unsigned Reg;
+    Register Reg;
     bool CanHandleRegImmOpt = ImmNode && ImmNode->getAPIntValue().ult(64);
 
     if (CopyFromRegOp->getOpcode() == ISD::CopyFromReg) {
       RegisterSDNode *RegNode =
           cast<RegisterSDNode>(CopyFromRegOp->getOperand(1));
       Reg = RegNode->getReg();
-      CanHandleRegImmOpt &= (Register::isVirtualRegister(Reg) ||
-                             AVR::PTRDISPREGSRegClass.contains(Reg));
+      CanHandleRegImmOpt &=
+          (Reg.isVirtual() || AVR::PTRDISPREGSRegClass.contains(Reg));
     } else {
       CanHandleRegImmOpt = false;
     }

--- a/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
@@ -139,8 +139,7 @@ void HexagonCopyHoisting::addMItoCopyList(MachineInstr *MI) {
   Register DstReg = MI->getOperand(0).getReg();
   Register SrcReg = MI->getOperand(1).getReg();
 
-  if (!Register::isVirtualRegister(DstReg) ||
-      !Register::isVirtualRegister(SrcReg) ||
+  if (!DstReg.isVirtual() || !SrcReg.isVirtual() ||
       MRI->getRegClass(DstReg) != &Hexagon::IntRegsRegClass ||
       MRI->getRegClass(SrcReg) != &Hexagon::IntRegsRegClass)
     return;

--- a/llvm/lib/Target/M68k/M68kISelLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kISelLowering.cpp
@@ -322,7 +322,7 @@ static bool MatchingStackOffset(SDValue Arg, unsigned Offset,
   int FI = INT_MAX;
   if (Arg.getOpcode() == ISD::CopyFromReg) {
     Register VR = cast<RegisterSDNode>(Arg.getOperand(1))->getReg();
-    if (!Register::isVirtualRegister(VR))
+    if (!VR.isVirtual())
       return false;
     MachineInstr *Def = MRI->getVRegDef(VR);
     if (!Def)

--- a/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXAsmPrinter.cpp
@@ -205,7 +205,7 @@ MCOperand NVPTXAsmPrinter::lowerOperand(const MachineOperand &MO) {
 }
 
 unsigned NVPTXAsmPrinter::encodeVirtualRegister(unsigned Reg) {
-  if (Register::isVirtualRegister(Reg)) {
+  if (Register(Reg).isVirtual()) {
     const TargetRegisterClass *RC = MRI->getRegClass(Reg);
 
     DenseMap<unsigned, unsigned> &RegMap = VRegMapping[RC];

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -5131,7 +5131,7 @@ static bool isOpZeroOfSubwordPreincLoad(int Opcode) {
 // This function checks for sign extension from 32 bits to 64 bits.
 static bool definedBySignExtendingOp(const unsigned Reg,
                                      const MachineRegisterInfo *MRI) {
-  if (!Register::isVirtualRegister(Reg))
+  if (!Register(Reg).isVirtual())
     return false;
 
   MachineInstr *MI = MRI->getVRegDef(Reg);
@@ -5178,7 +5178,7 @@ static bool definedBySignExtendingOp(const unsigned Reg,
 // in the higher 32 bits then this function will return true.
 static bool definedByZeroExtendingOp(const unsigned Reg,
                                      const MachineRegisterInfo *MRI) {
-  if (!Register::isVirtualRegister(Reg))
+  if (!Register(Reg).isVirtual())
     return false;
 
   MachineInstr *MI = MRI->getVRegDef(Reg);
@@ -5463,7 +5463,7 @@ std::pair<bool, bool>
 PPCInstrInfo::isSignOrZeroExtended(const unsigned Reg,
                                    const unsigned BinOpDepth,
                                    const MachineRegisterInfo *MRI) const {
-  if (!Register::isVirtualRegister(Reg))
+  if (!Register(Reg).isVirtual())
     return std::pair<bool, bool>(false, false);
 
   MachineInstr *MI = MRI->getVRegDef(Reg);

--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -1482,7 +1482,7 @@ static unsigned getSrcVReg(unsigned Reg, MachineBasicBlock *BB1,
     }
     else if (Inst->isFullCopy())
       NextReg = Inst->getOperand(1).getReg();
-    if (NextReg == SrcReg || !Register::isVirtualRegister(NextReg))
+    if (NextReg == SrcReg || !Register(NextReg).isVirtual())
       break;
     SrcReg = NextReg;
   }

--- a/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
+++ b/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
@@ -537,7 +537,7 @@ MachineInstr *PPCReduceCRLogicals::lookThroughCRCopy(unsigned Reg,
                                                      unsigned &Subreg,
                                                      MachineInstr *&CpDef) {
   Subreg = -1;
-  if (!Register::isVirtualRegister(Reg))
+  if (!Register(Reg).isVirtual())
     return nullptr;
   MachineInstr *Copy = MRI->getVRegDef(Reg);
   CpDef = Copy;

--- a/llvm/lib/Target/PowerPC/PPCVSXCopy.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXCopy.cpp
@@ -40,9 +40,9 @@ namespace {
 
     const TargetInstrInfo *TII;
 
-    bool IsRegInClass(unsigned Reg, const TargetRegisterClass *RC,
+    bool IsRegInClass(Register Reg, const TargetRegisterClass *RC,
                       MachineRegisterInfo &MRI) {
-      if (Register::isVirtualRegister(Reg)) {
+      if (Reg.isVirtual()) {
         return RC->hasSubClassEq(MRI.getRegClass(Reg));
       } else if (RC->contains(Reg)) {
         return true;

--- a/llvm/lib/Target/PowerPC/PPCVSXSwapRemoval.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXSwapRemoval.cpp
@@ -157,7 +157,7 @@ private:
 
   // Return true iff the given register is in the given class.
   bool isRegInClass(unsigned Reg, const TargetRegisterClass *RC) {
-    if (Register::isVirtualRegister(Reg))
+    if (Register(Reg).isVirtual())
       return RC->hasSubClassEq(MRI->getRegClass(Reg));
     return RC->contains(Reg);
   }
@@ -560,7 +560,7 @@ unsigned PPCVSXSwapRemoval::lookThruCopyLike(unsigned SrcReg,
   if (!MI->isCopyLike())
     return SrcReg;
 
-  unsigned CopySrcReg;
+  Register CopySrcReg;
   if (MI->isCopy())
     CopySrcReg = MI->getOperand(1).getReg();
   else {
@@ -568,7 +568,7 @@ unsigned PPCVSXSwapRemoval::lookThruCopyLike(unsigned SrcReg,
     CopySrcReg = MI->getOperand(2).getReg();
   }
 
-  if (!Register::isVirtualRegister(CopySrcReg)) {
+  if (!CopySrcReg.isVirtual()) {
     if (!isScalarVecReg(CopySrcReg))
       SwapVector[VecIdx].MentionsPhysVR = 1;
     return CopySrcReg;

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
@@ -64,7 +64,7 @@ void WebAssemblyInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   // exist. However we need to handle both here.
   auto &MRI = MBB.getParent()->getRegInfo();
   const TargetRegisterClass *RC =
-      Register::isVirtualRegister(DestReg)
+      Register(DestReg).isVirtual()
           ? MRI.getRegClass(DestReg)
           : MRI.getTargetRegisterInfo()->getMinimalPhysRegClass(DestReg);
 


### PR DESCRIPTION
Use nonstatic member instead. This requires explicit conversions, but many will go away as we continue converting unsigned to Register.

In a few places where it was simple, I changed unsigned to Register.