### PR TITLE
[AMDGPU] Add verification for amdgcn.init.exec.from.input

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6370,15 +6370,8 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
     break;
   }
   case Intrinsic::amdgcn_init_exec_from_input: {
-    const Value *InputVal = Call.getOperand(0);
-    bool InRegArgFound = false;
-    for (const Argument &Arg : Call.getCaller()->args()) {
-      if (Arg.hasInRegAttr() && &Arg == InputVal) {
-        InRegArgFound = true;
-        break;
-      }
-    }
-    Check(InRegArgFound,
+    const Argument *Arg = dyn_cast<Argument>(Call.getOperand(0));
+    Check(Arg && Arg->hasInRegAttr(),
           "only inreg arguments to the parent function are valid as inputs to "
           "this intrinsic",
           &Call);

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -6369,6 +6369,21 @@ void Verifier::visitIntrinsicCall(Intrinsic::ID ID, CallBase &Call) {
           "VGPR arguments must not have the `inreg` attribute", &Call);
     break;
   }
+  case Intrinsic::amdgcn_init_exec_from_input: {
+    const Value *InputVal = Call.getOperand(0);
+    bool InRegArgFound = false;
+    for (const Argument &Arg : Call.getCaller()->args()) {
+      if (Arg.hasInRegAttr() && &Arg == InputVal) {
+        InRegArgFound = true;
+        break;
+      }
+    }
+    Check(InRegArgFound,
+          "only inreg arguments to the parent function are valid as inputs to "
+          "this intrinsic",
+          &Call);
+    break;
+  }
   case Intrinsic::amdgcn_set_inactive_chain_arg: {
     auto CallerCC = Call.getCaller()->getCallingConv();
     switch (CallerCC) {

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -4,7 +4,7 @@ declare void @llvm.amdgcn.init.exec.from.input(i32, i32 immarg)
 
 ; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)
-define void @init_exec_from_input_fail_immarg(i32 inreg %a, i32 %b) {
+define void @init_exec_from_input_fail_constant() {
   call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)
   ret void
 }

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -1,0 +1,27 @@
+; RUN: sed -e '/^; MARK$/,$d' %s | not llc -mtriple=amdgcn -mcpu=gfx942 2>&1 | FileCheck %s
+; RUN: sed -e '1,/^; MARK$/d' %s | llc -mtriple=amdgcn -mcpu=gfx942 -filetype=null
+
+; Function Attrs: convergent nocallback nofree nounwind willreturn
+declare void @llvm.amdgcn.init.exec.from.input(i32, i32 immarg) #0
+attributes #0 = { convergent nocallback nofree nounwind willreturn }
+
+; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
+; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)
+define amdgpu_ps void @init_exec_from_input_fail_immarg(i32 inreg %a, i32 %b) {
+  call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)
+  ret void
+}
+
+; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
+; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
+define amdgpu_ps void @init_exec_from_input_fail_not_inreg(i32 inreg %a, i32 %b) {
+  call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
+  ret void
+}
+
+; MARK
+
+define amdgpu_ps void @init_exec_from_input_success(i32 inreg %a, i32 %b) {
+  call void @llvm.amdgcn.init.exec.from.input(i32 %a, i32 0)
+  ret void
+}

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -6,21 +6,21 @@ attributes #0 = { convergent nocallback nofree nounwind willreturn }
 
 ; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)
-define amdgpu_ps void @init_exec_from_input_fail_immarg(i32 inreg %a, i32 %b) {
+define void @init_exec_from_input_fail_immarg(i32 inreg %a, i32 %b) {
   call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)
   ret void
 }
 
 ; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
-define amdgpu_ps void @init_exec_from_input_fail_not_inreg(i32 inreg %a, i32 %b) {
+define void @init_exec_from_input_fail_not_inreg(i32 inreg %a, i32 %b) {
   call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
   ret void
 }
 
 ; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %c, i32 0)
