### PR TITLE
[SPIR-V] Add pass to remove spv_ptrcast intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -27,6 +27,7 @@ add_llvm_target(SPIRVCodeGen
   SPIRVInstrInfo.cpp
   SPIRVInstructionSelector.cpp
   SPIRVStripConvergentIntrinsics.cpp
+  SPIRVLegalizePointerLoad.cpp
   SPIRVMergeRegionExitTargets.cpp
   SPIRVISelLowering.cpp
   SPIRVLegalizerInfo.cpp

--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -27,7 +27,7 @@ add_llvm_target(SPIRVCodeGen
   SPIRVInstrInfo.cpp
   SPIRVInstructionSelector.cpp
   SPIRVStripConvergentIntrinsics.cpp
-  SPIRVLegalizePointerLoad.cpp
+  SPIRVLegalizePointerCast.cpp
   SPIRVMergeRegionExitTargets.cpp
   SPIRVISelLowering.cpp
   SPIRVLegalizerInfo.cpp

--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -23,6 +23,7 @@ ModulePass *createSPIRVPrepareFunctionsPass(const SPIRVTargetMachine &TM);
 FunctionPass *createSPIRVStructurizerPass();
 FunctionPass *createSPIRVMergeRegionExitTargetsPass();
 FunctionPass *createSPIRVStripConvergenceIntrinsicsPass();
+FunctionPass *createSPIRVLegalizePointerLoadPass(SPIRVTargetMachine *TM);
 FunctionPass *createSPIRVRegularizerPass();
 FunctionPass *createSPIRVPreLegalizerCombiner();
 FunctionPass *createSPIRVPreLegalizerPass();

--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -23,7 +23,7 @@ ModulePass *createSPIRVPrepareFunctionsPass(const SPIRVTargetMachine &TM);
 FunctionPass *createSPIRVStructurizerPass();
 FunctionPass *createSPIRVMergeRegionExitTargetsPass();
 FunctionPass *createSPIRVStripConvergenceIntrinsicsPass();
-FunctionPass *createSPIRVLegalizePointerLoadPass(SPIRVTargetMachine *TM);
+FunctionPass *createSPIRVLegalizePointerCastPass(SPIRVTargetMachine *TM);
 FunctionPass *createSPIRVRegularizerPass();
 FunctionPass *createSPIRVPreLegalizerCombiner();
 FunctionPass *createSPIRVPreLegalizerPass();

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -32,6 +32,20 @@
 
 using namespace llvm;
 
+namespace {
+
+bool allowEmitFakeUse(const Value *Arg) {
+  if (isSpvIntrinsic(Arg))
+    return false;
+  if (dyn_cast<AtomicCmpXchgInst>(Arg) || dyn_cast<InsertValueInst>(Arg) ||
+      dyn_cast<UndefValue>(Arg))
+    return false;
+  if (const auto *LI = dyn_cast<LoadInst>(Arg))
+    if (LI->getType()->isAggregateType())
+      return false;
+  return true;
+}
+
 inline unsigned typeToAddressSpace(const Type *Ty) {
   if (auto PType = dyn_cast<TypedPointerType>(Ty))
     return PType->getAddressSpace();
@@ -42,6 +56,8 @@ inline unsigned typeToAddressSpace(const Type *Ty) {
     return ExtTy->getIntParameter(0);
   report_fatal_error("Unable to convert LLVM type to SPIRVType", true);
 }
+
+} // anonymous namespace
 
 SPIRVGlobalRegistry::SPIRVGlobalRegistry(unsigned PointerSize)
     : PointerSize(PointerSize), Bound(0) {}
@@ -1741,6 +1757,33 @@ LLT SPIRVGlobalRegistry::getRegType(SPIRVType *SpvType) const {
   }
   }
   return LLT::scalar(64);
+}
+
+void SPIRVGlobalRegistry::replaceAllUsesWith(Value *Old, Value *New,
+                                             bool DeleteOld) {
+  Old->replaceAllUsesWith(New);
+  updateIfExistDeducedElementType(Old, New, DeleteOld);
+  updateIfExistAssignPtrTypeInstr(Old, New, DeleteOld);
+}
+
+void SPIRVGlobalRegistry::buildAssignType(IRBuilder<> &B, Type *Ty,
+                                          Value *Arg) {
+  Value *OfType = getNormalizedPoisonValue(Ty);
+  CallInst *AssignCI = nullptr;
+  if (Arg->getType()->isAggregateType() && Ty->isAggregateType() &&
+      allowEmitFakeUse(Arg)) {
+    LLVMContext &Ctx = Arg->getContext();
+    SmallVector<Metadata *, 2> ArgMDs{
+        MDNode::get(Ctx, ValueAsMetadata::getConstant(OfType)),
+        MDString::get(Ctx, Arg->getName())};
+    B.CreateIntrinsic(Intrinsic::spv_value_md, {},
+                      {MetadataAsValue::get(Ctx, MDTuple::get(Ctx, ArgMDs))});
+    AssignCI = B.CreateIntrinsic(Intrinsic::fake_use, {}, {Arg});
+  } else {
+    AssignCI = buildIntrWithMD(Intrinsic::spv_assign_type, {Arg->getType()},
+                               OfType, Arg, {}, B);
+  }
+  addAssignPtrTypeInstr(Arg, AssignCI);
 }
 
 void SPIRVGlobalRegistry::buildAssignPtr(IRBuilder<> &B, Type *ElemTy,

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -620,6 +620,9 @@ public:
 
   const TargetRegisterClass *getRegClass(SPIRVType *SpvType) const;
   LLT getRegType(SPIRVType *SpvType) const;
+
+  void buildAssignPtr(IRBuilder<> &B, Type *ElemTy, Value *Arg);
+  void updateAssignType(CallInst *AssignCI, Value *Arg, Value *OfType);
 };
 } // end namespace llvm
 #endif // LLLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -621,6 +621,11 @@ public:
   const TargetRegisterClass *getRegClass(SPIRVType *SpvType) const;
   LLT getRegType(SPIRVType *SpvType) const;
 
