### PR TITLE
[libc++] Mark _XOPEN_SOURCE test as unsupported on FreeBSD

### DIFF
--- a/libcxx/test/libcxx/xopen_source.gen.py
+++ b/libcxx/test/libcxx/xopen_source.gen.py
@@ -43,6 +43,9 @@ for header in public_headers:
 // recent value of _XOPEN_SOURCE.
 // UNSUPPORTED: LIBCXX-AIX-FIXME
 
+// This test fails on FreeBSD for an unknown reason.
+// UNSUPPORTED: LIBCXX-FREEBSD-FIXME
+
 {lit_header_restrictions.get(header, '')}
 {lit_header_undeprecations.get(header, '')}
 


### PR DESCRIPTION
The test otherwise fails on FreeBSD, which wasn't noticed when originally landing the patch that added the test because FreeBSD CI was disabled at that moment.