### PR TITLE
[clang][NFC] Remove CXXRecordDecl::lookupDependentName() and its helpers

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/bugprone/CMakeLists.txt
@@ -117,6 +117,7 @@ clang_target_link_libraries(clangTidyBugproneModule
   clangASTMatchers
   clangBasic
   clangLex
+  clangSema
   clangTooling
   clangTransformer
   )

--- a/clang-tools-extra/clang-tidy/bugprone/StandaloneEmptyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StandaloneEmptyCheck.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Lex/Lexer.h"
+#include "clang/Sema/HeuristicResolver.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
@@ -125,8 +126,8 @@ void StandaloneEmptyCheck::check(const MatchFinder::MatchResult &Result) {
     DeclarationName Name =
         Context.DeclarationNames.getIdentifier(&Context.Idents.get("clear"));
 
-    auto Candidates = MemberCall->getRecordDecl()->lookupDependentName(
-        Name, [](const NamedDecl *ND) {
+    auto Candidates = HeuristicResolver(Context).lookupDependentName(
+        MemberCall->getRecordDecl(), Name, [](const NamedDecl *ND) {
           return isa<CXXMethodDecl>(ND) &&
                  llvm::cast<CXXMethodDecl>(ND)->getMinRequiredArguments() ==
                      0 &&
@@ -174,8 +175,8 @@ void StandaloneEmptyCheck::check(const MatchFinder::MatchResult &Result) {
     DeclarationName Name =
         Context.DeclarationNames.getIdentifier(&Context.Idents.get("clear"));
 
-    auto Candidates =
-        ArgRecordDecl->lookupDependentName(Name, [](const NamedDecl *ND) {
+    auto Candidates = HeuristicResolver(Context).lookupDependentName(
+        ArgRecordDecl, Name, [](const NamedDecl *ND) {
           return isa<CXXMethodDecl>(ND) &&
                  llvm::cast<CXXMethodDecl>(ND)->getMinRequiredArguments() ==
                      0 &&

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -1720,14 +1720,6 @@ public:
   /// static analysis, or similar.
   bool hasMemberName(DeclarationName N) const;
 
-  /// Performs an imprecise lookup of a dependent name in this class.
-  ///
-  /// This function does not follow strict semantic rules and should be used
-  /// only when lookup rules can be relaxed, e.g. indexing.
-  std::vector<const NamedDecl *>
-  lookupDependentName(DeclarationName Name,
-                      llvm::function_ref<bool(const NamedDecl *ND)> Filter);
-
   /// Renders and displays an inheritance diagram
   /// for this C++ class and all of its base classes (transitively) using
   /// GraphViz.

--- a/clang/include/clang/Sema/HeuristicResolver.h
+++ b/clang/include/clang/Sema/HeuristicResolver.h
@@ -69,6 +69,13 @@ public:
   QualType
   resolveNestedNameSpecifierToType(const NestedNameSpecifier *NNS) const;
 
+  // Perform an imprecise lookup of a dependent name in `RD`.
+  // This function does not follow strict semantic rules and should be used
+  // only when lookup rules can be relaxed, e.g. indexing.
+  std::vector<const NamedDecl *>
+  lookupDependentName(CXXRecordDecl *RD, DeclarationName Name,
+                      llvm::function_ref<bool(const NamedDecl *ND)> Filter);
+
   // Given the type T of a dependent expression that appears of the LHS of a
   // "->", heuristically find a corresponding pointee type in whose scope we
   // could look up the name appearing on the RHS.


### PR DESCRIPTION
This function has been superseded by HeuristicResolver::lookupDependentName(), which implements the same heuristics and more.

Porting note for any out-of-tree callers:

```
RD->lookupDependentName(Name, Filter);
```

can be replaced with:

```
HeuristicResolver(RD->getASTContext())->lookupDependentName(Name, Filter);
```