### PR TITLE
[flang][cuda][NFC] Remove shared alloc addr space

### DIFF
--- a/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
+++ b/flang/lib/Optimizer/Builder/IntrinsicCall.cpp
@@ -2728,7 +2728,6 @@ mlir::Value IntrinsicLibrary::genAtomicOr(mlir::Type resultType,
 mlir::Value IntrinsicLibrary::genAtomicCas(mlir::Type resultType,
                                            llvm::ArrayRef<mlir::Value> args) {
   assert(args.size() == 3);
-  assert(args[1].getType() == args[2].getType());
   auto successOrdering = mlir::LLVM::AtomicOrdering::acq_rel;
   auto failureOrdering = mlir::LLVM::AtomicOrdering::monotonic;
   auto llvmPtrTy = mlir::LLVM::LLVMPointerType::get(resultType.getContext());

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -292,12 +292,6 @@ struct AllocaOpConversion : public fir::FIROpConversion<fir::AllocaOp> {
       rewriter.setInsertionPointAfter(size.getDefiningOp());
     }
 
-    if (auto dataAttr = alloc->getAttrOfType<cuf::DataAttributeAttr>(
-            cuf::getDataAttrName())) {
-      if (dataAttr.getValue() == cuf::DataAttribute::Shared)
-        allocaAs = 3;
-    }
-
     // NOTE: we used to pass alloc->getAttrs() in the builder for non opaque
     // pointers! Only propagate pinned and bindc_name to help debugging, but
     // this should have no functional purpose (and passing the operand segment


### PR DESCRIPTION
This was not intended to go upstream and actually does not work with the NVPTX lowering. The address space for alloca can only be generic or local.

This was pushed upstream with https://github.com/llvm/llvm-project/commit/726c4b9f77862d83b6e5e16c8d5a2fc4fb1589a2 that was not related to address space. 