### PR TITLE
DAG: Preserve range metadata when load is narrowed

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14906,20 +14906,18 @@ SDValue DAGCombiner::reduceLoadWidth(SDNode *N) {
   if (ExtType == ISD::NON_EXTLOAD) {
     const MDNode *OldRanges = LN0->getRanges();
     const MDNode *NewRanges = nullptr;
-    /* If LSBs are loaded and the truncated ConstantRange for the OldRanges
-       metadata is not the full-set for the NewWidth then create a NewRanges
-       metadata for the truncated load */
+    // If LSBs are loaded and the truncated ConstantRange for the OldRanges
+    // metadata is not the full-set for the NewWidth then create a NewRanges
+    // metadata for the truncated load
     if (ShAmt == 0 && OldRanges) {
-      Type *NewTy = VT.getTypeForEVT(*DAG.getContext());
-      const unsigned NewWidth = NewTy->getIntegerBitWidth();
-      const ConstantRange CR = getConstantRangeFromMetadata(*OldRanges);
-      const ConstantRange TruncatedCR = CR.truncate(NewWidth);
+      ConstantRange CR = getConstantRangeFromMetadata(*OldRanges);
+      ConstantRange TruncatedCR = CR.truncate(VT.getScalarSizeInBits());
 
       if (!TruncatedCR.isFullSet()) {
         Metadata *Bounds[2] = {ConstantAsMetadata::get(ConstantInt::get(
-                                   NewTy, TruncatedCR.getLower())),
+                                   *DAG.getContext(), TruncatedCR.getLower())),
                                ConstantAsMetadata::get(ConstantInt::get(
-                                   NewTy, TruncatedCR.getUpper()))};
+                                   *DAG.getContext(), TruncatedCR.getUpper()))};
         NewRanges = MDNode::get(*DAG.getContext(), Bounds);
       }
     }

--- a/llvm/test/CodeGen/AMDGPU/shl64_reduce.ll
+++ b/llvm/test/CodeGen/AMDGPU/shl64_reduce.ll
@@ -21,11 +21,39 @@ define i64 @shl_metadata(i64 %arg0, ptr %arg1.ptr) {
 ; CHECK-LABEL: shl_metadata:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    flat_load_dword v1, v[2:3]
+; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    v_lshlrev_b32_e32 v1, v1, v0
+; CHECK-NEXT:    v_mov_b32_e32 v0, 0
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
+  %shift.amt = load i64, ptr %arg1.ptr, !range !0, !noundef !{}
+  %shl = shl i64 %arg0, %shift.amt
+  ret i64 %shl
+}
+
+define i64 @shl_metadata_two_ranges(i64 %arg0, ptr %arg1.ptr) {
+; CHECK-LABEL: shl_metadata_two_ranges:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    flat_load_dword v1, v[2:3]
+; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; CHECK-NEXT:    v_lshlrev_b32_e32 v1, v1, v0
+; CHECK-NEXT:    v_mov_b32_e32 v0, 0
+; CHECK-NEXT:    s_setpc_b64 s[30:31]
+  %shift.amt = load i64, ptr %arg1.ptr, !range !1, !noundef !{}
+  %shl = shl i64 %arg0, %shift.amt
+  ret i64 %shl
+}
+
+define i64 @shl_metadata_out_of_range(i64 %arg0, ptr %arg1.ptr) {
+; CHECK-LABEL: shl_metadata_out_of_range:
+; CHECK:       ; %bb.0:
+; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    flat_load_dword v2, v[2:3]
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; CHECK-NEXT:    v_lshlrev_b64 v[0:1], v2, v[0:1]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %shift.amt = load i64, ptr %arg1.ptr, !range !0
+  %shift.amt = load i64, ptr %arg1.ptr, !range !2, !noundef !{}
   %shl = shl i64 %arg0, %shift.amt
   ret i64 %shl
 }
@@ -39,7 +67,7 @@ define <2 x i64> @shl_v2_metadata(<2 x i64> %arg0, ptr %arg1.ptr) {
 ; CHECK-NEXT:    v_lshlrev_b64 v[0:1], v4, v[0:1]
 ; CHECK-NEXT:    v_lshlrev_b64 v[2:3], v6, v[2:3]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %shift.amt = load <2 x i64>, ptr %arg1.ptr, !range !0
+  %shift.amt = load <2 x i64>, ptr %arg1.ptr, !range !0, !noundef !{}
   %shl = shl <2 x i64> %arg0, %shift.amt
   ret <2 x i64> %shl
 }
