### PR TITLE
[X86][DAGCombiner] Fix assertion failure in `combinei64TruncSrlAdd`

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -53713,7 +53713,7 @@ static SDValue combinei64TruncSrlAdd(SDValue N, EVT VT, SelectionDAG &DAG,
                                  m_ConstInt(SrlConst)))))
     return SDValue();
 
-  if (SrlConst.ule(31) || AddConst.lshr(SrlConst).shl(SrlConst) != AddConst)
+  if (SrlConst.ule(32) || AddConst.lshr(SrlConst).shl(SrlConst) != AddConst)
     return SDValue();
 
   SDValue AddLHSSrl =

--- a/llvm/test/CodeGen/X86/combine-i64-trunc-srl-add.ll
+++ b/llvm/test/CodeGen/X86/combine-i64-trunc-srl-add.ll
@@ -123,3 +123,31 @@ define i32 @test_trunc_add(i64 %x) {
   %conv = trunc i64 %shr to i32
   ret i32 %conv
 }
+
+; Make sure we don't crash on this test case.
+
+define i32 @pr128158(i64 %x) {
+; X64-LABEL: pr128158:
+; X64:       # %bb.0: # %entry
+; X64-NEXT:    movabsq $-4294967296, %rax # imm = 0xFFFFFFFF00000000
+; X64-NEXT:    addq %rdi, %rax
+; X64-NEXT:    shrq $32, %rax
+; X64-NEXT:    .p2align 4
+; X64-NEXT:  .LBB9_1: # %for.body
+; X64-NEXT:    # =>This Inner Loop Header: Depth=1
+; X64-NEXT:    cmpl $9, %eax
+; X64-NEXT:    jb .LBB9_1
+; X64-NEXT:  # %bb.2: # %exit
+; X64-NEXT:    xorl %eax, %eax
+; X64-NEXT:    retq
+entry:
+  br label %for.body
+
+for.body:
+  %add = add i64 %x, -4294967296
+  %cmp = icmp ult i64 %add, 38654705664
+  br i1 %cmp, label %for.body, label %exit
+
+exit:
+  ret i32 0
+}


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/128158.
