### PR TITLE
[NFC][libc++] Guard against operator& hijacking.

### DIFF
--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -363,7 +363,7 @@ private:
           // https://github.com/llvm/llvm-project/issues/47978
           // clang bug: __old is not updated on failure for atomic<long double>::compare_exchange_weak
           // Note __old = __self.load(memory_order_relaxed) will not work
-          std::__cxx_atomic_load_inplace(std::addressof(__self.__a_), &__old, memory_order_relaxed);
+          std::__cxx_atomic_load_inplace(std::addressof(__self.__a_), std::addressof(__old), memory_order_relaxed);
         }
 #  endif
         __new = __operation(__old, __operand);

--- a/libcxx/include/__atomic/atomic_ref.h
+++ b/libcxx/include/__atomic/atomic_ref.h
@@ -119,7 +119,7 @@ public:
   // that the pointer is going to be aligned properly at runtime because that is a (checked) precondition
   // of atomic_ref's constructor.
   static constexpr bool is_always_lock_free =
-      __atomic_always_lock_free(sizeof(_Tp), &__get_aligner_instance<required_alignment>::__instance);
+      __atomic_always_lock_free(sizeof(_Tp), std::addressof(__get_aligner_instance<required_alignment>::__instance));
 
   _LIBCPP_HIDE_FROM_ABI bool is_lock_free() const noexcept { return __atomic_is_lock_free(sizeof(_Tp), __ptr_); }
 

--- a/libcxx/include/__charconv/traits.h
+++ b/libcxx/include/__charconv/traits.h
@@ -15,6 +15,7 @@
 #include <__charconv/tables.h>
 #include <__charconv/to_chars_base_10.h>
 #include <__config>
+#include <__memory/addressof.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_unsigned.h>
 #include <cstdint>
@@ -142,7 +143,7 @@ __mul_overflowed(unsigned short __a, _Tp __b, unsigned short& __r) {
 template <typename _Tp>
 inline _LIBCPP_CONSTEXPR_SINCE_CXX23 _LIBCPP_HIDE_FROM_ABI bool __mul_overflowed(_Tp __a, _Tp __b, _Tp& __r) {
   static_assert(is_unsigned<_Tp>::value, "");
-  return __builtin_mul_overflow(__a, __b, &__r);
+  return __builtin_mul_overflow(__a, __b, std::addressof(__r));
 }
 
 template <typename _Tp, typename _Up>

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -17,6 +17,7 @@
 #include <__fwd/functional.h>
 #include <__iterator/back_insert_iterator.h>
 #include <__iterator/iterator_traits.h>
+#include <__memory/addressof.h>
 #include <__type_traits/decay.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_pointer.h>
@@ -584,7 +585,7 @@ public:
 
   template <class _ECharT, __enable_if_t<__can_convert_char<_ECharT>::value, int> = 0>
   _LIBCPP_HIDE_FROM_ABI path& operator+=(_ECharT __x) {
-    _PathCVT<_ECharT>::__append_source(__pn_, basic_string_view<_ECharT>(&__x, 1));
+    _PathCVT<_ECharT>::__append_source(__pn_, basic_string_view<_ECharT>(std::addressof(__x), 1));
     return *this;
   }
 

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -13,6 +13,7 @@
 #include <__cstddef/nullptr_t.h>
 #include <__functional/unary_function.h>
 #include <__fwd/functional.h>
+#include <__memory/addressof.h>
 #include <__type_traits/conjunction.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/invoke.h>
@@ -33,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Size>
 inline _LIBCPP_HIDE_FROM_ABI _Size __loadword(const void* __p) {
   _Size __r;
-  std::memcpy(&__r, __p, sizeof(__r));
+  std::memcpy(std::addressof(__r), __p, sizeof(__r));
   return __r;
 }
 
@@ -276,7 +277,7 @@ struct __scalar_hash<_Tp, 2> : public __unary_function<_Tp, size_t> {
       } __s;
     } __u;
     __u.__t = __v;
-    return __murmur2_or_cityhash<size_t>()(&__u, sizeof(__u));
+    return __murmur2_or_cityhash<size_t>()(std::addressof(__u), sizeof(__u));
   }
 };
 
@@ -292,7 +293,7 @@ struct __scalar_hash<_Tp, 3> : public __unary_function<_Tp, size_t> {
       } __s;
     } __u;
     __u.__t = __v;
-    return __murmur2_or_cityhash<size_t>()(&__u, sizeof(__u));
+    return __murmur2_or_cityhash<size_t>()(std::addressof(__u), sizeof(__u));
   }
 };
 
