### PR TITLE
[mlir] Remove unused outer loop (NFC)

### DIFF
--- a/mlir/lib/Analysis/DataFlowFramework.cpp
+++ b/mlir/lib/Analysis/DataFlowFramework.cpp
@@ -118,21 +118,17 @@ LogicalResult DataFlowSolver::initializeAndRun(Operation *top) {
   }
 
   // Run the analysis until fixpoint.
-  do {
-    // Exhaust the worklist.
-    while (!worklist.empty()) {
-      auto [point, analysis] = worklist.front();
-      worklist.pop();
+  // Iterate until all states are in some initialized state and the worklist
+  // is exhausted.
+  while (!worklist.empty()) {
+    auto [point, analysis] = worklist.front();
+    worklist.pop();
 
-      DATAFLOW_DEBUG(llvm::dbgs() << "Invoking '" << analysis->debugName
-                                  << "' on: " << point << "\n");
-      if (failed(analysis->visit(point)))
-        return failure();
-    }
-
-    // Iterate until all states are in some initialized state and the worklist
-    // is exhausted.
-  } while (!worklist.empty());
+    DATAFLOW_DEBUG(llvm::dbgs() << "Invoking '" << analysis->debugName
+                                << "' on: " << point << "\n");
+    if (failed(analysis->visit(point)))
+      return failure();
+  }
 
   return success();
 }


### PR DESCRIPTION
The program will exit the outer loop directly if inner loop ends, so the outer do {} while() is redundant.