### PR TITLE
[libclc] Define macros for users of gentype.inc

### DIFF
--- a/libclc/clc/include/clc/integer/gentype.inc
+++ b/libclc/clc/include/clc/integer/gentype.inc
@@ -1,5 +1,15 @@
 #include <clc/clcfunc.h>
 #include <clc/clctypes.h>
+#include <clc/utils.h>
+
+#define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
+#define __CLC_CONVERT_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_GENTYPE)
+
+#define __CLC_AS_U_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_U_GENTYPE)
+#define __CLC_CONVERT_U_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_U_GENTYPE)
+
+#define __CLC_AS_S_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_S_GENTYPE)
+#define __CLC_CONVERT_S_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_S_GENTYPE)
 
 // These 2 defines only change when switching between data sizes or base types
 // to keep this file manageable.
@@ -532,3 +542,12 @@
 #undef __CLC_GENSIZE
 #undef __CLC_SCALAR_GENTYPE
 #undef __CLC_BODY
+
+#undef __CLC_CONVERT_S_GENTYPE
+#undef __CLC_AS_S_GENTYPE
+
+#undef __CLC_CONVERT_U_GENTYPE
+#undef __CLC_AS_U_GENTYPE
+
+#undef __CLC_CONVERT_GENTYPE
+#undef __CLC_AS_GENTYPE

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -1,70 +1,120 @@
 #include <clc/clcfunc.h>
 #include <clc/clctypes.h>
+#include <clc/utils.h>
+
+// Define some useful macros for type conversions.
+#define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
+#define __CLC_CONVERT_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_GENTYPE)
+
+// Define some macros for types matching the same vector size as __CLC_GENTYPE.
+#define __CLC_HALFN __CLC_XCONCAT(half, __CLC_VECSIZE)
+#define __CLC_FLOATN __CLC_XCONCAT(float, __CLC_VECSIZE)
+#define __CLC_DOUBLEN __CLC_XCONCAT(double, __CLC_VECSIZE)
+
+#define __CLC_CHARN __CLC_XCONCAT(char, __CLC_VECSIZE)
+#define __CLC_SHORTN __CLC_XCONCAT(short, __CLC_VECSIZE)
+#define __CLC_INTN __CLC_XCONCAT(int, __CLC_VECSIZE)
+#define __CLC_LONGN __CLC_XCONCAT(long, __CLC_VECSIZE)
+
+#define __CLC_UCHARN __CLC_XCONCAT(uchar, __CLC_VECSIZE)
+#define __CLC_USHORTN __CLC_XCONCAT(ushort, __CLC_VECSIZE)
+#define __CLC_UINTN __CLC_XCONCAT(uint, __CLC_VECSIZE)
+#define __CLC_ULONGN __CLC_XCONCAT(ulong, __CLC_VECSIZE)
+
+#define __CLC_AS_CHARN __CLC_XCONCAT(__clc_as_, __CLC_CHARN)
+#define __CLC_AS_SHORTN __CLC_XCONCAT(__clc_as_, __CLC_SHORTN)
+#define __CLC_AS_INTN __CLC_XCONCAT(__clc_as_, __CLC_INTN)
+#define __CLC_AS_LONGN __CLC_XCONCAT(__clc_as_, __CLC_LONGN)
+
+#define __CLC_AS_UCHARN __CLC_XCONCAT(__clc_as_, __CLC_UCHARN)
+#define __CLC_AS_USHORTN __CLC_XCONCAT(__clc_as_, __CLC_USHORTN)
+#define __CLC_AS_UINTN __CLC_XCONCAT(__clc_as_, __CLC_UINTN)
+#define __CLC_AS_ULONGN __CLC_XCONCAT(__clc_as_, __CLC_ULONGN)
+
+#define __CLC_CONVERT_HALFN __CLC_XCONCAT(__clc_convert_half, __CLC_VECSIZE)
+#define __CLC_CONVERT_FLOATN __CLC_XCONCAT(__clc_convert_float, __CLC_VECSIZE)
+#define __CLC_CONVERT_DOUBLEN __CLC_XCONCAT(__clc_convert_double, __CLC_VECSIZE)
+
+#define __CLC_CONVERT_CHARN __CLC_XCONCAT(__clc_convert_, __CLC_CHARN)
+#define __CLC_CONVERT_SHORTN __CLC_XCONCAT(__clc_convert_, __CLC_SHORTN)
+#define __CLC_CONVERT_INTN __CLC_XCONCAT(__clc_convert_, __CLC_INTN)
+#define __CLC_CONVERT_LONGN __CLC_XCONCAT(__clc_convert_, __CLC_LONGN)
+
+#define __CLC_CONVERT_UCHARN __CLC_XCONCAT(__clc_convert_, __CLC_UCHARN)
+#define __CLC_CONVERT_USHORTN __CLC_XCONCAT(__clc_convert_, __CLC_USHORTN)
+#define __CLC_CONVERT_UINTN __CLC_XCONCAT(__clc_convert_, __CLC_UINTN)
+#define __CLC_CONVERT_ULONGN __CLC_XCONCAT(__clc_convert_, __CLC_ULONGN)
+
+// See definitions of __CLC_S_GENTYPE/__CLC_U_GENTYPE below, which depend on the
+// specific size of floating-point type. These are the signed and unsigned
+// integers of the same bitwidth and element count as the GENTYPE. They match
+// the naming conventions in the integer version gentype.inc, for
+// convenience.
+#define __CLC_AS_S_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_S_GENTYPE)
+#define __CLC_AS_U_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_U_GENTYPE)
+
+#define __CLC_CONVERT_S_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_S_GENTYPE)
+#define __CLC_CONVERT_U_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_U_GENTYPE)
 
 #define __CLC_SCALAR_GENTYPE float
 #define __CLC_FPSIZE 32
 #define __CLC_FP_LIT(x) x##F
 
