### PR TITLE
[HLSL][Sema] Fix Struct Size Calculation containing 16/32 bit scalars

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -173,12 +173,13 @@ Decl *SemaHLSL::ActOnStartBuffer(Scope *BufferScope, bool CBuffer,
 }
 
 static unsigned calculateLegacyCbufferFieldAlign(const ASTContext &Context,
-                                           QualType T) {
+                                                 QualType T) {
   // Aggregate types are always aligned to new buffer rows
   if (T->isAggregateType())
     return 16;
 
-  assert(Context.getTypeSize(T) <= 64 && "Scalar bit widths larger than 64 not supported");
+  assert(Context.getTypeSize(T) <= 64 &&
+         "Scalar bit widths larger than 64 not supported");
 
   // 64 bit types such as double and uint64_t align to 8 bytes
   if (Context.getTypeSize(T) == 64)

--- a/clang/test/CodeGenHLSL/cbuffer_align.hlsl
+++ b/clang/test/CodeGenHLSL/cbuffer_align.hlsl
@@ -57,15 +57,49 @@ cbuffer CB2Fail {
   // expected-error@-1 {{packoffset overlap between 'f2f', 's2f'}}
 }
 
-
-#if 0
 struct S3 {
   float3 a;
   float b;
 };
 
+cbuffer CB3Pass {
+  S3 s3p : packoffset(c0.x);
+  float f3p : packoffset(c1.x);
+}
+
+cbuffer CB3Fail {
+  S3 s3f : packoffset(c0.x);
+  float f3f : packoffset(c0.w);
+  // expected-error@-1 {{packoffset overlap between 'f3f', 's3f'}}
+}
+
 struct S4 {
   float2 a;
   float2 b;
 };
-#endif
+
+cbuffer CB4Pass {
+  S4 s4p : packoffset(c0.x);
+  float f4p : packoffset(c1.x);
+}
+
+cbuffer CB4Fail {
+  S4 s4f : packoffset(c0.x);
+  float f4f : packoffset(c0.w);
+  // expected-error@-1 {{packoffset overlap between 'f4f', 's4f'}}
+}
+
+struct S5 {
+  float a[3];
+};
+
+cbuffer CB5Pass {
+  S5 s5p : packoffset(c0.x);
+  float f5p : packoffset(c2.y);
+}
+
+cbuffer CB5Fail {
+  S5 s5f : packoffset(c0.x);
+  float f5f : packoffset(c2.x);
+  // expected-error@-1 {{packoffset overlap between 'f5f', 's5f'}}
+}

--- a/clang/test/CodeGenHLSL/cbuffer_align.hlsl
+++ b/clang/test/CodeGenHLSL/cbuffer_align.hlsl
@@ -103,3 +103,19 @@ cbuffer CB5Fail {
   float f5f : packoffset(c2.x);
   // expected-error@-1 {{packoffset overlap between 'f5f', 's5f'}}
 }
+
+struct S6 {
+  float a;
+  float2 b;
+};
+
+cbuffer CB6Pass {
+  S6 s6p : packoffset(c0.x);
+  float f6p : packoffset(c0.w);
+}
+
+cbuffer CB6Fail {
+  S6 s6f : packoffset(c0.x);
+  float f6f : packoffset(c0.y);
+  // expected-error@-1 {{packoffset overlap between 'f6f', 's6f'}}
+}

--- a/clang/test/CodeGenHLSL/cbuffer_align.hlsl
+++ b/clang/test/CodeGenHLSL/cbuffer_align.hlsl
@@ -1,0 +1,60 @@
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefix=CHECK-HALF
+
+// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
+// RUN:   dxil-pc-shadermodel6.3-library %s \
+// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefix=CHECK-FLOAT
+
+
+struct S1 {
+  half a;   // 2 bytes + 2 bytes pad or 4 bytes
+  float b;  // 4 bytes
+  half c;   // 2 bytes + 2 bytes pad or 4 bytes
+  float d;  // 4 bytes
+  double e; // 8 bytes
+};
+
+struct S2 {
+  half a;   // 2 bytes or 4 bytes
+  half b;   // 2 bytes or 4 bytes
+  float e;  // 4 bytes or 4 bytes + 4 padding
+  double f; // 8 bytes
+};
+
+struct S3 {
+  half a;     // 2 bytes + 6 bytes pad or 4 bytes + 4 bytes pad
+  uint64_t b; // 8 bytes
+};
+
+struct S4 {
+  float a;  // 4 bytes
+  half b;   // 2 bytes or 4 bytes
+  half c;   // 2 bytes or 4 bytes + 4 bytes pad
+  double d; // 8 bytes
+};
+
+
+cbuffer CB0 {
+  // CHECK-HALF: @CB0.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB0, 24, 0))
+  // CHECK-FLOAT: @CB0.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB0, 24, 0))
+  S1 s1;
+}
+
+cbuffer CB1 {
+  // CHECK-HALF: @CB1.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB1, 16, 0))
+  // CHECK-FLOAT: @CB1.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB1, 24, 0))
+  S2 s2;
+}
+
+cbuffer CB2 {
+  // CHECK-HALF: @CB2.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 16, 0))
+  // CHECK-FLOAT: @CB2.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 16, 0))
+  S3 s3;
+}
+
+cbuffer CB3 {
+  // CHECK-HALF: @CB3.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB3, 16, 0))
+  // CHECK-FLOAT: @CB3.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB3, 24, 0))
+  S4 s4;
+}

--- a/clang/test/CodeGenHLSL/cbuffer_align.hlsl
+++ b/clang/test/CodeGenHLSL/cbuffer_align.hlsl
@@ -1,60 +1,71 @@
 // RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
 // RUN:   dxil-pc-shadermodel6.3-library %s -fnative-half-type \
-// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefix=CHECK-HALF
+// RUN:   -fsyntax-only -verify -verify-ignore-unexpected=warning
 
-// RUN: %clang_cc1 -std=hlsl2021 -finclude-default-header -x hlsl -triple \
-// RUN:   dxil-pc-shadermodel6.3-library %s \
-// RUN:   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefix=CHECK-FLOAT
+struct S0 {
+  half a;
+  half b;
+  half c;
+  half d;
+  half e;
+  half f;
+  half g;
+  half h;
+};
 
+cbuffer CB0Pass {
+  S0 s0p : packoffset(c0.x);
+  float f0p : packoffset(c1.x);
+}
+
+cbuffer CB0Fail {
+  S0 s0f : packoffset(c0.x);
+  float f0f : packoffset(c0.w);
+  // expected-error@-1 {{packoffset overlap between 'f0f', 's0f'}}
+}
 
 struct S1 {
-  half a;   // 2 bytes + 2 bytes pad or 4 bytes
-  float b;  // 4 bytes
-  half c;   // 2 bytes + 2 bytes pad or 4 bytes
-  float d;  // 4 bytes
-  double e; // 8 bytes
+  float a;
+  double b;
+  float c;
 };
+
+cbuffer CB1Pass {
+  S1 s1p : packoffset(c0.x);
+  float f1p : packoffset(c1.y);
+}
+
+cbuffer CB1Fail {
+  S1 s1f : packoffset(c0.x);
+  float f1f : packoffset(c1.x);
+  // expected-error@-1 {{packoffset overlap between 'f1f', 's1f'}}
+}
 
 struct S2 {
-  half a;   // 2 bytes or 4 bytes
-  half b;   // 2 bytes or 4 bytes
-  float e;  // 4 bytes or 4 bytes + 4 padding
-  double f; // 8 bytes
+  float3 a;
+  float2 b;
 };
 
+cbuffer CB2Pass {
+  S2 s2p : packoffset(c0.x);
+  float f2p : packoffset(c1.z);
+}
+
+cbuffer CB2Fail {
+  S2 s2f : packoffset(c0.x);
+  float f2f : packoffset(c1.y);
+  // expected-error@-1 {{packoffset overlap between 'f2f', 's2f'}}
+}
+
+
+#if 0
 struct S3 {
-  half a;     // 2 bytes + 6 bytes pad or 4 bytes + 4 bytes pad
-  uint64_t b; // 8 bytes
+  float3 a;
+  float b;
 };
 
 struct S4 {
-  float a;  // 4 bytes
-  half b;   // 2 bytes or 4 bytes
-  half c;   // 2 bytes or 4 bytes + 4 bytes pad
-  double d; // 8 bytes
+  float2 a;
+  float2 b;
 };
-
-
-cbuffer CB0 {
-  // CHECK-HALF: @CB0.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB0, 24, 0))
-  // CHECK-FLOAT: @CB0.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB0, 24, 0))
-  S1 s1;
-}
-
-cbuffer CB1 {
-  // CHECK-HALF: @CB1.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB1, 16, 0))
-  // CHECK-FLOAT: @CB1.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB1, 24, 0))
-  S2 s2;
-}
-
-cbuffer CB2 {
-  // CHECK-HALF: @CB2.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 16, 0))
-  // CHECK-FLOAT: @CB2.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB2, 16, 0))
-  S3 s3;
-}
-
-cbuffer CB3 {
-  // CHECK-HALF: @CB3.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB3, 16, 0))
-  // CHECK-FLOAT: @CB3.cb = external constant target("dx.CBuffer", target("dx.Layout", %__cblayout_CB3, 24, 0))
-  S4 s4;
-}
+#endif


### PR DESCRIPTION
Fixes #119641

Update SemaHLSL to correctly calculate the alignment barrier for scalars that are not 4 bytes wide