### PR TITLE
[clangd] Find better insertion locations in DefineOutline tweak

### DIFF
--- a/clang-tools-extra/clangd/SourceCode.h
+++ b/clang-tools-extra/clangd/SourceCode.h
@@ -309,6 +309,11 @@ EligibleRegion getEligiblePoints(llvm::StringRef Code,
                                  llvm::StringRef FullyQualifiedName,
                                  const LangOptions &LangOpts);
 
+/// Returns the fully qualified name of the namespace at \p Pos in the \p Code.
+/// Employs pseudo-parsing to determine the start and end of namespaces.
+std::string getNamespaceAtPosition(llvm::StringRef Code, const Position &Pos,
+                                   const LangOptions &LangOpts);
+
 struct DefinedMacro {
   llvm::StringRef Name;
   const MacroInfo *Info;

--- a/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
+++ b/clang-tools-extra/clangd/unittests/tweaks/DefineOutlineTests.cpp
@@ -448,7 +448,6 @@ inline T Foo<T>::bar(const T& t, const U& u) { return {}; }
 
 TEST_F(DefineOutlineTest, InCppFile) {
   FileName = "Test.cpp";
-
   struct {
     llvm::StringRef Test;
     llvm::StringRef ExpectedSource;
@@ -773,8 +772,8 @@ class A {
 )cpp";
   std::string SourceAfter = R"cpp(
 #include "a.hpp"
-void A::bar(){}
-void A::foo(){}
+void A::bar(){}void A::foo(){}
+
 )cpp";
   Workspace.addSource("a.hpp", HeaderBefore.code());
   Workspace.addMainFile("a.cpp", SourceBefore);
@@ -786,6 +785,195 @@ void A::foo(){}
                         FileWithContents(testPath("a.cpp"), SourceAfter)))));
 }
 
+// Test that the definition is inserted in a sensible location
+// under various circumstances.
+// Note that the formatting looks a little off here and there,
+// which is because in contrast to the actual tweak, the test procedure
+// does not run clang-format on the resulting code.
+TEST_F(DefineOutlineWorkspaceTest, SensibleInsertionLocations) {
+  const struct {
+    llvm::StringRef HeaderBefore;
+    llvm::StringRef SourceBefore;
+    llvm::StringRef HeaderAfter;
+    llvm::StringRef SourceAfter;
+  } Cases[] = {
+      // Criterion 1: Distance
+      {
+          R"cpp(
+struct Foo {
+  void ignored1();     // Too far away
+  void ignored2();     // No definition
+  void ignored3() {}   // Defined inline
+  void fo^o() {}
+  void neighbor();
+};
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::ignored1() {}
+void Foo::neighbor() {}
+)cpp",
+          R"cpp(
+struct Foo {
+  void ignored1();     // Too far away
+  void ignored2();     // No definition
+  void ignored3() {}   // Defined inline
+  void foo() ;
+  void neighbor();
+};
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::ignored1() {}
+void Foo::foo() {}
+void Foo::neighbor() {}
+)cpp"},
+
+      // Criterion 2: Prefer preceding
+      {
+          R"cpp(
+struct Foo {
+  void neighbor();
+  void fo^o() {}
+  void ignored();
+};
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::neighbor() {}
+void Foo::ignored() {}
+)cpp",
+          R"cpp(
+struct Foo {
+  void neighbor();
+  void foo() ;
+  void ignored();
+};
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::neighbor() {}void Foo::foo() {}
+
+void Foo::ignored() {}
+)cpp"},
+
+      // Like above, but with a namespace
+      {
+          R"cpp(
+namespace NS {
+struct Foo {
+  void neighbor();
+  void fo^o() {}
+  void ignored();
+};
+}
+)cpp",
+          R"cpp(
+#include "a.hpp"
+namespace NS {
+void Foo::neighbor() {}
+void Foo::ignored() {}
+}
+)cpp",
+          R"cpp(
+namespace NS {
+struct Foo {
+  void neighbor();
+  void foo() ;
+  void ignored();
+};
+}
+)cpp",
+          R"cpp(
+#include "a.hpp"
+namespace NS {
+void Foo::neighbor() {}void Foo::foo() {}
+
+void Foo::ignored() {}
+}
+)cpp"},
+
+      // Like above, but there is no namespace at the definition site
+      {
+          R"cpp(
+namespace NS {
+struct Foo {
+  void neighbor();
+  void fo^o() {}
+  void ignored();
+};
+}
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void NS::Foo::neighbor() {}
+void NS::Foo::ignored() {}
+)cpp",
+          R"cpp(
+namespace NS {
+struct Foo {
+  void neighbor();
+  void foo() ;
+  void ignored();
+};
+}
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void NS::Foo::neighbor() {}void NS::Foo::foo() {}
+
+void NS::Foo::ignored() {}
+)cpp"},
+
+      // Neighbor's definition is in header
+      {
+          R"cpp(
+struct Foo {
+  void fo^o() {}
+  void neighbor();
+  void ignored();
+};
+inline void Foo::neighbor() {}
+)cpp",
+          R"cpp(
+#include "a.hpp"
+void Foo::ignored() {}
+)cpp",
+          R"cpp(
+struct Foo {
+  void foo() ;
+  void neighbor();
+  void ignored();
+};
+inline void Foo::foo() {}
+inline void Foo::neighbor() {}
+)cpp",
+          {}},
+
+  };
+
+  for (const auto &Case : Cases) {
+    Workspace = {};
+    llvm::Annotations Hdr(Case.HeaderBefore);
+    Workspace.addSource("a.hpp", Hdr.code());
+    Workspace.addMainFile("a.cpp", Case.SourceBefore);
+    auto Result = apply("a.hpp", {Hdr.point(), Hdr.point()});
+    if (Case.SourceAfter.empty()) {
+      EXPECT_THAT(Result,
+                  AllOf(withStatus("success"),
+                        editedFiles(UnorderedElementsAre(FileWithContents(
+                            testPath("a.hpp"), Case.HeaderAfter)))));
+
+    } else {
+      EXPECT_THAT(
+          Result,
+          AllOf(withStatus("success"),
+                editedFiles(UnorderedElementsAre(
+                    FileWithContents(testPath("a.hpp"), Case.HeaderAfter),
+                    FileWithContents(testPath("a.cpp"), Case.SourceAfter)))));
+    }
+  }
+}
 } // namespace
 } // namespace clangd
 } // namespace clang


### PR DESCRIPTION
If possible, put the definition next to the definition of an adjacent declaration. For example:

struct S {
  void f^oo1() {}
  void foo2();
  void f^oo3() {}
};

// S::foo1() goes here
void S::foo2() {}
// S::foo3() goes here