### PR TITLE
[RISCV] Simplify the debug messages in the disassembler.

### DIFF
--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -638,27 +638,21 @@ DecodeStatus RISCVDisassembler::getInstruction32(MCInst &MI, uint64_t &Size,
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadBs, DecoderTableXTHeadBs32,
                         "XTHeadBs");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadCondMov,
-                        DecoderTableXTHeadCondMov32,
-                        "XTHeadCondMov");
+                        DecoderTableXTHeadCondMov32, "XTHeadCondMov");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadCmo, DecoderTableXTHeadCmo32,
                         "XTHeadCmo");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadFMemIdx,
-                        DecoderTableXTHeadFMemIdx32,
-                        "XTHeadFMemIdx");
+                        DecoderTableXTHeadFMemIdx32, "XTHeadFMemIdx");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadMac, DecoderTableXTHeadMac32,
                         "XTHeadMac");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadMemIdx,
-                        DecoderTableXTHeadMemIdx32,
-                        "XTHeadMemIdx");
+                        DecoderTableXTHeadMemIdx32, "XTHeadMemIdx");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadMemPair,
-                        DecoderTableXTHeadMemPair32,
-                        "XTHeadMemPair");
+                        DecoderTableXTHeadMemPair32, "XTHeadMemPair");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadSync,
-                        DecoderTableXTHeadSync32,
-                        "XTHeadSync");
+                        DecoderTableXTHeadSync32, "XTHeadSync");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadVdot,
-                        DecoderTableXTHeadVdot32,
-                        "XTHeadVdot");
+                        DecoderTableXTHeadVdot32, "XTHeadVdot");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSfvcp, DecoderTableXSfvcp32,
                         "SiFive VCIX");
   TRY_TO_DECODE_FEATURE(
@@ -667,12 +661,12 @@ DecodeStatus RISCVDisassembler::getInstruction32(MCInst &MI, uint64_t &Size,
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXSfvqmaccqoq, DecoderTableXSfvqmaccqoq32,
       "SiFive Matrix Multiplication (4x8 and 8x4) Instruction");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXSfvfwmaccqqq, DecoderTableXSfvfwmaccqqq32,
-      "SiFive Matrix Multiplication Instruction");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXSfvfnrclipxfqf, DecoderTableXSfvfnrclipxfqf32,
-      "SiFive FP32-to-int8 Ranged Clip Instructions");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSfvfwmaccqqq,
+                        DecoderTableXSfvfwmaccqqq32,
+                        "SiFive Matrix Multiplication Instruction");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSfvfnrclipxfqf,
+                        DecoderTableXSfvfnrclipxfqf32,
+                        "SiFive FP32-to-int8 Ranged Clip Instructions");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSiFivecdiscarddlone,
                         DecoderTableXSiFivecdiscarddlone32,
                         "SiFive sf.cdiscard.d.l1");
@@ -684,11 +678,9 @@ DecodeStatus RISCVDisassembler::getInstruction32(MCInst &MI, uint64_t &Size,
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXMIPSLSP, DecoderTableXmipslsp32,
                         "MIPS mips.lsp");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXMIPSCMove,
-                        DecoderTableXmipscmove32,
-                        "MIPS mips.ccmov");
+                        DecoderTableXmipscmove32, "MIPS mips.ccmov");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVbitmanip,
-                        DecoderTableXCVbitmanip32,
-                        "CORE-V Bit Manipulation");
+                        DecoderTableXCVbitmanip32, "CORE-V Bit Manipulation");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVelw, DecoderTableXCVelw32,
                         "CORE-V Event load");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVmac, DecoderTableXCVmac32,
@@ -711,12 +703,10 @@ DecodeStatus RISCVDisassembler::getInstruction32(MCInst &MI, uint64_t &Size,
                         "Qualcomm uC Conditional Select");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcilsm, DecoderTableXqcilsm32,
                         "Qualcomm uC Load Store Multiple");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXqciac, DecoderTableXqciac32,
-      "Qualcomm uC Load-Store Address Calculation");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXqcicli, DecoderTableXqcicli32,
-      "Qualcomm uC Conditional Load Immediate");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqciac, DecoderTableXqciac32,
+                        "Qualcomm uC Load-Store Address Calculation");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcicli, DecoderTableXqcicli32,
+                        "Qualcomm uC Conditional Load Immediate");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcicm, DecoderTableXqcicm32,
                         "Qualcomm uC Conditional Move");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqciint, DecoderTableXqciint32,
