### PR TITLE
Match .exe on Windows

### DIFF
--- a/clang/test/Driver/hip-gz-options.hip
+++ b/clang/test/Driver/hip-gz-options.hip
@@ -9,6 +9,6 @@
 // RUN:   -ggdb -gz=zlib 2>&1 | FileCheck %s
 
 // CHECK-DAG: {{".*clang.*" .* "--compress-debug-sections=zlib"}}
-// CHECK-DAG: {{".*lld" .* "--compress-debug-sections=zlib"}}
+// CHECK-DAG: {{".*lld.*" .* "--compress-debug-sections=zlib"}}
 // CHECK-DAG: {{".*clang.*" .* "--compress-debug-sections=zlib"}}
 // CHECK: "--compress-debug-sections=zlib"


### PR DESCRIPTION
If you have zlib (not standard) on Windows, this test runs, and it was missing a match for the file extension on lld.