### PR TITLE
[MemProf] Display backedges with dotted line in dot graphs

### DIFF
--- a/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
+++ b/llvm/lib/Transforms/IPO/MemProfContextDisambiguation.cpp
@@ -3067,11 +3067,15 @@ struct DOTGraphTraits<const CallsiteContextGraph<DerivedCCG, FuncTy, CallTy> *>
                                        GraphType) {
     auto &Edge = *(ChildIter.getCurrent());
     auto Color = getColor(Edge->AllocTypes);
-    return (Twine("tooltip=\"") + getContextIds(Edge->ContextIds) + "\"" +
-            // fillcolor is the arrow head and color is the line
-            Twine(",fillcolor=\"") + Color + "\"" + Twine(",color=\"") + Color +
-            "\"")
-        .str();
+    std::string AttributeString =
+        (Twine("tooltip=\"") + getContextIds(Edge->ContextIds) + "\"" +
+         // fillcolor is the arrow head and color is the line
+         Twine(",fillcolor=\"") + Color + "\"" + Twine(",color=\"") + Color +
+         "\"")
+            .str();
+    if (Edge->IsBackedge)
+      AttributeString += ",style=\"dotted\"";
+    return AttributeString;
   }
 
   // Since the NodeOwners list includes nodes that are no longer connected to

--- a/llvm/test/ThinLTO/X86/memprof-recursive.ll
+++ b/llvm/test/ThinLTO/X86/memprof-recursive.ll
@@ -52,10 +52,19 @@
 ; RUN:  -r=%t.o,main,plx \
 ; RUN:  -r=%t.o,_Znam, \
 ; RUN:  -memprof-verify-ccg -memprof-verify-nodes -stats \
+; RUN:  -memprof-export-to-dot -memprof-dot-file-path-prefix=%t. \
 ; RUN:  -pass-remarks=memprof-context-disambiguation \
 ; RUN:  -o %t.out 2>&1 | FileCheck %s \
 ; RUN:  --check-prefix=ALLOW-RECUR-CALLSITES --check-prefix=ALLOW-RECUR-CONTEXTS \
 ; RUN:	--check-prefix=CLONE-RECUR-CALLSITES
+
+;; Check that the backedge was correctly detected and emitted to the dot file
+;; as a dotted edge.
+; RUN: cat %t.ccg.postbuild.dot | FileCheck %s --check-prefix=DOT
+; DOT-DAG: Node[[B:0x[a-f0-9]+]] {{.*}}_Z1Bi -\> _Z1Ci
+; DOT-DAG: Node[[C:0x[a-f0-9]+]] {{.*}}_Z1Ci -\> _Z1Bi
+; DOT-DAG: Node[[B]] -> Node[[C]]{{.*}}style="solid"
+; DOT-DAG: Node[[C]] -> Node[[B]]{{.*}}style="dotted"
 
 ;; Skipping recursive contexts should prevent spurious call to cloned version of
 ;; B from the context starting at memprof_recursive.cc:19:13, which is actually

--- a/llvm/test/ThinLTO/X86/memprof-recursive.ll
+++ b/llvm/test/ThinLTO/X86/memprof-recursive.ll
@@ -63,7 +63,6 @@
 ; RUN: cat %t.ccg.postbuild.dot | FileCheck %s --check-prefix=DOT
 ; DOT-DAG: Node[[B:0x[a-f0-9]+]] {{.*}}_Z1Bi -\> _Z1Ci
 ; DOT-DAG: Node[[C:0x[a-f0-9]+]] {{.*}}_Z1Ci -\> _Z1Bi
-; DOT-DAG: Node[[B]] -> Node[[C]]{{.*}}style="solid"
 ; DOT-DAG: Node[[C]] -> Node[[B]]{{.*}}style="dotted"
 
 ;; Skipping recursive contexts should prevent spurious call to cloned version of

--- a/llvm/test/Transforms/MemProfContextDisambiguation/recursive.ll
+++ b/llvm/test/Transforms/MemProfContextDisambiguation/recursive.ll
@@ -64,10 +64,19 @@
 ;; Check the default behavior (clone recursive callsites).
 ; RUN: opt -passes=memprof-context-disambiguation -supports-hot-cold-new \
 ; RUN:  -memprof-verify-ccg -memprof-verify-nodes -stats \
+; RUN:  -memprof-export-to-dot -memprof-dot-file-path-prefix=%t. \
 ; RUN:  -pass-remarks=memprof-context-disambiguation \
 ; RUN:  %s -S 2>&1 | FileCheck %s \
 ; RUN:  --check-prefix=ALL --check-prefix=ALLOW-RECUR-CALLSITES --check-prefix=ALLOW-RECUR-CONTEXTS \
 ; RUN:  --check-prefix=CLONE-RECUR-CALLSITES
+
+;; Check that the backedge was correctly detected and emitted to the dot file
+;; as a dotted edge.
+; RUN: cat %t.ccg.postbuild.dot | FileCheck %s --check-prefix=DOT
+; DOT-DAG: Node[[B:0x[a-f0-9]+]] {{.*}}_Z1Bi -\> _Z1Ci
+; DOT-DAG: Node[[C:0x[a-f0-9]+]] {{.*}}_Z1Ci -\> _Z1Bi
+; DOT-DAG: Node[[B]] -> Node[[C]]{{.*}}style="solid"
+; DOT-DAG: Node[[C]] -> Node[[B]]{{.*}}style="dotted"
 
 ;; Skipping recursive contexts should prevent spurious call to cloned version of
 ;; B from the context starting at memprof_recursive.cc:19:13, which is actually

--- a/llvm/test/Transforms/MemProfContextDisambiguation/recursive.ll
+++ b/llvm/test/Transforms/MemProfContextDisambiguation/recursive.ll
@@ -75,7 +75,6 @@
 ; RUN: cat %t.ccg.postbuild.dot | FileCheck %s --check-prefix=DOT
 ; DOT-DAG: Node[[B:0x[a-f0-9]+]] {{.*}}_Z1Bi -\> _Z1Ci
 ; DOT-DAG: Node[[C:0x[a-f0-9]+]] {{.*}}_Z1Ci -\> _Z1Bi
-; DOT-DAG: Node[[B]] -> Node[[C]]{{.*}}style="solid"
 ; DOT-DAG: Node[[C]] -> Node[[B]]{{.*}}style="dotted"
 
 ;; Skipping recursive contexts should prevent spurious call to cloned version of


### PR DESCRIPTION
Add checking of this behavior in the postbuild dot graphs, facilitated
by PR128226 which marked these edges at the end of the graph building.
