### PR TITLE
[libc] Fix missing includes in GPU scanf reader

### DIFF
--- a/libc/src/stdio/scanf_core/reader.h
+++ b/libc/src/stdio/scanf_core/reader.h
@@ -15,6 +15,11 @@
 #include "src/__support/File/file.h"
 #endif
 
+#if defined(LIBC_TARGET_ARCH_IS_GPU)
+#include "src/stdio/getc.h"
+#include "src/stdio/ungetc.h"
+#endif
+
 #include "src/__support/macros/attributes.h" // For LIBC_INLINE
 #include "src/__support/macros/config.h"
 

--- a/libc/src/stdio/scanf_core/vfscanf_internal.h
+++ b/libc/src/stdio/scanf_core/vfscanf_internal.h
@@ -18,8 +18,6 @@
 
 #if defined(LIBC_TARGET_ARCH_IS_GPU)
 #include "src/stdio/ferror.h"
-#include "src/stdio/getc.h"
-#include "src/stdio/ungetc.h"
 #endif
 
 #include "hdr/types/FILE.h"


### PR DESCRIPTION
In #121215 the reader was reorganized and the definitions of the
internal getc and ungetc functions were moved, but the includes that the
GPU builder depends on were not. This patch moves the includes to the
correct new place.
