### PR TITLE
Revert "DAG: Preserve range metadata when load is narrowed"

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -14903,29 +14903,12 @@ SDValue DAGCombiner::reduceLoadWidth(SDNode *N) {
   AddToWorklist(NewPtr.getNode());
 
   SDValue Load;
-  if (ExtType == ISD::NON_EXTLOAD) {
-    const MDNode *OldRanges = LN0->getRanges();
-    const MDNode *NewRanges = nullptr;
-    // If LSBs are loaded and the truncated ConstantRange for the OldRanges
-    // metadata is not the full-set for the NewWidth then create a NewRanges
-    // metadata for the truncated load
-    if (ShAmt == 0 && OldRanges) {
-      ConstantRange CR = getConstantRangeFromMetadata(*OldRanges);
-      ConstantRange TruncatedCR = CR.truncate(VT.getScalarSizeInBits());
-
-      if (!TruncatedCR.isFullSet()) {
-        Metadata *Bounds[2] = {ConstantAsMetadata::get(ConstantInt::get(
-                                   *DAG.getContext(), TruncatedCR.getLower())),
-                               ConstantAsMetadata::get(ConstantInt::get(
-                                   *DAG.getContext(), TruncatedCR.getUpper()))};
-        NewRanges = MDNode::get(*DAG.getContext(), Bounds);
-      }
-    }
-    Load = DAG.getLoad(
-        VT, DL, LN0->getChain(), NewPtr,
-        LN0->getPointerInfo().getWithOffset(PtrOff), LN0->getOriginalAlign(),
-        LN0->getMemOperand()->getFlags(), LN0->getAAInfo(), NewRanges);
-  } else
+  if (ExtType == ISD::NON_EXTLOAD)
+    Load = DAG.getLoad(VT, DL, LN0->getChain(), NewPtr,
+                       LN0->getPointerInfo().getWithOffset(PtrOff),
+                       LN0->getOriginalAlign(),
+                       LN0->getMemOperand()->getFlags(), LN0->getAAInfo());
+  else
     Load = DAG.getExtLoad(ExtType, DL, VT, LN0->getChain(), NewPtr,
                           LN0->getPointerInfo().getWithOffset(PtrOff), ExtVT,
                           LN0->getOriginalAlign(),


### PR DESCRIPTION
Reverts llvm/llvm-project#128144

Breaks clang prod x64 build (seen in Fuchsia toolchain)