### PR TITLE
[X86][DAGCombiner] Skip x87 fp80 values in `combineFMulOrFDivWithIntPow2`

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -353,6 +353,7 @@ struct APFloatBase {
   static bool semanticsHasSignedRepr(const fltSemantics &);
   static bool semanticsHasInf(const fltSemantics &);
   static bool semanticsHasNaN(const fltSemantics &);
+  static bool isIEEELikeFP(const fltSemantics &);
 
   // Returns true if any number described by \p Src can be precisely represented
   // by a normal (not subnormal) value in \p Dst.

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -17271,8 +17271,9 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
 // prefer it.
 SDValue DAGCombiner::combineFMulOrFDivWithIntPow2(SDNode *N) {
   EVT VT = N->getValueType(0);
-  if (!Type::getFloatingPointTy(*DAG.getContext(), VT.getFltSemantics())
-           ->isIEEELikeFPTy())
+  const fltSemantics &Sem = VT.getFltSemantics();
+  if (&Sem == &APFloat::x87DoubleExtended() ||
+      &Sem == &APFloat::PPCDoubleDouble())
     return SDValue();
 
   SDValue ConstOp, Pow2Op;

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -17271,6 +17271,10 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
 // prefer it.
 SDValue DAGCombiner::combineFMulOrFDivWithIntPow2(SDNode *N) {
   EVT VT = N->getValueType(0);
+  if (!Type::getFloatingPointTy(*DAG.getContext(), VT.getFltSemantics())
+           ->isIEEELikeFPTy())
+    return SDValue();
+
   SDValue ConstOp, Pow2Op;
 
   std::optional<int> Mantissa;
@@ -17297,8 +17301,8 @@ SDValue DAGCombiner::combineFMulOrFDivWithIntPow2(SDNode *N) {
 
       const APFloat &APF = CFP->getValueAPF();
 
-      // Make sure we have normal/ieee constant.
-      if (!APF.isNormal() || !APF.isIEEE())
+      // Make sure we have normal constant.
+      if (!APF.isNormal())
         return false;
 
       // Make sure the floats exponent is within the bounds that this transform

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -17271,9 +17271,7 @@ SDValue DAGCombiner::visitFSUB(SDNode *N) {
 // prefer it.
 SDValue DAGCombiner::combineFMulOrFDivWithIntPow2(SDNode *N) {
   EVT VT = N->getValueType(0);
-  const fltSemantics &Sem = VT.getFltSemantics();
-  if (&Sem == &APFloat::x87DoubleExtended() ||
-      &Sem == &APFloat::PPCDoubleDouble())
+  if (!APFloat::isIEEELikeFP(VT.getFltSemantics()))
     return SDValue();
 
   SDValue ConstOp, Pow2Op;

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -353,6 +353,11 @@ bool APFloatBase::semanticsHasNaN(const fltSemantics &semantics) {
   return semantics.nonFiniteBehavior != fltNonfiniteBehavior::FiniteOnly;
 }
 
+bool APFloatBase::isIEEELikeFP(const fltSemantics &semantics) {
+  // Keep in sync with Type::isIEEELikeFPTy
+  return SemanticsToEnum(semantics) <= S_IEEEquad;
+}
+
 bool APFloatBase::isRepresentableAsNormalIn(const fltSemantics &Src,
                                             const fltSemantics &Dst) {
   // Exponent range must be larger.

--- a/llvm/test/CodeGen/X86/fold-int-pow2-with-fmul-or-fdiv.ll
+++ b/llvm/test/CodeGen/X86/fold-int-pow2-with-fmul-or-fdiv.ll
@@ -1692,36 +1692,24 @@ define float @fdiv_pow_shl_cnt32_okay(i32 %cnt) nounwind {
 define x86_fp80 @pr128528(i1 %cond) {
 ; CHECK-SSE-LABEL: pr128528:
 ; CHECK-SSE:       # %bb.0:
-; CHECK-SSE-NEXT:    xorl %eax, %eax
 ; CHECK-SSE-NEXT:    testb $1, %dil
-; CHECK-SSE-NEXT:    setne %al
-; CHECK-SSE-NEXT:    movq %rax, %rcx
-; CHECK-SSE-NEXT:    shlq $63, %rcx
-; CHECK-SSE-NEXT:    fldl {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
-; CHECK-SSE-NEXT:    fstpt -{{[0-9]+}}(%rsp)
-; CHECK-SSE-NEXT:    addq -{{[0-9]+}}(%rsp), %rcx
-; CHECK-SSE-NEXT:    movq %rcx, -{{[0-9]+}}(%rsp)
-; CHECK-SSE-NEXT:    movl -{{[0-9]+}}(%rsp), %ecx
-; CHECK-SSE-NEXT:    adcq %rax, %rcx
-; CHECK-SSE-NEXT:    movw %cx, -{{[0-9]+}}(%rsp)
-; CHECK-SSE-NEXT:    fldt -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    movl $8, %eax
+; CHECK-SSE-NEXT:    movl $1, %ecx
+; CHECK-SSE-NEXT:    cmovnel %eax, %ecx
+; CHECK-SSE-NEXT:    movl %ecx, -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    fildl -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    fmull {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
 ; CHECK-SSE-NEXT:    retq
 ;
 ; CHECK-AVX-LABEL: pr128528:
 ; CHECK-AVX:       # %bb.0:
-; CHECK-AVX-NEXT:    xorl %eax, %eax
 ; CHECK-AVX-NEXT:    testb $1, %dil
-; CHECK-AVX-NEXT:    setne %al
-; CHECK-AVX-NEXT:    movq %rax, %rcx
-; CHECK-AVX-NEXT:    shlq $63, %rcx
-; CHECK-AVX-NEXT:    fldl {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
-; CHECK-AVX-NEXT:    fstpt -{{[0-9]+}}(%rsp)
-; CHECK-AVX-NEXT:    addq -{{[0-9]+}}(%rsp), %rcx
-; CHECK-AVX-NEXT:    movq %rcx, -{{[0-9]+}}(%rsp)
-; CHECK-AVX-NEXT:    movl -{{[0-9]+}}(%rsp), %ecx
-; CHECK-AVX-NEXT:    adcq %rax, %rcx
-; CHECK-AVX-NEXT:    movw %cx, -{{[0-9]+}}(%rsp)
-; CHECK-AVX-NEXT:    fldt -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    movl $8, %eax
+; CHECK-AVX-NEXT:    movl $1, %ecx
+; CHECK-AVX-NEXT:    cmovnel %eax, %ecx
+; CHECK-AVX-NEXT:    movl %ecx, -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    fildl -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    fmull {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
 ; CHECK-AVX-NEXT:    retq
   %sub9 = select i1 %cond, i32 8, i32 1
   %conv = uitofp i32 %sub9 to x86_fp80

--- a/llvm/test/CodeGen/X86/fold-int-pow2-with-fmul-or-fdiv.ll
+++ b/llvm/test/CodeGen/X86/fold-int-pow2-with-fmul-or-fdiv.ll
@@ -1688,3 +1688,43 @@ define float @fdiv_pow_shl_cnt32_okay(i32 %cnt) nounwind {
   %mul = fdiv float 0x3a20000000000000, %conv
   ret float %mul
 }
+
+define x86_fp80 @pr128528(i1 %cond) {
+; CHECK-SSE-LABEL: pr128528:
+; CHECK-SSE:       # %bb.0:
+; CHECK-SSE-NEXT:    xorl %eax, %eax
+; CHECK-SSE-NEXT:    testb $1, %dil
+; CHECK-SSE-NEXT:    setne %al
+; CHECK-SSE-NEXT:    movq %rax, %rcx
+; CHECK-SSE-NEXT:    shlq $63, %rcx
+; CHECK-SSE-NEXT:    fldl {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
+; CHECK-SSE-NEXT:    fstpt -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    addq -{{[0-9]+}}(%rsp), %rcx
+; CHECK-SSE-NEXT:    movq %rcx, -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    movl -{{[0-9]+}}(%rsp), %ecx
+; CHECK-SSE-NEXT:    adcq %rax, %rcx
+; CHECK-SSE-NEXT:    movw %cx, -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    fldt -{{[0-9]+}}(%rsp)
+; CHECK-SSE-NEXT:    retq
+;
+; CHECK-AVX-LABEL: pr128528:
+; CHECK-AVX:       # %bb.0:
+; CHECK-AVX-NEXT:    xorl %eax, %eax
+; CHECK-AVX-NEXT:    testb $1, %dil
+; CHECK-AVX-NEXT:    setne %al
+; CHECK-AVX-NEXT:    movq %rax, %rcx
+; CHECK-AVX-NEXT:    shlq $63, %rcx
+; CHECK-AVX-NEXT:    fldl {{\.?LCPI[0-9]+_[0-9]+}}(%rip)
+; CHECK-AVX-NEXT:    fstpt -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    addq -{{[0-9]+}}(%rsp), %rcx
+; CHECK-AVX-NEXT:    movq %rcx, -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    movl -{{[0-9]+}}(%rsp), %ecx
+; CHECK-AVX-NEXT:    adcq %rax, %rcx
+; CHECK-AVX-NEXT:    movw %cx, -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    fldt -{{[0-9]+}}(%rsp)
+; CHECK-AVX-NEXT:    retq
+  %sub9 = select i1 %cond, i32 8, i32 1
+  %conv = uitofp i32 %sub9 to x86_fp80
+  %mul = fmul x86_fp80 %conv, 0xK4007D055555555555800
+  ret x86_fp80 %mul
+}


### PR DESCRIPTION
f80 is not a valid IEEE floating-point type.
Closes https://github.com/llvm/llvm-project/issues/128528.
