### PR TITLE
[TypeID] Update private typeid definition in `DeferredLocInfo`

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -839,8 +839,8 @@ private:
 };
 } // namespace
 
-MLIR_DECLARE_EXPLICIT_TYPE_ID(OperationParser::DeferredLocInfo *)
-MLIR_DEFINE_EXPLICIT_TYPE_ID(OperationParser::DeferredLocInfo *)
+MLIR_DECLARE_EXPLICIT_SELF_OWNING_TYPE_ID(OperationParser::DeferredLocInfo *)
+MLIR_DEFINE_EXPLICIT_SELF_OWNING_TYPE_ID(OperationParser::DeferredLocInfo *)
 
 OperationParser::OperationParser(ParserState &state, ModuleOp topLevelOp)
     : Parser(state), opBuilder(topLevelOp.getRegion()), topLevelOp(topLevelOp) {


### PR DESCRIPTION
The parser's `DeferredLocInfo` uses an uncommon TypeID setup, where it defines a private TypeID for pointers to the struct.

When using the fallback TypeID mechanism introduced in https://github.com/llvm/llvm-project/pull/126999, the fallback TypeID mechanism doesn't support anonymous namespaces, and the `INTERNAL_INLINE` mechanism doesn't support pointer types.

Explicitly use `SELF_OWNING_TYPE_ID` for this case. This should always be safe for anonymous namespaces.