### PR TITLE
[MLIR][Affine] Fix fusion in the presence of cyclic deps in source nests

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/LoopAnalysis.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/LoopAnalysis.h
@@ -119,6 +119,14 @@ bool isOpwiseShiftValid(AffineForOp forOp, ArrayRef<uint64_t> shifts);
 /// any dependence component is negative along any of `loops`.
 bool isTilingValid(ArrayRef<AffineForOp> loops);
 
+/// Returns true if the affine nest rooted at `root` has a cyclic dependence
+/// among its affine memory accesses. The dependence could be through any
+/// dependences carried by loops contained in `root` (inclusive of `root`) and
+/// those carried by loop bodies (blocks) contained. Dependences carried by
+/// loops outer to `root` aren't relevant. This method doesn't consider/account
+/// for aliases.
+bool hasCyclicDependence(AffineForOp root);
+
 } // namespace affine
 } // namespace mlir
 

--- a/mlir/test/Dialect/Affine/loop-fusion-4.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-4.mlir
@@ -495,3 +495,52 @@ func.func @test_add_slice_bounds() {
   }
   return
 }
+
+// PRODUCER-CONSUMER-MAXIMAL-LABEL: func @producer_reduction_no_fusion
+func.func @producer_reduction_no_fusion(%input : memref<10xf32>, %output : memref<10xf32>, %reduc : memref<1xf32>) {
+  %zero = arith.constant 0. : f32
+  %one = arith.constant 1. : f32
+  // This producer can't be fused into inside %i without a violation of
+  // semantics.
+  // PRODUCER-CONSUMER-MAXIMAL: affine.for %{{.*}} = 0 to 10
+  affine.for %i = 0 to 10 {
+    %0 = affine.load %input[%i] : memref<10xf32>
+    %1 = affine.load %reduc[0] : memref<1xf32>
+    %2 = arith.addf %0, %1 : f32
+    affine.store %2, %reduc[0] : memref<1xf32>
+  }
+  // PRODUCER-CONSUMER-MAXIMAL: affine.for %{{.*}} = 0 to 10
+  affine.for %i = 0 to 10 {
+    %0 = affine.load %reduc[0] : memref<1xf32>
+    %2 = arith.addf %0, %one : f32
+    affine.store %2, %output[%i] : memref<10xf32>
+  }
+  return
+}
+
+// SIBLING-MAXIMAL-LABEL: func @sibling_reduction
+func.func @sibling_reduction(%input : memref<10xf32>, %output : memref<10xf32>, %reduc : memref<10xf32>) {
+  %zero = arith.constant 0. : f32
+  %one = arith.constant 1. : f32
+  affine.for %i = 0 to 10 {
+    %0 = affine.load %input[%i] : memref<10xf32>
+    %2 = arith.addf %0, %one : f32
+    affine.store %2, %output[%i] : memref<10xf32>
+  }
+  // Ensure that the fusion happens at the right depth.
+  affine.for %i = 0 to 10 {
+    %0 = affine.load %input[%i] : memref<10xf32>
+    %1 = affine.load %reduc[0] : memref<10xf32>
+    %2 = arith.addf %0, %1 : f32
+    affine.store %2, %reduc[0] : memref<10xf32>
+  }
+  // SIBLING-MAXIMAL:      affine.for %{{.*}} = 0 to 10
+  // SIBLING-MAXIMAL-NEXT:   affine.load
+  // SIBLING-MAXIMAL-NEXT:   addf
+  // SIBLING-MAXIMAL-NEXT:   affine.store
+  // SIBLING-MAXIMAL-NEXT:   affine.load
+  // SIBLING-MAXIMAL-NEXT:   affine.load
+  // SIBLING-MAXIMAL-NEXT:   addf
+  // SIBLING-MAXIMAL-NEXT:   affine.store
+  return
+}

--- a/mlir/test/Examples/mlir-opt/loop_fusion_options.mlir
+++ b/mlir/test/Examples/mlir-opt/loop_fusion_options.mlir
@@ -1,12 +1,13 @@
 // RUN: mlir-opt --pass-pipeline="builtin.module(affine-loop-fusion{compute-tolerance=0})" %s | FileCheck %s
 
 // CHECK-LABEL: @producer_consumer_fusion
-// CHECK-COUNT-3: affine.for
 module {
   func.func @producer_consumer_fusion(%arg0: memref<10xf32>, %arg1: memref<10xf32>) {
     %0 = memref.alloc() : memref<10xf32>
     %1 = memref.alloc() : memref<10xf32>
     %cst = arith.constant 0.000000e+00 : f32
+    // CHECK: affine.for
+    // CHECK-NOT: affine.for
     affine.for %arg2 = 0 to 10 {
       affine.store %cst, %0[%arg2] : memref<10xf32>
       affine.store %cst, %1[%arg2] : memref<10xf32>


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/61820

Fix affine fusion in the presence of cyclic deps in the source nest. In such cases, the nest being fused can't be executed multiple times. Add a utility to check for dependence cycles and use it in fusion. This fixes both sibling as well as producer consumer fusion where nests with cyclic dependences (typically reductions) were being in some cases incorrectly fused in.

The test case also exercises/required a fix to the check for the redundant computation being within the specified threshold.