### PR TITLE
Add target hook for automatic histogram vectorization

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -805,6 +805,9 @@ public:
   bool isLegalMaskedScatter(Type *DataType, Align Alignment) const;
   /// Return true if the target supports masked gather.
   bool isLegalMaskedGather(Type *DataType, Align Alignment) const;
+  /// Return true if the target supports vectorization of histograms.
+  bool isLegalForHistogramVectorization(const LoadInst *LI,
+                                        const StoreInst *SI) const;
   /// Return true if the target forces scalarizing of llvm.masked.gather
   /// intrinsics.
   bool forceScalarizeMaskedGather(VectorType *Type, Align Alignment) const;
@@ -2028,6 +2031,8 @@ public:
                                     ElementCount NumElements) const = 0;
   virtual bool isLegalMaskedScatter(Type *DataType, Align Alignment) = 0;
   virtual bool isLegalMaskedGather(Type *DataType, Align Alignment) = 0;
+  virtual bool isLegalForHistogramVectorization(const LoadInst *LI,
+                                                const StoreInst *SI) = 0;
   virtual bool forceScalarizeMaskedGather(VectorType *DataType,
                                           Align Alignment) = 0;
   virtual bool forceScalarizeMaskedScatter(VectorType *DataType,
@@ -2588,6 +2593,10 @@ public:
   }
   bool isLegalMaskedGather(Type *DataType, Align Alignment) override {
     return Impl.isLegalMaskedGather(DataType, Alignment);
+  }
+  bool isLegalForHistogramVectorization(const LoadInst *LI,
+                                        const StoreInst *SI) override {
+    return Impl.isLegalForHistogramVectorization(LI, SI);
   }
   bool forceScalarizeMaskedGather(VectorType *DataType,
                                   Align Alignment) override {

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -310,6 +310,22 @@ public:
     return false;
   }
 
+  bool isLegalForHistogramVectorization(const LoadInst *LI,
+                                        const StoreInst *SI) const {
+    // TODO: Currently, when a target wants to use histogram intrinsics, it adds
+    // the
+    // `-enable-histogram-loop-vectorization` flag to Clang.
+    //
+    // Once the histogram option is enabled by default, we will need to update
+    // the default hook to return `false`, and each target that wants automatic
+    // histogram vectorization will need to override it to return `true`.
+    //
+    // Additionally, we will need to deprecate the
+    // `-enable-histogram-loop-vectorization` flag, as it will no longer be
+    // necessary.
+    return true;
+  }
+
   bool forceScalarizeMaskedGather(VectorType *DataType, Align Alignment) const {
     return false;
   }

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -492,6 +492,11 @@ bool TargetTransformInfo::isLegalMaskedGather(Type *DataType,
   return TTIImpl->isLegalMaskedGather(DataType, Alignment);
 }
 
+bool TargetTransformInfo::isLegalForHistogramVectorization(
+    const LoadInst *LI, const StoreInst *SI) const {
+  return TTIImpl->isLegalForHistogramVectorization(LI, SI);
+}
+
 bool TargetTransformInfo::isLegalAltInstr(
     VectorType *VecTy, unsigned Opcode0, unsigned Opcode1,
     const SmallBitVector &OpcodeMask) const {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1193,6 +1193,9 @@ bool LoopVectorizationLegality::canVectorizeIndirectUnsafeDependences() {
   if (!LI || !SI)
     return false;
 
+  if (!TTI->isLegalForHistogramVectorization(LI, SI))
+    return false;
+
   LLVM_DEBUG(dbgs() << "LV: Checking for a histogram on: " << *SI << "\n");
   return findHistogram(LI, SI, TheLoop, LAI->getPSE(), Histograms);
 }


### PR DESCRIPTION
Now, each target, depending on the load/store instruction, can indicate whether it is safe to vectorize histogram operations.

For example, this allows distinguishing between different pointer address spaces.