### PR TITLE
[libc++][format] Enables formattable tests for chrono formatters.

### DIFF
--- a/libcxx/test/std/utilities/format/format.formattable/concept.formattable.compile.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formattable/concept.formattable.compile.pass.cpp
@@ -154,8 +154,8 @@ void test_P1361() {
 #  if !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB) && !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) &&                           \
       !defined(TEST_HAS_NO_FILESYSTEM)
   assert_is_formattable<std::chrono::utc_time<std::chrono::microseconds>, CharT>();
-  //assert_is_formattable<std::chrono::tai_time<std::chrono::microseconds>, CharT>();
-  //assert_is_formattable<std::chrono::gps_time<std::chrono::microseconds>, CharT>();
+  assert_is_formattable<std::chrono::tai_time<std::chrono::microseconds>, CharT>();
+  assert_is_formattable<std::chrono::gps_time<std::chrono::microseconds>, CharT>();
 
 #  endif // !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB) && !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) &&
          // !defined(TEST_HAS_NO_FILESYSTEM)
@@ -188,8 +188,10 @@ void test_P1361() {
   assert_is_formattable<std::chrono::sys_info, CharT>();
   assert_is_formattable<std::chrono::local_info, CharT>();
 
-  //assert_is_formattable<std::chrono::zoned_time, CharT>();
-#  endif // !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
+#    if !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM)
+  assert_is_formattable<std::chrono::zoned_time<std::chrono::microseconds>, CharT>();
+#    endif // !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM)
+#  endif   // !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
 
 #endif // TEST_HAS_NO_LOCALIZATION
 }

--- a/libcxx/test/std/utilities/format/format.formatter/format.formatter.locking/enable_nonlocking_formatter_optimization.compile.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.formatter/format.formatter.locking/enable_nonlocking_formatter_optimization.compile.pass.cpp
@@ -122,9 +122,13 @@ void test_P1361() {
   static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::microseconds>);
 
   static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::sys_time<std::chrono::microseconds>>);
-  //static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::utc_time<std::chrono::microseconds>>);
-  //static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::tai_time<std::chrono::microseconds>>);
-  //static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::gps_time<std::chrono::microseconds>>);
+#  if !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB) && !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) &&                           \
+      !defined(TEST_HAS_NO_FILESYSTEM)
+  static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::utc_time<std::chrono::microseconds>>);
+  static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::tai_time<std::chrono::microseconds>>);
+  static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::gps_time<std::chrono::microseconds>>);
+#  endif // !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB) && !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) &&
+         // !defined(TEST_HAS_NO_FILESYSTEM)
   static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::file_time<std::chrono::microseconds>>);
   static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::local_time<std::chrono::microseconds>>);
 
@@ -149,10 +153,14 @@ void test_P1361() {
 
   static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::hh_mm_ss<std::chrono::microseconds>>);
 
-  //static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::sys_info>);
-  //static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::local_info>);
+#  if !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
+  static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::sys_info>);
+  static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::local_info>);
 
-  //static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::zoned_time>);
+#    if !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM)
+  static_assert(!std::enable_nonlocking_formatter_optimization<std::chrono::zoned_time<std::chrono::microseconds>>);
+#    endif // !defined(TEST_HAS_NO_TIME_ZONE_DATABASE) && !defined(TEST_HAS_NO_FILESYSTEM)
+#  endif   // !defined(TEST_HAS_NO_EXPERIMENTAL_TZDB)
 
 #endif // TEST_HAS_NO_LOCALIZATION
 }


### PR DESCRIPTION
These were forgotten when these types were implemented.