### PR TITLE
[ConstraintElim] Preserve analyses when IR is unchanged.

### DIFF
--- a/llvm/test/Transforms/ConstraintElimination/analysis-invalidation.ll
+++ b/llvm/test/Transforms/ConstraintElimination/analysis-invalidation.ll
@@ -43,10 +43,6 @@
 ; CHECK-NEXT: Running analysis: ScalarEvolutionAnalysis on test_mul_const_nuw_unsigned_14
 ; CHECK-NEXT: Running analysis: TargetLibraryAnalysis on test_mul_const_nuw_unsigned_14
 ; CHECK-NEXT: Running analysis: OptimizationRemarkEmitterAnalysis on test_mul_const_nuw_unsigned_14
-; CHECK-NEXT: Invalidating analysis: DemandedBitsAnalysis on test_mul_const_nuw_unsigned_14
-; CHECK-NEXT: Running pass: RequireAnalysisPass
-; CHECK-NEXT: Running analysis: DemandedBitsAnalysis on test_mul_const_nuw_unsigned_14
-
 
 declare { i8, i1 } @llvm.ssub.with.overflow.i8(i8, i8)
 


### PR DESCRIPTION
Noticed that all Analys passes was not preserved for unchanged IR when the test was containing assumes.

`PreservedAnalyses::all()` is not called for E.g.  https://github.com/andjo403/llvm-project/blob/e24bb833b1af521fc2aec997a8b89de795b34449/llvm/test/Transforms/ConstraintElimination/mul.ll#L283-L301

Not sure how to/if possible to add a test for this.