### PR TITLE
[MLIR][ROCDL] Fix accessedOperands for Rocdl_RawPtrBufferLoadOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -470,7 +470,7 @@ def ROCDL_RawPtrBufferLoadOp :
   let assemblyFormat = "operands attr-dict `:` type($res)";
   let extraClassDefinition = [{
     ::llvm::SmallVector<::mlir::Value> $cppClass::getAccessedOperands() {
-      return {getRes()};
+      return {getRsrc()};
     }
   }];
 }


### PR DESCRIPTION
`getAccessedOperands` should return all accessed pointer operands. In the case for BufferLoads this is the source buffer and not the result.
