### PR TITLE
[Clang] Fix failing clang-tidy test

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/readability/named-parameter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/named-parameter.cpp
@@ -37,8 +37,8 @@ void operator delete[](void *x) throw();
 void operator delete[](void * /*x*/) throw();
 
 struct X {
-  X operator++(int) { throw 0; }
-  X operator--(int) { throw 0; }
+  void operator++(int) {}
+  void operator--(int) {}
 
   X(X&) = delete;
   X &operator=(X&) = default;


### PR DESCRIPTION
#123470 broke one of the clang-tidy tests; this fixes that.