### PR TITLE
[MLIR][NFC] Retire `let constructor` for Shape and MLProgram

### DIFF
--- a/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.h
@@ -23,8 +23,6 @@ namespace ml_program {
 // Registration
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<OperationPass<ModuleOp>> createMLProgramPipelineGlobalsPass();
-
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/MLProgram/Transforms/Passes.h.inc"

--- a/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.td
@@ -11,7 +11,8 @@
 
 include "mlir/Pass/PassBase.td"
 
-def MLProgramPipelineGlobalsPass : Pass<"mlprogram-pipeline-globals", "ModuleOp"> {
+def MLProgramPipelineGlobalsPass
+    : Pass<"mlprogram-pipeline-globals", "ModuleOp"> {
   let summary = "Optimize `ml_program` global operations for read and store";
   let description = [{
     `ml_program`'s load and store operations can be optimized for

--- a/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/MLProgram/Transforms/Passes.td
@@ -11,7 +11,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def MLProgramPipelineGlobals : Pass<"mlprogram-pipeline-globals", "ModuleOp"> {
+def MLProgramPipelineGlobalsPass : Pass<"mlprogram-pipeline-globals", "ModuleOp"> {
   let summary = "Optimize `ml_program` global operations for read and store";
   let description = [{
     `ml_program`'s load and store operations can be optimized for
@@ -21,7 +21,6 @@ def MLProgramPipelineGlobals : Pass<"mlprogram-pipeline-globals", "ModuleOp"> {
     The pass is designed to handle both nested regions and function calls
     safely.
   }];
-  let constructor = "mlir::ml_program::createMLProgramPipelineGlobalsPass()";
 }
 
 #endif // MLIR_DIALECT_MLPROGRAM_TRANSFORMS_PASSES

--- a/mlir/include/mlir/Dialect/Shape/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Shape/Transforms/Passes.h
@@ -30,11 +30,6 @@ namespace mlir {
 #define GEN_PASS_DECL
 #include "mlir/Dialect/Shape/Transforms/Passes.h.inc"
 
-/// Creates an instance of the ShapeToShapeLowering pass that legalizes Shape
-/// dialect to be convertible to Arith. For example, `shape.num_elements` get
-/// transformed to `shape.reduce`, which can be lowered to SCF and Arith.
-std::unique_ptr<Pass> createShapeToShapeLowering();
-
 /// Collects a set of patterns to rewrite ops within the Shape dialect.
 void populateShapeRewritePatterns(RewritePatternSet &patterns);
 
@@ -45,11 +40,6 @@ void populateShapeRewritePatterns(RewritePatternSet &patterns);
 //
 // After this pass, no cstr_ operations exist.
 void populateRemoveShapeConstraintsPatterns(RewritePatternSet &patterns);
-std::unique_ptr<OperationPass<func::FuncOp>> createRemoveShapeConstraintsPass();
-
-/// Outline the shape computation part by adding shape.func and populate
-/// conrresponding mapping infomation into ShapeMappingAnalysis.
-std::unique_ptr<OperationPass<ModuleOp>> createOutlineShapeComputationPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Dialect/Shape/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Shape/Transforms/Passes.td
@@ -11,7 +11,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def OutlineShapeComputation : Pass<"outline-shape-computation", "ModuleOp"> {
+def OutlineShapeComputationPass : Pass<"outline-shape-computation", "ModuleOp"> {
   let summary = "Using shape.func to preserve shape computation";
   let description = [{
     This pass outlines the shape computation part in high level IR by adding
@@ -89,18 +89,15 @@ def OutlineShapeComputation : Pass<"outline-shape-computation", "ModuleOp"> {
     // - Shape for: %1 = "test.concat"(%0, %arg1) {axis = 0 : i64} : (tensor<?x4x?xf32>, tensor<2x4x?xf32>) -> tensor<?x4x?xf32> :: @shape_cal_1(<block argument> of type 'tensor<?x4x?xf32>' at index: 0)
     ```
   }];
-  let constructor = "mlir::createOutlineShapeComputationPass()";
   let dependentDialects = ["shape::ShapeDialect"];
 }
 
-def RemoveShapeConstraints : Pass<"remove-shape-constraints", "func::FuncOp"> {
+def RemoveShapeConstraintsPass : Pass<"remove-shape-constraints", "func::FuncOp"> {
   let summary = "Replace all cstr_ ops with a true witness";
-  let constructor = "mlir::createRemoveShapeConstraintsPass()";
 }
 
-def ShapeToShapeLowering : Pass<"shape-to-shape-lowering", "func::FuncOp"> {
+def ShapeToShapeLoweringPass : Pass<"shape-to-shape-lowering", "func::FuncOp"> {
   let summary = "Legalize Shape dialect to be convertible to Arith";
-  let constructor = "mlir::createShapeToShapeLowering()";
 }
 
 #endif // MLIR_DIALECT_SHAPE_TRANSFORMS_PASSES

--- a/mlir/include/mlir/Dialect/Shape/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Shape/Transforms/Passes.td
@@ -11,7 +11,8 @@
 
 include "mlir/Pass/PassBase.td"
 
-def OutlineShapeComputationPass : Pass<"outline-shape-computation", "ModuleOp"> {
+def OutlineShapeComputationPass
+    : Pass<"outline-shape-computation", "ModuleOp"> {
   let summary = "Using shape.func to preserve shape computation";
   let description = [{
     This pass outlines the shape computation part in high level IR by adding
@@ -92,7 +93,8 @@ def OutlineShapeComputationPass : Pass<"outline-shape-computation", "ModuleOp"> 
   let dependentDialects = ["shape::ShapeDialect"];
 }
 
-def RemoveShapeConstraintsPass : Pass<"remove-shape-constraints", "func::FuncOp"> {
+def RemoveShapeConstraintsPass
+    : Pass<"remove-shape-constraints", "func::FuncOp"> {
   let summary = "Replace all cstr_ ops with a true witness";
 }
 

--- a/mlir/lib/Dialect/MLProgram/Transforms/PipelineGlobalOps.cpp
+++ b/mlir/lib/Dialect/MLProgram/Transforms/PipelineGlobalOps.cpp
@@ -16,13 +16,13 @@
 
 namespace mlir {
 namespace ml_program {
-#define GEN_PASS_DEF_MLPROGRAMPIPELINEGLOBALS
+#define GEN_PASS_DEF_MLPROGRAMPIPELINEGLOBALSPASS
 #include "mlir/Dialect/MLProgram/Transforms/Passes.h.inc"
 
 namespace {
 
 class MLProgramPipelineGlobals
-    : public impl::MLProgramPipelineGlobalsBase<MLProgramPipelineGlobals> {
+    : public impl::MLProgramPipelineGlobalsPassBase<MLProgramPipelineGlobals> {
 public:
   void runOnOperation() override;
 
@@ -223,11 +223,6 @@ void MLProgramPipelineGlobals::runOnOperation() {
 }
 
 } // namespace
-
-std::unique_ptr<OperationPass<mlir::ModuleOp>>
-createMLProgramPipelineGlobalsPass() {
-  return std::make_unique<MLProgramPipelineGlobals>();
-}
 
 } // namespace ml_program
 } // namespace mlir

--- a/mlir/lib/Dialect/Shape/Transforms/OutlineShapeComputation.cpp
+++ b/mlir/lib/Dialect/Shape/Transforms/OutlineShapeComputation.cpp
@@ -163,7 +163,8 @@ void constructShapeFunc(
 }
 
 struct OutlineShapeComputationPass
-    : public impl::OutlineShapeComputationPassBase<OutlineShapeComputationPass> {
+    : public impl::OutlineShapeComputationPassBase<
+          OutlineShapeComputationPass> {
 
   void runOnOperation() override;
 

--- a/mlir/lib/Dialect/Shape/Transforms/OutlineShapeComputation.cpp
+++ b/mlir/lib/Dialect/Shape/Transforms/OutlineShapeComputation.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 namespace mlir {
-#define GEN_PASS_DEF_OUTLINESHAPECOMPUTATION
+#define GEN_PASS_DEF_OUTLINESHAPECOMPUTATIONPASS
 #include "mlir/Dialect/Shape/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -163,7 +163,7 @@ void constructShapeFunc(
 }
 
 struct OutlineShapeComputationPass
-    : public impl::OutlineShapeComputationBase<OutlineShapeComputationPass> {
+    : public impl::OutlineShapeComputationPassBase<OutlineShapeComputationPass> {
 
   void runOnOperation() override;
 
@@ -324,8 +324,3 @@ bool OutlineShapeComputationPass::calOnlyUsedByWithShapesRecursively(
 }
 
 } // namespace
-
-std::unique_ptr<OperationPass<ModuleOp>>
-mlir::createOutlineShapeComputationPass() {
-  return std::make_unique<OutlineShapeComputationPass>();
-}

--- a/mlir/lib/Dialect/Shape/Transforms/RemoveShapeConstraints.cpp
+++ b/mlir/lib/Dialect/Shape/Transforms/RemoveShapeConstraints.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_REMOVESHAPECONSTRAINTS
+#define GEN_PASS_DEF_REMOVESHAPECONSTRAINTSPASS
 #include "mlir/Dialect/Shape/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -47,7 +47,7 @@ public:
 
 /// Removal pass.
 class RemoveShapeConstraintsPass
-    : public impl::RemoveShapeConstraintsBase<RemoveShapeConstraintsPass> {
+    : public impl::RemoveShapeConstraintsPassBase<RemoveShapeConstraintsPass> {
 
   void runOnOperation() override {
     MLIRContext &ctx = getContext();
@@ -64,9 +64,4 @@ class RemoveShapeConstraintsPass
 void mlir::populateRemoveShapeConstraintsPatterns(RewritePatternSet &patterns) {
   patterns.add<RemoveCstrBroadcastableOp, RemoveCstrEqOp>(
       patterns.getContext());
-}
-
-std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::createRemoveShapeConstraintsPass() {
-  return std::make_unique<RemoveShapeConstraintsPass>();
 }

--- a/mlir/lib/Dialect/Shape/Transforms/ShapeToShapeLowering.cpp
+++ b/mlir/lib/Dialect/Shape/Transforms/ShapeToShapeLowering.cpp
@@ -17,7 +17,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_SHAPETOSHAPELOWERING
+#define GEN_PASS_DEF_SHAPETOSHAPELOWERINGPASS
 #include "mlir/Dialect/Shape/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -59,7 +59,7 @@ NumElementsOpConverter::matchAndRewrite(NumElementsOp op,
 
 namespace {
 struct ShapeToShapeLowering
-    : public impl::ShapeToShapeLoweringBase<ShapeToShapeLowering> {
+    : public impl::ShapeToShapeLoweringPassBase<ShapeToShapeLowering> {
   void runOnOperation() override;
 };
 } // namespace
@@ -80,8 +80,4 @@ void ShapeToShapeLowering::runOnOperation() {
 
 void mlir::populateShapeRewritePatterns(RewritePatternSet &patterns) {
   patterns.add<NumElementsOpConverter>(patterns.getContext());
-}
-
-std::unique_ptr<Pass> mlir::createShapeToShapeLowering() {
-  return std::make_unique<ShapeToShapeLowering>();
 }


### PR DESCRIPTION
`let constructor` is legacy (do not use in tree!) since the table gen backend emits most of the glue logic to build a pass. This PR retires the td method for Shape and MLProgram