### PR TITLE
[flang] Align `-x f95[-cpp-input]` language modes with `gfortran`

### DIFF
--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -817,8 +817,12 @@ void Flang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // 'flang -E' always produces output that is suitable for use as fixed form
   // Fortran. However it is only valid free form source if the original is also
-  // free form.
-  if (InputType == types::TY_PP_Fortran &&
+  // free form. Ensure this logic does not incorrectly assume fixed-form for
+  // cases where it shouldn't, such as `flang -x f95 foo.f90`.
+  bool isAtemporaryPreprocessedFile =
+      llvm::sys::path::extension(Input.getFilename())
+          .ends_with(types::getTypeTempSuffix(InputType, /*CLStyle=*/false));
+  if (InputType == types::TY_PP_Fortran && isAtemporaryPreprocessedFile &&
       !Args.getLastArg(options::OPT_ffixed_form, options::OPT_ffree_form))
     CmdArgs.push_back("-ffixed-form");
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -863,6 +863,12 @@ static void parsePreprocessorArgs(Fortran::frontend::PreprocessorOptions &opts,
         (currentArg->getOption().matches(clang::driver::options::OPT_cpp))
             ? PPMacrosFlag::Include
             : PPMacrosFlag::Exclude;
+  // Enable -cpp based on -x unless explicitly disabled with -nocpp
+  if (opts.macrosFlag != PPMacrosFlag::Exclude)
+    if (const auto *dashX = args.getLastArg(clang::driver::options::OPT_x))
+      opts.macrosFlag = llvm::StringSwitch<PPMacrosFlag>(dashX->getValue())
+                            .Case("f95-cpp-input", PPMacrosFlag::Include)
+                            .Default(opts.macrosFlag);
 
   opts.noReformat = args.hasArg(clang::driver::options::OPT_fno_reformat);
   opts.preprocessIncludeLines =

--- a/flang/test/Driver/dash-x-f95-cpp-input.f
+++ b/flang/test/Driver/dash-x-f95-cpp-input.f
@@ -1,0 +1,35 @@
+program main
+  print *, __FILE__, __LINE__
+end
+
+! This test verifies that `flang`'s `-x` options behave like `gfortran`'s.
+! Specifically:
+! - `-x f95` should process the file based on its extension unless overridden.
+! - `-x f95-cpp-input` should behave like `-x f95` but with preprocessing
+!   (`-cpp`) enabled unless overridden.
+
+! ---
+! Ensure the file is treated as fixed-form unless explicitly set otherwise
+! ---
+! RUN: not %flang -Werror -x f95 -cpp %s 2>&1 | FileCheck --check-prefix=SCAN-ERROR %s
+! RUN: not %flang -Werror -x f95-cpp-input %s 2>&1 | FileCheck --check-prefix=SCAN-ERROR %s
+
+! SCAN-ERROR: error
+
+! RUN: %flang -Werror -x f95 -cpp -ffree-form %s 2>&1 | FileCheck --check-prefix=NO-SCAN-ERROR --allow-empty %s
+! RUN: %flang -Werror -x f95-cpp-input -ffree-form %s 2>&1 | FileCheck --check-prefix=NO-SCAN-ERROR --allow-empty %s
+
+! NO-SCAN-ERROR-NOT: error
+
+! ---
+! Ensure `-cpp` is not enabled by default unless explicitly requested
+! ---
+! RUN: not %flang -Werror -x f95 -ffree-form %s 2>&1 | FileCheck --check-prefix=SEMA-ERROR %s
+! RUN: not %flang -Werror -x f95-cpp-input -nocpp -ffree-form %s 2>&1 | FileCheck --check-prefix=SEMA-ERROR %s
+
+! SEMA-ERROR: error
+
+! RUN: %flang -Werror -x f95 -cpp -ffree-form %s 2>&1 | FileCheck --check-prefix=NO-SEMA-ERROR --allow-empty %s
+! RUN: %flang -Werror -x f95-cpp-input -ffree-form %s 2>&1 | FileCheck --check-prefix=NO-SEMA-ERROR --allow-empty %s
+
+! NO-SEMA-ERROR-NOT: error

--- a/flang/test/Driver/dash-x-f95-do-not-assume-fixed-form.f90
+++ b/flang/test/Driver/dash-x-f95-do-not-assume-fixed-form.f90
@@ -1,0 +1,12 @@
+! This test verifies that using `-x f95` does not cause the driver to assume
+! this file is in fixed-form.
+
+program main
+  print *, "Hello, World!"
+end
+
+! RUN: %flang -### -x f95 %s 2>&1 | FileCheck --check-prefix=PRINT-PHASES %s
+! PRINT-PHASES-NOT: -ffixed-form
+
+! RUN: %flang -Werror -x f95 %s 2>&1 | FileCheck --check-prefix=COMPILE --allow-empty %s
+! COMPILE-NOT: error

--- a/flang/test/Driver/input-from-stdin/input-from-stdin.f90
+++ b/flang/test/Driver/input-from-stdin/input-from-stdin.f90
@@ -6,7 +6,7 @@
 ! Input type is implicit
 ! RUN: cat %s | %flang -E -cpp - | FileCheck %s --check-prefix=PP-NOT-DEFINED
 ! RUN: cat %s | %flang -DNEW -E -cpp - | FileCheck %s --check-prefix=PP-DEFINED
-! RUN: cat %s | %flang -DNEW -E - | FileCheck %s --check-prefix=PP-NOT-DEFINED
+! RUN: cat %s | %flang -DNEW -E - | FileCheck %s --check-prefix=PP-DEFINED
 ! RUN: cat %s | %flang -DNEW -E -nocpp - | FileCheck %s --check-prefix=PP-NOT-DEFINED
 
 ! Input type is explicit


### PR DESCRIPTION
This PR may solve some of the issues described in: https://github.com/llvm/llvm-project/issues/127617. The reason to revert https://github.com/llvm/llvm-project/commit/81d82cac8c4cbd006bf991fd7380de2d72858d1c is detailed in [this comment](https://github.com/llvm/llvm-project/issues/127617#issuecomment-2670788908) in the associated issue.

EDIT:

The decision to revert https://github.com/llvm/llvm-project/commit/81d82cac8c4cbd006bf991fd7380de2d72858d1c was made because it does not provide a reasonable default. A preprocessed file is not necessarily in fixed-form. The root cause of OP's issue is that they did not pass the `-ffixed-form` flag when compiling the preprocessed code. Flang cannot infer the format solely based on the `.i` file extension.

Additionally, this commit introduced a regression where Flang incorrectly assumes free-form source files should be treated as fixed-form, even when no flag in the invocation suggests otherwise. This results in errors such as the following:

```bash
$ cat foo.f90
program main
end
$ flang -Werror -x f95 foo.f90
error: Could not scan foo.f90
foo.f90:1:1: warning: Character in fixed-form label field must be a digit
  program main
  ^
foo.f90:2:1: warning: Character in fixed-form label field must be a digit
  end
  ^
```

In this sense, this PR aims to align the behavior of `-x f95` and `-x f95-cpp-input` with `gfortran`. Specifically:
- `-x f95` should process the file according to its file extension or based on the flags explicitly passed by the user.
- `-x f95-cpp-input` should behave like `-x f95` but additionally enable the `-cpp` flag unless explicitly overridden by the user with `-nocpp`.