### PR TITLE
[libc] Skip scanf internals when no file available

### DIFF
--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -54,6 +54,12 @@ add_header_library(
     libc.src.__support.CPP.string_view
 )
 
+if(NOT(TARGET libc.src.__support.File.file) AND LLVM_LIBC_FULL_BUILD)
+  # Not all platforms have a file implementation. If file is unvailable, and a
+  # full build is requested, then we must skip all file based scanf sections.
+  return()
+endif()
+
 add_object_library(
   scanf_main
   SRCS

--- a/libc/test/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/test/src/stdio/scanf_core/CMakeLists.txt
@@ -18,6 +18,12 @@ add_libc_unittest(
     libc.src.__support.arg_list
 )
 
+if(NOT(TARGET libc.src.__support.File.file) AND LLVM_LIBC_FULL_BUILD)
+  # Not all platforms have a file implementation. If file is unvailable, and a
+  # full build is requested, then we must skip all file based scanf sections.
+  return()
+endif()
+
 add_libc_unittest(
   reader_test
   SUITE


### PR DESCRIPTION
A temporary fix based on discussions in #128079

Currently, baremetal targets are failing to build because the scanf
internals require FILE* (either from the system's libc or our libc).
Normally we'd just turn off the broken entrypoint, but since the scanf
internals are built separately that doesn't work. This patch adds extra
conditions to building those internals, which we can hopefully remove
once we have a proper way to build scanf for embedded.
