### PR TITLE
[LLD][ELF] Generically report "address assignment did not converge"

### DIFF
--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1531,8 +1531,7 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
     // With Thunk Size much smaller than branch range we expect to
     // converge quickly; if we get to 30 something has gone wrong.
     if (changed && pass >= 30) {
-      Err(ctx) << (ctx.target->needsThunks ? "thunk creation not converged"
-                                           : "relaxation not converged");
+      Err(ctx) << "address assignment did not converge";
       break;
     }
 

--- a/lld/test/ELF/linkerscript/symbol-assign-many-passes2.test
+++ b/lld/test/ELF/linkerscript/symbol-assign-many-passes2.test
@@ -6,7 +6,7 @@
 ## arm-thunk-many-passes.s is worst case case of thunk generation that takes 9
 ## passes to converge. It takes a few more passes to make symbol assignment
 ## converge. Test that
-## 1. we don't error that "thunk creation not converged".
+## 1. we don't error that "address assignment did not converge".
 ## 2. we check convergence of symbols defined in an output section descriptor.
 
 # CHECK: 01011050 T a


### PR DESCRIPTION
There are considerable number of changes done in the address assignment fixed point loop, and errors in any of them could cause address assignment not to converge. However, this is reported to the user as either "thunk creation not converged" or "relaxation not converged".

We saw a confused bug about this in the wild when spilling failed to converge. (I'm working on a fix for that.)

We may eventually want a complete reason system when reporting address assignment taking too many passes, but in the interim it seems prudent to generalize the error message to "address assignment did not converge".