### PR TITLE
[SandboxVec][Scheduler] Don't allow rescheduling of already scheduled

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Scheduler.h
@@ -130,6 +130,10 @@ public:
       N->clearSchedBundle();
   }
   bool empty() const { return Nodes.empty(); }
+  /// Singleton bundles are created when scheduling instructions temporarily to
+  /// fill in the schedule until we schedule the vector bundle. These are
+  /// non-vector bundles containing just a single instruction.
+  bool isSingleton() const { return Nodes.size() == 1u; }
   DGNode *back() const { return Nodes.back(); }
   using iterator = ContainerTy::iterator;
   using const_iterator = ContainerTy::const_iterator;
@@ -187,10 +191,12 @@ class Scheduler {
   /// The scheduling state of the instructions in the bundle.
   enum class BndlSchedState {
     NoneScheduled, ///> No instruction in the bundle was previously scheduled.
-    PartiallyOrDifferentlyScheduled, ///> Only some of the instrs in the bundle
-                                     /// were previously scheduled, or all of
-                                     /// them were but not in the same
-                                     /// SchedBundle.
+    AlreadyScheduled, ///> At least one instruction in the bundle belongs to a
+                      /// different non-singleton scheduling bundle.
+    TemporarilyScheduled, ///> Instructions were temporarily scheduled as
+                          /// singleton bundles or some of them were not
+                          /// scheduled at all. None of them were in a vector
+                          ///(non-singleton) bundle.
     FullyScheduled, ///> All instrs in the bundle were previously scheduled and
                     /// were in the same SchedBundle.
   };
@@ -243,6 +249,11 @@ public:
 class SchedulerInternalsAttorney {
 public:
   static DependencyGraph &getDAG(Scheduler &Sched) { return Sched.DAG; }
+  using BndlSchedState = Scheduler::BndlSchedState;
+  static BndlSchedState getBndlSchedState(const Scheduler &Sched,
+                                          ArrayRef<Instruction *> Instrs) {
+    return Sched.getBndlSchedState(Instrs);
+  }
 };
 
 } // namespace llvm::sandboxir

--- a/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/SandboxVectorizer/SchedulerTest.cpp
@@ -210,9 +210,10 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   EXPECT_TRUE(Sched.trySchedule({L0, L1}));
 }
 
