### PR TITLE
Support: Do not check if a file exists before executing

### DIFF
--- a/llvm/lib/Support/Unix/Program.inc
+++ b/llvm/lib/Support/Unix/Program.inc
@@ -168,13 +168,6 @@ static bool Execute(ProcessInfo &PI, StringRef Program,
                     ArrayRef<std::optional<StringRef>> Redirects,
                     unsigned MemoryLimit, std::string *ErrMsg,
                     BitVector *AffinityMask, bool DetachProcess) {
-  if (!llvm::sys::fs::exists(Program)) {
-    if (ErrMsg)
-      *ErrMsg = std::string("Executable \"") + Program.str() +
-                std::string("\" doesn't exist!");
-    return false;
-  }
-
   assert(!AffinityMask && "Starting a process with an affinity mask is "
                           "currently not supported on Unix!");
 

--- a/llvm/test/tools/llvm-rc/windres-preproc.test
+++ b/llvm/test/tools/llvm-rc/windres-preproc.test
@@ -20,7 +20,7 @@
 ;; Test error messages when unable to execute the preprocessor.
 
 ; RUN: not llvm-windres --preprocessor intentionally-missing-executable %p/Inputs/empty.rc %t.res 2>&1 | FileCheck %s --check-prefix=CHECK4
-; CHECK4: llvm-rc: Preprocessing failed: Executable "intentionally-missing-executable" doesn't exist!
+; CHECK4: llvm-rc: Preprocessing failed: posix_spawn failed: No such file or directory
 
 ;; Test --preprocessor with an argument with spaces.
 

--- a/llvm/test/tools/llvm-rc/windres-preproc.test
+++ b/llvm/test/tools/llvm-rc/windres-preproc.test
@@ -19,8 +19,8 @@
 
 ;; Test error messages when unable to execute the preprocessor.
 
-; RUN: not llvm-windres --preprocessor intentionally-missing-executable %p/Inputs/empty.rc %t.res 2>&1 | FileCheck %s --check-prefix=CHECK4
-; CHECK4: llvm-rc: Preprocessing failed: posix_spawn failed: No such file or directory
+; RUN: not llvm-windres --preprocessor intentionally-missing-executable %p/Inputs/empty.rc %t.res 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=CHECK4
+; CHECK4: llvm-rc: Preprocessing failed: posix_spawn failed: [[MSG]]
 
 ;; Test --preprocessor with an argument with spaces.
 


### PR DESCRIPTION
Let the actual syscall error if the file doesn't exist. This produces
a more standard "no such file or directory" phrasing of the error message,
and avoids an extra step.

The same antipattern appears in the windows code, we should probably
fix that one too.