### PR TITLE
[lldb] Add fzf_history command to examples

### DIFF
--- a/lldb/examples/python/fzf_history.py
+++ b/lldb/examples/python/fzf_history.py
@@ -8,6 +8,7 @@ import lldb
 
 @lldb.command()
 def fzf_history(debugger, cmdstr, ctx, result, _):
+    """Use fzf to search and select from lldb command history."""
     if sys.platform != "darwin":
         result.SetError("fzf_history supports macOS only")
         return

--- a/lldb/examples/python/fzf_history.py
+++ b/lldb/examples/python/fzf_history.py
@@ -8,7 +8,7 @@ import lldb
 
 @lldb.command()
 def fzf_history(debugger, cmdstr, ctx, result, _):
-    if sys.platform != 'darwin':
+    if sys.platform != "darwin":
         result.SetError("fzf_history supports macOS only")
         return
 

--- a/lldb/examples/python/fzf_history.py
+++ b/lldb/examples/python/fzf_history.py
@@ -19,7 +19,7 @@ def fzf_history(debugger, cmdstr, ctx, result, _):
         # The ability to integrate fzf's result into lldb uses copy and paste.
         # In absense of copy and paste, do the basics and forgo features.
         fzf_command = ("fzf", "--no-sort", f"--query={query}")
-        subprocess.run(fzf_command, input=history)
+        subprocess.run(fzf_command, input=history, text=True)
         return
 
     # Capture the current pasteboard contents to restore after overwriting.

--- a/lldb/examples/python/fzf_history.py
+++ b/lldb/examples/python/fzf_history.py
@@ -1,0 +1,99 @@
+import os
+import re
+import sys
+import subprocess
+
+import lldb
+
+
+@lldb.command()
+def fzf_history(debugger, cmdstr, ctx, result, _):
+    if sys.platform != 'darwin':
+        result.SetError("fzf_history supports macOS only")
+        return
+
+    # Capture the current pasteboard contents to restore after overwriting.
+    paste_snapshot = subprocess.run("pbpaste", text=True, capture_output=True).stdout
+
+    # On enter, copy the selected history entry into the pasteboard.
+    fzf_command = (
+        "fzf",
+        "--no-sort",
+        f"--query={cmdstr}",
+        "--bind=enter:execute-silent(echo -n {} | pbcopy)+close",
+    )
+
+    history_file = os.path.expanduser("~/.lldb/lldb-widehistory")
+    if not os.path.exists(history_file):
+        result.SetError("history file does not exist")
+        return
+
+    history_commands = _load_history(history_file)
+    fzf_input = "\n".join(history_commands)
+    completed = subprocess.run(fzf_command, input=fzf_input, text=True)
+    # 130 is used for CTRL-C or ESC.
+    if completed.returncode not in (0, 130):
+        result.SetError(f"fzf failed: {completed.stderr}")
+        return
+
+    # Get the user's selected history entry.
+    selected_command = subprocess.run("pbpaste", text=True, capture_output=True).stdout
+    if selected_command == paste_snapshot:
+        # Nothing was selected, no cleanup needed.
+        return
+
+    _handle_command(debugger, selected_command)
+
+    # Restore the pasteboard's contents.
+    subprocess.run("pbcopy", input=paste_snapshot, text=True)
+
+
+def _handle_command(debugger, command):
+    """Try pasting the command, and failing that, run it directly."""
+    if not command:
+        return
+
+    # Use applescript to paste the selected result into lldb's console.
+    paste_command = (
+        "osascript",
+        "-e",
+        'tell application "System Events" to keystroke "v" using command down',
+    )
+    completed = subprocess.run(paste_command, capture_output=True)
+
+    if completed.returncode != 0:
+        # The above applescript requires the "control your computer" permission.
+        #     Settings > Private & Security > Accessibility
+        # If not enabled, fallback to running the command.
+        debugger.HandleCommand(command)
+
+
+def _load_history(history_file):
+    """Load, decode, and parse an lldb history file."""
+    with open(history_file) as f:
+        history_contents = f.read()
+
+    history_decoded = re.sub(r"\\0([0-7][0-7])", _decode_char, history_contents)
+    history_lines = history_decoded.splitlines()
+
+    # Skip the header line (_HiStOrY_V2_)
+    del history_lines[0]
+    # Reverse to show latest first.
+    history_lines.reverse()
+
+    history_commands = []
+    history_seen = set()
+    for line in history_lines:
+        line = line.strip()
+        # Skip empty lines, single character commands, and duplicates.
+        if line and len(line) > 1 and line not in history_seen:
+            history_commands.append(line)
+            history_seen.add(line)
+
+    return history_commands
+
+
+def _decode_char(match):
+    """Decode octal strings ('\0NN') into a single character string."""
+    code = int(match.group(1), base=8)
+    return chr(code)

--- a/lldb/examples/python/fzf_history.py
+++ b/lldb/examples/python/fzf_history.py
@@ -18,7 +18,7 @@ def fzf_history(debugger, cmdstr, ctx, result, _):
     if sys.platform != "darwin":
         # The ability to integrate fzf's result into lldb uses copy and paste.
         # In absense of copy and paste, do the basics and forgo features.
-        fzf_command = ("fzf", "--no-sort", f"--query={query}")
+        fzf_command = ("fzf", "--no-sort", f"--query={cmdstr}")
         subprocess.run(fzf_command, input=history, text=True)
         return
 


### PR DESCRIPTION
Adds a `fzf_history` to the examples directory.

This python command invokes [fzf](https://github.com/junegunn/fzf) to select from lldb's command history.

Tighter integration is available on macOS, via commands for copy and paste. The user's chosen history entry back is pasted into the lldb console (via AppleScript). By pasting it, users have the opportunity to edit it before running it. This matches how fzf's history search works.

Without copy and paste, the user's chosen history entry is printed to screen and then run automatically.