### PR TITLE
[lib++][print] Don't pad the ostream output.

### DIFF
--- a/libcxx/include/__ostream/print.h
+++ b/libcxx/include/__ostream/print.h
@@ -49,21 +49,11 @@ __vprint_nonunicode(ostream& __os, string_view __fmt, format_args __args, bool _
     if (__write_nl)
       __o += '\n';
 
-    const char* __str = __o.data();
-    size_t __len      = __o.size();
-
 #    if _LIBCPP_HAS_EXCEPTIONS
     try {
 #    endif // _LIBCPP_HAS_EXCEPTIONS
-      typedef ostreambuf_iterator<char> _Ip;
-      if (std::__pad_and_output(
-              _Ip(__os),
-              __str,
-              (__os.flags() & ios_base::adjustfield) == ios_base::left ? __str + __len : __str,
-              __str + __len,
-              __os,
-              __os.fill())
-              .failed())
+      if (auto __rdbuf = __os.rdbuf();
+          !__rdbuf || __rdbuf->sputn(__o.data(), __o.size()) != static_cast<streamsize>(__o.size()))
         __os.setstate(ios_base::badbit | ios_base::failbit);
 
 #    if _LIBCPP_HAS_EXCEPTIONS

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/print.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/print.pass.cpp
@@ -133,6 +133,7 @@ static void test_write_failure() {
   assert(os.fail());
 }
 
+// Test the formatting does no padding.
 static void test_stream_formatting() {
   std::stringstream sstr;
   auto test = [&]<class... Args>(std::string_view expected, test_format_string<char, Args...> fmt, Args&&... args) {
@@ -148,37 +149,20 @@ static void test_stream_formatting() {
   test("hello", "{}", "hello");
 
   sstr.width(10);
-  test("     hello", "{}", "hello");
+  test("hello", "{}", "hello");
+  assert(sstr.width() == 10);
 
   sstr.fill('+');
 
   sstr.width(10);
-  test("+++++hello", "{}", "hello");
+  test("hello", "{}", "hello");
+  assert(sstr.width() == 10);
 
   // *** Test embedded NUL character ***
   using namespace std::literals;
   sstr.width(15);
-  test("++++hello\0world"sv, "hello{}{}", '\0', "world");
-
-  // *** Test Unicode ***
-  // Streams count code units not code points
-  // 2-byte code points
-  sstr.width(5);
-  test("+++\u00a1", "{}", "\u00a1"); // INVERTED EXCLAMATION MARK
-  sstr.width(5);
-  test("+++\u07ff", "{}", "\u07ff"); // NKO TAMAN SIGN
-
-  // 3-byte code points
-  sstr.width(5);
-  test("++\u0800", "{}", "\u0800"); // SAMARITAN LETTER ALAF
-  sstr.width(5);
-  test("++\ufffd", "{}", "\ufffd"); // REPLACEMENT CHARACTER
-
-  // 4-byte code points
-  sstr.width(5);
-  test("+\U00010000", "{}", "\U00010000"); // LINEAR B SYLLABLE B008 A
-  sstr.width(5);
-  test("+\U0010FFFF", "{}", "\U0010FFFF"); // Undefined Character
+  test("hello\0world"sv, "hello{}{}", '\0', "world");
+  assert(sstr.width() == 15);
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_nonunicode.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_nonunicode.pass.cpp
@@ -149,6 +149,7 @@ static void test_write_failure() {
   assert(os.fail());
 }
 
+// Test the formatting does no padding.
 static void test_stream_formatting() {
   std::stringstream sstr;
   auto test = [&]<class... Args>(std::string_view expected, test_format_string<char, Args...> fmt, Args&&... args) {
@@ -164,37 +165,20 @@ static void test_stream_formatting() {
   test("hello", "{}", "hello");
 
   sstr.width(10);
-  test("     hello", "{}", "hello");
+  test("hello", "{}", "hello");
+  assert(sstr.width() == 10);
 
   sstr.fill('+');
 
   sstr.width(10);
-  test("+++++hello", "{}", "hello");
+  test("hello", "{}", "hello");
+  assert(sstr.width() == 10);
 
   // *** Test embedded NUL character ***
   using namespace std::literals;
   sstr.width(15);
-  test("++++hello\0world"sv, "hello{}{}", '\0', "world");
-
-  // *** Test Unicode ***
-  // Streams count code units not code points
-  // 2-byte code points
-  sstr.width(5);
-  test("+++\u00a1", "{}", "\u00a1"); // INVERTED EXCLAMATION MARK
-  sstr.width(5);
-  test("+++\u07ff", "{}", "\u07ff"); // NKO TAMAN SIGN
-
-  // 3-byte code points
-  sstr.width(5);
-  test("++\u0800", "{}", "\u0800"); // SAMARITAN LETTER ALAF
-  sstr.width(5);
-  test("++\ufffd", "{}", "\ufffd"); // REPLACEMENT CHARACTER
-
-  // 4-byte code points
-  sstr.width(5);
-  test("+\U00010000", "{}", "\U00010000"); // LINEAR B SYLLABLE B008 A
-  sstr.width(5);
-  test("+\U0010FFFF", "{}", "\U0010FFFF"); // Undefined Character
+  test("hello\0world"sv, "hello{}{}", '\0', "world");
+  assert(sstr.width() == 15);
 }
 
 int main(int, char**) {

--- a/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/output.streams/ostream.formatted/ostream.formatted.print/vprint_unicode.pass.cpp
@@ -149,6 +149,7 @@ static void test_write_failure() {
   assert(os.fail());
 }
 
+// Test the formatting does no padding.
 static void test_stream_formatting() {
   std::stringstream sstr;
   auto test = [&]<class... Args>(std::string_view expected, test_format_string<char, Args...> fmt, Args&&... args) {
@@ -164,37 +165,20 @@ static void test_stream_formatting() {
   test("hello", "{}", "hello");
 
   sstr.width(10);
-  test("     hello", "{}", "hello");
+  test("hello", "{}", "hello");
+  assert(sstr.width() == 10);
 
   sstr.fill('+');
 
   sstr.width(10);
-  test("+++++hello", "{}", "hello");
+  test("hello", "{}", "hello");
+  assert(sstr.width() == 10);
 
   // *** Test embedded NUL character ***
   using namespace std::literals;
   sstr.width(15);
-  test("++++hello\0world"sv, "hello{}{}", '\0', "world");
-
-  // *** Test Unicode ***
-  // Streams count code units not code points
-  // 2-byte code points
-  sstr.width(5);
-  test("+++\u00a1", "{}", "\u00a1"); // INVERTED EXCLAMATION MARK
-  sstr.width(5);
-  test("+++\u07ff", "{}", "\u07ff"); // NKO TAMAN SIGN
-
-  // 3-byte code points
-  sstr.width(5);
-  test("++\u0800", "{}", "\u0800"); // SAMARITAN LETTER ALAF
-  sstr.width(5);
-  test("++\ufffd", "{}", "\ufffd"); // REPLACEMENT CHARACTER
-
-  // 4-byte code points
-  sstr.width(5);
-  test("+\U00010000", "{}", "\U00010000"); // LINEAR B SYLLABLE B008 A
-  sstr.width(5);
-  test("+\U0010FFFF", "{}", "\U0010FFFF"); // Undefined Character
+  test("hello\0world"sv, "hello{}{}", '\0', "world");
+  assert(sstr.width() == 15);
 }
 
 int main(int, char**) {


### PR DESCRIPTION
Per [ostream.formatted.reqmts]/3 padding should only be done when explicitly stated.

Fixes: #116054