### PR TITLE
[CodeGen][NVPTX][WebAssembly] Add copyReg interface to TargetInstrInfo that takes Register instead of MCRegister.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1040,6 +1040,16 @@ public:
                            bool RenamableSrc = false) const {
     llvm_unreachable("Target didn't implement TargetInstrInfo::copyPhysReg!");
   }
+  // Similar to copycopyPhysReg, but for targets that don't do register
+  // allocation and need to copy virtual registers like NVPTX, SPIR-V, and
+  // WebAssembly.
+  virtual void copyReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
+                       const DebugLoc &DL, Register DestReg, Register SrcReg,
+                       bool KillSrc, bool RenamableDest = false,
+                       bool RenamableSrc = false) const {
+    copyPhysReg(MBB, MI, DL, DestReg.asMCReg(), SrcReg.asMCReg(), KillSrc,
+                RenamableDest, RenamableSrc);
+  }
 
   /// Allow targets to tell MachineVerifier whether a specific register
   /// MachineOperand can be used as part of PC-relative addressing.

--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1040,7 +1040,7 @@ public:
                            bool RenamableSrc = false) const {
     llvm_unreachable("Target didn't implement TargetInstrInfo::copyPhysReg!");
   }
-  // Similar to copycopyPhysReg, but for targets that don't do register
+  // Similar to copyPhysReg, but for targets that don't do register
   // allocation and need to copy virtual registers like NVPTX, SPIR-V, and
   // WebAssembly.
   virtual void copyReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,

--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -822,10 +822,10 @@ void TargetInstrInfo::lowerCopy(MachineInstr *MI,
     return;
   }
 
-  copyPhysReg(*MI->getParent(), MI, MI->getDebugLoc(), DstMO.getReg(),
-              SrcMO.getReg(), SrcMO.isKill(),
-              DstMO.getReg().isPhysical() ? DstMO.isRenamable() : false,
-              SrcMO.getReg().isPhysical() ? SrcMO.isRenamable() : false);
+  copyReg(*MI->getParent(), MI, MI->getDebugLoc(), DstMO.getReg(),
+          SrcMO.getReg(), SrcMO.isKill(),
+          DstMO.getReg().isPhysical() ? DstMO.isRenamable() : false,
+          SrcMO.getReg().isPhysical() ? SrcMO.isRenamable() : false);
 
   if (MI->getNumOperands() > 2)
     transferImplicitOperands(MI, TRI);

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.cpp
@@ -26,11 +26,10 @@ void NVPTXInstrInfo::anchor() {}
 
 NVPTXInstrInfo::NVPTXInstrInfo() : RegInfo() {}
 
-void NVPTXInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
-                                 MachineBasicBlock::iterator I,
-                                 const DebugLoc &DL, MCRegister DestReg,
-                                 MCRegister SrcReg, bool KillSrc,
-                                 bool RenamableDest, bool RenamableSrc) const {
+void NVPTXInstrInfo::copyReg(MachineBasicBlock &MBB,
+                             MachineBasicBlock::iterator I, const DebugLoc &DL,
+                             Register DestReg, Register SrcReg, bool KillSrc,
+                             bool RenamableDest, bool RenamableSrc) const {
   const MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
   const TargetRegisterClass *DestRC = MRI.getRegClass(DestReg);
   const TargetRegisterClass *SrcRC = MRI.getRegClass(SrcReg);

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.h
@@ -50,10 +50,10 @@ public:
    *    MachineInstr::MIFlag Flags = MachineInstr::NoFlags) const;
    */
 
-  void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
-                   const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,
-                   bool KillSrc, bool RenamableDest = false,
-                   bool RenamableSrc = false) const override;
+  void copyReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
+               const DebugLoc &DL, Register DestReg, Register SrcReg,
+               bool KillSrc, bool RenamableDest = false,
+               bool RenamableSrc = false) const override;
 
   // Branch analysis.
   bool analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
