### PR TITLE
[lldb] Assorted improvements to the Pipe class

### DIFF
--- a/lldb/include/lldb/Host/PipeBase.h
+++ b/lldb/include/lldb/Host/PipeBase.h
@@ -10,12 +10,11 @@
 #ifndef LLDB_HOST_PIPEBASE_H
 #define LLDB_HOST_PIPEBASE_H
 
-#include <chrono>
-#include <string>
-
 #include "lldb/Utility/Status.h"
+#include "lldb/Utility/Timeout.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
 
 namespace lldb_private {
 class PipeBase {
@@ -32,10 +31,9 @@ public:
   virtual Status OpenAsReader(llvm::StringRef name,
                               bool child_process_inherit) = 0;
 
-  Status OpenAsWriter(llvm::StringRef name, bool child_process_inherit);
-  virtual Status
-  OpenAsWriterWithTimeout(llvm::StringRef name, bool child_process_inherit,
-                          const std::chrono::microseconds &timeout) = 0;
+  virtual llvm::Error OpenAsWriter(llvm::StringRef name,
+                                   bool child_process_inherit,
+                                   const Timeout<std::micro> &timeout) = 0;
 
   virtual bool CanRead() const = 0;
   virtual bool CanWrite() const = 0;
@@ -56,14 +54,13 @@ public:
   // Delete named pipe.
   virtual Status Delete(llvm::StringRef name) = 0;
 
-  virtual Status WriteWithTimeout(const void *buf, size_t size,
-                                  const std::chrono::microseconds &timeout,
-                                  size_t &bytes_written) = 0;
-  Status Write(const void *buf, size_t size, size_t &bytes_written);
-  virtual Status ReadWithTimeout(void *buf, size_t size,
-                                 const std::chrono::microseconds &timeout,
-                                 size_t &bytes_read) = 0;
-  Status Read(void *buf, size_t size, size_t &bytes_read);
+  virtual llvm::Expected<size_t>
+  Write(const void *buf, size_t size,
+        const Timeout<std::micro> &timeout = std::nullopt) = 0;
+
+  virtual llvm::Expected<size_t>
+  Read(void *buf, size_t size,
+       const Timeout<std::micro> &timeout = std::nullopt) = 0;
 };
 }
 

--- a/lldb/include/lldb/Host/posix/PipePosix.h
+++ b/lldb/include/lldb/Host/posix/PipePosix.h
@@ -8,6 +8,7 @@
 
 #ifndef LLDB_HOST_POSIX_PIPEPOSIX_H
 #define LLDB_HOST_POSIX_PIPEPOSIX_H
+
 #include "lldb/Host/PipeBase.h"
 #include <mutex>
 
@@ -38,9 +39,8 @@ public:
                               llvm::SmallVectorImpl<char> &name) override;
   Status OpenAsReader(llvm::StringRef name,
                       bool child_process_inherit) override;
-  Status
-  OpenAsWriterWithTimeout(llvm::StringRef name, bool child_process_inherit,
-                          const std::chrono::microseconds &timeout) override;
+  llvm::Error OpenAsWriter(llvm::StringRef name, bool child_process_inherit,
+                           const Timeout<std::micro> &timeout) override;
 
   bool CanRead() const override;
   bool CanWrite() const override;
@@ -64,12 +64,13 @@ public:
 
   Status Delete(llvm::StringRef name) override;
 
-  Status WriteWithTimeout(const void *buf, size_t size,
-                          const std::chrono::microseconds &timeout,
-                          size_t &bytes_written) override;
-  Status ReadWithTimeout(void *buf, size_t size,
-                         const std::chrono::microseconds &timeout,
-                         size_t &bytes_read) override;
+  llvm::Expected<size_t>
+  Write(const void *buf, size_t size,
+        const Timeout<std::micro> &timeout = std::nullopt) override;
+
+  llvm::Expected<size_t>
+  Read(void *buf, size_t size,
+       const Timeout<std::micro> &timeout = std::nullopt) override;
 
 private:
   bool CanReadUnlocked() const;

--- a/lldb/include/lldb/Host/windows/PipeWindows.h
+++ b/lldb/include/lldb/Host/windows/PipeWindows.h
@@ -38,9 +38,8 @@ public:
                               llvm::SmallVectorImpl<char> &name) override;
   Status OpenAsReader(llvm::StringRef name,
                       bool child_process_inherit) override;
