### PR TITLE
[utils] Use stricter SSA regexp for CHECK-SAME.

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -159,7 +159,7 @@ def get_num_ssa_results(input_line):
 
 
 # Process a line of input that has been split at each SSA identifier '%'.
-def process_line(line_chunks, variable_namer, strict=False):
+def process_line(line_chunks, variable_namer, strict_name_re=False):
     output_line = ""
 
     # Process the rest that contained an SSA value name.
@@ -180,7 +180,7 @@ def process_line(line_chunks, variable_namer, strict=False):
         else:
             # Otherwise, generate a new variable.
             variable = variable_namer.generate_name(ssa_name)
-            if strict:
+            if strict_name_re:
                 # Use stricter regexp for the variable name, if requested.
                 # Greedy matching may cause issues with the generic '.*'
                 # regexp when the checks are split across several
@@ -397,7 +397,7 @@ def main():
                 output_line += " " * len(ssa_split[0])
 
                 # Process the rest of the line.
-                output_line += process_line([argument], variable_namer, strict=True)
+                output_line += process_line([argument], variable_namer, strict_name_re=True)
 
         # Append the output line.
         output_segments[-1].append(output_line)

--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -159,7 +159,7 @@ def get_num_ssa_results(input_line):
 
 
 # Process a line of input that has been split at each SSA identifier '%'.
-def process_line(line_chunks, variable_namer):
+def process_line(line_chunks, variable_namer, strict=False):
     output_line = ""
 
     # Process the rest that contained an SSA value name.
@@ -180,7 +180,14 @@ def process_line(line_chunks, variable_namer):
         else:
             # Otherwise, generate a new variable.
             variable = variable_namer.generate_name(ssa_name)
-            output_line += "%[[" + variable + ":.*]]"
+            if strict:
+                # Use stricter regexp for the variable name, if requested.
+                # Greedy matching may cause issues with the generic '.*'
+                # regexp when the checks are split across several
+                # lines (e.g. for CHECK-SAME).
+                output_line += "%[[" + variable + ":" + SSA_RE_STR + "]]"
+            else:
+                output_line += "%[[" + variable + ":.*]]"
 
         # Append the non named group.
         output_line += chunk[len(ssa_name) :]
@@ -390,7 +397,7 @@ def main():
                 output_line += " " * len(ssa_split[0])
 
                 # Process the rest of the line.
-                output_line += process_line([argument], variable_namer)
+                output_line += process_line([argument], variable_namer, strict=True)
 
         # Append the output line.
         output_segments[-1].append(output_line)

--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -397,7 +397,9 @@ def main():
                 output_line += " " * len(ssa_split[0])
 
                 # Process the rest of the line.
-                output_line += process_line([argument], variable_namer, strict_name_re=True)
+                output_line += process_line(
+                    [argument], variable_namer, strict_name_re=True
+                )
 
         # Append the output line.
         output_segments[-1].append(output_line)


### PR DESCRIPTION
When CHECK-SAME checks are split across multiple lines,
the '.*' regexp for the SSA variable name may cause problems, e.g.:
```
// CHECK_LABEL: func.func @whatever(
// CHECK-SAME: %[[VAL_0:.*]]: i32,
// CHECK-SAME: %[[VAL_1:.*]]: i32,
// CHECK-SAME: %[[VAL_2:.*]]: i64)
```

This will not work for `func.func @whatever(%0: i32, %1: i32, %2: i64)`,
because VAL_0 will match to `0: i32, %1`.
