### PR TITLE
[AMDGPU][True16][CodeGen] test fix for uaddsat/usubsat true16 selection

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/fmed3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmed3.ll
@@ -7582,7 +7582,7 @@ define amdgpu_kernel void @v_test_nnan_input_fmed3_r_i_i_f16(ptr addrspace(1) %o
 ; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_1)
 ; GFX11-GISEL-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v0, v1, s[2:3]
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_b16 v0, v1, s[2:3]
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_f16_e32 v0.l, 1.0, v0.l
 ; GFX11-GISEL-TRUE16-NEXT:    v_med3_f16 v0.l, v0.l, 2.0, 4.0
@@ -7837,16 +7837,13 @@ define amdgpu_kernel void @v_nnan_inputs_med3_f16_pat0(ptr addrspace(1) %out, pt
 ; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-GISEL-TRUE16-NEXT:    v_lshlrev_b32_e32 v2, 1, v0
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v0, v2, s[2:3] glc dlc
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_b16 v0, v2, s[2:3] glc dlc
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v1, v2, s[4:5] glc dlc
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v2, s[4:5] glc dlc
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v3, v2, s[6:7] glc dlc
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_b16 v1, v2, s[6:7] glc dlc
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_f16_e32 v0.l, 1.0, v0.l
-; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v1.l
-; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v1.l, v3.l
-; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_f16_e32 v0.h, 2.0, v0.h
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_f16_e32 v1.l, 4.0, v1.l
 ; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)

--- a/llvm/test/CodeGen/AMDGPU/minimummaximum.ll
+++ b/llvm/test/CodeGen/AMDGPU/minimummaximum.ll
@@ -181,17 +181,29 @@ define amdgpu_ps void @s_test_minmax_f16(half inreg %a, half inreg %b, half inre
 ; SDAG-FAKE16-NEXT:    global_store_b16 v0, v1, s[4:5]
 ; SDAG-FAKE16-NEXT:    s_endpgm
 ;
-; GISEL-LABEL: s_test_minmax_f16:
-; GISEL:       ; %bb.0:
-; GISEL-NEXT:    s_maximum_f16 s0, s0, s1
-; GISEL-NEXT:    s_mov_b32 s6, s3
-; GISEL-NEXT:    s_mov_b32 s7, s4
-; GISEL-NEXT:    v_mov_b32_e32 v1, 0
-; GISEL-NEXT:    s_minimum_f16 s0, s0, s2
-; GISEL-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
-; GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GISEL-NEXT:    global_store_b16 v1, v0, s[6:7]
-; GISEL-NEXT:    s_endpgm
+; GISEL-TRUE16-LABEL: s_test_minmax_f16:
+; GISEL-TRUE16:       ; %bb.0:
+; GISEL-TRUE16-NEXT:    s_maximum_f16 s0, s0, s1
+; GISEL-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-TRUE16-NEXT:    s_mov_b32 s6, s3
+; GISEL-TRUE16-NEXT:    s_mov_b32 s7, s4
+; GISEL-TRUE16-NEXT:    s_minimum_f16 s0, s0, s2
+; GISEL-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
+; GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[6:7]
+; GISEL-TRUE16-NEXT:    s_endpgm
+;
+; GISEL-FAKE16-LABEL: s_test_minmax_f16:
+; GISEL-FAKE16:       ; %bb.0:
+; GISEL-FAKE16-NEXT:    s_maximum_f16 s0, s0, s1
+; GISEL-FAKE16-NEXT:    s_mov_b32 s6, s3
+; GISEL-FAKE16-NEXT:    s_mov_b32 s7, s4
+; GISEL-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-FAKE16-NEXT:    s_minimum_f16 s0, s0, s2
+; GISEL-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_3)
+; GISEL-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GISEL-FAKE16-NEXT:    global_store_b16 v1, v0, s[6:7]
+; GISEL-FAKE16-NEXT:    s_endpgm
   %smax = call half @llvm.maximum.f16(half %a, half %b)
   %sminmax = call half @llvm.minimum.f16(half %smax, half %c)
   store half %sminmax, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/minmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/minmax.ll
