### PR TITLE
[DirectX] Fix build breaks

### DIFF
--- a/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
@@ -243,6 +243,10 @@ private:
   }
   void writeDIDerivedType(const DIDerivedType *N,
                           SmallVectorImpl<uint64_t> &Record, unsigned Abbrev);
+  void writeDISubrangeType(const DISubrangeType *N,
+                           SmallVectorImpl<uint64_t> &Record, unsigned Abbrev) {
+    llvm_unreachable("DXIL cannot contain DISubrangeType Nodes");
+  }
   void writeDICompositeType(const DICompositeType *N,
                             SmallVectorImpl<uint64_t> &Record, unsigned Abbrev);
   void writeDISubroutineType(const DISubroutineType *N,

--- a/llvm/lib/Target/DirectX/DirectXInstrInfo.h
+++ b/llvm/lib/Target/DirectX/DirectXInstrInfo.h
@@ -21,8 +21,9 @@
 
 namespace llvm {
 struct DirectXInstrInfo : public DirectXGenInstrInfo {
+  const DirectXRegisterInfo RI;
   explicit DirectXInstrInfo() : DirectXGenInstrInfo() {}
-
+  const DirectXRegisterInfo &getRegisterInfo() const { return RI; }
   ~DirectXInstrInfo() override;
 };
 } // namespace llvm

--- a/llvm/lib/Target/DirectX/DirectXRegisterInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXRegisterInfo.cpp
@@ -22,3 +22,24 @@
 using namespace llvm;
 
 DirectXRegisterInfo::~DirectXRegisterInfo() {}
+
+const MCPhysReg *
+DirectXRegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
+  return nullptr;
+}
+BitVector
+DirectXRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
+  return BitVector(getNumRegs());
+}
+
+bool DirectXRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
+                                              int SPAdj, unsigned FIOperandNum,
+                                              RegScavenger *RS) const {
+  return false;
+}
+
+// Debug information queries.
+Register
+DirectXRegisterInfo::getFrameRegister(const MachineFunction &MF) const {
+  return Register();
+}

--- a/llvm/lib/Target/DirectX/DirectXRegisterInfo.h
+++ b/llvm/lib/Target/DirectX/DirectXRegisterInfo.h
@@ -22,6 +22,14 @@ namespace llvm {
 struct DirectXRegisterInfo : public DirectXGenRegisterInfo {
   DirectXRegisterInfo() : DirectXGenRegisterInfo(0) {}
   ~DirectXRegisterInfo();
+
+  const MCPhysReg *getCalleeSavedRegs(const MachineFunction *MF) const override;
+  BitVector getReservedRegs(const MachineFunction &MF) const override;
+  bool eliminateFrameIndex(MachineBasicBlock::iterator II, int SPAdj,
+                           unsigned FIOperandNum,
+                           RegScavenger *RS = nullptr) const override;
+  // Debug information queries.
+  Register getFrameRegister(const MachineFunction &MF) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/DirectX/DirectXSubtarget.h
+++ b/llvm/lib/Target/DirectX/DirectXSubtarget.h
@@ -49,6 +49,10 @@ public:
   const DirectXFrameLowering *getFrameLowering() const override { return &FL; }
 
   const DirectXInstrInfo *getInstrInfo() const override { return &InstrInfo; }
+
+  const DirectXRegisterInfo *getRegisterInfo() const override {
+    return &InstrInfo.getRegisterInfo();
+  }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
1. Fix build break caused by #126772 by adding `writeDISubrangeType` stub to `DXILBitcodeWriter.cpp`
2. Fix build break caused by #128480 by adding implementation of pure virtual method `TargetSubtargetInfo::getRegisterInfo`