@@ -309,7 +310,7 @@ struct __scalar_hash<_Tp, 4> : public __unary_function<_Tp, size_t> {
       } __s;
     } __u;
     __u.__t = __v;
-    return __murmur2_or_cityhash<size_t>()(&__u, sizeof(__u));
+    return __murmur2_or_cityhash<size_t>()(std::addressof(__u), sizeof(__u));
   }
 };
 
@@ -332,7 +333,7 @@ struct _LIBCPP_TEMPLATE_VIS hash<_Tp*> : public __unary_function<_Tp*, size_t> {
       size_t __a;
     } __u;
     __u.__t = __v;
-    return __murmur2_or_cityhash<size_t>()(&__u, sizeof(__u));
+    return __murmur2_or_cityhash<size_t>()(std::addressof(__u), sizeof(__u));
   }
 };
 

--- a/libcxx/include/__iterator/aliasing_iterator.h
+++ b/libcxx/include/__iterator/aliasing_iterator.h
@@ -12,6 +12,7 @@
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
 #include <__iterator/iterator_traits.h>
+#include <__memory/addressof.h>
 #include <__memory/pointer_traits.h>
 #include <__type_traits/is_trivial.h>
 
@@ -102,7 +103,7 @@ struct __aliasing_iterator_wrapper {
 
     _LIBCPP_HIDE_FROM_ABI _Alias operator*() const _NOEXCEPT {
       _Alias __val;
-      __builtin_memcpy(&__val, std::__to_address(__base_), sizeof(value_type));
+      __builtin_memcpy(std::addressof(__val), std::__to_address(__base_), sizeof(value_type));
       return __val;
     }
 

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -12,6 +12,7 @@
 
 #include <__config>
 #include <__locale_dir/locale_base_api.h>
+#include <__memory/addressof.h>
 #include <__memory/shared_count.h>
 #include <__mutex/once_flag.h>
 #include <__type_traits/make_unsigned.h>
@@ -156,7 +157,7 @@ locale locale::combine(const locale& __other) const {
   if (!std::has_facet<_Facet>(__other))
     std::__throw_runtime_error("locale::combine: locale missing facet");
 
-  return locale(*this, &const_cast<_Facet&>(std::use_facet<_Facet>(__other)));
+  return locale(*this, std::addressof(const_cast<_Facet&>(std::use_facet<_Facet>(__other))));
 }
 
 template <class _Facet>

--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -21,6 +21,7 @@
 #include <__config>
 #include <__fwd/mdspan.h>
 #include <__mdspan/extents.h>
+#include <__memory/addressof.h>
 #include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
@@ -58,7 +59,7 @@ private:
 
     index_type __prod = __ext.extent(0);
     for (rank_type __r = 1; __r < extents_type::rank(); __r++) {
-      bool __overflowed = __builtin_mul_overflow(__prod, __ext.extent(__r), &__prod);
+      bool __overflowed = __builtin_mul_overflow(__prod, __ext.extent(__r), std::addressof(__prod));
       if (__overflowed)
         return false;
     }

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -22,6 +22,7 @@
 #include <__cstddef/size_t.h>
 #include <__fwd/mdspan.h>
 #include <__mdspan/extents.h>
+#include <__memory/addressof.h>
 #include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
@@ -58,7 +59,7 @@ private:
 
     index_type __prod = __ext.extent(0);
     for (rank_type __r = 1; __r < extents_type::rank(); __r++) {
-      bool __overflowed = __builtin_mul_overflow(__prod, __ext.extent(__r), &__prod);
+      bool __overflowed = __builtin_mul_overflow(__prod, __ext.extent(__r), std::addressof(__prod));
       if (__overflowed)
         return false;
     }

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -22,6 +22,7 @@
 #include <__config>
 #include <__fwd/mdspan.h>
 #include <__mdspan/extents.h>
+#include <__memory/addressof.h>
 #include <__type_traits/common_type.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_convertible.h>
@@ -86,7 +87,7 @@ private:
 
     index_type __prod = __ext.extent(0);
     for (rank_type __r = 1; __r < __rank_; __r++) {
-      bool __overflowed = __builtin_mul_overflow(__prod, __ext.extent(__r), &__prod);
+      bool __overflowed = __builtin_mul_overflow(__prod, __ext.extent(__r), std::addressof(__prod));
       if (__overflowed)
         return false;
     }
@@ -109,11 +110,12 @@ private:
       }
       if (__ext.extent(__r) == static_cast<index_type>(0))
         return true;
