### PR TITLE
[libc] Make two include/llvm-libc-types/ headers more self-contained.

### DIFF
--- a/libc/include/inttypes.h.def
+++ b/libc/include/inttypes.h.def
@@ -11,7 +11,6 @@
 
 #include "__llvm-libc-common.h"
 #include "llvm-libc-macros/inttypes-macros.h"
-#include <stdint.h>
 
 %%public_api()
 

--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -99,7 +99,14 @@ add_header(tss_dtor_t HDR tss_dtor_t.h)
 add_header(__atexithandler_t HDR __atexithandler_t.h)
 add_header(speed_t HDR speed_t.h)
 add_header(tcflag_t HDR tcflag_t.h)
-add_header(struct_termios HDR struct_termios.h DEPENDS .cc_t .speed_t .tcflag_t)
+add_header(
+    struct_termios
+  HDR
+    struct_termios.h
+  DEPENDS
+    .cc_t .speed_t .tcflag_t
+    libc.include.llvm-libc-macros.termios_macros
+)
 add_header(__getoptargv_t HDR __getoptargv_t.h)
 add_header(wchar_t HDR wchar_t.h)
 add_header(char8_t HDR char8_t.h)

--- a/libc/include/llvm-libc-types/imaxdiv_t.h
+++ b/libc/include/llvm-libc-types/imaxdiv_t.h
@@ -9,6 +9,8 @@
 #ifndef __LLVM_LIBC_TYPES_IMAXDIV_T_H__
 #define __LLVM_LIBC_TYPES_IMAXDIV_T_H__
 
+#include <stdint.h>
+
 typedef struct {
   intmax_t quot;
   intmax_t rem;

--- a/libc/include/llvm-libc-types/struct_termios.h
+++ b/libc/include/llvm-libc-types/struct_termios.h
@@ -13,6 +13,8 @@
 #include "speed_t.h"
 #include "tcflag_t.h"
 
+#include "../llvm-libc-macros/termios-macros.h" // NCCS
+
 struct termios {
   tcflag_t c_iflag; // Input mode flags
   tcflag_t c_oflag; // Output mode flags

--- a/libc/include/llvm-libc-types/struct_termios.h
+++ b/libc/include/llvm-libc-types/struct_termios.h
@@ -23,7 +23,6 @@ struct termios {
 #ifdef __linux__
   cc_t c_line; // Line discipline
 #endif         // __linux__
-  // NCCS is defined in llvm-libc-macros/termios-macros.h.
   cc_t c_cc[NCCS]; // Control characters
 #ifdef __linux__
   speed_t c_ispeed; // Input speed


### PR DESCRIPTION
* imaxdiv_t.h needs intmax_t. Get it from <stdint.h> directly instead of relying on prior inclusion inside generated inttypes.h.
* include <termios-macros.h> for struct termios to get the #defined constant. We do allow inclusion of macro headers from types headers in other places.