### PR TITLE
[clang][bytecode] Always reject ctors of invalid parent decls

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1238,8 +1238,10 @@ static bool checkConstructor(InterpState &S, CodePtr OpPC, const Function *Func,
                              const Pointer &ThisPtr) {
   assert(Func->isConstructor());
 
-  const Descriptor *D = ThisPtr.getFieldDesc();
+  if (Func->getParentDecl()->isInvalidDecl())
+    return false;
 
+  const Descriptor *D = ThisPtr.getFieldDesc();
   // FIXME: I think this case is not 100% correct. E.g. a pointer into a
   // subobject of a composite array.
   if (!D->ElemRecord)

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1738,4 +1738,12 @@ namespace DeadUpcast {
 namespace CtorOfInvalidClass {
   constexpr struct { Unknown U; } InvalidCtor; // both-error {{unknown type name 'Unknown'}} \
                                                // both-error {{must be initialized by a constant expression}}
+
+#if __cplusplus >= 202002L
+  template <typename T, auto Q>
+  concept ReferenceOf = Q;
+  /// This calls a valid and constexpr copy constructor of InvalidCtor, 
+  /// but should still be rejected.
+  template<ReferenceOf<InvalidCtor> auto R, typename Rep> int F; // both-error {{non-type template argument is not a constant expression}}
+#endif
 }


### PR DESCRIPTION
The copy constructor of an invalid declaration might still be perfectly valid, but we still need to reject it.