### PR TITLE
Add unsigned integer overloads for abs

### DIFF
--- a/clang/lib/Headers/hlsl/hlsl_intrinsics.h
+++ b/clang/lib/Headers/hlsl/hlsl_intrinsics.h
@@ -58,6 +58,15 @@ int16_t3 abs(int16_t3);
 _HLSL_AVAILABILITY(shadermodel, 6.2)
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int16_t4 abs(int16_t4);
+
+_HLSL_AVAILABILITY(shadermodel, 6.2)
+constexpr uint16_t abs(uint16_t V) { return V; }
+_HLSL_AVAILABILITY(shadermodel, 6.2)
+constexpr uint16_t2 abs(uint16_t2 V) { return V; }
+_HLSL_AVAILABILITY(shadermodel, 6.2)
+constexpr uint16_t3 abs(uint16_t3 V) { return V; }
+_HLSL_AVAILABILITY(shadermodel, 6.2)
+constexpr uint16_t4 abs(uint16_t4 V) { return V; }
 #endif
 
 _HLSL_16BIT_AVAILABILITY(shadermodel, 6.2)
@@ -82,6 +91,11 @@ int3 abs(int3);
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int4 abs(int4);
 
+constexpr uint abs(uint V) { return V; }
+constexpr uint2 abs(uint2 V) { return V; }
+constexpr uint3 abs(uint3 V) { return V; }
+constexpr uint4 abs(uint4 V) { return V; }
+
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 float abs(float);
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
@@ -99,6 +113,11 @@ _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int64_t3 abs(int64_t3);
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 int64_t4 abs(int64_t4);
+
+constexpr uint64_t abs(uint64_t V) { return V; }
+constexpr uint64_t2 abs(uint64_t2 V) { return V; }
+constexpr uint64_t3 abs(uint64_t3 V) { return V; }
+constexpr uint64_t4 abs(uint64_t4 V) { return V; }
 
 _HLSL_BUILTIN_ALIAS(__builtin_elementwise_abs)
 double abs(double);

--- a/clang/test/CodeGenHLSL/builtins/abs.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/abs.hlsl
@@ -20,6 +20,34 @@ int16_t3 test_abs_int16_t3(int16_t3 p0) { return abs(p0); }
 // NATIVE_HALF-LABEL: define noundef <4 x i16> @_Z17test_abs_int16_t4
 // NATIVE_HALF: call <4 x i16> @llvm.abs.v4i16(
 int16_t4 test_abs_int16_t4(int16_t4 p0) { return abs(p0); }
+
+// NATIVE_HALF-LABEL: define {{.*}}hlsl3abs{{.*}}(i16
+// NATIVE_HALF: [[Alloca:%.*]] = alloca i16
+// NATIVE_HALF-NEXT: store i16 {{%.*}}, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: [[Val:%.*]] = load i16, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: ret i16 [[Val]]
+uint16_t test_abs_uint64_t(uint16_t p0) { return abs(p0); }
+
+// NATIVE_HALF-LABEL: define {{.*}}hlsl3abs{{.*}}(<2 x i16
+// NATIVE_HALF: [[Alloca:%.*]] = alloca <2 x i16>
+// NATIVE_HALF-NEXT: store <2 x i16> {{%.*}}, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: [[Val:%.*]] = load <2 x i16>, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: ret <2 x i16> [[Val]]
+uint16_t2 test_abs_uint64_t2(uint16_t2 p0) { return abs(p0); }
+
+// NATIVE_HALF-LABEL: define {{.*}}hlsl3abs{{.*}}(<3 x i16
+// NATIVE_HALF: [[Alloca:%.*]] = alloca <3 x i16>
+// NATIVE_HALF-NEXT: store <3 x i16> {{%.*}}, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: [[Val:%.*]] = load <3 x i16>, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: ret <3 x i16> [[Val]]
+uint16_t3 test_abs_uint64_t3(uint16_t3 p0) { return abs(p0); }
+
+// NATIVE_HALF-LABEL: define {{.*}}hlsl3abs{{.*}}(<4 x i16
+// NATIVE_HALF: [[Alloca:%.*]] = alloca <4 x i16>
+// NATIVE_HALF-NEXT: store <4 x i16> {{%.*}}, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: [[Val:%.*]] = load <4 x i16>, ptr [[Alloca]]
+// NATIVE_HALF-NEXT: ret <4 x i16> [[Val]]
+uint16_t4 test_abs_uint64_t4(uint16_t4 p0) { return abs(p0); }
 #endif // __HLSL_ENABLE_16_BIT
 
 // NATIVE_HALF-LABEL: define noundef nofpclass(nan inf) half @_Z13test_abs_half
