### PR TITLE
[Github][CI] Name Premerge Jobs Experimental

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   premerge-checks-linux:
-    name: Linux Premerge Checks (Experimental)
+    name: Linux Premerge Checks (Test Only - Please Ignore Results)
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
@@ -84,7 +84,7 @@ jobs:
           ./.ci/monolithic-linux.sh "$(echo ${linux_projects} | tr ' ' ';')" "$(echo ${linux_check_targets})" "$(echo ${linux_runtimes} | tr ' ' ';')" "$(echo ${linux_runtime_check_targets})"
 
   premerge-checks-windows:
-    name: Windows Premerge Checks (Experimental)
+    name: Windows Premerge Checks (Test Only - Please Ignore Results)
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   premerge-checks-linux:
+    name: Linux Premerge Checks (Experimental)
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
@@ -83,6 +84,7 @@ jobs:
           ./.ci/monolithic-linux.sh "$(echo ${linux_projects} | tr ' ' ';')" "$(echo ${linux_check_targets})" "$(echo ${linux_runtimes} | tr ' ' ';')" "$(echo ${linux_runtime_check_targets})"
 
   premerge-checks-windows:
+    name: Windows Premerge Checks (Experimental)
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
@@ -143,6 +145,7 @@ jobs:
           bash .ci/monolithic-windows.sh "${{ steps.vars.outputs.windows-projects }}" "${{ steps.vars.outputs.windows-check-targets }}"
 
   premerge-check-macos:
+    name: MacOS Premerge Checks
     runs-on: macos-14
     if: >-
       github.repository_owner == 'llvm' &&


### PR DESCRIPTION
As discussed on Discourse (https://discourse.llvm.org/t/googles-plan-for-the-llvm-presubmit-infrastructure/78940/8), this patch renames the premerge jobs to include experimental in them to hopefully better signal that these are still a prototype. This patch does not mark the MacOS job as experimental as that is being used in production on the release branch.