### PR TITLE
[MLIR][ROCDL] Add conversion of math.erfc to AMD GPU library calls

### DIFF
--- a/flang/test/Lower/OpenMP/math-amdgpu.f90
+++ b/flang/test/Lower/OpenMP/math-amdgpu.f90
@@ -99,6 +99,20 @@ subroutine omp_erf_f64(x, y)
   y = erf(x)
 end subroutine omp_erf_f64
 
+subroutine omp_erfc_f32(x, y)
+!$omp declare target
+  real :: x, y
+!CHECK: call float @__ocml_erfc_f32(float {{.*}})
+  y = erfc(x)
+end subroutine omp_erfc_f32
+
+subroutine omp_erfc_f64(x, y)
+!$omp declare target
+  real(8) :: x, y
+!CHECK: call double @__ocml_erfc_f64(double {{.*}})
+  y = erfc(x)
+end subroutine omp_erfc_f64
+
 subroutine omp_exp_f32(x, y)
 !$omp declare target
   real :: x, y

--- a/mlir/lib/Conversion/MathToROCDL/MathToROCDL.cpp
+++ b/mlir/lib/Conversion/MathToROCDL/MathToROCDL.cpp
@@ -113,6 +113,8 @@ void mlir::populateMathToROCDLConversionPatterns(
                                   "__ocml_tan_f64", "__ocml_tan_f16");
   populateOpPatterns<math::ErfOp>(converter, patterns, "__ocml_erf_f32",
                                   "__ocml_erf_f64", "__ocml_erf_f16");
+  populateOpPatterns<math::ErfcOp>(converter, patterns, "__ocml_erfc_f32",
+                                   "__ocml_erfc_f64", "__ocml_erfc_f16");
   populateOpPatterns<math::FPowIOp>(converter, patterns, "__ocml_pown_f32",
                                     "__ocml_pown_f64", "__ocml_pown_f16");
   // Single arith pattern that needs a ROCDL call, probably not

--- a/mlir/test/Conversion/MathToROCDL/math-to-rocdl.mlir
+++ b/mlir/test/Conversion/MathToROCDL/math-to-rocdl.mlir
@@ -463,6 +463,24 @@ module @test_module {
 // -----
 
 module @test_module {
+  // CHECK: llvm.func @__ocml_erfc_f16(f16) -> f16
+  // CHECK: llvm.func @__ocml_erfc_f32(f32) -> f32
+  // CHECK: llvm.func @__ocml_erfc_f64(f64) -> f64
+  // CHECK-LABEL: func @math_erfc
+  func.func @math_erfc(%arg_f16 : f16, %arg_f32 : f32, %arg_f64 : f64) -> (f16, f32, f64) {
+    %result16 = math.erfc %arg_f16 : f16
+    // CHECK: llvm.call @__ocml_erfc_f16(%{{.*}}) : (f16) -> f16
+    %result32 = math.erfc %arg_f32 : f32
+    // CHECK: llvm.call @__ocml_erfc_f32(%{{.*}}) : (f32) -> f32
+    %result64 = math.erfc %arg_f64 : f64
+    // CHECK: llvm.call @__ocml_erfc_f64(%{{.*}}) : (f64) -> f64
+    func.return %result16, %result32, %result64 : f16, f32, f64
+  }
+}
+
+// -----
+
+module @test_module {
   // CHECK: llvm.func @__ocml_sin_f16(f16) -> f16
   // CHECK: llvm.func @__ocml_sin_f32(f32) -> f32
   // CHECK: llvm.func @__ocml_sin_f64(f64) -> f64


### PR DESCRIPTION
This patch adds a pattern to convert the math.erfc operation to AMD GPU library calls.

Depends on: #128897 for the flang test
