### PR TITLE
[llvm] Fix missing includes

### DIFF
--- a/llvm/include/llvm/CodeGen/ByteProvider.h
+++ b/llvm/include/llvm/CodeGen/ByteProvider.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_CODEGEN_BYTEPROVIDER_H
 #define LLVM_CODEGEN_BYTEPROVIDER_H
 
+#include "llvm/Support/DataTypes.h"
 #include <optional>
 #include <type_traits>
 

--- a/llvm/include/llvm/ProfileData/Coverage/MCDCTypes.h
+++ b/llvm/include/llvm/ProfileData/Coverage/MCDCTypes.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_PROFILEDATA_COVERAGE_MCDCTYPES_H
 #define LLVM_PROFILEDATA_COVERAGE_MCDCTYPES_H
 
+#include "llvm/Support/DataTypes.h"
 #include <array>
 #include <cassert>
 #include <type_traits>

--- a/llvm/include/llvm/Support/thread.h
+++ b/llvm/include/llvm/Support/thread.h
@@ -18,6 +18,8 @@
 
 #include "llvm/Config/llvm-config.h"
 #include <optional>
+#include <tuple>
+#include <utility>
 
 #ifdef _WIN32
 typedef unsigned long DWORD;
@@ -202,8 +204,8 @@ private:
 };
 
 namespace this_thread {
-  inline thread::id get_id() { return std::this_thread::get_id(); }
-}
+inline thread::id get_id() { return std::this_thread::get_id(); }
+} // namespace this_thread
 
 #endif // LLVM_ON_UNIX || _WIN32
 


### PR DESCRIPTION
Compilation with `LLVM_ENABLE_MODULES:BOOL=ON` fails due to missing includes. This patch adds these includes (+missing tuple include in thread.h), fixing the module build for me.