### PR TITLE
[libclc] Make CLC library warning-free

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -377,8 +377,6 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       -D${CLC_TARGET_DEFINE}
       # All libclc builtin libraries see CLC headers
       -I${CMAKE_CURRENT_SOURCE_DIR}/clc/include
-      # FIXME: Fix libclc to not require disabling this noisy warning
-      -Wno-bitwise-conditional-parentheses
     )
 
     if( NOT "${cpu}" STREQUAL "" )
@@ -400,6 +398,8 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 
     list( APPEND build_flags
       -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
+      # FIXME: Fix libclc to not require disabling this noisy warning
+      -Wno-bitwise-conditional-parentheses
     )
 
     add_libclc_builtin_set(

--- a/libclc/clc/lib/generic/math/clc_ldexp.cl
+++ b/libclc/clc/lib/generic/math/clc_ldexp.cl
@@ -41,7 +41,7 @@ _CLC_DEF_ldexp _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
     int s = i & 0x80000000;
     int v = __clc_add_sat(e, n);
     v = __clc_clamp(v, 0, 0xff);
-    int mr = e == 0 | v == 0 | v == 0xff ? 0 : m;
+    int mr = (e == 0 || v == 0 || v == 0xff) ? 0 : m;
     int c = e == 0xff;
     mr = c ? m : mr;
     int er = c ? e : v;
@@ -96,7 +96,7 @@ _CLC_DEF_ldexp _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
   val_ui = dexp == 0 ? dval_ui : val_ui;
   val_f = __clc_as_float(val_ui);
 
-  val_f = __clc_isnan(x) | __clc_isinf(x) | val_x == 0 ? x : val_f;
+  val_f = (__clc_isnan(x) || __clc_isinf(x) || val_x == 0) ? x : val_f;
   return val_f;
 }
 


### PR DESCRIPTION
There is a long-standing workaround in the libclc build system that silences a warning about the use of parentheses in bitwise conditional operations.

In an effort to remove this workaround, this commit re-enables the warning on the internal CLC library, where most of the bodies of the builtins will eventually be defined. Thus as we move builtin implementations into this library, the warnings will trigger and we can clean up the codebase as we go.

As it happens the only instance in the CLC library which triggered the warning was in __clc_ldexp.