### PR TITLE
[ctxprof] Override type of instrumentation if `-profile-context-root` is specified

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1206,7 +1206,10 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
 
   // We already asserted this happens in non-FullLTOPostLink earlier.
   const bool IsPreLink = Phase != ThinOrFullLTOPhase::ThinLTOPostLink;
-  const bool IsPGOPreLink = PGOOpt && IsPreLink;
+  // Enable contextual profiling instrumentation.
+  const bool IsCtxProfGen =
+      IsPreLink && PGOCtxProfLoweringPass::isCtxIRPGOInstrEnabled();
+  const bool IsPGOPreLink = !IsCtxProfGen && PGOOpt && IsPreLink;
   const bool IsPGOInstrGen =
       IsPGOPreLink && PGOOpt->Action == PGOOptions::IRInstr;
   const bool IsPGOInstrUse =
@@ -1217,9 +1220,6 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
   assert(!(IsPGOInstrGen && PGOCtxProfLoweringPass::isCtxIRPGOInstrEnabled()) &&
          "Enabling both instrumented PGO and contextual instrumentation is not "
          "supported.");
-  // Enable contextual profiling instrumentation.
-  const bool IsCtxProfGen = !IsPGOInstrGen && IsPreLink &&
-                            PGOCtxProfLoweringPass::isCtxIRPGOInstrEnabled();
   const bool IsCtxProfUse =
       !UseCtxProfile.empty() && Phase == ThinOrFullLTOPhase::ThinLTOPreLink;
 

--- a/llvm/test/Transforms/PGOProfile/ctx-instrumentation-optin.ll
+++ b/llvm/test/Transforms/PGOProfile/ctx-instrumentation-optin.ll
@@ -1,0 +1,16 @@
+; REQUIRES: linux
+;
+; RUN: opt -O2 -debug-pass-manager -S -pgo-kind=pgo-instr-gen-pipeline -profile-file='temp' \
+; RUN:  < %s  2>&1 | FileCheck %s --check-prefixes=COMMON,PGO
+; RUN: opt -O2 -debug-pass-manager -S -pgo-kind=pgo-instr-gen-pipeline -profile-file='temp' \
+; RUN:  -profile-context-root=something < %s 2>&1 | FileCheck %s --check-prefixes=COMMON,CTXPROF
+
+; COMMON:   Running pass: PGOInstrumentationGen
+; COMMON:   Invalidating analysis: InnerAnalysisManagerProxy<FunctionAnalysisManager, Module>
+; COMMON:   Invalidating analysis: LazyCallGraphAnalysis
+; COMMON:   Invalidating analysis: InnerAnalysisManagerProxy<CGSCCAnalysisManager, Module>
+; CTXPROF:  Running pass: AssignGUIDPass
+; CTXPROF:  Running pass: NoinlineNonPrevailing
+; COMMON:   Running analysis: InnerAnalysisManagerProxy<FunctionAnalysisManager, Module>
+; PGO:      Running pass: InstrProfilingLoweringPass
+; CTXPROF:  Running pass: PGOCtxProfLoweringPass


### PR DESCRIPTION
This patch makes it easy to enable ctxprof instrumentation for targets where the build has a bunch of defaults for instrumented PGO that we want to inherit for ctxprof.

This is switching experimental defaults: we'll eventually enable ctxprof instrumentation through `PGOOpt` but that type is currently quite entangled and, for the time being, no point adding to that.
