### PR TITLE
[NFC] test interaction between array-bounds and hwaddress

### DIFF
--- a/clang/test/CodeGen/hwasan-stack-safety-analysis-with-array-bounds.c
+++ b/clang/test/CodeGen/hwasan-stack-safety-analysis-with-array-bounds.c
@@ -1,0 +1,26 @@
+// REQUIRES: aarch64-registered-target
+
+// RUN: %clang -fsanitize-trap=undefined -fsanitize=hwaddress,array-bounds -target aarch64-linux-gnu -S -emit-llvm -mllvm -hwasan-use-stack-safety=true -mllvm -hwasan-generate-tags-with-calls -O2 %s -o - | FileCheck %s --check-prefixes=CHECK,SAFETY
+// RUN: %clang -fsanitize-trap=undefined -fsanitize=hwaddress,array-bounds -target aarch64-linux-gnu -S -emit-llvm -mllvm -hwasan-use-stack-safety=false -mllvm -hwasan-generate-tags-with-calls -O2 %s -o - | FileCheck %s --check-prefixes=CHECK,NOSAFETY
+
+// Make sure that HWAsan does not re-check what has been validated by array-bounds
+
+void f(char*);
+
+int foo(unsigned int idx) {
+  char buf[10];
+  f(buf);
+  return buf[idx];
+  // CHECK-LABEL: {{.*}}foo
+  // NOSAFETY: call void @llvm.hwasan.check.memaccess.shortgranules
+  // SAFETY-NOT: call void @llvm.hwasan.check.memaccess.shortgranules
+}
+
+int bar(int idx) {
+  char buf[10];
+  f(buf);
+  return buf[idx];
+  // CHECK-LABEL: {{.*}}bar
+  // NOSAFETY: call void @llvm.hwasan.check.memaccess.shortgranules
+  // SAFETY-NOT: call void @llvm.hwasan.check.memaccess.shortgranules
+}


### PR DESCRIPTION
we want the stack safety analysis to be able to skip array accesses that
are already checked by array-bounds.
