### PR TITLE
[clang] Use ISO C90 style comment in C code

### DIFF
--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -1223,7 +1223,7 @@ static CXString createCXString(const char *CS) {
 static CXString duplicateCXString(const char *CS) {
   CXString Str;
   Str.data = strdup(CS);
-  Str.private_flags = 1; // CXS_Malloc
+  Str.private_flags = 1; /* CXS_Malloc */
   return Str;
 }
 


### PR DESCRIPTION
This patch fixes warning which occurs during compilation of clang with GCC:
```
C++ style comments are not allowed in ISO C90
```
