### PR TITLE
[clang] Improve module out of date error message

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -119,7 +119,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
   // Note: ExpectedSize and ExpectedModTime will be 0 for MK_ImplicitModule
   // when using an ASTFileSignature.
   if (lookupModuleFile(FileName, ExpectedSize, ExpectedModTime, Entry)) {
-    ErrorStr = "module file out of date";
+    ErrorStr = "module file has a different size or mtime than expected";
     return OutOfDate;
   }
 

--- a/clang/test/Modules/explicit-build.cpp
+++ b/clang/test/Modules/explicit-build.cpp
@@ -199,6 +199,6 @@
 // RUN:            -fmodule-file=%t/c.pcm \
 // RUN:            %s -DHAVE_A -DHAVE_B -DHAVE_C 2>&1 | FileCheck --check-prefix=CHECK-MISMATCHED-B %s
 //
-// CHECK-MISMATCHED-B:      fatal error: module file '{{.*}}b.pcm' is out of date and needs to be rebuilt: module file out of date
+// CHECK-MISMATCHED-B:      fatal error: module file '{{.*}}b.pcm' is out of date and needs to be rebuilt: module file has a different size or mtime than expected
 // CHECK-MISMATCHED-B-NEXT: note: imported by module 'c'
 // CHECK-MISMATCHED-B-NOT:  note:


### PR DESCRIPTION
When a pcm file has a different size or modification time than it had when it was written to another module's IMPORT table Clang emits:

`<pcm> is out of date and needs to be rebuilt: module file out of date`

This is difficult to understand what's happening because there are a lot of reasons that a module file can be out of date. This changes the latter part of that message to:

`module file has a different size or mtime than expected`

Which makes it clearer what the issue is. For future work it would be nice if a more detailed explanation of the issue could be emitted as a note instead.