### PR TITLE
[mlir][vector] Skip uniform vectorization for non scalar type

### DIFF
--- a/mlir/lib/Dialect/Affine/Transforms/SuperVectorize.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/SuperVectorize.cpp
@@ -1106,6 +1106,10 @@ static bool isUniformDefinition(Value value,
     if (!loop.isDefinedOutsideOfLoop(value))
       return false;
   }
+
+  if (!value.getType().isIntOrIndexOrFloat())
+    return false;
+
   return true;
 }
 

--- a/mlir/test/Dialect/Affine/SuperVectorize/vectorize_1d.mlir
+++ b/mlir/test/Dialect/Affine/SuperVectorize/vectorize_1d.mlir
@@ -684,3 +684,19 @@ func.func @vec_vecdim_reduction_rejected(%in: memref<256x512xf32>, %out: memref<
 
 // CHECK-LABEL: @vec_vecdim_reduction_rejected
 // CHECK-NOT: vector
+
+
+// -----
+
+// Non scalar type is not regarded as the uniform in the vectorization
+func.func @vec_non_scalar_type() {
+  %idx0 = index.constant 0
+  %alloc_82 = memref.alloc() : memref<1xi64>
+  affine.for %arg0 = 0 to 78 {
+    %dim_191 = memref.dim %alloc_82, %idx0 : memref<1xi64>
+  }
+  return
+}
+
+// CHECK-LABEL: @vec_non_scalar_type
+// CHECK-NOT: vector


### PR DESCRIPTION
The code to vectorize the uniform type effectively assume the scalar type such as integer, float and index type. We should not regard other types as vectorizable uniform type because the following vectorization cannot treat the type properlty for now.

Fixes https://github.com/llvm/llvm-project/issues/128277