### PR TITLE
Handle Call Operand vxi1 in Hexagon Backend

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonCallingConv.td
+++ b/llvm/lib/Target/Hexagon/HexagonCallingConv.td
@@ -65,6 +65,8 @@ def CC_Hexagon: CallingConv<[
   CCIfType<[i32],
     CCIfSplit<
       CCCustom<"CC_SkipOdd">>>,
+  CCIfType<[v4i1],  CCPromoteToType<v4i16>>,
+  CCIfType<[v8i1],  CCPromoteToType<v8i8>>,
 
   CCIfType<[i32,v2i16,v4i8],
     CCAssignToReg<[R0,R1,R2,R3,R4,R5]>>,
@@ -111,6 +113,14 @@ class CCIfHvx128<CCAction A>
 
 def CC_Hexagon_HVX: CallingConv<[
   // HVX 64-byte mode
+
+  CCIfHvx64<
+        CCIfType<[v16i1], CCPromoteToType<v16i32>>>,
+  CCIfHvx64<
+        CCIfType<[v32i1], CCPromoteToType<v32i16>>>,
+  CCIfHvx64<
+        CCIfType<[v64i1], CCPromoteToType<v64i8>>>,
+
   CCIfHvx64<
     CCIfType<[v16i32,v32i16,v64i8],
       CCAssignToReg<[V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12,V13,V14,V15]>>>,
@@ -125,6 +135,14 @@ def CC_Hexagon_HVX: CallingConv<[
       CCAssignToStack<128,64>>>,
 
   // HVX 128-byte mode
+
+  CCIfHvx128<
+        CCIfType<[v32i1], CCPromoteToType<v32i32>>>,
+  CCIfHvx128<
+        CCIfType<[v64i1], CCPromoteToType<v64i16>>>,
+  CCIfHvx128<
+        CCIfType<[v128i1], CCPromoteToType<v128i8>>>,
+
   CCIfHvx128<
     CCIfType<[v32i32,v64i16,v128i8,v32f32,v64f16],
       CCAssignToReg<[V0,V1,V2,V3,V4,V5,V6,V7,V8,V9,V10,V11,V12,V13,V14,V15]>>>,

--- a/llvm/test/CodeGen/Hexagon/calloperand-v128i1.ll
+++ b/llvm/test/CodeGen/Hexagon/calloperand-v128i1.ll
@@ -1,0 +1,39 @@
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length128b < %s -o - | FileCheck %s
+
+; CHECK-LABEL: compare_vectors
+; CHECK: [[REG1:(q[0-9]+)]] = vcmp.eq(v{{[0-9]+}}.b,v{{[0-9]+}}.b)
+; CHECK: [[REG2:(r[0-9]+)]] = #-1
+; CHECK: v0 = vand([[REG1]],[[REG2]])
+
+define void @compare_vectors(<128 x i8> %a, <128 x i8> %b) {
+entry:
+  %result = icmp eq <128 x i8> %a, %b
+  call i32 @f.1(<128 x i1> %result)
+  ret void
+}
+
+; CHECK-LABEL: f.1:
+; CHECK: [[REG3:(q[0-9]+)]] = vand(v0,r{{[0-9]+}})
+; CHECK: [[REG4:(v[0-9]+)]] = vand([[REG3]],r{{[0-9]+}})
+; CHECK: r{{[0-9]+}} = vextract([[REG4]],r{{[0-9]+}})
+
+define i32 @f.1(<128 x i1> %vec) {
+  %element = extractelement <128 x i1> %vec, i32 6
+  %is_true = icmp eq i1 %element, true
+  br i1 %is_true, label %if_true, label %if_false
+
+if_true:
+  call void @action_if_true()
+  br label %end
+
+if_false:
+  call void @action_if_false()
+  br label %end
+
+end:
+  %result = phi i32 [1, %if_true], [0, %if_false]
+  ret i32 %result
+}
+
+declare void @action_if_true()
+declare void @action_if_false()

--- a/llvm/test/CodeGen/Hexagon/calloperand-v16i1.ll
+++ b/llvm/test/CodeGen/Hexagon/calloperand-v16i1.ll
@@ -1,0 +1,40 @@
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length64b < %s -o - | FileCheck %s --check-prefix=CHECK
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length128b < %s -o - | FileCheck %s --check-prefix=CHECK
+
+; CHECK-LABEL: compare_vectors
+; CHECK: [[REG1:(q[0-9]+)]] = vcmp.eq(v{{[0-9]+}}.w,v{{[0-9]+}}.w)
+; CHECK: [[REG2:(r[0-9]+)]] = #-1
+; CHECK: v0  = vand([[REG1]],[[REG2]])
+
+define void @compare_vectors(<16 x i32> %a, <16 x i32> %b) {
+entry:
+  %result = icmp eq <16 x i32> %a, %b
+  call i32 @f.1(<16 x i1> %result)
+  ret void
+}
+
+; CHECK-LABEL: f.1:
+; CHECK: [[REG3:(q[0-9]+)]] = vand(v0,r{{[0-9]+}})
+; CHECK: [[REG4:(v[0-9]+)]] = vand([[REG3]],r{{[0-9]+}})
+; CHECK: r{{[0-9]+}} = vextract([[REG4]],r{{[0-9]+}})
+
+define i32 @f.1(<16 x i1> %vec) {
+  %element = extractelement <16 x i1> %vec, i32 6
+  %is_true = icmp eq i1 %element, true
+  br i1 %is_true, label %if_true, label %if_false
+
+if_true:
+  call void @action_if_true()
+  br label %end
+
+if_false:
+  call void @action_if_false()
+  br label %end
+
+end:
+  %result = phi i32 [1, %if_true], [0, %if_false]
+  ret i32 %result
+}
+
+declare void @action_if_true()
+declare void @action_if_false()

--- a/llvm/test/CodeGen/Hexagon/calloperand-v32i1.ll
+++ b/llvm/test/CodeGen/Hexagon/calloperand-v32i1.ll
@@ -1,0 +1,50 @@
+; RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length64b < %s -o - | FileCheck %s --check-prefix=CHECK-64
+; RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length128b < %s -o - | FileCheck %s --check-prefix=CHECK-128
+
+; CHECK-LABEL: compare_vectors
+; CHECK-64: [[REG1:(q[0-9]+)]] = vcmp.eq(v{{[0-9]+}}.h,v{{[0-9]+}}.h)
+; CHECK-64: [[REG2:(r[0-9]+)]] = #-1
+; CHECK-64: v0 = vand([[REG1]],[[REG2]])
+; CHECK-128: r{{[0-9]+}}:{{[0-9]+}} = combine(##.LCPI0_0,#-1)
+; CHECK-128: [[REG1:(q[0-9]+)]] = vcmp.eq(v0.h,v1.h)
+; CHECK-128: [[REG2:(v[0-9]+)]] = vand([[REG1]],r{{[0-9]+}})
+; CHECK-128: [[REG3:(v[0-9]+)]] = vmem(r{{[0-9]+}}+#0)
+; CHECK-128: [[REG4:(v[0-9]+)]] = vdelta([[REG2]],[[REG3]])
+; CHECK-128: [[REG5:(q[0-9]+)]] = vand([[REG4]],r{{[0-9]+}})
+; CHECK-128: v0 = vand([[REG5]],r{{[0-9]+}})
+
+define void @compare_vectors(<32 x i16> %a, <32 x i16> %b) {
+entry:
+  %result = icmp eq <32 x i16> %a, %b
+  call i32 @f.1(<32 x i1> %result)
+  ret void
+}
+
+; CHECK-LABEL: f.1:
+; CHECK-64: [[REG3:(q[0-9]+)]] = vand(v0,r{{[0-9]+}})
+; CHECK-64: [[REG4:(v[0-9]+)]] = vand([[REG3]],r{{[0-9]+}})
+; CHECK-64: r{{[0-9]+}} = vextract([[REG4]],r{{[0-9]+}})
+; CHECK-128: [[REG6:(q[0-9]+)]] = vand(v0,r{{[0-9]+}})
+; CHECK-128: [[REG7:(v[0-9]+)]] = vand([[REG6]],r{{[0-9]+}})
+; CHECK-128: r{{[0-9]+}} = vextract([[REG7]],r{{[0-9]+}})
+
+define i32 @f.1(<32 x i1> %vec) {
+  %element = extractelement <32 x i1> %vec, i32 6
+  %is_true = icmp eq i1 %element, true
+  br i1 %is_true, label %if_true, label %if_false
+
+if_true:
+  call void @action_if_true()
+  br label %end
+
+if_false:
+  call void @action_if_false()
+  br label %end
+
+end:
+  %result = phi i32 [1, %if_true], [0, %if_false]
+  ret i32 %result
+}
+
+declare void @action_if_true()
+declare void @action_if_false()

--- a/llvm/test/CodeGen/Hexagon/calloperand-v4i1.ll
+++ b/llvm/test/CodeGen/Hexagon/calloperand-v4i1.ll
@@ -1,0 +1,39 @@
+;RUN: llc -mtriple=hexagon  < %s -o - | FileCheck %s --check-prefix=CHECK
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length64b < %s -o - | FileCheck %s --check-prefix=CHECK
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length128b < %s -o - | FileCheck %s --check-prefix=CHECK
+
+; CHECK-LABEL: compare_vectors
+; CHECK: [[REG0:(p[0-9]+)]] = vcmph.eq([[REG1:(r[0-9]+):[0-9]]],[[REG2:(r[0-9]+):[0-9]]])
+; CHECK: [[REG1:(r[0-9]+):[0-9]]] = CONST64(#281479271743489)
+; CHECK: [[REG2:(r[0-9]+):[0-9]]] = mask([[REG0]])
+; CHECK: r{{[0-9]+}}:{{[0-9]+}} = and([[REG2]],[[REG1]])
+
+define void @compare_vectors(<4 x i16> %a, <4 x i16> %b) {
+entry:
+  %result = icmp eq <4 x i16> %a, %b
+  call i32 @f.1(<4 x i1> %result)
+  ret void
+}
+; CHECK-LABEL: f.1:
+; CHECK: [[REG3:(r[0-9]+)]] = and([[REG3]],##65537)
+; CHECK: [[REG4:(r[0-9]+)]] = and([[REG4]],##65537)
+define i32 @f.1(<4 x i1> %vec) {
+  %element = extractelement <4 x i1> %vec, i32 2
+  %is_true = icmp eq i1 %element, true
+  br i1 %is_true, label %if_true, label %if_false
+
+if_true:
+  call void @action_if_true()
+  br label %end
+
+if_false:
+  call void @action_if_false()
+  br label %end
+
+end:
+  %result = phi i32 [1, %if_true], [0, %if_false]
+  ret i32 %result
+}
+
+declare void @action_if_true()
+declare void @action_if_false()

--- a/llvm/test/CodeGen/Hexagon/calloperand-v64i1.ll
+++ b/llvm/test/CodeGen/Hexagon/calloperand-v64i1.ll
@@ -1,0 +1,50 @@
+; RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length64b < %s -o - | FileCheck %s --check-prefix=CHECK-64
+; RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length128b < %s -o - | FileCheck %s --check-prefix=CHECK-128
+
+; CHECK-LABEL: compare_vectors
+; CHECK-64: [[REG1:(q[0-9]+)]] = vcmp.eq(v{{[0-9]+}}.b,v{{[0-9]+}}.b)
+; CHECK-64: [[REG2:(r[0-9]+)]] = #-1
+; CHECK-64: v0 = vand([[REG1]],[[REG2]])
+; CHECK-128: r{{[0-9]+}}:{{[0-9]+}} = combine(##.LCPI0_0,#-1)
+; CHECK-128: [[REG1:(q[0-9]+)]] = vcmp.eq(v0.b,v1.b)
+; CHECK-128: [[REG2:(v[0-9]+)]] = vand([[REG1]],r{{[0-9]+}})
+; CHECK-128: [[REG3:(v[0-9]+)]] = vmem(r{{[0-9]+}}+#0)
+; CHECK-128: [[REG4:(v[0-9]+)]] = vdelta([[REG2]],[[REG3]])
+; CHECK-128: [[REG5:(q[0-9]+)]] = vand([[REG4]],r{{[0-9]+}})
+; CHECK-128: v0 = vand([[REG5]],r{{[0-9]+}})
+
+define void @compare_vectors(<64 x i8> %a, <64 x i8> %b) {
+entry:
+  %result = icmp eq <64 x i8> %a, %b
+  call i32 @f.1(<64 x i1> %result)
+  ret void
+}
+
+; CHECK-LABEL: f.1:
+; CHECK-64: [[REG3:(q[0-9]+)]] = vand(v0,r{{[0-9]+}})
+; CHECK-64: [[REG4:(v[0-9]+)]] = vand([[REG3]],r{{[0-9]+}})
+; CHECK-64: r{{[0-9]+}} = vextract([[REG4]],r{{[0-9]+}})
+; CHECK-128: [[REG6:(q[0-9]+)]] = vand(v0,r{{[0-9]+}})
+; CHECK-128: [[REG7:(v[0-9]+)]] = vand([[REG6]],r{{[0-9]+}})
+; CHECK-128: r{{[0-9]+}} = vextract([[REG7]],r{{[0-9]+}})
+
+define i32 @f.1(<64 x i1> %vec) {
+  %element = extractelement <64 x i1> %vec, i32 6
+  %is_true = icmp eq i1 %element, true
+  br i1 %is_true, label %if_true, label %if_false
+
+if_true:
+  call void @action_if_true()
+  br label %end
+
+if_false:
+  call void @action_if_false()
+  br label %end
+
+end:
+  %result = phi i32 [1, %if_true], [0, %if_false]
+  ret i32 %result
+}
+
+declare void @action_if_true()
+declare void @action_if_false()

--- a/llvm/test/CodeGen/Hexagon/calloperand-v8i1.ll
+++ b/llvm/test/CodeGen/Hexagon/calloperand-v8i1.ll
@@ -1,0 +1,39 @@
+;RUN: llc -mtriple=hexagon  < %s -o - | FileCheck %s --check-prefix=CHECK
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length64b < %s -o - | FileCheck %s --check-prefix=CHECK
+;RUN: llc -mtriple=hexagon -mattr=+hvxv79,+hvx-length128b < %s -o - | FileCheck %s --check-prefix=CHECK
+
+; CHECK-LABEL: compare_vectors
+; CHECK: [[REG0:(p[0-9]+)]] = vcmpb.eq([[REG1:(r[0-9]+):[0-9]]],[[REG2:(r[0-9]+):[0-9]]])
+; CHECK: [[REG1:(r[0-9]+):[0-9]]] = CONST64(#72340172838076673)
+; CHECK: [[REG2:(r[0-9]+):[0-9]]] = mask([[REG0]])
+; CHECK: r{{[0-9]+}}:{{[0-9]+}} = and([[REG2]],[[REG1]])
+
+define void @compare_vectors(<8 x i8> %a, <8 x i8> %b) {
+entry:
+  %result = icmp eq <8 x i8> %a, %b
+  call i32 @f.1(<8 x i1> %result)
+  ret void
+}
+; CHECK-LABEL: f.1:
+; CHECK: [[REG3:(r[0-9]+)]] = and([[REG3]],##16843009)
+; CHECK: [[REG4:(r[0-9]+)]] = and([[REG4]],##16843009)
+define i32 @f.1(<8 x i1> %vec) {
+  %element = extractelement <8 x i1> %vec, i32 6
+  %is_true = icmp eq i1 %element, true
+  br i1 %is_true, label %if_true, label %if_false
+
+if_true:
+  call void @action_if_true()
+  br label %end
+
+if_false:
+  call void @action_if_false()
+  br label %end
+
+end:
+  %result = phi i32 [1, %if_true], [0, %if_false]
+  ret i32 %result
+}
+
+declare void @action_if_true()
+declare void @action_if_false()


### PR DESCRIPTION
This commit updates the Hexagon backend to handle
vxi1 call operands. It ensures compatibility for
vector types of sizes 4, 8, 16, 32, 64, and 128 x i1 when HVX is enabled.

~Fixes #59009 and #118879~