### PR TITLE
[RISCV] Change the vendor prefix for Rivos from "rv." to "ri."

### DIFF
--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -468,6 +468,9 @@ The current vendor extensions supported are:
 ``Xmipslsp``
   LLVM implements load/store pair instructions for the `p8700 processor <https://mips.com/products/hardware/p8700/>` by MIPS.
 
+``experimental-XRivosVizip``
+  LLVM implements `version 0.1 of the Rivos Vector Register Zips extension specification <https://github.com/rivosinc/rivos-custom-extensions>`__.
+
 Experimental C Intrinsics
 =========================
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
@@ -18,10 +18,10 @@
 let Predicates = [HasVendorXRivosVizip], DecoderNamespace = "XRivos",
   Constraints = "@earlyclobber $vd", RVVConstraint = Vrgather,
   Inst<6-0> = OPC_CUSTOM_2.Value in  {
-defm RV_VZIPEVEN_V : VALU_IV_V<"rv.vzipeven", 0b001100>;
-defm RV_VZIPODD_V : VALU_IV_V<"rv.vzipodd", 0b011100>;
-defm RV_VZIP2A_V : VALU_IV_V<"rv.vzip2a", 0b000100>;
-defm RV_VZIP2B_V : VALU_IV_V<"rv.vzip2b", 0b010100>;
-defm RV_VUNZIP2A_V : VALU_IV_V<"rv.vunzip2a", 0b001000>;
-defm RV_VUNZIP2B_V : VALU_IV_V<"rv.vunzip2b", 0b011000>;
+defm RI_VZIPEVEN_V : VALU_IV_V<"ri.vzipeven", 0b001100>;
+defm RI_VZIPODD_V : VALU_IV_V<"ri.vzipodd", 0b011100>;
+defm RI_VZIP2A_V : VALU_IV_V<"ri.vzip2a", 0b000100>;
+defm RI_VZIP2B_V : VALU_IV_V<"ri.vzip2b", 0b010100>;
+defm RI_VUNZIP2A_V : VALU_IV_V<"ri.vunzip2a", 0b001000>;
+defm RI_VUNZIP2B_V : VALU_IV_V<"ri.vunzip2b", 0b011000>;
 }

--- a/llvm/test/MC/RISCV/xrivosvizip-invalid.s
+++ b/llvm/test/MC/RISCV/xrivosvizip-invalid.s
@@ -3,8 +3,8 @@
 
 # Disallowed source/dest overlap cases
 # CHECK:  error: the destination vector register group cannot overlap the source vector register group
-rv.vzipeven.vv v2, v2, v3
+ri.vzipeven.vv v2, v2, v3
 # CHECK:  error: the destination vector register group cannot overlap the source vector register group
-rv.vzipeven.vv v3, v2, v3
+ri.vzipeven.vv v3, v2, v3
 # CHECK: error: the destination vector register group cannot overlap the mask register
-rv.vzipeven.vv v0, v2, v3, v0.t
+ri.vzipeven.vv v0, v2, v3, v0.t

--- a/llvm/test/MC/RISCV/xrivosvizip-valid.s
+++ b/llvm/test/MC/RISCV/xrivosvizip-valid.s
@@ -9,51 +9,51 @@
 # RUN:     | llvm-objdump --mattr=+experimental-xrivosvizip -M no-aliases -d -r - \
 # RUN:     | FileCheck --check-prefix=CHECK-ASM-AND-OBJ %s
 
-# CHECK-ASM-AND-OBJ: rv.vzipeven.vv    v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vzipeven.vv    v1, v2, v3
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x32]
-rv.vzipeven.vv v1, v2, v3
-# CHECK-ASM-AND-OBJ: rv.vzipeven.vv    v1, v2, v3, v0.t
+ri.vzipeven.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vzipeven.vv    v1, v2, v3, v0.t
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x30]
-rv.vzipeven.vv v1, v2, v3, v0.t
-# CHECK-ASM-AND-OBJ: rv.vzipodd.vv  v1, v2, v3
+ri.vzipeven.vv v1, v2, v3, v0.t
+# CHECK-ASM-AND-OBJ: ri.vzipodd.vv  v1, v2, v3
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x72]
-rv.vzipodd.vv v1, v2, v3
-# CHECK-ASM-AND-OBJ: rv.vzipodd.vv  v1, v2, v3, v0.t
+ri.vzipodd.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vzipodd.vv  v1, v2, v3, v0.t
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x70]
-rv.vzipodd.vv v1, v2, v3, v0.t
+ri.vzipodd.vv v1, v2, v3, v0.t
 
