### PR TITLE
[libc] Enable 'strftime' for the GPU targets

### DIFF
--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -259,6 +259,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.clock_gettime
     libc.src.time.timespec_get
     libc.src.time.nanosleep
+    libc.src.time.strftime
+    libc.src.time.strftime_l
 
     # wchar.h entrypoints
     libc.src.wchar.wcslen

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -259,6 +259,8 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.clock_gettime
     libc.src.time.timespec_get
     libc.src.time.nanosleep
+    libc.src.time.strftime
+    libc.src.time.strftime_l
 
     # wchar.h entrypoints
     libc.src.wchar.wcslen

--- a/libc/docs/gpu/support.rst
+++ b/libc/docs/gpu/support.rst
@@ -268,6 +268,8 @@ Function Name  Available  RPC Required
 clock          |check|
 clock_gettime  |check|
 nanosleep      |check|
+strftime       |check|
+strftime_l     |check|
 =============  =========  ============
 
 assert.h


### PR DESCRIPTION
Summary:
These should allow us to build with locale support for libcxx.