-define amdgpu_ps void @init_exec_from_input_fail_constant(i32 inreg %a, i32 %b) {
+define void @init_exec_from_input_fail_constant(i32 inreg %a, i32 %b) {
   %c = add i32 %a, %b
   call void @llvm.amdgcn.init.exec.from.input(i32 %c, i32 0)
   ret void

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -1,8 +1,6 @@
 ; RUN: not llvm-as -disable-output 2>&1 %s | FileCheck %s
 
-; Function Attrs: convergent nocallback nofree nounwind willreturn
-declare void @llvm.amdgcn.init.exec.from.input(i32, i32 immarg) #0
-attributes #0 = { convergent nocallback nofree nounwind willreturn }
+declare void @llvm.amdgcn.init.exec.from.input(i32, i32 immarg)
 
 ; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 0, i32 0)

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -18,7 +18,7 @@ define void @init_exec_from_input_fail_not_inreg(i32 inreg %a, i32 %b) {
 
 ; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %c, i32 0)
-define void @init_exec_from_input_fail_constant(i32 inreg %a, i32 %b) {
+define void @init_exec_from_input_fail_instruction(i32 inreg %a, i32 %b) {
   %c = add i32 %a, %b
   call void @llvm.amdgcn.init.exec.from.input(i32 %c, i32 0)
   ret void

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -1,5 +1,4 @@
-; RUN: sed -e '/^; MARK$/,$d' %s | not llc -mtriple=amdgcn -mcpu=gfx942 2>&1 | FileCheck %s
-; RUN: sed -e '1,/^; MARK$/d' %s | llc -mtriple=amdgcn -mcpu=gfx942 -filetype=null
+; RUN: not llvm-as -o /dev/null 2>&1 %s | FileCheck %s
 
 ; Function Attrs: convergent nocallback nofree nounwind willreturn
 declare void @llvm.amdgcn.init.exec.from.input(i32, i32 immarg) #0
@@ -16,12 +15,5 @@ define amdgpu_ps void @init_exec_from_input_fail_immarg(i32 inreg %a, i32 %b) {
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
 define amdgpu_ps void @init_exec_from_input_fail_not_inreg(i32 inreg %a, i32 %b) {
   call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
-  ret void
-}
-
-; MARK
-
-define amdgpu_ps void @init_exec_from_input_success(i32 inreg %a, i32 %b) {
-  call void @llvm.amdgcn.init.exec.from.input(i32 %a, i32 0)
   ret void
 }

--- a/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
+++ b/llvm/test/Verifier/AMDGPU/intrinsic-amdgpu-init-exec-from-input.ll
@@ -1,4 +1,4 @@
-; RUN: not llvm-as -o /dev/null 2>&1 %s | FileCheck %s
+; RUN: not llvm-as -disable-output 2>&1 %s | FileCheck %s
 
 ; Function Attrs: convergent nocallback nofree nounwind willreturn
 declare void @llvm.amdgcn.init.exec.from.input(i32, i32 immarg) #0
@@ -15,5 +15,13 @@ define amdgpu_ps void @init_exec_from_input_fail_immarg(i32 inreg %a, i32 %b) {
 ; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
 define amdgpu_ps void @init_exec_from_input_fail_not_inreg(i32 inreg %a, i32 %b) {
   call void @llvm.amdgcn.init.exec.from.input(i32 %b, i32 0)
+  ret void
+}
+
+; CHECK: only inreg arguments to the parent function are valid as inputs to this intrinsic
+; CHECK-NEXT: call void @llvm.amdgcn.init.exec.from.input(i32 %c, i32 0)
+define amdgpu_ps void @init_exec_from_input_fail_constant(i32 inreg %a, i32 %b) {
+  %c = add i32 %a, %b
+  call void @llvm.amdgcn.init.exec.from.input(i32 %c, i32 0)
   ret void
 }


### PR DESCRIPTION
Check that the input register is an inreg argument to the parent function. (See the comment in `IntrinsicsAMDGPU.td`.)

This LLVM defect was identified via the AMD Fuzzing project.