### PR TITLE
[spirv][amdgpu] Set atomic size in the clang target info

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -399,6 +399,8 @@ public:
     HasLegalHalfType = true;
     HasFloat16 = true;
     HalfArgsAndReturns = true;
+
+    MaxAtomicPromoteWidth = MaxAtomicInlineWidth = 64;
   }
 
   bool hasBFloat16Type() const override { return true; }


### PR DESCRIPTION
Problem identified by Joseph. The openmp device runtime uses __scoped_atomic_load_n and similar which presently hit 

```
error: large atomic operation may incur significant performance
      penalty; the access size (4 bytes) exceeds the max lock-free size (0 bytes) [-Werror,-Watomic-alignment]
```

This is because the spirv class doesn't set the corresponding field. The base does, but only if there's a host toolchain, which there isn't.