@@ -744,20 +734,16 @@ DecodeStatus RISCVDisassembler::getInstruction16(MCInst &MI, uint64_t &Size,
                         "RVZicfiss (Shadow Stack)");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureStdExtZcmt, DecoderTableRVZcmt16,
                         "Zcmt (16-bit Table Jump Instructions)");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureStdExtZcmp, DecoderTableRVZcmp16,
-      "Zcmp (16-bit Push/Pop & Double Move Instructions)");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXqciac, DecoderTableXqciac16,
-      "Qualcomm uC Load-Store Address Calculation 16bit");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXqcicm, DecoderTableXqcicm16,
-      "Qualcomm uC Conditional Move 16bit");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureStdExtZcmp, DecoderTableRVZcmp16,
+                        "Zcmp (16-bit Push/Pop & Double Move Instructions)");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqciac, DecoderTableXqciac16,
+                        "Qualcomm uC Load-Store Address Calculation 16bit");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcicm, DecoderTableXqcicm16,
+                        "Qualcomm uC Conditional Move 16bit");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqciint, DecoderTableXqciint16,
                         "Qualcomm uC Interrupts 16bit");
   TRY_TO_DECODE_AND_ADD_SP(STI.hasFeature(RISCV::FeatureVendorXwchc),
-                           DecoderTableXwchc16,
-                           "WCH QingKe XW");
+                           DecoderTableXwchc16, "WCH QingKe XW");
   TRY_TO_DECODE_AND_ADD_SP(true, DecoderTable16,
                            "RISCV_C (16-bit Instruction)");
 
@@ -778,9 +764,8 @@ DecodeStatus RISCVDisassembler::getInstruction48(MCInst &MI, uint64_t &Size,
   for (size_t i = Size; i-- != 0;) {
     Insn += (static_cast<uint64_t>(Bytes[i]) << 8 * i);
   }
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXqcilo, DecoderTableXqcilo48,
-      "Qualcomm uC Large Offset Load Store 48bit");
+  TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcilo, DecoderTableXqcilo48,
+                        "Qualcomm uC Large Offset Load Store 48bit");
 
   return MCDisassembler::Fail;
 }

--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -589,7 +589,7 @@ void RISCVDisassembler::addSPOperands(MCInst &MI) const {
                                                 DESC, ADDITIONAL_OPERATION)    \
   do {                                                                         \
     if (FEATURE_CHECKS) {                                                      \
-      LLVM_DEBUG(dbgs() << "Trying " DESC ":\n");                              \
+      LLVM_DEBUG(dbgs() << "Trying " << DESC << " table:\n");                  \
       DecodeStatus Result =                                                    \
           decodeInstruction(DECODER_TABLE, MI, Insn, Address, this, STI);      \
       if (Result != MCDisassembler::Fail) {                                    \
@@ -622,106 +622,106 @@ DecodeStatus RISCVDisassembler::getInstruction32(MCInst &MI, uint64_t &Size,
   TRY_TO_DECODE(STI.hasFeature(RISCV::FeatureStdExtZdinx) &&
                     !STI.hasFeature(RISCV::Feature64Bit),
                 DecoderTableRV32Zdinx32,
-                "RV32Zdinx table (Double in Integer and rv32)");
+                "RV32Zdinx (Double in Integer and rv32)");
   TRY_TO_DECODE(STI.hasFeature(RISCV::FeatureStdExtZacas) &&
                     !STI.hasFeature(RISCV::Feature64Bit),
                 DecoderTableRV32Zacas32,
-                "RV32Zacas table (Compare-And-Swap and rv32)");
+                "RV32Zacas (Compare-And-Swap and rv32)");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureStdExtZfinx, DecoderTableRVZfinx32,
-                        "RVZfinx table (Float in Integer)");
+                        "RVZfinx (Float in Integer)");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXVentanaCondOps,
-                        DecoderTableXVentana32, "Ventana custom opcode table");
+                        DecoderTableXVentana32, "XVentanaCondOps");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadBa, DecoderTableXTHeadBa32,
-                        "XTHeadBa custom opcode table");
+                        "XTHeadBa");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadBb, DecoderTableXTHeadBb32,
-                        "XTHeadBb custom opcode table");
+                        "XTHeadBb");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadBs, DecoderTableXTHeadBs32,
-                        "XTHeadBs custom opcode table");
+                        "XTHeadBs");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadCondMov,
                         DecoderTableXTHeadCondMov32,
