### PR TITLE
[SPIRV] Stop including SPIRVInstrInfo.h in MCTargetDesc. NFC

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
@@ -222,6 +222,11 @@ struct ExtendedBuiltin {
   InstructionSet::InstructionSet Set;
   uint32_t Number;
 };
+
+enum InstFlags {
+  // It is a half type
+  INST_PRINTER_WIDTH16 = 1
+};
 } // namespace SPIRV
 
 using CapabilityList = SmallVector<SPIRV::Capability::Capability, 8>;

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -13,7 +13,6 @@
 #include "SPIRVInstPrinter.h"
 #include "SPIRV.h"
 #include "SPIRVBaseInfo.h"
-#include "SPIRVInstrInfo.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -51,7 +50,7 @@ void SPIRVInstPrinter::printRemainingVariableOps(const MCInst *MI,
 void SPIRVInstPrinter::printOpConstantVarOps(const MCInst *MI,
                                              unsigned StartIndex,
                                              raw_ostream &O) {
-  unsigned IsBitwidth16 = MI->getFlags() & SPIRV::ASM_PRINTER_WIDTH16;
+  unsigned IsBitwidth16 = MI->getFlags() & SPIRV::INST_PRINTER_WIDTH16;
   const unsigned NumVarOps = MI->getNumOperands() - StartIndex;
 
   assert((NumVarOps == 1 || NumVarOps == 2) &&

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
@@ -24,7 +24,8 @@ void SPIRVMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI,
                              SPIRV::ModuleAnalysisInfo *MAI) const {
   OutMI.setOpcode(MI->getOpcode());
   // Propagate previously set flags
-  OutMI.setFlags(MI->getAsmPrinterFlags());
+  if (MI->getAsmPrinterFlags() & SPIRV::ASM_PRINTER_WIDTH16)
+    OutMI.setFlags(SPIRV::INST_PRINTER_WIDTH16);
   const MachineFunction *MF = MI->getMF();
   for (unsigned i = 0, e = MI->getNumOperands(); i != e; ++i) {
     const MachineOperand &MO = MI->getOperand(i);


### PR DESCRIPTION
SPIRVInstrInfo.h is a CodeGen layer file, it should not be used in MC layer files.

This required adding a new enum for MCInst flags and a conversion from MachineInstr's AsmPrinter flags in SPIRVMCInstLower.