+#define __CLC_S_GENTYPE __CLC_XCONCAT(int, __CLC_VECSIZE)
+#define __CLC_U_GENTYPE __CLC_XCONCAT(uint, __CLC_VECSIZE)
+
 #define __CLC_GENTYPE float
-#define __CLC_INTN int
 #define __CLC_BIT_INTN int
 #define __CLC_SCALAR
+#define __CLC_VECSIZE
 #include __CLC_BODY
+#undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 #undef __CLC_SCALAR
 
 #define __CLC_GENTYPE float2
-#define __CLC_INTN int2
 #define __CLC_BIT_INTN int2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE float3
-#define __CLC_INTN int3
 #define __CLC_BIT_INTN int3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE float4
-#define __CLC_INTN int4
 #define __CLC_BIT_INTN int4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE float8
-#define __CLC_INTN int8
 #define __CLC_BIT_INTN int8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE float16
-#define __CLC_INTN int16
 #define __CLC_BIT_INTN int16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
+#undef __CLC_U_GENTYPE
+#undef __CLC_S_GENTYPE
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -77,66 +127,61 @@
 #define __CLC_FPSIZE 64
 #define __CLC_FP_LIT(x) (x)
 
+#define __CLC_S_GENTYPE __CLC_XCONCAT(long, __CLC_VECSIZE)
+#define __CLC_U_GENTYPE __CLC_XCONCAT(ulong, __CLC_VECSIZE)
+
 #define __CLC_SCALAR
+#define __CLC_VECSIZE
 #define __CLC_GENTYPE double
-#define __CLC_INTN int
 #define __CLC_BIT_INTN long
 #include __CLC_BODY
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
+#undef __CLC_VECSIZE
 #undef __CLC_SCALAR
 
 #define __CLC_GENTYPE double2
-#define __CLC_INTN int2
 #define __CLC_BIT_INTN long2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE double3
-#define __CLC_INTN int3
 #define __CLC_BIT_INTN long3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE double4
-#define __CLC_INTN int4
 #define __CLC_BIT_INTN long4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE double8
-#define __CLC_INTN int8
 #define __CLC_BIT_INTN long8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE double16
-#define __CLC_INTN int16
 #define __CLC_BIT_INTN long16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
+#undef __CLC_U_GENTYPE
+#undef __CLC_S_GENTYPE
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -151,66 +196,61 @@
 #define __CLC_FPSIZE 16
 #define __CLC_FP_LIT(x) x##H
 
