### PR TITLE
[Hexagon] Add a case to BitTracker for new register class

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonBitTracker.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonBitTracker.cpp
@@ -94,6 +94,7 @@ BT::BitMask HexagonEvaluator::mask(Register Reg, unsigned Sub) const {
   bool IsSubLo = (Sub == HRI.getHexagonSubRegIndex(RC, Hexagon::ps_sub_lo));
   switch (ID) {
     case Hexagon::DoubleRegsRegClassID:
+    case Hexagon::DoubleRegs_with_isub_hi_in_IntRegsLow8RegClassID:
     case Hexagon::HvxWRRegClassID:
     case Hexagon::HvxVQRRegClassID:
       return IsSubLo ? BT::BitMask(0, RW-1)
@@ -139,6 +140,7 @@ const TargetRegisterClass &HexagonEvaluator::composeWithSubRegIndex(
 
   switch (RC.getID()) {
     case Hexagon::DoubleRegsRegClassID:
+    case Hexagon::DoubleRegs_with_isub_hi_in_IntRegsLow8RegClassID:
       return Hexagon::IntRegsRegClass;
     case Hexagon::HvxWRRegClassID:
       return Hexagon::HvxVRRegClass;

--- a/llvm/test/CodeGen/Hexagon/bittracker-regclass.ll
+++ b/llvm/test/CodeGen/Hexagon/bittracker-regclass.ll
@@ -1,0 +1,40 @@
+; RUN: llc -mtriple=hexagon -mcpu=hexagonv75 -mattr=+hvxv75,+hvx-length64b,-small-data < %s | FileCheck %s
+
+; Test that the compiler generates code, and doesn't crash, when the compiler
+; creates a DoubleReg value with an IntLow8Reg value. The BitTracker pass
+; needs to handle this register class.
+
+; CHECK: [[REG:r[0-9]+:[0-9]+]] = combine(#33,#32)
+; CHECK: memd({{.*}}) = [[REG]]
+
+@out = external dso_local global [100 x i32], align 512
+@in55 = external dso_local global [55 x i32], align 256
+@.str.3 = external dso_local unnamed_addr constant [29 x i8], align 1
+
+define dso_local void @main(i1 %cond) local_unnamed_addr #0 {
+entry:
+  br label %for.body.i198
+
+for.body.i198:
+  br i1 %cond, label %for.body34.preheader, label %for.body.i198
+
+for.body34.preheader:
+  %wide.load269.5 = load <16 x i32>, <16 x i32>* bitcast (i32* getelementptr inbounds ([100 x i32], [100 x i32]* @out, i32 0, i32 80) to <16 x i32>*), align 64
+  %0 = add nsw <16 x i32> %wide.load269.5, zeroinitializer
+  %rdx.shuf270 = shufflevector <16 x i32> %0, <16 x i32> undef, <16 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
+  %bin.rdx271 = add <16 x i32> %0, %rdx.shuf270
+  %bin.rdx273 = add <16 x i32> %bin.rdx271, zeroinitializer
+  %bin.rdx275 = add <16 x i32> %bin.rdx273, zeroinitializer
+  %bin.rdx277 = add <16 x i32> %bin.rdx275, zeroinitializer
+  %1 = extractelement <16 x i32> %bin.rdx277, i32 0
+  %add45 = add nsw i32 0, %1
+  %add45.1 = add nsw i32 0, %add45
+  %add45.2 = add nsw i32 0, %add45.1
+  %add45.3 = add nsw i32 0, %add45.2
+  call void (i8*, ...) @printf(i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str.3, i32 0, i32 0), i32 %add45.3) #2
+  store i32 32, i32* getelementptr inbounds ([55 x i32], [55 x i32]* @in55, i32 0, i32 32), align 128
+  store i32 33, i32* getelementptr inbounds ([55 x i32], [55 x i32]* @in55, i32 0, i32 33), align 4
+  ret void
+}
+
+declare dso_local void @printf(i8*, ...) local_unnamed_addr #1


### PR DESCRIPTION
Code in the HexagonBitTracker checks for a specific register class when processing sub-registers. A crash occurred due to a register class that was not handled. The register class is DoubleRegs_with_isub_hi_in_IntRegsLow8RegClassID, which is a class formed by creating a register pair when one of the sub registers is a Low8 integer register.
Fixes #128078
Patch by: Brendon Cahoon