### PR TITLE
[MachineBasicBlock][NFC] Decouple SplitCriticalEdges from pass manager

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -34,6 +34,7 @@ namespace llvm {
 class BasicBlock;
 class MachineDomTreeUpdater;
 class MachineFunction;
+class MachineLoopInfo;
 class MCSymbol;
 class ModuleSlotTracker;
 class Pass;
@@ -42,6 +43,7 @@ class SlotIndexes;
 class StringRef;
 class raw_ostream;
 class LiveIntervals;
+class LiveVariables;
 class TargetRegisterClass;
 class TargetRegisterInfo;
 template <typename IRUnitT, typename... ExtraArgTs> class AnalysisManager;
@@ -971,6 +973,13 @@ public:
   ///
   /// This function updates LiveVariables, MachineDominatorTree, and
   /// MachineLoopInfo, as applicable.
+  struct SplitCriticalEdgeAnalyses {
+    LiveIntervals *LIS;
+    SlotIndexes *SI;
+    LiveVariables *LV;
+    MachineLoopInfo *MLI;
+  };
+
   MachineBasicBlock *
   SplitCriticalEdge(MachineBasicBlock *Succ, Pass &P,
                     std::vector<SparseBitVector<>> *LiveInSets = nullptr,
@@ -987,6 +996,10 @@ public:
   }
 
   // Helper method for new pass manager migration.
+  MachineBasicBlock *SplitCriticalEdge(
+      MachineBasicBlock *Succ, const SplitCriticalEdgeAnalyses &Analyses,
+      std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU);
+
   MachineBasicBlock *SplitCriticalEdge(
       MachineBasicBlock *Succ, Pass *P, MachineFunctionAnalysisManager *MFAM,
       std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU);

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -1137,6 +1137,9 @@ public:
   }
 };
 
+MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
+    MachineBasicBlock *Succ, Pass *P, MachineFunctionAnalysisManager *MFAM,
+    std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU) {
 #define GET_RESULT(RESULT, GETTER, INFIX)                                      \
   [MF, P, MFAM]() {                                                            \
     if (P) {                                                                   \
@@ -1146,10 +1149,19 @@ public:
     return MFAM->getCachedResult<RESULT##Analysis>(*MF);                       \
   }()
 
-MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
-    MachineBasicBlock *Succ, Pass *P, MachineFunctionAnalysisManager *MFAM,
-    std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU) {
   assert((P || MFAM) && "Need a way to get analysis results!");
+  MachineFunction *MF = getParent();
+  LiveIntervals *LIS = GET_RESULT(LiveIntervals, getLIS, );
+  SlotIndexes *Indexes = GET_RESULT(SlotIndexes, getSI, );
+  LiveVariables *LV = GET_RESULT(LiveVariables, getLV, );
+  MachineLoopInfo *MLI = GET_RESULT(MachineLoop, getLI, Info);
+  return SplitCriticalEdge(Succ, {LIS, Indexes, LV, MLI}, LiveInSets, MDTU);
+#undef GET_RESULT
+}
+
+MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
+    MachineBasicBlock *Succ, const SplitCriticalEdgeAnalyses &Analyses,
+    std::vector<SparseBitVector<>> *LiveInSets, MachineDomTreeUpdater *MDTU) {
   if (!canSplitCriticalEdge(Succ))
     return nullptr;
 
@@ -1172,19 +1184,16 @@ MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
   LLVM_DEBUG(dbgs() << "Splitting critical edge: " << printMBBReference(*this)
                     << " -- " << printMBBReference(*NMBB) << " -- "
                     << printMBBReference(*Succ) << '\n');
-
-  LiveIntervals *LIS = GET_RESULT(LiveIntervals, getLIS, );
-  SlotIndexes *Indexes = GET_RESULT(SlotIndexes, getSI, );
+  auto *LIS = Analyses.LIS;
   if (LIS)
     LIS->insertMBBInMaps(NMBB);
-  else if (Indexes)
-    Indexes->insertMBBInMaps(NMBB);
+  else if (Analyses.SI)
+    Analyses.SI->insertMBBInMaps(NMBB);
 
   // On some targets like Mips, branches may kill virtual registers. Make sure
   // that LiveVariables is properly updated after updateTerminator replaces the
   // terminators.
-  LiveVariables *LV = GET_RESULT(LiveVariables, getLV, );
-
+  auto *LV = Analyses.LV;
   // Collect a list of virtual registers killed by the terminators.
   SmallVector<Register, 4> KilledRegs;
   if (LV)
@@ -1223,7 +1232,7 @@ MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
   // as the fallthrough successor
   if (Succ == PrevFallthrough)
     PrevFallthrough = NMBB;
-
+  auto *Indexes = Analyses.SI;
   if (!ChangedIndirectJump) {
     SlotIndexUpdateDelegate SlotUpdater(*MF, Indexes);
     updateTerminator(PrevFallthrough);
@@ -1351,7 +1360,7 @@ MachineBasicBlock *MachineBasicBlock::SplitCriticalEdge(
   if (MDTU)
     MDTU->splitCriticalEdge(this, Succ, NMBB);
 
-  if (MachineLoopInfo *MLI = GET_RESULT(MachineLoop, getLI, Info))
+  if (MachineLoopInfo *MLI = Analyses.MLI)
     if (MachineLoop *TIL = MLI->getLoopFor(this)) {
       // If one or the other blocks were not in a loop, the new block is not
       // either, and thus LI doesn't need to be updated.


### PR DESCRIPTION
New clients should use this overload that accepts analyses directly.