### PR TITLE
[clang-tidy-diff] Add an option to treat warnings as errors

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
@@ -259,6 +259,11 @@ def main():
         action="store_true",
         help="Only check files in the compilation database",
     )
+    parser.add_argument(
+        "-warnings-as-errors",
+        help="Upgrades clang-tidy warnings to errors. Same format as '-checks'.",
+        default="",
+    )
 
     clang_tidy_args = []
     argv = sys.argv[1:]
@@ -374,6 +379,8 @@ def main():
         common_clang_tidy_args.append("-extra-arg-before=%s" % arg)
     for plugin in args.plugins:
         common_clang_tidy_args.append("-load=%s" % plugin)
+    if args.warnings_as_errors:
+        common_clang_tidy_args.append("-warnings-as-errors=" + args.warnings_as_errors)
 
     for name in lines_by_file:
         line_filter_json = json.dumps(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -97,6 +97,9 @@ Improvements to clang-tidy
   Note: this may lead to false negatives; downstream users may need to adjust
   their checks to preserve existing behavior.
 
+- Improved :program:`clang-tidy-diff.py` script. Add the `-warnings-as-errors`
+  argument to treat warnings as errors.
+
 New checks
 ^^^^^^^^^^
 


### PR DESCRIPTION
This patch allows to treat warnings as erros using clang-tidy-diff.