-# CHECK-ASM-AND-OBJ:  rv.vzip2a.vv   v1, v2, v3
+# CHECK-ASM-AND-OBJ:  ri.vzip2a.vv   v1, v2, v3
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x12]
-rv.vzip2a.vv v1, v2, v3
-# CHECK-ASM-AND-OBJ:  rv.vzip2a.vv   v1, v2, v3, v0.t
+ri.vzip2a.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ:  ri.vzip2a.vv   v1, v2, v3, v0.t
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x10]
-rv.vzip2a.vv v1, v2, v3, v0.t
-# CHECK-ASM-AND-OBJ: rv.vzip2b.vv   v1, v2, v3
+ri.vzip2a.vv v1, v2, v3, v0.t
+# CHECK-ASM-AND-OBJ: ri.vzip2b.vv   v1, v2, v3
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x52]
-rv.vzip2b.vv v1, v2, v3
-# CHECK-ASM-AND-OBJ: rv.vzip2b.vv   v1, v2, v3, v0.t
+ri.vzip2b.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vzip2b.vv   v1, v2, v3, v0.t
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x50]
-rv.vzip2b.vv v1, v2, v3, v0.t
+ri.vzip2b.vv v1, v2, v3, v0.t
 
-# CHECK-ASM-AND-OBJ: rv.vunzip2a.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vunzip2a.vv v1, v2, v3
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x22]
-rv.vunzip2a.vv v1, v2, v3
-# CHECK-ASM-AND-OBJ: rv.vunzip2a.vv v1, v2, v3, v0.t
+ri.vunzip2a.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vunzip2a.vv v1, v2, v3, v0.t
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x20]
-rv.vunzip2a.vv v1, v2, v3, v0.t
-# CHECK-ASM-AND-OBJ: rv.vunzip2b.vv v1, v2, v3
+ri.vunzip2a.vv v1, v2, v3, v0.t
+# CHECK-ASM-AND-OBJ: ri.vunzip2b.vv v1, v2, v3
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x62]
-rv.vunzip2b.vv v1, v2, v3
-# CHECK-ASM-AND-OBJ: rv.vunzip2b.vv v1, v2, v3, v0.t
+ri.vunzip2b.vv v1, v2, v3
+# CHECK-ASM-AND-OBJ: ri.vunzip2b.vv v1, v2, v3, v0.t
 # CHECK-ASM: encoding: [0xdb,0x80,0x21,0x60]
-rv.vunzip2b.vv v1, v2, v3, v0.t
+ri.vunzip2b.vv v1, v2, v3, v0.t
 
 # Overlap between source registers *is* allowed
 
-# CHECK-ASM-AND-OBJ: rv.vzipeven.vv    v1, v2, v2
+# CHECK-ASM-AND-OBJ: ri.vzipeven.vv    v1, v2, v2
 # CHECK-ASM: encoding: [0xdb,0x00,0x21,0x32]
-rv.vzipeven.vv v1, v2, v2
+ri.vzipeven.vv v1, v2, v2
 
-# CHECK-ASM-AND-OBJ: rv.vzipeven.vv    v1, v2, v0, v0.t
+# CHECK-ASM-AND-OBJ: ri.vzipeven.vv    v1, v2, v0, v0.t
 # CHECK-ASM: encoding: [0xdb,0x00,0x20,0x30]
-rv.vzipeven.vv v1, v2, v0, v0.t
+ri.vzipeven.vv v1, v2, v0, v0.t


### PR DESCRIPTION
There had been concern raised about possible confusion with "rvv". After internal discussion, we decided to go with an alternate prefix to reduce possible confusion going forward.  The specification document (https://github.com/rivosinc/rivos-custom-extensions) has been updated.

And also add the XRivosVizip extension to the documentation.  I'd missed that in the initial commit.