### PR TITLE
[lldb-dap] Add process picker command to VS Code extension

### DIFF
--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -65,6 +65,19 @@ This will attach to a process `a.out` whose process ID is 123:
 }
 ```
 
+You can also use the variable substituion `${command:PickProcess}` to select a
+process at the start of the debug session instead of setting the pid manually:
+
+```javascript
+{
+  "type": "lldb-dap",
+  "request": "attach",
+  "name": "Attach to PID",
+  "program": "/tmp/a.out",
+  "pid": "${command:PickProcess}"
+}
+```
+
 #### Attach by Name
 
 This will attach to an existing process whose base
@@ -224,7 +237,7 @@ the following `lldb-dap` specific key/value pairs:
 | Parameter                         | Type        | Req |         |
 |-----------------------------------|-------------|:---:|---------|
 | **program**                       | string      |     | Path to the executable to attach to. This value is optional but can help to resolve breakpoints prior the attaching to the program.
-| **pid**                           | number      |     | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **porgram**. Setting this value to `${command:pickMyProcess}` will allow interactive process selection in the IDE.
+| **pid**                           | number      |     | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **program**. Setting this value to `${command:PickProcess}` will allow interactive process selection in the IDE.
 | **waitFor**                       | boolean     |     | Wait for the process to launch.
 | **attachCommands**                | [string]    |     | LLDB commands that will be executed after **preRunCommands** which take place of the code that normally does the attach. The commands can create a new target and attach or launch it however desired. This allows custom launch and attach configurations. Core files can use `target create --core /path/to/core` to attach to core files.
 

--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -65,7 +65,7 @@ This will attach to a process `a.out` whose process ID is 123:
 }
 ```
 
-You can also use the variable substituion `${command:PickProcess}` to select a
+You can also use the variable substituion `${command:pickProcess}` to select a
 process at the start of the debug session instead of setting the pid manually:
 
 ```javascript
@@ -74,7 +74,7 @@ process at the start of the debug session instead of setting the pid manually:
   "request": "attach",
   "name": "Attach to PID",
   "program": "/tmp/a.out",
-  "pid": "${command:PickProcess}"
+  "pid": "${command:pickProcess}"
 }
 ```
 
@@ -237,7 +237,7 @@ the following `lldb-dap` specific key/value pairs:
 | Parameter                         | Type        | Req |         |
 |-----------------------------------|-------------|:---:|---------|
 | **program**                       | string      |     | Path to the executable to attach to. This value is optional but can help to resolve breakpoints prior the attaching to the program.
-| **pid**                           | number      |     | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **program**. Setting this value to `${command:PickProcess}` will allow interactive process selection in the IDE.
+| **pid**                           | number      |     | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **program**. Setting this value to `${command:pickProcess}` will allow interactive process selection in the IDE.
 | **waitFor**                       | boolean     |     | Wait for the process to launch.
 | **attachCommands**                | [string]    |     | LLDB commands that will be executed after **preRunCommands** which take place of the code that normally does the attach. The commands can create a new target and attach or launch it however desired. This allows custom launch and attach configurations. Core files can use `target create --core /path/to/core` to attach to core files.
 

--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -65,7 +65,7 @@ This will attach to a process `a.out` whose process ID is 123:
 }
 ```
 
-You can also use the variable substituion `${command:pickProcess}` to select a
+You can also use the variable substitution `${command:pickProcess}` to select a
 process at the start of the debug session instead of setting the pid manually:
 
 ```javascript
@@ -73,9 +73,14 @@ process at the start of the debug session instead of setting the pid manually:
   "type": "lldb-dap",
   "request": "attach",
   "name": "Attach to PID",
-  "pid": "${command:pickProcess}"
+  "pid": "${command:pickProcess}",
+  "program": "/path/to/program"
 }
 ```
+
+Note: The `program` path above is optional. If specified, `pickProcess` will
+filter the list of available process based on the full program path. If absent,
+`pickProcess` will offer a list of all processes running on the system.
 
 #### Attach by Name
 

--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -73,7 +73,6 @@ process at the start of the debug session instead of setting the pid manually:
   "type": "lldb-dap",
   "request": "attach",
   "name": "Attach to PID",
-  "program": "/tmp/a.out",
   "pid": "${command:pickProcess}"
 }
 ```

--- a/lldb/tools/lldb-dap/README.md
+++ b/lldb/tools/lldb-dap/README.md
@@ -250,8 +250,8 @@ the following `lldb-dap` specific key/value pairs:
 | Parameter                         | Type        | Req |         |
 |-----------------------------------|-------------|:---:|---------|
 | **program**                       | string      |     | Path to the executable to attach to. This value is optional but can help to resolve breakpoints prior the attaching to the program.
