### PR TITLE
[AMDGPUAA] Check Type before Taking AddressSpace of a Value

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUAliasAnalysis.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAliasAnalysis.cpp
@@ -49,8 +49,12 @@ void AMDGPUAAWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
 AliasResult AMDGPUAAResult::alias(const MemoryLocation &LocA,
                                   const MemoryLocation &LocB, AAQueryInfo &AAQI,
                                   const Instruction *) {
-  unsigned asA = LocA.Ptr->getType()->getPointerAddressSpace();
-  unsigned asB = LocB.Ptr->getType()->getPointerAddressSpace();
+  Type *TypeA = LocA.Ptr->getType();
+  Type *TypeB = LocB.Ptr->getType();
+  if (!TypeA->isPointerTy() || !TypeB->isPointerTy())
+    return AliasResult::MayAlias;
+  unsigned asA = TypeA->getPointerAddressSpace();
+  unsigned asB = TypeB->getPointerAddressSpace();
 
   if (!AMDGPU::addrspacesMayAlias(asA, asB))
     return AliasResult::NoAlias;


### PR DESCRIPTION
In current `AMDGPUAAResult::alias`, we directly take the AddressSpace of `LocA.Ptr->getType()`. It's unsafe as `LocA.Ptr->getType()` may be a non-pointer type. 

This patch adds a check to ensure we only take AddressSpace on a pointer value. If either of `LocA.Ptr` or `LocB.Ptr` is non-pointer, we return `AliasResult::MayAlias` which is the most conservative result.