### PR TITLE
[libc][bazel] Add targets for strfrom<float>

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3571,6 +3571,49 @@ libc_function(
     ],
 )
 
+libc_support_library(
+    name = "str_from_util",
+    hdrs = ["src/stdlib/str_from_util.h"],
+    deps = [
+        ":__support_common",
+        ":__support_cpp_type_traits",
+        ":__support_str_to_integer",
+        ":printf_converter",
+        ":printf_core_structs",
+        ":printf_writer",
+    ],
+)
+
+libc_function(
+    name = "strfromf",
+    srcs = ["src/stdlib/strfromf.cpp"],
+    hdrs = ["src/stdlib/strfromf.h"],
+    deps = [
+        ":__support_common",
+        ":str_from_util",
+    ],
+)
+
+libc_function(
+    name = "strfromd",
+    srcs = ["src/stdlib/strfromd.cpp"],
+    hdrs = ["src/stdlib/strfromd.h"],
+    deps = [
+        ":__support_common",
+        ":str_from_util",
+    ],
+)
+
+libc_function(
+    name = "strfroml",
+    srcs = ["src/stdlib/strfroml.cpp"],
+    hdrs = ["src/stdlib/strfroml.h"],
+    deps = [
+        ":__support_common",
+        ":str_from_util",
+    ],
+)
+
 libc_function(
     name = "strtol",
     srcs = ["src/stdlib/strtol.cpp"],

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -150,6 +150,37 @@ libc_test(
 )
 
 libc_support_library(
+    name = "strfrom_test_support",
+    hdrs = ["StrfromTest.h"],
+    deps = [
+        "//libc:__support_cpp_type_traits",
+        "//libc:__support_fputil_fp_bits",
+        "//libc/test/UnitTest:LibcUnitTest",
+    ],
+)
+
+libc_test(
+    name = "strfromf_test",
+    srcs = ["strfromf_test.cpp"],
+    libc_function_deps = ["//libc:strfromf"],
+    deps = [":strfrom_test_support"],
+)
+
+libc_test(
+    name = "strfromd_test",
+    srcs = ["strfromd_test.cpp"],
+    libc_function_deps = ["//libc:strfromd"],
+    deps = [":strfrom_test_support"],
+)
+
+libc_test(
+    name = "strfroml_test",
+    srcs = ["strfroml_test.cpp"],
+    libc_function_deps = ["//libc:strfroml"],
+    deps = [":strfrom_test_support"],
+)
+
+libc_support_library(
     name = "strtol_test_helper",
     hdrs = ["StrtolTest.h"],
     deps = [

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -150,7 +150,7 @@ libc_test(
 )
 
 libc_support_library(
-    name = "strfrom_test_support",
+    name = "strfrom_test_helper",
     hdrs = ["StrfromTest.h"],
     deps = [
         "//libc:__support_cpp_type_traits",
@@ -163,21 +163,21 @@ libc_test(
     name = "strfromf_test",
     srcs = ["strfromf_test.cpp"],
     libc_function_deps = ["//libc:strfromf"],
-    deps = [":strfrom_test_support"],
+    deps = [":strfrom_test_helper"],
 )
 
 libc_test(
     name = "strfromd_test",
     srcs = ["strfromd_test.cpp"],
     libc_function_deps = ["//libc:strfromd"],
-    deps = [":strfrom_test_support"],
+    deps = [":strfrom_test_helper"],
 )
 
 libc_test(
     name = "strfroml_test",
     srcs = ["strfroml_test.cpp"],
     libc_function_deps = ["//libc:strfroml"],
-    deps = [":strfrom_test_support"],
+    deps = [":strfrom_test_helper"],
 )
 
 libc_support_library(


### PR DESCRIPTION
Add targets and tests for strfromf, strfromd and strfroml.

No idea why the standard committee decided that the long double function
should be "strfroml" instead of "strfromld" which would match "strtold"
and leave them space to add string from integer functions in future.