@@ -94,3 +122,60 @@ double3 test_abs_double3(double3 p0) { return abs(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x double> @_Z16test_abs_double4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x double> @llvm.fabs.v4f64(
 double4 test_abs_double4(double4 p0) { return abs(p0); }
+
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(i32
+// CHECK: [[Alloca:%.*]] = alloca i32
+// CHECK-NEXT: store i32 {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load i32, ptr [[Alloca]]
+// CHECK-NEXT: ret i32 [[Val]]
+uint test_abs_uint(uint p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<2 x i32
+// CHECK: [[Alloca:%.*]] = alloca <2 x i32>
+// CHECK-NEXT: store <2 x i32> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <2 x i32>, ptr [[Alloca]]
+// CHECK-NEXT: ret <2 x i32> [[Val]]
+uint2 test_abs_uint2(uint2 p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<3 x i32
+// CHECK: [[Alloca:%.*]] = alloca <3 x i32>
+// CHECK-NEXT: store <3 x i32> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <3 x i32>, ptr [[Alloca]]
+// CHECK-NEXT: ret <3 x i32> [[Val]]
+uint3 test_abs_uint3(uint3 p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<4 x i32
+// CHECK: [[Alloca:%.*]] = alloca <4 x i32>
+// CHECK-NEXT: store <4 x i32> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <4 x i32>, ptr [[Alloca]]
+// CHECK-NEXT: ret <4 x i32> [[Val]]
+uint4 test_abs_uint4(uint4 p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(i64
+// CHECK: [[Alloca:%.*]] = alloca i64
+// CHECK-NEXT: store i64 {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load i64, ptr [[Alloca]]
+// CHECK-NEXT: ret i64 [[Val]]
+uint64_t test_abs_uint64_t(uint64_t p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<2 x i64
+// CHECK: [[Alloca:%.*]] = alloca <2 x i64>
+// CHECK-NEXT: store <2 x i64> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <2 x i64>, ptr [[Alloca]]
+// CHECK-NEXT: ret <2 x i64> [[Val]]
+uint64_t2 test_abs_uint64_t2(uint64_t2 p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<3 x i64
+// CHECK: [[Alloca:%.*]] = alloca <3 x i64>
+// CHECK-NEXT: store <3 x i64> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <3 x i64>, ptr [[Alloca]]
+// CHECK-NEXT: ret <3 x i64> [[Val]]
+uint64_t3 test_abs_uint64_t3(uint64_t3 p0) { return abs(p0); }
+
+// CHECK-LABEL: define {{.*}}hlsl3abs{{.*}}(<4 x i64
+// CHECK: [[Alloca:%.*]] = alloca <4 x i64>
+// CHECK-NEXT: store <4 x i64> {{%.*}}, ptr [[Alloca]]
+// CHECK-NEXT: [[Val:%.*]] = load <4 x i64>, ptr [[Alloca]]
+// CHECK-NEXT: ret <4 x i64> [[Val]]
+uint64_t4 test_abs_uint64_t4(uint64_t4 p0) { return abs(p0); }


### PR DESCRIPTION
This seems silly, but DXC supports unsigned integer versions of abs that are just no-ops. This adds the overloads for source compatability because apparently users actually use them...

Fixes #128249