### PR TITLE
[llvm-objdump]Correct .dynstr finding of getDynamicStrTab()

### DIFF
--- a/llvm/test/tools/llvm-objdump/ELF/private-headers.test
+++ b/llvm/test/tools/llvm-objdump/ELF/private-headers.test
@@ -30,6 +30,7 @@ Sections:
   - Name:    .dynamic
     Type:    SHT_DYNAMIC
     Flags:   [ SHF_ALLOC ]
+    Link:    1
     Entries:
      - Tag:   DT_NEEDED
        Value: 0x1

--- a/llvm/tools/llvm-objdump/ELFDump.cpp
+++ b/llvm/tools/llvm-objdump/ELFDump.cpp
@@ -78,8 +78,8 @@ static Expected<StringRef> getDynamicStrTab(const ELFFile<ELFT> &Elf) {
     return SectionsOrError.takeError();
 
   for (const typename ELFT::Shdr &Sec : *SectionsOrError) {
-    if (Sec.sh_type == ELF::SHT_DYNSYM)
-      return Elf.getStringTableForSymtab(Sec);
+    if (Sec.sh_type == ELF::SHT_DYNAMIC)
+      return Elf.getLinkAsStrtab(Sec);
   }
 
   return createError("dynamic string table not found");


### PR DESCRIPTION
The dynamic string table used by the dynamic section is referenced by the sh_link field of that section, so we should use that directly, rather than going via the dynamic symbol table.
More info: https://github.com/llvm/llvm-project/pull/125679#discussion_r1961333454