### PR TITLE
[InstrRef] Preserve debug instr num in aarch64-expand-pseudo LOADgot expansion

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1382,6 +1382,11 @@ bool AArch64ExpandPseudo::expandMI(MachineBasicBlock &MBB,
                                       AArch64II::MO_NC);
       }
 
+      // If the LOADgot instruction has a debug-instr-number, annotate the
+      // LDRWui instruction that it is expanded to with the same
+      // debug-instr-number to preserve debug information.
+      if (MI.peekDebugInstrNum() != 0)
+        MIB2->setDebugInstrNum(MI.peekDebugInstrNum());
       transferImpOps(MI, MIB1, MIB2);
     }
     MI.eraseFromParent();

--- a/llvm/test/CodeGen/AArch64/expand-load-got-pseudo.mir
+++ b/llvm/test/CodeGen/AArch64/expand-load-got-pseudo.mir
@@ -1,0 +1,45 @@
+# RUN: llc -run-pass=aarch64-expand-pseudo -mtriple=aarch64-unknown-linux-gnu -o - %s | FileCheck %s
+
+# This testcase was obtained by looking at FileCheck.cpp and reducing it down via llvm-reduce 
+
+# Check that the LDRXui preserves the debug info by retaining the debug-instr-number 1 in _ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_
+# CHECK: $x8 = ADRP target-flags(aarch64-page, aarch64-got) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev
+# CHECK-NEXT: renamable $x8 = LDRXui killed $x8, target-flags(aarch64-pageoff, aarch64-got, aarch64-nc) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, debug-instr-number 1
+# CHECK-NEXT: DBG_INSTR_REF !9, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0), debug-location
+
+--- |
+  declare i64 @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev()
+  define i1 @_ZNSt3__1neB8nn180100IPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEEEbRKNS_11__wrap_iterIT_EESC_(ptr readnone captures(address) %__x, ptr readonly captures(none) %__y) local_unnamed_addr #0 {
+    %1 = load ptr, ptr %__y, align 8
+    %cmp = icmp eq ptr %__x, %1
+    ret i1 %cmp
+  }
+  define ptr @_ZNKSt3__111__wrap_iterIPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEE4baseB8nn180100Ev(ptr readonly captures(none) %this) local_unnamed_addr #0 {
+  entry:
+    %0 = load ptr, ptr %this, align 8
+    ret ptr %0
+  }
+  define void @_ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_(ptr readnone captures(address) %call6) local_unnamed_addr #1 !dbg !4 {
+    ret void
+  }
+  !llvm.module.flags = !{!0}
+  !llvm.dbg.cu = !{!1}
+  !0 = !{i32 2, !"Debug Info Version", i32 3}
+  !1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !2, sdk: "MacOSX15.3.sdk")
+  !2 = !DIFile(filename: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/llvm/lib/FileCheck/FileCheck.cpp", directory: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/build-instr-ref-stage2", checksumkind: CSK_MD5, checksum: "e718c2a5b2d3baab240a5e370113901e")
+  !3 = !{}
+  !4 = distinct !DISubprogram(name: "handleErrors<(\0A\0A\0A\0Alambda at /Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/llvm/include/llvm/Support/Error.h:1070:35\0A\0A\0A\0A)>", scope: !6, file: !5, type: !7, unit: !1, retainedNodes: !8)
+  !5 = !DIFile(filename: "llvm/include/llvm/Support/Error.h", directory: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project", checksumkind: CSK_MD5, checksum: "0a75676311531ba2140b3f0d994b3c33")
+  !6 = !DINamespace(name: "llvm", scope: null)
+  !7 = distinct !DISubroutineType(types: !3)
+  !8 = !{!9}
+  !9 = !DILocalVariable(name: "__end3", scope: !10, flags: DIFlagArtificial)
+  !10 = distinct !DILexicalBlock(scope: !11, line: 963, column: 5)
+  !11 = distinct !DILexicalBlock(scope: !12, line: 960, column: 34)
+  !12 = distinct !DILexicalBlock(scope: !4, line: 960, column: 7)
+  !25 = !DILocation(line: 0, scope: !10)
+name:            _ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_
+body:             |
+  bb.0 (%ir-block.0):
+    renamable $x8 = LOADgot target-flags(aarch64-got) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, debug-instr-number 1
+    DBG_INSTR_REF !9, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0), debug-location !25


### PR DESCRIPTION
The aarch64-expand-pseudo pass expands the LOADgot instruction to an ADRP instruction and a LDRXui instruction. If the LOADgot had a debug-instr-number, the pass doesn't preserve this to the new expansion.

This patch fixes the issue by making sure the debug-instr-number is correctly applied to the LDRXui instruction generated.