### PR TITLE
[flang] Silence spurious error

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -3336,11 +3336,12 @@ void CheckHelper::CheckAlreadySeenDefinedIo(const DerivedTypeSpec &derivedType,
     return;
   }
   if (const Scope * dtScope{derivedType.scope()}) {
-    if (auto iter{dtScope->find(generic.name())}; iter != dtScope->end()) {
+    if (auto iter{dtScope->find(generic.name())}; iter != dtScope->end() &&
+        IsAccessible(*iter->second, generic.owner())) {
       for (auto specRef : iter->second->get<GenericDetails>().specificProcs()) {
         const Symbol &specific{specRef->get<ProcBindingDetails>().symbol()};
-        if (specific == proc) { // unambiguous, accept
-          continue;
+        if (specific == proc) {
+          continue; // unambiguous, accept
         }
         if (const auto *specDT{GetDtvArgDerivedType(specific)};
             specDT && evaluate::AreSameDerivedType(derivedType, *specDT)) {

--- a/flang/test/Semantics/io11.f90
+++ b/flang/test/Semantics/io11.f90
@@ -689,3 +689,34 @@ module m26b
     procedure unformattedRead
   end interface
 end
+
+module m27a
+  type t
+    integer c
+   contains
+    procedure ur1
+    generic, private :: read(unformatted) => ur1
+  end type
+ contains
+  subroutine ur1(dtv,unit,iostat,iomsg)
+    class(t),intent(inout) :: dtv
+    integer,intent(in) :: unit
+    integer,intent(out) :: iostat
+    character(*),intent(inout) :: iomsg
+    read(unit,iotype,iostat=iostat,iomsg=iomsg) dtv%c
+  end
+end
+module m27b
+  use m27a
+  interface read(unformatted)
+    module procedure ur2 ! ok, t's generic is inaccessible
+  end interface
+ contains
+  subroutine ur2(dtv,unit,iostat,iomsg)
+    class(t),intent(inout) :: dtv
+    integer,intent(in) :: unit
+    integer,intent(out) :: iostat
+    character(*),intent(inout) :: iomsg
+    read(unit,iotype,iostat=iostat,iomsg=iomsg) dtv%c
+  end
+end


### PR DESCRIPTION
When checking for conflicts between type-bound generic defined I/O procedures and non-type-bound defined I/O generic interfaces, don't worry about conflicts where the type-bound generic interface is inaccessible in the scope around the non-type-bound interface.

Fixes https://github.com/llvm/llvm-project/issues/126797.