-      index_type __prod     = (__ext.extent(__r) - 1);
-      bool __overflowed_mul = __builtin_mul_overflow(__prod, static_cast<index_type>(__strides[__r]), &__prod);
+      index_type __prod = (__ext.extent(__r) - 1);
+      bool __overflowed_mul =
+          __builtin_mul_overflow(__prod, static_cast<index_type>(__strides[__r]), std::addressof(__prod));
       if (__overflowed_mul)
         return false;
-      bool __overflowed_add = __builtin_add_overflow(__size, __prod, &__size);
+      bool __overflowed_add = __builtin_add_overflow(__size, __prod, std::addressof(__size));
       if (__overflowed_add)
         return false;
     }

--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -22,6 +22,7 @@
 #include <__fwd/mdspan.h>
 #include <__mdspan/default_accessor.h>
 #include <__mdspan/extents.h>
+#include <__memory/addressof.h>
 #include <__type_traits/extent.h>
 #include <__type_traits/is_abstract.h>
 #include <__type_traits/is_array.h>
@@ -215,7 +216,7 @@ public:
     _LIBCPP_ASSERT_UNCATEGORIZED(
         false == ([&]<size_t... _Idxs>(index_sequence<_Idxs...>) {
           size_type __prod = 1;
-          return (__builtin_mul_overflow(__prod, extent(_Idxs), &__prod) || ... || false);
+          return (__builtin_mul_overflow(__prod, extent(_Idxs), std::addressof(__prod)) || ... || false);
         }(make_index_sequence<rank()>())),
         "mdspan: size() is not representable as size_type");
     return [&]<size_t... _Idxs>(index_sequence<_Idxs...>) {

--- a/libcxx/include/__memory/shared_count.h
+++ b/libcxx/include/__memory/shared_count.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___MEMORY_SHARED_COUNT_H
 
 #include <__config>
+#include <__memory/addressof.h>
 #include <typeinfo>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -52,7 +53,7 @@ inline _LIBCPP_HIDE_FROM_ABI _ValueType __libcpp_acquire_load(_ValueType const* 
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _Tp __libcpp_atomic_refcount_increment(_Tp& __t) _NOEXCEPT {
 #if _LIBCPP_HAS_BUILTIN_ATOMIC_SUPPORT && _LIBCPP_HAS_THREADS
-  return __atomic_add_fetch(&__t, 1, __ATOMIC_RELAXED);
+  return __atomic_add_fetch(std::addressof(__t), 1, __ATOMIC_RELAXED);
 #else
   return __t += 1;
 #endif
@@ -61,7 +62,7 @@ inline _LIBCPP_HIDE_FROM_ABI _Tp __libcpp_atomic_refcount_increment(_Tp& __t) _N
 template <class _Tp>
 inline _LIBCPP_HIDE_FROM_ABI _Tp __libcpp_atomic_refcount_decrement(_Tp& __t) _NOEXCEPT {
 #if _LIBCPP_HAS_BUILTIN_ATOMIC_SUPPORT && _LIBCPP_HAS_THREADS
-  return __atomic_add_fetch(&__t, -1, __ATOMIC_ACQ_REL);
+  return __atomic_add_fetch(std::addressof(__t), -1, __ATOMIC_ACQ_REL);
 #else
   return __t -= 1;
 #endif

--- a/libcxx/include/__ostream/basic_ostream.h
+++ b/libcxx/include/__ostream/basic_ostream.h
@@ -15,6 +15,7 @@
 
 #  include <__exception/operations.h>
 #  include <__fwd/memory.h>
+#  include <__memory/addressof.h>
 #  include <__memory/unique_ptr.h>
 #  include <__new/exceptions.h>
 #  include <__ostream/put_character_sequence.h>
@@ -339,7 +340,7 @@ basic_ostream<_CharT, _Traits>& basic_ostream<_CharT, _Traits>::operator<<(const
 
 template <class _CharT, class _Traits>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& __os, _CharT __c) {
-  return std::__put_character_sequence(__os, &__c, 1);
+  return std::__put_character_sequence(__os, std::addressof(__c), 1);
 }
 
 template <class _CharT, class _Traits>
@@ -353,9 +354,9 @@ _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_
       typedef ostreambuf_iterator<_CharT, _Traits> _Ip;
       if (std::__pad_and_output(
               _Ip(__os),
-              &__c,
-              (__os.flags() & ios_base::adjustfield) == ios_base::left ? &__c + 1 : &__c,
-              &__c + 1,
+              std::addressof(__c),
+              std::addressof(__c) + (((__os.flags() & ios_base::adjustfield) == ios_base::left) ? 1 : 0),
+              std::addressof(__c) + 1,
               __os,
               __os.fill())
               .failed())

--- a/libcxx/include/__split_buffer
+++ b/libcxx/include/__split_buffer
@@ -233,7 +233,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 bool __split_buffer<_Tp, _Allocator>::__invariants
 //  Postcondition:  size() == size() + __n
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::__construct_at_end(size_type __n) {
-  _ConstructTransaction __tx(&this->__end_, __n);
+  _ConstructTransaction __tx(std::addressof(this->__end_), __n);
   for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_) {
     __alloc_traits::construct(__alloc_, std::__to_address(__tx.__pos_));
   }
@@ -248,7 +248,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 void __split_buffer<_Tp, _Allocator>::__construct_
 template <class _Tp, class _Allocator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 __split_buffer<_Tp, _Allocator>::__construct_at_end(size_type __n, const_reference __x) {
-  _ConstructTransaction __tx(&this->__end_, __n);
+  _ConstructTransaction __tx(std::addressof(this->__end_), __n);
   for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_) {
     __alloc_traits::construct(__alloc_, std::__to_address(__tx.__pos_), __x);
   }
@@ -283,7 +283,7 @@ template <class _Tp, class _Allocator>
 template <class _ForwardIterator>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 __split_buffer<_Tp, _Allocator>::__construct_at_end_with_size(_ForwardIterator __first, size_type __n) {
-  _ConstructTransaction __tx(&this->__end_, __n);
+  _ConstructTransaction __tx(std::addressof(this->__end_), __n);
   for (; __tx.__pos_ != __tx.__end_; ++__tx.__pos_, (void)++__first) {
     __alloc_traits::construct(__alloc_, std::__to_address(__tx.__pos_), *__first);
   }

--- a/libcxx/include/__stop_token/intrusive_shared_ptr.h
+++ b/libcxx/include/__stop_token/intrusive_shared_ptr.h
@@ -14,6 +14,7 @@
 #include <__atomic/memory_order.h>
 #include <__config>
 #include <__cstddef/nullptr_t.h>
+#include <__memory/addressof.h>
 #include <__type_traits/is_reference.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
@@ -113,7 +114,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI static void __decrement_ref_count(_Tp& __obj) {
     if (__get_atomic_ref_count(__obj).fetch_sub(1, std::memory_order_acq_rel) == 1) {
-      delete &__obj;
+      delete std::addressof(__obj);
     }
   }
 

--- a/libcxx/include/__string/constexpr_c_functions.h
+++ b/libcxx/include/__string/constexpr_c_functions.h
@@ -146,7 +146,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_memchr(_Tp*
     return nullptr;
   } else {
     char __value_buffer = 0;
-    __builtin_memcpy(&__value_buffer, &__value, sizeof(char));
+    __builtin_memcpy(&__value_buffer, std::addressof(__value), sizeof(char));
     return static_cast<_Tp*>(__builtin_memchr(__str, __value_buffer, __count));
   }
 }

--- a/libcxx/include/__thread/thread.h
+++ b/libcxx/include/__thread/thread.h
@@ -16,6 +16,7 @@
 #include <__exception/terminate.h>
 #include <__functional/hash.h>
 #include <__functional/unary_function.h>
+#include <__memory/addressof.h>
 #include <__memory/unique_ptr.h>
 #include <__mutex/mutex.h>
 #include <__system_error/throw_system_error.h>
@@ -215,7 +216,7 @@ thread::thread(_Fp&& __f, _Args&&... __args) {
   _TSPtr __tsp(new __thread_struct);
   typedef tuple<_TSPtr, __decay_t<_Fp>, __decay_t<_Args>...> _Gp;
   unique_ptr<_Gp> __p(new _Gp(std::move(__tsp), std::forward<_Fp>(__f), std::forward<_Args>(__args)...));
-  int __ec = std::__libcpp_thread_create(&__t_, &__thread_proxy<_Gp>, __p.get());
+  int __ec = std::__libcpp_thread_create(&__t_, std::addressof(__thread_proxy<_Gp>), __p.get());
   if (__ec == 0)
     __p.release();
   else

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -107,6 +107,7 @@ size_t wcsrtombs(char* restrict dst, const wchar_t** restrict src, size_t len,
 #else
 #  include <__config>
 #  include <__cstddef/size_t.h>
+#  include <__memory/addressof.h>
 #  include <__type_traits/copy_cv.h>
 #  include <__type_traits/is_constant_evaluated.h>
 #  include <__type_traits/is_equality_comparable.h>
@@ -237,7 +238,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp
 #  if __has_builtin(__builtin_wmemchr)
   if (!__libcpp_is_constant_evaluated()) {
     wchar_t __value_buffer = 0;
-    __builtin_memcpy(&__value_buffer, &__value, sizeof(wchar_t));
+    __builtin_memcpy(&__value_buffer, std::addressof(__value), sizeof(wchar_t));
     return reinterpret_cast<_Tp*>(
         __builtin_wmemchr(reinterpret_cast<__copy_cv_t<_Tp, wchar_t>*>(__str), __value_buffer, __count));
   }

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -420,7 +420,7 @@ basic_filebuf<_CharT, _Traits>::basic_filebuf()
       __owns_ib_(false),
       __always_noconv_(false) {
   if (std::has_facet<codecvt<char_type, char, state_type> >(this->getloc())) {
-    __cv_            = &std::use_facet<codecvt<char_type, char, state_type> >(this->getloc());
+    __cv_            = std::addressof(std::use_facet<codecvt<char_type, char, state_type> >(this->getloc()));
     __always_noconv_ = __cv_->always_noconv();
   }
   setbuf(nullptr, 4096);
@@ -753,7 +753,7 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
   bool __initial = __read_mode();
   char_type __1buf;
   if (this->gptr() == nullptr)
-    this->setg(&__1buf, &__1buf + 1, &__1buf + 1);
+    this->setg(std::addressof(__1buf), std::addressof(__1buf) + 1, std::addressof(__1buf) + 1);
   const size_t __unget_sz = __initial ? 0 : std::min<size_t>((this->egptr() - this->eback()) / 2, 4);
   int_type __c            = traits_type::eof();
   if (this->gptr() == this->egptr()) {
@@ -797,7 +797,7 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
     }
   } else
     __c = traits_type::to_int_type(*this->gptr());
-  if (this->eback() == &__1buf)
+  if (this->eback() == std::addressof(__1buf))
     this->setg(nullptr, nullptr, nullptr);
   return __c;
 }
@@ -828,7 +828,7 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
   char_type* __epb_save = this->epptr();
   if (!traits_type::eq_int_type(__c, traits_type::eof())) {
     if (this->pptr() == nullptr)
-      this->setp(&__1buf, &__1buf + 1);
+      this->setp(std::addressof(__1buf), std::addressof(__1buf) + 1);
     *this->pptr() = traits_type::to_char_type(__c);
     this->pbump(1);
   }
@@ -1029,7 +1029,7 @@ int basic_filebuf<_CharT, _Traits>::sync() {
 template <class _CharT, class _Traits>
 void basic_filebuf<_CharT, _Traits>::imbue(const locale& __loc) {
   sync();
-  __cv_            = &std::use_facet<codecvt<char_type, char, state_type> >(__loc);
+  __cv_            = std::addressof(std::use_facet<codecvt<char_type, char, state_type> >(__loc));
   bool __old_anc   = __always_noconv_;
   __always_noconv_ = __cv_->always_noconv();
   if (__old_anc != __always_noconv_) {

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -612,7 +612,7 @@ public:
 template <class _Rp>
 void __assoc_state<_Rp>::__on_zero_shared() _NOEXCEPT {
   if (this->__state_ & base::__constructed)
-    reinterpret_cast<_Rp*>(&__value_)->~_Rp();
+    reinterpret_cast<_Rp*>(std::addressof(__value_))->~_Rp();
   delete this;
 }
 
@@ -622,7 +622,7 @@ void __assoc_state<_Rp>::set_value(_Arg&& __arg) {
   unique_lock<mutex> __lk(this->__mut_);
   if (this->__has_value())
     std::__throw_future_error(future_errc::promise_already_satisfied);
-  ::new ((void*)&__value_) _Rp(std::forward<_Arg>(__arg));
+  ::new ((void*)std::addressof(__value_)) _Rp(std::forward<_Arg>(__arg));
   this->__state_ |= base::__constructed | base::ready;
   __cv_.notify_all();
 }
@@ -633,7 +633,7 @@ void __assoc_state<_Rp>::set_value_at_thread_exit(_Arg&& __arg) {
   unique_lock<mutex> __lk(this->__mut_);
   if (this->__has_value())
     std::__throw_future_error(future_errc::promise_already_satisfied);
-  ::new ((void*)&__value_) _Rp(std::forward<_Arg>(__arg));
+  ::new ((void*)std::addressof(__value_)) _Rp(std::forward<_Arg>(__arg));
   this->__state_ |= base::__constructed;
   __thread_local_data()->__make_ready_at_thread_exit(this);
 }
@@ -644,7 +644,7 @@ _Rp __assoc_state<_Rp>::move() {
   this->__sub_wait(__lk);
   if (this->__exception_ != nullptr)
     std::rethrow_exception(this->__exception_);
-  return std::move(*reinterpret_cast<_Rp*>(&__value_));
+  return std::move(*reinterpret_cast<_Rp*>(std::addressof(__value_)));
 }
 
 template <class _Rp>
@@ -653,7 +653,7 @@ _Rp& __assoc_state<_Rp>::copy() {
   this->__sub_wait(__lk);
   if (this->__exception_ != nullptr)
     std::rethrow_exception(this->__exception_);
-  return *reinterpret_cast<_Rp*>(&__value_);
+  return *reinterpret_cast<_Rp*>(std::addressof(__value_));
 }
 
 template <class _Rp>

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -207,6 +207,7 @@ template <class charT> class messages_byname;
 #    include <__iterator/ostreambuf_iterator.h>
 #    include <__locale>
 #    include <__locale_dir/pad_and_output.h>
+#    include <__memory/addressof.h>
 #    include <__memory/unique_ptr.h>
 #    include <__new/exceptions.h>
 #    include <__type_traits/make_unsigned.h>
@@ -2451,14 +2452,14 @@ bool money_get<_CharT, _InputIterator>::__do_get(
         ++__b;
         __neg = false;
         if (__psn.size() > 1)
-          __trailing_sign = &__psn;
+          __trailing_sign = std::addressof(__psn);
         break;
       }
       if (__nsn.size() > 0 && *__b == __nsn[0]) {
         ++__b;
         __neg = true;
         if (__nsn.size() > 1)
-          __trailing_sign = &__nsn;
+          __trailing_sign = std::addressof(__nsn);
         break;
       }
       if (__psn.size() > 0 && __nsn.size() > 0) { // sign is required

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -800,6 +800,7 @@ typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
 #  include <__iterator/default_sentinel.h>
 #  include <__iterator/wrap_iter.h>
 #  include <__locale>
+#  include <__memory/addressof.h>
 #  include <__memory/shared_ptr.h>
 #  include <__memory_resource/polymorphic_allocator.h>
 #  include <__type_traits/is_swappable.h>
@@ -1106,8 +1107,8 @@ regex_traits<_CharT>::transform(_ForwardIterator __f, _ForwardIterator __l) cons
 
 template <class _CharT>
 void regex_traits<_CharT>::__init() {
-  __ct_  = &std::use_facet<ctype<char_type> >(__loc_);
-  __col_ = &std::use_facet<collate<char_type> >(__loc_);
+  __ct_  = std::addressof(std::use_facet<ctype<char_type> >(__loc_));
+  __col_ = std::addressof(std::use_facet<collate<char_type> >(__loc_));
 }
 
 template <class _CharT>
@@ -1222,7 +1223,7 @@ template <class _ForwardIterator>
 typename regex_traits<_CharT>::char_class_type
 regex_traits<_CharT>::__lookup_classname(_ForwardIterator __f, _ForwardIterator __l, bool __icase, char) const {
   string_type __s(__f, __l);
-  __ct_->tolower(&__s[0], &__s[0] + __s.size());
+  __ct_->tolower(std::addressof(__s[0]), std::addressof(__s[0]) + __s.size());
   return std::__get_classname(__s.c_str(), __icase);
 }
 
@@ -1232,7 +1233,7 @@ template <class _ForwardIterator>
 typename regex_traits<_CharT>::char_class_type
 regex_traits<_CharT>::__lookup_classname(_ForwardIterator __f, _ForwardIterator __l, bool __icase, wchar_t) const {
   string_type __s(__f, __l);
-  __ct_->tolower(&__s[0], &__s[0] + __s.size());
+  __ct_->tolower(std::addressof(__s[0]), std::addressof(__s[0]) + __s.size());
   string __n;
   __n.reserve(__s.size());
   for (typename string_type::const_iterator __i = __s.begin(), __e = __s.end(); __i != __e; ++__i) {
@@ -2157,7 +2158,7 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
           __ch2.first  = __traits_.translate(__ch2.first);
           __ch2.second = __traits_.translate(__ch2.second);
         }
-        if (!__traits_.lookup_collatename(&__ch2.first, &__ch2.first + 2).empty()) {
+        if (!__traits_.lookup_collatename(std::addressof(__ch2.first), std::addressof(__ch2.first) + 2).empty()) {
           // __ch2 is a digraph in this locale
           ++__consumed;
           for (size_t __i = 0; __i < __digraphs_.size(); ++__i) {
@@ -2167,7 +2168,7 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
             }
           }
           if (__collate_ && !__ranges_.empty()) {
-            string_type __s2 = __traits_.transform(&__ch2.first, &__ch2.first + 2);
+            string_type __s2 = __traits_.transform(std::addressof(__ch2.first), std::addressof(__ch2.first) + 2);
             for (size_t __i = 0; __i < __ranges_.size(); ++__i) {
               if (__ranges_[__i].first <= __s2 && __s2 <= __ranges_[__i].second) {
                 __found = true;
@@ -2176,7 +2177,7 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
             }
           }
           if (!__equivalences_.empty()) {
-            string_type __s2 = __traits_.transform_primary(&__ch2.first, &__ch2.first + 2);
+            string_type __s2 = __traits_.transform_primary(std::addressof(__ch2.first), std::addressof(__ch2.first) + 2);
             for (size_t __i = 0; __i < __equivalences_.size(); ++__i) {
               if (__s2 == __equivalences_[__i]) {
                 __found = true;
@@ -2224,7 +2225,7 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
       }
     }
     if (!__ranges_.empty()) {
-      string_type __s2 = __collate_ ? __traits_.transform(&__ch, &__ch + 1) : string_type(1, __ch);
+      string_type __s2 = __collate_ ? __traits_.transform(std::addressof(__ch), std::addressof(__ch) + 1) : string_type(1, __ch);
       for (size_t __i = 0; __i < __ranges_.size(); ++__i) {
         if (__ranges_[__i].first <= __s2 && __s2 <= __ranges_[__i].second) {
           __found = true;
@@ -2233,7 +2234,7 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
       }
     }
     if (!__equivalences_.empty()) {
-      string_type __s2 = __traits_.transform_primary(&__ch, &__ch + 1);
+      string_type __s2 = __traits_.transform_primary(std::addressof(__ch), std::addressof(__ch) + 1);
       for (size_t __i = 0; __i < __equivalences_.size(); ++__i) {
         if (__s2 == __equivalences_[__i]) {
           __found = true;
@@ -3347,7 +3348,7 @@ _ForwardIterator basic_regex<_CharT, _Traits>::__parse_expression_term(
         if (__grammar == ECMAScript)
           __first = __parse_class_escape(++__first, __last, __start_range, __ml);
         else
-          __first = __parse_awk_escape(++__first, __last, &__start_range);
+          __first = __parse_awk_escape(++__first, __last, std::addressof(__start_range));
       } else {
         __start_range = *__first;
         ++__first;
@@ -3367,7 +3368,7 @@ _ForwardIterator basic_regex<_CharT, _Traits>::__parse_expression_term(
             if (__grammar == ECMAScript)
               __first = __parse_class_escape(++__first, __last, __end_range, __ml);
             else
-              __first = __parse_awk_escape(++__first, __last, &__end_range);
+              __first = __parse_awk_escape(++__first, __last, std::addressof(__end_range));
           } else {
             __end_range = *__first;
             ++__first;
@@ -3427,7 +3428,7 @@ _ForwardIterator basic_regex<_CharT, _Traits>::__parse_class_escape(
     __ml->__add_neg_char('_');
     return ++__first;
   }
-  __first = __parse_character_escape(__first, __last, &__str);
+  __first = __parse_character_escape(__first, __last, std::addressof(__str));
   return __first;
 }
 
@@ -5568,9 +5569,9 @@ private:
   void __init(_BidirectionalIterator __a, _BidirectionalIterator __b);
   void __establish_result() {
     if (__subs_[__n_] == -1)
-      __result_ = &__position_->prefix();
+      __result_ = std::addressof(__position_->prefix());
     else
-      __result_ = &(*__position_)[__subs_[__n_]];
+      __result_ = std::addressof((*__position_)[__subs_[__n_]]);
   }
 };
 
@@ -5587,7 +5588,7 @@ void regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::__init(
     __suffix_.matched = true;
     __suffix_.first   = __a;
     __suffix_.second  = __b;
-    __result_         = &__suffix_;
+    __result_         = std::addressof(__suffix_);
   } else
     __result_ = nullptr;
 }
@@ -5648,8 +5649,8 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_itera
       __suffix_(__x.__suffix_),
       __n_(__x.__n_),
       __subs_(__x.__subs_) {
-  if (__x.__result_ == &__x.__suffix_)
-    __result_ = &__suffix_;
+  if (__x.__result_ == std::addressof(__x.__suffix_))
+    __result_ = std::addressof(__suffix_);
   else if (__result_ != nullptr)
     __establish_result();
 }
@@ -5657,17 +5658,17 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_itera
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>&
 regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::operator=(const regex_token_iterator& __x) {
-  if (this != &__x) {
+  if (this != std::addressof(__x)) {
     __position_ = __x.__position_;
-    if (__x.__result_ == &__x.__suffix_)
-      __result_ = &__suffix_;
+    if (__x.__result_ == std::addressof(__x.__suffix_))
+      __result_ = std::addressof(__suffix_);
     else
       __result_ = __x.__result_;
     __suffix_ = __x.__suffix_;
     __n_      = __x.__n_;
     __subs_   = __x.__subs_;
 
-    if (__result_ != nullptr && __result_ != &__suffix_)
+    if (__result_ != nullptr && __result_ != std::addressof(__suffix_))
       __establish_result();
   }
   return *this;
@@ -5677,11 +5678,11 @@ template <class _BidirectionalIterator, class _CharT, class _Traits>
 bool regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::operator==(const regex_token_iterator& __x) const {
   if (__result_ == nullptr && __x.__result_ == nullptr)
     return true;
-  if (__result_ == &__suffix_ && __x.__result_ == &__x.__suffix_ && __suffix_ == __x.__suffix_)
+  if (__result_ == std::addressof(__suffix_) && __x.__result_ == std::addressof(__x.__suffix_) && __suffix_ == __x.__suffix_)
     return true;
   if (__result_ == nullptr || __x.__result_ == nullptr)
     return false;
-  if (__result_ == &__suffix_ || __x.__result_ == &__x.__suffix_)
+  if (__result_ == std::addressof(__suffix_) || __x.__result_ == std::addressof(__x.__suffix_))
     return false;
   return __position_ == __x.__position_ && __n_ == __x.__n_ && __subs_ == __x.__subs_;
 }
@@ -5690,7 +5691,7 @@ template <class _BidirectionalIterator, class _CharT, class _Traits>
 regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>&
 regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++() {
   _Position __prev = __position_;
-  if (__result_ == &__suffix_)
+  if (__result_ == std::addressof(__suffix_))
     __result_ = nullptr;
   else if (static_cast<size_t>(__n_ + 1) < __subs_.size()) {
     ++__n_;
@@ -5705,7 +5706,7 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++() {
         __suffix_.matched = true;
         __suffix_.first   = __prev->suffix().first;
         __suffix_.second  = __prev->suffix().second;
-        __result_         = &__suffix_;
+        __result_         = std::addressof(__suffix_);
       } else
         __result_ = nullptr;
     }

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -3811,7 +3811,7 @@ template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>
 operator+(_CharT __lhs, const basic_string<_CharT, _Traits, _Allocator>& __rhs) {
   return std::__concatenate_strings<_CharT, _Traits>(
-      __rhs.get_allocator(), basic_string_view<_CharT, _Traits>(&__lhs, 1), __rhs);
+      __rhs.get_allocator(), basic_string_view<_CharT, _Traits>(std::addressof(__lhs), 1), __rhs);
 }
 
 template <class _CharT, class _Traits, class _Allocator>
@@ -3824,7 +3824,7 @@ template <class _CharT, class _Traits, class _Allocator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>
 operator+(const basic_string<_CharT, _Traits, _Allocator>& __lhs, _CharT __rhs) {
   return std::__concatenate_strings<_CharT, _Traits>(
-      __lhs.get_allocator(), __lhs, basic_string_view<_CharT, _Traits>(&__rhs, 1));
+      __lhs.get_allocator(), __lhs, basic_string_view<_CharT, _Traits>(std::addressof(__rhs), 1));
 }
 #  if _LIBCPP_STD_VER >= 26
 


### PR DESCRIPTION
This set usage of operator& instead of std::addressof seems not be easy to "abuse". Some seem easy to misuse, like basic_ostream::operator<<, trying to do that results in compilation errors since the `widen` function is not specialized for the hijacking character type. Hence there are no tests.