### PR TITLE
[clang][bytecode] Silently reject ctors of invalid decls

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -732,6 +732,11 @@ bool CheckCallable(InterpState &S, CodePtr OpPC, const Function *F) {
         DiagDecl = CD = Inherited;
     }
 
+    // Silently reject constructors of invalid classes. The invalid class
+    // has been rejected elsewhere before.
+    if (CD && CD->getParent()->isInvalidDecl())
+      return false;
+
     // FIXME: If DiagDecl is an implicitly-declared special member function
     // or an inheriting constructor, we should be much more explicit about why
     // it's not constexpr.

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1734,3 +1734,8 @@ namespace DeadUpcast {
   static_assert(foo(), "");
 }
 #endif
+
+namespace CtorOfInvalidClass {
+  constexpr struct { Unknown U; } InvalidCtor; // both-error {{unknown type name 'Unknown'}} \
+                                               // both-error {{must be initialized by a constant expression}}
+}


### PR DESCRIPTION
The follow-up diagnostic would otherwise be:

array.cpp:111:33: note: undefined constructor '(unnamed struct at array.cpp:111:11)' cannot be used in a constant expression array.cpp:111:11: note: declared here
  111 | constexpr struct { Unknown U; } InvalidCtor;
      |           ^

... and complaining about the undefined constructor of a class that is invalid anyway doesn't make much sense.