### PR TITLE
[RISCV] Correct RISCVTTIImpl::getIntImmCostInst for Zba

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -207,7 +207,8 @@ InstructionCost RISCVTTIImpl::getIntImmCostInst(unsigned Opcode, unsigned Idx,
     if (Imm == UINT64_C(0xffff) && ST->hasStdExtZbb())
       return TTI::TCC_Free;
     // zext.w
-    if (Imm == UINT64_C(0xffffffff) && ST->hasStdExtZba())
+    if (Imm == UINT64_C(0xffffffff) &&
+        ((ST->hasStdExtZba() && ST->isRV64()) || ST->isRV32()))
       return TTI::TCC_Free;
     // bclri
     if (ST->hasStdExtZbs() && (~Imm).isPowerOf2())

--- a/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
+++ b/llvm/test/Transforms/ConstantHoisting/RISCV/immediates.ll
@@ -1,5 +1,5 @@
-; RUN: opt -mtriple=riscv32-unknown-elf -S -passes=consthoist < %s | FileCheck %s
-; RUN: opt -mtriple=riscv64-unknown-elf -S -passes=consthoist < %s | FileCheck %s
+; RUN: opt -mtriple=riscv32-unknown-elf -S -passes=consthoist < %s | FileCheck %s -check-prefixes=CHECK,RV32I
+; RUN: opt -mtriple=riscv64-unknown-elf -S -passes=consthoist < %s | FileCheck %s -check-prefixes=CHECK,RV64I
 
 ; Check that we don't hoist immediates with small values.
 define i64 @test1(i64 %a) nounwind {
@@ -55,16 +55,21 @@ define i32 @test6(i32 %a) nounwind "target-features"="+zbb" {
   ret i32 %2
 }
 
-; Check that we hoist zext.w without Zba.
+; Check that we hoist zext.w without Zba on RV64.
+; Check that we don't hoist on RV32.
 define i64 @test7(i64 %a) nounwind {
-; CHECK-LABEL: test7
-; CHECK: %const = bitcast i64 4294967295 to i64
+; RV32I-LABEL: test7
+; RV32I: and i64 %a, 4294967295
+
+; RV64I-LABEL: test7
+; RV64I: %const = bitcast i64 4294967295 to i64
   %1 = and i64 %a, 4294967295
   %2 = and i64 %1, 4294967295
   ret i64 %2
 }
 
-; Check that we don't hoist zext.w with Zba.
+; Check that we don't hoist zext.w with Zba on RV64.
+; Check that we don't hoist on RV32.
 define i64 @test8(i64 %a) nounwind "target-features"="+zba" {
 ; CHECK-LABEL: test8
 ; CHECK: and i64 %a, 4294967295


### PR DESCRIPTION
zext.w is only available on RV64.