### PR TITLE
[RISCV] Xqcia 0.4 Spec renamed qc.(sla/sll)sat to qc.(shl/shlu)sat 

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -193,7 +193,7 @@
 // CHECK-NEXT:     smctr                1.0       'Smctr' (Control Transfer Records Machine Level)
 // CHECK-NEXT:     ssctr                1.0       'Ssctr' (Control Transfer Records Supervisor Level)
 // CHECK-NEXT:     svukte               0.3       'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses)
-// CHECK-NEXT:     xqcia                0.2       'Xqcia' (Qualcomm uC Arithmetic Extension)
+// CHECK-NEXT:     xqcia                0.4       'Xqcia' (Qualcomm uC Arithmetic Extension)
 // CHECK-NEXT:     xqciac               0.3       'Xqciac' (Qualcomm uC Load-Store Address Calculation Extension)
 // CHECK-NEXT:     xqcicli              0.2       'Xqcicli' (Qualcomm uC Conditional Load Immediate Extension)
 // CHECK-NEXT:     xqcicm               0.2       'Xqcicm' (Qualcomm uC Conditional Move Extension)

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -430,7 +430,7 @@ The current vendor extensions supported are:
   LLVM implements `the custom compressed opcodes present in some QingKe cores` by WCH / Nanjing Qinheng Microelectronics. The vendor refers to these opcodes by the name "XW".
 
 ``experimental-Xqcia``
-  LLVM implements `version 0.2 of the Qualcomm uC Arithmetic extension specification <https://github.com/quic/riscv-unified-db/releases/latest>`__ by Qualcomm.  All instructions are prefixed with `qc.` as described in the specification. These instructions are only available for riscv32.
+  LLVM implements `version 0.4 of the Qualcomm uC Arithmetic extension specification <https://github.com/quic/riscv-unified-db/releases/latest>`__ by Qualcomm.  All instructions are prefixed with `qc.` as described in the specification. These instructions are only available for riscv32.
 
 ``experimental-Xqciac``
   LLVM implements `version 0.3 of the Qualcomm uC Load-Store Address Calculation extension specification <https://github.com/quic/riscv-unified-db/releases/latest>`__ by Qualcomm.  All instructions are prefixed with `qc.` as described in the specification. These instructions are only available for riscv32.

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1305,7 +1305,7 @@ def HasVendorXqcisls
                          "'Xqcisls' (Qualcomm uC Scaled Load Store Extension)">;
 
 def FeatureVendorXqcia
