### PR TITLE
[clang-tidy][NFC] Expose HeuristicResolver::lookupDependentName() and use it in StandaloneEmptyCheck

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
@@ -117,6 +117,7 @@ clang_target_link_libraries(clangTidyBugproneModule
   clangASTMatchers
   clangBasic
   clangLex
+  clangSema
   clangTooling
   clangTransformer
   )

--- a/clang-tools-extra/clang-tidy/bugprone/StandaloneEmptyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StandaloneEmptyCheck.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Lex/Lexer.h"
+#include "clang/Sema/HeuristicResolver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
@@ -125,8 +126,8 @@ void StandaloneEmptyCheck::check(const MatchFinder::MatchResult &Result) {
     DeclarationName Name =
         Context.DeclarationNames.getIdentifier(&Context.Idents.get("clear"));
 
-    auto Candidates = MemberCall->getRecordDecl()->lookupDependentName(
-        Name, [](const NamedDecl *ND) {
+    auto Candidates = HeuristicResolver(Context).lookupDependentName(
+        MemberCall->getRecordDecl(), Name, [](const NamedDecl *ND) {
           return isa<CXXMethodDecl>(ND) &&
                  llvm::cast<CXXMethodDecl>(ND)->getMinRequiredArguments() ==
                      0 &&
@@ -174,8 +175,8 @@ void StandaloneEmptyCheck::check(const MatchFinder::MatchResult &Result) {
     DeclarationName Name =
         Context.DeclarationNames.getIdentifier(&Context.Idents.get("clear"));
 
-    auto Candidates =
-        ArgRecordDecl->lookupDependentName(Name, [](const NamedDecl *ND) {
+    auto Candidates = HeuristicResolver(Context).lookupDependentName(
+        ArgRecordDecl, Name, [](const NamedDecl *ND) {
           return isa<CXXMethodDecl>(ND) &&
                  llvm::cast<CXXMethodDecl>(ND)->getMinRequiredArguments() ==
                      0 &&

--- a/clang/include/clang/Sema/HeuristicResolver.h
+++ b/clang/include/clang/Sema/HeuristicResolver.h
@@ -69,6 +69,13 @@ public:
   QualType
   resolveNestedNameSpecifierToType(const NestedNameSpecifier *NNS) const;
 
+  // Perform an imprecise lookup of a dependent name in `RD`.
+  // This function does not follow strict semantic rules and should be used
+  // only when lookup rules can be relaxed, e.g. indexing.
+  std::vector<const NamedDecl *>
+  lookupDependentName(CXXRecordDecl *RD, DeclarationName Name,
+                      llvm::function_ref<bool(const NamedDecl *ND)> Filter);
+
   // Given the type T of a dependent expression that appears of the LHS of a
   // "->", heuristically find a corresponding pointee type in whose scope we
   // could look up the name appearing on the RHS.


### PR DESCRIPTION
The use replaces CXXRecordDecl::lookupDependentName() which HeuristicResolver aims to supersede.