### PR TITLE
[MLIR][EmitC][cf] Bugfix: correctly inline emitc.expression op in the emitted if condition of a cf.cond_br

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -613,8 +613,10 @@ static LogicalResult printOperation(CppEmitter &emitter,
   Block &trueSuccessor = *condBranchOp.getTrueDest();
   Block &falseSuccessor = *condBranchOp.getFalseDest();
 
-  os << "if (" << emitter.getOrCreateName(condBranchOp.getCondition())
-     << ") {\n";
+  os << "if (";
+  if (failed(emitter.emitOperand(condBranchOp.getCondition())))
+    return failure();
+  os << ") {\n";
 
   os.indent();
 

--- a/mlir/test/Target/Cpp/control_flow.mlir
+++ b/mlir/test/Target/Cpp/control_flow.mlir
@@ -68,3 +68,22 @@ func.func @block_labels1() {
   // CPP-DECLTOP-NEXT: label2:
   // CPP-DECLTOP-NEXT: return;
   // CPP-DECLTOP-NEXT: }
+
+emitc.func @expression_inlining(%0 : i32, %1 : i32) {
+  %2 = expression : i1 {
+    %3 = cmp lt, %0, %1 : (i32, i32) -> i1
+    yield %3 : i1
+  }
+  cf.cond_br %2, ^bb1, ^bb1
+  ^bb1:  // 2 preds: ^bb0, ^bb0
+    return
+}
+// CPP-DECLTOP: void expression_inlining(int32_t [[v1:v.*]], int32_t [[v2:v.*]]) {
+// CPP-DECLTOP-NEXT:   if ([[v1]] < [[v2]]) {
+// CPP-DECLTOP-NEXT:     goto label2;
+// CPP-DECLTOP-NEXT:   } else {
+// CPP-DECLTOP-NEXT:     goto label2;
+// CPP-DECLTOP-NEXT:   }
+// CPP-DECLTOP-NEXT: label2:
+// CPP-DECLTOP-NEXT:   return;
+// CPP-DECLTOP-NEXT: }


### PR DESCRIPTION
emitc.expression ops are expected to be inlined in the if condition in the lowering of cf.cond_br if this is their only use but they weren't inlined.
Instead, a use of the variable corresponding to the expression result was generated but with no declaration/definition.