+#define __CLC_S_GENTYPE __CLC_XCONCAT(short, __CLC_VECSIZE)
+#define __CLC_U_GENTYPE __CLC_XCONCAT(ushort, __CLC_VECSIZE)
+
 #define __CLC_SCALAR
+#define __CLC_VECSIZE
 #define __CLC_GENTYPE half
-#define __CLC_INTN int
 #define __CLC_BIT_INTN short
 #include __CLC_BODY
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
+#undef __CLC_VECSIZE
 #undef __CLC_SCALAR
 
 #define __CLC_GENTYPE half2
-#define __CLC_INTN int2
 #define __CLC_BIT_INTN short2
 #define __CLC_VECSIZE 2
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE half3
-#define __CLC_INTN int3
 #define __CLC_BIT_INTN short3
 #define __CLC_VECSIZE 3
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE half4
-#define __CLC_INTN int4
 #define __CLC_BIT_INTN short4
 #define __CLC_VECSIZE 4
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE half8
-#define __CLC_INTN int8
 #define __CLC_BIT_INTN short8
 #define __CLC_VECSIZE 8
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
 #define __CLC_GENTYPE half16
-#define __CLC_INTN int16
 #define __CLC_BIT_INTN short16
 #define __CLC_VECSIZE 16
 #include __CLC_BODY
 #undef __CLC_VECSIZE
 #undef __CLC_GENTYPE
 #undef __CLC_BIT_INTN
-#undef __CLC_INTN
 
+#undef __CLC_U_GENTYPE
+#undef __CLC_S_GENTYPE
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -218,3 +258,50 @@
 #endif
 
 #undef __CLC_BODY
+
+#undef __CLC_AS_U_GENTYPE
+#undef __CLC_AS_S_GENTYPE
+
+#undef __CLC_CONVERT_U_GENTYPE
+#undef __CLC_CONVERT_S_GENTYPE
+
+#undef __CLC_AS_CHARN
+#undef __CLC_AS_SHORTN
+#undef __CLC_AS_INTN
+#undef __CLC_AS_LONGN
+
+#undef __CLC_AS_UCHARN
+#undef __CLC_AS_USHORTN
+#undef __CLC_AS_UINTN
+#undef __CLC_AS_ULONGN
+
+#undef __CLC_CONVERT_HALFN
+#undef __CLC_CONVERT_FLOATN
+#undef __CLC_CONVERT_DOUBLEN
+
+#undef __CLC_CONVERT_CHARN
+#undef __CLC_CONVERT_SHORTN
+#undef __CLC_CONVERT_INTN
+#undef __CLC_CONVERT_LONGN
+
+#undef __CLC_CONVERT_UCHARN
+#undef __CLC_CONVERT_USHORTN
+#undef __CLC_CONVERT_UINTN
+#undef __CLC_CONVERT_ULONGN
+
+#undef __CLC_ULONGN
+#undef __CLC_UINTN
+#undef __CLC_USHORTN
+#undef __CLC_UCHARN
+
+#undef __CLC_LONGN
+#undef __CLC_INTN
+#undef __CLC_SHORTN
+#undef __CLC_CHARN
+
+#undef __CLC_DOUBLEN
+#undef __CLC_FLOATN
+#undef __CLC_HALFN
+
+#undef __CLC_AS_GENTYPE
+#undef __CLC_CONVERT_GENTYPE

--- a/libclc/clc/include/clc/relational/clc_select_decl.inc
+++ b/libclc/clc/include/clc/relational/clc_select_decl.inc
@@ -1,29 +1,6 @@
-#ifdef __CLC_SCALAR
-#define __CLC_VECSIZE
-#endif
-
-#if __CLC_FPSIZE == 64
-#define __CLC_S_GENTYPE __CLC_XCONCAT(long, __CLC_VECSIZE)
-#define __CLC_U_GENTYPE __CLC_XCONCAT(ulong, __CLC_VECSIZE)
-#elif __CLC_FPSIZE == 32
-#define __CLC_S_GENTYPE __CLC_XCONCAT(int, __CLC_VECSIZE)
-#define __CLC_U_GENTYPE __CLC_XCONCAT(uint, __CLC_VECSIZE)
-#elif __CLC_FPSIZE == 16
-#define __CLC_S_GENTYPE __CLC_XCONCAT(short, __CLC_VECSIZE)
-#define __CLC_U_GENTYPE __CLC_XCONCAT(ushort, __CLC_VECSIZE)
-#endif
-
 _CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __CLC_SELECT_FN(__CLC_GENTYPE x,
                                                       __CLC_GENTYPE y,
                                                       __CLC_S_GENTYPE z);
 _CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __CLC_SELECT_FN(__CLC_GENTYPE x,
                                                       __CLC_GENTYPE y,
                                                       __CLC_U_GENTYPE z);