-  Status
-  OpenAsWriterWithTimeout(llvm::StringRef name, bool child_process_inherit,
-                          const std::chrono::microseconds &timeout) override;
+  llvm::Error OpenAsWriter(llvm::StringRef name, bool child_process_inherit,
+                           const Timeout<std::micro> &timeout) override;
 
   bool CanRead() const override;
   bool CanWrite() const override;
@@ -59,12 +58,13 @@ public:
 
   Status Delete(llvm::StringRef name) override;
 
-  Status WriteWithTimeout(const void *buf, size_t size,
-                          const std::chrono::microseconds &timeout,
-                          size_t &bytes_written) override;
-  Status ReadWithTimeout(void *buf, size_t size,
-                         const std::chrono::microseconds &timeout,
-                         size_t &bytes_read) override;
+  llvm::Expected<size_t>
+  Write(const void *buf, size_t size,
+        const Timeout<std::micro> &timeout = std::nullopt) override;
+
+  llvm::Expected<size_t>
+  Read(void *buf, size_t size,
+       const Timeout<std::micro> &timeout = std::nullopt) override;
 
   // PipeWindows specific methods.  These allow access to the underlying OS
   // handle.

--- a/lldb/source/Host/common/PipeBase.cpp
+++ b/lldb/source/Host/common/PipeBase.cpp
@@ -11,19 +11,3 @@
 using namespace lldb_private;
 
 PipeBase::~PipeBase() = default;
-
-Status PipeBase::OpenAsWriter(llvm::StringRef name,
-                              bool child_process_inherit) {
-  return OpenAsWriterWithTimeout(name, child_process_inherit,
-                                 std::chrono::microseconds::zero());
-}
-
-Status PipeBase::Write(const void *buf, size_t size, size_t &bytes_written) {
-  return WriteWithTimeout(buf, size, std::chrono::microseconds::zero(),
-                          bytes_written);
-}
-
-Status PipeBase::Read(void *buf, size_t size, size_t &bytes_read) {
-  return ReadWithTimeout(buf, size, std::chrono::microseconds::zero(),
-                         bytes_read);
-}

--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -99,7 +99,8 @@ Status SharedSocket::CompleteSending(lldb::pid_t child_pid) {
     return Status::FromError(num_bytes.takeError());
   if (*num_bytes != sizeof(protocol_info))
     return Status::FromErrorStringWithFormatv(
-        "Write(WSAPROTOCOL_INFO) failed: {0} bytes", *num_bytes);
+        "Write(WSAPROTOCOL_INFO) failed: wrote {0}/{1} bytes", *num_bytes,
+        sizeof(protocol_info));
 #endif
   return Status();
 }
