### PR TITLE
[memprof] Export __memprof_default_options_str on Darwin

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/ProfileData/InstrProf.h"
+#include "llvm/ProfileData/MemProf.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ScopedPrinter.h"
 #include "llvm/Support/Threading.h"
@@ -1619,7 +1620,9 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
 
   if (Sanitize.needsMemProfRt())
     if (hasExportSymbolDirective(Args))
-      addExportedSymbol(CmdArgs, "___memprof_default_options_str");
+      addExportedSymbol(
+          CmdArgs,
+          llvm::memprof::getMemprofOptionsSymbolDarwinLinkageName().data());
 
   const XRayArgs &XRay = getXRayArgs();
   if (XRay.needsXRayRt()) {

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1617,6 +1617,10 @@ void DarwinClang::AddLinkRuntimeLibArgs(const ArgList &Args,
     }
   }
 
+  if (Sanitize.needsMemProfRt())
+    if (hasExportSymbolDirective(Args))
+      addExportedSymbol(CmdArgs, "___memprof_default_options_str");
+
   const XRayArgs &XRay = getXRayArgs();
   if (XRay.needsXRayRt()) {
     AddLinkRuntimeLib(Args, CmdArgs, "xray");

--- a/clang/test/Driver/fmemprof.cpp
+++ b/clang/test/Driver/fmemprof.cpp
@@ -17,3 +17,11 @@
 
 // RUN: not %clangxx --target=x86_64-linux-gnu -fprofile-generate -fmemory-profile-use=foo %s -### 2>&1 | FileCheck %s --check-prefix=CONFLICTWITHPGOINSTR
 // CONFLICTWITHPGOINSTR: error: invalid argument '-fmemory-profile-use=foo' not allowed with '-fprofile-generate'
+
+// Test that we export the __memprof_default_options_str on Darwin because it has WeakAnyLinkage
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile %s -### 2>&1 | FileCheck %s -check-prefix=EXPORT-BASE --implicit-check-not=exported_symbol
+// RUN: %clangxx --target=x86_64-linux-gnu -fmemory-profile %s -### 2>&1 | FileCheck %s -check-prefix=EXPORT-BASE --implicit-check-not=exported_symbol
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=EXPORT-BASE,EXPORT
+// FIXME: Darwin needs to link in the runtime, then we can use the regular CHECK prefix
+// EXPORT-BASE: "-cc1" {{.*}} "-fmemory-profile"
+// EXPORT: "-exported_symbol" "___memprof_default_options_str"

--- a/clang/test/Driver/fmemprof.cpp
+++ b/clang/test/Driver/fmemprof.cpp
@@ -19,8 +19,7 @@
 // CONFLICTWITHPGOINSTR: error: invalid argument '-fmemory-profile-use=foo' not allowed with '-fprofile-generate'
 
 // Test that we export the __memprof_default_options_str on Darwin because it has WeakAnyLinkage
-// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile %s -### 2>&1 | FileCheck %s -check-prefix=EXPORT-BASE --implicit-check-not=exported_symbol
-// RUN: %clangxx --target=x86_64-linux-gnu -fmemory-profile %s -### 2>&1 | FileCheck %s -check-prefix=EXPORT-BASE --implicit-check-not=exported_symbol
+// RUN: %clangxx --target=arm64-apple-ios -fmemory-profile %s -### 2>&1 | FileCheck %s --check-prefix=EXPORT-BASE --implicit-check-not=exported_symbol
 // RUN: %clangxx --target=arm64-apple-ios -fmemory-profile -exported_symbols_list /dev/null %s -### 2>&1 | FileCheck %s --check-prefixes=EXPORT-BASE,EXPORT
 // FIXME: Darwin needs to link in the runtime, then we can use the regular CHECK prefix
 // EXPORT-BASE: "-cc1" {{.*}} "-fmemory-profile"

--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -6,6 +6,7 @@
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/ProfileData/MemProfData.inc"
 #include "llvm/Support/BLAKE3.h"
@@ -41,6 +42,16 @@ constexpr uint64_t MaximumSupportedVersion = Version3;
 
 // Verify that the minimum and maximum satisfy the obvious constraint.
 static_assert(MinimumSupportedVersion <= MaximumSupportedVersion);
+
+inline llvm::StringRef getMemprofOptionsSymbolDarwinLinkageName() {
+  return "___memprof_default_options_str";
+}
+
+inline llvm::StringRef getMemprofOptionsSymbolName() {
+  // Darwin linkage names are prefixed with an extra "_". See
+  // DataLayout::getGlobalPrefix().
+  return getMemprofOptionsSymbolDarwinLinkageName().drop_front();
+}
 
 enum class Meta : uint64_t {
   Start = 0,

--- a/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp
@@ -568,10 +568,9 @@ void createMemprofHistogramFlagVar(Module &M) {
 void createMemprofDefaultOptionsVar(Module &M) {
   Constant *OptionsConst = ConstantDataArray::getString(
       M.getContext(), MemprofRuntimeDefaultOptions, /*AddNull=*/true);
-  GlobalVariable *OptionsVar =
-      new GlobalVariable(M, OptionsConst->getType(), /*isConstant=*/true,
-                         GlobalValue::WeakAnyLinkage, OptionsConst,
-                         "__memprof_default_options_str");
+  GlobalVariable *OptionsVar = new GlobalVariable(
+      M, OptionsConst->getType(), /*isConstant=*/true,
+      GlobalValue::WeakAnyLinkage, OptionsConst, getMemprofOptionsSymbolName());
   Triple TT(M.getTargetTriple());
   if (TT.supportsCOMDAT()) {
     OptionsVar->setLinkage(GlobalValue::ExternalLinkage);


### PR DESCRIPTION
The `-memprof-runtime-default-options` LLVM flag introduced in https://github.com/llvm/llvm-project/pull/118874 creates the `__memprof_default_options_str` symbol with `WeakAnyLinkage` on Darwin.

https://github.com/ellishg/llvm-project/blob/fa0202169af23419c4bcbf66eabd1beb6b6e8e34/llvm/lib/Transforms/Instrumentation/MemProfiler.cpp#L573-L576

This ensures Darwin passes `-exported_symbol ___memprof_default_options_str` to the linker so that the runtime library has visibility into this symbol.

This will replace the earlier PR https://github.com/llvm/llvm-project/pull/128615