### PR TITLE
[MLIR] Separate the scalarization part of MathToROCDL

### DIFF
--- a/mlir/include/mlir/Conversion/MathToROCDL/MathToROCDL.h
+++ b/mlir/include/mlir/Conversion/MathToROCDL/MathToROCDL.h
@@ -18,9 +18,18 @@ class Pass;
 #define GEN_PASS_DECL_CONVERTMATHTOROCDL
 #include "mlir/Conversion/Passes.h.inc"
 
+enum class MathToROCDLConversionPatternKind { All, Scalarizations, Lowerings };
+
 /// Populate the given list with patterns that convert from Math to ROCDL calls.
-void populateMathToROCDLConversionPatterns(const LLVMTypeConverter &converter,
-                                           RewritePatternSet &patterns);
+///
+/// Note that the default parameter value MathToROCDLConversionPatternKind::All
+/// is only for compatibility but is not recommended, because lumping together
+/// multiple conversion patters in the same pattern application can result in
+/// type conversion failures when one of the patterns failed.
+void populateMathToROCDLConversionPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns,
+    MathToROCDLConversionPatternKind patternKind =
+        MathToROCDLConversionPatternKind::All);
 } // namespace mlir
 
 #endif // MLIR_CONVERSION_MATHTOROCDL_MATHTOROCDL_H_

--- a/mlir/test/Conversion/MathToROCDL/math-to-rocdl.mlir
+++ b/mlir/test/Conversion/MathToROCDL/math-to-rocdl.mlir
@@ -578,3 +578,20 @@ module @test_module {
     func.return %result : vector<2x2xf16>
   }
 }
+
+// -----
+
+module @test_module {
+  // This test case covers the case of math ops that do not have a lowering to
+  // a function call. When lowerings to call were lumped together with
+  // scalarization in the same pattern application, they were preventing
+  // scalarization.
+  // CHECK-LABEL: func @math_log_f32_vector_0d
+  func.func @math_log_f32_vector_0d(%arg : vector<f32>) -> vector<f32> {
+    // CHECK: llvm.extractelement {{.*}} : vector<1xf32>
+    // CHECK: math.log {{.*}} : f32
+    // CHECK: llvm.insertelement {{.*}} : vector<1xf32>
+    %result = math.log %arg : vector<f32>
+    func.return %result : vector<f32>
+  }
+}


### PR DESCRIPTION
MathToROCDL was lumping together scalarization and lowering to calls. The latter may legitimately fail if an op does not have a lowering to a function call. In that case, we still want the scalarization, because that is necessary to keep the ops in sync with the type conversion.