-
-#ifdef __CLC_FPSIZE
-#undef __CLC_S_GENTYPE
-#undef __CLC_U_GENTYPE
-#endif
-#ifdef __CLC_SCALAR
-#undef __CLC_VECSIZE
-#endif

--- a/libclc/clc/include/clc/relational/clc_select_impl.inc
+++ b/libclc/clc/include/clc/relational/clc_select_impl.inc
@@ -1,18 +1,3 @@
-#ifdef __CLC_SCALAR
-#define __CLC_VECSIZE
-#endif
-
-#if __CLC_FPSIZE == 64
-#define __CLC_S_GENTYPE __CLC_XCONCAT(long, __CLC_VECSIZE)
-#define __CLC_U_GENTYPE __CLC_XCONCAT(ulong, __CLC_VECSIZE)
-#elif __CLC_FPSIZE == 32
-#define __CLC_S_GENTYPE __CLC_XCONCAT(int, __CLC_VECSIZE)
-#define __CLC_U_GENTYPE __CLC_XCONCAT(uint, __CLC_VECSIZE)
-#elif __CLC_FPSIZE == 16
-#define __CLC_S_GENTYPE __CLC_XCONCAT(short, __CLC_VECSIZE)
-#define __CLC_U_GENTYPE __CLC_XCONCAT(ushort, __CLC_VECSIZE)
-#endif
-
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_SELECT_FN(__CLC_GENTYPE x,
                                                      __CLC_GENTYPE y,
                                                      __CLC_S_GENTYPE z) {
@@ -24,12 +9,3 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_SELECT_FN(__CLC_GENTYPE x,
                                                      __CLC_U_GENTYPE z) {
   __CLC_SELECT_DEF(x, y, z);
 }
-
-#ifdef __CLC_FPSIZE
-#undef __CLC_S_GENTYPE
-#undef __CLC_U_GENTYPE
-#endif
-
-#ifdef __CLC_SCALAR
-#undef __CLC_VECSIZE
-#endif

--- a/libclc/clc/lib/generic/integer/clc_rotate.inc
+++ b/libclc/clc/lib/generic/integer/clc_rotate.inc
@@ -1,6 +1,3 @@
-#define __CLC_AS_GENTYPE(x) __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)(x)
-#define __CLC_AS_U_GENTYPE(x) __CLC_XCONCAT(__clc_as_, __CLC_U_GENTYPE)(x)
-
 // The rotate(A, B) builtin left-shifts corresponding to the usual OpenCL shift
 // modulo rules. These rules state that A is left-shifted by the log2(N) least
 // significant bits in B when viewed as an unsigned integer value. Thus we don't

--- a/libclc/clc/lib/generic/math/clc_frexp.inc
+++ b/libclc/clc/lib/generic/math/clc_frexp.inc
@@ -24,9 +24,6 @@
 #include <clc/clcmacro.h>
 #include <clc/utils.h>
 
-#define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
-#define __CLC_AS_INTN __CLC_XCONCAT(__clc_as_, __CLC_INTN)
-
 #if __CLC_FPSIZE == 32
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
 __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
@@ -46,31 +43,15 @@ __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
 #endif
 
 #if __CLC_FPSIZE == 16
-#ifdef __CLC_SCALAR
-#define __CLC_CONVERT_HALFN __clc_convert_half
-#define __CLC_CONVERT_FLOATN __clc_convert_float
-#else
-#define __CLC_CONVERT_HALFN __CLC_XCONCAT(__clc_convert_half, __CLC_VECSIZE)
-#define __CLC_CONVERT_FLOATN __CLC_XCONCAT(__clc_convert_float, __CLC_VECSIZE)
-#endif
+
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
 __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
   return __CLC_CONVERT_HALFN(__clc_frexp(__CLC_CONVERT_FLOATN(x), ep));
 }
