### PR TITLE
[flang] Extend `omp loop` semantic checks for `reduction`

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3134,6 +3134,18 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Reduction &x) {
   if (llvm::omp::nestedReduceWorkshareAllowedSet.test(GetContext().directive)) {
     CheckSharedBindingInOuterContext(objects);
   }
+
+  if (GetContext().directive == llvm::omp::Directive::OMPD_loop) {
+    for (auto clause : GetContext().clauseInfo) {
+      if (const auto *bindClause{
+              std::get_if<parser::OmpClause::Bind>(&clause.second->u)}) {
+        if (bindClause->v.v == parser::OmpBindClause::Binding::Teams) {
+          context_.Say(GetContext().clauseSource,
+              "'REDUCTION' clause not allowed with '!$OMP LOOP BIND(TEAMS)'."_err_en_US);
+        }
+      }
+    }
+  }
 }
 
 void OmpStructureChecker::Enter(const parser::OmpClause::InReduction &x) {

--- a/flang/test/Semantics/OpenMP/loop-bind.f90
+++ b/flang/test/Semantics/OpenMP/loop-bind.f90
@@ -30,4 +30,9 @@ program main
   end do
   !$omp end teams loop
 
+  !ERROR: 'REDUCTION' clause not allowed with '!$OMP LOOP BIND(TEAMS)'.
+  !$omp loop bind(teams) reduction(+: x)
+  do i = 0, 10
+    x = x + i
+  end do
 end program main


### PR DESCRIPTION
Extend semantic checks for `omp loop` directive to report errors when a `reduction` clause is specified on a standalone `loop` directive with `teams` binding.

This is similar to how clang behaves.