### PR TITLE
[clang modules] Setting `DebugCompilationDir` when it is safe to ignore current working directory

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -317,7 +317,7 @@ private:
 
   /// Compute the context hash for \p Deps, and create the mapping
   /// \c ModuleDepsByID[Deps.ID] = &Deps.
-  void associateWithContextHash(const CowCompilerInvocation &CI,
+  void associateWithContextHash(const CowCompilerInvocation &CI, bool IgnoreCWD,
                                 ModuleDeps &Deps);
 };
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -129,10 +129,9 @@ static void optimizeDiagnosticOpts(DiagnosticOptions &Opts,
   Opts.Remarks.clear();
 }
 
-static void optimizeCWD(FileSystemOptions &FSOpts, CodeGenOptions &CGOpts,
-                        const std::string &CWD) {
-  FSOpts.WorkingDir.clear();
-  if (CGOpts.DwarfVersion) {
+static void optimizeCWD(CowCompilerInvocation &BuildInvocation, StringRef CWD) {
+  BuildInvocation.getMutFileSystemOpts().WorkingDir.clear();
+  if (BuildInvocation.getCodeGenOpts().DwarfVersion) {
     // It is necessary to explicitly set the DebugCompilationDir
     // to a common directory (e.g. root) if IgnoreCWD is true.
     // When IgnoreCWD is true, the module's content should not
@@ -145,7 +144,16 @@ static void optimizeCWD(FileSystemOptions &FSOpts, CodeGenOptions &CGOpts,
     // ignore the CWD. Thus in such cases,
     // CGOpts.DebugCompilationDir is explicitly set to a common
     // directory.
-    CGOpts.DebugCompilationDir = llvm::sys::path::root_path(CWD);
+    // FIXME: It is still excessive to create a copy of
+    // CodeGenOpts for each module. Since we do not modify the
+    // CodeGenOpts otherwise per module, the following code
+    // ends up generating identical CodeGenOpts for each module
+    // with DebugCompilationDir pointing to the root directory.
+    // We can optimize this away by creating a _single_ copy of
+    // CodeGenOpts whose DebugCompilationDir points to the root
+    // directory and reuse it across modules.
+    BuildInvocation.getMutCodeGenOpts().DebugCompilationDir =
+        llvm::sys::path::root_path(CWD);
   }
 }
 
@@ -765,8 +773,7 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
                   MDC.ScanInstance.getVirtualFileSystem()
                       .getCurrentWorkingDirectory();
               if (CWD)
-                optimizeCWD(BuildInvocation.getMutFileSystemOpts(),
-                            BuildInvocation.getMutCodeGenOpts(), *CWD);
+                optimizeCWD(BuildInvocation, *CWD);
             }
           });
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -129,6 +129,26 @@ static void optimizeDiagnosticOpts(DiagnosticOptions &Opts,
   Opts.Remarks.clear();
 }
 
