### PR TITLE
[libc] Fix scanf cmake for targets without FILE

### DIFF
--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -8,6 +8,22 @@ if(scanf_config_copts)
   list(PREPEND scanf_config_copts "COMPILE_OPTIONS")
 endif()
 
+
+list(APPEND file_deps
+  libc.hdr.types.FILE
+)
+if(LIBC_TARGET_OS_IS_GPU)
+  list(APPEND file_deps
+    libc.src.stdio.getc
+    libc.src.stdio.ungetc
+    libc.src.stdio.ferror
+  )
+elseif(LLVM_LIBC_FULL_BUILD)
+  list(APPEND file_deps
+    libc.src.__support.File.file
+  )
+endif()
+
 add_header_library(
   scanf_config
   HDRS
@@ -52,30 +68,19 @@ add_object_library(
     .converter
     .core_structs
     libc.src.__support.arg_list
-)
-
-if(LIBC_TARGET_OS_IS_GPU)
-add_header_library(
-  reader
-  HDRS
-    reader.h
-  DEPENDS
-    libc.src.__support.macros.attributes
-    libc.src.stdio.getc
-    libc.src.stdio.ungetc
-)
-elseif((TARGET libc.src.__support.File.file) OR (NOT LLVM_LIBC_FULL_BUILD))
-add_header_library(
-  reader
-  HDRS
-    reader.h
-  DEPENDS
-    libc.src.__support.macros.attributes
-    libc.hdr.types.FILE
-    libc.src.__support.File.file
+    ${file_deps}
   ${use_system_file}
 )
-endif()
+
+add_header_library(
+  reader
+  HDRS
+    reader.h
+  DEPENDS
+    libc.src.__support.macros.attributes
+    ${file_deps}
+  ${use_system_file}
+)
 
 add_object_library(
   converter
@@ -103,33 +108,19 @@ add_object_library(
     libc.src.__support.CPP.limits
     libc.src.__support.char_vector
     libc.src.__support.str_to_float
+    ${file_deps}
+  ${use_system_file}
 )
 
-if(LIBC_TARGET_OS_IS_GPU)
-  add_header_library(
+#TODO: condense the file-related code as possible.
+add_header_library(
     vfscanf_internal
     HDRS
       vfscanf_internal.h
     DEPENDS
       .reader
       .scanf_main
-      libc.include.stdio
       libc.src.__support.arg_list
-      libc.src.stdio.getc
-      libc.src.stdio.ungetc
-      libc.src.stdio.ferror
-  )
-elseif(TARGET libc.src.__support.File.file OR (NOT LLVM_LIBC_FULL_BUILD))
-  add_header_library(
-    vfscanf_internal
-    HDRS
-      vfscanf_internal.h
-    DEPENDS
-      .reader
-      .scanf_main
-      libc.include.stdio
-      libc.src.__support.File.file
-      libc.src.__support.arg_list
+      ${file_deps}
     ${use_system_file}
-  )
-endif()
+)

--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -9,9 +9,7 @@ if(scanf_config_copts)
 endif()
 
 
-list(APPEND file_deps
-  libc.hdr.types.FILE
-)
+list(APPEND file_deps libc.hdr.types.FILE)
 if(LIBC_TARGET_OS_IS_GPU)
   list(APPEND file_deps
     libc.src.stdio.getc

--- a/libc/test/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/test/src/stdio/scanf_core/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(NOT(LLVM_LIBC_FULL_BUILD))
+  # in overlay mode, use the system's file to test the reader.
+  set(use_system_file "-DLIBC_COPT_STDIO_USE_SYSTEM_FILE")
+endif()
+
 add_libc_unittest(
   parser_test
   SUITE
@@ -22,13 +27,9 @@ add_libc_unittest(
   DEPENDS
     libc.src.stdio.scanf_core.reader
     libc.src.__support.CPP.string_view
+  COMPILE_OPTIONS
+    ${use_system_file}
 )
-
-if(NOT (TARGET libc.src.__support.File.file))
-  # Not all platforms have a file implementation. If file is unvailable,
-  # then we must skip all the parts that need file.
-  return()
-endif()
 
 add_libc_unittest(
   converter_test
@@ -40,4 +41,6 @@ add_libc_unittest(
     libc.src.stdio.scanf_core.reader
     libc.src.stdio.scanf_core.converter
     libc.src.__support.CPP.string_view
+  COMPILE_OPTIONS
+    ${use_system_file}
 )


### PR DESCRIPTION
Another followup fix to #121215

The new cmake wouldn't define the readerat all if the target wasn't GPU
or didn't have a definition of FILE. This patch rewrites the cmake to be
more general.

As a followup, I'd like to make `use_system_file` consistent between
/test and /src. Currently in /src it includes the `COMPILE_OPTIONS` and
in /test it does not.