-TEST_F(SchedulerTest, RescheduleAlreadyScheduled) {
+TEST_F(SchedulerTest, TrimSchedule) {
   parseIR(C, R"IR(
-define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, i8 %arg) {
+  %zext = zext i8 0 to i32
   %ld0 = load i8, ptr %ptr0
   %ld1 = load i8, ptr %ptr1
   %add0 = add i8 %ld0, %ld0
@@ -227,6 +228,7 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   auto *F = Ctx.createFunction(LLVMF);
   auto *BB = &*F->begin();
   auto It = BB->begin();
+  auto *Z = cast<sandboxir::CastInst>(&*It++);
   auto *L0 = cast<sandboxir::LoadInst>(&*It++);
   auto *L1 = cast<sandboxir::LoadInst>(&*It++);
   auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
@@ -240,10 +242,224 @@ define void @foo(ptr noalias %ptr0, ptr noalias %ptr1) {
   EXPECT_TRUE(Sched.trySchedule({S0, S1}));
   EXPECT_TRUE(Sched.trySchedule({L0, L1}));
   // At this point Add0 and Add1 should have been individually scheduled
-  // as single bundles.
+  // as singleton bundles, but {S0,S1} and {L0,L1} as vector bundles.
   // Check if rescheduling works.
   EXPECT_TRUE(Sched.trySchedule({Add0, Add1}));
+  // These should fail because {L0,L1} is a vector bundle.
+  EXPECT_FALSE(Sched.trySchedule({L0, Z}));
+  EXPECT_FALSE(Sched.trySchedule({L1, Z}));
+  // This should succeed because it matches the original vec bundle.
   EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+}
+
+// Test that an instruction can't belong in two bundles!
+TEST_F(SchedulerTest, CheckBundles) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, ptr noalias %ptr2) {
+  %L0 = load i8, ptr %ptr0
+  %L1 = load i8, ptr %ptr1 ; This belongs in 2 bundles!
+  %L2 = load i8, ptr %ptr2
+  %add0 = add i8 %L0, %L1
+  %add1 = add i8 %L1, %L2
+  store i8 %add0, ptr %ptr0
+  store i8 %add1, ptr %ptr1
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L2 = cast<sandboxir::LoadInst>(&*It++);
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+  EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+  EXPECT_TRUE(Sched.trySchedule({Add0, Add1}));
+  EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+  // This should fail because L1 is already part of {L0,L1}
+  EXPECT_FALSE(Sched.trySchedule({L1, L2}));
+  EXPECT_FALSE(Sched.trySchedule({L2, L1}));
+}
+
+// Try schedule a bundle {L1,L2} where L1 is already scheduled in {L0,L1}
+// but L2 is not in the DAG at all
+TEST_F(SchedulerTest, CheckBundles2) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, ptr noalias %ptr2) {
+  %L2 = load i8, ptr %ptr2 ; This is not in the DAG
+  %L1 = load i8, ptr %ptr1 ; This belongs in 2 bundles!
+  %L0 = load i8, ptr %ptr0
+  %add1 = add i8 %L1, %L2
+  %add0 = add i8 %L0, %L1
+  store i8 %add1, ptr %ptr1
+  store i8 %add0, ptr %ptr0
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *L2 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+  EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+  EXPECT_TRUE(Sched.trySchedule({Add0, Add1}));
+  EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+  // This should fail because L1 is already part of {L0,L1}.
+  EXPECT_FALSE(Sched.trySchedule({L1, L2}));
+  EXPECT_FALSE(Sched.trySchedule({L2, L1}));
+}
+
+// Try schedule a bundle {L1,L2} where L1 is already scheduled in {L0,L1}
+// but L2 is in the DAG but isn't scheduled.
+TEST_F(SchedulerTest, CheckBundles3) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, ptr noalias %ptr2) {
+  %L2 = load i8, ptr %ptr2 ; This is not in the DAG
+  %L1 = load i8, ptr %ptr1 ; This belongs in 2 bundles!
+  %L0 = load i8, ptr %ptr0
+  %add1 = add i8 %L1, %L2
+  %add0 = add i8 %L0, %L1
+  store i8 %add1, ptr %ptr1
+  store i8 %add0, ptr %ptr0
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *L2 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+  EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+  EXPECT_TRUE(Sched.trySchedule({Add0, Add1}));
+  EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+  // Add L2 to the DAG, but don't schedule it.
+  auto &DAG = sandboxir::SchedulerInternalsAttorney::getDAG(Sched);
+  DAG.extend(L2);
+  // This should fail because L1 is already part of {L0,L1}.
+  EXPECT_FALSE(Sched.trySchedule({L1, L2}));
+  EXPECT_FALSE(Sched.trySchedule({L2, L1}));
+}
+
+// Check that Scheduler::getBndlSchedState() works correctly.
+TEST_F(SchedulerTest, GetBndlSchedState) {
+  parseIR(C, R"IR(
+define void @foo(ptr noalias %ptr0, ptr noalias %ptr1, ptr noalias %ptr2) {
+  %L2 = load i8, ptr %ptr2 ; This is not in the DAG
+  %L1 = load i8, ptr %ptr1 ; This belongs in 2 bundles!
+  %L0 = load i8, ptr %ptr0
+  %add1 = add i8 %L1, %L2
+  %add0 = add i8 %L0, %L1
+  store i8 %add1, ptr %ptr1
+  store i8 %add0, ptr %ptr0
+  ret void
+}
+)IR");
+  llvm::Function *LLVMF = &*M->getFunction("foo");
+  sandboxir::Context Ctx(C);
+  auto *F = Ctx.createFunction(LLVMF);
+  auto *BB = &*F->begin();
+  auto It = BB->begin();
+  auto *L2 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L1 = cast<sandboxir::LoadInst>(&*It++);
+  auto *L0 = cast<sandboxir::LoadInst>(&*It++);
+  auto *Add1 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *Add0 = cast<sandboxir::BinaryOperator>(&*It++);
+  auto *S1 = cast<sandboxir::StoreInst>(&*It++);
+  auto *S0 = cast<sandboxir::StoreInst>(&*It++);
+
+  sandboxir::Scheduler Sched(getAA(*LLVMF), Ctx);
+  auto &DAG = sandboxir::SchedulerInternalsAttorney::getDAG(Sched);
+  auto GetBndlSchedState = [&Sched](ArrayRef<sandboxir::Instruction *> Instrs) {
+    return sandboxir::SchedulerInternalsAttorney::getBndlSchedState(Sched,
+                                                                    Instrs);
+  };
+  using BndlSchedState = sandboxir::SchedulerInternalsAttorney::BndlSchedState;
+  // Check when instructions are not in the DAG.
+  EXPECT_EQ(GetBndlSchedState({S0}), BndlSchedState::NoneScheduled);
+  EXPECT_EQ(GetBndlSchedState({S0, S1}), BndlSchedState::NoneScheduled);
+  EXPECT_EQ(GetBndlSchedState({S0, S1}), BndlSchedState::NoneScheduled);
+  // Check when instructions are in the DAG.
+  DAG.extend({S0, S1});
+  EXPECT_EQ(GetBndlSchedState({S0}), BndlSchedState::NoneScheduled);
+  EXPECT_EQ(GetBndlSchedState({S0, S1}), BndlSchedState::NoneScheduled);
+  EXPECT_EQ(GetBndlSchedState({S0, S1}), BndlSchedState::NoneScheduled);
+  // One instruction in the DAG and the other not in the DAG.
+  EXPECT_EQ(GetBndlSchedState({S0, Add0}), BndlSchedState::NoneScheduled);
+
+  // Check with scheduled instructions.
+  Sched.clear(); // Manually extending the DAG messes with the scheduler.
+  EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+  // Check fully scheduled.
+  EXPECT_EQ(GetBndlSchedState({S0, S1}), BndlSchedState::FullyScheduled);
+  // Check scheduled + not in DAG.
+  EXPECT_EQ(GetBndlSchedState({S0, Add0}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add0, S0}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add0, S1}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add0, Add1}), BndlSchedState::NoneScheduled);
+  // Extend DAG such that Add0 and Add1 are in the DAG but are not scheduled.
+  DAG.extend({Add0, Add1});
+  // Check both in DAG but not scheduled.
+  EXPECT_EQ(GetBndlSchedState({Add0, Add1}), BndlSchedState::NoneScheduled);
+  // Check scheduled + in DAG but not scheduled.
+  EXPECT_EQ(GetBndlSchedState({S0, Add0}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add0, S0}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add0, S1}), BndlSchedState::AlreadyScheduled);
+
+  Sched.clear(); // Manually extending the DAG messes with the scheduler.
+  // Schedule instructions towards the top so that intermediate instructions
+  // (namely Add0, Add1) get temporarily scheduled in singleton bundles.
+  EXPECT_TRUE(Sched.trySchedule({S0, S1}));
+  EXPECT_TRUE(Sched.trySchedule({L0, L1}));
+  // Check fully scheduled.
+  EXPECT_EQ(GetBndlSchedState({L0, L1}), BndlSchedState::FullyScheduled);
+  // Check both singletons.
+  EXPECT_EQ(GetBndlSchedState({Add0, Add1}),
+            BndlSchedState::TemporarilyScheduled);
+  // Check single singleton.
+  EXPECT_EQ(GetBndlSchedState({Add0}), BndlSchedState::TemporarilyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add1}), BndlSchedState::TemporarilyScheduled);
+  // Check singleton + scheduled.
+  EXPECT_EQ(GetBndlSchedState({L0, S1}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({S1, L0}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({L0, Add1}), BndlSchedState::AlreadyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add1, L0}), BndlSchedState::AlreadyScheduled);
+  // Check singleton + not in DAG.
+  EXPECT_EQ(GetBndlSchedState({Add1, L2}),
+            BndlSchedState::TemporarilyScheduled);
+  EXPECT_EQ(GetBndlSchedState({L2, Add0}),
+            BndlSchedState::TemporarilyScheduled);
+
+  // Check duplicates.
+  // TODO: Should duplicates be allowed?
+  EXPECT_EQ(GetBndlSchedState({L2, L2}), BndlSchedState::NoneScheduled);
+  EXPECT_EQ(GetBndlSchedState({S0, S0}), BndlSchedState::FullyScheduled);
+  EXPECT_EQ(GetBndlSchedState({Add0, Add1}),
+            BndlSchedState::TemporarilyScheduled);
 }
 
 // Check scheduling in the following order: {A0,A1},{B0,B1},{C0,C1},{D0,D1}


### PR DESCRIPTION
This patch implements the check for not allowing re-scheduling of instructions that have already been scheduled in a scheduling bundle. Rescheduling should only happen if the instructions were temporarily scheduled in singleton bundles during a previous call to `trySchedule()`.