### PR TITLE
Revert "[compiler-rt][rtsan] stat api interception."

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -285,45 +285,6 @@ INTERCEPTOR(int, unlinkat, int fd, const char *pathname, int flag) {
   return REAL(unlinkat)(fd, pathname, flag);
 }
 
-INTERCEPTOR(int, stat, const char *pathname, struct stat *s) {
-  __rtsan_notify_intercepted_call("stat");
-  return REAL(stat)(pathname, s);
-}
-
-INTERCEPTOR(int, lstat, const char *pathname, struct stat *s) {
-  __rtsan_notify_intercepted_call("lstat");
-  return REAL(lstat)(pathname, s);
-}
-
-INTERCEPTOR(int, fstat, int fd, struct stat *s) {
-  __rtsan_notify_intercepted_call("fstat");
-  return REAL(fstat)(fd, s);
-}
-
-#if !SANITIZER_APPLE // deprecated for darwin
-INTERCEPTOR(int, stat64, const char *pathname, struct stat64 *s) {
-  __rtsan_notify_intercepted_call("stat64");
-  return REAL(stat64)(pathname, s);
-}
-
-INTERCEPTOR(int, lstat64, const char *pathname, struct stat64 *s) {
-  __rtsan_notify_intercepted_call("lstat64");
-  return REAL(lstat64)(pathname, s);
-}
-
-INTERCEPTOR(int, fstat64, int fd, struct stat64 *s) {
-  __rtsan_notify_intercepted_call("fstat64");
-  return REAL(fstat64)(fd, s);
-}
-#define RTSAN_MAYBE_INTERCEPT_STAT64 INTERCEPT_FUNCTION(stat64)
-#define RTSAN_MAYBE_INTERCEPT_LSTAT64 INTERCEPT_FUNCTION(lstat64)
-#define RTSAN_MAYBE_INTERCEPT_FSTAT64 INTERCEPT_FUNCTION(fstat64)
-#else
-#define RTSAN_MAYBE_INTERCEPT_STAT64
-#define RTSAN_MAYBE_INTERCEPT_LSTAT64
-#define RTSAN_MAYBE_INTERCEPT_FSTAT64
-#endif
-
 // Streams
 
 INTERCEPTOR(FILE *, fopen, const char *path, const char *mode) {
@@ -1476,12 +1437,6 @@ void __rtsan::InitializeInterceptors() {
   RTSAN_MAYBE_INTERCEPT_READLINKAT;
   INTERCEPT_FUNCTION(unlink);
   INTERCEPT_FUNCTION(unlinkat);
-  INTERCEPT_FUNCTION(stat);
-  INTERCEPT_FUNCTION(lstat);
-  INTERCEPT_FUNCTION(fstat);
-  RTSAN_MAYBE_INTERCEPT_STAT64;
-  RTSAN_MAYBE_INTERCEPT_LSTAT64;
-  RTSAN_MAYBE_INTERCEPT_FSTAT64;
   INTERCEPT_FUNCTION(fopen);
   RTSAN_MAYBE_INTERCEPT_FOPEN64;
   RTSAN_MAYBE_INTERCEPT_FREOPEN64;

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -401,7 +401,7 @@ TEST_F(RtsanFileTest, FcntlFlockDiesWhenRealtime) {
   ASSERT_THAT(fd, Ne(-1));
 
   auto Func = [fd]() {
-    struct flock lock{};
+    struct flock lock {};
     lock.l_type = F_RDLCK;
     lock.l_whence = SEEK_SET;
     lock.l_start = 0;
@@ -735,7 +735,7 @@ TEST(TestRtsanInterceptors, IoctlBehavesWithOutputPointer) {
     GTEST_SKIP();
   }
 
-  struct ifreq ifr{};
+  struct ifreq ifr {};
   strncpy(ifr.ifr_name, ifaddr->ifa_name, IFNAMSIZ - 1);
 
   int retval = ioctl(sock, SIOCGIFADDR, &ifr);
@@ -872,33 +872,6 @@ TEST_F(RtsanOpenedFileTest, UnlinkDiesWhenRealtime) {
 TEST_F(RtsanOpenedFileTest, UnlinkatDiesWhenRealtime) {
   auto Func = [&]() { unlinkat(0, GetTemporaryFilePath(), 0); };
   ExpectRealtimeDeath(Func, "unlinkat");
-  ExpectNonRealtimeSurvival(Func);
-}
-
-TEST_F(RtsanOpenedFileTest, StatDiesWhenRealtime) {
-  auto Func = [&]() {
-    struct stat s{};
-    stat(GetTemporaryFilePath(), &s);
-  };
-  ExpectRealtimeDeath(Func, MAYBE_APPEND_64("stat"));
-  ExpectNonRealtimeSurvival(Func);
-}
-
-TEST_F(RtsanOpenedFileTest, LstatDiesWhenRealtime) {
-  auto Func = [&]() {
-    struct stat s{};
-    lstat(GetTemporaryFilePath(), &s);
-  };
-  ExpectRealtimeDeath(Func, MAYBE_APPEND_64("lstat"));
-  ExpectNonRealtimeSurvival(Func);
-}
-
-TEST_F(RtsanOpenedFileTest, FstatDiesWhenRealtime) {
-  auto Func = [&]() {
-    struct stat s{};
-    fstat(GetOpenFd(), &s);
-  };
-  ExpectRealtimeDeath(Func, MAYBE_APPEND_64("fstat"));
   ExpectNonRealtimeSurvival(Func);
 }
 


### PR DESCRIPTION
Reverts llvm/llvm-project#128430

Reverting this as I could repro the failure here:

> Hi @devnexen I believe this change is causing failures on a bot. Any idea what might be causing the problems?
> https://lab.llvm.org/staging/#/builders/202/builds/1324

https://github.com/llvm/llvm-project/pull/128430#issuecomment-2677298624