### PR TITLE
[libc] Add missing dependencies on `getc` and `ungetc` for GPU

### DIFF
--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -61,6 +61,8 @@ add_header_library(
     reader.h
   DEPENDS
     libc.src.__support.macros.attributes
+    libc.src.stdio.getc
+    libc.src.stdio.ungetc
 )
 elseif((TARGET libc.src.__support.File.file) OR (NOT LLVM_LIBC_FULL_BUILD))
 add_header_library(


### PR DESCRIPTION
Summary:
These are required because we don't use the `file` interface.