-                        "XTHeadCondMov custom opcode table");
+                        "XTHeadCondMov");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadCmo, DecoderTableXTHeadCmo32,
-                        "XTHeadCmo custom opcode table");
+                        "XTHeadCmo");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadFMemIdx,
                         DecoderTableXTHeadFMemIdx32,
-                        "XTHeadFMemIdx custom opcode table");
+                        "XTHeadFMemIdx");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadMac, DecoderTableXTHeadMac32,
-                        "XTHeadMac custom opcode table");
+                        "XTHeadMac");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadMemIdx,
                         DecoderTableXTHeadMemIdx32,
-                        "XTHeadMemIdx custom opcode table");
+                        "XTHeadMemIdx");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadMemPair,
                         DecoderTableXTHeadMemPair32,
-                        "XTHeadMemPair custom opcode table");
+                        "XTHeadMemPair");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadSync,
                         DecoderTableXTHeadSync32,
-                        "XTHeadSync custom opcode table");
+                        "XTHeadSync");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXTHeadVdot,
                         DecoderTableXTHeadVdot32,
-                        "XTHeadVdot custom opcode table");
+                        "XTHeadVdot");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSfvcp, DecoderTableXSfvcp32,
-                        "SiFive VCIX custom opcode table");
+                        "SiFive VCIX");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXSfvqmaccdod, DecoderTableXSfvqmaccdod32,
-      "SiFive Matrix Multiplication (2x8 and 8x2) Instruction opcode table");
+      "SiFive Matrix Multiplication (2x8 and 8x2) Instruction");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXSfvqmaccqoq, DecoderTableXSfvqmaccqoq32,
-      "SiFive Matrix Multiplication (4x8 and 8x4) Instruction opcode table");
+      "SiFive Matrix Multiplication (4x8 and 8x4) Instruction");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXSfvfwmaccqqq, DecoderTableXSfvfwmaccqqq32,
-      "SiFive Matrix Multiplication Instruction opcode table");
+      "SiFive Matrix Multiplication Instruction");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXSfvfnrclipxfqf, DecoderTableXSfvfnrclipxfqf32,
-      "SiFive FP32-to-int8 Ranged Clip Instructions opcode table");
+      "SiFive FP32-to-int8 Ranged Clip Instructions");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSiFivecdiscarddlone,
                         DecoderTableXSiFivecdiscarddlone32,
-                        "SiFive sf.cdiscard.d.l1 custom opcode table");
+                        "SiFive sf.cdiscard.d.l1");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSiFivecflushdlone,
                         DecoderTableXSiFivecflushdlone32,
-                        "SiFive sf.cflush.d.l1 custom opcode table");
+                        "SiFive sf.cflush.d.l1");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXSfcease, DecoderTableXSfcease32,
-                        "SiFive sf.cease custom opcode table");
+                        "SiFive sf.cease");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXMIPSLSP, DecoderTableXmipslsp32,
-                        "MIPS mips.lsp custom opcode table");
+                        "MIPS mips.lsp");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXMIPSCMove,
                         DecoderTableXmipscmove32,
-                        "MIPS mips.ccmov custom opcode table");
+                        "MIPS mips.ccmov");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVbitmanip,
                         DecoderTableXCVbitmanip32,
