### PR TITLE
[flang] Silence warnings from hermetic module files

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1563,6 +1563,10 @@ Scope *ModFileReader::Read(SourceName name, std::optional<bool> isIntrinsic,
     Scope &hermeticScope{topScope.MakeScope(Scope::Kind::Global)};
     context_.set_currentHermeticModuleFileScope(&hermeticScope);
     ResolveNames(context_, hermeticModules, hermeticScope);
+    for (auto &[_, ref] : hermeticScope) {
+      CHECK(ref->has<ModuleDetails>());
+      ref->set(Symbol::Flag::ModFile);
+    }
   }
   GetModuleDependences(context_.moduleDependences(), sourceFile->content());
   ResolveNames(context_, parseTree, topScope);


### PR DESCRIPTION
Modules read from module files must have their symbols tagged with the ModFile flag to suppress all warnings messages that might be emitted for their contents.  (Actionable warnings will have been emitted when the modules were originally compiled, so we don't want to repeat them later when the modules are USE'd.)  The module symbols of the additional modules in hermetic module files were not being tagged with that flag; fix.