### PR TITLE
[lldb-dap] Support cancel requests and add explicit DAP structures.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -144,9 +144,17 @@ class DebugCommunication(object):
     @classmethod
     def validate_response(cls, command, response):
         if command["command"] != response["command"]:
-            raise ValueError("command mismatch in response")
+            raise ValueError(
+                "command mismatch in response, got '{}', expected '{}', response: {}".format(
+                    command["command"], response["command"], response
+                )
+            )
         if command["seq"] != response["request_seq"]:
-            raise ValueError("seq mismatch in response")
+            raise ValueError(
+                "seq mismatch in response, got '{}', expected {}, response: {}".format(
+                    command["seq"], response["request_seq"], response
+                )
+            )
 
     def get_modules(self):
         module_list = self.request_modules()["body"]["modules"]

--- a/lldb/test/API/tools/lldb-dap/cancel/Makefile
+++ b/lldb/test/API/tools/lldb-dap/cancel/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -1,0 +1,92 @@
+"""
+Test lldb-dap cancel request
+"""
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbdap_testcase
+
+
+class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
+    def send_async_req(self, command: str, arguments={}) -> int:
+        seq = self.dap_server.sequence
+        self.dap_server.send_packet(
+            {
+                "type": "request",
+                "command": command,
+                "arguments": arguments,
+            }
+        )
+        return seq
+
+    def async_blocking_request(self, duration: float) -> int:
+        """
+        Sends an evaluate request that will sleep for the specified duration to
+        block the request handling thread.
+        """
+        return self.send_async_req(
+            command="evaluate",
+            arguments={
+                "expression": "`script import time; time.sleep({})".format(duration),
+                "context": "repl",
+            },
+        )
+
+    def async_cancel(self, requestId: int) -> int:
+        return self.send_async_req(command="cancel", arguments={"requestId": requestId})
+
+    def test_pending_request(self):
+        """
+        Tests cancelling a pending request.
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program, stopOnEntry=True)
+        self.continue_to_next_stop()
+
+        # Use a relatively short timeout since this is only to ensure the
+        # following request is queued.
+        blocking_seq = self.async_blocking_request(duration=1.0)
+        # Use a longer timeout to ensure we catch if the request was interrupted
+        # properly.
+        pending_seq = self.async_blocking_request(duration=self.timeoutval)
+        cancel_seq = self.async_cancel(requestId=pending_seq)
+
+        blocking_resp = self.dap_server.recv_packet(filter_type=["response"])
+        self.assertEqual(blocking_resp["request_seq"], blocking_seq)
+        self.assertEqual(blocking_resp["command"], "evaluate")
+        self.assertEqual(blocking_resp["success"], True)
+
+        pending_resp = self.dap_server.recv_packet(filter_type=["response"])
+        self.assertEqual(pending_resp["request_seq"], pending_seq)
+        self.assertEqual(pending_resp["command"], "evaluate")
+        self.assertEqual(pending_resp["success"], False)
+        self.assertEqual(pending_resp["message"], "cancelled")
+
+        cancel_resp = self.dap_server.recv_packet(filter_type=["response"])
+        self.assertEqual(cancel_resp["request_seq"], cancel_seq)
+        self.assertEqual(cancel_resp["command"], "cancel")
+        self.assertEqual(cancel_resp["success"], True)
+        self.continue_to_exit()
+
+    def test_inflight_request(self):
+        """
+        Tests cancelling an inflight request.
+        """
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program, stopOnEntry=True)
+        self.continue_to_next_stop()
+
+        blocking_seq = self.async_blocking_request(duration=self.timeoutval)
+        cancel_seq = self.async_cancel(requestId=blocking_seq)
+
+        blocking_resp = self.dap_server.recv_packet(filter_type=["response"])
+        self.assertEqual(blocking_resp["request_seq"], blocking_seq)
+        self.assertEqual(blocking_resp["command"], "evaluate")
+        self.assertEqual(blocking_resp["success"], False)
+        self.assertEqual(blocking_resp["message"], "cancelled")
+
+        cancel_resp = self.dap_server.recv_packet(filter_type=["response"])
+        self.assertEqual(cancel_resp["request_seq"], cancel_seq)
+        self.assertEqual(cancel_resp["command"], "cancel")
+        self.assertEqual(cancel_resp["success"], True)
+        self.continue_to_exit()

--- a/lldb/test/API/tools/lldb-dap/cancel/main.c
+++ b/lldb/test/API/tools/lldb-dap/cancel/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char const *argv[]) {
+  printf("Hello world!\n");
+  return 0;
+}

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -1,13 +1,10 @@
 """
-Test lldb-dap setBreakpoints request
+Test lldb-dap launch request
 """
 
-import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import lldbutil
 import lldbdap_testcase
-import time
 import os
 import re
 
@@ -41,7 +38,9 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         self.dap_server.request_disconnect()
 
         # Wait until the underlying lldb-dap process dies.
-        self.dap_server.process.wait(timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval)
+        self.dap_server.process.wait(
+            timeout=lldbdap_testcase.DAPTestCaseBase.timeoutval
+        )
 
         # Check the return code
         self.assertEqual(self.dap_server.process.poll(), 0)

--- a/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
+++ b/lldb/test/API/tools/lldb-dap/optimized/TestDAP_optimized.py
@@ -24,11 +24,11 @@ class TestDAP_optimized(lldbdap_testcase.DAPTestCaseBase):
         )
         self.continue_to_breakpoints(breakpoint_ids)
         leaf_frame = self.dap_server.get_stackFrame(frameIndex=0)
-        self.assertTrue(leaf_frame["name"].endswith(" [opt]"))
+        self.assertRegex(leaf_frame["name"], r"\[.*opt.*\]")
         parent_frame = self.dap_server.get_stackFrame(frameIndex=1)
-        self.assertTrue(parent_frame["name"].endswith(" [opt]"))
+        self.assertRegex(parent_frame["name"], r"\[.*opt.*\]")
 
-    @skipIfAsan # On ASAN builds this test intermittently fails https://github.com/llvm/llvm-project/issues/111061
+    @skipIfAsan  # On ASAN builds this test intermittently fails https://github.com/llvm/llvm-project/issues/111061
     @skipIfWindows
     def test_optimized_variable(self):
         """Test optimized variable value contains error."""

--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -23,6 +23,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
 
         def cleanup():
             process.terminate()
+            dap_server.dump_dap_log(log_file_path)
 
         self.addTearDownHook(cleanup)
 
@@ -47,6 +48,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         output = self.get_stdout()
         self.assertEqual(output, f"Hello {name}!\r\n")
         self.dap_server.request_disconnect()
+        self.dap_server.terminate()
 
     def test_server_port(self):
         """