@@ -256,11 +256,10 @@ unsigned SPIRVInstrInfo::insertBranch(MachineBasicBlock &MBB,
   return 1;
 }
 
-void SPIRVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
-                                 MachineBasicBlock::iterator I,
-                                 const DebugLoc &DL, MCRegister DestReg,
-                                 MCRegister SrcReg, bool KillSrc,
-                                 bool RenamableDest, bool RenamableSrc) const {
+void SPIRVInstrInfo::copyReg(MachineBasicBlock &MBB,
+                             MachineBasicBlock::iterator I, const DebugLoc &DL,
+                             Register DestReg, Register SrcReg, bool KillSrc,
+                             bool RenamableDest, bool RenamableSrc) const {
   // Actually we don't need this COPY instruction. However if we do nothing with
   // it, post RA pseudo instrs expansion just removes it and we get the code
   // with undef registers. Therefore, we need to replace all uses of dst with

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
@@ -50,10 +50,10 @@ public:
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
                         const DebugLoc &DL,
                         int *BytesAdded = nullptr) const override;
-  void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
-                   const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,
-                   bool KillSrc, bool RenamableDest = false,
-                   bool RenamableSrc = false) const override;
+  void copyReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
+               const DebugLoc &DL, Register DestReg, Register SrcReg,
+               bool KillSrc, bool RenamableDest = false,
+               bool RenamableSrc = false) const override;
   bool expandPostRAPseudo(MachineInstr &MI) const override;
 };
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.cpp
@@ -54,17 +54,17 @@ bool WebAssemblyInstrInfo::isReallyTriviallyReMaterializable(
   }
 }
 
-void WebAssemblyInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
-                                       MachineBasicBlock::iterator I,
-                                       const DebugLoc &DL, MCRegister DestReg,
-                                       MCRegister SrcReg, bool KillSrc,
-                                       bool RenamableDest,
-                                       bool RenamableSrc) const {
+void WebAssemblyInstrInfo::copyReg(MachineBasicBlock &MBB,
+                                   MachineBasicBlock::iterator I,
+                                   const DebugLoc &DL, Register DestReg,
+                                   Register SrcReg, bool KillSrc,
+                                   bool RenamableDest,
+                                   bool RenamableSrc) const {
   // This method is called by post-RA expansion, which expects only pregs to
   // exist. However we need to handle both here.
   auto &MRI = MBB.getParent()->getRegInfo();
   const TargetRegisterClass *RC =
-      Register::isVirtualRegister(DestReg)
+      DestReg.isVirtual()
           ? MRI.getRegClass(DestReg)
           : MRI.getTargetRegisterInfo()->getMinimalPhysRegClass(DestReg);
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyInstrInfo.h
@@ -39,10 +39,10 @@ public:
 
   bool isReallyTriviallyReMaterializable(const MachineInstr &MI) const override;
 
-  void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
-                   const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,
-                   bool KillSrc, bool RenamableDest = false,
-                   bool RenamableSrc = false) const override;
+  void copyReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
+               const DebugLoc &DL, Register DestReg, Register SrcReg,
+               bool KillSrc, bool RenamableDest = false,
+               bool RenamableSrc = false) const override;
   MachineInstr *commuteInstructionImpl(MachineInstr &MI, bool NewMI,
                                        unsigned OpIdx1,
                                        unsigned OpIdx2) const override;


### PR DESCRIPTION
NVPTX, SPIRV, and WebAssembly all need to expand copies of virtual registers because they don't go through register allocation.

The copyPhysReg interface currently used takes two MCRegister arguments that get implicitly converted from Registers in LowerCopy. It should be illegal to convert a virtual register Register to an MCRegister.

This patch adds a new interface copyReg that takes two Registers. The default implementation falls back to copyPhysReg with an explicit conversion. NVPTX, SPIRV, and WebAssembly are modified to implement the new interface.

I chose this approach to be least disruptive to out of tree targets. Alternatively, we could change copyPhysReg to take Register operands, though we would probably want to rename it to remove "Phys".