-#undef __CLC_CONVERT_FLOATN
-#undef __CLC_CONVERT_HALFN
+
 #endif
 
 #if __CLC_FPSIZE == 64
-#ifdef __CLC_SCALAR
-#define __CLC_AS_LONGN __clc_as_long
-#define __CLC_LONGN long
-#define __CLC_CONVERT_INTN __clc_convert_int
-#else
-#define __CLC_AS_LONGN __CLC_XCONCAT(__clc_as_long, __CLC_VECSIZE)
-#define __CLC_LONGN __CLC_XCONCAT(long, __CLC_VECSIZE)
-#define __CLC_CONVERT_INTN __CLC_XCONCAT(__clc_convert_int, __CLC_VECSIZE)
-#endif
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE
 __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
@@ -90,10 +71,4 @@ __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
   return __clc_select(__CLC_AS_GENTYPE(i), x, t);
 }
 
-#undef __CLC_AS_LONGN
-#undef __CLC_LONGN
-#undef __CLC_CONVERT_INTN
 #endif
-
-#undef __CLC_AS_GENTYPE
-#undef __CLC_AS_INTN

--- a/libclc/clspv/lib/shared/vstore_half.inc
+++ b/libclc/clspv/lib/shared/vstore_half.inc
@@ -1,6 +1,6 @@
 // This does exist only for fp32
 #if __CLC_FPSIZE == 32
-#ifdef __CLC_VECSIZE
+#ifndef __CLC_SCALAR
 
 FUNC(__CLC_VECSIZE, __CLC_VECSIZE, __CLC_GENTYPE, __private);
 FUNC(__CLC_VECSIZE, __CLC_VECSIZE, __CLC_GENTYPE, __local);

--- a/libclc/generic/include/clc/math/nan.h
+++ b/libclc/generic/include/clc/math/nan.h
@@ -1,8 +1,2 @@
-#define __CLC_CONCAT(x, y) x ## y
-#define __CLC_XCONCAT(x, y) __CLC_CONCAT(x, y)
-
 #define __CLC_BODY <clc/math/nan.inc>
 #include <clc/math/gentype.inc>
-
-#undef __CLC_XCONCAT
-#undef __CLC_CONCAT

--- a/libclc/generic/include/clc/math/nan.inc
+++ b/libclc/generic/include/clc/math/nan.inc
@@ -1,18 +1,1 @@
-#ifdef __CLC_SCALAR
-#define __CLC_VECSIZE
-#endif
-
-#if __CLC_FPSIZE == 64
-#define __CLC_NATN __CLC_XCONCAT(ulong, __CLC_VECSIZE)
-#elif __CLC_FPSIZE == 32
-#define __CLC_NATN __CLC_XCONCAT(uint, __CLC_VECSIZE)
-#elif __CLC_FPSIZE == 16
-#define __CLC_NATN __CLC_XCONCAT(ushort, __CLC_VECSIZE)
-#endif
-
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE nan(__CLC_NATN code);
-
-#undef __CLC_NATN
-#ifdef __CLC_SCALAR
-#undef __CLC_VECSIZE
-#endif
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE nan(__CLC_U_GENTYPE code);

--- a/libclc/generic/include/clc/relational/select.h
+++ b/libclc/generic/include/clc/relational/select.h
@@ -1,7 +1,3 @@
-/* Duplciate these so we don't have to distribute utils.h */
-#define __CLC_CONCAT(x, y) x ## y
-#define __CLC_XCONCAT(x, y) __CLC_CONCAT(x, y)
-
 #define __CLC_SELECT_FN select
 
 #define __CLC_BODY <clc/relational/clc_select_decl.inc>
@@ -10,5 +6,3 @@
 #include <clc/integer/gentype.inc>
 
 #undef __CLC_SELECT_FN
-#undef __CLC_CONCAT
-#undef __CLC_XCONCAT

--- a/libclc/generic/lib/math/maxmag.inc
+++ b/libclc/generic/lib/math/maxmag.inc
@@ -1,7 +1,3 @@
-#ifdef __CLC_SCALAR
-#define __CLC_VECSIZE
-#endif
-
 #if __CLC_FPSIZE == 64
 #define __CLC_CONVERT_NATN __CLC_XCONCAT(convert_long, __CLC_VECSIZE)
 #elif __CLC_FPSIZE == 32
