### PR TITLE
release/20.x: [Clang] Fix an integer overflow issue in computing CTAD's parameter depth

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1058,6 +1058,7 @@ Bug Fixes to C++ Support
 - Fixed a substitution bug in transforming CTAD aliases when the type alias contains a non-pack template argument
   corresponding to a pack parameter (#GH124715)
 - Clang is now better at keeping track of friend function template instance contexts. (#GH55509)
+- Fixed an integer overflow bug in computing template parameter depths when synthesizing CTAD guides. (#GH128691)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This fixes a potential integer overflow bug that has been around for many versions and was exposed by my patch recently. So we think it warrants a backport.

Backports b8d1f3d62.