### PR TITLE
[mlir][Parser] Fix crash after block parsing failure

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2228,6 +2228,14 @@ ParseResult OperationParser::parseRegionBody(Region &region, SMLoc startLoc,
 
   // Parse the first block directly to allow for it to be unnamed.
   auto owningBlock = std::make_unique<Block>();
+  auto failureCleanup = llvm::make_scope_exit([&] {
+    if (owningBlock) {
+      // If parsing failed, as indicated by the fact that `owningBlock` still
+      // owns the block, drop all forward references from preceding operations
+      // to definitions within the parsed block.
+      owningBlock->dropAllDefinedValueUses();
+    }
+  });
   Block *block = owningBlock.get();
 
   // If this block is not defined in the source file, add a definition for it

--- a/mlir/test/IR/invalid.mlir
+++ b/mlir/test/IR/invalid.mlir
@@ -675,3 +675,17 @@ func.func @error_at_end_of_line() {
 // -----
 
 @foo   // expected-error {{expected operation name in quotes}}
+
+// -----
+
+func.func @drop_references_on_block_parse_error(){
+  "test.user"(%i, %1) : (index, index) -> ()
+  "test.op_with_region"() ({
+  ^bb0(%i : index):
+    // expected-error @below{{expected operation name in quotes}}
+    %1 = "test.foo"() : () -> (index)
+    // Syntax error to abort parsing this block.
+    123
+  }) : () -> ()
+  return
+}


### PR DESCRIPTION
Fix a crash when parsing malformed block that defines values that preceding operations refer to (which would be a dominance error).

Previously: Producer multiple error messages and then crashes as follows:
```
LLVM ERROR: operation destroyed but still has uses
```

Now: Report an error that the block is malformed. No crash.
