### PR TITLE
[mlir][tosa] Remove section numbers in operator tablegen

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -25,7 +25,6 @@ include "mlir/Dialect/Tosa/IR/TosaTypesBase.td"
 include "mlir/Dialect/Tosa/IR/TosaOpBase.td"
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.2
 // Operator Class: Tensor Data Engine Operators.
 //===----------------------------------------------------------------------===//
 
@@ -348,7 +347,6 @@ def Tosa_TransposeConv2DOp : Tosa_ConvOp<"transpose_conv2d"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.3
 // Operator Class: Activation Functions.
 //===----------------------------------------------------------------------===//
 
@@ -451,7 +449,6 @@ def Tosa_ErfOp : Tosa_ElementwiseUnaryOp<"erf"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.4
 // Operator Class: Elementwise unary/binary/ternary operators.
 // Operator Subclass: Elementwise binary ops.
 //===----------------------------------------------------------------------===//
@@ -890,7 +887,6 @@ def Tosa_TableOp : Tosa_InferShapedTypeOp<"table"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.5
 // Operator Class: Elementwise unary/binary/ternary operators.
 // Operator Subclass: Elementwise unary ops.
 //===----------------------------------------------------------------------===//
@@ -1174,7 +1170,6 @@ def Tosa_SinOp : Tosa_ElementwiseUnaryOp<"sin"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.6
 // Operator Class: Elementwise unary/binary/ternary operators.
 // Operator Subclass: Elementwise ternary ops.
 //===----------------------------------------------------------------------===//
@@ -1208,7 +1203,6 @@ def Tosa_SelectOp : Tosa_ElementwiseOp<"select"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.7
 // Operator Class: Logical Operations.
 //===----------------------------------------------------------------------===//
 
@@ -1289,7 +1283,6 @@ def Tosa_GreaterEqualOp : Tosa_ElementwiseOp<"greater_equal",
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.8
 // Operator Class: Reduction Ops.
 //===----------------------------------------------------------------------===//
 
@@ -1502,7 +1495,6 @@ def Tosa_ReduceSumOp : Tosa_InferTensorTypeOp<"reduce_sum"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.9
 // Operator Class: Data Layout / Memory Reinterpretation.
 //===----------------------------------------------------------------------===//
 
@@ -1727,7 +1719,6 @@ def Tosa_TransposeOp : Tosa_InferShapedTypeOp<"transpose",
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.10
 // Operator Class: Scatter/gather Operations.
 //===----------------------------------------------------------------------===//
 
@@ -1775,7 +1766,6 @@ def Tosa_ScatterOp : Tosa_InferShapedTypeOp<"scatter"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.11
 // Operator Class: Image Frontend Functions.
 //===----------------------------------------------------------------------===//
 
@@ -1811,7 +1801,6 @@ def Tosa_ResizeOp : Tosa_InferShapedTypeOp<"resize"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.12
 // Operator Class: Type Conversion.
 //===----------------------------------------------------------------------===//
 
@@ -1912,7 +1901,6 @@ def Tosa_RescaleOp: Tosa_Op<"rescale", [Pure,
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.13
 // Operator Class: Data Node Ops.
 //===----------------------------------------------------------------------===//
 
@@ -1972,7 +1960,6 @@ def Tosa_IdentityOp: Tosa_Op<"identity", [Pure,
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.14
 // Operator Class: Custom Operators.
 //===----------------------------------------------------------------------===//
 
@@ -2027,7 +2014,6 @@ def Tosa_CustomOp : Tosa_Op<"custom"> {
 }
 
 //===----------------------------------------------------------------------===//
-// TOSA Spec Section 2.15
 // Operator Class: Control Flow Operators.
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
The section numbers don't currently match what is in the v1.0 spec(https://www.mlplatform.org/tosa/tosa_spec.html) It can be a burden to remember to update these, and they didn't seem to have much use, so proposing to remove these comments.
