### PR TITLE
[AMDGPU] Verify SdwaSel value range

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -4916,6 +4916,18 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       return false;
     }
 
+    for (auto Op : {AMDGPU::OpName::src0_sel, AMDGPU::OpName::src1_sel,
+                    AMDGPU::OpName::dst_sel}) {
+      const MachineOperand *MO = getNamedOperand(MI, Op);
+      if (!MO)
+        continue;
+      int64_t Imm = MO->getImm();
+      if (Imm < 0 || Imm > AMDGPU::SDWA::SdwaSel::DWORD) {
+        ErrInfo = "Invalid SDWA selection";
+        return false;
+      }
+    }
+
     int DstIdx = AMDGPU::getNamedOperandIdx(Opcode, AMDGPU::OpName::vdst);
 
     for (int OpIdx : {DstIdx, Src0Idx, Src1Idx, Src2Idx}) {

--- a/llvm/test/CodeGen/AMDGPU/verifier-sdwa-selection.mir
+++ b/llvm/test/CodeGen/AMDGPU/verifier-sdwa-selection.mir
@@ -1,0 +1,22 @@
+# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx1030 --verify-machineinstrs -o - %s 2>&1 | FileCheck %s
+
+# CHECK-COUNT-6: *** Bad machine code: Invalid SDWA selection ***
+# CHECK-NOT: *** Bad machine code
+# CHECK: LLVM ERROR: Found 6 machine code errors
+
+---
+name: invalid_sdwa_selection
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $vgpr0
+    %0:vgpr_32 = COPY $vgpr0
+    %1:vgpr_32 = V_LSHRREV_B32_sdwa 0, %0:vgpr_32, 0, %0:vgpr_32, 0, 1, 0, 7, 0, implicit $exec
+    %2:vgpr_32 = V_LSHRREV_B32_sdwa 0, %0:vgpr_32, 0, %0:vgpr_32, 0, 1, 0, -1, 0, implicit $exec
+    %3:vgpr_32 = V_LSHRREV_B32_sdwa 0, %0:vgpr_32, 0, %0:vgpr_32, 0, 7, 0, 6, 0, implicit $exec
+    %4:vgpr_32 = V_LSHRREV_B32_sdwa 0, %0:vgpr_32, 0, %0:vgpr_32, 0, -1, 0, 6, 0, implicit $exec
+    %5:vgpr_32 = V_LSHRREV_B32_sdwa 0, %0:vgpr_32, 0, %0:vgpr_32, 0, 0, 0, 0, 7, implicit $exec
+    %6:vgpr_32 = V_LSHRREV_B32_sdwa 0, %0:vgpr_32, 0, %0:vgpr_32, 0, 0, 0, 0, -1, implicit $exec
+
+    S_ENDPGM 0
+...

--- a/llvm/test/MachineVerifier/AMDGPU/verifier-sdwa-selection.mir
+++ b/llvm/test/MachineVerifier/AMDGPU/verifier-sdwa-selection.mir
@@ -1,4 +1,4 @@
-# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx1030 --verify-machineinstrs -o - %s 2>&1 | FileCheck %s
+# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx1030 -run-pass=none -o - %s 2>&1 | FileCheck %s
 
 # CHECK-COUNT-6: *** Bad machine code: Invalid SDWA selection ***
 # CHECK-NOT: *** Bad machine code


### PR DESCRIPTION
Ensure that the MachineVerifier verifies that the value provided for an SDWA selection is a valid value for the SdwaSel enum.