### PR TITLE
[MLIR][Bufferization] Remove `GEN_PASS_DEF_BUFFERIZATIONBUFFERIZE`

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
@@ -26,7 +26,6 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_BUFFERIZATIONBUFFERIZE
 #define GEN_PASS_DEF_ONESHOTBUFFERIZE
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization


### PR DESCRIPTION
It was related to the old bufferization mechanism, which has since been retired.