### PR TITLE
[llvm] Use ISO C90 style comment in C code

### DIFF
--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -55,14 +55,14 @@ std::error_code restorezOSStdHandleAutoConversion(int FD);
 /** \brief Set the tag information for a file descriptor. */
 std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
 
-// Get the the tag ccsid for a file name or a file descriptor.
+/** Get the the tag ccsid for a file name or a file descriptor. */
 ErrorOr<__ccsid_t> getzOSFileTag(const char *FileName, const int FD = -1);
 
-// Query the file tag to determine if it needs conversion to UTF-8 codepage.
+/** Query the file tag to determine if it needs conversion to UTF-8 codepage. */
 ErrorOr<bool> needzOSConversion(const char *FileName, const int FD = -1);
 
-} // namespace llvm
-#endif // __cplusplus
+} /* namespace llvm */
+#endif /* __cplusplus */
 
 #endif /* __MVS__ */
 


### PR DESCRIPTION
This patch fixes warning which occurs during compilation of clang with GCC:
```
C++ style comments are not allowed in ISO C90
```

Similar PR for clang: #128189 