### PR TITLE
[libc++] Prohibits initializer_list specializations.

### DIFF
--- a/libcxx/docs/Status/Cxx17Issues.csv
+++ b/libcxx/docs/Status/Cxx17Issues.csv
@@ -12,7 +12,7 @@
 "`LWG2404 <https://wg21.link/LWG2404>`__","``mismatch()``\ 's complexity needs to be updated","2014-11 (Urbana)","|Complete|","",""
 "`LWG2408 <https://wg21.link/LWG2408>`__","SFINAE-friendly ``common_type``\  / ``iterator_traits``\  is missing in C++14","2014-11 (Urbana)","|Complete|","",""
 "`LWG2106 <https://wg21.link/LWG2106>`__","``move_iterator``\  wrapping iterators returning prvalues","2014-11 (Urbana)","|Complete|","",""
-"`LWG2129 <https://wg21.link/LWG2129>`__","User specializations of ``std::initializer_list``\ ","2014-11 (Urbana)","|Complete|","",""
+"`LWG2129 <https://wg21.link/LWG2129>`__","User specializations of ``std::initializer_list``\ ","2014-11 (Urbana)","|Complete|","21",""
 "`LWG2212 <https://wg21.link/LWG2212>`__","``tuple_size``\  for ``const pair``\  request <tuple> header","2014-11 (Urbana)","|Complete|","",""
 "`LWG2217 <https://wg21.link/LWG2217>`__","``operator==(sub_match, string)``\  slices on embedded '\0's","2014-11 (Urbana)","|Complete|","",""
 "`LWG2230 <https://wg21.link/LWG2230>`__","""see below"" for ``initializer_list``\  constructors of unordered containers","2014-11 (Urbana)","|Complete|","",""

--- a/libcxx/include/initializer_list
+++ b/libcxx/include/initializer_list
@@ -59,7 +59,7 @@ namespace std // purposefully not versioned
 #  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Ep>
-class _LIBCPP_TEMPLATE_VIS initializer_list {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS initializer_list {
   const _Ep* __begin_;
   size_t __size_;
 

--- a/libcxx/test/std/language.support/support.initlist/support.initlist.syn/specialization.verify.cpp
+++ b/libcxx/test/std/language.support/support.initlist/support.initlist.syn/specialization.verify.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+
+// template<class E> class initializer_list;
+//
+// If an explicit specialization or partial specialization of initializer_list
+// is declared, the program is ill-formed.
+
+#include <initializer_list>
+
+#if !__has_warning("-Winvalid-specializations")
+// expected-no-diagnostics
+#else
+
+// expected-error@+2 {{'initializer_list' cannot be specialized: Users are not allowed to specialize this standard library entity}}
+template <>
+class std::initializer_list<int> {
+}; //expected-error 0-1 {{explicit specialization of 'std::initializer_list<int>' after instantiation}}
+
+// expected-error@+2 {{'initializer_list' cannot be specialized: Users are not allowed to specialize this standard library entity}}
+template <typename T>
+class std::initializer_list<T*> {};
+
+#endif


### PR DESCRIPTION
This relies on Clang's no_specializations attribute which is not supported by GCC.

Implements:
- LWG2129: User specializations of std::initializer_list

Fixes: #126270