### PR TITLE
[BOLT] pacret-scanner: fix regression tests...

### DIFF
--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -13,7 +13,7 @@ f1:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         // autiasp
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f1, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f1, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -66,7 +66,7 @@ f_intermediate_overwrite2:
         ldp     x29, x30, [sp], #16
         autiasp
         mov     x30, x0
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite2, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite2, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: mov     x30, x0
@@ -109,7 +109,7 @@ f_intermediate_overwrite3:
         ldp     x29, x30, [sp], #16
         autiasp
         mov     w30, w0
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite3, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_intermediate_overwrite3, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: mov     w30, w0
@@ -137,7 +137,7 @@ f_nonx30_ret:
         ldp     x29, x30, [sp], #16
         mov     x16, x30
         autiasp
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_nonx30_ret, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_nonx30_ret, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret     x16
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: mov     x16, x30
@@ -222,7 +222,7 @@ f_nonx30_ret_non_auted:
         .type   f_callclobbered_x30,@function
 f_callclobbered_x30:
         bl      g
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_callclobbered_x30, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_callclobbered_x30, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: bl      g@PLT
@@ -236,7 +236,7 @@ f_callclobbered_x30:
         .type   f_callclobbered_calleesaved,@function
 f_callclobbered_calleesaved:
         bl      g
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_callclobbered_calleesaved, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_callclobbered_calleesaved, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret x19
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: bl      g@PLT
@@ -325,7 +325,7 @@ f_autia1716:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autia1716
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autia1716, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autia1716, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -351,7 +351,7 @@ f_autib1716:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autib1716
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autib1716, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autib1716, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -377,7 +377,7 @@ f_autiax12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autia   x12, sp
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autiax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autiax12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -403,7 +403,7 @@ f_autibx12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autib   x12, sp
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autibx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autibx12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -458,7 +458,7 @@ f_autdax12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autda   x12, sp
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdax12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -484,7 +484,7 @@ f_autdbx12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autdb   x12, sp
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdbx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdbx12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -539,7 +539,7 @@ f_autizax12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autiza  x12
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autizax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autizax12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -565,7 +565,7 @@ f_autizbx12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autizb  x12
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autizbx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autizbx12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -620,7 +620,7 @@ f_autdzax12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autdza  x12
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdzax12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdzax12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -646,7 +646,7 @@ f_autdzbx12:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autdzb  x12
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdzbx12, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autdzbx12, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -725,7 +725,7 @@ f_eretaa:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eretaa, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eretaa, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:   The return instruction is     {{[0-9a-f]+}}:       eretaa
         eretaa
         .size f_eretaa, .-f_eretaa
@@ -739,7 +739,7 @@ f_eretab:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eretab, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eretab, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:   The return instruction is     {{[0-9a-f]+}}:       eretab
         eretab
         .size f_eretab, .-f_eretab
@@ -753,7 +753,7 @@ f_eret:
         bl      g
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
-// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eret, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: Warning: pac-ret analysis could not analyze this return instruction in function f_eret, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:   The return instruction is     {{[0-9a-f]+}}:       eret
         eret
         .size f_eret, .-f_eret
@@ -761,7 +761,7 @@ f_eret:
         .globl f_movx30reg
         .type   f_movx30reg,@function
 f_movx30reg:
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_movx30reg, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_movx30reg, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: mov x30, x22
@@ -908,7 +908,7 @@ f_autia171615:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autia171615
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autia171615, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autia171615, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10
@@ -934,7 +934,7 @@ f_autib171615:
         add     x0, x0, #3
         ldp     x29, x30, [sp], #16
         autib171615
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autib171615, basic block .LBB{{[0-9]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_autib171615, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1. {{[0-9a-f]+}}: ldp     x29, x30, [sp], #0x10

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-multi-bb.s
@@ -15,7 +15,7 @@ f_crossbb1:
 1:
         ret
         .size f_crossbb1, .-f_crossbb1
-// CHECK-LABEL:     GS-PACRET: non-protected ret found in function f_crossbb1, basic block .L{{[^,]+}}, at address
+// CHECK-LABEL:     GS-PACRET: non-protected ret found in function f_crossbb1, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:  The 2 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10
@@ -37,7 +37,7 @@ f_mergebb1:
 1:
         ret
         .size f_mergebb1, .-f_mergebb1
-// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_mergebb1, basic block .L{{[^,]+}}, at address
+// CHECK-LABEL: GS-PACRET: non-protected ret found in function f_mergebb1, basic block {{[^,]+}}, at address
 // CHECK-NEXT:    The return instruction is     {{[0-9a-f]+}}:       ret
 // CHECK-NEXT:    The 1 instructions that write to the return register after any authentication are:
 // CHECK-NEXT:    1.     {{[0-9a-f]+}}:      ldp     x29, x30, [sp], #0x10


### PR DESCRIPTION
by making the regex to match basic block names more general. See failing test case that was reported on some system in comment https://github.com/llvm/llvm-project/pull/122304#issuecomment-2679460678

These test cases were introduced in PR #122304, commit 850b49297615a613ac83adca2c9cf823a4b8ef95 .