### PR TITLE
[libc] Add missing stdc_first_trailing_zero_ to stdbit.yaml

### DIFF
--- a/libc/include/stdbit.yaml
+++ b/libc/include/stdbit.yaml
@@ -245,6 +245,36 @@ functions:
     return_type: unsigned int
     arguments:
       - type: unsigned short
+  - name: stdc_first_trailing_zero_uc
+    standards:
+      - stdc
+    return_type: unsigned int
+    arguments:
+      - type: unsigned char
+  - name: stdc_first_trailing_zero_ui
+    standards:
+      - stdc
+    return_type: unsigned int
+    arguments:
+      - type: unsigned int
+  - name: stdc_first_trailing_zero_ul
+    standards:
+      - stdc
+    return_type: unsigned int
+    arguments:
+      - type: unsigned long
+  - name: stdc_first_trailing_zero_ull
+    standards:
+      - stdc
+    return_type: unsigned int
+    arguments:
+      - type: unsigned long long
+  - name: stdc_first_trailing_zero_us
+    standards:
+      - stdc
+    return_type: unsigned int
+    arguments:
+      - type: unsigned short
   - name: stdc_has_single_bit_uc
     standards:
       - stdc


### PR DESCRIPTION
These declarations were missing in the generated header. Make sure to add them, otherwise <stdbit.h> inclusion fails, since the subsequently included "stdbit-macros.h" expects these declarations to be present.