### PR TITLE
[llvm-readtapi] Avoid repeated hash lookups (NFC)

### DIFF
--- a/llvm/tools/llvm-readtapi/llvm-readtapi.cpp
+++ b/llvm/tools/llvm-readtapi/llvm-readtapi.cpp
@@ -358,17 +358,19 @@ static void stubifyDirectory(const StringRef InputPath, Context &Ctx) {
     SmallString<PATH_MAX> NormalizedPath(Path);
     replace_extension(NormalizedPath, "");
 
+    auto [It, Inserted] = Dylibs.try_emplace(NormalizedPath.str());
+
     if ((IF->getFileType() == FileType::MachO_DynamicLibrary) ||
         (IF->getFileType() == FileType::MachO_DynamicLibrary_Stub)) {
       OriginalNames[NormalizedPath.c_str()] = IF->getPath();
 
       // Don't add this MachO dynamic library because we already have a
       // text-based stub recorded for this path.
-      if (Dylibs.count(NormalizedPath.c_str()))
+      if (!Inserted)
         continue;
     }
 
-    Dylibs[NormalizedPath.c_str()] = std::move(IF);
+    It->second = std::move(IF);
   }
 
   for (auto &Lib : Dylibs) {


### PR DESCRIPTION
Dylibs is a StringMap, which takes StringRef as the key type, so
NormalizedPath.str() is good enough.  We don't need to create a null
terminated string.  Neither do we need to recompute the string length
as part of StringRef construction.
