### PR TITLE
[libc][bazel] Add targets for stdbit functions

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3356,6 +3356,64 @@ libc_function(
     ],
 )
 
+############################### stdbit targets ###############################
+
+bit_suffix_list = [
+    "uc",
+    "us",
+    "ui",
+    "ul",
+    "ull",
+]
+
+bit_prefix_list = [
+    "stdc_leading_zeros_",
+    "stdc_leading_ones_",
+    "stdc_trailing_zeros_",
+    "stdc_trailing_ones_",
+    "stdc_count_ones_",
+    "stdc_has_single_bit_",
+    "stdc_bit_width_",
+    "stdc_bit_floor_",
+    "stdc_bit_ceil_",
+]
+
+bit_prefix_needs_math_list = [
+    "stdc_first_leading_zero_",
+    "stdc_first_leading_one_",
+    "stdc_first_trailing_zero_",
+    "stdc_first_trailing_one_",
+    "stdc_count_zeros_",
+]
+
+[
+    libc_function(
+        name = bit_prefix + bit_suffix,
+        srcs = ["src/stdbit/" + bit_prefix + bit_suffix + ".cpp"],
+        hdrs = ["src/stdbit/" + bit_prefix + bit_suffix + ".h"],
+        deps = [
+            ":__support_common",
+            ":__support_cpp_bit",
+        ],
+    )
+    for bit_prefix in bit_prefix_list
+    for bit_suffix in bit_suffix_list
+]
+
+[
+    libc_function(
+        name = bit_prefix + bit_suffix,
+        srcs = ["src/stdbit/" + bit_prefix + bit_suffix + ".cpp"],
+        hdrs = ["src/stdbit/" + bit_prefix + bit_suffix + ".h"],
+        deps = [
+            ":__support_common",
+            ":__support_math_extras",
+        ],
+    )
+    for bit_prefix in bit_prefix_needs_math_list
+    for bit_suffix in bit_suffix_list
+]
+
 ############################### stdlib targets ###############################
 
 libc_function(

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -128,7 +128,7 @@ def libc_math_function(
 
     Args:
       name: The name of the function.
-      additional_deps: Other deps like helper cc_library targes used by the
+      additional_deps: Other deps like helper cc_library targets used by the
                        math function.
     """
     additional_deps = additional_deps or []

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Tests for LLVM libc stdio.h functions.
+# Tests for LLVM libc stdbit.h functions.
 
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
@@ -1,0 +1,47 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc stdio.h functions.
+
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+bit_suffix_list = [
+    "uc",
+    "us",
+    "ui",
+    "ul",
+    "ull",
+]
+
+bit_prefix_list = [
+    "stdc_leading_zeros_",
+    "stdc_leading_ones_",
+    "stdc_trailing_zeros_",
+    "stdc_trailing_ones_",
+    "stdc_count_ones_",
+    "stdc_has_single_bit_",
+    "stdc_bit_width_",
+    "stdc_bit_floor_",
+    "stdc_bit_ceil_",
+    "stdc_first_leading_zero_",
+    "stdc_first_leading_one_",
+    "stdc_first_trailing_zero_",
+    "stdc_first_trailing_one_",
+    "stdc_count_zeros_",
+]
+
+[
+    libc_test(
+        name = bit_prefix + bit_suffix + "_test",
+        srcs = [bit_prefix + bit_suffix + "_test.cpp"],
+        libc_function_deps = ["//libc:" + bit_prefix + bit_suffix],
+        deps = ["//libc:__support_cpp_limits"],
+    )
+    for bit_prefix in bit_prefix_list
+    for bit_suffix in bit_suffix_list
+]


### PR DESCRIPTION
Adds targets for the stdbit functions. Since the names follow a strict
pattern, this is done via list comprehensions. I don't want to handwrite
all 50.