@@ -16,7 +12,3 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE maxmag(__CLC_GENTYPE x, __CLC_GENTYPE y) {
 }
 
 #undef __CLC_CONVERT_NATN
-
-#ifdef __CLC_SCALAR
-#undef __CLC_VECSIZE
-#endif

--- a/libclc/generic/lib/math/nan.cl
+++ b/libclc/generic/lib/math/nan.cl
@@ -1,6 +1,6 @@
 #include <clc/clc.h>
 #include <clc/utils.h>
 
-#define __CLC_AS_GENTYPE __CLC_XCONCAT(as_, __CLC_GENTYPE)
+#define __OPENCL_AS_GENTYPE __CLC_XCONCAT(as_, __CLC_GENTYPE)
 #define __CLC_BODY <nan.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/generic/lib/math/nan.inc
+++ b/libclc/generic/lib/math/nan.inc
@@ -1,27 +1,15 @@
-#ifdef __CLC_SCALAR
-#define __CLC_VECSIZE
-#endif
-
 #if __CLC_FPSIZE == 64
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE nan(__CLC_XCONCAT(ulong, __CLC_VECSIZE) code)
-{
-	return __CLC_AS_GENTYPE(code | 0x7ff0000000000000ul);
-}
+#define NAN_MASK 0x7ff0000000000000ul
 #elif __CLC_FPSIZE == 32
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE nan(__CLC_XCONCAT(uint, __CLC_VECSIZE) code)
-{
-	return __CLC_AS_GENTYPE(code | 0x7fc00000);
-}
+#define NAN_MASK 0x7fc00000
 #elif __CLC_FPSIZE == 16
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE nan(__CLC_XCONCAT(ushort, __CLC_VECSIZE) code)
-{
-	const ushort mask = 0x7e00;
-	const __CLC_XCONCAT(ushort, __CLC_VECSIZE) res = code | mask;
-	return __CLC_AS_GENTYPE(res);
+#define NAN_MASK 0x7e00
+#endif
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE nan(__CLC_U_GENTYPE code) {
+  const __CLC_U_GENTYPE mask = NAN_MASK;
+  const __CLC_U_GENTYPE res = code | mask;
+  return __OPENCL_AS_GENTYPE(res);
 }
-#endif
 
-
-#ifdef __CLC_SCALAR
-#undef __CLC_VECSIZE
-#endif
+#undef NAN_MASK

--- a/libclc/generic/lib/shared/vload_half.inc
+++ b/libclc/generic/lib/shared/vload_half.inc
@@ -1,6 +1,6 @@
 #if __CLC_FPSIZE == 32
 
-#ifdef __CLC_VECSIZE
+#ifndef __CLC_SCALAR
 
 #if __CLC_VECSIZE == 3
 #  define __CLC_OFFSET 4

--- a/libclc/generic/lib/shared/vstore_half.inc
+++ b/libclc/generic/lib/shared/vstore_half.inc
@@ -1,6 +1,6 @@
 // This does not exist for fp16
 #if __CLC_FPSIZE > 16
-#ifdef __CLC_VECSIZE
+#ifndef __CLC_SCALAR
 
 #if __CLC_VECSIZE == 3
 #  define __CLC_OFFSET 4


### PR DESCRIPTION
Several users of (mostly math/) gentype.inc rely on types other than the 'gentype'. This is commonly intN as several maths builtins expose this as a return or paramter type. We were previously explicitly defining this type for every gentype.

Other implementations rely on integer types of the same size and element width as the gentype, such as short/ushort for half, long/ulong for double, etc.

Users might also rely on as_type or convert_type builtins to/from these types.

The previous method we used to define intN was unscalable if we wanted to expose more types and helpers.

This commit introduces a simpler system whereby several macros are defined at the beginning of gentype.inc. These rely on concatenating with the vector size. To facilitate this system, scalar gentypes now define an empty vector size. It was previously undefined, which was dangerous. An added benefit is that it matches how the integer gentype.inc vector size has been working.

These macros will be especially helpful for the definitions of logb/ilogb in an upcoming patch.