+static void optimizeCWD(FileSystemOptions &FSOpts, CodeGenOptions &CGOpts,
+                        const std::string &CWD) {
+  FSOpts.WorkingDir.clear();
+  if (CGOpts.DwarfVersion) {
+    // It is necessary to explicitly set the DebugCompilationDir
+    // to a common directory (e.g. root) if IgnoreCWD is true.
+    // When IgnoreCWD is true, the module's content should not
+    // depend on the current working directory. However, if dwarf
+    // information is needed (when CGOpts.DwarfVersion is
+    // non-zero), then CGOpts.DebugCompilationDir must be
+    // populated, because otherwise the current working directory
+    // will be automatically embedded in the dwarf information in
+    // the pcm, contradicting the assumption that it is safe to
+    // ignore the CWD. Thus in such cases,
+    // CGOpts.DebugCompilationDir is explicitly set to a common
+    // directory.
+    CGOpts.DebugCompilationDir = llvm::sys::path::root_path(CWD);
+  }
+}
+
 static std::vector<std::string> splitString(std::string S, char Separator) {
   SmallVector<StringRef> Segments;
   StringRef(S).split(Segments, Separator, /*MaxSplit=*/-1, /*KeepEmpty=*/false);
@@ -489,26 +509,8 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
   HashBuilder.add(getClangFullRepositoryVersion());
   HashBuilder.add(serialization::VERSION_MAJOR, serialization::VERSION_MINOR);
   llvm::ErrorOr<std::string> CWD = VFS.getCurrentWorkingDirectory();
-  auto &FSOpts = const_cast<FileSystemOptions &>(CI.getFileSystemOpts());
   if (CWD && !IgnoreCWD)
     HashBuilder.add(*CWD);
-  else {
-    FSOpts.WorkingDir.clear();
-    auto &CGOpts = const_cast<CodeGenOptions &>(CI.getCodeGenOpts());
-    if (CGOpts.DwarfVersion && CWD) {
-      // It is necessary to explicitly set the DebugCompilationDir
-      // to a common directory (e.g. root) if IgnoreCWD is true.
-      // When IgnoreCWD is true, the module's content should not depend
-      // on the current working directory. However, if dwarf information
-      // is needed (when CGOpts.DwarfVersion is non-zero), and if
-      // CGOpts.DebugCompilationDir is not explicitly set,
-      // the current working directory will be automatically embedded
-      // in the dwarf information in the pcm, contradicting the assumption
-      // that it is safe to ignore the CWD. Thus in such cases,
-      // CGOpts.DebugCompilationDir is explicitly set to a common directory.
-      CGOpts.DebugCompilationDir = llvm::sys::path::root_path(*CWD);
-    }
-  }
 
   // Hash the BuildInvocation without any input files.
   SmallString<0> ArgVec;
@@ -539,9 +541,7 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
 }
 
 void ModuleDepCollector::associateWithContextHash(
-    const CowCompilerInvocation &CI, ModuleDeps &Deps) {
-  bool IgnoreCWD = any(OptimizeArgs & ScanningOptimizations::IgnoreCWD) &&
-                   isSafeToIgnoreCWD(CI);
+    const CowCompilerInvocation &CI, bool IgnoreCWD, ModuleDeps &Deps) {
   Deps.ID.ContextHash =
       getModuleContextHash(Deps, CI, EagerLoadModules, IgnoreCWD,
                            ScanInstance.getVirtualFileSystem());
@@ -741,6 +741,7 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
         MD.ModuleMapFileDeps.emplace_back(*ResolvedFilenameAsRequested);
       });
 
+  bool IgnoreCWD = false;
   CowCompilerInvocation CI =
       MDC.getInvocationAdjustedForModuleBuildWithoutOutputs(
           MD, [&](CowCompilerInvocation &BuildInvocation) {
@@ -750,13 +751,26 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
                                        *MDC.ScanInstance.getASTReader(), *MF,
                                        MDC.PrebuiltModuleVFSMap,
                                        MDC.OptimizeArgs);
+
             if (any(MDC.OptimizeArgs & ScanningOptimizations::SystemWarnings))
               optimizeDiagnosticOpts(
                   BuildInvocation.getMutDiagnosticOpts(),
                   BuildInvocation.getFrontendOpts().IsSystemModule);
+
+            IgnoreCWD =
+                any(MDC.OptimizeArgs & ScanningOptimizations::IgnoreCWD) &&
+                isSafeToIgnoreCWD(BuildInvocation);
+            if (IgnoreCWD) {
+              llvm::ErrorOr<std::string> CWD =
+                  MDC.ScanInstance.getVirtualFileSystem()
+                      .getCurrentWorkingDirectory();
+              if (CWD)
+                optimizeCWD(BuildInvocation.getMutFileSystemOpts(),
+                            BuildInvocation.getMutCodeGenOpts(), *CWD);
+            }
           });
 
-  MDC.associateWithContextHash(CI, MD);
+  MDC.associateWithContextHash(CI, IgnoreCWD, MD);
 
   // Finish the compiler invocation. Requires dependencies and the context hash.
   MDC.addOutputPaths(CI, MD);

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -8,7 +8,7 @@
 //--- cdb.json.in
 [{
   "directory": "DIR",
-  "command": "clang -c -g -gmodules DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -fdebug-compilation-dir=DIR -o DIR/tu.o",
+  "command": "clang -target x86_64-apple-darwin -c -g -gmodules DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -fdebug-compilation-dir=DIR -o DIR/tu.o",
   "file": "DIR/tu.c"
 }]
 
