### PR TITLE
[libc++] Fix the locale base API on Linux with musl

### DIFF
--- a/libcxx/include/__locale_dir/support/linux.h
+++ b/libcxx/include/__locale_dir/support/linux.h
@@ -95,12 +95,20 @@ inline _LIBCPP_HIDE_FROM_ABI long double __strtold(const char* __nptr, char** __
 }
 
 inline _LIBCPP_HIDE_FROM_ABI long long __strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
+#if !defined(_LIBCPP_HAS_MUSL_LIBC)
   return ::strtoll_l(__nptr, __endptr, __base, __loc);
+#else
+  return ::strtoll(__nptr, __endptr, __base);
+#endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI unsigned long long
 __strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
+#if !defined(_LIBCPP_HAS_MUSL_LIBC)
   return ::strtoull_l(__nptr, __endptr, __base, __loc);
+#else
+  return ::strtoull(__nptr, __endptr, __base);
+#endif
 }
 
 //

--- a/libcxx/include/__locale_dir/support/linux.h
+++ b/libcxx/include/__locale_dir/support/linux.h
@@ -95,7 +95,7 @@ inline _LIBCPP_HIDE_FROM_ABI long double __strtold(const char* __nptr, char** __
 }
 
 inline _LIBCPP_HIDE_FROM_ABI long long __strtoll(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
-#if !defined(_LIBCPP_HAS_MUSL_LIBC)
+#if !_LIBCPP_HAS_MUSL_LIBC
   return ::strtoll_l(__nptr, __endptr, __base, __loc);
 #else
   (void)__loc;
@@ -105,7 +105,7 @@ inline _LIBCPP_HIDE_FROM_ABI long long __strtoll(const char* __nptr, char** __en
 
 inline _LIBCPP_HIDE_FROM_ABI unsigned long long
 __strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
-#if !defined(_LIBCPP_HAS_MUSL_LIBC)
+#if !_LIBCPP_HAS_MUSL_LIBC
   return ::strtoull_l(__nptr, __endptr, __base, __loc);
 #else
   (void)__loc;

--- a/libcxx/include/__locale_dir/support/linux.h
+++ b/libcxx/include/__locale_dir/support/linux.h
@@ -98,6 +98,7 @@ inline _LIBCPP_HIDE_FROM_ABI long long __strtoll(const char* __nptr, char** __en
 #if !defined(_LIBCPP_HAS_MUSL_LIBC)
   return ::strtoll_l(__nptr, __endptr, __base, __loc);
 #else
+  (void)__loc;
   return ::strtoll(__nptr, __endptr, __base);
 #endif
 }
@@ -107,6 +108,7 @@ __strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
 #if !defined(_LIBCPP_HAS_MUSL_LIBC)
   return ::strtoull_l(__nptr, __endptr, __base, __loc);
 #else
+  (void)__loc;
   return ::strtoull(__nptr, __endptr, __base);
 #endif
 }


### PR DESCRIPTION
Since `363bfd6090b0 ([libc++] Use the new locale base API on Linux (#128007), 2025-02-24)`, musl targets will fail to build with errors like the below:

    In file included from /[b/f/w/src/git/out/stage2/include/c++/v1/__locale:14](https://cs.corp.google.com/piper///depot/google3/b/f/w/src/git/out/stage2/include/c%2B%2B/v1/__locale?l=14):
    In file included from /[b/f/w/src/git/out/stage2/include/c++/v1/__locale_dir/locale_base_api.h:123](https://cs.corp.google.com/piper///depot/google3/b/f/w/src/git/out/stage2/include/c%2B%2B/v1/__locale_dir/locale_base_api.h?l=123):
    /[b/f/w/src/git/out/stage2/include/c++/v1/__locale_dir/support/linux.h:98](https://cs.corp.google.com/piper///depot/google3/b/f/w/src/git/out/stage2/include/c%2B%2B/v1/__locale_dir/support/linux.h?l=98):12: error: no member named 'strtoll_l' in the global namespace
       98 |   return ::strtoll_l(__nptr, __endptr, __base, __loc);
          |          ~~^
    /[b/f/w/src/git/out/stage2/include/c++/v1/__locale_dir/support/linux.h:103](https://cs.corp.google.com/piper///depot/google3/b/f/w/src/git/out/stage2/include/c%2B%2B/v1/__locale_dir/support/linux.h?l=103):10: error: no member named 'strtoull_l' in the global namespace; did you mean '__strtoull'?
      103 |   return ::strtoull_l(__nptr, __endptr, __base, __loc);
          |          ^~~~~~~~~~~~
          |          __strtoull
    /[b/f/w/src/git/out/stage2/include/c++/v1/__locale_dir/support/linux.h:102](https://cs.corp.google.com/piper///depot/google3/b/f/w/src/git/out/stage2/include/c%2B%2B/v1/__locale_dir/support/linux.h?l=102):1: note: '__strtoull' declared here
      102 | __strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
          | ^
    2 errors generated.