### PR TITLE
clang-format aliasing analysis files

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -54,8 +54,8 @@
 
 using namespace llvm;
 
-STATISTIC(NumNoAlias,   "Number of NoAlias results");
-STATISTIC(NumMayAlias,  "Number of MayAlias results");
+STATISTIC(NumNoAlias, "Number of NoAlias results");
+STATISTIC(NumMayAlias, "Number of MayAlias results");
 STATISTIC(NumMustAlias, "Number of MustAlias results");
 
 namespace llvm {
@@ -116,8 +116,8 @@ AliasResult AAResults::alias(const MemoryLocation &LocA,
   if (EnableAATrace) {
     for (unsigned I = 0; I < AAQI.Depth; ++I)
       dbgs() << "  ";
-    dbgs() << "Start " << *LocA.Ptr << " @ " << LocA.Size << ", "
-           << *LocB.Ptr << " @ " << LocB.Size << "\n";
+    dbgs() << "Start " << *LocA.Ptr << " @ " << LocA.Size << ", " << *LocB.Ptr
+           << " @ " << LocB.Size << "\n";
   }
 
   AAQI.Depth++;
@@ -131,8 +131,8 @@ AliasResult AAResults::alias(const MemoryLocation &LocA,
   if (EnableAATrace) {
     for (unsigned I = 0; I < AAQI.Depth; ++I)
       dbgs() << "  ";
-    dbgs() << "End " << *LocA.Ptr << " @ " << LocA.Size << ", "
-           << *LocB.Ptr << " @ " << LocB.Size << " = " << Result << "\n";
+    dbgs() << "End " << *LocA.Ptr << " @ " << LocA.Size << ", " << *LocB.Ptr
+           << " @ " << LocB.Size << " = " << Result << "\n";
   }
 
   if (AAQI.Depth == 0) {
@@ -548,7 +548,8 @@ ModRefInfo AAResults::getModRefInfo(const AtomicCmpXchgInst *CX,
 ModRefInfo AAResults::getModRefInfo(const AtomicRMWInst *RMW,
                                     const MemoryLocation &Loc,
                                     AAQueryInfo &AAQI) {
-  // Acquire/Release atomicrmw has properties that matter for arbitrary addresses.
+  // Acquire/Release atomicrmw has properties that matter for arbitrary
+  // addresses.
   if (isStrongerThanMonotonic(RMW->getOrdering()))
     return ModRefInfo::ModRef;
 
@@ -610,8 +611,7 @@ ModRefInfo AAResults::getModRefInfo(const Instruction *I,
 /// with a smarter AA in place, this test is just wasting compile time.
 ModRefInfo AAResults::callCapturesBefore(const Instruction *I,
                                          const MemoryLocation &MemLoc,
-                                         DominatorTree *DT,
-                                         AAQueryInfo &AAQI) {
+                                         DominatorTree *DT, AAQueryInfo &AAQI) {
   if (!DT)
     return ModRefInfo::ModRef;
 
@@ -679,7 +679,7 @@ bool AAResults::canInstructionRangeModRef(const Instruction &I1,
          "Instructions not in same basic block!");
   BasicBlock::const_iterator I = I1.getIterator();
   BasicBlock::const_iterator E = I2.getIterator();
-  ++E;  // Convert from inclusive to exclusive range.
+  ++E; // Convert from inclusive to exclusive range.
 
   for (; I != E; ++I) // Check every instruction in range
     if (isModOrRefSet(getModRefInfo(&*I, Loc) & Mode))

--- a/llvm/lib/Analysis/AliasAnalysisEvaluator.cpp
+++ b/llvm/lib/Analysis/AliasAnalysisEvaluator.cpp
@@ -22,7 +22,8 @@ static cl::opt<bool> PrintAll("print-all-alias-modref-info", cl::ReallyHidden);
 
 static cl::opt<bool> PrintNoAlias("print-no-aliases", cl::ReallyHidden);
 static cl::opt<bool> PrintMayAlias("print-may-aliases", cl::ReallyHidden);
-static cl::opt<bool> PrintPartialAlias("print-partial-aliases", cl::ReallyHidden);
+static cl::opt<bool> PrintPartialAlias("print-partial-aliases",
+                                       cl::ReallyHidden);
 static cl::opt<bool> PrintMustAlias("print-must-aliases", cl::ReallyHidden);
 
 static cl::opt<bool> PrintNoModRef("print-no-modref", cl::ReallyHidden);
@@ -66,9 +67,9 @@ static void PrintResults(AliasResult AR, bool P,
   }
 }
 
-static inline void PrintModRefResults(
-    const char *Msg, bool P, Instruction *I,
-    std::pair<const Value *, Type *> Loc, Module *M) {
+static inline void PrintModRefResults(const char *Msg, bool P, Instruction *I,
+                                      std::pair<const Value *, Type *> Loc,
+                                      Module *M) {
   if (PrintAll || P) {
     errs() << "  " << Msg << ":  Ptr: ";
     Loc.second->print(errs(), false, /* NoDetails */ true);
@@ -113,8 +114,8 @@ void AAEvaluator::runInternal(Function &F, AAResults &AA) {
       Pointers.insert({LI->getPointerOperand(), LI->getType()});
       Loads.insert(LI);
     } else if (auto *SI = dyn_cast<StoreInst>(&Inst)) {
-      Pointers.insert({SI->getPointerOperand(),
-                       SI->getValueOperand()->getType()});
+      Pointers.insert(
+          {SI->getPointerOperand(), SI->getValueOperand()->getType()});
       Stores.insert(SI);
     } else if (auto *CB = dyn_cast<CallBase>(&Inst))
       Calls.insert(CB);
@@ -169,7 +170,8 @@ void AAEvaluator::runInternal(Function &F, AAResults &AA) {
           ++MayAliasCount;
           break;
         case AliasResult::PartialAlias:
-          PrintLoadStoreResults(AR, PrintPartialAlias, Load, Store, F.getParent());
+          PrintLoadStoreResults(AR, PrintPartialAlias, Load, Store,
+                                F.getParent());
           ++PartialAliasCount;
           break;
         case AliasResult::MustAlias:

--- a/llvm/lib/Analysis/AliasSetTracker.cpp
+++ b/llvm/lib/Analysis/AliasSetTracker.cpp
@@ -47,7 +47,7 @@ void AliasSet::mergeSetIn(AliasSet &AS, AliasSetTracker &AST,
 
   // Update the alias and access types of this set...
   Access |= AS.Access;
-  Alias  |= AS.Alias;
+  Alias |= AS.Alias;
 
   if (Alias == SetMustAlias) {
     // Check that these two merged sets really are must aliases. If we cannot
@@ -69,7 +69,7 @@ void AliasSet::mergeSetIn(AliasSet &AS, AliasSetTracker &AST,
   }
 
   bool ASHadUnknownInsts = !AS.UnknownInsts.empty();
-  if (UnknownInsts.empty()) {            // Merge call sites...
+  if (UnknownInsts.empty()) { // Merge call sites...
     if (ASHadUnknownInsts) {
       std::swap(UnknownInsts, AS.UnknownInsts);
       addRef();
@@ -133,8 +133,9 @@ void AliasSet::addUnknownInst(Instruction *I, BatchAAResults &AA) {
   // Guards are marked as modifying memory for control flow modelling purposes,
   // but don't actually modify any specific memory location.
   using namespace PatternMatch;
-  bool MayWriteMemory = I->mayWriteToMemory() && !isGuard(I) &&
-    !(I->use_empty() && match(I, m_Intrinsic<Intrinsic::invariant_start>()));
+  bool MayWriteMemory =
+      I->mayWriteToMemory() && !isGuard(I) &&
+      !(I->use_empty() && match(I, m_Intrinsic<Intrinsic::invariant_start>()));
   if (!MayWriteMemory) {
     Alias = SetMayAlias;
     Access |= RefAccess;
@@ -510,17 +511,26 @@ AliasSet &AliasSetTracker::addMemoryLocation(MemoryLocation Loc,
 //===----------------------------------------------------------------------===//
 
 void AliasSet::print(raw_ostream &OS) const {
-  OS << "  AliasSet[" << (const void*)this << ", " << RefCount << "] ";
+  OS << "  AliasSet[" << (const void *)this << ", " << RefCount << "] ";
   OS << (Alias == SetMustAlias ? "must" : "may") << " alias, ";
   switch (Access) {
-  case NoAccess:     OS << "No access "; break;
-  case RefAccess:    OS << "Ref       "; break;
-  case ModAccess:    OS << "Mod       "; break;
-  case ModRefAccess: OS << "Mod/Ref   "; break;
-  default: llvm_unreachable("Bad value for Access!");
+  case NoAccess:
+    OS << "No access ";
+    break;
+  case RefAccess:
+    OS << "Ref       ";
+    break;
+  case ModAccess:
+    OS << "Mod       ";
+    break;
+  case ModRefAccess:
+    OS << "Mod/Ref   ";
+    break;
+  default:
+    llvm_unreachable("Bad value for Access!");
   }
   if (Forward)
-    OS << " forwarding to " << (void*)Forward;
+    OS << " forwarding to " << (void *)Forward;
 
   if (!MemoryLocs.empty()) {
     ListSeparator LS;


### PR DESCRIPTION
These files were not formatted according to the LLVM clang-format style. This PR fixes that.