### PR TITLE
[test] Remove `-emit-llvm` from the `and-errors.hlsl` test to avoid writing to a potentially write-protected directory

### DIFF
--- a/clang/test/SemaHLSL/BuiltIns/and-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/and-errors.hlsl
@@ -1,6 +1,5 @@
 // RUN: %clang_cc1 -finclude-default-header -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s \
-// RUN:   -emit-llvm -O1 -verify
+// RUN:   dxil-pc-shadermodel6.3-library %s -O1 -verify
 
 bool test_too_few_arg(bool a) {
   return __builtin_hlsl_and(a);


### PR DESCRIPTION
@mikaelholmen [mentioned](https://github.com/llvm/llvm-project/pull/127098#discussion_r1962897888) that the `-emit-llvm` argument isn't necessary for the `and-errors.hlsl` test and may cause issues due to writing to the current (potentially write-protected) directory.

This PR removes the `-emit-llvm` argument from clang in the RUN lines of the test.