-                        "CORE-V Bit Manipulation custom opcode table");
+                        "CORE-V Bit Manipulation");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVelw, DecoderTableXCVelw32,
-                        "CORE-V Event load custom opcode table");
+                        "CORE-V Event load");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVmac, DecoderTableXCVmac32,
-                        "CORE-V MAC custom opcode table");
+                        "CORE-V MAC");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVmem, DecoderTableXCVmem32,
-                        "CORE-V MEM custom opcode table");
+                        "CORE-V MEM");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCValu, DecoderTableXCValu32,
-                        "CORE-V ALU custom opcode table");
+                        "CORE-V ALU");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVsimd, DecoderTableXCVsimd32,
-                        "CORE-V SIMD extensions custom opcode table");
+                        "CORE-V SIMD extensions");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXCVbi, DecoderTableXCVbi32,
-                        "CORE-V Immediate Branching custom opcode table");
+                        "CORE-V Immediate Branching");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcicsr, DecoderTableXqcicsr32,
-                        "Qualcomm uC CSR custom opcode table");
+                        "Qualcomm uC CSR");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcisls, DecoderTableXqcisls32,
-                        "Qualcomm uC Scaled Load Store custom opcode table");
+                        "Qualcomm uC Scaled Load Store");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcia, DecoderTableXqcia32,
-                        "Qualcomm uC Arithmetic custom opcode table");
+                        "Qualcomm uC Arithmetic");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcics, DecoderTableXqcics32,
-                        "Qualcomm uC Conditional Select custom opcode table");
+                        "Qualcomm uC Conditional Select");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcilsm, DecoderTableXqcilsm32,
-                        "Qualcomm uC Load Store Multiple custom opcode table");
+                        "Qualcomm uC Load Store Multiple");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXqciac, DecoderTableXqciac32,
-      "Qualcomm uC Load-Store Address Calculation custom opcode table");
+      "Qualcomm uC Load-Store Address Calculation");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXqcicli, DecoderTableXqcicli32,
-      "Qualcomm uC Conditional Load Immediate custom opcode table");
+      "Qualcomm uC Conditional Load Immediate");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqcicm, DecoderTableXqcicm32,
-                        "Qualcomm uC Conditional Move custom opcode table");
+                        "Qualcomm uC Conditional Move");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqciint, DecoderTableXqciint32,
-                        "Qualcomm uC Interrupts custom opcode table");
-  TRY_TO_DECODE(true, DecoderTable32, "RISCV32 table");
+                        "Qualcomm uC Interrupts");
+  TRY_TO_DECODE(true, DecoderTable32, "RISCV32");
 
   return MCDisassembler::Fail;
 }
@@ -739,27 +739,27 @@ DecodeStatus RISCVDisassembler::getInstruction16(MCInst &MI, uint64_t &Size,
   uint32_t Insn = support::endian::read16le(Bytes.data());
   TRY_TO_DECODE_AND_ADD_SP(!STI.hasFeature(RISCV::Feature64Bit),
                            DecoderTableRISCV32Only_16,
-                           "RISCV32Only_16 table (16-bit Instruction)");
+                           "RISCV32Only_16 (16-bit Instruction)");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureStdExtZicfiss, DecoderTableZicfiss16,
-                        "RVZicfiss table (Shadow Stack)");
+                        "RVZicfiss (Shadow Stack)");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureStdExtZcmt, DecoderTableRVZcmt16,
-                        "Zcmt table (16-bit Table Jump Instructions)");
+                        "Zcmt (16-bit Table Jump Instructions)");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureStdExtZcmp, DecoderTableRVZcmp16,
-      "Zcmp table (16-bit Push/Pop & Double Move Instructions)");
+      "Zcmp (16-bit Push/Pop & Double Move Instructions)");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXqciac, DecoderTableXqciac16,
-      "Qualcomm uC Load-Store Address Calculation custom 16bit opcode table");
+      "Qualcomm uC Load-Store Address Calculation 16bit");
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXqcicm, DecoderTableXqcicm16,
-      "Qualcomm uC Conditional Move custom 16bit opcode table");
+      "Qualcomm uC Conditional Move 16bit");
   TRY_TO_DECODE_FEATURE(RISCV::FeatureVendorXqciint, DecoderTableXqciint16,
-                        "Qualcomm uC Interrupts custom 16bit opcode table");
+                        "Qualcomm uC Interrupts 16bit");
   TRY_TO_DECODE_AND_ADD_SP(STI.hasFeature(RISCV::FeatureVendorXwchc),
                            DecoderTableXwchc16,
-                           "WCH QingKe XW custom opcode table");
+                           "WCH QingKe XW");
   TRY_TO_DECODE_AND_ADD_SP(true, DecoderTable16,
-                           "RISCV_C table (16-bit Instruction)");
+                           "RISCV_C (16-bit Instruction)");
 
   return MCDisassembler::Fail;
 }
@@ -780,7 +780,7 @@ DecodeStatus RISCVDisassembler::getInstruction48(MCInst &MI, uint64_t &Size,
   }
   TRY_TO_DECODE_FEATURE(
       RISCV::FeatureVendorXqcilo, DecoderTableXqcilo48,
-      "Qualcomm uC Large Offset Load Store custom 48bit opcode table");
+      "Qualcomm uC Large Offset Load Store 48bit");
 
   return MCDisassembler::Fail;
 }


### PR DESCRIPTION
Move the printing of "table" to the macro instantiation.

Don't use string concatenation in the macro. Print DESC as it own string. This allows the "Trying " and " table:" to only appear in the binary once instead of being part of every string.

Remove "custom opcode" from the messages, I don't think it provides much value after mentioning the vendor.

I'm hoping to replace the macros with a table of features, decoder table pointer, and string that we can iterate over.