### PR TITLE
[clang][SYCL] Disable float128 device mode diagnostic

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4700,7 +4700,8 @@ void Sema::AddModeAttr(Decl *D, const AttributeCommonInfo &CI,
 
   if (NewElemTy.isNull()) {
     // Only emit diagnostic on host for 128-bit mode attribute
-    if (!(DestWidth == 128 && getLangOpts().CUDAIsDevice))
+    if (!(DestWidth == 128 &&
+          (getLangOpts().CUDAIsDevice || getLangOpts().SYCLIsDevice)))
       Diag(AttrLoc, diag::err_machine_mode) << 1 /*Unsupported*/ << Name;
     return;
   }

--- a/clang/test/SemaSYCL/float128.cpp
+++ b/clang/test/SemaSYCL/float128.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify -fsyntax-only %s
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fsycl-is-device -fsyntax-only %s
 
+typedef _Complex float __cfloat128 __attribute__ ((__mode__ (__TC__)));
 typedef __float128 BIGTY;
 
 template <class T>


### PR DESCRIPTION
This diagnostic is disabled for device compilation as float128 is not supported on the device side.

Other diagnostics are already covering the cases where float128 is actually used in the kernel code, and it's already tested for in the existing test.

This is expanding on the patch 318bff6 that handled this for cuda compilation.