### PR TITLE
[SystemZ] Drop regstate of SELRMux operand in selectSLRMux().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZPostRewrite.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZPostRewrite.cpp
@@ -114,7 +114,7 @@ void SystemZPostRewrite::selectSELRMux(MachineBasicBlock &MBB,
   if (Src1Reg == Src2Reg) {
     BuildMI(*MBBI->getParent(), MBBI, MBBI->getDebugLoc(),
             TII->get(SystemZ::COPY), DestReg)
-        .addReg(MBBI->getOperand(1).getReg(), getRegState(MBBI->getOperand(1)));
+        .addReg(MBBI->getOperand(1).getReg(), RegState::Renamable);
     MBBI->eraseFromParent();
     return;
   }

--- a/llvm/lib/Target/SystemZ/SystemZPostRewrite.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZPostRewrite.cpp
@@ -101,8 +101,10 @@ void SystemZPostRewrite::selectSELRMux(MachineBasicBlock &MBB,
                                        unsigned LowOpcode,
                                        unsigned HighOpcode) {
   Register DestReg = MBBI->getOperand(0).getReg();
-  Register Src1Reg = MBBI->getOperand(1).getReg();
-  Register Src2Reg = MBBI->getOperand(2).getReg();
+  MachineOperand &Src1MO = MBBI->getOperand(1);
+  MachineOperand &Src2MO = MBBI->getOperand(2);
+  Register Src1Reg = Src1MO.getReg();
+  Register Src2Reg = Src2MO.getReg();
   bool DestIsHigh = SystemZ::isHighReg(DestReg);
   bool Src1IsHigh = SystemZ::isHighReg(Src1Reg);
   bool Src2IsHigh = SystemZ::isHighReg(Src2Reg);
@@ -114,7 +116,7 @@ void SystemZPostRewrite::selectSELRMux(MachineBasicBlock &MBB,
   if (Src1Reg == Src2Reg) {
     BuildMI(*MBBI->getParent(), MBBI, MBBI->getDebugLoc(),
             TII->get(SystemZ::COPY), DestReg)
-        .addReg(MBBI->getOperand(1).getReg(), RegState::Renamable);
+        .addReg(Src1Reg, getRegState(Src1MO) & getRegState(Src2MO));
     MBBI->eraseFromParent();
     return;
   }
@@ -126,15 +128,15 @@ void SystemZPostRewrite::selectSELRMux(MachineBasicBlock &MBB,
     if (DestIsHigh != Src1IsHigh) {
       BuildMI(*MBBI->getParent(), MBBI, MBBI->getDebugLoc(),
               TII->get(SystemZ::COPY), DestReg)
-        .addReg(MBBI->getOperand(1).getReg(), getRegState(MBBI->getOperand(1)));
-      MBBI->getOperand(1).setReg(DestReg);
+          .addReg(Src1Reg, getRegState(Src1MO));
+      Src1MO.setReg(DestReg);
       Src1Reg = DestReg;
       Src1IsHigh = DestIsHigh;
     } else if (DestIsHigh != Src2IsHigh) {
       BuildMI(*MBBI->getParent(), MBBI, MBBI->getDebugLoc(),
               TII->get(SystemZ::COPY), DestReg)
-        .addReg(MBBI->getOperand(2).getReg(), getRegState(MBBI->getOperand(2)));
-      MBBI->getOperand(2).setReg(DestReg);
+          .addReg(Src2Reg, getRegState(Src2MO));
+      Src2MO.setReg(DestReg);
       Src2Reg = DestReg;
       Src2IsHigh = DestIsHigh;
     }

--- a/llvm/test/CodeGen/SystemZ/cond-move-10.mir
+++ b/llvm/test/CodeGen/SystemZ/cond-move-10.mir
@@ -5,7 +5,7 @@
 # CHECK:      name: fun0
 # CHECK:      renamable $r1l = AHIMuxK killed renamable $r1l, -1, implicit-def dead $cc
 # CHECK-NEXT: CHIMux renamable $r5h, 9, implicit-def $cc
-# CHECK-NEXT: $r14h = COPY killed renamable $r1l
+# CHECK-NEXT: $r14h = COPY renamable $r1l
 ---
 name:            fun0
 tracksRegLiveness: true

--- a/llvm/test/CodeGen/SystemZ/cond-move-11.mir
+++ b/llvm/test/CodeGen/SystemZ/cond-move-11.mir
@@ -1,5 +1,5 @@
 # RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z15 -start-before=systemz-post-rewrite \
-# RUN:   -stop-after=machine-cp 2>&1 | FileCheck %s
+# RUN:   -stop-after=machine-cp -verify-machineinstrs 2>&1 | FileCheck %s
 
 # The chained SELRMux:es both has two operands with the same register but
 # where one of the operands have been marked as undef (resulting from

--- a/llvm/test/CodeGen/SystemZ/cond-move-11.mir
+++ b/llvm/test/CodeGen/SystemZ/cond-move-11.mir
@@ -1,0 +1,43 @@
+# RUN: llc -o - %s -mtriple=s390x-linux-gnu -mcpu=z15 -start-before=systemz-post-rewrite \
+# RUN:   -stop-after=machine-cp 2>&1 | FileCheck %s
+
+# The chained SELRMux:es both has two operands with the same register but
+# where one of the operands have been marked as undef (resulting from
+# early-ifcvt). Check that the resulting COPY after machine-cp is from $r0l
+# to $r2l.
+
+# CHECK:      name: fun0
+# CHECK:      $r2l = COPY $r0l
+--- |
+  
+  @Res = global i32 0, align 4
+  @Z = global i32 0, align 4
+  define signext i32 @fun0() { ret i32 0 }
+...
+---
+name:            fun0
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1(0x80000000)
+  
+    renamable $r0l = LRL @Z :: (dereferenceable load (s32) from @Z)
+    renamable $r1l = LHIMux 1
+  
+  bb.1:
+    successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+    liveins: $r0l, $r1l
+  
+    CHIMux renamable $r1l, 0, implicit-def $cc
+    renamable $r2l = SELRMux undef renamable $r0l, renamable $r0l, 14, 6, implicit $cc
+    renamable $r2l = SELRMux undef renamable $r2l, killed renamable $r2l, 14, 6, implicit $cc
+    BRC 14, 8, %bb.1, implicit killed $cc
+    J %bb.2
+  
+  bb.2:
+    liveins: $r2l
+  
+    STRL renamable $r2l, @Res :: (store (s32) into @Res)
+    renamable $r2d = LGFR killed renamable $r2l
+    Return implicit $r2d
+...


### PR DESCRIPTION
It seems that there can be other cases with this that also can lead to wrong code (discovered with csmith). This time it involved not the kill flag but the undef flag.

It seems safest then to drop all the flags except for the renamable flag, which should always be true.

