### PR TITLE
[lldb] Fix GCC's `-Wreturn-type` warnings

### DIFF
--- a/lldb/source/DataFormatters/TypeSummary.cpp
+++ b/lldb/source/DataFormatters/TypeSummary.cpp
@@ -58,9 +58,8 @@ std::string TypeSummaryImpl::GetSummaryKindName() {
     return "c++";
   case Kind::eBytecode:
     return "bytecode";
-  default:
-    llvm_unreachable("Unknown type kind name");
   }
+  llvm_unreachable("Unknown type kind name");
 }
 
 StringSummaryFormat::StringSummaryFormat(const TypeSummaryImpl::Flags &flags,

--- a/lldb/source/DataFormatters/TypeSummary.cpp
+++ b/lldb/source/DataFormatters/TypeSummary.cpp
@@ -58,6 +58,8 @@ std::string TypeSummaryImpl::GetSummaryKindName() {
     return "c++";
   case Kind::eBytecode:
     return "bytecode";
+  default:
+    llvm_unreachable("Unknown type kind name");
   }
 }
 

--- a/lldb/source/ValueObject/DILLexer.cpp
+++ b/lldb/source/ValueObject/DILLexer.cpp
@@ -29,9 +29,8 @@ llvm::StringRef Token::GetTokenName(Kind kind) {
     return "l_paren";
   case Kind::r_paren:
     return "r_paren";
-  default:
-    llvm_unreachable("Unknown token name");
   }
+  llvm_unreachable("Unknown token name");
 }
 
 static bool IsLetter(char c) {

--- a/lldb/source/ValueObject/DILLexer.cpp
+++ b/lldb/source/ValueObject/DILLexer.cpp
@@ -29,6 +29,8 @@ llvm::StringRef Token::GetTokenName(Kind kind) {
     return "l_paren";
   case Kind::r_paren:
     return "r_paren";
+  default:
+    llvm_unreachable("Unknown token name");
   }
 }
 


### PR DESCRIPTION
This patch fixes `-Wreturn-type` warnings which happens if LLVM is built with GCC compiler (14.1 is used for detecting)

Warnings:
```
llvm-project/lldb/source/ValueObject/DILLexer.cpp: In static member function ‘static llvm::StringRef lldb_private::dil::Token::GetTokenName(Kind)’:
llvm-project/lldb/source/ValueObject/DILLexer.cpp:33:1: warning: control reaches end of non-void function [-Wreturn-type]
   33 | }
      | ^
```
and:
```
llvm-project/lldb/source/DataFormatters/TypeSummary.cpp: In member function ‘virtual std::string lldb_private::TypeSummaryImpl::GetSummaryKindName()’:
llvm-project/lldb/source/DataFormatters/TypeSummary.cpp:62:1: warning: control reaches end of non-void function [-Wreturn-type]
   62 | }
      | ^
```

Technically, it is a bug in Clang (see #115345), however, UBSan with Clang should detect these places, therefore it would be nice to provide a return statement for all possible inputs (even invalid). 