### PR TITLE
[LangRef] Document accessing memory outside of object is UB.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3293,7 +3293,9 @@ heap allocation calls, and global variable definitions. Once it is allocated,
 the bytes stored in the region can only be read or written through a pointer
 that is :ref:`based on <pointeraliasing>` the allocation value. If a pointer
 that is not based on the object tries to read or write to the object, it is
-undefined behavior.
+undefined behavior. Trying to read or write memory outside of an allocated
+object, including accesses partially outside an allocated object, is undefined
+behavior.
 
 The following properties hold for all allocated objects:
 
@@ -11108,12 +11110,9 @@ operation (that is, the alignment of the memory address). It is the
 responsibility of the code emitter to ensure that the alignment information is
 correct. Overestimating the alignment results in undefined behavior.
 Underestimating the alignment may produce less efficient code. An alignment of
-1 is always safe. The maximum possible alignment is ``1 << 32``. An alignment
-value higher than the size of the loaded type implies memory up to the
-alignment value bytes can be safely loaded without trapping in the default
-address space. Access of the high bytes can interfere with debugging tools, so
-should not be accessed if the function has the ``sanitize_thread`` or
-``sanitize_address`` attributes.
+1 is always safe. The maximum possible alignment is ``1 << 32``. Access of the
+high bytes can interfere with debugging tools, so should not be accessed if the
+function has the ``sanitize_thread`` or ``sanitize_address`` attributes.
 
 The alignment is only optional when parsing textual IR; for in-memory IR, it is
 always present. An omitted ``align`` argument means that the operation has the

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3299,8 +3299,8 @@ The following properties hold for all allocated objects:
 
 -  no allocated object may cross the unsigned address space boundary (including
    the pointer after the end of the object),
--  the size of all allocated objects must be non-negative and smaller than
-   the largest signed integer that fits into the index type,
+-  the size of all allocated objects must be non-negative and not exceed the
+   largest signed integer that fits into the index type.
 
 .. _objectlifetime:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -11721,8 +11721,9 @@ As a corollary, the only pointer in bounds of the null pointer in the default
 address space is the null pointer itself.
 
 These rules are based on the assumption that no allocated object may cross
-the unsigned address space boundary, and no allocated object may be larger
-than half the pointer index type space.
+the unsigned address space boundary, the pointer after the object must be valid,
+and no allocated object may be larger than half the pointer index type space
+- 1.
 
 If ``inbounds`` is present on a ``getelementptr`` instruction, the ``nusw``
 attribute will be automatically set as well. For this reason, the ``nusw``


### PR DESCRIPTION
Currently the LangRef isn't very clear on whether accessing objects out of bounds is allowed or not. Clarify that accessing memory outside an allocated object, including accesses partially outside, are undefined behavior.

This removes the sentence regarding loading values up to the `!align` does not trap. My reading of that sentence implies that alignment would imply dereferenceability, but it is not clear if that's only intended for the !align metadata.

If alignment in general implies dereferenceability, I will update the PR to clarify, although that may cause issues with various security-related HW/SW extensions.

(Includes the changes from https://github.com/llvm/llvm-project/pull/127892, which should go in first)