@@ -55,7 +83,7 @@ define <3 x i64> @shl_v3_metadata(<3 x i64> %arg0, ptr %arg1.ptr) {
 ; CHECK-NEXT:    v_lshlrev_b64 v[0:1], v8, v[0:1]
 ; CHECK-NEXT:    v_lshlrev_b64 v[2:3], v10, v[2:3]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %shift.amt = load <3 x i64>, ptr %arg1.ptr, !range !0
+  %shift.amt = load <3 x i64>, ptr %arg1.ptr, !range !0, !noundef !{}
   %shl = shl <3 x i64> %arg0, %shift.amt
   ret <3 x i64> %shl
 }
@@ -74,12 +102,14 @@ define <4 x i64> @shl_v4_metadata(<4 x i64> %arg0, ptr %arg1.ptr) {
 ; CHECK-NEXT:    v_lshlrev_b64 v[4:5], v13, v[4:5]
 ; CHECK-NEXT:    v_lshlrev_b64 v[6:7], v15, v[6:7]
 ; CHECK-NEXT:    s_setpc_b64 s[30:31]
-  %shift.amt = load <4 x i64>, ptr %arg1.ptr, !range !0
+  %shift.amt = load <4 x i64>, ptr %arg1.ptr, !range !0, !noundef !{}
   %shl = shl <4 x i64> %arg0, %shift.amt
   ret <4 x i64> %shl
 }
 
 !0 = !{i64 32, i64 64}
+!1 = !{i64 32, i64 38, i64 42, i64 48}
+!2 = !{i64 31, i64 38, i64 42, i64 48}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Test range with an "or X, 16"

--- a/llvm/test/CodeGen/AMDGPU/shl64_reduce.ll
+++ b/llvm/test/CodeGen/AMDGPU/shl64_reduce.ll
@@ -13,10 +13,6 @@
 ; Test range with metadata
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; FIXME: This case should be reduced, but SelectionDAG::computeKnownBits() cannot
-;        determine the minimum from metadata in this case.  Match current results
-;        for now.
-
 define i64 @shl_metadata(i64 %arg0, ptr %arg1.ptr) {
 ; CHECK-LABEL: shl_metadata:
 ; CHECK:       ; %bb.0:
@@ -45,6 +41,7 @@ define i64 @shl_metadata_two_ranges(i64 %arg0, ptr %arg1.ptr) {
   ret i64 %shl
 }
 
+; Known minimum is too low.  Reduction must not be done.
 define i64 @shl_metadata_out_of_range(i64 %arg0, ptr %arg1.ptr) {
 ; CHECK-LABEL: shl_metadata_out_of_range:
 ; CHECK:       ; %bb.0:
@@ -59,7 +56,7 @@ define i64 @shl_metadata_out_of_range(i64 %arg0, ptr %arg1.ptr) {
 }
 
 ; Bounds cannot be truncated to i32 when load is narrowed to i32.
-; Reduction not done.
+; Reduction must not be done.
 ; Bounds were chosen so that if bounds were truncated to i32 the
 ; known minimum would be 32 and the shl would be erroneously reduced.
 define i64 @shl_metadata_cant_be_narrowed_to_i32(i64 %arg0, ptr %arg1.ptr) {
@@ -75,6 +72,7 @@ define i64 @shl_metadata_cant_be_narrowed_to_i32(i64 %arg0, ptr %arg1.ptr) {
   ret i64 %shl
 }
 
+; FIXME: This case should be reduced
 define <2 x i64> @shl_v2_metadata(<2 x i64> %arg0, ptr %arg1.ptr) {
 ; CHECK-LABEL: shl_v2_metadata:
 ; CHECK:       ; %bb.0:
@@ -89,6 +87,7 @@ define <2 x i64> @shl_v2_metadata(<2 x i64> %arg0, ptr %arg1.ptr) {
   ret <2 x i64> %shl
 }
 
+; FIXME: This case should be reduced
 define <3 x i64> @shl_v3_metadata(<3 x i64> %arg0, ptr %arg1.ptr) {
 ; CHECK-LABEL: shl_v3_metadata:
 ; CHECK:       ; %bb.0:
@@ -105,6 +104,7 @@ define <3 x i64> @shl_v3_metadata(<3 x i64> %arg0, ptr %arg1.ptr) {
   ret <3 x i64> %shl
 }
 
+; FIXME: This case should be reduced
 define <4 x i64> @shl_v4_metadata(<4 x i64> %arg0, ptr %arg1.ptr) {
 ; CHECK-LABEL: shl_v4_metadata:
 ; CHECK:       ; %bb.0:


### PR DESCRIPTION
In DAGCombiner.cpp preserve range metadata when load is narrowed to load LSBs if original range metadata bounds can fit in the narrower type.

Utilize preserved range metadata to reduce 64-bit shl to 32-bit shl.