### PR TITLE
[SystemZ] Handle scalar to vector bitcasts.

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZTargetTransformInfo.cpp
@@ -887,7 +887,8 @@ InstructionCost SystemZTTIImpl::getCastInstrCost(unsigned Opcode, Type *Dst,
   unsigned SrcScalarBits = Src->getScalarSizeInBits();
 
   if (!Src->isVectorTy()) {
-    assert (!Dst->isVectorTy());
+    if (Dst->isVectorTy())
+      return BaseT::getCastInstrCost(Opcode, Dst, Src, CCH, CostKind, I);
 
     if (Opcode == Instruction::SIToFP || Opcode == Instruction::UIToFP) {
       if (Src->isIntegerTy(128))

--- a/llvm/test/Analysis/CostModel/SystemZ/bitcast.ll
+++ b/llvm/test/Analysis/CostModel/SystemZ/bitcast.ll
@@ -1,0 +1,36 @@
+; RUN: opt < %s -mtriple=systemz-unknown -mcpu=z15 -passes="print<cost-model>" \
+; RUN:   -disable-output 2>&1 | FileCheck %s
+
+; Check bitcast from scalar to vector.
+
+@Glob = dso_local local_unnamed_addr global i32 0, align 4
+
+define dso_local void @fun() {
+entry:
+  %d.sroa.0 = alloca i64, align 8
+  store i64 0, ptr %d.sroa.0, align 8
+  store i32 2, ptr @Glob, align 4
+  br label %for.cond1
+
+for.cond1:                                        ; preds = %for.cond1, %entry
+  %L = load i64, ptr %d.sroa.0, align 8
+  %A0 = and i64 %L, 4294967295
+  store i64 %A0, ptr %d.sroa.0, align 8
+  %BC = bitcast i64 %A0 to <2 x i32>
+  %0 = and <2 x i32> %BC, splat (i32 10)
+  store <2 x i32> %0, ptr %d.sroa.0, align 8
+  br label %for.cond1
+
+; CHECK:      Printing analysis 'Cost Model Analysis' for function 'fun':
+; CHECK-NEXT: Cost Model: Found an estimated cost of 0 for instruction:   %d.sroa.0 = alloca i64, align 8
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   store i64 0, ptr %d.sroa.0, align 8
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   store i32 2, ptr @Glob, align 4
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   br label %for.cond1
+; CHECK-NEXT: Cost Model: Found an estimated cost of 0 for instruction:   %L = load i64, ptr %d.sroa.0, align 8
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   %A0 = and i64 %L, 4294967295
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   store i64 %A0, ptr %d.sroa.0, align 8
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   %BC = bitcast i64 %A0 to <2 x i32>
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   %0 = and <2 x i32> %BC, splat (i32 10)
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   store <2 x i32> %0, ptr %d.sroa.0, align 8
+; CHECK-NEXT: Cost Model: Found an estimated cost of 1 for instruction:   br label %for.cond1
+}


### PR DESCRIPTION
CSmith found a case where SROA produces bitcasts from scalar to vector. This was previously asserted against in SystemZTTI, but now the BaseT implementation takes care of it.

Reduced C test case:

clang -O3 -march=z15 crash5_aftercreduce.c -o a.out -w -mllvm -slp-min-reg-size=64 -mllvm -sroa-skip-mem2reg -mllvm -unroll-full-max-count=1 -mllvm -disable-select-optimize=false

[crash5_aftercreduce.c.tar.gz](https://github.com/user-attachments/files/18956655/crash5_aftercreduce.c.tar.gz)

@dominik-steenken 