### PR TITLE
[lldb] Don't hand out UnwindPlan::Row shared_ptrs

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -175,13 +175,13 @@ public:
 
       void SetIsDWARFExpression(const uint8_t *opcodes, uint32_t len);
 
-      const uint8_t *GetDWARFExpressionBytes() {
+      const uint8_t *GetDWARFExpressionBytes() const {
         if (m_type == atDWARFExpression || m_type == isDWARFExpression)
           return m_location.expr.opcodes;
         return nullptr;
       }
 
-      int GetDWARFExpressionLength() {
+      int GetDWARFExpressionLength() const {
         if (m_type == atDWARFExpression || m_type == isDWARFExpression)
           return m_location.expr.length;
         return 0;
@@ -308,13 +308,13 @@ public:
         }
       }
 
-      const uint8_t *GetDWARFExpressionBytes() {
+      const uint8_t *GetDWARFExpressionBytes() const {
         if (m_type == isDWARFExpression)
           return m_value.expr.opcodes;
         return nullptr;
       }
 
-      int GetDWARFExpressionLength() {
+      int GetDWARFExpressionLength() const {
         if (m_type == isDWARFExpression)
           return m_value.expr.length;
         return 0;
@@ -362,8 +362,10 @@ public:
 
     void SlideOffset(lldb::addr_t offset) { m_offset += offset; }
 
+    const FAValue &GetCFAValue() const { return m_cfa_value; }
     FAValue &GetCFAValue() { return m_cfa_value; }
 
+    const FAValue &GetAFAValue() const { return m_afa_value; }
     FAValue &GetAFAValue() { return m_afa_value; }
 
     bool SetRegisterLocationToAtCFAPlusOffset(uint32_t reg_num, int32_t offset,
@@ -464,7 +466,7 @@ public:
   // unknown - the final row in the UnwindPlan is returned. In practice, the
   // UnwindPlan for a function with no known start address will be the
   // architectural default UnwindPlan which will only have one row.
-  UnwindPlan::RowSP GetRowForFunctionOffset(int offset) const;
+  const UnwindPlan::Row *GetRowForFunctionOffset(int offset) const;
 
   lldb::RegisterKind GetRegisterKind() const { return m_register_kind; }
 
@@ -495,9 +497,9 @@ public:
 
   bool IsValidRowIndex(uint32_t idx) const;
 
-  const UnwindPlan::RowSP GetRowAtIndex(uint32_t idx) const;
+  const UnwindPlan::Row *GetRowAtIndex(uint32_t idx) const;
 
-  const UnwindPlan::RowSP GetLastRow() const;
+  const UnwindPlan::Row *GetLastRow() const;
 
   lldb_private::ConstString GetSourceName() const;
 

--- a/lldb/include/lldb/Target/RegisterContextUnwind.h
+++ b/lldb/include/lldb/Target/RegisterContextUnwind.h
@@ -191,7 +191,8 @@ private:
 
   // Get the Frame Address register for a given frame.
   bool ReadFrameAddress(lldb::RegisterKind register_kind,
-                          UnwindPlan::Row::FAValue &fa, lldb::addr_t &address);
+                        const UnwindPlan::Row::FAValue &fa,
+                        lldb::addr_t &address);
 
   lldb::UnwindPlanSP GetFastUnwindPlanForFrame();
 

--- a/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
@@ -116,11 +116,9 @@ bool UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly(
 
         // Make a copy of the current instruction Row and save it in m_curr_row
         // so we can add updates as we process the instructions.
-        UnwindPlan::RowSP last_row = unwind_plan.GetLastRow();
-        UnwindPlan::Row *newrow = new UnwindPlan::Row;
-        if (last_row.get())
-          *newrow = *last_row.get();
-        m_curr_row.reset(newrow);
+        UnwindPlan::RowSP last_row =
+            std::make_shared<UnwindPlan::Row>(*unwind_plan.GetLastRow());
+        m_curr_row = std::make_shared<UnwindPlan::Row>(*last_row);
 
         // Add the initial state to the save list with offset 0.
         saved_unwind_states.insert({0, {last_row, m_register_values}});

--- a/lldb/source/Plugins/UnwindAssembly/x86/UnwindAssembly-x86.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/UnwindAssembly-x86.cpp
@@ -68,8 +68,8 @@ bool UnwindAssembly_x86::AugmentUnwindPlanFromCallSite(
     AddressRange &func, Thread &thread, UnwindPlan &unwind_plan) {
   bool do_augment_unwindplan = true;
 
-  UnwindPlan::RowSP first_row = unwind_plan.GetRowForFunctionOffset(0);
-  UnwindPlan::RowSP last_row = unwind_plan.GetRowForFunctionOffset(-1);
+  const UnwindPlan::Row *first_row = unwind_plan.GetRowForFunctionOffset(0);
+  const UnwindPlan::Row *last_row = unwind_plan.GetLastRow();
 
   int wordsize = 8;
   ProcessSP process_sp(thread.GetProcess());

--- a/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
@@ -1359,7 +1359,7 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
   if (unwind_plan.GetRowCount() < 2)
     return false;
 
-  UnwindPlan::RowSP first_row = unwind_plan.GetRowAtIndex(0);
+  const UnwindPlan::Row *first_row = unwind_plan.GetRowAtIndex(0);
   if (first_row->GetOffset() != 0)
     return false;
   uint32_t cfa_reg = first_row->GetCFAValue().GetRegisterNumber();
@@ -1372,7 +1372,7 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
       first_row->GetCFAValue().GetOffset() != m_wordsize)
     return false;
 
-  UnwindPlan::RowSP original_last_row = unwind_plan.GetRowForFunctionOffset(-1);
+  const UnwindPlan::Row *original_last_row = unwind_plan.GetLastRow();
 
   size_t offset = 0;
   int row_id = 1;
@@ -1417,7 +1417,7 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
            unwind_plan.GetRowAtIndex(row_id)->GetOffset() <= offset) {
       row_id++;
     }
-    UnwindPlan::RowSP original_row = unwind_plan.GetRowAtIndex(row_id - 1);
+    const UnwindPlan::Row *original_row = unwind_plan.GetRowAtIndex(row_id - 1);
     if (original_row->GetOffset() == offset) {
       *row = *original_row;
       continue;

--- a/lldb/source/Symbol/FuncUnwinders.cpp
+++ b/lldb/source/Symbol/FuncUnwinders.cpp
@@ -366,11 +366,11 @@ LazyBool FuncUnwinders::CompareUnwindPlansForIdenticalInitialPCLocation(
   RegisterNumber pc_reg(thread, eRegisterKindGeneric, LLDB_REGNUM_GENERIC_PC);
   uint32_t pc_reg_lldb_regnum = pc_reg.GetAsKind(eRegisterKindLLDB);
 
-  if (a.get() && b.get()) {
-    UnwindPlan::RowSP a_first_row = a->GetRowAtIndex(0);
-    UnwindPlan::RowSP b_first_row = b->GetRowAtIndex(0);
+  if (a && b) {
+    const UnwindPlan::Row *a_first_row = a->GetRowAtIndex(0);
+    const UnwindPlan::Row *b_first_row = b->GetRowAtIndex(0);
 
-    if (a_first_row.get() && b_first_row.get()) {
+    if (a_first_row && b_first_row) {
       UnwindPlan::Row::AbstractRegisterLocation a_pc_regloc;
       UnwindPlan::Row::AbstractRegisterLocation b_pc_regloc;
 

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -412,48 +412,44 @@ void UnwindPlan::InsertRow(const UnwindPlan::RowSP &row_sp,
     *it = row_sp;
 }
 
-UnwindPlan::RowSP UnwindPlan::GetRowForFunctionOffset(int offset) const {
+const UnwindPlan::Row *UnwindPlan::GetRowForFunctionOffset(int offset) const {
+  if (m_row_list.empty())
+    return nullptr;
+  if (offset == -1)
+    return m_row_list.back().get();
+
   RowSP row;
-  if (!m_row_list.empty()) {
-    if (offset == -1)
-      row = m_row_list.back();
-    else {
-      collection::const_iterator pos, end = m_row_list.end();
-      for (pos = m_row_list.begin(); pos != end; ++pos) {
-        if ((*pos)->GetOffset() <= static_cast<lldb::offset_t>(offset))
-          row = *pos;
-        else
-          break;
-      }
-    }
+  collection::const_iterator pos, end = m_row_list.end();
+  for (pos = m_row_list.begin(); pos != end; ++pos) {
+    if ((*pos)->GetOffset() <= static_cast<lldb::offset_t>(offset))
+      row = *pos;
+    else
+      break;
   }
-  return row;
+  return row.get();
 }
 
 bool UnwindPlan::IsValidRowIndex(uint32_t idx) const {
   return idx < m_row_list.size();
 }
 
-const UnwindPlan::RowSP UnwindPlan::GetRowAtIndex(uint32_t idx) const {
+const UnwindPlan::Row *UnwindPlan::GetRowAtIndex(uint32_t idx) const {
   if (idx < m_row_list.size())
-    return m_row_list[idx];
-  else {
-    Log *log = GetLog(LLDBLog::Unwind);
-    LLDB_LOGF(log,
-              "error: UnwindPlan::GetRowAtIndex(idx = %u) invalid index "
-              "(number rows is %u)",
-              idx, (uint32_t)m_row_list.size());
-    return UnwindPlan::RowSP();
-  }
+    return m_row_list[idx].get();
+  LLDB_LOG(GetLog(LLDBLog::Unwind),
+           "error: UnwindPlan::GetRowAtIndex(idx = {0}) invalid index "
+           "(number rows is {1})",
+           idx, m_row_list.size());
+  return nullptr;
 }
 
-const UnwindPlan::RowSP UnwindPlan::GetLastRow() const {
+const UnwindPlan::Row *UnwindPlan::GetLastRow() const {
   if (m_row_list.empty()) {
     Log *log = GetLog(LLDBLog::Unwind);
     LLDB_LOGF(log, "UnwindPlan::GetLastRow() when rows are empty");
-    return UnwindPlan::RowSP();
+    return nullptr;
   }
-  return m_row_list.back();
+  return m_row_list.back().get();
 }
 
 int UnwindPlan::GetRowCount() const { return m_row_list.size(); }
@@ -486,7 +482,7 @@ bool UnwindPlan::PlanValidAtAddress(Address addr) {
   // If the 0th Row of unwind instructions is missing, or if it doesn't provide
   // a register to use to find the Canonical Frame Address, this is not a valid
   // UnwindPlan.
-  if (GetRowAtIndex(0).get() == nullptr ||
+  if (GetRowAtIndex(0) == nullptr ||
       GetRowAtIndex(0)->GetCFAValue().GetValueType() ==
           Row::FAValue::unspecified) {
     Log *log = GetLog(LLDBLog::Unwind);

--- a/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp
+++ b/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp
@@ -59,7 +59,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -89,74 +89,74 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // CFA=sp +0 => fp= <same> lr= <same>
-  row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
   // CFA=sp+16 => fp=[CFA-16] lr=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // CFA=fp+16 => fp=[CFA-16] lr=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(8);
+  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // CFA=sp+16 => fp=[CFA-16] lr=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // CFA=sp +0 => fp= <same> lr= <same>
-  row_sp = unwind_plan.GetRowForFunctionOffset(20);
-  EXPECT_EQ(20ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(20);
+  EXPECT_EQ(20ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 }
 
@@ -167,7 +167,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -218,107 +218,107 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // 0: CFA=sp +0 =>
-  row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 4: CFA=sp+48 => x21=[CFA-40] x22=[CFA-48]
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_EQ(48, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x21_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x21_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-40, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x22_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x22_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-48, regloc.GetOffset());
 
   // 8: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
-  row_sp = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_EQ(48, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(8);
+  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x19_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x19_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-24, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x20_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x20_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-32, regloc.GetOffset());
 
   // 12: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   // fp=[CFA-16] lr=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_EQ(48, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 16: CFA=fp+16 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   // fp=[CFA-16] lr=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   // 28: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   // fp=[CFA-16] lr=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(48, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(28);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
   // 32: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48] fp=
   // <same> lr= <same>
-  row_sp = unwind_plan.GetRowForFunctionOffset(32);
-  EXPECT_EQ(32ull, row_sp->GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(32);
+  EXPECT_EQ(32ull, row->GetOffset());
 
   // I'd prefer if these restored registers were cleared entirely instead of set
   // to IsSame...
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
   // 36: CFA=sp+48 => x19= <same> x20= <same> x21=[CFA-40] x22=[CFA-48] fp=
   // <same> lr= <same>
-  row_sp = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(36ull, row_sp->GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(36);
+  EXPECT_EQ(36ull, row->GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x19_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x19_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x20_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x20_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
   // 40: CFA=sp +0 => x19= <same> x20= <same> x21= <same> x22= <same> fp= <same>
   // lr= <same>
-  row_sp = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(40ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(40);
+  EXPECT_EQ(40ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x21_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x21_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x22_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x22_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 }
 
@@ -329,7 +329,7 @@ TEST_F(TestArm64InstEmulation, TestFramelessThreeEpilogueFunction) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -372,53 +372,53 @@ TEST_F(TestArm64InstEmulation, TestFramelessThreeEpilogueFunction) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // 0: CFA=sp +0 =>
-  row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(32);
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(32);
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x19_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x20_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x21_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x22_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x23_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x24_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x25_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x26_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x27_arm64, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(gpr_x28_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x19_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x20_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x21_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x22_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x23_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x24_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x25_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x26_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x27_arm64, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(gpr_x28_arm64, regloc));
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_fp_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(36);
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(52);
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(52);
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(56);
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(56);
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(60);
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(60);
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(TestArm64InstEmulation, TestRegisterSavedTwice) {
@@ -428,7 +428,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterSavedTwice) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -502,23 +502,23 @@ TEST_F(TestArm64InstEmulation, TestRegisterSavedTwice) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       sample_range, data, sizeof(data), unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(36);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x20_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x20_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-32, regloc.GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(40);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_x20_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_x20_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-32, regloc.GetOffset());
 }
@@ -530,7 +530,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterDoubleSpills) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -618,79 +618,79 @@ TEST_F(TestArm64InstEmulation, TestRegisterDoubleSpills) {
   //  28: CFA=fp+16 => x27=[CFA-24] x28=[CFA-32] fp=[CFA-16] lr=[CFA-8]
   //  d8=[CFA-40] d9=[CFA-48] d10=[CFA-56] d11=[CFA-64] d12=[CFA-72]
   //  d13=[CFA-80] d14=[CFA-88] d15=[CFA-96]
-  row_sp = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(28);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d15_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d15_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-96, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d14_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d14_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-88, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d13_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d13_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-80, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d12_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d12_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-72, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d11_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d11_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-64, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d10_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d10_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-56, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d9_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d9_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-48, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(fpu_d8_arm64, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(fpu_d8_arm64, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-40, regloc.GetOffset());
 
   //  60: CFA=sp +0 =>
-  row_sp = unwind_plan.GetRowForFunctionOffset(60);
-  EXPECT_EQ(60ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(60);
+  EXPECT_EQ(60ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  if (row_sp->GetRegisterInfo(fpu_d8_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d8_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d9_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d9_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d10_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d10_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d11_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d11_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d12_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d12_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d13_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d13_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d14_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d14_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(fpu_d15_arm64, regloc)) {
+  if (row->GetRegisterInfo(fpu_d15_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(gpr_x27_arm64, regloc)) {
+  if (row->GetRegisterInfo(gpr_x27_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
-  if (row_sp->GetRegisterInfo(gpr_x28_arm64, regloc)) {
+  if (row->GetRegisterInfo(gpr_x28_arm64, regloc)) {
     EXPECT_TRUE(regloc.IsSame());
   }
 }
@@ -702,7 +702,7 @@ TEST_F(TestArm64InstEmulation, TestCFARegisterTrackedAcrossJumps) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -764,34 +764,34 @@ TEST_F(TestArm64InstEmulation, TestCFARegisterTrackedAcrossJumps) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // Confirm CFA at mid-func epilogue 'ret' is $sp+0
-  row_sp = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(40ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(40);
+  EXPECT_EQ(40ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // After the 'ret', confirm we're back to the correct CFA of $fp+16
-  row_sp = unwind_plan.GetRowForFunctionOffset(44);
-  EXPECT_EQ(44ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(44);
+  EXPECT_EQ(44ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   // Confirm that we have no additional UnwindPlan rows before the 
   // real epilogue -- we still get the Row at offset 44.
-  row_sp = unwind_plan.GetRowForFunctionOffset(60);
-  EXPECT_EQ(44ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(60);
+  EXPECT_EQ(44ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   // And in the epilogue, confirm that we start by switching back to 
   // defining the CFA in terms of $sp.
-  row_sp = unwind_plan.GetRowForFunctionOffset(64);
-  EXPECT_EQ(64ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(32, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(64);
+  EXPECT_EQ(64ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(32, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(TestArm64InstEmulation, TestCFAResetToSP) {
@@ -801,7 +801,7 @@ TEST_F(TestArm64InstEmulation, TestCFAResetToSP) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -844,15 +844,15 @@ TEST_F(TestArm64InstEmulation, TestCFAResetToSP) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // Confirm CFA before epilogue instructions is in terms of $fp
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
 
   // Confirm that after restoring $fp to caller's value, CFA is now in
   // terms of $sp
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
 }

--- a/lldb/unittests/UnwindAssembly/PPC64/TestPPC64InstEmulation.cpp
+++ b/lldb/unittests/UnwindAssembly/PPC64/TestPPC64InstEmulation.cpp
@@ -58,7 +58,7 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -96,76 +96,76 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // 0: CFA=sp+0
-  row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 1: CFA=sp+0 => fp=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_r31_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_r31_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 2: CFA=sp+0 => fp=[CFA-8] lr=[CFA+16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(20);
-  EXPECT_EQ(20ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(20);
+  EXPECT_EQ(20ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(16, regloc.GetOffset());
 
   // 3: CFA=sp+112 => fp=[CFA-8] lr=[CFA+16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(24);
-  EXPECT_EQ(24ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(112, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(24);
+  EXPECT_EQ(24ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(112, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_r31_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_r31_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(16, regloc.GetOffset());
 
   // 4: CFA=r31+112 => fp=[CFA-8] lr=[CFA+16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r31_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(112, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(28);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r31_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(112, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_r31_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_r31_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(16, regloc.GetOffset());
 
   // 5: CFA=sp+0 => fp=[CFA-8] lr=[CFA+16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(40ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(40);
+  EXPECT_EQ(40ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_r31_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_r31_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(16, regloc.GetOffset());
 }
@@ -177,7 +177,7 @@ TEST_F(TestPPC64InstEmulation, TestMediumFunction) {
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
 
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   UnwindPlan::Row::AbstractRegisterLocation regloc;
@@ -208,51 +208,51 @@ TEST_F(TestPPC64InstEmulation, TestMediumFunction) {
       sample_range, data, sizeof(data), unwind_plan));
 
   // 0: CFA=sp+0
-  row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 1: CFA=sp+0 => fp=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(8);
+  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_r31_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_r31_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 2: CFA=sp+0 => fp=[CFA-8] lr=[CFA+16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(gpr_lr_ppc64le, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_lr_ppc64le, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(16, regloc.GetOffset());
 
   // 3: CFA=r30
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r30_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r30_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(32);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r30_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(32);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r30_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 4: CFA=sp+0
-  row_sp = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(36ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(0, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(36);
+  EXPECT_EQ(36ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 }

--- a/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
+++ b/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
@@ -171,46 +171,46 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple64bitFrameFunction) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // 0: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 1: CFA=rsp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 4: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 7: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
@@ -247,46 +247,46 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple32bitFrameFunction) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // offset 0 -- pushl %ebp
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_eip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_eip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_TRUE(regloc.GetOffset() == -4);
 
   // 1: CFA=esp +8 => ebp=[CFA-8] esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_eip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_eip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-4, regloc.GetOffset());
 
   // 3: CFA=ebp +8 => ebp=[CFA-8] esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_ebp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(3);
+  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_eip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_eip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-4, regloc.GetOffset());
 
   // 6: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(6);
+  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_eip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_eip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-4, regloc.GetOffset());
 }
@@ -387,52 +387,52 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessBigStackFrame) {
   // 17: CFA=rsp+14496 => rbx=[CFA-56] rbp=[CFA-16] rsp=CFA+0 r12=[CFA-48]
   // r13=[CFA-40] r14=[CFA-32] r15=[CFA-24] rip=[CFA-8]
 
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(17);
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(17);
 
-  EXPECT_EQ(17ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(14496, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(17ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(14496, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r15, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r15, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-24, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r14, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r14, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-32, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r13, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r13, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-40, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r12, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r12, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-48, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbx, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbx, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-56, regloc.GetOffset());
 
   // grab the Row for when the epilogue has finished executing:
   // 34: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(34);
+  row = unwind_plan.GetRowForFunctionOffset(34);
 
-  EXPECT_EQ(34ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
@@ -440,21 +440,21 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessBigStackFrame) {
   // register value is the same as the caller's -- but I'd rather
   // they not be mentioned at all.
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rax, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rcx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rdx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rsi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rdi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r8, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r9, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r10, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r11, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r12, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r13, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r14, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r15, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rax, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rcx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rdx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rsi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rdi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r8, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r9, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r10, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r11, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r12, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r13, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r14, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r15, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
@@ -651,49 +651,49 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
   //  esp=CFA+0 eip=[CFA-4]
 
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   // Check that we get the CFA correct for the pic base setup sequence
 
   // CFA=esp+14464 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(10);
-  EXPECT_EQ(10ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(14464, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(10);
+  EXPECT_EQ(10ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(14464, row->GetCFAValue().GetOffset());
 
   // 15: CFA=esp+14468 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(15);
-  EXPECT_EQ(15ull, row_sp->GetOffset());
-  EXPECT_EQ(14468, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(15);
+  EXPECT_EQ(15ull, row->GetOffset());
+  EXPECT_EQ(14468, row->GetCFAValue().GetOffset());
 
   // 16: CFA=esp+14464 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_EQ(14464, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(14464, row->GetCFAValue().GetOffset());
 
   // Check that the row for offset 16 has the registers saved that we expect
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_eip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_eip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-4, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_ebp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_ebx, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_ebx, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-12, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_edi, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_edi, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_esi, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_esi, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-20, regloc.GetOffset());
 
@@ -702,56 +702,56 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
 
   // 23: CFA=esp+14472 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(23);
-  EXPECT_EQ(23ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(14472, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(23);
+  EXPECT_EQ(23ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(14472, row->GetCFAValue().GetOffset());
 
   // 24: CFA=esp+14476 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(24);
-  EXPECT_EQ(24ull, row_sp->GetOffset());
-  EXPECT_EQ(14476, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(24);
+  EXPECT_EQ(24ull, row->GetOffset());
+  EXPECT_EQ(14476, row->GetCFAValue().GetOffset());
 
   // 28: CFA=esp+14480 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_EQ(14480, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(28);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(14480, row->GetCFAValue().GetOffset());
 
   // 36: CFA=esp+14464 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(36ull, row_sp->GetOffset());
-  EXPECT_EQ(14464, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(36);
+  EXPECT_EQ(36ull, row->GetOffset());
+  EXPECT_EQ(14464, row->GetCFAValue().GetOffset());
 
   // Check that the epilogue gets us back to the original unwind state
 
   //  47: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(47);
-  EXPECT_EQ(47ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(47);
+  EXPECT_EQ(47ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_eip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_eip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-4, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_esp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_esp, regloc));
   EXPECT_TRUE(regloc.IsCFAPlusOffset());
   EXPECT_EQ(0, regloc.GetOffset());
 
   // Check that no unexpected registers were saved
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_eax, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ecx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_edx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_esi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_edi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_eax, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ecx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_edx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_esi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_edi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessSmallStackFrame) {
@@ -807,46 +807,46 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessSmallStackFrame) {
   // grab the Row for when the prologue has finished executing:
   //     1: CFA=rsp+16 => rsp=CFA+0 rip=[CFA-8]
 
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(13);
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(13);
 
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // none of these were spilled
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rax, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rcx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rdx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rsi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rdi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r8, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r9, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r10, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r11, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r12, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r13, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r14, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r15, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rax, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rcx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rdx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rsi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rdi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r8, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r9, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r10, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r11, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r12, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r13, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r14, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_r15, regloc));
 
   // grab the Row for when the epilogue has finished executing:
   //     22: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(22);
+  row = unwind_plan.GetRowForFunctionOffset(22);
 
-  EXPECT_EQ(22ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(22ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
@@ -916,54 +916,54 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
   // Check unwind state before we set up the picbase register
   //      3: CFA=esp+16 => esp=CFA+0 eip=[CFA-4]
 
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(3);
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(3);
 
-  EXPECT_EQ(3ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   // Check unwind state after we call the next instruction
   // 8: CFA=esp+20 => esp=CFA+0 eip=[CFA-4]
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(20, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(8);
+  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(20, row->GetCFAValue().GetOffset());
 
   // Check unwind state after we pop the pic base value off the stack
   // row[3]:    9: CFA=esp+16 => esp=CFA+0 eip=[CFA-4]
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(9);
-  EXPECT_EQ(9ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(9);
+  EXPECT_EQ(9ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   // Check that no unexpected registers were saved
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_eax, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ecx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_edx, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_esi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_edi, regloc));
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_eax, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ecx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_edx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_esi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_edi, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebp, regloc));
 
   // verify that we get back to the original unwind state before the ret
   //  34: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(34);
-  EXPECT_EQ(34ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(34);
+  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x55, // pushq %rbp
@@ -977,14 +977,14 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
+  row = unwind_plan.GetRowForFunctionOffset(1);
 
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 
@@ -992,21 +992,21 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
+  row = unwind_plan.GetRowForFunctionOffset(1);
 
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x68, 0xff, 0xff, 0x01, 0x69, // pushq $0x6901ffff
@@ -1021,33 +1021,33 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(5);
+  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(24, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(24, row->GetCFAValue().GetOffset());
 
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(5);
+  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(12, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(12, row->GetCFAValue().GetOffset());
 }
 
 // We treat 'pushq $0' / 'pushl $0' specially - this shows up
@@ -1055,7 +1055,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
 // put a 0 as the saved pc.  We pretend it didn't change the CFA.
 TEST_F(Testx86AssemblyInspectionEngine, TestPush0) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x6a, 0x00, // pushq $0
@@ -1069,24 +1069,24 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPush0) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
   // We're verifying that no row was created for the 'pushq $0'
-  EXPECT_EQ(0ull, row_sp->GetOffset());
+  EXPECT_EQ(0ull, row->GetOffset());
 
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
   // We're verifying that no row was created for the 'pushq $0'
-  EXPECT_EQ(0ull, row_sp->GetOffset());
+  EXPECT_EQ(0ull, row->GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0xff, 0x74, 0x24, 0x20,             // pushl 0x20(%esp)
@@ -1102,39 +1102,39 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
+  row = unwind_plan.GetRowForFunctionOffset(4);
 
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(10);
-  EXPECT_EQ(10ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(12, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(10);
+  EXPECT_EQ(10ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(12, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR15) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x41, 0x57, // pushq %r15
@@ -1148,21 +1148,21 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR15) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r15, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r15, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR14) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x41, 0x56, // pushq %r14
@@ -1176,21 +1176,21 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR14) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r14, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r14, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR13) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x41, 0x55, // pushq %r13
@@ -1204,21 +1204,21 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR13) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r13, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r13, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushR12) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x41, 0x54, // pushq %r13
@@ -1232,21 +1232,21 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR12) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r12, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r12, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushRBX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x53, // pushq %rbx
@@ -1260,14 +1260,14 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBX) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
+  row = unwind_plan.GetRowForFunctionOffset(1);
 
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbx, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbx, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 }
@@ -1277,7 +1277,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBX) {
 // not tracked (except to keep track of stack pointer movement)
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEAX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1292,13 +1292,13 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEAX) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_eax, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_eax, regloc));
 }
 
 // The ABI is hardcoded in x86AssemblyInspectionEngine such that
@@ -1306,7 +1306,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEAX) {
 // not tracked (except to keep track of stack pointer movement)
 TEST_F(Testx86AssemblyInspectionEngine, TestPushECX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1321,13 +1321,13 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushECX) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ecx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_ecx, regloc));
 }
 
 // The ABI is hardcoded in x86AssemblyInspectionEngine such that
@@ -1335,7 +1335,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushECX) {
 // not tracked (except to keep track of stack pointer movement)
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEDX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1350,18 +1350,18 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEDX) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_edx, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_edx, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEBX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1376,20 +1376,20 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEBX) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_ebx, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_ebx, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEBP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1404,20 +1404,20 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEBP) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_ebp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushRBPWithREX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data[] = {
       0x40, 0x55, // pushq %rbp
@@ -1431,21 +1431,21 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBPWithREX) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
+  row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-16, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushESI) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1460,20 +1460,20 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushESI) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_esi, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_esi, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushEDI) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1488,20 +1488,20 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEDI) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_edi, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_edi, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
 
   uint8_t data64_1[] = {
       0x48, 0x8b, 0xec, // movq %rsp, %rbp
@@ -1515,12 +1515,12 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data64_1, sizeof(data64_1), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(3);
+  row = unwind_plan.GetRowForFunctionOffset(3);
 
-  EXPECT_EQ(3ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
   uint8_t data64_2[] = {
       0x48, 0x89, 0xe5, // movq %rsp, %rbp
@@ -1532,11 +1532,11 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data64_2, sizeof(data64_2), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(3);
+  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
   uint8_t data32_1[] = {
       0x8b, 0xec, // movl %rsp, %rbp
@@ -1548,11 +1548,11 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data32_1, sizeof(data32_1), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_ebp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
   uint8_t data32_2[] = {
       0x89, 0xe5, // movl %rsp, %rbp
@@ -1564,16 +1564,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data32_2, sizeof(data32_2), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_ebp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine64 = Getx86_64Inspector();
@@ -1588,11 +1588,11 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data1, sizeof(data1), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(264, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(264, row->GetCFAValue().GetOffset());
 
   uint8_t data2[] = {
       0x48, 0x83, 0xec, 0x10, // subq $0x10, %rsp
@@ -1604,16 +1604,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data2, sizeof(data2), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(24, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(24, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1628,11 +1628,11 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data1, sizeof(data1), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(260, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(6);
+  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(260, row->GetCFAValue().GetOffset());
 
   uint8_t data2[] = {
       0x83, 0xec, 0x10, // subq $0x10, %esp
@@ -1644,16 +1644,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data2, sizeof(data2), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(20, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(3);
+  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(20, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine64 = Getx86_64Inspector();
@@ -1668,11 +1668,11 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data1, sizeof(data1), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8 - 256, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8 - 256, row->GetCFAValue().GetOffset());
 
   uint8_t data2[] = {
       0x48, 0x83, 0xc4, 0x10, // addq $0x10, %rsp
@@ -1684,16 +1684,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data2, sizeof(data2), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8 - 16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8 - 16, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -1708,11 +1708,11 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data1, sizeof(data1), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4 - 256, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(6);
+  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4 - 256, row->GetCFAValue().GetOffset());
 
   uint8_t data2[] = {
       0x83, 0xc4, 0x10, // addq $0x10, %esp
@@ -1724,16 +1724,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data2, sizeof(data2), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4 - 16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(3);
+  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4 - 16, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestLEA_RSP_Pattern) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1748,16 +1748,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEA_RSP_Pattern) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopRBX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1773,17 +1773,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBX) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbx, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbx, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopRBP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1799,17 +1799,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBP) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR12) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1825,17 +1825,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR12) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r12, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_r12, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR13) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1851,17 +1851,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR13) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r13, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_r13, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR14) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1877,17 +1877,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR14) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r14, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_r14, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopR15) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1903,17 +1903,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR15) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_r15, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_r15, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopEBX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Geti386Inspector();
@@ -1929,17 +1929,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEBX) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebx, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebx, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopEBP) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Geti386Inspector();
@@ -1955,17 +1955,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEBP) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopRBPWithREX) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Getx86_64Inspector();
@@ -1981,17 +1981,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBPWithREX) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopESI) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Geti386Inspector();
@@ -2007,17 +2007,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopESI) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_esi, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_esi, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPopEDI) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Geti386Inspector();
@@ -2033,19 +2033,19 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEDI) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_edi, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_edi, regloc));
 }
 
 // We don't track these registers, but make sure the CFA address is updated
 // if we're defining the CFA in term of esp.
 TEST_F(Testx86AssemblyInspectionEngine, Testi386IgnoredRegisters) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine = Geti386Inspector();
@@ -2068,22 +2068,22 @@ TEST_F(Testx86AssemblyInspectionEngine, Testi386IgnoredRegisters) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(20, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(20, row->GetCFAValue().GetOffset());
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine64 = Getx86_64Inspector();
@@ -2100,22 +2100,22 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
 
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebp, regloc));
 }
 
 // In i386, which lacks pc-relative addressing, a common code sequence
@@ -2124,7 +2124,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
 // into a register (the "pic base" register).
 TEST_F(Testx86AssemblyInspectionEngine, TestCALLNextInsn) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -2139,17 +2139,17 @@ TEST_F(Testx86AssemblyInspectionEngine, TestCALLNextInsn) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  row = unwind_plan.GetRowForFunctionOffset(5);
+  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
+  EXPECT_FALSE(row->GetRegisterInfo(k_ebp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVx86_64) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine64 = Getx86_64Inspector();
@@ -2168,27 +2168,27 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVx86_64) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(19);
-  EXPECT_EQ(19ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(19);
+  EXPECT_EQ(19ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r14, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r14, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-80, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_r15, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_r15, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-1512, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rbx, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rbx, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-88, regloc.GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVi386) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -2206,16 +2206,16 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVi386) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_ebx, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_ebx, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-344, regloc.GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_esi, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_esi, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-40, regloc.GetOffset());
 }
@@ -2290,25 +2290,25 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
 
   // Before we touch the stack pointer, we should still refer to the
   // row from after the prologue.
-  row_sp = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(5);
+  EXPECT_EQ(4ull, row->GetOffset());
 
   // Check the first stack pointer update.
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_EQ(152, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_EQ(152, row->GetCFAValue().GetOffset());
 
   // After the nop, we should still refer to the same row.
-  row_sp = unwind_plan.GetRowForFunctionOffset(13);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(13);
+  EXPECT_EQ(12ull, row->GetOffset());
 
   // Check that the second stack pointer update is reflected in the
   // unwind plan.
-  row_sp = unwind_plan.GetRowForFunctionOffset(20);
-  EXPECT_EQ(20ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(20);
+  EXPECT_EQ(20ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
@@ -2375,10 +2375,10 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
   EXPECT_TRUE(engine64->AugmentUnwindPlanFromCallSite(
       data, sizeof(data), sample_range, unwind_plan, reg_ctx_sp));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(6);
+  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
   // x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite
   // doesn't track register restores (pop'ing a reg value back from
@@ -2386,7 +2386,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
   // Technically we should be able to do the following test, but it
   // won't work today - the unwind plan will still say that the caller's
   // rbp is on the stack.
-  // EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  // EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
@@ -2453,10 +2453,10 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
   EXPECT_TRUE(engine32->AugmentUnwindPlanFromCallSite(
       data, sizeof(data), sample_range, unwind_plan, reg_ctx_sp));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_EQ(4, row_sp->GetCFAValue().GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(5);
+  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_EQ(4, row->GetCFAValue().GetOffset());
 
   // x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite
   // doesn't track register restores (pop'ing a reg value back from
@@ -2464,7 +2464,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
   // Technically we should be able to do the following test, but it
   // won't work today - the unwind plan will still say that the caller's
   // ebp is on the stack.
-  // EXPECT_FALSE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  // EXPECT_FALSE(row->GetRegisterInfo(k_ebp, regloc));
 }
 
 // Check that the i386 disassembler disassembles past an opcode that
@@ -2473,7 +2473,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
 // disassembling at that point (long-mode).
 TEST_F(Testx86AssemblyInspectionEngine, Test32BitOnlyInstruction) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
+  const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -2490,13 +2490,13 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32BitOnlyInstruction) {
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_ebp, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_ebp, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
@@ -2505,13 +2505,13 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32BitOnlyInstruction) {
   EXPECT_TRUE(engine64->GetNonCallSiteUnwindPlanFromAssembly(
       data, sizeof(data), sample_range, unwind_plan));
 
-  row_sp = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_FALSE(row_sp->GetRegisterInfo(k_rbp, regloc));
+  EXPECT_FALSE(row->GetRegisterInfo(k_rbp, regloc));
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestStackRealign8BitDisp_i386) {
@@ -2715,123 +2715,123 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   //  0: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   //  1: CFA=rsp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(1);
+  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   //  4: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   //  7: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(7);
+  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   //  8: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(8);
+  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 11: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(11);
-  EXPECT_EQ(11ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(11);
+  EXPECT_EQ(11ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 12: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(12);
+  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 15: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(15);
-  EXPECT_EQ(15ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(15);
+  EXPECT_EQ(15ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 18: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(18);
-  EXPECT_EQ(18ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(18);
+  EXPECT_EQ(18ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 21: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(21);
-  EXPECT_EQ(21ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(8, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(21);
+  EXPECT_EQ(21ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 
   // 24: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(24);
-  EXPECT_EQ(24ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(16, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(24);
+  EXPECT_EQ(24ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
-  EXPECT_TRUE(row_sp->GetRegisterInfo(k_rip, regloc));
+  EXPECT_TRUE(row->GetRegisterInfo(k_rip, regloc));
   EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
   EXPECT_EQ(-8, regloc.GetOffset());
 }
@@ -2881,39 +2881,38 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
 
   // Check that we've unwound the stack after the first mid-function epilogue
   // row:   CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
-  UnwindPlan::RowSP row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize, row_sp->GetCFAValue().GetOffset());
+  const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
 
   // Check that we've reinstated the stack frame setup 
   // unwind instructions after a jmpq *%eax
   // row:   CFA=ebp +8 => esp=CFA+0 eip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(18);
-  EXPECT_EQ(18ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_ebp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize * 2, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(18);
+  EXPECT_EQ(18ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
 
   // Check that we've reinstated the stack frame setup 
   // unwind instructions after a mid-function retq
   // row:   CFA=ebp +8 => esp=CFA+0 eip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_ebp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize * 2, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(28);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
 
   // After last instruction in the function, verify that
   // the stack frame has been unwound
   // row:   CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
-  row_sp = unwind_plan.GetRowForFunctionOffset(34);
-  EXPECT_EQ(34ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_esp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize, row_sp->GetCFAValue().GetOffset());
-
+  row = unwind_plan.GetRowForFunctionOffset(34);
+  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
 
   unwind_plan.Clear();
 
@@ -2923,38 +2922,36 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
 
   // Check that we've unwound the stack after the first mid-function epilogue
   // row:   CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(16);
+  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
 
   // Check that we've reinstated the stack frame setup 
   // unwind instructions after a jmpq *%eax
   // row:   CFA=rbp+16 => rsp=CFA+0 rip=[CFA-16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(18);
-  EXPECT_EQ(18ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize * 2, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(18);
+  EXPECT_EQ(18ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
 
   // Check that we've reinstated the stack frame setup 
   // unwind instructions after a mid-function retq
   // row:   CFA=rbp+16 => rsp=CFA+0 rip=[CFA-16]
-  row_sp = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rbp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize * 2, row_sp->GetCFAValue().GetOffset());
+  row = unwind_plan.GetRowForFunctionOffset(28);
+  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
 
   // After last instruction in the function, verify that
   // the stack frame has been unwound
   // row:   CFA=rsp +8 => esp=CFA+0 rip=[CFA-8]
-  row_sp = unwind_plan.GetRowForFunctionOffset(34);
-  EXPECT_EQ(34ull, row_sp->GetOffset());
-  EXPECT_TRUE(row_sp->GetCFAValue().GetRegisterNumber() == k_rsp);
-  EXPECT_TRUE(row_sp->GetCFAValue().IsRegisterPlusOffset() == true);
-  EXPECT_EQ(wordsize, row_sp->GetCFAValue().GetOffset());
-
-
+  row = unwind_plan.GetRowForFunctionOffset(34);
+  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
 }


### PR DESCRIPTION
The whole unwind plan is already stored in a shared pointer, and there's no need to persist Rows individually. If there's ever a need to do that, there are at least two options:
- copy the row (they're not that big, and they're being copied left and right during construction already)
- use the shared_ptr subobject constructor to create a shared_ptr which points to a Row but holds the entire unwind plan alive

This also changes all of the getter functions to return const Row pointers, which is important for safety because all of these objects are cached and potentially accessed from multiple threads. (Technically one could hand out `shared_ptr<const Row>`s, but we don't have a habit of doing that.)

As a next step, I'd like to remove the internal UnwindPlan usages of the shared pointer, but I'm doing this separately to gauge feedback, and also because the patch got rather big.