### PR TITLE
[mlir][emitc][NFC] Add an example to the description of the emitc.verbatim operation

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1271,7 +1271,6 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     #endif
     ```
 
-<<<<<<< HEAD
     If the `emitc.verbatim` op has operands, then the `value` is interpreted as
     format string, where `{}` is a placeholder for an operand in their order.
     For example, `emitc.verbatim "#pragma my src={} dst={}" %src, %dest : i32, i32`
@@ -1279,7 +1278,7 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     `%dest` became `b` in the C code.
     `{{` in the format string is interpreted as a single `{` and doesn't introduce
     a placeholder.
-=======
+
     Example:
 
     ```mlir
@@ -1291,7 +1290,6 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     typedef float f32;
     #pragma my var=v1 property
     ```
->>>>>>> cabdac5e5703 ([mlir][emitc][NFC] Add an example to the description of the emitc.verbatim operation)
   }];
 
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1271,6 +1271,7 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     #endif
     ```
 
+<<<<<<< HEAD
     If the `emitc.verbatim` op has operands, then the `value` is interpreted as
     format string, where `{}` is a placeholder for an operand in their order.
     For example, `emitc.verbatim "#pragma my src={} dst={}" %src, %dest : i32, i32`
@@ -1278,6 +1279,14 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     `%dest` became `b` in the C code.
     `{{` in the format string is interpreted as a single `{` and doesn't introduce
     a placeholder.
+=======
+    Example:
+
+    ```mlir
+    emitc.verbatim "typedef float f32;"
+    emitc.verbatim "#pragma my var={} property" args %arg : f32
+    ```
+>>>>>>> cabdac5e5703 ([mlir][emitc][NFC] Add an example to the description of the emitc.verbatim operation)
   }];
 
   let extraClassDeclaration = [{

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1286,6 +1286,11 @@ def EmitC_VerbatimOp : EmitC_Op<"verbatim"> {
     emitc.verbatim "typedef float f32;"
     emitc.verbatim "#pragma my var={} property" args %arg : f32
     ```
+    ```c++
+    // Code emitted for the operation above.
+    typedef float f32;
+    #pragma my var=v1 property
+    ```
 >>>>>>> cabdac5e5703 ([mlir][emitc][NFC] Add an example to the description of the emitc.verbatim operation)
   }];
 


### PR DESCRIPTION
The official page provides an explanation of the **new** functionality of `emitc.verbatim`, but a classic example in the `.td` file for this operation is still missing.