### PR TITLE
[clang][bytecode] Handle non-primitive array index expressions

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1689,14 +1689,17 @@ bool Compiler<Emitter>::VisitArraySubscriptExpr(const ArraySubscriptExpr *E) {
   if (!Success)
     return false;
 
-  PrimType IndexT = classifyPrim(Index->getType());
+  std::optional<PrimType> IndexT = classify(Index->getType());
+  // In error-recovery cases, the index expression has a dependent type.
+  if (!IndexT)
+    return this->emitError(E);
   // If the index is first, we need to change that.
   if (LHS == Index) {
-    if (!this->emitFlip(PT_Ptr, IndexT, E))
+    if (!this->emitFlip(PT_Ptr, *IndexT, E))
       return false;
   }
 
-  return this->emitArrayElemPtrPop(IndexT, E);
+  return this->emitArrayElemPtrPop(*IndexT, E);
 }
 
 template <class Emitter>

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -654,3 +654,11 @@ namespace ZeroSizeTypes {
                               // both-warning {{subtraction of pointers to type 'int[0]' of zero size has undefined behavior}}
   }
 }
+
+namespace InvalidIndex {
+  constexpr int foo(int i) { // both-error {{no return statement in constexpr function}}
+    int a[] = {1,2,3};
+    return a[_z]; // both-error {{use of undeclared identifier}}
+  }
+  static_assert(foo(0) == 1, "");
+}


### PR DESCRIPTION
By rejecting them instead of asserting in `classifyPrim()`.