### PR TITLE
[CodeGen][NPM] Parse MachineFunctions in NPM driver

### DIFF
--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -153,13 +153,12 @@ int llvm::compileModuleWithNewPM(
     FPM.addPass(createFunctionToMachineFunctionPassAdaptor(std::move(MFPM)));
     MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
 
-    if (MIR->parseMachineFunctions(*M, MAM))
-      return 1;
   } else {
     ExitOnErr(Target->buildCodeGenPipeline(
         MPM, *OS, DwoOut ? &DwoOut->os() : nullptr, FileType, Opt, &PIC));
   }
 
+  // If user only wants to print the pipeline, print it before parsing the MIR.
   if (PrintPipelinePasses) {
     std::string PipelineStr;
     raw_string_ostream OS(PipelineStr);
@@ -170,6 +169,9 @@ int llvm::compileModuleWithNewPM(
     outs() << PipelineStr << '\n';
     return 0;
   }
+
+  if (MIR->parseMachineFunctions(*M, MAM))
+    return 1;
 
   // Before executing passes, print the final values of the LLVM options.
   cl::PrintOptionValues();

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -170,7 +170,7 @@ int llvm::compileModuleWithNewPM(
     return 0;
   }
 
-  if (MIR->parseMachineFunctions(*M, MAM))
+  if (MIR && MIR->parseMachineFunctions(*M, MAM))
     return 1;
 
   // Before executing passes, print the final values of the LLVM options.


### PR DESCRIPTION
MachineFunctions were not being parsed when target is allowed to build the pipeline.

This will allow us to use `-start-before` and other options.