### PR TITLE
[CodeGen][NPM] Allow nested MF pass managers for -passes

### DIFF
--- a/llvm/test/tools/llc/new-pm/pipeline.mir
+++ b/llvm/test/tools/llc/new-pm/pipeline.mir
@@ -1,10 +1,18 @@
 # RUN: llc -mtriple=x86_64-pc-linux-gnu -x mir -passes=no-op-machine-function --print-pipeline-passes -filetype=null < %s | FileCheck %s --match-full-lines
 # RUN: llc -mtriple=x86_64-pc-linux-gnu -x mir -passes='require<machine-dom-tree>,print<machine-dom-tree>' -print-pipeline-passes < %s | FileCheck --check-prefix=ANALYSIS %s
 
+# Check same nested pass managers
+# RUN: llc -mtriple=x86_64-pc-linux-gnu -x mir \
+# RUN:     -passes='function(machine-function(machine-function(machine-cp)))' \
+# RUN:     -print-pipeline-passes < %s | FileCheck %s --check-prefix=NESTED
+
+# RUN: not llc -mtriple=x86_64-pc-linux-gnu -x mir -passes='machine-function(whoops(verify))' -print-pipeline-passes < %s 2>&1
+
 # CHECK: function(machine-function(no-op-machine-function)),PrintMIRPreparePass,function(machine-function(verify,print))
 
 # ANALYSIS: require<machine-dom-tree>,print<machine-dom-tree>
 
+# NESTED: function(machine-function(machine-cp))
 ---
 name: f
 body: |


### PR DESCRIPTION
This allows `machine-function(p1,machine-function(...))` instead of erroring.

Effectively it is flattened to a single MFPM.