@@ -117,7 +118,8 @@ Status SharedSocket::GetNativeSocket(shared_fd_t fd, NativeSocket &socket) {
       return Status::FromError(num_bytes.takeError());
     if (*num_bytes != sizeof(protocol_info)) {
       return Status::FromErrorStringWithFormatv(
-          "socket_pipe.Read(WSAPROTOCOL_INFO) failed: {0} bytes", *num_bytes);
+          "Read(WSAPROTOCOL_INFO) failed: read {0}/{1} bytes", *num_bytes,
+          sizeof(protocol_info));
     }
   }
   socket = ::WSASocket(FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO,

--- a/lldb/source/Host/posix/MainLoopPosix.cpp
+++ b/lldb/source/Host/posix/MainLoopPosix.cpp
@@ -392,9 +392,5 @@ void MainLoopPosix::Interrupt() {
     return;
 
   char c = '.';
-  size_t bytes_written;
-  Status error = m_interrupt_pipe.Write(&c, 1, bytes_written);
-  assert(error.Success());
-  UNUSED_IF_ASSERT_DISABLED(error);
-  assert(bytes_written == 1);
+  cantFail(m_interrupt_pipe.Write(&c, 1));
 }

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -1162,9 +1162,9 @@ Status GDBRemoteCommunication::StartDebugserverProcess(
           char buf[10];
           if (llvm::Expected<size_t> num_bytes = socket_pipe.Read(
                   buf, std::size(buf), std::chrono::seconds(10))) {
-            port_str.append(buf, *num_bytes);
             if (*num_bytes == 0)
               break;
+            port_str.append(buf, *num_bytes);
           } else {
             error = Status::FromError(num_bytes.takeError());
           }

--- a/lldb/tools/lldb-server/lldb-gdbserver.cpp
+++ b/lldb/tools/lldb-server/lldb-gdbserver.cpp
@@ -167,27 +167,35 @@ void handle_launch(GDBRemoteCommunicationServerLLGS &gdb_server,
   }
 }
 
-Status writeSocketIdToPipe(Pipe &port_pipe, llvm::StringRef socket_id) {
-  size_t bytes_written = 0;
-  // Write the port number as a C string with the NULL terminator.
-  return port_pipe.Write(socket_id.data(), socket_id.size() + 1, bytes_written);
+static Status writeSocketIdToPipe(Pipe &port_pipe,
+                                  const std::string &socket_id) {
+  // NB: Include the nul character at the end.
+  llvm::StringRef buf(socket_id.data(), socket_id.size() + 1);
+  while (!buf.empty()) {
+    if (llvm::Expected<size_t> written =
+            port_pipe.Write(buf.data(), buf.size()))
+      buf = buf.drop_front(*written);
+    else
+      return Status::FromError(written.takeError());
+  }
+  return Status();
 }
 
 Status writeSocketIdToPipe(const char *const named_pipe_path,
                            llvm::StringRef socket_id) {
   Pipe port_name_pipe;
   // Wait for 10 seconds for pipe to be opened.
-  auto error = port_name_pipe.OpenAsWriterWithTimeout(named_pipe_path, false,
-                                                      std::chrono::seconds{10});
-  if (error.Fail())
-    return error;
-  return writeSocketIdToPipe(port_name_pipe, socket_id);
+  if (llvm::Error err = port_name_pipe.OpenAsWriter(named_pipe_path, false,
+                                                    std::chrono::seconds{10}))
+    return Status::FromError(std::move(err));
+
+  return writeSocketIdToPipe(port_name_pipe, socket_id.str());
 }
 
 Status writeSocketIdToPipe(lldb::pipe_t unnamed_pipe,
                            llvm::StringRef socket_id) {
   Pipe port_pipe{LLDB_INVALID_PIPE, unnamed_pipe};
-  return writeSocketIdToPipe(port_pipe, socket_id);
+  return writeSocketIdToPipe(port_pipe, socket_id.str());
 }
 
 void ConnectToRemote(MainLoop &mainloop,

--- a/lldb/unittests/Host/PipeTest.cpp
+++ b/lldb/unittests/Host/PipeTest.cpp
@@ -190,7 +190,7 @@ TEST_F(PipeTest, ReadWithTimeout) {
   memset(buf, 0, sizeof(buf));
   std::future<llvm::Expected<size_t>> future_num_bytes = std::async(
       std::launch::async, [&] { return pipe.Read(buf, sizeof(buf)); });
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   ASSERT_THAT_EXPECTED(pipe.Write(hello_world.data(), hello_world.size()),
                        llvm::HasValue(hello_world.size()));
   ASSERT_THAT_EXPECTED(future_num_bytes.get(),

--- a/lldb/unittests/Host/PipeTest.cpp
+++ b/lldb/unittests/Host/PipeTest.cpp
@@ -14,10 +14,10 @@
 #include "gtest/gtest.h"
 #include <chrono>
 #include <fcntl.h>
+#include <future>
 #include <numeric>
 #include <thread>
 #include <vector>
-#include <future>
 
 using namespace lldb_private;
 


### PR DESCRIPTION
The main motivation for this was the inconsistency in handling of partial reads/writes between the windows and posix implementations (windows was returning partial reads, posix was trying to fill the buffer completely). I settle on the windows implementation, as that's the more common behavior, and the "eager" version can be implemented on top of that (in most cases, it isn't necessary, since we're writing just a single byte).

Since this also required auditing the callers to make sure they're handling partial reads/writes correctly, I used the opportunity to modernize the function signatures as a forcing function. They now use the `Timeout` class (basically an `optional<duration>`) to support both polls (timeout=0) and blocking (timeout=nullopt) operations in a single function, and use an `Expected` instead of a by-ref result to return the number of bytes read/written.

As a drive-by, I also fix a problem with the windows implementation where we were rounding the timeout value down, which meant that calls could time out slightly sooner than expected.