### PR TITLE
[HLSL] Allow EmptyDecl in cbuffer/tbuffer

### DIFF
--- a/clang/lib/Parse/ParseHLSL.cpp
+++ b/clang/lib/Parse/ParseHLSL.cpp
@@ -30,7 +30,7 @@ static bool validateDeclsInsideHLSLBuffer(Parser::DeclGroupPtrTy DG,
   // Only allow function, variable, record decls inside HLSLBuffer.
   for (DeclGroupRef::iterator I = Decls.begin(), E = Decls.end(); I != E; ++I) {
     Decl *D = *I;
-    if (isa<CXXRecordDecl, RecordDecl, FunctionDecl, VarDecl>(D))
+    if (isa<CXXRecordDecl, RecordDecl, FunctionDecl, VarDecl, EmptyDecl>(D))
       continue;
 
     // FIXME: support nested HLSLBuffer and namespace inside HLSLBuffer.

--- a/clang/lib/Parse/ParseHLSL.cpp
+++ b/clang/lib/Parse/ParseHLSL.cpp
@@ -27,7 +27,7 @@ static bool validateDeclsInsideHLSLBuffer(Parser::DeclGroupPtrTy DG,
     return false;
   DeclGroupRef Decls = DG.get();
   bool IsValid = true;
-  // Only allow function, variable, record decls inside HLSLBuffer.
+  // Only allow function, variable, record, and empty decls inside HLSLBuffer.
   for (DeclGroupRef::iterator I = Decls.begin(), E = Decls.end(); I != E; ++I) {
     Decl *D = *I;
     if (isa<CXXRecordDecl, RecordDecl, FunctionDecl, VarDecl, EmptyDecl>(D))

--- a/clang/test/SemaHLSL/cb_error.hlsl
+++ b/clang/test/SemaHLSL/cb_error.hlsl
@@ -47,3 +47,15 @@ tbuffer B {
   // expected-error@+1 {{unknown type name 'flaot'}}
   flaot f;
 }
+
+// None of these should produce an error!
+cbuffer EmptyCBuffer {}
+
+cbuffer EmptyDeclCBuffer {
+  ;
+}
+
+cbuffer EmptyDecl2CBuffer {
+  ;
+  int X;
+}


### PR DESCRIPTION
We do handle EmptyDecls in codegen already as of #124886, but we were blocking them in Sema. EmptyDecls tend to be caused by extra semicolons which are not illegal.

Fixes #128238