### PR TITLE
[X86] Enhance FABS/FNEG lowering for scalar _Float16 with bitwise operations

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -22288,8 +22288,7 @@ static SDValue LowerFABSorFNEG(SDValue Op, SelectionDAG &DAG) {
 
   bool IsFABS = (Op.getOpcode() == ISD::FABS);
   SDLoc dl(Op);
-  MVT VT 
-  = Op.getSimpleValueType();
+  MVT VT = Op.getSimpleValueType();
 
   // Handle scalar _Float16 (f16) directly via integer bitwise operations.
   if (VT == MVT::f16) {
@@ -22306,13 +22305,13 @@ static SDValue LowerFABSorFNEG(SDValue Op, SelectionDAG &DAG) {
     APInt MaskVal;
     unsigned LogicOp;
     if (IsFABS) {
-      MaskVal = APInt(16, 0x7FFF);  // Clear sign bit.
+      MaskVal = APInt(16, 0x7FFF); // Clear sign bit.
       LogicOp = ISD::AND;
     } else if (IsFNABS) {
-      MaskVal = APInt(16, 0x8000);  // Combine masks via OR.
+      MaskVal = APInt(16, 0x8000); // Combine masks via OR.
       LogicOp = ISD::OR;
     } else {
-      MaskVal = APInt(16, 0x8000);  // Flip sign bit.
+      MaskVal = APInt(16, 0x8000); // Flip sign bit.
       LogicOp = ISD::XOR;
     }
 


### PR DESCRIPTION
This patch optimizes _Float16 FABS and FNEG operations by using direct 
bitwise operations instead of converting to/from float (#126892).

Before this patch, f16 FABS/FNEG would:
1. Convert f16->f32 (vcvtph2ps)
2. Perform operation on f32
3. Convert f32->f16 (vcvtps2ph)

With this patch, we now:
1. Bitcast f16->i16
2. Use AND/XOR with appropriate mask
3. Bitcast i16->f16

Test Plan:
- Added test cases for scalar f16 FABS/FNEG
- Verified generated assembly shows direct bitwise operations
- Ran X86 regression tests

Performance Impact:
- Eliminates f16<->f32 conversion overhead
- Reduces instruction count from 3 to 1