### PR TITLE
[InstCombine] Use known bits to simplify mask in foldSelectICmpAnd

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -121,7 +121,7 @@ static Instruction *foldSelectBinOpIdentity(SelectInst &Sel,
 /// isn't needed, or the bit widths don't match.
 static Value *foldSelectICmpAnd(SelectInst &Sel, ICmpInst *Cmp,
                                 InstCombiner::BuilderTy &Builder,
-                                SimplifyQuery &SQ) {
+                                const SimplifyQuery &SQ) {
   const APInt *SelTC, *SelFC;
   if (!match(Sel.getTrueValue(), m_APInt(SelTC)) ||
       !match(Sel.getFalseValue(), m_APInt(SelFC)))
@@ -151,7 +151,8 @@ static Value *foldSelectICmpAnd(SelectInst &Sel, ICmpInst *Cmp,
     assert(ICmpInst::isEquality(Res->Pred) && "Not equality test?");
     AndMask = Res->Mask;
     V = Res->X;
-    KnownBits Known = computeKnownBits(V, 0, SQ.getWithInstruction(Cmp));
+    KnownBits Known =
+        computeKnownBits(V, /*Depth=*/0, SQ.getWithInstruction(&Sel));
     AndMask &= Known.getMaxValue();
     if (!AndMask.isPowerOf2())
       return nullptr;

--- a/llvm/test/Transforms/InstCombine/select-icmp-and.ll
+++ b/llvm/test/Transforms/InstCombine/select-icmp-and.ll
@@ -912,3 +912,14 @@ define i16 @select_trunc_nuw_bittest_or(i8 %x) {
   %res = or i16 4, %select
   ret i16 %res
 }
+
+define i16 @select_icmp_bittest_range(i16 range (i16 0, 512) %a) {
+; CHECK-LABEL: @select_icmp_bittest_range(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i16 [[A:%.*]], 256
+; CHECK-NEXT:    [[RES:%.*]] = select i1 [[CMP]], i16 0, i16 256
+; CHECK-NEXT:    ret i16 [[RES]]
+;
+  %cmp = icmp ult i16 %a, 256
+  %res = select i1 %cmp, i16 0, i16 256
+  ret i16 %res
+}

--- a/llvm/test/Transforms/InstCombine/select-icmp-and.ll
+++ b/llvm/test/Transforms/InstCombine/select-icmp-and.ll
@@ -915,8 +915,7 @@ define i16 @select_trunc_nuw_bittest_or(i8 %x) {
 
 define i16 @select_icmp_bittest_range(i16 range (i16 0, 512) %a) {
 ; CHECK-LABEL: @select_icmp_bittest_range(
-; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i16 [[A:%.*]], 256
-; CHECK-NEXT:    [[RES:%.*]] = select i1 [[CMP]], i16 0, i16 256
+; CHECK-NEXT:    [[RES:%.*]] = and i16 [[A:%.*]], 256
 ; CHECK-NEXT:    ret i16 [[RES]]
 ;
   %cmp = icmp ult i16 %a, 256

--- a/llvm/test/Transforms/InstCombine/select-icmp-and.ll
+++ b/llvm/test/Transforms/InstCombine/select-icmp-and.ll
@@ -922,3 +922,25 @@ define i16 @select_icmp_bittest_range(i16 range (i16 0, 512) %a) {
   %res = select i1 %cmp, i16 0, i16 256
   ret i16 %res
 }
+
+define i16 @select_icmp_bittest_range_negative_test(i16 range (i16 0, 513) %a) {
+; CHECK-LABEL: @select_icmp_bittest_range_negative_test(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i16 [[A:%.*]], 256
+; CHECK-NEXT:    [[RES:%.*]] = select i1 [[CMP]], i16 0, i16 256
+; CHECK-NEXT:    ret i16 [[RES]]
+;
+  %cmp = icmp ult i16 %a, 256
+  %res = select i1 %cmp, i16 0, i16 256
+  ret i16 %res
+}
+
+define i16 @select_icmp_bittest_range_negative_test2(i16 range (i16 0, 512) %a) {
+; CHECK-LABEL: @select_icmp_bittest_range_negative_test2(
+; CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i16 [[A:%.*]], 255
+; CHECK-NEXT:    [[RES:%.*]] = select i1 [[CMP]], i16 0, i16 255
+; CHECK-NEXT:    ret i16 [[RES]]
+;
+  %cmp = icmp ult i16 %a, 255
+  %res = select i1 %cmp, i16 0, i16 255
+  ret i16 %res
+}


### PR DESCRIPTION
We currently do not make use of known bits when trying to decompose a select/icmp bittest and folding it into an and. This means we lose some folds when additional information, for instance via range attribute or metadata, would allow us to conclude that the resulting mask is in fact a power of two. See also https://alive2.llvm.org/ce/z/MM8wz2

