### PR TITLE
[analyzer][clang-tidy] Fixup build after 3dc159431be7

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -462,7 +462,7 @@ ClangTidyASTConsumerFactory::createASTConsumer(
     std::unique_ptr<ento::AnalysisASTConsumer> AnalysisConsumer =
         ento::CreateAnalysisConsumer(Compiler);
     AnalysisConsumer->AddDiagnosticConsumer(
-        new AnalyzerDiagnosticConsumer(Context));
+        std::make_unique<AnalyzerDiagnosticConsumer>(Context));
     Consumers.push_back(std::move(AnalysisConsumer));
   }
 #endif // CLANG_TIDY_ENABLE_STATIC_ANALYZER


### PR DESCRIPTION
There was one place I forgot to update, clang-tidy. I only ran the CSA tests in #128368.

Fixes:
https://lab.llvm.org/buildbot/#/builders/52/builds/6286/steps/9/logs/stdio