### PR TITLE
[MLIR] Improve error handling when parsing dense attributes

### DIFF
--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -680,6 +680,11 @@ DenseElementsAttr TensorLiteralParser::getStringAttr(SMLoc loc, ShapedType type,
   stringRefValues.reserve(storage.size());
 
   for (auto val : storage) {
+    if (!val.second.is(Token::string)) {
+      p.emitError(loc) << "expected string token, got "
+                       << val.second.getSpelling();
+      return nullptr;
+    }
     stringValues.push_back(val.second.getStringValue());
     stringRefValues.emplace_back(stringValues.back());
   }

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -626,3 +626,13 @@ func.func @print_error_on_correct_line() {
     sparse <> : i32
   return
 }
+
+// -----
+
+// Prevent assertions when parsing a dense attribute expected to be a string 
+// but encountering a different type. 
+func.func @expect_to_parse_literal() {
+  // expected-error@below {{expected string token, got 23}}
+  %0 = arith.constant dense<[23]> : tensor<1x!unknown<>>
+  return
+}


### PR DESCRIPTION
Avoid triggering assertions when we expect to parse a string but encounter a different type. Instead, handle the mismatch gracefully by emitting a parser error.