### PR TITLE
Reland [mlir] Fix integration test when %host_cc path contains spaces

### DIFF
--- a/mlir/test/Integration/Dialect/MemRef/memref_abi.c
+++ b/mlir/test/Integration/Dialect/MemRef/memref_abi.c
@@ -12,7 +12,7 @@
 // RUN: llc %t.ll -o %t.o -filetype=obj
 
 // Compile the current C file and link it to the MLIR code:
-// RUN: %host_cc %s %t.o -o %t.exe
+// RUN: "%host_cc" %s %t.o -o %t.exe
 
 // Exec
 // RUN: %t.exe | FileCheck %s

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -55,8 +55,8 @@ config.substitutions.append(("%PATH%", config.environment["PATH"]))
 config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
 config.substitutions.append(("%llvm_src_root", config.llvm_src_root))
 config.substitutions.append(("%mlir_src_root", config.mlir_src_root))
-config.substitutions.append(("%host_cxx", config.host_cxx))
-config.substitutions.append(("%host_cc", config.host_cc))
+config.substitutions.append(("%host_cxx", config.host_cxx.strip()))
+config.substitutions.append(("%host_cc", config.host_cc.strip()))
 
 
 # Searches for a runtime library with the given name and returns the found path.


### PR DESCRIPTION
Reland https://github.com/llvm/llvm-project/pull/128439

Some builders have spaces at the end of the `host_cc` path.