### PR TITLE
[flang] Enforce C1503

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1496,6 +1496,14 @@ void CheckHelper::CheckSubprogram(
       messages_.Say(details.result().name(),
           "A function interface may not declare an assumed-length CHARACTER(*) result"_err_en_US);
     }
+    if (symbol.attrs().test(Attr::ABSTRACT) &&
+        (symbol.name() == "integer" || symbol.name() == "unsigned" ||
+            symbol.name() == "real" || symbol.name() == "complex" ||
+            symbol.name() == "character" ||
+            symbol.name() == "logical")) { // F'2023 C1503
+      messages_.Say(
+          "An ABSTRACT interface may not have the same name as an intrinsic type"_err_en_US);
+    }
   }
   CheckExternal(symbol);
   CheckModuleProcedureDef(symbol);

--- a/flang/test/Semantics/abstract02.f90
+++ b/flang/test/Semantics/abstract02.f90
@@ -4,6 +4,12 @@ program test
   abstract interface
     subroutine abstract
     end subroutine
+    !ERROR: An ABSTRACT interface may not have the same name as an intrinsic type
+    function integer()
+    end
+    !ERROR: An ABSTRACT interface may not have the same name as an intrinsic type
+    subroutine logical
+    end
   end interface
   procedure(abstract), pointer :: p
   !ERROR: Abstract procedure interface 'abstract' may not be referenced


### PR DESCRIPTION
Enforce an obscure constraint from the standard: an abstract interface is not allowed to have the same name as an intrinsic type keyword.  I suspect this is meant to prevent a declaration like "PROCEDURE(REAL), POINTER :: P" from being ambiguous.

Fixes https://github.com/llvm/llvm-project/issues/128744.