### PR TITLE
[mlir] Remove duplicate comment(NFC)

### DIFF
--- a/mlir/lib/IR/Types.cpp
+++ b/mlir/lib/IR/Types.cpp
@@ -46,7 +46,6 @@ bool Type::isIndex() const { return llvm::isa<IndexType>(*this); }
 
 bool Type::isInteger() const { return llvm::isa<IntegerType>(*this); }
 
-/// Return true if this is an integer type with the specified width.
 bool Type::isInteger(unsigned width) const {
   if (auto intTy = llvm::dyn_cast<IntegerType>(*this))
     return intTy.getWidth() == width;


### PR DESCRIPTION
The comments in the source file duplicate the documentation already present in the header file `mlir/IR/Types.h`.
https://github.com/llvm/llvm-project/blob/876174ffd7533dc220f94721173bb767b659fa7f/mlir/include/mlir/IR/Types.h#L136-L141