### PR TITLE
[clang][NFC] Update isAuxBuiltinID comment

### DIFF
--- a/clang/include/clang/Basic/Builtins.h
+++ b/clang/include/clang/Basic/Builtins.h
@@ -408,7 +408,9 @@ public:
 
   unsigned getRequiredVectorWidth(unsigned ID) const;
 
-  /// Return true if builtin ID belongs to AuxTarget.
+  /// Return true if builtin ID belongs to only the AuxTarget.
+  /// Return false if builtin ID belongs to both the primary
+  /// and auxiliary target.
   bool isAuxBuiltinID(unsigned ID) const {
     return ID >= (Builtin::FirstTSBuiltin + NumTargetBuiltins);
   }

--- a/clang/include/clang/Basic/Builtins.h
+++ b/clang/include/clang/Basic/Builtins.h
@@ -408,9 +408,8 @@ public:
 
   unsigned getRequiredVectorWidth(unsigned ID) const;
 
-  /// Return true if builtin ID belongs to only the AuxTarget.
-  /// Return false if builtin ID belongs to both the primary
-  /// and auxiliary target.
+  /// Return true if the builtin ID belongs exclusively to the AuxTarget,
+  /// and false if it belongs to both primary and aux target, or neither.
   bool isAuxBuiltinID(unsigned ID) const {
     return ID >= (Builtin::FirstTSBuiltin + NumTargetBuiltins);
   }


### PR DESCRIPTION
Clarify behavior of the function when the builtin is also supported on the main target.
Based on feedback from https://github.com/llvm/llvm-project/pull/126324