### PR TITLE
[memprof] Add memprof options as a clang frontend flag

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2288,6 +2288,15 @@ def fmemory_profile_use_EQ : Joined<["-"], "fmemory-profile-use=">,
     MetaVarName<"<pathname>">,
     HelpText<"Use memory profile for profile-guided memory optimization">,
     MarshallingInfoString<CodeGenOpts<"MemoryProfileUsePath">>;
+def fmemory_profile_runtime_default_options_EQ
+    : Joined<["-"], "fmemory-profile-runtime-default-options=">,
+      Group<f_Group>,
+      Visibility<[ClangOption, CC1Option, CLOption]>,
+      MetaVarName<"<options>">,
+      HelpText<"Set the default memprof runtime options to <options>">;
+def fmemory_profile_runtime_default_options
+    : Separate<["-"], "fmemory-profile-runtime-default-options">,
+      Alias<fmemory_profile_runtime_default_options_EQ>;
 
 // Begin sanitizer flags. These should all be core options exposed in all driver
 // modes.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5456,6 +5456,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           << MemProfUseArg->getAsString(Args) << PGOInstrArg->getAsString(Args);
     MemProfUseArg->render(Args, CmdArgs);
   }
+  StringRef MemprofOptionsStr = Args.getLastArgValue(
+      options::OPT_fmemory_profile_runtime_default_options_EQ);
+  if (!MemprofOptionsStr.empty()) {
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back(Args.MakeArgString("-memprof-runtime-default-options=" +
+                                         MemprofOptionsStr));
+  }
 
   // Embed-bitcode option.
   // Only white-listed flags below are allowed to be embedded.

--- a/clang/test/Driver/fmemprof.cpp
+++ b/clang/test/Driver/fmemprof.cpp
@@ -17,3 +17,10 @@
 
 // RUN: not %clangxx --target=x86_64-linux-gnu -fprofile-generate -fmemory-profile-use=foo %s -### 2>&1 | FileCheck %s --check-prefix=CONFLICTWITHPGOINSTR
 // CONFLICTWITHPGOINSTR: error: invalid argument '-fmemory-profile-use=foo' not allowed with '-fprofile-generate'
+
+// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options="verbose=1" %s -### 2>&1 | FileCheck %s --check-prefix=OPTS
+// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options "verbose=1" %s -### 2>&1 | FileCheck %s --check-prefix=OPTS
+// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options="verbose=1" -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=OPTS,OPTS-EXPORT
+// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options "verbose=1" -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=OPTS,OPTS-EXPORT
+// OPTS: "-mllvm" "-memprof-runtime-default-options=verbose=1"
+// OPTS-EXPORT: "-exported_symbol" "___memprof_default_options_str"

--- a/clang/test/Driver/fmemprof.cpp
+++ b/clang/test/Driver/fmemprof.cpp
@@ -18,9 +18,9 @@
 // RUN: not %clangxx --target=x86_64-linux-gnu -fprofile-generate -fmemory-profile-use=foo %s -### 2>&1 | FileCheck %s --check-prefix=CONFLICTWITHPGOINSTR
 // CONFLICTWITHPGOINSTR: error: invalid argument '-fmemory-profile-use=foo' not allowed with '-fprofile-generate'
 
-// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options="verbose=1" %s -### 2>&1 | FileCheck %s --check-prefix=OPTS
-// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options "verbose=1" %s -### 2>&1 | FileCheck %s --check-prefix=OPTS
-// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options="verbose=1" -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=OPTS,OPTS-EXPORT
-// RUN: %clangxx -target arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options "verbose=1" -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=OPTS,OPTS-EXPORT
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options="verbose=1" %s -### 2>&1 | FileCheck %s --check-prefix=OPTS
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options "verbose=1" %s -### 2>&1 | FileCheck %s --check-prefix=OPTS
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options="verbose=1" -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=OPTS,OPTS-EXPORT
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile -fmemory-profile-runtime-default-options "verbose=1" -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=OPTS,OPTS-EXPORT
 // OPTS: "-mllvm" "-memprof-runtime-default-options=verbose=1"
 // OPTS-EXPORT: "-exported_symbol" "___memprof_default_options_str"

--- a/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
@@ -566,6 +566,8 @@ void createMemprofHistogramFlagVar(Module &M) {
 }
 
 void createMemprofDefaultOptionsVar(Module &M) {
+  if (!MemprofRuntimeDefaultOptions.getNumOccurrences())
+    return;
   Constant *OptionsConst = ConstantDataArray::getString(
       M.getContext(), MemprofRuntimeDefaultOptions, /*AddNull=*/true);
   GlobalVariable *OptionsVar =

--- a/llvm/test/Instrumentation/HeapProfiler/memprof-options.ll
+++ b/llvm/test/Instrumentation/HeapProfiler/memprof-options.ll
@@ -1,11 +1,12 @@
-; RUN: opt < %s -mtriple=x86_64-unknown-linux -passes='function(memprof),memprof-module' -S | FileCheck %s --check-prefixes=CHECK,EMPTY
-; RUN: opt < %s -mtriple=x86_64-unknown-linux -passes='function(memprof),memprof-module' -S -memprof-runtime-default-options="verbose=1" | FileCheck %s --check-prefixes=CHECK,VERBOSE
+; RUN: opt < %s -mtriple=x86_64-unknown-linux -passes='function(memprof),memprof-module' -S | FileCheck %s --check-prefix=EMPTY
+; RUN: opt < %s -mtriple=x86_64-unknown-linux -passes='function(memprof),memprof-module' -S -memprof-runtime-default-options="verbose=1" | FileCheck %s
 
 define i32 @main() {
 entry:
   ret i32 0
 }
 
+; EMPTY-NOT: memprof_default_options_str
+
 ; CHECK: $__memprof_default_options_str = comdat any
-; EMPTY: @__memprof_default_options_str = constant [1 x i8] zeroinitializer, comdat
-; VERBOSE: @__memprof_default_options_str = constant [10 x i8] c"verbose=1\00", comdat
+; CHECK: @__memprof_default_options_str = constant [10 x i8] c"verbose=1\00", comdat


### PR DESCRIPTION
Add the clang frontend flag `-fmemory-profile-runtime-default-options` to support the `-memprof-runtime-default-options` LLVM flag introduced in https://github.com/llvm/llvm-project/pull/118874.

This enables us to easily pass the `-exported_symbol ___memprof_default_options_str` flag to the linker on Darwin, which is required because `__memprof_default_options_str` uses `WeakAnyLinkage` on Darwin.

https://github.com/ellishg/llvm-project/blob/fa0202169af23419c4bcbf66eabd1beb6b6e8e34/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp#L573-L576

Also, do not emit the `__memprof_default_options_str` symbol when `-memprof-runtime-default-options` is not supplied.