-| **pid**                           | number      |     | The process id of the process you wish to attach to. If **pid** is omitted, the debugger will attempt to attach to the program by finding a process whose file name matches the file name from **program**. Setting this value to `${command:pickProcess}` will allow interactive process selection in the IDE.
-| **waitFor**                       | boolean     |     | Wait for the process to launch.
+| **pid**                           | number      |     | The process id of the process you wish to attach to. If **pid** is omitted or set to `"${command:pickProcess}"` then the extension will show a process picker with a list of running processes on the system. Choosing one of these process will launch a new debug session where `lldb-dap` will attach to the chosen process.
+| **waitFor**                       | boolean     |     | Wait for a new process that matches the **program** basename to launch. The process picker will not be shown in this case.
 | **attachCommands**                | [string]    |     | LLDB commands that will be executed after **preRunCommands** which take place of the code that normally does the attach. The commands can create a new target and attach or launch it however desired. This allows custom launch and attach configurations. Core files can use `target create --core /path/to/core` to attach to core files.
 
 ## Debug Console

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -146,6 +146,9 @@
         "windows": {
           "program": "./bin/lldb-dap.exe"
         },
+        "variables": {
+          "PickProcess": "lldb-dap.pickProcess"
+        },
         "configurationAttributes": {
           "launch": {
             "required": [
@@ -518,6 +521,16 @@
             }
           },
           {
+            "label": "LLDB: Attach to Process",
+            "description": "",
+            "body": {
+              "type": "lldb-dap",
+              "request": "attach",
+              "name": "${1:Attach}",
+              "pid": "^\"\\${command:PickProcess}\""
+            }
+          },
+          {
             "label": "LLDB: Attach",
             "description": "",
             "body": {
@@ -541,6 +554,21 @@
           }
         ]
       }