+  // Replace all uses of a |Old| with |New| updates the global registry type
+  // mappings.
+  void replaceAllUsesWith(Value *Old, Value *New, bool DeleteOld = true);
+
+  void buildAssignType(IRBuilder<> &B, Type *Ty, Value *Arg);
   void buildAssignPtr(IRBuilder<> &B, Type *ElemTy, Value *Arg);
   void updateAssignType(CallInst *AssignCI, Value *Arg, Value *OfType);
 };

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerLoad.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerLoad.cpp
@@ -13,8 +13,8 @@
 // by logical SPIR-V.
 //
 // This pass relies on the assign_ptr_type intrinsic to deduce the type of the
-// pointed values, must replace all occurences of `ptrcast`. This is why
-// unhandled cases are reported as unreachable: we MUST cover all cases.
+// pointee. All occurrences of `ptrcast` must be replaced because the lead to
+// invalid SPIR-V. Unhandled cases result in an error.
 //
 // 1. Loading the first element of an array
 //

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerLoad.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerLoad.cpp
@@ -1,0 +1,265 @@
+//===-- SPIRVLegalizePointerLoad.cpp ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The LLVM IR has multiple legal patterns we cannot lower to Logical SPIR-V.
+// This pass modifies such loads to have an IR we can directly lower to valid
+// logical SPIR-V.
+// OpenCL can avoid this because they rely on ptrcast, which is not supported
+// by logical SPIR-V.
+//
+// This pass relies on the assign_ptr_type intrinsic to deduce the type of the
+// pointed values, must replace all occurences of `ptrcast`. This is why
+// unhandled cases are reported as unreachable: we MUST cover all cases.
+//
+// 1. Loading the first element of an array
+//
+//        %array = [10 x i32]
+//        %value = load i32, ptr %array
+//
+//    LLVM can skip the GEP instruction, and only request loading the first 4
+//    bytes. In logical SPIR-V, we need an OpAccessChain to access the first
+//    element. This pass will add a getelementptr instruction before the load.
+//
+//
+// 2. Implicit downcast from load
+//
+//        %1 = getelementptr <4 x i32>, ptr %vec4, i64 0
+//        %2 = load <3 x i32>, ptr %1
+//
+//    The pointer in the GEP instruction is only used for offset computations,
+//    but it doesn't NEED to match the pointed type. OpAccessChain however
+//    requires this. Also, LLVM loads define the bitwidth of the load, not the
+//    pointer. In this example, we can guess %vec4 is a vec4 thanks to the GEP
+//    instruction basetype, but we only want to load the first 3 elements, hence
+//    do a partial load. In logical SPIR-V, this is not legal. What we must do
+//    is load the full vector (basetype), extract 3 elements, and recombine them
+//    to form a 3-element vector.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRV.h"
+#include "SPIRVSubtarget.h"
+#include "SPIRVTargetMachine.h"
+#include "SPIRVUtils.h"
+#include "llvm/CodeGen/IntrinsicLowering.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsSPIRV.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/LowerMemIntrinsics.h"
+
+using namespace llvm;
+
+namespace llvm {
+void initializeSPIRVLegalizePointerLoadPass(PassRegistry &);
+}
+
+class SPIRVLegalizePointerLoad : public FunctionPass {
+
+  // Replace all uses of a |Old| with |New| updates the global registry type
+  // mappings.
+  void replaceAllUsesWith(Value *Old, Value *New) {
+    Old->replaceAllUsesWith(New);
+    GR->updateIfExistDeducedElementType(Old, New, /* deleteOld = */ true);
+    GR->updateIfExistAssignPtrTypeInstr(Old, New, /* deleteOld = */ true);
+  }
+
+  // Builds the `spv_assign_type` assigning |Ty| to |Value| at the current
+  // builder position.
+  void buildAssignType(IRBuilder<> &B, Type *Ty, Value *Arg) {
+    Value *OfType = PoisonValue::get(Ty);
+    CallInst *AssignCI = buildIntrWithMD(Intrinsic::spv_assign_type,
+                                         {Arg->getType()}, OfType, Arg, {}, B);
+    GR->addAssignPtrTypeInstr(Arg, AssignCI);
+  }
+
+  // Loads a single scalar of type |To| from the vector pointed by |Source| of
+  // the type |From|. Returns the loaded value.
+  Value *loadScalarFromVector(IRBuilder<> &B, Value *Source,
+                              FixedVectorType *From) {
+
+    LoadInst *NewLoad = B.CreateLoad(From, Source);
+    buildAssignType(B, From, NewLoad);
+
+    SmallVector<Value *, 2> Args = {NewLoad, B.getInt64(0)};
+    SmallVector<Type *, 3> Types = {From->getElementType(), Args[0]->getType(),
+                                    Args[1]->getType()};
+    Value *Extracted =
+        B.CreateIntrinsic(Intrinsic::spv_extractelt, {Types}, {Args});
+    buildAssignType(B, Extracted->getType(), Extracted);
+    return Extracted;
+  }
+
+  // Loads parts of the vector of type |From| from the pointer |Source| and
+  // create a new vector of type |To|. |To| must be a vector type, and element
+  // types of |To| and |From| must match. Returns the loaded value.
+  Value *loadVectorFromVector(IRBuilder<> &B, FixedVectorType *From,
+                              FixedVectorType *To, Value *Source) {
+    // We expect the codegen to avoid doing implicit bitcast from a load.
+    assert(To->getElementType() == From->getElementType());
+    assert(To->getNumElements() < From->getNumElements());
+
+    LoadInst *NewLoad = B.CreateLoad(From, Source);
+    buildAssignType(B, From, NewLoad);
+
+    auto ConstInt = ConstantInt::get(IntegerType::get(B.getContext(), 32), 0);
+    ElementCount VecElemCount = ElementCount::getFixed(To->getNumElements());
+    Value *Output = ConstantVector::getSplat(VecElemCount, ConstInt);
+    for (unsigned I = 0; I < To->getNumElements(); ++I) {
+      Value *Extracted = nullptr;
+      {
+        SmallVector<Value *, 2> Args = {NewLoad, B.getInt64(I)};
+        SmallVector<Type *, 3> Types = {To->getElementType(),
+                                        Args[0]->getType(), Args[1]->getType()};
+        Extracted =
+            B.CreateIntrinsic(Intrinsic::spv_extractelt, {Types}, {Args});
+        buildAssignType(B, Extracted->getType(), Extracted);
+      }
+      assert(Extracted != nullptr);
+
+      {
+        SmallVector<Value *, 3> Args = {Output, Extracted, B.getInt64(I)};
+        SmallVector<Type *, 4> Types = {Args[0]->getType(), Args[0]->getType(),
+                                        Args[1]->getType(), Args[2]->getType()};
+        Output = B.CreateIntrinsic(Intrinsic::spv_insertelt, {Types}, {Args});
+        buildAssignType(B, Output->getType(), Output);
+      }
+    }
+    return Output;
+  }
+
+  // Loads the first value in an array pointed by |Source| of type |From|. Load
+  // flags will be copied from |BadLoad|, which should be the illegal load being
+  // legalized. Returns the loaded value.
+  Value *loadFirstValueFromArray(IRBuilder<> &B, ArrayType *From, Value *Source,
+                                 LoadInst *BadLoad) {
+    SmallVector<Type *, 2> Types = {BadLoad->getPointerOperandType(),
+                                    BadLoad->getPointerOperandType()};
+    SmallVector<Value *, 3> Args{/* isInBounds= */ B.getInt1(true), Source,
+                                 B.getInt64(0), B.getInt64(0)};
+    auto *GEP = B.CreateIntrinsic(Intrinsic::spv_gep, {Types}, {Args});
+    GR->buildAssignPtr(B, From->getElementType(), GEP);
+
+    const auto *TLI = TM->getSubtargetImpl()->getTargetLowering();
+    MachineMemOperand::Flags Flags = TLI->getLoadMemOperandFlags(
+        *BadLoad, BadLoad->getFunction()->getDataLayout());
+    Instruction *LI = B.CreateIntrinsic(
+        Intrinsic::spv_load, {BadLoad->getOperand(0)->getType()},
+        {GEP, B.getInt16(Flags), B.getInt8(BadLoad->getAlign().value())});
+    buildAssignType(B, From->getElementType(), LI);
+    return LI;
+  }
+
+  // Transforms an illegal partial load into a sequence we can lower to logical
+  // SPIR-V.
+  void transformLoad(IRBuilder<> &B, LoadInst *LI, Value *CastedOperand,
+                     Value *OriginalOperand) {
+    Type *FromTy = GR->findDeducedElementType(OriginalOperand);
+    Type *ToTy /*-fruity*/ = GR->findDeducedElementType(CastedOperand);
+    Value *Output = nullptr;
+
+    auto *SAT = dyn_cast<ArrayType>(FromTy);
+    auto *SVT = dyn_cast<FixedVectorType>(FromTy);
+    auto *DVT = dyn_cast<FixedVectorType>(ToTy);
+
+    B.SetInsertPoint(LI);
+
+    // Destination is the element type of Source, and source is an array ->
+    // Loading 1st element.
+    // - float a = array[0];
+    if (SAT && SAT->getElementType() == ToTy)
+      Output = loadFirstValueFromArray(B, SAT, OriginalOperand, LI);
+    // Destination is the element type of Source, and source is a vector ->
+    // Vector to scalar.
+    // - float a = vector.x;
+    else if (!DVT && SVT && SVT->getElementType() == ToTy) {
+      Output = loadScalarFromVector(B, OriginalOperand, SVT);
+    }
+    // Destination is a smaller vector than source.
+    // - float3 v3 = vector4;
+    else if (SVT && DVT)
+      Output = loadVectorFromVector(B, SVT, DVT, OriginalOperand);
+    else
+      llvm_unreachable("Unimplemented implicit down-cast from load.");
+
+    replaceAllUsesWith(LI, Output);
+    DeadInstructions.push_back(LI);
+  }
+
+  void legalizePointerCast(IntrinsicInst *II) {
+    Value *CastedOperand = II;
+    Value *OriginalOperand = II->getOperand(0);
+
+    IRBuilder<> B(II->getContext());
+    std::vector<Value *> Users;
+    for (Use &U : II->uses())
+      Users.push_back(U.getUser());
+
+    for (Value *User : Users) {
+      if (LoadInst *LI = dyn_cast<LoadInst>(User)) {
+        transformLoad(B, LI, CastedOperand, OriginalOperand);
+        continue;
+      }
+
+      IntrinsicInst *Intrin = dyn_cast<IntrinsicInst>(User);
+      if (Intrin->getIntrinsicID() == Intrinsic::spv_assign_ptr_type) {
+        DeadInstructions.push_back(Intrin);
+        continue;
+      }
+
+      llvm_unreachable("Unsupported ptrcast user. Please fix.");
+    }
+
+    DeadInstructions.push_back(II);
+  }
+
+public:
+  SPIRVLegalizePointerLoad(SPIRVTargetMachine *TM) : FunctionPass(ID), TM(TM) {
+    initializeSPIRVLegalizePointerLoadPass(*PassRegistry::getPassRegistry());
+  };
+
+  virtual bool runOnFunction(Function &F) override {
+    const SPIRVSubtarget &ST = TM->getSubtarget<SPIRVSubtarget>(F);
+    GR = ST.getSPIRVGlobalRegistry();
+    DeadInstructions.clear();
+
+    std::vector<IntrinsicInst *> WorkList;
+    for (auto &BB : F) {
+      for (auto &I : BB) {
+        auto *II = dyn_cast<IntrinsicInst>(&I);
+        if (II && II->getIntrinsicID() == Intrinsic::spv_ptrcast)
+          WorkList.push_back(II);
+      }
+    }
+
+    for (IntrinsicInst *II : WorkList)
+      legalizePointerCast(II);
+
+    for (Instruction *I : DeadInstructions)
+      I->eraseFromParent();
+
+    return DeadInstructions.size() != 0;
+  }
+
+private:
+  SPIRVTargetMachine *TM = nullptr;
+  SPIRVGlobalRegistry *GR = nullptr;
+  std::vector<Instruction *> DeadInstructions;
+
+public:
+  static char ID;
+};
+
+char SPIRVLegalizePointerLoad::ID = 0;
+INITIALIZE_PASS(SPIRVLegalizePointerLoad, "spirv-legalize-bitcast",
+                "SPIRV legalize bitcast pass", false, false)
+
+FunctionPass *llvm::createSPIRVLegalizePointerLoadPass(SPIRVTargetMachine *TM) {
+  return new SPIRVLegalizePointerLoad(TM);
+}

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -209,6 +209,8 @@ void SPIRVPassConfig::addIRPasses() {
 
 void SPIRVPassConfig::addISelPrepare() {
   addPass(createSPIRVEmitIntrinsicsPass(&getTM<SPIRVTargetMachine>()));
+  if (TM.getSubtargetImpl()->isVulkanEnv())
+    addPass(createSPIRVLegalizePointerLoadPass(&getTM<SPIRVTargetMachine>()));
   TargetPassConfig::addISelPrepare();
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -210,7 +210,7 @@ void SPIRVPassConfig::addIRPasses() {
 void SPIRVPassConfig::addISelPrepare() {
   addPass(createSPIRVEmitIntrinsicsPass(&getTM<SPIRVTargetMachine>()));
   if (TM.getSubtargetImpl()->isVulkanEnv())
-    addPass(createSPIRVLegalizePointerLoadPass(&getTM<SPIRVTargetMachine>()));
+    addPass(createSPIRVLegalizePointerCastPass(&getTM<SPIRVTargetMachine>()));
   TargetPassConfig::addISelPrepare();
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -775,6 +775,17 @@ Register createVirtualRegister(
       MIRBuilder);
 }
 
+CallInst *buildIntrWithMD(Intrinsic::ID IntrID, ArrayRef<Type *> Types,
+                          Value *Arg, Value *Arg2, ArrayRef<Constant *> Imms,
+                          IRBuilder<> &B) {
+  SmallVector<Value *, 4> Args;
+  Args.push_back(Arg2);
+  Args.push_back(buildMD(Arg));
+  for (auto *Imm : Imms)
+    Args.push_back(Imm);
+  return B.CreateIntrinsic(IntrID, {Types}, Args);
+}
+
 // Return true if there is an opaque pointer type nested in the argument.
 bool isNestedPointer(const Type *Ty) {
   if (Ty->isPtrOrPtrVectorTy())

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -405,6 +405,16 @@ inline PoisonValue *getNormalizedPoisonValue(Type *Ty) {
   return PoisonValue::get(normalizeType(Ty));
 }
 
+inline MetadataAsValue *buildMD(Value *Arg) {
+  LLVMContext &Ctx = Arg->getContext();
+  return MetadataAsValue::get(
+      Ctx, MDNode::get(Ctx, ValueAsMetadata::getConstant(Arg)));
+}
+
+CallInst *buildIntrWithMD(Intrinsic::ID IntrID, ArrayRef<Type *> Types,
+                          Value *Arg, Value *Arg2, ArrayRef<Constant *> Imms,
+                          IRBuilder<> &B);
+
 MachineInstr *getVRegDef(MachineRegisterInfo &MRI, Register Reg);
 
 #define SPIRV_BACKEND_SERVICE_FUN_NAME "__spirv_backend_service_fun"

--- a/llvm/test/CodeGen/SPIRV/pointers/array-skips-gep.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/array-skips-gep.ll
@@ -1,0 +1,38 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG:   %[[#int_ty:]] = OpTypeInt 32 0
+; CHECK-DAG:  %[[#long_ty:]] = OpTypeInt 64 0
+; CHECK-DAG:   %[[#int_10:]] = OpConstant %[[#int_ty]] 10
+; CHECK-DAG:   %[[#long_0:]] = OpConstantNull %[[#long_ty]]
+; CHECK-DAG: %[[#array_ty:]] = OpTypeArray %[[#int_ty]] %[[#int_10]]
+; CHECK-DAG: %[[#array_fp:]] = OpTypePointer Function %[[#array_ty]]
+; CHECK-DAG: %[[#array_pp:]] = OpTypePointer Private %[[#array_ty]]
+; CHECK-DAG:   %[[#int_fp:]] = OpTypePointer Function %[[#int_ty]]
+; CHECK-DAG:   %[[#int_pp:]] = OpTypePointer Private %[[#int_ty]]
+
+@gv = external addrspace(10) global [10 x i32]
+; CHECK: %[[#gv:]] = OpVariable %[[#array_pp]] Private
+
+define internal spir_func i32 @foo() {
+  %array = alloca [10 x i32], align 4
+; CHECK: %[[#array:]] = OpVariable %[[#array_fp:]] Function
+
+  ; Direct load from the pointer index. This requires an OpAccessChain
+  %1 = load i32, ptr %array, align 4
+; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#int_fp]] %[[#array]] %[[#long_0]]
+; CHECK: %[[#val:]] = OpLoad %[[#int_ty]] %[[#ptr]] Aligned 4
+
+  ret i32 %1
+; CHECK: OpReturnValue %[[#val]]
+}
+
+define internal spir_func i32 @bar() {
+  ; Direct load from the pointer index. This requires an OpAccessChain
+  %1 = load i32, ptr addrspace(10) @gv
+; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#int_pp]] %[[#gv]] %[[#long_0]]
+; CHECK: %[[#val:]] = OpLoad %[[#int_ty]] %[[#ptr]] Aligned 4
+
+  ret i32 %1
+; CHECK: OpReturnValue %[[#val]]
+}

--- a/llvm/test/CodeGen/SPIRV/pointers/array-skips-gep.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/array-skips-gep.ll
@@ -1,15 +1,14 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-DAG:   %[[#int_ty:]] = OpTypeInt 32 0
-; CHECK-DAG:  %[[#long_ty:]] = OpTypeInt 64 0
-; CHECK-DAG:   %[[#int_10:]] = OpConstant %[[#int_ty]] 10
-; CHECK-DAG:   %[[#long_0:]] = OpConstantNull %[[#long_ty]]
-; CHECK-DAG: %[[#array_ty:]] = OpTypeArray %[[#int_ty]] %[[#int_10]]
+; CHECK-DAG:  %[[#uint_ty:]] = OpTypeInt 32 0
+; CHECK-DAG:   %[[#uint_0:]] = OpConstant %[[#uint_ty]] 0
+; CHECK-DAG:   %[[#int_10:]] = OpConstant %[[#uint_ty]] 10
+; CHECK-DAG: %[[#array_ty:]] = OpTypeArray %[[#uint_ty]] %[[#int_10]]
 ; CHECK-DAG: %[[#array_fp:]] = OpTypePointer Function %[[#array_ty]]
 ; CHECK-DAG: %[[#array_pp:]] = OpTypePointer Private %[[#array_ty]]
-; CHECK-DAG:   %[[#int_fp:]] = OpTypePointer Function %[[#int_ty]]
-; CHECK-DAG:   %[[#int_pp:]] = OpTypePointer Private %[[#int_ty]]
+; CHECK-DAG:   %[[#int_fp:]] = OpTypePointer Function %[[#uint_ty]]
+; CHECK-DAG:   %[[#int_pp:]] = OpTypePointer Private %[[#uint_ty]]
 
 @gv = external addrspace(10) global [10 x i32]
 ; CHECK: %[[#gv:]] = OpVariable %[[#array_pp]] Private
@@ -20,8 +19,8 @@ define internal spir_func i32 @foo() {
 
   ; Direct load from the pointer index. This requires an OpAccessChain
   %1 = load i32, ptr %array, align 4
-; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#int_fp]] %[[#array]] %[[#long_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#int_ty]] %[[#ptr]] Aligned 4
+; CHECK: %[[#ptr:]] = OpAccessChain %[[#int_fp]] %[[#array]] %[[#uint_0]]
+; CHECK: %[[#val:]] = OpLoad %[[#uint_ty]] %[[#ptr]] Aligned 4
 
   ret i32 %1
 ; CHECK: OpReturnValue %[[#val]]
@@ -30,8 +29,8 @@ define internal spir_func i32 @foo() {
 define internal spir_func i32 @bar() {
   ; Direct load from the pointer index. This requires an OpAccessChain
   %1 = load i32, ptr addrspace(10) @gv
-; CHECK: %[[#ptr:]] = OpInBoundsAccessChain %[[#int_pp]] %[[#gv]] %[[#long_0]]
-; CHECK: %[[#val:]] = OpLoad %[[#int_ty]] %[[#ptr]] Aligned 4
+; CHECK: %[[#ptr:]] = OpAccessChain %[[#int_pp]] %[[#gv]] %[[#uint_0]]
+; CHECK: %[[#val:]] = OpLoad %[[#uint_ty]] %[[#ptr]] Aligned 4
 
   ret i32 %1
 ; CHECK: OpReturnValue %[[#val]]

--- a/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-vector.ll
+++ b/llvm/test/CodeGen/SPIRV/pointers/getelementptr-downcast-vector.ll
@@ -1,0 +1,128 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-DAG:   %[[#uint:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#uint_0:]] = OpConstant %[[#uint]] 0
+; CHECK-DAG:     %[[#v2:]] = OpTypeVector %[[#uint]] 2
+; CHECK-DAG:     %[[#v3:]] = OpTypeVector %[[#uint]] 3
+; CHECK-DAG:     %[[#v4:]] = OpTypeVector %[[#uint]] 4
+; CHECK-DAG: %[[#v4_pp:]] = OpTypePointer Private %[[#v4]]
+; CHECK-DAG: %[[#v4_fp:]] = OpTypePointer Function %[[#v4]]
+; CHECK-DAG: %[[#v3_000:]] = OpConstantComposite %[[#v3]] %[[#uint_0]] %[[#uint_0]] %[[#uint_0]]
+; CHECK-DAG: %[[#v2_00:]] = OpConstantComposite %[[#v2]] %[[#uint_0]] %[[#uint_0]]
+
+define internal spir_func <3 x i32> @foo(ptr addrspace(10) %a) {
+
+  %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
+
+  ; partial loading of a vector: v4 -> v3.
+  %2 = load <3 x i32>, ptr addrspace(10) %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+; CHECK-DAG: %[[#y:]] = OpCompositeExtract %[[#uint]] %[[#load]] 1
+; CHECK-DAG: %[[#z:]] = OpCompositeExtract %[[#uint]] %[[#load]] 2
+; CHECK-DAG: %[[#tmp0:]] = OpCompositeInsert %[[#v3]] %[[#x]] %[[#v3_000]] 0
+; CHECK-DAG: %[[#tmp1:]] = OpCompositeInsert %[[#v3]] %[[#y]] %[[#tmp0]]   1
+; CHECK-DAG: %[[#tmp2:]] = OpCompositeInsert %[[#v3]] %[[#z]] %[[#tmp1]]   2
+
+  ret <3 x i32> %2
+; CHECK: OpReturnValue %[[#tmp2]]
+}
+
+define internal spir_func <3 x i32> @fooDefault(ptr %a) {
+
+  %1 = getelementptr inbounds <4 x i32>, ptr %a, i64 0
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
+
+  ; partial loading of a vector: v4 -> v3.
+  %2 = load <3 x i32>, ptr %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+; CHECK-DAG: %[[#y:]] = OpCompositeExtract %[[#uint]] %[[#load]] 1
+; CHECK-DAG: %[[#z:]] = OpCompositeExtract %[[#uint]] %[[#load]] 2
+; CHECK-DAG: %[[#tmp0:]] = OpCompositeInsert %[[#v3]] %[[#x]] %[[#v3_000]] 0
+; CHECK-DAG: %[[#tmp1:]] = OpCompositeInsert %[[#v3]] %[[#y]] %[[#tmp0]]   1
+; CHECK-DAG: %[[#tmp2:]] = OpCompositeInsert %[[#v3]] %[[#z]] %[[#tmp1]]   2
+
+  ret <3 x i32> %2
+; CHECK: OpReturnValue %[[#tmp2]]
+}
+
+define internal spir_func <3 x i32> @fooBounds(ptr %a) {
+
+  %1 = getelementptr <4 x i32>, ptr %a, i64 0
+; CHECK: %[[#tmp:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
+
+  ; partial loading of a vector: v4 -> v3.
+  %2 = load <3 x i32>, ptr %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+; CHECK-DAG: %[[#y:]] = OpCompositeExtract %[[#uint]] %[[#load]] 1
+; CHECK-DAG: %[[#z:]] = OpCompositeExtract %[[#uint]] %[[#load]] 2
+; CHECK-DAG: %[[#tmp0:]] = OpCompositeInsert %[[#v3]] %[[#x]] %[[#v3_000]] 0
+; CHECK-DAG: %[[#tmp1:]] = OpCompositeInsert %[[#v3]] %[[#y]] %[[#tmp0]]   1
+; CHECK-DAG: %[[#tmp2:]] = OpCompositeInsert %[[#v3]] %[[#z]] %[[#tmp1]]   2
+
+  ret <3 x i32> %2
+; CHECK: OpReturnValue %[[#tmp2]]
+}
+
+define internal spir_func <2 x i32> @bar(ptr addrspace(10) %a) {
+
+  %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
+
+  ; partial loading of a vector: v4 -> v2.
+  %2 = load <2 x i32>, ptr addrspace(10) %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+; CHECK-DAG: %[[#y:]] = OpCompositeExtract %[[#uint]] %[[#load]] 1
+; CHECK-DAG: %[[#tmp0:]] = OpCompositeInsert %[[#v2]] %[[#x]] %[[#v2_00]] 0
+; CHECK-DAG: %[[#tmp1:]] = OpCompositeInsert %[[#v2]] %[[#y]] %[[#tmp0]]   1
+
+  ret <2 x i32> %2
+; CHECK: OpReturnValue %[[#tmp1]]
+}
+
+define internal spir_func i32 @baz(ptr addrspace(10) %a) {
+
+  %1 = getelementptr inbounds <4 x i32>, ptr addrspace(10) %a, i64 0
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_pp]] %[[#]]
+
+  ; Loading of the first scalar of a vector: v4 -> int.
+  %2 = load i32, ptr addrspace(10) %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+
+  ret i32 %2
+; CHECK: OpReturnValue %[[#x]]
+}
+
+define internal spir_func i32 @bazDefault(ptr %a) {
+
+  %1 = getelementptr inbounds <4 x i32>, ptr %a, i64 0
+; CHECK: %[[#tmp:]]  = OpInBoundsAccessChain %[[#v4_fp]] %[[#]]
+
+  ; Loading of the first scalar of a vector: v4 -> int.
+  %2 = load i32, ptr %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+
+  ret i32 %2
+; CHECK: OpReturnValue %[[#x]]
+}
+
+define internal spir_func i32 @bazBounds(ptr %a) {
+
+  %1 = getelementptr <4 x i32>, ptr %a, i64 0
+; CHECK: %[[#tmp:]]  = OpAccessChain %[[#v4_fp]] %[[#]]
+
+  ; Loading of the first scalar of a vector: v4 -> int.
+  %2 = load i32, ptr %1, align 16
+; CHECK: %[[#load:]] = OpLoad %[[#v4]] %[[#tmp]] Aligned 16
+; CHECK-DAG: %[[#x:]] = OpCompositeExtract %[[#uint]] %[[#load]] 0
+
+  ret i32 %2
+; CHECK: OpReturnValue %[[#x]]
+}


### PR DESCRIPTION
OpenCL is allowed to cast pointers, meaning they can resolve some type mismatches this way. In logical SPIR-V, those are restricted. This new pass legalizes such pointer cast when targeting logical SPIR-V.

For now, this pass supports 3 cases we witnessed:
 - loading a vec3 from a vec4*.
 - loading a scalar from a vec*.
 - loading the 1st element of an array.