### PR TITLE
[lldb-dap] Finish refactoring the request handlers (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -758,17 +758,9 @@ bool DAP::HandleObject(const llvm::json::Object &object) {
   if (packet_type == "request") {
     const auto command = GetString(object, "command");
 
-    // Try the new request handler first.
-    auto new_handler_pos = new_request_handlers.find(command);
-    if (new_handler_pos != new_request_handlers.end()) {
+    auto new_handler_pos = request_handlers.find(command);
+    if (new_handler_pos != request_handlers.end()) {
       (*new_handler_pos->second)(object);
-      return true; // Success
-    }
-
-    // FIXME: Remove request_handlers once everything has been migrated.
-    auto handler_pos = request_handlers.find(command);
-    if (handler_pos != request_handlers.end()) {
-      handler_pos->second(*this, object);
       return true; // Success
     }
 
@@ -898,11 +890,6 @@ void DAP::SendReverseRequest(llvm::StringRef command,
       {"command", command},
       {"arguments", std::move(arguments)},
   });
-}
-
-void DAP::RegisterRequestCallback(std::string request,
-                                  RequestCallback callback) {
-  request_handlers[request] = callback;
 }
 
 lldb::SBError DAP::WaitForProcessToStop(uint32_t seconds) {

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -336,8 +336,7 @@ struct DAP {
 
   /// Registers a request handler.
   template <typename Handler> void RegisterRequest() {
-    request_handlers[Handler::getCommand()] =
-        std::make_unique<Handler>(*this);
+    request_handlers[Handler::getCommand()] = std::make_unique<Handler>(*this);
   }
 
   /// Debuggee will continue from stopped state.

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -44,7 +44,7 @@ namespace lldb_dap {
 //   }]
 // }
 
-void AttachRequestHandler::operator()(const llvm::json::Object &request) {
+void AttachRequestHandler::operator()(const llvm::json::Object &request) const {
   dap.is_attach = true;
   dap.last_launch_or_attach_request = request;
   llvm::json::Object response;

--- a/lldb/tools/lldb-dap/Handler/BreakpointLocationsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/BreakpointLocationsHandler.cpp
@@ -125,7 +125,7 @@ namespace lldb_dap {
 //   "required": [ "line" ]
 // },
 void BreakpointLocationsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/CompileUnitsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompileUnitsRequestHandler.cpp
@@ -53,7 +53,8 @@ namespace lldb_dap {
 //     }
 //   }]
 // }
-void CompileUnitsRequestHandler::operator()(const llvm::json::Object &request) {
+void CompileUnitsRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/CompletionsHandler.cpp
@@ -128,7 +128,8 @@ namespace lldb_dap {
 //   "interface", "module", "property", "unit", "value", "enum", "keyword",
 //   "snippet", "text", "color", "file", "reference", "customcolor" ]
 // }
-void CompletionsRequestHandler::operator()(const llvm::json::Object &request) {
+void CompletionsRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/ConfigurationDoneRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ConfigurationDoneRequestHandler.cpp
@@ -45,7 +45,7 @@ namespace lldb_dap {
 //             }]
 // },
 void ConfigurationDoneRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   dap.SendJSON(llvm::json::Value(std::move(response)));

--- a/lldb/tools/lldb-dap/Handler/ContinueRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ContinueRequestHandler.cpp
@@ -66,7 +66,8 @@ namespace lldb_dap {
 //     "required": [ "body" ]
 //   }]
 // }
-void ContinueRequestHandler::operator()(const llvm::json::Object &request) {
+void ContinueRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   lldb::SBProcess process = dap.target.GetProcess();

--- a/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DataBreakpointInfoRequestHandler.cpp
@@ -108,7 +108,7 @@ namespace lldb_dap {
 //   }]
 // }
 void DataBreakpointInfoRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -87,7 +87,8 @@ namespace lldb_dap {
 //     }
 //   }]
 // }
-void DisassembleRequestHandler::operator()(const llvm::json::Object &request) {
+void DisassembleRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/DisconnectRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisconnectRequestHandler.cpp
@@ -57,7 +57,8 @@ namespace lldb_dap {
 //                     acknowledgement, so no body field is required."
 //   }]
 // }
-void DisconnectRequestHandler::operator()(const llvm::json::Object &request) {
+void DisconnectRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   const auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -138,7 +138,8 @@ namespace lldb_dap {
 //      "required": [ "body" ]
 //    }]
 //  }
-void EvaluateRequestHandler::operator()(const llvm::json::Object &request) {
+void EvaluateRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
@@ -112,7 +112,7 @@ namespace lldb_dap {
 //   }
 // },
 void ExceptionInfoRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   const auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -246,7 +246,8 @@ static void EventThreadFunction(DAP &dap) {
 //     }
 //   }]
 // }
-void InitializeRequestHandler::operator()(const llvm::json::Object &request) {
+void InitializeRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -48,7 +48,7 @@ namespace lldb_dap {
 //                     acknowledgement, so no body field is required."
 //   }]
 // }
-void LaunchRequestHandler::operator()(const llvm::json::Object &request) {
+void LaunchRequestHandler::operator()(const llvm::json::Object &request) const {
   dap.is_attach = false;
   dap.last_launch_or_attach_request = request;
   llvm::json::Object response;

--- a/lldb/tools/lldb-dap/Handler/LocationsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LocationsRequestHandler.cpp
@@ -91,7 +91,8 @@ namespace lldb_dap {
 //     }
 //   }]
 // },
-void LocationsRequestHandler::operator()(const llvm::json::Object &request) {
+void LocationsRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/ModulesRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ModulesRequestHandler.cpp
@@ -39,7 +39,8 @@ namespace lldb_dap {
 //     }
 //   }]
 // }
-void ModulesRequestHandler::operator()(const llvm::json::Object &request) {
+void ModulesRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
 

--- a/lldb/tools/lldb-dap/Handler/NextRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/NextRequestHandler.cpp
@@ -56,7 +56,7 @@ namespace lldb_dap {
 //                     acknowledgement, so no body field is required."
 //   }]
 // }
-void NextRequestHandler::operator()(const llvm::json::Object &request) {
+void NextRequestHandler::operator()(const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   const auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/PauseRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/PauseRequestHandler.cpp
@@ -49,7 +49,7 @@ namespace lldb_dap {
 //     acknowledgement, so no body field is required."
 //   }]
 // }
-void PauseRequestHandler::operator()(const llvm::json::Object &request) {
+void PauseRequestHandler::operator()(const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   lldb::SBProcess process = dap.target.GetProcess();

--- a/lldb/tools/lldb-dap/Handler/ReadMemoryRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ReadMemoryRequestHandler.cpp
@@ -92,7 +92,8 @@ namespace lldb_dap {
 //     }
 //   }]
 // },
-void ReadMemoryRequestHandler::operator()(const llvm::json::Object &request) {
+void ReadMemoryRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -34,7 +34,7 @@ MakeArgv(const llvm::ArrayRef<std::string> &strs) {
 // Both attach and launch take a either a sourcePath or sourceMap
 // argument (or neither), from which we need to set the target.source-map.
 void RequestHandler::SetSourceMapFromArguments(
-    const llvm::json::Object &arguments) {
+    const llvm::json::Object &arguments) const {
   const char *sourceMapHelp =
       "source must be be an array of two-element arrays, "
       "each containing a source and replacement path string.\n";
@@ -153,7 +153,8 @@ static llvm::Error RunInTerminal(DAP &dap,
                                  error.GetCString());
 }
 
-lldb::SBError RequestHandler::LaunchProcess(const llvm::json::Object &request) {
+lldb::SBError
+RequestHandler::LaunchProcess(const llvm::json::Object &request) const {
   lldb::SBError error;
   const auto *arguments = request.getObject("arguments");
   auto launchCommands = GetStrings(arguments, "launchCommands");
@@ -219,14 +220,14 @@ lldb::SBError RequestHandler::LaunchProcess(const llvm::json::Object &request) {
   return error;
 }
 
-void RequestHandler::PrintWelcomeMessage() {
+void RequestHandler::PrintWelcomeMessage() const {
 #ifdef LLDB_DAP_WELCOME_MESSAGE
   dap.SendOutput(OutputType::Console, LLDB_DAP_WELCOME_MESSAGE);
 #endif
 }
 
 bool RequestHandler::HasInstructionGranularity(
-    const llvm::json::Object &arguments) {
+    const llvm::json::Object &arguments) const {
   if (std::optional<llvm::StringRef> value = arguments.getString("granularity"))
     return value == "instruction";
   return false;

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.h
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.h
@@ -28,7 +28,7 @@ public:
 
   virtual ~RequestHandler() = default;
 
-  virtual void operator()(const llvm::json::Object &request) = 0;
+  virtual void operator()(const llvm::json::Object &request) const = 0;
 
 protected:
   /// Helpers used by multiple request handlers.
@@ -37,20 +37,20 @@ protected:
 
   /// Both attach and launch take a either a sourcePath or sourceMap
   /// argument (or neither), from which we need to set the target.source-map.
-  void SetSourceMapFromArguments(const llvm::json::Object &arguments);
+  void SetSourceMapFromArguments(const llvm::json::Object &arguments) const;
 
   /// Prints a welcome message on the editor if the preprocessor variable
   /// LLDB_DAP_WELCOME_MESSAGE is defined.
-  void PrintWelcomeMessage();
+  void PrintWelcomeMessage() const;
 
   // Takes a LaunchRequest object and launches the process, also handling
   // runInTerminal if applicable. It doesn't do any of the additional
   // initialization and bookkeeping stuff that is needed for `request_launch`.
   // This way we can reuse the process launching logic for RestartRequest too.
-  lldb::SBError LaunchProcess(const llvm::json::Object &request);
+  lldb::SBError LaunchProcess(const llvm::json::Object &request) const;
 
   // Check if the step-granularity is `instruction`.
-  bool HasInstructionGranularity(const llvm::json::Object &request);
+  bool HasInstructionGranularity(const llvm::json::Object &request) const;
 
   /// @}
 
@@ -61,140 +61,140 @@ class AttachRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "attach"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class BreakpointLocationsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "breakpointLocations"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class CompletionsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "completions"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ContinueRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "continue"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ConfigurationDoneRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "configurationDone"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class DisconnectRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "disconnect"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class EvaluateRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "evaluate"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ExceptionInfoRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "exceptionInfo"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class InitializeRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "initialize"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class LaunchRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "launch"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class RestartRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "restart"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class NextRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "next"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class StepInRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "stepIn"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class StepInTargetsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "stepInTargets"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class StepOutRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "stepOut"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SetBreakpointsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "setBreakpoints"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SetExceptionBreakpointsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "setExceptionBreakpoints"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SetFunctionBreakpointsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "setFunctionBreakpoints"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class DataBreakpointInfoRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "dataBreakpointInfo"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SetDataBreakpointsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "setDataBreakpoints"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SetInstructionBreakpointsRequestHandler : public RequestHandler {
@@ -203,91 +203,91 @@ public:
   static llvm::StringLiteral getCommand() {
     return "setInstructionBreakpoints";
   }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class CompileUnitsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "compileUnits"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ModulesRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "modules"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class PauseRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "pause"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ScopesRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "scopes"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SetVariableRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "setVariable"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class SourceRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "source"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class StackTraceRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "stackTrace"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ThreadsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "threads"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class VariablesRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "variables"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class LocationsRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "locations"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class DisassembleRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "disassemble"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 class ReadMemoryRequestHandler : public RequestHandler {
 public:
   using RequestHandler::RequestHandler;
   static llvm::StringLiteral getCommand() { return "readMemory"; }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 /// A request used in testing to get the details on all breakpoints that are
@@ -300,7 +300,7 @@ public:
   static llvm::StringLiteral getCommand() {
     return "_testGetTargetBreakpoints";
   }
-  void operator()(const llvm::json::Object &request) override;
+  void operator()(const llvm::json::Object &request) const override;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/RestartRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RestartRequestHandler.cpp
@@ -56,7 +56,8 @@ namespace lldb_dap {
 //     acknowledgement, so no body field is required."
 //   }]
 // },
-void RestartRequestHandler::operator()(const llvm::json::Object &request) {
+void RestartRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   if (!dap.last_launch_or_attach_request) {

--- a/lldb/tools/lldb-dap/Handler/ScopesRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ScopesRequestHandler.cpp
@@ -64,7 +64,7 @@ namespace lldb_dap {
 //     "required": [ "body" ]
 //   }]
 // }
-void ScopesRequestHandler::operator()(const llvm::json::Object &request) {
+void ScopesRequestHandler::operator()(const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/SetBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetBreakpointsRequestHandler.cpp
@@ -124,7 +124,7 @@ namespace lldb_dap {
 //   "required": [ "line" ]
 // }
 void SetBreakpointsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   lldb::SBError error;
   FillResponse(request, response);

--- a/lldb/tools/lldb-dap/Handler/SetDataBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetDataBreakpointsRequestHandler.cpp
@@ -76,7 +76,7 @@ namespace lldb_dap {
 //   }]
 // }
 void SetDataBreakpointsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   lldb::SBError error;
   FillResponse(request, response);

--- a/lldb/tools/lldb-dap/Handler/SetExceptionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetExceptionBreakpointsRequestHandler.cpp
@@ -62,7 +62,7 @@ namespace lldb_dap {
 //   }]
 // }
 void SetExceptionBreakpointsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   lldb::SBError error;
   FillResponse(request, response);

--- a/lldb/tools/lldb-dap/Handler/SetFunctionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetFunctionBreakpointsRequestHandler.cpp
@@ -92,7 +92,7 @@ namespace lldb_dap {
 //   }]
 // }
 void SetFunctionBreakpointsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   lldb::SBError error;
   FillResponse(request, response);

--- a/lldb/tools/lldb-dap/Handler/SetInstructionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetInstructionBreakpointsRequestHandler.cpp
@@ -201,7 +201,7 @@ namespace lldb_dap {
 //   "required": ["verified"]
 // },
 void SetInstructionBreakpointsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   llvm::json::Array response_breakpoints;
   llvm::json::Object body;

--- a/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetVariableRequestHandler.cpp
@@ -106,7 +106,8 @@ namespace lldb_dap {
 //     "required": [ "body" ]
 //   }]
 // }
-void SetVariableRequestHandler::operator()(const llvm::json::Object &request) {
+void SetVariableRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Array variables;

--- a/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SourceRequestHandler.cpp
@@ -71,7 +71,7 @@ namespace lldb_dap {
 //     "required": [ "body" ]
 //   }]
 // }
-void SourceRequestHandler::operator()(const llvm::json::Object &request) {
+void SourceRequestHandler::operator()(const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Object body{{"content", ""}};

--- a/lldb/tools/lldb-dap/Handler/StackTraceRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/StackTraceRequestHandler.cpp
@@ -168,7 +168,8 @@ static bool FillStackFrames(DAP &dap, lldb::SBThread &thread,
 //     "required": [ "body" ]
 //   }]
 // }
-void StackTraceRequestHandler::operator()(const llvm::json::Object &request) {
+void StackTraceRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   lldb::SBError error;

--- a/lldb/tools/lldb-dap/Handler/StepInRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/StepInRequestHandler.cpp
@@ -63,7 +63,7 @@ namespace lldb_dap {
 //     acknowledgement, so no body field is required."
 //   }]
 // }
-void StepInRequestHandler::operator()(const llvm::json::Object &request) {
+void StepInRequestHandler::operator()(const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   const auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/StepInTargetsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/StepInTargetsRequestHandler.cpp
@@ -68,7 +68,7 @@ namespace lldb_dap {
 //   }]
 // }
 void StepInTargetsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   const auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/StepOutRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/StepOutRequestHandler.cpp
@@ -49,7 +49,8 @@ namespace lldb_dap {
 //     acknowledgement, so no body field is required."
 //   }]
 // }
-void StepOutRequestHandler::operator()(const llvm::json::Object &request) {
+void StepOutRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   const auto *arguments = request.getObject("arguments");

--- a/lldb/tools/lldb-dap/Handler/TestGetTargetBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/TestGetTargetBreakpointsRequestHandler.cpp
@@ -14,7 +14,7 @@
 namespace lldb_dap {
 
 void TestGetTargetBreakpointsRequestHandler::operator()(
-    const llvm::json::Object &request) {
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Array response_breakpoints;

--- a/lldb/tools/lldb-dap/Handler/ThreadsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ThreadsRequestHandler.cpp
@@ -48,7 +48,8 @@ namespace lldb_dap {
 //     "required": [ "body" ]
 //   }]
 // }
-void ThreadsRequestHandler::operator()(const llvm::json::Object &request) {
+void ThreadsRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   lldb::SBProcess process = dap.target.GetProcess();
   llvm::json::Object response;
   FillResponse(request, response);

--- a/lldb/tools/lldb-dap/Handler/VariablesRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/VariablesRequestHandler.cpp
@@ -86,7 +86,8 @@ namespace lldb_dap {
 //     "required": [ "body" ]
 //   }]
 // }
-void VariablesRequestHandler::operator()(const llvm::json::Object &request) {
+void VariablesRequestHandler::operator()(
+    const llvm::json::Object &request) const {
   llvm::json::Object response;
   FillResponse(request, response);
   llvm::json::Array variables;

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -123,8 +123,6 @@ public:
                                    InfoTable, true) {}
 };
 
-typedef void (*RequestCallback)(const llvm::json::Object &command);
-
 void RegisterRequestCallbacks(DAP &dap) {
   dap.RegisterRequest<AttachRequestHandler>();
   dap.RegisterRequest<BreakpointLocationsRequestHandler>();


### PR DESCRIPTION
Completes the work started in https://github.com/llvm/llvm-project/pull/128262. This PR removes the old way of register request handlers with callbacks. Builds on top of https://github.com/llvm/llvm-project/pull/128551. 