@@ -577,16 +577,27 @@ define amdgpu_ps void @s_test_minmax_f16_ieee_false(half inreg %a, half inreg %b
 ; SDAG-GFX12-FAKE16-NEXT:    global_store_b16 v1, v0, s[4:5]
 ; SDAG-GFX12-FAKE16-NEXT:    s_endpgm
 ;
-; GISEL-GFX12-LABEL: s_test_minmax_f16_ieee_false:
-; GISEL-GFX12:       ; %bb.0:
-; GISEL-GFX12-NEXT:    s_max_num_f16 s0, s0, s1
-; GISEL-GFX12-NEXT:    s_mov_b32 s6, s3
-; GISEL-GFX12-NEXT:    s_mov_b32 s7, s4
-; GISEL-GFX12-NEXT:    v_mov_b32_e32 v1, 0
-; GISEL-GFX12-NEXT:    s_min_num_f16 s0, s0, s2
-; GISEL-GFX12-NEXT:    v_mov_b32_e32 v0, s0
-; GISEL-GFX12-NEXT:    global_store_b16 v1, v0, s[6:7]
-; GISEL-GFX12-NEXT:    s_endpgm
+; GISEL-GFX12-TRUE16-LABEL: s_test_minmax_f16_ieee_false:
+; GISEL-GFX12-TRUE16:       ; %bb.0:
+; GISEL-GFX12-TRUE16-NEXT:    s_max_num_f16 s0, s0, s1
+; GISEL-GFX12-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-GFX12-TRUE16-NEXT:    s_mov_b32 s6, s3
+; GISEL-GFX12-TRUE16-NEXT:    s_mov_b32 s7, s4
+; GISEL-GFX12-TRUE16-NEXT:    s_min_num_f16 s0, s0, s2
+; GISEL-GFX12-TRUE16-NEXT:    v_mov_b16_e32 v0.l, s0
+; GISEL-GFX12-TRUE16-NEXT:    global_store_b16 v1, v0, s[6:7]
+; GISEL-GFX12-TRUE16-NEXT:    s_endpgm
+;
+; GISEL-GFX12-FAKE16-LABEL: s_test_minmax_f16_ieee_false:
+; GISEL-GFX12-FAKE16:       ; %bb.0:
+; GISEL-GFX12-FAKE16-NEXT:    s_max_num_f16 s0, s0, s1
+; GISEL-GFX12-FAKE16-NEXT:    s_mov_b32 s6, s3
+; GISEL-GFX12-FAKE16-NEXT:    s_mov_b32 s7, s4
+; GISEL-GFX12-FAKE16-NEXT:    v_mov_b32_e32 v1, 0
+; GISEL-GFX12-FAKE16-NEXT:    s_min_num_f16 s0, s0, s2
+; GISEL-GFX12-FAKE16-NEXT:    v_mov_b32_e32 v0, s0
+; GISEL-GFX12-FAKE16-NEXT:    global_store_b16 v1, v0, s[6:7]
+; GISEL-GFX12-FAKE16-NEXT:    s_endpgm
   %smax = call half @llvm.maxnum.f16(half %a, half %b)
   %sminmax = call half @llvm.minnum.f16(half %smax, half %c)
   store half %sminmax, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/shrink-add-sub-constant.ll
+++ b/llvm/test/CodeGen/AMDGPU/shrink-add-sub-constant.ll
@@ -1366,7 +1366,7 @@ define amdgpu_kernel void @v_test_i16_x_sub_64(ptr addrspace(1) %out, ptr addrsp
 ; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-GISEL-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v0, v1, s[2:3]
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_b16 v0, v1, s[2:3]
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u16 v0.l, 0xffc0, v0.l
 ; GFX11-GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1]
@@ -1559,7 +1559,7 @@ define amdgpu_kernel void @v_test_i16_x_sub_64_zext_to_i32(ptr addrspace(1) %out
 ; GFX11-GISEL-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 1, v1
 ; GFX11-GISEL-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 2, v1
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v0, v0, s[2:3]
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_b16 v0, v0, s[2:3]
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u16 v0.l, 0xffc0, v0.l
 ; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -1799,20 +1799,15 @@ define amdgpu_kernel void @v_test_i16_x_sub_64_multi_use(ptr addrspace(1) %out, 
 ; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-GISEL-TRUE16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v0, v1, s[2:3] glc dlc
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_b16 v0, v1, s[2:3] glc dlc
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-TRUE16-NEXT:    global_load_u16 v2, v1, s[2:3] glc dlc
+; GFX11-GISEL-TRUE16-NEXT:    global_load_d16_hi_b16 v0, v1, s[2:3] glc dlc
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u16 v0.l, 0xffc0, v0.l
-; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.h, v2.l
-; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v2.l, v0.l
 ; GFX11-GISEL-TRUE16-NEXT:    v_add_nc_u16 v0.h, 0xffc0, v0.h
-; GFX11-GISEL-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-TRUE16-NEXT:    v_mov_b16_e32 v0.l, v0.h
-; GFX11-GISEL-TRUE16-NEXT:    global_store_b16 v1, v2, s[0:1] dlc
-; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-GISEL-TRUE16-NEXT:    global_store_b16 v1, v0, s[0:1] dlc
+; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
+; GFX11-GISEL-TRUE16-NEXT:    global_store_d16_hi_b16 v1, v0, s[0:1] dlc
 ; GFX11-GISEL-TRUE16-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-GISEL-TRUE16-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/v_pack.ll
+++ b/llvm/test/CodeGen/AMDGPU/v_pack.ll
@@ -108,15 +108,12 @@ define amdgpu_kernel void @v_pack_b32_v2f16(ptr addrspace(1) %in0, ptr addrspace
 ; GFX11-GISEL-REAL16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-GISEL-REAL16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v0, 1, v0
+; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v1, v0, s[0:1] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_b16 v0, v1, s[0:1] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v2, v0, s[2:3] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_hi_b16 v0, v1, s[2:3] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.l, v1.l
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.h, v2.l
-; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.l, 2.0, v0.l
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.h, 2.0, v0.h
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -240,15 +237,12 @@ define amdgpu_kernel void @v_pack_b32_v2f16_sub(ptr addrspace(1) %in0, ptr addrs
 ; GFX11-GISEL-REAL16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-GISEL-REAL16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v0, 1, v0
+; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v1, v0, s[0:1] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_b16 v0, v1, s[0:1] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v2, v0, s[2:3] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_hi_b16 v0, v1, s[2:3] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.l, v1.l
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.h, v2.l
-; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-GISEL-REAL16-NEXT:    v_subrev_f16_e32 v0.l, 2.0, v0.l
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.h, 2.0, v0.h
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -486,15 +480,12 @@ define amdgpu_kernel void @v_pack_b32.fabs(ptr addrspace(1) %in0, ptr addrspace(
 ; GFX11-GISEL-REAL16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-GISEL-REAL16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v0, 1, v0
+; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v1, v0, s[0:1] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_b16 v0, v1, s[0:1] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v2, v0, s[2:3] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_hi_b16 v0, v1, s[2:3] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.l, v1.l
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.h, v2.l
-; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.l, 2.0, v0.l
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.h, 2.0, v0.h
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -620,15 +611,12 @@ define amdgpu_kernel void @v_pack_b32.fneg(ptr addrspace(1) %in0, ptr addrspace(
 ; GFX11-GISEL-REAL16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-GISEL-REAL16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v0, 1, v0
+; GFX11-GISEL-REAL16-NEXT:    v_lshlrev_b32_e32 v1, 1, v0
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v1, v0, s[0:1] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_b16 v0, v1, s[0:1] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    global_load_u16 v2, v0, s[2:3] glc dlc
+; GFX11-GISEL-REAL16-NEXT:    global_load_d16_hi_b16 v0, v1, s[2:3] glc dlc
 ; GFX11-GISEL-REAL16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.l, v1.l
-; GFX11-GISEL-REAL16-NEXT:    v_mov_b16_e32 v0.h, v2.l
-; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.l, 2.0, v0.l
 ; GFX11-GISEL-REAL16-NEXT:    v_add_f16_e32 v0.h, 2.0, v0.h
 ; GFX11-GISEL-REAL16-NEXT:    s_delay_alu instid0(VALU_DEP_1)


### PR DESCRIPTION
This is a NFC change. Update the test file and fix the build

https://github.com/llvm/llvm-project/pull/128233 is causing a build issue. This is caused by PR https://github.com/llvm/llvm-project/pull/127945 being merged while the 128233 is pending for review.
