### PR TITLE
AMDGPU: Enable RELA for PAL target

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUAsmBackend.cpp
@@ -239,7 +239,8 @@ class ELFAMDGPUAsmBackend : public AMDGPUAsmBackend {
 public:
   ELFAMDGPUAsmBackend(const Target &T, const Triple &TT)
       : AMDGPUAsmBackend(T), Is64Bit(TT.getArch() == Triple::amdgcn),
-        HasRelocationAddend(TT.getOS() == Triple::AMDHSA) {
+        HasRelocationAddend(TT.getOS() == Triple::AMDHSA ||
+                            TT.getOS() == Triple::AMDPAL) {
     switch (TT.getOS()) {
     case Triple::AMDHSA:
       OSABI = ELF::ELFOSABI_AMDGPU_HSA;


### PR DESCRIPTION
This fixes the generation of dwarf data for this target.