### PR TITLE
Refactored llvm::UpgradeIntrinsicCall() function in lib/IR/AutoUpgrade.cpp with lookup table based on #30382

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4375,13 +4375,13 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
         not_consumed = false;
         if (entry.first == prefix_x86 || Name != "stackprotectorcheck") {
           if (entry.first == prefix_dbg) {
-            // We might have decided we don't want the new format after all between
-            // first requesting the upgrade and now; skip the conversion if that is
-            // the case, and check here to see if the intrinsic needs to be upgraded
-            // normally.
+            // We might have decided we don't want the new format after all
+            // between first requesting the upgrade and now; skip the conversion
+            // if that is the case, and check here to see if the intrinsic needs
+            // to be upgraded normally.
             if (!CI->getModule()->IsNewDbgInfoFormat) {
-              bool NeedsUpgrade =
-                  upgradeIntrinsicFunction1(CI->getCalledFunction(), NewFn, false);
+              bool NeedsUpgrade = upgradeIntrinsicFunction1(
+                  CI->getCalledFunction(), NewFn, false);
               if (!NeedsUpgrade)
                 return;
               FallthroughToDefaultUpgrade = true;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/AutoUpgrade.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -48,7 +49,6 @@
 #include "llvm/TargetParser/Triple.h"
 #include <cstring>
 #include <numeric>
-#include <unordered_map>
 
 using namespace llvm;
 
@@ -4359,7 +4359,7 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     const std::string prefix_amdgcn = "amdgcn.";
     const std::string prefix_dbg = "dbg.";
 
-    std::unordered_map<StringRef, UpgradeFunc> lookupTable;
+    DenseMap<StringRef, UpgradeFunc> lookupTable;
     lookupTable[prefix_x86] = upgradeX86IntrinsicCall;
     lookupTable[prefix_nvvm] = upgradeNVVMIntrinsicCall;
     lookupTable[prefix_aarch64] = upgradeAArch64IntrinsicCall;

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4352,12 +4352,12 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     assert(Name.starts_with("llvm.") && "Intrinsic doesn't start with 'llvm.'");
     Name = Name.substr(5);
 
-    const std::string prefix_x86 = "x86.";
-    const std::string prefix_nvvm = "nvvm.";
-    const std::string prefix_aarch64 = "aarch64.";
-    const std::string prefix_arm = "arm.";
-    const std::string prefix_amdgcn = "amdgcn.";
-    const std::string prefix_dbg = "dbg.";
+    const StringRef prefix_x86 = "x86.";
+    const StringRef prefix_nvvm = "nvvm.";
+    const StringRef prefix_aarch64 = "aarch64.";
+    const StringRef prefix_arm = "arm.";
+    const StringRef prefix_amdgcn = "amdgcn.";
+    const StringRef prefix_dbg = "dbg.";
 
     DenseMap<StringRef, UpgradeFunc> lookupTable;
     lookupTable[prefix_x86] = upgradeX86IntrinsicCall;


### PR DESCRIPTION
Changed the logic to a lookup table instead of series of `if else` statements because of #30382 

I would appreciate your feedback. 