### PR TITLE
[clang-tidy][NFC][docs] Use single tick for 'false' and 'true' values in options

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.rst
@@ -37,20 +37,20 @@ Options
 .. option:: UseCXXStaticCastsInCppSources
 
    When suggesting fix-its for C++ code, should C++-style ``static_cast<>()``'s
-   be suggested, or C-style casts. Defaults to ``true``.
+   be suggested, or C-style casts. Defaults to `true`.
 
 .. option:: UseCXXHeadersInCppSources
 
    When suggesting to include the appropriate header in C++ code,
    should ``<cstddef>`` header be suggested, or ``<stddef.h>``.
-   Defaults to ``true``.
+   Defaults to `true`.
 
 .. option:: IgnoreConstantIntExpr
 
    If the multiplication operands are compile-time constants (like literals or
    are ``constexpr``) and fit within the source expression type, do not emit a
    diagnostic or suggested fix.  Only considers expressions where the source
-   expression is a signed integer type.  Defaults to ``false``.
+   expression is a signed integer type.  Defaults to `false`.
 
 Examples:
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/err33-c.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/err33-c.rst
@@ -190,7 +190,7 @@ This check is an alias of check :doc:`bugprone-unused-return-value <../bugprone/
 with a fixed set of functions.
 
 Suppressing issues by casting to ``void`` is enabled by default and can be
-disabled by setting `AllowCastToVoid` option to ``false``.
+disabled by setting `AllowCastToVoid` option to `false`.
 
 The check corresponds to a part of CERT C Coding Standard rule `ERR33-C.
 Detect and handle standard library errors

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
@@ -144,7 +144,7 @@ lives.
 
    When set to true convert loops when in C++20 or later mode using
    ``std::ranges::reverse_view``.
-   Default value is ``true``.
+   Default value is `true`.
 
 .. option:: MakeReverseRangeFunction
 


### PR DESCRIPTION
Unify doc style for options that use `true` or `false` as default values.