### PR TITLE
[NVPTX][NFC] Rename hasAAFeatures()

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -142,7 +142,7 @@ def hasLDU : Predicate<"Subtarget->hasLDU()">;
 def hasPTXASUnreachableBug : Predicate<"Subtarget->hasPTXASUnreachableBug()">;
 def noPTXASUnreachableBug : Predicate<"!Subtarget->hasPTXASUnreachableBug()">;
 def hasOptEnabled : Predicate<"TM.getOptLevel() != CodeGenOptLevel::None">;
-def hasAcceleratedFeatures : Predicate<"Subtarget->hasAAFeatures()">;
+def hasArchAccelFeatures : Predicate<"Subtarget->hasArchAccelFeatures()">;
 
 def doF32FTZ : Predicate<"useF32FTZ()">;
 def doNoF32FTZ : Predicate<"!useF32FTZ()">;

--- a/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
+++ b/llvm/lib/Target/NVPTX/NVPTXIntrinsics.td
@@ -7596,7 +7596,7 @@ multiclass SET_MAXNREG<string Action, Intrinsic Intr> {
   def : NVPTXInst<(outs), (ins i32imm:$reg_count),
           "setmaxnreg." # Action # ".sync.aligned.u32 $reg_count;",
           [(Intr timm:$reg_count)]>,
-    Requires<[hasAcceleratedFeatures, hasSM<90>, hasPTX<80>]>;
+    Requires<[hasArchAccelFeatures, hasSM<90>, hasPTX<80>]>;
 }
 
 defm INT_SET_MAXNREG_INC : SET_MAXNREG<"inc", int_nvvm_setmaxnreg_inc_sync_aligned_u32>;

--- a/llvm/lib/Target/NVPTX/NVPTXSubtarget.h
+++ b/llvm/lib/Target/NVPTX/NVPTXSubtarget.h
@@ -125,11 +125,11 @@ public:
   unsigned int getSmVersion() const { return getFullSmVersion() / 10; }
   // GPUs with "a" suffix have include architecture-accelerated features that
   // are supported on the specified architecture only, hence such targets do not
-  // follow the onion layer model. hasAAFeatures() allows distinguishing such
-  // GPU variants from the base GPU architecture.
+  // follow the onion layer model. hasArchAccelFeatures() allows
+  // distinguishing such GPU variants from the base GPU architecture.
   // - 0 represents base GPU model,
   // - non-zero value identifies particular architecture-accelerated variant.
-  bool hasAAFeatures() const { return getFullSmVersion() % 10; }
+  bool hasArchAccelFeatures() const { return getFullSmVersion() % 10; }
 
   // If the user did not provide a target we default to the `sm_30` target.
   std::string getTargetName() const {


### PR DESCRIPTION
This patch renames hasAAFeatures() to hasArchAccelFeatures()
and updates its usages in tablegen files.