-    ]
+    ],
+    "commands": [
+      {
+        "command": "lldb-dap.pickProcess",
+        "title": "Pick Process",
+        "category": "LLDB DAP"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "lldb-dap.pickProcess",
+          "when": "false"
+        }
+      ]
+    }
   }
 }

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -147,7 +147,7 @@
           "program": "./bin/lldb-dap.exe"
         },
         "variables": {
-          "PickProcess": "lldb-dap.pickProcess"
+          "pickProcess": "lldb-dap.pickProcess"
         },
         "configurationAttributes": {
           "launch": {
@@ -527,7 +527,7 @@
               "type": "lldb-dap",
               "request": "attach",
               "name": "${1:Attach}",
-              "pid": "^\"\\${command:PickProcess}\""
+              "pid": "^\"\\${command:pickProcess}\""
             }
           },
           {

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -557,6 +557,11 @@
     ],
     "commands": [
       {
+        "command": "lldb-dap.attachToProcess",
+        "title": "Attach to Process...",
+        "category": "LLDB DAP"
+      },
+      {
         "command": "lldb-dap.pickProcess",
         "title": "Pick Process",
         "category": "LLDB DAP"

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -358,7 +358,8 @@
                   "number",
                   "string"
                 ],
-                "description": "System process ID to attach to."
+                "description": "Optional process ID to attach to. Defaults to the process picker UI.",
+                "default": "${command:pickProcess}"
               },
               "waitFor": {
                 "type": "boolean",

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -363,7 +363,7 @@
               },
               "waitFor": {
                 "type": "boolean",
-                "description": "If set to true, then wait for the process to launch by looking for a process with a basename that matches `program`. No process ID needs to be specified when using this flag.",
+                "description": "If set to true, then wait for the process to launch by looking for a process with a basename that matches `program`. The process ID is ignored when using this flag.",
                 "default": true
               },
               "sourcePath": {

--- a/lldb/tools/lldb-dap/src-ts/commands/attach-to-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/attach-to-process.ts
@@ -1,0 +1,10 @@
+import * as vscode from "vscode";
+
+export async function attachToProcess(): Promise<boolean> {
+  return await vscode.debug.startDebugging(undefined, {
+    type: "lldb-dap",
+    request: "attach",
+    name: "Attach to Process",
+    pid: "${command:pickProcess}",
+  });
+}

--- a/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
@@ -9,6 +9,10 @@ interface ProcessQuickPick extends vscode.QuickPickItem {
 /**
  * Prompts the user to select a running process.
  *
+ * The return value must be a string so that it is compatible with VS Code's
+ * string substitution infrastructure. The value will eventually be converted
+ * to a number by the debug configuration provider.
+ *
  * @returns The pid of the process as a string or undefined if cancelled.
  */
 export async function pickProcess(): Promise<string | undefined> {

--- a/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
@@ -32,6 +32,7 @@ export async function pickProcess(): Promise<string | undefined> {
     }),
     {
       placeHolder: "Select a process to attach the debugger to",
+      matchOnDetail: true,
     },
   );
   if (!selectedProcess) {

--- a/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
@@ -1,0 +1,37 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { createProcessTree } from "../process-tree";
+
+interface ProcessQuickPick extends vscode.QuickPickItem {
+  processId: number;
+}
+
+/**
+ * Prompts the user to select a running process.
+ *
+ * @returns The pid of the process as a string or undefined if cancelled.
+ */
+export async function pickProcess(): Promise<string | undefined> {
+  const processTree = createProcessTree();
+  const selectedProcess = await vscode.window.showQuickPick<ProcessQuickPick>(
+    processTree.listAllProcesses().then((processes): ProcessQuickPick[] => {
+      return processes
+        .sort((a, b) => b.start - a.start) // Sort by start date in descending order
+        .map((proc) => {
+          return {
+            processId: proc.id,
+            label: path.basename(proc.command),
+            description: proc.id.toString(),
+            detail: proc.arguments,
+          } satisfies ProcessQuickPick;
+        });
+    }),
+    {
+      placeHolder: "Select a process to attach the debugger to",
+    },
+  );
+  if (!selectedProcess) {
+    return;
+  }
+  return selectedProcess.processId.toString();
+}

--- a/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
@@ -51,6 +51,7 @@ export async function pickProcess(
     {
       placeHolder: "Select a process to attach the debugger to",
       matchOnDetail: true,
+      matchOnDescription: true,
     },
   );
   return selectedProcess?.processId?.toString();

--- a/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { createProcessTree } from "../process-tree";
 
 interface ProcessQuickPick extends vscode.QuickPickItem {
-  processId: number;
+  processId?: number;
 }
 
 /**
@@ -13,30 +13,45 @@ interface ProcessQuickPick extends vscode.QuickPickItem {
  * string substitution infrastructure. The value will eventually be converted
  * to a number by the debug configuration provider.
  *
+ * @param configuration The related debug configuration, if any
  * @returns The pid of the process as a string or undefined if cancelled.
  */
-export async function pickProcess(): Promise<string | undefined> {
+export async function pickProcess(
+  configuration?: vscode.DebugConfiguration,
+): Promise<string | undefined> {
   const processTree = createProcessTree();
   const selectedProcess = await vscode.window.showQuickPick<ProcessQuickPick>(
     processTree.listAllProcesses().then((processes): ProcessQuickPick[] => {
-      return processes
-        .sort((a, b) => b.start - a.start) // Sort by start date in descending order
-        .map((proc) => {
-          return {
-            processId: proc.id,
-            label: path.basename(proc.command),
-            description: proc.id.toString(),
-            detail: proc.arguments,
-          } satisfies ProcessQuickPick;
-        });
+      // Sort by start date in descending order
+      processes.sort((a, b) => b.start - a.start);
+      // Filter by program if requested
+      if (typeof configuration?.program === "string") {
+        processes = processes.filter(
+          (proc) => proc.command === configuration.program,
+        );
+        // Show a better message if all processes were filtered out
+        if (processes.length === 0) {
+          return [
+            {
+              label: "No processes matched the debug configuration's program",
+            },
+          ];
+        }
+      }
+      // Convert to a QuickPickItem
+      return processes.map((proc) => {
+        return {
+          processId: proc.id,
+          label: path.basename(proc.command),
+          description: proc.id.toString(),
+          detail: proc.arguments,
+        } satisfies ProcessQuickPick;
+      });
     }),
     {
       placeHolder: "Select a process to attach the debugger to",
       matchOnDetail: true,
     },
   );
-  if (!selectedProcess) {
-    return;
-  }
-  return selectedProcess.processId.toString();
+  return selectedProcess?.processId?.toString();
 }

--- a/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
+++ b/lldb/tools/lldb-dap/src-ts/commands/pick-process.ts
@@ -26,9 +26,16 @@ export async function pickProcess(
       processes.sort((a, b) => b.start - a.start);
       // Filter by program if requested
       if (typeof configuration?.program === "string") {
-        processes = processes.filter(
-          (proc) => proc.command === configuration.program,
-        );
+        const program = configuration.program;
+        const programBaseName = path.basename(program);
+        processes = processes
+          .filter((proc) => path.basename(proc.command) === programBaseName)
+          .sort((a, b) => {
+            // Bring exact command matches to the top
+            const aIsExactMatch = a.command === program ? 1 : 0;
+            const bIsExactMatch = b.command === program ? 1 : 0;
+            return bIsExactMatch - aIsExactMatch;
+          });
         // Show a better message if all processes were filtered out
         if (processes.length === 0) {
           return [

--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -1,0 +1,54 @@
+import * as vscode from "vscode";
+
+/**
+ * Converts the given value to an integer if it isn't already.
+ *
+ * If the value cannot be converted then this function will return undefined.
+ *
+ * @param value the value to to be converted
+ * @returns the integer value or undefined if unable to convert
+ */
+function convertToInteger(value: any): number | undefined {
+  let result: number | undefined;
+  switch (typeof value) {
+    case "number":
+      result = value;
+      break;
+    case "string":
+      result = Number(value);
+      break;
+    default:
+      return undefined;
+  }
+  if (!Number.isInteger(result)) {
+    return undefined;
+  }
+  return result;
+}
+
+/**
+ * A {@link vscode.DebugConfigurationProvider} used to resolve LLDB DAP debug configurations.
+ *
+ * Performs checks on the debug configuration before launching a debug session.
+ */
+export class LLDBDapConfigurationProvider
+  implements vscode.DebugConfigurationProvider
+{
+  resolveDebugConfigurationWithSubstitutedVariables(
+    _folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // Convert the "pid" option to a number if it is a string
+    if ("pid" in debugConfiguration) {
+      const pid = convertToInteger(debugConfiguration.pid);
+      if (pid === undefined) {
+        vscode.window.showErrorMessage(
+          "Invalid debug configuration: property 'pid' must either be an integer or a string containing an integer value.",
+        );
+        return null;
+      }
+      debugConfiguration.pid = pid;
+    }
+    return debugConfiguration;
+  }
+}

--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -48,6 +48,23 @@ export class LLDBDapConfigurationProvider
       // Remove the property even if the user explicitly requested it.
       if (debugConfiguration.waitFor === true) {
         delete debugConfiguration.pid;
+        if (!("program" in debugConfiguration)) {
+          return vscode.window
+            .showErrorMessage(
+              "Failed to attach to process: 'waitFor' requires that a 'program' be provided . Please update your launch configuration.",
+              { modal: true },
+              "Configure",
+            )
+            .then((userChoice) => {
+              switch (userChoice) {
+                case "Configure":
+                  // returning null from resolveDebugConfiguration() causes VS Code to open the launch configuration
+                  return null;
+                default:
+                  return undefined;
+              }
+            });
+        }
       }
     }
     return debugConfiguration;

--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -39,14 +39,16 @@ export class LLDBDapConfigurationProvider
     debugConfiguration: vscode.DebugConfiguration,
     _token?: vscode.CancellationToken,
   ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    // Default "pid" to ${command:pickProcess} if neither "pid" nor "program" are specified
-    // in an "attach" request.
-    if (
-      debugConfiguration.request === "attach" &&
-      !("pid" in debugConfiguration) &&
-      !("program" in debugConfiguration)
-    ) {
-      debugConfiguration.pid = "${command:pickProcess}";
+    if (debugConfiguration.request === "attach") {
+      // Use the process picker by default in attach mode to select the pid.
+      if (!("pid" in debugConfiguration)) {
+        debugConfiguration.pid = "${command:pickProcess}";
+      }
+      // The process picker cannot be used in "waitFor" mode.
+      // Remove the property even if the user explicitly requested it.
+      if (debugConfiguration.waitFor === true) {
+        delete debugConfiguration.pid;
+      }
     }
     return debugConfiguration;
   }

--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -34,6 +34,23 @@ function convertToInteger(value: any): number | undefined {
 export class LLDBDapConfigurationProvider
   implements vscode.DebugConfigurationProvider
 {
+  resolveDebugConfiguration(
+    _folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+    _token?: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // Default "pid" to ${command:pickProcess} if neither "pid" nor "program" are specified
+    // in an "attach" request.
+    if (
+      debugConfiguration.request === "attach" &&
+      !("pid" in debugConfiguration) &&
+      !("program" in debugConfiguration)
+    ) {
+      debugConfiguration.pid = "${command:pickProcess}";
+    }
+    return debugConfiguration;
+  }
+
   resolveDebugConfigurationWithSubstitutedVariables(
     _folder: vscode.WorkspaceFolder | undefined,
     debugConfiguration: vscode.DebugConfiguration,

--- a/lldb/tools/lldb-dap/src-ts/extension.ts
+++ b/lldb/tools/lldb-dap/src-ts/extension.ts
@@ -1,7 +1,6 @@
-import * as path from "path";
-import * as util from "util";
 import * as vscode from "vscode";
 
+import { pickProcess } from "./commands/pick-process";
 import {
   LLDBDapDescriptorFactory,
   isExecutable,
@@ -37,6 +36,10 @@ export class LLDBDapExtension extends DisposableContext {
           LLDBDapDescriptorFactory.showLLDBDapNotFoundMessage(dapPath || "");
         }
       }),
+    );
+
+    this.pushSubscription(
+      vscode.commands.registerCommand("lldb-dap.pickProcess", pickProcess),
     );
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/extension.ts
+++ b/lldb/tools/lldb-dap/src-ts/extension.ts
@@ -6,6 +6,7 @@ import {
   isExecutable,
 } from "./debug-adapter-factory";
 import { DisposableContext } from "./disposable-context";
+import { LLDBDapConfigurationProvider } from "./debug-configuration-provider";
 
 /**
  * This class represents the extension and manages its life cycle. Other extensions
@@ -14,6 +15,12 @@ import { DisposableContext } from "./disposable-context";
 export class LLDBDapExtension extends DisposableContext {
   constructor() {
     super();
+    this.pushSubscription(
+      vscode.debug.registerDebugConfigurationProvider(
+        "lldb-dap",
+        new LLDBDapConfigurationProvider(),
+      ),
+    );
     this.pushSubscription(
       vscode.debug.registerDebugAdapterDescriptorFactory(
         "lldb-dap",

--- a/lldb/tools/lldb-dap/src-ts/extension.ts
+++ b/lldb/tools/lldb-dap/src-ts/extension.ts
@@ -7,6 +7,7 @@ import {
 } from "./debug-adapter-factory";
 import { DisposableContext } from "./disposable-context";
 import { LLDBDapConfigurationProvider } from "./debug-configuration-provider";
+import { attachToProcess } from "./commands/attach-to-process";
 
 /**
  * This class represents the extension and manages its life cycle. Other extensions
@@ -47,6 +48,12 @@ export class LLDBDapExtension extends DisposableContext {
 
     this.pushSubscription(
       vscode.commands.registerCommand("lldb-dap.pickProcess", pickProcess),
+    );
+    this.pushSubscription(
+      vscode.commands.registerCommand(
+        "lldb-dap.attachToProcess",
+        attachToProcess,
+      ),
     );
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/process-tree/base-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/base-process-tree.ts
@@ -1,0 +1,102 @@
+import { ChildProcessWithoutNullStreams } from "child_process";
+import { Process, ProcessTree } from ".";
+import { Transform } from "stream";
+
+/** Parses process information from a given line of process output. */
+export type ProcessTreeParser = (line: string) => Process | undefined;
+
+/**
+ * Implements common behavior between the different {@link ProcessTree} implementations.
+ */
+export abstract class BaseProcessTree implements ProcessTree {
+  /**
+   * Spawn the process responsible for collecting all processes on the system.
+   */
+  protected abstract spawnProcess(): ChildProcessWithoutNullStreams;
+
+  /**
+   * Create a new parser that can read the process information from stdout of the process
+   * spawned by {@link spawnProcess spawnProcess()}.
+   */
+  protected abstract createParser(): ProcessTreeParser;
+
+  listAllProcesses(): Promise<Process[]> {
+    return new Promise<Process[]>((resolve, reject) => {
+      const proc = this.spawnProcess();
+      const parser = this.createParser();
+
+      // Capture processes from stdout
+      const processes: Process[] = [];
+      proc.stdout.pipe(new LineBasedStream()).on("data", (line) => {
+        const process = parser(line.toString());
+        if (process && process.id !== proc.pid) {
+          processes.push(process);
+        }
+      });
+
+      // Resolve or reject the promise based on exit code/signal/error
+      proc.on("error", reject);
+      proc.on("exit", (code, signal) => {
+        if (code === 0) {
+          resolve(processes);
+        } else if (signal) {
+          reject(
+            new Error(
+              `Unable to list processes: process exited due to signal ${signal}`,
+            ),
+          );
+        } else {
+          reject(
+            new Error(
+              `Unable to list processes: process exited with code ${code}`,
+            ),
+          );
+        }
+      });
+    });
+  }
+}
+
+/**
+ * A stream that emits each line as a single chunk of data. The end of a line is denoted
+ * by the newline character '\n'.
+ */
+export class LineBasedStream extends Transform {
+  private readonly newline: number = "\n".charCodeAt(0);
+  private buffer: Buffer = Buffer.alloc(0);
+
+  override _transform(
+    chunk: Buffer,
+    _encoding: string,
+    callback: () => void,
+  ): void {
+    let currentIndex = 0;
+    while (currentIndex < chunk.length) {
+      const newlineIndex = chunk.indexOf(this.newline, currentIndex);
+      if (newlineIndex === -1) {
+        this.buffer = Buffer.concat([
+          this.buffer,
+          chunk.subarray(currentIndex),
+        ]);
+        break;
+      }
+
+      const newlineChunk = chunk.subarray(currentIndex, newlineIndex);
+      const line = Buffer.concat([this.buffer, newlineChunk]);
+      this.push(line);
+      this.buffer = Buffer.alloc(0);
+
+      currentIndex = newlineIndex + 1;
+    }
+
+    callback();
+  }
+
+  override _flush(callback: () => void): void {
+    if (this.buffer.length) {
+      this.push(this.buffer);
+    }
+
+    callback();
+  }
+}

--- a/lldb/tools/lldb-dap/src-ts/process-tree/base-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/base-process-tree.ts
@@ -1,6 +1,8 @@
-import { ChildProcessWithoutNullStreams } from "child_process";
+import * as util from "util";
+import * as child_process from "child_process";
 import { Process, ProcessTree } from ".";
-import { Transform } from "stream";
+
+const exec = util.promisify(child_process.execFile);
 
 /** Parses process information from a given line of process output. */
 export type ProcessTreeParser = (line: string) => Process | undefined;
@@ -10,9 +12,14 @@ export type ProcessTreeParser = (line: string) => Process | undefined;
  */
 export abstract class BaseProcessTree implements ProcessTree {
   /**
-   * Spawn the process responsible for collecting all processes on the system.
+   * Get the command responsible for collecting all processes on the system.
    */
-  protected abstract spawnProcess(): ChildProcessWithoutNullStreams;
+  protected abstract getCommand(): string;
+
+  /**
+   * Get the list of arguments used to launch the command.
+   */
+  protected abstract getCommandArguments(): string[];
 
   /**
    * Create a new parser that can read the process information from stdout of the process
@@ -20,83 +27,15 @@ export abstract class BaseProcessTree implements ProcessTree {
    */
   protected abstract createParser(): ProcessTreeParser;
 
-  listAllProcesses(): Promise<Process[]> {
-    return new Promise<Process[]>((resolve, reject) => {
-      const proc = this.spawnProcess();
-      const parser = this.createParser();
-
-      // Capture processes from stdout
-      const processes: Process[] = [];
-      proc.stdout.pipe(new LineBasedStream()).on("data", (line) => {
-        const process = parser(line.toString());
-        if (process && process.id !== proc.pid) {
-          processes.push(process);
-        }
-      });
-
-      // Resolve or reject the promise based on exit code/signal/error
-      proc.on("error", reject);
-      proc.on("exit", (code, signal) => {
-        if (code === 0) {
-          resolve(processes);
-        } else if (signal) {
-          reject(
-            new Error(
-              `Unable to list processes: process exited due to signal ${signal}`,
-            ),
-          );
-        } else {
-          reject(
-            new Error(
-              `Unable to list processes: process exited with code ${code}`,
-            ),
-          );
-        }
-      });
-    });
-  }
-}
-
-/**
- * A stream that emits each line as a single chunk of data. The end of a line is denoted
- * by the newline character '\n'.
- */
-export class LineBasedStream extends Transform {
-  private readonly newline: number = "\n".charCodeAt(0);
-  private buffer: Buffer = Buffer.alloc(0);
-
-  override _transform(
-    chunk: Buffer,
-    _encoding: string,
-    callback: () => void,
-  ): void {
-    let currentIndex = 0;
-    while (currentIndex < chunk.length) {
-      const newlineIndex = chunk.indexOf(this.newline, currentIndex);
-      if (newlineIndex === -1) {
-        this.buffer = Buffer.concat([
-          this.buffer,
-          chunk.subarray(currentIndex),
-        ]);
-        break;
+  async listAllProcesses(): Promise<Process[]> {
+    const execCommand = exec(this.getCommand(), this.getCommandArguments());
+    const parser = this.createParser();
+    return (await execCommand).stdout.split("\n").flatMap((line) => {
+      const process = parser(line.toString());
+      if (!process || process.id === execCommand.child.pid) {
+        return [];
       }
-
-      const newlineChunk = chunk.subarray(currentIndex, newlineIndex);
-      const line = Buffer.concat([this.buffer, newlineChunk]);
-      this.push(line);
-      this.buffer = Buffer.alloc(0);
-
-      currentIndex = newlineIndex + 1;
-    }
-
-    callback();
-  }
-
-  override _flush(callback: () => void): void {
-    if (this.buffer.length) {
-      this.push(this.buffer);
-    }
-
-    callback();
+      return [process];
+    });
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/process-tree/index.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/index.ts
@@ -1,0 +1,36 @@
+import { DarwinProcessTree } from "./platforms/darwin-process-tree";
+import { LinuxProcessTree } from "./platforms/linux-process-tree";
+import { WindowsProcessTree } from "./platforms/windows-process-tree";
+
+/**
+ * Represents a single process running on the system.
+ */
+export interface Process {
+  /** Process ID */
+  id: number;
+
+  /** Command that was used to start the process */
+  command: string;
+
+  /** The full command including arguments that was used to start the process */
+  arguments: string;
+
+  /** The date when the process was started */
+  start: number;
+}
+
+export interface ProcessTree {
+  listAllProcesses(): Promise<Process[]>;
+}
+
+/** Returns a {@link ProcessTree} based on the current platform. */
+export function createProcessTree(): ProcessTree {
+  switch (process.platform) {
+    case "darwin":
+      return new DarwinProcessTree();
+    case "win32":
+      return new WindowsProcessTree();
+    default:
+      return new LinuxProcessTree();
+  }
+}

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
@@ -1,4 +1,3 @@
-import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { LinuxProcessTree } from "./linux-process-tree";
 
 function fill(prefix: string, suffix: string, length: number): string {
@@ -6,11 +5,11 @@ function fill(prefix: string, suffix: string, length: number): string {
 }
 
 export class DarwinProcessTree extends LinuxProcessTree {
-  protected override spawnProcess(): ChildProcessWithoutNullStreams {
-    return spawn("ps", [
+  protected override getCommandArguments(): string[] {
+    return [
       "-xo",
       // The length of comm must be large enough or data will be truncated.
       `pid=PID,lstart=START,comm=${fill("COMMAND", "-", 256)},command=ARGUMENTS`,
-    ]);
+    ];
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
@@ -1,0 +1,16 @@
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { LinuxProcessTree } from "./linux-process-tree";
+
+function fill(prefix: string, suffix: string, length: number): string {
+  return prefix + suffix.repeat(length - prefix.length);
+}
+
+export class DarwinProcessTree extends LinuxProcessTree {
+  protected override spawnProcess(): ChildProcessWithoutNullStreams {
+    return spawn("ps", [
+      "-xo",
+      // The length of comm must be large enough or data will be truncated.
+      `pid=PID,lstart=START,comm=${fill("COMMAND", "-", 256)},command=ARGUMENTS`,
+    ]);
+  }
+}

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
@@ -5,7 +5,7 @@ export class DarwinProcessTree extends LinuxProcessTree {
     return [
       "-axo",
       // The length of comm must be large enough or data will be truncated.
-      `pid=PID,lstart=START,comm=${"COMMAND".padEnd(256, "-")},args=ARGUMENTS`,
+      `pid=PID,state=STATE,lstart=START,comm=${"COMMAND".padEnd(256, "-")},args=ARGUMENTS`,
     ];
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/darwin-process-tree.ts
@@ -1,15 +1,11 @@
 import { LinuxProcessTree } from "./linux-process-tree";
 
-function fill(prefix: string, suffix: string, length: number): string {
-  return prefix + suffix.repeat(length - prefix.length);
-}
-
 export class DarwinProcessTree extends LinuxProcessTree {
   protected override getCommandArguments(): string[] {
     return [
-      "-xo",
+      "-axo",
       // The length of comm must be large enough or data will be truncated.
-      `pid=PID,lstart=START,comm=${fill("COMMAND", "-", 256)},command=ARGUMENTS`,
+      `pid=PID,lstart=START,comm=${"COMMAND".padEnd(256, "-")},args=ARGUMENTS`,
     ];
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
@@ -1,15 +1,12 @@
-import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { BaseProcessTree, ProcessTreeParser } from "../base-process-tree";
 
 export class LinuxProcessTree extends BaseProcessTree {
-  protected override spawnProcess(): ChildProcessWithoutNullStreams {
-    return spawn(
-      "ps",
-      ["-axo", `pid=PID,lstart=START,comm:128=COMMAND,command=ARGUMENTS`],
-      {
-        stdio: "pipe",
-      },
-    );
+  protected override getCommand(): string {
+    return "ps";
+  }
+
+  protected override getCommandArguments(): string[] {
+    return ["-axo", "pid=PID,lstart=START,comm:128=COMMAND,command=ARGUMENTS"];
   }
 
   protected override createParser(): ProcessTreeParser {

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
@@ -1,0 +1,38 @@
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+import { BaseProcessTree, ProcessTreeParser } from "../base-process-tree";
+
+export class LinuxProcessTree extends BaseProcessTree {
+  protected override spawnProcess(): ChildProcessWithoutNullStreams {
+    return spawn(
+      "ps",
+      ["-axo", `pid=PID,lstart=START,comm:128=COMMAND,command=ARGUMENTS`],
+      {
+        stdio: "pipe",
+      },
+    );
+  }
+
+  protected override createParser(): ProcessTreeParser {
+    let commandOffset: number | undefined;
+    let argumentsOffset: number | undefined;
+    return (line) => {
+      if (!commandOffset || !argumentsOffset) {
+        commandOffset = line.indexOf("COMMAND");
+        argumentsOffset = line.indexOf("ARGUMENTS");
+        return;
+      }
+
+      const pid = /^\s*([0-9]+)\s*/.exec(line);
+      if (!pid) {
+        return;
+      }
+
+      return {
+        id: Number(pid[1]),
+        command: line.slice(commandOffset, argumentsOffset).trim(),
+        arguments: line.slice(argumentsOffset).trim(),
+        start: Date.parse(line.slice(pid[0].length, commandOffset).trim()),
+      };
+    };
+  }
+}

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
@@ -6,7 +6,11 @@ export class LinuxProcessTree extends BaseProcessTree {
   }
 
   protected override getCommandArguments(): string[] {
-    return ["-axo", "pid=PID,lstart=START,comm:128=COMMAND,command=ARGUMENTS"];
+    return [
+      "-axo",
+      // The length of exe must be large enough or data will be truncated.
+      `pid=PID,lstart=START,exe:128=COMMAND,args=ARGUMENTS`,
+    ];
   }
 
   protected override createParser(): ProcessTreeParser {
@@ -24,9 +28,14 @@ export class LinuxProcessTree extends BaseProcessTree {
         return;
       }
 
+      const command = line.slice(commandOffset, argumentsOffset).trim();
+      if (command === "-") {
+        return;
+      }
+
       return {
         id: Number(pid[1]),
-        command: line.slice(commandOffset, argumentsOffset).trim(),
+        command,
         arguments: line.slice(argumentsOffset).trim(),
         start: Date.parse(line.slice(pid[0].length, commandOffset).trim()),
       };

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/linux-process-tree.ts
@@ -28,6 +28,7 @@ export class LinuxProcessTree extends BaseProcessTree {
         return;
       }
 
+      // ps will list "-" as the command if it does not know where the executable is located
       const command = line.slice(commandOffset, argumentsOffset).trim();
       if (command === "-") {
         return;

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/windows-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/windows-process-tree.ts
@@ -1,20 +1,18 @@
 import * as path from "path";
 import { BaseProcessTree, ProcessTreeParser } from "../base-process-tree";
-import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 
 export class WindowsProcessTree extends BaseProcessTree {
-  protected override spawnProcess(): ChildProcessWithoutNullStreams {
-    const wmic = path.join(
+  protected override getCommand(): string {
+    return path.join(
       process.env["WINDIR"] || "C:\\Windows",
       "System32",
       "wbem",
       "WMIC.exe",
     );
-    return spawn(
-      wmic,
-      ["process", "get", "CommandLine,CreationDate,ProcessId"],
-      { stdio: "pipe" },
-    );
+  }
+
+  protected override getCommandArguments(): string[] {
+    return ["process", "get", "CommandLine,CreationDate,ProcessId"];
   }
 
   protected override createParser(): ProcessTreeParser {

--- a/lldb/tools/lldb-dap/src-ts/process-tree/platforms/windows-process-tree.ts
+++ b/lldb/tools/lldb-dap/src-ts/process-tree/platforms/windows-process-tree.ts
@@ -1,0 +1,52 @@
+import * as path from "path";
+import { BaseProcessTree, ProcessTreeParser } from "../base-process-tree";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+
+export class WindowsProcessTree extends BaseProcessTree {
+  protected override spawnProcess(): ChildProcessWithoutNullStreams {
+    const wmic = path.join(
+      process.env["WINDIR"] || "C:\\Windows",
+      "System32",
+      "wbem",
+      "WMIC.exe",
+    );
+    return spawn(
+      wmic,
+      ["process", "get", "CommandLine,CreationDate,ProcessId"],
+      { stdio: "pipe" },
+    );
+  }
+
+  protected override createParser(): ProcessTreeParser {
+    const lineRegex = /^(.*)\s+([0-9]+)\.[0-9]+[+-][0-9]+\s+([0-9]+)$/;
+
+    return (line) => {
+      const matches = lineRegex.exec(line.trim());
+      if (!matches || matches.length !== 4) {
+        return;
+      }
+
+      const id = Number(matches[3]);
+      const start = Number(matches[2]);
+      let fullCommandLine = matches[1].trim();
+      if (isNaN(id) || !fullCommandLine) {
+        return;
+      }
+      // Extract the command from the full command line
+      let command = fullCommandLine;
+      if (fullCommandLine[0] === '"') {
+        const end = fullCommandLine.indexOf('"', 1);
+        if (end > 0) {
+          command = fullCommandLine.slice(1, end - 1);
+        }
+      } else {
+        const end = fullCommandLine.indexOf(" ");
+        if (end > 0) {
+          command = fullCommandLine.slice(0, end);
+        }
+      }
+
+      return { id, command, arguments: fullCommandLine, start };
+    };
+  }
+}


### PR DESCRIPTION
Adds a process picker command to the LLDB DAP extension that will prompt the user to select a process running on their machine. It is hidden from the command palette, but can be used in an `"attach"` debug configuration to select a process at the start of a debug session. I've also added a debug configuration snippet for this called `"LLDB: Attach to Process"` that will fill in the appropriate variable substitution. e.g:

```json
{
    "type": "lldb-dap",
    "request": "attach",
    "name": "Attach to Process",
    "pid": "${command:pickProcess}"
}
```

The logic is largely the same as the process picker in the `vscode-js-debug` extension created by Microsoft. It will use available executables based on the current platform to find the list of available processes:
- **Linux**: uses the `ps` executable to list processes
- **macOS**: nearly identical to Linux except that the command line options passed to `ps` are different
- **Windows**: uses the PowerShell cmdlet`Get-CimInstance` to query for processes

I manually tested this on a MacBook Pro running macOS Sequoia, a Windows 11 VM, and an Ubuntu 22.04 VM.

Fixes #96279