### PR TITLE
[InstCombine] Simplify nonnull phi nodes

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -1011,6 +1011,20 @@ Value *InstCombinerImpl::simplifyNonNullOperand(Value *V,
     }
   }
 
+  if (auto *PHI = dyn_cast<PHINode>(V)) {
+    bool Changed = false;
+    for (Use &U : PHI->incoming_values()) {
+      if (auto *Res =
+              simplifyNonNullOperand(U.get(), HasDereferenceable, Depth + 1)) {
+        replaceUse(U, Res);
+        Changed = true;
+      }
+    }
+    if (Changed)
+      addToWorklist(PHI);
+    return nullptr;
+  }
+
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
@@ -1014,8 +1014,9 @@ Value *InstCombinerImpl::simplifyNonNullOperand(Value *V,
   if (auto *PHI = dyn_cast<PHINode>(V)) {
     bool Changed = false;
     for (Use &U : PHI->incoming_values()) {
-      if (auto *Res =
-              simplifyNonNullOperand(U.get(), HasDereferenceable, Depth + 1)) {
+      // We set Depth to RecursionLimit to avoid expensive recursion.
+      if (auto *Res = simplifyNonNullOperand(U.get(), HasDereferenceable,
+                                             RecursionLimit)) {
         replaceUse(U, Res);
         Changed = true;
       }

--- a/llvm/test/Transforms/InstCombine/load.ll
+++ b/llvm/test/Transforms/InstCombine/load.ll
@@ -487,10 +487,8 @@ define i32 @test_load_phi_with_select(ptr %p, i1 %cond1) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[LOOP_BODY:%.*]]
 ; CHECK:       loop.body:
-; CHECK-NEXT:    [[BASE:%.*]] = phi ptr [ [[P1:%.*]], [[ENTRY:%.*]] ], [ [[P:%.*]], [[LOOP_BODY]] ]
-; CHECK-NEXT:    [[TARGET:%.*]] = getelementptr inbounds nuw i8, ptr [[BASE]], i64 24
+; CHECK-NEXT:    [[TARGET:%.*]] = getelementptr inbounds nuw i8, ptr [[BASE:%.*]], i64 24
 ; CHECK-NEXT:    [[LOAD:%.*]] = load i32, ptr [[TARGET]], align 4
-; CHECK-NEXT:    [[P]] = select i1 [[COND1:%.*]], ptr null, ptr [[P1]]
 ; CHECK-NEXT:    [[COND21:%.*]] = icmp eq i32 [[LOAD]], 0
 ; CHECK-NEXT:    br i1 [[COND21]], label [[LOOP_BODY]], label [[EXIT:%.*]]
 ; CHECK:       exit:


### PR DESCRIPTION
Fix some regressions caused by https://github.com/llvm/llvm-project/pull/128111.
Compile-time impact: https://llvm-compile-time-tracker.com/compare.php?from=1e0e4169dd00bf8a37cef8d74d0add7861982c4e&to=3a27268e264826ef9cf493f645507e490f05e7f3&stat=instructions%3Au
