### PR TITLE
[llvm] Remove `br i1 undef` in `llvm/test/CodeGen` tests

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-early-ifcvt.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-early-ifcvt.ll
@@ -395,13 +395,13 @@ done:
 
 ; This function from 175.vpr folds an ADDWri into a CSINC.
 ; Remember to clear the kill flag on the ADDWri.
-define i32 @get_ytrack_to_xtracks() nounwind ssp {
+define i32 @get_ytrack_to_xtracks(i1 %arg) nounwind ssp {
 entry:
   br label %for.body
 
 for.body:
   %x0 = load i32, ptr undef, align 4
-  br i1 undef, label %if.then.i146, label %is_sbox.exit155
+  br i1 %arg, label %if.then.i146, label %is_sbox.exit155
 
 if.then.i146:
   %add8.i143 = add nsw i32 0, %x0
@@ -414,7 +414,7 @@ is_sbox.exit155:                                  ; preds = %if.then.i146, %for.
   %idxprom15.i152 = sext i32 %seg_offset.0.i151 to i64
   %arrayidx18.i154 = getelementptr inbounds i32, ptr null, i64 %idxprom15.i152
   %x1 = load i32, ptr %arrayidx18.i154, align 4
-  br i1 undef, label %for.body51, label %for.body
+  br i1 %arg, label %for.body51, label %for.body
 
 for.body51:                                       ; preds = %is_sbox.exit155
   call fastcc void @get_switch_type(i32 %x1, i32 undef, i16 signext undef, i16 signext undef, ptr undef)

--- a/llvm/test/CodeGen/AArch64/swift-error-unreachable-use.ll
+++ b/llvm/test/CodeGen/AArch64/swift-error-unreachable-use.ll
@@ -33,7 +33,7 @@ thirtythree:
   br i1 false, label %UelOc2l.exit, label %thirtythree
 
 thirtyeight:
-  br i1 undef, label %thirtyeight, label %thirtythree
+  br i1 poison, label %thirtyeight, label %thirtythree
 }
 
 attributes #0 = { noinline optnone }

--- a/llvm/test/CodeGen/AMDGPU/dagcomb-shuffle-vecextend-non2.ll
+++ b/llvm/test/CodeGen/AMDGPU/dagcomb-shuffle-vecextend-non2.ll
@@ -10,9 +10,10 @@
 ;
 ; GCN: s_endpgm
 
-define amdgpu_ps void @main(i32 %in1, i1 %arg) local_unnamed_addr {
+define amdgpu_ps void @main(i32 %in1, i32 inreg %arg) local_unnamed_addr {
 .entry:
-  br i1 %arg, label %bb12, label %bb
+  %cond = icmp eq i32 %arg, 0
+  br i1 %cond, label %bb12, label %bb
 
 bb:
   %__llpc_global_proxy_r5.12.vec.insert = insertelement <4 x i32> undef, i32 %in1, i32 3

--- a/llvm/test/CodeGen/X86/mbp-false-cfg-break.ll
+++ b/llvm/test/CodeGen/X86/mbp-false-cfg-break.ll
@@ -9,7 +9,7 @@ define void @test(i1 %cnd) !prof !{!"function_entry_count", i64 1024} {
 ; CHECK: # %rare
 ; CHECK: # %rare.1
 
-  br i1 undef, label %rare.1, label %preheader, !prof !{!"branch_weights", i32 0, i32 1000}
+  br i1 %cnd, label %rare.1, label %preheader, !prof !{!"branch_weights", i32 0, i32 1000}
 rare.1:
   call void @foo()
   br label %preheader

--- a/llvm/test/CodeGen/X86/misched-aa-mmos.ll
+++ b/llvm/test/CodeGen/X86/misched-aa-mmos.ll
@@ -12,10 +12,10 @@ target triple = "x86_64-unknown-linux-gnu"
 
 declare zeroext i1 @bar(ptr, i32) #5
 
-define i32 @foo() #0 align 2 {
+define i32 @foo(i1 %arg) #0 align 2 {
 entry:
   %temp_rhs = alloca %c1, align 8
-  br i1 undef, label %if.else56, label %cond.end.i
+  br i1 %arg, label %if.else56, label %cond.end.i
 
 cond.end.i:
   %significand.i18.i = getelementptr inbounds %c1, ptr %temp_rhs, i64 0, i32 1

--- a/llvm/test/CodeGen/X86/multiple-loop-post-inc.ll
+++ b/llvm/test/CodeGen/X86/multiple-loop-post-inc.ll
@@ -265,7 +265,7 @@ return:                                           ; preds = %entry
 
 ; Codegen shouldn't crash on this testcase.
 
-define void @bar(i32 %a, i32 %b) nounwind {
+define void @bar(i32 %a, i32 %b, i1 %arg) nounwind {
 entry:                           ; preds = %bb1, %entry, %for.end204
   br label %outer
 
@@ -283,7 +283,7 @@ inner:                                       ; preds = %bb0, %if.end275
 
 bb0:                                     ; preds = %for.body332
   %indvar.next159 = add i32 %i8, 1     ; <i32> [#uses=1]
-  br i1 undef, label %bb1, label %inner
+  br i1 %arg, label %bb1, label %inner
 
 bb1:                                     ; preds = %bb0, %outer
   %midx.4 = phi i32 [ %t179, %bb0 ] ; <i32> [#uses=0]

--- a/llvm/test/CodeGen/X86/phi-bit-propagation.ll
+++ b/llvm/test/CodeGen/X86/phi-bit-propagation.ll
@@ -34,9 +34,9 @@ return:                                           ; preds = %for.body, %for.cond
 }
 
 ; This test case caused an assertion failure; see PR9324.
-define void @func_37() noreturn nounwind ssp {
+define void @func_37(i1 %arg) noreturn nounwind ssp {
 entry:
-  br i1 undef, label %lbl_919, label %entry.for.inc_crit_edge
+  br i1 %arg, label %lbl_919, label %entry.for.inc_crit_edge
 
 entry.for.inc_crit_edge:                          ; preds = %entry
   br label %for.inc
@@ -46,7 +46,7 @@ lbl_919:                                          ; preds = %for.cond7.preheader
 
 for.cond7.preheader:                              ; preds = %for.inc, %lbl_919
   %storemerge.ph = phi i8 [ 0, %lbl_919 ], [ %add, %for.inc ]
-  br i1 undef, label %for.inc, label %lbl_919
+  br i1 %arg, label %for.inc, label %lbl_919
 
 for.inc:                                          ; preds = %for.cond7.preheader, %entry.for.inc_crit_edge
   %add = add i8 undef, 1

--- a/llvm/test/CodeGen/X86/pr18846.ll
+++ b/llvm/test/CodeGen/X86/pr18846.ll
@@ -13,12 +13,12 @@ target triple = "x86_64-unknown-unknown"
 ;CHECK-NOT:   vmovups {{.*#+}} 32-byte Folded Reload
 
 ; Function Attrs: uwtable
-define void @_Z16opt_kernel_cachePfS_S_() #0 {
+define void @_Z16opt_kernel_cachePfS_S_(i1 %arg) #0 {
 entry:
   br label %for.body29
 
 for.body29:                                       ; preds = %for.body29, %entry
-  br i1 undef, label %for.body29, label %for.body65
+  br i1 %arg, label %for.body29, label %for.body65
 
 for.body65:                                       ; preds = %for.body29
   %0 = load float, ptr undef, align 4, !tbaa !1

--- a/llvm/test/CodeGen/X86/remat-fold-load.ll
+++ b/llvm/test/CodeGen/X86/remat-fold-load.ll
@@ -18,9 +18,9 @@ target triple = "i386-unknown-linux-gnu"
 
 declare void @llvm.memcpy.p0.p0.i32(ptr nocapture, ptr nocapture, i32, i1) nounwind
 
-define linkonce_odr void @test() nounwind {
+define linkonce_odr void @test(i1 %arg) nounwind {
 entry:
-  br i1 undef, label %while.end.while.end26_crit_edge, label %while.body12.lr.ph
+  br i1 %arg, label %while.end.while.end26_crit_edge, label %while.body12.lr.ph
 
 while.end.while.end26_crit_edge:                  ; preds = %entry
   br label %while.end26
@@ -104,7 +104,7 @@ if.then.i.i.i.i.i43:                              ; preds = %if.then17
   unreachable
 
 D:                                                ; preds = %if.then17
-  br i1 undef, label %if.then.i.i.i.i.i, label %E
+  br i1 %arg, label %if.then.i.i.i.i.i, label %E
 
 if.then.i.i.i.i.i:                                ; preds = %D
   unreachable
@@ -125,7 +125,7 @@ while.cond10.while.end26_crit_edge:               ; preds = %if.end24
   br label %while.end26
 
 while.end26:                                      ; preds = %while.cond10.while.end26_crit_edge, %while.end.while.end26_crit_edge
-  br i1 undef, label %while.body.lr.ph.i, label %F
+  br i1 %arg, label %while.body.lr.ph.i, label %F
 
 while.body.lr.ph.i:                               ; preds = %while.end26
   br label %while.body.i

--- a/llvm/test/CodeGen/X86/selectiondag-cse.ll
+++ b/llvm/test/CodeGen/X86/selectiondag-cse.ll
@@ -23,10 +23,10 @@ target triple = "x86_64-apple-macosx"
 
 @images = external hidden global %0, align 8
 
-define hidden fastcc void @Mode_Decision_for_4x4IntraBlocks() nounwind uwtable ssp {
+define hidden fastcc void @Mode_Decision_for_4x4IntraBlocks(i1 %arg) nounwind uwtable ssp {
 bb4:
   %tmp = or i208 undef, 0
-  br i1 undef, label %bb35, label %bb5
+  br i1 %arg, label %bb35, label %bb5
 
 bb5:
   %tmp6 = add i32 0, 2

--- a/llvm/test/CodeGen/X86/tailcall-cgp-dup.ll
+++ b/llvm/test/CodeGen/X86/tailcall-cgp-dup.ll
@@ -113,7 +113,7 @@ define hidden ptr @thingWithValue(ptr %self) uwtable ssp {
 ; CHECK-NEXT:  ## %bb.1: ## %someThingWithValue.exit
 ; CHECK-NEXT:    retq
 entry:
-  br i1 undef, label %if.then.i, label %if.else.i
+  br i1 poison, label %if.then.i, label %if.else.i
 
 if.then.i:                                        ; preds = %entry
   br label %someThingWithValue.exit

--- a/llvm/test/CodeGen/X86/tailcall-ssp-split-debug.ll
+++ b/llvm/test/CodeGen/X86/tailcall-ssp-split-debug.ll
@@ -1,9 +1,9 @@
 ; RUN: llc -mtriple=x86_64-apple-macosx %s -o - | FileCheck %s
 
-define void @foo() ssp {
+define void @foo(i1 %arg) ssp {
 ; CHECK-LABEL: foo:
   %ptr = alloca [32 x i32], align 16
-  br i1 undef, label %true, label %false
+  br i1 %arg, label %true, label %false
 
 true:
   unreachable

--- a/llvm/test/CodeGen/X86/taildup-crash.ll
+++ b/llvm/test/CodeGen/X86/taildup-crash.ll
@@ -8,9 +8,9 @@ target triple = "x86_64--"
 ; CHECK: je
 ; CHECK: retq
 ; CHECK: jmp
-define hidden void @func() {
+define hidden void @func(i1 %arg) {
 entry:
-  br i1 undef, label %for.cond.cleanup, label %while.cond.preheader
+  br i1 %arg, label %for.cond.cleanup, label %while.cond.preheader
 
 while.cond.preheader:
   br label %while.cond

--- a/llvm/test/CodeGen/X86/vaargs-prolog-insert.ll
+++ b/llvm/test/CodeGen/X86/vaargs-prolog-insert.ll
@@ -31,7 +31,7 @@ define void @reduce(i32, i32, i32, i32, i32, i32, ...) nounwind {
 ; CHECK-NEXT:  .LBB0_2:
 ; CHECK-NEXT:    addq $56, %rsp
 ; CHECK-NEXT:    retq
-  br i1 undef, label %8, label %7
+  br i1 poison, label %8, label %7
 
 7:                                                ; preds = %6
   call void @llvm.va_start(ptr null)


### PR DESCRIPTION
This PR replaces some instances of `br i1 undef` with function argument value in several tests under `llvm/test/CodeGen/` directory. This PR is a continuation of PR #125460

@nunoplopes @arsenm 