-    : RISCVExperimentalExtension<0, 2, "Qualcomm uC Arithmetic Extension">;
+    : RISCVExperimentalExtension<0, 4, "Qualcomm uC Arithmetic Extension">;
 def HasVendorXqcia
     : Predicate<"Subtarget->hasVendorXqcia()">,
       AssemblerPredicate<(all_of FeatureVendorXqcia),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -309,8 +309,8 @@ let Predicates = [HasVendorXqcisls, IsRV32], DecoderNamespace = "Xqcisls" in {
 
 let Predicates = [HasVendorXqcia, IsRV32], DecoderNamespace = "Xqcia" in {
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
-  def QC_SLASAT : QCIRVInstRR<0b01010, GPRNoX0, "qc.slasat">;
-  def QC_SLLSAT : QCIRVInstRR<0b01100, GPRNoX0, "qc.sllsat">;
+  def QC_SHLSAT : QCIRVInstRR<0b01010, GPRNoX0, "qc.shlsat">;
+  def QC_SHLUSAT : QCIRVInstRR<0b01100, GPRNoX0, "qc.shlusat">;
   def QC_ADDSAT : QCIRVInstRR<0b01110, GPRNoX0, "qc.addsat">;
   def QC_ADDUSAT : QCIRVInstRR<0b01111, GPRNoX0, "qc.addusat">;
   def QC_SUBSAT : QCIRVInstRR<0b10000, GPRNoX0, "qc.subsat">;

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -398,7 +398,7 @@
 ; RV32XTHEADMEMPAIR: .attribute 5, "rv32i2p1_xtheadmempair1p0"
 ; RV32XTHEADSYNC: .attribute 5, "rv32i2p1_xtheadsync1p0"
 ; RV32XWCHC: .attribute 5, "rv32i2p1_xwchc2p2"
-; RV32XQCIA: .attribute 5, "rv32i2p1_xqcia0p2"
+; RV32XQCIA: .attribute 5, "rv32i2p1_xqcia0p4"
 ; RV32XQCIAC: .attribute 5, "rv32i2p1_zca1p0_xqciac0p3"
 ; RV32XQCICLI: .attribute 5, "rv32i2p1_xqcicli0p2"
 ; RV32XQCICM: .attribute 5, "rv32i2p1_zca1p0_xqcicm0p2"

--- a/llvm/test/MC/RISCV/xqcia-invalid.s
+++ b/llvm/test/MC/RISCV/xqcia-invalid.s
@@ -6,48 +6,48 @@
 
 # CHECK-PLUS: :[[@LINE+2]]:20: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:20: error: invalid operand for instruction
-qc.slasat x10, x3, 17
+qc.shlsat x10, x3, 17
 
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
-qc.slasat x10, x3
+qc.shlsat x10, x3
 
 # CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
-qc.slasat x0, x3, x17
+qc.shlsat x0, x3, x17
 
 # CHECK-PLUS: :[[@LINE+2]]:16: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:16: error: invalid operand for instruction
-qc.slasat x10, x0, x17
+qc.shlsat x10, x0, x17
 
 # CHECK-PLUS: :[[@LINE+2]]:20: error: register must be a GPR excluding zero (x0)
 # CHECK-MINUS: :[[@LINE+1]]:20: error: invalid operand for instruction
-qc.slasat x10, x3, x0
+qc.shlsat x10, x3, x0
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcia' (Qualcomm uC Arithmetic Extension)
-qc.slasat x10, x3, x17
+qc.shlsat x10, x3, x17
 
 
-# CHECK-PLUS: :[[@LINE+2]]:21: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:21: error: invalid operand for instruction
-qc.sllsat x23, x25, 27
+# CHECK-PLUS: :[[@LINE+2]]:22: error: register must be a GPR excluding zero (x0)
+# CHECK-MINUS: :[[@LINE+1]]:22: error: invalid operand for instruction
+qc.shlusat x23, x25, 27
 
 # CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
-qc.sllsat x23, x25
+qc.shlusat x23, x25
 
-# CHECK-PLUS: :[[@LINE+2]]:11: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
-qc.sllsat x0, x25, x27
+# CHECK-PLUS: :[[@LINE+2]]:12: error: register must be a GPR excluding zero (x0)
+# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
+qc.shlusat x0, x25, x27
 
-# CHECK-PLUS: :[[@LINE+2]]:16: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:16: error: invalid operand for instruction
-qc.sllsat x23, x0, x27
+# CHECK-PLUS: :[[@LINE+2]]:17: error: register must be a GPR excluding zero (x0)
+# CHECK-MINUS: :[[@LINE+1]]:17: error: invalid operand for instruction
+qc.shlusat x23, x0, x27
 
-# CHECK-PLUS: :[[@LINE+2]]:21: error: register must be a GPR excluding zero (x0)
-# CHECK-MINUS: :[[@LINE+1]]:21: error: invalid operand for instruction
-qc.sllsat x23, x25, x0
+# CHECK-PLUS: :[[@LINE+2]]:22: error: register must be a GPR excluding zero (x0)
+# CHECK-MINUS: :[[@LINE+1]]:22: error: invalid operand for instruction
+qc.shlusat x23, x25, x0
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcia' (Qualcomm uC Arithmetic Extension)
-qc.sllsat x23, x25, x27
+qc.shlusat x23, x25, x27
 
 
 # CHECK-PLUS: :[[@LINE+2]]:21: error: register must be a GPR excluding zero (x0)

--- a/llvm/test/MC/RISCV/xqcia-valid.s
+++ b/llvm/test/MC/RISCV/xqcia-valid.s
@@ -10,13 +10,13 @@
 # RUN:     | llvm-objdump --mattr=+experimental-xqcia --no-print-imm-hex -d - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 
-# CHECK-INST: qc.slasat    a0, gp, a7
+# CHECK-INST: qc.shlsat    a0, gp, a7
 # CHECK-ENC: encoding: [0x0b,0xb5,0x11,0x15]
-qc.slasat x10, x3, x17
+qc.shlsat x10, x3, x17
 
-# CHECK-INST: qc.sllsat    s7, s9, s11
+# CHECK-INST: qc.shlusat    s7, s9, s11
 # CHECK-ENC: encoding: [0x8b,0xbb,0xbc,0x19]
-qc.sllsat x23, x25, x27
+qc.shlusat x23, x25, x27
 
 # CHECK-INST: qc.addsat    a7, a4, t2
 # CHECK-ENC: encoding: [0x8b,0x38,0x77,0x1c]

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -654,7 +654,7 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
   }
 
   for (StringRef Input :
-       {"rv64i_xqcisls0p2", "rv64i_xqcia0p2", "rv64i_xqciac0p3",
+       {"rv64i_xqcisls0p2", "rv64i_xqcia0p4", "rv64i_xqciac0p3",
         "rv64i_xqcicsr0p2", "rv64i_xqcilsm0p2", "rv64i_xqcicm0p2",
         "rv64i_xqcics0p2", "rv64i_xqcicli0p2", "rv64i_xqciint0p2",
         "rv64i_xqcilo0p2", "rv64i_xqcilia0p2"}) {
@@ -1119,7 +1119,7 @@ Experimental extensions
     smctr                1.0
     ssctr                1.0
     svukte               0.3
-    xqcia                0.2
+    xqcia                0.4
     xqciac               0.3
     xqcicli              0.2
     xqcicm               0.2


### PR DESCRIPTION
The spec was recently updated, this changes the name in the TD files associated and increments the Extension number in the clang driver. This is mostly a MC change as there is no other generated code for these instructions yet.