### PR TITLE
workflows/release-binaries: Limit the number of projects built for pull requests

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -145,6 +145,11 @@ jobs:
             target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS='clang;lld;lldb;clang-tools-extra;polly;mlir'"
           fi
           target_cmake_flags="$target_cmake_flags -DBOOTSTRAP_BOOTSTRAP_DARWIN_osx_ARCHS=$arches -DBOOTSTRAP_BOOTSTRAP_DARWIN_osx_BUILTIN_ARCHS=$arches"
+
+          # For pull requests we use the github-hosted runners, which aren't
+          # powerful enough to do a full build, so build less projects so that
+          # the build has a chance to succeed.
+          target_cmake_flags="$target_cmake_flags -DLLVM_RELEASE_ENABLE_PROJECTS='clang;lld'"
         fi
 
         build_flang="true"


### PR DESCRIPTION
The github hosted runners can't do a full build before the 6 hour timeout, so build less projects to give the build a chance to finish.

We use more powerful runners for the actual release builds, so we just need to make this change for pull requests where we use the slower github hosted runners.