### PR TITLE
[PowerPC] Update LLVM 20.1.0 Release Notes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1269,6 +1269,8 @@ CUDA Support
 
 AIX Support
 ^^^^^^^^^^^
+- Fixed the ``-print-runtime-dir`` option.
+- Enable continuous profile syncing feature on AIX.
 
 NetBSD Support
 ^^^^^^^^^^^^^^

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -263,7 +263,23 @@ Changes to the PowerPC Backend
 ------------------------------
 
 * The Linux `ppc64` LLC default cpu is updated from `ppc` to `ppc64`.
-* The AIX LLC default cpu is updated from `generic` to `pwr7`.
+* Replaced PPCMergeStringPool with GlobalMerge.
+* Disabled vsx and altivec when -msoft-float is used.
+* Added support for -mcpu=pwr11 -mtune=pwr11.
+* Implemented BCD assist builtins.
+* Expanded global named register support.
+* Updated to use tablegen's MatchRegisterName().
+* Fixed saving of Link Register when using ROP Protect.
+* Fixed SUBREG_TO_REG handling in the RegisterCoalescer.
+* Fixed data layout alignment of i128 to 16.
+* Fixed codegen for transparent_union function parameters.
+* Added an error for incorrect use of memory operands.
+* Other various bug fixes and codegen improvements.
+
+AIX Specific:
+* LLC default cpu is updated from `generic` to `pwr7`.
+* Fixed handling in emitGlobalConstantImpl to emit aliases to subobjects at proper offsets.
+* Enabled aggressive merging of constants to reduce TOC entries.
 
 Changes to the RISC-V Backend
 -----------------------------
@@ -478,6 +494,10 @@ Changes to the LLVM tools
 
 * llvm-objcopy now prints the correct file path in the error message when the output file specified by `--dump-section` cannot be opened.
 
+* llvm-cxxfilt now supports demangling call expressions encoded using `cp` instead of `cl`.
+
+* llvm-objdump now supports printing the file header, load section header and auxillary header for XCOFF object files under the ``--private-headers`` option.
+
 Changes to LLDB
 ---------------------------------
 
@@ -629,6 +649,14 @@ Changes to BOLT
 
 Changes to Sanitizers
 ---------------------
+
+Changes to the Profile Runtime
+------------------------------
+
+* On platforms where ``atexit``-registered functions are not called when
+  a DSO is ``dlclose``'d, a mechanism is added that implements this
+  missing functionality for calls to ``atexit`` in the profile runtime.
+  [This is currently only enabled on AIX](https://github.com/llvm/llvm-project/pull/102940).
 
 Other Changes
 -------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -496,7 +496,7 @@ Changes to the LLVM tools
 
 * llvm-cxxfilt now supports demangling call expressions encoded using `cp` instead of `cl`.
 
-* llvm-objdump now supports printing the file header, load section header and auxillary header for XCOFF object files under the ``--private-headers`` option.
+* llvm-objdump now supports printing the file header, load section header and auxiliary header for XCOFF object files under the ``--private-headers`` option.
 
 Changes to LLDB
 ---------------------------------


### PR DESCRIPTION
This PR adds LLVM 20.1.0 release notes that are related to the PowerPC target.