### PR TITLE
[libc++] Make .verify.cpp tests more robust against changing headers

### DIFF
--- a/libcxx/test/libcxx/atomics/atomics.syn/compatible_with_stdatomic.compile.pass.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.syn/compatible_with_stdatomic.compile.pass.cpp
@@ -9,8 +9,6 @@
 // UNSUPPORTED: no-threads
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // This test verifies that <stdatomic.h> redirects to <atomic>.
 
 // Before C++23, <stdatomic.h> can be included after <atomic>, but including it

--- a/libcxx/test/libcxx/input.output/file.streams/fstreams/filebuf/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/file.streams/fstreams/filebuf/traits_mismatch.verify.cpp
@@ -15,18 +15,8 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <fstream>
 
 std::basic_filebuf<char, std::char_traits<wchar_t> > f;
-// expected-error-re@streambuf:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@fstream:* {{only virtual member functions can be marked 'override'}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error@*:* 9 {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/file.streams/fstreams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/file.streams/fstreams/traits_mismatch.verify.cpp
@@ -15,13 +15,11 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <fstream>
 
 std::basic_fstream<char, std::char_traits<wchar_t> > f;
-// expected-error-re@ios:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
-// expected-error-re@streambuf:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 
 // expected-error@*:* 11 {{only virtual member functions can be marked 'override'}}
 

--- a/libcxx/test/libcxx/input.output/iostream.format/input.streams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/input.streams/traits_mismatch.verify.cpp
@@ -15,13 +15,11 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <istream>
 #include <string>
 
 struct test_istream
     : public std::basic_istream<char, std::char_traits<wchar_t> > {};
 
-// expected-error-re@ios:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
-// expected-error@istream:* {{only virtual member functions can be marked 'override'}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error@*:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/iostream.format/output.streams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/output.streams/traits_mismatch.verify.cpp
@@ -15,13 +15,11 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <ostream>
 #include <string>
 
 struct test_ostream
     : public std::basic_ostream<char, std::char_traits<wchar_t> > {};
 
-// expected-error-re@ios:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 // expected-error@*:* {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/libcxx/input.output/string.streams/traits_mismatch.verify.cpp
+++ b/libcxx/test/libcxx/input.output/string.streams/traits_mismatch.verify.cpp
@@ -16,16 +16,10 @@
 
 // UNSUPPORTED: no-wide-characters
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <sstream>
 
 std::basic_stringbuf<char, std::char_traits<wchar_t> > sb;
-// expected-error-re@streambuf:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
-// expected-error-re@string:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
+// expected-error-re@*:* {{static assertion failed{{.*}}traits_type::char_type must be the same type as CharT}}
 
-// expected-error@sstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@sstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@sstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@sstream:* {{only virtual member functions can be marked 'override'}}
-// expected-error@sstream:* {{only virtual member functions can be marked 'override'}}
+// expected-error@*:* 5 {{only virtual member functions can be marked 'override'}}

--- a/libcxx/test/std/containers/sequences/array/array.fill/fill.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.fill/fill.verify.cpp
@@ -10,8 +10,6 @@
 
 // void fill(const T& u);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <array>
 #include <cassert>
 
@@ -20,7 +18,7 @@ int main(int, char**) {
     typedef double T;
     typedef std::array<const T, 0> C;
     C c = {};
-    // expected-error-re@array:* {{static assertion failed{{.*}}cannot fill zero-sized array of type 'const T'}}
+    // expected-error-re@*:* {{static assertion failed{{.*}}cannot fill zero-sized array of type 'const T'}}
     c.fill(5.5); // expected-note {{requested here}}
   }
 

--- a/libcxx/test/std/containers/sequences/array/array.swap/swap.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.swap/swap.verify.cpp
@@ -10,8 +10,6 @@
 
 // void swap(array& a);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <array>
 #include <cassert>
 
@@ -21,7 +19,7 @@ int main(int, char**) {
     typedef std::array<const T, 0> C;
     C c  = {};
     C c2 = {};
-    // expected-error-re@array:* {{static assertion failed{{.*}}cannot swap zero-sized array of type 'const T'}}
+    // expected-error-re@*:* {{static assertion failed{{.*}}cannot swap zero-sized array of type 'const T'}}
     c.swap(c2); // expected-note {{requested here}}
   }
 

--- a/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/get.verify.cpp
@@ -10,8 +10,6 @@
 
 // template <size_t I, class T, size_t N> T& get(array<T, N>& a);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 // Prevent -Warray-bounds from issuing a diagnostic when testing with clang verify.
 // ADDITIONAL_COMPILE_FLAGS(gcc-style-warnings): -Wno-array-bounds
 
@@ -23,5 +21,5 @@ void f() {
   typedef std::array<T, 3> C;
   C c            = {1, 2, 3.5};
   std::get<3>(c) = 5.5; // expected-note {{requested here}}
-  // expected-error-re@array:* {{static assertion failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::get<> (std::array)}}
+  // expected-error-re@*:* {{static assertion failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::get<> (std::array)}}
 }

--- a/libcxx/test/std/containers/sequences/array/array.tuple/tuple_element.verify.cpp
+++ b/libcxx/test/std/containers/sequences/array/array.tuple/tuple_element.verify.cpp
@@ -10,12 +10,10 @@
 
 // tuple_element<I, array<T, N> >::type
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <array>
 #include <cassert>
 
 typedef double T;
 typedef std::array<T, 3> C;
 std::tuple_element<3, C> foo; // expected-note {{requested here}}
-// expected-error-re@array:* {{static assertion failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::tuple_element<> (std::array)}}
+// expected-error-re@*:* {{static assertion failed{{( due to requirement '3U[L]{0,2} < 3U[L]{0,2}')?}}{{.*}}Index out of bounds in std::tuple_element<> (std::array)}}

--- a/libcxx/test/std/strings/basic.string/char.bad.verify.cpp
+++ b/libcxx/test/std/strings/basic.string/char.bad.verify.cpp
@@ -9,8 +9,6 @@
 // <string>
 //   ... manipulating sequences of any non-array trivial standard-layout types.
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <string>
 #include "test_traits.h"
 
@@ -35,20 +33,20 @@ void f() {
     typedef char C[3];
     static_assert(std::is_array<C>::value, "");
     std::basic_string<C, test_traits<C> > s;
-    // expected-error-re@string:* {{static assertion failed{{.*}}Character type of basic_string must not be an array}}
+    // expected-error-re@*:* {{static assertion failed{{.*}}Character type of basic_string must not be an array}}
   }
 
   {
     // not trivial
     static_assert(!std::is_trivial<NotTrivial>::value, "");
     std::basic_string<NotTrivial, test_traits<NotTrivial> > s;
-    // expected-error-re@string:* {{static assertion failed{{.*}}Character type of basic_string must be trivial}}
+    // expected-error-re@*:* {{static assertion failed{{.*}}Character type of basic_string must be trivial}}
   }
 
   {
     // not standard layout
     static_assert(!std::is_standard_layout<NotStandardLayout>::value, "");
     std::basic_string<NotStandardLayout, test_traits<NotStandardLayout> > s;
-    // expected-error-re@string:* {{static assertion failed{{.*}}Character type of basic_string must be standard-layout}}
+    // expected-error-re@*:* {{static assertion failed{{.*}}Character type of basic_string must be standard-layout}}
   }
 }


### PR DESCRIPTION
This is fixes the tests for the frozen headers, but is an improvement either way.
