### PR TITLE
Revert "[mlir] Fix integration test when `%host_cc` path contains spaces"

### DIFF
--- a/mlir/test/Integration/Dialect/MemRef/memref_abi.c
+++ b/mlir/test/Integration/Dialect/MemRef/memref_abi.c
@@ -12,7 +12,7 @@
 // RUN: llc %t.ll -o %t.o -filetype=obj
 
 // Compile the current C file and link it to the MLIR code:
-// RUN: "%host_cc" %s %t.o -o %t.exe
+// RUN: %host_cc %s %t.o -o %t.exe
 
 // Exec
 // RUN: %t.exe | FileCheck %s


### PR DESCRIPTION
Reverts llvm/llvm-project#128439

Builtbot are broken, see: https://lab.llvm.org/buildbot/#/builders/138/builds/10710