### PR TITLE
[libclc] Remove clspv-specific clc conversions

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -258,13 +258,6 @@ if ( clspv-- IN_LIST LIBCLC_TARGETS_TO_BUILD OR clspv64-- IN_LIST LIBCLC_TARGETS
     DEPENDS ${script_loc} )
   add_custom_target( generate-clspv-convert.cl DEPENDS clspv-convert.cl )
   set_target_properties( generate-clspv-convert.cl PROPERTIES FOLDER "libclc/Sourcegenning" )
-
-  add_custom_command(
-    OUTPUT clc-clspv-convert.cl
-    COMMAND ${Python3_EXECUTABLE} ${script_loc} --clc --clspv > clc-clspv-convert.cl
-    DEPENDS ${script_loc} )
-  add_custom_target( generate-clc-clspv-convert.cl DEPENDS clc-clspv-convert.cl )
-  set_target_properties( generate-clc-clspv-convert.cl PROPERTIES FOLDER "libclc/Sourcegenning" )
 endif()
 
 enable_testing()
@@ -314,12 +307,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
   endif()
 
   set( clc_lib_files )
-
-  if( ARCH STREQUAL clspv OR ARCH STREQUAL clspv64 )
-    set( clc_gen_files clc-clspv-convert.cl )
-  else()
-    set( clc_gen_files clc-convert.cl )
-  endif()
+  set( clc_gen_files clc-convert.cl )
 
   libclc_configure_lib_source(
     clc_lib_files

--- a/libclc/generic/lib/gen_convert.py
+++ b/libclc/generic/lib/gen_convert.py
@@ -28,6 +28,7 @@
 # convert_<destTypen><_sat><_roundingMode>(<sourceTypen>)
 
 import argparse
+from sys import stderr
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -40,6 +41,14 @@ args = parser.parse_args()
 
 clc = args.clc
 clspv = args.clspv
+
+
+# We don't generate clspv-specific code for clc conversions - don't allow this
+# accidentally (later checks rely on mutual exclusivity)
+if clc and clspv:
+    print("Error: clc and clspv conversions are mutually exclusive", file=stderr)
+    exit(1)
+
 
 types = [
     "char",
@@ -308,7 +317,7 @@ def generate_default_conversion(src, dst, mode):
 
 # Do not generate user-facing default conversions for clspv as they are handled
 # natively
-if clc or not clspv:
+if not clspv:
     for src in types:
         for dst in types:
             generate_default_conversion(src, dst, "")
@@ -318,7 +327,7 @@ for src in int_types:
         for mode in rounding_modes:
             # Do not generate user-facing "_rte" conversions for clspv as they
             # are handled natively
-            if clspv and not clc and mode == "_rte":
+            if clspv and mode == "_rte":
                 continue
             generate_default_conversion(src, dst, mode)
 
@@ -560,6 +569,6 @@ for src in types:
             for mode in rounding_modes:
                 # Do not generate user-facing "_rte" conversions for clspv as
                 # they are handled natively
-                if clspv and not clc and mode == "_rte":
+                if clspv and mode == "_rte":
                     continue
                 generate_float_conversion(src, dst, size, mode, "")


### PR DESCRIPTION
The clc and clc+clspv modes produced the same conversions code, so this patch simplifies the process. It further simplifies the internal checks the script makes by assuming the mutual exclusivity.