### PR TITLE
[CIR] React to breaking change to DataLayoutTypeInterface

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -125,12 +125,6 @@ uint64_t IntType::getABIAlignment(const mlir::DataLayout &dataLayout,
   return (uint64_t)(getWidth() / 8);
 }
 
-uint64_t
-IntType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                               ::mlir::DataLayoutEntryListRef params) const {
-  return (uint64_t)(getWidth() / 8);
-}
-
 mlir::LogicalResult
 IntType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
                 unsigned width, bool isSigned) {
@@ -163,12 +157,6 @@ SingleType::getABIAlignment(const mlir::DataLayout &dataLayout,
   return (uint64_t)(getWidth() / 8);
 }
 
-uint64_t
-SingleType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                  ::mlir::DataLayoutEntryListRef params) const {
-  return (uint64_t)(getWidth() / 8);
-}
-
 const llvm::fltSemantics &DoubleType::getFloatSemantics() const {
   return llvm::APFloat::IEEEdouble();
 }
@@ -182,12 +170,6 @@ DoubleType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
 uint64_t
 DoubleType::getABIAlignment(const mlir::DataLayout &dataLayout,
                             mlir::DataLayoutEntryListRef params) const {
-  return (uint64_t)(getWidth() / 8);
-}
-
-uint64_t
-DoubleType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                  ::mlir::DataLayoutEntryListRef params) const {
   return (uint64_t)(getWidth() / 8);
 }
 
@@ -206,12 +188,6 @@ uint64_t FP16Type::getABIAlignment(const mlir::DataLayout &dataLayout,
   return (uint64_t)(getWidth() / 8);
 }
 
-uint64_t
-FP16Type::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                ::mlir::DataLayoutEntryListRef params) const {
-  return (uint64_t)(getWidth() / 8);
-}
-
 const llvm::fltSemantics &BF16Type::getFloatSemantics() const {
   return llvm::APFloat::BFloat();
 }
@@ -224,12 +200,6 @@ BF16Type::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
 
 uint64_t BF16Type::getABIAlignment(const mlir::DataLayout &dataLayout,
                                    mlir::DataLayoutEntryListRef params) const {
-  return (uint64_t)(getWidth() / 8);
-}
-
-uint64_t
-BF16Type::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                ::mlir::DataLayoutEntryListRef params) const {
   return (uint64_t)(getWidth() / 8);
 }
 
@@ -249,12 +219,6 @@ uint64_t FP80Type::getABIAlignment(const mlir::DataLayout &dataLayout,
   return 16;
 }
 
-uint64_t
-FP80Type::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                ::mlir::DataLayoutEntryListRef params) const {
-  return 16;
-}
-
 const llvm::fltSemantics &FP128Type::getFloatSemantics() const {
   return llvm::APFloat::IEEEquad();
 }
@@ -267,12 +231,6 @@ FP128Type::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
 
 uint64_t FP128Type::getABIAlignment(const mlir::DataLayout &dataLayout,
                                     mlir::DataLayoutEntryListRef params) const {
-  return 16;
-}
-
-uint64_t
-FP128Type::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                 ::mlir::DataLayoutEntryListRef params) const {
   return 16;
 }
 
@@ -293,13 +251,6 @@ LongDoubleType::getABIAlignment(const mlir::DataLayout &dataLayout,
                                 mlir::DataLayoutEntryListRef params) const {
   return mlir::cast<mlir::DataLayoutTypeInterface>(getUnderlying())
       .getABIAlignment(dataLayout, params);
-}
-
-uint64_t LongDoubleType::getPreferredAlignment(
-    const ::mlir::DataLayout &dataLayout,
-    mlir::DataLayoutEntryListRef params) const {
-  return mlir::cast<mlir::DataLayoutTypeInterface>(getUnderlying())
-      .getPreferredAlignment(dataLayout, params);
 }
 
 LogicalResult
@@ -397,12 +348,6 @@ BoolType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
   return 1;
 }
 
-uint64_t
-BoolType::getPreferredAlignment(const ::mlir::DataLayout &dataLayout,
-                                ::mlir::DataLayoutEntryListRef params) const {
-  return 1;
-}
-
 //===----------------------------------------------------------------------===//
 // PointerType Definitions
 //===----------------------------------------------------------------------===//
@@ -417,13 +362,6 @@ PointerType::getTypeSizeInBits(const ::mlir::DataLayout &dataLayout,
 uint64_t
 PointerType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                              ::mlir::DataLayoutEntryListRef params) const {
-  // FIXME: improve this in face of address spaces
-  return 8;
-}
-
-uint64_t PointerType::getPreferredAlignment(
-    const ::mlir::DataLayout &dataLayout,
-    ::mlir::DataLayoutEntryListRef params) const {
   // FIXME: improve this in face of address spaces
   return 8;
 }


### PR DESCRIPTION
In #128754, `DataLayoutTypeInterface` was changed to give `getPreferredAlignment` a default implemention.  As a result, table-gen no longer declared `getPreferredAlignment` when defining a class that contained `[DeclareTypeInterfaceMethods<DataLayoutTypeInterface>]` in the table-gen definition.  That means all of the definitions in `CIRTypes.cpp`, such as `PointerType::getPreferredAligment`, were compilation errors.

Delete all the definitions of `getPreferredAlignment`.  I verified that the default implementation does the exact same thing as the explicit overrides that are being deleted.