### PR TITLE
[clang][diagnostics] add '-Wundef-true' warning option

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -107,6 +107,8 @@ Non-comprehensive list of changes in this release
 New Compiler Flags
 ------------------
 
+- New option ``-Wundef-true`` added and enabled by default to warn when `true` is used in the C preprocessor without being defined before C23.
+
 - New option ``-fprofile-continuous`` added to enable continuous profile syncing to file (#GH124353, `docs <https://clang.llvm.org/docs/UsersManual.html#cmdoption-fprofile-continuous>`_).
   The feature has `existed <https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program>`_)
   for a while and this is just a user facing option.

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -791,6 +791,8 @@ def ReservedIdAsMacroAlias : DiagGroup<"reserved-id-macro", [ReservedIdAsMacro]>
 def ReservedAttributeIdentifier : DiagGroup<"reserved-attribute-identifier">;
 def RestrictExpansionMacro : DiagGroup<"restrict-expansion">;
 def FinalMacro : DiagGroup<"final-macro">;
+def UndefinedTrueIdentifier : DiagGroup<"undef-true">;
+def UndefinedIdentifier : DiagGroup<"undef", [UndefinedTrueIdentifier]>;
 
 // Just silence warnings about -Wstrict-aliasing for now.
 def : DiagGroup<"strict-aliasing=0">;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -392,7 +392,10 @@ def pp_macro_not_used : Warning<"macro is not used">, DefaultIgnore,
   InGroup<DiagGroup<"unused-macros">>;
 def warn_pp_undef_identifier : Warning<
   "%0 is not defined, evaluates to 0">,
-  InGroup<DiagGroup<"undef">>, DefaultIgnore;
+  InGroup<UndefinedIdentifier>, DefaultIgnore;
+def warn_pp_undef_true_identifier : Warning<
+  "'true' is not defined, evaluates to 0">,
+  InGroup<UndefinedTrueIdentifier>;
 def warn_pp_undef_prefix : Warning<
   "%0 is not defined, evaluates to 0">,
   InGroup<DiagGroup<"undef-prefix">>, DefaultIgnore;

--- a/clang/lib/Lex/PPExpressions.cpp
+++ b/clang/lib/Lex/PPExpressions.cpp
@@ -257,12 +257,14 @@ static bool EvaluateValue(PPValue &Result, Token &PeekTok, DefinedTracker &DT,
         // preprocessor keywords and it wasn't macro expanded, it turns
         // into a simple 0
         if (ValueLive) {
-          PP.Diag(PeekTok, diag::warn_pp_undef_identifier) << II;
+          unsigned DiagID = II->getName() == "true"
+                                ? diag::warn_pp_undef_true_identifier
+                                : diag::warn_pp_undef_identifier;
+          PP.Diag(PeekTok, DiagID) << II;
 
           const DiagnosticsEngine &DiagEngine = PP.getDiagnostics();
           // If 'Wundef' is enabled, do not emit 'undef-prefix' diagnostics.
-          if (DiagEngine.isIgnored(diag::warn_pp_undef_identifier,
-                                   PeekTok.getLocation())) {
+          if (DiagEngine.isIgnored(DiagID, PeekTok.getLocation())) {
             const std::vector<std::string> UndefPrefixes =
                 DiagEngine.getDiagnosticOptions().UndefPrefixes;
             const StringRef IdentifierName = II->getName();

--- a/clang/test/Preprocessor/warn-macro-undef-true.c
+++ b/clang/test/Preprocessor/warn-macro-undef-true.c
@@ -1,0 +1,78 @@
+// RUN: %clang_cc1 %s -Eonly -std=c89 -verify=undef-true
+// RUN: %clang_cc1 %s -Eonly -std=c99 -verify=undef-true
+// RUN: %clang_cc1 %s -Eonly -std=c11 -verify=undef-true
+// RUN: %clang_cc1 %s -Eonly -std=c17 -verify=undef-true
+// RUN: %clang_cc1 %s -Eonly -std=c23 -verify=undef-true
+
+#if __STDC_VERSION__ >= 202311L
+/* undef-true-no-diagnostics */
+#endif
+
+#define FOO true
+#if FOO /* #1 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#1 {{'true' is not defined, evaluates to 0}} */
+#endif
+
+#if true /* #2 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#2 {{'true' is not defined, evaluates to 0}} */
+#endif
+
+#if false || true /* #3 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#3 {{'true' is not defined, evaluates to 0}} */
+#endif
+
+#define true 1
+
+#define FOO true
+#if FOO
+#endif
+
+#if true
+#endif
+
+#if false || true
+#endif
+
+#undef true
+
+#define FOO true
+#if FOO /* #4 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#4 {{'true' is not defined, evaluates to 0}} */
+#endif
+
+#if true /* #5 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#5 {{'true' is not defined, evaluates to 0}} */
+#endif
+
+#if false || true /* #6 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#6 {{'true' is not defined, evaluates to 0}} */
+#endif
+
+#define true true
+#if true /* #7 */
+#endif
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#7 {{'true' is not defined, evaluates to 0}} */
+#endif
+#undef true
+
+/* Test that #pragma-enabled 'Wundef' can override 'Wundef-true' */
+#pragma clang diagnostic warning "-Wundef"
+#if true /* #8 */
+#endif
+#pragma clang diagnostic ignored "-Wundef"
+#if __STDC_VERSION__ < 202311L
+/* undef-true-warning@#8 {{'true' is not defined, evaluates to 0}} */
+#endif


### PR DESCRIPTION
In C++, `true` is considered a keyword by the preprocessor so an `#if true` enters the true branch,
while in C, ``true`` is not treated as a special keyword by the preprocessor, so the false branch is entered.

The following snippet returns `1` in C++, but `0` in C.

```c++
int main() {
#if true
  return 1;
#else
  return 0;
#endif
}
```
The check identifies such cases, when `true` is used without being defined first and also offers fix-its in 
some cases.