### PR TITLE
[mlir][Tosa] Add unreachable case for bad Extension type in TosaProfileCompliance

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaProfileCompliance.h
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaProfileCompliance.h
@@ -148,6 +148,7 @@ public:
     case Extension::none:
       return {};
     };
+    llvm_unreachable("bad Extension type");
   }
 
   // Debug utilites.


### PR DESCRIPTION
add `llvm_unreachable` at the end of `getCooperativeProfiles` to eliminate compiler warning of "control reaches end of non-void function"