### PR TITLE
[SafeBuffers] Check if unsafe-buffers* warnings are enabled earlier

### DIFF
--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -44,6 +44,7 @@ public:
     unsigned enableConsumedAnalysis : 1;
     LLVM_PREFERRED_TYPE(bool)
     unsigned enableUnsafeBufferUsage : 1;
+
   public:
     Policy();
     void disableCheckFallThrough() { enableCheckFallThrough = 0; }

--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -42,6 +42,8 @@ public:
     unsigned enableThreadSafetyAnalysis : 1;
     LLVM_PREFERRED_TYPE(bool)
     unsigned enableConsumedAnalysis : 1;
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned enableUnsafeBufferUsage : 1;
   public:
     Policy();
     void disableCheckFallThrough() { enableCheckFallThrough = 0; }

--- a/clang/test/SemaCXX/unsafe-buffer-usage-pragma.cpp
+++ b/clang/test/SemaCXX/unsafe-buffer-usage-pragma.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -std=c++17 -Wno-all -Wunsafe-buffer-usage \
+// RUN:            -verify %s
+
+// Previously we had a bug where we would diagnose *no* unsafe buffer warnings
+// if the warning was disabled by pragma and left disabled until end-of-TU.
+// This is a reasonable way to disable unsafe buffer warnings on an entire
+// .c/cpp file, and it shouldn't disable the warnings in headers or previous
+// source locations, so we test that this works.
+
+// FIXME: This RUNX line should pass, but it does not, because we check if the
+// warning is enabled *at startup*. If we ever implement a way to query if the
+// warning is enabled anywhere in the TU, we can enable this RUN line.
+// RUNX: %clang_cc1 -std=c++17 -Wno-all -verify %s
+
+#pragma clang diagnostic warning "-Wunsafe-buffer-usage"
+int *w1(int *p) {
+  return p + 1; // expected-warning{{unsafe pointer arithmetic}}
+}
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
+int *w2(int *p) {
+  return p + 1;
+}


### PR DESCRIPTION
Wunsafe-buffers* warnings are implemented by traversing the entire AST at the end of the translation unit. This is expensive, so we don't want to do it unless the user explicitly asked for these diagnostics.

Ideally we want to check if the warning was enabled anywhere in the translation unit, but we do not appear to have that functionality. Users mostly use pragmas to disable warnings, not enable them, so checking at startup is a better heuristic for implementing this compile time optimization. This is at least consistent with what we do for the other existing analyzer warnings.

Fixes issue #79379 