### PR TITLE
[lldb] Add missing calls to SetThreadHitBreakpointSite/DetectThreadStoppedAtUnexecutedBP

### DIFF
--- a/lldb/source/Plugins/Process/Utility/ThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/ThreadMemory.cpp
@@ -66,6 +66,7 @@ ThreadMemory::CreateRegisterContextForFrame(StackFrame *frame) {
 }
 
 bool ThreadMemory::CalculateStopInfo() {
+  DetectThreadStoppedAtUnexecutedBP();
   if (m_backing_thread_sp) {
     lldb::StopInfoSP backing_stop_info_sp(
         m_backing_thread_sp->GetPrivateStopInfo());

--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -1451,6 +1451,8 @@ StopInfoSP StopInfo::CreateStopReasonWithBreakpointSiteID(Thread &thread,
 StopInfoSP StopInfo::CreateStopReasonWithBreakpointSiteID(Thread &thread,
                                                           break_id_t break_id,
                                                           bool should_stop) {
+  thread.SetThreadHitBreakpointSite();
+
   return StopInfoSP(new StopInfoBreakpoint(thread, break_id, should_stop));
 }
 

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -462,6 +462,10 @@ void Thread::ResetStopInfo() {
 }
 
 void Thread::SetStopInfo(const lldb::StopInfoSP &stop_info_sp) {
+  if (stop_info_sp &&
+      stop_info_sp->GetStopReason() == lldb::eStopReasonBreakpoint)
+    SetThreadHitBreakpointSite();
+
   m_stop_info_sp = stop_info_sp;
   if (m_stop_info_sp) {
     m_stop_info_sp->MakeStopInfoValid();


### PR DESCRIPTION
* One of the overloads of CreateStopReasonWithBreakpointSiteID was missing a call to SetThreadHitBreakpointSite.
* ThreadMemory was missing a "DetectThreadStoppedAtUnexecutedBP" in its CalculateStopInfo.
* When OS plugins are involved, they will sometimes calculate the stop info for the backing thread, and then "grab" it from them (see for example `ThreadMemory::CalculateStopInfo`. So the stop info is created on the backing thread (e.g. a GDBRemoteThread), and then we call SetStopInfo on the OS plugin thread. As a result, we never call `SetThreadHitBreakpointSite" for MemoryThreads, as this is done at the StopInfo creation. To address this, we add a check in SetStopInfo.)