### PR TITLE
[clangd] Add `HeaderInsertion` yaml config option

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -455,6 +455,7 @@ void ClangdServer::codeComplete(PathRef File, Position Pos,
     CodeCompleteOpts.MainFileSignals = IP->Signals;
     CodeCompleteOpts.AllScopes = Config::current().Completion.AllScopes;
     CodeCompleteOpts.ArgumentLists = Config::current().Completion.ArgumentLists;
+    CodeCompleteOpts.InsertIncludes = Config::current().HeaderInsertion.Policy;
     // FIXME(ibiryukov): even if Preamble is non-null, we may want to check
     // both the old and the new version in case only one of them matches.
     CodeCompleteResult Result = clangd::codeComplete(

--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -455,7 +455,8 @@ void ClangdServer::codeComplete(PathRef File, Position Pos,
     CodeCompleteOpts.MainFileSignals = IP->Signals;
     CodeCompleteOpts.AllScopes = Config::current().Completion.AllScopes;
     CodeCompleteOpts.ArgumentLists = Config::current().Completion.ArgumentLists;
-    CodeCompleteOpts.InsertIncludes = Config::current().HeaderInsertion.Policy;
+    CodeCompleteOpts.InsertIncludes =
+        Config::current().Completion.HeaderInsertion;
     // FIXME(ibiryukov): even if Preamble is non-null, we may want to check
     // both the old and the new version in case only one of them matches.
     CodeCompleteResult Result = clangd::codeComplete(

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -294,8 +294,7 @@ struct CompletionCandidate {
   std::optional<llvm::StringRef>
   headerToInsertIfAllowed(const CodeCompleteOptions &Opts,
                           CodeCompletionContext::Kind ContextKind) const {
-    if (Opts.InsertIncludes ==
-            CodeCompleteOptions::IncludeInsertion::NeverInsert ||
+    if (Opts.InsertIncludes == Config::HeaderInsertionPolicy::NeverInsert ||
         RankedIncludeHeaders.empty() ||
         !contextAllowsHeaderInsertion(ContextKind))
       return std::nullopt;

--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -294,7 +294,8 @@ struct CompletionCandidate {
   std::optional<llvm::StringRef>
   headerToInsertIfAllowed(const CodeCompleteOptions &Opts,
                           CodeCompletionContext::Kind ContextKind) const {
-    if (Opts.InsertIncludes == CodeCompleteOptions::NeverInsert ||
+    if (Opts.InsertIncludes ==
+            CodeCompleteOptions::IncludeInsertion::NeverInsert ||
         RankedIncludeHeaders.empty() ||
         !contextAllowsHeaderInsertion(ContextKind))
       return std::nullopt;

--- a/clang-tools-extra/clangd/CodeComplete.h
+++ b/clang-tools-extra/clangd/CodeComplete.h
@@ -71,10 +71,8 @@ struct CodeCompleteOptions {
   /// Whether to present doc comments as plain-text or markdown.
   MarkupKind DocumentationFormat = MarkupKind::PlainText;
 
-  enum IncludeInsertion {
-    IWYU,
-    NeverInsert,
-  } InsertIncludes = IncludeInsertion::IWYU;
+  using IncludeInsertion = Config::HeaderInsertionPolicy;
+  Config::HeaderInsertionPolicy InsertIncludes = IncludeInsertion::IWYU;
 
   /// Whether include insertions for Objective-C code should use #import instead
   /// of #include.

--- a/clang-tools-extra/clangd/CodeComplete.h
+++ b/clang-tools-extra/clangd/CodeComplete.h
@@ -71,8 +71,8 @@ struct CodeCompleteOptions {
   /// Whether to present doc comments as plain-text or markdown.
   MarkupKind DocumentationFormat = MarkupKind::PlainText;
 
-  using IncludeInsertion = Config::HeaderInsertionPolicy;
-  Config::HeaderInsertionPolicy InsertIncludes = IncludeInsertion::IWYU;
+  Config::HeaderInsertionPolicy InsertIncludes =
+      Config::HeaderInsertionPolicy::IWYU;
 
   /// Whether include insertions for Objective-C code should use #import instead
   /// of #include.

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -147,6 +147,11 @@ struct Config {
     FullPlaceholders,
   };
 
+  enum class HeaderInsertionPolicy {
+    IWYU,       // Include what you use
+    NeverInsert // Never insert headers as part of code completion
+  };
+
   /// Configures code completion feature.
   struct {
     /// Whether code completion includes results that are not visible in current
@@ -154,16 +159,9 @@ struct Config {
     bool AllScopes = true;
     /// controls the completion options for argument lists.
     ArgumentListsPolicy ArgumentLists = ArgumentListsPolicy::FullPlaceholders;
+    /// Controls if headers should be inserted when completions are accepted
+    HeaderInsertionPolicy HeaderInsertion = HeaderInsertionPolicy::IWYU;
   } Completion;
-
-  enum class HeaderInsertionPolicy {
-    IWYU,       // Include what you use
-    NeverInsert // Never insert headers as part of code completion
-  };
-
-  struct {
-    HeaderInsertionPolicy Policy = HeaderInsertionPolicy::IWYU;
-  } HeaderInsertion;
 
   /// Configures hover feature.
   struct {

--- a/clang-tools-extra/clangd/Config.h
+++ b/clang-tools-extra/clangd/Config.h
@@ -156,6 +156,15 @@ struct Config {
     ArgumentListsPolicy ArgumentLists = ArgumentListsPolicy::FullPlaceholders;
   } Completion;
 
+  enum class HeaderInsertionPolicy {
+    IWYU,       // Include what you use
+    NeverInsert // Never insert headers as part of code completion
+  };
+
+  struct {
+    HeaderInsertionPolicy Policy = HeaderInsertionPolicy::IWYU;
+  } HeaderInsertion;
+
   /// Configures hover feature.
   struct {
     /// Whether hover show a.k.a type.

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -697,6 +697,17 @@ struct FragmentCompiler {
           C.Completion.ArgumentLists = *Val;
         });
     }
+    if (F.HeaderInsertion) {
+      if (auto Val =
+              compileEnum<Config::HeaderInsertionPolicy>("HeaderInsertion",
+                                                         *F.HeaderInsertion)
+                  .map("IWYU", Config::HeaderInsertionPolicy::IWYU)
+                  .map("Never", Config::HeaderInsertionPolicy::NeverInsert)
+                  .value())
+        Out.Apply.push_back([Val](const Params &, Config &C) {
+          C.HeaderInsertion.Policy = *Val;
+        });
+    }
   }
 
   void compile(Fragment::HoverBlock &&F) {

--- a/clang-tools-extra/clangd/ConfigCompile.cpp
+++ b/clang-tools-extra/clangd/ConfigCompile.cpp
@@ -705,7 +705,7 @@ struct FragmentCompiler {
                   .map("Never", Config::HeaderInsertionPolicy::NeverInsert)
                   .value())
         Out.Apply.push_back([Val](const Params &, Config &C) {
-          C.HeaderInsertion.Policy = *Val;
+          C.Completion.HeaderInsertion = *Val;
         });
     }
   }

--- a/clang-tools-extra/clangd/ConfigFragment.h
+++ b/clang-tools-extra/clangd/ConfigFragment.h
@@ -341,6 +341,14 @@ struct Fragment {
     ///   Delimiters: empty pair of delimiters "()" or "<>"
     ///   FullPlaceholders: full name of both type and parameter
     std::optional<Located<std::string>> ArgumentLists;
+    /// Add #include directives when accepting code completions. Config
+    /// equivalent of the CLI option '--header-insertion'
+    /// Valid values are enum Config::HeaderInsertionPolicy values:
+    ///   "IWYU": Include what you use. Insert the owning header for top-level
+    ///     symbols, unless the header is already directly included or the
+    ///     symbol is forward-declared
+    ///   "NeverInsert": Never insert headers
+    std::optional<Located<std::string>> HeaderInsertion;
   };
   CompletionBlock Completion;
 

--- a/clang-tools-extra/clangd/ConfigYAML.cpp
+++ b/clang-tools-extra/clangd/ConfigYAML.cpp
@@ -245,6 +245,10 @@ private:
       if (auto ArgumentLists = scalarValue(N, "ArgumentLists"))
         F.ArgumentLists = *ArgumentLists;
     });
+    Dict.handle("HeaderInsertion", [&](Node &N) {
+      if (auto HeaderInsertion = scalarValue(N, "HeaderInsertion"))
+        F.HeaderInsertion = *HeaderInsertion;
+    });
     Dict.parse(N);
   }
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -257,13 +257,13 @@ opt<CodeCompleteOptions::IncludeInsertion> HeaderInsertion{
     desc("Add #include directives when accepting code completions"),
     init(CodeCompleteOptions().InsertIncludes),
     values(
-        clEnumValN(CodeCompleteOptions::IWYU, "iwyu",
+        clEnumValN(CodeCompleteOptions::IncludeInsertion::IWYU, "iwyu",
                    "Include what you use. "
                    "Insert the owning header for top-level symbols, unless the "
                    "header is already directly included or the symbol is "
                    "forward-declared"),
         clEnumValN(
-            CodeCompleteOptions::NeverInsert, "never",
+            CodeCompleteOptions::IncludeInsertion::NeverInsert, "never",
             "Never insert #include directives as part of code completion")),
 };
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -668,6 +668,7 @@ public:
     std::optional<Config::ExternalIndexSpec> IndexSpec;
     std::optional<Config::BackgroundPolicy> BGPolicy;
     std::optional<Config::ArgumentListsPolicy> ArgumentLists;
+    std::optional<Config::HeaderInsertionPolicy> _HeaderInsertion;
 
     // If --compile-commands-dir arg was invoked, check value and override
     // default path.
@@ -712,6 +713,11 @@ public:
       BGPolicy = Config::BackgroundPolicy::Skip;
     }
 
+    // If CLI has set never, use that regardless of what the config files have
+    if (HeaderInsertion == CodeCompleteOptions::IncludeInsertion::NeverInsert) {
+      _HeaderInsertion = CodeCompleteOptions::IncludeInsertion::NeverInsert;
+    }
+
     if (std::optional<bool> Enable = shouldEnableFunctionArgSnippets()) {
       ArgumentLists = *Enable ? Config::ArgumentListsPolicy::FullPlaceholders
                               : Config::ArgumentListsPolicy::Delimiters;
@@ -726,6 +732,8 @@ public:
         C.Index.Background = *BGPolicy;
       if (ArgumentLists)
         C.Completion.ArgumentLists = *ArgumentLists;
+      if (_HeaderInsertion)
+        C.Completion.HeaderInsertion = *_HeaderInsertion;
       if (AllScopesCompletion.getNumOccurrences())
         C.Completion.AllScopes = AllScopesCompletion;
 

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -251,19 +251,19 @@ opt<std::string> EnableFunctionArgSnippets{
     init("-1"),
 };
 
-opt<CodeCompleteOptions::IncludeInsertion> HeaderInsertion{
+opt<Config::HeaderInsertionPolicy> HeaderInsertion{
     "header-insertion",
     cat(Features),
     desc("Add #include directives when accepting code completions"),
     init(CodeCompleteOptions().InsertIncludes),
     values(
-        clEnumValN(CodeCompleteOptions::IncludeInsertion::IWYU, "iwyu",
+        clEnumValN(Config::HeaderInsertionPolicy::IWYU, "iwyu",
                    "Include what you use. "
                    "Insert the owning header for top-level symbols, unless the "
                    "header is already directly included or the symbol is "
                    "forward-declared"),
         clEnumValN(
-            CodeCompleteOptions::IncludeInsertion::NeverInsert, "never",
+            Config::HeaderInsertionPolicy::NeverInsert, "never",
             "Never insert #include directives as part of code completion")),
 };
 
@@ -668,7 +668,7 @@ public:
     std::optional<Config::ExternalIndexSpec> IndexSpec;
     std::optional<Config::BackgroundPolicy> BGPolicy;
     std::optional<Config::ArgumentListsPolicy> ArgumentLists;
-    std::optional<Config::HeaderInsertionPolicy> _HeaderInsertion;
+    std::optional<Config::HeaderInsertionPolicy> HeaderInsertionPolicy;
 
     // If --compile-commands-dir arg was invoked, check value and override
     // default path.
@@ -714,8 +714,8 @@ public:
     }
 
     // If CLI has set never, use that regardless of what the config files have
-    if (HeaderInsertion == CodeCompleteOptions::IncludeInsertion::NeverInsert) {
-      _HeaderInsertion = CodeCompleteOptions::IncludeInsertion::NeverInsert;
+    if (HeaderInsertion == Config::HeaderInsertionPolicy::NeverInsert) {
+      HeaderInsertionPolicy = Config::HeaderInsertionPolicy::NeverInsert;
     }
 
     if (std::optional<bool> Enable = shouldEnableFunctionArgSnippets()) {
@@ -732,8 +732,8 @@ public:
         C.Index.Background = *BGPolicy;
       if (ArgumentLists)
         C.Completion.ArgumentLists = *ArgumentLists;
-      if (_HeaderInsertion)
-        C.Completion.HeaderInsertion = *_HeaderInsertion;
+      if (HeaderInsertionPolicy)
+        C.Completion.HeaderInsertion = *HeaderInsertionPolicy;
       if (AllScopesCompletion.getNumOccurrences())
         C.Completion.AllScopes = AllScopesCompletion;
 

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -882,7 +882,8 @@ TEST(CompletionTest, IncludeInsertionPreprocessorIntegrationTests) {
               ElementsAre(AllOf(named("X"), insertInclude("\"bar.h\""))));
   // Can be disabled via option.
   CodeCompleteOptions NoInsertion;
-  NoInsertion.InsertIncludes = CodeCompleteOptions::NeverInsert;
+  NoInsertion.InsertIncludes =
+      CodeCompleteOptions::IncludeInsertion::NeverInsert;
   Results = completions(TU, Test.point(), {Sym}, NoInsertion);
   EXPECT_THAT(Results.Completions,
               ElementsAre(AllOf(named("X"), Not(insertInclude()))));

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -882,8 +882,7 @@ TEST(CompletionTest, IncludeInsertionPreprocessorIntegrationTests) {
               ElementsAre(AllOf(named("X"), insertInclude("\"bar.h\""))));
   // Can be disabled via option.
   CodeCompleteOptions NoInsertion;
-  NoInsertion.InsertIncludes =
-      CodeCompleteOptions::IncludeInsertion::NeverInsert;
+  NoInsertion.InsertIncludes = Config::HeaderInsertionPolicy::NeverInsert;
   Results = completions(TU, Test.point(), {Sym}, NoInsertion);
   EXPECT_THAT(Results.Completions,
               ElementsAre(AllOf(named("X"), Not(insertInclude()))));
@@ -1192,7 +1191,7 @@ TEST(CompletionTest, CommentsOnMembersFromHeaderOverloadBundling) {
       int delta(int i);
 
       void epsilon(long l);
-      
+
       /// This one has a comment.
       void epsilon(int i);
     };


### PR DESCRIPTION
This is the yaml config equivalent of `--header-insertion` CLI

Fix for [issue](https://github.com/clangd/clangd/issues/2032)