### PR TITLE
[clang][ARM][AArch64] Define intrinsics guarded by __has_builtin on all platforms 

### DIFF
--- a/clang/include/clang/Basic/BuiltinHeaders.def
+++ b/clang/include/clang/Basic/BuiltinHeaders.def
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 HEADER(NO_HEADER, nullptr)
+HEADER(ARMACLE_H, "arm_acle.h")
 HEADER(BLOCKS_H, "Blocks.h")
 HEADER(COMPLEX_H, "complex.h")
 HEADER(CTYPE_H, "ctype.h")

--- a/clang/include/clang/Basic/BuiltinsAArch64.def
+++ b/clang/include/clang/Basic/BuiltinsAArch64.def
@@ -50,6 +50,11 @@ BUILTIN(__builtin_arm_wfi, "v", "")
 BUILTIN(__builtin_arm_sev, "v", "")
 BUILTIN(__builtin_arm_sevl, "v", "")
 BUILTIN(__builtin_arm_chkfeat, "WUiWUi", "")
+TARGET_HEADER_BUILTIN(__yield, "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__wfe,   "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__wfi,   "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__sev,   "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__sevl,  "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
 
 // Like __builtin_trap but provide an 16-bit immediate reason code (which goes into `brk #N`).
 BUILTIN(__builtin_arm_trap, "vUIs", "nr")
@@ -82,6 +87,9 @@ TARGET_BUILTIN(__builtin_arm_mops_memset_tag, "v*v*iz", "", "mte,mops")
 BUILTIN(__builtin_arm_dmb, "vUi", "nc")
 BUILTIN(__builtin_arm_dsb, "vUi", "nc")
 BUILTIN(__builtin_arm_isb, "vUi", "nc")
+TARGET_HEADER_BUILTIN(__dmb, "vUi", "nch", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__dsb, "vUi", "nch", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__isb, "vUi", "nch", ARMACLE_H, ALL_LANGUAGES, "")
 
 TARGET_BUILTIN(__builtin_arm_jcvt, "Zid", "nc", "v8.3a")
 
@@ -97,16 +105,6 @@ BUILTIN(__builtin_arm_wsr, "vcC*Ui", "nc")
 BUILTIN(__builtin_arm_wsr64, "vcC*WUi", "nc")
 TARGET_BUILTIN(__builtin_arm_wsr128, "vcC*LLLUi", "nc", "d128")
 BUILTIN(__builtin_arm_wsrp, "vcC*vC*", "nc")
-
-// MSVC
-LANGBUILTIN(__dmb, "vUi", "nc", ALL_MS_LANGUAGES)
-LANGBUILTIN(__dsb, "vUi", "nc", ALL_MS_LANGUAGES)
-LANGBUILTIN(__isb, "vUi", "nc", ALL_MS_LANGUAGES)
-LANGBUILTIN(__yield, "v", "",   ALL_MS_LANGUAGES)
-LANGBUILTIN(__wfe,   "v", "",   ALL_MS_LANGUAGES)
-LANGBUILTIN(__wfi,   "v", "",   ALL_MS_LANGUAGES)
-LANGBUILTIN(__sev,   "v", "",   ALL_MS_LANGUAGES)
-LANGBUILTIN(__sevl,  "v", "",   ALL_MS_LANGUAGES)
 
 // Misc
 BUILTIN(__builtin_sponentry, "v*", "c")

--- a/clang/include/clang/Basic/BuiltinsARM.def
+++ b/clang/include/clang/Basic/BuiltinsARM.def
@@ -186,11 +186,19 @@ BUILTIN(__builtin_arm_wfi, "v", "")
 BUILTIN(__builtin_arm_sev, "v", "")
 BUILTIN(__builtin_arm_sevl, "v", "")
 BUILTIN(__builtin_arm_dbg, "vUi", "")
+TARGET_HEADER_BUILTIN(__yield, "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__wfe, "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__wfi, "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__sev, "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__sevl, "v", "h", ARMACLE_H, ALL_LANGUAGES, "")
 
 // Data barrier
 BUILTIN(__builtin_arm_dmb, "vUi", "nc")
 BUILTIN(__builtin_arm_dsb, "vUi", "nc")
 BUILTIN(__builtin_arm_isb, "vUi", "nc")
+TARGET_HEADER_BUILTIN(__dmb, "vUi", "nch", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__dsb, "vUi", "nch", ARMACLE_H, ALL_LANGUAGES, "")
+TARGET_HEADER_BUILTIN(__isb, "vUi", "nch", ARMACLE_H, ALL_LANGUAGES, "")
 
 // Prefetch
 BUILTIN(__builtin_arm_prefetch, "vvC*UiUi", "nc")
@@ -209,15 +217,6 @@ BUILTIN(__builtin_sponentry, "v*", "c")
 // MSVC
 LANGBUILTIN(__emit, "vIUiC", "", ALL_MS_LANGUAGES)
 
-LANGBUILTIN(__yield, "v", "", ALL_MS_LANGUAGES)
-LANGBUILTIN(__wfe, "v", "", ALL_MS_LANGUAGES)
-LANGBUILTIN(__wfi, "v", "", ALL_MS_LANGUAGES)
-LANGBUILTIN(__sev, "v", "", ALL_MS_LANGUAGES)
-LANGBUILTIN(__sevl, "v", "", ALL_MS_LANGUAGES)
-
-LANGBUILTIN(__dmb, "vUi", "nc", ALL_MS_LANGUAGES)
-LANGBUILTIN(__dsb, "vUi", "nc", ALL_MS_LANGUAGES)
-LANGBUILTIN(__isb, "vUi", "nc", ALL_MS_LANGUAGES)
 LANGBUILTIN(__ldrexd, "WiWiCD*", "", ALL_MS_LANGUAGES)
 LANGBUILTIN(_MoveFromCoprocessor, "UiIUiIUiIUiIUiIUi", "", ALL_MS_LANGUAGES)
 LANGBUILTIN(_MoveFromCoprocessor2, "UiIUiIUiIUiIUiIUi", "", ALL_MS_LANGUAGES)

--- a/clang/lib/Headers/arm_acle.h
+++ b/clang/lib/Headers/arm_acle.h
@@ -29,47 +29,16 @@ extern "C" {
 
 /* 7 SYNCHRONIZATION, BARRIER AND HINT INTRINSICS */
 /* 7.3 Memory barriers */
-#if !__has_builtin(__dmb)
-#define __dmb(i) __builtin_arm_dmb(i)
-#endif
-#if !__has_builtin(__dsb)
-#define __dsb(i) __builtin_arm_dsb(i)
-#endif
-#if !__has_builtin(__isb)
-#define __isb(i) __builtin_arm_isb(i)
-#endif
+void __dmb(unsigned int);
+void __dsb(unsigned int);
+void __isb(unsigned int);
 
 /* 7.4 Hints */
-
-#if !__has_builtin(__wfi)
-static __inline__ void __attribute__((__always_inline__, __nodebug__)) __wfi(void) {
-  __builtin_arm_wfi();
-}
-#endif
-
-#if !__has_builtin(__wfe)
-static __inline__ void __attribute__((__always_inline__, __nodebug__)) __wfe(void) {
-  __builtin_arm_wfe();
-}
-#endif
-
-#if !__has_builtin(__sev)
-static __inline__ void __attribute__((__always_inline__, __nodebug__)) __sev(void) {
-  __builtin_arm_sev();
-}
-#endif
-
-#if !__has_builtin(__sevl)
-static __inline__ void __attribute__((__always_inline__, __nodebug__)) __sevl(void) {
-  __builtin_arm_sevl();
-}
-#endif
-
-#if !__has_builtin(__yield)
-static __inline__ void __attribute__((__always_inline__, __nodebug__)) __yield(void) {
-  __builtin_arm_yield();
-}
-#endif
+void __wfi(void);
+void __wfe(void);
+void __sev(void);
+void __sevl(void);
+void __yield(void);
 
 #if defined(__ARM_32BIT_STATE) && __ARM_32BIT_STATE
 #define __dbg(t) __builtin_arm_dbg(t)

--- a/clang/lib/Sema/SemaARM.cpp
+++ b/clang/lib/Sema/SemaARM.cpp
@@ -1010,8 +1010,11 @@ bool SemaARM::CheckARMBuiltinFunctionCall(const TargetInfo &TI,
   case ARM::BI__builtin_arm_vcvtr_d:
     return SemaRef.BuiltinConstantArgRange(TheCall, 1, 0, 1);
   case ARM::BI__builtin_arm_dmb:
+  case ARM::BI__dmb:
   case ARM::BI__builtin_arm_dsb:
+  case ARM::BI__dsb:
   case ARM::BI__builtin_arm_isb:
+  case ARM::BI__isb:
   case ARM::BI__builtin_arm_dbg:
     return SemaRef.BuiltinConstantArgRange(TheCall, 0, 0, 15);
   case ARM::BI__builtin_arm_cdp:
@@ -1108,8 +1111,11 @@ bool SemaARM::CheckAArch64BuiltinFunctionCall(const TargetInfo &TI,
   switch (BuiltinID) {
   default: return false;
   case AArch64::BI__builtin_arm_dmb:
+  case AArch64::BI__dmb:
   case AArch64::BI__builtin_arm_dsb:
+  case AArch64::BI__dsb:
   case AArch64::BI__builtin_arm_isb:
+  case AArch64::BI__isb:
     l = 0;
     u = 15;
     break;

--- a/clang/test/CodeGen/arm-former-microsoft-intrinsics-header-warning.c
+++ b/clang/test/CodeGen/arm-former-microsoft-intrinsics-header-warning.c
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -triple thumbv7-windows -fms-compatibility -Wno-everything -Wimplicit-function-declaration -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple armv7-eabi -Wno-everything -Wimplicit-function-declaration -fsyntax-only -verify %s
+
+void check__dmb(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __dmb(0);
+}
+
+void check__dsb(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __dsb(0);
+}
+
+void check__isb(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __isb(0);
+}
+
+void check__yield(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __yield();
+}
+
+void check__wfe(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __wfe();
+}
+
+void check__wfi(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __wfi();
+}
+
+void check__sev(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __sev();
+}
+
+void check__sevl(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __sevl();
+}

--- a/clang/test/CodeGen/arm-former-microsoft-intrinsics.c
+++ b/clang/test/CodeGen/arm-former-microsoft-intrinsics.c
@@ -1,0 +1,53 @@
+// RUN: %clang_cc1 -triple thumbv7-windows -fms-compatibility -emit-llvm -o - %s \
+// RUN:    | FileCheck %s
+
+// RUN: %clang_cc1 -triple armv7-eabi -Werror -emit-llvm -o - %s \
+// RUN:    | FileCheck %s
+#include <arm_acle.h>
+void check__dmb(void) {
+  __dmb(0);
+}
+
+// CHECK: @llvm.arm.dmb(i32 0)
+
+void check__dsb(void) {
+  __dsb(0);
+}
+
+// CHECK: @llvm.arm.dsb(i32 0)
+
+void check__isb(void) {
+  __isb(0);
+}
+
+// CHECK: @llvm.arm.isb(i32 0)
+
+void check__yield(void) {
+  __yield();
+}
+
+// CHECK: @llvm.arm.hint(i32 1)
+
+void check__wfe(void) {
+  __wfe();
+}
+
+// CHECK: @llvm.arm.hint(i32 2)
+
+void check__wfi(void) {
+  __wfi();
+}
+
+// CHECK: @llvm.arm.hint(i32 3)
+
+void check__sev(void) {
+  __sev();
+}
+
+// CHECK: @llvm.arm.hint(i32 4)
+
+void check__sevl(void) {
+  __sevl();
+}
+
+// CHECK: @llvm.arm.hint(i32 5)

--- a/clang/test/CodeGen/arm-microsoft-intrinsics.c
+++ b/clang/test/CodeGen/arm-microsoft-intrinsics.c
@@ -4,27 +4,6 @@
 // RUN: not %clang_cc1 -triple armv7-eabi -Werror -S -o /dev/null %s 2>&1 \
 // RUN:    | FileCheck %s -check-prefix CHECK-EABI
 
-void check__dmb(void) {
-  __dmb(0);
-}
-
-// CHECK-MSVC: @llvm.arm.dmb(i32 0)
-// CHECK-EABI: error: call to undeclared function '__dmb'
-
-void check__dsb(void) {
-  __dsb(0);
-}
-
-// CHECK-MSVC: @llvm.arm.dsb(i32 0)
-// CHECK-EABI: error: call to undeclared function '__dsb'
-
-void check__isb(void) {
-  __isb(0);
-}
-
-// CHECK-MSVC: @llvm.arm.isb(i32 0)
-// CHECK-EABI: error: call to undeclared function '__isb'
-
 __INT64_TYPE__ check__ldrexd(void) {
   __INT64_TYPE__ i64;
   return __ldrexd(&i64);

--- a/clang/test/CodeGen/arm64-former-microsoft-intrinsics-header-warning.c
+++ b/clang/test/CodeGen/arm64-former-microsoft-intrinsics-header-warning.c
@@ -1,0 +1,53 @@
+// RUN: %clang_cc1 -triple arm64-windows -Wno-everything -Wimplicit-function-declaration -fms-compatibility -fsyntax-only -verify %s
+
+// RUN: %clang_cc1 -triple arm64-linux -Wno-everything -Wimplicit-function-declaration -fsyntax-only -verify %s
+
+// RUN: %clang_cc1 -triple arm64-darwin -Wno-everything -Wimplicit-function-declaration -fms-compatibility -fsyntax-only -verify %s
+
+void check__dmb(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __dmb(0);
+}
+
+void check__dsb(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __dsb(0);
+}
+
+void check__isb(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __isb(0);
+}
+
+void check__yield(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __yield();
+}
+
+void check__wfe(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __wfe();
+}
+
+void check__wfi(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __wfi();
+}
+
+void check__sev(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __sev();
+}
+
+void check__sevl(void) {
+  // expected-warning@+2{{call to undeclared library function}}
+  // expected-note@+1{{include the header <arm_acle.h> or explicitly provide a declaration for}}
+  __sevl();
+}

--- a/clang/test/CodeGen/arm64-former-microsoft-intrinsics.c
+++ b/clang/test/CodeGen/arm64-former-microsoft-intrinsics.c
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -triple arm64-windows -Wno-implicit-function-declaration -fms-compatibility -emit-llvm -o - %s \
+// RUN:    | FileCheck %s
+
+// RUN: %clang_cc1 -triple arm64-linux -Werror -emit-llvm -o - %s 2>&1 \
+// RUN:    | FileCheck %s
+
+// RUN: %clang_cc1 -triple arm64-darwin -Wno-implicit-function-declaration -fms-compatibility -emit-llvm -o - %s \
+// RUN:    | FileCheck %s
+
+#include <arm_acle.h>
+
+void check__dmb(void) {
+  __dmb(0);
+}
+
+// CHECK: @llvm.aarch64.dmb(i32 0)
+
+void check__dsb(void) {
+  __dsb(0);
+}
+
+// CHECK: @llvm.aarch64.dsb(i32 0)
+
+void check__isb(void) {
+  __isb(0);
+}
+
+// CHECK: @llvm.aarch64.isb(i32 0)
+
+void check__yield(void) {
+  __yield();
+}
+
+// CHECK: @llvm.aarch64.hint(i32 1)
+
+void check__wfe(void) {
+  __wfe();
+}
+
+// CHECK: @llvm.aarch64.hint(i32 2)
+
+void check__wfi(void) {
+  __wfi();
+}
+
+// CHECK: @llvm.aarch64.hint(i32 3)
+
+void check__sev(void) {
+  __sev();
+}
+
+// CHECK: @llvm.aarch64.hint(i32 4)
+
+void check__sevl(void) {
+  __sevl();
+}
+
+// CHECK: @llvm.aarch64.hint(i32 5)
+

--- a/clang/test/CodeGen/arm64-microsoft-intrinsics.c
+++ b/clang/test/CodeGen/arm64-microsoft-intrinsics.c
@@ -35,62 +35,6 @@ __int64 test_InterlockedAdd64_constant(__int64 volatile *Addend) {
 // CHECK-MSVC: ret i64 %[[NEWVAL:[0-9]+]]
 // CHECK-LINUX: error: call to undeclared function '_InterlockedAdd64'
 
-void check__dmb(void) {
-  __dmb(0);
-}
-
-// CHECK-MSVC: @llvm.aarch64.dmb(i32 0)
-// CHECK-LINUX: error: call to undeclared function '__dmb'
-
-void check__dsb(void) {
-  __dsb(0);
-}
-
-// CHECK-MSVC: @llvm.aarch64.dsb(i32 0)
-// CHECK-LINUX: error: call to undeclared function '__dsb'
-
-void check__isb(void) {
-  __isb(0);
-}
-
-// CHECK-MSVC: @llvm.aarch64.isb(i32 0)
-// CHECK-LINUX: error: call to undeclared function '__isb'
-
-void check__yield(void) {
-  __yield();
-}
-
-// CHECK-MSVC: @llvm.aarch64.hint(i32 1)
-// CHECK-LINUX: error: call to undeclared function '__yield'
-
-void check__wfe(void) {
-  __wfe();
-}
-
-// CHECK-MSVC: @llvm.aarch64.hint(i32 2)
-// CHECK-LINUX: error: call to undeclared function '__wfe'
-
-void check__wfi(void) {
-  __wfi();
-}
-
-// CHECK-MSVC: @llvm.aarch64.hint(i32 3)
-// CHECK-LINUX: error: call to undeclared function '__wfi'
-
-void check__sev(void) {
-  __sev();
-}
-
-// CHECK-MSVC: @llvm.aarch64.hint(i32 4)
-// CHECK-LINUX: error: call to undeclared function '__sev'
-
-void check__sevl(void) {
-  __sevl();
-}
-
-// CHECK-MSVC: @llvm.aarch64.hint(i32 5)
-// CHECK-LINUX: error: call to undeclared function '__sevl'
-
 void check_ReadWriteBarrier(void) {
   _ReadWriteBarrier();
 }

--- a/clang/test/CodeGen/builtins-arm-microsoft.c
+++ b/clang/test/CodeGen/builtins-arm-microsoft.c
@@ -4,38 +4,40 @@
 // RUN:     | FileCheck %s -check-prefix CHECK-EABI
 // REQUIRES: arm-registered-target
 
+#include <arm_acle.h>
+
 void test_yield_intrinsic() {
   __yield();
 }
 
 // CHECK-MSVC: call void @llvm.arm.hint(i32 1)
-// CHECK-EABI-NOT: call void @llvm.arm.hint(i32 1)
+// CHECK-EABI: call void @llvm.arm.hint(i32 1)
 
 void wfe() {
   __wfe();
 }
 
 // CHECK-MSVC: call {{.*}} @llvm.arm.hint(i32 2)
-// CHECK-EABI-NOT: call {{.*}} @llvm.arm.hint(i32 2)
+// CHECK-EABI: call {{.*}} @llvm.arm.hint(i32 2)
 
 void wfi() {
   __wfi();
 }
 
 // CHECK-MSVC: call {{.*}} @llvm.arm.hint(i32 3)
-// CHECK-EABI-NOT: call {{.*}} @llvm.arm.hint(i32 3)
+// CHECK-EABI: call {{.*}} @llvm.arm.hint(i32 3)
 
 void sev() {
   __sev();
 }
 
 // CHECK-MSVC: call {{.*}} @llvm.arm.hint(i32 4)
-// CHECK-EABI-NOT: call {{.*}} @llvm.arm.hint(i32 4)
+// CHECK-EABI: call {{.*}} @llvm.arm.hint(i32 4)
 
 void sevl() {
   __sevl();
 }
 
 // CHECK-MSVC: call {{.*}} @llvm.arm.hint(i32 5)
-// CHECK-EABI-NOT: call {{.*}} @llvm.arm.hint(i32 5)
+// CHECK-EABI: call {{.*}} @llvm.arm.hint(i32 5)
 

--- a/clang/test/Headers/Inputs/include/stdint.h
+++ b/clang/test/Headers/Inputs/include/stdint.h
@@ -1,11 +1,23 @@
 #ifndef STDINT_H
 #define STDINT_H
 
+#ifdef __INT8_TYPE__
+typedef __INT8_TYPE__ int8_t;
+#endif
+typedef unsigned char uint8_t;
+
+#ifdef __INT16_TYPE__
+typedef __INT16_TYPE__ int16_t;
+typedef unsigned __INT16_TYPE__ uint16_t;
+#endif
+
 #ifdef __INT32_TYPE__
+typedef __INT32_TYPE__ int32_t;
 typedef unsigned __INT32_TYPE__ uint32_t;
 #endif
 
 #ifdef __INT64_TYPE__
+typedef __INT64_TYPE__ int64_t;
 typedef unsigned __INT64_TYPE__ uint64_t;
 #endif
 

--- a/clang/test/Headers/ms-intrin.cpp
+++ b/clang/test/Headers/ms-intrin.cpp
@@ -36,6 +36,28 @@ typedef __SIZE_TYPE__ size_t;
 
 #include <intrin.h>
 
+#ifdef __ARM_ACLE
+// arm_acle.h needs some stdint types, but -ffreestanding prevents us from
+// getting it from stddef.h.  Work around it with these typedefs.
+#ifdef __INT8_TYPE__
+typedef __INT8_TYPE__ int8_t;
+#endif
+typedef unsigned char uint8_t;
+#ifdef __INT16_TYPE__
+typedef __INT16_TYPE__ int16_t;
+typedef unsigned __INT16_TYPE__ uint16_t;
+#endif
+#ifdef __INT32_TYPE__
+typedef __INT32_TYPE__ int32_t;
+typedef unsigned __INT32_TYPE__ uint32_t;
+#endif
+#ifdef __INT64_TYPE__
+typedef __INT64_TYPE__ int64_t;
+typedef unsigned __INT64_TYPE__ uint64_t;
+#endif
+#include <arm_acle.h>
+#endif
+
 // Use some C++ to make sure we closed the extern "C" brackets.
 template <typename T>
 void foo(T V) {}

--- a/clang/test/Headers/ms-intrin.cpp
+++ b/clang/test/Headers/ms-intrin.cpp
@@ -37,24 +37,6 @@ typedef __SIZE_TYPE__ size_t;
 #include <intrin.h>
 
 #ifdef __ARM_ACLE
-// arm_acle.h needs some stdint types, but -ffreestanding prevents us from
-// getting it from stddef.h.  Work around it with these typedefs.
-#ifdef __INT8_TYPE__
-typedef __INT8_TYPE__ int8_t;
-#endif
-typedef unsigned char uint8_t;
-#ifdef __INT16_TYPE__
-typedef __INT16_TYPE__ int16_t;
-typedef unsigned __INT16_TYPE__ uint16_t;
-#endif
-#ifdef __INT32_TYPE__
-typedef __INT32_TYPE__ int32_t;
-typedef unsigned __INT32_TYPE__ uint32_t;
-#endif
-#ifdef __INT64_TYPE__
-typedef __INT64_TYPE__ int64_t;
-typedef unsigned __INT64_TYPE__ uint64_t;
-#endif
 #include <arm_acle.h>
 #endif
 


### PR DESCRIPTION
Instead of defining ARM ACLE intrinsics only on MSVC and guarding wrapper functions in headers with `__has_builtin`, universally define the intrinsics as target header builtins.