### PR TITLE
[emacs] Check for a 'buffer' type instead of 'buffer-live'

### DIFF
--- a/clang-tools-extra/clang-include-fixer/tool/clang-include-fixer.el
+++ b/clang-tools-extra/clang-include-fixer/tool/clang-include-fixer.el
@@ -249,7 +249,7 @@ Add a missing header if there is any.  If there are multiple
 possible headers the user can select one of them to be included.
 Temporarily highlight the affected symbols.  Asynchronously call
 clang-include-fixer to insert the selected header."
-  (cl-check-type stdout buffer-live)
+  (cl-check-type stdout buffer)
   (let ((context (clang-include-fixer--parse-json stdout)))
     (let-alist context
       (cond


### PR DESCRIPTION
This is a follow-up to commit f69110dcc973 ("Check for a 'buffer' type instead of 'buffer-live'.").

In Emacs 29, 'buffer-live' is no longer recognized as a type and generates a compilation warning.  Every function that requires a live buffer already checks whether the buffer is live, so we don't need to check ourselves.