### PR TITLE
[MC][CodeGen] Move FirstStackSlot and VirtualRegFlag from MCRegister to Register. NFC

### DIFF
--- a/llvm/include/llvm/CodeGen/RDFRegisters.h
+++ b/llvm/include/llvm/CodeGen/RDFRegisters.h
@@ -119,14 +119,14 @@ struct RegisterRef {
   static constexpr bool isMaskId(unsigned Id) { return Register(Id).isStack(); }
 
   static constexpr RegisterId toUnitId(unsigned Idx) {
-    return Idx | MCRegister::VirtualRegFlag;
+    return Idx | Register::VirtualRegFlag;
   }
 
   static constexpr unsigned toIdx(RegisterId Id) {
     // Not using virtReg2Index or stackSlot2Index, because they are
     // not constexpr.
     if (isUnitId(Id))
-      return Id & ~MCRegister::VirtualRegFlag;
+      return Id & ~Register::VirtualRegFlag;
     // RegId and MaskId are unchanged.
     return Id;
   }

--- a/llvm/include/llvm/CodeGen/Register.h
+++ b/llvm/include/llvm/CodeGen/Register.h
@@ -35,17 +35,19 @@ public:
   // DenseMapInfo<unsigned> uses -1u and -2u.
   static_assert(std::numeric_limits<decltype(Reg)>::max() >= 0xFFFFFFFF,
                 "Reg isn't large enough to hold full range.");
+  static constexpr unsigned FirstStackSlot = 1u << 30;
+  static_assert(FirstStackSlot >= MCRegister::LastPhysicalReg);
+  static constexpr unsigned VirtualRegFlag = 1u << 31;
 
   /// Return true if this is a stack slot.
   constexpr bool isStack() const {
-    return MCRegister::FirstStackSlot <= Reg &&
-           Reg < MCRegister::VirtualRegFlag;
+    return Register::FirstStackSlot <= Reg && Reg < Register::VirtualRegFlag;
   }
 
   /// Convert a non-negative frame index to a stack slot register value.
   static Register index2StackSlot(int FI) {
     assert(FI >= 0 && "Cannot hold a negative frame index.");
-    return Register(FI + MCRegister::FirstStackSlot);
+    return Register(FI + Register::FirstStackSlot);
   }
 
   /// Return true if the specified register number is in
@@ -57,14 +59,14 @@ public:
   /// Return true if the specified register number is in
   /// the virtual register namespace.
   static constexpr bool isVirtualRegister(unsigned Reg) {
-    return Reg & MCRegister::VirtualRegFlag;
+    return Reg & Register::VirtualRegFlag;
   }
 
   /// Convert a 0-based index to a virtual register number.
   /// This is the inverse operation of VirtReg2IndexFunctor below.
   static Register index2VirtReg(unsigned Index) {
     assert(Index < (1u << 31) && "Index too large for virtual register range.");
-    return Index | MCRegister::VirtualRegFlag;
+    return Index | Register::VirtualRegFlag;
   }
 
   /// Return true if the specified register number is in the virtual register
@@ -79,13 +81,13 @@ public:
   /// register in a function will get the index 0.
   unsigned virtRegIndex() const {
     assert(isVirtual() && "Not a virtual register");
-    return Reg & ~MCRegister::VirtualRegFlag;
+    return Reg & ~Register::VirtualRegFlag;
   }
 
   /// Compute the frame index from a register value representing a stack slot.
   int stackSlotIndex() const {
     assert(isStack() && "Not a stack slot");
-    return static_cast<int>(Reg - MCRegister::FirstStackSlot);
+    return static_cast<int>(Reg - Register::FirstStackSlot);
   }
 
   constexpr operator unsigned() const { return Reg; }

--- a/llvm/include/llvm/MC/MCRegister.h
+++ b/llvm/include/llvm/MC/MCRegister.h
@@ -51,13 +51,12 @@ public:
                 "Reg isn't large enough to hold full range.");
   static constexpr unsigned NoRegister = 0u;
   static constexpr unsigned FirstPhysicalReg = 1u;
-  static constexpr unsigned FirstStackSlot = 1u << 30;
-  static constexpr unsigned VirtualRegFlag = 1u << 31;
+  static constexpr unsigned LastPhysicalReg = (1u << 30) - 1;
 
   /// Return true if the specified register number is in
   /// the physical register namespace.
   static constexpr bool isPhysicalRegister(unsigned Reg) {
-    return FirstPhysicalReg <= Reg && Reg < FirstStackSlot;
+    return FirstPhysicalReg <= Reg && Reg <= LastPhysicalReg;
   }
 
   /// Return true if the specified register number is in the physical register


### PR DESCRIPTION
These concepts don't exist for MCRegister.

I think there is a need for virtual registers in MCRegister for NVPTX, SPIR-V and WebAssembly, but those should not be confused with Register's virtual register. I will try to make a separate proposal for that with a real interface.