### PR TITLE
[RISCV] Update MicroOpBufferSize in P400 & P600 scheduling models

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP400.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP400.td
@@ -119,7 +119,7 @@ class SiFiveP400VSM3CCycles<string mx> {
 
 def SiFiveP400Model : SchedMachineModel {
   let IssueWidth = 3;         // 3 micro-ops are dispatched per cycle.
-  let MicroOpBufferSize = 56; // Max micro-ops that can be buffered.
+  let MicroOpBufferSize = 96; // Max micro-ops that can be buffered.
   let LoadLatency = 4;        // Cycles for loads to access the cache.
   let MispredictPenalty = 9;  // Extra cycles for a mispredicted branch.
   let UnsupportedFeatures = [HasStdExtZbkb, HasStdExtZbkc, HasStdExtZbkx,

--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP600.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP600.td
@@ -286,10 +286,10 @@ class SiFiveP600VSHA2MSCycles<string mx, int sew> {
 
 // SiFiveP600 machine model for scheduling and other instruction cost heuristics.
 def SiFiveP600Model : SchedMachineModel {
-  let IssueWidth = 4;         // 4 micro-ops are dispatched per cycle.
-  let MicroOpBufferSize = 160; // Max micro-ops that can be buffered.
-  let LoadLatency = 4;        // Cycles for loads to access the cache.
-  let MispredictPenalty = 9;  // Extra cycles for a mispredicted branch.
+  let IssueWidth = 4;          // 4 micro-ops are dispatched per cycle.
+  let MicroOpBufferSize = 192; // Max micro-ops that can be buffered.
+  let LoadLatency = 4;         // Cycles for loads to access the cache.
+  let MispredictPenalty = 9;   // Extra cycles for a mispredicted branch.
   let UnsupportedFeatures = [HasStdExtZbkb, HasStdExtZbkc, HasStdExtZbkx,
                              HasStdExtZknd, HasStdExtZkne, HasStdExtZknh,
                              HasStdExtZksed, HasStdExtZksh, HasStdExtZkr,

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/div.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/div.s
@@ -328,12 +328,12 @@ vfsqrt.v v8, v16
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      320
-# CHECK-NEXT: Total Cycles:      22358
+# CHECK-NEXT: Total Cycles:      19388
 # CHECK-NEXT: Total uOps:        320
 
 # CHECK:      Dispatch Width:    3
-# CHECK-NEXT: uOps Per Cycle:    0.01
-# CHECK-NEXT: IPC:               0.01
+# CHECK-NEXT: uOps Per Cycle:    0.02
+# CHECK-NEXT: IPC:               0.02
 # CHECK-NEXT: Block RThroughput: 14361.0
 
 # CHECK:      Instruction Info:

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/vlseg-vsseg.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP400/vlseg-vsseg.s
@@ -1606,7 +1606,7 @@ vsoxseg8ei64.v  v8, (a0), v16
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      1540
-# CHECK-NEXT: Total Cycles:      29967
+# CHECK-NEXT: Total Cycles:      28335
 # CHECK-NEXT: Total uOps:        1540
 
 # CHECK:      Dispatch Width:    3

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveP600/div.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveP600/div.s
@@ -328,7 +328,7 @@ vfsqrt.v v8, v16
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      320
-# CHECK-NEXT: Total Cycles:      14613
+# CHECK-NEXT: Total Cycles:      14397
 # CHECK-NEXT: Total uOps:        320
 
 # CHECK:      Dispatch Width:    4


### PR DESCRIPTION
The numbers we previously picked for MicroOpBufferSize in both P400 and P600's scheduling models turned out to be too conservative and didn't properly reflect the characteristics of our microarchitectures. This patch updates these numbers to be more faithful to our hardware.

This is unlikely to have any significant impact on MachineScheduler as it only uses MicroOpBufferSize in few places. That said, it is supposed to improve the accuracy of llvm-mca.