### PR TITLE
[PPC][MC] Restore support for case-insensitive register names

### DIFF
--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -1320,7 +1320,10 @@ MCRegister PPCAsmParser::matchRegisterName(int64_t &IntVal) {
   if (!getParser().getTok().is(AsmToken::Identifier))
     return MCRegister();
 
-  StringRef Name = getParser().getTok().getString();
+  // MatchRegisterName() expects lower-case registers, but we want to support
+  // case-insensitive spelling.
+  std::string NameBuf = getParser().getTok().getString().lower();
+  StringRef Name(NameBuf);
   MCRegister RegNo = MatchRegisterName(Name);
   if (!RegNo)
     return RegNo;
@@ -1329,15 +1332,15 @@ MCRegister PPCAsmParser::matchRegisterName(int64_t &IntVal) {
 
   // MatchRegisterName doesn't seem to have special handling for 64bit vs 32bit
   // register types.
-  if (Name.equals_insensitive("lr")) {
+  if (Name == "lr") {
     RegNo = isPPC64() ? PPC::LR8 : PPC::LR;
     IntVal = 8;
-  } else if (Name.equals_insensitive("ctr")) {
+  } else if (Name == "ctr") {
     RegNo = isPPC64() ? PPC::CTR8 : PPC::CTR;
     IntVal = 9;
-  } else if (Name.equals_insensitive("vrsave"))
+  } else if (Name == "vrsave")
     IntVal = 256;
-  else if (Name.starts_with_insensitive("r"))
+  else if (Name.starts_with("r"))
     RegNo = isPPC64() ? XRegs[IntVal] : RRegs[IntVal];
 
   getParser().Lex();

--- a/llvm/test/MC/PowerPC/case-insensitive-regs.s
+++ b/llvm/test/MC/PowerPC/case-insensitive-regs.s
@@ -1,0 +1,11 @@
+# RUN: llvm-mc -triple powerpc64le-unknown-unknown %s 2>&1 | FileCheck %s
+
+# Test that upper case registers are accepted.
+
+# CHECK-LABEL: test:
+# CHECK-NEXT: ld 1, 0(3)
+# CHECK-NEXT: blr
+
+test:
+    ld %R1, 0(%R3)
+    blr


### PR DESCRIPTION
Lowercase the name before calling MatchRegisterName(), to restore support for using `%R3` instead of `%r3` and similar, matching the GNU assembler.

Fixes https://github.com/llvm/llvm-project/issues/126786.