### PR TITLE
[RegAllocFast][NPM] Make RegAllocFastPassOptions a nested class

### DIFF
--- a/llvm/include/llvm/CodeGen/RegAllocFast.h
+++ b/llvm/include/llvm/CodeGen/RegAllocFast.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_CODEGEN_REGALLOCFAST_H
 #define LLVM_CODEGEN_REGALLOCFAST_H
 
-#include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/RegAllocCommon.h"
 

--- a/llvm/include/llvm/CodeGen/RegAllocFast.h
+++ b/llvm/include/llvm/CodeGen/RegAllocFast.h
@@ -9,23 +9,24 @@
 #ifndef LLVM_CODEGEN_REGALLOCFAST_H
 #define LLVM_CODEGEN_REGALLOCFAST_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/RegAllocCommon.h"
 
 namespace llvm {
 
-struct RegAllocFastPassOptions {
-  RegAllocFilterFunc Filter = nullptr;
-  StringRef FilterName = "all";
-  bool ClearVRegs = true;
-};
-
 class RegAllocFastPass : public PassInfoMixin<RegAllocFastPass> {
-  RegAllocFastPassOptions Opts;
-
 public:
-  RegAllocFastPass(RegAllocFastPassOptions Opts = RegAllocFastPassOptions())
-      : Opts(Opts) {}
+  struct Options {
+    RegAllocFilterFunc Filter;
+    StringRef FilterName;
+    bool ClearVRegs;
+    Options(RegAllocFilterFunc F = nullptr, StringRef FN = "all",
+            bool CV = true)
+        : Filter(F), FilterName(FN), ClearVRegs(CV) {}
+  };
+
+  RegAllocFastPass(Options Opts = Options()) : Opts(Opts) {}
 
   MachineFunctionProperties getRequiredProperties() const {
     return MachineFunctionProperties().set(
@@ -52,6 +53,9 @@ public:
                      function_ref<StringRef(StringRef)> MapClassName2PassName);
 
   static bool isRequired() { return true; }
+
+private:
+  Options Opts;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -189,7 +189,7 @@ MACHINE_FUNCTION_PASS("verify<machine-trace-metrics>", MachineTraceMetricsVerifi
 #endif
 MACHINE_FUNCTION_PASS_WITH_PARAMS(
     "regallocfast", "RegAllocFastPass",
-    [](RegAllocFastPassOptions Opts) { return RegAllocFastPass(Opts); },
+    [](RegAllocFastPass::Options Opts) { return RegAllocFastPass(Opts); },
     [PB = this](StringRef Params) {
       return parseRegAllocFastPassOptions(*PB, Params);
     },

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1332,9 +1332,9 @@ Expected<SmallVector<std::string, 0>> parseInternalizeGVs(StringRef Params) {
   return Expected<SmallVector<std::string, 0>>(std::move(PreservedGVs));
 }
 
-Expected<RegAllocFastPassOptions>
+Expected<RegAllocFastPass::Options>
 parseRegAllocFastPassOptions(PassBuilder &PB, StringRef Params) {
-  RegAllocFastPassOptions Opts;
+  RegAllocFastPass::Options Opts;
   while (!Params.empty()) {
     StringRef ParamName;
     std::tie(ParamName, Params) = Params.split(';');


### PR DESCRIPTION
Making all reg alloc classes have an `::Option` class makes things nicer to construct them.