### PR TITLE
[lldb][cmake] Use STATUS instead of explicit '--' in message logging

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -206,23 +206,23 @@ if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
     # If we're not exporting all symbols, we'll want to explicitly set
     # the exported symbols here.  This prevents 'log enable --stack ...'
     # from working on some systems but limits the liblldb size.
-    MESSAGE(STATUS "Symbols (liblldb): exporting all symbols from the lldb namespace")
+    message(STATUS "Symbols (liblldb): exporting all symbols from the lldb namespace")
     add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb.exports)
   elseif (NOT LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE)
     # Don't use an explicit export. Instead, tell the linker to export all symbols.
-    MESSAGE(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
-    MESSAGE(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
+    message(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
+    message(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
                     "Only the SB API is guaranteed to be stable.")
     add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb-private.exports)
   else ()
-    MESSAGE(STATUS "Symbols (liblldb): exporting all symbols specified in the exports "
+    message(STATUS "Symbols (liblldb): exporting all symbols specified in the exports "
             " file '${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}'")
-    MESSAGE(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
+    message(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
                     "Only the SB API is guaranteed to be stable.")
     add_llvm_symbol_exports(liblldb "${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}")
   endif()
 elseif (LLDB_EXPORT_ALL_SYMBOLS)
-  MESSAGE(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
+  message(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
 
   # Pull out the various lldb libraries linked into liblldb, these will be used
   # when looking for symbols to extract. We ignore most plugin libraries here,

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -206,23 +206,23 @@ if (NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
     # If we're not exporting all symbols, we'll want to explicitly set
     # the exported symbols here.  This prevents 'log enable --stack ...'
     # from working on some systems but limits the liblldb size.
-    MESSAGE("-- Symbols (liblldb): exporting all symbols from the lldb namespace")
+    MESSAGE(STATUS "Symbols (liblldb): exporting all symbols from the lldb namespace")
     add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb.exports)
   elseif (NOT LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE)
     # Don't use an explicit export. Instead, tell the linker to export all symbols.
-    MESSAGE("-- Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
+    MESSAGE(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
     MESSAGE(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
                     "Only the SB API is guaranteed to be stable.")
     add_llvm_symbol_exports(liblldb ${CMAKE_CURRENT_SOURCE_DIR}/liblldb-private.exports)
   else ()
-    MESSAGE("-- Symbols (liblldb): exporting all symbols specified in the exports "
+    MESSAGE(STATUS "Symbols (liblldb): exporting all symbols specified in the exports "
             " file '${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}'")
     MESSAGE(WARNING "Private LLDB symbols frequently change and no API stability is guaranteed. "
                     "Only the SB API is guaranteed to be stable.")
     add_llvm_symbol_exports(liblldb "${LLDB_EXPORT_ALL_SYMBOLS_EXPORTS_FILE}")
   endif()
 elseif (LLDB_EXPORT_ALL_SYMBOLS)
-  MESSAGE("-- Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
+  MESSAGE(STATUS "Symbols (liblldb): exporting all symbols from the lldb and lldb_private namespaces")
 
   # Pull out the various lldb libraries linked into liblldb, these will be used
   # when looking for symbols to extract. We ignore most plugin libraries here,


### PR DESCRIPTION
Currently, configuring lldb with cmake with separated stdout and stderr gives some unnecessary output in stderr which happens since message statement is used without `[mode]` (See https://cmake.org/cmake/help/v3.31/command/message.html). This patch adds mode `STATUS` instead of explicit `--` at the beginning of messages. 