### PR TITLE
[X86] Allow using the lzcnt intrinsics for non-LZCNT targets

### DIFF
--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -832,11 +832,6 @@ let Features = "rdseed", Attributes = [NoThrow] in {
   def rdseed32_step : X86Builtin<"unsigned int(unsigned int *)">;
 }
 
-let Features = "lzcnt", Attributes = [NoThrow, Const, Constexpr] in {
-  def lzcnt_u16 : X86Builtin<"unsigned short(unsigned short)">;
-  def lzcnt_u32 : X86Builtin<"unsigned int(unsigned int)">;
-}
-
 let Features = "bmi", Attributes = [NoThrow, Const, Constexpr] in {
   def bextr_u32 : X86Builtin<"unsigned int(unsigned int, unsigned int)">;
 }
@@ -844,6 +839,8 @@ let Features = "bmi", Attributes = [NoThrow, Const, Constexpr] in {
 let Attributes = [NoThrow, Const, Constexpr] in {
   def tzcnt_u16 : X86Builtin<"unsigned short(unsigned short)">;
   def tzcnt_u32 : X86Builtin<"unsigned int(unsigned int)">;
+  def lzcnt_u16 : X86Builtin<"unsigned short(unsigned short)">;
+  def lzcnt_u32 : X86Builtin<"unsigned int(unsigned int)">;
 }
 
 let Features = "bmi2", Attributes = [NoThrow, Const, Constexpr] in {

--- a/clang/include/clang/Basic/BuiltinsX86_64.td
+++ b/clang/include/clang/Basic/BuiltinsX86_64.td
@@ -126,16 +126,13 @@ let Features = "rdseed", Attributes = [NoThrow] in {
   def rdseed64_step : X86Builtin<"unsigned int(unsigned long long int *)">;
 }
 
-let Features = "lzcnt", Attributes = [NoThrow, Const, Constexpr] in {
-  def lzcnt_u64 : X86Builtin<"unsigned long long int(unsigned long long int)">;
-}
-
 let Features = "bmi", Attributes = [NoThrow, Const, Constexpr] in {
   def bextr_u64 : X86Builtin<"unsigned long long int(unsigned long long int, unsigned long long int)">;
 }
 
 let Attributes = [NoThrow, Const, Constexpr] in {
   def tzcnt_u64 : X86Builtin<"unsigned long long int(unsigned long long int)">;
+  def lzcnt_u64 : X86Builtin<"unsigned long long int(unsigned long long int)">;
 }
 
 let Features = "bmi2", Attributes = [NoThrow, Const, Constexpr] in {

--- a/clang/lib/Headers/lzcntintrin.h
+++ b/clang/lib/Headers/lzcntintrin.h
@@ -17,10 +17,9 @@
 /* Define the default attributes for the functions in this file. */
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define __DEFAULT_FN_ATTRS                                                     \
-  __attribute__((__always_inline__, __nodebug__, __target__("lzcnt"))) constexpr
+  __attribute__((__always_inline__, __nodebug__)) constexpr
 #else
-#define __DEFAULT_FN_ATTRS                                                     \
-  __attribute__((__always_inline__, __nodebug__, __target__("lzcnt")))
+#define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, __nodebug__))
 #endif
 
 #ifndef _MSC_VER

--- a/clang/lib/Headers/lzcntintrin.h
+++ b/clang/lib/Headers/lzcntintrin.h
@@ -14,7 +14,10 @@
 #ifndef __LZCNTINTRIN_H
 #define __LZCNTINTRIN_H
 
-/* Define the default attributes for the functions in this file. */
+/* Define the default attributes for the functions in this file.
+   Allow using the lzcnt intrinsics even for non-LZCNT targets. Since the LZCNT
+   intrinsics are mapped to llvm.ctlz.*, false, which can be lowered to BSR on
+   non-LZCNT targets with zero-value input handled correctly. */
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define __DEFAULT_FN_ATTRS                                                     \
   __attribute__((__always_inline__, __nodebug__)) constexpr

--- a/clang/test/CodeGen/X86/lzcnt-builtins.c
+++ b/clang/test/CodeGen/X86/lzcnt-builtins.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -target-feature +lzcnt -emit-llvm -o - | FileCheck %s
-// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -target-feature +lzcnt -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -emit-llvm -o - | FileCheck %s
 
 
 #include <immintrin.h>


### PR DESCRIPTION
Similar to D14748, we can relax lzcnt intrinsics too, especially with improved BSR lowering by #123623