### PR TITLE
[libc++] Shuffle the order of pre-commit CI jobs a bit

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -124,7 +124,7 @@ jobs:
             **/crash_diagnostics/*
   stage3:
     if: github.repository_owner == 'llvm'
-    needs: [ stage1, stage2 ]
+    needs: [ stage2 ]
     continue-on-error: false
     strategy:
       fail-fast: false
@@ -188,7 +188,7 @@ jobs:
             **/crash_diagnostics/*
 
   macos:
-    needs: [ stage1 ]
+    needs: [ stage3 ]
     strategy:
       fail-fast: false
       matrix:
@@ -232,7 +232,7 @@ jobs:
 
   windows:
     runs-on: windows-2022
-    needs: [ stage1 ]
+    needs: [ stage2 ]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I've recently noticed that our CI is bottlenecked around platforms on which we don't have a lot of capacity like macOS (mostly) and Windows. To try to alleviate that, this patch moves the macOS builds and the Windows builds further down the pipeline so that they will get triggered less often (if an earlier job fails).