--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -32,6 +32,7 @@ add_lldb_tool(lldb-dap
   LLDBUtils.cpp
   OutputRedirector.cpp
   ProgressEvent.cpp
+  Protocol.cpp
   RunInTerminal.cpp
   SourceBreakpoint.cpp
   Watchpoint.cpp

--- a/lldb/tools/lldb-dap/IOStream.cpp
+++ b/lldb/tools/lldb-dap/IOStream.cpp
@@ -7,83 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "IOStream.h"
+#include "lldb/Utility/IOObject.h" // IWYU pragma: keep
+#include "lldb/Utility/Status.h"
 #include <fstream>
 #include <string>
 
-#if defined(_WIN32)
-#include <io.h>
-#else
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
-#endif
-
 using namespace lldb_dap;
 
-StreamDescriptor::StreamDescriptor() = default;
-
-StreamDescriptor::StreamDescriptor(StreamDescriptor &&other) {
-  *this = std::move(other);
-}
-
-StreamDescriptor::~StreamDescriptor() {
-  if (!m_close)
-    return;
-
-  if (m_is_socket)
-#if defined(_WIN32)
-    ::closesocket(m_socket);
-#else
-    ::close(m_socket);
-#endif
-  else
-    ::close(m_fd);
-}
-
-StreamDescriptor &StreamDescriptor::operator=(StreamDescriptor &&other) {
-  m_close = other.m_close;
-  other.m_close = false;
-  m_is_socket = other.m_is_socket;
-  if (m_is_socket)
-    m_socket = other.m_socket;
-  else
-    m_fd = other.m_fd;
-  return *this;
-}
-
-StreamDescriptor StreamDescriptor::from_socket(SOCKET s, bool close) {
-  StreamDescriptor sd;
-  sd.m_is_socket = true;
-  sd.m_socket = s;
-  sd.m_close = close;
-  return sd;
-}
-
-StreamDescriptor StreamDescriptor::from_file(int fd, bool close) {
-  StreamDescriptor sd;
-  sd.m_is_socket = false;
-  sd.m_fd = fd;
-  sd.m_close = close;
-  return sd;
-}
-
 bool OutputStream::write_full(llvm::StringRef str) {
-  while (!str.empty()) {
-    int bytes_written = 0;
-    if (descriptor.m_is_socket)
-      bytes_written = ::send(descriptor.m_socket, str.data(), str.size(), 0);
-    else
-      bytes_written = ::write(descriptor.m_fd, str.data(), str.size());
+  if (!descriptor || !descriptor->IsValid())
+    return false;
 
-    if (bytes_written < 0) {
-      if (errno == EINTR || errno == EAGAIN)
-        continue;
-      return false;
-    }
-    str = str.drop_front(bytes_written);
-  }
-
-  return true;
+  size_t bytes = str.size();
+  return descriptor->Write(str.data(), bytes).Success();
 }
 
 bool InputStream::read_full(std::ofstream *log, size_t length,
@@ -92,40 +28,9 @@ bool InputStream::read_full(std::ofstream *log, size_t length,
   data.resize(length);
 
   char *ptr = &data[0];
-  while (length != 0) {
-    int bytes_read = 0;
-    if (descriptor.m_is_socket)
-      bytes_read = ::recv(descriptor.m_socket, ptr, length, 0);
-    else
-      bytes_read = ::read(descriptor.m_fd, ptr, length);
-
-    if (bytes_read == 0) {
-      if (log)
-        *log << "End of file (EOF) reading from input file.\n";
-      return false;
-    }
-    if (bytes_read < 0) {
-      int reason = 0;
-#if defined(_WIN32)
-      if (descriptor.m_is_socket)
-        reason = WSAGetLastError();
-      else
-        reason = errno;
-#else
-      reason = errno;
-      if (reason == EINTR || reason == EAGAIN)
-        continue;
-#endif
-
-      if (log)
-        *log << "Error " << reason << " reading from input file.\n";
-      return false;
-    }
-
-    assert(bytes_read >= 0 && (size_t)bytes_read <= length);
-    ptr += bytes_read;
-    length -= bytes_read;
-  }
+  size_t bytes_read = length;
+  if (!descriptor->Read(ptr, bytes_read).Success())
+    return false;
   text += data;
   return true;
 }

--- a/lldb/tools/lldb-dap/IOStream.h
+++ b/lldb/tools/lldb-dap/IOStream.h
@@ -9,45 +9,17 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_IOSTREAM_H
 #define LLDB_TOOLS_LLDB_DAP_IOSTREAM_H
 
-#if defined(_WIN32)
-#include "lldb/Host/windows/windows.h"
-#include <winsock2.h>
-#else
-typedef int SOCKET;
-#endif
-
+#include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
-
 #include <fstream>
 #include <string>
 
-// Windows requires different system calls for dealing with sockets and other
-// types of files, so we can't simply have one code path that just uses read
-// and write everywhere.  So we need an abstraction in order to allow us to
-// treat them identically.
 namespace lldb_dap {
-struct StreamDescriptor {
-  StreamDescriptor();
-  ~StreamDescriptor();
-  StreamDescriptor(StreamDescriptor &&other);
-
-  StreamDescriptor &operator=(StreamDescriptor &&other);
-
-  static StreamDescriptor from_socket(SOCKET s, bool close);
-  static StreamDescriptor from_file(int fd, bool close);
-
-  bool m_is_socket = false;
-  bool m_close = false;
-  union {
-    int m_fd;
-    SOCKET m_socket;
-  };
-};
 
 struct InputStream {
-  StreamDescriptor descriptor;
+  lldb::IOObjectSP descriptor;
 
-  explicit InputStream(StreamDescriptor descriptor)
+  explicit InputStream(lldb::IOObjectSP descriptor)
       : descriptor(std::move(descriptor)) {}
 
   bool read_full(std::ofstream *log, size_t length, std::string &text);
@@ -58,9 +30,9 @@ struct InputStream {
 };
 
 struct OutputStream {
-  StreamDescriptor descriptor;
+  lldb::IOObjectSP descriptor;
 
-  explicit OutputStream(StreamDescriptor descriptor)
+  explicit OutputStream(lldb::IOObjectSP descriptor)
       : descriptor(std::move(descriptor)) {}
 
   bool write_full(llvm::StringRef str);

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -10,6 +10,7 @@
 #define LLDB_TOOLS_LLDB_DAP_JSONUTILS_H
 
 #include "DAPForward.h"
+#include "Protocol.h"
 #include "lldb/API/SBCompileUnit.h"
 #include "lldb/API/SBFileSpec.h"
 #include "lldb/API/SBFormat.h"
@@ -353,15 +354,7 @@ llvm::json::Value CreateSource(const lldb::SBLineEntry &line_entry);
 ///     definition outlined by Microsoft.
 llvm::json::Value CreateSource(llvm::StringRef source_path);
 
-/// Create a "StackFrame" object for a LLDB frame object.
-///
-/// This function will fill in the following keys in the returned
-/// object:
-///   "id" - the stack frame ID as an integer
-///   "name" - the function name as a string
-///   "source" - source file information as a "Source" DAP object
-///   "line" - the source file line number as an integer
-///   "column" - the source file column number as an integer
+/// Returns a DAP protocol StackFrame from the given lldb frame and format.
 ///
 /// \param[in] frame
 ///     The LLDB stack frame to use when populating out the "StackFrame"
@@ -374,8 +367,7 @@ llvm::json::Value CreateSource(llvm::StringRef source_path);
 /// \return
 ///     A "StackFrame" JSON object with that follows the formal JSON
 ///     definition outlined by Microsoft.
-llvm::json::Value CreateStackFrame(lldb::SBFrame &frame,
-                                   lldb::SBFormat &format);
+protocol::StackFrame toStackFrame(lldb::SBFrame &frame, lldb::SBFormat &format);
 
 /// Create a "StackFrame" label object for a LLDB thread.
 ///
@@ -497,7 +489,7 @@ struct VariableDescription {
   llvm::json::Object GetVariableExtensionsJSON();
 
   /// Returns a description of the value appropriate for the specified context.
-  std::string GetResult(llvm::StringRef context);
+  std::string GetResult(bool multiline);
 };
 
 /// Does the given variable have an associated value location?

--- a/lldb/tools/lldb-dap/Protocol.cpp
+++ b/lldb/tools/lldb-dap/Protocol.cpp
@@ -1,0 +1,453 @@
+//===-- Protocol.cpp --------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Protocol.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/JSON.h"
+#include <optional>
+#include <utility>
+
+namespace llvm {
+namespace json {
+bool fromJSON(const llvm::json::Value &Params, llvm::json::Value &V,
+              llvm::json::Path P) {
+  V = std::move(Params);
+  return true;
+}
+} // namespace json
+} // namespace llvm
+
+namespace lldb_dap {
+namespace protocol {
+
+enum class MessageType { request, response, event };
+
+bool fromJSON(const llvm::json::Value &Params, MessageType &M,
+              llvm::json::Path P) {
+  auto rawType = Params.getAsString();
+  if (!rawType) {
+    P.report("expected a string");
+    return false;
+  }
+  std::optional<MessageType> type =
+      llvm::StringSwitch<std::optional<MessageType>>(*rawType)
+          .Case("request", MessageType::request)
+          .Case("response", MessageType::response)
+          .Case("event", MessageType::event)
+          .Default(std::nullopt);
+  if (!type) {
+    P.report("unexpected value");
+    return false;
+  }
+  M = *type;
+  return true;
+}
+
+bool fromJSON(const llvm::json::Value &Params, ProtocolMessage &PM,
+              llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  if (!O)
+    return false;
+
+  MessageType type;
+  if (!O.map("type", type))
+    return false;
+
+  switch (type) {
+  case MessageType::request: {
+    Request req;
+    if (!fromJSON(Params, req, P)) {
+      return false;
+    }
+    PM = std::move(req);
+    return true;
+  }
+  case MessageType::response: {
+    Response resp;
+    if (!fromJSON(Params, resp, P)) {
+      return false;
+    }
+    PM = std::move(resp);
+    return true;
+  }
+  case MessageType::event:
+    Event evt;
+    if (!fromJSON(Params, evt, P)) {
+      return false;
+    }
+    PM = std::move(evt);
+    return true;
+  }
+  llvm_unreachable("Unsupported protocol message");
+}
+
+llvm::json::Value toJSON(const ProtocolMessage &PM) {
+  if (auto const *Req = std::get_if<Request>(&PM)) {
+    return toJSON(*Req);
+  }
+  if (auto const *Resp = std::get_if<Response>(&PM)) {
+    return toJSON(*Resp);
+  }
+  if (auto const *Evt = std::get_if<Event>(&PM)) {
+    return toJSON(*Evt);
+  }
+  llvm_unreachable("Unsupported protocol message");
+}
+
+llvm::json::Value toJSON(const Request &R) {
+  llvm::json::Object Result{
+      {"type", "request"},
+      {"seq", R.seq},
+      {"command", R.command},
+  };
+  if (R.rawArguments)
+    Result.insert({"arguments", R.rawArguments});
+  return std::move(Result);
+}
+
+bool fromJSON(llvm::json::Value const &Params, Request &R, llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  MessageType type;
+  if (!O.map("type", type)) {
+    return false;
+  }
+  if (type != MessageType::request) {
+    P.field("type").report("expected to be 'request'");
+    return false;
+  }
+
+  return O && O.map("command", R.command) && O.map("seq", R.seq) &&
+         O.map("arguments", R.rawArguments);
+}
+
+bool fromJSON(llvm::json::Value const &Params, Response &R,
+              llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  MessageType type;
+  if (!O.map("type", type)) {
+    return false;
+  }
+  if (type != MessageType::response) {
+    P.field("type").report("expected to be 'response'");
+    return false;
+  }
+  return O && O.map("command", R.command) &&
+         O.map("request_seq", R.request_seq) && O.map("success", R.success) &&
+         O.mapOptional("message", R.message) &&
+         O.mapOptional("body", R.rawBody);
+}
+
+bool fromJSON(llvm::json::Value const &Params, Event &E, llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  MessageType type;
+  if (!O.map("type", type)) {
+    return false;
+  }
+  if (type != MessageType::event) {
+    P.field("type").report("expected to be 'event'");
+    return false;
+  }
+
+  return O && O.map("event", E.event) && O.mapOptional("body", E.rawBody);
+}
+
+llvm::json::Value toJSON(const Response &R) {
+  llvm::json::Object Result{{"type", "response"},
+                            {"req", 0},
+                            {"command", R.command},
+                            {"request_seq", R.request_seq},
+                            {"success", R.success}};
+
+  if (R.message)
+    Result.insert({"message", R.message});
+  if (R.rawBody)
+    Result.insert({"body", R.rawBody});
+
+  return std::move(Result);
+}
+
+llvm::json::Value toJSON(lldb_dap::protocol::ErrorResponseBody const &ERB) {
+  return llvm::json::Object{{"error", ERB.error}};
+}
+
+llvm::json::Value toJSON(std::map<std::string, std::string> const &KV) {
+  llvm::json::Object Result;
+  for (const auto &[K, V] : KV)
+    Result.insert({K, V});
+  return std::move(Result);
+}
+
+llvm::json::Value toJSON(lldb_dap::protocol::Message const &M) {
+  return llvm::json::Object{{"id", M.id},
+                            {"format", M.format},
+                            {"showUser", M.showUser},
+                            {"sendTelemetry", M.sendTelemetry},
+                            {"variables", toJSON(*M.variables)},
+                            {"url", M.url},
+                            {"urlLabel", M.urlLabel}};
+}
+
+bool fromJSON(const llvm::json::Value &Params, Source::PresentationHint &PH,
+              llvm::json::Path P) {
+  auto rawHint = Params.getAsString();
+  if (!rawHint) {
+    P.report("expected a string");
+    return false;
+  }
+  std::optional<Source::PresentationHint> hint =
+      llvm::StringSwitch<std::optional<Source::PresentationHint>>(*rawHint)
+          .Case("normal", Source::PresentationHint::normal)
+          .Case("emphasize", Source::PresentationHint::emphasize)
+          .Case("deemphasize", Source::PresentationHint::deemphasize)
+          .Default(std::nullopt);
+  if (!hint) {
+    P.report("unexpected value");
+    return false;
+  }
+  PH = *hint;
+  return true;
+}
+
+bool fromJSON(const llvm::json::Value &Params, Source &S, llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  return O && O.mapOptional("name", S.name) && O.mapOptional("path", S.path) &&
+         O.mapOptional("presentationHint", S.presentationHint) &&
+         O.mapOptional("sourceReference", S.sourceReference) &&
+         O.mapOptional("origin", S.origin);
+}
+
+bool fromJSON(const llvm::json::Value &Params, CancelArguments &CA,
+              llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  return O && O.mapOptional("requestId", CA.requestId) &&
+         O.mapOptional("progressId", CA.progressId);
+}
+
+llvm::json::Value toJSON(const Source &S) {
+  llvm::json::Object Result;
+
+  if (S.name)
+    Result.insert({"name", S.name});
+  if (S.path)
+    Result.insert({"path", S.path});
+  if (S.presentationHint)
+    switch (*S.presentationHint) {
+    case Source::PresentationHint::normal:
+      Result.insert({"presentationHint", "normal"});
+      break;
+    case Source::PresentationHint::emphasize:
+      Result.insert({"presentationHint", "emphasize"});
+      break;
+    case Source::PresentationHint::deemphasize:
+      Result.insert({"presentationHint", "deemphasize"});
+      break;
+    }
+  if (S.sourceReference)
+    Result.insert({"sourceReference", S.sourceReference});
+  if (S.origin)
+    Result.insert({"origin", S.origin});
+
+  return std::move(Result);
+}
+
+llvm::json::Value toJSON(const StackFrame &SF) {
+  llvm::json::Object Result{{"id", SF.id},
+                            {"name", SF.name},
+                            {"line", SF.line},
+                            {"column", SF.column}};
+
+  if (SF.source)
+    Result.insert({"source", SF.source});
+  if (SF.endLine)
+    Result.insert({"endLine", SF.endLine});
+  if (SF.endColumn)
+    Result.insert({"endColumn", SF.endColumn});
+  if (SF.canRestart)
+    Result.insert({"canRestart", SF.canRestart});
+  if (SF.instructionPointerReference)
+    Result.insert(
+        {"instructionPointerReference", SF.instructionPointerReference});
+  if (SF.presentationHint)
+    switch (*SF.presentationHint) {
+    case StackFrame::PresentationHint::normal:
+      Result.insert({"presentationHint", "normal"});
+      break;
+    case StackFrame::PresentationHint::label:
+      Result.insert({"presentationHint", "label"});
+      break;
+    case StackFrame::PresentationHint::subtle:
+      Result.insert({"presentationHint", "subtle"});
+      break;
+    }
+  return std::move(Result);
+}
+
+bool fromJSON(const llvm::json::Value &Params, SourceArguments &SA,
+              llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  return O && O.mapOptional("source", SA.source) &&
+         O.map("sourceReference", SA.sourceReference);
+}
+
+llvm::json::Value toJSON(const SourceResponseBody &SA) {
+  llvm::json::Object Result{{"content", SA.content}};
+
+  if (SA.mimeType)
+    Result.insert({"mimeType", SA.mimeType});
+
+  return std::move(Result);
+}
+
+bool fromJSON(const llvm::json::Value &Params, EvaluateArguments::Context &C,
+              llvm::json::Path P) {
+  auto rawContext = Params.getAsString();
+  if (!rawContext) {
+    P.report("expected a string");
+    return false;
+  }
+  std::optional<EvaluateArguments::Context> context =
+      llvm::StringSwitch<std::optional<EvaluateArguments::Context>>(*rawContext)
+          .Case("repl", EvaluateArguments::Context::repl)
+          .Case("watch", EvaluateArguments::Context::watch)
+          .Case("clipboard", EvaluateArguments::Context::clipboard)
+          .Case("hover", EvaluateArguments::Context::hover)
+          .Case("variables", EvaluateArguments::Context::variables)
+          .Default(std::nullopt);
+  if (!context) {
+    P.report("unexpected value");
+    return false;
+  }
+  C = *context;
+  return true;
+}
+
+bool fromJSON(const llvm::json::Value &Params, EvaluateArguments &EA,
+              llvm::json::Path P) {
+  llvm::json::ObjectMapper O(Params, P);
+  return O && O.map("expression", EA.expression) &&
+         O.mapOptional("frameId", EA.frameId) &&
+         O.mapOptional("line", EA.line) && O.mapOptional("column", EA.column) &&
+         O.mapOptional("source", EA.source) &&
+         O.mapOptional("context", EA.context);
+}
+
+llvm::json::Value toJSON(const EvaluateResponseBody &ERB) {
+  llvm::json::Object Result{{"result", ERB.result},
+                            {"variablesReference", ERB.variablesReference}};
+
+  if (ERB.type)
+    Result.insert({"type", ERB.type});
+  if (ERB.presentationHint)
+    Result.insert({"presentationHint", ERB.presentationHint});
+  if (ERB.namedVariables)
+    Result.insert({"namedVariables", ERB.namedVariables});
+  if (ERB.indexedVariables)
+    Result.insert({"indexedVariables", ERB.indexedVariables});
+  if (ERB.memoryReference)
+    Result.insert({"memoryReference", ERB.memoryReference});
+  if (ERB.valueLocationReference)
+    Result.insert({"valueLocationReference", ERB.valueLocationReference});
+
+  return std::move(Result);
+}
+
+llvm::json::Value toJSON(const VariablePresentationHint::Kind &K) {
+  switch (K) {
+  case VariablePresentationHint::Kind::property_:
+    return "property";
+  case VariablePresentationHint::Kind::method_:
+    return "method";
+  case VariablePresentationHint::Kind::class_:
+    return "class";
+  case VariablePresentationHint::Kind::data_:
+    return "data";
+  case VariablePresentationHint::Kind::event_:
+    return "event";
+  case VariablePresentationHint::Kind::baseClass_:
+    return "baseClass";
+  case VariablePresentationHint::Kind::innerClass_:
+    return "innerClass";
+  case VariablePresentationHint::Kind::interface_:
+    return "interface";
+  case VariablePresentationHint::Kind::mostDerivedClass_:
+    return "mostDerivedClass";
+  case VariablePresentationHint::Kind::virtual_:
+    return "virtual";
+  case VariablePresentationHint::Kind::dataBreakpoint_:
+    return "dataBreakpoint";
+  }
+}
+
+llvm::json::Value toJSON(const VariablePresentationHint::Attributes &A) {
+  switch (A) {
+  case VariablePresentationHint::Attributes::static_:
+    return "static";
+  case VariablePresentationHint::Attributes::constant:
+    return "constant";
+  case VariablePresentationHint::Attributes::readOnly:
+    return "readOnly";
+  case VariablePresentationHint::Attributes::rawString:
+    return "rawString";
+  case VariablePresentationHint::Attributes::hasObjectId:
+    return "hasObjectId";
+  case VariablePresentationHint::Attributes::canHaveObjectId:
+    return "canHaveObjectId";
+  case VariablePresentationHint::Attributes::hasSideEffects:
+    return "hasSideEffects";
+  case VariablePresentationHint::Attributes::hasDataBreakpoint:
+    return "hasDataBreakpoint";
+  }
+}
+
+llvm::json::Value toJSON(const VariablePresentationHint::Visibility &V) {
+  switch (V) {
+  case VariablePresentationHint::Visibility::public_:
+    return "public";
+  case VariablePresentationHint::Visibility::private_:
+    return "private";
+  case VariablePresentationHint::Visibility::protected_:
+    return "protected";
+  case VariablePresentationHint::Visibility::internal_:
+    return "internal";
+  case VariablePresentationHint::Visibility::final_:
+    return "final";
+  }
+}
+
+llvm::json::Value toJSON(const VariablePresentationHint &VPH) {
+  llvm::json::Object Result;
+  if (VPH.kind)
+    Result.insert({"kind", VPH.kind});
+  if (VPH.attributes)
+    Result.insert({"attributes", VPH.attributes});
+  if (VPH.visibility)
+    Result.insert({"visibility", VPH.visibility});
+  if (VPH.lazy)
+    Result.insert({"lazy", VPH.lazy});
+  return std::move(Result);
+}
+
+llvm::json::Value toJSON(const Event &E) {
+  llvm::json::Object Result{
+      {"type", "event"},
+      {"seq", 0},
+      {"event", E.event},
+  };
+  if (E.rawBody)
+    Result.insert({"body", E.rawBody});
+  return std::move(Result);
+}
+
+llvm::json::Value toJSON(const ExitedEventBody &EEB) {
+  return llvm::json::Object{{"exitCode", EEB.exitCode}};
+}
+
+} // namespace protocol
+} // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Protocol.h
+++ b/lldb/tools/lldb-dap/Protocol.h
@@ -1,0 +1,908 @@
+//===-- Protocol.h ----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains POD structs based on the DAP specification at
+// https://microsoft.github.io/debug-adapter-protocol/specification
+//
+// This is not meant to be a complete implementation, new interfaces are added
+// when they're needed.
+//
+// Each struct has a toJSON and fromJSON function, that converts between
+// the struct and a JSON representation. (See JSON.h)
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_H
+#define LLDB_TOOLS_LLDB_DAP_PROTOCOL_H
+
+#include "llvm/Support/JSON.h"
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+#include <map>
+
+namespace lldb_dap {
+namespace protocol {
+
+// MARK: Base Protocol
+
+// "Request": {
+//   "allOf": [ { "$ref": "#/definitions/ProtocolMessage" }, {
+//     "type": "object",
+//     "description": "A client or debug adapter initiated request.",
+//     "properties": {
+//       "type": {
+//         "type": "string",
+//         "enum": [ "request" ]
+//       },
+//       "command": {
+//         "type": "string",
+//         "description": "The command to execute."
+//       },
+//       "arguments": {
+//         "type": [ "array", "boolean", "integer", "null", "number" , "object",
+//         "string" ], "description": "Object containing arguments for the
+//         command."
+//       }
+//     },
+//     "required": [ "type", "command" ]
+//   }]
+// },
+struct Request {
+  int64_t seq;
+  std::string command;
+  std::optional<llvm::json::Value> rawArguments;
+};
+llvm::json::Value toJSON(const Request &);
+bool fromJSON(const llvm::json::Value &, Request &, llvm::json::Path);
+
+// "Event": {
+//   "allOf": [ { "$ref": "#/definitions/ProtocolMessage" }, {
+//     "type": "object",
+//     "description": "A debug adapter initiated event.",
+//     "properties": {
+//       "type": {
+//         "type": "string",
+//         "enum": [ "event" ]
+//       },
+//       "event": {
+//         "type": "string",
+//         "description": "Type of event."
+//       },
+//       "body": {
+//         "type": [ "array", "boolean", "integer", "null", "number" , "object",
+//         "string" ], "description": "Event-specific information."
+//       }
+//     },
+//     "required": [ "type", "event" ]
+//   }]
+// },
+struct Event {
+  std::string event;
+  std::optional<llvm::json::Value> rawBody;
+};
+llvm::json::Value toJSON(const Event &);
+bool fromJSON(const llvm::json::Value &, Event &, llvm::json::Path);
+
+// "Response" : {
+//   "allOf" : [
+//     {"$ref" : "#/definitions/ProtocolMessage"}, {
+//       "type" : "object",
+//       "description" : "Response for a request.",
+//       "properties" : {
+//         "type" : {"type" : "string", "enum" : ["response"]},
+//         "request_seq" : {
+//           "type" : "integer",
+//           "description" : "Sequence number of the corresponding request."
+//         },
+//         "success" : {
+//           "type" : "boolean",
+//           "description" :
+//               "Outcome of the request.\nIf true, the request was successful "
+//               "and the `body` attribute may contain the result of the "
+//               "request.\nIf the value is false, the attribute `message` "
+//               "contains the error in short form and the `body` may contain "
+//               "additional information (see `ErrorResponse.body.error`)."
+//         },
+//         "command" :
+//             {"type" : "string", "description" : "The command requested."},
+//         "message" : {
+//           "type" : "string",
+//           "description" :
+//               "Contains the raw error in short form if `success` is "
+//               "false.\nThis raw error might be interpreted by the client and
+//               " "is not shown in the UI.\nSome predefined values exist.",
+//           "_enum" : [ "cancelled", "notStopped" ],
+//           "enumDescriptions" : [
+//             "the request was cancelled.", "the request may be retried once
+//             the "
+//                                           "adapter is in a 'stopped' state."
+//           ]
+//         },
+//         "body" : {
+//           "type" : [
+//             "array", "boolean", "integer", "null", "number", "object",
+//             "string"
+//           ],
+//           "description" : "Contains request result if success is true and "
+//                           "error details if success is false."
+//         }
+//       },
+//       "required" : [ "type", "request_seq", "success", "command" ]
+//     }
+//   ]
+// }
+struct Response {
+  int64_t request_seq;
+  bool success;
+  std::string command;
+  std::optional<std::string> message;
+  std::optional<llvm::json::Value> rawBody;
+};
+bool fromJSON(const llvm::json::Value &, Response &, llvm::json::Path);
+llvm::json::Value toJSON(const Response &);
+
+// A void response body for any response without a specific value.
+using VoidResponseBody = std::nullptr_t;
+
+// "ProtocolMessage": {
+//   "type": "object",
+//   "title": "Base Protocol",
+//   "description": "Base class of requests, responses, and events.",
+//   "properties": {
+//     "seq": {
+//       "type": "integer",
+//       "description": "Sequence number of the message (also known as
+//       message ID). The `seq` for the first message sent by a client or
+//       debug adapter is 1, and for each subsequent message is 1 greater
+//       than the previous message sent by that actor. `seq` can be used to
+//       order requests, responses, and events, and to associate requests
+//       with their corresponding responses. For protocol messages of type
+//       `request` the sequence number can be used to cancel the request."
+//     },
+//     "type": {
+//       "type": "string",
+//       "description": "Message type.",
+//       "_enum": [ "request", "response", "event" ]
+//     }
+//   },
+//   "required": [ "seq", "type" ]
+// },
+// struct ProtocolMessage {
+//   MessageType type;
+//   int64_t seq;
+// };
+// enum class MessageType { request, event, response };
+using ProtocolMessage = std::variant<Request, Response, Event>;
+bool fromJSON(const llvm::json::Value &, ProtocolMessage &, llvm::json::Path);
+llvm::json::Value toJSON(const ProtocolMessage &);
+
+// "CancelRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "The `cancel` request is used by the client in two
+//     situations:\n- to indicate that it is no longer interested in the result
+//     produced by a specific request issued earlier\n- to cancel a progress
+//     sequence.\nClients should only call this request if the corresponding
+//     capability `supportsCancelRequest` is true.\nThis request has a hint
+//     characteristic: a debug adapter can only be expected to make a 'best
+//     effort' in honoring this request but there are no guarantees.\nThe
+//     `cancel` request may return an error if it could not cancel an operation
+//     but a client should refrain from presenting this error to end users.\nThe
+//     request that got cancelled still needs to send a response back. This can
+//     either be a normal result (`success` attribute true) or an error response
+//     (`success` attribute false and the `message` set to
+//     `cancelled`).\nReturning partial results from a cancelled request is
+//     possible but please note that a client has no generic way for detecting
+//     that a response is partial or not.\nThe progress that got cancelled still
+//     needs to send a `progressEnd` event back.\n A client should not assume
+//     that progress just got cancelled after sending the `cancel` request.",
+//     "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "cancel" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/CancelArguments"
+//       }
+//     },
+//     "required": [ "command" ]
+//   }]
+// },
+// "CancelArguments": {
+//   "type": "object",
+//   "description": "Arguments for `cancel` request.",
+//   "properties": {
+//     "requestId": {
+//       "type": "integer",
+//       "description": "The ID (attribute `seq`) of the request to cancel. If
+//       missing no request is cancelled.\nBoth a `requestId` and a `progressId`
+//       can be specified in one request."
+//     },
+//     "progressId": {
+//       "type": "string",
+//       "description": "The ID (attribute `progressId`) of the progress to
+//       cancel. If missing no progress is cancelled.\nBoth a `requestId` and a
+//       `progressId` can be specified in one request."
+//     }
+//   }
+// },
+struct CancelArguments {
+  std::optional<int64_t> requestId;
+  std::optional<int64_t> progressId;
+};
+bool fromJSON(const llvm::json::Value &, CancelArguments &, llvm::json::Path);
+
+// "CancelResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to `cancel` request. This is just an
+//     acknowledgement, so no body field is required."
+//   }]
+// },
+using CancelResponseBody = VoidResponseBody;
+
+// "Message": {
+//   "type": "object",
+//   "description": "A structured message object. Used to return errors from
+//   requests.", "properties": {
+//     "id": {
+//       "type": "integer",
+//       "description": "Unique (within a debug adapter implementation)
+//       identifier for the message. The purpose of these error IDs is to
+//       help extension authors that have the requirement that every user
+//       visible error message needs a corresponding error number, so that
+//       users or customer support can find information about the specific
+//       error more easily."
+//     },
+//     "format": {
+//       "type": "string",
+//       "description": "A format string for the message. Embedded variables
+//       have the form `{name}`.\nIf variable name starts with an underscore
+//       character, the variable does not contain user data (PII) and can be
+//       safely used for telemetry purposes."
+//     },
+//     "variables": {
+//       "type": "object",
+//       "description": "An object used as a dictionary for looking up the
+//       variables in the format string.", "additionalProperties": {
+//         "type": "string",
+//         "description": "All dictionary values must be strings."
+//       }
+//     },
+//     "sendTelemetry": {
+//       "type": "boolean",
+//       "description": "If true send to telemetry."
+//     },
+//     "showUser": {
+//       "type": "boolean",
+//       "description": "If true show user."
+//     },
+//     "url": {
+//       "type": "string",
+//       "description": "A url where additional information about this
+//       message can be found."
+//     },
+//     "urlLabel": {
+//       "type": "string",
+//       "description": "A label that is presented to the user as the UI for
+//       opening the url."
+//     }
+//   },
+//   "required": [ "id", "format" ]
+// },
+struct Message {
+  int id;
+  std::string format;
+  std::optional<bool> showUser;
+  std::optional<std::map<std::string, std::string>> variables;
+  std::optional<bool> sendTelemetry;
+  std::optional<std::string> url;
+  std::optional<std::string> urlLabel;
+};
+llvm::json::Value toJSON(const Message &);
+
+// "ErrorResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "On error (whenever `success` is false), the body can
+//     provide more details.", "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "error": {
+//             "$ref": "#/definitions/Message",
+//             "description": "A structured error message."
+//           }
+//         }
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// },
+struct ErrorResponseBody {
+  std::optional<Message> error;
+};
+llvm::json::Value toJSON(const ErrorResponseBody &);
+
+// MARK: Types
+
+// "Source" : {
+//   "type" : "object",
+//   "description" : "A `Source` is a descriptor for source
+//   code.\nIt is returned "
+//                   "from the debug adapter as part of a
+//                   `StackFrame` and it is " "used by clients when
+//                   specifying breakpoints.",
+//   "properties" : {
+//     "name" : {
+//       "type" : "string",
+//       "description" : "The short name of the source. Every
+//       source returned "
+//                       "from the debug adapter has a name.\nWhen
+//                       sending a " "source to the debug adapter
+//                       this name is optional."
+//     },
+//     "path" : {
+//       "type" : "string",
+//       "description" :
+//           "The path of the source to be shown in the UI.\nIt is
+//           only used to " "locate and load the content of the
+//           source if no `sourceReference` " "is specified (or its
+//           value is 0)."
+//     },
+//     "sourceReference" : {
+//       "type" : "integer",
+//       "description" :
+//           "If the value > 0 the contents of the source must be
+//           retrieved " "through the `source` request (even if a
+//           path is specified).\nSince " "a `sourceReference` is
+//           only valid for a session, it can not be used " "to
+//           persist a source.\nThe value should be less than or
+//           equal to " "2147483647 (2^31-1)."
+//     },
+//     "presentationHint" : {
+//       "type" : "string",
+//       "description" :
+//           "A hint for how to present the source in the UI.\nA
+//           value of "
+//           "`deemphasize` can be used to indicate that the source
+//           is not " "available or that it is skipped on
+//           stepping.",
+//       "enum" : [ "normal", "emphasize", "deemphasize" ]
+//     },
+//     "origin" : {
+//       "type" : "string",
+//       "description" : "The origin of this source. For example,
+//       'internal "
+//                       "module', 'inlined content from source
+//                       map', etc."
+//     },
+//     "sources" : {
+//       "type" : "array",
+//       "items" : {"$ref" : "#/definitions/Source"},
+//       "description" : "A list of sources that are related to
+//       this source. "
+//                       "These may be the source that generated
+//                       this source."
+//     },
+//     "adapterData" : {
+//       "type" : [
+//         "array", "boolean", "integer", "null", "number",
+//         "object", "string"
+//       ],
+//       "description" :
+//           "Additional data that a debug adapter might want to
+//           loop through the " "client.\nThe client should leave
+//           the data intact and persist it " "across sessions. The
+//           client should not interpret the data."
+//     },
+//     "checksums" : {
+//       "type" : "array",
+//       "items" : {"$ref" : "#/definitions/Checksum"},
+//       "description" : "The checksums associated with this file."
+//     }
+//   }
+struct Source {
+  enum class PresentationHint { normal, emphasize, deemphasize };
+
+  std::optional<std::string> name;
+  std::optional<std::string> path;
+  std::optional<int64_t> sourceReference;
+  std::optional<PresentationHint> presentationHint;
+  std::optional<std::string> origin;
+
+  // Unsupported fields: adapterData, checksums
+};
+bool fromJSON(const llvm::json::Value &, Source &, llvm::json::Path);
+llvm::json::Value toJSON(const Source &);
+
+// "StackFrame" : {
+//   "type" : "object",
+//   "description" : "A Stackframe contains the source location.",
+//   "properties" : {
+//     "id" : {
+//       "type" : "integer",
+//       "description" : "An identifier for the stack frame. It must be unique "
+//                       "across all threads.\nThis id can be used to retrieve "
+//                       "the scopes of the frame with the `scopes` request or
+//                       to " "restart the execution of a stack frame."
+//     },
+//     "name" : {
+//       "type" : "string",
+//       "description" : "The name of the stack frame, typically a method name."
+//     },
+//     "source" : {
+//       "$ref" : "#/definitions/Source",
+//       "description" : "The source of the frame."
+//     },
+//     "line" : {
+//       "type" : "integer",
+//       "description" : "The line within the source of the frame. If the source
+//       "
+//                       "attribute is missing or doesn't exist, `line` is 0 and
+//                       " "should be ignored by the client."
+//     },
+//     "column" : {
+//       "type" : "integer",
+//       "description" :
+//           "Start position of the range covered by the stack frame. It is "
+//           "measured in UTF-16 code units and the client capability "
+//           "`columnsStartAt1` determines whether it is 0- or 1-based. If "
+//           "attribute `source` is missing or doesn't exist, `column` is 0 and
+//           " "should be ignored by the client."
+//     },
+//     "endLine" : {
+//       "type" : "integer",
+//       "description" : "The end line of the range covered by the stack frame."
+//     },
+//     "endColumn" : {
+//       "type" : "integer",
+//       "description" :
+//           "End position of the range covered by the stack frame. It is "
+//           "measured in UTF-16 code units and the client capability "
+//           "`columnsStartAt1` determines whether it is 0- or 1-based."
+//     },
+//     "canRestart" : {
+//       "type" : "boolean",
+//       "description" :
+//           "Indicates whether this frame can be restarted with the "
+//           "`restartFrame` request. Clients should only use this if the debug
+//           " "adapter supports the `restart` request and the corresponding "
+//           "capability `supportsRestartFrame` is true. If a debug adapter has
+//           " "this capability, then `canRestart` defaults to `true` if the "
+//           "property is absent."
+//     },
+//     "instructionPointerReference" : {
+//       "type" : "string",
+//       "description" : "A memory reference for the current instruction pointer
+//       "
+//                       "in this frame."
+//     },
+//     "moduleId" : {
+//       "type" : [ "integer", "string" ],
+//       "description" : "The module associated with this frame, if any."
+//     },
+//     "presentationHint" : {
+//       "type" : "string",
+//       "enum" : [ "normal", "label", "subtle" ],
+//       "description" :
+//           "A hint for how to present this frame in the UI.\nA value of
+//           `label` " "can be used to indicate that the frame is an artificial
+//           frame that " "is used as a visual label or separator. A value of
+//           `subtle` can be " "used to change the appearance of a frame in a
+//           'subtle' way."
+//     }
+//   },
+//   "required" : [ "id", "name", "line", "column" ]
+// }
+struct StackFrame {
+  enum class PresentationHint { normal, label, subtle };
+  int64_t id = 0;
+  std::string name = "";
+  uint32_t line = 0;
+  uint32_t column = 0;
+  std::optional<Source> source;
+  std::optional<uint32_t> endLine;
+  std::optional<uint32_t> endColumn;
+  std::optional<bool> canRestart;
+  std::optional<std::string> instructionPointerReference;
+  std::optional<PresentationHint> presentationHint;
+  // Unsupported fields: "moduleId"
+};
+llvm::json::Value toJSON(const StackFrame &);
+
+// "VariablePresentationHint": {
+//   "type": "object",
+//   "description": "Properties of a variable that can be used to determine how
+//   to render the variable in the UI.", "properties": {
+//     "kind": {
+//       "description": "The kind of variable. Before introducing additional
+//       values, try to use the listed values.", "type": "string",
+//       "_enum": [ "property", "method", "class", "data", "event", "baseClass",
+//       "innerClass", "interface", "mostDerivedClass", "virtual",
+//       "dataBreakpoint" ], "enumDescriptions": [
+//         "Indicates that the object is a property.",
+//         "Indicates that the object is a method.",
+//         "Indicates that the object is a class.",
+//         "Indicates that the object is data.",
+//         "Indicates that the object is an event.",
+//         "Indicates that the object is a base class.",
+//         "Indicates that the object is an inner class.",
+//         "Indicates that the object is an interface.",
+//         "Indicates that the object is the most derived class.",
+//         "Indicates that the object is virtual, that means it is a synthetic
+//         object introduced by the adapter for rendering purposes, e.g. an
+//         index range for large arrays.", "Deprecated: Indicates that a data
+//         breakpoint is registered for the object. The `hasDataBreakpoint`
+//         attribute should generally be used instead."
+//       ]
+//     },
+//     "attributes": {
+//       "description": "Set of attributes represented as an array of strings.
+//       Before introducing additional values, try to use the listed values.",
+//       "type": "array",
+//       "items": {
+//         "type": "string",
+//         "_enum": [ "static", "constant", "readOnly", "rawString",
+//         "hasObjectId", "canHaveObjectId", "hasSideEffects",
+//         "hasDataBreakpoint" ], "enumDescriptions": [
+//           "Indicates that the object is static.",
+//           "Indicates that the object is a constant.",
+//           "Indicates that the object is read only.",
+//           "Indicates that the object is a raw string.",
+//           "Indicates that the object can have an Object ID created for it.
+//           This is a vestigial attribute that is used by some clients; 'Object
+//           ID's are not specified in the protocol.", "Indicates that the
+//           object has an Object ID associated with it. This is a vestigial
+//           attribute that is used by some clients; 'Object ID's are not
+//           specified in the protocol.", "Indicates that the evaluation had
+//           side effects.", "Indicates that the object has its value tracked by
+//           a data breakpoint."
+//         ]
+//       }
+//     },
+//     "visibility": {
+//       "description": "Visibility of variable. Before introducing additional
+//       values, try to use the listed values.", "type": "string",
+//       "_enum": [ "public", "private", "protected", "internal", "final" ]
+//     },
+//     "lazy": {
+//       "description": "If true, clients can present the variable with a UI
+//       that supports a specific gesture to trigger its evaluation.\nThis
+//       mechanism can be used for properties that require executing code when
+//       retrieving their value and where the code execution can be expensive
+//       and/or produce side-effects. A typical example are properties based on
+//       a getter function.\nPlease note that in addition to the `lazy` flag,
+//       the variable's `variablesReference` is expected to refer to a variable
+//       that will provide the value through another `variable` request.",
+//       "type": "boolean"
+//     }
+//   }
+// },
+struct VariablePresentationHint {
+  enum class Kind {
+    property_,
+    method_,
+    class_,
+    data_,
+    event_,
+    baseClass_,
+    innerClass_,
+    interface_,
+    mostDerivedClass_,
+    virtual_,
+    dataBreakpoint_,
+  };
+  enum class Attributes {
+    static_,
+    constant,
+    readOnly,
+    rawString,
+    hasObjectId,
+    canHaveObjectId,
+    hasSideEffects,
+    hasDataBreakpoint,
+  };
+  enum class Visibility {
+    public_,
+    private_,
+    protected_,
+    internal_,
+    final_,
+  };
+
+  std::optional<Kind> kind;
+  std::optional<std::vector<Attributes>> attributes;
+  std::optional<Visibility> visibility;
+  std::optional<bool> lazy;
+};
+llvm::json::Value toJSON(const VariablePresentationHint &);
+llvm::json::Value toJSON(const VariablePresentationHint::Kind &);
+llvm::json::Value toJSON(const VariablePresentationHint::Attributes &);
+llvm::json::Value toJSON(const VariablePresentationHint::Visibility &);
+
+// MARK: Events
+
+// "ExitedEvent": {
+//   "allOf": [ { "$ref": "#/definitions/Event" }, {
+//     "type": "object",
+//     "description": "The event indicates that the debuggee has exited and
+//     returns its exit code.", "properties": {
+//       "event": {
+//         "type": "string",
+//         "enum": [ "exited" ]
+//       },
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "exitCode": {
+//             "type": "integer",
+//             "description": "The exit code returned from the debuggee."
+//           }
+//         },
+//         "required": [ "exitCode" ]
+//       }
+//     },
+//     "required": [ "event", "body" ]
+//   }]
+// }
+struct ExitedEventBody {
+  int exitCode;
+};
+llvm::json::Value toJSON(const ExitedEventBody &);
+
+// MARK: Requests
+
+// "EvaluateRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "Evaluates the given expression in the context of a stack
+//     frame.\nThe expression has access to any variables and arguments that are
+//     in scope.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "evaluate" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/EvaluateArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "EvaluateArguments": {
+//   "type": "object",
+//   "description": "Arguments for `evaluate` request.",
+//   "properties": {
+//     "expression": {
+//       "type": "string",
+//       "description": "The expression to evaluate."
+//     },
+//     "frameId": {
+//       "type": "integer",
+//       "description": "Evaluate the expression in the scope of this stack
+//       frame. If not specified, the expression is evaluated in the global
+//       scope."
+//     },
+//     "line": {
+//       "type": "integer",
+//       "description": "The contextual line where the expression should be
+//       evaluated. In the 'hover' context, this should be set to the start of
+//       the expression being hovered."
+//     },
+//     "column": {
+//       "type": "integer",
+//       "description": "The contextual column where the expression should be
+//       evaluated. This may be provided if `line` is also provided.\n\nIt is
+//       measured in UTF-16 code units and the client capability
+//       `columnsStartAt1` determines whether it is 0- or 1-based."
+//     },
+//     "source": {
+//       "$ref": "#/definitions/Source",
+//       "description": "The contextual source in which the `line` is found.
+//       This must be provided if `line` is provided."
+//     },
+//     "context": {
+//       "type": "string",
+//       "_enum": [ "watch", "repl", "hover", "clipboard", "variables" ],
+//       "enumDescriptions": [
+//         "evaluate is called from a watch view context.",
+//         "evaluate is called from a REPL context.",
+//         "evaluate is called to generate the debug hover contents.\nThis value
+//         should only be used if the corresponding capability
+//         `supportsEvaluateForHovers` is true.", "evaluate is called to
+//         generate clipboard contents.\nThis value should only be used if the
+//         corresponding capability `supportsClipboardContext` is true.",
+//         "evaluate is called from a variables view context."
+//       ],
+//       "description": "The context in which the evaluate request is used."
+//     },
+//     "format": {
+//       "$ref": "#/definitions/ValueFormat",
+//       "description": "Specifies details on how to format the result.\nThe
+//       attribute is only honored by a debug adapter if the corresponding
+//       capability `supportsValueFormattingOptions` is true."
+//     }
+//   },
+//   "required": [ "expression" ]
+// },
+struct EvaluateArguments {
+  enum class Context { watch, repl, hover, clipboard, variables };
+
+  std::string expression;
+  std::optional<int64_t> frameId;
+  std::optional<int> line;
+  std::optional<int> column;
+  std::optional<Source> source;
+  std::optional<Context> context;
+  // std::optional<ValueFormat> format; // unsupported
+};
+bool fromJSON(const llvm::json::Value &, EvaluateArguments &, llvm::json::Path);
+
+// "EvaluateResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to `evaluate` request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "result": {
+//             "type": "string",
+//             "description": "The result of the evaluate request."
+//           },
+//           "type": {
+//             "type": "string",
+//             "description": "The type of the evaluate result.\nThis attribute
+//             should only be returned by a debug adapter if the corresponding
+//             capability `supportsVariableType` is true."
+//           },
+//           "presentationHint": {
+//             "$ref": "#/definitions/VariablePresentationHint",
+//             "description": "Properties of an evaluate result that can be used
+//             to determine how to render the result in the UI."
+//           },
+//           "variablesReference": {
+//             "type": "integer",
+//             "description": "If `variablesReference` is > 0, the evaluate
+//             result is structured and its children can be retrieved by passing
+//             `variablesReference` to the `variables` request as long as
+//             execution remains suspended. See 'Lifetime of Object References'
+//             in the Overview section for details."
+//           },
+//           "namedVariables": {
+//             "type": "integer",
+//             "description": "The number of named child variables.\nThe client
+//             can use this information to present the variables in a paged UI
+//             and fetch them in chunks.\nThe value should be less than or equal
+//             to 2147483647 (2^31-1)."
+//           },
+//           "indexedVariables": {
+//             "type": "integer",
+//             "description": "The number of indexed child variables.\nThe
+//             client can use this information to present the variables in a
+//             paged UI and fetch them in chunks.\nThe value should be less than
+//             or equal to 2147483647 (2^31-1)."
+//           },
+//           "memoryReference": {
+//             "type": "string",
+//             "description": "A memory reference to a location appropriate for
+//             this result.\nFor pointer type eval results, this is generally a
+//             reference to the memory address contained in the pointer.\nThis
+//             attribute may be returned by a debug adapter if corresponding
+//             capability `supportsMemoryReferences` is true."
+//           },
+//           "valueLocationReference": {
+//             "type": "integer",
+//             "description": "A reference that allows the client to request the
+//             location where the returned value is declared. For example, if a
+//             function pointer is returned, the adapter may be able to look up
+//             the function's location. This should be present only if the
+//             adapter is likely to be able to resolve the location.\n\nThis
+//             reference shares the same lifetime as the `variablesReference`.
+//             See 'Lifetime of Object References' in the Overview section for
+//             details."
+//           }
+//         },
+//         "required": [ "result", "variablesReference" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// },
+struct EvaluateResponseBody {
+  std::string result = "";
+  std::optional<std::string> type;
+  std::optional<VariablePresentationHint> presentationHint;
+  int64_t variablesReference = 0;
+  std::optional<int> namedVariables;
+  std::optional<int> indexedVariables;
+  std::optional<std::string> memoryReference;
+  std::optional<int> valueLocationReference;
+};
+llvm::json::Value toJSON(const EvaluateResponseBody &);
+
+// "SourceRequest": {
+//   "allOf": [ { "$ref": "#/definitions/Request" }, {
+//     "type": "object",
+//     "description": "The request retrieves the source code for a given source
+//     reference.", "properties": {
+//       "command": {
+//         "type": "string",
+//         "enum": [ "source" ]
+//       },
+//       "arguments": {
+//         "$ref": "#/definitions/SourceArguments"
+//       }
+//     },
+//     "required": [ "command", "arguments"  ]
+//   }]
+// },
+// "SourceArguments": {
+//   "type": "object",
+//   "description": "Arguments for 'source' request.",
+//   "properties": {
+//     "source": {
+//       "$ref": "#/definitions/Source",
+//       "description": "Specifies the source content to load. Either
+//       source.path or source.sourceReference must be specified."
+//     },
+//     "sourceReference": {
+//       "type": "integer",
+//       "description": "The reference to the source. This is the same as
+//       source.sourceReference. This is provided for backward compatibility
+//       since old backends do not understand the 'source' attribute."
+//     }
+//   },
+//   "required": [ "sourceReference" ]
+// }
+struct SourceArguments {
+  std::optional<Source> source;
+  int64_t sourceReference;
+};
+bool fromJSON(const llvm::json::Value &, SourceArguments &, llvm::json::Path);
+
+// "SourceResponse": {
+//   "allOf": [ { "$ref": "#/definitions/Response" }, {
+//     "type": "object",
+//     "description": "Response to 'source' request.",
+//     "properties": {
+//       "body": {
+//         "type": "object",
+//         "properties": {
+//           "content": {
+//             "type": "string",
+//             "description": "Content of the source reference."
+//           },
+//           "mimeType": {
+//             "type": "string",
+//             "description": "Optional content type (mime type) of the source."
+//           }
+//         },
+//         "required": [ "content" ]
+//       }
+//     },
+//     "required": [ "body" ]
+//   }]
+// }
+struct SourceResponseBody {
+  std::string content = "";
+  std::optional<std::string> mimeType;
+};
+llvm::json::Value toJSON(const SourceResponseBody &);
+
+// MARK: Reverse Requests
+
+} // namespace protocol
+} // namespace lldb_dap
+
+#endif // LLDB_TOOLS_LLDB_DAP_PROTOCOL_H


### PR DESCRIPTION
This is a refactor of lldb-dap focused on supporting cancel requests and well defined Debug Adapter Protocol (DAP) structures.

Existing request handlers today tend to use unstructured `llvm::json::Object`'s to represent requests and replies. The lack of structure makes it hard for us to apply some unfirom handling around requests to better support cancellation. To address this, this change includes a new `Protocol.h` file with a set of well defined POD structures to represent the types in the DAP and includes `toJSON`/`fromJSON` serialization support.

Building on these types, this includes a new approach to registering request handlers with these new well defined types.

```
template <typename Args, typename Body>
void DAP::RegisterRequest(llvm::StringLiteral command,
                          RequestHandler<Args, Body> handler);
...
llvm::Expected<SourceResponseBody> request_source(DAP &dap, const SourceArguments &args) {
  SourceResponseBody body;
  ...
  if (/*some error*/)
    return llvm::make_error<DAPError>("msg");
  return std::move(body);
}
...
  dap.RegisterRequest("source", request_source);
...
```

The main features of this refactor are:

* Created a queue of pending protocol messages to allow for preemptive cancellations and active cancellations.
* A cleaner separation between the Debug Adapter Protocol types and lldb types that include serialization support toJSON/fromJSON.
* Improved error handling using toJSON/fromJSON.
* Unified handling of responses and errors.
* Unified handling of cancel requests.

This change include minimal support to implement the Debug Adapter Protocol 'source' request, 'evaluate' request and the 'exited' event.