### PR TITLE
[libc][bazel] add targets to build the scanf family

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4614,8 +4614,6 @@ libc_function(
 libc_support_library(
     name = "scanf_config",
     hdrs = ["src/stdio/scanf_core/scanf_config.h"],
-    deps = [
-    ],
 )
 
 libc_support_library(
@@ -4656,19 +4654,19 @@ libc_support_library(
     name = "scanf_converter",
     srcs = [
         "src/stdio/scanf_core/converter.cpp",
+        "src/stdio/scanf_core/converter_utils.h",
+        "src/stdio/scanf_core/current_pos_converter.h",
         "src/stdio/scanf_core/float_converter.cpp",
+        "src/stdio/scanf_core/float_converter.h",
         "src/stdio/scanf_core/int_converter.cpp",
+        "src/stdio/scanf_core/int_converter.h",
         "src/stdio/scanf_core/ptr_converter.cpp",
+        "src/stdio/scanf_core/ptr_converter.h",
         "src/stdio/scanf_core/string_converter.cpp",
+        "src/stdio/scanf_core/string_converter.h",
     ],
     hdrs = [
         "src/stdio/scanf_core/converter.h",
-        "src/stdio/scanf_core/converter_utils.h",
-        "src/stdio/scanf_core/current_pos_converter.h",
-        "src/stdio/scanf_core/float_converter.h",
-        "src/stdio/scanf_core/int_converter.h",
-        "src/stdio/scanf_core/ptr_converter.h",
-        "src/stdio/scanf_core/string_converter.h",
     ],
     deps = [
         ":__support_char_vector",

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4611,6 +4611,178 @@ libc_function(
     ],
 )
 
+libc_support_library(
+    name = "scanf_config",
+    hdrs = ["src/stdio/scanf_core/scanf_config.h"],
+    deps = [
+    ],
+)
+
+libc_support_library(
+    name = "scanf_core_structs",
+    hdrs = ["src/stdio/scanf_core/core_structs.h"],
+    deps = [
+        ":__support_cpp_bitset",
+        ":__support_cpp_string_view",
+        ":__support_fputil_fp_bits",
+        ":scanf_config",
+    ],
+)
+
+libc_support_library(
+    name = "scanf_parser",
+    hdrs = ["src/stdio/scanf_core/parser.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_cpp_bitset",
+        ":__support_ctype_utils",
+        ":__support_str_to_integer",
+        ":scanf_config",
+        ":scanf_core_structs",
+    ],
+)
+
+libc_support_library(
+    name = "scanf_reader",
+    hdrs = ["src/stdio/scanf_core/reader.h"],
+    deps = [
+        ":__support_cpp_string_view",
+        ":__support_macros_attributes",
+        ":types_FILE",
+    ],
+)
+
+libc_support_library(
+    name = "scanf_converter",
+    srcs = [
+        "src/stdio/scanf_core/converter.cpp",
+        "src/stdio/scanf_core/float_converter.cpp",
+        "src/stdio/scanf_core/int_converter.cpp",
+        "src/stdio/scanf_core/ptr_converter.cpp",
+        "src/stdio/scanf_core/string_converter.cpp",
+    ],
+    hdrs = [
+        "src/stdio/scanf_core/converter.h",
+        "src/stdio/scanf_core/converter_utils.h",
+        "src/stdio/scanf_core/current_pos_converter.h",
+        "src/stdio/scanf_core/float_converter.h",
+        "src/stdio/scanf_core/int_converter.h",
+        "src/stdio/scanf_core/ptr_converter.h",
+        "src/stdio/scanf_core/string_converter.h",
+    ],
+    deps = [
+        ":__support_char_vector",
+        ":__support_cpp_bitset",
+        ":__support_cpp_limits",
+        ":__support_cpp_string_view",
+        ":__support_ctype_utils",
+        ":__support_str_to_float",
+        ":scanf_core_structs",
+        ":scanf_reader",
+    ],
+)
+
+libc_support_library(
+    name = "scanf_main",
+    srcs = ["src/stdio/scanf_core/scanf_main.cpp"],
+    hdrs = ["src/stdio/scanf_core/scanf_main.h"],
+    deps = [
+        ":__support_arg_list",
+        ":scanf_config",
+        ":scanf_converter",
+        ":scanf_core_structs",
+        ":scanf_parser",
+        ":scanf_reader",
+    ],
+)
+
+libc_support_library(
+    name = "vfscanf_internal",
+    hdrs = ["src/stdio/scanf_core/vfscanf_internal.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":__support_macros_attributes",
+        ":scanf_main",
+        ":scanf_reader",
+        ":types_FILE",
+    ],
+)
+
+libc_function(
+    name = "scanf",
+    srcs = ["src/stdio/scanf.cpp"],
+    hdrs = ["src/stdio/scanf.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":types_FILE",
+        ":vfscanf_internal",
+    ],
+)
+
+libc_function(
+    name = "vscanf",
+    srcs = ["src/stdio/vscanf.cpp"],
+    hdrs = ["src/stdio/vscanf.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":types_FILE",
+        ":vfscanf_internal",
+    ],
+)
+
+libc_function(
+    name = "fscanf",
+    srcs = ["src/stdio/fscanf.cpp"],
+    hdrs = ["src/stdio/fscanf.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":types_FILE",
+        ":vfscanf_internal",
+    ],
+)
+
+libc_function(
+    name = "vfscanf",
+    srcs = ["src/stdio/vfscanf.cpp"],
+    hdrs = ["src/stdio/vfscanf.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":types_FILE",
+        ":vfscanf_internal",
+    ],
+)
+
+libc_function(
+    name = "sscanf",
+    srcs = ["src/stdio/sscanf.cpp"],
+    hdrs = ["src/stdio/sscanf.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":scanf_main",
+        ":scanf_reader",
+        ":types_FILE",
+    ],
+)
+
+libc_function(
+    name = "vsscanf",
+    srcs = ["src/stdio/vsscanf.cpp"],
+    hdrs = ["src/stdio/vsscanf.h"],
+    deps = [
+        ":__support_arg_list",
+        ":__support_file_file",
+        ":scanf_main",
+        ":scanf_reader",
+        ":types_FILE",
+    ],
+)
+
 libc_function(
     name = "remove",
     srcs = ["src/stdio/linux/remove.cpp"],

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
@@ -132,3 +132,43 @@ libc_test(
         "//libc:close",
     ],
 )
+
+libc_test(
+    name = "sscanf_test",
+    srcs = ["sscanf_test.cpp"],
+    libc_function_deps = [
+        "//libc:sscanf",
+    ],
+    deps = [
+        "//libc:__support_cpp_limits",
+        "//libc:__support_fputil_fp_bits",
+        "//libc:hdr_stdio_macros",
+        "//libc/test/UnitTest:fp_test_helpers",
+    ],
+)
+
+libc_test(
+    name = "fscanf_test",
+    srcs = ["fscanf_test.cpp"],
+    libc_function_deps = [
+        "//libc:fscanf",
+    ],
+    deps = ["//libc:__support_cpp_string_view"],
+)
+
+libc_test(
+    name = "vsscanf_test",
+    srcs = ["vsscanf_test.cpp"],
+    libc_function_deps = [
+        "//libc:vsscanf",
+    ],
+)
+
+libc_test(
+    name = "vfscanf_test",
+    srcs = ["vfscanf_test.cpp"],
+    libc_function_deps = [
+        "//libc:vfscanf",
+    ],
+    deps = ["//libc:__support_cpp_string_view"],
+)


### PR DESCRIPTION
Now that scanf is a little cleaner, this patch adds rules to build it
via bazel.