@@ -26,5 +26,5 @@ module mod {
 // directory when current working directory optimization is in effect.
 // CHECK:  "modules": [
 // CHECK: "command-line": [
-// CHECK: "-fdebug-compilation-dir={{\/|C:|\/\/net}}",
+// CHECK: "-fdebug-compilation-dir=/",
 // CHECK:  "translation-units": [

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -1,5 +1,3 @@
-// REQUIRES: shell
-
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format \
+// RUN:   experimental-full > %t/result.json
+
+//--- cdb.json.in
+[{
+  "directory": "DIR",
+  "command": "clang -g -fdebug-info-for-profiling DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -o DIR/tu.o",
+  "file": "DIR/tu.c"
+}]
+
+//--- include/module.modulemap
+module mod {
+  header "mod.h"
+}
+
+//--- include/mod.h
+
+//--- tu.c
+#include "mod.h"

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -1,9 +1,11 @@
+// REQUIRES: shell
+
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format \
 // RUN:   experimental-full > %t/result.json
-// RUN: cat %t/result.json | FileCheck %s
+// RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck %s
 
 //--- cdb.json.in
 [{
@@ -26,5 +28,5 @@ module mod {
 // directory when current working directory optimization is in effect.
 // CHECK:  "modules": [
 // CHECK: "command-line": [
-// CHECK: "-fdebug-compilation-dir={{\/|.*:}}",
+// CHECK: "-fdebug-compilation-dir={{\/|.*:(\\)?}}",
 // CHECK:  "translation-units": [

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -1,3 +1,5 @@
+// REQUIRES: shell
+
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -8,7 +8,7 @@
 //--- cdb.json.in
 [{
   "directory": "DIR",
-  "command": "clang -target x86_64-apple-darwin -c -g -gmodules DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -fdebug-compilation-dir=DIR -o DIR/tu.o",
+  "command": "clang -c -g -gmodules DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -fdebug-compilation-dir=DIR -o DIR/tu.o",
   "file": "DIR/tu.c"
 }]
 
@@ -26,5 +26,5 @@ module mod {
 // directory when current working directory optimization is in effect.
 // CHECK:  "modules": [
 // CHECK: "command-line": [
-// CHECK: "-fdebug-compilation-dir=/",
+// CHECK: "-fdebug-compilation-dir={{\/|.*:}}",
 // CHECK:  "translation-units": [

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -3,11 +3,12 @@
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format \
 // RUN:   experimental-full > %t/result.json
+// RUN: cat %t/result.json | FileCheck %s
 
 //--- cdb.json.in
 [{
   "directory": "DIR",
-  "command": "clang -g -fdebug-info-for-profiling DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -o DIR/tu.o",
+  "command": "clang -c -g -gmodules DIR/tu.c -fmodules -fmodules-cache-path=DIR/cache -IDIR/include/ -fdebug-compilation-dir=DIR -o DIR/tu.o",
   "file": "DIR/tu.c"
 }]
 
@@ -20,3 +21,10 @@ module mod {
 
 //--- tu.c
 #include "mod.h"
+
+// Check the -fdebug-compilation-dir used for the module is the root
+// directory when current working directory optimization is in effect.
+// CHECK:  "modules": [
+// CHECK: "command-line": [
+// CHECK: "-fdebug-compilation-dir={{\/|C:|\/\/net}}",
+// CHECK:  "translation-units": [


### PR DESCRIPTION
This PR explicitly sets `DebugCompilationDir` to the system's root directory if it is safe to ignore the current working directory. 

This fixes a problem where a PCM file's embedded debug information can lead to compilation failure. The compiler may have decided it is indeed safe to ignore the current working directory. In this case, the PCM file's content is functionally correct regardless of the current working directory because no inputs use relative paths (see https://github.com/llvm/llvm-project/pull/124786). However, a PCM may contain debug info. If debug info is requested, the compiler uses the current working directory value to set `DW_AT_comp_dir`.  This may lead to the following situation: 
1. Two different compilations need the same PCM file. 
2. The PCM file is compiled assuming a working directory, which is embedded in the debug info, but otherwise has no effect. 
3. The second compilation assumes a different working directory, and expects an identically-sized pcm file. However, it cannot find such a PCM, because the existing PCM file has been compiled assuming a different `DW_AT_comp_dir `, which is embedded in the debug info. 

This PR resets the  `DebugCompilationDir` if it is functionally safe to ignore the working directory so the above situation is avoided, since all debug information will share the same working directory.

rdar://145249881