### PR TITLE
[CLANG-CL] Remove the 'static' specifier for _FUNCTION_ in MSVC mode.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -157,6 +157,8 @@ Bug Fixes in This Version
 - Clang now outputs correct values when #embed data contains bytes with negative
   signed char values (#GH102798).
 
+- Remove the ``static`` specifier for the value of ``_FUNCTION_`` for static functions, in MSVC compatibility mode.
+
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -747,8 +747,12 @@ std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
     if (const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(FD)) {
       if (MD->isVirtual() && IK != PredefinedIdentKind::PrettyFunctionNoVirtual)
         Out << "virtual ";
-      if (MD->isStatic())
-        Out << "static ";
+      if (MD->isStatic()) {
+        bool IsFunctionInMSVCCommpatEnv =
+            IK == PredefinedIdentKind::Function && LO.MSVCCompat;
+        if (ForceElaboratedPrinting && !IsFunctionInMSVCCommpatEnv)
+          Out << "static ";
+      }
     }
 
     class PrettyCallbacks final : public PrintingCallbacks {

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -748,9 +748,7 @@ std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
       if (MD->isVirtual() && IK != PredefinedIdentKind::PrettyFunctionNoVirtual)
         Out << "virtual ";
       if (MD->isStatic()) {
-        bool IsFunctionInMSVCCommpatEnv =
-            IK == PredefinedIdentKind::Function && LO.MSVCCompat;
-        if (ForceElaboratedPrinting && !IsFunctionInMSVCCommpatEnv)
+        if (!ForceElaboratedPrinting)
           Out << "static ";
       }
     }

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -747,10 +747,8 @@ std::string PredefinedExpr::ComputeName(PredefinedIdentKind IK,
     if (const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(FD)) {
       if (MD->isVirtual() && IK != PredefinedIdentKind::PrettyFunctionNoVirtual)
         Out << "virtual ";
-      if (MD->isStatic()) {
-        if (!ForceElaboratedPrinting)
-          Out << "static ";
-      }
+      if (MD->isStatic() && !ForceElaboratedPrinting)
+        Out << "static ";
     }
 
     class PrettyCallbacks final : public PrintingCallbacks {

--- a/clang/test/SemaCXX/source_location.cpp
+++ b/clang/test/SemaCXX/source_location.cpp
@@ -524,6 +524,37 @@ TestClass<test_func::C> t2;
 TestStruct<test_func::S> t3;
 TestEnum<test_func::E> t4;
 
+class A { int b;};
+namespace inner {
+  template <class Ty>
+  class C {
+  public:
+    template <class T>
+    static void f(int i) {
+      (void)i;
+#ifdef MS
+     static_assert(is_equal(__FUNCTION__, "test_func::inner::C<class test_func::A>::f"));
+#else
+     static_assert(is_equal(__FUNCTION__, "f"));
+#endif
+    }
+    template <class T>
+    static void f(double f) {
+      (void)f;
+#ifdef MS
+     static_assert(is_equal(__FUNCTION__, "test_func::inner::C<class test_func::A>::f"));
+#else
+     static_assert(is_equal(__FUNCTION__, "f"));
+#endif
+    }
+  };
+}
+
+  void foo() {
+  test_func::inner::C<test_func::A>::f<char>(1);
+  test_func::inner::C<test_func::A>::f<void>(1.0);
+}
+
 } // namespace test_func
 
 

--- a/clang/test/SemaCXX/source_location.cpp
+++ b/clang/test/SemaCXX/source_location.cpp
@@ -539,12 +539,30 @@ namespace inner {
 #endif
     }
     template <class T>
-    static void f(double f) {
+    static constexpr void cf(int i) {
+      (void)i;
+#ifdef MS
+     static_assert(is_equal(__FUNCTION__, "test_func::inner::C<class test_func::A>::cf"));
+#else
+     static_assert(is_equal(__FUNCTION__, "cf"));
+#endif
+    }
+    template <class T>
+    static void df(double f) {
       (void)f;
 #ifdef MS
-     static_assert(is_equal(__FUNCTION__, "test_func::inner::C<class test_func::A>::f"));
+      static_assert(is_equal(__FUNCTION__, "test_func::inner::C<class test_func::A>::df"));
 #else
-     static_assert(is_equal(__FUNCTION__, "f"));
+      static_assert(is_equal(__FUNCTION__, "df"));
+#endif
+    }
+    template <class T>
+    static constexpr void cdf(double f) {
+      (void)f;
+#ifdef MS
+      static_assert(is_equal(__FUNCTION__, "test_func::inner::C<class test_func::A>::cdf"));
+#else
+      static_assert(is_equal(__FUNCTION__, "cdf"));
 #endif
     }
   };
@@ -552,7 +570,9 @@ namespace inner {
 
   void foo() {
   test_func::inner::C<test_func::A>::f<char>(1);
-  test_func::inner::C<test_func::A>::f<void>(1.0);
+  test_func::inner::C<test_func::A>::cf<char>(1);
+  test_func::inner::C<test_func::A>::df<void>(1.0);
+  test_func::inner::C<test_func::A>::cdf<void>(1.0);
 }
 
 } // namespace test_func


### PR DESCRIPTION
The macro `FUNCTION` is returning the `static` specifier for static templated functions. It's not the case for MSVC.
See https://godbolt.org/z/KnhWhqs47
Clang-cl is returning:
`__FUNCTION__ static inner::C<class A>::f`
`__FUNCTION__ static inner::C<class A>::f`
for the reproducer.