### PR TITLE
[clang][ASTImporter] Fix AST import if anonymous namespaces are merged

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -2638,11 +2638,12 @@ ExpectedDecl ASTNodeImporter::VisitNamespaceDecl(NamespaceDecl *D) {
   if (!Name) {
     // This is an anonymous namespace. Adopt an existing anonymous
     // namespace if we can.
-    // FIXME: Not testable.
-    if (auto *TU = dyn_cast<TranslationUnitDecl>(DC))
+    DeclContext *EnclosingDC = DC->getEnclosingNamespaceContext();
+    if (auto *TU = dyn_cast<TranslationUnitDecl>(EnclosingDC))
       MergeWithNamespace = TU->getAnonymousNamespace();
     else
-      MergeWithNamespace = cast<NamespaceDecl>(DC)->getAnonymousNamespace();
+      MergeWithNamespace =
+          cast<NamespaceDecl>(EnclosingDC)->getAnonymousNamespace();
   } else {
     SmallVector<NamedDecl *, 4> ConflictingDecls;
     auto FoundDecls = Importer.findDeclsInToCtx(DC, Name);

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -10492,6 +10492,79 @@ TEST_P(ASTImporterOptionSpecificTestBase,
   EXPECT_EQ(ToFr1Imp, ToFr1);
 }
 
+struct ImportAndMergeAnonymousNamespace
+    : public ASTImporterOptionSpecificTestBase {
+protected:
+  void test(const char *ToCode, const char *FromCode) {
+    Decl *ToTU = getToTuDecl(ToCode, Lang_CXX11);
+    Decl *FromTU = getTuDecl(FromCode, Lang_CXX11);
+    auto *FromNS = FirstDeclMatcher<NamespaceDecl>().match(
+        FromTU, namespaceDecl(isAnonymous()));
+    auto *ToNS = FirstDeclMatcher<NamespaceDecl>().match(
+        ToTU, namespaceDecl(isAnonymous()));
+    auto *FromF = FirstDeclMatcher<FunctionDecl>().match(
+        FromTU, functionDecl(hasName("f")));
+    auto *ImportedF = Import(FromF, Lang_CXX11);
+    EXPECT_TRUE(ImportedF);
+    EXPECT_EQ(ImportedF->getDeclContext(), ToNS);
+    auto *ImportedNS = Import(FromNS, Lang_CXX11);
+    EXPECT_EQ(ImportedNS, ToNS);
+  }
+};
+
+TEST_P(ImportAndMergeAnonymousNamespace, NamespaceInTU) {
+  const char *ToCode =
+      R"(
+      namespace {
+      }
+      )";
+  const char *FromCode =
+      R"(
+      namespace {
+        void f();
+      }
+      )";
+  test(ToCode, FromCode);
+}
+
+TEST_P(ImportAndMergeAnonymousNamespace, NamespaceInLinkageSpec) {
+  const char *ToCode =
+      R"(
+      extern "C" {
+      namespace {
+      }
+      }
+      )";
+  const char *FromCode =
+      R"(
+      extern "C" {
+      namespace {
+        void f();
+      }
+      }
+      )";
+  test(ToCode, FromCode);
+}
+
+TEST_P(ImportAndMergeAnonymousNamespace, NamespaceInNamespace) {
+  const char *ToCode =
+      R"(
+      namespace X {
+        namespace {
+        }
+      }
+      )";
+  const char *FromCode =
+      R"(
+      namespace X {
+        namespace {
+          void f();
+        }
+      }
+      )";
+  test(ToCode, FromCode);
+}
+
 INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ASTImporterLookupTableTest,
                          DefaultTestValuesForRunOptions);
 
@@ -10577,6 +10650,9 @@ INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportMatrixType,
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportTemplateParmDeclDefaultValue,
                          DefaultTestValuesForRunOptions);
+
+ISTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportAndMergeAnonymousNamespace,
+                        DefaultTestValuesForRunOptions);
 
 // FIXME: Make ImportOpenCLPipe test work.
 // INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportOpenCLPipe,

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -10651,8 +10651,8 @@ INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportMatrixType,
 INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportTemplateParmDeclDefaultValue,
                          DefaultTestValuesForRunOptions);
 
-ISTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportAndMergeAnonymousNamespace,
-                        DefaultTestValuesForRunOptions);
+INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportAndMergeAnonymousNamespace,
+                         DefaultTestValuesForRunOptions);
 
 // FIXME: Make ImportOpenCLPipe test work.
 // INSTANTIATE_TEST_SUITE_P(ParameterizedTests, ImportOpenCLPipe,


### PR DESCRIPTION
I discovered one faulty case that is shown in the second of the added tests (an anonymous namespace is imported that resides in a `extern "C"` block). I did not check for other possibilities for namespaces that are not in a TU or namespace but at least the code should handle all cases.