### PR TITLE
[ValueTracking] Make instructions part of the assume condition always ephemeral.

### DIFF
--- a/llvm/include/llvm/Analysis/ValueTracking.h
+++ b/llvm/include/llvm/Analysis/ValueTracking.h
@@ -1268,7 +1268,8 @@ std::optional<bool> isImpliedByDomCondition(CmpPredicate Pred, const Value *LHS,
 /// affected by the condition \p Cond. Used by AssumptionCache and
 /// DomConditionCache.
 void findValuesAffectedByCondition(Value *Cond, bool IsAssume,
-                                   function_ref<void(Value *)> InsertAffected);
+                                   function_ref<void(Value *)> InsertAffected,
+                                   bool EphemeralOnly = false);
 
 } // end namespace llvm
 

--- a/llvm/test/Analysis/ValueTracking/numsignbits-from-assume.ll
+++ b/llvm/test/Analysis/ValueTracking/numsignbits-from-assume.ll
@@ -48,7 +48,7 @@ define i32 @computeNumSignBits_sub1(i32 %in) {
 
 define i32 @computeNumSignBits_sub2(i32 %in) {
 ; CHECK-LABEL: @computeNumSignBits_sub2(
-; CHECK-NEXT:    [[SUB:%.*]] = add nsw i32 [[IN:%.*]], -1
+; CHECK-NEXT:    [[SUB:%.*]] = add i32 [[IN:%.*]], -1
 ; CHECK-NEXT:    [[COND:%.*]] = icmp ult i32 [[SUB]], 43
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
 ; CHECK-NEXT:    [[SH:%.*]] = shl nuw nsw i32 [[SUB]], 3

--- a/llvm/test/Transforms/CorrelatedValuePropagation/add.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/add.ll
@@ -562,12 +562,12 @@ join:
   ret i32 %add
 }
 
-; todo do not remove the assume condition
 define i32 @issue90206(i32 noundef %x) {
 ; CHECK-LABEL: define range(i32 0, -2147483648) i32 @issue90206(
 ; CHECK-SAME: i32 noundef [[X:%.*]]) {
 ; CHECK-NEXT:    [[R:%.*]] = add i32 [[X]], -1
-; CHECK-NEXT:    tail call void @llvm.assume(i1 true)
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt i32 [[R]], -1
+; CHECK-NEXT:    tail call void @llvm.assume(i1 [[TMP1]])
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %r = add i32 %x, -1

--- a/llvm/test/Transforms/CorrelatedValuePropagation/add.ll
+++ b/llvm/test/Transforms/CorrelatedValuePropagation/add.ll
@@ -562,6 +562,20 @@ join:
   ret i32 %add
 }
 
+; todo do not remove the assume condition
+define i32 @issue90206(i32 noundef %x) {
+; CHECK-LABEL: define range(i32 0, -2147483648) i32 @issue90206(
+; CHECK-SAME: i32 noundef [[X:%.*]]) {
+; CHECK-NEXT:    [[R:%.*]] = add i32 [[X]], -1
+; CHECK-NEXT:    tail call void @llvm.assume(i1 true)
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %r = add i32 %x, -1
+  %17 = icmp sgt i32 %r, -1
+  tail call void @llvm.assume(i1 %17)
+  ret i32 %r
+}
+
 ;.
 ; CHECK: [[RNG0]] = !{i32 0, i32 2147483647}
 ;.

--- a/llvm/test/Transforms/InstCombine/zext-or-icmp.ll
+++ b/llvm/test/Transforms/InstCombine/zext-or-icmp.ll
@@ -180,11 +180,11 @@ define i8 @PR49475_infloop(i32 %t0, i16 %insert, i64 %e, i8 %i162) "instcombine-
 ; CHECK-NEXT:    [[SEXT:%.*]] = shl i64 [[SUB17]], 32
 ; CHECK-NEXT:    [[CONV18:%.*]] = ashr exact i64 [[SEXT]], 32
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sge i64 [[XOR]], [[CONV18]]
-; CHECK-NEXT:    [[TRUNC44:%.*]] = zext i1 [[CMP]] to i8
-; CHECK-NEXT:    [[INC:%.*]] = add i8 [[I162]], [[TRUNC44]]
-; CHECK-NEXT:    [[TOBOOL23_NOT:%.*]] = xor i1 [[CMP]], true
+; CHECK-NEXT:    [[CONV19:%.*]] = zext i1 [[CMP]] to i16
+; CHECK-NEXT:    [[OR21:%.*]] = or i16 [[INSERT]], [[CONV19]]
+; CHECK-NEXT:    [[TOBOOL23_NOT:%.*]] = icmp eq i16 [[OR21]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[TOBOOL23_NOT]])
-; CHECK-NEXT:    ret i8 [[INC]]
+; CHECK-NEXT:    ret i8 [[I162]]
 ;
   %b = icmp eq i32 %t0, 0
   %b2 = icmp eq i16 %insert, 0

--- a/llvm/test/Transforms/InstSimplify/ctpop-pow2.ll
+++ b/llvm/test/Transforms/InstSimplify/ctpop-pow2.ll
@@ -148,10 +148,12 @@ define <2 x i32> @ctpop_lshr_intmin_vec(<2 x i32> %x) {
   ret <2 x i32> %cnt
 }
 
-; todo do not remove the assume
 define i1 @issue128152(i32 %x) {
 ; CHECK-LABEL: @issue128152(
-; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[X:%.*]], 0
+; CHECK-NEXT:    [[CTPOP:%.*]] = call i32 @llvm.ctpop.i32(i32 [[X:%.*]])
+; CHECK-NEXT:    [[COND:%.*]] = icmp eq i32 [[CTPOP]], 1
+; CHECK-NEXT:    call void @llvm.assume(i1 [[COND]])
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[X]], 0
 ; CHECK-NEXT:    ret i1 [[RES]]
 ;
   %ctpop = call i32 @llvm.ctpop.i32(i32 %x)

--- a/llvm/test/Transforms/InstSimplify/ctpop-pow2.ll
+++ b/llvm/test/Transforms/InstSimplify/ctpop-pow2.ll
@@ -148,6 +148,19 @@ define <2 x i32> @ctpop_lshr_intmin_vec(<2 x i32> %x) {
   ret <2 x i32> %cnt
 }
 
+; todo do not remove the assume
+define i1 @issue128152(i32 %x) {
+; CHECK-LABEL: @issue128152(
+; CHECK-NEXT:    [[RES:%.*]] = icmp eq i32 [[X:%.*]], 0
+; CHECK-NEXT:    ret i1 [[RES]]
+;
+  %ctpop = call i32 @llvm.ctpop.i32(i32 %x)
+  %cond = icmp eq i32 %ctpop, 1
+  %ext = zext i1 %cond to i8
+  call void @llvm.assume(i1 %cond)
+  %res = icmp eq i32 %x, 0
+  ret i1 %res
+}
 
 define <2 x i32> @ctpop_lshr_intmin_intmin_plus1_vec(<2 x i32> %x) {
 ; CHECK-LABEL: @ctpop_lshr_intmin_intmin_plus1_vec(


### PR DESCRIPTION
This use findValuesAffectedByCondition to find what instructions that is part of the assume condition and always make them ephemeral independent of usage.
This results in that only patterns supported by the AssumptionCache is checked and if new patterns is added the isEphemeralValueOf will reflect that eg to support assume(not cond) only an update in findValuesAffectedByCondition is needed.

Avoids the problem for calls to safeCxtI with no CxtI that make isEphemeralValueOf return true for https://github.com/nikic/llvm-project/commit/37f1d405e40d9a12c0de48acd3bcb15a01d88f25

maybe possible to remove the loop in isEphemeralValueOf and only use this new functionality but that make more instructions non ephemeral instead of that this PR do now where it only will be more ephemeral instructions then before.